### PR TITLE
fix(mcp): route outbox external_id claim through the owner bookkeeping path

### DIFF
--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -387,6 +387,7 @@ fn spawn_email_channel_loops(server: &KhiveMcpServer) {
             ch_registry.register(dyn_ch);
             let ch_registry = Arc::new(ch_registry);
             let verb_reg = server.verb_registry_clone();
+            let runtime = server.runtime_clone();
             let ingest_ns = ingest_namespace_from_env();
             let default_actor = default_inbound_actor_from_env();
             let mut allowlist = allowed_recipients_from_env();
@@ -403,6 +404,7 @@ fn spawn_email_channel_loops(server: &KhiveMcpServer) {
             let allowlist_clone = allowlist.clone();
             let mailbox_clone = mailbox.clone();
             let email_ch_clone = Arc::clone(&email_ch);
+            let runtime_outbox = runtime.clone();
 
             let spawned = run_if_authorized(&ingest_ns, &verb_reg, || {
                 tokio::task::spawn(async move {
@@ -421,14 +423,27 @@ fn spawn_email_channel_loops(server: &KhiveMcpServer) {
                     )
                     .await;
                 });
-                tokio::task::spawn(channel_outbox_loop(
-                    email_ch_clone,
-                    verb_reg_outbox,
-                    ingest_ns_outbox,
-                    mailbox_clone,
-                    allowlist_clone,
-                ));
-                tracing::info!("email channel polling and outbox loops started");
+                match runtime_outbox {
+                    Some(rt) => {
+                        tokio::task::spawn(channel_outbox_loop(
+                            email_ch_clone,
+                            verb_reg_outbox,
+                            rt,
+                            ingest_ns_outbox,
+                            mailbox_clone,
+                            allowlist_clone,
+                        ));
+                        tracing::info!("email channel polling and outbox loops started");
+                    }
+                    None => {
+                        tracing::error!(
+                            "email polling started but the outbox loop was NOT started: server \
+                             has no default-backend runtime handle, which the outbox loop needs \
+                             to claim external_id on outbound notes; outbound mail will not be \
+                             sent"
+                        );
+                    }
+                }
             });
             if !spawned {
                 tracing::error!(
@@ -1302,11 +1317,19 @@ fn note_already_delivered(props: &serde_json::Map<String, serde_json::Value>) ->
 /// `delivered_at` write causes a duplicate send on restart; the duplicate carries
 /// the same Message-ID so receiving MTAs typically collapse it.
 ///
+/// The `external_id` claim goes through `runtime`'s non-wire
+/// `claim_outbound_message_external_id` rather than a `registry.dispatch("update",
+/// ...)` call: `external_id` is one of the owner-established properties the
+/// generic `update` verb refuses to patch on a pack-owned note kind, so a caller
+/// patch through `dispatch` is rejected by design and would leave every note
+/// stuck retrying forever.
+///
 /// Only compiled when the `channel-email` feature is enabled.
 #[cfg(feature = "channel-email")]
 async fn channel_outbox_loop(
     email_channel: std::sync::Arc<khive_channel_email::EmailChannel>,
     registry: khive_runtime::VerbRegistry,
+    runtime: khive_runtime::KhiveRuntime,
     ingest_namespace: String,
     mailbox: String,
     allowlist: Vec<String>,
@@ -1316,6 +1339,17 @@ async fn channel_outbox_loop(
     use serde_json::json;
 
     let domain = mailbox.split('@').nth(1).unwrap_or("localhost").to_string();
+    let namespace = match khive_runtime::Namespace::parse(&ingest_namespace) {
+        Ok(ns) => ns,
+        Err(e) => {
+            tracing::error!(
+                namespace = %ingest_namespace,
+                error = %e,
+                "outbox loop: ingest namespace does not parse; loop will not run"
+            );
+            return;
+        }
+    };
 
     loop {
         tokio::time::sleep(std::time::Duration::from_secs(5)).await;
@@ -1428,17 +1462,24 @@ async fn channel_outbox_loop(
                 Some(eid) if !eid.is_empty() => eid.to_string(),
                 _ => {
                     let mid = format!("<{note_id}@{domain}>");
-                    // Persist the claimed external_id before sending.
-                    let claim_result = registry
-                        .dispatch(
-                            "update",
-                            json!({
-                                "namespace": ingest_namespace,
-                                "id": note_id,
-                                "properties": { "external_id": mid.clone() },
-                            }),
-                        )
-                        .await;
+                    // Persist the claimed external_id before sending, through the
+                    // non-wire owner path: the generic `update` verb refuses any
+                    // patch naming `external_id` on a `message` note (it is an
+                    // owner-established property), so this cannot go through
+                    // `registry.dispatch`.
+                    let claim_result = match uuid::Uuid::parse_str(&note_id) {
+                        Ok(uuid) => match runtime.authorize(namespace.clone()) {
+                            Ok(token) => {
+                                runtime
+                                    .claim_outbound_message_external_id(&token, uuid, mid.clone())
+                                    .await
+                            }
+                            Err(e) => Err(e),
+                        },
+                        Err(e) => Err(khive_runtime::RuntimeError::InvalidInput(format!(
+                            "note id {note_id} is not a valid UUID: {e}"
+                        ))),
+                    };
                     if let Err(e) = claim_result {
                         tracing::warn!(
                             note_id = %note_id,
@@ -2735,6 +2776,7 @@ pub fn build_server_from_multi_backend_registry(
     // leaving them permanently invisible to cross-process WAL-pin attribution.
     let secondary_pools = secondary_file_backed_pools(&multi);
     let fmt = apply_env_output_format(khive_cfg.runtime.default_output_format);
+    let default_runtime = multi.default_runtime.clone();
 
     let server = KhiveMcpServer::from_registry_with_meta(
         multi.registry,
@@ -2742,7 +2784,8 @@ pub fn build_server_from_multi_backend_registry(
         &multi.config_id,
     )
     .with_default_output_format(fmt)
-    .with_secondary_pools(secondary_pools);
+    .with_secondary_pools(secondary_pools)
+    .with_runtime(default_runtime);
 
     let server = match coordinator {
         Some(c) => server.with_coordinator(c),

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -437,6 +437,14 @@ pub struct KhiveMcpServer {
     /// deployments. `None` in single-backend mode — all dispatch goes through the
     /// `VerbRegistry` unchanged (zero-change invariant).
     coordinator: Option<Arc<dyn CoordinatorService>>,
+    /// The default-backend `KhiveRuntime` this server was built from, kept so
+    /// background daemon tasks (e.g. the email outbox loop) can reach
+    /// non-wire owner APIs — such as the ADR-124-sanctioned store-level
+    /// property claim — that have no verb surface and so cannot go through
+    /// `registry.dispatch`. `None` only for servers built via
+    /// [`Self::from_registry`]/[`Self::from_registry_with_meta`] without an
+    /// explicit [`Self::with_runtime`] call (test-only construction paths).
+    runtime: Option<KhiveRuntime>,
     /// Pool arc for the WAL checkpoint background task. `None` for in-memory
     /// or registry-only servers that have no persistent database.
     pool: Option<Arc<ConnectionPool>>,
@@ -639,6 +647,7 @@ impl KhiveMcpServer {
             secondary_pools: Vec::new(),
             default_output_format: OutputFormat::Json,
             schedule_ticker_last_tick_micros: Arc::new(AtomicI64::new(0)),
+            runtime: Some(runtime),
         })
     }
 
@@ -661,6 +670,7 @@ impl KhiveMcpServer {
             secondary_pools: Vec::new(),
             default_output_format: OutputFormat::Json,
             schedule_ticker_last_tick_micros: Arc::new(AtomicI64::new(0)),
+            runtime: None,
         }
     }
 
@@ -682,7 +692,17 @@ impl KhiveMcpServer {
             secondary_pools: Vec::new(),
             default_output_format: OutputFormat::Json,
             schedule_ticker_last_tick_micros: Arc::new(AtomicI64::new(0)),
+            runtime: None,
         }
+    }
+
+    /// Attach the default-backend `KhiveRuntime` (see the `runtime` field docs
+    /// on [`KhiveMcpServer`]). Used by the multi-backend boot path to wire in
+    /// the same `default_runtime` it already resolved while building the
+    /// registry.
+    pub fn with_runtime(mut self, runtime: KhiveRuntime) -> Self {
+        self.runtime = Some(runtime);
+        self
     }
 
     /// Override the server-level default output format (ADR-078).
@@ -731,6 +751,15 @@ impl KhiveMcpServer {
     #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
     pub(crate) fn verb_registry_clone(&self) -> VerbRegistry {
         self.registry.clone()
+    }
+
+    /// Clone the default-backend `KhiveRuntime`, if this server was built with
+    /// one, for use by background tasks that need a non-wire owner API (e.g.
+    /// the email outbox loop's `external_id` claim). `KhiveRuntime` is
+    /// internally `Arc`-wrapped so this clone is cheap.
+    #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
+    pub(crate) fn runtime_clone(&self) -> Option<KhiveRuntime> {
+        self.runtime.clone()
     }
 
     /// Route a `link` or `search` verb through the coordinator when in multi-backend mode.

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -1442,6 +1442,67 @@ impl KhiveRuntime {
         Ok((note, embedding_report))
     }
 
+    /// Claim `external_id` on an outbound `message` note through the
+    /// ADR-124-sanctioned store-level one-key atomic path, bypassing the
+    /// caller-facing owner-established-property refusal in
+    /// [`Self::update_note`]/[`Self::prepare_update_note`]. This is deliberately
+    /// NOT exposed through any registered verb (ADR-124's stated bound): it is
+    /// reachable only from pack/runtime code that owns outbox bookkeeping for
+    /// the `message` note kind.
+    ///
+    /// Refuses (returns `Err`, never writes) unless the live row is a
+    /// `message` note, `properties.direction == "outbound"`, and
+    /// `properties.external_id` is currently absent or empty.
+    pub async fn claim_outbound_message_external_id(
+        &self,
+        token: &NamespaceToken,
+        id: Uuid,
+        external_id: String,
+    ) -> RuntimeResult<khive_storage::note::Note> {
+        let store = self.notes(token)?;
+        let note = store
+            .get_note(id)
+            .await?
+            .ok_or_else(|| RuntimeError::NotFound(format!("note {id}")))?;
+        if note.kind != "message" {
+            return Err(RuntimeError::InvalidInput(format!(
+                "external_id can only be claimed on a `message` note; note {id} is a `{}`",
+                note.kind
+            )));
+        }
+        let props = note.properties.as_ref().and_then(|v| v.as_object());
+        let direction = props
+            .and_then(|p| p.get("direction"))
+            .and_then(|v| v.as_str());
+        if direction != Some("outbound") {
+            return Err(RuntimeError::InvalidInput(format!(
+                "external_id can only be claimed on an outbound message note; note {id} has \
+                 direction {:?}",
+                direction
+            )));
+        }
+        let existing = props
+            .and_then(|p| p.get("external_id"))
+            .and_then(|v| v.as_str());
+        if existing.is_some_and(|v| !v.is_empty()) {
+            return Err(RuntimeError::InvalidInput(format!(
+                "note {id} already has an external_id claimed"
+            )));
+        }
+        store
+            .set_note_property(
+                id,
+                "external_id",
+                Value::String(external_id),
+                note.updated_at,
+            )
+            .await?;
+        store
+            .get_note(id)
+            .await?
+            .ok_or_else(|| RuntimeError::NotFound(format!("note {id}")))
+    }
+
     /// Merge `from_id` note into `into_id` note.
     ///
     /// Both notes must exist in the namespace and have the same `kind`. Content is merged
@@ -3175,6 +3236,203 @@ mod tests {
 
     fn rt() -> KhiveRuntime {
         KhiveRuntime::memory().unwrap()
+    }
+
+    fn outbound_message_note() -> Note {
+        let mut note = Note::new("local", "message", "hello");
+        note.properties = Some(serde_json::json!({"direction": "outbound"}));
+        note
+    }
+
+    #[tokio::test]
+    async fn claim_outbound_message_external_id_sets_value_and_survives_readback() {
+        let rt = rt();
+        rt.install_pack_owned_note_kinds(vec!["message".to_string()]);
+        let tok = NamespaceToken::local();
+        let note = outbound_message_note();
+        let note_id = note.id;
+        rt.notes(&tok)
+            .expect("note store")
+            .upsert_note(note)
+            .await
+            .expect("seed note");
+
+        let claimed = rt
+            .claim_outbound_message_external_id(&tok, note_id, "<abc@example.com>".to_string())
+            .await
+            .expect("claim succeeds on a fresh outbound message note");
+        assert_eq!(
+            claimed
+                .properties
+                .as_ref()
+                .and_then(|p| p.get("external_id"))
+                .and_then(|v| v.as_str()),
+            Some("<abc@example.com>")
+        );
+
+        // Reads the persisted row back independently of the claim call's own
+        // return value. This is the check that fails if the fix is reverted
+        // to routing the claim through `dispatch("update", ...)`: that path is
+        // refused by the owner-established-property gate exercised in
+        // `generic_update_still_refuses_external_id_on_message_note` below, so
+        // external_id would never actually persist and this read would come
+        // back `None`.
+        let reread = rt
+            .notes(&tok)
+            .expect("note store")
+            .get_note(note_id)
+            .await
+            .expect("read note")
+            .expect("note still exists");
+        assert_eq!(
+            reread
+                .properties
+                .as_ref()
+                .and_then(|p| p.get("external_id"))
+                .and_then(|v| v.as_str()),
+            Some("<abc@example.com>")
+        );
+    }
+
+    #[tokio::test]
+    async fn generic_update_still_refuses_external_id_on_message_note() {
+        let rt = rt();
+        rt.install_pack_owned_note_kinds(vec!["message".to_string()]);
+        let tok = NamespaceToken::local();
+        let note = outbound_message_note();
+        let note_id = note.id;
+        rt.notes(&tok)
+            .expect("note store")
+            .upsert_note(note)
+            .await
+            .expect("seed note");
+
+        let err = rt
+            .update_note(
+                &tok,
+                note_id,
+                NotePatch {
+                    properties: Some(serde_json::json!({"external_id": "<forged@example.com>"})),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect_err("caller-facing update must keep refusing external_id on a message note");
+        assert!(matches!(err, RuntimeError::InvalidInput(_)), "error: {err}");
+        assert!(err.to_string().contains("is not patchable"), "error: {err}");
+
+        // The owner path is unaffected by the caller-side refusal above.
+        let claimed = rt
+            .claim_outbound_message_external_id(&tok, note_id, "<claimed@example.com>".to_string())
+            .await
+            .expect("owner-bookkeeping path still claims after a refused caller patch");
+        assert_eq!(
+            claimed
+                .properties
+                .as_ref()
+                .and_then(|p| p.get("external_id"))
+                .and_then(|v| v.as_str()),
+            Some("<claimed@example.com>")
+        );
+    }
+
+    #[tokio::test]
+    async fn claim_refuses_non_message_note() {
+        let rt = rt();
+        rt.install_pack_owned_note_kinds(vec!["message".to_string()]);
+        let tok = NamespaceToken::local();
+        let mut note = Note::new("local", "observation", "not a message");
+        note.properties = Some(serde_json::json!({"direction": "outbound"}));
+        let note_id = note.id;
+        rt.notes(&tok)
+            .expect("note store")
+            .upsert_note(note)
+            .await
+            .expect("seed note");
+
+        let err = rt
+            .claim_outbound_message_external_id(&tok, note_id, "<x@example.com>".to_string())
+            .await
+            .expect_err("a non-message note must never accept the claim");
+        assert!(matches!(err, RuntimeError::InvalidInput(_)), "error: {err}");
+    }
+
+    #[tokio::test]
+    async fn claim_refuses_inbound_message() {
+        let rt = rt();
+        rt.install_pack_owned_note_kinds(vec!["message".to_string()]);
+        let tok = NamespaceToken::local();
+        let mut note = Note::new("local", "message", "inbound content");
+        note.properties = Some(serde_json::json!({"direction": "inbound"}));
+        let note_id = note.id;
+        rt.notes(&tok)
+            .expect("note store")
+            .upsert_note(note)
+            .await
+            .expect("seed note");
+
+        let err = rt
+            .claim_outbound_message_external_id(&tok, note_id, "<x@example.com>".to_string())
+            .await
+            .expect_err("an inbound message note must never accept the claim");
+        assert!(matches!(err, RuntimeError::InvalidInput(_)), "error: {err}");
+    }
+
+    #[tokio::test]
+    async fn claim_refuses_when_external_id_already_set() {
+        let rt = rt();
+        rt.install_pack_owned_note_kinds(vec!["message".to_string()]);
+        let tok = NamespaceToken::local();
+        let mut note = outbound_message_note();
+        note.properties = Some(
+            serde_json::json!({"direction": "outbound", "external_id": "<already@example.com>"}),
+        );
+        let note_id = note.id;
+        rt.notes(&tok)
+            .expect("note store")
+            .upsert_note(note)
+            .await
+            .expect("seed note");
+
+        let err = rt
+            .claim_outbound_message_external_id(&tok, note_id, "<new@example.com>".to_string())
+            .await
+            .expect_err("a note that already carries external_id must refuse re-claim");
+        assert!(matches!(err, RuntimeError::InvalidInput(_)), "error: {err}");
+    }
+
+    #[tokio::test]
+    async fn generic_update_can_still_patch_delivered_at_on_message_note() {
+        let rt = rt();
+        rt.install_pack_owned_note_kinds(vec!["message".to_string()]);
+        let tok = NamespaceToken::local();
+        let note = outbound_message_note();
+        let note_id = note.id;
+        rt.notes(&tok)
+            .expect("note store")
+            .upsert_note(note)
+            .await
+            .expect("seed note");
+
+        let updated = rt
+            .update_note(
+                &tok,
+                note_id,
+                NotePatch {
+                    properties: Some(serde_json::json!({"delivered_at": "2026-08-09T00:00:00Z"})),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("delivered_at is not owner-established and must remain patchable");
+        assert_eq!(
+            updated
+                .properties
+                .as_ref()
+                .and_then(|p| p.get("delivered_at"))
+                .and_then(|v| v.as_str()),
+            Some("2026-08-09T00:00:00Z")
+        );
     }
 
     fn secret_shaped_reason() -> String {

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -1445,7 +1445,7 @@ impl KhiveRuntime {
     /// Claim `external_id` on an outbound `message` note through the
     /// ADR-124-sanctioned store-level one-key atomic path, bypassing the
     /// caller-facing owner-established-property refusal in
-    /// [`Self::update_note`]/[`Self::prepare_update_note`]. This is deliberately
+    /// [`Self::update_note`] (and its crate-internal prepare path). This is deliberately
     /// NOT exposed through any registered verb (ADR-124's stated bound): it is
     /// reachable only from pack/runtime code that owns outbox bookkeeping for
     /// the `message` note kind.


### PR DESCRIPTION
## Summary

The email outbox loop could not deliver mail: it minted a Message-ID for
outbound notes and tried to persist it as `external_id` through the generic
`update` verb before sending. `external_id` is an owner-established note
property, so that patch is refused by design — the note retried forever and
was never handed to SMTP.

- Added a narrow, non-wire runtime method that performs the same one-key
  atomic property set already used for other owner-side bookkeeping fields,
  gated on the note being an outbound `message` with no `external_id`
  claimed yet.
- The outbox loop now calls this method directly instead of going through
  the verb dispatch path. The generic `update` verb's behavior for external
  callers is unchanged — it still refuses any patch naming `external_id` on
  a message note.
- The existing `delivered_at` mark-as-sent step (a non-owner-established
  property) is untouched.

## Test plan

- [x] Claim path: an outbound message note without `external_id` gets
      claimed through the new path, and the persisted value is confirmed by
      an independent re-read (fails if reverted to the old dispatch-based
      form).
- [x] Gate intact: a caller `update` naming `external_id` on a message note
      is still refused with the existing error.
- [x] Precondition arms: claim refused on a non-message note, on an inbound
      message, and on a note whose `external_id` is already set.
- [x] Regression guard: patching `delivered_at` via the generic `update`
      verb on a message note still succeeds.
- [x] `cargo check --workspace`
- [x] `cargo test -p khive-runtime -p khive-mcp`
- [x] `cargo fmt --all -- --check`

## Scope

This fixes the claim rejection itself (#1853 acceptance criteria (a) and
(b)): the loop's stamp now succeeds through an owner-side path, and the
ownership rule still refuses external callers. Retry classification
(#1853 acceptance criterion (c) — transitioning a permanently rejected
note to a visible failed/parked state) is intentionally out of scope
here. It is also bounded by #1859: the loop's fixed-size newest-first
selection window can stop scanning a long-stalled note entirely, so no
in-loop state transition can be guaranteed reachable until the selection
defect is fixed. #1853 should stay open for criterion (c).

Addresses the claim path of #1853. Refs #1859.
