### PR TITLE
fix(mcp): close the request envelope contract

### DIFF
--- a/crates/khive-mcp/README.md
+++ b/crates/khive-mcp/README.md
@@ -12,7 +12,8 @@ lifetime.
 ## Features
 
 - **One tool, `request`** — `RequestParams { ops, presentation, format, save_to, .. }` is
-  the entire MCP-visible surface (ADR-016); verb-specific schemas live in packs, not here
+  the entire MCP-visible surface (ADR-016); its outer envelope is closed to undeclared
+  fields, while verb-specific schemas live in packs
 - **Pluggable transports** — `Transport` trait + `TransportRegistry`; ships `StdioTransport`,
   open for more (e.g. Streamable HTTP) via `TransportRegistry::register`
 - **Daemon-aware dispatch** — `compute_config_id` fingerprints a resolved `RuntimeConfig`

--- a/crates/khive-mcp/src/tools/request.rs
+++ b/crates/khive-mcp/src/tools/request.rs
@@ -128,7 +128,7 @@ mod tests {
 
     #[test]
     fn request_tool_schema_is_closed() {
-        let schema = schemars::schema_for!(RequestParams);
+        let schema = rmcp::schemars::schema_for!(RequestParams);
         let value = serde_json::to_value(schema).expect("serialize request schema");
 
         assert_eq!(

--- a/crates/khive-mcp/src/tools/request.rs
+++ b/crates/khive-mcp/src/tools/request.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 /// Input for `request` — a DSL string (function-call or JSON form) plus
 /// optional presentation controls (`presentation` and `presentation_per_op`).
 #[derive(Debug, Default, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct RequestParams {
     /// One or more operations as a function-call DSL or JSON-form string.
     ///

--- a/crates/khive-mcp/src/tools/request.rs
+++ b/crates/khive-mcp/src/tools/request.rs
@@ -105,3 +105,35 @@ pub struct RequestParams {
     )]
     pub request_id: Option<u64>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::RequestParams;
+    use serde_json::json;
+
+    #[test]
+    fn request_params_reject_unknown_envelope_fields() {
+        let error = serde_json::from_value::<RequestParams>(json!({
+            "ops": "verbs()",
+            "presentaton": "verbose"
+        }))
+        .expect_err("misspelled request-envelope fields must be rejected");
+
+        assert!(
+            error.to_string().contains("presentaton"),
+            "the validation error must name the rejected field: {error}"
+        );
+    }
+
+    #[test]
+    fn request_tool_schema_is_closed() {
+        let schema = schemars::schema_for!(RequestParams);
+        let value = serde_json::to_value(schema).expect("serialize request schema");
+
+        assert_eq!(
+            value.get("additionalProperties"),
+            Some(&json!(false)),
+            "the MCP request schema must reject fields outside its declared properties"
+        );
+    }
+}

--- a/docs/adr/ADR-045-verb-response-presentation.md
+++ b/docs/adr/ADR-045-verb-response-presentation.md
@@ -6,7 +6,7 @@
 **Extended by**: ADR-078 (Output Format and Shape-Aware Rendering), which introduces an orthogonal
 `format` axis (`json` / `auto` / `table`) and revises Agent-mode redundancy rules. ADR-078
 §7.1 partially supersedes the P-C1 implementation behavior that kept `full_id` present in all
-modes; see the note below at the `include_full_id` override section.
+modes; see Amendment 1 below.
 **Depends on**:
 
 - ADR-016 (Request DSL — short-UUID-prefix resolution on input)
@@ -140,18 +140,12 @@ full-UUID-only parameter is never shortened. Field-level exceptions keep
 record identifier is also included as `full_id` if the caller needs
 disambiguation, but is NOT included by default.
 
-### `include_full_id` override (envelope-level)
+### Canonical-ID retention
 
-Independent of `PresentationMode`, callers may pass `include_full_id=true` at the
-envelope level (alongside `presentation`) to force full UUIDs in the response even
-under `PresentationMode::Agent` (which normally returns 8-char shortcodes). This is
-a separate axis from presentation mode and does NOT create a fourth mode.
-
-> **Note (ADR-078 §7.1)**: ADR-078 makes `full_id` suppression explicit for `format=auto` and
-> `format=table`. In those formats, `full_id` is omitted regardless of `PresentationMode`. It is
-> retained in `format=json`, in `PresentationMode::Verbose`, and when `include_full_id=true` is
-> set. This resolves the discrepancy between this ADR's stated "NOT included by default" intent
-> and the P-C1 code rule in `presentation.rs` that was keeping `full_id` unconditionally.
+ADR-078 makes `full_id` suppression explicit for `format=auto` and `format=table`.
+The canonical field is retained by the lossless `format=json` default and by
+`PresentationMode::Verbose`; callers that require it must select one of those two
+implemented paths. Agent presentation continues to shorten the ordinary `id` field.
 
 Score truncation preserves ordering (3 sig figs is enough to compare scores)
 without burning tokens on float noise.
@@ -572,6 +566,21 @@ Verbose remains the default for `kkernel exec` and library callers.
 Agents that previously parsed against full-shape MCP responses must either
 migrate to Agent-mode shapes or set `presentation=verbose` per call (or
 `KHIVE_DEFAULT_PRESENTATION=verbose` globally during the transition window).
+
+## Amendment 1 (2026-08-09): close the request envelope and withdraw the phantom override
+
+The original canonical-ID section described an envelope-level `include_full_id=true`
+override that was never implemented in `RequestParams`, daemon forwarding, or the
+renderer. That unshipped field is withdrawn rather than added as a third rendering
+axis. Canonical IDs remain available through the two implemented mechanisms above:
+the lossless `format=json` default and `presentation=verbose`.
+
+The MCP `request` envelope is now closed to undeclared fields. Its serde decoder and
+generated JSON Schema reject names outside the published `RequestParams` properties,
+so a misspelling such as `presentaton` fails at the call boundary instead of silently
+falling back to the default presentation. This closure applies only to the outer MCP
+tool envelope; verb arguments continue through the separately governed request DSL and
+pack validation seams.
 
 ## References
 

--- a/docs/adr/ADR-078-output-format-shape-aware-rendering.md
+++ b/docs/adr/ADR-078-output-format-shape-aware-rendering.md
@@ -242,8 +242,7 @@ contract is shape-stable. A deployment that wants these reductions on every call
 
 In `format=auto` and `format=table`, the `full_id` field (the 36-character canonical UUID emitted
 alongside the 8-character `id` shortcode) is omitted from the output. `full_id` is retained in
-`format=json`, in `PresentationMode::Verbose`, and when the caller passes the existing
-`include_full_id=true` envelope override (ADR-045 §"`include_full_id` override").
+`format=json` and in `PresentationMode::Verbose`.
 
 **This partially supersedes the P-C1 code rule in `crates/khive-runtime/src/presentation.rs`**, which
 treated `full_id` as a stable chaining handle kept unconditionally in all modes. That rule was
@@ -435,8 +434,6 @@ retained as an extension point for cases where the generic rules produce a poor 
 - `PresentationMode` and its Agent-mode transformation rules are unchanged. Callers that set
   `presentation=verbose` receive the canonical shape regardless of `format`, because `Verbose` mode
   bypasses the redundancy-reduction pass.
-- The existing `include_full_id=true` envelope override (ADR-045 §"`include_full_id` override")
-  continues to work and takes effect before the `full_id` suppression rule in §7.1.
 - A future `yaml` variant would need a YAML emitter. `serde_yaml` is NOT currently a workspace
   dependency (verified 2026-06-27), so adding `yaml` later means either taking on `serde_yaml` as a
   new optional dependency or writing a small in-tree minimal-YAML emitter over the pruned `Value`.
@@ -502,12 +499,24 @@ before shape detection. The pass is skipped entirely when `format=json` or
   callers that parse must stay on `json` if they do.
 - Pack handlers require no changes. The canonical `serde_json::Value` return shape is unchanged.
 
+## Amendment 1 (2026-08-09): canonical-ID escape hatches and closed envelope
+
+The original §7.1 and Neutral text inherited an `include_full_id=true` request-envelope
+override from ADR-045. No shipped `RequestParams`, daemon frame, or rendering path ever
+implemented that field. ADR-045 Amendment 1 withdraws the phantom override; the lossless
+`format=json` default and `presentation=verbose` are the two canonical-ID retention paths.
+
+The same amendment closes the generated MCP tool schema and serde decoder to unknown
+outer-envelope fields. This makes format and presentation misspellings explicit validation
+errors instead of silent requests for the server defaults. It does not change the DSL's
+per-verb validation rules or the canonical handler result shape.
+
 ## References
 
 - ADR-016 (Request DSL) — short-UUID-prefix resolution; `$prev` chain semantics; `RequestParams`
   wire shape
 - ADR-035 (CLI Config and Auto-Embed) — `khive.toml` `[runtime]` operator config; `RuntimeSectionConfig` shape
-- ADR-045 (Verb Response Presentation Modes) — `PresentationMode`; `include_full_id` override;
+- ADR-045 (Verb Response Presentation Modes) — `PresentationMode`; canonical-ID retention;
   §3.5 error envelope invariant; Chain `$prev` invariant; partially superseded on `full_id` default
   behavior by §7.1 of this ADR
 - Measurement artifact: local output-verbosity table-flavor measurement notes.


### PR DESCRIPTION
AI-assisted contribution: implemented and reviewed with Codex.

## Summary

- reject unknown fields in the outer MCP `request` envelope instead of silently
  discarding misspellings or undocumented parameters
- close the generated request-tool JSON Schema with `additionalProperties: false`
- withdraw the never-implemented `include_full_id` override from ADR-045 and ADR-078
- document the two canonical-ID retention paths that actually ship: lossless
  `format=json` and `presentation=verbose`

## Verification

- focused serde rejection and generated-schema closure regressions
- independent exact-head review: READY with zero findings at `ebaf2786d85f551a72a79ddb972a0bb2bde80855`
- exact-head full CI: PASS ([run 31295264893](https://github.com/ohdearquant/khive/actions/runs/31295264893))
- `cargo test --workspace`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`

## ADR

- ADR-045 Amendment 1
- ADR-078 Amendment 1

Fixes #1813
