### PR TITLE
fix(code-ingest): preserve consumed tombstone ids

### DIFF
--- a/crates/khive-pack-code/docs/api/findings-ingest.md
+++ b/crates/khive-pack-code/docs/api/findings-ingest.md
@@ -46,6 +46,11 @@ String impact renders verbatim in note content, other JSON uses canonical JSON t
 impact renders empty. The batch is ready for existing storage/runtime paths but is not committed by
 this function.
 
+The sole persistence surface, `kkernel code-ingest`, treats every deterministic ID as consumed once
+any row with that ID exists. This check includes soft-deleted entity, note, and edge rows: both real
+ingest and `--dry-run` report those records as skipped, and re-ingest never reactivates a tombstone
+or resets its curated lifecycle state.
+
 ## Error taxonomy
 
 `CodeIngestError` distinguishes invalid roots, missing fields, wrong types, invalid governed values,

--- a/crates/kkernel/src/code_ingest.rs
+++ b/crates/kkernel/src/code_ingest.rs
@@ -763,6 +763,87 @@ mod tests {
         path
     }
 
+    const TOMBSTONE_WITNESS: i64 = 1_772_812_800_000_000;
+
+    fn mapped_batch(findings: &Path) -> CodeIngestBatch {
+        let bytes = std::fs::read(findings).expect("read findings fixture");
+        ingest_findings_json(
+            &bytes,
+            CodeIngestOptions {
+                namespace: "local",
+                observed_at: Utc::now(),
+                source_run: Some("test-run"),
+            },
+        )
+        .expect("map valid findings fixture")
+    }
+
+    async fn soft_delete_mapped_batch(db: &Path, batch: &CodeIngestBatch) {
+        let backend = StorageBackend::sqlite(db).expect("open tombstone writer");
+        let sql = backend.sql();
+        let mut writer = sql.writer().await.expect("acquire tombstone writer");
+
+        let rows = [
+            (
+                "entities",
+                SqlValue::Uuid(batch.entities[0].id),
+                "soft-delete mapped entity",
+            ),
+            (
+                "notes",
+                SqlValue::Uuid(batch.notes[0].id),
+                "soft-delete mapped note",
+            ),
+            (
+                "graph_edges",
+                SqlValue::Uuid(uuid::Uuid::from(batch.edges[0].id)),
+                "soft-delete mapped edge",
+            ),
+        ];
+
+        for (table, id, label) in rows {
+            let changed = writer
+                .execute(SqlStatement {
+                    sql: format!("UPDATE {table} SET deleted_at = ?1 WHERE id = ?2"),
+                    params: vec![SqlValue::Integer(TOMBSTONE_WITNESS), id],
+                    label: Some(label.to_string()),
+                })
+                .await
+                .expect("soft-delete mapped row");
+            assert_eq!(changed, 1, "fixture must tombstone exactly one {table} row");
+        }
+    }
+
+    async fn assert_mapped_batch_remains_tombstoned(db: &Path, batch: &CodeIngestBatch) {
+        let backend = StorageBackend::sqlite_read_only(db).expect("open tombstone reader");
+        let sql = backend.sql();
+        let mut reader = sql.reader().await.expect("acquire tombstone reader");
+
+        let rows = [
+            ("entities", SqlValue::Uuid(batch.entities[0].id)),
+            ("notes", SqlValue::Uuid(batch.notes[0].id)),
+            (
+                "graph_edges",
+                SqlValue::Uuid(uuid::Uuid::from(batch.edges[0].id)),
+            ),
+        ];
+
+        for (table, id) in rows {
+            let marker = reader
+                .query_scalar(SqlStatement {
+                    sql: format!("SELECT deleted_at FROM {table} WHERE id = ?1"),
+                    params: vec![id],
+                    label: Some(format!("read mapped {table} tombstone")),
+                })
+                .await
+                .expect("read mapped tombstone");
+            assert!(
+                matches!(&marker, Some(SqlValue::Integer(value)) if *value == TOMBSTONE_WITNESS),
+                "re-ingest must preserve the exact {table} tombstone marker, got {marker:?}"
+            );
+        }
+    }
+
     #[serial]
     #[tokio::test]
     async fn code_ingest_creates_once_then_skips_on_rerun() {
@@ -790,6 +871,47 @@ mod tests {
         assert_eq!(second.notes_skipped_existing, 1);
         assert_eq!(second.entities_skipped_existing, 1);
         assert_eq!(second.edges_skipped_existing, 1);
+    }
+
+    #[serial]
+    #[tokio::test]
+    async fn code_ingest_never_reactivates_consumed_tombstone_ids() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let findings = write_valid_findings(tmp.path());
+        let db = tmp.path().join("tombstones.db");
+        let batch = mapped_batch(&findings);
+
+        code_ingest_batch(base_args(findings.clone(), db.clone()))
+            .await
+            .expect("initial ingest must succeed");
+        soft_delete_mapped_batch(&db, &batch).await;
+        assert_mapped_batch_remains_tombstoned(&db, &batch).await;
+
+        let mut dry_args = base_args(findings.clone(), db.clone());
+        dry_args.dry_run = true;
+        let dry = code_ingest_batch(dry_args)
+            .await
+            .expect("dry-run over tombstones must succeed");
+        assert!(dry.dry_run);
+        assert_eq!(dry.entities_created, 0);
+        assert_eq!(dry.entities_skipped_existing, 1);
+        assert_eq!(dry.notes_created, 0);
+        assert_eq!(dry.notes_skipped_existing, 1);
+        assert_eq!(dry.edges_created, 0);
+        assert_eq!(dry.edges_skipped_existing, 1);
+        assert_mapped_batch_remains_tombstoned(&db, &batch).await;
+
+        let real = code_ingest_batch(base_args(findings, db.clone()))
+            .await
+            .expect("real re-ingest over tombstones must succeed");
+        assert!(!real.dry_run);
+        assert_eq!(real.entities_created, 0);
+        assert_eq!(real.entities_skipped_existing, 1);
+        assert_eq!(real.notes_created, 0);
+        assert_eq!(real.notes_skipped_existing, 1);
+        assert_eq!(real.edges_created, 0);
+        assert_eq!(real.edges_skipped_existing, 1);
+        assert_mapped_batch_remains_tombstoned(&db, &batch).await;
     }
 
     #[serial]

--- a/crates/kkernel/src/code_ingest.rs
+++ b/crates/kkernel/src/code_ingest.rs
@@ -77,8 +77,9 @@ pub struct CodeIngestReport {
 /// Run one `kkernel code-ingest` pass: resolve config, validate the
 /// `findings.json` document as a whole (fail-closed, before any write), then
 /// persist the deterministic entity/note/edge batch record-by-record.
-/// Records whose content-derived ID already exists are reported as skipped,
-/// not overwritten: a `finding` note's lifecycle state (`kind_status`) is
+/// Records whose content-derived ID has ever existed, including soft-deleted
+/// tombstones, are reported as skipped and never overwritten or reactivated:
+/// a `finding` note's lifecycle state (`kind_status`) and deletion state are
 /// curated data, not something re-ingesting the same sweep should reset.
 pub async fn run_code_ingest(args: CodeIngestArgs) -> Result<()> {
     let human = args.human;
@@ -220,7 +221,7 @@ where
             .map_err(|e| anyhow::anyhow!("{e}"))?;
         for entity in &batch.entities {
             let existing = entities
-                .get_entity(entity.id)
+                .get_entity_including_deleted(entity.id)
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
             if existing.is_some() {
@@ -293,7 +294,7 @@ where
         let notes = runtime.notes(&token).map_err(|e| anyhow::anyhow!("{e}"))?;
         for note in &batch.notes {
             let existing = notes
-                .get_note(note.id)
+                .get_note_including_deleted(note.id)
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
             if existing.is_some() {
@@ -359,7 +360,7 @@ where
         let graph = runtime.graph(&token).map_err(|e| anyhow::anyhow!("{e}"))?;
         for edge in &batch.edges {
             let existing = graph
-                .get_edge(edge.id)
+                .get_edge_including_deleted(edge.id)
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
             if existing.is_some() {
@@ -503,8 +504,9 @@ fn preflight_secret_gate(batch: &CodeIngestBatch) -> Result<()> {
 /// thereby creating) a database purely to answer "does this id exist" would
 /// itself be the mutation the dry-run contract forbids.
 ///
-/// When the path exists, existence is checked against a snapshot copy of
-/// it: `StorageBackend::sqlite_read_only`'s `SQLITE_OPEN_READ_ONLY` plus
+/// When the path exists, existence (including soft-deleted rows, because a
+/// deterministic ID is never reusable) is checked against a snapshot copy
+/// of it: `StorageBackend::sqlite_read_only`'s `SQLITE_OPEN_READ_ONLY` plus
 /// `PRAGMA query_only = ON` blocks logical writes, but SQLite still performs
 /// ordinary WAL shared-memory maintenance on open, which creates or updates
 /// the `-shm` sidecar next to whatever path it is pointed at. Opening the
@@ -538,7 +540,7 @@ async fn dry_run_report(
     for entity in &batch.entities {
         let row = reader
             .query_scalar(SqlStatement {
-                sql: "SELECT 1 FROM entities WHERE id = ?1 AND deleted_at IS NULL".to_string(),
+                sql: "SELECT 1 FROM entities WHERE id = ?1".to_string(),
                 params: vec![SqlValue::Uuid(entity.id)],
                 label: Some("code-ingest dry-run entity existence".to_string()),
             })
@@ -553,7 +555,7 @@ async fn dry_run_report(
     for note in &batch.notes {
         let row = reader
             .query_scalar(SqlStatement {
-                sql: "SELECT 1 FROM notes WHERE id = ?1 AND deleted_at IS NULL".to_string(),
+                sql: "SELECT 1 FROM notes WHERE id = ?1".to_string(),
                 params: vec![SqlValue::Uuid(note.id)],
                 label: Some("code-ingest dry-run note existence".to_string()),
             })
@@ -568,7 +570,7 @@ async fn dry_run_report(
     for edge in &batch.edges {
         let row = reader
             .query_scalar(SqlStatement {
-                sql: "SELECT 1 FROM graph_edges WHERE id = ?1 AND deleted_at IS NULL".to_string(),
+                sql: "SELECT 1 FROM graph_edges WHERE id = ?1".to_string(),
                 params: vec![SqlValue::Uuid(uuid::Uuid::from(edge.id))],
                 label: Some("code-ingest dry-run edge existence".to_string()),
             })

--- a/docs/adr/ADR-085-code-pack.md
+++ b/docs/adr/ADR-085-code-pack.md
@@ -757,10 +757,14 @@ subcommand (`crates/kkernel/src/code_ingest.rs`), following the same shape as
 set, validates the whole document before any write (Amendment 1 A3's
 fail-closed, all-or-nothing contract, unchanged), and persists the resulting
 entity/note/edge batch by content-derived id: a record whose id already
-exists is reported as skipped, never overwritten, so re-running the same
-sweep is a no-op and a `finding`'s curated lifecycle state (`kind_status`) is
-never reset by re-ingestion. `--dry-run` runs the same validation and
-existence checks and reports what would happen without writing.
+exists is reported as skipped, never overwritten. "Exists" is
+history-preserving here: a soft-deleted row has already consumed its id and
+is skipped by both the real path and `--dry-run`; re-ingestion never clears
+its `deleted_at` marker or otherwise resurrects it. Thus re-running the same
+sweep is a no-op and a `finding`'s curated lifecycle state (`kind_status`)
+and deletion state are never reset by re-ingestion. `--dry-run` runs the same
+including-tombstones existence checks and reports what would happen without
+writing.
 
 No MCP verb calls this path, and none is added. Agents that participate in
 an audit never hold a bulk-ingest verb; only the CLI, run by the audit

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -48,6 +48,10 @@ three schedule verbs remain available without `comm`.
 manifest + L1.5 import-scan source ingest, ADR-085 Amendment 2 — see below); its
 `findings.json` batch ingest still runs only through the `kkernel code-ingest` admin CLI
 path, not the MCP verb surface.
+That admin path is history-preserving: a deterministic entity, finding-note,
+or annotation-edge ID is skipped even when its row is soft-deleted, so neither
+real re-ingest nor `--dry-run` treats a tombstone as a new record or resurrects
+it.
 
 `blob` registers no note or entity kinds; its three verbs (`blob.put` / `blob.get` /
 `blob.stat`) dispatch over the `BlobStore` content-addressed storage trait (ADR-111). A


### PR DESCRIPTION
## Summary

- treat every deterministic findings-ingest ID as consumed once any entity, note, or edge row exists
- include soft-deleted rows in both real-ingest and dry-run existence checks
- preserve exact tombstone and curated lifecycle state instead of reactivating records during replay

## Lifecycle contract

`kkernel code-ingest` now queries entity, finding-note, and annotation-edge identity through including-deleted storage paths. A soft-deleted row is reported in the existing skipped counters and never reaches an upsert. The read-only dry-run snapshot applies the same history-preserving rule rather than filtering `deleted_at`.

The regression creates all three deterministic records, assigns an exact tombstone witness to each, and proves both dry-run and real re-ingest return zero creates, one skip per substrate, and leave every marker byte-for-byte unchanged.

This is the findings-tombstone tranche of #1758. It completes only that acceptance condition; this PR must not close the umbrella issue unless all sibling tranches have merged and a final strict issue audit confirms the complete contract.

## Verification

- TDD RED/GREEN commits at exact head `7b94e248521bcc6dc2f21dcc8c576a8a403bea7c` on exact live base `2dc0bbc8b188eaeba39e9c66f8d5c0f4df97cae4`
- independent exact-head review: READY (0 findings)
- exact-head full CI: [run 31305251455](https://github.com/ohdearquant/khive/actions/runs/31305251455) — passed
- direct Rust and Deno formatting, ADR-reference, JSON-data, SQL, stub-marker, and diff checks
- focused real-ingest/dry-run entity, note, and edge tombstone-preservation regression

Refs #1758

AI-assisted contribution: implemented and reviewed with Codex.
