### PR TITLE
fix(release): complete publish inventory

### DIFF
--- a/crates/khive-db/src/writer_task.rs
+++ b/crates/khive-db/src/writer_task.rs
@@ -868,12 +868,6 @@ mod tests {
         }
     }
 
-    struct NoopWake;
-
-    impl Wake for NoopWake {
-        fn wake(self: Arc<Self>) {}
-    }
-
     fn arm_parked_wake<F: Future>(
         mut future: Pin<&mut F>,
     ) -> (std_mpsc::Receiver<()>, std_mpsc::Sender<()>) {
@@ -892,8 +886,7 @@ mod tests {
     }
 
     fn poll_ready<F: Future>(mut future: Pin<&mut F>) -> F::Output {
-        let waker = Waker::from(Arc::new(NoopWake));
-        let mut context = Context::from_waker(&waker);
+        let mut context = Context::from_waker(Waker::noop());
         match future.as_mut().poll(&mut context) {
             Poll::Ready(output) => output,
             Poll::Pending => panic!("reply wake must make the writer send ready"),

--- a/scripts/lib/semver_excludes.txt
+++ b/scripts/lib/semver_excludes.txt
@@ -7,4 +7,7 @@
 # preflight/live gate) and .github/workflows/release.yml (release SemVer gate).
 # One blank-/comment-filtered crate name per line.
 khive-channel-telegram
+khive-pack-agent
 khive-pack-blob
+khive-repo-showcase
+khive-wire-protocol

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -52,6 +52,7 @@ CRATES=(
     khive-quant
     khive-vamana
     khive-fold
+    khive-wire-protocol # no khive-* dependencies; shared native frame contract
     khive-storage
     khive-text          # khive-bm25 depends on it (normal dep); the old dev-dep cycle is gone
     khive-bm25
@@ -70,6 +71,7 @@ CRATES=(
     # khive-merge — excluded from workspace (ADR-043 forward-deployed, ahead of khive-vcs)
     khive-pack-formal    # needs khive-runtime + khive-types (both above); dev-dep of khive-pack-kg, so publish first
     khive-pack-kg
+    khive-pack-agent     # needs khive-runtime/storage/types + dev-dep khive-pack-kg (all above)
     khive-pack-git       # needs khive-runtime/storage + khive-pack-kg (all above)
     khive-pack-code      # needs khive-runtime/storage + khive-pack-kg (all above)
     khive-pack-gtd
@@ -87,6 +89,7 @@ CRATES=(
     khive-channel-email    # needs khive-channel (above); optional dep of khive-mcp
     khive-channel-telegram # needs khive-channel (above); optional dep of khive-mcp
     khive-mcp
+    khive-repo-showcase    # no khive-* dependencies; normal dep of kkernel, so publish first
     kkernel
 )
 


### PR DESCRIPTION
> AI-assisted contribution: OpenAI Codex prepared this change and PR description under maintainer direction.

## Summary

- add the three publishable current-main crates missing from `scripts/publish.sh` in dependency-safe order:
  - `khive-wire-protocol` before storage and its consumers;
  - `khive-pack-agent` after runtime/storage/types and its dev dependency `khive-pack-kg`;
  - `khive-repo-showcase` before its normal consumer `kkernel`;
- add those never-published crates to the first-release SemVer exclusion source of truth;
- replace a hand-written test no-op waker with `Waker::noop()`, restoring all-target Clippy on current stable Rust without changing runtime behavior.

## Verification

- [x] publish guard reports 43/43 publishable workspace members
- [x] `scripts/publish-guard-test.sh`
- [x] shell syntax and ShellCheck for the changed release script
- [x] `cargo package --list --allow-dirty` for all three newly inventoried crates
- [x] `cargo clippy --locked -p khive-db --all-targets --all-features -- -D warnings`
- [x] `cargo test --locked -p khive-db writer_task::tests --lib` — 20 passed
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`

## Publish-dry disposition

`make publish-dry` now passes the repaired 43/43 ladder guard. It then correctly reaches genuine API incompatibilities accumulated on current main across 11 already-published crates. Those require the planned workspace `0.7.0 -> 0.8.0` release boundary described by ADR-130; they must not be hidden with more first-release exclusions. If a 0.7.x release were required instead, the breaking public fields/variants/signatures would need compatibility redesign.

## AI-assisted contribution checklist

- [x] The PR text begins with attribution
- [x] Every claim is tied to current-main source or recorded command output
- [x] No release is performed and no version is changed
- [x] The Moodboard feature diff remains separate
