### PR TITLE
fix(mcp): fail closed on unreachable daemon sockets

### DIFF
--- a/crates/khive-mcp/docs/api/daemon-lifecycle.md
+++ b/crates/khive-mcp/docs/api/daemon-lifecycle.md
@@ -156,13 +156,21 @@ regardless of which task drives it.
 ## `forward_or_spawn` — the `None` contract (#644)
 
 Returns `None` only when nothing was ever written to the daemon and local
-dispatch is therefore safe: `KHIVE_NO_DAEMON` is set, or no daemon socket
-could be reached (`NoSocket`). It never returns `None` after the real frame
-has been written — `Some(Ok)`/`Some(Err)` both mean the request's fate is
-already decided at the daemon and the caller must not dispatch locally.
+dispatch is therefore safe: `KHIVE_NO_DAEMON` is set, or the socket is
+definitively absent/refused (`NoSocket`). A connect error that does not prove
+absence (`Unreachable`) returns `Some(Err)` immediately because the client
+cannot know whether a healthy daemon is serving other processes. It never
+returns `None` after the real frame has been written — `Some(Ok)`/`Some(Err)`
+both mean the caller must not dispatch locally.
 Under `KHIVE_DAEMON_STRICT=1`, the `NoSocket` case becomes `Some(Err(..))`
 instead (see `fallback_or_reject`) — `KHIVE_NO_DAEMON` itself is unaffected,
 since it is the caller's explicit, unconditional opt-out (nothing is ever
 recorded or counted for it). Once the real frame IS fully written
 (`ParseFailure`/`ProtocolMismatch`), this returns a hard error immediately
 instead of killing/respawning/retrying or falling back locally.
+
+Connection classification is intentionally narrow (#1242): `ENOENT` and
+`ECONNREFUSED` are `NoSocket`, preserving first-spawn and stale-socket
+self-heal. `EACCES`, `EPERM`, and every other indeterminate connect failure
+are `Unreachable`; they return the structured `daemon_unreachable` error and
+perform zero lifecycle actions in both strict and non-strict mode.

--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -30,8 +30,8 @@ mod test_harness;
 
 #[cfg(test)]
 use test_harness::{
-    reset_counters, DAEMON_DISPATCH, FORCE_PID_IS_DAEMON, FORCE_PID_IS_FOREIGN, KILL_COUNT,
-    RECOVERY_RACE_BARRIER, SPAWN_COUNT,
+    reset_counters, DAEMON_DISPATCH, FORCED_CONNECT_ERROR, FORCE_PID_IS_DAEMON,
+    FORCE_PID_IS_FOREIGN, KILL_COUNT, RECOVERY_RACE_BARRIER, SPAWN_COUNT,
 };
 
 // ── local-dispatch fallback telemetry ─────────────────────────────────────────
@@ -105,8 +105,9 @@ impl FallbackReason {
             FallbackReason::ProtocolMismatch | FallbackReason::ParseFailure => {
                 FallbackSeverity::RolloutTransient
             }
-            // No daemon reachable at all — the ADR-049-mandated fallback
-            // path (CI, `KHIVE_NO_DAEMON=1`, read-only FS, spawn failure).
+            // The socket is definitively absent/refused — the ADR-049-mandated
+            // fallback path. Access-denied/indeterminate connect failures are
+            // terminal and never enter this metrics tier (#1242).
             FallbackReason::NoSocket => FallbackSeverity::NoDaemon,
         }
     }
@@ -451,8 +452,16 @@ impl daemon::DaemonDispatch for crate::server::KhiveMcpServer {
 enum ForwardOutcome {
     /// Successfully received and decoded a response frame.
     Response(Box<DaemonResponseFrame>),
-    /// Socket was unreachable (connection refused / no file).
+    /// The socket is absent/refused, or the frame failed before it could reach
+    /// dispatch. These outcomes are safe to route through recovery.
     NoSocket,
+    /// This process could not establish whether a daemon is listening. An OS
+    /// access/policy failure is not proof that the daemon is absent, so it must
+    /// never enter lifecycle recovery or local fallback (#1242).
+    Unreachable {
+        kind: std::io::ErrorKind,
+        os_error_code: Option<i32>,
+    },
     /// Connected but the response could not be decoded — most likely a stale
     /// daemon speaking a different wire format.
     ParseFailure,
@@ -466,11 +475,32 @@ enum ForwardOutcome {
     ProtocolMismatch,
 }
 
+fn classify_socket_connect_error(error: std::io::Error) -> ForwardOutcome {
+    if matches!(
+        error.kind(),
+        std::io::ErrorKind::NotFound | std::io::ErrorKind::ConnectionRefused
+    ) {
+        ForwardOutcome::NoSocket
+    } else {
+        ForwardOutcome::Unreachable {
+            kind: error.kind(),
+            os_error_code: error.raw_os_error(),
+        }
+    }
+}
+
 async fn try_forward_inner(frame: &DaemonRequestFrame) -> ForwardOutcome {
     let sock = socket_path();
+    #[cfg(test)]
+    {
+        let forced_error = FORCED_CONNECT_ERROR.load(std::sync::atomic::Ordering::SeqCst);
+        if forced_error != 0 {
+            return classify_socket_connect_error(std::io::Error::from_raw_os_error(forced_error));
+        }
+    }
     let mut stream = match UnixStream::connect(&sock).await {
         Ok(s) => s,
-        Err(_) => return ForwardOutcome::NoSocket,
+        Err(error) => return classify_socket_connect_error(error),
     };
     let payload = match serde_json::to_vec(frame) {
         Ok(p) => p,
@@ -1106,6 +1136,18 @@ async fn probe_daemon_identity(config_id: &str, namespace: &str, timeout_ms: u64
             | ForwardOutcome::ParseFailure
             | ForwardOutcome::ProtocolMismatch,
         ) => ProbeOutcome::Dead,
+        Ok(ForwardOutcome::Unreachable {
+            kind,
+            os_error_code,
+        }) => {
+            tracing::debug!(
+                ?kind,
+                ?os_error_code,
+                "under-lock probe could not reach the daemon socket; treating its state as \
+                 uncertain and suppressing lifecycle recovery"
+            );
+            ProbeOutcome::Timeout
+        }
     }
 }
 
@@ -1433,6 +1475,31 @@ fn ambiguous_forward_error() -> McpError {
         "daemon response lost after request was sent; not retrying or locally \
          dispatching to avoid duplicate execution",
         None,
+    )
+}
+
+fn daemon_unreachable_error(
+    frame: &DaemonRequestFrame,
+    kind: std::io::ErrorKind,
+    os_error_code: Option<i32>,
+) -> McpError {
+    let config_id = opaque_config_id(&frame.config_id);
+    tracing::error!(
+        reason = "daemon_unreachable",
+        config_id = %config_id,
+        namespace = %frame.namespace,
+        ?kind,
+        ?os_error_code,
+        "daemon socket is unreachable from this process; lifecycle recovery suppressed"
+    );
+    McpError::internal_error(
+        "cannot reach daemon socket from this process; refusing daemon lifecycle recovery \
+         because the daemon may still be healthy",
+        Some(serde_json::json!({
+            "reason": "daemon_unreachable",
+            "os_error_kind": format!("{kind:?}"),
+            "os_error_code": os_error_code,
+        })),
     )
 }
 
@@ -1952,13 +2019,13 @@ async fn wait_for_boot_quiescence_then_reprobe(frame: &DaemonRequestFrame) -> Bo
 /// Forward a request to the daemon, auto-spawning it if absent.
 ///
 /// Returns `None` only when nothing was ever written to the daemon and local
-/// dispatch is therefore safe: `KHIVE_NO_DAEMON` is set, or no daemon socket
-/// could be reached (`NoSocket`) — never after the real frame has been
-/// written. `Some(Ok)` / `Some(Err)` both mean the request's fate is already
-/// decided at the daemon and the caller must not dispatch locally. Under
-/// `KHIVE_DAEMON_STRICT=1` the `NoSocket` case instead becomes
-/// `Some(Err(..))` (`KHIVE_NO_DAEMON` is unaffected — it is an explicit
-/// caller opt-out, not a fallback).
+/// dispatch is therefore safe: `KHIVE_NO_DAEMON` is set, or the socket is
+/// definitively absent/refused (`NoSocket`) — never when connection access is
+/// denied (`Unreachable`) and never after the real frame has been written.
+/// `Some(Ok)` / `Some(Err)` both mean the caller must not dispatch locally.
+/// Under `KHIVE_DAEMON_STRICT=1` the `NoSocket` case instead becomes
+/// `Some(Err(..))` (`KHIVE_NO_DAEMON` is unaffected — it is an explicit caller
+/// opt-out, not a fallback).
 ///
 /// The real (possibly mutating) request frame is written to the daemon
 /// socket at most once per call; a `NoSocket` outcome never writes anything,
@@ -2020,6 +2087,10 @@ where
             // Nothing was written; fall through to the spawn/recover-then-send
             // path below.
         }
+        ForwardOutcome::Unreachable {
+            kind,
+            os_error_code,
+        } => return Some(Err(daemon_unreachable_error(frame, kind, os_error_code))),
         ForwardOutcome::ParseFailure => {
             let config_id = opaque_config_id(&frame.config_id);
             tracing::warn!(
@@ -2177,6 +2248,10 @@ where
                     None,
                 )));
             }
+            ForwardOutcome::Unreachable {
+                kind,
+                os_error_code,
+            } => return Some(Err(daemon_unreachable_error(frame, kind, os_error_code))),
             ForwardOutcome::NoSocket => {
                 tokio::time::sleep(std::time::Duration::from_millis(100)).await;
             }
@@ -2939,6 +3014,105 @@ mod tests {
             from_wire: false,
             request_id: None,
         }
+    }
+
+    #[test]
+    fn socket_connect_error_classification_distinguishes_absence_from_denial() {
+        for error_code in [libc::ENOENT, libc::ECONNREFUSED] {
+            assert!(matches!(
+                classify_socket_connect_error(std::io::Error::from_raw_os_error(error_code)),
+                ForwardOutcome::NoSocket
+            ));
+        }
+
+        for error_code in [libc::EACCES, libc::EPERM] {
+            match classify_socket_connect_error(std::io::Error::from_raw_os_error(error_code)) {
+                ForwardOutcome::Unreachable {
+                    kind,
+                    os_error_code,
+                } => {
+                    assert_eq!(kind, std::io::ErrorKind::PermissionDenied);
+                    assert_eq!(os_error_code, Some(error_code));
+                }
+                _ => panic!("EACCES/EPERM must be unreachable, never safe-to-recover NoSocket"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn permission_denied_socket_fails_without_lifecycle_or_local_fallback() {
+        clear_daemon_env();
+        reset_counters();
+        reset_fallback_counters();
+        let _cleanup = RecoveryTestGuard::new();
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("KHIVE_SOCKET", dir.path().join("khived.sock"));
+        std::env::set_var("KHIVE_PID", dir.path().join("khived.pid"));
+        std::env::set_var("KHIVE_LOCK", dir.path().join("khived.recovery.lock"));
+        std::env::set_var(
+            "KHIVE_RECOVERER_LOCK",
+            dir.path().join("khived.recoverer.lock"),
+        );
+        FORCED_CONNECT_ERROR.store(libc::EPERM, std::sync::atomic::Ordering::SeqCst);
+
+        let config_id = crate::server::compute_config_id(&memory_runtime_config(), None);
+        let result = forward_or_spawn(&unreachable_daemon_frame(&config_id)).await;
+
+        assert_eq!(
+            KILL_COUNT.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "an unreachable socket must never trigger a kill"
+        );
+        assert_eq!(
+            SPAWN_COUNT.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "an unreachable socket must never trigger a spawn"
+        );
+        assert_eq!(
+            fallback_total(),
+            0,
+            "an unreachable socket must return an error, not local fallback"
+        );
+        match result {
+            Some(Err(error)) => {
+                assert!(
+                    error.message.contains("cannot reach daemon socket"),
+                    "the caller-visible error must name the unreachable socket: {}",
+                    error.message
+                );
+                let data = error.data.as_ref().expect("unreachable error data");
+                assert_eq!(data["reason"], "daemon_unreachable");
+                assert_eq!(data["os_error_kind"], "PermissionDenied");
+                assert_eq!(data["os_error_code"], libc::EPERM);
+            }
+            other => panic!(
+                "unreachable must be Some(Err), never None/local fallback or success: {other:?}"
+            ),
+        }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn stale_socket_connection_refused_remains_safe_to_recover() {
+        clear_daemon_env();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sock = dir.path().join("khived.sock");
+        std::env::set_var("KHIVE_SOCKET", &sock);
+
+        {
+            let listener = tokio::net::UnixListener::bind(&sock).expect("bind stale socket");
+            drop(listener);
+        }
+        assert!(sock.exists(), "dropped listener must leave a stale socket");
+
+        let config_id = crate::server::compute_config_id(&memory_runtime_config(), None);
+        assert!(matches!(
+            try_forward_inner(&unreachable_daemon_frame(&config_id)).await,
+            ForwardOutcome::NoSocket
+        ));
+
+        clear_daemon_env();
     }
 
     struct RespawnDisclosureFixture {

--- a/crates/khive-mcp/src/daemon/test_harness.rs
+++ b/crates/khive-mcp/src/daemon/test_harness.rs
@@ -5,7 +5,7 @@
 //! exchange helpers, and in-process launcher together gives recovery tests one
 //! fail-closed teardown path instead of open-coded variants in `daemon.rs`.
 
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -19,6 +19,7 @@ pub(super) static KILL_COUNT: AtomicUsize = AtomicUsize::new(0);
 pub(super) static SPAWN_COUNT: AtomicUsize = AtomicUsize::new(0);
 pub(super) static FORCE_PID_IS_DAEMON: AtomicBool = AtomicBool::new(false);
 pub(super) static FORCE_PID_IS_FOREIGN: AtomicBool = AtomicBool::new(false);
+pub(super) static FORCED_CONNECT_ERROR: AtomicI32 = AtomicI32::new(0);
 pub(super) static DAEMON_DISPATCH: AtomicUsize = AtomicUsize::new(0);
 
 /// Rendezvous after every recoverer independently observes an absent daemon.
@@ -30,6 +31,7 @@ pub(super) fn reset_counters() {
     SPAWN_COUNT.store(0, Ordering::SeqCst);
     FORCE_PID_IS_DAEMON.store(false, Ordering::SeqCst);
     FORCE_PID_IS_FOREIGN.store(false, Ordering::SeqCst);
+    FORCED_CONNECT_ERROR.store(0, Ordering::SeqCst);
     DAEMON_DISPATCH.store(0, Ordering::SeqCst);
     *RECOVERY_RACE_BARRIER
         .lock()

--- a/docs/adr/ADR-049-khived-daemon.md
+++ b/docs/adr/ADR-049-khived-daemon.md
@@ -277,3 +277,22 @@ lose their response only after the real frame is read and requires eight termina
 zero lifecycle actions, and no follow-up connections. Both scenarios repeat 25 times on every CI
 operating system. Shared recovery counters, framing fixtures, environment cleanup, and the
 in-process launcher live in `crates/khive-mcp/src/daemon/test_harness.rs`.
+
+## Amendment 4 (2026-08-09): an inaccessible socket is not an absent daemon
+
+This amendment narrows Amendment 2's phrase "genuinely absent or unreachable" and Amendment 3's
+generic reference to connection-establishment failure. Only an error that positively establishes
+there is no live listener is a recoverable `NoSocket` outcome:
+
+- `ENOENT` / `NotFound` means no socket path exists.
+- `ECONNREFUSED` / `ConnectionRefused` means a stale socket path exists with no listener.
+
+Both remain eligible for the ordinary `NoSocket` recovery path, including stale-socket self-heal.
+Any other connect error, including sandbox or filesystem-policy denial reported as `EACCES` or
+`EPERM` (`PermissionDenied`), is `Unreachable`. It proves only that this client cannot inspect the
+daemon rendezvous; it does not prove the daemon is dead. `Unreachable` therefore returns a
+structured `daemon_unreachable` hard error and performs no local dispatch, retry, kill, or spawn,
+regardless of `KHIVE_DAEMON_STRICT`.
+
+`KHIVE_NO_DAEMON=1` remains the explicit operator opt-out for intentionally daemonless execution.
+This amendment changes neither that opt-out nor the exactly-once boundary after a frame write.


### PR DESCRIPTION
## Summary

- distinguish a genuinely absent/refused daemon socket from an inaccessible or otherwise indeterminate socket
- keep `ENOENT` and `ECONNREFUSED` on the existing stale-socket self-heal path
- fail closed with structured `daemon_unreachable` diagnostics for `EACCES`, `EPERM`, and every other connect error
- prove an unreachable socket cannot trigger kill, spawn, retry recovery, or local-dispatch fallback

## Contract

The old forward path treated every Unix-socket connect failure as “no daemon.” That was safe for a missing path or a stale listener, but unsafe for permission and other reachability failures: recovery could manipulate a daemon the caller could not inspect, then silently execute against another runtime.

The new classification is deliberately narrow. Only OS `NotFound`/`ENOENT` and `ConnectionRefused`/`ECONNREFUSED` are recoverable `NoSocket`. Every other failure retains its error kind/code as `Unreachable`; the initial and post-recovery forward paths return the structured error immediately, while recovery probes classify it as uncertain and never kill.

`KHIVE_NO_DAEMON` remains the explicit caller-controlled local-dispatch opt-out. A real stale Unix socket remains recoverable.

## Verification

- independent exact-head review: READY with zero findings at `40aeac1304f115045a48f0f1ba0880312d7db331`
- exact-head full CI: PASS ([run 31296770316](https://github.com/ohdearquant/khive/actions/runs/31296770316))
- errno classification table for `ENOENT`, `ECONNREFUSED`, `EACCES`, and `EPERM`
- public forward-path regression with zero kill/spawn/local fallback
- stale dropped-listener recovery regression
- Rust and Deno formatting, ADR-reference, stub-marker, JSON-data, SQL, and diff checks

## ADR

- ADR-049 Amendment 4
- daemon lifecycle API documentation

Fixes #1242

AI-assisted contribution: implemented and reviewed with Codex.
