### PR TITLE
fix(mcp): quarantine channel ingest refusals instead of retrying forever

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1986,6 +1986,7 @@ version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64 0.22.1",
  "chrono",
  "clap",
  "futures",

--- a/crates/khive-channel-email/src/channel.rs
+++ b/crates/khive-channel-email/src/channel.rs
@@ -26,6 +26,11 @@ const IMAP_FOLDER: &str = "INBOX";
 /// `poll_page` path.
 const IMAP_PAGE_LIMIT: usize = 50;
 
+// Quarantine sender prefix invariant: `email:quarantine` must retain the
+// channel's `email:` prefix because prefix-keyed consumers use it to surface
+// the notification. Renaming it outside that prefix silently hides alerts.
+const EMAIL_QUARANTINE_SENDER: &str = "email:quarantine";
+
 /// Reason a message failed the attribution gate (ADR-056 Amendment
 /// 2026-07-02) and was quarantined instead of attributed to the maintainer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -262,7 +267,8 @@ impl EmailChannel {
     /// legitimate thread's context.
     fn quarantine_envelope(&self, email: &RawEmail, reason: QuarantineReason) -> ChannelEnvelope {
         let to = format!("email:{}", self.maintainer_address());
-        let mut env = ChannelEnvelope::new("email:quarantine", to, email.best_body());
+        let mut env = ChannelEnvelope::new(EMAIL_QUARANTINE_SENDER, to.clone(), email.best_body())
+            .with_quarantine_replay(email.raw_bytes.clone(), to);
 
         if !email.subject.is_empty() {
             env = env.with_subject(&email.subject);
@@ -296,11 +302,13 @@ impl EmailChannel {
         uid: u32,
         imap_external_id: &str,
         reason: QuarantineReason,
+        raw_bytes: Option<Vec<u8>>,
     ) -> ChannelEnvelope {
         let to = format!("email:{}", self.maintainer_address());
         let body =
             format!("(khive: IMAP message UID {uid} could not be parsed and was quarantined)");
-        let mut env = ChannelEnvelope::new("email:quarantine", to, body);
+        let mut env = ChannelEnvelope::new(EMAIL_QUARANTINE_SENDER, to.clone(), body)
+            .with_quarantine_replay(raw_bytes.unwrap_or_default(), to);
         env = env.with_external_id(imap_external_id);
         env.metadata
             .insert("quarantined".to_string(), "true".to_string());
@@ -423,6 +431,7 @@ impl EmailChannel {
                     uid,
                     imap_external_id,
                     reason,
+                    raw_bytes,
                 } => {
                     let reason: QuarantineReason = reason.into();
                     warn!(
@@ -434,6 +443,7 @@ impl EmailChannel {
                         uid,
                         &imap_external_id,
                         reason,
+                        raw_bytes,
                     ));
                 }
             }
@@ -477,7 +487,10 @@ impl EmailChannel {
             env = env.with_wire_references(refs);
         }
 
-        env
+        env.with_quarantine_replay(
+            email.raw_bytes,
+            format!("email:{}", self.maintainer_address()),
+        )
     }
 }
 
@@ -658,6 +671,7 @@ mod tests {
     fn make_email(from_addr: &str, imap_id: &str) -> RawEmail {
         RawEmail {
             uid: 1,
+            raw_bytes: Vec::new(),
             imap_external_id: imap_id.to_string(),
             from_addrs: vec![from_addr.to_string()],
             sender_addr: None,
@@ -681,6 +695,7 @@ mod tests {
             .unwrap_or_else(|| format!("{TEST_AUTHSERV_ID}; dmarc=pass header.from=example.com"));
         RawEmail {
             uid: 1,
+            raw_bytes: Vec::new(),
             imap_external_id: imap_id.to_string(),
             from_addrs,
             sender_addr: None,
@@ -810,6 +825,18 @@ mod tests {
             "both ancestor ids parsed from raw bytes must survive into wire_references; \
              got envs={envs:?}"
         );
+        let replay = envs[0]
+            .quarantine_replay
+            .as_ref()
+            .expect("parsed email must retain in-memory replay context");
+        assert_eq!(
+            replay.bytes, raw,
+            "email replay context must preserve the byte-exact RFC 822 payload"
+        );
+        assert_eq!(
+            replay.notification_to, "email:maintainer@example.com",
+            "content refusal notifications must route to the configured maintainer"
+        );
     }
 
     #[tokio::test]
@@ -852,7 +879,10 @@ mod tests {
         );
         let envs = ch.poll(Utc::now()).await.unwrap();
         assert_eq!(envs.len(), 1, "must be stored as quarantine, not dropped");
-        assert_eq!(envs[0].from, "email:quarantine");
+        assert_eq!(
+            envs[0].from, EMAIL_QUARANTINE_SENDER,
+            "quarantine sender prefix invariant: `email:` keeps the alert visible to prefix-keyed consumers"
+        );
         assert_eq!(
             envs[0]
                 .metadata
@@ -943,7 +973,10 @@ mod tests {
             1,
             "multi-From message must be quarantined, not dropped"
         );
-        assert_eq!(envs[0].from, "email:quarantine");
+        assert_eq!(
+            envs[0].from, EMAIL_QUARANTINE_SENDER,
+            "quarantine sender prefix invariant: `email:` keeps the alert visible to prefix-keyed consumers"
+        );
         assert_eq!(
             envs[0]
                 .metadata
@@ -1055,7 +1088,10 @@ mod tests {
             envs[0].from, "email:maintainer@example.com",
             "quarantined mail must never carry the claimed maintainer address as `from`"
         );
-        assert_eq!(envs[0].from, "email:quarantine");
+        assert_eq!(
+            envs[0].from, EMAIL_QUARANTINE_SENDER,
+            "quarantine sender prefix invariant: `email:` keeps the alert visible to prefix-keyed consumers"
+        );
         assert_eq!(
             envs[0]
                 .metadata
@@ -1141,7 +1177,10 @@ mod tests {
         let ch = build_channel("maintainer@example.com", vec![email]);
         let envs = ch.poll(Utc::now()).await.unwrap();
         assert_eq!(envs.len(), 1);
-        assert_eq!(envs[0].from, "email:quarantine");
+        assert_eq!(
+            envs[0].from, EMAIL_QUARANTINE_SENDER,
+            "quarantine sender prefix invariant: `email:` keeps the alert visible to prefix-keyed consumers"
+        );
         assert_eq!(
             envs[0]
                 .metadata
@@ -1169,8 +1208,8 @@ mod tests {
         let envs = ch.poll(Utc::now()).await.unwrap();
         assert_eq!(envs.len(), 1);
         assert_eq!(
-            envs[0].from, "email:quarantine",
-            "a forged dmarc=pass hidden inside a quoted reason pvalue must never attribute mail"
+            envs[0].from, EMAIL_QUARANTINE_SENDER,
+            "quarantine sender prefix invariant: `email:` keeps the alert visible to prefix-keyed consumers"
         );
         assert_eq!(
             envs[0]
@@ -1201,8 +1240,8 @@ mod tests {
         let envs = ch.poll(Utc::now()).await.unwrap();
         assert_eq!(envs.len(), 1);
         assert_eq!(
-            envs[0].from, "email:quarantine",
-            "a forged smtp.mailfrom hidden inside a quoted pvalue's embedded whitespace must never attribute mail"
+            envs[0].from, EMAIL_QUARANTINE_SENDER,
+            "quarantine sender prefix invariant: `email:` keeps the alert visible to prefix-keyed consumers"
         );
         assert_eq!(
             envs[0]
@@ -1225,7 +1264,10 @@ mod tests {
         let ch = build_channel("maintainer@example.com", vec![email]);
         let envs = ch.poll(Utc::now()).await.unwrap();
         assert_eq!(envs.len(), 1);
-        assert_eq!(envs[0].from, "email:quarantine");
+        assert_eq!(
+            envs[0].from, EMAIL_QUARANTINE_SENDER,
+            "quarantine sender prefix invariant: `email:` keeps the alert visible to prefix-keyed consumers"
+        );
         assert_eq!(
             envs[0]
                 .metadata
@@ -1301,7 +1343,10 @@ mod tests {
         let ch = build_channel_from(config, vec![email]);
         let envs = ch.poll(Utc::now()).await.unwrap();
         assert_eq!(envs.len(), 1);
-        assert_eq!(envs[0].from, "email:quarantine");
+        assert_eq!(
+            envs[0].from, EMAIL_QUARANTINE_SENDER,
+            "quarantine sender prefix invariant: `email:` keeps the alert visible to prefix-keyed consumers"
+        );
         assert_eq!(
             envs[0]
                 .metadata
@@ -1349,7 +1394,10 @@ mod tests {
             .iter()
             .find(|e| e.external_id.as_deref() == Some("imap:test:0:1"))
             .expect("unauthorized message must still be present, quarantined");
-        assert_eq!(quarantined.from, "email:quarantine");
+        assert_eq!(
+            quarantined.from, EMAIL_QUARANTINE_SENDER,
+            "quarantine sender prefix invariant: `email:` keeps the alert visible to prefix-keyed consumers"
+        );
         assert_eq!(
             quarantined
                 .metadata
@@ -1828,6 +1876,7 @@ mod tests {
                             uid: 1,
                             imap_external_id: "imap:imap.example.com:4:1".to_string(),
                             reason: MalformedReason::MissingBody,
+                            raw_bytes: None,
                         },
                         SelectedMessage::Email(Box::new(self.good.clone())),
                     ],
@@ -1861,9 +1910,15 @@ mod tests {
                  envelope actually handed to comm.ingest",
             );
         assert_eq!(
-            quarantined.from, "email:quarantine",
-            "a malformed UID must be attributed to the fixed quarantine marker"
+            quarantined.from, EMAIL_QUARANTINE_SENDER,
+            "quarantine sender prefix invariant: `email:` keeps the alert visible to prefix-keyed consumers"
         );
+        let replay = quarantined
+            .quarantine_replay
+            .as_ref()
+            .expect("even a missing IMAP body carries an explicit empty replay context");
+        assert!(replay.bytes.is_empty());
+        assert_eq!(replay.notification_to, "email:maintainer@example.com");
         assert_eq!(
             quarantined.metadata.get("quarantined").map(String::as_str),
             Some("true"),

--- a/crates/khive-channel-email/src/connector/imap.rs
+++ b/crates/khive-channel-email/src/connector/imap.rs
@@ -84,6 +84,9 @@ pub(crate) enum SelectedMessage {
         /// it from.
         imap_external_id: String,
         reason: MalformedReason,
+        /// RFC 822 bytes returned by IMAP, when a body was present but could
+        /// not be parsed. `None` means the server returned no body at all.
+        raw_bytes: Option<Vec<u8>>,
     },
 }
 
@@ -492,6 +495,7 @@ pub(crate) fn process_selected_page(
                     uid,
                     imap_external_id,
                     reason: MalformedReason::MissingBody,
+                    raw_bytes: None,
                 }
             }
             Some(raw) => match parse_raw_bytes(uid, &raw, host, uid_validity.get()) {
@@ -506,6 +510,7 @@ pub(crate) fn process_selected_page(
                         uid,
                         imap_external_id,
                         reason: MalformedReason::ParseFailure,
+                        raw_bytes: Some(raw),
                     }
                 }
             },
@@ -627,6 +632,7 @@ pub(crate) fn parse_raw_bytes(
 
     Some(RawEmail {
         uid,
+        raw_bytes: raw.to_vec(),
         imap_external_id,
         from_addrs,
         sender_addr,
@@ -751,6 +757,7 @@ mod tests {
     fn make_email(uid: u32, imap_id: &str, from_addr: &str) -> RawEmail {
         RawEmail {
             uid,
+            raw_bytes: Vec::new(),
             imap_external_id: imap_id.to_string(),
             from_addrs: vec![from_addr.to_string()],
             sender_addr: None,
@@ -953,6 +960,7 @@ mod tests {
         headers.insert("x-khive-thread-id".to_string(), "some-uuid".to_string());
         let email = RawEmail {
             uid: 1,
+            raw_bytes: Vec::new(),
             imap_external_id: "imap:host:1:1".to_string(),
             from_addrs: vec!["a@example.com".to_string()],
             sender_addr: None,
@@ -1265,11 +1273,12 @@ mod tests {
                 SelectedMessage::Malformed {
                     uid: 1,
                     reason: MalformedReason::ParseFailure,
+                    raw_bytes: Some(bytes),
                     ..
-                }
+                } if bytes.is_empty()
             ),
-            "malformed selected RFC822 bytes must quarantine, not fail the whole page \
-             or silently advance without a record"
+            "malformed selected RFC822 bytes must remain available for replay while the page \
+             advances to quarantine"
         );
     }
 
@@ -1405,6 +1414,7 @@ mod tests {
         headers.insert("in-reply-to".to_string(), "<orig@example.com>".to_string());
         let email = RawEmail {
             uid: 2,
+            raw_bytes: Vec::new(),
             imap_external_id: "imap:host:1:2".to_string(),
             from_addrs: vec!["b@example.com".to_string()],
             sender_addr: None,

--- a/crates/khive-channel-email/src/connector/mod.rs
+++ b/crates/khive-channel-email/src/connector/mod.rs
@@ -81,10 +81,12 @@ impl std::fmt::Display for MailAddress {
 }
 
 /// A raw email fetched from the IMAP server before enrichment.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct RawEmail {
     /// IMAP UID (opaque; used for message identification).
     pub uid: u32,
+    /// Byte-exact RFC 822 payload returned by IMAP for replay after quarantine.
+    pub raw_bytes: Vec<u8>,
     /// Stable dedup key: `imap:{host}:{uidvalidity}:{uid}`.
     ///
     /// Always set by the IMAP connector. Never empty. Used as the primary
@@ -122,6 +124,27 @@ pub struct RawEmail {
     /// whose `authserv-id` matches the configured trust anchor -- an MTA can
     /// legitimately stamp more than one hop's worth of this header.
     pub authentication_results: Vec<String>,
+}
+
+impl std::fmt::Debug for RawEmail {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RawEmail")
+            .field("uid", &self.uid)
+            .field("imap_external_id", &self.imap_external_id)
+            .field("raw_bytes_len", &self.raw_bytes.len())
+            .field("from_addrs_len", &self.from_addrs.len())
+            .field("to_len", &self.to.len())
+            .field("has_sender", &self.sender_addr.is_some())
+            .field("has_date", &self.date.is_some())
+            .field("has_text_body", &self.body_text.is_some())
+            .field("has_html_body", &self.body_html.is_some())
+            .field("header_count", &self.headers.len())
+            .field(
+                "authentication_results_count",
+                &self.authentication_results.len(),
+            )
+            .finish()
+    }
 }
 
 impl RawEmail {
@@ -163,5 +186,33 @@ impl RawEmail {
     /// Return the best available body text.
     pub fn best_body(&self) -> String {
         self.body_text.clone().unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn raw_email_debug_redacts_replay_and_message_content() {
+        let secret = "AKIAFAKEKEY1234567890";
+        let email = RawEmail {
+            uid: 7,
+            raw_bytes: secret.as_bytes().to_vec(),
+            imap_external_id: "imap:test:1:7".to_string(),
+            from_addrs: vec!["maintainer@example.com".to_string()],
+            sender_addr: None,
+            to: vec!["inbox@example.com".to_string()],
+            subject: secret.to_string(),
+            date: None,
+            body_text: Some(secret.to_string()),
+            body_html: None,
+            headers: HashMap::from([("authorization".to_string(), secret.to_string())]),
+            authentication_results: Vec::new(),
+        };
+
+        let rendered = format!("{email:?}");
+        assert!(!rendered.contains(secret));
+        assert!(rendered.contains(&format!("raw_bytes_len: {}", secret.len())));
     }
 }

--- a/crates/khive-channel-telegram/src/channel.rs
+++ b/crates/khive-channel-telegram/src/channel.rs
@@ -98,8 +98,9 @@ impl TelegramChannel {
         let from = format!("telegram:{}", self.config.maintainer_slug);
         let sent_at = Utc.timestamp_opt(message.date, 0).single();
 
-        let mut env = ChannelEnvelope::new(from, BOT_SELF_ADDRESS, text.clone())
-            .with_external_id(external_id);
+        let mut env = ChannelEnvelope::new(from.clone(), BOT_SELF_ADDRESS, text.clone())
+            .with_external_id(external_id)
+            .with_quarantine_replay(text.as_bytes().to_vec(), from);
         if let Some(ts) = sent_at {
             env = env.with_sent_at(ts);
         }

--- a/crates/khive-channel/src/lib.rs
+++ b/crates/khive-channel/src/lib.rs
@@ -13,6 +13,31 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+/// In-memory replay context retained only until an inbound envelope is
+/// durably handled.
+///
+/// The exact transport bytes deliberately bypass `metadata`: metadata is sent
+/// through `comm.ingest` and would re-present content to the same write gate
+/// that can reject the message. Serialization skips this context, and its
+/// `Debug` implementation reports only byte length so logs cannot expose the
+/// original message.
+#[derive(Clone)]
+pub struct QuarantineReplay {
+    /// Byte-exact transport payload stored in content-addressed blob storage.
+    pub bytes: Vec<u8>,
+    /// Channel address that should receive a body-free quarantine notification.
+    pub notification_to: String,
+}
+
+impl std::fmt::Debug for QuarantineReplay {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("QuarantineReplay")
+            .field("bytes_len", &self.bytes.len())
+            .field("notification_to", &self.notification_to)
+            .finish()
+    }
+}
+
 /// A message envelope passed between the channel transport and the runtime.
 ///
 /// Outbound envelopes are produced by the runtime and delivered by a `Channel`.
@@ -43,6 +68,9 @@ pub struct ChannelEnvelope {
     pub correlation_external_id: Option<String>,
     /// Arbitrary transport-specific key-value metadata.
     pub metadata: HashMap<String, String>,
+    /// Non-serialized replay context for a message that may need quarantine.
+    #[serde(skip)]
+    pub quarantine_replay: Option<QuarantineReplay>,
     /// RFC 822 Message-ID to set on the outbound email (including angle brackets,
     /// e.g. `<uuid@domain>`). `None` on inbound envelopes and when the transport
     /// should auto-generate the identifier.
@@ -82,6 +110,7 @@ impl ChannelEnvelope {
             external_id: None,
             correlation_external_id: None,
             metadata: HashMap::new(),
+            quarantine_replay: None,
             message_id: None,
             wire_message_id: None,
             wire_references: None,
@@ -105,6 +134,19 @@ impl ChannelEnvelope {
     /// Attach an external deduplication key.
     pub fn with_external_id(mut self, id: impl Into<String>) -> Self {
         self.external_id = Some(id.into());
+        self
+    }
+
+    /// Retain exact source bytes and the safe notification target in memory.
+    pub fn with_quarantine_replay(
+        mut self,
+        bytes: Vec<u8>,
+        notification_to: impl Into<String>,
+    ) -> Self {
+        self.quarantine_replay = Some(QuarantineReplay {
+            bytes,
+            notification_to: notification_to.into(),
+        });
         self
     }
 

--- a/crates/khive-mcp/Cargo.toml
+++ b/crates/khive-mcp/Cargo.toml
@@ -42,6 +42,7 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 clap = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
+base64 = { workspace = true }
 libc = { workspace = true }
 sha2 = { workspace = true }
 chrono = { workspace = true }

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -405,12 +405,22 @@ fn spawn_email_channel_loops(server: &KhiveMcpServer) {
             let email_ch_clone = Arc::clone(&email_ch);
 
             let spawned = run_if_authorized(&ingest_ns, &verb_reg, || {
-                tokio::task::spawn(channel_poll_loop(
-                    ch_registry,
-                    verb_reg_poll,
-                    ingest_ns_clone,
-                    default_actor_clone,
-                ));
+                tokio::task::spawn(async move {
+                    if let Err(error) = ensure_channel_quarantine_storage(&verb_reg_poll).await {
+                        tracing::error!(
+                            error = %error,
+                            "email polling disabled: quarantine blob storage is unavailable"
+                        );
+                        return;
+                    }
+                    channel_poll_loop(
+                        ch_registry,
+                        verb_reg_poll,
+                        ingest_ns_clone,
+                        default_actor_clone,
+                    )
+                    .await;
+                });
                 tokio::task::spawn(channel_outbox_loop(
                     email_ch_clone,
                     verb_reg_outbox,
@@ -533,6 +543,216 @@ fn preflight_ingest_namespace(ns_str: &str, registry: &khive_runtime::VerbRegist
 #[cfg(feature = "channel-email")]
 const CHANNEL_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
 
+#[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
+const UNKNOWN_INGEST_QUARANTINE_THRESHOLD: u8 = 5;
+
+#[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ChannelIngestDisposition {
+    Hold { attempt: Option<u8> },
+    Quarantine,
+}
+
+#[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
+fn channel_ingest_attempt_key(channel_kind: &str, external_id: Option<&str>) -> Option<String> {
+    external_id.map(|external_id| format!("{channel_kind}:{external_id}"))
+}
+
+#[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
+fn channel_ingest_disposition(
+    classification: khive_runtime::ChannelIngestFailureClass,
+    channel_kind: &str,
+    external_id: Option<&str>,
+    unknown_attempts: &mut std::collections::HashMap<String, u8>,
+) -> ChannelIngestDisposition {
+    use khive_runtime::ChannelIngestFailureClass;
+
+    match classification {
+        ChannelIngestFailureClass::Retryable { .. } => {
+            ChannelIngestDisposition::Hold { attempt: None }
+        }
+        ChannelIngestFailureClass::Permanent { .. } => ChannelIngestDisposition::Quarantine,
+        ChannelIngestFailureClass::Unknown { .. } => {
+            let Some(key) = channel_ingest_attempt_key(channel_kind, external_id) else {
+                return ChannelIngestDisposition::Hold { attempt: None };
+            };
+            let attempt = unknown_attempts.entry(key).or_default();
+            *attempt = attempt.saturating_add(1);
+            if *attempt >= UNKNOWN_INGEST_QUARANTINE_THRESHOLD {
+                ChannelIngestDisposition::Quarantine
+            } else {
+                ChannelIngestDisposition::Hold {
+                    attempt: Some(*attempt),
+                }
+            }
+        }
+    }
+}
+
+#[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
+fn log_channel_quarantine(
+    channel_kind: &str,
+    classification: khive_runtime::ChannelIngestFailureClass,
+    external_id: &str,
+) {
+    tracing::warn!(
+        channel = channel_kind,
+        classification = classification.name(),
+        reason = classification.reason(),
+        external_id,
+        "quarantined inbound message after comm.ingest refusal"
+    );
+}
+
+#[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
+async fn ensure_channel_quarantine_storage(
+    registry: &khive_runtime::VerbRegistry,
+) -> Result<(), khive_runtime::RuntimeError> {
+    use serde_json::json;
+
+    if !registry.has_verb("blob.put") || !registry.has_verb("blob.stat") {
+        return Err(khive_runtime::RuntimeError::Unconfigured(
+            "channel quarantine requires the blob pack".to_string(),
+        ));
+    }
+
+    // `blob.stat` is read-only. Probing a valid, absent digest verifies both
+    // verb registration and that the pack's BlobStore is installed without
+    // publishing a startup artifact.
+    registry
+        .dispatch(
+            "blob.stat",
+            json!({"content_ref": "0000000000000000000000000000000000000000000000000000000000000000"}),
+        )
+        .await?;
+    Ok(())
+}
+
+#[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
+async fn quarantine_channel_ingest_failure(
+    registry: &khive_runtime::VerbRegistry,
+    ingest_namespace: &str,
+    channel_kind: &str,
+    default_inbound_actor: Option<&str>,
+    envelope: &khive_channel::ChannelEnvelope,
+    classification: khive_runtime::ChannelIngestFailureClass,
+) -> Result<(), khive_runtime::RuntimeError> {
+    use base64::engine::general_purpose::STANDARD as BASE64;
+    use base64::Engine as _;
+    use serde_json::json;
+
+    let external_id = envelope.external_id.as_deref().ok_or_else(|| {
+        khive_runtime::RuntimeError::InvalidInput(
+            "cannot quarantine a channel message without external_id".to_string(),
+        )
+    })?;
+    let (replay_bytes, notification_to) = envelope
+        .quarantine_replay
+        .as_ref()
+        .map(|replay| (replay.bytes.as_slice(), replay.notification_to.as_str()))
+        .unwrap_or_else(|| (envelope.content.as_bytes(), envelope.to.as_str()));
+
+    let put = registry
+        .dispatch("blob.put", json!({"bytes": BASE64.encode(replay_bytes)}))
+        .await?;
+    let content_ref = put
+        .get("content_ref")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| {
+            khive_runtime::RuntimeError::Internal(
+                "blob.put returned no string content_ref for channel quarantine".to_string(),
+            )
+        })?;
+
+    // Quarantine sender prefix invariant: the sender retains the originating
+    // channel prefix because prefix-keyed consumers depend on it for alert
+    // visibility. Moving `email:quarantine` outside `email:` hides the alert.
+    let quarantine_sender = format!("{channel_kind}:quarantine");
+    debug_assert!(
+        quarantine_sender.starts_with(&format!("{channel_kind}:")),
+        "quarantine sender prefix invariant: prefix-keyed consumers require the channel prefix"
+    );
+
+    let mut params = json!({
+        "namespace": ingest_namespace,
+        "from": quarantine_sender,
+        "to": notification_to,
+        "content": "Inbound channel message quarantined. Original bytes are available through the attached content reference.",
+        "channel_kind": channel_kind,
+        "external_id": external_id,
+        "metadata": {
+            "quarantined": "true",
+            "quarantine_classification": classification.name(),
+            "quarantine_reason": classification.reason(),
+            "quarantine_external_id": external_id,
+            "quarantine_content_ref": content_ref,
+        },
+    });
+    if let Some(actor) = default_inbound_actor {
+        params["default_inbound_actor"] = json!(actor);
+    }
+    registry.dispatch("comm.ingest", params).await?;
+    log_channel_quarantine(channel_kind, classification, external_id);
+    Ok(())
+}
+
+#[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
+async fn handle_channel_ingest_failure(
+    registry: &khive_runtime::VerbRegistry,
+    ingest_namespace: &str,
+    channel_kind: &str,
+    default_inbound_actor: Option<&str>,
+    envelope: &khive_channel::ChannelEnvelope,
+    error: &khive_runtime::RuntimeError,
+    unknown_attempts: &mut std::collections::HashMap<String, u8>,
+) -> bool {
+    let classification = error.channel_ingest_failure_class();
+    match channel_ingest_disposition(
+        classification,
+        channel_kind,
+        envelope.external_id.as_deref(),
+        unknown_attempts,
+    ) {
+        ChannelIngestDisposition::Hold { attempt } => {
+            tracing::warn!(
+                channel = channel_kind,
+                classification = classification.name(),
+                reason = classification.reason(),
+                external_id = envelope.external_id.as_deref(),
+                attempt,
+                threshold = UNKNOWN_INGEST_QUARANTINE_THRESHOLD,
+                "comm.ingest failed; holding channel progress"
+            );
+            false
+        }
+        ChannelIngestDisposition::Quarantine => {
+            match quarantine_channel_ingest_failure(
+                registry,
+                ingest_namespace,
+                channel_kind,
+                default_inbound_actor,
+                envelope,
+                classification,
+            )
+            .await
+            {
+                Ok(()) => true,
+                Err(quarantine_error) => {
+                    tracing::warn!(
+                        channel = channel_kind,
+                        classification = classification.name(),
+                        reason = classification.reason(),
+                        external_id = envelope.external_id.as_deref(),
+                        error = %quarantine_error,
+                        "channel quarantine failed; holding progress for retry"
+                    );
+                    false
+                }
+            }
+        }
+    }
+}
+
 /// Background task that polls all registered channels every 5 seconds and
 /// ingests new inbound messages via `comm.ingest`.
 ///
@@ -583,6 +803,10 @@ async fn channel_poll_loop(
     // (first failure since success, or a change in error class) rather than
     // once per retry. Cleared on every success.
     let mut last_error_class: HashMap<(String, String), &'static str> = HashMap::new();
+    // Unknown ingest failures are bounded per external message ID. Entries
+    // remain pinned through quarantine until the page cursor itself commits,
+    // so a cursor-commit failure cannot restart the five-attempt wait.
+    let mut unknown_ingest_attempts: HashMap<String, u8> = HashMap::new();
     let mut next_interval = CHANNEL_POLL_INTERVAL;
     let event_store = registry.event_store();
     // Captured before the loop's first sleep (issue #449 follow-up).
@@ -693,29 +917,44 @@ async fn channel_poll_loop(
                     // the whole page -- comm.ingest's `INSERT OR IGNORE`
                     // dedup then skips re-storing the messages that already
                     // succeeded, and only the failed one is retried.
+                    let page_attempt_keys: Vec<String> = page
+                        .envelopes
+                        .iter()
+                        .filter_map(|env| {
+                            channel_ingest_attempt_key(kind, env.external_id.as_deref())
+                        })
+                        .collect();
                     let mut page_fully_ingested = true;
                     for env in page.envelopes {
                         let params = json!({
                             "namespace": ingest_namespace,
-                            "from": env.from,
-                            "to": env.to,
-                            "content": env.content,
-                            "subject": env.subject,
+                            "from": env.from.clone(),
+                            "to": env.to.clone(),
+                            "content": env.content.clone(),
+                            "subject": env.subject.clone(),
                             "channel_kind": kind,
-                            "external_id": env.external_id,
-                            "sent_at": env.sent_at.map(|ts| ts.to_rfc3339()),
-                            "correlation_external_id": env.correlation_external_id,
+                            "external_id": env.external_id.clone(),
+                            "sent_at": env.sent_at.as_ref().map(|ts| ts.to_rfc3339()),
+                            "correlation_external_id": env.correlation_external_id.clone(),
                             "default_inbound_actor": default_inbound_actor,
-                            "wire_message_id": env.wire_message_id,
-                            "wire_references": env.wire_references,
-                            "metadata": env.metadata,
+                            "wire_message_id": env.wire_message_id.clone(),
+                            "wire_references": env.wire_references.clone(),
+                            "metadata": env.metadata.clone(),
                         });
-                        if let Err(e) = registry.dispatch("comm.ingest", params).await {
-                            tracing::warn!(
-                                channel = kind,
-                                "comm.ingest failed for inbound message: {e}"
-                            );
-                            page_fully_ingested = false;
+                        if let Err(error) = registry.dispatch("comm.ingest", params).await {
+                            let handled = handle_channel_ingest_failure(
+                                &registry,
+                                &ingest_namespace,
+                                kind,
+                                Some(&default_inbound_actor),
+                                &env,
+                                &error,
+                                &mut unknown_ingest_attempts,
+                            )
+                            .await;
+                            if !handled {
+                                page_fully_ingested = false;
+                            }
                         }
                     }
 
@@ -738,6 +977,11 @@ async fn channel_poll_loop(
                             // Nothing new to commit this tick is not a
                             // failure -- safe to advance the bootstrap floor.
                             None => bootstrap_floor_advances = true,
+                        }
+                        if bootstrap_floor_advances {
+                            for key in page_attempt_keys {
+                                unknown_ingest_attempts.remove(&key);
+                            }
                         }
                     } else {
                         tracing::warn!(
@@ -1324,11 +1568,16 @@ fn spawn_telegram_channel_loops(server: &KhiveMcpServer) {
             let tg_ch_outbox = Arc::clone(&tg_ch);
 
             let spawned = run_if_authorized(&ingest_ns, &verb_reg, || {
-                tokio::task::spawn(telegram_poll_loop(
-                    tg_ch_poll,
-                    verb_reg_poll,
-                    ingest_ns_poll,
-                ));
+                tokio::task::spawn(async move {
+                    if let Err(error) = ensure_channel_quarantine_storage(&verb_reg_poll).await {
+                        tracing::error!(
+                            error = %error,
+                            "telegram polling disabled: quarantine blob storage is unavailable"
+                        );
+                        return;
+                    }
+                    telegram_poll_loop(tg_ch_poll, verb_reg_poll, ingest_ns_poll).await;
+                });
                 tokio::task::spawn(telegram_outbox_loop(
                     tg_ch_outbox,
                     verb_reg_outbox,
@@ -1392,33 +1641,49 @@ async fn telegram_poll_loop(
     use serde_json::json;
 
     const ERROR_BACKOFF: std::time::Duration = std::time::Duration::from_secs(5);
+    let mut unknown_ingest_attempts = std::collections::HashMap::<String, u8>::new();
 
     loop {
         match telegram_channel.poll(Utc::now()).await {
             Ok(envelopes) => {
                 let kind = telegram_channel.kind();
+                let batch_attempt_keys: Vec<String> = envelopes
+                    .iter()
+                    .filter_map(|env| channel_ingest_attempt_key(kind, env.external_id.as_deref()))
+                    .collect();
                 let mut all_ingested = true;
                 for env in envelopes {
                     let params = json!({
                         "namespace": ingest_namespace,
-                        "from": env.from,
-                        "to": env.to,
-                        "content": env.content,
+                        "from": env.from.clone(),
+                        "to": env.to.clone(),
+                        "content": env.content.clone(),
                         "channel_kind": kind,
-                        "external_id": env.external_id,
-                        "sent_at": env.sent_at.map(|ts| ts.to_rfc3339()),
+                        "external_id": env.external_id.clone(),
+                        "sent_at": env.sent_at.as_ref().map(|ts| ts.to_rfc3339()),
                     });
-                    if let Err(e) = registry.dispatch("comm.ingest", params).await {
-                        tracing::warn!(
-                            channel = kind,
-                            "comm.ingest failed for inbound telegram message: {e}"
-                        );
-                        all_ingested = false;
+                    if let Err(error) = registry.dispatch("comm.ingest", params).await {
+                        let handled = handle_channel_ingest_failure(
+                            &registry,
+                            &ingest_namespace,
+                            kind,
+                            None,
+                            &env,
+                            &error,
+                            &mut unknown_ingest_attempts,
+                        )
+                        .await;
+                        if !handled {
+                            all_ingested = false;
+                        }
                     }
                 }
 
                 if all_ingested {
                     telegram_channel.commit_offset();
+                    for key in batch_attempt_keys {
+                        unknown_ingest_attempts.remove(&key);
+                    }
                 } else {
                     tracing::warn!(
                         channel = kind,
@@ -6893,6 +7158,93 @@ region = "us-east-1"
         }
     }
 
+    #[cfg(feature = "channel-email")]
+    mod channel_ingest_disposition_tests {
+        use super::*;
+        use khive_runtime::ChannelIngestFailureClass;
+        use std::collections::HashMap;
+
+        #[tokio::test]
+        async fn quarantine_storage_preflight_rejects_a_missing_blob_pack() {
+            let registry = khive_runtime::VerbRegistryBuilder::new()
+                .build()
+                .expect("empty registry builds");
+            let error = ensure_channel_quarantine_storage(&registry)
+                .await
+                .expect_err("channel polling must fail closed without blob storage");
+            assert!(matches!(
+                error,
+                khive_runtime::RuntimeError::Unconfigured(_)
+            ));
+        }
+
+        #[test]
+        fn unknown_failure_holds_four_attempts_then_quarantines_on_five() {
+            let mut attempts = HashMap::new();
+            let classification = ChannelIngestFailureClass::Unknown {
+                reason: "InvalidInput",
+            };
+
+            for expected_attempt in 1..UNKNOWN_INGEST_QUARANTINE_THRESHOLD {
+                assert_eq!(
+                    channel_ingest_disposition(
+                        classification,
+                        "email",
+                        Some("imap:h:1:7"),
+                        &mut attempts,
+                    ),
+                    ChannelIngestDisposition::Hold {
+                        attempt: Some(expected_attempt),
+                    }
+                );
+            }
+            assert_eq!(
+                channel_ingest_disposition(
+                    classification,
+                    "email",
+                    Some("imap:h:1:7"),
+                    &mut attempts,
+                ),
+                ChannelIngestDisposition::Quarantine,
+                "the fifth unknown failure must close the retry livelock"
+            );
+        }
+
+        #[test]
+        fn retryable_never_increments_and_permanent_quarantines_immediately() {
+            let mut attempts = HashMap::new();
+            assert_eq!(
+                channel_ingest_disposition(
+                    ChannelIngestFailureClass::Retryable { reason: "Storage" },
+                    "email",
+                    Some("imap:h:1:8"),
+                    &mut attempts,
+                ),
+                ChannelIngestDisposition::Hold { attempt: None }
+            );
+            assert!(
+                attempts.is_empty(),
+                "retryable failures must not consume the unknown budget"
+            );
+
+            assert_eq!(
+                channel_ingest_disposition(
+                    ChannelIngestFailureClass::Permanent {
+                        reason: "SecretDetected",
+                    },
+                    "email",
+                    Some("imap:h:1:9"),
+                    &mut attempts,
+                ),
+                ChannelIngestDisposition::Quarantine
+            );
+            assert!(
+                attempts.is_empty(),
+                "permanent failures bypass the unknown budget"
+            );
+        }
+    }
+
     // --- log_eligible_poll_failure: edge-triggered warn ---
 
     #[cfg(feature = "channel-email")]
@@ -6908,26 +7260,35 @@ region = "us-east-1"
         struct CapturedEvent {
             level: Option<tracing::Level>,
             message: Option<String>,
+            reason: Option<String>,
         }
 
         #[derive(Default)]
-        struct CapturedEventVisitor(Option<String>);
+        struct CapturedEventVisitor {
+            message: Option<String>,
+            reason: Option<String>,
+        }
 
         impl Visit for CapturedEventVisitor {
             fn record_str(&mut self, field: &Field, value: &str) {
-                if field.name() == "message" {
-                    self.0 = Some(value.to_string());
+                match field.name() {
+                    "message" => self.message = Some(value.to_string()),
+                    "reason" => self.reason = Some(value.to_string()),
+                    _ => {}
                 }
             }
             fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
-                if field.name() == "message" {
+                if matches!(field.name(), "message" | "reason") {
                     let formatted = format!("{value:?}");
-                    self.0 = Some(
-                        formatted
-                            .trim_start_matches('"')
-                            .trim_end_matches('"')
-                            .to_string(),
-                    );
+                    let value = formatted
+                        .trim_start_matches('"')
+                        .trim_end_matches('"')
+                        .to_string();
+                    match field.name() {
+                        "message" => self.message = Some(value),
+                        "reason" => self.reason = Some(value),
+                        _ => {}
+                    }
                 }
             }
         }
@@ -6955,7 +7316,8 @@ region = "us-east-1"
                 event.record(&mut visitor);
                 self.events.lock().unwrap().push(CapturedEvent {
                     level: Some(*event.metadata().level()),
-                    message: visitor.0,
+                    message: visitor.message,
+                    reason: visitor.reason,
                 });
             }
             fn enter(&self, _: &tracing::span::Id) {}
@@ -7069,6 +7431,33 @@ region = "us-east-1"
             assert!(
                 message.contains("slot exhausted"),
                 "escalation warn must carry the underlying error text, got: {message}"
+            );
+        }
+
+        #[test]
+        fn quarantine_warn_names_typed_reason() {
+            let buffer = Arc::new(Mutex::new(Vec::new()));
+            let subscriber = CaptureSubscriber {
+                events: Arc::clone(&buffer),
+            };
+
+            tracing::subscriber::with_default(subscriber, || {
+                log_channel_quarantine(
+                    "email",
+                    khive_runtime::ChannelIngestFailureClass::Permanent {
+                        reason: "SecretDetected",
+                    },
+                    "imap:h:11:7",
+                );
+            });
+
+            let events = buffer.lock().unwrap();
+            assert_eq!(events.len(), 1, "quarantine must emit exactly one event");
+            assert_eq!(events[0].level, Some(tracing::Level::WARN));
+            assert_eq!(
+                events[0].reason.as_deref(),
+                Some("SecretDetected"),
+                "quarantine WARN must name the typed refusal variant"
             );
         }
     }
@@ -8473,6 +8862,8 @@ backend = "kg-backend"
     mod cursor_commit_gating_tests {
         use super::*;
         use async_trait::async_trait;
+        use base64::engine::general_purpose::STANDARD as BASE64;
+        use base64::Engine as _;
         use chrono::{DateTime, Utc};
         use khive_channel::{
             Channel, ChannelCheckpoint, ChannelEnvelope, ChannelError, ChannelPollPage,
@@ -8788,6 +9179,49 @@ backend = "kg-backend"
             envelope: Mutex<Option<ChannelEnvelope>>,
         }
 
+        struct ContentRefusalOnceChannel {
+            envelope: Mutex<Option<ChannelEnvelope>>,
+        }
+
+        #[async_trait]
+        impl Channel for ContentRefusalOnceChannel {
+            fn kind(&self) -> &'static str {
+                "email"
+            }
+
+            async fn send(&self, _envelope: ChannelEnvelope) -> Result<(), ChannelError> {
+                Ok(())
+            }
+
+            async fn poll(
+                &self,
+                _since: DateTime<Utc>,
+            ) -> Result<Vec<ChannelEnvelope>, ChannelError> {
+                panic!("the daemon poll loop must call poll_page, not poll");
+            }
+
+            async fn poll_page(
+                &self,
+                _since: DateTime<Utc>,
+                _checkpoint: Option<&StoredChannelCheckpoint>,
+            ) -> Result<ChannelPollPage, ChannelError> {
+                let Some(envelope) = self.envelope.lock().unwrap().take() else {
+                    return Ok(ChannelPollPage {
+                        envelopes: vec![],
+                        next_checkpoint: None,
+                    });
+                };
+                Ok(ChannelPollPage {
+                    envelopes: vec![envelope],
+                    next_checkpoint: Some(ChannelCheckpoint {
+                        source: SOURCE.to_string(),
+                        generation: 11,
+                        high_water: Some(7),
+                    }),
+                })
+            }
+        }
+
         #[async_trait]
         impl Channel for QuarantineOnceChannel {
             fn kind(&self) -> &'static str {
@@ -8925,6 +9359,141 @@ backend = "kg-backend"
                 props.get("quarantine_reason").and_then(|v| v.as_str()),
                 Some("missing-body"),
                 "the quarantine reason must survive comm.ingest: {props:?}"
+            );
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn content_refusal_stores_exact_replay_and_ingests_body_free_quarantine() {
+            const EXTERNAL_ID: &str = "imap:h:11:7";
+            const REFUSED_BODY: &str = "AKIAFAKEKEY1234567890"; // gitleaks:allow
+            const ORIGINAL_BYTES: &[u8] = b"From: maintainer@example.com\r\n\
+                To: mailbox@example.com\r\n\
+                Subject: replay fixture\r\n\
+                \r\n\
+                AKIAFAKEKEY1234567890"; // gitleaks:allow
+
+            let envelope = ChannelEnvelope::new(
+                "email:maintainer@example.com",
+                "email:mailbox@example.com",
+                REFUSED_BODY,
+            )
+            .with_external_id(EXTERNAL_ID)
+            .with_quarantine_replay(ORIGINAL_BYTES.to_vec(), "email:maintainer@example.com");
+
+            let mut ch_registry = ChannelRegistry::new();
+            ch_registry.register(Arc::new(ContentRefusalOnceChannel {
+                envelope: Mutex::new(Some(envelope)),
+            }));
+
+            let blob_dir = tempfile::tempdir().expect("blob tempdir");
+            let blob_store =
+                khive_db::stores::blob::FsBlobStore::new(blob_dir.path().to_path_buf(), 0)
+                    .expect("fs blob store");
+            let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+            runtime.install_blob_store(Arc::new(blob_store));
+            let mut builder = VerbRegistryBuilder::new();
+            builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
+            builder.register(khive_pack_comm::CommPack::new(runtime.clone()));
+            builder.register(khive_pack_blob::BlobPack::new(runtime.clone()));
+            let registry = builder.build().expect("registry builds");
+            ensure_channel_quarantine_storage(&registry)
+                .await
+                .expect("configured replay storage must pass channel startup preflight");
+
+            let refused = registry
+                .dispatch(
+                    "comm.ingest",
+                    json!({
+                        "namespace": "test-ns",
+                        "from": "email:maintainer@example.com",
+                        "to": "email:mailbox@example.com",
+                        "content": REFUSED_BODY,
+                        "channel_kind": "email",
+                        "external_id": EXTERNAL_ID,
+                        "default_inbound_actor": "actor:test",
+                    }),
+                )
+                .await
+                .expect_err("the fixture must exercise the real content gate");
+            assert!(
+                matches!(refused, khive_runtime::RuntimeError::SecretDetected(_)),
+                "the replay test is invalid unless comm.ingest refuses the original content"
+            );
+
+            let task = tokio::spawn(channel_poll_loop(
+                Arc::new(ch_registry),
+                registry.clone(),
+                "test-ns".to_string(),
+                "actor:test".to_string(),
+            ));
+
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+            loop {
+                let restored = load_channel_cursor(&registry, "email", "email")
+                    .await
+                    .expect("cursor_get must succeed");
+                if restored
+                    .as_ref()
+                    .is_some_and(|stored| stored.checkpoint.high_water == Some(7))
+                {
+                    break;
+                }
+                assert!(
+                    std::time::Instant::now() < deadline,
+                    "a permanently refused message must quarantine and advance the cursor"
+                );
+                tokio::time::advance(std::time::Duration::from_millis(250)).await;
+                for _ in 0..10 {
+                    tokio::task::yield_now().await;
+                }
+            }
+            task.abort();
+
+            let inbox = registry
+                .dispatch(
+                    "list",
+                    json!({"namespace": "test-ns", "kind": "message", "limit": 50}),
+                )
+                .await
+                .expect("list must succeed");
+            let notes = inbox.as_array().expect("list returns an array");
+            assert_eq!(notes.len(), 1, "only the quarantine notification is stored");
+            let quarantined = &notes[0];
+            assert_eq!(
+                quarantined["properties"]["from_actor"],
+                "email:quarantine",
+                "quarantine sender prefix invariant: `email:` keeps the notification visible to prefix-keyed consumers"
+            );
+            assert_eq!(quarantined["properties"]["external_id"], EXTERNAL_ID);
+            assert_eq!(
+                quarantined["properties"]["quarantine_classification"],
+                "permanent"
+            );
+            assert_eq!(
+                quarantined["properties"]["quarantine_reason"],
+                "SecretDetected"
+            );
+            assert!(
+                !quarantined["content"]
+                    .as_str()
+                    .expect("note content")
+                    .contains(REFUSED_BODY),
+                "the notification must never re-present the refused body"
+            );
+
+            let content_ref = quarantined["properties"]["quarantine_content_ref"]
+                .as_str()
+                .expect("quarantine ContentRef");
+            let fetched = registry
+                .dispatch("blob.get", json!({"content_ref": content_ref}))
+                .await
+                .expect("quarantine replay blob must be retrievable");
+            let replay = BASE64
+                .decode(fetched["bytes"].as_str().expect("base64 replay bytes"))
+                .expect("valid base64 replay bytes");
+            assert_eq!(
+                replay, ORIGINAL_BYTES,
+                "the replay ContentRef must round-trip the byte-exact original message"
             );
         }
 

--- a/crates/khive-runtime/src/error.rs
+++ b/crates/khive-runtime/src/error.rs
@@ -56,6 +56,41 @@ pub struct AdmissionFailureContext {
     pub retry_after_ms: Option<u64>,
 }
 
+/// Typed disposition for a channel message whose `comm.ingest` write failed.
+///
+/// Every bucket carries the stable [`RuntimeError`] variant name that selected
+/// it. Consumers can therefore make retry/quarantine decisions and report a
+/// reason without inspecting the error's rendered text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChannelIngestFailureClass {
+    /// A pre-execution admission failure that is safe to retry indefinitely.
+    Retryable { reason: &'static str },
+    /// A deterministic policy refusal that should quarantine immediately.
+    Permanent { reason: &'static str },
+    /// An error with no explicit retry or permanent policy classification.
+    Unknown { reason: &'static str },
+}
+
+impl ChannelIngestFailureClass {
+    /// Stable lowercase bucket name persisted on quarantine notifications.
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Retryable { .. } => "retryable",
+            Self::Permanent { .. } => "permanent",
+            Self::Unknown { .. } => "unknown",
+        }
+    }
+
+    /// Stable typed error-variant name; never derived from `Display` output.
+    pub const fn reason(self) -> &'static str {
+        match self {
+            Self::Retryable { reason } | Self::Permanent { reason } | Self::Unknown { reason } => {
+                reason
+            }
+        }
+    }
+}
+
 /// Structured context recovered from either a direct SQLite runtime error or
 /// a typed SQLite source preserved inside a storage-driver wrapper.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -353,6 +388,61 @@ pub enum RuntimeError {
 }
 
 impl RuntimeError {
+    /// Classify a failed inbound channel write without inspecting rendered
+    /// error text.
+    ///
+    /// Existing typed admission failures remain retryable. Secret detection is
+    /// the first deterministic policy refusal and is permanent. `None` from
+    /// [`Self::admission_failure_context`] is deliberately not interpreted as
+    /// permanent: every other variant starts in the bounded `Unknown` bucket.
+    pub fn channel_ingest_failure_class(&self) -> ChannelIngestFailureClass {
+        let reason = self.variant_name();
+        if self.admission_failure_context().is_some() {
+            ChannelIngestFailureClass::Retryable { reason }
+        } else if matches!(self, Self::SecretDetected(_)) {
+            ChannelIngestFailureClass::Permanent { reason }
+        } else {
+            ChannelIngestFailureClass::Unknown { reason }
+        }
+    }
+
+    /// Stable top-level variant name used by typed policy classifiers.
+    const fn variant_name(&self) -> &'static str {
+        match self {
+            Self::Storage(_) => "Storage",
+            Self::Sqlite(_) => "Sqlite",
+            Self::Query(_) => "Query",
+            Self::NotFound(_) => "NotFound",
+            Self::InvalidInput(_) => "InvalidInput",
+            Self::UnknownVerb(_) => "UnknownVerb",
+            Self::Unconfigured(_) => "Unconfigured",
+            Self::UnknownModel(_) => "UnknownModel",
+            Self::Embedding(_) => "Embedding",
+            Self::Ambiguous(_) => "Ambiguous",
+            Self::Fusion(_) => "Fusion",
+            Self::Internal(_) => "Internal",
+            Self::GuardedWriteFailed(_) => "GuardedWriteFailed",
+            Self::MissingPackDependency(_) => "MissingPackDependency",
+            Self::MissingPackDependencies(_) => "MissingPackDependencies",
+            Self::CircularPackDependency(_) => "CircularPackDependency",
+            Self::PackRedeclared { .. } => "PackRedeclared",
+            Self::VerbCollision { .. } => "VerbCollision",
+            Self::PermissionDenied { .. } => "PermissionDenied",
+            Self::Khive(_) => "Khive",
+            Self::NamespaceMismatch { .. } => "NamespaceMismatch",
+            Self::AmbiguousPrefix { .. } => "AmbiguousPrefix",
+            Self::CrossBackendMergeUnsupported { .. } => "CrossBackendMergeUnsupported",
+            Self::UnknownRemote { .. } => "UnknownRemote",
+            Self::RemoteCacheMissing { .. } => "RemoteCacheMissing",
+            Self::AmbiguousId { .. } => "AmbiguousId",
+            Self::CrossNamespaceWrite { .. } => "CrossNamespaceWrite",
+            Self::RemoteFetchError { .. } => "RemoteFetchError",
+            Self::WriteBudgetExceeded { .. } => "WriteBudgetExceeded",
+            Self::SecretDetected(_) => "SecretDetected",
+            Self::DeadlineExceeded { .. } => "DeadlineExceeded",
+        }
+    }
+
     /// Recover a finite-wait pool-checkout timeout without inspecting rendered
     /// error text.
     ///
@@ -462,5 +552,59 @@ impl From<khive_types::EntityTypeError> for RuntimeError {
 impl From<khive_types::KhiveError> for RuntimeError {
     fn from(e: khive_types::KhiveError) -> Self {
         Self::Khive(e)
+    }
+}
+
+#[cfg(test)]
+mod channel_ingest_failure_class_tests {
+    use super::{ChannelIngestFailureClass, RuntimeError};
+    use crate::secret_gate::SecretMatch;
+
+    #[test]
+    fn secret_detected_is_permanent_by_typed_variant_not_display_text() {
+        let first = RuntimeError::SecretDetected(SecretMatch {
+            detector: "fixture",
+            masked: "first-rendering".to_string(),
+        });
+        let second = RuntimeError::SecretDetected(SecretMatch {
+            detector: "fixture",
+            masked: "completely-different-rendering".to_string(),
+        });
+
+        assert_ne!(first.to_string(), second.to_string());
+        assert_eq!(
+            first.channel_ingest_failure_class(),
+            ChannelIngestFailureClass::Permanent {
+                reason: "SecretDetected"
+            }
+        );
+        assert_eq!(
+            second.channel_ingest_failure_class(),
+            ChannelIngestFailureClass::Permanent {
+                reason: "SecretDetected"
+            },
+            "rendered error details must not participate in ingest classification"
+        );
+    }
+
+    #[test]
+    fn admission_failures_are_retryable_and_unclassified_errors_are_unknown() {
+        let retryable =
+            RuntimeError::Storage(khive_storage::StorageError::WriteQueueFull { timeout_ms: 25 });
+        assert_eq!(
+            retryable.channel_ingest_failure_class(),
+            ChannelIngestFailureClass::Retryable { reason: "Storage" }
+        );
+
+        let unknown = RuntimeError::InvalidInput(
+            "write blocked: SecretDetected text must not affect classification".to_string(),
+        );
+        assert_eq!(
+            unknown.channel_ingest_failure_class(),
+            ChannelIngestFailureClass::Unknown {
+                reason: "InvalidInput"
+            },
+            "a rendered message resembling SecretDetected must remain Unknown unless its typed variant is SecretDetected"
+        );
     }
 }

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -74,9 +74,9 @@ pub use engine_config::{
     GitWriteEntryConfig, GitWriteSectionConfig, KhiveConfig, PackConfig, StorageSectionConfig,
 };
 pub use error::{
-    fts_text_leg_or_err, AdmissionFailureContext, GuardedWriteFailure, RuntimeError, RuntimeResult,
-    WriterPoolCheckoutTimeoutContext, WRITER_ADMISSION_SCOPE, WRITER_POOL_CHECKOUT_TIMEOUT_STAGE,
-    WRITER_QUEUE_SATURATED_STAGE,
+    fts_text_leg_or_err, AdmissionFailureContext, ChannelIngestFailureClass, GuardedWriteFailure,
+    RuntimeError, RuntimeResult, WriterPoolCheckoutTimeoutContext, WRITER_ADMISSION_SCOPE,
+    WRITER_POOL_CHECKOUT_TIMEOUT_STAGE, WRITER_QUEUE_SATURATED_STAGE,
 };
 pub use fusion::FusionStrategy;
 pub use graph_traversal::PathNode;


### PR DESCRIPTION
Closes #1831.

## Problem

A deterministic `comm.ingest` refusal in a channel poll loop retried forever: the email loop's `page_fully_ingested` gate held the IMAP cursor on any failure, so a message the store refuses deterministically (measured live: a secret-gate refusal, 3,887 iterations) wedged the channel behind it. The Telegram loop shares the shape via `all_ingested`.

## Change

Typed three-way classification of ingest failures, decided by error variant, never by rendered text:

- **Retryable** — the existing `admission_failure_context()` set; cursor held, unchanged behavior.
- **Permanent** — deterministic policy refusals (`SecretDetected` is the first member); the message is quarantined immediately and the cursor advances.
- **Unknown** — everything else; the cursor is held and a per-`(channel, external_id)` attempt counter escalates to quarantine at 5 attempts, closing the livelock for deterministic failures nobody enumerated. Counters are retained until the cursor/offset actually commits, so a failed progress commit cannot reset the bound.

The quarantine record splits in two, because routing a content-refused message through the existing quarantine envelope would re-present identical bytes to the identical gate and wedge the quarantine path itself:

- Full original bytes (byte-exact RFC 822, including unparseable bodies) go to the content-addressed blob store; a regression test proves the replay path stores content the ingest path refuses, and fails loudly if blob writes are ever gated.
- The inbox notification is body-free: classification, typed reason, external id, and the blob ContentRef.

Additional hardening in the same change:

- Startup preflight (`blob.stat` on a valid absent digest, read-only) disables a channel poller when the blob store is unavailable, instead of discovering it at first quarantine.
- The quarantine sender marker keeps the channel's `email:` prefix; the invariant is documented at the constant and the existing sender assertions now carry messages stating it, so a mechanical rename cannot silence them without reading why.
- Structured WARN on every quarantine naming classification, typed reason, channel, and external id (the path previously logged nothing).
- Replay bytes are `#[serde(skip)]` and redacted from `Debug` in both `ChannelEnvelope` and `RawEmail`.

Telegram gets the same classifier, threshold, and quarantine helpers as email.

## Tests

Red-first for the classifier and the content-refusal regression. Coverage includes: typed classification surviving display-text changes, four holds then fifth-attempt quarantine, retryable-never-counts, permanent-immediate, byte-exact `blob.get` round-trip, body-free notification ingesting successfully for content the gate refuses, malformed-byte replay, missing-blob preflight, and `Debug` redaction. `cargo fmt`, `clippy --workspace --all-targets -D warnings`, all-features clippy for both channel crates, and the three-package test suite all pass.

## Known boundary

Blob orphan-sweep liveness currently scans entity `content_ref` fields; quarantine ContentRefs live in message-note properties, so replay retention past the orphan grace window needs a storage-contract follow-up (kept out of this change's scope).
