### PR TITLE
fix(git): reap abandoned cache staging directories

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2160,6 +2160,7 @@ dependencies = [
  "khive-storage",
  "khive-types",
  "lattice-embed",
+ "libc",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/khive-pack-git/Cargo.toml
+++ b/crates/khive-pack-git/Cargo.toml
@@ -26,6 +26,7 @@ tokio = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true }
 blake3 = { workspace = true }
+libc = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }

--- a/crates/khive-pack-git/docs/api/cache.md
+++ b/crates/khive-pack-git/docs/api/cache.md
@@ -195,10 +195,14 @@ namespace, then runs `reap_stale_staging` at most once per
 `REAP_THROTTLE_INTERVAL` (see above). `reap_stale_staging` enumerates only
 the namespace's direct children. A deletion candidate must be a real
 directory (never a symlink, file, or nested path) whose name is exactly the
-lowercase canonical hyphenated spelling of a UUID; its liveness is then
-decided by `staging_liveness` — `try_lock`-acquirable (or missing its lock
-file _and_ older than the 24h age fallback) means abandoned, anything else
-means live and untouched regardless of age. Removal uses the same bounded
+lowercase canonical hyphenated spelling of a UUID (an in-flight clone
+wrapper) or `trash-` followed by one (an interrupted
+`delete_verified_owned_entry`, whose renamed slot would otherwise be
+unreclaimable residue); its liveness is then decided by `staging_liveness` —
+`try_lock`-acquirable (or missing its lock file _and_ older than the 24h age
+fallback) means abandoned, anything else means live and untouched regardless
+of age. Trash residue never carries a lock file, so the age fallback alone
+governs it: a fresh entry (a recursive delete still in flight) survives. Removal uses the same bounded
 retry helper as owned cache eviction and tolerates another process winning
 the same cleanup race; other I/O failures surface instead of silently
 leaving disk growth unobservable.

--- a/crates/khive-pack-git/docs/api/cache.md
+++ b/crates/khive-pack-git/docs/api/cache.md
@@ -45,15 +45,39 @@ process-wide `EVICTION_LOCK`), and that pass defers — rather than blocks on
 — any candidate whose per-slot lock is currently held. See `slot_lock` and
 `evict_lru` below.
 
-Every cache mutation opens the root through `prepare_cache_root`, which
-reclaims crash residue named by the exact canonical `.staging-<uuid>` shape
-once its directory mtime is more than 24 hours old. This is deliberately
-separate from LRU accounting: a staging clone has not yet earned an ownership
-marker or addressable cache key. The exact-name, direct-child, real-directory,
-and age checks leave files, symlinks, nested paths, prefix lookalikes, and
-fresh clones untouched. The age fence lets separate daemon processes clone
-different repositories concurrently without one deleting another process's
-ordinary in-flight staging directory.
+### Private staging namespace and liveness-based reaping
+
+Fresh clones never stage directly in `root` (which may be shared, or
+`KHIVE_GIT_DIGEST_SCRATCH_ROOT`-overridden to a broader or pre-existing
+directory). They stage under `<root>/.khive-git-staging/`, a subdirectory
+this cache owns outright — a staging entry's canonical-UUID shape can never
+collide with unrelated operator data sitting in a shared root, closing the
+class of bug where a broad scratch-root override made shape-matching alone
+an unsafe ownership test.
+
+Each staging entry (`<namespace>/<uuid>/`, containing a `.khive-staging.lock`
+file and a `repo/` clone destination) holds an exclusive advisory lock
+(`std::fs::File::try_lock` — `flock` on unix, `LockFileEx` on Windows,
+portable stable API since Rust 1.89) on that lock file for the entire span
+of `install_fresh_clone`. Reaping is a liveness check, not an age check:
+`reap_stale_staging` tries to acquire the same lock with `try_lock`. If it
+succeeds, nothing holds it — the owning process is gone (including a
+`SIGKILL`, which the kernel releases the lock for automatically) — and the
+entry is abandoned. If it would block, a live process holds it, and the
+entry survives no matter how old it looks; there is no documented wall-clock
+bound on a digest pass, so age alone was never a sound staleness signal for
+an active clone. A missing lock file (the brief mkdir-then-open-lock gap at
+the very start of `install_fresh_clone`, or residue from before this design)
+falls back to the old age-only check (`STALE_STAGING_AGE`, 24h) as a narrow
+belt-and-suspenders case — this cannot false-positive against a live clone,
+since a live clone writes its lock file within microseconds of creating its
+staging directory, well before `git clone` itself starts.
+
+`prepare_cache_root` runs this sweep before every public cache mutation, but
+throttled to at most once per `REAP_THROTTLE_INTERVAL` (5 minutes, tracked
+by a `.khive-last-swept` marker file's mtime) rather than on every single
+mutation — once the namespace is clean, a full scan+liveness pass on every
+`ensure_clone` call is unbounded latency for no benefit.
 
 ## `CacheError::UnsafeToReplace`
 
@@ -146,39 +170,81 @@ caps is covered under `evict_lru` below.
 ## `install_fresh_clone`
 
 Shared staging-clone-then-move path for both a first-time `ensure_clone`
-and a `reclone` repair: clones into a private staging directory outside the
-cache root, measures it against the per-clone cap, writes the
-`.khive-last-used` ownership marker into the staging directory itself, and
-only then moves it into the addressable `<root>/<cache_key>/` slot — an
-oversized clone never enters the cache slot, and because the marker is
-written before the atomic rename, a process interruption between clone and
-rename can never leave a live, markerless slot at the cache-key path (issue
-#765).
+and a `reclone` repair: creates a per-call wrapper directory under the
+private staging namespace, opens and `try_lock`s its `.khive-staging.lock`
+file (held for this whole function — see "Private staging namespace and
+liveness-based reaping" above), clones into `<wrapper>/repo`, measures it
+against the per-clone cap, writes the `.khive-last-used` ownership marker
+into it, and only then moves it into the addressable `<root>/<cache_key>/`
+slot — an oversized clone never enters the cache slot, and because the
+marker is written before the atomic rename, a process interruption between
+clone and rename can never leave a live, markerless slot at the cache-key
+path (issue #765). The wrapper (lock file included) is removed on both the
+success and every failure path.
 
 A kill can still interrupt the process before any Rust cleanup guard runs and
-leave the unaddressable staging directory behind. `prepare_cache_root` /
-`reap_stale_staging` are the cross-process recovery boundary for that case:
-the next cache operation removes exact staging directories only after the
-24-hour freshness fence has elapsed.
+leave the wrapper directory behind. `prepare_cache_root` / `reap_stale_staging`
+are the cross-process recovery boundary for that case: the kernel releases
+the wrapper's lock the instant the process dies, and the next sweep reaps it
+regardless of age.
 
-## `prepare_cache_root` / `reap_stale_staging`
+## `prepare_cache_root` / `reap_stale_staging` / `staging_liveness`
 
-Creates the scratch root when needed, then enumerates only its direct
-children. A deletion candidate must be a real directory whose name is exactly
-`.staging-` plus the lowercase canonical hyphenated spelling of a UUID, and
-its mtime must be strictly older than 24 hours. Future-dated entries are
-conservatively retained. Removal uses the same bounded retry helper as owned
-cache eviction and tolerates another process winning the same cleanup race;
-other I/O failures surface instead of silently leaving disk growth
-unobservable.
+`prepare_cache_root` creates the scratch root and the private staging
+namespace, then runs `reap_stale_staging` at most once per
+`REAP_THROTTLE_INTERVAL` (see above). `reap_stale_staging` enumerates only
+the namespace's direct children. A deletion candidate must be a real
+directory (never a symlink, file, or nested path) whose name is exactly the
+lowercase canonical hyphenated spelling of a UUID; its liveness is then
+decided by `staging_liveness` — `try_lock`-acquirable (or missing its lock
+file _and_ older than the 24h age fallback) means abandoned, anything else
+means live and untouched regardless of age. Removal uses the same bounded
+retry helper as owned cache eviction and tolerates another process winning
+the same cleanup race; other I/O failures surface instead of silently
+leaving disk growth unobservable.
 
-## `remove_owned_entry`
+## `remove_owned_entry` / `delete_verified_owned_entry`
 
-Removes `repo_dir` only when it is a direct child of `root` AND passes
-`is_owned_entry` — refuses (`CacheError::UnsafeToReplace`) rather than
-deleting anything else, including a not-yet-existing or foreign-shaped
-path. A slot that does not currently exist is not an error: there is
-simply nothing to remove before installing a fresh clone.
+`remove_owned_entry` removes `repo_dir` only when it is a direct child of
+`root` AND passes `is_owned_entry` — refuses (`CacheError::UnsafeToReplace`)
+rather than deleting anything else, including a not-yet-existing or
+foreign-shaped path. A slot that does not currently exist is not an error:
+there is simply nothing to remove before installing a fresh clone.
+
+The actual deletion is `delete_verified_owned_entry`. Unlike a staging
+wrapper (isolated in a namespace nothing else writes to), an owned cache
+slot necessarily lives in the shared, possibly-overridden root — so a
+pathname-based check-then-`remove_dir_all` leaves a TOCTOU window an
+external writer could race for as long as the recursive delete takes
+(potentially seconds against a large git tree). On unix,
+`delete_verified_owned_entry` instead: opens `root`, then `openat`s `name`
+with `O_DIRECTORY | O_NOFOLLOW` (refusing a symlink or non-directory
+outright); re-verifies ownership (`.git` entry present, `.khive-last-used`
+a regular file) against that fd, not a fresh pathname walk; `fstat`s it to
+capture `(dev, ino)`; moves it into the private staging namespace with one
+fd-relative `renameat` call; and confirms the entry that landed under the
+new name has the identical `(dev, ino)` before running the (possibly slow)
+recursive delete on it. This shrinks the external-writer race window from
+"however long the delete takes" down to the handful of syscalls between the
+`openat` and the `renameat` — POSIX has no primitive to rename "the exact
+inode this fd points to" without a name lookup, so this is race-_resistant_
+rather than race-proof, matching the residual-risk shape of every `rm -rf`
+implementation's final directory-removal step. Non-unix targets (Windows CI
+exists for this workspace) keep the prior pathname-based
+`remove_dir_all_retrying` behavior — no fd-relative directory API is stable
+there yet.
+
+## `unix_fd` / `is_owned_entry_via_fd`
+
+`unix_fd` is a small private module of `openat`/`fstatat`/`fstat`/`renameat`
+wrappers bound to an already-opened directory descriptor, mirroring the
+`O_NOFOLLOW`/`fstat` idiom already used by `khive-db`'s WAL-pin sidecar
+(`crates/khive-db/src/walpin.rs`) and `khive-vamana`'s external-id sidecar
+(`crates/khive-vamana/src/external_ids.rs`): every operation after the
+initial `open`/`openat` is relative to a handle the kernel resolved once,
+immune to the original pathname being swapped out from under it afterward.
+`is_owned_entry_via_fd` is `is_owned_entry`'s fd-relative mirror, used by
+`delete_verified_owned_entry` right before it acts.
 
 ## `remove_dir_all_retrying`
 
@@ -341,15 +407,32 @@ sync `#[test]`s).
 ## Test module notes
 
 - `ensure_clone_cleans_up_staging_dir_on_clone_failure`: a `git clone`
-  failure must not leave a `.staging-<uuid>` directory behind — `evict_lru`
-  deliberately never touches non-owned names, so a leaked staging dir
-  would otherwise accumulate forever across repeated failures.
-- `stale_staging_sweep_removes_a_direct_canonical_uuid_directory`: advances
-  the deterministic observation clock past the age fence and proves killed-
-  clone-shaped residue is deleted.
-- `staging_sweep_preserves_fresh_foreign_nested_and_nondirectory_entries`:
-  pins the containment and freshness boundary so a broad prefix match cannot
-  delete an in-flight clone or unrelated operator data.
+  failure must not leave a staging wrapper behind under the private
+  namespace — `evict_lru` deliberately never touches non-owned names, so a
+  leaked staging dir would otherwise accumulate forever across repeated
+  failures.
+- `stale_staging_sweep_removes_an_abandoned_wrapper_lacking_a_lock_file_once_old`:
+  the age-fallback path for a wrapper that crashed before writing its own
+  lock file.
+- `stale_staging_sweep_preserves_a_wrapper_whose_lock_is_still_held_past_the_age_fence`:
+  the blocking-finding acceptance test — a wrapper whose lock a live handle
+  still holds must survive the sweep a full year past the old 24h age
+  fence, proving liveness (not age) is the deletion criterion.
+- `stale_staging_sweep_removes_an_abandoned_wrapper_even_when_fresh`: the
+  flip side — an abandoned wrapper (lock file present, nothing holds it) is
+  reclaimed even when it was created moments ago.
+- `staging_sweep_preserves_foreign_nested_and_nondirectory_entries_even_when_stale`:
+  pins the containment/name/type boundary with every fixture entry driven
+  stale by a far-future `now`, so only those checks (never freshness) can
+  save them — regression coverage for a prior version of this fixture that
+  dated preserved entries in the future, so they never reached those checks
+  at all.
+- `remove_owned_entry_deletes_a_genuinely_owned_slot` /
+  `remove_owned_entry_refuses_a_symlink_planted_at_the_cache_key_path_after_the_check`:
+  the fd-verified deletion path (`delete_verified_owned_entry`) still
+  deletes a genuinely owned slot, and independently refuses a symlink at
+  the cache-key path even if some future caller skipped the earlier
+  pathname-based `is_owned_entry` gate.
 - `dir_size_errors_when_the_root_itself_is_missing` (PR #847): the walk
   root vanishing must surface as an error, never a laundered `Ok(0)` —
   distinct from a descendant vanishing beneath a still-existing root.

--- a/crates/khive-pack-git/docs/api/cache.md
+++ b/crates/khive-pack-git/docs/api/cache.md
@@ -11,17 +11,18 @@ least-recently-used clone (by a `.khive-last-used` marker file's mtime,
 touched on every successful `ensure_clone`) once the cache exceeds
 `digest_cache_max_repos` entries or `digest_cache_max_bytes` total size —
 eviction is safe because ingest cursors live in the database, not the clone.
-Eviction only ever removes entries it can *prove* it owns (`is_owned_entry`:
+Eviction only ever removes entries it can _prove_ it owns (`is_owned_entry`:
 a 16-hex cache-key directory name containing both a `.git` dir and the
 `.khive-last-used` marker) — a `KHIVE_GIT_DIGEST_SCRATCH_ROOT` override
 pointed at a broader or pre-existing directory must never lose unrelated
 operator data.
 
 A per-clone size cap (`digest_cache_clone_max_bytes`) rejects a clone/fetch
-that grows past its own budget *before* it ever enters the addressable cache
-slot: `ensure_clone` clones/fetches into a staging directory outside the
-cache root, measures it, and only moves it into `<root>/<cache_key>/` when
-it is under the cap. A too-large clone is deleted from staging and never
+that grows past its own budget _before_ it ever enters the addressable cache
+slot: `ensure_clone` clones/fetches into a private staging directory under
+the cache root but outside every addressable `<cache_key>` slot, measures it,
+and only moves it into `<root>/<cache_key>/` when it is under the cap. A
+too-large clone is deleted from staging and never
 touches `evict_lru`'s bookkeeping or the cache slot. This guarantees the cap
 is enforced before the clone enters the cache — it does NOT bound the
 transient disk usage of the clone/fetch child process itself while it runs
@@ -44,6 +45,16 @@ process-wide `EVICTION_LOCK`), and that pass defers — rather than blocks on
 — any candidate whose per-slot lock is currently held. See `slot_lock` and
 `evict_lru` below.
 
+Every cache mutation opens the root through `prepare_cache_root`, which
+reclaims crash residue named by the exact canonical `.staging-<uuid>` shape
+once its directory mtime is more than 24 hours old. This is deliberately
+separate from LRU accounting: a staging clone has not yet earned an ownership
+marker or addressable cache key. The exact-name, direct-child, real-directory,
+and age checks leave files, symlinks, nested paths, prefix lookalikes, and
+fresh clones untouched. The age fence lets separate daemon processes clone
+different repositories concurrently without one deleting another process's
+ordinary in-flight staging directory.
+
 ## `CacheError::UnsafeToReplace`
 
 A repair operation (refetch/reclone) would have to touch a path that does
@@ -61,7 +72,7 @@ crashed prior run left in a pre-`touch` state) is refused with
 `CacheError::UnsafeToReplace` rather than fetched into or adopted (issue
 #765). A fresh clone is written into a private staging directory first
 (`git clone --filter=blob:none`), measured there, marked with
-`.khive-last-used` there, and only *moved* into the addressable
+`.khive-last-used` there, and only _moved_ into the addressable
 `<root>/<cache_key>/` slot once it is under the cap and already carries its
 ownership marker — an oversized clone never enters the cache slot, never
 participates in `evict_lru`'s accounting, and is removed from staging
@@ -122,7 +133,7 @@ Returns the per-`cache_key` advisory `Mutex` from a process-global registry
 calls racing the same slot cannot interleave a check against another call's
 mutation. The lock is advisory and same-process only: it serializes this
 crate's own cache mutations, not an external process touching the scratch
-root. It is deliberately *not* held across a caller's separate `ensure_clone`
+root. It is deliberately _not_ held across a caller's separate `ensure_clone`
 and later `refetch_clone` calls within one request — that intra-request
 staleness window is what `refetch_clone`'s pre-fetch ownership re-check
 narrows instead.
@@ -143,6 +154,23 @@ oversized clone never enters the cache slot, and because the marker is
 written before the atomic rename, a process interruption between clone and
 rename can never leave a live, markerless slot at the cache-key path (issue
 #765).
+
+A kill can still interrupt the process before any Rust cleanup guard runs and
+leave the unaddressable staging directory behind. `prepare_cache_root` /
+`reap_stale_staging` are the cross-process recovery boundary for that case:
+the next cache operation removes exact staging directories only after the
+24-hour freshness fence has elapsed.
+
+## `prepare_cache_root` / `reap_stale_staging`
+
+Creates the scratch root when needed, then enumerates only its direct
+children. A deletion candidate must be a real directory whose name is exactly
+`.staging-` plus the lowercase canonical hyphenated spelling of a UUID, and
+its mtime must be strictly older than 24 hours. Future-dated entries are
+conservatively retained. Removal uses the same bounded retry helper as owned
+cache eviction and tolerates another process winning the same cleanup race;
+other I/O failures surface instead of silently leaving disk growth
+unobservable.
 
 ## `remove_owned_entry`
 
@@ -165,7 +193,7 @@ otherwise succeed.
 `-c maintenance.auto=false` on every clone/fetch into a cache slot, as
 defensive hardening. `git fetch` runs auto-maintenance after it finishes
 when `maintenance.auto` (default true) is set, and since git 2.47 that
-maintenance runs as a *detached background child*
+maintenance runs as a _detached background child_
 (`git maintenance run --auto --detach`) that can outlive the foreground
 command; on 2.46 and earlier it ran synchronously. The spawn is
 trace2-proven in both directions on the `fetch --refetch` path
@@ -218,7 +246,7 @@ throughout, so a symlink itself is sized but never traversed — clones
 never legitimately contain symlinked directories pointing outside the
 clone, and this avoids any possibility of a symlink loop).
 
-Tolerant of a *descendant* disappearing mid-walk (a vanished entry beneath
+Tolerant of a _descendant_ disappearing mid-walk (a vanished entry beneath
 an existing root contributes 0 bytes rather than aborting the whole size
 computation): a cache slot's `.git` tree can legitimately be mutated by
 something outside this function's control while it walks it — a concurrent
@@ -264,7 +292,7 @@ before calling `evict_lru` in the same synchronous call chain, so `keep`
 disappearing out from under this call is not an expected repair race — it
 is either a genuine bug or an external actor deleting our slot, and
 silently sizing it to `0` would let eviction report success while the slot
-the caller asked to keep is actually gone. A listed *candidate* entry is
+the caller asked to keep is actually gone. A listed _candidate_ entry is
 different — another `evict_lru`/`ensure_clone` repairing the same root can
 legitimately delete it between the `read_dir` listing and the `dir_size`
 call, so that vanish is tolerated by skipping the entry rather than
@@ -275,7 +303,7 @@ that key) is deferred: `evict_lru` takes each candidate lock with `try_lock`
 and skips a `WouldBlock` rather than waiting, so an eviction pass never
 blocks on a concurrent clone/fetch (and, holding `EVICTION_LOCK` while a
 mutation may hold a slot lock and be about to wait on `EVICTION_LOCK`, must
-not). A deferred candidate is therefore *not* counted in this pass — so this
+not). A deferred candidate is therefore _not_ counted in this pass — so this
 pass alone can return with the caps still exceeded. The guarantee that the
 caps are nonetheless restored is `enforce_caps` (below): every mutation runs
 a cap pass on its own exit, so the last of a set of concurrent mutations to
@@ -290,7 +318,7 @@ only in whether a `keep` slot is protected.
 The keep-less cap pass (`evict_to_caps` with no protected slot). Run after a
 cache mutation releases its slot lock on a FAILURE path (issue #960). On
 success a mutation already ran `evict_lru` under its lock, protecting the
-slot it returns; a *failed* `ensure_clone`/`refetch_clone`/`reclone` returns
+slot it returns; a _failed_ `ensure_clone`/`refetch_clone`/`reclone` returns
 before that pass, and a concurrent eviction may have deferred this slot while
 its lock was held — leaving the caps exceeded with nothing scheduled to
 correct them. `finish_mutation` runs `enforce_caps` once the lock is free (no
@@ -316,6 +344,12 @@ sync `#[test]`s).
   failure must not leave a `.staging-<uuid>` directory behind — `evict_lru`
   deliberately never touches non-owned names, so a leaked staging dir
   would otherwise accumulate forever across repeated failures.
+- `stale_staging_sweep_removes_a_direct_canonical_uuid_directory`: advances
+  the deterministic observation clock past the age fence and proves killed-
+  clone-shaped residue is deleted.
+- `staging_sweep_preserves_fresh_foreign_nested_and_nondirectory_entries`:
+  pins the containment and freshness boundary so a broad prefix match cannot
+  delete an in-flight clone or unrelated operator data.
 - `dir_size_errors_when_the_root_itself_is_missing` (PR #847): the walk
   root vanishing must surface as an error, never a laundered `Ok(0)` —
   distinct from a descendant vanishing beneath a still-existing root.
@@ -337,7 +371,7 @@ sync `#[test]`s).
   empty-directory removal is a single `rmdir` syscall, the same order of
   cost as the `symlink_metadata`/`read_dir` calls `dir_size` opens with —
   a populated root, by contrast, has its own directory entry removed
-  *last* by `remove_dir_all` after every child, which would make the
+  _last_ by `remove_dir_all` after every child, which would make the
   root-vanish race effectively unreachable). Runs 500 iterations and
   asserts the race was hit at least once.
 - `refetch_clone_updates_an_existing_slot_to_the_remote_tip`: the primary
@@ -356,7 +390,7 @@ sync `#[test]`s).
   it un-owned.
 - `refetch_clone_refuses_a_markerless_slot_under_the_cap`: remediation
   (issue #765 follow-up PR #788) — `refetch_clone` must refuse a
-  markerless slot *before* ever calling `fetch_refetch`. The origin is
+  markerless slot _before_ ever calling `fetch_refetch`. The origin is
   given fresh history so a fetch that ran despite the missing marker would
   be directly observable via a moved `HEAD`.
 - `reclone_replaces_a_slot_whose_refetch_cannot_succeed`: #765's fallback

--- a/crates/khive-pack-git/src/cache.rs
+++ b/crates/khive-pack-git/src/cache.rs
@@ -8,12 +8,22 @@
 //! or total-byte limit; a per-clone size cap rejects an oversized
 //! clone/fetch before it enters the addressable cache slot. A per-`cache_key`
 //! advisory `slot_lock` (issue #805) serializes each slot's check-and-mutate
-//! span. Opening the cache root also reclaims exact `.staging-<uuid>`
-//! directories older than 24 hours, covering process-kill residue that no
-//! in-process error handler can remove. See
+//! span.
+//!
+//! Fresh clones stage under a private namespace this cache owns outright
+//! (`<root>/.khive-git-staging/`), never directly in the (possibly shared,
+//! possibly `KHIVE_GIT_DIGEST_SCRATCH_ROOT`-overridden) cache root -- a
+//! staging entry's shape can never collide with unrelated operator data
+//! there. Each staging entry holds an exclusive advisory lock
+//! (`std::fs::File::try_lock`) on a file inside it for the whole span of the
+//! clone; opening the cache root reclaims a staging entry only once that
+//! lock is provably free (killed-clone residue no in-process handler could
+//! remove), never merely because it looks old -- a legitimate clone still
+//! running holds the lock regardless of how long it has been running. See
 //! crates/khive-pack-git/docs/api/cache.md for the full design rationale
-//! (ownership-proof eviction, staging-then-move installation, crash-residue
-//! reaping, per-clone cap enforcement, slot serialization).
+//! (ownership-proof eviction, staging-then-move installation, liveness-based
+//! crash-residue reaping, fd-verified owned-slot deletion, per-clone cap
+//! enforcement, slot serialization).
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -30,10 +40,26 @@ pub const DEFAULT_MAX_TOTAL_BYTES: u64 = 2 * 1024 * 1024 * 1024;
 pub const DEFAULT_CLONE_MAX_BYTES: u64 = 1024 * 1024 * 1024;
 
 const MARKER_FILE: &str = ".khive-last-used";
-const STAGING_PREFIX: &str = ".staging-";
-/// A fresh staging directory may belong to a clone still running in another
-/// process. Only residue older than this deliberately conservative window is
-/// reclaimed when the cache root is opened.
+/// Private subdirectory of the cache root this crate owns outright: fresh
+/// clones stage here (never directly in `root`), and an owned cache slot's
+/// deletion is routed through here too (unix). Never treated as a cache
+/// slot itself -- its name is not `cache_key`-shaped.
+const STAGING_NAMESPACE: &str = ".khive-git-staging";
+/// Advisory-lock file inside one staging entry, held for the whole span of
+/// the clone that owns it. See the module doc.
+const STAGING_LOCK_FILE: &str = ".khive-staging.lock";
+/// Marker file recording when the namespace was last swept, so
+/// `prepare_cache_root` does a full scan+liveness pass at most once per
+/// `REAP_THROTTLE_INTERVAL` instead of on every cache mutation.
+const REAP_SWEEP_MARKER: &str = ".khive-last-swept";
+const REAP_THROTTLE_INTERVAL: Duration = Duration::from_secs(5 * 60);
+/// Belt-and-suspenders fallback for a staging entry that crashed before it
+/// could write its own lock file (the brief mkdir-then-open-lock gap at the
+/// very start of `install_fresh_clone`) -- not the primary staleness
+/// signal, which is the lock itself. This cannot false-positive against a
+/// long-running live clone: a live clone writes its lock file within
+/// microseconds of creating its staging directory, well before `git clone`
+/// itself ever starts.
 const STALE_STAGING_AGE: Duration = Duration::from_secs(24 * 60 * 60);
 
 #[derive(Debug)]
@@ -331,6 +357,21 @@ fn reclone_locked(root: &Path, canonical_url: &str) -> Result<PathBuf, CacheErro
     Ok(repo_dir)
 }
 
+fn staging_namespace_path(root: &Path) -> PathBuf {
+    root.join(STAGING_NAMESPACE)
+}
+
+/// Create (if needed) and return the private staging namespace: a
+/// subdirectory of `root` this cache owns outright, never shared with
+/// operator data even under a broad `KHIVE_GIT_DIGEST_SCRATCH_ROOT`
+/// override. Fresh clones stage here; an owned slot's deletion is routed
+/// through here too (unix).
+fn ensure_staging_namespace(root: &Path) -> std::io::Result<PathBuf> {
+    let path = staging_namespace_path(root);
+    std::fs::create_dir_all(&path)?;
+    Ok(path)
+}
+
 /// Shared staging-clone-then-move path for both a first-time `ensure_clone`
 /// and a `reclone` repair. See
 /// crates/khive-pack-git/docs/api/cache.md#install_fresh_clone.
@@ -340,30 +381,66 @@ fn install_fresh_clone(
     repo_dir: &Path,
     cap: u64,
 ) -> Result<(), CacheError> {
-    let staging_dir = root.join(format!(".staging-{}", Uuid::new_v4()));
+    let namespace_root = ensure_staging_namespace(root)
+        .map_err(|e| io_err("install_fresh_clone: staging namespace", root, e))?;
+    let wrapper = namespace_root.join(Uuid::new_v4().to_string());
+    std::fs::create_dir_all(&wrapper)
+        .map_err(|e| io_err("install_fresh_clone: create staging wrapper", &wrapper, e))?;
+
+    let lock_path = wrapper.join(STAGING_LOCK_FILE);
+    let lock_file = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .write(true)
+        .open(&lock_path)
+        .map_err(|e| {
+            let _ = std::fs::remove_dir_all(&wrapper);
+            io_err("install_fresh_clone: open staging lock", &lock_path, e)
+        })?;
+    // Held for this whole span: while this handle (or any dup of its
+    // underlying fd) stays open, `reap_stale_staging`'s `try_lock` on this
+    // same path observes contention and treats this wrapper as live
+    // regardless of its age. A process kill (including SIGKILL) closes
+    // every fd the kernel holds for it and releases the lock automatically
+    // -- exactly the abandoned-staging signal the reaper needs, and never a
+    // false positive against a clone that is merely slow.
+    lock_file.try_lock().map_err(|e| {
+        let _ = std::fs::remove_dir_all(&wrapper);
+        io_err(
+            "install_fresh_clone: lock staging wrapper",
+            &lock_path,
+            std::io::Error::from(e),
+        )
+    })?;
+
+    let staging_dir = wrapper.join("repo");
     clone(canonical_url, &staging_dir).inspect_err(|_| {
         // `git clone` can create and partially populate the destination
-        // before failing (network drop, auth failure, bad ref) -- clean
-        // it up so a run of failures doesn't leave `.staging-*` litter
-        // under the scratch root. `evict_lru` deliberately never touches
-        // non-owned names (`is_owned_entry`), so nothing else would ever
-        // reclaim this on its own.
-        let _ = std::fs::remove_dir_all(&staging_dir);
+        // before failing (network drop, auth failure, bad ref) -- clean up
+        // the whole wrapper so a run of failures doesn't leave staging
+        // litter under the private namespace.
+        let _ = std::fs::remove_dir_all(&wrapper);
     })?;
     let size = dir_size(&staging_dir).inspect_err(|_| {
-        let _ = std::fs::remove_dir_all(&staging_dir);
+        let _ = std::fs::remove_dir_all(&wrapper);
     })?;
     if size > cap {
-        let _ = std::fs::remove_dir_all(&staging_dir);
+        let _ = std::fs::remove_dir_all(&wrapper);
         return Err(CacheError::CloneTooLarge { bytes: size, cap });
     }
     touch(&staging_dir).inspect_err(|_| {
-        let _ = std::fs::remove_dir_all(&staging_dir);
+        let _ = std::fs::remove_dir_all(&wrapper);
     })?;
     std::fs::rename(&staging_dir, repo_dir).map_err(|e| {
-        let _ = std::fs::remove_dir_all(&staging_dir);
+        let _ = std::fs::remove_dir_all(&wrapper);
         CacheError::Io(e)
     })?;
+    // The wrapper now contains only the lock file; drop the lock after
+    // removal is queued so a concurrent reaper never observes a
+    // still-locked-but-empty wrapper as a decision point (it simply won't
+    // see it at all once removed).
+    let _ = std::fs::remove_dir_all(&wrapper);
+    drop(lock_file);
     Ok(())
 }
 
@@ -376,8 +453,223 @@ fn remove_owned_entry(root: &Path, repo_dir: &Path) -> Result<(), CacheError> {
     if repo_dir.parent() != Some(root) || !is_owned_entry(repo_dir) {
         return Err(CacheError::UnsafeToReplace(repo_dir.to_path_buf()));
     }
-    remove_dir_all_retrying(repo_dir).map_err(CacheError::Io)?;
-    Ok(())
+    delete_verified_owned_entry(root, repo_dir)
+}
+
+/// Race-resistant deletion of an owned cache slot living in the (possibly
+/// shared, possibly `KHIVE_GIT_DIGEST_SCRATCH_ROOT`-overridden) cache root.
+/// `remove_owned_entry` already checked ownership by pathname above; on
+/// unix this re-verifies it against an `openat(O_NOFOLLOW)`-opened handle
+/// bound to the inode at that name right now, then moves it into the
+/// private staging namespace with a single fd-relative `renameat` call
+/// before the (possibly slow, for a multi-GB clone) recursive delete runs.
+/// This shrinks the pathname-TOCTOU window an external writer racing the
+/// shared root could exploit from "however long the recursive delete
+/// takes" down to the handful of syscalls between the `openat` and the
+/// `renameat`; a final fd-vs-renamed-entry identity check (inode never
+/// changes across a same-filesystem rename) confirms the move carried
+/// exactly the directory that was validated. See
+/// crates/khive-pack-git/docs/api/cache.md#delete_verified_owned_entry.
+#[cfg(unix)]
+fn delete_verified_owned_entry(root: &Path, repo_dir: &Path) -> Result<(), CacheError> {
+    let name = repo_dir
+        .file_name()
+        .ok_or_else(|| CacheError::UnsafeToReplace(repo_dir.to_path_buf()))?;
+    let root_fd = unix_fd::open_dir_nofollow(root)
+        .map_err(|e| io_err("delete_verified_owned_entry: open root", root, e))?;
+    let target_fd = unix_fd::openat_dir_nofollow(&root_fd, name)
+        .map_err(|_| CacheError::UnsafeToReplace(repo_dir.to_path_buf()))?;
+    if !is_owned_entry_via_fd(&target_fd) {
+        return Err(CacheError::UnsafeToReplace(repo_dir.to_path_buf()));
+    }
+    let target_id = unix_fd::fstat(&target_fd)
+        .map_err(|e| io_err("delete_verified_owned_entry: fstat target", repo_dir, e))?;
+
+    let namespace_root = ensure_staging_namespace(root)
+        .map_err(|e| io_err("delete_verified_owned_entry: staging namespace", root, e))?;
+    let namespace_fd = unix_fd::open_dir_nofollow(&namespace_root).map_err(|e| {
+        io_err(
+            "delete_verified_owned_entry: open staging namespace",
+            &namespace_root,
+            e,
+        )
+    })?;
+    let trash_name = format!("trash-{}", Uuid::new_v4());
+    let trash_name_os = std::ffi::OsStr::new(&trash_name);
+    unix_fd::renameat(&root_fd, name, &namespace_fd, trash_name_os).map_err(|e| {
+        io_err(
+            "delete_verified_owned_entry: renameat to private namespace",
+            repo_dir,
+            e,
+        )
+    })?;
+
+    // `target_fd` still refers to the same inode after the rename (a file
+    // descriptor tracks the open file, not its name). Compare it against
+    // what `renameat` actually landed under `trash_name` to confirm the
+    // move carried exactly the directory validated above, not something
+    // that slipped into `name`'s place in the syscalls between the checks
+    // above and the `renameat` call.
+    let moved_path = namespace_root.join(&trash_name);
+    let moved_id = unix_fd::fstatat_nofollow(&namespace_fd, trash_name_os).map_err(|e| {
+        io_err(
+            "delete_verified_owned_entry: fstat moved entry",
+            &moved_path,
+            e,
+        )
+    })?;
+    if (moved_id.st_dev, moved_id.st_ino) != (target_id.st_dev, target_id.st_ino) {
+        return Err(CacheError::UnsafeToReplace(repo_dir.to_path_buf()));
+    }
+
+    remove_dir_all_retrying(&moved_path).map_err(CacheError::Io)
+}
+
+#[cfg(not(unix))]
+fn delete_verified_owned_entry(_root: &Path, repo_dir: &Path) -> Result<(), CacheError> {
+    remove_dir_all_retrying(repo_dir).map_err(CacheError::Io)
+}
+
+/// fd-relative mirror of `is_owned_entry`: proves ownership against an
+/// already-opened, `O_NOFOLLOW`-bound handle instead of re-resolving
+/// `path.join(...)` by name. See crates/khive-pack-git/docs/api/cache.md#is_owned_entry.
+#[cfg(unix)]
+fn is_owned_entry_via_fd(target_fd: &std::fs::File) -> bool {
+    let has_git = unix_fd::fstatat_nofollow(target_fd, std::ffi::OsStr::new(".git")).is_ok();
+    let marker_is_regular_file =
+        unix_fd::fstatat_nofollow(target_fd, std::ffi::OsStr::new(MARKER_FILE))
+            .is_ok_and(|st| (st.st_mode & libc::S_IFMT) == libc::S_IFREG);
+    has_git && marker_is_regular_file
+}
+
+/// `openat`/`fstatat`/`renameat` primitives bound to an already-opened
+/// directory descriptor rather than a pathname, mirroring the
+/// `O_NOFOLLOW`/`fstat` idiom used in `khive-db`'s WAL-pin sidecar and
+/// `khive-vamana`'s external-id sidecar: every operation after the initial
+/// `open`/`openat` is relative to a handle the kernel resolved once, immune
+/// to the original pathname being swapped out from under it afterward.
+#[cfg(unix)]
+mod unix_fd {
+    use std::ffi::{CString, OsStr};
+    use std::fs;
+    use std::io;
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::io::{AsRawFd, FromRawFd};
+    use std::path::Path;
+
+    fn cstring(component: &OsStr) -> io::Result<CString> {
+        CString::new(component.as_bytes()).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "path component contains a NUL byte",
+            )
+        })
+    }
+
+    /// Open `path` as a directory, refusing to follow a symlink at the
+    /// final component. The returned handle is bound to that exact inode:
+    /// every later `*at()` call against it is immune to `path` being
+    /// replaced out from under it afterward.
+    pub(super) fn open_dir_nofollow(path: &Path) -> io::Result<fs::File> {
+        let c_path = CString::new(path.as_os_str().as_bytes())
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "path contains a NUL byte"))?;
+        // SAFETY: `c_path` is NUL-terminated and lives for the duration of
+        // the call; `O_NOFOLLOW` refuses a symlink at the final component
+        // and `O_DIRECTORY` refuses a non-directory.
+        let fd = unsafe {
+            libc::open(
+                c_path.as_ptr(),
+                libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+            )
+        };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: `fd` was just returned by a successful `open` and is
+        // owned here.
+        Ok(unsafe { fs::File::from_raw_fd(fd) })
+    }
+
+    /// `openat(dir, name, O_DIRECTORY | O_NOFOLLOW)` — open the single path
+    /// component `name` as a directory relative to `dir`'s own descriptor,
+    /// refusing a symlink at that component.
+    pub(super) fn openat_dir_nofollow(dir: &fs::File, name: &OsStr) -> io::Result<fs::File> {
+        let c_name = cstring(name)?;
+        // SAFETY: `dir.as_raw_fd()` is a live directory descriptor;
+        // `c_name` is NUL-terminated for the duration of the call.
+        let fd = unsafe {
+            libc::openat(
+                dir.as_raw_fd(),
+                c_name.as_ptr(),
+                libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+            )
+        };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: `fd` was just returned by a successful `openat`.
+        Ok(unsafe { fs::File::from_raw_fd(fd) })
+    }
+
+    /// `fstatat(dir, name, AT_SYMLINK_NOFOLLOW)` — the identity of `name`
+    /// as it stands right now, resolved relative to `dir`'s own descriptor
+    /// rather than a fresh pathname walk from the filesystem root.
+    pub(super) fn fstatat_nofollow(dir: &fs::File, name: &OsStr) -> io::Result<libc::stat> {
+        let c_name = cstring(name)?;
+        let mut st: libc::stat = unsafe { std::mem::zeroed() };
+        // SAFETY: `dir.as_raw_fd()` is live; `c_name` is NUL-terminated;
+        // `st` is a valid out-param for the duration of the call.
+        let rc = unsafe {
+            libc::fstatat(
+                dir.as_raw_fd(),
+                c_name.as_ptr(),
+                &mut st,
+                libc::AT_SYMLINK_NOFOLLOW,
+            )
+        };
+        if rc != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(st)
+    }
+
+    pub(super) fn fstat(file: &fs::File) -> io::Result<libc::stat> {
+        let mut st: libc::stat = unsafe { std::mem::zeroed() };
+        // SAFETY: `file.as_raw_fd()` is live; `st` is a valid out-param for
+        // the duration of the call.
+        let rc = unsafe { libc::fstat(file.as_raw_fd(), &mut st) };
+        if rc != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(st)
+    }
+
+    /// `renameat(from, name, to, to_name)` — move `name` out of `from` and
+    /// into `to` under `to_name`, both endpoints fd-relative so neither is
+    /// re-resolved by pathname at the moment of the move.
+    pub(super) fn renameat(
+        from: &fs::File,
+        name: &OsStr,
+        to: &fs::File,
+        to_name: &OsStr,
+    ) -> io::Result<()> {
+        let c_name = cstring(name)?;
+        let c_to_name = cstring(to_name)?;
+        // SAFETY: both fds are live directory descriptors; both C strings
+        // are NUL-terminated for the duration of the call.
+        let rc = unsafe {
+            libc::renameat(
+                from.as_raw_fd(),
+                c_name.as_ptr(),
+                to.as_raw_fd(),
+                c_to_name.as_ptr(),
+            )
+        };
+        if rc != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
+    }
 }
 
 /// Retries `remove_dir_all` a few times before giving up — see
@@ -526,62 +818,179 @@ fn io_err(op: &str, path: &Path, e: std::io::Error) -> CacheError {
     ))
 }
 
-/// Create/open the daemon-owned cache root and reclaim staging directories a
-/// killed clone could not clean up itself. This runs before every public
-/// cache mutation; the age fence prevents one process from deleting a fresh
-/// clone legitimately in flight in another process.
+/// Create/open the daemon-owned cache root and the private staging
+/// namespace inside it. Reclaims abandoned staging directories a killed
+/// clone could not clean up itself -- at most once per
+/// `REAP_THROTTLE_INTERVAL`, since every public cache mutation runs this
+/// before its own work and a full liveness pass over every staging entry on
+/// every single mutation is unbounded latency for no benefit once the
+/// namespace is already clean.
 fn prepare_cache_root(root: &Path) -> Result<(), CacheError> {
     std::fs::create_dir_all(root)
         .map_err(|e| io_err("prepare_cache_root: create_dir_all", root, e))?;
+    let namespace_root = ensure_staging_namespace(root)
+        .map_err(|e| io_err("prepare_cache_root: create staging namespace", root, e))?;
+    if !reap_due(&namespace_root)? {
+        return Ok(());
+    }
     let removed = reap_stale_staging(root, SystemTime::now(), STALE_STAGING_AGE)?;
+    mark_reap_swept(&namespace_root);
     if removed > 0 {
         tracing::info!(
             removed,
             root = %root.display(),
-            "reclaimed stale git-digest staging directories"
+            "reclaimed abandoned git-digest staging directories"
         );
     }
     Ok(())
 }
 
-/// Exact ownership proof for an unaddressable staging clone: a canonical
-/// lowercase hyphenated UUID under the private `.staging-` prefix. Prefix
-/// lookalikes are left untouched, which matters when an operator overrides
-/// the scratch root to an existing directory.
-fn is_staging_name(name: &std::ffi::OsStr) -> bool {
+/// Whether enough time has passed since the last sweep to run another one.
+/// A missing marker (first call ever, or a namespace a previous sweep just
+/// emptied without leaving the marker readable) always sweeps.
+fn reap_due(namespace_root: &Path) -> Result<bool, CacheError> {
+    let marker = namespace_root.join(REAP_SWEEP_MARKER);
+    match std::fs::metadata(&marker).and_then(|m| m.modified()) {
+        Ok(last) => {
+            let elapsed = SystemTime::now()
+                .duration_since(last)
+                .unwrap_or(Duration::MAX);
+            Ok(elapsed >= REAP_THROTTLE_INTERVAL)
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(true),
+        Err(e) => Err(io_err("prepare_cache_root: read sweep marker", &marker, e)),
+    }
+}
+
+/// Best-effort: a failure to record the sweep marker only costs an extra
+/// sweep next time, never correctness.
+fn mark_reap_swept(namespace_root: &Path) {
+    let marker = namespace_root.join(REAP_SWEEP_MARKER);
+    if let Err(e) = std::fs::write(&marker, b"") {
+        tracing::warn!(
+            error = %e,
+            "failed to record git-digest staging sweep marker"
+        );
+    }
+}
+
+/// Exact ownership proof for a staging wrapper: a canonical lowercase
+/// hyphenated UUID, a direct child of the private staging namespace.
+fn is_staging_wrapper_name(name: &std::ffi::OsStr) -> bool {
     let Some(name) = name.to_str() else {
         return false;
     };
-    let Some(suffix) = name.strip_prefix(STAGING_PREFIX) else {
-        return false;
-    };
-    Uuid::parse_str(suffix).is_ok_and(|id| id.to_string() == suffix)
+    Uuid::parse_str(name).is_ok_and(|id| id.to_string() == name)
 }
 
-/// Remove stale staging directories that are direct children of `root`.
-/// Symlinks, files, nested paths, prefix lookalikes, future-dated entries,
-/// and entries at or below `max_age` are never removed. `now`/`max_age` are
-/// explicit so the age boundary is deterministic in tests.
+/// Liveness verdict for one staging wrapper.
+enum StagingLiveness {
+    /// A live handle holds the wrapper's lock (or it has not existed long
+    /// enough yet for a missing lock file to mean anything) -- must survive
+    /// regardless of age.
+    Live,
+    /// No live handle holds the lock: either `try_lock` acquired it
+    /// (nothing else has it open), or the lock file was never written and
+    /// the wrapper is old enough that it cannot be a legitimate in-flight
+    /// clone.
+    Abandoned,
+}
+
+/// Liveness, not age, is the deletion criterion (see the module doc). A
+/// wrapper whose lock file exists is judged purely by whether `try_lock`
+/// can acquire it -- an active clone running past `max_age` still holds the
+/// lock and survives; a killed clone's lock is released by the kernel the
+/// instant the process dies and is reaped on the very next sweep,
+/// regardless of how fresh its mtime looks. A missing lock file (the
+/// narrow crash-before-lock-file window) falls back to the same
+/// conservative age fence the old age-only check used.
+fn staging_liveness(
+    wrapper: &Path,
+    now: SystemTime,
+    max_age: Duration,
+) -> Result<StagingLiveness, CacheError> {
+    let lock_path = wrapper.join(STAGING_LOCK_FILE);
+    match std::fs::OpenOptions::new().write(true).open(&lock_path) {
+        Ok(lock_file) => match lock_file.try_lock() {
+            Ok(()) => Ok(StagingLiveness::Abandoned),
+            Err(std::fs::TryLockError::WouldBlock) => Ok(StagingLiveness::Live),
+            Err(std::fs::TryLockError::Error(e)) => {
+                Err(io_err("reap_stale_staging: try_lock", &lock_path, e))
+            }
+        },
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            let modified = std::fs::symlink_metadata(wrapper)
+                .and_then(|m| m.modified())
+                .map_err(|e| io_err("reap_stale_staging: wrapper mtime", wrapper, e))?;
+            match now.duration_since(modified) {
+                Ok(age) if age > max_age => Ok(StagingLiveness::Abandoned),
+                _ => Ok(StagingLiveness::Live),
+            }
+        }
+        Err(e) => Err(io_err(
+            "reap_stale_staging: open staging lock",
+            &lock_path,
+            e,
+        )),
+    }
+}
+
+/// Remove a staging wrapper found abandoned by `staging_liveness`. The
+/// wrapper lives inside the private namespace this cache owns outright, so
+/// unlike an owned cache slot in the shared root (`delete_verified_owned_entry`)
+/// there is no external-writer exposure to harden against here -- nothing
+/// but this cache ever creates entries under `STAGING_NAMESPACE`.
+fn remove_staging_wrapper(namespace_root: &Path, name: &std::ffi::OsStr) -> Result<(), CacheError> {
+    match remove_dir_all_retrying(&namespace_root.join(name)) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(CacheError::Io(e)),
+    }
+}
+
+/// Reclaim abandoned staging wrappers under the private namespace. A
+/// deletion candidate must be a real directory (never a symlink, file, or
+/// nested path) whose name is exactly a canonical lowercase hyphenated
+/// UUID, and must be judged `Abandoned` by `staging_liveness`. `now`/
+/// `max_age` are explicit so the fallback age boundary is deterministic in
+/// tests.
 fn reap_stale_staging(
     root: &Path,
     now: SystemTime,
     max_age: Duration,
 ) -> Result<usize, CacheError> {
-    let read_dir = std::fs::read_dir(root)
-        .map_err(|e| io_err("reap_stale_staging: read_dir root", root, e))?;
+    let namespace_root = staging_namespace_path(root);
+    let read_dir = match std::fs::read_dir(&namespace_root) {
+        Ok(read_dir) => read_dir,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(e) => {
+            return Err(io_err(
+                "reap_stale_staging: read_dir namespace",
+                &namespace_root,
+                e,
+            ));
+        }
+    };
     let mut removed = 0usize;
 
     for entry in read_dir {
         let entry = match entry {
             Ok(entry) => entry,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
-            Err(e) => return Err(io_err("reap_stale_staging: read_dir entry", root, e)),
+            Err(e) => {
+                return Err(io_err(
+                    "reap_stale_staging: read_dir entry",
+                    &namespace_root,
+                    e,
+                ));
+            }
         };
-        if !is_staging_name(&entry.file_name()) {
+        let name = entry.file_name();
+        if !is_staging_wrapper_name(&name) {
             continue;
         }
         let path = entry.path();
-        if path.parent() != Some(root) {
+        if path.parent() != Some(namespace_root.as_path()) {
             continue;
         }
         let metadata = match std::fs::symlink_metadata(&path) {
@@ -592,20 +1001,13 @@ fn reap_stale_staging(
         if !metadata.file_type().is_dir() {
             continue;
         }
-        let modified = metadata
-            .modified()
-            .map_err(|e| io_err("reap_stale_staging: modified", &path, e))?;
-        let Ok(age) = now.duration_since(modified) else {
-            continue;
-        };
-        if age <= max_age {
-            continue;
-        }
 
-        match remove_dir_all_retrying(&path) {
-            Ok(()) => removed += 1,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-            Err(e) => return Err(io_err("reap_stale_staging: remove", &path, e)),
+        match staging_liveness(&path, now, max_age)? {
+            StagingLiveness::Live => continue,
+            StagingLiveness::Abandoned => {
+                remove_staging_wrapper(&namespace_root, &name)?;
+                removed += 1;
+            }
         }
     }
 
@@ -816,6 +1218,31 @@ mod tests {
         p
     }
 
+    /// Build a staging wrapper directly (bypassing `install_fresh_clone`)
+    /// under the private namespace, optionally with a lock file held open
+    /// by the returned guard (drop the guard to simulate the owning
+    /// process dying / releasing the lock).
+    fn make_staging_wrapper(root: &Path, held: bool) -> (PathBuf, Uuid, Option<std::fs::File>) {
+        let namespace_root = ensure_staging_namespace(root).expect("staging namespace");
+        let id = Uuid::new_v4();
+        let wrapper = namespace_root.join(id.to_string());
+        std::fs::create_dir_all(wrapper.join("repo")).expect("create staging wrapper");
+        let held_file = if held {
+            let lock_path = wrapper.join(STAGING_LOCK_FILE);
+            let f = std::fs::OpenOptions::new()
+                .create(true)
+                .truncate(false)
+                .write(true)
+                .open(&lock_path)
+                .expect("open lock file");
+            f.try_lock().expect("acquire lock");
+            Some(f)
+        } else {
+            None
+        };
+        (wrapper, id, held_file)
+    }
+
     fn slot_lock_registry_len() -> usize {
         SLOT_LOCKS
             .lock()
@@ -831,16 +1258,16 @@ mod tests {
     }
 
     #[test]
-    fn stale_staging_sweep_removes_a_direct_canonical_uuid_directory() {
+    fn stale_staging_sweep_removes_an_abandoned_wrapper_lacking_a_lock_file_once_old() {
         let root = tempfile::tempdir().expect("tempdir");
-        let orphan = root.path().join(format!(".staging-{}", Uuid::new_v4()));
-        std::fs::create_dir_all(orphan.join("partial.git/objects")).expect("create orphan");
-        std::fs::write(orphan.join("partial.git/objects/pack"), b"partial")
+        let (wrapper, _id, _held) = make_staging_wrapper(root.path(), false);
+        std::fs::create_dir_all(wrapper.join("repo/partial.git/objects")).expect("nested payload");
+        std::fs::write(wrapper.join("repo/partial.git/objects/pack"), b"partial")
             .expect("write orphan payload");
-        let observed_mtime = std::fs::symlink_metadata(&orphan)
-            .expect("orphan metadata")
+        let observed_mtime = std::fs::symlink_metadata(&wrapper)
+            .expect("wrapper metadata")
             .modified()
-            .expect("orphan mtime");
+            .expect("wrapper mtime");
 
         let removed = reap_stale_staging(
             root.path(),
@@ -850,50 +1277,102 @@ mod tests {
         .expect("reap stale staging directory");
 
         assert_eq!(removed, 1);
-        assert!(!orphan.exists(), "stale staging payload must be reclaimed");
+        assert!(
+            !wrapper.exists(),
+            "abandoned staging payload must be reclaimed"
+        );
     }
 
+    /// Blocking-finding acceptance test: a wrapper whose lock is still held
+    /// by a live handle must survive the sweep no matter how far past the
+    /// age fence it is -- age alone must never be the deletion criterion.
     #[test]
-    fn staging_sweep_preserves_fresh_foreign_nested_and_nondirectory_entries() {
+    fn stale_staging_sweep_preserves_a_wrapper_whose_lock_is_still_held_past_the_age_fence() {
         let root = tempfile::tempdir().expect("tempdir");
-        let fresh = root.path().join(format!(".staging-{}", Uuid::new_v4()));
-        std::fs::create_dir_all(&fresh).expect("create fresh staging dir");
-        let fresh_mtime = std::fs::symlink_metadata(&fresh)
-            .expect("fresh metadata")
-            .modified()
-            .expect("fresh mtime");
+        let (wrapper, _id, held) = make_staging_wrapper(root.path(), true);
+        let _held = held.expect("lock guard");
 
-        let foreign = root.path().join(".staging-not-a-canonical-uuid");
-        std::fs::create_dir_all(&foreign).expect("create foreign prefix dir");
-        let staging_file = root.path().join(format!(".staging-{}", Uuid::new_v4()));
-        std::fs::write(&staging_file, b"operator file").expect("write staging-shaped file");
-        let nested = root
-            .path()
-            .join("operator-owned")
-            .join(format!(".staging-{}", Uuid::new_v4()));
-        std::fs::create_dir_all(&nested).expect("create nested staging-shaped dir");
-
-        let removed = reap_stale_staging(
-            root.path(),
-            fresh_mtime,
-            std::time::Duration::from_secs(24 * 60 * 60),
-        )
-        .expect("scan fresh staging entries");
+        let far_future = SystemTime::now() + std::time::Duration::from_secs(365 * 24 * 60 * 60);
+        let removed =
+            reap_stale_staging(root.path(), far_future, std::time::Duration::from_secs(1))
+                .expect("sweep around a live wrapper");
 
         assert_eq!(removed, 0);
         assert!(
-            fresh.is_dir(),
-            "an in-flight fresh staging dir must survive"
-        );
-        assert!(foreign.is_dir(), "prefix alone is not ownership proof");
-        assert!(staging_file.is_file(), "the sweep removes directories only");
-        assert!(
-            nested.is_dir(),
-            "the sweep never descends below the cache root"
+            wrapper.exists(),
+            "a wrapper whose lock is still held by a live process must survive, \
+             even a full year past the age fence"
         );
     }
 
-    /// A `git clone` failure must not leave a `.staging-<uuid>` dir behind.
+    /// The flip side of the test above: liveness, not freshness, is what
+    /// matters. An abandoned wrapper (its lock file exists but nothing
+    /// holds the lock) is reclaimed even when it was created moments ago.
+    #[test]
+    fn stale_staging_sweep_removes_an_abandoned_wrapper_even_when_fresh() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let (wrapper, _id, held) = make_staging_wrapper(root.path(), true);
+        // Simulate the owning process dying: release the lock (dropping the
+        // handle is exactly what the kernel does on process exit/kill).
+        drop(held);
+
+        let removed = reap_stale_staging(
+            root.path(),
+            SystemTime::now(),
+            std::time::Duration::from_secs(24 * 60 * 60),
+        )
+        .expect("sweep an abandoned-but-fresh wrapper");
+
+        assert_eq!(removed, 1);
+        assert!(
+            !wrapper.exists(),
+            "an abandoned wrapper must be reclaimed even when it is not old"
+        );
+    }
+
+    #[test]
+    fn staging_sweep_preserves_foreign_nested_and_nondirectory_entries_even_when_stale() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let namespace_root = ensure_staging_namespace(root.path()).expect("namespace");
+
+        let live_id = Uuid::new_v4();
+        let live_wrapper = namespace_root.join(live_id.to_string());
+        std::fs::create_dir_all(&live_wrapper).expect("create live wrapper");
+
+        let foreign = namespace_root.join("not-a-canonical-uuid");
+        std::fs::create_dir_all(&foreign).expect("create foreign-named dir");
+        let staging_file = namespace_root.join(Uuid::new_v4().to_string());
+        std::fs::write(&staging_file, b"operator file").expect("write uuid-shaped file");
+        let nested = namespace_root
+            .join("operator-owned")
+            .join(Uuid::new_v4().to_string());
+        std::fs::create_dir_all(&nested).expect("create nested uuid-shaped dir");
+
+        // Every entry above is missing its lock file, so the fallback age
+        // check applies -- drive `now` far enough past `max_age` that every
+        // candidate would be reclaimed by age alone. Only the containment,
+        // name-shape, and type checks may save them (regression coverage
+        // for the bug where a future-dated fixture never reached those
+        // checks at all).
+        let far_future = SystemTime::now() + std::time::Duration::from_secs(365 * 24 * 60 * 60);
+        let removed =
+            reap_stale_staging(root.path(), far_future, std::time::Duration::from_secs(1))
+                .expect("scan namespace entries");
+
+        assert_eq!(
+            removed, 1,
+            "only the canonical-UUID live wrapper is reclaimed"
+        );
+        assert!(!live_wrapper.exists());
+        assert!(foreign.is_dir(), "a non-UUID name is not staging-shaped");
+        assert!(staging_file.is_file(), "the sweep removes directories only");
+        assert!(
+            nested.is_dir(),
+            "the sweep never descends below the namespace root"
+        );
+    }
+
+    /// A `git clone` failure must not leave a staging wrapper behind.
     #[test]
     fn ensure_clone_cleans_up_staging_dir_on_clone_failure() {
         let _guard = ENV_MUTEX.blocking_lock();
@@ -907,15 +1386,16 @@ mod tests {
             "cloning a nonexistent local path must fail: {result:?}"
         );
 
-        let leftovers: Vec<_> = std::fs::read_dir(dir.path())
-            .expect("read scratch root")
+        let namespace_root = staging_namespace_path(dir.path());
+        let leftovers: Vec<_> = std::fs::read_dir(&namespace_root)
+            .expect("read staging namespace")
             .filter_map(|e| e.ok())
-            .map(|e| e.file_name().to_string_lossy().into_owned())
-            .filter(|name| name.starts_with(".staging-"))
+            .map(|e| e.file_name())
+            .filter(|name| is_staging_wrapper_name(name))
             .collect();
         assert!(
             leftovers.is_empty(),
-            "a failed clone must not leave .staging-* directories behind: {leftovers:?}"
+            "a failed clone must not leave staging wrappers behind: {leftovers:?}"
         );
 
         std::env::remove_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT");
@@ -1718,6 +2198,48 @@ mod tests {
         );
 
         std::env::remove_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT");
+    }
+
+    /// Blocking-finding regression: an owned cache slot deleted through
+    /// `remove_owned_entry` (LRU eviction / repair over-cap cleanup) must
+    /// actually disappear, and a directory that is NOT a proven owned slot
+    /// -- even one an external writer swapped in at the exact cache-key
+    /// path after the caller last checked -- must never be deleted by the
+    /// fd-verified path either.
+    #[test]
+    fn remove_owned_entry_deletes_a_genuinely_owned_slot() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        let owned = make_owned_entry(root, "aaaaaaaaaaaaaaaa", true);
+        std::fs::write(owned.join("payload.txt"), b"clone contents").unwrap();
+
+        remove_owned_entry(root, &owned).expect("remove owned slot");
+        assert!(!owned.exists(), "an owned slot must be deleted");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remove_owned_entry_refuses_a_symlink_planted_at_the_cache_key_path_after_the_check() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        let target = tempfile::tempdir().expect("symlink target");
+        std::fs::write(target.path().join("victim.txt"), b"do not delete me").unwrap();
+
+        // `remove_owned_entry`'s own top-level `is_owned_entry` check cannot
+        // be satisfied by a bare symlink (it is filtered out before this
+        // function is ever reached in the real callers), so this test drives
+        // the fd-verified path directly to prove it independently refuses a
+        // symlink even if some future caller skipped that earlier gate.
+        let repo_dir = root.join("bbbbbbbbbbbbbbbb");
+        std::os::unix::fs::symlink(target.path(), &repo_dir).expect("plant symlink");
+
+        let err = delete_verified_owned_entry(root, &repo_dir)
+            .expect_err("a symlink at the cache-key path must be refused");
+        assert!(matches!(err, CacheError::UnsafeToReplace(_)));
+        assert!(
+            target.path().join("victim.txt").exists(),
+            "the symlink target's contents must survive a refused deletion"
+        );
     }
 
     // ── issue #805: same-key mutation serialization ────────────────────────

--- a/crates/khive-pack-git/src/cache.rs
+++ b/crates/khive-pack-git/src/cache.rs
@@ -735,6 +735,69 @@ mod tests {
             .capacity()
     }
 
+    #[test]
+    fn stale_staging_sweep_removes_a_direct_canonical_uuid_directory() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let orphan = root.path().join(format!(".staging-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(orphan.join("partial.git/objects")).expect("create orphan");
+        std::fs::write(orphan.join("partial.git/objects/pack"), b"partial")
+            .expect("write orphan payload");
+        let observed_mtime = std::fs::symlink_metadata(&orphan)
+            .expect("orphan metadata")
+            .modified()
+            .expect("orphan mtime");
+
+        let removed = reap_stale_staging(
+            root.path(),
+            observed_mtime + std::time::Duration::from_secs(2),
+            std::time::Duration::from_secs(1),
+        )
+        .expect("reap stale staging directory");
+
+        assert_eq!(removed, 1);
+        assert!(!orphan.exists(), "stale staging payload must be reclaimed");
+    }
+
+    #[test]
+    fn staging_sweep_preserves_fresh_foreign_nested_and_nondirectory_entries() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let fresh = root.path().join(format!(".staging-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&fresh).expect("create fresh staging dir");
+        let fresh_mtime = std::fs::symlink_metadata(&fresh)
+            .expect("fresh metadata")
+            .modified()
+            .expect("fresh mtime");
+
+        let foreign = root.path().join(".staging-not-a-canonical-uuid");
+        std::fs::create_dir_all(&foreign).expect("create foreign prefix dir");
+        let staging_file = root.path().join(format!(".staging-{}", Uuid::new_v4()));
+        std::fs::write(&staging_file, b"operator file").expect("write staging-shaped file");
+        let nested = root
+            .path()
+            .join("operator-owned")
+            .join(format!(".staging-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&nested).expect("create nested staging-shaped dir");
+
+        let removed = reap_stale_staging(
+            root.path(),
+            fresh_mtime,
+            std::time::Duration::from_secs(24 * 60 * 60),
+        )
+        .expect("scan fresh staging entries");
+
+        assert_eq!(removed, 0);
+        assert!(
+            fresh.is_dir(),
+            "an in-flight fresh staging dir must survive"
+        );
+        assert!(foreign.is_dir(), "prefix alone is not ownership proof");
+        assert!(staging_file.is_file(), "the sweep removes directories only");
+        assert!(
+            nested.is_dir(),
+            "the sweep never descends below the cache root"
+        );
+    }
+
     /// A `git clone` failure must not leave a `.staging-<uuid>` dir behind.
     #[test]
     fn ensure_clone_cleans_up_staging_dir_on_clone_failure() {

--- a/crates/khive-pack-git/src/cache.rs
+++ b/crates/khive-pack-git/src/cache.rs
@@ -8,15 +8,18 @@
 //! or total-byte limit; a per-clone size cap rejects an oversized
 //! clone/fetch before it enters the addressable cache slot. A per-`cache_key`
 //! advisory `slot_lock` (issue #805) serializes each slot's check-and-mutate
-//! span. See crates/khive-pack-git/docs/api/cache.md for the full design
-//! rationale (ownership-proof eviction, staging-then-move installation,
-//! per-clone cap enforcement, slot serialization).
+//! span. Opening the cache root also reclaims exact `.staging-<uuid>`
+//! directories older than 24 hours, covering process-kill residue that no
+//! in-process error handler can remove. See
+//! crates/khive-pack-git/docs/api/cache.md for the full design rationale
+//! (ownership-proof eviction, staging-then-move installation, crash-residue
+//! reaping, per-clone cap enforcement, slot serialization).
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::{Arc, Mutex};
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 use uuid::Uuid;
 
@@ -27,6 +30,11 @@ pub const DEFAULT_MAX_TOTAL_BYTES: u64 = 2 * 1024 * 1024 * 1024;
 pub const DEFAULT_CLONE_MAX_BYTES: u64 = 1024 * 1024 * 1024;
 
 const MARKER_FILE: &str = ".khive-last-used";
+const STAGING_PREFIX: &str = ".staging-";
+/// A fresh staging directory may belong to a clone still running in another
+/// process. Only residue older than this deliberately conservative window is
+/// reclaimed when the cache root is opened.
+const STALE_STAGING_AGE: Duration = Duration::from_secs(24 * 60 * 60);
 
 #[derive(Debug)]
 pub enum CacheError {
@@ -220,7 +228,7 @@ fn finish_mutation(root: &Path, outcome: &Result<PathBuf, CacheError>) {
 }
 
 fn ensure_clone_locked(root: &Path, canonical_url: &str) -> Result<PathBuf, CacheError> {
-    std::fs::create_dir_all(root)?;
+    prepare_cache_root(root)?;
     let key = cache_key(canonical_url);
     let lock = slot_lock(&key);
     let _guard = lock.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -263,6 +271,7 @@ pub(crate) fn refetch_clone(canonical_url: &str) -> Result<PathBuf, CacheError> 
 }
 
 fn refetch_clone_locked(root: &Path, canonical_url: &str) -> Result<PathBuf, CacheError> {
+    prepare_cache_root(root)?;
     let key = cache_key(canonical_url);
     let lock = slot_lock(&key);
     let _guard = lock.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -308,7 +317,7 @@ pub(crate) fn reclone(canonical_url: &str) -> Result<PathBuf, CacheError> {
 }
 
 fn reclone_locked(root: &Path, canonical_url: &str) -> Result<PathBuf, CacheError> {
-    std::fs::create_dir_all(root)?;
+    prepare_cache_root(root)?;
     let key = cache_key(canonical_url);
     let lock = slot_lock(&key);
     let _guard = lock.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -515,6 +524,92 @@ fn io_err(op: &str, path: &Path, e: std::io::Error) -> CacheError {
         e.kind(),
         format!("{op} {}: {e}", path.display()),
     ))
+}
+
+/// Create/open the daemon-owned cache root and reclaim staging directories a
+/// killed clone could not clean up itself. This runs before every public
+/// cache mutation; the age fence prevents one process from deleting a fresh
+/// clone legitimately in flight in another process.
+fn prepare_cache_root(root: &Path) -> Result<(), CacheError> {
+    std::fs::create_dir_all(root)
+        .map_err(|e| io_err("prepare_cache_root: create_dir_all", root, e))?;
+    let removed = reap_stale_staging(root, SystemTime::now(), STALE_STAGING_AGE)?;
+    if removed > 0 {
+        tracing::info!(
+            removed,
+            root = %root.display(),
+            "reclaimed stale git-digest staging directories"
+        );
+    }
+    Ok(())
+}
+
+/// Exact ownership proof for an unaddressable staging clone: a canonical
+/// lowercase hyphenated UUID under the private `.staging-` prefix. Prefix
+/// lookalikes are left untouched, which matters when an operator overrides
+/// the scratch root to an existing directory.
+fn is_staging_name(name: &std::ffi::OsStr) -> bool {
+    let Some(name) = name.to_str() else {
+        return false;
+    };
+    let Some(suffix) = name.strip_prefix(STAGING_PREFIX) else {
+        return false;
+    };
+    Uuid::parse_str(suffix).is_ok_and(|id| id.to_string() == suffix)
+}
+
+/// Remove stale staging directories that are direct children of `root`.
+/// Symlinks, files, nested paths, prefix lookalikes, future-dated entries,
+/// and entries at or below `max_age` are never removed. `now`/`max_age` are
+/// explicit so the age boundary is deterministic in tests.
+fn reap_stale_staging(
+    root: &Path,
+    now: SystemTime,
+    max_age: Duration,
+) -> Result<usize, CacheError> {
+    let read_dir = std::fs::read_dir(root)
+        .map_err(|e| io_err("reap_stale_staging: read_dir root", root, e))?;
+    let mut removed = 0usize;
+
+    for entry in read_dir {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(io_err("reap_stale_staging: read_dir entry", root, e)),
+        };
+        if !is_staging_name(&entry.file_name()) {
+            continue;
+        }
+        let path = entry.path();
+        if path.parent() != Some(root) {
+            continue;
+        }
+        let metadata = match std::fs::symlink_metadata(&path) {
+            Ok(metadata) => metadata,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(io_err("reap_stale_staging: stat", &path, e)),
+        };
+        if !metadata.file_type().is_dir() {
+            continue;
+        }
+        let modified = metadata
+            .modified()
+            .map_err(|e| io_err("reap_stale_staging: modified", &path, e))?;
+        let Ok(age) = now.duration_since(modified) else {
+            continue;
+        };
+        if age <= max_age {
+            continue;
+        }
+
+        match remove_dir_all_retrying(&path) {
+            Ok(()) => removed += 1,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(io_err("reap_stale_staging: remove", &path, e)),
+        }
+    }
+
+    Ok(removed)
 }
 
 fn touch(repo_dir: &Path) -> Result<(), CacheError> {

--- a/crates/khive-pack-git/src/cache.rs
+++ b/crates/khive-pack-git/src/cache.rs
@@ -535,11 +535,12 @@ fn delete_verified_owned_entry(_root: &Path, repo_dir: &Path) -> Result<(), Cach
 /// `path.join(...)` by name. See crates/khive-pack-git/docs/api/cache.md#is_owned_entry.
 #[cfg(unix)]
 fn is_owned_entry_via_fd(target_fd: &std::fs::File) -> bool {
-    let has_git = unix_fd::fstatat_nofollow(target_fd, std::ffi::OsStr::new(".git")).is_ok();
+    let git_is_directory = unix_fd::fstatat_nofollow(target_fd, std::ffi::OsStr::new(".git"))
+        .is_ok_and(|st| (st.st_mode & libc::S_IFMT) == libc::S_IFDIR);
     let marker_is_regular_file =
         unix_fd::fstatat_nofollow(target_fd, std::ffi::OsStr::new(MARKER_FILE))
             .is_ok_and(|st| (st.st_mode & libc::S_IFMT) == libc::S_IFREG);
-    has_git && marker_is_regular_file
+    git_is_directory && marker_is_regular_file
 }
 
 /// `openat`/`fstatat`/`renameat` primitives bound to an already-opened
@@ -883,6 +884,24 @@ fn is_staging_wrapper_name(name: &std::ffi::OsStr) -> bool {
     Uuid::parse_str(name).is_ok_and(|id| id.to_string() == name)
 }
 
+/// Deletion residue owned by this cache: `delete_verified_owned_entry`
+/// renames a doomed cache slot to `trash-<canonical UUID>` inside the
+/// private namespace before recursively deleting it. A kill in that window
+/// leaves the renamed directory behind, so the sweep must admit these names
+/// too or the deletion path reintroduces the unreclaimable-residue class
+/// this module exists to close. Trash entries never carry a staging lock
+/// file, so `staging_liveness` judges them by the conservative age fence
+/// alone; an entry whose recursive delete is still in flight is protected
+/// by that fence, and a concurrent double-delete resolves benignly because
+/// `remove_staging_wrapper` tolerates `NotFound`.
+fn is_trash_residue_name(name: &std::ffi::OsStr) -> bool {
+    let Some(name) = name.to_str() else {
+        return false;
+    };
+    name.strip_prefix("trash-")
+        .is_some_and(|suffix| Uuid::parse_str(suffix).is_ok_and(|id| id.to_string() == suffix))
+}
+
 /// Liveness verdict for one staging wrapper.
 enum StagingLiveness {
     /// A live handle holds the wrapper's lock (or it has not existed long
@@ -948,12 +967,13 @@ fn remove_staging_wrapper(namespace_root: &Path, name: &std::ffi::OsStr) -> Resu
     }
 }
 
-/// Reclaim abandoned staging wrappers under the private namespace. A
-/// deletion candidate must be a real directory (never a symlink, file, or
-/// nested path) whose name is exactly a canonical lowercase hyphenated
-/// UUID, and must be judged `Abandoned` by `staging_liveness`. `now`/
-/// `max_age` are explicit so the fallback age boundary is deterministic in
-/// tests.
+/// Reclaim abandoned staging wrappers and interrupted-deletion residue
+/// under the private namespace. A deletion candidate must be a real
+/// directory (never a symlink, file, or nested path) whose name is exactly
+/// a canonical lowercase hyphenated UUID (clone wrapper) or
+/// `trash-<canonical UUID>` (deletion residue), and must be judged
+/// `Abandoned` by `staging_liveness`. `now`/`max_age` are explicit so the
+/// fallback age boundary is deterministic in tests.
 fn reap_stale_staging(
     root: &Path,
     now: SystemTime,
@@ -986,7 +1006,7 @@ fn reap_stale_staging(
             }
         };
         let name = entry.file_name();
-        if !is_staging_wrapper_name(&name) {
+        if !is_staging_wrapper_name(&name) && !is_trash_residue_name(&name) {
             continue;
         }
         let path = entry.path();
@@ -1369,6 +1389,58 @@ mod tests {
         assert!(
             nested.is_dir(),
             "the sweep never descends below the namespace root"
+        );
+    }
+
+    /// An interrupted `delete_verified_owned_entry` leaves its renamed
+    /// `trash-<uuid>` slot behind with no lock file. The sweep must reclaim
+    /// it once past the age fence (or the deletion path reintroduces the
+    /// unreclaimable-residue class this module closes), must preserve it
+    /// while fresh (an in-flight recursive delete), and must never touch a
+    /// trash-prefixed name whose suffix is not a canonical UUID.
+    #[test]
+    fn staging_sweep_reclaims_old_trash_residue_but_preserves_fresh_and_lookalikes() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let namespace_root = ensure_staging_namespace(root.path()).expect("namespace");
+
+        let old_trash = namespace_root.join(format!("trash-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(old_trash.join("repo/.git/objects")).expect("old trash payload");
+        let lookalike = namespace_root.join("trash-not-a-canonical-uuid");
+        std::fs::create_dir_all(&lookalike).expect("create trash lookalike");
+        let observed_mtime = std::fs::symlink_metadata(&old_trash)
+            .expect("trash metadata")
+            .modified()
+            .expect("trash mtime");
+
+        let removed = reap_stale_staging(
+            root.path(),
+            observed_mtime + std::time::Duration::from_secs(2),
+            std::time::Duration::from_secs(1),
+        )
+        .expect("reap trash residue");
+        assert_eq!(removed, 1, "only the canonical trash residue is reclaimed");
+        assert!(!old_trash.exists(), "aged trash residue must be reclaimed");
+        assert!(
+            lookalike.is_dir(),
+            "a non-canonical trash suffix is not cache-owned"
+        );
+
+        let fresh_trash = namespace_root.join(format!("trash-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(fresh_trash.join("repo/.git")).expect("fresh trash payload");
+        let fresh_mtime = std::fs::symlink_metadata(&fresh_trash)
+            .expect("fresh trash metadata")
+            .modified()
+            .expect("fresh trash mtime");
+        let removed = reap_stale_staging(
+            root.path(),
+            fresh_mtime + std::time::Duration::from_secs(1),
+            std::time::Duration::from_secs(60),
+        )
+        .expect("scan fresh trash residue");
+        assert_eq!(removed, 0, "an in-flight deletion must survive the sweep");
+        assert!(
+            fresh_trash.is_dir(),
+            "fresh trash residue is protected by the age fence"
         );
     }
 

--- a/docs/adr/ADR-088-amendment-1-git-digest.md
+++ b/docs/adr/ADR-088-amendment-1-git-digest.md
@@ -175,6 +175,19 @@ frozen `until`; temporary absence is not evidence that the pass failed or commit
 4. Cleanup on eviction uses directory removal of the scratch path only (never touches
    user-owned paths).
 
+### Accepted cache crash-residue rider (2026-08-09)
+
+The staging-then-rename design can clean every ordinary error return, but no
+in-process guard runs after `SIGKILL`, OOM termination, or host loss. Each
+cache-root open therefore reclaims a staging directory only when all of these
+hold: it is a direct child of the scratch root, its name is exactly
+`.staging-<canonical UUID>`, it is a real directory rather than a symlink, and
+its mtime is strictly more than 24 hours old. Files, nested paths, prefix
+lookalikes, future-dated entries, and fresh staging clones are retained. This
+recovery is distinct from LRU eviction because an interrupted staging clone
+has no addressable cache key or ownership marker and otherwise lies outside
+both configured cache caps forever.
+
 ### Security posture
 
 - `git clone` of an untrusted remote does not execute repository-supplied code (no hooks

--- a/docs/adr/ADR-088-amendment-1-git-digest.md
+++ b/docs/adr/ADR-088-amendment-1-git-digest.md
@@ -178,15 +178,28 @@ frozen `until`; temporary absence is not evidence that the pass failed or commit
 ### Accepted cache crash-residue rider (2026-08-09)
 
 The staging-then-rename design can clean every ordinary error return, but no
-in-process guard runs after `SIGKILL`, OOM termination, or host loss. Each
-cache-root open therefore reclaims a staging directory only when all of these
-hold: it is a direct child of the scratch root, its name is exactly
-`.staging-<canonical UUID>`, it is a real directory rather than a symlink, and
-its mtime is strictly more than 24 hours old. Files, nested paths, prefix
-lookalikes, future-dated entries, and fresh staging clones are retained. This
-recovery is distinct from LRU eviction because an interrupted staging clone
-has no addressable cache key or ownership marker and otherwise lies outside
-both configured cache caps forever.
+in-process guard runs after `SIGKILL`, OOM termination, or host loss. All
+staging state therefore lives in a private namespace directory
+(`<scratch root>/.khive-git-staging/`) that nothing but this cache creates
+entries under, and a throttled sweep of that namespace reclaims residue on
+cache-root open.
+
+A sweep candidate must be a real directory (never a symlink, file, or nested
+path) that is a direct child of the private namespace and whose name is
+either exactly a canonical lowercase hyphenated UUID (an in-flight clone
+wrapper) or `trash-<canonical UUID>` (an interrupted deletion moved out of
+the shared root). The deletion criterion is liveness, not age: every live
+clone holds an advisory lock on a file inside its wrapper, so a candidate
+whose lock is still held survives regardless of how old it is, while a
+killed process's lock is released by the kernel the instant it dies and the
+wrapper is reclaimed on the next sweep regardless of how fresh it looks. A
+candidate with no lock file — the narrow crash-before-lock-file window, and
+every `trash-` entry — falls back to a conservative mtime fence (strictly
+older than 24 hours) before it may be reclaimed. Prefix lookalikes,
+non-canonical names, future-dated entries, and fresh lock-less entries are
+retained. This recovery is distinct from LRU eviction because interrupted
+staging residue has no addressable cache key or ownership marker and
+otherwise lies outside both configured cache caps forever.
 
 ### Security posture
 


### PR DESCRIPTION
## Summary

- reclaim killed-clone `.staging-<uuid>` residue whenever the git-digest scratch cache is opened
- preserve in-flight clones and unrelated operator data through exact name, containment, file-type, and age checks
- document the crash-recovery boundary separately from ordinary LRU and per-clone cap enforcement

## Cleanup contract

Every cache mutation now initializes the scratch root through a bounded stale-staging sweep. A candidate must be a direct child, a real directory, and have the exact lowercase canonical `.staging-<uuid>` name generated by the clone installer. It is removed only when its directory mtime is strictly more than 24 hours old; fresh, future-dated, nested, symlink/file, and prefix-lookalike entries are retained.

Removal uses the cache's bounded retry helper and tolerates another process winning the same cleanup race. Other inspection or deletion failures remain visible rather than silently leaving unbounded data outside both configured cache caps.

## Verification

- TDD RED/GREEN implementation at exact head `b4df88d7130aca0262525eae5b1adccce7cdc08e`
- independent exact-head review: READY (0 findings)
- exact-head full CI: [run 31304945936](https://github.com/ohdearquant/khive/actions/runs/31304945936) — passed
- direct Rust and Deno formatting, ADR-reference, JSON-data, SQL, stub-marker, and diff checks
- focused deterministic stale deletion plus fresh/foreign/nested/non-directory preservation regressions

Fixes #1826

AI-assisted contribution: implemented and reviewed with Codex.
