### PR TITLE
fix(ids): make read identifiers round-trippable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,6 +138,8 @@ false, id, full_id, from, to, note: "already in target status"}` — the task fi
 `memory.recall` supports `tags` and `tag_mode` ("any"|"all") for tag-based post-filtering.
 Its optional `namespace` is an exact-match read override; absent means the caller's normal
 visible namespace set.
+Every hit carries `full_id`, a canonical dashed UUID that can be passed directly to
+the strict `memory.feedback(target_id=...)` contract across requests.
 The returned relevance score is normalized to [0,1]. The ranking `rank_score` is nominally
 [0,1] but can exceed 1.0 by up to 15% when a brain profile applies posterior terms. Typical
 production floor: 0.3-0.7.
@@ -278,6 +280,9 @@ unrecognized `section_type` returns a validation error listing the valid values.
 | `session.list`   | List stored sessions, newest first                | "What sessions have I run?"              |
 | `session.resume` | Fetch one session's full content by UUID/prefix   | Continue or reference a specific session |
 | `session.export` | Serialize one session as JSON or markdown         | Share or archive a session outside khive |
+
+Each `session.list` summary carries `full_id`, the canonical UUID to reuse with
+`session.resume` or `session.export` even under Agent presentation.
 
 ### How to call a verb
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,7 +235,7 @@ caller receives the server-generated UUID.
 | -------------------------- | ------------------------------------------------------- | -------------------------------------------- |
 | `knowledge.upsert_atoms`   | Bulk insert/update atoms by slug                        | Ingesting knowledge corpus                   |
 | `knowledge.upsert_domains` | Bulk insert/update domain groupings                     | Organizing atoms into domains                |
-| `knowledge.get`            | Fetch atom/domain by UUID, unique short prefix, or slug | Read a specific knowledge entry              |
+| `knowledge.get`            | Fetch atom/domain by UUID, exact slug, or short prefix  | Read a specific knowledge entry              |
 | `knowledge.list`           | Paginated listing of atoms or domains                   | Browse the corpus                            |
 | `knowledge.search`         | TF-IDF search with embedding rerank (default on)        | Finding relevant knowledge                   |
 | `knowledge.suggest`        | Orient query against domains for composition            | "Which domains cover topic X?"               |
@@ -258,6 +258,9 @@ cases). Scores are normalized to [0,1] when `rerank` is active (default).
 `knowledge.compose(namespace=...)` uses that exact namespace for corpus, section, KG-blend, and
 brain-profile weight reads, including its namespace-keyed Tier-3 fallback; absent preserves the
 caller-token default.
+`knowledge.get` resolves a full UUID first; for non-UUID input, an exact slug in the caller
+namespace wins before unique 8+ hex-prefix resolution. UUID and prefix reads are
+namespace-agnostic under ADR-007.
 Pass `kind=` (`"atom"` or `"domain"`) to filter by result type; `type=` is accepted as a legacy
 alias. `knowledge.list` accepts the same `kind=`/`type=` discriminant.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,9 @@ false, id, full_id, from, to, note: "already in target status"}` — the task fi
 Its optional `namespace` is an exact-match read override; absent means the caller's normal
 visible namespace set.
 Every hit carries `full_id`, a canonical dashed UUID that can be passed directly to
-the strict `memory.feedback(target_id=...)` contract across requests.
+the strict `memory.feedback(target_id=...)` contract across requests. `full_id` is
+present under the default `json` output format in any presentation mode; the `auto`
+and `table` formats omit it unless the request sets `presentation=verbose`.
 The returned relevance score is normalized to [0,1]. The ranking `rank_score` is nominally
 [0,1] but can exceed 1.0 by up to 15% when a brain profile applies posterior terms. Typical
 production floor: 0.3-0.7.
@@ -282,7 +284,9 @@ unrecognized `section_type` returns a validation error listing the valid values.
 | `session.export` | Serialize one session as JSON or markdown         | Share or archive a session outside khive |
 
 Each `session.list` summary carries `full_id`, the canonical UUID to reuse with
-`session.resume` or `session.export` even under Agent presentation.
+`session.resume` or `session.export`. Presentation mode does not remove it; the
+`auto` and `table` output formats do, unless the request sets
+`presentation=verbose`.
 
 ### How to call a verb
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,7 +235,7 @@ caller receives the server-generated UUID.
 | -------------------------- | ------------------------------------------------------- | -------------------------------------------- |
 | `knowledge.upsert_atoms`   | Bulk insert/update atoms by slug                        | Ingesting knowledge corpus                   |
 | `knowledge.upsert_domains` | Bulk insert/update domain groupings                     | Organizing atoms into domains                |
-| `knowledge.get`            | Fetch atom/domain by UUID or slug                       | Read a specific knowledge entry              |
+| `knowledge.get`            | Fetch atom/domain by UUID, unique short prefix, or slug | Read a specific knowledge entry              |
 | `knowledge.list`           | Paginated listing of atoms or domains                   | Browse the corpus                            |
 | `knowledge.search`         | TF-IDF search with embedding rerank (default on)        | Finding relevant knowledge                   |
 | `knowledge.suggest`        | Orient query against domains for composition            | "Which domains cover topic X?"               |

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -605,6 +605,77 @@ async fn memory_feedback_target_id_round_trips_in_agent_mode() -> anyhow::Result
     Ok(())
 }
 
+/// #1762: a recalled memory must expose a canonical handle in the default
+/// Agent presentation so the next request can feed it directly to the strict
+/// `memory.feedback(target_id=...)` contract without an intervening `get`.
+#[tokio::test]
+async fn memory_recall_full_id_chains_to_feedback_in_agent_mode() -> anyhow::Result<()> {
+    let client = connect_full().await?;
+    let remembered = ok_one(
+        &client,
+        r#"memory.remember(content="identifier continuity recall sentinel", salience=0.9)"#,
+    )
+    .await?;
+    let expected_id = remembered["id"]
+        .as_str()
+        .expect("remember must return a canonical id");
+
+    let recalled = agent_one(
+        &client,
+        r#"memory.recall(query="identifier continuity recall sentinel", limit=10, fusion_strategy="keyword_only", min_score=0.0)"#,
+    )
+    .await?;
+    let hit = recalled
+        .as_array()
+        .expect("recall result must be an array")
+        .iter()
+        .find(|row| row["full_id"] == expected_id)
+        .expect("recall must expose the remembered row by canonical full_id");
+    let full_id = hit["full_id"]
+        .as_str()
+        .expect("recall hit must expose full_id");
+    assert_eq!(full_id.len(), 36, "full_id must remain canonical");
+
+    let feedback = agent_one(
+        &client,
+        &format!(r#"memory.feedback(target_id="{full_id}", signal="useful")"#),
+    )
+    .await?;
+    assert_eq!(feedback["target_id"], full_id);
+    Ok(())
+}
+
+/// #1762: session summaries keep a canonical cross-request handle even though
+/// Agent presentation may compact their display-oriented `id` field.
+#[tokio::test]
+async fn session_list_full_id_chains_to_resume_in_agent_mode() -> anyhow::Result<()> {
+    let client = connect_full().await?;
+    let stored = ok_one(
+        &client,
+        r#"session.store(content="identifier continuity session sentinel", title="continuity sentinel")"#,
+    )
+    .await?;
+    let expected_id = stored["session"]["id"]
+        .as_str()
+        .expect("session.store must return a canonical session id");
+
+    let listed = agent_one(&client, r#"session.list(limit=20)"#).await?;
+    let summary = listed["sessions"]
+        .as_array()
+        .expect("session.list must return summaries")
+        .iter()
+        .find(|row| row["full_id"] == expected_id)
+        .expect("session.list must expose the stored session by canonical full_id");
+    let full_id = summary["full_id"]
+        .as_str()
+        .expect("session summary must expose full_id");
+    assert_eq!(full_id.len(), 36, "full_id must remain canonical");
+
+    let resumed = agent_one(&client, &format!(r#"session.resume(id="{full_id}")"#)).await?;
+    assert_eq!(resumed["session"]["id"], full_id);
+    Ok(())
+}
+
 /// `brain.auto_feedback` acknowledges the canonical target it credited; that
 /// acknowledgement feeds the strict `memory.feedback`/`brain.feedback`
 /// target_id parameter, so the default Agent transform must not shorten it
@@ -2581,11 +2652,12 @@ fn make_full_server() -> KhiveMcpServer {
             "gtd".to_string(),
             "memory".to_string(),
             "brain".to_string(),
+            "session".to_string(),
         ],
         ..RuntimeConfig::default()
     };
     let runtime = KhiveRuntime::new(config).expect("in-memory runtime with all packs");
-    KhiveMcpServer::new(runtime).expect("server builds with kg+gtd+memory+brain")
+    KhiveMcpServer::new(runtime).expect("server builds with kg+gtd+memory+brain+session")
 }
 
 async fn connect_full(

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -672,7 +672,11 @@ async fn session_list_full_id_chains_to_resume_in_agent_mode() -> anyhow::Result
     assert_eq!(full_id.len(), 36, "full_id must remain canonical");
 
     let resumed = agent_one(&client, &format!(r#"session.resume(id="{full_id}")"#)).await?;
-    assert_eq!(resumed["session"]["id"], full_id);
+    assert_eq!(
+        resumed["session"]["id"].as_str(),
+        Some(&full_id[..8]),
+        "the canonical list handle must be accepted even though the Standard resume response compacts id"
+    );
     Ok(())
 }
 

--- a/crates/khive-pack-knowledge/src/knowledge/crud.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/crud.rs
@@ -3,7 +3,7 @@
 use serde_json::{json, Value};
 use uuid::Uuid;
 
-use khive_runtime::{KhiveRuntime, NamespaceToken, RuntimeError};
+use khive_runtime::{hex_prefix_to_uuid_pattern, KhiveRuntime, NamespaceToken, RuntimeError};
 use khive_storage::types::{SqlStatement, SqlValue};
 
 use super::schema::{
@@ -407,20 +407,65 @@ impl KnowledgeHandlers {
         let id = p.id.trim().to_string();
         let with_sections = p.include_sections.unwrap_or(false);
 
-        let is_uuid = id.parse::<Uuid>().is_ok();
-
         let mut reader = sql.reader().await.map_err(|e| sql_err("get reader", e))?;
 
-        if is_uuid {
+        // ADR-007 Rule 2: UUID and short-prefix forms are by-ID reads, so they
+        // are namespace-agnostic. Slugs remain namespace-scoped below. Parse a
+        // complete UUID before the prefix branch so 32-character compact UUIDs
+        // are complete identifiers, not prefixes (runtime protocol contract).
+        let resolved_id = if let Ok(uuid) = id.parse::<Uuid>() {
+            Some(uuid.to_string())
+        } else if id.len() >= 8 && id.chars().all(|c| c.is_ascii_hexdigit()) {
+            let pattern = format!("{}%", hex_prefix_to_uuid_pattern(&id));
+            // A domain's FTS mirror atom has the same UUID. UNION (rather than
+            // UNION ALL) deduplicates that legitimate cross-table duplicate so
+            // one domain is not reported as an ambiguous prefix.
+            let rows = reader
+                .query_all(SqlStatement {
+                    sql: "SELECT id FROM knowledge_domains \
+                          WHERE id LIKE ?1 AND deleted_at IS NULL \
+                          UNION \
+                          SELECT id FROM knowledge_atoms \
+                          WHERE id LIKE ?1 AND deleted_at IS NULL \
+                          ORDER BY id LIMIT 2"
+                        .into(),
+                    params: vec![SqlValue::Text(pattern)],
+                    label: Some("knowledge.get.resolve_prefix".into()),
+                })
+                .await
+                .map_err(|e| sql_err("get by prefix", e))?;
+            let matches: Vec<String> = rows.iter().filter_map(|row| row_str(row, "id")).collect();
+            match matches.as_slice() {
+                [] => {
+                    return Err(RuntimeError::InvalidInput(format!(
+                        "no knowledge record matches prefix: {id:?}"
+                    )))
+                }
+                [only] => Some(only.clone()),
+                _ => {
+                    return Err(RuntimeError::AmbiguousPrefix {
+                        prefix: id.clone(),
+                        matches: matches
+                            .iter()
+                            .filter_map(|matched| matched.parse::<Uuid>().ok())
+                            .collect(),
+                    })
+                }
+            }
+        } else {
+            None
+        };
+
+        if let Some(resolved_id) = resolved_id {
             // Domain-first: a domain's canonical row and its FTS mirror atom share
             // the same UUID, so the UUID branch must match the slug branch below
             // and prefer knowledge_domains — otherwise a domain UUID resolves to
             // its own mirror atom instead of the canonical domain record.
             let row = reader
                 .query_row(SqlStatement {
-                    sql: "SELECT * FROM knowledge_domains WHERE id = ?1 AND namespace = ?2 AND deleted_at IS NULL LIMIT 1".into(),
-                    params: vec![SqlValue::Text(id.clone()), SqlValue::Text(ns.clone())],
-                    label: None,
+                    sql: "SELECT * FROM knowledge_domains WHERE id = ?1 AND deleted_at IS NULL LIMIT 1".into(),
+                    params: vec![SqlValue::Text(resolved_id.clone())],
+                    label: Some("knowledge.get.domain_by_id".into()),
                 })
                 .await
                 .map_err(|e| sql_err("get domain by id", e))?;
@@ -431,9 +476,11 @@ impl KnowledgeHandlers {
             }
             let row = reader
                 .query_row(SqlStatement {
-                    sql: "SELECT * FROM knowledge_atoms WHERE id = ?1 AND namespace = ?2 AND deleted_at IS NULL LIMIT 1".into(),
-                    params: vec![SqlValue::Text(id.clone()), SqlValue::Text(ns.clone())],
-                    label: None,
+                    sql:
+                        "SELECT * FROM knowledge_atoms WHERE id = ?1 AND deleted_at IS NULL LIMIT 1"
+                            .into(),
+                    params: vec![SqlValue::Text(resolved_id)],
+                    label: Some("knowledge.get.atom_by_id".into()),
                 })
                 .await
                 .map_err(|e| sql_err("get atom by id", e))?;
@@ -441,12 +488,19 @@ impl KnowledgeHandlers {
                 let atom = atom_from_row(&r)
                     .ok_or_else(|| RuntimeError::Internal("atom row parse failed".into()))?;
                 let atom_id = atom.id.to_string();
+                let atom_namespace = atom.namespace.clone();
                 let mut out = atom_to_json(&atom);
                 if with_sections {
-                    out["sections"] = fetch_sections(runtime, &ns, &atom_id).await?;
+                    out["sections"] = fetch_sections(runtime, &atom_namespace, &atom_id).await?;
                 }
                 return Ok(out);
             }
+
+            // An ID-shaped input names one record or misses. It must not fall
+            // through and accidentally resolve a slug with the same spelling.
+            return Err(RuntimeError::NotFound(format!(
+                "atom or domain not found: {id:?}"
+            )));
         }
 
         // Slug lookup — domains first (authoritative for members), then atoms.

--- a/crates/khive-pack-knowledge/src/knowledge/crud.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/crud.rs
@@ -410,50 +410,91 @@ impl KnowledgeHandlers {
         let mut reader = sql.reader().await.map_err(|e| sql_err("get reader", e))?;
 
         // ADR-007 Rule 2: UUID and short-prefix forms are by-ID reads, so they
-        // are namespace-agnostic. Slugs remain namespace-scoped below. Parse a
-        // complete UUID before the prefix branch so 32-character compact UUIDs
-        // are complete identifiers, not prefixes (runtime protocol contract).
+        // are namespace-agnostic. Parse a complete UUID first so 32-character
+        // compact UUIDs are complete identifiers, not prefixes. For non-UUID
+        // input, preserve the pack's registered-slug contract: an exact slug in
+        // the caller namespace wins before an all-hex value is interpreted as a
+        // UUID prefix.
         let resolved_id = if let Ok(uuid) = id.parse::<Uuid>() {
             Some(uuid.to_string())
-        } else if id.len() >= 8 && id.chars().all(|c| c.is_ascii_hexdigit()) {
-            let pattern = format!("{}%", hex_prefix_to_uuid_pattern(&id));
-            // A domain's FTS mirror atom has the same UUID. UNION (rather than
-            // UNION ALL) deduplicates that legitimate cross-table duplicate so
-            // one domain is not reported as an ambiguous prefix.
-            let rows = reader
-                .query_all(SqlStatement {
-                    sql: "SELECT id FROM knowledge_domains \
-                          WHERE id LIKE ?1 AND deleted_at IS NULL \
-                          UNION \
-                          SELECT id FROM knowledge_atoms \
-                          WHERE id LIKE ?1 AND deleted_at IS NULL \
-                          ORDER BY id LIMIT 2"
-                        .into(),
-                    params: vec![SqlValue::Text(pattern)],
-                    label: Some("knowledge.get.resolve_prefix".into()),
+        } else {
+            // Exact slug lookup precedes prefix interpretation so a registered
+            // all-hex slug remains addressable. Domains are authoritative over
+            // their same-slug mirror atoms.
+            let row = reader
+                .query_row(SqlStatement {
+                    sql: "SELECT * FROM knowledge_domains WHERE namespace = ?1 AND slug = ?2 AND deleted_at IS NULL LIMIT 1".into(),
+                    params: vec![SqlValue::Text(ns.clone()), SqlValue::Text(id.clone())],
+                    label: Some("knowledge.get.domain_by_slug".into()),
                 })
                 .await
-                .map_err(|e| sql_err("get by prefix", e))?;
-            let matches: Vec<String> = rows.iter().filter_map(|row| row_str(row, "id")).collect();
-            match matches.as_slice() {
-                [] => {
-                    return Err(RuntimeError::InvalidInput(format!(
-                        "no knowledge record matches prefix: {id:?}"
-                    )))
-                }
-                [only] => Some(only.clone()),
-                _ => {
-                    return Err(RuntimeError::AmbiguousPrefix {
-                        prefix: id.clone(),
-                        matches: matches
-                            .iter()
-                            .filter_map(|matched| matched.parse::<Uuid>().ok())
-                            .collect(),
-                    })
-                }
+                .map_err(|e| sql_err("get domain by slug", e))?;
+            if let Some(r) = row {
+                return domain_from_row(&r)
+                    .map(|d| domain_to_json(&d))
+                    .ok_or_else(|| RuntimeError::Internal("domain row parse failed".into()));
             }
-        } else {
-            None
+
+            let row = reader
+                .query_row(SqlStatement {
+                    sql: "SELECT * FROM knowledge_atoms WHERE namespace = ?1 AND slug = ?2 AND deleted_at IS NULL LIMIT 1".into(),
+                    params: vec![SqlValue::Text(ns.clone()), SqlValue::Text(id.clone())],
+                    label: Some("knowledge.get.atom_by_slug".into()),
+                })
+                .await
+                .map_err(|e| sql_err("get atom by slug", e))?;
+            if let Some(r) = row {
+                let atom = atom_from_row(&r)
+                    .ok_or_else(|| RuntimeError::Internal("atom row parse failed".into()))?;
+                let atom_id = atom.id.to_string();
+                let mut out = atom_to_json(&atom);
+                if with_sections {
+                    out["sections"] = fetch_sections(runtime, &ns, &atom_id).await?;
+                }
+                return Ok(out);
+            }
+
+            if id.len() >= 8 && id.chars().all(|c| c.is_ascii_hexdigit()) {
+                let pattern = format!("{}%", hex_prefix_to_uuid_pattern(&id));
+                // A domain's FTS mirror atom has the same UUID. UNION (rather than
+                // UNION ALL) deduplicates that legitimate cross-table duplicate so
+                // one domain is not reported as an ambiguous prefix.
+                let rows = reader
+                    .query_all(SqlStatement {
+                        sql: "SELECT id FROM knowledge_domains \
+                              WHERE id LIKE ?1 AND deleted_at IS NULL \
+                              UNION \
+                              SELECT id FROM knowledge_atoms \
+                              WHERE id LIKE ?1 AND deleted_at IS NULL \
+                              ORDER BY id LIMIT 2"
+                            .into(),
+                        params: vec![SqlValue::Text(pattern)],
+                        label: Some("knowledge.get.resolve_prefix".into()),
+                    })
+                    .await
+                    .map_err(|e| sql_err("get by prefix", e))?;
+                let matches: Vec<String> =
+                    rows.iter().filter_map(|row| row_str(row, "id")).collect();
+                match matches.as_slice() {
+                    [] => {
+                        return Err(RuntimeError::InvalidInput(format!(
+                            "no knowledge record matches prefix: {id:?}"
+                        )))
+                    }
+                    [only] => Some(only.clone()),
+                    _ => {
+                        return Err(RuntimeError::AmbiguousPrefix {
+                            prefix: id.clone(),
+                            matches: matches
+                                .iter()
+                                .filter_map(|matched| matched.parse::<Uuid>().ok())
+                                .collect(),
+                        })
+                    }
+                }
+            } else {
+                None
+            }
         };
 
         if let Some(resolved_id) = resolved_id {
@@ -501,40 +542,6 @@ impl KnowledgeHandlers {
             return Err(RuntimeError::NotFound(format!(
                 "atom or domain not found: {id:?}"
             )));
-        }
-
-        // Slug lookup — domains first (authoritative for members), then atoms.
-        let row = reader
-            .query_row(SqlStatement {
-                sql: "SELECT * FROM knowledge_domains WHERE namespace = ?1 AND slug = ?2 AND deleted_at IS NULL LIMIT 1".into(),
-                params: vec![SqlValue::Text(ns.clone()), SqlValue::Text(id.clone())],
-                label: None,
-            })
-            .await
-            .map_err(|e| sql_err("get domain by slug", e))?;
-        if let Some(r) = row {
-            return domain_from_row(&r)
-                .map(|d| domain_to_json(&d))
-                .ok_or_else(|| RuntimeError::Internal("domain row parse failed".into()));
-        }
-
-        let row = reader
-            .query_row(SqlStatement {
-                sql: "SELECT * FROM knowledge_atoms WHERE namespace = ?1 AND slug = ?2 AND deleted_at IS NULL LIMIT 1".into(),
-                params: vec![SqlValue::Text(ns.clone()), SqlValue::Text(id.clone())],
-                label: None,
-            })
-            .await
-            .map_err(|e| sql_err("get atom by slug", e))?;
-        if let Some(r) = row {
-            let atom = atom_from_row(&r)
-                .ok_or_else(|| RuntimeError::Internal("atom row parse failed".into()))?;
-            let atom_id = atom.id.to_string();
-            let mut out = atom_to_json(&atom);
-            if with_sections {
-                out["sections"] = fetch_sections(runtime, &ns, &atom_id).await?;
-            }
-            return Ok(out);
         }
 
         Err(RuntimeError::NotFound(format!(

--- a/crates/khive-pack-knowledge/src/knowledge/schema.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/schema.rs
@@ -138,7 +138,7 @@ pub(crate) struct UpsertDomainsParams {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct GetParams {
-    /// Full UUID, unique 8+ hexadecimal UUID prefix, or namespace-scoped slug.
+    /// Full UUID, exact namespace-scoped slug, or unique 8+ hexadecimal UUID prefix.
     pub id: String,
     /// When `true`, include the atom's sections in the response under a `sections` key.
     /// Defaults to `false`; domains ignore this flag (they have no sections).

--- a/crates/khive-pack-knowledge/src/knowledge/schema.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/schema.rs
@@ -138,6 +138,7 @@ pub(crate) struct UpsertDomainsParams {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct GetParams {
+    /// Full UUID, unique 8+ hexadecimal UUID prefix, or namespace-scoped slug.
     pub id: String,
     /// When `true`, include the atom's sections in the response under a `sections` key.
     /// Defaults to `false`; domains ignore this flag (they have no sections).

--- a/crates/khive-pack-knowledge/src/vocab.rs
+++ b/crates/khive-pack-knowledge/src/vocab.rs
@@ -59,7 +59,7 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 20] = [
     },
     HandlerDef {
         name: "knowledge.get",
-        description: "Fetch a single atom or domain by UUID, unique short prefix, or slug",
+        description: "Fetch a single atom or domain by UUID, exact slug, or unique short prefix",
         visibility: Visibility::Verb,
         category: VerbCategory::Assertive,
         params: &[
@@ -67,7 +67,7 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 20] = [
                 name: "id",
                 param_type: "string",
                 required: true,
-                description: "Atom/domain full UUID, unique 8+ hex UUID prefix, or slug. UUID and prefix forms are namespace-agnostic by-ID reads; slug lookup uses the caller namespace.",
+                description: "Atom/domain full UUID, exact slug, or unique 8+ hex UUID prefix. Resolution order is full UUID, exact caller-namespace slug, then prefix. UUID and prefix forms are namespace-agnostic by-ID reads.",
             },
             ParamDef {
                 name: "include_sections",

--- a/crates/khive-pack-knowledge/src/vocab.rs
+++ b/crates/khive-pack-knowledge/src/vocab.rs
@@ -59,7 +59,7 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 20] = [
     },
     HandlerDef {
         name: "knowledge.get",
-        description: "Fetch a single atom or domain by UUID or slug",
+        description: "Fetch a single atom or domain by UUID, unique short prefix, or slug",
         visibility: Visibility::Verb,
         category: VerbCategory::Assertive,
         params: &[
@@ -67,7 +67,7 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 20] = [
                 name: "id",
                 param_type: "string",
                 required: true,
-                description: "Atom/domain UUID or slug",
+                description: "Atom/domain full UUID, unique 8+ hex UUID prefix, or slug. UUID and prefix forms are namespace-agnostic by-ID reads; slug lookup uses the caller namespace.",
             },
             ParamDef {
                 name: "include_sections",

--- a/crates/khive-pack-knowledge/tests/integration.rs
+++ b/crates/khive-pack-knowledge/tests/integration.rs
@@ -1013,6 +1013,73 @@ async fn get_resolves_atom_by_compact_prefix_longer_than_eight_chars() {
 }
 
 #[tokio::test]
+async fn get_exact_all_hex_slug_wins_over_uuid_prefix_collision() {
+    let f = pack(rt());
+    f.dispatch(
+        "knowledge.upsert_atoms",
+        json!({ "atoms": [{
+            "slug": "hex-prefix-source",
+            "name": "Hex Prefix Source",
+            "content": "dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity"
+        }] }),
+    )
+    .await
+    .expect("upsert prefix source");
+
+    let source = f
+        .dispatch("knowledge.get", json!({ "id": "hex-prefix-source" }))
+        .await
+        .expect("get prefix source");
+    let source_id = source["id"].as_str().expect("source id").to_string();
+    let hex_slug = source_id.replace('-', "")[..16].to_string();
+
+    f.dispatch(
+        "knowledge.upsert_atoms",
+        json!({ "atoms": [{
+            "slug": hex_slug.clone(),
+            "name": "Exact Hex Slug",
+            "content": "exact hexadecimal slug retrieval must precede compact identifier prefix interpretation across knowledge corpus reads and preserve deterministic registered slug addressing"
+        }] }),
+    )
+    .await
+    .expect("upsert exact all-hex slug");
+
+    let by_slug = f
+        .dispatch("knowledge.get", json!({ "id": hex_slug.clone() }))
+        .await
+        .expect("exact all-hex slug must win over UUID prefix collision");
+    assert_eq!(by_slug["slug"], hex_slug);
+    assert_eq!(by_slug["name"], "Exact Hex Slug");
+    assert_ne!(
+        by_slug["id"], source_id,
+        "prefix interpretation must not return the colliding source record"
+    );
+}
+
+#[tokio::test]
+async fn get_exact_all_hex_slug_wins_when_uuid_prefix_matches_nothing() {
+    const HEX_SLUG: &str = "fffffffffffffffffffffffffffffffff";
+    let f = pack(rt());
+    f.dispatch(
+        "knowledge.upsert_atoms",
+        json!({ "atoms": [{
+            "slug": HEX_SLUG,
+            "name": "Overlong Hex Slug",
+            "content": "overlong hexadecimal slug lookup remains exact and addressable even though no canonical UUID can match a prefix longer than thirty two hexadecimal characters"
+        }] }),
+    )
+    .await
+    .expect("upsert overlong all-hex slug");
+
+    let by_slug = f
+        .dispatch("knowledge.get", json!({ "id": HEX_SLUG }))
+        .await
+        .expect("exact all-hex slug must resolve before a guaranteed prefix miss");
+    assert_eq!(by_slug["slug"], HEX_SLUG);
+    assert_eq!(by_slug["name"], "Overlong Hex Slug");
+}
+
+#[tokio::test]
 async fn get_domain_prefix_deduplicates_same_uuid_mirror_atom() {
     let f = pack(rt());
     f.dispatch(
@@ -1123,6 +1190,7 @@ async fn get_by_id_is_namespace_agnostic_and_loads_sections_from_stored_namespac
         .await
         .expect("get foreign atom by scoped slug");
     let full_id = foreign["id"].as_str().expect("foreign atom id").to_string();
+    let compact_prefix = full_id.replace('-', "")[..12].to_string();
 
     f.dispatch("knowledge.get", json!({ "id": "foreign-prefix-atom" }))
         .await
@@ -1131,7 +1199,7 @@ async fn get_by_id_is_namespace_agnostic_and_loads_sections_from_stored_namespac
     let by_id = f
         .dispatch(
             "knowledge.get",
-            json!({ "id": full_id, "include_sections": true }),
+            json!({ "id": full_id.clone(), "include_sections": true }),
         )
         .await
         .expect("full UUID read must be namespace-agnostic");
@@ -1140,6 +1208,24 @@ async fn get_by_id_is_namespace_agnostic_and_loads_sections_from_stored_namespac
         by_id["sections"].as_array().expect("sections array").len(),
         1,
         "section lookup must use the resolved atom's stored namespace"
+    );
+
+    let by_prefix = f
+        .dispatch(
+            "knowledge.get",
+            json!({ "id": compact_prefix, "include_sections": true }),
+        )
+        .await
+        .expect("unique prefix read must be namespace-agnostic");
+    assert_eq!(by_prefix["id"], full_id);
+    assert_eq!(by_prefix["namespace"], foreign_namespace);
+    assert_eq!(
+        by_prefix["sections"]
+            .as_array()
+            .expect("prefix sections array")
+            .len(),
+        1,
+        "prefix section lookup must use the resolved atom's stored namespace"
     );
 }
 

--- a/crates/khive-pack-knowledge/tests/integration.rs
+++ b/crates/khive-pack-knowledge/tests/integration.rs
@@ -976,6 +976,173 @@ async fn get_by_domain_uuid_returns_canonical_domain_not_mirror_atom() {
     assert_eq!(members[0], "rag");
 }
 
+#[tokio::test]
+async fn get_resolves_atom_by_compact_prefix_longer_than_eight_chars() {
+    let f = pack(rt());
+    f.dispatch(
+        "knowledge.upsert_atoms",
+        json!({ "atoms": [{
+            "slug": "prefix-atom",
+            "name": "Prefix Atom",
+            "content": "dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity"
+        }] }),
+    )
+    .await
+    .expect("upsert atom");
+
+    let by_slug = f
+        .dispatch("knowledge.get", json!({ "id": "prefix-atom" }))
+        .await
+        .expect("get atom by slug");
+    let full_id = by_slug["id"].as_str().expect("full atom id");
+    let compact: String = full_id.chars().filter(|ch| *ch != '-').take(12).collect();
+
+    let by_prefix = f
+        .dispatch("knowledge.get", json!({ "id": compact }))
+        .await
+        .expect("get atom by unique compact prefix");
+    assert_eq!(by_prefix["id"], full_id);
+    assert_eq!(by_prefix["kind"], "atom");
+
+    let compact_uuid = full_id.replace('-', "");
+    let by_compact_uuid = f
+        .dispatch("knowledge.get", json!({ "id": compact_uuid }))
+        .await
+        .expect("32-character compact UUID is a complete identifier");
+    assert_eq!(by_compact_uuid["id"], full_id);
+}
+
+#[tokio::test]
+async fn get_domain_prefix_deduplicates_same_uuid_mirror_atom() {
+    let f = pack(rt());
+    f.dispatch(
+        "knowledge.upsert_domains",
+        json!({ "domains": [{
+            "slug": "prefix-domain",
+            "name": "Prefix Domain",
+            "description": "Retrieval concepts techniques algorithms implementations applications use cases and design patterns in sufficient detail for this deterministic domain prefix regression fixture"
+        }] }),
+    )
+    .await
+    .expect("upsert domain");
+
+    let by_slug = f
+        .dispatch("knowledge.get", json!({ "id": "prefix-domain" }))
+        .await
+        .expect("get domain by slug");
+    let full_id = by_slug["id"].as_str().expect("full domain id");
+    let prefix = &full_id[..8];
+
+    let by_prefix = f
+        .dispatch("knowledge.get", json!({ "id": prefix }))
+        .await
+        .expect("domain and mirror atom must count as one prefix match");
+    assert_eq!(by_prefix["id"], full_id);
+    assert_eq!(by_prefix["kind"], "domain");
+}
+
+#[tokio::test]
+async fn get_rejects_ambiguous_prefix_across_distinct_knowledge_records() {
+    let runtime = rt();
+    let f = pack(runtime.clone());
+    let mut writer = runtime.sql().writer().await.expect("knowledge writer");
+    writer
+        .execute_batch(vec![
+            SqlStatement {
+                sql: "INSERT INTO knowledge_atoms \
+                      (id, namespace, slug, name, content, created_at, updated_at) \
+                      VALUES (?1, 'local', 'ambiguous-a', 'Ambiguous A', 'content a', 1, 1)"
+                    .into(),
+                params: vec![SqlValue::Text(
+                    "deadbeef-0000-4000-8000-000000000001".into(),
+                )],
+                label: Some("test.knowledge_get.ambiguous_a".into()),
+            },
+            SqlStatement {
+                sql: "INSERT INTO knowledge_atoms \
+                      (id, namespace, slug, name, content, created_at, updated_at) \
+                      VALUES (?1, 'local', 'ambiguous-b', 'Ambiguous B', 'content b', 2, 2)"
+                    .into(),
+                params: vec![SqlValue::Text(
+                    "deadbeef-0000-4000-8000-000000000002".into(),
+                )],
+                label: Some("test.knowledge_get.ambiguous_b".into()),
+            },
+        ])
+        .await
+        .expect("seed colliding prefixes");
+    drop(writer);
+
+    let err = f
+        .dispatch("knowledge.get", json!({ "id": "deadbeef" }))
+        .await
+        .expect_err("distinct UUIDs sharing a prefix must be ambiguous");
+    let RuntimeError::AmbiguousPrefix { prefix, matches } = err else {
+        panic!("expected AmbiguousPrefix, got {err:?}");
+    };
+    assert_eq!(prefix, "deadbeef");
+    assert_eq!(matches.len(), 2);
+}
+
+#[tokio::test]
+async fn get_by_id_is_namespace_agnostic_and_loads_sections_from_stored_namespace() {
+    let f = pack(rt());
+    let foreign_namespace = "identifier-contract-foreign";
+    f.dispatch(
+        "knowledge.upsert_atoms",
+        json!({
+            "namespace": foreign_namespace,
+            "atoms": [{
+                "slug": "foreign-prefix-atom",
+                "name": "Foreign Prefix Atom",
+                "content": "dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity"
+            }]
+        }),
+    )
+    .await
+    .expect("upsert foreign atom");
+    f.dispatch(
+        "knowledge.edit",
+        json!({
+            "namespace": foreign_namespace,
+            "id": "foreign-prefix-atom",
+            "sections": [{
+                "section_type": "overview",
+                "content": "This section belongs to the foreign namespace atom and proves that a namespace-agnostic by-ID read loads sections using the resolved record namespace."
+            }]
+        }),
+    )
+    .await
+    .expect("add foreign section");
+
+    let foreign = f
+        .dispatch(
+            "knowledge.get",
+            json!({ "namespace": foreign_namespace, "id": "foreign-prefix-atom" }),
+        )
+        .await
+        .expect("get foreign atom by scoped slug");
+    let full_id = foreign["id"].as_str().expect("foreign atom id").to_string();
+
+    f.dispatch("knowledge.get", json!({ "id": "foreign-prefix-atom" }))
+        .await
+        .expect_err("slug lookup must remain scoped to the caller namespace");
+
+    let by_id = f
+        .dispatch(
+            "knowledge.get",
+            json!({ "id": full_id, "include_sections": true }),
+        )
+        .await
+        .expect("full UUID read must be namespace-agnostic");
+    assert_eq!(by_id["namespace"], foreign_namespace);
+    assert_eq!(
+        by_id["sections"].as_array().expect("sections array").len(),
+        1,
+        "section lookup must use the resolved atom's stored namespace"
+    );
+}
+
 // ── knowledge.get + include_sections ─────────────────────────────────────────
 
 #[tokio::test]

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -777,6 +777,7 @@ impl MemoryPack {
                     };
                 let mut result = json!({
                     "id": sn.id.to_string(),
+                    "full_id": sn.id.to_string(),
                     "score": sn.score,
                     "rank_score": sn.rank_score,
                     "raw_score": sn.raw_score,

--- a/crates/khive-pack-session/src/handlers/mod.rs
+++ b/crates/khive-pack-session/src/handlers/mod.rs
@@ -40,6 +40,7 @@ pub(crate) struct SessionRecord {
 #[derive(Debug, Serialize)]
 pub(crate) struct SessionSummary {
     pub id: String,
+    pub full_id: String,
     pub kind: &'static str,
     pub title: Option<String>,
     pub provider: Option<String>,
@@ -124,6 +125,7 @@ pub(crate) fn to_session_summary(note: &Note) -> SessionSummary {
     let properties = note.properties.clone().unwrap_or_else(|| json!({}));
     SessionSummary {
         id: note.id.as_hyphenated().to_string(),
+        full_id: note.id.as_hyphenated().to_string(),
         kind: SESSION_KIND,
         title: note.name.clone(),
         provider: string_property(&properties, "provider"),

--- a/docs/adr/ADR-047-knowledge-pack.md
+++ b/docs/adr/ADR-047-knowledge-pack.md
@@ -4,6 +4,17 @@
 **Date**: 2026-05-25
 **Authors**: khive maintainers
 
+## Amendment (2026-08-06): identifier parity for `knowledge.get`
+
+`knowledge.get(id=...)` follows the shared identifier ladder: a complete UUID is parsed
+first, an undashed hexadecimal string of at least eight characters resolves as a unique
+short UUID prefix, and other strings resolve as slugs. UUID and prefix forms are
+namespace-agnostic by-ID reads under ADR-007 Rule 2; slug lookup remains scoped to the
+caller's namespace. Prefix resolution deduplicates a domain and its same-UUID FTS mirror
+atom before deciding ambiguity, while distinct matching UUIDs fail closed. Atom section
+loading follows the resolved atom's stored namespace so `include_sections=true` preserves
+the same by-ID contract.
+
 ## Amendment (2026-08-06): fail-closed search filter values
 
 `knowledge.search` accepts only `atom` or `domain` for `kind`/`type`. Its atom-status
@@ -187,14 +198,15 @@ upsert_domains(domains: [{slug, name, description?, tags?, members?}, ...]) → 
 Inserts or updates domains by `(namespace, slug)` key. Members is a JSON array of
 atom slugs.
 
-#### `knowledge.get` — fetch by ID or slug
+#### `knowledge.get` — fetch by ID, short prefix, or slug
 
 ```
-get(id: <uuid|slug>) → {type: "atom"|"domain", ...fields}
+get(id: <uuid|short-prefix|slug>) → {type: "atom"|"domain", ...fields}
 ```
 
-Resolves by UUID first, then by slug against both `knowledge_atoms` and
-`knowledge_domains`. Returns 404 if not found.
+Resolves by complete UUID first, then by unique 8+ hex UUID prefix, then by slug against
+both `knowledge_atoms` and `knowledge_domains`. UUID and prefix reads are
+namespace-agnostic; slug reads use the caller namespace. Returns 404 if not found.
 
 #### `knowledge.list` — paginated listing
 

--- a/docs/adr/ADR-047-knowledge-pack.md
+++ b/docs/adr/ADR-047-knowledge-pack.md
@@ -7,13 +7,13 @@
 ## Amendment (2026-08-06): identifier parity for `knowledge.get`
 
 `knowledge.get(id=...)` follows the shared identifier ladder: a complete UUID is parsed
-first, an undashed hexadecimal string of at least eight characters resolves as a unique
-short UUID prefix, and other strings resolve as slugs. UUID and prefix forms are
-namespace-agnostic by-ID reads under ADR-007 Rule 2; slug lookup remains scoped to the
-caller's namespace. Prefix resolution deduplicates a domain and its same-UUID FTS mirror
-atom before deciding ambiguity, while distinct matching UUIDs fail closed. Atom section
-loading follows the resolved atom's stored namespace so `include_sections=true` preserves
-the same by-ID contract.
+first; for non-UUID input, an exact registered slug in the caller's namespace wins before
+an undashed hexadecimal string of at least eight characters is interpreted as a unique
+short UUID prefix. UUID and prefix forms are namespace-agnostic by-ID reads under ADR-007
+Rule 2, while slug lookup remains scoped to the caller's namespace. Prefix resolution
+deduplicates a domain and its same-UUID FTS mirror atom before deciding ambiguity, while
+distinct matching UUIDs fail closed. Atom section loading follows the resolved atom's
+stored namespace so `include_sections=true` preserves the same by-ID contract.
 
 ## Amendment (2026-08-06): fail-closed search filter values
 
@@ -135,7 +135,7 @@ they do not introduce new ones.
 | -------------------------- | ------- | ---------- | ---------------------------------------------------------------------------- |
 | `knowledge.upsert_atoms`   | Corpus  | Commissive | Bulk insert/update slug-keyed knowledge atoms                                |
 | `knowledge.upsert_domains` | Corpus  | Commissive | Bulk insert/update domain groupings of atoms                                 |
-| `knowledge.get`            | Corpus  | Assertive  | Fetch one atom or domain by ID or slug                                       |
+| `knowledge.get`            | Corpus  | Assertive  | Fetch one atom or domain by ID, exact slug, or short prefix                   |
 | `knowledge.list`           | Corpus  | Assertive  | Paginated listing of atoms or domains                                        |
 | `knowledge.delete_atoms`   | Corpus  | Commissive | Soft-delete atoms by slug                                                    |
 | `knowledge.stats`          | Corpus  | Assertive  | Corpus statistics (counts, coverage)                                         |
@@ -198,15 +198,16 @@ upsert_domains(domains: [{slug, name, description?, tags?, members?}, ...]) → 
 Inserts or updates domains by `(namespace, slug)` key. Members is a JSON array of
 atom slugs.
 
-#### `knowledge.get` — fetch by ID, short prefix, or slug
+#### `knowledge.get` — fetch by ID, exact slug, or short prefix
 
 ```
-get(id: <uuid|short-prefix|slug>) → {type: "atom"|"domain", ...fields}
+get(id: <uuid|slug|short-prefix>) → {type: "atom"|"domain", ...fields}
 ```
 
-Resolves by complete UUID first, then by unique 8+ hex UUID prefix, then by slug against
-both `knowledge_atoms` and `knowledge_domains`. UUID and prefix reads are
-namespace-agnostic; slug reads use the caller namespace. Returns 404 if not found.
+Resolves by complete UUID first. For non-UUID input, it tries an exact slug against both
+`knowledge_atoms` and `knowledge_domains` in the caller namespace, then interprets a
+remaining 8+ hex string as a unique UUID prefix. UUID and prefix reads are
+namespace-agnostic. Returns 404 if not found.
 
 #### `knowledge.list` — paginated listing
 

--- a/docs/adr/ADR-047-knowledge-pack.md
+++ b/docs/adr/ADR-047-knowledge-pack.md
@@ -135,7 +135,7 @@ they do not introduce new ones.
 | -------------------------- | ------- | ---------- | ---------------------------------------------------------------------------- |
 | `knowledge.upsert_atoms`   | Corpus  | Commissive | Bulk insert/update slug-keyed knowledge atoms                                |
 | `knowledge.upsert_domains` | Corpus  | Commissive | Bulk insert/update domain groupings of atoms                                 |
-| `knowledge.get`            | Corpus  | Assertive  | Fetch one atom or domain by ID, exact slug, or short prefix                   |
+| `knowledge.get`            | Corpus  | Assertive  | Fetch one atom or domain by ID, exact slug, or short prefix                  |
 | `knowledge.list`           | Corpus  | Assertive  | Paginated listing of atoms or domains                                        |
 | `knowledge.delete_atoms`   | Corpus  | Commissive | Soft-delete atoms by slug                                                    |
 | `knowledge.stats`          | Corpus  | Assertive  | Corpus statistics (counts, coverage)                                         |

--- a/docs/adr/ADR-084-verb-surface-consistency.md
+++ b/docs/adr/ADR-084-verb-surface-consistency.md
@@ -73,9 +73,10 @@ added, each individually small, collectively a memorization tax:
 
 - **Param-name divergence**: `query` vs `q`, `at` (not `due`), `id` (not `thread_id`),
   `ids` (not `slugs`) -- correct names are operational folklore, not a stated convention.
-- **ID-resolution divergence**: most `id`-typed params accept a short unique prefix;
-  `brain.feedback` requires a full UUID; `knowledge.get` accepts slug or full UUID but
-  not a prefix.
+- **ID-resolution divergence**: most `id`-typed params accept a short unique prefix, while
+  `brain.feedback` requires a full UUID. `knowledge.get` was another violator at this
+  snapshot; its later fix preserves the Rule 1 order: full UUID, exact registered slug,
+  then short unique prefix.
 - **Silent enum coercion**: `parse_direction` (`khive-pack-kg/src/handlers/common.rs`)
   maps any unrecognized `direction` value to `Direction::Out` (`Some(_) => Direction::Out`)
   instead of erroring -- a direct violation of the codebase's own "never silently coerce
@@ -107,7 +108,8 @@ grandfathered exceptions.
 resolves, in order: full UUID → registered slug (where the verb declares slug support) →
 short unique hex prefix. A prefix that matches zero or multiple records is an error naming
 the ambiguity. Violators at ratification: `brain.feedback` (full UUID only),
-`knowledge.get` (slug or full UUID, no prefix).
+`knowledge.get` (slug or full UUID, no prefix). The latter was resolved after this proposal's
+snapshot; it now implements this order while keeping UUID/prefix reads namespace-agnostic.
 
 **Rule 2 -- no silent enum coercion.** A parameter with a closed value set rejects
 unrecognized values with an error listing the valid values. Defaulting applies only to
@@ -274,9 +276,10 @@ DSL section (§5). The grammar itself is unchanged (see Alternatives §6).
 
 **3d. Tracked conformance failures (Rules 1-3).** `brain.feedback` full-UUID-only,
 `knowledge.get` missing prefix resolution, `parse_direction` silent coercion, and the
-`neighbors` help/default mismatch are recorded as conformance issues at ratification.
-Their fixes are ordinary bugfix PRs referencing this ADR; none of them is gated on the
-`schema` verb landing.
+`neighbors` help/default mismatch were recorded as conformance issues at ratification.
+`knowledge.get` has since been resolved with full UUID → exact scoped slug → unique prefix
+precedence. The remaining fixes are ordinary bugfix PRs referencing this ADR; none is gated
+on the `schema` verb landing.
 
 ### 4. The conformance test -- two declared phases
 

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -1558,12 +1558,13 @@ request(ops="[{\"tool\":\"knowledge.upsert_domains\",\"args\":{\"domains\":[{\"s
 
 ### `knowledge.get` — Assertive
 
-Fetch a single atom or domain by UUID, unique short prefix, or slug. UUID and prefix
-forms are namespace-agnostic by-ID reads; slug lookup uses the caller namespace.
+Fetch a single atom or domain by full UUID, exact slug, or unique short prefix, in that
+order. Exact slug lookup uses the caller namespace; UUID and prefix forms are
+namespace-agnostic by-ID reads.
 
 | Param              | Type   | Required | Notes                                                                                                                                                                                                                                                                           |
 | ------------------ | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`               | string | yes      | Atom/domain full UUID, unique 8+ hex UUID prefix, or slug.                                                                                                                                                                                                                      |
+| `id`               | string | yes      | Atom/domain full UUID, exact caller-namespace slug, or unique 8+ hex UUID prefix.                                                                                                                                                                                               |
 | `include_sections` | bool   | no       | Include the atom's sections under a `sections` key (ignored for domains). Each section: `id, atom_id, namespace, section_type, heading, content, content_hash, status, tokens, sort_order, created_at, updated_at`, ordered by `sort_order`, `created_at`, `id`. Default false. |
 
 ```

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -950,6 +950,8 @@ Each result carries `serve_attribution` (`profile`, `unattributed`, or
 `unspecified`). `profile` also carries `served_by_profile_id`; `unattributed`
 means a selected profile record was unreadable and downstream feedback must not
 fall back to a current binding/default.
+Each result also carries canonical `full_id`; pass it directly to
+`memory.feedback(target_id=...)` in a later request without an extra `get`.
 
 ```
 request(ops="memory.recall(query=\"ADR-016 DSL grammar\", limit=5, min_score=0.3)")
@@ -1840,6 +1842,8 @@ request(ops="session.store(content=\"...\", provider=\"claude_code\", title=\"pa
 ### `session.list` — Assertive
 
 List stored sessions newest first.
+Every summary includes canonical `full_id` for direct reuse with
+`session.resume` or `session.export` across requests.
 
 | Param      | Type    | Required | Notes                                               |
 | ---------- | ------- | -------- | --------------------------------------------------- |

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -1558,11 +1558,12 @@ request(ops="[{\"tool\":\"knowledge.upsert_domains\",\"args\":{\"domains\":[{\"s
 
 ### `knowledge.get` — Assertive
 
-Fetch a single atom or domain by UUID or slug.
+Fetch a single atom or domain by UUID, unique short prefix, or slug. UUID and prefix
+forms are namespace-agnostic by-ID reads; slug lookup uses the caller namespace.
 
 | Param              | Type   | Required | Notes                                                                                                                                                                                                                                                                           |
 | ------------------ | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`               | string | yes      | Atom/domain UUID or slug.                                                                                                                                                                                                                                                       |
+| `id`               | string | yes      | Atom/domain full UUID, unique 8+ hex UUID prefix, or slug.                                                                                                                                                                                                                      |
 | `include_sections` | bool   | no       | Include the atom's sections under a `sections` key (ignored for domains). Each section: `id, atom_id, namespace, section_type, heading, content, content_hash, status, tokens, sort_order, created_at, updated_at`, ordered by `sort_order`, `created_at`, `id`. Default false. |
 
 ```

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -952,6 +952,9 @@ means a selected profile record was unreadable and downstream feedback must not
 fall back to a current binding/default.
 Each result also carries canonical `full_id`; pass it directly to
 `memory.feedback(target_id=...)` in a later request without an extra `get`.
+`full_id` is present when the resolved output format is `json`, the builtin
+default, under any presentation mode. The `auto` and `table` formats omit it
+unless the request sets `presentation=verbose`.
 
 ```
 request(ops="memory.recall(query=\"ADR-016 DSL grammar\", limit=5, min_score=0.3)")
@@ -1843,7 +1846,9 @@ request(ops="session.store(content=\"...\", provider=\"claude_code\", title=\"pa
 
 List stored sessions newest first.
 Every summary includes canonical `full_id` for direct reuse with
-`session.resume` or `session.export` across requests.
+`session.resume` or `session.export` across requests. As with other records,
+`full_id` is present under the default `json` output format and is omitted by
+`format=auto` and `format=table` unless the request sets `presentation=verbose`.
 
 | Param      | Type    | Required | Notes                                               |
 | ---------- | ------- | -------- | --------------------------------------------------- |


### PR DESCRIPTION
## Summary

- align `knowledge.get` with the shared read-identifier ladder: full UUID, exact scoped slug, then globally unique UUID prefix
- make UUID reads namespace-agnostic while loading sections from the record's stored namespace and deduplicating domain mirrors
- expose canonical `full_id` handles from `memory.recall` and `session.list` so Agent-mode results chain directly into strict downstream verbs

## Behavior

`knowledge.get` now preserves exact slug precedence (including all-hex slugs), resolves unique UUID
prefixes, reports ambiguous prefixes, and accepts a full UUID regardless of the caller's current
namespace. Domain rows and their mirror atoms collapse to one logical result, and section loading
uses the namespace of the resolved record rather than the caller namespace.

Compact Agent presentation remains compact, but recall and session-list rows now carry a canonical
`full_id`. Callers can feed that handle directly into `memory.feedback` or `session.resume` without
an extra generic `get` round trip. MCP regressions exercise those default-presentation chains while
preserving the existing compact display `id` where applicable.

The public API guide, ADR-047, ADR-084, and agent guidance now describe the same resolution and
response contracts.

## Validation

- independent exact-head review: READY with no findings
- `cargo test --workspace`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`

Closes #1762

> AI-assisted contribution: Codex prepared this change and PR description.
