### PR TITLE
fix(knowledge): make filesystem imports preflight-atomic

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2228,6 +2228,7 @@ dependencies = [
  "khive-types",
  "khive-vamana",
  "lattice-embed",
+ "libc",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/khive-pack-knowledge/Cargo.toml
+++ b/crates/khive-pack-knowledge/Cargo.toml
@@ -33,6 +33,7 @@ tracing = { workspace = true }
 chrono = { workspace = true }
 sha2 = { workspace = true }
 toml = { workspace = true }
+libc = { workspace = true }
 
 [dev-dependencies]
 khive-pack-kg = { version = "0.7.0", path = "../khive-pack-kg" }

--- a/crates/khive-pack-knowledge/Cargo.toml
+++ b/crates/khive-pack-knowledge/Cargo.toml
@@ -60,6 +60,10 @@ name = "fixes"
 path = "tests/fixes.rs"
 
 [[test]]
+name = "import_integrity"
+path = "tests/import_integrity.rs"
+
+[[test]]
 name = "feedback"
 path = "tests/feedback.rs"
 

--- a/crates/khive-pack-knowledge/README.md
+++ b/crates/khive-pack-knowledge/README.md
@@ -65,18 +65,18 @@ let report = reindex_knowledge(&runtime, &token, opts, None, None).await?;
 
 ## Verbs
 
-| Verb                                                                              | What it does                                               |
-| --------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| `knowledge.upsert_atoms` / `knowledge.upsert_domains`                             | Bulk insert or update atoms / domains                      |
-| `knowledge.get` / `knowledge.list` / `knowledge.delete_atoms` / `knowledge.stats` | Corpus CRUD and aggregate counts                           |
-| `knowledge.index`                                                                 | Backfill embeddings + FTS for atoms/domains                |
-| `knowledge.search` / `knowledge.suggest` / `knowledge.compose`                    | TF-IDF search, domain suggestion, briefing assembly        |
-| `knowledge.fold`                                                                  | Knapsack selection of scored candidates against a budget   |
-| `knowledge.edit`                                                                  | Upsert one atom's sections without wiping the rest         |
-| `knowledge.import`                                                                | Ingest atlas-format markdown as atoms with parsed sections |
-| `knowledge.challenge` / `knowledge.adjudicate`                                    | Dispute and resolve a section's content                    |
-| `knowledge.learn` / `knowledge.cite` / `knowledge.topic`                          | Register/link/browse `concept` entities                    |
-| `knowledge.feedback`                                                              | Apply per-section signals to posterior weights             |
+| Verb                                                                              | What it does                                             |
+| --------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| `knowledge.upsert_atoms` / `knowledge.upsert_domains`                             | Bulk insert or update atoms / domains                    |
+| `knowledge.get` / `knowledge.list` / `knowledge.delete_atoms` / `knowledge.stats` | Corpus CRUD and aggregate counts                         |
+| `knowledge.index`                                                                 | Backfill embeddings + FTS for atoms/domains              |
+| `knowledge.search` / `knowledge.suggest` / `knowledge.compose`                    | TF-IDF search, domain suggestion, briefing assembly      |
+| `knowledge.fold`                                                                  | Knapsack selection of scored candidates against a budget |
+| `knowledge.edit`                                                                  | Upsert one atom's sections without wiping the rest       |
+| `knowledge.import`                                                                | Validate/import atlas markdown with stable path identity |
+| `knowledge.challenge` / `knowledge.adjudicate`                                    | Dispute and resolve a section's content                  |
+| `knowledge.learn` / `knowledge.cite` / `knowledge.topic`                          | Register/link/browse `concept` entities                  |
+| `knowledge.feedback`                                                              | Apply per-section signals to posterior weights           |
 
 All 19 verbs are `Visibility::Verb` (exposed on the agent-facing MCP surface).
 

--- a/crates/khive-pack-knowledge/docs/api/scoring-and-retrieval.md
+++ b/crates/khive-pack-knowledge/docs/api/scoring-and-retrieval.md
@@ -115,10 +115,23 @@ the first `##` heading as the atom body, and maps each `##` heading to a `Sectio
 any canonical type are classified as `Other`.
 
 An optional `atlas_id:` front-matter line in the first 32 lines is extracted and stored in
-`properties.atlas_id` and as `source_uri = atlas:<id>`.
+`properties.atlas_id` and as `source_uri = atlas:<id>`. Every import also stores the original
+root-relative markdown path in `properties.source_path`; without an Atlas ID, `source_uri` is
+`file:<source_path>`.
 
 The chunk strategy `"section"` (default) creates one atom + N sections per file.
-The `"atom"` strategy creates one atom with the full content as `content` and no sections.
+The `"atom"` strategy creates one atom with the byte-exact UTF-8 file content as `content` and no
+sections.
+
+Directory slugs are stable root-relative identities: normalized path components join with `--`
+(`guides/rope.md` becomes `guides--rope`). A direct file keeps its normalized stem. Any
+normalization collision fails before writes and names both paths. Discovery is deterministic,
+does not follow symlinks, and fails closed at 32 directory levels, 100,000 entries, or 10,000
+markdown files. A root directory symlink is rejected even with a trailing separator. Limit errors
+name the exact failing path and report the current/configured depth, entry, and markdown-file
+counts. The response retains `imported_atoms`, `imported_sections`, and `files_processed`, and
+adds `entries_visited`, `files_discovered`, `files_skipped`, `traversal_errors`,
+`sections_discovered`, and `sections_skipped`.
 
 ## Numeric Validation
 

--- a/crates/khive-pack-knowledge/docs/design.md
+++ b/crates/khive-pack-knowledge/docs/design.md
@@ -86,23 +86,24 @@
 
 ## Module Boundaries
 
-| Module                  | Responsibility                                                              |
-| ----------------------- | --------------------------------------------------------------------------- |
-| `lib.rs`                | Public exports and the operator-facing `reindex_knowledge` library entry    |
-| `pack.rs`               | Pack registration, `Pack` trait impl, `PackRuntime::dispatch` shim          |
+| Module                  | Responsibility                                                                           |
+| ----------------------- | ---------------------------------------------------------------------------------------- |
+| `lib.rs`                | Public exports and the operator-facing `reindex_knowledge` library entry                 |
+| `pack.rs`               | Pack registration, `Pack` trait impl, `PackRuntime::dispatch` shim                       |
 | `vocab.rs`              | Pack schema statements and the handler descriptor table (19 public verbs + 1 subhandler) |
-| `handlers.rs`           | `learn`, `cite`, `topic` verbs (KG concept tier sugar)                      |
-| `knowledge/mod.rs`      | Knowledge handler module boundaries and shared exports                      |
-| `knowledge/eval.rs`     | Offline query-set validation, atom retrieval scoring, and run persistence   |
-| `knowledge/schema.rs`   | Param and record types for serde deserialization and SQL row mapping        |
-| `knowledge/vamana.rs`   | Shared Vamana ANN index lifecycle (warm-start, build, search, RRF fusion)   |
-| `knowledge/matching.rs` | TF-IDF term matching primitives (tokenize, exact match, count)              |
+| `handlers.rs`           | `learn`, `cite`, `topic` verbs (KG concept tier sugar)                                   |
+| `knowledge/mod.rs`      | Knowledge handler module boundaries and shared exports                                   |
+| `knowledge/eval.rs`     | Offline query-set validation, atom retrieval scoring, and run persistence                |
+| `knowledge/schema.rs`   | Param and record types for serde deserialization and SQL row mapping                     |
+| `knowledge/vamana.rs`   | Shared Vamana ANN index lifecycle (warm-start, build, search, RRF fusion)                |
+| `knowledge/matching.rs` | TF-IDF term matching primitives (tokenize, exact match, count)                           |
 
 ## Namespace Isolation
 
 All corpus SQL queries include `AND namespace = ?` predicates scoped to the caller token's
-namespace. The `knowledge.import` verb delegates to `upsert_atoms` and `edit`, which each
-enforce the caller namespace — no cross-namespace write is possible. `knowledge.compose`
+namespace. The `knowledge.import` verb delegates to the import-preserving atom upsert path and
+`edit`, which each enforce the caller namespace — no cross-namespace write is possible.
+`knowledge.compose`
 accepts an explicit `namespace` as ADR-007's exact single-namespace escape. The same derived
 token scopes automatic suggestion, corpus/section reads, KG blending, and the cross-pack
 brain-profile weight read; Tier-3 pack-local feedback state is keyed by that namespace too.
@@ -117,6 +118,8 @@ run summaries; `knowledge.stats` reads only summaries from that namespace.
 
 - `tests/integration.rs` — full verb surface, happy path + edge cases
 - `tests/fixes.rs` — targeted regression coverage for audit-identified invariants
+- `tests/import_integrity.rs` — bounded traversal, stable path identity, validate-first writes,
+  whole-file atom mode, and additive import reporting
 - `tests/eval_retrieval.rs` — schema routing/idempotence, validation, draft-corpus scoring,
   persistence, and namespace isolation
 - `tests/bench.rs` — warm-latency smoke test (ignored by default; see `docs/benchmarks.md`)

--- a/crates/khive-pack-knowledge/src/knowledge/crud.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/crud.rs
@@ -23,6 +23,25 @@ impl KnowledgeHandlers {
         token: &NamespaceToken,
         params: Value,
     ) -> Result<Value, RuntimeError> {
+        Self::upsert_atoms_with_content_policy(runtime, token, params, false).await
+    }
+
+    /// Import has already validated the complete source document and must retain its
+    /// boundary whitespace. The public upsert verb keeps its established trim behavior.
+    pub(super) async fn upsert_import_atoms(
+        runtime: &KhiveRuntime,
+        token: &NamespaceToken,
+        params: Value,
+    ) -> Result<Value, RuntimeError> {
+        Self::upsert_atoms_with_content_policy(runtime, token, params, true).await
+    }
+
+    async fn upsert_atoms_with_content_policy(
+        runtime: &KhiveRuntime,
+        token: &NamespaceToken,
+        params: Value,
+        preserve_content_whitespace: bool,
+    ) -> Result<Value, RuntimeError> {
         let p: UpsertAtomsParams = deser(params)?;
         if p.chunk_size.is_some() {
             tracing::warn!(
@@ -56,7 +75,12 @@ impl KnowledgeHandlers {
                 ));
             }
 
-            let content = atom_in.content.as_deref().unwrap_or("").trim().to_string();
+            let raw_content = atom_in.content.as_deref().unwrap_or("");
+            let content = if preserve_content_whitespace {
+                raw_content.to_string()
+            } else {
+                raw_content.trim().to_string()
+            };
             validate_atom_content(&content)?;
             // Secret gate: scan all caller-supplied text and structured fields
             // before any reader/writer is acquired.

--- a/crates/khive-pack-knowledge/src/knowledge/schema.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/schema.rs
@@ -398,8 +398,8 @@ pub(crate) struct ImportParams {
     /// Markdown format hint.  Only `"atlas_md"` is supported in v1.
     #[serde(default)]
     pub format: Option<String>,
-    /// Chunk strategy: `"section"` (one section per atom, default) or `"atom"`
-    /// (entire file as one atom).
+    /// Chunk strategy: `"section"` (atom plus parsed section rows, default) or
+    /// `"atom"` (whole markdown in one atom with no section rows).
     #[serde(default)]
     pub chunk_strategy: Option<String>,
 }

--- a/crates/khive-pack-knowledge/src/knowledge/sections.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/sections.rs
@@ -1,6 +1,7 @@
 //! Section handlers: edit, import, challenge, adjudicate; markdown parsing helpers.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
+use std::path::{Component, Path, PathBuf};
 
 use serde_json::{json, Value};
 use uuid::Uuid;
@@ -14,7 +15,8 @@ use super::schema::{
 use super::sections_index::embed_sections;
 use super::util::resolve_atom_id;
 use super::util::{
-    content_hash, deser, new_id, now_us, row_str, sql_err, validate_section_content,
+    content_hash, deser, new_id, now_us, row_str, sql_err, validate_atom_content,
+    validate_section_content,
 };
 use super::vamana;
 use super::KnowledgeHandlers;
@@ -78,17 +80,147 @@ pub(super) fn section_to_json(s: &Section) -> Value {
 
 // ─── markdown parsing helpers ─────────────────────────────────────────────────
 
-fn collect_md_files(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
-    if let Ok(entries) = std::fs::read_dir(dir) {
-        for entry in entries.flatten() {
+const MAX_IMPORT_DEPTH: usize = 32;
+const MAX_IMPORT_ENTRIES: usize = 100_000;
+const MAX_IMPORT_FILES: usize = 10_000;
+
+#[derive(Clone, Copy, Debug)]
+struct ImportTraversalLimits {
+    max_depth: usize,
+    max_entries: usize,
+    max_files: usize,
+}
+
+const IMPORT_TRAVERSAL_LIMITS: ImportTraversalLimits = ImportTraversalLimits {
+    max_depth: MAX_IMPORT_DEPTH,
+    max_entries: MAX_IMPORT_ENTRIES,
+    max_files: MAX_IMPORT_FILES,
+};
+
+#[derive(Debug)]
+struct ImportDiscovery {
+    files: Vec<PathBuf>,
+    entries_visited: usize,
+    files_skipped: usize,
+}
+
+fn traversal_error(
+    path: &Path,
+    entries_visited: usize,
+    error: impl std::fmt::Display,
+) -> RuntimeError {
+    RuntimeError::InvalidInput(format!(
+        "knowledge.import traversal failed at {:?} after {entries_visited} entries: {error}",
+        path
+    ))
+}
+
+fn traversal_limit_error(
+    limit_kind: &str,
+    path: &Path,
+    depth: usize,
+    entries_visited: usize,
+    files_discovered: usize,
+    limits: ImportTraversalLimits,
+) -> RuntimeError {
+    RuntimeError::InvalidInput(format!(
+        "knowledge.import traversal {limit_kind} limit exceeded at {:?}: \
+         depth={depth} max_depth={} entries_visited={entries_visited} max_entries={} \
+         files_discovered={files_discovered} max_files={}",
+        path, limits.max_depth, limits.max_entries, limits.max_files
+    ))
+}
+
+/// Rebuild the caller path from lexical components before metadata inspection.
+/// In particular, this removes a trailing separator that would otherwise make
+/// `symlink_metadata("directory-link/")` dereference the final symlink on Unix.
+fn normalize_import_root(path: &Path) -> PathBuf {
+    path.components().collect()
+}
+
+fn collect_md_files_with_limits(
+    root: &Path,
+    limits: ImportTraversalLimits,
+) -> Result<ImportDiscovery, RuntimeError> {
+    let mut directories = VecDeque::from([(root.to_path_buf(), 0usize)]);
+    let mut files = Vec::new();
+    let mut entries_visited = 0usize;
+    let mut files_skipped = 0usize;
+
+    while let Some((directory, depth)) = directories.pop_front() {
+        let read_dir = std::fs::read_dir(&directory)
+            .map_err(|error| traversal_error(&directory, entries_visited, error))?;
+        let mut entries = Vec::new();
+        for entry in read_dir {
+            let entry =
+                entry.map_err(|error| traversal_error(&directory, entries_visited, error))?;
+            let next_entries_visited = entries_visited.saturating_add(1);
+            if next_entries_visited > limits.max_entries {
+                return Err(traversal_limit_error(
+                    "entry",
+                    &entry.path(),
+                    depth,
+                    next_entries_visited,
+                    files.len(),
+                    limits,
+                ));
+            }
+            entries_visited = next_entries_visited;
+            entries.push(entry);
+        }
+        entries.sort_by_key(std::fs::DirEntry::file_name);
+
+        for entry in entries {
             let path = entry.path();
-            if path.is_dir() {
-                collect_md_files(&path, out);
-            } else if path.extension().and_then(|e| e.to_str()) == Some("md") {
-                out.push(path);
+            let file_type = entry
+                .file_type()
+                .map_err(|error| traversal_error(&path, entries_visited, error))?;
+            if file_type.is_symlink() {
+                files_skipped = files_skipped.saturating_add(1);
+            } else if file_type.is_dir() {
+                let child_depth = depth.saturating_add(1);
+                if child_depth > limits.max_depth {
+                    return Err(traversal_limit_error(
+                        "depth",
+                        &path,
+                        child_depth,
+                        entries_visited,
+                        files.len(),
+                        limits,
+                    ));
+                }
+                directories.push_back((path, child_depth));
+            } else if file_type.is_file()
+                && path.extension().and_then(|extension| extension.to_str()) == Some("md")
+            {
+                let files_discovered = files.len().saturating_add(1);
+                if files_discovered > limits.max_files {
+                    return Err(traversal_limit_error(
+                        "markdown file",
+                        &path,
+                        depth,
+                        entries_visited,
+                        files_discovered,
+                        limits,
+                    ));
+                }
+                files.push(path);
+            } else {
+                files_skipped = files_skipped.saturating_add(1);
             }
         }
     }
+
+    files.sort();
+    Ok(ImportDiscovery {
+        files,
+        entries_visited,
+        files_skipped,
+    })
+}
+
+fn collect_md_files(root: &Path) -> Result<ImportDiscovery, RuntimeError> {
+    collect_md_files_with_limits(root, IMPORT_TRAVERSAL_LIMITS)
 }
 
 fn to_slug(stem: &str) -> String {
@@ -106,6 +238,195 @@ fn to_slug(stem: &str) -> String {
         .filter(|s| !s.is_empty())
         .collect::<Vec<_>>()
         .join("-")
+}
+
+#[derive(Debug)]
+struct ImportSourceIdentity {
+    slug: String,
+    source_path: String,
+}
+
+fn import_source_identity(
+    root: &Path,
+    file: &Path,
+    root_is_file: bool,
+) -> Result<ImportSourceIdentity, RuntimeError> {
+    let relative = if root_is_file {
+        file.file_name().map(PathBuf::from).ok_or_else(|| {
+            RuntimeError::InvalidInput(format!("import file has no filename: {file:?}"))
+        })?
+    } else {
+        file.strip_prefix(root).map(PathBuf::from).map_err(|_| {
+            RuntimeError::InvalidInput(format!(
+                "import file {file:?} is outside traversal root {root:?}"
+            ))
+        })?
+    };
+
+    let mut source_components = Vec::new();
+    for component in relative.components() {
+        let Component::Normal(component) = component else {
+            return Err(RuntimeError::InvalidInput(format!(
+                "import source path is not root-relative: {relative:?}"
+            )));
+        };
+        let component = component.to_str().ok_or_else(|| {
+            RuntimeError::InvalidInput(format!(
+                "import source path is not valid UTF-8: {relative:?}"
+            ))
+        })?;
+        source_components.push(component.to_string());
+    }
+    let source_path = source_components.join("/");
+    let filename = source_components.last().ok_or_else(|| {
+        RuntimeError::InvalidInput(format!("import source path is empty: {relative:?}"))
+    })?;
+    let stem = Path::new(filename)
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .ok_or_else(|| {
+            RuntimeError::InvalidInput(format!(
+                "import source filename has no valid UTF-8 stem: {relative:?}"
+            ))
+        })?;
+
+    let mut slug_components = source_components[..source_components.len() - 1]
+        .iter()
+        .map(|component| to_slug(component))
+        .collect::<Vec<_>>();
+    slug_components.push(to_slug(stem));
+    if slug_components.iter().any(String::is_empty) {
+        return Err(RuntimeError::InvalidInput(format!(
+            "import source path normalizes to an empty slug component: {source_path:?}"
+        )));
+    }
+
+    Ok(ImportSourceIdentity {
+        slug: slug_components.join("--"),
+        source_path,
+    })
+}
+
+#[derive(Debug)]
+struct PreparedSection {
+    section_type: SectionType,
+    heading: String,
+    content: String,
+}
+
+#[derive(Debug)]
+struct PreparedImportFile {
+    slug: String,
+    name: String,
+    atom_content: String,
+    properties: serde_json::Map<String, Value>,
+    source_uri: String,
+    source_type: &'static str,
+    sections: Vec<PreparedSection>,
+    sections_discovered: usize,
+    sections_skipped: usize,
+}
+
+fn prepare_import_file(
+    file: &Path,
+    identity: ImportSourceIdentity,
+    chunk_strategy: &str,
+) -> Result<PreparedImportFile, RuntimeError> {
+    let content = std::fs::read_to_string(file).map_err(|error| {
+        RuntimeError::InvalidInput(format!(
+            "failed to read import source {:?} before writes: {error}",
+            identity.source_path
+        ))
+    })?;
+    let (atom_name, atom_body, parsed_sections) = parse_atlas_md(&content);
+    let atlas_id = extract_atlas_id(&content);
+    let name = if atom_name.is_empty() {
+        identity
+            .slug
+            .rsplit("--")
+            .next()
+            .unwrap_or(&identity.slug)
+            .replace('-', " ")
+    } else {
+        atom_name
+    };
+    let atom_content = if chunk_strategy == "atom" {
+        content
+    } else if atom_body.split_whitespace().count() >= super::util::MIN_ATOM_CONTENT_WORDS {
+        atom_body
+    } else {
+        parsed_sections
+            .iter()
+            .map(|(_, _, body)| body.as_str())
+            .collect::<Vec<_>>()
+            .join("\n\n")
+    };
+    validate_atom_content(&atom_content)?;
+
+    let citation_count = parsed_sections
+        .iter()
+        .filter(|(section_type, _, _)| *section_type == SectionType::References)
+        .map(|(_, _, body)| body.lines().filter(|line| !line.trim().is_empty()).count())
+        .sum::<usize>();
+    let source_uri = atlas_id
+        .as_ref()
+        .map(|id| format!("atlas:{id}"))
+        .unwrap_or_else(|| format!("file:{}", identity.source_path));
+    let source_type = if citation_count > 0 {
+        "paper"
+    } else {
+        "imported"
+    };
+    let mut properties = serde_json::Map::new();
+    properties.insert(
+        "source_path".to_string(),
+        Value::String(identity.source_path.clone()),
+    );
+    if let Some(id) = atlas_id {
+        properties.insert("atlas_id".to_string(), Value::String(id));
+    }
+
+    let sections_discovered = parsed_sections.len();
+    let (sections, sections_skipped) = if chunk_strategy == "section" {
+        let mut prepared = Vec::new();
+        let mut skipped = 0usize;
+        for (section_type, heading, content) in parsed_sections {
+            if content.len() < super::util::MIN_SECTION_CONTENT_LEN {
+                skipped = skipped.saturating_add(1);
+                continue;
+            }
+            validate_section_content(&content)?;
+            khive_runtime::secret_gate::check(&heading)?;
+            khive_runtime::secret_gate::check(&content)?;
+            prepared.push(PreparedSection {
+                section_type,
+                heading,
+                content,
+            });
+        }
+        (prepared, skipped)
+    } else {
+        (Vec::new(), 0)
+    };
+
+    khive_runtime::secret_gate::check(&identity.slug)?;
+    khive_runtime::secret_gate::check(&name)?;
+    khive_runtime::secret_gate::check(&atom_content)?;
+    khive_runtime::secret_gate::check_json(&Value::Object(properties.clone()))?;
+    khive_runtime::secret_gate::check(&source_uri)?;
+    khive_runtime::secret_gate::check(source_type)?;
+
+    Ok(PreparedImportFile {
+        slug: identity.slug,
+        name,
+        atom_content,
+        properties,
+        source_uri,
+        source_type,
+        sections,
+        sections_discovered,
+        sections_skipped,
+    })
 }
 
 fn extract_atlas_id(content: &str) -> Option<String> {
@@ -437,130 +758,108 @@ impl KnowledgeHandlers {
             )));
         }
 
-        let md_path = std::path::Path::new(&path_str);
-        if !md_path.exists() {
-            return Err(RuntimeError::NotFound(format!(
-                "path does not exist: {path_str:?}"
+        let normalized_md_path = normalize_import_root(Path::new(&path_str));
+        let md_path = normalized_md_path.as_path();
+        let metadata = std::fs::symlink_metadata(md_path).map_err(|error| {
+            if error.kind() == std::io::ErrorKind::NotFound {
+                RuntimeError::NotFound(format!("path does not exist: {path_str:?}"))
+            } else {
+                RuntimeError::InvalidInput(format!(
+                    "failed to inspect import path {path_str:?}: {error}"
+                ))
+            }
+        })?;
+        if metadata.file_type().is_symlink() {
+            return Err(RuntimeError::InvalidInput(format!(
+                "import path must not be a symbolic link: {path_str:?}"
             )));
         }
 
-        let files: Vec<std::path::PathBuf> = if md_path.is_file() {
-            vec![md_path.to_path_buf()]
-        } else if md_path.is_dir() {
-            let mut v = Vec::new();
-            collect_md_files(md_path, &mut v);
-            v
+        let root_is_file = metadata.is_file();
+        let discovery = if root_is_file {
+            if md_path.extension().and_then(|extension| extension.to_str()) != Some("md") {
+                return Err(RuntimeError::InvalidInput(format!(
+                    "import file must have a .md extension: {path_str:?}"
+                )));
+            }
+            ImportDiscovery {
+                files: vec![md_path.to_path_buf()],
+                entries_visited: 1,
+                files_skipped: 0,
+            }
+        } else if metadata.is_dir() {
+            collect_md_files(md_path)?
         } else {
             return Err(RuntimeError::InvalidInput(format!(
-                "path is not a file or directory: {path_str:?}"
+                "path is not a regular file or directory: {path_str:?}"
             )));
         };
 
-        if files.is_empty() {
-            return Ok(json!({
-                "imported_atoms": 0,
-                "imported_sections": 0,
-                "files_processed": 0,
-            }));
+        let mut identities = Vec::with_capacity(discovery.files.len());
+        let mut sources_by_slug = BTreeMap::new();
+        for file in &discovery.files {
+            let identity = import_source_identity(md_path, file, root_is_file)?;
+            if let Some(previous_source) =
+                sources_by_slug.insert(identity.slug.clone(), identity.source_path.clone())
+            {
+                return Err(RuntimeError::InvalidInput(format!(
+                    "normalized slug collision for {:?}: {:?} and {:?}",
+                    identity.slug, previous_source, identity.source_path
+                )));
+            }
+            identities.push((file.clone(), identity));
         }
 
+        let mut prepared_files = Vec::with_capacity(identities.len());
+        for (file, identity) in identities {
+            prepared_files.push(prepare_import_file(&file, identity, &chunk_strategy)?);
+        }
+
+        let sections_discovered = prepared_files
+            .iter()
+            .map(|prepared| prepared.sections_discovered)
+            .sum::<usize>();
+        let sections_skipped = prepared_files
+            .iter()
+            .map(|prepared| prepared.sections_skipped)
+            .sum::<usize>();
         let mut imported_atoms = 0usize;
         let mut imported_sections = 0usize;
 
-        for file in &files {
-            let content = std::fs::read_to_string(file)
-                .map_err(|e| RuntimeError::Internal(format!("failed to read {:?}: {e}", file)))?;
-
-            let stem = file
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .unwrap_or("unknown");
-            let slug = to_slug(stem);
-
-            let (atom_name, atom_body, sections) = parse_atlas_md(&content);
-            let name = if atom_name.is_empty() {
-                slug.replace('-', " ")
-            } else {
-                atom_name
-            };
-
-            // Atom content is its description. A section-only document (e.g.
-            // `# Title` followed entirely by `##` sections) has an empty/short
-            // pre-section body, which would fail the atom content minimum before
-            // the sections are imported. Synthesize atom content from the section
-            // bodies in that case so the atom carries meaningful text.
-            let atom_content =
-                if atom_body.split_whitespace().count() >= super::util::MIN_ATOM_CONTENT_WORDS {
-                    atom_body
-                } else {
-                    sections
-                        .iter()
-                        .map(|(_, _, body)| body.as_str())
-                        .collect::<Vec<_>>()
-                        .join("\n\n")
-                };
-
-            let atlas_id = extract_atlas_id(&content);
-            let citation_count = sections
-                .iter()
-                .filter(|(stype, _, _)| *stype == SectionType::References)
-                .map(|(_, _, body)| body.lines().filter(|line| !line.trim().is_empty()).count())
-                .sum::<usize>();
-            let source_uri = atlas_id.as_ref().map(|id| format!("atlas:{id}"));
-            let source_type = if citation_count > 0 {
-                "paper"
-            } else {
-                "imported"
-            };
-            let mut properties = serde_json::Map::new();
-            if let Some(ref id) = atlas_id {
-                properties.insert("atlas_id".to_string(), Value::String(id.clone()));
-            }
-
-            // finalized=true so imported atoms land at status="reviewed" instead of the
-            // upsert_atoms default "draft" — knowledge.search/suggest exclude "draft" by
-            // default (SearchParams::include_drafts defaults false), so a bulk-imported
-            // corpus was previously present (knowledge.list, no default status filter)
-            // but unretrievable through search/suggest until someone finalized every atom
-            // individually. Imported content is externally-authored source material the
-            // caller already chose to ingest, not an agent-proposed draft pending review.
+        for prepared in &prepared_files {
             let upsert_params = serde_json::json!({
                 "atoms": [{
-                    "slug": slug,
-                    "name": name,
-                    "content": atom_content,
-                    "properties": Value::Object(properties),
-                    "source_uri": source_uri,
-                    "source_type": source_type,
+                    "slug": prepared.slug,
+                    "name": prepared.name,
+                    "content": prepared.atom_content,
+                    "properties": Value::Object(prepared.properties.clone()),
+                    "source_uri": prepared.source_uri,
+                    "source_type": prepared.source_type,
                     "finalized": true,
                 }]
             });
-            KnowledgeHandlers::upsert_atoms(runtime, token, upsert_params).await?;
+            KnowledgeHandlers::upsert_import_atoms(runtime, token, upsert_params).await?;
             imported_atoms += 1;
 
-            if chunk_strategy == "section" && !sections.is_empty() {
-                // Filter out stub sections below the 80-char minimum to avoid
-                // errors during import of markdown files with short sections.
-                let section_updates: Vec<Value> = sections
+            if !prepared.sections.is_empty() {
+                let section_updates = prepared
+                    .sections
                     .iter()
-                    .filter(|(_, _, body)| body.len() >= super::util::MIN_SECTION_CONTENT_LEN)
-                    .map(|(stype, heading, body)| {
+                    .map(|section| {
                         json!({
-                            "section_type": stype.as_str(),
-                            "heading": heading,
-                            "content": body,
+                            "section_type": section.section_type.as_str(),
+                            "heading": section.heading,
+                            "content": section.content,
                         })
                     })
-                    .collect();
-                if !section_updates.is_empty() {
-                    let edit_params = json!({
-                        "id": slug,
-                        "sections": section_updates,
-                    });
-                    let result = KnowledgeHandlers::edit(runtime, token, edit_params, ann).await?;
-                    if let Some(n) = result.get("upserted").and_then(|v| v.as_u64()) {
-                        imported_sections += n as usize;
-                    }
+                    .collect::<Vec<_>>();
+                let edit_params = json!({
+                    "id": prepared.slug,
+                    "sections": section_updates,
+                });
+                let result = KnowledgeHandlers::edit(runtime, token, edit_params, ann).await?;
+                if let Some(count) = result.get("upserted").and_then(Value::as_u64) {
+                    imported_sections += count as usize;
                 }
             }
         }
@@ -568,7 +867,13 @@ impl KnowledgeHandlers {
         Ok(json!({
             "imported_atoms": imported_atoms,
             "imported_sections": imported_sections,
-            "files_processed": files.len(),
+            "files_processed": imported_atoms,
+            "entries_visited": discovery.entries_visited,
+            "files_discovered": discovery.files.len(),
+            "files_skipped": discovery.files_skipped,
+            "traversal_errors": 0,
+            "sections_discovered": sections_discovered,
+            "sections_skipped": sections_skipped,
         }))
     }
 
@@ -799,5 +1104,135 @@ impl KnowledgeHandlers {
             "new_status": new_status,
             "resolved": affected,
         }))
+    }
+}
+
+#[cfg(test)]
+mod import_traversal_tests {
+    use super::{collect_md_files_with_limits, ImportTraversalLimits};
+    use tempfile::TempDir;
+
+    #[test]
+    fn traversal_surfaces_root_read_errors() {
+        let root = TempDir::new().expect("temp root");
+        let missing = root.path().join("missing");
+        let error = collect_md_files_with_limits(
+            &missing,
+            ImportTraversalLimits {
+                max_depth: 8,
+                max_entries: 100,
+                max_files: 100,
+            },
+        )
+        .expect_err("missing traversal root must be surfaced");
+        assert!(error.to_string().contains("traversal failed"));
+    }
+
+    #[test]
+    fn traversal_enforces_depth_limit() {
+        let root = TempDir::new().expect("temp root");
+        let nested = root.path().join("nested");
+        std::fs::create_dir_all(&nested).expect("nested directory fixture");
+        let error = collect_md_files_with_limits(
+            root.path(),
+            ImportTraversalLimits {
+                max_depth: 0,
+                max_entries: 100,
+                max_files: 100,
+            },
+        )
+        .expect_err("depth over limit must fail closed");
+        let message = error.to_string();
+        assert!(message.contains("depth limit"), "{message}");
+        assert!(
+            message.contains(nested.to_string_lossy().as_ref()),
+            "{message}"
+        );
+        assert!(message.contains("depth=1"), "{message}");
+        assert!(message.contains("max_depth=0"), "{message}");
+        assert!(message.contains("entries_visited=1"), "{message}");
+        assert!(message.contains("max_entries=100"), "{message}");
+        assert!(message.contains("files_discovered=0"), "{message}");
+        assert!(message.contains("max_files=100"), "{message}");
+    }
+
+    #[test]
+    fn traversal_enforces_entry_limit() {
+        let root = TempDir::new().expect("temp root");
+        let first = root.path().join("a.md");
+        std::fs::write(&first, "a").expect("fixture");
+        let error = collect_md_files_with_limits(
+            root.path(),
+            ImportTraversalLimits {
+                max_depth: 8,
+                max_entries: 0,
+                max_files: 100,
+            },
+        )
+        .expect_err("entry over limit must fail closed");
+        let message = error.to_string();
+        assert!(message.contains("entry limit"), "{message}");
+        assert!(
+            message.contains(first.to_string_lossy().as_ref()),
+            "{message}"
+        );
+        assert!(message.contains("entries_visited=1"), "{message}");
+        assert!(message.contains("max_entries=0"), "{message}");
+        assert!(message.contains("files_discovered=0"), "{message}");
+        assert!(message.contains("max_files=100"), "{message}");
+        assert!(message.contains("depth=0"), "{message}");
+        assert!(message.contains("max_depth=8"), "{message}");
+    }
+
+    #[test]
+    fn traversal_enforces_markdown_file_limit() {
+        let root = TempDir::new().expect("temp root");
+        std::fs::write(root.path().join("a.md"), "a").expect("first fixture");
+        let second = root.path().join("b.md");
+        std::fs::write(&second, "b").expect("second fixture");
+        let error = collect_md_files_with_limits(
+            root.path(),
+            ImportTraversalLimits {
+                max_depth: 8,
+                max_entries: 100,
+                max_files: 1,
+            },
+        )
+        .expect_err("file over limit must fail closed");
+        let message = error.to_string();
+        assert!(message.contains("markdown file limit"), "{message}");
+        assert!(
+            message.contains(second.to_string_lossy().as_ref()),
+            "{message}"
+        );
+        assert!(message.contains("files_discovered=2"), "{message}");
+        assert!(message.contains("max_files=1"), "{message}");
+        assert!(message.contains("entries_visited=2"), "{message}");
+        assert!(message.contains("max_entries=100"), "{message}");
+        assert!(message.contains("depth=0"), "{message}");
+        assert!(message.contains("max_depth=8"), "{message}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn traversal_does_not_follow_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let root = TempDir::new().expect("temp root");
+        let markdown = root.path().join("source.md");
+        std::fs::write(&markdown, "source").expect("source fixture");
+        symlink(&markdown, root.path().join("alias.md")).expect("symlink fixture");
+        let discovery = collect_md_files_with_limits(
+            root.path(),
+            ImportTraversalLimits {
+                max_depth: 8,
+                max_entries: 100,
+                max_files: 100,
+            },
+        )
+        .expect("traversal");
+
+        assert_eq!(discovery.files, vec![markdown]);
+        assert_eq!(discovery.files_skipped, 1);
     }
 }

--- a/crates/khive-pack-knowledge/src/knowledge/sections.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/sections.rs
@@ -84,6 +84,22 @@ const MAX_IMPORT_DEPTH: usize = 32;
 const MAX_IMPORT_ENTRIES: usize = 100_000;
 const MAX_IMPORT_FILES: usize = 10_000;
 
+/// Per-file cap for `knowledge.import` source reads. Sized generously above
+/// any legitimate markdown atom (a full research paper rarely exceeds a few
+/// hundred KiB of prose) while still bounding worst-case memory for a single
+/// file read. Mirrors the crate-wide byte-limit idiom used for
+/// `MAX_CARGO_MANIFEST_BYTES` (khive-repo-showcase) and `DAEMON_LOG_MAX_BYTES`
+/// (khive-mcp): a `metadata.len()` pre-check plus a `take(cap + 1)` read-time
+/// re-check so a file that grows after the pre-check is still caught.
+const MAX_IMPORT_FILE_BYTES: u64 = 10 * 1024 * 1024;
+
+/// Aggregate cap across every file read by one `knowledge.import` call.
+/// `MAX_IMPORT_FILES` alone bounds file *count*, not total bytes — up to
+/// 10,000 files each just under `MAX_IMPORT_FILE_BYTES` could otherwise sum
+/// to tens of GB of prepared document content in one call. This caps total
+/// import size independent of how it's distributed across files.
+const MAX_IMPORT_TOTAL_BYTES: u64 = 256 * 1024 * 1024;
+
 #[derive(Clone, Copy, Debug)]
 struct ImportTraversalLimits {
     max_depth: usize,
@@ -327,17 +343,105 @@ struct PreparedImportFile {
     sections_skipped: usize,
 }
 
+/// Open `file` for reading without following a symlink at its final
+/// component. Closes the gap between [`collect_md_files_with_limits`]'s
+/// traversal-time `file_type()` check (or the root-file `symlink_metadata`
+/// check in [`import`](super::KnowledgeHandlers::import)) and the later
+/// content read: without `O_NOFOLLOW` an attacker who swaps the path for a
+/// symlink or special file in that window would have their read followed
+/// transparently. The subsequent [`read_import_file`] call `fstat`s this
+/// same handle rather than the path, so the type check and the read
+/// observe the same inode.
+#[cfg(unix)]
+fn open_import_file_handle(file: &Path) -> std::io::Result<std::fs::File> {
+    use std::os::unix::fs::OpenOptionsExt;
+    std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(file)
+}
+
+/// Best-effort fallback where `O_NOFOLLOW` isn't available: the opened
+/// handle is still `fstat`-checked in [`read_import_file`], just without
+/// the open-time symlink refusal.
+#[cfg(not(unix))]
+fn open_import_file_handle(file: &Path) -> std::io::Result<std::fs::File> {
+    std::fs::OpenOptions::new().read(true).open(file)
+}
+
+/// Read one import source through an opened, `fstat`-checked handle and
+/// enforce the per-file and running aggregate byte caps. `total_bytes` is
+/// threaded across every file in one `knowledge.import` call so the
+/// aggregate cap trips regardless of how the total is distributed across
+/// files.
+fn read_import_file(
+    file: &Path,
+    source_path: &str,
+    total_bytes: &mut u64,
+) -> Result<String, RuntimeError> {
+    use std::io::Read;
+
+    let mut handle = open_import_file_handle(file).map_err(|error| {
+        RuntimeError::InvalidInput(format!(
+            "failed to open import source {source_path:?}: {error}"
+        ))
+    })?;
+    let metadata = handle.metadata().map_err(|error| {
+        RuntimeError::InvalidInput(format!(
+            "failed to inspect opened import source {source_path:?}: {error}"
+        ))
+    })?;
+    if !metadata.is_file() {
+        return Err(RuntimeError::InvalidInput(format!(
+            "import source {source_path:?} is not a regular file on the opened handle \
+             (symlink or special-file swap after validation)"
+        )));
+    }
+    if metadata.len() > MAX_IMPORT_FILE_BYTES {
+        return Err(RuntimeError::InvalidInput(format!(
+            "import source {source_path:?} is {} bytes, exceeding the per-file cap of \
+             {MAX_IMPORT_FILE_BYTES} bytes",
+            metadata.len()
+        )));
+    }
+
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    handle
+        .by_ref()
+        .take(MAX_IMPORT_FILE_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|error| {
+            RuntimeError::InvalidInput(format!(
+                "failed to read import source {source_path:?}: {error}"
+            ))
+        })?;
+    if bytes.len() as u64 > MAX_IMPORT_FILE_BYTES {
+        return Err(RuntimeError::InvalidInput(format!(
+            "import source {source_path:?} grew beyond the per-file cap of \
+             {MAX_IMPORT_FILE_BYTES} bytes while being read"
+        )));
+    }
+
+    *total_bytes = total_bytes.saturating_add(bytes.len() as u64);
+    if *total_bytes > MAX_IMPORT_TOTAL_BYTES {
+        return Err(RuntimeError::InvalidInput(format!(
+            "knowledge.import aggregate size {total_bytes} bytes exceeds the total-import \
+             cap of {MAX_IMPORT_TOTAL_BYTES} bytes at {source_path:?}"
+        )));
+    }
+
+    String::from_utf8(bytes).map_err(|_| {
+        RuntimeError::InvalidInput(format!("import source {source_path:?} is not valid UTF-8"))
+    })
+}
+
 fn prepare_import_file(
     file: &Path,
     identity: ImportSourceIdentity,
     chunk_strategy: &str,
+    total_bytes: &mut u64,
 ) -> Result<PreparedImportFile, RuntimeError> {
-    let content = std::fs::read_to_string(file).map_err(|error| {
-        RuntimeError::InvalidInput(format!(
-            "failed to read import source {:?} before writes: {error}",
-            identity.source_path
-        ))
-    })?;
+    let content = read_import_file(file, &identity.source_path, total_bytes)?;
     let (atom_name, atom_body, parsed_sections) = parse_atlas_md(&content);
     let atlas_id = extract_atlas_id(&content);
     let name = if atom_name.is_empty() {
@@ -811,8 +915,14 @@ impl KnowledgeHandlers {
         }
 
         let mut prepared_files = Vec::with_capacity(identities.len());
+        let mut total_bytes = 0u64;
         for (file, identity) in identities {
-            prepared_files.push(prepare_import_file(&file, identity, &chunk_strategy)?);
+            prepared_files.push(prepare_import_file(
+                &file,
+                identity,
+                &chunk_strategy,
+                &mut total_bytes,
+            )?);
         }
 
         let sections_discovered = prepared_files
@@ -1234,5 +1344,97 @@ mod import_traversal_tests {
 
         assert_eq!(discovery.files, vec![markdown]);
         assert_eq!(discovery.files_skipped, 1);
+    }
+}
+
+#[cfg(test)]
+mod import_read_tests {
+    use super::{read_import_file, MAX_IMPORT_FILE_BYTES, MAX_IMPORT_TOTAL_BYTES};
+    use tempfile::TempDir;
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_swap_at_read_time_is_rejected() {
+        use std::os::unix::fs::symlink;
+
+        let root = TempDir::new().expect("temp root");
+        let outside = TempDir::new().expect("outside root");
+        let secret = outside.path().join("secret.md");
+        std::fs::write(&secret, "outside content").expect("secret fixture");
+
+        // Simulates the post-validation swap: the path traversal accepted
+        // as a regular file is, by read time, a symlink pointing outside
+        // the import root.
+        let swapped = root.path().join("swapped.md");
+        symlink(&secret, &swapped).expect("swap symlink fixture");
+
+        let mut total_bytes = 0u64;
+        let error = read_import_file(&swapped, "swapped.md", &mut total_bytes)
+            .expect_err("a symlink swapped in after validation must be refused at read time");
+        assert!(
+            error.to_string().contains("failed to open import source"),
+            "{error}"
+        );
+        assert_eq!(
+            total_bytes, 0,
+            "a rejected read must not count toward the aggregate cap"
+        );
+    }
+
+    #[test]
+    fn oversize_single_file_is_refused() {
+        let root = TempDir::new().expect("temp root");
+        let big = root.path().join("big.md");
+        let file = std::fs::File::create(&big).expect("create big fixture");
+        file.set_len(MAX_IMPORT_FILE_BYTES + 1)
+            .expect("grow big fixture past the per-file cap");
+        drop(file);
+
+        let mut total_bytes = 0u64;
+        let error = read_import_file(&big, "big.md", &mut total_bytes)
+            .expect_err("a file over the per-file cap must be refused");
+        assert!(
+            error.to_string().contains("exceeding the per-file cap"),
+            "{error}"
+        );
+        assert_eq!(
+            total_bytes, 0,
+            "a rejected read must not count toward the aggregate cap"
+        );
+    }
+
+    #[test]
+    fn aggregate_cap_is_refused_once_tripped() {
+        let root = TempDir::new().expect("temp root");
+        let small = root.path().join("small.md");
+        std::fs::write(
+            &small,
+            "a small file that pushes the running total over the cap",
+        )
+        .expect("small fixture");
+
+        // Seed the running total just under the aggregate cap so this one
+        // small read is what tips it over, without needing to write a
+        // 256 MiB fixture to disk.
+        let mut total_bytes = MAX_IMPORT_TOTAL_BYTES - 5;
+        let error = read_import_file(&small, "small.md", &mut total_bytes)
+            .expect_err("a read that crosses the aggregate cap must be refused");
+        assert!(
+            error.to_string().contains("exceeds the total-import cap"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn clean_read_under_both_caps_succeeds() {
+        let root = TempDir::new().expect("temp root");
+        let clean = root.path().join("clean.md");
+        std::fs::write(&clean, "# Clean\n\nWell under every cap.").expect("clean fixture");
+
+        let mut total_bytes = 0u64;
+        let content = read_import_file(&clean, "clean.md", &mut total_bytes)
+            .expect("a file under both caps must read successfully");
+        assert_eq!(content, "# Clean\n\nWell under every cap.");
+        assert_eq!(total_bytes, content.len() as u64);
     }
 }

--- a/crates/khive-pack-knowledge/src/vocab.rs
+++ b/crates/khive-pack-knowledge/src/vocab.rs
@@ -429,7 +429,7 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 20] = [
     },
     HandlerDef {
         name: "knowledge.import",
-        description: "Ingest atlas markdown file(s) as atoms with parsed sections",
+        description: "Validate and ingest atlas markdown file(s) with stable path identity",
         visibility: Visibility::Verb,
         category: VerbCategory::Commissive,
         params: &[
@@ -437,7 +437,7 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 20] = [
                 name: "path",
                 param_type: "string",
                 required: true,
-                description: "Filesystem path to a markdown file or directory",
+                description: "Filesystem path to a .md file or bounded directory tree",
             },
             ParamDef {
                 name: "format",
@@ -449,7 +449,7 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 20] = [
                 name: "chunk_strategy",
                 param_type: "string",
                 required: false,
-                description: "\"section\" (one section per atom, default) or \"atom\" (entire file as one atom)",
+                description: "\"section\" (atom plus parsed section rows, default) or \"atom\" (whole markdown in one atom, no section rows)",
             },
         ],
     },

--- a/crates/khive-pack-knowledge/tests/import_integrity.rs
+++ b/crates/khive-pack-knowledge/tests/import_integrity.rs
@@ -247,3 +247,31 @@ async fn import_report_counts_discovery_and_intentional_skips() {
     assert_eq!(response["imported_sections"], 0);
     assert_eq!(response["sections_skipped"], 1);
 }
+
+#[tokio::test]
+async fn clean_directory_import_still_succeeds_under_the_byte_caps() {
+    let f = fixture();
+    let root = TempDir::new().expect("temp root");
+    for (dir, title) in [("alpha", "Alpha Topic"), ("beta", "Beta Topic")] {
+        let nested = root.path().join(dir);
+        std::fs::create_dir_all(&nested).expect("nested dir");
+        std::fs::write(nested.join("topic.md"), markdown(title)).expect("markdown fixture");
+    }
+
+    let response = f
+        .dispatch(
+            "knowledge.import",
+            json!({ "path": root.path().to_str().expect("utf-8 root") }),
+        )
+        .await
+        .expect("a clean, well-under-cap import must still succeed");
+
+    assert_eq!(response["imported_atoms"], 2);
+    assert_eq!(response["files_processed"], 2);
+    assert_eq!(
+        f.count("SELECT COUNT(*) AS count FROM knowledge_atoms")
+            .await,
+        2,
+        "both well-under-cap atoms must be persisted"
+    );
+}

--- a/crates/khive-pack-knowledge/tests/import_integrity.rs
+++ b/crates/khive-pack-knowledge/tests/import_integrity.rs
@@ -1,0 +1,249 @@
+//! Regression coverage for issue #1758's `knowledge.import` integrity slice.
+
+use khive_pack_kg::KgPack;
+use khive_pack_knowledge::KnowledgePack;
+use khive_runtime::{KhiveRuntime, RuntimeError, VerbRegistry, VerbRegistryBuilder};
+use khive_storage::{SqlStatement, SqlValue};
+use serde_json::{json, Value};
+use tempfile::TempDir;
+
+struct Fixture {
+    registry: VerbRegistry,
+    rt: KhiveRuntime,
+}
+
+impl Fixture {
+    async fn dispatch(&self, verb: &str, args: Value) -> Result<Value, RuntimeError> {
+        self.registry.dispatch(verb, args).await
+    }
+
+    async fn count(&self, sql: &str) -> i64 {
+        let access = self.rt.sql();
+        let mut reader = access.reader().await.expect("reader");
+        let row = reader
+            .query_row(SqlStatement {
+                sql: sql.to_string(),
+                params: vec![],
+                label: None,
+            })
+            .await
+            .expect("count query")
+            .expect("count row");
+        match row.get("count") {
+            Some(SqlValue::Integer(count)) => *count,
+            other => panic!("expected integer count, got {other:?}"),
+        }
+    }
+}
+
+fn fixture() -> Fixture {
+    let rt = KhiveRuntime::memory().expect("memory runtime");
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    builder.register(KnowledgePack::new(rt.clone()));
+    let registry = builder.build().expect("registry builds");
+    registry.apply_schema_plans(rt.backend());
+    rt.install_edge_rules(registry.all_edge_rules());
+    Fixture { registry, rt }
+}
+
+fn markdown(title: &str) -> String {
+    format!(
+        "# {title}\n\nThis imported markdown document contains enough meaningful words to satisfy the atom content validation while preserving deterministic knowledge corpus identity and source provenance across nested directories."
+    )
+}
+
+#[cfg(unix)]
+async fn assert_directory_symlink_root_rejected(trailing_slash: bool) {
+    use std::os::unix::fs::symlink;
+
+    let f = fixture();
+    let root = TempDir::new().expect("temp root");
+    let target = root.path().join("target");
+    std::fs::create_dir_all(&target).expect("target directory");
+    std::fs::write(target.join("topic.md"), markdown("Symlink Target")).expect("target markdown");
+    let alias = root.path().join("alias");
+    symlink(&target, &alias).expect("directory symlink");
+    let mut import_path = alias.to_str().expect("utf-8 symlink path").to_string();
+    if trailing_slash {
+        import_path.push('/');
+    }
+
+    let error = f
+        .dispatch("knowledge.import", json!({ "path": import_path }))
+        .await
+        .expect_err("a directory symlink root must fail closed");
+    assert!(
+        error.to_string().contains("must not be a symbolic link"),
+        "{error}"
+    );
+    assert_eq!(
+        f.count("SELECT COUNT(*) AS count FROM knowledge_atoms")
+            .await,
+        0,
+        "a rejected root symlink must not import its target"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn directory_symlink_root_is_rejected_without_trailing_slash() {
+    assert_directory_symlink_root_rejected(false).await;
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn directory_symlink_root_is_rejected_with_trailing_slash() {
+    assert_directory_symlink_root_rejected(true).await;
+}
+
+#[tokio::test]
+async fn directory_import_uses_root_relative_slugs_and_provenance() {
+    let f = fixture();
+    let root = TempDir::new().expect("temp root");
+    let alpha = root.path().join("alpha");
+    let beta = root.path().join("beta");
+    std::fs::create_dir_all(&alpha).expect("alpha dir");
+    std::fs::create_dir_all(&beta).expect("beta dir");
+    std::fs::write(alpha.join("topic.md"), markdown("Alpha Topic")).expect("alpha markdown");
+    std::fs::write(beta.join("topic.md"), markdown("Beta Topic")).expect("beta markdown");
+
+    let response = f
+        .dispatch(
+            "knowledge.import",
+            json!({ "path": root.path().to_str().expect("utf-8 root") }),
+        )
+        .await
+        .expect("directory import");
+
+    assert_eq!(response["imported_atoms"], 2);
+    assert_eq!(response["files_discovered"], 2);
+    assert_eq!(response["files_processed"], 2);
+    for (slug, source_path) in [
+        ("alpha--topic", "alpha/topic.md"),
+        ("beta--topic", "beta/topic.md"),
+    ] {
+        let atom = f
+            .dispatch("knowledge.get", json!({ "id": slug }))
+            .await
+            .expect("root-relative atom");
+        assert_eq!(atom["slug"], slug);
+        assert_eq!(atom["properties"]["source_path"], source_path);
+        assert_eq!(atom["source_uri"], format!("file:{source_path}"));
+    }
+}
+
+#[tokio::test]
+async fn normalized_slug_collision_is_rejected_before_any_write() {
+    let f = fixture();
+    let root = TempDir::new().expect("temp root");
+    for directory in ["alpha beta", "alpha-beta"] {
+        let nested = root.path().join(directory);
+        std::fs::create_dir_all(&nested).expect("nested dir");
+        std::fs::write(nested.join("topic.md"), markdown(directory)).expect("markdown");
+    }
+
+    let error = f
+        .dispatch(
+            "knowledge.import",
+            json!({ "path": root.path().to_str().expect("utf-8 root") }),
+        )
+        .await
+        .expect_err("normalization collision must fail closed");
+    let message = error.to_string();
+    assert!(message.contains("normalized slug collision"), "{message}");
+    assert!(message.contains("alpha beta/topic.md"), "{message}");
+    assert!(message.contains("alpha-beta/topic.md"), "{message}");
+    assert_eq!(
+        f.count("SELECT COUNT(*) AS count FROM knowledge_atoms")
+            .await,
+        0,
+        "collision validation must finish before the first atom write"
+    );
+}
+
+#[tokio::test]
+async fn later_invalid_source_is_rejected_before_any_write() {
+    let f = fixture();
+    let root = TempDir::new().expect("temp root");
+    std::fs::write(root.path().join("a-valid.md"), markdown("Valid First"))
+        .expect("valid markdown");
+    std::fs::write(root.path().join("z-invalid.md"), "# Too Short\n").expect("invalid markdown");
+
+    let error = f
+        .dispatch(
+            "knowledge.import",
+            json!({ "path": root.path().to_str().expect("utf-8 root") }),
+        )
+        .await
+        .expect_err("all source content must validate before writes");
+    assert!(error.to_string().contains("atom content must be at least"));
+    assert_eq!(
+        f.count("SELECT COUNT(*) AS count FROM knowledge_atoms")
+            .await,
+        0,
+        "a later invalid source must not leave an earlier atom behind"
+    );
+}
+
+#[tokio::test]
+async fn atom_mode_preserves_full_markdown_without_section_rows() {
+    let f = fixture();
+    let root = TempDir::new().expect("temp root");
+    let markdown = "\n# Complete Atom\n\nThis preamble deliberately contains more than twenty words so the previous implementation selected it alone and silently discarded every structured section that followed from atom content.\n\n## Overview\n\nThe overview remains part of the whole markdown document and must be preserved with its heading in atom mode.\n\n## Formalism\n\nThe formalism also remains part of the whole markdown document with equations, definitions, and explanatory context intact.  \n";
+    let path = root.path().join("complete-atom.md");
+    std::fs::write(&path, markdown).expect("markdown");
+
+    let response = f
+        .dispatch(
+            "knowledge.import",
+            json!({
+                "path": path.to_str().expect("utf-8 path"),
+                "chunk_strategy": "atom"
+            }),
+        )
+        .await
+        .expect("atom import");
+    assert_eq!(response["imported_atoms"], 1);
+    assert_eq!(response["imported_sections"], 0);
+    assert_eq!(response["sections_discovered"], 2);
+    assert_eq!(response["sections_skipped"], 0);
+
+    let atom = f
+        .dispatch("knowledge.get", json!({ "id": "complete-atom" }))
+        .await
+        .expect("atom");
+    assert_eq!(atom["content"], markdown);
+    assert_eq!(
+        f.count("SELECT COUNT(*) AS count FROM knowledge_sections")
+            .await,
+        0,
+        "atom mode must not create section rows"
+    );
+}
+
+#[tokio::test]
+async fn import_report_counts_discovery_and_intentional_skips() {
+    let f = fixture();
+    let root = TempDir::new().expect("temp root");
+    let markdown = "# Counted Atom\n\nThis preamble has enough meaningful words for a valid searchable atom while the deliberately short section below is counted honestly instead of disappearing without explanation.\n\n## Overview\n\nshort section";
+    std::fs::write(root.path().join("counted.md"), markdown).expect("markdown");
+    std::fs::write(root.path().join("ignored.txt"), "not markdown").expect("ignored file");
+
+    let response = f
+        .dispatch(
+            "knowledge.import",
+            json!({ "path": root.path().to_str().expect("utf-8 root") }),
+        )
+        .await
+        .expect("import");
+
+    assert_eq!(response["entries_visited"], 2);
+    assert_eq!(response["files_discovered"], 1);
+    assert_eq!(response["files_processed"], 1);
+    assert_eq!(response["files_skipped"], 1);
+    assert_eq!(response["traversal_errors"], 0);
+    assert_eq!(response["sections_discovered"], 1);
+    assert_eq!(response["imported_sections"], 0);
+    assert_eq!(response["sections_skipped"], 1);
+}

--- a/docs/adr/ADR-048-knowledge-section-profiles.md
+++ b/docs/adr/ADR-048-knowledge-section-profiles.md
@@ -16,7 +16,7 @@ compose/suggest, hooks, lint, export, and observability phases.
 | Section write-side embedding backfill                         | shipped  | `kkernel reindex` and `knowledge.edit` (inline atom-scoped re-embed) populate `knowledge_sections.embedding` via breadcrumb-enriched embed text (ADR-051 phase 1). Direct section-cosine scoring in `knowledge.search` and `knowledge.compose` is shipped (ADR-051 phase 2). Profile-weighted compose and the Vamana section ANN snapshot remain deferred. |
 | V22 lifecycle/source fields                                   | shipped  | Status/source columns on atoms, status columns on sections/domains, status indexes, and finalized atom backfill to `reviewed`.                                                                                                                                                                                                                             |
 | `knowledge.edit`                                              | shipped  | Upserts sections content-addressed by `content_hash`; identical content is idempotent, distinct content inserts a sibling row, and existing siblings (including verified ones) are left untouched.                                                                                                                                                         |
-| `knowledge.import`                                            | shipped  | Supports `atlas_md` files/directories with `chunk_strategy=section                                                                                                                                                                                                                                                                                         |
+| `knowledge.import`                                            | shipped  | Supports bounded, validate-first `atlas_md` file/directory import. Directory identities derive from root-relative paths; `section` creates section rows and `atom` preserves the whole markdown in one atom with no section rows.                                                                                                                          |
 | `knowledge.challenge` / `knowledge.adjudicate`                | shipped  | Challenge moves eligible sections to `disputed` and increments atom `dispute_count`; adjudicate requires disputed sections and resolves accept -> `verified`, reject -> `reviewed`.                                                                                                                                                                        |
 | Brain section posterior primitives                            | shipped  | Brain state, fold, feedback parsing, and `brain.create_profile(seed_priors.section_posteriors)` exist for section posteriors.                                                                                                                                                                                                                              |
 | `knowledge.suggest` / `knowledge.compose` profile weighting   | deferred | `suggest` is domain-oriented search with optional Vamana signal; `compose` uses explicit `domain_ids`/`atom_ids` and formats atom-body markdown. Neither resolves `brain` profiles or emits section-weighted manifests.                                                                                                                                    |
@@ -779,12 +779,14 @@ Two new verbs support corpus maintenance:
 knowledge.import(
   path="/path/to/atoms/",
   format="atlas_md",      # atlas markdown with ## section headers
-  chunk_strategy="section" # one section per chunk, or "atom" for whole-file
+  chunk_strategy="section" # atom plus section rows, or "atom" for byte-exact whole-file content
 )
 ```
 
-Parses markdown into section-typed atoms using the atlas header normalization map.
-Supports glob patterns for batch import.
+Parses markdown headings with the atlas section-type normalization map. The path is one `.md`
+file or a bounded directory tree; glob patterns are not part of the shipped wire contract.
+Directory atom identity derives from the root-relative file path as governed by the import
+integrity amendment below.
 
 **`knowledge.edit`** — agent-driven atom editing:
 
@@ -1354,6 +1356,56 @@ lattice-transport 0.2.5 to crates.io (currently only 0.2.1 published).
 | AND-composition of lint rules (Q7)        | Confirmed; auto-fix should NOT chain                                                     | No change           |
 | ESS cap as primary temporal strategy (Q1) | Confirmed but as approximation, not principled posterior; combine with BOCD in Phase 2-3 | Deferred            |
 | Binary feedback (Q9)                      | Under-specified; Dirichlet-tree recommended                                              | Deferred to Phase 3 |
+
+## Amendment: Import Integrity and Stable File Identity (2026-08-09)
+
+`knowledge.import` treats filesystem discovery and source parsing as a validate-first phase.
+Directory traversal is iterative and deterministic, does not follow symbolic links, and is
+bounded to 32 directory levels, 100,000 visited entries, and 10,000 markdown files. A symbolic
+link supplied as the root is rejected, including when the caller appends a trailing path
+separator; the root is rebuilt from lexical components before metadata inspection so the
+separator cannot cause the final directory symlink to be dereferenced. Descendant symbolic links,
+non-markdown files, and non-regular entries are skipped and reported. A directory-read,
+entry-inspection, depth, entry, file-count, source-read, identity, content-validation, or
+secret-scan failure aborts before the first atom write. Every depth, entry, or markdown-file limit
+failure names the exact path that crossed the bound and reports current and configured values for
+`depth`, `entries_visited`, and `files_discovered`; traversal failures are never silently
+flattened.
+
+For a directory import, an atom slug derives from the markdown file's path relative to the
+caller-supplied root. Each directory component and the filename stem use the existing lowercase
+ASCII slug normalization, and normalized components join with `--`; for example,
+`guides/retrieval/overview.md` becomes `guides--retrieval--overview`. A directly imported file
+retains its normalized filename-stem slug. The original root-relative path is stored as
+`properties.source_path` with `/` separators. `source_uri` remains `atlas:<id>` when an
+`atlas_id` is present and otherwise becomes `file:<source_path>`. If two source paths normalize
+to the same slug, the entire request is rejected before any write and the error names both paths.
+This deliberately replaces basename-only directory identity; previously collapsed nested files
+cannot be migrated automatically because their original path was not stored.
+
+The chunk strategies have distinct preservation contracts:
+
+- `section` creates one atom per file and eligible section rows. A section shorter than the
+  governed 80-character minimum is intentionally omitted and counted in `sections_skipped`.
+- `atom` stores the complete UTF-8 markdown document byte-for-byte as atom content, including
+  boundary whitespace, headings, and section bodies, and creates zero section rows. Parsed
+  headings count as discovered structure, not as skipped sections, because section-row creation
+  was not requested.
+
+Successful responses retain `imported_atoms`, `imported_sections`, and `files_processed` and add
+the following counters:
+
+| Counter               | Meaning                                                             |
+| --------------------- | ------------------------------------------------------------------- |
+| `entries_visited`     | Directory entries inspected, or 1 for a direct file                 |
+| `files_discovered`    | Regular `.md` files admitted to source preflight                    |
+| `files_skipped`       | Symbolic links, non-markdown files, and non-regular entries ignored |
+| `traversal_errors`    | Zero on success; any traversal error aborts the request             |
+| `sections_discovered` | Parsed `##` sections across admitted markdown files                 |
+| `sections_skipped`    | Sub-80-character sections omitted by the `section` strategy         |
+
+On a successful response, `files_processed` is the number of file-level atom upserts completed;
+it is no longer populated from discovery alone.
 
 ## References
 

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -1742,17 +1742,25 @@ request(ops="[{\"tool\":\"knowledge.edit\",\"args\":{\"id\":\"rope\",\"sections\
 
 ### `knowledge.import` — Commissive
 
-Ingest atlas markdown file(s) as atoms with parsed sections.
+Validate and ingest atlas markdown file(s) with stable root-relative identity.
 
-| Param            | Type   | Required | Notes                                                                         |
-| ---------------- | ------ | -------- | ----------------------------------------------------------------------------- |
-| `path`           | string | yes      | Filesystem path to a markdown file or directory.                              |
-| `format`         | string | no       | Only `atlas_md` supported (default).                                          |
-| `chunk_strategy` | string | no       | `section` (default, one section per atom) or `atom` (whole file as one atom). |
+| Param            | Type   | Required | Notes                                                                           |
+| ---------------- | ------ | -------- | ------------------------------------------------------------------------------- |
+| `path`           | string | yes      | Filesystem path to a `.md` file or bounded directory tree.                      |
+| `format`         | string | no       | Only `atlas_md` supported (default).                                            |
+| `chunk_strategy` | string | no       | `section` (atom plus section rows) or `atom` (whole markdown, no section rows). |
 
 ```
 request(ops="knowledge.import(path=\"/path/to/atlas/rope.md\")")
 ```
+
+Directory slugs use normalized root-relative components joined by `--`; source paths are
+retained in `properties.source_path`. Traversal and source validation complete before writes,
+normalization collisions fail closed, and symlinks are not followed. Root directory symlinks are
+rejected with or without a trailing separator. Entry, depth, and file-limit errors include the
+exact failing path plus current and configured traversal counts. Successful responses add
+`entries_visited`, `files_discovered`, `files_skipped`, `traversal_errors`, `sections_discovered`,
+and `sections_skipped` to the existing import counters.
 
 ### `knowledge.challenge` — Commissive
 

--- a/docs/guide/prompt-cookbook.md
+++ b/docs/guide/prompt-cookbook.md
@@ -251,7 +251,7 @@ Both must be full UUIDs. Source must be a document, person, or org entity.
 ### Import markdown as atoms
 
 ```
-request(ops="knowledge.import(path=\"/path/to/notes.md\", chunk_strategy=\"heading\")")
+request(ops="knowledge.import(path=\"/path/to/notes.md\", chunk_strategy=\"section\")")
 ```
 
 ### Search the corpus

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -420,7 +420,7 @@ verb; `exec` has no special-casing for any verb name; it forwards the DSL string
 pack owns it, exactly like the MCP `request` tool:
 
 ```bash
-kkernel exec 'knowledge.import(path="/path/to/corpus.jsonl", format="ndjson")' --db ~/.khive/khive.db
+kkernel exec 'knowledge.import(path="/path/to/atlas-markdown", format="atlas_md")' --db ~/.khive/khive.db
 kkernel exec 'stats()' --config /absolute/path/to/config.toml
 ```
 


### PR DESCRIPTION
## Summary

- preflight filesystem imports into a deterministic, bounded inventory before the first database write
- derive stable root-relative atom identities and provenance, rejecting normalized collisions and every directory-symlink root spelling
- preserve whole-file markdown byte-for-byte in atom mode and report honest discovery, skip, and section counts

## Integrity contract

Directory traversal is iterative, does not follow symlinks, and is bounded to 32 levels, 100,000 visited entries, and 10,000 markdown files. Read, file-type, traversal, identity, and normalized-slug failures now stop during preflight with the exact crossing path and governed progress fields, so a later bad file cannot leave a partially imported corpus.

Directory imports use root-relative `--` slugs and retain the original relative path in `properties.source_path`; single-file imports keep their existing identity contract. Atom mode stores the complete UTF-8 markdown source—including headings and boundary whitespace—and creates no section rows.

This is the filesystem-import tranche of #1758. The issue's separate VCS adapter validation, findings identity, and findings tombstone-preservation requirements remain open and will land in later reviewable PRs.

## Verification

- independent exact-head review: READY with zero findings at `1e47820ba6350f8fd6ac88d52357836349a3ecd7`
- exact-head full CI: PASS ([run 31299960178](https://github.com/ohdearquant/khive/actions/runs/31299960178))
- direct Rust formatting and Deno documentation formatting checks
- ADR-reference, JSON-data, SQL, stub-marker, and diff checks
- focused regressions for root symlinks (including trailing `/`), traversal bounds/errors, same-basename paths, pre-write collisions, later invalid files, whole-file atom preservation, and counters

Refs #1758

AI-assisted contribution: implemented and reviewed with Codex.
