### PR TITLE
fix(code): scope finding identities by repository

### DIFF
--- a/crates/khive-pack-code/docs/api/findings-ingest.md
+++ b/crates/khive-pack-code/docs/api/findings-ingest.md
@@ -10,6 +10,10 @@ the KG namespace, an observation timestamp, and an optional stable `source_run`.
 non-empty run is supplied, the function derives `audit.date:audit.commit`; missing components are
 `CodeIngestError::MissingSourceRun`.
 
+The required audit identity strings (`date`, `scope`, `repo`, `branch`, `commit`, and
+`standards_file`) and every `findings[].id` must contain at least one non-whitespace character.
+Their original bytes are retained after validation; ingest does not trim or otherwise rewrite them.
+
 `observed_at` becomes record creation/update time but is excluded from identity, so retrying the
 same audit later reproduces the same IDs.
 
@@ -31,9 +35,18 @@ is treated as absence. Unknown finding keys are preserved under `raw`.
 
 All IDs are UUIDv5 values under `CODE_INGEST_NAMESPACE`. Object keys are recursively sorted before
 identity serialization; array order remains significant content. The project tuple includes
-namespace, repository, and scope. A finding tuple includes source run, normalized title, all
-validated/preserved content, and raw extensions, but excludes observation time. Any substantive
-content change creates a new ID rather than overwriting the prior finding.
+namespace, repository, and scope. Finding identity schema v2 includes that project UUID and the
+repository string in addition to source run, normalized title, all validated/preserved content,
+and raw extensions; it excludes observation time. Equal findings in different repositories are
+therefore disjoint, while a retry in the same repository reproduces its ID. Any substantive content
+change creates a new ID rather than overwriting the prior finding.
+
+Identity v1 omitted repository/project scope. Existing v1 rows are immutable and are not guessed,
+rewritten, or auto-merged because one collided v1 UUID may already have evidence from more than one
+repository. Every v2 note carries `identity_schema_version=2`, `repo`, `project_id`, and the exact
+deterministic `legacy_id_v1` witness. Operators or a future migration can use that witness plus the
+annotation target to adjudicate a merge; the normal ingest path creates the correctly scoped v2 row
+once and leaves curated v1 history untouched.
 
 ## Output records
 
@@ -48,6 +61,7 @@ this function.
 
 ## Error taxonomy
 
-`CodeIngestError` distinguishes invalid roots, missing fields, wrong types, invalid governed values,
+`CodeIngestError` distinguishes invalid roots, missing fields, blank/wrong-typed identity strings,
+invalid governed values,
 missing failure scenarios, invalid indexed evidence, unavailable source-run identity, and JSON parse
 failures. Messages include the accepted value set or shape so callers can repair input directly.

--- a/crates/khive-pack-code/docs/code-ontology.md
+++ b/crates/khive-pack-code/docs/code-ontology.md
@@ -79,7 +79,8 @@ database, with an opt-in L2 Rust symbol tier. Its optional `tiers` array accepts
 `l2`. Omission or `null` preserves the L1+L1.5 default with L2 disabled; an empty array performs no
 map writes. When L2 is disabled, its five report counters are omitted so the existing default
 report shape is unchanged. `findings.json` ingestion is an admin CLI path through `kkernel
-code-ingest`, not an MCP operation. Unknown dispatch attempts fail
+code-ingest`, not an MCP operation. Its v2 finding identity is repository/project-scoped and carries
+a deterministic v1 UUID witness without rewriting legacy curated rows. Unknown dispatch attempts fail
 with `RuntimeError::InvalidInput` rather than silently succeeding.
 
 The dedicated map is an ordinary khive database, not a private code-pack format. Every

--- a/crates/khive-pack-code/src/ingest.rs
+++ b/crates/khive-pack-code/src/ingest.rs
@@ -28,7 +28,8 @@ pub struct CodeIngestOptions<'a> {
     pub source_run: Option<&'a str>,
 }
 
-/// Deterministic entity, finding-note, and annotation-edge records ready for persistence.
+/// Deterministic entity, repository-scoped v2 finding-note, and annotation-edge records ready for
+/// persistence.
 ///
 /// See `crates/khive-pack-code/docs/api/findings-ingest.md`.
 #[derive(Clone, Debug)]
@@ -101,6 +102,21 @@ fn require_str<'a>(
             expected: "string",
         }),
     }
+}
+
+fn require_nonblank_str<'a>(
+    obj: &'a Map<String, Value>,
+    key: &'static str,
+    path: &'static str,
+) -> Result<&'a str, CodeIngestError> {
+    let value = require_str(obj, key, path)?;
+    if value.trim().is_empty() {
+        return Err(CodeIngestError::InvalidType {
+            path: path.to_string(),
+            expected: "non-blank string",
+        });
+    }
+    Ok(value)
 }
 
 fn optional_str(
@@ -204,12 +220,13 @@ impl ValidatedAudit {
             }
         }
         Ok(Self {
-            date: require_str(obj, "date", "audit.date")?.to_string(),
-            scope: require_str(obj, "scope", "audit.scope")?.to_string(),
-            repo: require_str(obj, "repo", "audit.repo")?.to_string(),
-            branch: require_str(obj, "branch", "audit.branch")?.to_string(),
-            commit: require_str(obj, "commit", "audit.commit")?.to_string(),
-            standards_file: require_str(obj, "standards_file", "audit.standards_file")?.to_string(),
+            date: require_nonblank_str(obj, "date", "audit.date")?.to_string(),
+            scope: require_nonblank_str(obj, "scope", "audit.scope")?.to_string(),
+            repo: require_nonblank_str(obj, "repo", "audit.repo")?.to_string(),
+            branch: require_nonblank_str(obj, "branch", "audit.branch")?.to_string(),
+            commit: require_nonblank_str(obj, "commit", "audit.commit")?.to_string(),
+            standards_file: require_nonblank_str(obj, "standards_file", "audit.standards_file")?
+                .to_string(),
             extra,
         })
     }
@@ -253,7 +270,7 @@ const KNOWN_FINDING_KEYS: &[&str] = &[
 
 impl ValidatedFinding {
     fn parse(obj: &Map<String, Value>, finding_index: usize) -> Result<Self, CodeIngestError> {
-        let id = require_str(obj, "id", "findings[].id")?.to_string();
+        let id = require_nonblank_str(obj, "id", "findings[].id")?.to_string();
         let title = require_str(obj, "title", "findings[].title")?.to_string();
         if title.trim().is_empty() {
             return Err(CodeIngestError::InvalidType {
@@ -419,7 +436,10 @@ pub fn ingest_findings_json(
 
     for finding in &validated_findings {
         // Excluding observation time makes retries stable while content changes create new IDs.
-        let identity_value = sort_json_keys(&json!({
+        // Retain the exact v1 tuple as an audit witness, but mint v2 from the
+        // repository/project-scoped extension so identical producer runs in
+        // different repositories can never share a finding note.
+        let legacy_identity_value = sort_json_keys(&json!({
             "kind": "code-finding",
             "schema_version": 1,
             "namespace": options.namespace,
@@ -441,11 +461,24 @@ pub fn ingest_findings_json(
             "refs": finding.refs,
             "raw": finding.raw,
         }));
+        let legacy_id_v1 = uuid5_tuple(&legacy_identity_value)?;
+        let mut identity_object = legacy_identity_value
+            .as_object()
+            .expect("finding identity is constructed as an object")
+            .clone();
+        identity_object.insert("schema_version".into(), json!(2));
+        identity_object.insert("repo".into(), json!(audit.repo));
+        identity_object.insert("project_id".into(), json!(project_id));
+        let identity_value = sort_json_keys(&Value::Object(identity_object));
         let finding_id = uuid5_tuple(&identity_value)?;
         let finding_external_id = serde_json::to_string(&identity_value)?;
 
         let mut props = Map::new();
         props.insert("external_id".into(), json!(finding_external_id));
+        props.insert("identity_schema_version".into(), json!(2));
+        props.insert("legacy_id_v1".into(), json!(legacy_id_v1));
+        props.insert("repo".into(), json!(audit.repo));
+        props.insert("project_id".into(), json!(project_id));
         props.insert("finding_id".into(), json!(finding.id));
         props.insert("severity".into(), json!(finding.severity));
         props.insert("confidence".into(), json!(finding.confidence));

--- a/crates/khive-pack-code/tests/integration.rs
+++ b/crates/khive-pack-code/tests/integration.rs
@@ -15,6 +15,7 @@ use khive_runtime::pack::PackRuntime;
 use khive_runtime::{KhiveRuntime, RuntimeError, VerbRegistry, VerbRegistryBuilder};
 use khive_types::{EdgeRelation, EndpointKind};
 use serde_json::{json, Value};
+use uuid::Uuid;
 
 #[allow(dead_code)]
 fn rt() -> KhiveRuntime {
@@ -533,6 +534,94 @@ fn ingest_findings_json_same_ids_across_different_observed_at() {
     );
     assert_eq!(batch_early.notes[0].id, batch_late.notes[0].id);
     assert_eq!(batch_early.edges[0].id, batch_late.edges[0].id);
+}
+
+#[test]
+fn ingest_rejects_whitespace_only_audit_identity_fields() {
+    for field in [
+        "date",
+        "scope",
+        "repo",
+        "branch",
+        "commit",
+        "standards_file",
+    ] {
+        let mut doc = sample_findings_json();
+        doc["audit"][field] = json!("   ");
+        let bytes = serde_json::to_vec(&doc).expect("serializes");
+
+        let err = ingest_findings_json(&bytes, ingest_options(Some("fixed-run")))
+            .expect_err("whitespace-only audit identity must be rejected before construction");
+        assert!(
+            err.to_string().contains(field),
+            "the validation error must identify audit.{field}, got: {err}"
+        );
+    }
+}
+
+#[test]
+fn ingest_rejects_whitespace_only_finding_id() {
+    let mut doc = sample_findings_json();
+    doc["findings"][0]["id"] = json!("   ");
+    let bytes = serde_json::to_vec(&doc).expect("serializes");
+
+    let err = ingest_findings_json(&bytes, ingest_options(Some("fixed-run")))
+        .expect_err("a whitespace-only finding id must be rejected before record construction");
+    assert!(
+        err.to_string().contains("findings[].id"),
+        "the validation error must identify findings[].id, got: {err}"
+    );
+}
+
+#[test]
+fn ingest_finding_identity_is_disjoint_across_repositories() {
+    let doc_a = sample_findings_json();
+    let mut doc_b = doc_a.clone();
+    doc_b["audit"]["repo"] = json!("fork-owner/khive");
+
+    let batch_a = ingest_findings_json(
+        &serde_json::to_vec(&doc_a).expect("serializes"),
+        ingest_options(Some("fixed-run")),
+    )
+    .expect("first repository ingests");
+    let batch_b = ingest_findings_json(
+        &serde_json::to_vec(&doc_b).expect("serializes"),
+        ingest_options(Some("fixed-run")),
+    )
+    .expect("second repository ingests");
+
+    assert_ne!(batch_a.entities[0].id, batch_b.entities[0].id);
+    assert_ne!(
+        batch_a.notes[0].id, batch_b.notes[0].id,
+        "the same finding content and source_run in two repositories must not share a note id"
+    );
+    assert_ne!(
+        batch_a.edges[0].id, batch_b.edges[0].id,
+        "repository-disjoint finding notes must also produce disjoint annotation edges"
+    );
+}
+
+#[test]
+fn ingest_finding_v2_identity_carries_project_and_legacy_witnesses() {
+    let batch = ingest_findings_json(&valid_findings_bytes(), ingest_options(Some("fixed-run")))
+        .expect("valid finding ingests");
+    let props = batch.notes[0]
+        .properties
+        .as_ref()
+        .expect("finding carries identity properties");
+
+    assert_eq!(props["identity_schema_version"], 2);
+    assert_eq!(props["repo"], "khive");
+    assert_eq!(props["project_id"], batch.entities[0].id.to_string());
+    let legacy_id = props["legacy_id_v1"]
+        .as_str()
+        .expect("v2 finding exposes its deterministic v1 identity witness");
+    assert!(Uuid::parse_str(legacy_id).is_ok());
+    assert_eq!(
+        legacy_id, "0a6d294d-26ca-568f-8986-814e94843d25",
+        "the migration witness must remain byte-identical to the shipped v1 tuple"
+    );
+    assert_ne!(legacy_id, batch.notes[0].id.to_string());
 }
 
 #[test]

--- a/docs/adr/ADR-085-code-pack.md
+++ b/docs/adr/ADR-085-code-pack.md
@@ -1553,3 +1553,41 @@ one identity.
    advances.
 4. Both endpoints of every fixture `project contains module` edge expose the
    same non-empty `source_project` value.
+
+## Amendment 6 (2026-08-09): repository-scoped findings identity v2
+
+Amendment 1 A1's tolerated free-form posture remains in force for producer content fields. The
+following fields are instead the structural identity envelope and are now governed as non-blank
+strings: `audit.date`, `audit.scope`, `audit.repo`, `audit.branch`, `audit.commit`,
+`audit.standards_file`, and `findings[].id`. This is the future amendment A1 required before stricter
+ingest validation; it is justified because blank identity material collapses unrelated producer
+runs and makes provenance unqueryable. Validation preserves the original non-blank string bytes.
+
+The project UUID remains the v1 tuple over namespace, repository, and scope. Finding identity moves
+to schema version 2 and adds both `audit.repo` and the computed project UUID to the recursively
+canonicalized content tuple. Observation time remains excluded. Consequently:
+
+- the same input in the same namespace/repository/project scope remains idempotent;
+- equal producer IDs/content/source runs in different repositories produce different finding notes
+  and annotation edges; and
+- substantive finding content changes still produce new notes rather than overwriting curated
+  history.
+
+### V1 compatibility and migration decision
+
+V1 finding UUIDs omitted repository/project scope and may already denote evidence from multiple
+repositories. The runtime must not guess their ownership or rewrite/merge them automatically. New
+ingest creates the correctly scoped v2 row and leaves every v1 note and lifecycle state immutable.
+Each v2 note records `identity_schema_version=2`, `repo`, `project_id`, and `legacy_id_v1`, where the
+last field is the exact UUID the same input would have produced under v1. An operator or future
+migration may join that witness to the v1 note and the current annotation target, then explicitly
+merge only after provenance is unambiguous. This one-time coexistence is preferred to silently
+attaching a colliding legacy finding to the wrong project.
+
+Acceptance:
+
+1. Every governed identity string rejects whitespace-only input before record construction.
+2. Equal findings under two `audit.repo` values have disjoint project, note, and edge UUIDs.
+3. Repeated same-repository input and changes only to `observed_at` retain stable v2 UUIDs.
+4. A v2 note exposes its schema version, repository, project UUID, and parseable deterministic v1
+   UUID witness; ingest does not mutate or claim an existing v1 row.


### PR DESCRIPTION
## Summary

- require nonblank audit and finding identity fields before constructing any graph record
- scope new finding UUIDs to repository and project identity so equal audit runs in different repositories cannot collide
- retain an explicit v1 identity witness for later compatibility adjudication without silently mutating legacy records

## Identity contract

The mapper validates `audit.date`, `scope`, `repo`, `branch`, `commit`, and `standards_file`, plus every `findings[].id`, as present nonblank strings while preserving their accepted bytes. Project identity remains repository-scoped. New finding notes use identity schema v2, whose UUID tuple includes the audit repository and deterministic project UUID in addition to the existing run, scope, and content witnesses.

Each v2 note records `identity_schema_version=2`, `legacy_id_v1`, `repo`, and `project_id`. Existing v1 rows are not implicitly merged, rewritten, or deleted: they may be cross-repository ambiguous, so the v1 witness and annotation target provide the evidence needed for an explicit later adjudication. Re-ingesting one v2 document remains deterministic and idempotent.

This is the findings-identity tranche of #1758. The separate tombstone-preservation tranche remains open, and this PR must not close the umbrella issue.

## Verification

- implementation source checks: clean at `54588bfa4f5d029808a3184388eb478b1d1ec153` on exact live base `2dc0bbc8b188eaeba39e9c66f8d5c0f4df97cae4`
- independent exact-head review: READY (0 findings)
- exact-head full CI: [run 31305214780](https://github.com/ohdearquant/khive/actions/runs/31305214780) — passed
- direct Rust and Deno formatting, ADR-reference, JSON-data, SQL, stub-marker, static identity, and diff checks
- focused blank-field, cross-repository project/note/edge separation, stable legacy-v1 witness, and deterministic-v2 regressions

Refs #1758

AI-assisted contribution: implemented and reviewed with Codex.
