### PR TITLE
fix(memory): capture fresh-tail policy per runtime

### DIFF
--- a/crates/khive-mcp/README.md
+++ b/crates/khive-mcp/README.md
@@ -16,8 +16,9 @@ lifetime.
 - **Pluggable transports** — `Transport` trait + `TransportRegistry`; ships `StdioTransport`,
   open for more (e.g. Streamable HTTP) via `TransportRegistry::register`
 - **Daemon-aware dispatch** — `compute_config_id` fingerprints a resolved `RuntimeConfig`
-  (packs, db target, embedders, backend routing, outbound policy) so a thin
-  client only forwards to a warm daemon (ADR-049) when the fingerprints match;
+  plus captured serving policy (packs, db target, embedders, fresh-tail policy,
+  backend routing, outbound policy) so a thin client only forwards to a warm daemon
+  (ADR-049) when the fingerprints match;
   otherwise it falls back to local dispatch
 - **Result sinking** — `RequestParams::save_to` writes results as JSONL and returns a
   manifest (`path`, `rows`, `per_column_null_counts`, `schema_fingerprint`, `checksum`,

--- a/crates/khive-mcp/docs/api/daemon-lifecycle.md
+++ b/crates/khive-mcp/docs/api/daemon-lifecycle.md
@@ -88,8 +88,8 @@ shared boot/recovery lock (bounded by `BOOT_QUIESCENCE_LOCK_TIMEOUT_MS` =
 500ms), then re-probes daemon identity — successfully reacquiring-then-
 dropping the lock proves neither a peer's kill+spawn nor a daemon's own cold
 boot is currently mid-critical-section. Before #838 this used an unbounded
-blocking `flock`, so `DEAD_CONFIRM_ROUNDS` bounded probe *count* but not
-elapsed *time* — a wedged lock holder blocked recovery forever. A
+blocking `flock`, so `DEAD_CONFIRM_ROUNDS` bounded probe _count_ but not
+elapsed _time_ — a wedged lock holder blocked recovery forever. A
 deadline-elapsed or otherwise-failed acquisition returns the distinct
 `ProbeOutcome::LockContended` rather than collapsing into `Timeout` (which
 means something different: "the daemon itself answered slowly").
@@ -141,11 +141,11 @@ outstanding client request when the mismatch fires, only the request that
 triggered this arm gets the ambiguous-error-then-resume treatment; any other
 in-flight request loses its response the same way it would if the process
 crashed — a pre-existing risk, not introduced by this change.
-`fire_pending_self_heal` fires on the next successful flush of *any*
+`fire_pending_self_heal` fires on the next successful flush of _any_
 message, not specifically the mismatch response's own flush — on this
 bridge's dominant single-request-at-a-time usage those are the same event,
 but a genuinely concurrent second in-flight request could in principle flush
-first. Strictly better than the pre-fix timer (which could fire before *any*
+first. Strictly better than the pre-fix timer (which could fire before _any_
 flush completed), and the same class of pre-existing risk, not a new one.
 
 `SelfHealOnFlushTransport` wraps the transport (rather than the handler)

--- a/crates/khive-mcp/docs/api/daemon-lifecycle.md
+++ b/crates/khive-mcp/docs/api/daemon-lifecycle.md
@@ -122,8 +122,10 @@ The `daemon_fallback` event renders client and daemon configuration identifiers
 as stable, full SHA-256 identifiers rather than the path- and topology-bearing
 fingerprints used for the equality check. A configuration mismatch also carries
 `config_mismatch_field`, naming the first differing fingerprint field without
-emitting either field value. The wire equality check and fallback decision still
-use the original full fingerprints.
+emitting either field value. Its ordered vocabulary follows the production fingerprint:
+`packs`, `db`, `embed`, `extra`, `fresh_tail`, `backend`, `outbound`, `git_write`,
+`backends`, then `pack_backends`. The wire equality check and fallback decision still use
+the original full fingerprints.
 
 The `khive_strict_daemon_fallback` marker on a strict-fallback rejection's
 `McpError` (#947) lets `request()` in `server.rs` distinguish "the daemon was

--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -211,6 +211,7 @@ struct ConfigIdFields<'a> {
     db: &'a str,
     embed: &'a str,
     extra: &'a str,
+    fresh_tail: &'a str,
     backend: &'a str,
     outbound: &'a str,
     git_write: &'a str,
@@ -234,6 +235,7 @@ fn parse_config_id(config_id: &str) -> Option<ConfigIdFields<'_>> {
     let (rest, outbound) = rest.rsplit_once(";outbound=[")?;
     let outbound = outbound.strip_suffix(']')?;
     let (rest, backend) = rest.rsplit_once(";backend=")?;
+    let (rest, fresh_tail) = rest.rsplit_once(";fresh_tail=")?;
     let (rest, extra) = rest.rsplit_once(";extra=[")?;
     let extra = extra.strip_suffix(']')?;
     let (db, embed) = rest.rsplit_once(";embed=")?;
@@ -243,6 +245,7 @@ fn parse_config_id(config_id: &str) -> Option<ConfigIdFields<'_>> {
         db,
         embed,
         extra,
+        fresh_tail,
         backend,
         outbound,
         git_write,
@@ -267,6 +270,8 @@ fn first_config_mismatch_field(client: &str, daemon: Option<&str>) -> &'static s
         "embed"
     } else if client.extra != daemon.extra {
         "extra"
+    } else if client.fresh_tail != daemon.fresh_tail {
+        "fresh_tail"
     } else if client.backend != daemon.backend {
         "backend"
     } else if client.outbound != daemon.outbound {
@@ -2554,17 +2559,43 @@ mod tests {
 
     #[test]
     fn first_config_mismatch_field_follows_fingerprint_order() {
-        let client = "packs=[kg];db=/private/client.db;embed=none;extra=[];\
+        let client = "packs=[kg];db=/private/client.db;embed=none;extra=[];fresh_tail=true;\
                       backend=main;outbound=[];git_write=client-policy";
-        let daemon = "packs=[kg,gtd];db=/private/daemon.db;embed=none;extra=[];\
+        let daemon = "packs=[kg,gtd];db=/private/daemon.db;embed=none;extra=[];fresh_tail=true;\
                       backend=main;outbound=[];git_write=daemon-policy";
 
         assert_eq!(first_config_mismatch_field(client, Some(daemon)), "packs");
     }
 
     #[test]
+    fn first_config_mismatch_field_names_fresh_tail_from_computed_ids() {
+        let config = RuntimeConfig::no_embeddings();
+        let enabled = crate::server::compute_config_id_with_ann_fresh_tail(&config, None, true);
+        let disabled = crate::server::compute_config_id_with_ann_fresh_tail(&config, None, false);
+
+        assert_eq!(
+            first_config_mismatch_field(&enabled, Some(&disabled)),
+            "fresh_tail"
+        );
+    }
+
+    #[test]
+    fn first_config_mismatch_field_names_later_field_from_computed_ids() {
+        let config = RuntimeConfig::no_embeddings();
+        let mut changed = config.clone();
+        changed.allowed_outbound_namespaces = vec![Namespace::parse("remote").unwrap()];
+        let client = crate::server::compute_config_id_with_ann_fresh_tail(&config, None, true);
+        let daemon = crate::server::compute_config_id_with_ann_fresh_tail(&changed, None, true);
+
+        assert_eq!(
+            first_config_mismatch_field(&client, Some(&daemon)),
+            "outbound"
+        );
+    }
+
+    #[test]
     fn first_config_mismatch_field_names_backend_topology_without_values() {
-        let base = "packs=[kg];db=:memory:;embed=none;extra=[];backend=main;\
+        let base = "packs=[kg];db=:memory:;embed=none;extra=[];fresh_tail=true;backend=main;\
                     outbound=[];git_write=policy";
         let client =
             format!("{base};backends=[main:Sqlite:/private/client.db];pack_backends=[kg=main]");
@@ -2581,9 +2612,11 @@ mod tests {
     #[serial]
     fn map_response_config_mismatch_logs_opaque_ids_and_field_without_values() {
         reset_fallback_counters();
-        let client = "packs=[kg];db=/private/client-topology/main.db;embed=none;extra=[];\
+        let client =
+            "packs=[kg];db=/private/client-topology/main.db;embed=none;extra=[];fresh_tail=true;\
                       backend=main;outbound=[];git_write=same-policy";
-        let daemon = "packs=[kg];db=/private/daemon-topology/main.db;embed=none;extra=[];\
+        let daemon =
+            "packs=[kg];db=/private/daemon-topology/main.db;embed=none;extra=[];fresh_tail=true;\
                       backend=main;outbound=[];git_write=same-policy";
         let response = DaemonResponseFrame {
             ok: false,

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -1923,7 +1923,11 @@ fn build_registry_for_multi_backend_inner(
 
     let gate = default_runtime.config().gate.clone();
     let default_namespace = default_runtime.config().default_namespace.clone();
-    let config_id = crate::server::compute_config_id(default_runtime.config(), Some(khive_cfg));
+    let config_id = crate::server::compute_config_id_with_ann_fresh_tail(
+        default_runtime.config(),
+        Some(khive_cfg),
+        default_runtime.ann_fresh_tail_enabled(),
+    );
     let visible_namespaces = default_runtime.config().visible_namespaces.clone();
 
     let mut builder = khive_runtime::VerbRegistryBuilder::new();

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -225,8 +225,8 @@ impl DispatchFailure {
 ///
 /// Two servers produce the same id iff they can safely share one warm engine:
 /// same pack set (order-independent), same storage target, same embedders, same
-/// backend topology/routing, and same construction-baked outbound and git-write
-/// policies.
+/// backend topology/routing, and same construction-baked fresh-tail, outbound,
+/// and git-write policies.
 /// Identity fields (`namespace`, `actor_id`, `visible_namespaces`) are carried
 /// per request in the daemon frame and must never enter this key. The daemon
 /// compares this against each forwarded request's `config_id` and rejects
@@ -251,6 +251,22 @@ impl DispatchFailure {
 pub fn compute_config_id(
     config: &RuntimeConfig,
     khive_cfg: Option<&khive_runtime::KhiveConfig>,
+) -> String {
+    compute_config_id_with_ann_fresh_tail(
+        config,
+        khive_cfg,
+        khive_runtime::ann_fresh_tail_enabled_from_env(),
+    )
+}
+
+/// Compute the daemon identity with an already-snapshotted ADR-118 policy.
+///
+/// Runtime-owning call sites use this form so an environment mutation after
+/// construction cannot make the fingerprint disagree with serving behavior.
+pub(crate) fn compute_config_id_with_ann_fresh_tail(
+    config: &RuntimeConfig,
+    khive_cfg: Option<&khive_runtime::KhiveConfig>,
+    ann_fresh_tail_enabled: bool,
 ) -> String {
     let mut packs = config.packs.clone();
     packs.sort();
@@ -292,11 +308,12 @@ pub fn compute_config_id(
     let git_write = format!("{:x}", git_write_hasher.finalize());
 
     let base = format!(
-        "packs=[{}];db={};embed={};extra=[{}];backend={:?};outbound=[{}];git_write={}",
+        "packs=[{}];db={};embed={};extra=[{}];fresh_tail={};backend={:?};outbound=[{}];git_write={}",
         packs.join(","),
         db,
         primary,
         extra.join(","),
+        ann_fresh_tail_enabled,
         config.backend_id,
         outbound.join(","),
         git_write,
@@ -543,7 +560,11 @@ impl KhiveMcpServer {
     pub fn with_packs(runtime: KhiveRuntime, packs: &[String]) -> Result<Self, PackRegError> {
         let gate = runtime.config().gate.clone();
         let default_namespace = runtime.config().default_namespace.clone();
-        let config_id = compute_config_id(runtime.config(), None);
+        let config_id = compute_config_id_with_ann_fresh_tail(
+            runtime.config(),
+            None,
+            runtime.ann_fresh_tail_enabled(),
+        );
         let visible_namespaces = runtime.config().visible_namespaces.clone();
         let actor_id = runtime.config().actor_id.clone();
         let mut builder = VerbRegistryBuilder::new();
@@ -2902,6 +2923,20 @@ mod tests {
         assert_eq!(
             error.data.as_ref().and_then(|data| data["reason"].as_str()),
             Some("parse-error")
+        );
+    }
+
+    /// ADR-118's serving toggle is baked into a runtime. Opposite policies
+    /// must never share one warm daemon even when every `RuntimeConfig` field
+    /// is otherwise identical.
+    #[test]
+    fn config_id_differs_when_ann_fresh_tail_policy_differs() {
+        let config = RuntimeConfig::no_embeddings();
+
+        assert_ne!(
+            compute_config_id_with_ann_fresh_tail(&config, None, true),
+            compute_config_id_with_ann_fresh_tail(&config, None, false),
+            "opposite fresh-tail policies must not share one warm daemon"
         );
     }
 

--- a/crates/khive-pack-knowledge/docs/api/vamana.md
+++ b/crates/khive-pack-knowledge/docs/api/vamana.md
@@ -63,6 +63,8 @@ Every process rejects cached, v2, and legacy-v1 state while `-1` remains; only a
 full scan may transition it to a normal watermark. Failed or Empty scans keep the sentinel so a
 re-created row cannot be mistaken for uninterrupted registry history.
 `KHIVE_ANN_FRESH_TAIL=0` disables the exact leg but does not bypass this registry guard.
+The variable is sampled once at `KhiveRuntime` construction; request-time serving reads
+the immutable runtime value rather than process-global environment state.
 
 Migration V18 also distinguishes a never-activated registration (`-2` plus a timestamp) from a
 real active checkpoint at `S = 0`. Knowledge treats `-2` exactly like registry loss and promotes it

--- a/crates/khive-pack-knowledge/src/knowledge/vamana.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/vamana.rs
@@ -1536,12 +1536,6 @@ async fn replay_final_states(
 
 // ── ADR-118: fresh-tail exact leg ─────────────────────────────────────────
 
-fn fresh_tail_enabled() -> bool {
-    std::env::var("KHIVE_ANN_FRESH_TAIL")
-        .map(|value| value != "0")
-        .unwrap_or(true)
-}
-
 struct FreshTailSnapshot {
     own_watermark: Option<i64>,
     registry_min: Option<i64>,
@@ -1831,7 +1825,7 @@ pub(crate) async fn fresh_tail_leg(
             source_exhausted: true,
         };
     }
-    if !fresh_tail_enabled() {
+    if !rt.ann_fresh_tail_enabled() {
         return match read_own_watermark(rt, ns, model).await {
             Ok(Some(watermark)) if watermark >= 0 => FreshTailOutcome::Skipped,
             Ok(_) => force_cold_after_registry_loss(rt, ann, key).await,

--- a/crates/khive-pack-memory/src/ann.rs
+++ b/crates/khive-pack-memory/src/ann.rs
@@ -1805,14 +1805,6 @@ async fn fetch_final_tail_on(
 
 // ── ADR-118: fresh-tail exact leg (read-your-writes recall visibility) ─────────
 
-/// `KHIVE_ANN_FRESH_TAIL=0` disables the exact leg (default enabled). Any
-/// other value, including unset, leaves it enabled.
-fn fresh_tail_enabled() -> bool {
-    std::env::var("KHIVE_ANN_FRESH_TAIL")
-        .map(|v| v != "0")
-        .unwrap_or(true)
-}
-
 /// Read the currently-installed bridge's fresh-tail watermark for `key`: the
 /// `ann_write_log` seq its corpus state reflects, or `None` if no bridge is
 /// installed. Test-only: production call sites need this paired atomically
@@ -2063,8 +2055,10 @@ pub(crate) async fn fresh_tail_leg(
         }
     }
 
-    if !fresh_tail_enabled() {
-        return FreshTailOutcome::Skipped("fresh-tail leg disabled via KHIVE_ANN_FRESH_TAIL");
+    if !rt.ann_fresh_tail_enabled() {
+        return FreshTailOutcome::Skipped(
+            "fresh-tail leg disabled by runtime policy (KHIVE_ANN_FRESH_TAIL is sampled at construction)",
+        );
     }
 
     match s {

--- a/crates/khive-pack-memory/src/handlers/fresh_tail_tests.rs
+++ b/crates/khive-pack-memory/src/handlers/fresh_tail_tests.rs
@@ -17,30 +17,6 @@ use crate::MemoryPack;
 const MODEL: &str = "adr118-e2e-test-model";
 const DIMS: usize = 16;
 
-/// Guards a mutated `KHIVE_ANN_FRESH_TAIL` value, restoring whatever value
-/// (present or absent) it held before the guard was created, even if the
-/// test panics.
-struct EnvGuard {
-    prior: Option<String>,
-}
-
-impl EnvGuard {
-    fn disable_fresh_tail() -> Self {
-        let prior = std::env::var("KHIVE_ANN_FRESH_TAIL").ok();
-        std::env::set_var("KHIVE_ANN_FRESH_TAIL", "0");
-        Self { prior }
-    }
-}
-
-impl Drop for EnvGuard {
-    fn drop(&mut self) {
-        match self.prior.take() {
-            Some(v) => std::env::set_var("KHIVE_ANN_FRESH_TAIL", v),
-            None => std::env::remove_var("KHIVE_ANN_FRESH_TAIL"),
-        }
-    }
-}
-
 async fn build_registry(rt: &KhiveRuntime) -> VerbRegistry {
     let mut builder = VerbRegistryBuilder::new();
     builder.register(KgPack::new(rt.clone()));
@@ -49,6 +25,13 @@ async fn build_registry(rt: &KhiveRuntime) -> VerbRegistry {
 }
 
 fn new_runtime(tmp: &std::path::Path) -> KhiveRuntime {
+    new_runtime_with_fresh_tail(tmp, true)
+}
+
+fn new_runtime_with_fresh_tail(
+    tmp: &std::path::Path,
+    ann_fresh_tail_enabled: bool,
+) -> KhiveRuntime {
     let db_path = tmp.join("khive-graph.db");
     let rt = KhiveRuntime::new(RuntimeConfig {
         db_path: Some(db_path),
@@ -56,7 +39,8 @@ fn new_runtime(tmp: &std::path::Path) -> KhiveRuntime {
         additional_embedding_models: vec![],
         ..RuntimeConfig::default()
     })
-    .expect("runtime");
+    .expect("runtime")
+    .with_ann_fresh_tail_enabled(ann_fresh_tail_enabled);
     rt.register_embedder(HashVecProvider {
         model_name: MODEL.to_owned(),
         dims: DIMS,
@@ -286,18 +270,18 @@ async fn empty_tail_leaves_vector_candidates_unchanged() {
     );
 }
 
-/// `KHIVE_ANN_FRESH_TAIL=0` disables the exact leg: a note written after the
-/// ANN cache is warm must NOT appear in the vector leg's own candidates
+/// A runtime constructed with the ADR-118 exact leg disabled must not surface
+/// a post-warm write in the vector leg's own candidates
 /// (`memory.recall_candidates`'s `vector_candidates`, sourced only from the
 /// vector leg — unlike full `memory.recall`, unaffected by FTS finding it).
 #[tokio::test]
 #[serial(adr118_fresh_tail)]
-async fn env_var_disables_fresh_tail_restoring_pre_adr_behavior() {
+async fn runtime_policy_disables_fresh_tail_restoring_pre_adr_behavior() {
     let tmp = tempfile::Builder::new()
         .prefix("khive-adr118-e2e-6-")
         .tempdir_in(std::env::temp_dir())
         .expect("tempdir");
-    let rt = new_runtime(tmp.path());
+    let rt = new_runtime_with_fresh_tail(tmp.path(), false);
     let ns = Namespace::parse("local").expect("local namespace");
     let token = rt.authorize(ns).expect("authorize local");
 
@@ -306,7 +290,7 @@ async fn env_var_disables_fresh_tail_restoring_pre_adr_behavior() {
             &token,
             "memory",
             None,
-            &format!("adr118 e2e env-disable seed note {i}"),
+            &format!("adr118 e2e policy-disable seed note {i}"),
             Some(0.7),
             None,
             vec![],
@@ -319,14 +303,12 @@ async fn env_var_disables_fresh_tail_restoring_pre_adr_behavior() {
     registry
         .dispatch(
             "memory.recall_candidates",
-            json!({"query": "adr118 e2e env-disable seed note", "limit": 10}),
+            json!({"query": "adr118 e2e policy-disable seed note", "limit": 10}),
         )
         .await
         .expect("warm recall_candidates");
 
-    let _guard = EnvGuard::disable_fresh_tail();
-
-    const MARKER: &str = "adr118 e2e env-disable distinctive marker xyzzy";
+    const MARKER: &str = "adr118 e2e policy-disable distinctive marker xyzzy";
     let fresh = rt
         .create_note(&token, "memory", None, MARKER, Some(0.7), None, vec![])
         .await
@@ -344,7 +326,7 @@ async fn env_var_disables_fresh_tail_restoring_pre_adr_behavior() {
         .expect("vector_candidates must be an array");
     assert!(
         !contains_id(vector_candidates, fresh.id),
-        "KHIVE_ANN_FRESH_TAIL=0 must restore pre-ADR-118 behavior: a note \
+        "a disabled runtime must restore pre-ADR-118 behavior: a note \
          written after the cache warmed must stay invisible to the vector \
          leg until a rebuild, got: {vector_candidates:?}"
     );

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -1157,6 +1157,12 @@ mod tests {
 
     use crate::MemoryPack;
 
+    fn memory_runtime_with_fresh_tail(ann_fresh_tail_enabled: bool) -> KhiveRuntime {
+        KhiveRuntime::memory()
+            .expect("in-memory runtime")
+            .with_ann_fresh_tail_enabled(ann_fresh_tail_enabled)
+    }
+
     #[derive(Clone, Debug, Default)]
     struct CapturedWarning {
         fields: HashMap<String, String>,
@@ -1388,7 +1394,7 @@ mod tests {
         const DIMS: usize = 16;
         const NOTE_TEXT: &str = "issue 836 normal path recall without any ann contention";
 
-        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let rt = memory_runtime_with_fresh_tail(true);
         rt.register_embedder(HashVecProvider {
             model_name: MODEL.to_owned(),
             dims: DIMS,
@@ -1430,31 +1436,8 @@ mod tests {
         }
     }
 
-    /// Guards a mutated `KHIVE_ANN_FRESH_TAIL` value, restoring whatever value
-    /// (present or absent) it held before the guard was created, even if the
-    /// test panics.
-    struct FreshTailEnvGuard {
-        prior: Option<String>,
-    }
-
-    impl FreshTailEnvGuard {
-        fn disable() -> Self {
-            let prior = std::env::var("KHIVE_ANN_FRESH_TAIL").ok();
-            std::env::set_var("KHIVE_ANN_FRESH_TAIL", "0");
-            Self { prior }
-        }
-    }
-
-    impl Drop for FreshTailEnvGuard {
-        fn drop(&mut self) {
-            match self.prior.take() {
-                Some(v) => std::env::set_var("KHIVE_ANN_FRESH_TAIL", v),
-                None => std::env::remove_var("KHIVE_ANN_FRESH_TAIL"),
-            }
-        }
-    }
-
-    /// #1477: an exceptional fresh-tail skip (here, the exact leg disabled via
+    /// #1477: an exceptional fresh-tail skip (here, the runtime's exact leg is
+    /// disabled, as production can request via construction-time
     /// `KHIVE_ANN_FRESH_TAIL=0`) forfeits read-your-writes visibility on the
     /// warm-index path — that is degraded serving, not an ordinary healthy
     /// response, and must be disclosed on a non-empty response the same way
@@ -1468,9 +1451,7 @@ mod tests {
         const DIMS: usize = 16;
         const NOTE_TEXT: &str = "issue 1477 fresh tail disabled recall degradation note";
 
-        let _env_guard = FreshTailEnvGuard::disable();
-
-        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let rt = memory_runtime_with_fresh_tail(false);
         rt.register_embedder(HashVecProvider {
             model_name: MODEL.to_owned(),
             dims: DIMS,
@@ -1546,9 +1527,7 @@ mod tests {
         const DIMS: usize = 16;
         const NOTE_TEXT: &str = "budget capped degraded disclosure note body";
 
-        let _env_guard = FreshTailEnvGuard::disable();
-
-        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let rt = memory_runtime_with_fresh_tail(false);
         rt.register_embedder(HashVecProvider {
             model_name: MODEL.to_owned(),
             dims: DIMS,

--- a/crates/khive-runtime/src/config.rs
+++ b/crates/khive-runtime/src/config.rs
@@ -313,6 +313,24 @@ pub fn parse_pack_list(s: &str) -> Vec<String> {
         .collect()
 }
 
+/// Interpret the construction-time `KHIVE_ANN_FRESH_TAIL` value.
+///
+/// Preserve the escape hatch's existing semantics while moving its read out of
+/// request serving: only `0` disables; unset and every other value enable.
+fn ann_fresh_tail_enabled_from_value(value: Option<&str>) -> bool {
+    value != Some("0")
+}
+
+/// Sample ADR-118's fresh-tail escape hatch for runtime construction.
+///
+/// Callers must retain the returned value for the runtime's lifetime instead
+/// of re-reading the environment on a serving path. Only the exact value `0`
+/// disables; unset and every other value enable.
+pub fn ann_fresh_tail_enabled_from_env() -> bool {
+    let value = std::env::var("KHIVE_ANN_FRESH_TAIL").ok();
+    ann_fresh_tail_enabled_from_value(value.as_deref())
+}
+
 impl Default for RuntimeConfig {
     fn default() -> Self {
         let db_path = std::env::var("HOME")
@@ -1005,6 +1023,20 @@ mod no_embeddings_tests {
             configured_embedding_models(&config),
             vec![EmbeddingModel::AllMiniLmL6V2]
         );
+    }
+}
+
+#[cfg(test)]
+mod ann_fresh_tail_config_tests {
+    use super::ann_fresh_tail_enabled_from_value;
+
+    #[test]
+    fn only_exact_zero_disables_fresh_tail() {
+        assert!(ann_fresh_tail_enabled_from_value(None));
+        assert!(!ann_fresh_tail_enabled_from_value(Some("0")));
+        assert!(ann_fresh_tail_enabled_from_value(Some("1")));
+        assert!(ann_fresh_tail_enabled_from_value(Some("false")));
+        assert!(ann_fresh_tail_enabled_from_value(Some(" 0")));
     }
 }
 

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -54,7 +54,7 @@ pub use atomic_runner::{
 };
 pub use blob::resolve_blob_store;
 pub use build_info::{BuildInfo, BUILD_INFO, BUILD_VERSION};
-pub use config::process_ref_from_env;
+pub use config::{ann_fresh_tail_enabled_from_env, process_ref_from_env};
 pub use cost_unit::{base_resource_payload, cost_unit_for_dispatch, resource_payload};
 pub use curation::{
     entity_embedding_text, entity_fts_document, entity_merge_guard_error, note_embedding_text,

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -80,6 +80,10 @@ pub struct KhiveRuntime {
     /// `None` when this runtime is already bound to the main backend.
     core_backend: Option<Arc<StorageBackend>>,
     config: RuntimeConfig,
+    /// ADR-118 exact-leg policy, sampled once at runtime construction.
+    /// Request-time memory/knowledge serving must never re-read the process
+    /// environment because tests and embedded runtimes share one process.
+    ann_fresh_tail_enabled: bool,
     /// Pack-extensible embedder registry.
     ///
     /// Shared across clones via `Arc<RwLock<_>>` so that
@@ -154,6 +158,7 @@ impl KhiveRuntime {
     /// For the preferred boot path in multi-backend deployments, use
     /// [`from_backend`](Self::from_backend) instead.
     pub fn new(config: RuntimeConfig) -> RuntimeResult<Self> {
+        let ann_fresh_tail_enabled = crate::config::ann_fresh_tail_enabled_from_env();
         let backend = match &config.db_path {
             Some(path) => {
                 if let Some(parent) = path.parent() {
@@ -175,6 +180,7 @@ impl KhiveRuntime {
             backend: Arc::new(backend),
             core_backend: None,
             config,
+            ann_fresh_tail_enabled,
             embedder_registry: Arc::new(std::sync::RwLock::new(registry)),
             default_embedder_name,
             edge_rules: Arc::new(RwLock::new(Vec::new())),
@@ -194,6 +200,7 @@ impl KhiveRuntime {
     /// so `engine list` / `engine status` cannot mutate the registry as a side effect.
     /// Returns `None` when `db_path` is `None` and the default DB does not exist.
     pub fn new_readonly(config: RuntimeConfig) -> RuntimeResult<Self> {
+        let ann_fresh_tail_enabled = crate::config::ann_fresh_tail_enabled_from_env();
         let backend = match &config.db_path {
             Some(path) => StorageBackend::sqlite(path)?,
             None => StorageBackend::memory()?,
@@ -207,6 +214,7 @@ impl KhiveRuntime {
             backend: Arc::new(backend),
             core_backend: None,
             config,
+            ann_fresh_tail_enabled,
             embedder_registry: Arc::new(std::sync::RwLock::new(registry)),
             default_embedder_name,
             edge_rules: Arc::new(RwLock::new(Vec::new())),
@@ -230,6 +238,7 @@ impl KhiveRuntime {
     /// storage access is through the provided `backend`. Set `backend_id` and
     /// `default_namespace` via the config builder pattern if non-defaults are needed.
     pub fn from_backend(backend: Arc<StorageBackend>, config: RuntimeConfig) -> Self {
+        let ann_fresh_tail_enabled = crate::config::ann_fresh_tail_enabled_from_env();
         if let Err(err) = register_configured_embedding_models(&backend, &config) {
             tracing::warn!(error = %err, "failed to register configured embedding models");
         }
@@ -238,6 +247,7 @@ impl KhiveRuntime {
             backend,
             core_backend: None,
             config,
+            ann_fresh_tail_enabled,
             embedder_registry: Arc::new(std::sync::RwLock::new(registry)),
             default_embedder_name,
             edge_rules: Arc::new(RwLock::new(Vec::new())),
@@ -298,6 +308,7 @@ impl KhiveRuntime {
                     backend: main_arc.clone(),
                     core_backend: None,
                     config: core_config,
+                    ann_fresh_tail_enabled: self.ann_fresh_tail_enabled,
                     embedder_registry: self.embedder_registry.clone(),
                     default_embedder_name: self.default_embedder_name.clone(),
                     edge_rules: self.edge_rules.clone(),
@@ -345,6 +356,22 @@ impl KhiveRuntime {
     /// Return a reference to the runtime config.
     pub fn config(&self) -> &RuntimeConfig {
         &self.config
+    }
+
+    /// Return the immutable ADR-118 fresh-tail serving policy captured when
+    /// this runtime was constructed.
+    pub fn ann_fresh_tail_enabled(&self) -> bool {
+        self.ann_fresh_tail_enabled
+    }
+
+    /// Override ADR-118's fresh-tail serving policy for this runtime instance.
+    ///
+    /// This is primarily useful for embedded runtimes and deterministic tests:
+    /// it avoids mutating process-global environment state. Clones and `core()`
+    /// handles preserve the chosen value.
+    pub fn with_ann_fresh_tail_enabled(mut self, enabled: bool) -> Self {
+        self.ann_fresh_tail_enabled = enabled;
+        self
     }
 
     /// Return a reference to the underlying storage backend.
@@ -1199,6 +1226,21 @@ mod tests {
     fn memory_runtime_creates_successfully() {
         let rt = KhiveRuntime::memory().expect("memory runtime should create");
         assert!(rt.config().db_path.is_none());
+    }
+
+    #[test]
+    fn fresh_tail_policy_is_instance_scoped_and_clone_stable() {
+        let enabled = KhiveRuntime::memory()
+            .expect("enabled memory runtime")
+            .with_ann_fresh_tail_enabled(true);
+        let disabled = KhiveRuntime::memory()
+            .expect("disabled memory runtime")
+            .with_ann_fresh_tail_enabled(false);
+
+        assert!(enabled.ann_fresh_tail_enabled());
+        assert!(enabled.clone().ann_fresh_tail_enabled());
+        assert!(!disabled.ann_fresh_tail_enabled());
+        assert!(!disabled.clone().ann_fresh_tail_enabled());
     }
 
     #[tokio::test]

--- a/docs/adr/ADR-096-warm-daemon-per-request-identity.md
+++ b/docs/adr/ADR-096-warm-daemon-per-request-identity.md
@@ -351,7 +351,8 @@ This ADR is accepted with the following binding conditions:
 
 ADR-096 Fork 1 makes the daemon request frame the authority for request identity. Therefore
 `config_id` is an engine-coherence key only: it covers the pack set, database target, primary and
-additional embedding models, backend topology/routing, and construction-baked outbound policy.
+additional embedding models, construction-baked ADR-118 fresh-tail serving policy, backend
+topology/routing, and construction-baked outbound policy.
 
 Identity-derived fields are excluded from `config_id`: `namespace`, `actor_id`, and
 `visible_namespaces`, including the actor namespace that ADR-007 Rev 4 folds into
@@ -362,6 +363,10 @@ are consumed when dispatch mints the request token.
 construction-baked and is not carried in `RequestIdentity`. Excluding it before outbound policy is
 threaded per request would allow a client with stricter outbound policy to reuse a daemon built
 with a broader outbound allowlist.
+
+The ADR-118 fresh-tail policy is likewise part of `config_id`: it is sampled when each
+`KhiveRuntime` is constructed and is not carried per request. Runtimes with opposite policies
+must not share a warm daemon because they provide different committed-write visibility guarantees.
 
 ---
 

--- a/docs/adr/ADR-118-fresh-tail-recall-visibility.md
+++ b/docs/adr/ADR-118-fresh-tail-recall-visibility.md
@@ -7,7 +7,8 @@
 delta-log/watermark classifier), [ADR-107](ADR-107-memory-ann-lifecycle.md) (Memory ANN
 lifecycle — eventual consistency contract)
 **References**: issue #1143 (write-to-visibility regression), issue #752 (process-local
-generation counter), issue #942 (fresh-query scoring quality — related, out of scope)
+generation counter), issue #942 (fresh-query scoring quality — related, out of scope), issue
+#1802 (process-global fresh-tail toggle race)
 
 ## Context
 
@@ -212,7 +213,9 @@ contradicted by it.
 
 No new tuning knob is introduced. One escape hatch is added for operational isolation:
 `KHIVE_ANN_FRESH_TAIL=0` disables the exact leg (default enabled). Values other than `0`
-are ignored.
+are ignored. The environment is sampled once during `KhiveRuntime` construction;
+memory and knowledge serving read that immutable per-runtime policy and never re-read or
+mutate process-global environment state on a request path.
 
 ### 4. Scope: both delta-log consumers
 


### PR DESCRIPTION
AI-assisted contribution: implemented and reviewed with Codex.

## Summary

- sample `KHIVE_ANN_FRESH_TAIL` once when each `KhiveRuntime` is constructed
- carry that immutable policy through runtime clones and core handles, with an explicit
  per-runtime override for embedded callers and deterministic tests
- make both memory and knowledge fresh-tail serving read the runtime policy instead of
  process-global environment state
- include the captured policy in the daemon `config_id`, preventing enabled and disabled
  clients from sharing one warm serving runtime
- replace the memory pack's process-global environment guards with instance-scoped tests

## Verification

- independent exact-head review: READY with zero findings at `ea3f838721e5d2a0f3aed7146dd72388dd602ba4`
- [full exact-head CI](https://github.com/ohdearquant/khive/actions/runs/31293844352): PASS
- focused runtime/config/daemon-identity and memory fresh-tail regressions
- exact source census: one construction-time environment read, zero memory/knowledge test
  mutations, zero request-path reads
- `cargo test --workspace`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`

Fixes #1802
