### PR TITLE
fix(db): drop transaction span before writer reply

### DIFF
--- a/crates/khive-db/docs/api/writer-task.md
+++ b/crates/khive-db/docs/api/writer-task.md
@@ -51,6 +51,10 @@ classification table in `writer_task.rs`'s module docs still opens its own
 writer; strict routing per ADR-136 D1 has not landed) replies the request's
 error via `AnyWriteRequest::reply_error` without ever invoking the
 request's operation closure via `AnyWriteRequest::execute_and_reply`.
+For transaction-wrapped requests, the scoped `writer_task_tx` registry span
+is dropped before the oneshot reply wakes the caller, both after a completed
+transaction and after a failed `BEGIN`. A caller that has observed its reply
+therefore cannot still observe that request as an open SQL transaction.
 There is no watchdog/retry story for a failed `BEGIN` (ADR-067
 Component D remains future work); the connection simply tries
 `BEGIN IMMEDIATE` fresh on the next request.

--- a/crates/khive-db/src/writer_task.rs
+++ b/crates/khive-db/src/writer_task.rs
@@ -88,6 +88,7 @@ mod sealed {
         fn execute_and_reply_reporting_terminal(
             self: Box<Self>,
             conn: &rusqlite::Connection,
+            tx_span: Option<khive_storage::tx_registry::TxHandle>,
         ) -> Option<khive_storage::error::WriterTaskRequestState>;
 
         fn execute_and_reply_top_level_reporting_terminal(
@@ -250,12 +251,18 @@ impl<R: Send + 'static> sealed::Sealed for WriteRequest<R> {
     fn execute_and_reply_reporting_terminal(
         self: Box<Self>,
         conn: &Connection,
+        tx_span: Option<khive_storage::tx_registry::TxHandle>,
     ) -> Option<WriterTaskRequestState> {
         // Keep the typed reply sender outside the unwind boundary. Calling
         // `(self.op)(conn)` directly would drop `self.reply` while unwinding,
         // leaving the active caller with only an untyped RecvError.
         let WriteRequest { op, reply, .. } = *self;
         let (result, terminal_state) = execute_wrapped_transaction(conn, "writer_task_commit", op);
+        // The reply wake can make the caller immediately observe the
+        // committed/error result. Deregister the transaction span first so
+        // tx_registry continues to mean "currently open SQL transaction",
+        // never "a transaction whose caller has already resumed" (#1790).
+        drop(tx_span);
         // The receiver may already be gone (caller dropped its future) —
         // that is not this task's problem to report.
         let _ = reply.send(result);
@@ -297,7 +304,7 @@ impl<R: Send + 'static> sealed::Sealed for WriteRequest<R> {
 
 impl<R: Send + 'static> AnyWriteRequest for WriteRequest<R> {
     fn execute_and_reply(self: Box<Self>, conn: &Connection) {
-        let _ = sealed::Sealed::execute_and_reply_reporting_terminal(self, conn);
+        let _ = sealed::Sealed::execute_and_reply_reporting_terminal(self, conn, None);
     }
 
     fn execute_and_reply_top_level(self: Box<Self>, conn: &Connection) {
@@ -707,14 +714,18 @@ async fn run_writer_task(
                 acquisition_counters.record_writer_task_acquisition();
                 sealed::Sealed::execute_and_reply_top_level_reporting_terminal(request, &conn)
             } else {
-                let _tx_handle = khive_storage::tx_registry::register_scoped(
+                let tx_span = khive_storage::tx_registry::register_scoped(
                     Some("writer_task_tx".to_string()),
                     origin,
                 );
                 match conn.execute_batch("BEGIN IMMEDIATE") {
                     Ok(()) => {
                         acquisition_counters.record_writer_task_acquisition();
-                        sealed::Sealed::execute_and_reply_reporting_terminal(request, &conn)
+                        sealed::Sealed::execute_and_reply_reporting_terminal(
+                            request,
+                            &conn,
+                            Some(tx_span),
+                        )
                     }
                     Err(e) => {
                         // Do NOT run the request's operation: `conn` never
@@ -727,6 +738,11 @@ async fn run_writer_task(
                             "writer task: BEGIN IMMEDIATE failed; replying an \
                              error without running the request's operation"
                         );
+                        // Although BEGIN never opened a SQL transaction, the
+                        // scoped attempt is observable in tx_registry. Drop
+                        // it before waking the caller for the same reply-side
+                        // lifecycle guarantee as successful requests (#1790).
+                        drop(tx_span);
                         request.reply_error(StorageError::Pool {
                             operation: "writer_task_begin".into(),
                             message: e.to_string(),
@@ -1574,7 +1590,7 @@ mod tests {
         };
 
         let terminal_state =
-            sealed::Sealed::execute_and_reply_reporting_terminal(Box::new(request), &conn);
+            sealed::Sealed::execute_and_reply_reporting_terminal(Box::new(request), &conn, None);
         assert_eq!(
             terminal_state,
             Some(WriterTaskRequestState::SideEffectsUnknown)
@@ -1706,7 +1722,7 @@ mod tests {
         };
 
         let terminal_state =
-            sealed::Sealed::execute_and_reply_reporting_terminal(Box::new(request), &conn);
+            sealed::Sealed::execute_and_reply_reporting_terminal(Box::new(request), &conn, None);
         assert_eq!(
             terminal_state,
             Some(WriterTaskRequestState::SideEffectsUnknown)
@@ -1745,7 +1761,7 @@ mod tests {
         };
 
         let terminal_state =
-            sealed::Sealed::execute_and_reply_reporting_terminal(Box::new(request), &conn);
+            sealed::Sealed::execute_and_reply_reporting_terminal(Box::new(request), &conn, None);
         assert_eq!(
             terminal_state,
             Some(WriterTaskRequestState::SideEffectsUnknown)

--- a/crates/khive-db/src/writer_task.rs
+++ b/crates/khive-db/src/writer_task.rs
@@ -777,9 +777,12 @@ mod tests {
     use crate::pool::PoolConfig;
     use rusqlite::hooks::{AuthAction, AuthContext, Authorization, TransactionOperation};
     use serial_test::serial;
+    use std::future::Future;
+    use std::pin::Pin;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::mpsc as std_mpsc;
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
+    use std::task::{Context, Poll, Wake, Waker};
     use std::time::Duration;
 
     fn file_pool(path: &std::path::Path) -> ConnectionPool {
@@ -829,6 +832,180 @@ mod tests {
             }
             other => panic!("expected WriterTaskTerminated({expected:?}), got {other:?}"),
         }
+    }
+
+    struct ParkedWake {
+        entered: std_mpsc::SyncSender<()>,
+        release: Mutex<std_mpsc::Receiver<()>>,
+    }
+
+    impl Wake for ParkedWake {
+        fn wake(self: Arc<Self>) {
+            self.entered
+                .send(())
+                .expect("reply sender must rendezvous with the test");
+            self.release
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .recv()
+                .expect("test must release the parked reply sender");
+        }
+    }
+
+    struct NoopWake;
+
+    impl Wake for NoopWake {
+        fn wake(self: Arc<Self>) {}
+    }
+
+    fn arm_parked_wake<F: Future>(
+        mut future: Pin<&mut F>,
+    ) -> (std_mpsc::Receiver<()>, std_mpsc::Sender<()>) {
+        let (entered_tx, entered_rx) = std_mpsc::sync_channel(0);
+        let (release_tx, release_rx) = std_mpsc::channel();
+        let waker = Waker::from(Arc::new(ParkedWake {
+            entered: entered_tx,
+            release: Mutex::new(release_rx),
+        }));
+        let mut context = Context::from_waker(&waker);
+        assert!(
+            matches!(future.as_mut().poll(&mut context), Poll::Pending),
+            "writer send must remain pending until its operation replies"
+        );
+        (entered_rx, release_tx)
+    }
+
+    fn poll_ready<F: Future>(mut future: Pin<&mut F>) -> F::Output {
+        let waker = Waker::from(Arc::new(NoopWake));
+        let mut context = Context::from_waker(&waker);
+        match future.as_mut().poll(&mut context) {
+            Poll::Ready(output) => output,
+            Poll::Pending => panic!("reply wake must make the writer send ready"),
+        }
+    }
+
+    fn database_tx_view(pool: &ConnectionPool) -> khive_storage::tx_registry::TxOriginFilter {
+        match pool.origin() {
+            khive_storage::tx_registry::TxOrigin::Database(identity) => {
+                khive_storage::tx_registry::TxOriginFilter::Secondary(identity)
+            }
+            other => panic!("expected a file-backed database origin, got {other:?}"),
+        }
+    }
+
+    async fn wait_for_writer_span_to_close(view: &khive_storage::tx_registry::TxOriginFilter) {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while khive_storage::tx_registry::any_open_labeled(view, "writer_task_tx") {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("writer task transaction span must eventually close");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[serial(tx_registry)]
+    async fn successful_send_reply_waits_for_writer_tx_deregistration() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("writer_task_success_reply_lifecycle.db");
+        let pool = file_pool(&path);
+        let view = database_tx_view(&pool);
+        let handle = spawn(&pool, 8).expect("writer task spawn");
+        let (op_started_tx, op_started_rx) = std_mpsc::sync_channel(0);
+        let (op_release_tx, op_release_rx) = std_mpsc::channel();
+
+        let send = handle.send(move |_conn| {
+            op_started_tx
+                .send(())
+                .expect("operation must rendezvous with the test");
+            op_release_rx
+                .recv()
+                .expect("test must release the operation");
+            Ok::<_, StorageError>(())
+        });
+        tokio::pin!(send);
+        let (reply_entered_rx, reply_release_tx) = arm_parked_wake(send.as_mut());
+
+        op_started_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("writer operation must start");
+        op_release_tx.send(()).expect("release writer operation");
+        reply_entered_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("reply sender must wake the waiting caller");
+
+        let reply = poll_ready(send.as_mut());
+        let span_was_open_at_reply =
+            khive_storage::tx_registry::any_open_labeled(&view, "writer_task_tx");
+
+        reply_release_tx
+            .send(())
+            .expect("release parked reply sender");
+        wait_for_writer_span_to_close(&view).await;
+
+        reply.expect("committed operation reply");
+        assert!(
+            !span_was_open_at_reply,
+            "a successful caller reply must not become observable while its committed writer_task_tx span remains registered"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[serial(tx_registry)]
+    async fn begin_failure_reply_waits_for_writer_tx_deregistration() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("writer_task_begin_reply_lifecycle.db");
+        let cfg = PoolConfig {
+            path: Some(path),
+            busy_timeout: Duration::from_millis(150),
+            ..PoolConfig::default()
+        };
+        let pool = ConnectionPool::new(cfg).unwrap();
+        let view = database_tx_view(&pool);
+        let handle = spawn(&pool, 8).expect("writer task spawn");
+        let lock_holder = pool.try_writer().expect("pool writer");
+        lock_holder
+            .conn()
+            .execute_batch("BEGIN IMMEDIATE")
+            .expect("hold database write lock");
+        let op_ran = Arc::new(AtomicBool::new(false));
+        let op_ran_in_request = Arc::clone(&op_ran);
+
+        let send = handle.send(move |_conn| {
+            op_ran_in_request.store(true, Ordering::SeqCst);
+            Ok::<_, StorageError>(())
+        });
+        tokio::pin!(send);
+        let (reply_entered_rx, reply_release_tx) = arm_parked_wake(send.as_mut());
+        reply_entered_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("BEGIN failure must wake the waiting caller");
+
+        let reply = poll_ready(send.as_mut());
+        let span_was_open_at_reply =
+            khive_storage::tx_registry::any_open_labeled(&view, "writer_task_tx");
+
+        reply_release_tx
+            .send(())
+            .expect("release parked reply sender");
+        wait_for_writer_span_to_close(&view).await;
+        lock_holder
+            .conn()
+            .execute_batch("ROLLBACK")
+            .expect("release database write lock");
+
+        assert!(
+            matches!(
+                &reply,
+                Err(StorageError::Pool { operation, .. }) if operation == "writer_task_begin"
+            ),
+            "expected writer_task_begin failure, got {reply:?}"
+        );
+        assert!(!op_ran.load(Ordering::SeqCst));
+        assert!(
+            !span_was_open_at_reply,
+            "a BEGIN-failure caller reply must not become observable while its writer_task_tx span remains registered"
+        );
     }
 
     // `#[serial(tx_registry)]`: `run_writer_task` registers a `writer_task_tx`


### PR DESCRIPTION
AI-assisted contribution: implemented and reviewed with Codex.

## Summary

- keep the writer-task transaction registry span alive through commit/rollback processing
- drop that span before the typed oneshot reply can wake the caller
- preserve the same ordering when `BEGIN IMMEDIATE` fails without running the request
- add deterministic reply-wake regressions for both successful writes and failed `BEGIN`

## Verification

- independent exact-head review: READY at
  `1a63fc6e5164562831c2f47e215cfe589b32f535`
- full exact-head CI: [run 31291706085](https://github.com/ohdearquant/khive/actions/runs/31291706085) — success
- focused writer reply/transaction-registry lifecycle regressions
- `cargo test --workspace`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`

Fixes #1790
