### PR TITLE
fix(gate): fail loudly on unsupported policy config

### DIFF
--- a/crates/khive-runtime/docs/design.md
+++ b/crates/khive-runtime/docs/design.md
@@ -126,6 +126,9 @@
 ### Gate Authorization (ADR-029)
 
 - `RuntimeConfig::gate` defaults to `AllowAllGate`; production deployments plug in a policy-backed impl
+- Operator `[gate]` configuration is reserved and rejected until ADR-143's
+  store-held caller grants ship; an unenforced enrollment policy must not be
+  accepted silently
 
 ### Layered Retrieval Architecture (ADR-030)
 

--- a/crates/khive-runtime/src/engine_config.rs
+++ b/crates/khive-runtime/src/engine_config.rs
@@ -1270,6 +1270,30 @@ default = true
     }
 
     #[test]
+    fn home_gate_config_is_rejected_while_explicit_empty_config_is_hermetic() {
+        let project_dir = tempfile::tempdir().unwrap();
+        let home_dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(home_dir.path().join(".khive")).unwrap();
+        std::fs::write(
+            home_dir.path().join(".khive/config.toml"),
+            "[gate]\ngranted_actors = [\"lambda:enrolled\"]\n",
+        )
+        .unwrap();
+
+        let err = KhiveConfig::load_with_roots(project_dir.path(), Some(home_dir.path()), None)
+            .expect_err("an unsupported home gate policy must still fail loud");
+        assert!(matches!(err, ConfigError::UnsupportedGateSection));
+
+        let empty = project_dir.path().join("empty-khive-config.toml");
+        std::fs::write(&empty, "").unwrap();
+        let isolated = KhiveConfig::load_with_home_fallback(Some(&empty), None)
+            .expect("an explicit empty fixture must isolate config discovery")
+            .expect("the explicit config exists");
+        assert!(isolated.engines.is_empty());
+        assert!(isolated.actor.id.is_none());
+    }
+
+    #[test]
     fn test_load_with_home_fallback_explicit_path() {
         let dir = tempfile::tempdir().unwrap();
         let path = write_toml(

--- a/crates/khive-runtime/src/engine_config.rs
+++ b/crates/khive-runtime/src/engine_config.rs
@@ -75,6 +75,11 @@ pub enum ConfigError {
 
     #[error("the explicitly selected config file does not exist: {path}")]
     ExplicitConfigMissing { path: PathBuf },
+
+    #[error(
+        "[gate] configuration is not supported by this build; refusing to start because the requested caller-enrollment policy would not be enforced"
+    )]
+    UnsupportedGateSection,
 }
 
 // ---- Config structs ----
@@ -348,7 +353,10 @@ pub struct GitWriteSectionConfig {
 /// - `[[backends]]`: storage backend declarations (ADR-028)
 /// - `[packs.<name>]`: per-pack backend assignments (ADR-028)
 ///
-/// Unknown keys are silently ignored by serde — forward-compatible.
+/// Unknown keys are silently ignored by serde for forward compatibility. The
+/// security-sensitive `[gate]` exception is detected by [`KhiveConfig::load`]
+/// before deserialization so a request for caller enrollment can never be
+/// mistaken for active enforcement.
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct KhiveConfig {
     /// Typed only so a top-level `db` key can be rejected loudly by
@@ -462,7 +470,17 @@ impl KhiveConfig {
         }
 
         let raw = std::fs::read_to_string(&resolved)?;
-        let cfg: KhiveConfig = toml::from_str(&raw).map_err(|source| ConfigError::Parse {
+        let parsed: toml::Value = toml::from_str(&raw).map_err(|source| ConfigError::Parse {
+            path: resolved.clone(),
+            source,
+        })?;
+        if parsed
+            .as_table()
+            .is_some_and(|table| table.contains_key("gate"))
+        {
+            return Err(ConfigError::UnsupportedGateSection);
+        }
+        let cfg: KhiveConfig = parsed.try_into().map_err(|source| ConfigError::Parse {
             path: resolved,
             source,
         })?;
@@ -1890,6 +1908,48 @@ db = "/tmp/scratch/demo.db"
             matches!(err, ConfigError::UnsupportedTopLevelDb { ref value } if value == "/tmp/scratch/demo.db"),
             "expected UnsupportedTopLevelDb {{ value: \"/tmp/scratch/demo.db\" }}, got {err:?}"
         );
+    }
+
+    #[test]
+    fn gate_caller_enrollment_is_rejected_instead_of_ignored() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_toml(
+            &dir,
+            r#"
+[gate]
+granted_actors = ["lambda:enrolled"]
+grant_unattributed = false
+"#,
+        );
+
+        let err = KhiveConfig::load(Some(&path))
+            .expect_err("an unenforced caller-enrollment policy must abort startup");
+        assert!(
+            matches!(err, ConfigError::UnsupportedGateSection),
+            "expected UnsupportedGateSection, got {err:?}"
+        );
+        assert!(
+            err.to_string().contains("would not be enforced"),
+            "operator-facing error must explain the fail-loud reason: {err}"
+        );
+    }
+
+    #[test]
+    fn empty_gate_table_is_still_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_toml(&dir, "[gate]\n");
+        let err = KhiveConfig::load(Some(&path))
+            .expect_err("a present gate table must never disappear through serde defaults");
+        assert!(matches!(err, ConfigError::UnsupportedGateSection));
+    }
+
+    #[test]
+    fn unrelated_unknown_top_level_sections_remain_forward_compatible() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_toml(&dir, "[future_feature]\nenabled = true\n");
+        KhiveConfig::load(Some(&path))
+            .expect("unrelated future config stays forward compatible")
+            .expect("config exists");
     }
 
     // ── [git_write] section (ADR-108 Amendment) ─────────────────────────────

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -5212,6 +5212,129 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn update_denial_precedes_id_existence_resolution() {
+        #[derive(Debug)]
+        struct AlwaysDenyUpdateGate {
+            checked: Arc<AtomicUsize>,
+        }
+        impl Gate for AlwaysDenyUpdateGate {
+            fn check(&self, _req: &GateRequest) -> Result<GateDecision, GateError> {
+                self.checked.fetch_add(1, Ordering::SeqCst);
+                Ok(GateDecision::deny("caller has no update capability"))
+            }
+        }
+
+        #[derive(Debug)]
+        struct ExistenceOracleUpdatePack {
+            existing_id: String,
+            invoked: Arc<AtomicUsize>,
+        }
+
+        impl khive_types::Pack for ExistenceOracleUpdatePack {
+            const NAME: &'static str = "existence_oracle";
+            const NOTE_KINDS: &'static [&'static str] = &[];
+            const ENTITY_KINDS: &'static [&'static str] = &[];
+            const HANDLERS: &'static [HandlerDef] = &[HandlerDef {
+                name: "update",
+                description: "distinguish a present id from an absent id",
+                visibility: Visibility::Verb,
+                category: VerbCategory::Declaration,
+                params: &[],
+            }];
+        }
+
+        #[async_trait]
+        impl PackRuntime for ExistenceOracleUpdatePack {
+            fn name(&self) -> &str {
+                Self::NAME
+            }
+            fn note_kinds(&self) -> &'static [&'static str] {
+                Self::NOTE_KINDS
+            }
+            fn entity_kinds(&self) -> &'static [&'static str] {
+                Self::ENTITY_KINDS
+            }
+            fn handlers(&self) -> &'static [HandlerDef] {
+                Self::HANDLERS
+            }
+            async fn dispatch(
+                &self,
+                _verb: &str,
+                params: Value,
+                _registry: &VerbRegistry,
+                _token: &NamespaceToken,
+            ) -> Result<Value, RuntimeError> {
+                self.invoked.fetch_add(1, Ordering::SeqCst);
+                match params.get("id").and_then(Value::as_str) {
+                    Some(id) if id == self.existing_id => Ok(serde_json::json!({"updated": id})),
+                    _ => Err(RuntimeError::NotFound("record".to_string())),
+                }
+            }
+        }
+
+        let existing_id = uuid::Uuid::new_v4().to_string();
+        let absent_id = uuid::Uuid::new_v4().to_string();
+        let invoked = Arc::new(AtomicUsize::new(0));
+        let checked = Arc::new(AtomicUsize::new(0));
+
+        let pack = || ExistenceOracleUpdatePack {
+            existing_id: existing_id.clone(),
+            invoked: Arc::clone(&invoked),
+        };
+
+        let mut control_builder = VerbRegistryBuilder::new();
+        control_builder.register(pack());
+        let control = control_builder.build().expect("control registry builds");
+        control
+            .dispatch("update", serde_json::json!({"id": existing_id.clone()}))
+            .await
+            .expect("positive control resolves the present id");
+        assert!(matches!(
+            control
+                .dispatch("update", serde_json::json!({"id": absent_id.clone()}))
+                .await,
+            Err(RuntimeError::NotFound(_))
+        ));
+        assert_eq!(invoked.load(Ordering::SeqCst), 2);
+
+        let mut denied_builder = VerbRegistryBuilder::new();
+        denied_builder.register(pack());
+        denied_builder.with_gate(Arc::new(AlwaysDenyUpdateGate {
+            checked: Arc::clone(&checked),
+        }));
+        let denied = denied_builder.build().expect("denied registry builds");
+
+        let present_error = denied
+            .dispatch("update", serde_json::json!({"id": existing_id.clone()}))
+            .await
+            .expect_err("denied present-id update must not resolve the id");
+        let absent_error = denied
+            .dispatch("update", serde_json::json!({"id": absent_id.clone()}))
+            .await
+            .expect_err("denied absent-id update must not resolve the id");
+
+        let denial = |error: RuntimeError| match error {
+            RuntimeError::PermissionDenied { verb, reason } => (verb, reason),
+            other => panic!("expected gate refusal, got {other:?}"),
+        };
+        let present_denial = denial(present_error);
+        let absent_denial = denial(absent_error);
+        assert_eq!(present_denial.0, "update");
+        assert_eq!(present_denial.1, "caller has no update capability");
+        assert_eq!(present_denial, absent_denial);
+        assert_eq!(
+            checked.load(Ordering::SeqCst),
+            2,
+            "both denied requests must consult the configured gate"
+        );
+        assert_eq!(
+            invoked.load(Ordering::SeqCst),
+            2,
+            "neither denied request may reach the existence oracle"
+        );
+    }
+
+    #[tokio::test]
     async fn audit_event_persists_to_event_store_on_allow() {
         let store = Arc::new(MemoryEventStore::default());
         let mut builder = VerbRegistryBuilder::new();

--- a/crates/kkernel/src/code_ingest.rs
+++ b/crates/kkernel/src/code_ingest.rs
@@ -136,13 +136,24 @@ async fn code_ingest_batch_with_runtime_setup<F>(
 where
     F: FnOnce(&KhiveRuntime) -> Result<()>,
 {
+    code_ingest_batch_with_config_and_runtime_setup(args, None, runtime_setup).await
+}
+
+async fn code_ingest_batch_with_config_and_runtime_setup<F>(
+    args: CodeIngestArgs,
+    config: Option<&Path>,
+    runtime_setup: F,
+) -> Result<CodeIngestReport>
+where
+    F: FnOnce(&KhiveRuntime) -> Result<()>,
+{
     let bytes = std::fs::read(&args.findings)
         .with_context(|| format!("failed to read {}", args.findings.display()))?;
 
     let ns = Namespace::parse(&args.namespace).map_err(|e| anyhow::anyhow!("{e}"))?;
     let cfg = resolve_runtime_config(RuntimeConfigInputs {
         db: args.db.as_deref(),
-        config: None,
+        config,
         namespace: ns,
         namespace_explicit: true,
         actor_explicit: false,
@@ -733,6 +744,38 @@ mod tests {
         }
     }
 
+    fn write_empty_test_config(dir: &Path) -> PathBuf {
+        let path = dir.join("empty-khive-config.toml");
+        std::fs::write(&path, "").expect("write isolated empty config");
+        path
+    }
+
+    async fn code_ingest_batch(args: CodeIngestArgs) -> Result<CodeIngestReport> {
+        let config = write_empty_test_config(
+            args.findings
+                .parent()
+                .expect("findings fixture must have a parent directory"),
+        );
+        super::code_ingest_batch_with_config_and_runtime_setup(args, Some(&config), |_| Ok(()))
+            .await
+    }
+
+    async fn code_ingest_batch_with_runtime_setup<F>(
+        args: CodeIngestArgs,
+        runtime_setup: F,
+    ) -> Result<CodeIngestReport>
+    where
+        F: FnOnce(&KhiveRuntime) -> Result<()>,
+    {
+        let config = write_empty_test_config(
+            args.findings
+                .parent()
+                .expect("findings fixture must have a parent directory"),
+        );
+        super::code_ingest_batch_with_config_and_runtime_setup(args, Some(&config), runtime_setup)
+            .await
+    }
+
     fn write_valid_findings(dir: &std::path::Path) -> PathBuf {
         let path = dir.join("findings.json");
         std::fs::write(
@@ -1188,9 +1231,10 @@ mod tests {
         .await
         .expect("ingest must succeed");
 
+        let config = write_empty_test_config(tmp.path());
         let cfg = resolve_runtime_config(RuntimeConfigInputs {
             db: Some(db.to_str().expect("utf8 path")),
-            config: None,
+            config: Some(&config),
             namespace: Namespace::parse("local").expect("valid namespace"),
             namespace_explicit: true,
             actor_explicit: false,
@@ -1519,9 +1563,13 @@ mod tests {
     /// of any in-process `CodeIngestReport`, proving what was actually
     /// written to storage rather than trusting the report alone.
     async fn finding_note_count(db: &std::path::Path) -> u64 {
+        let config = write_empty_test_config(
+            db.parent()
+                .expect("scratch database must have a parent directory"),
+        );
         let cfg = resolve_runtime_config(RuntimeConfigInputs {
             db: Some(db.to_str().expect("utf8 path")),
-            config: None,
+            config: Some(&config),
             namespace: Namespace::parse("local").expect("valid namespace"),
             namespace_explicit: true,
             actor_explicit: false,

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -2057,6 +2057,33 @@ mod tests {
         let _server = isolated_server(&db_path);
     }
 
+    fn rerun_in_command_scoped_empty_home(child_marker: &str, test_name: &str) -> bool {
+        if std::env::var_os(child_marker).is_some() {
+            return false;
+        }
+
+        let calling_process_home = std::env::var_os("HOME");
+        let empty_home = tempfile::tempdir().expect("isolated child HOME");
+        let status =
+            std::process::Command::new(std::env::current_exe().expect("current test executable"))
+                .arg(test_name)
+                .arg("--exact")
+                .env("HOME", empty_home.path())
+                .env_remove("KHIVE_EMBEDDING_MODEL")
+                .env_remove("KHIVE_ADDITIONAL_EMBEDDING_MODELS")
+                .env_remove("KHIVE_ACTOR")
+                .env(child_marker, "1")
+                .status()
+                .expect("spawn isolated config-discovery test process");
+        assert_eq!(
+            std::env::var_os("HOME"),
+            calling_process_home,
+            "command-scoped HOME must not mutate the calling test process"
+        );
+        assert!(status.success(), "isolated child test failed: {status}");
+        true
+    }
+
     // ── exec-path / serve-path config_id parity (#581) ────────────────────────
     //
     // `run_exec`'s cfg construction (above) and `kkernel mcp`'s `build_server`
@@ -2074,10 +2101,12 @@ mod tests {
     #[test]
     #[serial]
     fn exec_config_id_matches_serve_config_id_for_project_toml_actor() {
-        std::env::remove_var("KHIVE_EMBEDDING_MODEL");
-        std::env::remove_var("KHIVE_ADDITIONAL_EMBEDDING_MODELS");
-        std::env::remove_var("KHIVE_ACTOR");
-        let (previous_home, _home_dir) = isolate_home_for_test();
+        const CHILD_MARKER: &str = "KKERNEL_EXEC_PROJECT_CONFIG_TEST_CHILD";
+        const TEST_NAME: &str =
+            "exec::tests::exec_config_id_matches_serve_config_id_for_project_toml_actor";
+        if rerun_in_command_scoped_empty_home(CHILD_MARKER, TEST_NAME) {
+            return;
+        }
 
         let dir = tempfile::tempdir().expect("tempdir");
         let khive_dir = dir.path().join(".khive");
@@ -2169,7 +2198,6 @@ default = true
             compute_config_id(&serve_cfg, None),
             "exec-path config_id must match the serve/daemon-path config_id for the same db"
         );
-        restore_home(previous_home);
     }
 
     /// Regression guard: an explicit `--actor` pin must rebuild the
@@ -2185,10 +2213,12 @@ default = true
     #[test]
     #[serial]
     fn actor_pin_rebuilds_visible_namespaces_dropping_displaced_fallback() {
-        std::env::remove_var("KHIVE_EMBEDDING_MODEL");
-        std::env::remove_var("KHIVE_ADDITIONAL_EMBEDDING_MODELS");
-        std::env::remove_var("KHIVE_ACTOR");
-        let (previous_home, _home_dir) = isolate_home_for_test();
+        const CHILD_MARKER: &str = "KKERNEL_ACTOR_PIN_CONFIG_TEST_CHILD";
+        const TEST_NAME: &str =
+            "exec::tests::actor_pin_rebuilds_visible_namespaces_dropping_displaced_fallback";
+        if rerun_in_command_scoped_empty_home(CHILD_MARKER, TEST_NAME) {
+            return;
+        }
 
         let dir = tempfile::tempdir().expect("tempdir");
         let khive_dir = dir.path().join(".khive");
@@ -2261,7 +2291,6 @@ id = "lambda:fallback"
              fallback actor nor adding a new one: {:?}",
             local_cfg.visible_namespaces
         );
-        restore_home(previous_home);
     }
 
     /// Settles the `namespace_explicit` design question by constructing both

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -2077,6 +2077,7 @@ mod tests {
         std::env::remove_var("KHIVE_EMBEDDING_MODEL");
         std::env::remove_var("KHIVE_ADDITIONAL_EMBEDDING_MODELS");
         std::env::remove_var("KHIVE_ACTOR");
+        let (previous_home, _home_dir) = isolate_home_for_test();
 
         let dir = tempfile::tempdir().expect("tempdir");
         let khive_dir = dir.path().join(".khive");
@@ -2168,6 +2169,7 @@ default = true
             compute_config_id(&serve_cfg, None),
             "exec-path config_id must match the serve/daemon-path config_id for the same db"
         );
+        restore_home(previous_home);
     }
 
     /// Regression guard: an explicit `--actor` pin must rebuild the
@@ -2186,6 +2188,7 @@ default = true
         std::env::remove_var("KHIVE_EMBEDDING_MODEL");
         std::env::remove_var("KHIVE_ADDITIONAL_EMBEDDING_MODELS");
         std::env::remove_var("KHIVE_ACTOR");
+        let (previous_home, _home_dir) = isolate_home_for_test();
 
         let dir = tempfile::tempdir().expect("tempdir");
         let khive_dir = dir.path().join(".khive");
@@ -2258,6 +2261,7 @@ id = "lambda:fallback"
              fallback actor nor adding a new one: {:?}",
             local_cfg.visible_namespaces
         );
+        restore_home(previous_home);
     }
 
     /// Settles the `namespace_explicit` design question by constructing both

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -1285,6 +1285,12 @@ mod tests {
     use khive_storage::types::{SqlStatement, SqlValue};
     use serial_test::serial;
 
+    fn write_empty_test_config(dir: &std::path::Path) -> PathBuf {
+        let path = dir.join("empty-khive-config.toml");
+        std::fs::write(&path, "").expect("write isolated empty config");
+        path
+    }
+
     #[test]
     fn allocation_free_embedding_eligibility_matches_canonical_text() {
         let entities = [
@@ -2415,12 +2421,14 @@ mod tests {
         // verification pass share the same on-disk state.
         let db_file = tempfile::NamedTempFile::new().expect("temp db file");
         let db_path = db_file.path().to_str().expect("utf8 path").to_string();
+        let config_dir = tempfile::tempdir().expect("config temp dir");
+        let config = write_empty_test_config(config_dir.path());
 
         // Seed notes via a runtime opened on the same file BEFORE calling run_reindex.
         {
             let cfg = resolve_runtime_config(RuntimeConfigInputs {
                 db: Some(&db_path),
-                config: None,
+                config: Some(&config),
                 namespace: Namespace::parse("local").expect("ns"),
                 namespace_explicit: true,
                 actor_explicit: false,
@@ -2449,7 +2457,7 @@ mod tests {
         // run_reindex with no embedding model and --no-knowledge.
         let args = ReindexArgs {
             db: Some(db_path.clone()),
-            config: None,
+            config: Some(config.clone()),
             model: None,
             batch_size: 100,
             keep_existing: false,
@@ -2466,7 +2474,7 @@ mod tests {
         // Verify FTS was populated by re-opening the db.
         let cfg = resolve_runtime_config(RuntimeConfigInputs {
             db: Some(&db_path),
-            config: None,
+            config: Some(&config),
             namespace: Namespace::parse("local").expect("ns"),
             namespace_explicit: true,
             actor_explicit: false,
@@ -2686,12 +2694,14 @@ mod tests {
 
         let db_file = tempfile::NamedTempFile::new().expect("temp db file");
         let db_path = db_file.path().to_str().expect("utf8 path").to_string();
+        let config_dir = tempfile::tempdir().expect("config temp dir");
+        let config = write_empty_test_config(config_dir.path());
 
         // Seed entities via EntityStore (bypassing runtime FTS write).
         {
             let cfg = resolve_runtime_config(RuntimeConfigInputs {
                 db: Some(&db_path),
-                config: None,
+                config: Some(&config),
                 namespace: Namespace::parse("local").expect("ns"),
                 namespace_explicit: true,
                 actor_explicit: false,
@@ -2719,7 +2729,7 @@ mod tests {
 
         let args = ReindexArgs {
             db: Some(db_path.clone()),
-            config: None,
+            config: Some(config.clone()),
             model: None,
             batch_size: 100,
             keep_existing: false,
@@ -2736,7 +2746,7 @@ mod tests {
         // Verify entity FTS was populated.
         let cfg = resolve_runtime_config(RuntimeConfigInputs {
             db: Some(&db_path),
-            config: None,
+            config: Some(&config),
             namespace: Namespace::parse("local").expect("ns"),
             namespace_explicit: true,
             actor_explicit: false,

--- a/crates/kkernel/tests/code_ingest_cli.rs
+++ b/crates/kkernel/tests/code_ingest_cli.rs
@@ -229,10 +229,19 @@ fn write_invalid_findings(dir: &Path) -> std::path::PathBuf {
 }
 
 fn code_ingest(args: &[&str]) -> std::process::Output {
+    // Config discovery is intentionally part of the real binary path this
+    // helper exercises, but the operator running the test is not. Isolate
+    // both cwd-anchored and HOME-anchored discovery so an unrelated local
+    // config (including a now-rejected legacy `[gate]` section) cannot abort
+    // before the code-ingest behavior under test is reached.
+    let seat = tempfile::tempdir().expect("isolated code-ingest config seat");
     Command::new(kkernel_bin())
         .arg("code-ingest")
         .args(args)
+        .current_dir(seat.path())
+        .env("HOME", seat.path())
         .env("KHIVE_NO_DAEMON", "1")
+        .env_remove("KHIVE_CONFIG")
         .output()
         .expect("run kkernel code-ingest")
 }

--- a/crates/kkernel/tests/mcp_bridge_reexec_protocol_mismatch.rs
+++ b/crates/kkernel/tests/mcp_bridge_reexec_protocol_mismatch.rs
@@ -194,9 +194,16 @@ async fn bridge_self_heals_across_in_place_reexec_without_losing_the_client_sess
         .arg(":memory:")
         .arg("--pack")
         .arg("kg")
+        // Keep both generations of the exec-preserved bridge on a hermetic
+        // config-discovery seat. An operator's cwd/HOME config (including a
+        // now-rejected legacy `[gate]` section) is unrelated to the protocol
+        // mismatch behavior and must not terminate generation one first.
+        .current_dir(dir.path())
+        .env("HOME", dir.path())
         .env("KHIVE_SOCKET", &sock)
         .env("KHIVE_PID", &pid_file)
         .env("KHIVE_LOCK", &lock_file)
+        .env_remove("KHIVE_CONFIG")
         .env_remove("KHIVE_NO_DAEMON");
 
     let (child_transport, stderr) = TokioChildProcess::builder(command)

--- a/docs/adr/ADR-018-authorization-gate.md
+++ b/docs/adr/ADR-018-authorization-gate.md
@@ -10,6 +10,14 @@ fail-closed verb class; proposed [ADR-068](ADR-068-process-isolation-topology.md
 would replace the deployment-topology clause.\
 **Authors**: khive maintainers
 
+> **Implementation status (2026-08-08):** The `Gate` trait, hard `Deny`
+> enforcement, and explicit programmatic `AllowAllGate` are implemented. The
+> accepted ADR-129 default flip and ADR-143 store-held caller-grant model are
+> not yet implemented; the current runtime default remains `AllowAllGate`.
+> Operator configuration therefore rejects every `[gate]` table instead of
+> accepting an enrollment policy that this build would not enforce. This note
+> records implementation state only and does not amend the accepted decisions.
+
 ## Context
 
 khive's verb dispatch path is the chokepoint where every operation reaches storage.

--- a/docs/adr/ADR-129-fail-closed-gate-default.md
+++ b/docs/adr/ADR-129-fail-closed-gate-default.md
@@ -10,7 +10,8 @@
   Apache-2.0) plus `khive-capability`
 - Amended by: [ADR-143](ADR-143-store-held-caller-grants.md), which supersedes
   Amendment 2's configuration-text roster and "no runtime registration API"
-  invariant with store-held caller grants and hierarchical subactor identity
+  invariant with store-held caller grants and hierarchical subactor identity,
+  delivering per-caller differentiation in per-view form
 
 > **Implementation status (2026-08-08):** This accepted staged design is not
 > fully shipped. The current runtime default remains `AllowAllGate`, and the

--- a/docs/adr/ADR-129-fail-closed-gate-default.md
+++ b/docs/adr/ADR-129-fail-closed-gate-default.md
@@ -8,10 +8,17 @@
 - Depends on: ADR-127 (authenticated actor and grant primitive), the capability
   substrate this design builds on — the published `lion-core` crate (crates.io,
   Apache-2.0) plus `khive-capability`
-- Amended by: a forthcoming amendment on hierarchical subactor identity, which
-  supersedes Amendment 2's "no runtime registration API" invariant with an
-  audited grant surface and delivers its per-caller differentiation in
-  per-view form
+- Amended by: [ADR-143](ADR-143-store-held-caller-grants.md), which supersedes
+  Amendment 2's configuration-text roster and "no runtime registration API"
+  invariant with store-held caller grants and hierarchical subactor identity
+
+> **Implementation status (2026-08-08):** This accepted staged design is not
+> fully shipped. The current runtime default remains `AllowAllGate`, and the
+> ADR-143 store-held caller-grant model has not been implemented. Because
+> silently accepting Amendment 2's now-superseded `[gate]` roster would claim
+> enforcement that does not exist, this build rejects every `[gate]` table at
+> configuration load. This note records implementation state only; it does not
+> change the accepted fail-closed decision or ADR-143's superseding design.
 
 ## Context
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,6 +40,20 @@ env pair (or built-in defaults), and storage falls back to the single-file
 A malformed file at whichever tier is found is always an error. A parse
 failure is never silently skipped in favor of a lower tier.
 
+### Authorization configuration is reserved
+
+The current runtime does not expose an operator `[gate]` configuration
+surface. Any present `[gate]` table, including an empty one, is rejected during
+startup. This is deliberate: accepting caller-enrollment keys that the runtime
+does not enforce would give operators a false authorization boundary.
+
+The accepted authorization direction remains ADR-129's fail-closed gate and
+ADR-143's store-held caller grants. ADR-143 supersedes a steady-state
+configuration roster; its one-time legacy import is not implemented in this
+build. Until that store-held model ships, do not add `[gate]` to `khive.toml`.
+Embedders can still install a `Gate` implementation programmatically through
+`RuntimeConfig::gate`.
+
 (Source: `KhiveConfig::load_with_home_fallback` and the inner
 `load_with_roots`, `crates/khive-runtime/src/engine_config.rs`, the `load`
 family starting around line 298.)

--- a/docs/khive-config-example.toml
+++ b/docs/khive-config-example.toml
@@ -13,12 +13,15 @@
 #   3. ./.khive/config.toml                           (project-local hidden dir)
 #   4. ~/.khive/config.toml                           (user-global)
 #
-# Unknown keys are ignored (forward-compatible): a config written for a newer khive
-# still loads on an older build, and vice versa.
+# Unknown keys are ignored (forward-compatible), except for the security-sensitive
+# [gate] table: this build rejects any present [gate] table because it does not yet
+# implement ADR-143's store-held caller-grant model. It must never silently accept
+# an enrollment policy it will not enforce.
 #
 # Sections in this file:
 #   [actor]         default identity + namespace read/write scope
 #   [runtime]       brain profile + default output format
+#   [gate]          reserved; rejected by this build (do not configure)
 #   [[engines]]     embedding engines (replaces the KHIVE_EMBEDDING_MODEL env pair)
 #   [[backends]]    named storage backends (ADR-028)
 #   [packs.<name>]  per-pack backend assignment (ADR-028)
@@ -78,6 +81,12 @@
 # Precedence (high→low): per-request `format` → KHIVE_OUTPUT_FORMAT → this → "json".
 # Keep "json" if anything parses khive's output.
 # default_output_format = "json"
+
+# ── [gate] — reserved authorization surface ───────────────────────────────────────
+#
+# Do not add a live [gate] table. The accepted design uses store-held caller grants
+# (ADR-143), which are not implemented by this build. Startup rejects even an empty
+# [gate] table so caller-enrollment policy cannot be mistaken for active enforcement.
 
 # ── Embedding engines ──────────────────────────────────────────────────────────
 #


### PR DESCRIPTION
## Summary

- reject every top-level `[gate]` configuration section, including an empty table, instead of silently ignoring requested authorization policy
- pin gate-before-handler ordering with present/absent `update` targets so a denied caller cannot obtain an existence oracle
- align the authorization ADRs, configuration guide, example config, and runtime design notes with the current interim posture

## Scope

Issue #1642 explicitly permits loud rejection as the alternative to porting the retired interim roster. All configuration discovery tiers use the same loader and now return `UnsupportedGateSection` before typed config deserialization or server startup.

For #1738, the mutation-sensitive regression proves both present and absent identifiers consult the gate, return the same named `PermissionDenied`, and invoke no existence-resolving handler. A permissive control proves the test would fail if the handler were never reached.

This does not implement or claim #1376's superseded steady-state config roster. It also does not claim #1426's contract-test authorization provisioning or the broader unshipped store-grant/fail-closed runtime. Those gaps remain documented.

## Verification

- independent exact-head review: READY with zero findings at `e5c41ebc2342087b9353904ffb6df93e498fa1a3`
- exact-head full CI: PASS ([run 31295297687](https://github.com/ohdearquant/khive/actions/runs/31295297687))
- `cargo test --workspace`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`

Fixes #1642
Fixes #1738

AI-assisted contribution: implemented and reviewed with Codex.
