### PR TITLE
test(db): scope traversal-span assertions to the span they name

### DIFF
--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -1392,11 +1392,19 @@ async fn graph_traverse_read_span_scoped_to_secondary_backend_visible_only_in_it
         khive_storage::tx_registry::TxOriginFilter::Secondary(secondary_identity.clone());
     let main_view = khive_storage::tx_registry::TxOriginFilter::Main(other_identity);
 
-    let span = khive_storage::tx_registry::oldest_for(&secondary_view)
-        .expect("statement-scoped traversal span must be visible while its seam is held");
-    assert_eq!(span.label.as_deref(), Some("graph_traverse_read"));
+    // Ask about the traversal span by label rather than through `oldest_for`.
+    // Writes on this same pool open their own `writer_task_tx` spans, and the
+    // writer task replies to its caller *before* dropping that handle, so an
+    // acknowledged write can still hold an open span on this backend. Such a
+    // span is unrelated to what this test asserts, but it is older than the
+    // traversal's, so `oldest_for` returns it and the assertion reads a
+    // different span's lifetime as the traversal's.
     assert!(
-        khive_storage::tx_registry::oldest_for(&main_view).is_none(),
+        khive_storage::tx_registry::any_open_labeled(&secondary_view, "graph_traverse_read"),
+        "statement-scoped traversal span must be visible while its seam is held"
+    );
+    assert!(
+        !khive_storage::tx_registry::any_open_labeled(&main_view, "graph_traverse_read"),
         "a secondary-origin graph_traverse_read span must never be visible through a different backend's Main view"
     );
 
@@ -1414,7 +1422,7 @@ async fn graph_traverse_read_span_scoped_to_secondary_backend_visible_only_in_it
         .expect("the next frontier statement must see the concurrent commit");
     assert_eq!(grandchild_node.depth, 2);
     assert!(
-        khive_storage::tx_registry::oldest_for(&secondary_view).is_none(),
+        !khive_storage::tx_registry::any_open_labeled(&secondary_view, "graph_traverse_read"),
         "the statement-scoped traversal span must be gone when its bounded query returns"
     );
 }
@@ -2719,7 +2727,7 @@ async fn traverse_work_budget_boundary_and_error_are_deterministic() {
     }
     assert_eq!(ctx.snapshot()["graph_hops"], 4);
     assert!(
-        khive_storage::tx_registry::oldest_for(&origin_view).is_none(),
+        !khive_storage::tx_registry::any_open_labeled(&origin_view, "graph_traverse_read"),
         "an over-budget return must drop its statement-scoped registry span"
     );
 }
@@ -2785,7 +2793,7 @@ async fn traverse_progress_handler_interrupts_statement_and_is_cleared() {
         "the test must enter SQLite's VM progress callback"
     );
     assert!(
-        khive_storage::tx_registry::oldest_for(&origin_view).is_none(),
+        !khive_storage::tx_registry::any_open_labeled(&origin_view, "graph_traverse_read"),
         "the interrupted statement must drop its graph_traverse_read span"
     );
 

--- a/crates/khive-storage/src/tx_registry.rs
+++ b/crates/khive-storage/src/tx_registry.rs
@@ -218,11 +218,20 @@ mod tests {
     // binary (cargo runs `#[test]`s in parallel threads of the same process). A
     // module-local lock serializes these tests so one test's entries can't be
     // observed as another's "oldest" or leak into another's snapshot assertion.
+    //
+    // Acquired with the same poison recovery the registry itself uses. A failing
+    // assertion panics while holding this lock, so under `.unwrap()` every later
+    // test in the module dies of `PoisonError` instead of running: one real
+    // failure presents as a dozen, and the reader has to work out which one is
+    // the signal. Measured — a single-predicate mutation reddened 13 of 15 tests,
+    // 10 of them purely as poison cascade.
     static TEST_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn register_reports_oldest_with_label() {
-        let _guard = TEST_LOCK.lock().unwrap();
+        let _guard = TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let handle = register(Some("test_span".to_string()));
         let (_, _, label) = oldest().expect("expected an open entry");
         assert_eq!(label.as_deref(), Some("test_span"));
@@ -231,7 +240,9 @@ mod tests {
 
     #[test]
     fn drop_deregisters() {
-        let _guard = TEST_LOCK.lock().unwrap();
+        let _guard = TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let handle = register(Some("drop_me".to_string()));
         let id_present_before = snapshot()
             .iter()
@@ -246,7 +257,9 @@ mod tests {
 
     #[test]
     fn oldest_is_genuinely_oldest() {
-        let _guard = TEST_LOCK.lock().unwrap();
+        let _guard = TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let first = register(Some("first".to_string()));
         std::thread::sleep(Duration::from_millis(5));
         let second = register(Some("second".to_string()));
@@ -264,7 +277,9 @@ mod tests {
 
     #[test]
     fn snapshot_contains_all_open_entries() {
-        let _guard = TEST_LOCK.lock().unwrap();
+        let _guard = TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let a = register(Some("snap_a".to_string()));
         let b = register(Some("snap_b".to_string()));
         let labels: Vec<Option<String>> = snapshot().into_iter().map(|(_, label)| label).collect();
@@ -276,7 +291,9 @@ mod tests {
 
     #[test]
     fn oldest_for_partitions_by_origin() {
-        let _guard = TEST_LOCK.lock().unwrap();
+        let _guard = TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let main_id = DbIdentity::new("main.db");
         let secondary_id = DbIdentity::new("secondary.db");
         let main_view = TxOriginFilter::Main(main_id.clone());
@@ -305,7 +322,9 @@ mod tests {
 
     #[test]
     fn register_delegates_to_unscoped_origin() {
-        let _guard = TEST_LOCK.lock().unwrap();
+        let _guard = TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let main_id = DbIdentity::new("main.db");
         let main_view = TxOriginFilter::Main(main_id);
         let handle = register(Some("legacy_span".to_string()));
@@ -318,7 +337,9 @@ mod tests {
 
     #[test]
     fn unscoped_visible_in_main_view_and_oldest() {
-        let _guard = TEST_LOCK.lock().unwrap();
+        let _guard = TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let main_id = DbIdentity::new("main.db");
         let main_view = TxOriginFilter::Main(main_id);
         let handle = register_scoped(Some("unscoped_span".to_string()), TxOrigin::Unscoped);
@@ -335,7 +356,9 @@ mod tests {
 
     #[test]
     fn memory_absent_from_attribution_views_but_present_in_oldest() {
-        let _guard = TEST_LOCK.lock().unwrap();
+        let _guard = TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let main_id = DbIdentity::new("main.db");
         let secondary_id = DbIdentity::new("secondary.db");
         let main_view = TxOriginFilter::Main(main_id);
@@ -353,7 +376,9 @@ mod tests {
 
     #[test]
     fn database_entries_never_leak_across_views() {
-        let _guard = TEST_LOCK.lock().unwrap();
+        let _guard = TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let main_id = DbIdentity::new("main.db");
         let secondary_id = DbIdentity::new("secondary.db");
         let main_view = TxOriginFilter::Main(main_id);
@@ -373,7 +398,9 @@ mod tests {
 
     #[test]
     fn panic_inside_scope_still_deregisters() {
-        let _guard = TEST_LOCK.lock().unwrap();
+        let _guard = TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let result = panic::catch_unwind(AssertUnwindSafe(|| {
             let _handle = register(Some("panics".to_string()));
             panic!("boom");
@@ -383,5 +410,109 @@ mod tests {
             .iter()
             .any(|(_, label)| label.as_deref() == Some("panics"));
         assert!(!still_present);
+    }
+
+    #[test]
+    fn any_open_labeled_matches_only_the_named_label() {
+        let _guard = TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let main_id = DbIdentity::new("main.db");
+        let main_view = TxOriginFilter::Main(main_id.clone());
+        let handle = register_scoped(
+            Some("wanted".to_string()),
+            TxOrigin::Database(main_id.clone()),
+        );
+
+        assert!(any_open_labeled(&main_view, "wanted"));
+        assert!(!any_open_labeled(&main_view, "other"));
+        assert!(!any_open_labeled(&main_view, "wante"));
+
+        drop(handle);
+        assert!(!any_open_labeled(&main_view, "wanted"));
+    }
+
+    /// The whole reason this predicate exists: an unrelated span open on the
+    /// same backend satisfies [`oldest_for`] while saying nothing about the
+    /// span the caller named. A caller asking "is *my* span still open" must
+    /// not read a different span's presence as its own.
+    #[test]
+    fn any_open_labeled_ignores_unrelated_spans_that_oldest_for_reports() {
+        let _guard = TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let main_id = DbIdentity::new("main.db");
+        let main_view = TxOriginFilter::Main(main_id.clone());
+        let unrelated = register_scoped(
+            Some("someone_elses_write".to_string()),
+            TxOrigin::Database(main_id.clone()),
+        );
+
+        assert!(
+            oldest_for(&main_view).is_some(),
+            "aggregate must observe the unrelated span — otherwise this test \
+             proves nothing about the discrimination"
+        );
+        assert!(!any_open_labeled(&main_view, "mine"));
+
+        drop(unrelated);
+    }
+
+    #[test]
+    fn any_open_labeled_survives_duplicate_labels() {
+        let _guard = TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let main_id = DbIdentity::new("main.db");
+        let main_view = TxOriginFilter::Main(main_id.clone());
+        let first = register_scoped(Some("dup".to_string()), TxOrigin::Database(main_id.clone()));
+        let second = register_scoped(Some("dup".to_string()), TxOrigin::Database(main_id.clone()));
+
+        assert!(any_open_labeled(&main_view, "dup"));
+        drop(first);
+        assert!(
+            any_open_labeled(&main_view, "dup"),
+            "one of two same-labeled spans closing must not read as all of them closing"
+        );
+        drop(second);
+        assert!(!any_open_labeled(&main_view, "dup"));
+    }
+
+    #[test]
+    fn any_open_labeled_never_matches_an_unlabeled_span() {
+        let _guard = TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let main_id = DbIdentity::new("main.db");
+        let main_view = TxOriginFilter::Main(main_id.clone());
+        let unlabeled = register_scoped(None, TxOrigin::Database(main_id.clone()));
+
+        assert!(
+            oldest_for(&main_view).is_some(),
+            "the unlabeled span must be registered for this test to discriminate"
+        );
+        assert!(!any_open_labeled(&main_view, "anything"));
+
+        drop(unlabeled);
+    }
+
+    #[test]
+    fn any_open_labeled_partitions_by_origin() {
+        let _guard = TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let main_id = DbIdentity::new("main.db");
+        let secondary_id = DbIdentity::new("secondary.db");
+        let main_view = TxOriginFilter::Main(main_id);
+        let secondary_view = TxOriginFilter::Secondary(secondary_id.clone());
+        let handle = register_scoped(
+            Some("secondary_only".to_string()),
+            TxOrigin::Database(secondary_id),
+        );
+
+        assert!(any_open_labeled(&secondary_view, "secondary_only"));
+        assert!(!any_open_labeled(&main_view, "secondary_only"));
+
+        drop(handle);
     }
 }

--- a/crates/khive-storage/src/tx_registry.rs
+++ b/crates/khive-storage/src/tx_registry.rs
@@ -176,6 +176,26 @@ pub fn oldest_for(filter: &TxOriginFilter) -> Option<OldestSpan> {
         })
 }
 
+/// Whether an attribution view currently observes an open span carrying
+/// `label`.
+///
+/// [`oldest_for`] cannot answer this. It reports the oldest span on the
+/// backend, so any other span opened earlier on the same backend masks the
+/// one the caller is asking about — a caller reasoning about the lifetime of
+/// *its own* span reads a different span's presence as its own. Callers that
+/// need "is this span still open" need this predicate; callers that need
+/// "how long has this backend held a read open" need [`oldest_for`].
+///
+/// Recovers a poisoned lock via `into_inner()` (see [`register_scoped`]).
+pub fn any_open_labeled(filter: &TxOriginFilter, label: &str) -> bool {
+    let registry = REGISTRY
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    registry
+        .values()
+        .any(|meta| filter.matches(&meta.origin) && meta.label.as_deref() == Some(label))
+}
+
 /// Age and label of every currently-open registry entry. Recovers a poisoned
 /// lock via `into_inner()` (see [`register`]) instead of returning an empty
 /// `Vec` — see `crates/khive-storage/docs/api/tx-registry.md`.


### PR DESCRIPTION
## Problem

Three assertions in `graph_tests.rs` check that a `graph_traverse_read` span is present or has been released, but express that check as `tx_registry::oldest_for(origin).is_none()`. `oldest_for` reports the **oldest span on the backend**, not the span the assertion names.

Writes on the same pool open a `writer_task_tx` span. The writer task replies to its caller *before* dropping that handle (`writer_task.rs`, the `_tx_handle` guard outlives `execute_and_reply_reporting_terminal`), so a write whose result has already been awaited can still hold an open span on that backend. That span is older than the traversal's, so `oldest_for` returns it, and the assertion reads an unrelated span's lifetime as the traversal's.

The result is an intermittent failure with no product defect behind it. It has failed the coverage job on documentation-only changes, where the diff cannot have touched the behaviour under test.

## Fix

`oldest_for` structurally cannot answer "is *this* span still open" — for any caller, not just these tests. Add the missing predicate:

```rust
pub fn any_open_labeled(filter: &TxOriginFilter, label: &str) -> bool
```

and use it at all three sites. `oldest_for`'s contract and every existing caller are unchanged.

All three sites are fixed, not only the one observed failing: the same label-blind check appears in the over-budget-return and interrupted-statement tests, both of which write to the same pool and are exposed to the same lingering span.

## Verification

Mutation, with the expected reddened arm stated before each run and reconciled after:

| Mutation | Tests | Expected | Observed |
| --- | --- | --- | --- |
| writer holds `_tx_handle` past its reply | unchanged | fail | fail, `left: Some("writer_task_tx")` |
| writer holds `_tx_handle` past its reply | fixed | pass | pass |
| traversal span guard leaked (`mem::forget`) | fixed | fail on release assertion | fail at the release assertion |
| traversal span registration removed | fixed | fail on presence assertion | fail at the presence assertion |

The first arm is the reported mechanism reproduced deterministically; the last two show the fix does not blunt either property the assertions exist to protect.

`cargo test -p khive-db -p khive-storage --lib`: 723 passed, 0 failed. `cargo fmt --check` and `cargo clippy --all-targets` clean.

## Note, not fixed here

The writer task replying before releasing its registry handle means an acknowledged write can briefly appear as an open transaction to `oldest_for`, which is what the checkpoint heartbeat reads. The window is small and the transaction has committed by then, so this is an observability inaccuracy rather than a correctness problem, and changing writer ordering is out of scope for a test fix.