### PR TITLE
fix(contracts): align fresh-tail, comm-read, and import-scan semantics

### DIFF
--- a/crates/khive-pack-code/docs/code-ontology.md
+++ b/crates/khive-pack-code/docs/code-ontology.md
@@ -22,6 +22,15 @@ portable policy contract in `metadata.dependency_scopes` (`normal`, `dev`, or `b
 imports default to `build`; project imports inherit a matching manifest declaration's scope and
 otherwise default to `build`. An edge is dev-only only when its scope set is exactly `{dev}`.
 
+L1.5 import edges are a **static lexical-coupling signal**, not a runtime import graph. The
+coverage-floor scanner is regex-based and does not classify block or guard scope: it includes
+Python imports under `if TYPE_CHECKING:`, function-local imports, and equivalently indented or
+nested matches in the other supported languages. Consequently, a `depends_on` cycle derived from
+L1.5 says that the source texts reference one another; it does not by itself establish a
+module-initialization or runtime dependency cycle. The current edge metadata does not distinguish
+these cases, so consumers needing runtime-cycle claims must confirm scope from source or wait for a
+scope-aware scanner tier.
+
 L2 reuses the closed edge vocabulary: modules `contains` their current declarations, symbols
 `depends_on` other declarations for resolved path calls and supported type references, and
 datatypes `implements` interfaces for positive trait implementations. L2-derived edges are limited

--- a/crates/khive-pack-code/src/imports.rs
+++ b/crates/khive-pack-code/src/imports.rs
@@ -1,9 +1,12 @@
 //! Regex-based import scan for `code.ingest` L1.5 (ADR-085 Amendment 2 B3).
 //!
 //! Syntax-only, per B2: no type-checking, no compilation. Coverage-floor
-//! extraction — good enough to produce `depends_on` edges and module paths,
-//! not a full parser. Pure functions; no filesystem or storage access beyond
-//! the caller-supplied file path (used only for path arithmetic).
+//! extraction — good enough to produce static-coupling `depends_on` edges and
+//! module paths, not a full parser. The regexes are deliberately scope-blind:
+//! guarded, type-check-only, and function-local imports are included, so these
+//! edges do not assert a module-initialization or runtime dependency. Pure
+//! functions; no filesystem or storage access beyond the caller-supplied file
+//! path (used only for path arithmetic).
 
 use std::path::{Component, Path};
 
@@ -71,7 +74,11 @@ fn python_imported_names(names: &str) -> Vec<&str> {
         .collect()
 }
 
-/// Extract raw, unclassified import specifiers from `content`.
+/// Extract raw, scope-unclassified import specifiers from `content`.
+///
+/// Leading whitespace is accepted intentionally, so imports nested in a
+/// function or guard (including Python `if TYPE_CHECKING:` blocks) are part of
+/// this static-coupling signal. See ADR-085 Amendment 2 B3.
 pub(crate) fn extract_raw_imports(language: &str, content: &str) -> Vec<String> {
     let mut out = Vec::new();
     match language {

--- a/crates/khive-pack-memory/src/ann.rs
+++ b/crates/khive-pack-memory/src/ann.rs
@@ -1610,11 +1610,11 @@ pub(crate) async fn fetch_final_tail(
     rt: &KhiveRuntime,
     model: &str,
     s: u64,
-    limit: Option<u64>,
+    live_threshold: Option<f64>,
 ) -> Result<(Vec<(Uuid, Option<Vec<f32>>)>, u64), String> {
     let sql = rt.sql();
     let mut reader = sql.reader().await.map_err(|e| e.to_string())?;
-    fetch_final_tail_on(reader.as_mut(), model, s, limit).await
+    fetch_final_tail_on(reader.as_mut(), model, s, live_threshold).await
 }
 
 /// Same as [`fetch_final_tail`] but runs every read through a caller-supplied
@@ -1625,35 +1625,56 @@ async fn fetch_final_tail_on(
     reader: &mut dyn khive_storage::SqlReader,
     model: &str,
     s: u64,
-    limit: Option<u64>,
+    live_threshold: Option<f64>,
 ) -> Result<(Vec<(Uuid, Option<Vec<f32>>)>, u64), String> {
-    // `limit` (ADR-118 §3, Cold/Empty tier): cap the scan to the newest
-    // `limit` log rows instead of the entire scope, taking the highest-seq
-    // suffix so the freshest writes stay visible. The DESC+LIMIT rows are
-    // reversed back to ascending order below so final-op-per-subject
-    // coalescing (insert-overwrite = last write wins) is unaffected.
-    let order_limit = match limit {
-        Some(n) => format!("ORDER BY seq DESC LIMIT {n}"),
-        None => "ORDER BY seq".to_string(),
+    // `live_threshold` (ADR-118 §3, Cold/Empty tier): cap the scan to
+    // ceil(threshold × live corpus) newest log rows. The live count and log
+    // suffix are selected by one SQL statement so they describe one snapshot,
+    // matching the knowledge consumer's equivalent fallback. The DESC+LIMIT
+    // rows are reversed below so final-op-per-subject coalescing still sees
+    // ascending sequence order (insert-overwrite = last write wins).
+    let table_name = format!("vec_{}", sanitize_model_key(model));
+    let (live_cte, order_limit) = match live_threshold {
+        Some(_) => (
+            format!(
+                "WITH live AS (\
+                   SELECT COUNT(*) AS live_count FROM {table_name} v \
+                   JOIN notes n ON n.id = v.subject_id \
+                   WHERE v.embedding_model = ?1 \
+                     AND v.kind = 'note' AND v.field = 'note.content' \
+                     AND n.deleted_at IS NULL\
+                 ) "
+            ),
+            "ORDER BY seq DESC \
+             LIMIT (SELECT CAST(live_count * ?3 AS INTEGER) + \
+                       CASE WHEN CAST(live_count * ?3 AS INTEGER) < live_count * ?3 \
+                            THEN 1 ELSE 0 END FROM live)"
+                .to_string(),
+        ),
+        None => (String::new(), "ORDER BY seq".to_string()),
     };
+    let mut params = vec![
+        SqlValue::Text(model.to_owned()),
+        SqlValue::Integer(s as i64),
+    ];
+    if let Some(threshold) = live_threshold {
+        params.push(SqlValue::Float(threshold));
+    }
     let rows = reader
         .query_all(SqlStatement {
             sql: format!(
-                "SELECT seq, subject_id, op FROM ann_write_log \
+                "{live_cte}SELECT seq, subject_id, op FROM ann_write_log \
                   WHERE embedding_model = ?1 \
                     AND kind = 'note' AND field = 'note.content' AND seq > ?2 \
                   {order_limit}"
             ),
-            params: vec![
-                SqlValue::Text(model.to_owned()),
-                SqlValue::Integer(s as i64),
-            ],
+            params,
             label: Some("memory_ann_fetch_tail".into()),
         })
         .await
         .map_err(|e| e.to_string())?;
     let mut rows = rows;
-    if limit.is_some() {
+    if live_threshold.is_some() {
         rows.reverse();
     }
 
@@ -1698,7 +1719,6 @@ async fn fetch_final_tail_on(
     // A vec row that is absent, or present but out of this consumer's scope,
     // contradicts the log's committed final upsert (vec writes and log appends
     // are same-transaction) → Err, which the caller treats as Cold.
-    let table_name = format!("vec_{}", sanitize_model_key(model));
     let mut embeddings: HashMap<Uuid, Vec<f32>> = HashMap::with_capacity(upsert_ids.len());
     for subject in &upsert_ids {
         let rows = reader
@@ -1973,9 +1993,9 @@ pub(crate) enum FreshTailOutcome {
 /// (and primary) tier: a serving bridge exists, and every committed write
 /// above its watermark is merged in, giving read-your-writes visibility.
 /// `s = None` is the second tier (§3): no serving index is available at all,
-/// so the leg caps its scan at a fixed-ceiling newest suffix of the log
-/// instead of the entire scope, guaranteeing visibility of only the
-/// caller's most recent writes until a serving index exists again.
+/// so the leg caps its scan at a corpus-relative newest suffix of the log
+/// instead of the entire scope, guaranteeing visibility of only the caller's
+/// most recent writes until a serving index exists again.
 /// `query`/`k` are the recall vector and fetch limit — needed only by the
 /// serving tier's mismatch re-resolution path, which must run a fresh ANN
 /// search against a newly loaded segment.
@@ -2375,19 +2395,19 @@ async fn fresh_tail_reresolve(
     unreachable!("the loop always returns on or before its terminal round")
 }
 
-/// Fixed ceiling for the Cold/Empty-tier capped scan (ADR-118 §3). Deriving
-/// a corpus-proportional cap (`ann_rebuild_threshold() * live`) needs an
-/// O(corpus) live-count join — appropriate for the background restart
-/// classifier, not for this per-query path. The ceiling is
-/// a fixed, conservative match to the ADR's own worked example (a 0.20
-/// threshold on a 68k-row corpus is ~13.6k comparisons).
-const FRESH_TAIL_CAPPED_MAX_ROWS: u64 = 20_000;
-
 /// Tier 2 (§3): no serving index at all. A cheap, log-only existence probe
 /// (no corpus join) fast-paths the common empty-tail case; a non-empty tail
-/// is capped at a fixed ceiling rather than a live-corpus-proportional one,
-/// so this bounded fallback never itself pays an O(corpus) cost.
+/// is capped at ceil(`ann_rebuild_threshold() * live corpus`) rows. The live
+/// count and selected newest suffix share one SQL statement/snapshot.
 async fn fresh_tail_capped(rt: &KhiveRuntime, model: &str) -> FreshTailOutcome {
+    fresh_tail_capped_at_threshold(rt, model, ann_rebuild_threshold()).await
+}
+
+async fn fresh_tail_capped_at_threshold(
+    rt: &KhiveRuntime,
+    model: &str,
+    live_threshold: f64,
+) -> FreshTailOutcome {
     match tail_exists(rt, model, 0).await {
         Ok(false) => return FreshTailOutcome::Ops(Vec::new()),
         Ok(true) => {}
@@ -2396,7 +2416,7 @@ async fn fresh_tail_capped(rt: &KhiveRuntime, model: &str) -> FreshTailOutcome {
             return FreshTailOutcome::Skipped("fresh-tail: tail-existence read failed");
         }
     }
-    match fetch_final_tail(rt, model, 0, Some(FRESH_TAIL_CAPPED_MAX_ROWS)).await {
+    match fetch_final_tail(rt, model, 0, Some(live_threshold)).await {
         Ok((ops, _new_s)) => FreshTailOutcome::Ops(ops),
         Err(e) => {
             tracing::warn!(error = %e, model, "fresh-tail: capped tail fetch failed; skipping exact leg");
@@ -4562,6 +4582,54 @@ mod tests {
     }
 
     // ── ADR-118: fresh-tail exact leg ───────────────────────────────────────
+
+    /// #1161 regression: the no-index fallback follows ADR-118's
+    /// ceil(threshold × live corpus) ceiling instead of a flat 20,000-row
+    /// suffix. Six live vectors at 0.20 admit exactly the two newest raw log
+    /// rows; this also pins ceil rounding rather than truncation.
+    #[tokio::test]
+    #[serial(adr118_fresh_tail)]
+    async fn fresh_tail_no_index_cap_tracks_live_corpus_fraction() {
+        const MODEL: &str = "adr118-corpus-relative-cap-test-model";
+        const DIMS: usize = 8;
+        let rt = test_runtime_with_hash_embedder(MODEL, DIMS);
+        let token = rt.authorize(Namespace::local()).expect("authorize local");
+        let mut ids = Vec::new();
+
+        for i in 0..6u32 {
+            let note = rt
+                .create_note_with_decay_for_embedding_model(
+                    &token,
+                    "memory",
+                    None,
+                    &format!("corpus-relative cap note {i}"),
+                    Some(0.7),
+                    0.01,
+                    None,
+                    vec![],
+                    None,
+                )
+                .await
+                .expect("create note");
+            ids.push(note.id);
+        }
+
+        let ops = match fresh_tail_capped_at_threshold(&rt, MODEL, 0.20).await {
+            FreshTailOutcome::Ops(ops) => ops,
+            FreshTailOutcome::Replace(..) => {
+                panic!("no-index capped leg must not produce replacement candidates")
+            }
+            FreshTailOutcome::Skipped(reason) => {
+                panic!("no-index capped leg unexpectedly skipped: {reason}")
+            }
+        };
+        let selected: Vec<Uuid> = ops.into_iter().map(|(id, _)| id).collect();
+        assert_eq!(
+            selected,
+            ids[4..].to_vec(),
+            "ceil(0.20 × 6) must select the two newest raw log rows"
+        );
+    }
 
     /// A subject present in the stale warm ANN index whose final tail op is
     /// `delete` must be dropped from the merged candidate list — the tail is

--- a/docs/adr/ADR-085-code-pack.md
+++ b/docs/adr/ADR-085-code-pack.md
@@ -563,7 +563,11 @@ independently of the ones after it:
 - **L1.5 (import-scan edges).** A regex-based import scan produces
   module-to-module and project-to-project `depends_on` edges. This is the
   coverage floor for a language that has no Scanner yet, and doubles as the
-  signal for which language to build a Scanner for next.
+  signal for which language to build a Scanner for next. The regex tier is
+  intentionally scope-blind: guarded/type-check-only and function-local imports
+  are included. Its edges and any cycles derived from them therefore mean static
+  lexical coupling, not proven module-initialization or runtime dependency; L1.5
+  carries no scope discriminator from which a consumer could infer otherwise.
 - **L2 (symbol tier).** The full Scanner/Extractor pipeline (B2) over the D2
   subtypes and D3 edge rules, at declaration granularity.
 
@@ -1469,6 +1473,9 @@ The normalization is:
 | L1.5 undeclared project import                                 | `build`        |
 
 The L1.5 module default makes D3's existing compile-time guidance concrete.
+That `build` policy scope does not override B3's scope-blind scanner caveat:
+it classifies the edge for filtering but does not prove that the import runs at
+module initialization or at runtime.
 For project imports, the governing manifest is authoritative when it declares
 the imported project: an import of a dev-only dependency remains dev-scoped
 instead of fabricating a production back-edge. An undeclared project import

--- a/docs/adr/ADR-118-fresh-tail-recall-visibility.md
+++ b/docs/adr/ADR-118-fresh-tail-recall-visibility.md
@@ -185,8 +185,15 @@ it counts the live, join-filtered vector corpus and caps its scan at
 log (the newest raw writes, before final-state coalescing) so the freshest writes stay visible
 while FTS covers the rest, and otherwise
 defers to the existing Cold-path behavior (FTS-only serving while the rebuild runs). The leg
-restores freshness on a serving index; it is not a general exact-search fallback. This is
-the second tier of the §"Decision" guarantee stated precisely: with no serving index, a
+restores freshness on a serving index; it is not a general exact-search fallback. The no-index
+path has an intentionally asymmetric cost boundary. An empty-tail existence probe returns before
+any corpus count. Once that probe finds retained rows, however, each Cold/Empty query pays an
+O(live-vector-corpus) `COUNT` over the vector-to-note join, followed by at most
+`ceil(KHIVE_ANN_REBUILD_THRESHOLD × live_vector_count)` newest raw-log point reads and exact
+scores. Only the suffix and scoring work are threshold-bounded; the live-corpus count/join is
+not. This remaining no-index cost is accepted to keep the bound corpus-relative without adding
+a separately maintained count. This is the second tier of the §"Decision" guarantee stated
+precisely: with no serving index, a
 committed write is visible to the vector legs **iff its `ann_write_log` row is still
 retained — compaction has not passed it — and fewer than
 `ceil(KHIVE_ANN_REBUILD_THRESHOLD × live_vector_count)` retained raw log rows committed after
@@ -267,10 +274,12 @@ deletes that write no log rows — see ADR-079's rule 5 qualification).
   the overwhelmingly common state — matching the pre-Vamana behavior and the synchronous
   write path's implicit promise; the Cold/Empty window keeps the newest-suffix guarantee
   only (§3).
-- Recall pays a small per-query cost (log-tail scan + registry-minimum coverage check +
-  exact scoring) that is near zero when the tail is empty. The Cold/Empty fallback is bounded
-  by the corpus-relative rebuild threshold; the serving-index path scans the full suffix to
-  preserve read-your-writes and has no separate hard row cap.
+- Recall's serving-index path pays a small per-query cost (log-tail scan + registry-minimum
+  coverage check + exact scoring) that is near zero when the tail is empty. A non-empty
+  Cold/Empty fallback additionally pays an O(live-vector-corpus) count/join; only its newest
+  raw-log suffix reads and scoring are bounded by the corpus-relative rebuild threshold. The
+  serving-index path scans the full suffix to preserve read-your-writes and has no separate hard
+  row cap.
 - The tail query adds read traffic on `ann_write_log`; its index must serve
   `(embedding_model, seq)`-shaped scans efficiently (the existing namespace-first index
   shape is a known follow-up).

--- a/docs/adr/ADR-118-fresh-tail-recall-visibility.md
+++ b/docs/adr/ADR-118-fresh-tail-recall-visibility.md
@@ -55,10 +55,10 @@ inside §1's checkpoint mismatch window, which re-resolution closes for both cro
 checkpoints and same-process queries that captured candidates before the bridge swap. While no
 index is serving (Cold rebuild in flight, or Empty), a
 committed write is visible to the vector legs iff its log row is still retained and fewer
-than threshold-many retained writes committed after it in scope (§3 states the precise
-condition); ADR-107 governs everything else until the rebuild lands. The
-per-query cost is proportional to the tail length, which the checkpoint lifecycle already
-bounds.
+than `ceil(KHIVE_ANN_REBUILD_THRESHOLD × live_vector_count)` retained writes committed after
+it in scope (§3 states the precise condition); ADR-107 governs everything else until the
+rebuild lands. The per-query cost is proportional to the full tail length when an index is
+serving and to the corpus-relative suffix when one is not (§3).
 
 ### 1. Tail enumeration
 
@@ -160,32 +160,38 @@ near ties. This is bounded and accepted; if it shows up in practice, the remedy 
 full-precision re-scoring of the ANN candidates within the merge window — explicitly a
 scoring refinement inside the leg, never a fusion change.
 
-### 3. Cost bound and the no-index case
+### 3. Cost shape and the no-index case
 
-The exact leg is O(|tail| × dims) per model per query. The tail is small by construction:
+The exact leg is O(|tail| × dims) per model per query. The serving-index tail is normally small:
 
 - The checkpoint lifecycle (ADR-079 §"checkpoint") drains the tail on a cadence; the
   steady-state tail is the writes since the last checkpoint.
-- The rebuild threshold (`KHIVE_ANN_REBUILD_THRESHOLD`, default 0.20) caps how long a tail
-  can grow relative to the live corpus before a full rebuild is already in flight. A tail at
+- The rebuild threshold (`KHIVE_ANN_REBUILD_THRESHOLD`, default 0.20) determines when the
+  classifier starts a full rebuild instead of replaying the tail. A tail at
   the threshold on a 68k-row corpus is ~13.6k exact comparisons. The similarity arithmetic at
   that ceiling is sub-millisecond, but the dominant cost there is the ~13.6k embedding-row
   point-reads per model, which is not — the honest bound at the pathological ceiling is the
-  point-read I/O, and it applies only while a full rebuild is already in flight. The
-  steady-state tail (writes since the last checkpoint) is small enough that both terms are
-  negligible, and the steady state is the case the leg exists for.
+  point-read I/O. The threshold is a rebuild trigger, not a hard query cap: while a serving
+  index exists, the exact leg continues to scan the complete retained suffix above its
+  watermark so read-your-writes is not traded away if a rebuild is delayed and later writes
+  push the suffix past the trigger. The steady-state tail (writes since the last checkpoint)
+  is small enough that both terms are negligible, and the steady state is the case the leg
+  exists for.
 
 When no ANN index is serving at all (Cold rebuild in flight, or Empty classification), the
 watermark is 0 and the tail is the entire scope. The exact leg does **not** absorb that case:
-it caps its scan at the threshold-sized tail, taking the highest-seq suffix of the log (the
-newest raw writes, before final-state coalescing) so the freshest writes stay visible while FTS
-covers the rest, and otherwise
+it counts the live, join-filtered vector corpus and caps its scan at
+`ceil(KHIVE_ANN_REBUILD_THRESHOLD × live_vector_count)`, taking the highest-seq suffix of the
+log (the newest raw writes, before final-state coalescing) so the freshest writes stay visible
+while FTS covers the rest, and otherwise
 defers to the existing Cold-path behavior (FTS-only serving while the rebuild runs). The leg
 restores freshness on a serving index; it is not a general exact-search fallback. This is
 the second tier of the §"Decision" guarantee stated precisely: with no serving index, a
 committed write is visible to the vector legs **iff its `ann_write_log` row is still
-retained — compaction has not passed it — and fewer than threshold-many retained writes
-committed after it in scope**. Both conjuncts are load-bearing. Under concurrent load,
+retained — compaction has not passed it — and fewer than
+`ceil(KHIVE_ANN_REBUILD_THRESHOLD × live_vector_count)` retained raw log rows committed after
+it in scope**. Both conjuncts are load-bearing. The live count and selected log suffix come
+from one SQL statement, so the ceiling and rows describe the same snapshot. Under concurrent load,
 later commits can push an earlier write outside the newest suffix, so recency of the
 caller's own write is not guaranteed by construction. And a write already compacted out of
 the log — possible only after every registered consumer durably checkpointed past it —
@@ -262,8 +268,9 @@ deletes that write no log rows — see ADR-079's rule 5 qualification).
   write path's implicit promise; the Cold/Empty window keeps the newest-suffix guarantee
   only (§3).
 - Recall pays a small per-query cost (log-tail scan + registry-minimum coverage check +
-  exact scoring) that is near zero when the tail is empty and bounded by the rebuild
-  threshold when it is not.
+  exact scoring) that is near zero when the tail is empty. The Cold/Empty fallback is bounded
+  by the corpus-relative rebuild threshold; the serving-index path scans the full suffix to
+  preserve read-your-writes and has no separate hard row cap.
 - The tail query adds read traffic on `ann_write_log`; its index must serve
   `(embedding_model, seq)`-shaped scans efficiently (the existing namespace-first index
   shape is a known follow-up).

--- a/docs/adr/ADR-133-incidental-writes-off-the-request-hot-path.md
+++ b/docs/adr/ADR-133-incidental-writes-off-the-request-hot-path.md
@@ -393,17 +393,23 @@ Fail-closed in this direction because the cost of wrongly strict is a caller see
 could have been spared, and the cost of wrongly lenient is an accounting or authorization record
 silently lost while its operation reports success.
 
-### D6 — Read-flag mutation is batched; its semantics are unchanged
+### D6 — Read-flag mutation is batched; acknowledgement remains best-effort
 
 A bulk form taking a list of ids becomes the primary surface for sweeping an inbox, collapsing N
 dispatches into one and N statements into one transaction.
 
-**Plain `comm.read` continues to write the flag, and continues to write it before returning.** It
-is batched in the D1 sense — its statement shares a transaction with whatever else is committing —
-and it is never made asynchronous, optional, or deferred past its own return. The unread surface is
-load-bearing for other subsystems: the inbox monitor's stale check reads these flags, and a `comm.read` that
-returned before its flag was committed (store-visible) would make that check read stale state. This
-decision changes how many acquisitions a sweep costs, not what a read means.
+**Plain `comm.read` attempts the flag write before returning, but the patch is best-effort.** A
+successful patch returns `read: true`. Writer contention, a storage error, or a row that disappears
+between fetch and patch does not discard the successful fetch: the response instead returns
+`read: false` plus `mark_error`, and the message remains unread. This is the contract established by
+ADR-040's 2026-08-01 `comm.read` amendment and implemented by
+`crates/khive-pack-comm/src/handlers.rs::read_response`; batching does not strengthen that
+acknowledgement into an unconditional durability guarantee.
+
+The unread surface remains load-bearing for the inbox monitor's stale check. Consequently, an inbox
+sweep MUST count only per-item responses with `read == true` as acknowledged and SHOULD retry rows
+that carry `mark_error`; dispatch success alone does not establish that the flag became
+store-visible. A bulk form preserves these per-item outcomes while reducing acquisitions.
 
 ### D7 — Serve-ledger writes are batched per call
 

--- a/docs/adr/ADR-133-incidental-writes-off-the-request-hot-path.md
+++ b/docs/adr/ADR-133-incidental-writes-off-the-request-hot-path.md
@@ -396,7 +396,10 @@ silently lost while its operation reports success.
 ### D6 — Read-flag mutation is batched; acknowledgement remains best-effort
 
 A bulk form taking a list of ids becomes the primary surface for sweeping an inbox, collapsing N
-dispatches into one and N statements into one transaction.
+dispatches into one. Collapsing N statements into one transaction is a separate, opt-in property
+rather than a consequence of batching: `comm.mark_read(atomic=true)` commits every unique mark in
+one transaction or none, while the default `atomic=false` path — and `comm.read(ids=...)`, whose
+behaviour it matches — applies each patch independently.
 
 **Plain `comm.read` attempts the flag write before returning, but the patch is best-effort.** A
 successful patch returns `read: true`. Writer contention, a storage error, or a row that disappears
@@ -409,7 +412,9 @@ acknowledgement into an unconditional durability guarantee.
 The unread surface remains load-bearing for the inbox monitor's stale check. Consequently, an inbox
 sweep MUST count only per-item responses with `read == true` as acknowledged and SHOULD retry rows
 that carry `mark_error`; dispatch success alone does not establish that the flag became
-store-visible. A bulk form preserves these per-item outcomes while reducing acquisitions.
+store-visible. A bulk form preserves these per-item outcomes. It reduces dispatches
+unconditionally; it reduces write acquisitions only on the `atomic=true` path, since the default
+per-item path still takes one write acquisition per row.
 
 ### D7 — Serve-ledger writes are batched per call
 

--- a/docs/adr/ADR-144-memory-write-visibility-fence.md
+++ b/docs/adr/ADR-144-memory-write-visibility-fence.md
@@ -105,10 +105,9 @@ Add an additive, operation-scoped visibility contract to the memory pack:
 
 ## Out of scope
 
-- The Cold/Empty cap divergence (fixed 20,000-row constant vs ADR-118's
-  threshold-relative text vs the knowledge pack's corpus-relative
-  implementation) is a live divergence tracked in #1161 and belongs to an
-  ADR-118 alignment, not this contract.
+- The Cold/Empty cap belongs to ADR-118, not this contract. Its former
+  cross-pack divergence was resolved by #1161: both memory and knowledge use
+  the corpus-relative rebuild threshold for the newest log suffix.
 - Knowledge-pack freshness: the fresh-tail helper landed (#1589) and the pack
   proves no current gap; this ADR adds no knowledge-pack requirement.
 


### PR DESCRIPTION
> AI-assisted contribution: Codex prepared this change and PR description.

## Summary

- replace memory's fixed 20,000-row no-index fresh-tail ceiling with the
  ADR-118 corpus-relative bound, selecting
  `ceil(KHIVE_ANN_REBUILD_THRESHOLD × live_vector_count)` newest raw log rows
  from the same SQL snapshot as the live count
- reconcile ADR-133 with the shipped ADR-040 `comm.read` contract: mark-read is
  attempted before return but remains best-effort, and callers must inspect
  each row's `read` / `mark_error` outcome
- define L1.5 import edges as a scope-blind static lexical-coupling signal,
  explicitly covering guarded, type-check-only, and function-local imports
  without misrepresenting them as proven runtime dependencies

## Contract notes

The Cold/Empty memory path still fast-paths an empty tail without counting the
corpus. Once a retained row exists, the corpus-relative bound requires an
O(live-vector-corpus) count/join; ADR-118 now discloses that cost directly. A
six-row regression pins ceil rounding and proves that a 0.20 threshold selects
the two newest raw log rows.

The import scanner remains intentionally regex-based. Its `build` policy scope
supports filtering but does not prove initialization/runtime execution scope;
consumers that need runtime-cycle claims must confirm them from source or a
future scope-aware scanner tier.

## Validation

- [x] Independent exact-head review: **READY, no findings**
- [x] Exact head: `6f85a2318d7d37ae2797d90bf7b69976a4e4c501`
- [x] Current-main parent: `ca70e4ea2a546ebc4f4887d19f8be146db6fe7f5`
- [x] `cargo test --workspace`
- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `git diff --check`

Available disk was checked before and after every Cargo invocation. Completed
temporary build targets were reclaimed after the gates.

Closes #1161
Closes #1655
Closes #1663
