### PR TITLE
fix(runtime): read-only snapshot inspection runtimes (ADR-028 A2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -422,6 +422,11 @@ AlwaysVerbose (`get`, `link`, `query`, `traverse`, `neighbors`, `brain.feedback`
 `memory.feedback`, `comm.delivered`) are exempt from
 the redundancy-drop even under `auto`/`table`, so agents still get their full output.
 
+A successful per-op envelope may also include transport-owned `advisories` beside `result`.
+These warnings do not change the verb result or batch summary and are never presentation- or
+format-transformed. In particular, a read-only snapshot inspection returns the normal result plus
+`audit_persistence_skipped_read_only` so callers know its dispatch audit event was not durable.
+
 **Precedence** (ADR-078 §2, highest to lowest):
 
 1. Per-call `format` on the `request` envelope, or `kkernel exec --output-format <json|auto|table>`

--- a/crates/khive-db/src/backend.rs
+++ b/crates/khive-db/src/backend.rs
@@ -15,6 +15,45 @@ use crate::pool::{ConnectionPool, PoolConfig};
 use crate::sql_bridge::SqlBridge;
 use crate::stores::{agents, blob, entity, event, graph, note, sparse, text, vectors};
 
+fn sqlite_table_exists(conn: &rusqlite::Connection, table: &str) -> Result<bool, SqliteError> {
+    conn.query_row(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?1",
+        rusqlite::params![table],
+        |row| row.get::<_, i64>(0),
+    )
+    .optional()
+    .map(|row| row.is_some())
+    .map_err(SqliteError::Rusqlite)
+}
+
+fn validate_vector_table_columns(
+    conn: &rusqlite::Connection,
+    table: &str,
+) -> Result<(), SqliteError> {
+    let pragma = format!("PRAGMA table_xinfo({table})");
+    let mut stmt = conn.prepare(&pragma)?;
+    let mut rows = stmt.query([])?;
+    let mut has_field = false;
+    let mut has_embedding_model = false;
+    while let Some(row) = rows.next()? {
+        let name: String = row.get(1)?;
+        if name == "field" {
+            has_field = true;
+        }
+        if name == "embedding_model" {
+            has_embedding_model = true;
+        }
+    }
+    if !has_field || !has_embedding_model {
+        return Err(SqliteError::InvalidData(format!(
+            "vec0 table '{table}' is missing required column(s) (field={has_field}, \
+             embedding_model={has_embedding_model}); this is a pre-v0.2.8 vector schema and is \
+             not supported — recreate the database"
+        )));
+    }
+    Ok(())
+}
+
 /// Concrete storage backend providing capability traits.
 pub struct StorageBackend {
     pool: Arc<ConnectionPool>,
@@ -378,6 +417,30 @@ impl StorageBackend {
         crate::extension::ensure_extensions_loaded();
 
         let table = format!("vec_{}", model_key);
+
+        if self.is_read_only() {
+            // Snapshot inspection must not check schema through the pool's
+            // query-only writer slot: even a SELECT there is a writer-class
+            // acquisition and violates ADR-028 A2's write-free lifecycle.
+            let reader = self.pool.reader()?;
+            if !sqlite_table_exists(reader.conn(), &table)? {
+                return Err(SqliteError::InvalidData(format!(
+                    "read-only database has no vector table '{table}'; create and populate it in \
+                     a writable copy before opening the snapshot"
+                )));
+            }
+            validate_vector_table_columns(reader.conn(), &table)?;
+            drop(reader);
+            return Ok(Arc::new(vectors::SqliteVecStore::new(
+                Arc::clone(&self.pool),
+                self.is_file_backed,
+                model_key.to_string(),
+                embedding_model.to_string(),
+                dimensions,
+                namespace.trim().to_string(),
+            )?));
+        }
+
         let writer = self.pool.try_writer()?;
 
         // Detect old-schema vec0 tables that predate the `field` column.
@@ -386,16 +449,7 @@ impl StorageBackend {
         // callers can re-embed from the source record after the table is rebuilt.
         // Use pragma_table_info to check columns directly; substring matching on the
         // CREATE DDL is fragile (a model_key containing "field" would false-match).
-        let table_exists: bool = writer
-            .conn()
-            .query_row(
-                "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?1",
-                rusqlite::params![&table],
-                |row| row.get::<_, i64>(0),
-            )
-            .optional()
-            .map_err(SqliteError::Rusqlite)?
-            .is_some();
+        let table_exists = sqlite_table_exists(writer.conn(), &table)?;
 
         if table_exists {
             // V17 migration (vector_embedding_model_tag_preserving_rebuild) adds
@@ -403,33 +457,7 @@ impl StorageBackend {
             // migration time.  If this table still lacks either column post-migration
             // that indicates the database was not migrated — return a hard error
             // rather than silently dropping data.
-            let pragma = format!("PRAGMA table_xinfo({})", table);
-            let mut stmt = writer.conn().prepare(&pragma)?;
-            let mut rows = stmt.query([])?;
-            let mut has_field = false;
-            let mut has_embedding_model = false;
-            while let Some(row) = rows.next()? {
-                let name: String = row.get(1)?;
-                if name == "field" {
-                    has_field = true;
-                }
-                if name == "embedding_model" {
-                    has_embedding_model = true;
-                }
-            }
-            if !has_field || !has_embedding_model {
-                return Err(SqliteError::InvalidData(format!(
-                    "vec0 table '{}' is missing required column(s) (field={}, \
-                     embedding_model={}); this is a pre-v0.2.8 vector schema and is \
-                     not supported — recreate the database",
-                    table, has_field, has_embedding_model,
-                )));
-            }
-        } else if self.is_read_only() {
-            return Err(SqliteError::InvalidData(format!(
-                "read-only database has no vector table '{table}'; create and populate it in a \
-                 writable copy before opening the snapshot"
-            )));
+            validate_vector_table_columns(writer.conn(), &table)?;
         }
 
         // Ensure the _embedding_models registry table exists.
@@ -440,39 +468,37 @@ impl StorageBackend {
         // creates the registry via V14; this is a belt-and-suspenders fallback.
         // Schema is defined in `migrations::EMBEDDING_MODELS_DDL` (single source of
         // truth) to prevent the two copies from silently drifting.
-        if !self.is_read_only() {
-            writer
-                .conn()
-                .execute_batch(crate::migrations::EMBEDDING_MODELS_DDL)?;
+        writer
+            .conn()
+            .execute_batch(crate::migrations::EMBEDDING_MODELS_DDL)?;
 
-            // Same guarantee for the ANN write log: vector write paths append to it
-            // in the same transaction as the vec0 mutation, so it must exist in any
-            // database that hosts vec_* tables.
-            writer
-                .conn()
-                .execute_batch(crate::migrations::ANN_WRITE_LOG_DDL)?;
-            writer
-                .conn()
-                .execute_batch(crate::migrations::ANN_WRITE_LOG_MODEL_SEQ_INDEX_DDL)?;
-            writer
-                .conn()
-                .execute_batch(crate::migrations::ANN_CONSUMER_PENDING_DDL)?;
+        // Same guarantee for the ANN write log: vector write paths append to it
+        // in the same transaction as the vec0 mutation, so it must exist in any
+        // database that hosts vec_* tables.
+        writer
+            .conn()
+            .execute_batch(crate::migrations::ANN_WRITE_LOG_DDL)?;
+        writer
+            .conn()
+            .execute_batch(crate::migrations::ANN_WRITE_LOG_MODEL_SEQ_INDEX_DDL)?;
+        writer
+            .conn()
+            .execute_batch(crate::migrations::ANN_CONSUMER_PENDING_DDL)?;
 
-            // Create the vec0 virtual table. Idempotent on fresh databases and after the
-            // old-schema rebuild above.
-            let ddl = format!(
-                "CREATE VIRTUAL TABLE IF NOT EXISTS vec_{} USING vec0(\
-                 subject_id TEXT PRIMARY KEY, \
-                 namespace TEXT NOT NULL, \
-                 kind TEXT NOT NULL, \
-                 field TEXT NOT NULL, \
-                 embedding_model TEXT NOT NULL, \
-                 embedding float[{}] distance_metric=cosine\
-                 )",
-                model_key, dimensions
-            );
-            writer.conn().execute_batch(&ddl)?;
-        }
+        // Create the vec0 virtual table. Idempotent on fresh databases and after the
+        // old-schema rebuild above.
+        let ddl = format!(
+            "CREATE VIRTUAL TABLE IF NOT EXISTS vec_{} USING vec0(\
+             subject_id TEXT PRIMARY KEY, \
+             namespace TEXT NOT NULL, \
+             kind TEXT NOT NULL, \
+             field TEXT NOT NULL, \
+             embedding_model TEXT NOT NULL, \
+             embedding float[{}] distance_metric=cosine\
+             )",
+            model_key, dimensions
+        );
+        writer.conn().execute_batch(&ddl)?;
 
         Ok(Arc::new(vectors::SqliteVecStore::new(
             Arc::clone(&self.pool),
@@ -560,7 +586,16 @@ impl StorageBackend {
             ));
         }
 
-        if !self.is_read_only() {
+        if self.is_read_only() {
+            let table = format!("sparse_{model_key}");
+            let reader = self.pool.reader()?;
+            if !sqlite_table_exists(reader.conn(), &table)? {
+                return Err(SqliteError::InvalidData(format!(
+                    "read-only database has no sparse table '{table}'; create and populate it in \
+                     a writable copy before opening the snapshot"
+                )));
+            }
+        } else {
             let writer = self.pool.try_writer()?;
             sparse::ensure_sparse_schema(writer.conn(), model_key)
                 .map_err(SqliteError::Rusqlite)?;
@@ -633,7 +668,16 @@ impl StorageBackend {
              )",
             table_key, tokenizer
         );
-        if !self.is_read_only() {
+        if self.is_read_only() {
+            let table = format!("fts_{table_key}");
+            let reader = self.pool.reader()?;
+            if !sqlite_table_exists(reader.conn(), &table)? {
+                return Err(SqliteError::InvalidData(format!(
+                    "read-only database has no text-search table '{table}'; create and populate \
+                     it in a writable copy before opening the snapshot"
+                )));
+            }
+        } else {
             let writer = self.pool.try_writer()?;
             writer.conn().execute_batch(&ddl)?;
         }
@@ -941,6 +985,96 @@ mod tests {
         assert!(
             !path.exists(),
             "opening a missing path read-only must not create the file"
+        );
+    }
+
+    #[test]
+    fn sqlite_read_only_sparse_store_requires_existing_table_without_writer_acquisition() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ro_sparse_tables.db");
+        {
+            let writable = StorageBackend::sqlite(&path).unwrap();
+            writable
+                .sparse("present")
+                .expect("create the optional sparse table while writable");
+        }
+
+        let read_only = StorageBackend::sqlite_read_only(&path).unwrap();
+        let before = read_only.pool().writer_acquisition_snapshot();
+        read_only
+            .sparse("present")
+            .expect("an existing sparse table must open read-only");
+        let missing = match read_only.sparse("missing") {
+            Ok(_) => panic!("a missing sparse table must fail during store acquisition"),
+            Err(error) => error,
+        };
+        assert!(
+            missing.to_string().contains("sparse_missing"),
+            "the diagnostic must name the absent table: {missing}"
+        );
+        assert_eq!(
+            read_only.pool().writer_acquisition_snapshot(),
+            before,
+            "read-only optional-table inspection must use a reader connection"
+        );
+    }
+
+    #[test]
+    fn sqlite_read_only_text_store_requires_existing_table_without_writer_acquisition() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ro_text_tables.db");
+        {
+            let writable = StorageBackend::sqlite(&path).unwrap();
+            writable
+                .text("present")
+                .expect("create the optional FTS table while writable");
+        }
+
+        let read_only = StorageBackend::sqlite_read_only(&path).unwrap();
+        let before = read_only.pool().writer_acquisition_snapshot();
+        read_only
+            .text("present")
+            .expect("an existing FTS table must open read-only");
+        let missing = match read_only.text("missing") {
+            Ok(_) => panic!("a missing FTS table must fail during store acquisition"),
+            Err(error) => error,
+        };
+        assert!(
+            missing.to_string().contains("fts_missing"),
+            "the diagnostic must name the absent table: {missing}"
+        );
+        assert_eq!(
+            read_only.pool().writer_acquisition_snapshot(),
+            before,
+            "read-only optional-table inspection must use a reader connection"
+        );
+    }
+
+    #[cfg(feature = "vectors")]
+    #[test]
+    fn sqlite_read_only_vector_store_schema_check_uses_no_writer_acquisition() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ro_vector_tables.db");
+        {
+            let writable = StorageBackend::sqlite(&path).unwrap();
+            writable
+                .vectors("present", "present", 3)
+                .expect("create the optional vector table while writable");
+        }
+
+        let read_only = StorageBackend::sqlite_read_only(&path).unwrap();
+        let before = read_only.pool().writer_acquisition_snapshot();
+        read_only
+            .vectors("present", "present", 3)
+            .expect("an existing vector table must open read-only");
+        assert!(
+            read_only.vectors("missing", "missing", 3).is_err(),
+            "a missing vector table must fail during store acquisition"
+        );
+        assert_eq!(
+            read_only.pool().writer_acquisition_snapshot(),
+            before,
+            "read-only vector schema inspection must use a reader connection"
         );
     }
 

--- a/crates/khive-db/src/backend.rs
+++ b/crates/khive-db/src/backend.rs
@@ -1081,6 +1081,8 @@ mod tests {
                 .text("present")
                 .expect("create the optional FTS table while writable");
         }
+        #[cfg(unix)]
+        freeze_snapshot_sidecars(&path);
 
         let read_only = StorageBackend::sqlite_read_only(&path).unwrap();
         read_only
@@ -1119,6 +1121,8 @@ mod tests {
                 .vectors("present", "present", 3)
                 .expect("create the optional vector table while writable");
         }
+        #[cfg(unix)]
+        freeze_snapshot_sidecars(&path);
 
         let read_only = StorageBackend::sqlite_read_only(&path).unwrap();
         read_only
@@ -1154,6 +1158,8 @@ mod tests {
                 .await
                 .unwrap();
         }
+        #[cfg(unix)]
+        freeze_snapshot_sidecars(&path);
 
         let ro = StorageBackend::sqlite_read_only(&path).unwrap();
         let sql = ro.sql();
@@ -1364,6 +1370,8 @@ mod tests {
             let writable = StorageBackend::sqlite(&path).unwrap();
             writable.events().unwrap();
         }
+        #[cfg(unix)]
+        freeze_snapshot_sidecars(&path);
 
         let ro = StorageBackend::sqlite_read_only(&path).unwrap();
         let store = match ro.events() {
@@ -1399,6 +1407,8 @@ mod tests {
             let writable = StorageBackend::sqlite(&path).unwrap();
             writable.text("ro_test").unwrap();
         }
+        #[cfg(unix)]
+        freeze_snapshot_sidecars(&path);
 
         let ro = StorageBackend::sqlite_read_only(&path).unwrap();
         let store = match ro.text("ro_test") {

--- a/crates/khive-db/src/backend.rs
+++ b/crates/khive-db/src/backend.rs
@@ -778,6 +778,28 @@ mod tests {
     use super::*;
     use khive_storage::types::{SqlStatement, SqlValue};
 
+    /// A writable fixture backend can leave `-wal`/`-shm` sidecars behind at
+    /// scope drop (their owning connection closes asynchronously), and
+    /// read-only admission rejects a writable `-shm` as potentially live.
+    /// Freeze any lingering sidecars so the reopened path is the documented
+    /// frozen-snapshot form: read-only `-wal` plus read-only `-shm`.
+    #[cfg(unix)]
+    fn freeze_snapshot_sidecars(path: &std::path::Path) {
+        use std::os::unix::fs::PermissionsExt;
+        for suffix in ["-wal", "-shm"] {
+            let mut name = path.file_name().expect("db file name").to_os_string();
+            name.push(suffix);
+            let sidecar = path.parent().expect("db parent dir").join(name);
+            if sidecar.exists() {
+                let mut permissions = std::fs::metadata(&sidecar)
+                    .expect("sidecar metadata")
+                    .permissions();
+                permissions.set_mode(0o444);
+                std::fs::set_permissions(&sidecar, permissions).expect("freeze sidecar");
+            }
+        }
+    }
+
     #[cfg(unix)]
     #[tokio::test]
     async fn sqlite_detects_chmod_read_only_snapshot_and_core_reads_succeed() {
@@ -795,6 +817,7 @@ mod tests {
         let mut permissions = std::fs::metadata(&path).unwrap().permissions();
         permissions.set_mode(0o444);
         std::fs::set_permissions(&path, permissions).unwrap();
+        freeze_snapshot_sidecars(&path);
 
         let read_only = StorageBackend::sqlite(&path).expect("auto-detect read-only mode");
         assert!(read_only.is_read_only());
@@ -1019,6 +1042,8 @@ mod tests {
                 .sparse("present")
                 .expect("create the optional sparse table while writable");
         }
+        #[cfg(unix)]
+        freeze_snapshot_sidecars(&path);
 
         let read_only = StorageBackend::sqlite_read_only(&path).unwrap();
         read_only
@@ -1295,6 +1320,8 @@ mod tests {
             let writable = StorageBackend::sqlite(&path).unwrap();
             writable.graph().unwrap();
         }
+        #[cfg(unix)]
+        freeze_snapshot_sidecars(&path);
 
         let ro = StorageBackend::sqlite_read_only(&path).unwrap();
         let store = match ro.graph() {

--- a/crates/khive-db/src/backend.rs
+++ b/crates/khive-db/src/backend.rs
@@ -710,6 +710,20 @@ impl StorageBackend {
         Ok(Arc::new(blob::FsBlobStore::new(root, floor)?))
     }
 
+    /// Resolve the filesystem blob root exactly like [`Self::blob_store`] but
+    /// require it to exist instead of creating it. Snapshot runtimes wrap the
+    /// returned capability so its read methods remain available while every
+    /// mutator is refused.
+    pub fn blob_store_read_only(
+        &self,
+        config_root: Option<&Path>,
+        floor_bytes: Option<u64>,
+    ) -> Result<Arc<dyn khive_storage::BlobStore>, SqliteError> {
+        let root = blob::resolve_blob_root(self.data_dir().as_deref(), config_root)?;
+        let floor = floor_bytes.unwrap_or(blob::FsBlobStore::DEFAULT_FLOOR_BYTES);
+        Ok(Arc::new(blob::FsBlobStore::open_existing(root, floor)?))
+    }
+
     /// Is this a file-backed backend?
     pub fn is_file_backed(&self) -> bool {
         self.is_file_backed

--- a/crates/khive-db/src/backend.rs
+++ b/crates/khive-db/src/backend.rs
@@ -995,12 +995,17 @@ mod tests {
         {
             let writable = StorageBackend::sqlite(&path).unwrap();
             writable
+                .prepare_core_schema()
+                .expect("migrate snapshot source");
+            writable
                 .sparse("present")
                 .expect("create the optional sparse table while writable");
         }
 
         let read_only = StorageBackend::sqlite_read_only(&path).unwrap();
-        let before = read_only.pool().writer_acquisition_snapshot();
+        read_only
+            .prepare_core_schema()
+            .expect("validate exact current migration ledger");
         read_only
             .sparse("present")
             .expect("an existing sparse table must open read-only");
@@ -1014,8 +1019,9 @@ mod tests {
         );
         assert_eq!(
             read_only.pool().writer_acquisition_snapshot(),
-            before,
-            "read-only optional-table inspection must use a reader connection"
+            crate::pool::WriterAcquisitionSnapshot::default(),
+            "construction, exact-ledger validation, and optional sparse-table inspection must \
+             use reader connections only"
         );
     }
 
@@ -1026,12 +1032,17 @@ mod tests {
         {
             let writable = StorageBackend::sqlite(&path).unwrap();
             writable
+                .prepare_core_schema()
+                .expect("migrate snapshot source");
+            writable
                 .text("present")
                 .expect("create the optional FTS table while writable");
         }
 
         let read_only = StorageBackend::sqlite_read_only(&path).unwrap();
-        let before = read_only.pool().writer_acquisition_snapshot();
+        read_only
+            .prepare_core_schema()
+            .expect("validate exact current migration ledger");
         read_only
             .text("present")
             .expect("an existing FTS table must open read-only");
@@ -1045,8 +1056,9 @@ mod tests {
         );
         assert_eq!(
             read_only.pool().writer_acquisition_snapshot(),
-            before,
-            "read-only optional-table inspection must use a reader connection"
+            crate::pool::WriterAcquisitionSnapshot::default(),
+            "construction, exact-ledger validation, and optional FTS inspection must use reader \
+             connections only"
         );
     }
 
@@ -1058,12 +1070,17 @@ mod tests {
         {
             let writable = StorageBackend::sqlite(&path).unwrap();
             writable
+                .prepare_core_schema()
+                .expect("migrate snapshot source");
+            writable
                 .vectors("present", "present", 3)
                 .expect("create the optional vector table while writable");
         }
 
         let read_only = StorageBackend::sqlite_read_only(&path).unwrap();
-        let before = read_only.pool().writer_acquisition_snapshot();
+        read_only
+            .prepare_core_schema()
+            .expect("validate exact current migration ledger");
         read_only
             .vectors("present", "present", 3)
             .expect("an existing vector table must open read-only");
@@ -1073,8 +1090,9 @@ mod tests {
         );
         assert_eq!(
             read_only.pool().writer_acquisition_snapshot(),
-            before,
-            "read-only vector schema inspection must use a reader connection"
+            crate::pool::WriterAcquisitionSnapshot::default(),
+            "construction, exact-ledger validation, and optional vector inspection must use \
+             reader connections only"
         );
     }
 

--- a/crates/khive-db/src/backend.rs
+++ b/crates/khive-db/src/backend.rs
@@ -32,14 +32,20 @@ pub struct StorageBackend {
 impl StorageBackend {
     /// File-backed SQLite database.
     ///
-    /// Opens (or creates) the database at `path`. The underlying pool provides
+    /// Opens (or creates) the database at `path`. An existing filesystem path
+    /// whose mode is read-only is opened with the same locked-down pool
+    /// configuration as [`Self::sqlite_read_only`]. The writable pool provides
     /// 1 writer + N readers in WAL mode for concurrent access.
     /// No schema is applied — call `apply_schema()` for each service.
     pub fn sqlite(path: impl AsRef<Path>) -> Result<Self, SqliteError> {
         crate::extension::ensure_extensions_loaded();
         let resolved = path.as_ref().to_path_buf();
+        let read_only =
+            std::fs::metadata(&resolved).is_ok_and(|metadata| metadata.permissions().readonly());
         let config = PoolConfig {
             path: Some(resolved.clone()),
+            read_only,
+            write_queue_enabled: read_only.then_some(false),
             ..PoolConfig::default()
         };
         let pool = ConnectionPool::new(config)?;
@@ -66,6 +72,7 @@ impl StorageBackend {
         let config = PoolConfig {
             path: Some(resolved.clone()),
             read_only: true,
+            write_queue_enabled: Some(false),
             ..PoolConfig::default()
         };
         // `ConnectionPool::new` opens the writer slot with `SQLITE_OPEN_READ_ONLY`
@@ -151,6 +158,20 @@ impl StorageBackend {
         })
     }
 
+    /// Prepare the core schema for runtime boot.
+    ///
+    /// Writable backends apply pending migrations. Read-only backends perform
+    /// a query-only compatibility check and require the snapshot to be at this
+    /// build's exact latest schema version.
+    pub fn prepare_core_schema(&self) -> Result<u32, SqliteError> {
+        let mut writer = self.pool.try_writer()?;
+        if self.is_read_only() {
+            crate::migrations::validate_schema_is_current(writer.conn())
+        } else {
+            crate::migrations::run_migrations(writer.conn_mut())
+        }
+    }
+
     /// Get an EntityStore. Applies the entities DDL if not already present.
     ///
     /// Idempotent — safe to call multiple times.
@@ -170,8 +191,10 @@ impl StorageBackend {
                 "entities namespace must be non-empty".to_string(),
             ));
         }
-        let writer = self.pool.try_writer()?;
-        entity::ensure_entities_schema(writer.conn())?;
+        if !self.is_read_only() {
+            let writer = self.pool.try_writer()?;
+            entity::ensure_entities_schema(writer.conn())?;
+        }
 
         Ok(Arc::new(entity::SqlEntityStore::new(
             Arc::clone(&self.pool),
@@ -197,8 +220,10 @@ impl StorageBackend {
                 "graph namespace must be non-empty".to_string(),
             ));
         }
-        let writer = self.pool.try_writer()?;
-        graph::ensure_graph_schema(writer.conn())?;
+        if !self.is_read_only() {
+            let writer = self.pool.try_writer()?;
+            graph::ensure_graph_schema(writer.conn())?;
+        }
 
         Ok(Arc::new(graph::SqlGraphStore::new_scoped(
             Arc::clone(&self.pool),
@@ -226,18 +251,20 @@ impl StorageBackend {
                 "notes namespace must be non-empty".to_string(),
             ));
         }
-        let writer = self.pool.try_writer()?;
-        note::ensure_notes_schema(writer.conn())?;
+        if !self.is_read_only() {
+            let writer = self.pool.try_writer()?;
+            note::ensure_notes_schema(writer.conn())?;
 
-        // The anti-join repair is a full `notes` scan -- gate it to run at
-        // most once per backend/pool. `try_writer()` blocks for exclusive
-        // access to the single writer connection for this whole function,
-        // so this load-then-run-then-store is race-free: no other caller on
-        // this pool can observe or advance `notes_seq_repair_runs` while we
-        // hold the writer guard (khive #827).
-        if self.notes_seq_repair_runs.load(Ordering::Relaxed) == 0 {
-            note::repair_notes_seq(writer.conn())?;
-            self.notes_seq_repair_runs.fetch_add(1, Ordering::Relaxed);
+            // The anti-join repair is a full `notes` scan -- gate it to run at
+            // most once per backend/pool. `try_writer()` blocks for exclusive
+            // access to the single writer connection for this whole function,
+            // so this load-then-run-then-store is race-free: no other caller on
+            // this pool can observe or advance `notes_seq_repair_runs` while we
+            // hold the writer guard (khive #827).
+            if self.notes_seq_repair_runs.load(Ordering::Relaxed) == 0 {
+                note::repair_notes_seq(writer.conn())?;
+                self.notes_seq_repair_runs.fetch_add(1, Ordering::Relaxed);
+            }
         }
 
         Ok(Arc::new(note::SqlNoteStore::new(
@@ -272,8 +299,10 @@ impl StorageBackend {
                 "events namespace must be non-empty".to_string(),
             ));
         }
-        let writer = self.pool.try_writer()?;
-        event::ensure_events_schema(writer.conn())?;
+        if !self.is_read_only() {
+            let writer = self.pool.try_writer()?;
+            event::ensure_events_schema(writer.conn())?;
+        }
 
         Ok(Arc::new(event::SqlEventStore::new_scoped(
             Arc::clone(&self.pool),
@@ -287,8 +316,10 @@ impl StorageBackend {
     /// other stores here, agent-process records are not namespace-scoped, so
     /// there is no `_for_namespace` variant.
     pub fn agents(&self) -> Result<Arc<dyn khive_storage::AgentStore>, SqliteError> {
-        let writer = self.pool.try_writer()?;
-        agents::ensure_agents_schema(writer.conn())?;
+        if !self.is_read_only() {
+            let writer = self.pool.try_writer()?;
+            agents::ensure_agents_schema(writer.conn())?;
+        }
 
         Ok(Arc::new(agents::SqlAgentStore::new(
             Arc::clone(&self.pool),
@@ -394,6 +425,11 @@ impl StorageBackend {
                     table, has_field, has_embedding_model,
                 )));
             }
+        } else if self.is_read_only() {
+            return Err(SqliteError::InvalidData(format!(
+                "read-only database has no vector table '{table}'; create and populate it in a \
+                 writable copy before opening the snapshot"
+            )));
         }
 
         // Ensure the _embedding_models registry table exists.
@@ -404,37 +440,39 @@ impl StorageBackend {
         // creates the registry via V14; this is a belt-and-suspenders fallback.
         // Schema is defined in `migrations::EMBEDDING_MODELS_DDL` (single source of
         // truth) to prevent the two copies from silently drifting.
-        writer
-            .conn()
-            .execute_batch(crate::migrations::EMBEDDING_MODELS_DDL)?;
+        if !self.is_read_only() {
+            writer
+                .conn()
+                .execute_batch(crate::migrations::EMBEDDING_MODELS_DDL)?;
 
-        // Same guarantee for the ANN write log: vector write paths append to it
-        // in the same transaction as the vec0 mutation, so it must exist in any
-        // database that hosts vec_* tables.
-        writer
-            .conn()
-            .execute_batch(crate::migrations::ANN_WRITE_LOG_DDL)?;
-        writer
-            .conn()
-            .execute_batch(crate::migrations::ANN_WRITE_LOG_MODEL_SEQ_INDEX_DDL)?;
-        writer
-            .conn()
-            .execute_batch(crate::migrations::ANN_CONSUMER_PENDING_DDL)?;
+            // Same guarantee for the ANN write log: vector write paths append to it
+            // in the same transaction as the vec0 mutation, so it must exist in any
+            // database that hosts vec_* tables.
+            writer
+                .conn()
+                .execute_batch(crate::migrations::ANN_WRITE_LOG_DDL)?;
+            writer
+                .conn()
+                .execute_batch(crate::migrations::ANN_WRITE_LOG_MODEL_SEQ_INDEX_DDL)?;
+            writer
+                .conn()
+                .execute_batch(crate::migrations::ANN_CONSUMER_PENDING_DDL)?;
 
-        // Create the vec0 virtual table. Idempotent on fresh databases and after the
-        // old-schema rebuild above.
-        let ddl = format!(
-            "CREATE VIRTUAL TABLE IF NOT EXISTS vec_{} USING vec0(\
-             subject_id TEXT PRIMARY KEY, \
-             namespace TEXT NOT NULL, \
-             kind TEXT NOT NULL, \
-             field TEXT NOT NULL, \
-             embedding_model TEXT NOT NULL, \
-             embedding float[{}] distance_metric=cosine\
-             )",
-            model_key, dimensions
-        );
-        writer.conn().execute_batch(&ddl)?;
+            // Create the vec0 virtual table. Idempotent on fresh databases and after the
+            // old-schema rebuild above.
+            let ddl = format!(
+                "CREATE VIRTUAL TABLE IF NOT EXISTS vec_{} USING vec0(\
+                 subject_id TEXT PRIMARY KEY, \
+                 namespace TEXT NOT NULL, \
+                 kind TEXT NOT NULL, \
+                 field TEXT NOT NULL, \
+                 embedding_model TEXT NOT NULL, \
+                 embedding float[{}] distance_metric=cosine\
+                 )",
+                model_key, dimensions
+            );
+            writer.conn().execute_batch(&ddl)?;
+        }
 
         Ok(Arc::new(vectors::SqliteVecStore::new(
             Arc::clone(&self.pool),
@@ -522,8 +560,11 @@ impl StorageBackend {
             ));
         }
 
-        let writer = self.pool.try_writer()?;
-        sparse::ensure_sparse_schema(writer.conn(), model_key).map_err(SqliteError::Rusqlite)?;
+        if !self.is_read_only() {
+            let writer = self.pool.try_writer()?;
+            sparse::ensure_sparse_schema(writer.conn(), model_key)
+                .map_err(SqliteError::Rusqlite)?;
+        }
 
         Ok(Arc::new(sparse::SqliteSparseStore::new(
             Arc::clone(&self.pool),
@@ -592,8 +633,10 @@ impl StorageBackend {
              )",
             table_key, tokenizer
         );
-        let writer = self.pool.try_writer()?;
-        writer.conn().execute_batch(&ddl)?;
+        if !self.is_read_only() {
+            let writer = self.pool.try_writer()?;
+            writer.conn().execute_batch(&ddl)?;
+        }
 
         Ok(Arc::new(text::Fts5TextSearch::new(
             Arc::clone(&self.pool),
@@ -622,6 +665,12 @@ impl StorageBackend {
     /// Is this a file-backed backend?
     pub fn is_file_backed(&self) -> bool {
         self.is_file_backed
+    }
+
+    /// Whether this backend was opened with SQLite's read-only/query-only
+    /// contract, explicitly or after filesystem-mode detection.
+    pub fn is_read_only(&self) -> bool {
+        self.pool.config().read_only
     }
 
     /// Return the directory containing the backend's database file, or `None`
@@ -666,6 +715,73 @@ fn ann_root_for(path: &std::path::Path) -> Option<std::path::PathBuf> {
 mod tests {
     use super::*;
     use khive_storage::types::{SqlStatement, SqlValue};
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn sqlite_detects_chmod_read_only_snapshot_and_core_reads_succeed() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("chmod_snapshot.db");
+        {
+            let writable = StorageBackend::sqlite(&path).expect("create writable database");
+            writable
+                .prepare_core_schema()
+                .expect("migrate writable snapshot source");
+        }
+
+        let mut permissions = std::fs::metadata(&path).unwrap().permissions();
+        permissions.set_mode(0o444);
+        std::fs::set_permissions(&path, permissions).unwrap();
+
+        let read_only = StorageBackend::sqlite(&path).expect("auto-detect read-only mode");
+        assert!(read_only.is_read_only());
+        assert_eq!(
+            read_only.pool().config().write_queue_enabled,
+            Some(false),
+            "read-only boot must not attempt to spawn a writer task"
+        );
+        assert!(read_only
+            .pool()
+            .writer_task_handle()
+            .expect("disabled writer task is a valid configuration")
+            .is_none());
+        read_only
+            .prepare_core_schema()
+            .expect("current snapshot validates without migration writes");
+
+        let entities = read_only.entities().expect("entity store opens read-only");
+        let graph = read_only.graph().expect("graph store opens read-only");
+        let notes = read_only.notes().expect("note store opens read-only");
+        let events = read_only.events().expect("event store opens read-only");
+        assert_eq!(
+            entities
+                .count_entities("local", khive_storage::EntityFilter::default())
+                .await
+                .unwrap(),
+            0
+        );
+        assert_eq!(
+            graph
+                .count_edges(khive_storage::types::EdgeFilter::default())
+                .await
+                .unwrap(),
+            0
+        );
+        assert_eq!(notes.count_notes("local", None).await.unwrap(), 0);
+        assert_eq!(
+            events
+                .count_events(khive_storage::EventFilter::default())
+                .await
+                .unwrap(),
+            0
+        );
+        assert_eq!(
+            read_only.notes_seq_repair_run_count(),
+            0,
+            "read-only store acquisition must not run the DML repair"
+        );
+    }
 
     #[test]
     fn memory_backend_creates_successfully() {

--- a/crates/khive-db/src/backend.rs
+++ b/crates/khive-db/src/backend.rs
@@ -101,7 +101,8 @@ impl StorageBackend {
     /// Opens the database at `path` and sets `PRAGMA query_only = ON` on the
     /// writer connection so that any write attempt (INSERT/UPDATE/DELETE) returns
     /// an error. Reader connections are opened with `SQLITE_OPEN_READ_ONLY` by the
-    /// pool; this PRAGMA extends that protection to the writer slot.
+    /// pool; at least one remains dedicated even for a rollback-journal snapshot,
+    /// while this PRAGMA extends the protection to the otherwise-unused writer slot.
     ///
     /// The database file must already exist — unlike `sqlite()` this constructor
     /// does not create a new file.
@@ -203,10 +204,11 @@ impl StorageBackend {
     /// a query-only compatibility check and require the snapshot to be at this
     /// build's exact latest schema version.
     pub fn prepare_core_schema(&self) -> Result<u32, SqliteError> {
-        let mut writer = self.pool.try_writer()?;
         if self.is_read_only() {
-            crate::migrations::validate_schema_is_current(writer.conn())
+            let reader = self.pool.reader()?;
+            crate::migrations::validate_schema_is_current(reader.conn())
         } else {
+            let mut writer = self.pool.try_writer()?;
             crate::migrations::run_migrations(writer.conn_mut())
         }
     }

--- a/crates/khive-db/src/backend.rs
+++ b/crates/khive-db/src/backend.rs
@@ -81,12 +81,14 @@ impl StorageBackend {
         let resolved = path.as_ref().to_path_buf();
         let read_only =
             std::fs::metadata(&resolved).is_ok_and(|metadata| metadata.permissions().readonly());
-        let config = PoolConfig {
+        let mut config = PoolConfig {
             path: Some(resolved.clone()),
             read_only,
-            write_queue_enabled: read_only.then_some(false),
             ..PoolConfig::default()
         };
+        if read_only {
+            config.write_queue_enabled = Some(false);
+        }
         let pool = ConnectionPool::new(config)?;
         Ok(Self {
             pool: Arc::new(pool),

--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -5391,6 +5391,23 @@ mod tests {
                 .unwrap();
         }
 
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            for suffix in ["-wal", "-shm"] {
+                let mut name = path.file_name().expect("db file name").to_os_string();
+                name.push(suffix);
+                let sidecar = path.parent().expect("db parent dir").join(name);
+                if sidecar.exists() {
+                    let mut permissions = std::fs::metadata(&sidecar)
+                        .expect("sidecar metadata")
+                        .permissions();
+                    permissions.set_mode(0o444);
+                    std::fs::set_permissions(&sidecar, permissions).expect("freeze sidecar");
+                }
+            }
+        }
+
         let pool = Arc::new(
             ConnectionPool::new(PoolConfig {
                 path: Some(path.clone()),

--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -277,11 +277,12 @@ fn read_applied_migration_ledger(
         "SELECT version, name FROM _schema_migrations \
          WHERE version <= ?1 ORDER BY version ASC",
     )?;
-    Ok(stmt
+    let rows = stmt
         .query_map([through_version], |row| {
             Ok((row.get::<_, u32>(0)?, row.get::<_, String>(1)?))
         })?
-        .collect::<Result<Vec<_>, _>>()?)
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(rows)
 }
 
 /// Require the applied versions through `through_version` to be the exact

--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -268,40 +268,108 @@ pub const MIGRATIONS: &[VersionedMigration] = &[
     },
 ];
 
-/// Confirm every applied migration through `through_version` is recorded
-/// under its canonical name. A deployment-time rename of an applied
-/// migration (the divergence #1649 repairs for versions 13/14) must not be
-/// silently accepted for any other version: an unknown name mismatch means
-/// this database's history cannot be trusted to match `MIGRATIONS`, so
-/// startup fails loudly instead of treating the recorded name as
-/// informational.
-fn validate_applied_migration_names(
+/// Read the ordered migration ledger prefix without interpreting its rows.
+fn read_applied_migration_ledger(
     conn: &Connection,
     through_version: u32,
-) -> Result<(), SqliteError> {
-    let mut stmt =
-        conn.prepare("SELECT version, name FROM _schema_migrations WHERE version <= ?1")?;
-    let applied = stmt
+) -> Result<Vec<(u32, String)>, SqliteError> {
+    let mut stmt = conn.prepare(
+        "SELECT version, name FROM _schema_migrations \
+         WHERE version <= ?1 ORDER BY version ASC",
+    )?;
+    Ok(stmt
         .query_map([through_version], |row| {
             Ok((row.get::<_, u32>(0)?, row.get::<_, String>(1)?))
         })?
-        .collect::<Result<Vec<_>, _>>()?;
+        .collect::<Result<Vec<_>, _>>()?)
+}
 
-    for (version, applied_name) in applied {
-        if let Some(migration) = MIGRATIONS.iter().find(|m| m.version == version) {
-            if migration.name != applied_name {
-                return Err(SqliteError::InvalidData(format!(
-                    "migration version {version} is recorded under name '{applied_name}', \
-                     expected '{expected}'. This database's migration history does not match \
-                     the current binary; recreate it from the current schema or repair the \
-                     specific known divergence via a dedicated migration.",
-                    expected = migration.name,
-                )));
+/// Require the applied versions through `through_version` to be the exact
+/// contiguous canonical prefix of [`MIGRATIONS`]. A matching `MAX(version)` is
+/// insufficient: a missing middle row or foreign version can expose a
+/// materially different schema while retaining the same maximum.
+fn validate_applied_migration_versions(
+    applied: &[(u32, String)],
+    through_version: u32,
+) -> Result<(), SqliteError> {
+    let expected: Vec<&VersionedMigration> = MIGRATIONS
+        .iter()
+        .filter(|migration| migration.version <= through_version)
+        .collect();
+    let mut applied_index = 0;
+
+    for migration in expected {
+        let Some((version, applied_name)) = applied.get(applied_index) else {
+            return Err(SqliteError::InvalidData(format!(
+                "migration history is missing version {} ('{}'); the applied ledger must be \
+                 the exact contiguous canonical sequence through version {through_version}",
+                migration.version, migration.name,
+            )));
+        };
+        if *version < migration.version {
+            return Err(SqliteError::InvalidData(format!(
+                "migration history contains unknown version {version} recorded as \
+                 '{applied_name}'; the applied ledger must contain only canonical versions"
+            )));
+        }
+        if *version > migration.version {
+            return Err(SqliteError::InvalidData(format!(
+                "migration history is missing version {} ('{}'); found version {version} \
+                 next instead",
+                migration.version, migration.name,
+            )));
+        }
+        applied_index += 1;
+    }
+
+    if let Some((version, name)) = applied.get(applied_index) {
+        return Err(SqliteError::InvalidData(format!(
+            "migration history contains unknown version {version} recorded as '{name}'; \
+             the applied ledger must contain only canonical versions"
+        )));
+    }
+
+    Ok(())
+}
+
+fn validate_applied_migration_names(
+    applied: &[(u32, String)],
+    through_version: u32,
+    allow_known_v19_repairs: bool,
+) -> Result<(), SqliteError> {
+    for ((version, applied_name), migration) in applied.iter().zip(
+        MIGRATIONS
+            .iter()
+            .filter(|migration| migration.version <= through_version),
+    ) {
+        debug_assert_eq!(*version, migration.version);
+        if migration.name != applied_name.as_str() {
+            if allow_known_v19_repairs && matches!(*version, 13 | 14) {
+                continue;
             }
+            return Err(SqliteError::InvalidData(format!(
+                "migration version {version} is recorded under name '{applied_name}', \
+                 expected '{expected}'. This database's migration history does not match \
+                 the current binary; recreate it from the current schema or repair the \
+                 specific known divergence via a dedicated migration.",
+                expected = migration.name,
+            )));
         }
     }
 
     Ok(())
+}
+
+/// Confirm the complete applied ledger is the canonical prefix, including
+/// names. The only historical V13/V14 name divergence is repaired by V19
+/// before this validator runs for a pre-V19 database.
+fn validate_applied_migration_ledger(
+    conn: &Connection,
+    through_version: u32,
+) -> Result<(), SqliteError> {
+    let applied = read_applied_migration_ledger(conn, through_version)?;
+    validate_applied_migration_versions(&applied, through_version)?;
+    validate_applied_migration_names(&applied, through_version, false)
 }
 
 const MIGRATION_TRACKING_TABLE: &str = include_str!("../sql/schema-migrations-table.sql");
@@ -375,7 +443,7 @@ pub fn validate_schema_is_current(conn: &Connection) -> Result<u32, SqliteError>
     // closed-name validation in `run_migrations_locked`; snapshot inspection
     // must not accept a history that ordinary boot would reject merely because
     // it cannot repair it in place.
-    validate_applied_migration_names(conn, current_version)?;
+    validate_applied_migration_ledger(conn, current_version)?;
 
     Ok(current_version)
 }
@@ -478,15 +546,15 @@ fn run_migrations_locked(conn: &mut Connection) -> Result<u32, SqliteError> {
         )));
     }
 
-    // A database already at or past V19 has no known-divergence repair left
-    // to run; validate its recorded names up front rather than after
-    // fast-forwarding past migrations that will not execute again. A
-    // pre-V19 database may still carry the V13/V14 divergence V19 exists to
-    // repair, so it is validated after the loop instead, once V19 (if
-    // still pending) has had a chance to run.
-    if current_version >= 19 {
-        validate_applied_migration_names(conn, current_version)?;
-    }
+    // Every writable upgrade starts from an exact canonical version sequence;
+    // fail before applying new migrations if MAX(version) hides a missing or
+    // foreign row. A pre-V19 database may still carry the V13/V14 name
+    // divergence that V19 exists to repair. Name validation therefore permits
+    // exactly those two rows before V19, while every unrelated mismatch still
+    // fails before any new migration is applied.
+    let applied = read_applied_migration_ledger(conn, current_version)?;
+    validate_applied_migration_versions(&applied, current_version)?;
+    validate_applied_migration_names(&applied, current_version, current_version < 19)?;
 
     let mut applied_version = current_version;
     // Floor advanced when a sibling's work is observed under the write lock,
@@ -585,7 +653,7 @@ fn run_migrations_locked(conn: &mut Connection) -> Result<u32, SqliteError> {
         // runner (not by any migration file), so the normalization lives
         // here, in the same transaction that applies V19's SQL. Exact,
         // closed set — versions 13 and 14 only; any other (version, name)
-        // mismatch still fails startup via validate_applied_migration_names.
+        // mismatch still fails startup via validate_applied_migration_ledger.
         if migration.version == 19 {
             tx.execute_batch(
                 "UPDATE _schema_migrations SET name = 'list_cursor_sequences' WHERE version = 13;\n\
@@ -621,9 +689,10 @@ fn run_migrations_locked(conn: &mut Connection) -> Result<u32, SqliteError> {
         applied_version = migration.version;
     }
 
-    if current_version < 18 {
-        validate_applied_migration_names(conn, applied_version)?;
-    }
+    // Validate again after the loop: our own commits and any under-lock
+    // sibling fast-forward must both leave the exact canonical ledger, not
+    // merely advance its maximum version.
+    validate_applied_migration_ledger(conn, applied_version)?;
 
     Ok(applied_version)
 }

--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -341,6 +341,45 @@ pub fn inspect_schema_version(path: &std::path::Path) -> Result<u32, SqliteError
     read_schema_version(&conn)
 }
 
+/// Require an already-open database to match this build's latest core schema
+/// without applying migrations.
+///
+/// A read-only snapshot behind the current migration set cannot be repaired in
+/// place, while a snapshot ahead of the binary may contain schema this build
+/// does not understand. Both directions fail with an actionable diagnostic; an
+/// exact match performs no writes.
+pub fn validate_schema_is_current(conn: &Connection) -> Result<u32, SqliteError> {
+    let current_version = read_schema_version(conn)?;
+    let latest_version = MIGRATIONS
+        .last()
+        .map(|migration| migration.version)
+        .unwrap_or(0);
+
+    if current_version < latest_version {
+        return Err(SqliteError::InvalidData(format!(
+            "read-only database schema version {current_version} is behind the latest known \
+             migration {latest_version}; migrate a writable copy with this build before opening \
+             the snapshot read-only"
+        )));
+    }
+    if current_version > latest_version {
+        return Err(SqliteError::InvalidData(format!(
+            "read-only database schema version {current_version} is ahead of the latest known \
+             migration {latest_version}; use a compatible newer build or recreate the snapshot"
+        )));
+    }
+
+    // Numeric equality alone is not enough: a database can carry the current
+    // maximum version under renamed or foreign migration ledger entries while
+    // exposing a materially different schema. Writable boot runs this same
+    // closed-name validation in `run_migrations_locked`; snapshot inspection
+    // must not accept a history that ordinary boot would reject merely because
+    // it cannot repair it in place.
+    validate_applied_migration_names(conn, current_version)?;
+
+    Ok(current_version)
+}
+
 #[cfg(test)]
 pub(crate) mod test_sync {
     use std::sync::atomic::AtomicU32;

--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -403,10 +403,7 @@ pub fn read_schema_version(conn: &Connection) -> Result<u32, SqliteError> {
 /// missing file read-only errors rather than creating it. This is the path used
 /// by schema-inspection commands that must not mutate the database.
 pub fn inspect_schema_version(path: &std::path::Path) -> Result<u32, SqliteError> {
-    let conn = Connection::open_with_flags(
-        path,
-        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
-    )?;
+    let conn = crate::pool::open_read_only_snapshot_connection(path)?;
     read_schema_version(&conn)
 }
 

--- a/crates/khive-db/src/migrations_tests.rs
+++ b/crates/khive-db/src/migrations_tests.rs
@@ -87,6 +87,34 @@ fn read_only_schema_validation_requires_exact_current_version_without_writes() {
         "name-divergence diagnostic must match writable boot: {wrong_name_error}"
     );
 
+    let mut missing_middle = open_memory();
+    run_migrations(&mut missing_middle).expect("migrate missing-row schema");
+    missing_middle
+        .execute("DELETE FROM _schema_migrations WHERE version = 7", [])
+        .expect("remove one canonical ledger row below the maximum");
+    let missing_error = validate_schema_is_current(&missing_middle)
+        .expect_err("MAX(version) equality must not hide a missing migration row");
+    assert!(
+        missing_error.to_string().contains("missing version 7"),
+        "missing-row diagnostic must name the exact gap: {missing_error}"
+    );
+
+    let mut unknown_version = open_memory();
+    run_migrations(&mut unknown_version).expect("migrate unknown-row schema");
+    unknown_version
+        .execute(
+            "INSERT INTO _schema_migrations (version, name, applied_at) \
+             VALUES (0, 'foreign_baseline', 0)",
+            [],
+        )
+        .expect("inject a non-canonical version below the maximum");
+    let unknown_error = validate_schema_is_current(&unknown_version)
+        .expect_err("MAX(version) equality must not hide an unknown ledger version");
+    assert!(
+        unknown_error.to_string().contains("unknown version 0"),
+        "unknown-version diagnostic must name the foreign row: {unknown_error}"
+    );
+
     let behind = open_memory();
     let behind_error = validate_schema_is_current(&behind)
         .expect_err("an un-migrated read-only snapshot must be rejected");
@@ -106,6 +134,65 @@ fn read_only_schema_validation_requires_exact_current_version_without_writes() {
     assert!(
         ahead_error.to_string().contains("compatible newer build"),
         "ahead-version diagnostic must be actionable: {ahead_error}"
+    );
+}
+
+#[test]
+fn writable_upgrade_rejects_noncanonical_ledger_before_applying_next_migration() {
+    let mut missing_middle = open_memory();
+    run_migrations(&mut missing_middle).expect("migrate missing-row upgrade source");
+    missing_middle
+        .execute(
+            "DELETE FROM _schema_migrations WHERE version IN (7, 19)",
+            [],
+        )
+        .expect("simulate a pre-V19 ledger with a hidden middle gap");
+    let missing_error = run_migrations(&mut missing_middle)
+        .expect_err("writable migration must reject a missing row before applying V19");
+    assert!(
+        missing_error.to_string().contains("missing version 7"),
+        "writable missing-row diagnostic must name the exact gap: {missing_error}"
+    );
+    assert_eq!(
+        missing_middle
+            .query_row(
+                "SELECT COUNT(*) FROM _schema_migrations WHERE version = 19",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap(),
+        0,
+        "ledger validation must fail before V19 is recorded"
+    );
+
+    let mut unknown_version = open_memory();
+    run_migrations(&mut unknown_version).expect("migrate foreign-row upgrade source");
+    unknown_version
+        .execute("DELETE FROM _schema_migrations WHERE version = 19", [])
+        .expect("simulate a pre-V19 ledger");
+    unknown_version
+        .execute(
+            "INSERT INTO _schema_migrations (version, name, applied_at) \
+             VALUES (0, 'foreign_baseline', 0)",
+            [],
+        )
+        .expect("inject a non-canonical version below the maximum");
+    let unknown_error = run_migrations(&mut unknown_version)
+        .expect_err("writable migration must reject a foreign row before applying V19");
+    assert!(
+        unknown_error.to_string().contains("unknown version 0"),
+        "writable foreign-row diagnostic must name the exact version: {unknown_error}"
+    );
+    assert_eq!(
+        unknown_version
+            .query_row(
+                "SELECT COUNT(*) FROM _schema_migrations WHERE version = 19",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap(),
+        0,
+        "ledger validation must fail before V19 is recorded"
     );
 }
 

--- a/crates/khive-db/src/migrations_tests.rs
+++ b/crates/khive-db/src/migrations_tests.rs
@@ -56,6 +56,60 @@ fn insert_dependency_test_edge(
 }
 
 #[test]
+fn read_only_schema_validation_requires_exact_current_version_without_writes() {
+    let mut current = open_memory();
+    let latest = run_migrations(&mut current).expect("migrate current schema");
+    let changes_before = current.total_changes();
+    assert_eq!(
+        validate_schema_is_current(&current).expect("current schema validates"),
+        latest
+    );
+    assert_eq!(
+        current.total_changes(),
+        changes_before,
+        "compatibility validation must perform no writes"
+    );
+
+    let mut wrong_name = open_memory();
+    let wrong_name_latest = run_migrations(&mut wrong_name).expect("migrate name-check schema");
+    wrong_name
+        .execute(
+            "UPDATE _schema_migrations SET name = 'foreign_current_schema' WHERE version = ?1",
+            [wrong_name_latest],
+        )
+        .expect("inject a foreign current-version ledger name");
+    let wrong_name_error = validate_schema_is_current(&wrong_name)
+        .expect_err("numeric equality must not hide a foreign migration history");
+    assert!(
+        wrong_name_error
+            .to_string()
+            .contains("migration history does not match"),
+        "name-divergence diagnostic must match writable boot: {wrong_name_error}"
+    );
+
+    let behind = open_memory();
+    let behind_error = validate_schema_is_current(&behind)
+        .expect_err("an un-migrated read-only snapshot must be rejected");
+    assert!(
+        behind_error.to_string().contains("migrate a writable copy"),
+        "behind-version diagnostic must be actionable: {behind_error}"
+    );
+
+    current
+        .execute(
+            "INSERT INTO _schema_migrations (version, name, applied_at) VALUES (?1, 'future', 0)",
+            [latest + 1],
+        )
+        .expect("inject future schema ledger row");
+    let ahead_error = validate_schema_is_current(&current)
+        .expect_err("a snapshot newer than this build must be rejected");
+    assert!(
+        ahead_error.to_string().contains("compatible newer build"),
+        "ahead-version diagnostic must be actionable: {ahead_error}"
+    );
+}
+
+#[test]
 fn apply_schema_plan_rolls_back_migration_when_ledger_insert_fails() {
     static MIGRATIONS: &[Migration] = &[Migration {
         id: "001_atomic",

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -4,6 +4,7 @@ use parking_lot::Mutex;
 use rusqlite::hooks::{AuthContext, Authorization};
 use rusqlite::{Connection, OpenFlags};
 use std::fs;
+use std::io::Read as _;
 use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -319,6 +320,14 @@ pub struct ConnectionPool {
     readers: ArrayQueue<Connection>,
     max_readers: usize,
     config: PoolConfig,
+    /// URI target used only for a clean, checkpointed persistent-WAL snapshot
+    /// with no committed WAL frames and no shared-memory index. `immutable=1`
+    /// prevents SQLite from creating fresh sidecars for that exact frozen
+    /// case. Rollback-journal databases and WAL databases with an existing
+    /// read-only `-shm` keep the ordinary path and SQLite locking/change
+    /// detection; a non-empty WAL without its index is refused because
+    /// immutable SQLite would silently omit those committed frames.
+    read_only_open_uri: Option<PathBuf>,
     sql_bridge_reader_slots: Arc<Semaphore>,
     sql_bridge_writer_slots: Arc<Semaphore>,
     /// The pool-wide ADR-067 Component A writer task, spawned lazily and at
@@ -554,7 +563,8 @@ impl ConnectionPool {
             );
         }
 
-        let writer = open_writer_connection(&config)?;
+        let read_only_open_uri = read_only_wal_open_uri(&config)?;
+        let writer = open_writer_connection(&config, read_only_open_uri.as_deref())?;
         let wal_enabled = configure_writer_connection(&writer, &config)?;
         let max_readers = effective_reader_count(&config, wal_enabled);
 
@@ -575,6 +585,7 @@ impl ConnectionPool {
             readers,
             max_readers,
             config,
+            read_only_open_uri,
             sql_bridge_reader_slots: Arc::new(Semaphore::new(max_readers.max(1))),
             sql_bridge_writer_slots: Arc::new(Semaphore::new(1)),
             writer_task: OnceLock::new(),
@@ -979,12 +990,19 @@ impl ConnectionPool {
     }
 
     fn open_reader_connection(&self) -> Result<Connection, SqliteError> {
-        let path = self
-            .config
-            .path
-            .as_ref()
-            .expect("reader connections require a file-backed database");
+        let path = self.read_connection_path()?;
         open_reader_connection(path, &self.config)
+    }
+
+    fn read_connection_path(&self) -> Result<&Path, SqliteError> {
+        self.read_only_open_uri
+            .as_deref()
+            .or(self.config.path.as_deref())
+            .ok_or_else(|| {
+                SqliteError::InvalidData(
+                    "in-memory databases do not support standalone connections".to_string(),
+                )
+            })
     }
 
     /// Open a standalone read-write connection to the same file-backed database.
@@ -1044,11 +1062,7 @@ impl ConnectionPool {
     /// Companion to `open_standalone_writer` for stores that also need an
     /// independent reader connection outside the pooled reader queue.
     pub fn open_standalone_reader(&self) -> Result<Connection, SqliteError> {
-        let path = self.config.path.as_ref().ok_or_else(|| {
-            SqliteError::InvalidData(
-                "in-memory databases do not support standalone connections".to_string(),
-            )
-        })?;
+        let path = self.read_connection_path()?;
 
         let conn = Connection::open_with_flags(
             path,
@@ -1056,8 +1070,7 @@ impl ConnectionPool {
                 | OpenFlags::SQLITE_OPEN_NO_MUTEX
                 | OpenFlags::SQLITE_OPEN_URI,
         )?;
-        conn.busy_timeout(self.config.busy_timeout)?;
-        conn.pragma_update(None, "foreign_keys", "ON")?;
+        configure_reader_connection(&conn, &self.config)?;
         conn.pragma_update(None, "synchronous", "NORMAL")?;
         Ok(conn)
     }
@@ -1218,7 +1231,10 @@ fn effective_reader_count(config: &PoolConfig, wal_enabled: bool) -> usize {
     }
 }
 
-fn open_writer_connection(config: &PoolConfig) -> Result<Connection, SqliteError> {
+fn open_writer_connection(
+    config: &PoolConfig,
+    read_only_open_uri: Option<&Path>,
+) -> Result<Connection, SqliteError> {
     match config.path.as_ref() {
         Some(path) => {
             let flags = if config.read_only {
@@ -1226,9 +1242,166 @@ fn open_writer_connection(config: &PoolConfig) -> Result<Connection, SqliteError
             } else {
                 writer_open_flags()
             };
-            Connection::open_with_flags(path, flags).map_err(Into::into)
+            let target = read_only_open_uri.unwrap_or(path);
+            Connection::open_with_flags(target, flags).map_err(Into::into)
         }
         None => Connection::open_in_memory().map_err(Into::into),
+    }
+}
+
+/// Select the one case that may safely use SQLite's immutable URI contract: a
+/// clean, checkpointed persistent-WAL snapshot with neither a shared-memory
+/// index nor committed frames in `<db>-wal`. A normal read-only connection can
+/// create fresh `-wal`/`-shm` files even for that clean database, while
+/// `immutable=1` keeps the source directory untouched. We deliberately do not
+/// apply `immutable=1` to:
+///
+/// - rollback-journal databases, which can read safely with normal locking and
+///   should continue observing committed changes when an operator points a
+///   read-only connection at a live database; or
+/// - WAL databases with a read-only `-shm`, where ordinary read-only SQLite can
+///   consume committed WAL frames without writing the frozen index; or
+/// - WAL databases with a writable `-shm`, which are potentially live. Those
+///   fail closed before SQLite is opened rather than mutating shared state or
+///   suppressing change detection unsafely.
+///
+/// A non-empty WAL without `-shm` is also refused before open. Immutable SQLite
+/// does not rebuild a missing WAL index: it ignores the WAL entirely, which can
+/// make a committed row disappear from inspection. Ordinary read-only SQLite
+/// would recover the frames but create `-shm`, violating the physical
+/// read-only contract. The operator must provide the frozen read-only `-shm`
+/// alongside that WAL (or checkpoint a writable copy first).
+fn read_only_wal_open_uri(config: &PoolConfig) -> Result<Option<PathBuf>, SqliteError> {
+    if !config.read_only {
+        return Ok(None);
+    }
+    let Some(path) = config.path.as_deref() else {
+        return Ok(None);
+    };
+    read_only_wal_open_uri_for_path(path)
+}
+
+fn read_only_wal_open_uri_for_path(path: &Path) -> Result<Option<PathBuf>, SqliteError> {
+    if !sqlite_header_uses_wal(path)? {
+        return Ok(None);
+    }
+
+    let shm = sqlite_sidecar_path(path, "-shm");
+    match fs::metadata(&shm) {
+        Ok(metadata) if metadata.permissions().readonly() => {
+            let wal = sqlite_sidecar_path(path, "-wal");
+            match fs::metadata(&wal) {
+                Ok(_) => Ok(None),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                    Err(SqliteError::InvalidData(format!(
+                        "read-only WAL snapshot {} has a shared-memory sidecar {} but no WAL \
+                         sidecar {}; refusing the inconsistent sidecar set before SQLite open",
+                        path.display(),
+                        shm.display(),
+                        wal.display(),
+                    )))
+                }
+                Err(error) => Err(SqliteError::Io(error)),
+            }
+        }
+        Ok(_) => Err(SqliteError::InvalidData(format!(
+            "read-only WAL snapshot {} has a writable WAL shared-memory sidecar {}; close every \
+             live writer and remove the transient -shm file (or make a genuinely frozen snapshot) \
+             before inspection",
+            path.display(),
+            shm.display(),
+        ))),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            let wal = sqlite_sidecar_path(path, "-wal");
+            match fs::metadata(&wal) {
+                Ok(metadata) if metadata.len() > 0 => Err(SqliteError::InvalidData(format!(
+                    "read-only WAL snapshot {} has a non-empty WAL sidecar {} but no read-only \
+                     shared-memory sidecar {}; refusing before SQLite open because immutable \
+                     mode would omit committed WAL frames and ordinary read-only mode would \
+                     create or mutate -shm; include the frozen read-only -shm beside this \
+                     snapshot, or checkpoint a writable copy before inspection",
+                    path.display(),
+                    wal.display(),
+                    shm.display(),
+                ))),
+                Ok(_) => Ok(Some(sqlite_immutable_uri(path)?)),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                    Ok(Some(sqlite_immutable_uri(path)?))
+                }
+                Err(error) => Err(SqliteError::Io(error)),
+            }
+        }
+        Err(error) => Err(SqliteError::Io(error)),
+    }
+}
+
+pub(crate) fn open_read_only_snapshot_connection(path: &Path) -> Result<Connection, SqliteError> {
+    let uri = read_only_wal_open_uri_for_path(path)?;
+    Connection::open_with_flags(uri.as_deref().unwrap_or(path), reader_open_flags())
+        .map_err(Into::into)
+}
+
+fn sqlite_header_uses_wal(path: &Path) -> Result<bool, SqliteError> {
+    let mut file = fs::File::open(path)?;
+    let mut header = [0_u8; 20];
+    if let Err(error) = file.read_exact(&mut header) {
+        if error.kind() == std::io::ErrorKind::UnexpectedEof {
+            return Ok(false);
+        }
+        return Err(SqliteError::Io(error));
+    }
+    Ok(&header[..16] == b"SQLite format 3\0" && header[18] == 2 && header[19] == 2)
+}
+
+fn sqlite_sidecar_path(path: &Path, suffix: &str) -> PathBuf {
+    let mut sidecar = path.as_os_str().to_os_string();
+    sidecar.push(suffix);
+    PathBuf::from(sidecar)
+}
+
+fn sqlite_immutable_uri(path: &Path) -> Result<PathBuf, SqliteError> {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(path)
+    };
+    let mut uri = String::from("file:");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt as _;
+        push_sqlite_uri_path(&mut uri, absolute.as_os_str().as_bytes());
+    }
+
+    #[cfg(not(unix))]
+    {
+        let path = absolute.to_str().ok_or_else(|| {
+            SqliteError::InvalidData(format!(
+                "read-only WAL snapshot path is not representable as a SQLite URI: {}",
+                absolute.display()
+            ))
+        })?;
+        let normalized = path.replace('\\', "/");
+        if cfg!(windows) && !normalized.starts_with('/') {
+            uri.push('/');
+        }
+        push_sqlite_uri_path(&mut uri, normalized.as_bytes());
+    }
+
+    uri.push_str("?mode=ro&immutable=1");
+    Ok(PathBuf::from(uri))
+}
+
+fn push_sqlite_uri_path(uri: &mut String, bytes: &[u8]) {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+    for &byte in bytes {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~' | b'/') {
+            uri.push(byte as char);
+        } else {
+            uri.push('%');
+            uri.push(HEX[(byte >> 4) as usize] as char);
+            uri.push(HEX[(byte & 0x0f) as usize] as char);
+        }
     }
 }
 
@@ -1521,6 +1694,315 @@ mod tests {
             WriterAcquisitionSnapshot::default(),
             "constructing and reading a rollback-journal snapshot must never acquire the writer"
         );
+    }
+
+    fn sqlite_sidecar(path: &Path, suffix: &str) -> PathBuf {
+        let mut sidecar = path.as_os_str().to_os_string();
+        sidecar.push(suffix);
+        PathBuf::from(sidecar)
+    }
+
+    fn directory_entries(path: &Path) -> Vec<std::ffi::OsString> {
+        let mut entries = std::fs::read_dir(path)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect::<Vec<_>>();
+        entries.sort();
+        entries
+    }
+
+    /// A persistent-WAL snapshot can carry committed rows that exist only in
+    /// `<db>-wal`. With no copied `-shm`, immutable SQLite silently ignores
+    /// those frames while ordinary read-only SQLite creates a new `-shm`.
+    /// Refuse before either open strategy can lose data or mutate the source.
+    #[test]
+    fn read_only_persistent_wal_without_shm_is_refused_without_mutation() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("wal-source.db");
+        let snapshot = dir.path().join("snapshot ?#%.db");
+        let source_wal = sqlite_sidecar(&source, "-wal");
+        let snapshot_wal = sqlite_sidecar(&snapshot, "-wal");
+        let snapshot_shm = sqlite_sidecar(&snapshot, "-shm");
+
+        let source_conn = Connection::open(&source).unwrap();
+        let mode: String = source_conn
+            .pragma_update_and_check(None, "journal_mode", "WAL", |row| row.get(0))
+            .unwrap();
+        assert_eq!(mode.to_ascii_lowercase(), "wal");
+        source_conn
+            .pragma_update(None, "wal_autocheckpoint", 0)
+            .unwrap();
+        source_conn
+            .execute_batch(
+                "CREATE TABLE snapshot_row(id INTEGER PRIMARY KEY, body TEXT NOT NULL);\
+                 INSERT INTO snapshot_row(body) VALUES ('committed-only-in-wal');",
+            )
+            .unwrap();
+        assert!(source_wal.exists(), "fixture must retain a WAL sidecar");
+
+        std::fs::copy(&source, &snapshot).unwrap();
+        std::fs::copy(&source_wal, &snapshot_wal).unwrap();
+        assert!(
+            !snapshot_shm.exists(),
+            "fixture intentionally omits the transient shared-memory index"
+        );
+
+        let main_before = std::fs::read(&snapshot).unwrap();
+        let wal_before = std::fs::read(&snapshot_wal).unwrap();
+        let entries_before = directory_entries(dir.path());
+
+        let error = match ConnectionPool::new(PoolConfig {
+            path: Some(snapshot.clone()),
+            read_only: true,
+            write_queue_enabled: Some(false),
+            ..PoolConfig::default()
+        }) {
+            Ok(_) => panic!("a non-empty WAL without its frozen -shm must fail closed"),
+            Err(error) => error,
+        };
+        assert!(
+            error
+                .to_string()
+                .contains("would omit committed WAL frames"),
+            "diagnostic must explain why neither unsafe open mode is allowed: {error}"
+        );
+
+        assert_eq!(std::fs::read(&snapshot).unwrap(), main_before);
+        assert_eq!(std::fs::read(&snapshot_wal).unwrap(), wal_before);
+        assert_eq!(directory_entries(dir.path()), entries_before);
+        assert!(
+            !snapshot_shm.exists(),
+            "read-only admission and every reader must keep the source free of -shm"
+        );
+
+        drop(source_conn);
+    }
+
+    /// A complete frozen WAL snapshot includes the WAL index. Once all three
+    /// files are read-only, ordinary SQLite read-only mode consumes the
+    /// committed WAL frames without changing the source. This is intentionally
+    /// not `immutable=1`: immutable SQLite ignores WAL contents.
+    #[test]
+    fn read_only_persistent_wal_with_read_only_shm_reads_without_mutation() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("wal-source.db");
+        let snapshot = dir.path().join("frozen-wal-snapshot.db");
+        let source_wal = sqlite_sidecar(&source, "-wal");
+        let source_shm = sqlite_sidecar(&source, "-shm");
+        let snapshot_wal = sqlite_sidecar(&snapshot, "-wal");
+        let snapshot_shm = sqlite_sidecar(&snapshot, "-shm");
+
+        let source_conn = Connection::open(&source).unwrap();
+        let mode: String = source_conn
+            .pragma_update_and_check(None, "journal_mode", "WAL", |row| row.get(0))
+            .unwrap();
+        assert_eq!(mode.to_ascii_lowercase(), "wal");
+        source_conn
+            .pragma_update(None, "wal_autocheckpoint", 0)
+            .unwrap();
+        source_conn
+            .execute_batch(
+                "CREATE TABLE snapshot_row(id INTEGER PRIMARY KEY, body TEXT NOT NULL);\
+                 INSERT INTO snapshot_row(body) VALUES ('committed-only-in-wal');",
+            )
+            .unwrap();
+        assert!(source_wal.exists() && source_shm.exists());
+
+        std::fs::copy(&source, &snapshot).unwrap();
+        std::fs::copy(&source_wal, &snapshot_wal).unwrap();
+        std::fs::copy(&source_shm, &snapshot_shm).unwrap();
+
+        let snapshot_paths = [&snapshot, &snapshot_wal, &snapshot_shm];
+        let original_permissions =
+            snapshot_paths.map(|path| std::fs::metadata(path).unwrap().permissions());
+        for path in snapshot_paths {
+            let mut permissions = std::fs::metadata(path).unwrap().permissions();
+            permissions.set_readonly(true);
+            std::fs::set_permissions(path, permissions).unwrap();
+        }
+
+        let main_before = std::fs::read(&snapshot).unwrap();
+        let wal_before = std::fs::read(&snapshot_wal).unwrap();
+        let shm_before = std::fs::read(&snapshot_shm).unwrap();
+        let entries_before = directory_entries(dir.path());
+
+        let pool = ConnectionPool::new(PoolConfig {
+            path: Some(snapshot.clone()),
+            read_only: true,
+            write_queue_enabled: Some(false),
+            ..PoolConfig::default()
+        })
+        .unwrap();
+        let reader = pool.reader().unwrap();
+        let body: String = reader
+            .query_row("SELECT body FROM snapshot_row", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(body, "committed-only-in-wal");
+        drop(reader);
+
+        let standalone = pool.open_standalone_reader().unwrap();
+        let count: i64 = standalone
+            .query_row("SELECT COUNT(*) FROM snapshot_row", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+        drop(standalone);
+        drop(pool);
+
+        assert_eq!(std::fs::read(&snapshot).unwrap(), main_before);
+        assert_eq!(std::fs::read(&snapshot_wal).unwrap(), wal_before);
+        assert_eq!(std::fs::read(&snapshot_shm).unwrap(), shm_before);
+        assert_eq!(directory_entries(dir.path()), entries_before);
+
+        for (path, permissions) in snapshot_paths.into_iter().zip(original_permissions) {
+            std::fs::set_permissions(path, permissions).unwrap();
+        }
+        drop(source_conn);
+    }
+
+    /// A clean persistent-WAL database has no committed frames outside the
+    /// checkpointed main file. This is the narrow case where an encoded
+    /// `immutable=1` URI is safe and necessary to prevent SQLite from creating
+    /// fresh sidecars. Reserved URI bytes in the filesystem path must still
+    /// resolve to the exact database.
+    #[test]
+    fn read_only_clean_wal_snapshot_is_sidecar_free() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("clean snapshot ?#%.db");
+        {
+            let conn = Connection::open(&path).unwrap();
+            let mode: String = conn
+                .pragma_update_and_check(None, "journal_mode", "WAL", |row| row.get(0))
+                .unwrap();
+            assert_eq!(mode.to_ascii_lowercase(), "wal");
+            conn.execute_batch(
+                "CREATE TABLE snapshot_row(id INTEGER PRIMARY KEY, body TEXT NOT NULL);\
+                 INSERT INTO snapshot_row(body) VALUES ('checkpointed');",
+            )
+            .unwrap();
+        }
+        let wal = sqlite_sidecar(&path, "-wal");
+        let shm = sqlite_sidecar(&path, "-shm");
+        assert!(!wal.exists() && !shm.exists());
+        assert!(sqlite_header_uses_wal(&path).unwrap());
+
+        let original_permissions = std::fs::metadata(&path).unwrap().permissions();
+        let mut read_only_permissions = original_permissions.clone();
+        read_only_permissions.set_readonly(true);
+        std::fs::set_permissions(&path, read_only_permissions).unwrap();
+        let main_before = std::fs::read(&path).unwrap();
+        let entries_before = directory_entries(dir.path());
+
+        let pool = ConnectionPool::new(PoolConfig {
+            path: Some(path.clone()),
+            read_only: true,
+            write_queue_enabled: Some(false),
+            ..PoolConfig::default()
+        })
+        .unwrap();
+        let reader = pool.reader().unwrap();
+        let body: String = reader
+            .query_row("SELECT body FROM snapshot_row", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(body, "checkpointed");
+        drop(reader);
+        let standalone = pool.open_standalone_reader().unwrap();
+        let count: i64 = standalone
+            .query_row("SELECT COUNT(*) FROM snapshot_row", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+        drop(standalone);
+        drop(pool);
+
+        assert_eq!(std::fs::read(&path).unwrap(), main_before);
+        assert_eq!(directory_entries(dir.path()), entries_before);
+        assert!(!wal.exists() && !shm.exists());
+        std::fs::set_permissions(&path, original_permissions).unwrap();
+    }
+
+    /// `immutable=1` is unsafe for a database that can still change and is not
+    /// needed for rollback-journal reads. Keep ordinary SQLite locking/change
+    /// detection there so an already-open read-only pool observes a later
+    /// committed transaction from a live writer.
+    #[test]
+    fn read_only_live_rollback_journal_keeps_change_detection() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("live-delete-journal.db");
+        let writer = Connection::open(&path).unwrap();
+        writer
+            .execute_batch("CREATE TABLE live_row(id INTEGER PRIMARY KEY);")
+            .unwrap();
+
+        let pool = ConnectionPool::new(PoolConfig {
+            path: Some(path),
+            read_only: true,
+            write_queue_enabled: Some(false),
+            ..PoolConfig::default()
+        })
+        .unwrap();
+        {
+            let reader = pool.reader().unwrap();
+            let count: i64 = reader
+                .query_row("SELECT COUNT(*) FROM live_row", [], |row| row.get(0))
+                .unwrap();
+            assert_eq!(count, 0);
+        }
+
+        writer
+            .execute("INSERT INTO live_row DEFAULT VALUES", [])
+            .unwrap();
+        let reader = pool.reader().unwrap();
+        let count: i64 = reader
+            .query_row("SELECT COUNT(*) FROM live_row", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(
+            count, 1,
+            "rollback-journal read-only connections must retain live change detection"
+        );
+    }
+
+    /// A writable `-shm` beside a WAL database is evidence that the database is
+    /// not a sidecar-free frozen snapshot (and may have a live writer). Refuse
+    /// before opening SQLite rather than mutate the shared index or unsafely
+    /// assert `immutable=1` over a live database.
+    #[test]
+    fn read_only_live_wal_with_writable_shm_is_refused_without_mutation() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("live-wal.db");
+        let wal = sqlite_sidecar(&path, "-wal");
+        let shm = sqlite_sidecar(&path, "-shm");
+        let writer = Connection::open(&path).unwrap();
+        writer.pragma_update(None, "journal_mode", "WAL").unwrap();
+        writer
+            .execute_batch(
+                "CREATE TABLE live_row(id INTEGER PRIMARY KEY);\
+                 INSERT INTO live_row DEFAULT VALUES;",
+            )
+            .unwrap();
+        assert!(wal.exists() && shm.exists());
+
+        let main_before = std::fs::read(&path).unwrap();
+        let wal_before = std::fs::read(&wal).unwrap();
+        let shm_before = std::fs::read(&shm).unwrap();
+        let error = match ConnectionPool::new(PoolConfig {
+            path: Some(path.clone()),
+            read_only: true,
+            write_queue_enabled: Some(false),
+            ..PoolConfig::default()
+        }) {
+            Ok(_) => panic!("a live WAL database with writable -shm must fail closed"),
+            Err(error) => error,
+        };
+        assert!(
+            error
+                .to_string()
+                .contains("writable WAL shared-memory sidecar"),
+            "diagnostic must explain how to freeze the snapshot: {error}"
+        );
+        assert_eq!(std::fs::read(&path).unwrap(), main_before);
+        assert_eq!(std::fs::read(&wal).unwrap(), wal_before);
+        assert_eq!(std::fs::read(&shm).unwrap(), shm_before);
+
+        drop(writer);
     }
 
     #[test]

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -1479,6 +1479,46 @@ mod tests {
     }
 
     #[test]
+    fn read_only_rollback_journal_pool_keeps_a_dedicated_reader() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("read_only_delete_journal.db");
+        {
+            let conn = Connection::open(&path).unwrap();
+            conn.execute_batch("CREATE TABLE snapshot_row(id INTEGER PRIMARY KEY);")
+                .unwrap();
+            let mode: String = conn
+                .pragma_query_value(None, "journal_mode", |row| row.get(0))
+                .unwrap();
+            assert_eq!(mode.to_ascii_lowercase(), "delete");
+        }
+
+        let pool = ConnectionPool::new(PoolConfig {
+            path: Some(path),
+            read_only: true,
+            write_queue_enabled: Some(false),
+            ..PoolConfig::default()
+        })
+        .unwrap();
+
+        assert!(
+            pool.max_readers() > 0,
+            "a read-only rollback-journal snapshot must use a genuine read-only reader, not \
+             alias reader() onto the query-only writer slot"
+        );
+        let reader = pool.reader().expect("dedicated read-only reader checkout");
+        let count: i64 = reader
+            .query_row("SELECT COUNT(*) FROM snapshot_row", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 0);
+        drop(reader);
+        assert_eq!(
+            pool.writer_acquisition_snapshot(),
+            WriterAcquisitionSnapshot::default(),
+            "constructing and reading a rollback-journal snapshot must never acquire the writer"
+        );
+    }
+
+    #[test]
     #[serial]
     fn pool_config_default_values_match_constants() {
         // Ensure defaults are not accidentally changed. The process env may

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -298,9 +298,12 @@ fn validate_write_admission_deadline(deadline_ms: u64) -> Result<(), SqliteError
 /// - N reader connections in a lock-free queue (concurrent access)
 /// - All connections share the same database file in WAL mode
 ///
-/// For in-memory databases, or when WAL mode is disabled/unavailable, the pool
-/// degrades to single-connection mode and routes all operations through the
-/// writer connection.
+/// Writable in-memory databases, or writable file databases when WAL mode is
+/// disabled/unavailable, degrade to single-connection mode and route all
+/// operations through the writer connection. A file-backed read-only pool
+/// always retains at least one dedicated read-only connection: rollback-journal
+/// snapshots do not need WAL to support concurrent readers, and inspection must
+/// never alias a read onto the query-only writer slot.
 pub struct ConnectionPool {
     writer: Arc<Mutex<Connection>>,
     /// Fail-closed guard for the legacy pool-mutex writer. A transaction
@@ -529,9 +532,9 @@ impl ConnectionPool {
     ///
     /// Opens 1 writer + N reader connections to the same database when pooling
     /// is enabled. All connections are configured consistently (busy timeout,
-    /// foreign keys, cache, mmap, temp store). For in-memory databases, or when
-    /// WAL is disabled or unavailable, the pool falls back to single-connection
-    /// mode.
+    /// foreign keys, cache, mmap, temp store). Writable in-memory databases and
+    /// writable non-WAL files fall back to single-connection mode. Read-only
+    /// files retain a dedicated reader regardless of journal mode.
     pub fn new(config: PoolConfig) -> Result<Self, SqliteError> {
         refuse_home_data_store_in_tests(&config)?;
         validate_write_admission_deadline(config.write_admission_deadline_ms)?;
@@ -1206,7 +1209,9 @@ fn resolve_symlink_chain(path: &Path) -> Result<PathBuf, SqliteError> {
 }
 
 fn effective_reader_count(config: &PoolConfig, wal_enabled: bool) -> usize {
-    if config.path.is_some() && config.wal_mode && wal_enabled {
+    if config.path.is_some() && config.read_only {
+        config.max_readers.max(1)
+    } else if config.path.is_some() && config.wal_mode && wal_enabled {
         config.max_readers
     } else {
         0

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -320,14 +320,14 @@ pub struct ConnectionPool {
     readers: ArrayQueue<Connection>,
     max_readers: usize,
     config: PoolConfig,
-    /// URI target used only for a clean, checkpointed persistent-WAL snapshot
-    /// with no committed WAL frames and no shared-memory index. `immutable=1`
-    /// prevents SQLite from creating fresh sidecars for that exact frozen
-    /// case. Rollback-journal databases and WAL databases with an existing
-    /// read-only `-shm` keep the ordinary path and SQLite locking/change
-    /// detection; a non-empty WAL without its index is refused because
-    /// immutable SQLite would silently omit those committed frames.
-    read_only_open_uri: Option<PathBuf>,
+    /// Canonical physical target used by every connection in a file-backed
+    /// read-only pool. Classification and open must share this exact spelling:
+    /// deriving WAL sidecars from a configured symlink while SQLite follows it
+    /// to another file can hide committed frames or a live writable `-shm`.
+    /// The value is an `immutable=1` URI only for a clean, checkpointed WAL;
+    /// rollback-journal databases and frozen WAL+SHM snapshots retain the
+    /// canonical ordinary path and SQLite locking/change detection.
+    read_only_open_target: Option<PathBuf>,
     sql_bridge_reader_slots: Arc<Semaphore>,
     sql_bridge_writer_slots: Arc<Semaphore>,
     /// The pool-wide ADR-067 Component A writer task, spawned lazily and at
@@ -563,13 +563,10 @@ impl ConnectionPool {
             );
         }
 
-        let read_only_open_uri = read_only_wal_open_uri(&config)?;
-        let writer = open_writer_connection(&config, read_only_open_uri.as_deref())?;
-        let wal_enabled = configure_writer_connection(&writer, &config)?;
-        let max_readers = effective_reader_count(&config, wal_enabled);
-
-        let readers = ArrayQueue::new(max_readers.max(1));
-
+        // Mint the physical identity before WAL classification or SQLite open.
+        // Every read-only connection below uses this same canonical path (or
+        // an immutable URI derived from it), so a symlink cannot split main-file
+        // resolution from sidecar resolution.
         let (origin, identity_path) = match config.path.as_ref() {
             Some(path) => {
                 let (identity, canonical) = mint_db_identity(path)?;
@@ -577,6 +574,12 @@ impl ConnectionPool {
             }
             None => (TxOrigin::Memory, None),
         };
+        let read_only_open_target = read_only_open_target(&config, identity_path.as_deref())?;
+        let writer = open_writer_connection(&config, read_only_open_target.as_deref())?;
+        let wal_enabled = configure_writer_connection(&writer, &config)?;
+        let max_readers = effective_reader_count(&config, wal_enabled);
+
+        let readers = ArrayQueue::new(max_readers.max(1));
 
         let pool = Self {
             writer: Arc::new(Mutex::new(writer)),
@@ -585,7 +588,7 @@ impl ConnectionPool {
             readers,
             max_readers,
             config,
-            read_only_open_uri,
+            read_only_open_target,
             sql_bridge_reader_slots: Arc::new(Semaphore::new(max_readers.max(1))),
             sql_bridge_writer_slots: Arc::new(Semaphore::new(1)),
             writer_task: OnceLock::new(),
@@ -604,14 +607,16 @@ impl ConnectionPool {
                 .expect("reader queue must have capacity during pool initialization");
         }
 
-        // Best-effort, process-global: the first pool to boot in this
-        // process resolves the writer-timeout sink's log directory and
-        // spawns its heartbeat thread; every later pool's call here is a
-        // cheap no-op. See `crate::timeout_sink` module docs.
-        crate::timeout_sink::init(
-            pool.canonical_path().and_then(Path::parent),
-            &crate::timeout_sink::db_label(&pool),
-        );
+        // Best-effort, process-global diagnostics belong only to pools that
+        // can acquire a writer. A read-only inspection pool has no writer
+        // timeout to report and must neither mutate `<db_parent>/.khive-logs`
+        // nor consume the global sink claim before a later writable pool.
+        if !pool.config.read_only {
+            crate::timeout_sink::init(
+                pool.canonical_path().and_then(Path::parent),
+                &crate::timeout_sink::db_label(&pool),
+            );
+        }
 
         Ok(pool)
     }
@@ -995,7 +1000,7 @@ impl ConnectionPool {
     }
 
     fn read_connection_path(&self) -> Result<&Path, SqliteError> {
-        self.read_only_open_uri
+        self.read_only_open_target
             .as_deref()
             .or(self.config.path.as_deref())
             .ok_or_else(|| {
@@ -1233,7 +1238,7 @@ fn effective_reader_count(config: &PoolConfig, wal_enabled: bool) -> usize {
 
 fn open_writer_connection(
     config: &PoolConfig,
-    read_only_open_uri: Option<&Path>,
+    read_only_open_target: Option<&Path>,
 ) -> Result<Connection, SqliteError> {
     match config.path.as_ref() {
         Some(path) => {
@@ -1242,7 +1247,15 @@ fn open_writer_connection(
             } else {
                 writer_open_flags()
             };
-            let target = read_only_open_uri.unwrap_or(path);
+            let target = if config.read_only {
+                read_only_open_target.ok_or_else(|| {
+                    SqliteError::InvalidData(
+                        "file-backed read-only pool has no canonical open target".to_string(),
+                    )
+                })?
+            } else {
+                path
+            };
             Connection::open_with_flags(target, flags).map_err(Into::into)
         }
         None => Connection::open_in_memory().map_err(Into::into),
@@ -1271,19 +1284,22 @@ fn open_writer_connection(
 /// would recover the frames but create `-shm`, violating the physical
 /// read-only contract. The operator must provide the frozen read-only `-shm`
 /// alongside that WAL (or checkpoint a writable copy first).
-fn read_only_wal_open_uri(config: &PoolConfig) -> Result<Option<PathBuf>, SqliteError> {
+fn read_only_open_target(
+    config: &PoolConfig,
+    physical_path: Option<&Path>,
+) -> Result<Option<PathBuf>, SqliteError> {
     if !config.read_only {
         return Ok(None);
     }
-    let Some(path) = config.path.as_deref() else {
+    let Some(path) = physical_path else {
         return Ok(None);
     };
-    read_only_wal_open_uri_for_path(path)
+    read_only_wal_open_target_for_path(path).map(Some)
 }
 
-fn read_only_wal_open_uri_for_path(path: &Path) -> Result<Option<PathBuf>, SqliteError> {
+fn read_only_wal_open_target_for_path(path: &Path) -> Result<PathBuf, SqliteError> {
     if !sqlite_header_uses_wal(path)? {
-        return Ok(None);
+        return Ok(path.to_path_buf());
     }
 
     let shm = sqlite_sidecar_path(path, "-shm");
@@ -1291,7 +1307,7 @@ fn read_only_wal_open_uri_for_path(path: &Path) -> Result<Option<PathBuf>, Sqlit
         Ok(metadata) if metadata.permissions().readonly() => {
             let wal = sqlite_sidecar_path(path, "-wal");
             match fs::metadata(&wal) {
-                Ok(_) => Ok(None),
+                Ok(_) => Ok(path.to_path_buf()),
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
                     Err(SqliteError::InvalidData(format!(
                         "read-only WAL snapshot {} has a shared-memory sidecar {} but no WAL \
@@ -1324,9 +1340,9 @@ fn read_only_wal_open_uri_for_path(path: &Path) -> Result<Option<PathBuf>, Sqlit
                     wal.display(),
                     shm.display(),
                 ))),
-                Ok(_) => Ok(Some(sqlite_immutable_uri(path)?)),
+                Ok(_) => sqlite_immutable_uri(path),
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                    Ok(Some(sqlite_immutable_uri(path)?))
+                    sqlite_immutable_uri(path)
                 }
                 Err(error) => Err(SqliteError::Io(error)),
             }
@@ -1336,9 +1352,9 @@ fn read_only_wal_open_uri_for_path(path: &Path) -> Result<Option<PathBuf>, Sqlit
 }
 
 pub(crate) fn open_read_only_snapshot_connection(path: &Path) -> Result<Connection, SqliteError> {
-    let uri = read_only_wal_open_uri_for_path(path)?;
-    Connection::open_with_flags(uri.as_deref().unwrap_or(path), reader_open_flags())
-        .map_err(Into::into)
+    let (_, physical_path) = mint_db_identity(path)?;
+    let target = read_only_wal_open_target_for_path(&physical_path)?;
+    Connection::open_with_flags(&target, reader_open_flags()).map_err(Into::into)
 }
 
 fn sqlite_header_uses_wal(path: &Path) -> Result<bool, SqliteError> {
@@ -1859,6 +1875,95 @@ mod tests {
         drop(source_conn);
     }
 
+    /// The configured spelling must not decide which WAL sidecars SQLite sees.
+    /// A symlinked snapshot is classified and opened through one canonical
+    /// physical path so committed frames beside the target remain visible and
+    /// no sidecars are ever derived beside the alias.
+    #[cfg(unix)]
+    #[test]
+    fn read_only_frozen_wal_symlink_reads_target_frames_without_mutation() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("wal-source.db");
+        let snapshot = dir.path().join("frozen-target.db");
+        let alias = dir.path().join("frozen-alias.db");
+        let source_wal = sqlite_sidecar(&source, "-wal");
+        let source_shm = sqlite_sidecar(&source, "-shm");
+        let snapshot_wal = sqlite_sidecar(&snapshot, "-wal");
+        let snapshot_shm = sqlite_sidecar(&snapshot, "-shm");
+        let alias_wal = sqlite_sidecar(&alias, "-wal");
+        let alias_shm = sqlite_sidecar(&alias, "-shm");
+
+        let source_conn = Connection::open(&source).unwrap();
+        let mode: String = source_conn
+            .pragma_update_and_check(None, "journal_mode", "WAL", |row| row.get(0))
+            .unwrap();
+        assert_eq!(mode.to_ascii_lowercase(), "wal");
+        source_conn
+            .pragma_update(None, "wal_autocheckpoint", 0)
+            .unwrap();
+        source_conn
+            .execute_batch(
+                "CREATE TABLE snapshot_row(id INTEGER PRIMARY KEY, body TEXT NOT NULL);\
+                 INSERT INTO snapshot_row(body) VALUES ('visible-through-target-wal');",
+            )
+            .unwrap();
+        assert!(source_wal.exists() && source_shm.exists());
+
+        std::fs::copy(&source, &snapshot).unwrap();
+        std::fs::copy(&source_wal, &snapshot_wal).unwrap();
+        std::fs::copy(&source_shm, &snapshot_shm).unwrap();
+        symlink(&snapshot, &alias).unwrap();
+        assert!(!alias_wal.exists() && !alias_shm.exists());
+
+        let snapshot_paths = [&snapshot, &snapshot_wal, &snapshot_shm];
+        let original_permissions =
+            snapshot_paths.map(|path| std::fs::metadata(path).unwrap().permissions());
+        for path in snapshot_paths {
+            let mut permissions = std::fs::metadata(path).unwrap().permissions();
+            permissions.set_readonly(true);
+            std::fs::set_permissions(path, permissions).unwrap();
+        }
+
+        let main_before = std::fs::read(&snapshot).unwrap();
+        let wal_before = std::fs::read(&snapshot_wal).unwrap();
+        let shm_before = std::fs::read(&snapshot_shm).unwrap();
+        let entries_before = directory_entries(dir.path());
+
+        let pool = ConnectionPool::new(PoolConfig {
+            path: Some(alias.clone()),
+            read_only: true,
+            write_queue_enabled: Some(false),
+            ..PoolConfig::default()
+        })
+        .unwrap();
+        let reader = pool.reader().unwrap();
+        let body: String = reader
+            .query_row("SELECT body FROM snapshot_row", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(body, "visible-through-target-wal");
+        drop(reader);
+        let standalone = pool.open_standalone_reader().unwrap();
+        let count: i64 = standalone
+            .query_row("SELECT COUNT(*) FROM snapshot_row", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+        drop(standalone);
+        drop(pool);
+
+        assert_eq!(std::fs::read(&snapshot).unwrap(), main_before);
+        assert_eq!(std::fs::read(&snapshot_wal).unwrap(), wal_before);
+        assert_eq!(std::fs::read(&snapshot_shm).unwrap(), shm_before);
+        assert_eq!(directory_entries(dir.path()), entries_before);
+        assert!(!alias_wal.exists() && !alias_shm.exists());
+
+        for (path, permissions) in snapshot_paths.into_iter().zip(original_permissions) {
+            std::fs::set_permissions(path, permissions).unwrap();
+        }
+        drop(source_conn);
+    }
+
     /// A clean persistent-WAL database has no committed frames outside the
     /// checkpointed main file. This is the narrow case where an encoded
     /// `immutable=1` URI is safe and necessary to prevent SQLite from creating
@@ -2001,6 +2106,64 @@ mod tests {
         assert_eq!(std::fs::read(&path).unwrap(), main_before);
         assert_eq!(std::fs::read(&wal).unwrap(), wal_before);
         assert_eq!(std::fs::read(&shm).unwrap(), shm_before);
+
+        drop(writer);
+    }
+
+    /// A symlink cannot hide a writable target `-shm`. Admission inspects the
+    /// canonical target sidecar set before SQLite opens any connection and
+    /// therefore refuses a potentially live WAL without touching either
+    /// target or alias-adjacent paths.
+    #[cfg(unix)]
+    #[test]
+    fn read_only_live_wal_symlink_rejects_target_writable_shm_without_mutation() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("live-target.db");
+        let alias = dir.path().join("live-alias.db");
+        let target_wal = sqlite_sidecar(&target, "-wal");
+        let target_shm = sqlite_sidecar(&target, "-shm");
+        let alias_wal = sqlite_sidecar(&alias, "-wal");
+        let alias_shm = sqlite_sidecar(&alias, "-shm");
+
+        let writer = Connection::open(&target).unwrap();
+        writer.pragma_update(None, "journal_mode", "WAL").unwrap();
+        writer
+            .execute_batch(
+                "CREATE TABLE live_row(id INTEGER PRIMARY KEY);\
+                 INSERT INTO live_row DEFAULT VALUES;",
+            )
+            .unwrap();
+        assert!(target_wal.exists() && target_shm.exists());
+        symlink(&target, &alias).unwrap();
+        assert!(!alias_wal.exists() && !alias_shm.exists());
+
+        let main_before = std::fs::read(&target).unwrap();
+        let wal_before = std::fs::read(&target_wal).unwrap();
+        let shm_before = std::fs::read(&target_shm).unwrap();
+        let entries_before = directory_entries(dir.path());
+
+        let error = match ConnectionPool::new(PoolConfig {
+            path: Some(alias),
+            read_only: true,
+            write_queue_enabled: Some(false),
+            ..PoolConfig::default()
+        }) {
+            Ok(_) => panic!("a symlink must not hide the target's writable -shm"),
+            Err(error) => error,
+        };
+        assert!(
+            error
+                .to_string()
+                .contains("writable WAL shared-memory sidecar"),
+            "diagnostic must identify the canonical target's live sidecar: {error}"
+        );
+        assert_eq!(std::fs::read(&target).unwrap(), main_before);
+        assert_eq!(std::fs::read(&target_wal).unwrap(), wal_before);
+        assert_eq!(std::fs::read(&target_shm).unwrap(), shm_before);
+        assert_eq!(directory_entries(dir.path()), entries_before);
+        assert!(!alias_wal.exists() && !alias_shm.exists());
 
         drop(writer);
     }

--- a/crates/khive-db/src/sql_bridge.rs
+++ b/crates/khive-db/src/sql_bridge.rs
@@ -516,28 +516,8 @@ async fn acquire_handle_slot(
 // =============================================================================
 
 fn open_standalone_reader(pool: &ConnectionPool) -> Result<rusqlite::Connection, StorageError> {
-    let config = pool.config();
-    let path = config.path.as_ref().ok_or_else(|| StorageError::Pool {
-        operation: "reader".into(),
-        message: "in-memory databases do not support standalone readers; use pool-backed".into(),
-    })?;
-
-    let conn = rusqlite::Connection::open_with_flags(
-        path,
-        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY
-            | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX
-            | rusqlite::OpenFlags::SQLITE_OPEN_URI,
-    )
-    .map_err(|e| map_rusqlite_err(e, "open_reader"))?;
-
-    conn.busy_timeout(config.busy_timeout)
-        .map_err(|e| map_rusqlite_err(e, "open_reader"))?;
-    conn.pragma_update(None, "cache_size", "-65536")
-        .map_err(|e| map_rusqlite_err(e, "open_reader"))?;
-    conn.pragma_update(None, "mmap_size", "1073741824")
-        .map_err(|e| map_rusqlite_err(e, "open_reader"))?;
-
-    Ok(conn)
+    pool.open_standalone_reader()
+        .map_err(|error| StorageError::driver(StorageCapability::Sql, "open_reader", error))
 }
 
 fn open_standalone_writer(pool: &ConnectionPool) -> Result<rusqlite::Connection, StorageError> {

--- a/crates/khive-db/src/stores/blob.rs
+++ b/crates/khive-db/src/stores/blob.rs
@@ -357,6 +357,21 @@ impl FsBlobStore {
     /// Create a store rooted at `root`, creating the directory if absent.
     pub fn new(root: PathBuf, floor_bytes: u64) -> Result<Self, SqliteError> {
         fs::create_dir_all(&root)?;
+        Self::open_existing(root, floor_bytes)
+    }
+
+    /// Open a store rooted at an existing directory without creating any
+    /// filesystem entry. Used by snapshot runtimes so boot can retain blob
+    /// reads while remaining side-effect free; mutation is fenced by the
+    /// runtime's read-only wrapper.
+    pub fn open_existing(root: PathBuf, floor_bytes: u64) -> Result<Self, SqliteError> {
+        let metadata = fs::metadata(&root)?;
+        if !metadata.is_dir() {
+            return Err(SqliteError::InvalidData(format!(
+                "blob store root is not a directory: {}",
+                root.display()
+            )));
+        }
         let write_lock = write_lock_for_root(&root)?;
         Ok(Self {
             root,

--- a/crates/khive-db/src/stores/entity.rs
+++ b/crates/khive-db/src/stores/entity.rs
@@ -165,28 +165,9 @@ impl SqlEntityStore {
     }
 
     fn open_standalone_reader(&self) -> Result<rusqlite::Connection, StorageError> {
-        let config = self.pool.config();
-        let path = config.path.as_ref().ok_or_else(|| StorageError::Pool {
-            operation: "entity_reader".into(),
-            message: "in-memory databases do not support standalone connections".into(),
-        })?;
-
-        let conn = rusqlite::Connection::open_with_flags(
-            path,
-            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY
-                | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX
-                | rusqlite::OpenFlags::SQLITE_OPEN_URI,
-        )
-        .map_err(|e| map_err(e, "open_entity_reader"))?;
-
-        conn.busy_timeout(config.busy_timeout)
-            .map_err(|e| map_err(e, "open_entity_reader"))?;
-        conn.pragma_update(None, "foreign_keys", "ON")
-            .map_err(|e| map_err(e, "open_entity_reader"))?;
-        conn.pragma_update(None, "synchronous", "NORMAL")
-            .map_err(|e| map_err(e, "open_entity_reader"))?;
-
-        Ok(conn)
+        self.pool
+            .open_standalone_reader()
+            .map_err(|error| map_sqlite_err(error, "open_entity_reader"))
     }
 
     /// Route a single-row write through the pool-wide `WriterTask` when

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -298,28 +298,9 @@ impl SqlNoteStore {
     }
 
     fn open_standalone_reader(&self) -> Result<rusqlite::Connection, StorageError> {
-        let config = self.pool.config();
-        let path = config.path.as_ref().ok_or_else(|| StorageError::Pool {
-            operation: "note_reader".into(),
-            message: "in-memory databases do not support standalone connections".into(),
-        })?;
-
-        let conn = rusqlite::Connection::open_with_flags(
-            path,
-            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY
-                | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX
-                | rusqlite::OpenFlags::SQLITE_OPEN_URI,
-        )
-        .map_err(|e| map_err(e, "open_note_reader"))?;
-
-        conn.busy_timeout(config.busy_timeout)
-            .map_err(|e| map_err(e, "open_note_reader"))?;
-        conn.pragma_update(None, "foreign_keys", "ON")
-            .map_err(|e| map_err(e, "open_note_reader"))?;
-        conn.pragma_update(None, "synchronous", "NORMAL")
-            .map_err(|e| map_err(e, "open_note_reader"))?;
-
-        Ok(conn)
+        self.pool
+            .open_standalone_reader()
+            .map_err(|error| map_sqlite_err(error, "open_note_reader"))
     }
 
     /// Route a single-row write through the pool-wide `WriterTask` when

--- a/crates/khive-db/src/stores/sparse.rs
+++ b/crates/khive-db/src/stores/sparse.rs
@@ -265,18 +265,10 @@ impl SqliteSparseStore {
     {
         if self.is_file_backed {
             // For file-backed DBs open a standalone read-only connection.
-            let config = self.pool.config();
-            let path = config.path.as_ref().ok_or_else(|| StorageError::Pool {
-                operation: "sparse_reader".into(),
-                message: "in-memory databases do not support standalone connections".into(),
-            })?;
-            let conn = rusqlite::Connection::open_with_flags(
-                path,
-                rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY
-                    | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX
-                    | rusqlite::OpenFlags::SQLITE_OPEN_URI,
-            )
-            .map_err(|e| map_err(e, op))?;
+            let conn = self
+                .pool
+                .open_standalone_reader()
+                .map_err(|error| map_sqlite_err(error, op))?;
             tokio::task::spawn_blocking(move || f(&conn).map_err(|e| map_err(e, op)))
                 .await
                 .map_err(|e| StorageError::driver(StorageCapability::Sparse, op, e))?

--- a/crates/khive-db/src/stores/vectors.rs
+++ b/crates/khive-db/src/stores/vectors.rs
@@ -343,28 +343,9 @@ impl SqliteVecStore {
     }
 
     fn open_standalone_reader(&self) -> Result<rusqlite::Connection, StorageError> {
-        let config = self.pool.config();
-        let path = config.path.as_ref().ok_or_else(|| StorageError::Pool {
-            operation: "vec_reader".into(),
-            message: "in-memory databases do not support standalone connections".into(),
-        })?;
-
-        let conn = rusqlite::Connection::open_with_flags(
-            path,
-            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY
-                | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX
-                | rusqlite::OpenFlags::SQLITE_OPEN_URI,
-        )
-        .map_err(|e| map_err(e, "open_vec_reader"))?;
-
-        conn.busy_timeout(config.busy_timeout)
-            .map_err(|e| map_err(e, "open_vec_reader"))?;
-        conn.pragma_update(None, "foreign_keys", "ON")
-            .map_err(|e| map_err(e, "open_vec_reader"))?;
-        conn.pragma_update(None, "synchronous", "NORMAL")
-            .map_err(|e| map_err(e, "open_vec_reader"))?;
-
-        Ok(conn)
+        self.pool
+            .open_standalone_reader()
+            .map_err(|error| map_sqlite_err(error, "open_vec_reader"))
     }
 
     /// Re-derive writer-task availability at write time instead of trusting

--- a/crates/khive-db/src/timeout_sink.rs
+++ b/crates/khive-db/src/timeout_sink.rs
@@ -22,9 +22,11 @@
 //! continuous `heartbeat` rows: a silent sink (crashed thread, rotated-away
 //! file, dead process) looks identical to a healthy quiet one unless the
 //! heartbeat cadence is also checked. The sink is never initialized for an
-//! in-memory pool (no database file to name it after) — only a file-backed
-//! pool's boot claims the process-global writer thread, so `startup`/
-//! `heartbeat` rows always carry a real, file-backed database identity.
+//! in-memory or read-only pool (neither can report a writer-admission timeout)
+//! — only a writable file-backed pool's boot claims the process-global writer
+//! thread, so `startup`/`heartbeat` rows always carry a real, writable database
+//! identity. Skipping read-only pools also prevents inspection from writing a
+//! sibling log tree or starving a later writable pool of the global claim.
 //!
 //! A short write (the OS accepting only part of a line) is treated as
 //! TERMINAL for the sink instance rather than retried: with a single writer
@@ -846,7 +848,7 @@ fn write_delay_from_env() -> Duration {
         .unwrap_or(Duration::ZERO)
 }
 
-/// Initialize the process-global sink on first call from a file-backed
+/// Initialize the process-global sink on first call from a writable file-backed
 /// pool; every later call (from another pool booting in the same process)
 /// is a cheap no-op once a sink is in place. Does no filesystem I/O itself —
 /// only path resolution (pure) plus spawning the writer thread, which does
@@ -855,10 +857,10 @@ fn write_delay_from_env() -> Duration {
 /// filesystem-latency hook entirely.
 ///
 /// `db_parent` is the booting pool's database file's parent directory,
-/// `None` for an in-memory pool. An in-memory pool never claims the sink:
-/// there is no database file to name a `startup` row after, and claiming
-/// the slot first would starve out a later file-backed pool that could
-/// have supplied a real identity. `db_identity` names the claiming pool in
+/// `None` for an in-memory pool. The caller also skips this function entirely
+/// for a read-only pool. Neither kind may claim the sink: there is no possible
+/// writer timeout to report, and claiming the slot first would starve out a
+/// later writable file-backed pool. `db_identity` names the claiming pool in
 /// the `startup` row.
 pub(crate) fn init(db_parent: Option<&Path>, db_identity: &str) {
     let Some(db_parent) = db_parent else {

--- a/crates/khive-db/tests/writer_timeout_sink.rs
+++ b/crates/khive-db/tests/writer_timeout_sink.rs
@@ -396,6 +396,11 @@ async fn text_busy_standalone_writer_emits_ndjson_row() {
         Some(v) => std::env::set_var("KHIVE_WRITE_QUEUE", v),
         None => std::env::remove_var("KHIVE_WRITE_QUEUE"),
     }
+    assert_eq!(
+        backend.pool().config().write_queue_enabled,
+        Some(false),
+        "writable StorageBackend::sqlite must preserve an explicit queue-off override"
+    );
 
     let store = backend.text("wts_busy_test").expect("text search");
 

--- a/crates/khive-db/tests/writer_timeout_sink.rs
+++ b/crates/khive-db/tests/writer_timeout_sink.rs
@@ -92,6 +92,120 @@ fn wait_for_ndjson_line(predicate: impl Fn(&str) -> bool, timeout: Duration) -> 
     }
 }
 
+/// Read-only inspection must neither start the process-global writer-timeout
+/// sink nor consume its one-time claim. Run the assertion in a freshly
+/// spawned copy of this integration-test binary because other tests in the
+/// parent process intentionally initialize that global sink.
+#[test]
+fn read_only_pool_does_not_claim_sink_and_later_writable_pool_can() {
+    const CHILD_MARKER: &str = "KHIVE_READ_ONLY_SINK_FRESH_PROCESS";
+
+    if std::env::var(CHILD_MARKER).as_deref() != Ok("1") {
+        let output = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "read_only_pool_does_not_claim_sink_and_later_writable_pool_can",
+                "--nocapture",
+            ])
+            .env(CHILD_MARKER, "1")
+            .env("KHIVE_TEST_HARNESS", "1")
+            .env_remove("KHIVE_WRITER_TIMEOUT_SINK_DIR")
+            .output()
+            .expect("fresh integration-test process must start");
+        assert!(
+            output.status.success(),
+            "fresh-process read-only sink regression failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+        return;
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let read_only_path = dir.path().join("inspection.db");
+    {
+        let conn = rusqlite::Connection::open(&read_only_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE inspected(id INTEGER PRIMARY KEY);\
+             INSERT INTO inspected DEFAULT VALUES;",
+        )
+        .unwrap();
+    }
+    let main_before = std::fs::read(&read_only_path).unwrap();
+    let mut entries_before = std::fs::read_dir(dir.path())
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name())
+        .collect::<Vec<_>>();
+    entries_before.sort();
+
+    let read_only_pool = ConnectionPool::new(PoolConfig {
+        path: Some(read_only_path.clone()),
+        read_only: true,
+        write_queue_enabled: Some(false),
+        ..PoolConfig::default()
+    })
+    .expect("read-only inspection pool must open");
+    let count: i64 = read_only_pool
+        .reader()
+        .unwrap()
+        .query_row("SELECT COUNT(*) FROM inspected", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(count, 1);
+
+    // The sink thread performs its first directory creation asynchronously.
+    // Wait beyond its one-second drain cadence before proving absence so this
+    // cannot pass merely because a wrongly-started writer has not run yet.
+    std::thread::sleep(Duration::from_millis(1_500));
+    let mut entries_after = std::fs::read_dir(dir.path())
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name())
+        .collect::<Vec<_>>();
+    entries_after.sort();
+    assert_eq!(std::fs::read(&read_only_path).unwrap(), main_before);
+    assert_eq!(entries_after, entries_before);
+    assert!(
+        !dir.path().join(".khive-logs").exists(),
+        "a read-only pool must not initialize filesystem-writing diagnostics"
+    );
+
+    // A later writable pool in this same fresh process must still be able to
+    // claim the global sink, proving the read-only constructor skipped init
+    // rather than claiming a permanently inert handle.
+    let writable_path = dir.path().join("writable.db");
+    let _writable_pool = ConnectionPool::new(PoolConfig {
+        path: Some(writable_path.clone()),
+        write_queue_enabled: Some(false),
+        ..PoolConfig::default()
+    })
+    .expect("later writable pool must open");
+    let sink_path = dir
+        .path()
+        .join(".khive-logs")
+        .join(format!("writer_timeouts.{}.ndjson", std::process::id()));
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let sink_contents = loop {
+        if let Ok(contents) = std::fs::read_to_string(&sink_path) {
+            if contents.contains("\"kind\":\"startup\"") {
+                break contents;
+            }
+        }
+        assert!(
+            std::time::Instant::now() <= deadline,
+            "later writable pool did not claim the sink at {sink_path:?}"
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    };
+    let writable_marker = writable_path
+        .canonicalize()
+        .unwrap_or(writable_path)
+        .display()
+        .to_string();
+    assert!(
+        sink_contents.contains(&writable_marker),
+        "startup row must name the later writable pool: {sink_contents}"
+    );
+}
+
 /// A genuine `ConnectionPool::writer()` admission timeout (a held writer +
 /// a tiny `checkout_timeout`) must produce a `"kind":"timeout"` /
 /// `"site":"pool_admission"` row naming this pool's own database path.

--- a/crates/khive-mcp/docs/api/pending-events.md
+++ b/crates/khive-mcp/docs/api/pending-events.md
@@ -64,11 +64,12 @@ draining immediately at daemon start.
 ## ADR-119 component supervision (issue #1409)
 
 The daemon no longer drops a bare `tokio::spawn` handle for this loop. When the
-resolved daemon pack set includes `schedule`, the host adds exactly one dynamic
-`schedule-tick` registration to the ADR-119 component roster. The factory captures
-the already-resolved schedule runtime and receives the daemon's live server through
-`HostContext`. Client/stdio roles and daemon configurations without the schedule pack
-add no ticker.
+resolved daemon pack set includes `schedule` and that pack's own assigned backend is
+writable, the host adds exactly one dynamic `schedule-tick` registration to the
+ADR-119 component roster. The factory captures the already-resolved schedule runtime
+and receives the daemon's live server through `HostContext`. Client/stdio roles,
+daemon configurations without the schedule pack, and read-only schedule runtimes add
+no ticker. This gate is per assigned runtime rather than the main backend's mode.
 
 The concrete policy is `OnFailure`, five restarts per daemon lifetime, exponential
 backoff with positive jitter from 1 second to a hard 60-second total-delay cap, and a

--- a/crates/khive-mcp/src/components.rs
+++ b/crates/khive-mcp/src/components.rs
@@ -632,6 +632,23 @@ mod tests {
         (f, path)
     }
 
+    #[cfg(unix)]
+    fn freeze_snapshot_sidecars(path: &std::path::Path) {
+        use std::os::unix::fs::PermissionsExt;
+        for suffix in ["-wal", "-shm"] {
+            let mut name = path.file_name().expect("db file name").to_os_string();
+            name.push(suffix);
+            let sidecar = path.parent().expect("db parent dir").join(name);
+            if sidecar.exists() {
+                let mut permissions = std::fs::metadata(&sidecar)
+                    .expect("sidecar metadata")
+                    .permissions();
+                permissions.set_mode(0o444);
+                std::fs::set_permissions(&sidecar, permissions).expect("freeze sidecar");
+            }
+        }
+    }
+
     async fn make_server(db_path: &str) -> KhiveMcpServer {
         let cfg = RuntimeConfig {
             db_path: Some(std::path::PathBuf::from(db_path)),
@@ -766,6 +783,8 @@ mod tests {
             ..Default::default()
         };
         KhiveRuntime::new(cfg.clone()).expect("create and migrate snapshot source");
+        #[cfg(unix)]
+        freeze_snapshot_sidecars(cfg.db_path.as_ref().expect("db path"));
         let read_only = KhiveRuntime::new_readonly(cfg).expect("open schedule snapshot read-only");
         let before = read_only.backend().pool().writer_acquisition_snapshot();
 

--- a/crates/khive-mcp/src/components.rs
+++ b/crates/khive-mcp/src/components.rs
@@ -354,7 +354,10 @@ fn component_registrations(
         .into_iter()
         .map(ComponentRegistration::from)
         .collect();
-    if let Some(runtime) = schedule_runtime {
+    // Defense in depth for callers outside the normal serve constructor: the
+    // schedule loop begins every tick with stale-claim reclaim DML, so a
+    // read-only assigned runtime must never become a supervised component.
+    if let Some(runtime) = schedule_runtime.filter(|runtime| !runtime.is_read_only()) {
         regs.push(schedule_component_registration(
             runtime,
             crate::pending_events::tick_interval_from_env(),
@@ -749,6 +752,37 @@ mod tests {
         assert_eq!(reg.backoff_initial_ms, 1_000);
         assert_eq!(reg.backoff_max_ms, 60_000);
         assert_eq!(reg.shutdown_timeout_ms, 5_000);
+    }
+
+    #[test]
+    fn schedule_roster_omits_read_only_assigned_runtime_without_writer_acquisition() {
+        let (_f, db) = tmp_db();
+        let cfg = RuntimeConfig {
+            db_path: Some(std::path::PathBuf::from(db)),
+            default_namespace: Namespace::parse("local").unwrap(),
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            packs: vec!["kg".to_string(), "schedule".to_string()],
+            ..Default::default()
+        };
+        KhiveRuntime::new(cfg.clone()).expect("create and migrate snapshot source");
+        let read_only = KhiveRuntime::new_readonly(cfg).expect("open schedule snapshot read-only");
+        let before = read_only.backend().pool().writer_acquisition_snapshot();
+
+        let schedule_count = component_registrations(Some(read_only.clone()))
+            .into_iter()
+            .filter(|reg| reg.name == SCHEDULE_COMPONENT_NAME)
+            .count();
+
+        assert_eq!(
+            schedule_count, 0,
+            "a read-only schedule backend must not launch the writer-dependent ticker"
+        );
+        assert_eq!(
+            read_only.backend().pool().writer_acquisition_snapshot(),
+            before,
+            "component roster construction must not probe a read-only backend through a writer"
+        );
     }
 
     #[tokio::test]

--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -2685,13 +2685,14 @@ mod tests {
 
     #[test]
     fn first_config_mismatch_field_recognizes_read_only_runtime_mode() {
-        let writable = "packs=[kg];db=/private/snapshot.db;embed=none;extra=[];\
-                        backend=main;outbound=[];git_write=policy";
-        let read_only = "packs=[kg];db=/private/snapshot.db;embed=none;extra=[];\
-                         backend=main:read_only;outbound=[];git_write=policy";
+        let config = RuntimeConfig::no_embeddings();
+        let writable =
+            crate::server::compute_config_id_with_runtime_policies(&config, None, true, false);
+        let read_only =
+            crate::server::compute_config_id_with_runtime_policies(&config, None, true, true);
 
         assert_eq!(
-            first_config_mismatch_field(read_only, Some(writable)),
+            first_config_mismatch_field(&read_only, Some(&writable)),
             "backend",
             "storage-mode separation must retain a structured mismatch field"
         );

--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -2684,6 +2684,20 @@ mod tests {
     }
 
     #[test]
+    fn first_config_mismatch_field_recognizes_read_only_runtime_mode() {
+        let writable = "packs=[kg];db=/private/snapshot.db;embed=none;extra=[];\
+                        backend=main;outbound=[];git_write=policy";
+        let read_only = "packs=[kg];db=/private/snapshot.db;embed=none;extra=[];\
+                         backend=main:read_only;outbound=[];git_write=policy";
+
+        assert_eq!(
+            first_config_mismatch_field(read_only, Some(writable)),
+            "backend",
+            "storage-mode separation must retain a structured mismatch field"
+        );
+    }
+
+    #[test]
     #[serial]
     fn map_response_config_mismatch_logs_opaque_ids_and_field_without_values() {
         reset_fallback_counters();

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -9533,6 +9533,8 @@ backend = "kg-backend"
                 ..RuntimeConfig::no_embeddings()
             };
             KhiveRuntime::new(config.clone()).expect("seed exact-current snapshot");
+            #[cfg(unix)]
+            freeze_snapshot_sidecars(config.db_path.as_ref().expect("db path"));
             let snapshot = KhiveRuntime::new_readonly(config).expect("open read-only snapshot");
             let server = KhiveMcpServer::new(snapshot).expect("build snapshot server");
 
@@ -9626,6 +9628,8 @@ backend = "kg-backend"
                 ..RuntimeConfig::no_embeddings()
             };
             KhiveRuntime::new(config.clone()).expect("seed exact-current snapshot");
+            #[cfg(unix)]
+            freeze_snapshot_sidecars(config.db_path.as_ref().expect("db path"));
             let snapshot = KhiveRuntime::new_readonly(config).expect("open read-only snapshot");
             let server = KhiveMcpServer::new(snapshot).expect("build snapshot server");
             let daemon = Args::parse_from(["mcp", "--daemon"]);

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -422,7 +422,7 @@ fn spawn_email_channel_loops(
             ch_registry.register(dyn_ch);
             let ch_registry = Arc::new(ch_registry);
             let verb_reg = server.verb_registry_clone();
-            let runtime = server.runtime_clone();
+            let runtime = server.channel_outbox_runtime_clone();
             let ingest_ns = ingest_namespace_from_env();
             let default_actor = default_inbound_actor_from_env();
             let mut allowlist = allowed_recipients_from_env();
@@ -477,7 +477,7 @@ fn spawn_email_channel_loops(
                         }
                         None => {
                             tracing::error!(
-                                "email outbox loop was NOT started: server has no default-backend \
+                                "email outbox loop was NOT started: server has no KG-routed \
                                  runtime handle, which the loop needs to claim external_id on \
                                  outbound notes; outbound mail will not be sent"
                             );
@@ -1374,10 +1374,6 @@ async fn channel_outbox_loop(
     mailbox: String,
     allowlist: Vec<String>,
 ) {
-    use chrono::Utc;
-    use khive_channel::{Channel, ChannelEnvelope};
-    use serde_json::json;
-
     let domain = mailbox.split('@').nth(1).unwrap_or("localhost").to_string();
     let namespace = match khive_runtime::Namespace::parse(&ingest_namespace) {
         Ok(ns) => ns,
@@ -1393,204 +1389,201 @@ async fn channel_outbox_loop(
 
     loop {
         tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+        channel_outbox_once(
+            email_channel.as_ref(),
+            &registry,
+            &runtime,
+            &namespace,
+            &ingest_namespace,
+            &mailbox,
+            &domain,
+            &allowlist,
+        )
+        .await;
+    }
+}
 
-        // Query outbound messages via the registry. The note `list` handler applies
-        // the `direction` filter server-side (scanning up to its internal cap) and
-        // returns a bare JSON array of full note objects. There is no `delivered_at`
-        // or recipient-prefix filter, so the `email:` prefix and the
-        // already-delivered check are applied per-note below.
-        let list_params = json!({
-            "namespace": ingest_namespace,
-            "kind": "message",
-            "direction": "outbound",
-            "delivered": false,
-            "limit": 200,
-        });
-        let list_result = match registry.dispatch("list", list_params).await {
-            Ok(r) => r,
-            Err(e) => {
-                tracing::warn!(error = %e, "outbox loop: list failed");
-                continue;
-            }
+/// Execute one email outbox scan. Kept separate from the five-second loop so
+/// routing and owner-claim behavior can be verified without sleeping or
+/// opening a network transport.
+#[cfg(feature = "channel-email")]
+#[allow(clippy::too_many_arguments)]
+async fn channel_outbox_once(
+    email_channel: &dyn khive_channel::Channel,
+    registry: &khive_runtime::VerbRegistry,
+    runtime: &khive_runtime::KhiveRuntime,
+    namespace: &khive_runtime::Namespace,
+    ingest_namespace: &str,
+    mailbox: &str,
+    domain: &str,
+    allowlist: &[String],
+) {
+    use chrono::Utc;
+    use khive_channel::ChannelEnvelope;
+    use serde_json::json;
+
+    // Query outbound messages via the registry. The note `list` handler applies
+    // the `direction` filter server-side (scanning up to its internal cap) and
+    // returns a bare JSON array of full note objects. There is no recipient-prefix
+    // filter, so the `email:` prefix is applied per-note below.
+    let list_params = json!({
+        "namespace": ingest_namespace,
+        "kind": "message",
+        "direction": "outbound",
+        "delivered": false,
+        "limit": 200,
+    });
+    let list_result = match registry.dispatch("list", list_params).await {
+        Ok(result) => result,
+        Err(error) => {
+            tracing::warn!(error = %error, "outbox loop: list failed");
+            return;
+        }
+    };
+
+    let Some(notes) = list_result.as_array() else {
+        return;
+    };
+    for note_val in notes {
+        let props = match note_val.get("properties") {
+            Some(serde_json::Value::Object(properties)) => properties.clone(),
+            _ => continue,
         };
 
-        let notes = match list_result.as_array() {
-            Some(arr) => arr.clone(),
+        if props.get("direction").and_then(|value| value.as_str()) != Some("outbound") {
+            continue;
+        }
+        let to_actor = match props.get("to_actor").and_then(|value| value.as_str()) {
+            Some(actor) if actor.starts_with("email:") => actor.to_string(),
+            _ => continue,
+        };
+        if note_already_delivered(&props) {
+            continue;
+        }
+        let note_id = match note_val.get("id").and_then(|value| value.as_str()) {
+            Some(id) => id.to_string(),
             None => continue,
         };
+        let recipient = to_actor
+            .strip_prefix("email:")
+            .unwrap_or(to_actor.as_str())
+            .to_string();
+        if !allowlist.is_empty() && !allowlist.contains(&recipient) {
+            tracing::warn!(
+                note_id = %note_id,
+                recipient = %recipient,
+                "outbox loop: recipient not in allowlist; skipping"
+            );
+            continue;
+        }
 
-        for note_val in notes {
-            let props = match note_val.get("properties") {
-                Some(serde_json::Value::Object(m)) => m.clone(),
-                _ => continue,
-            };
+        let subject = props
+            .get("subject")
+            .and_then(|value| value.as_str())
+            .unwrap_or("(no subject)")
+            .to_string();
+        let content = match note_val.get("content").and_then(|value| value.as_str()) {
+            Some(content) => content.to_string(),
+            None => continue,
+        };
+        let thread_id = props
+            .get("thread_id")
+            .and_then(|value| value.as_str())
+            .map(str::to_string);
+        let in_reply_to = props
+            .get("in_reply_to_message_id")
+            .and_then(|value| value.as_str())
+            .map(str::to_string);
+        let references = props
+            .get("references_chain")
+            .and_then(|value| value.as_str())
+            .map(str::to_string);
 
-            // Only outbound direction. The `delivered=false` filter on the list query
-            // ensures only undelivered notes are returned; this check is a cheap
-            // defensive guard for any note that slips through.
-            if props.get("direction").and_then(|v| v.as_str()) != Some("outbound") {
-                continue;
-            }
-
-            // Only email-addressed notes.
-            let to_actor = match props.get("to_actor").and_then(|v| v.as_str()) {
-                Some(a) if a.starts_with("email:") => a.to_string(),
-                _ => continue,
-            };
-
-            // Defensive: skip already-delivered notes in case the query filter missed any.
-            if note_already_delivered(&props) {
-                continue;
-            }
-
-            let note_id = match note_val.get("id").and_then(|v| v.as_str()) {
-                Some(id) => id.to_string(),
-                None => continue,
-            };
-
-            let recipient = to_actor
-                .strip_prefix("email:")
-                .unwrap_or(to_actor.as_str())
-                .to_string();
-
-            // Allowlist check.
-            if !allowlist.is_empty() && !allowlist.contains(&recipient) {
-                tracing::warn!(
-                    note_id = %note_id,
-                    recipient = %recipient,
-                    "outbox loop: recipient not in allowlist; skipping"
-                );
-                continue;
-            }
-
-            let subject = props
-                .get("subject")
-                .and_then(|v| v.as_str())
-                .unwrap_or("(no subject)")
-                .to_string();
-
-            let content = match note_val.get("content").and_then(|v| v.as_str()) {
-                Some(c) => c.to_string(),
-                None => continue,
-            };
-
-            let thread_id = props
-                .get("thread_id")
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string());
-
-            // Issue #403: the parent's wire Message-ID, computed at reply time by
-            // comm.reply (khive-pack-comm) and stored on this note. Forwarded
-            // verbatim so the SMTP layer can set In-Reply-To for native MUA
-            // conversation grouping; absent for non-reply sends.
-            let in_reply_to = props
-                .get("in_reply_to_message_id")
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string());
-
-            // Issue #403: the full References chain (parent's existing
-            // chain, if any, followed by the parent's Message-ID), computed at
-            // reply time by comm.reply. Forwarded verbatim so the SMTP layer can
-            // set References without truncating ancestry; absent for non-reply sends.
-            let references = props
-                .get("references_chain")
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string());
-
-            // Mint-before-send: derive or reuse the Message-ID.
-            let message_id = match props.get("external_id").and_then(|v| v.as_str()) {
-                Some(eid) if !eid.is_empty() => eid.to_string(),
-                _ => {
-                    let mid = format!("<{note_id}@{domain}>");
-                    // Persist the claimed external_id before sending, through the
-                    // non-wire owner path: the generic `update` verb refuses any
-                    // patch naming `external_id` on a `message` note (it is an
-                    // owner-established property), so this cannot go through
-                    // `registry.dispatch`.
-                    let claim_result = match uuid::Uuid::parse_str(&note_id) {
-                        Ok(uuid) => match runtime.authorize(namespace.clone()) {
-                            Ok(token) => {
-                                runtime
-                                    .claim_outbound_message_external_id(&token, uuid, mid.clone())
-                                    .await
-                            }
-                            Err(e) => Err(e),
-                        },
-                        Err(e) => Err(khive_runtime::RuntimeError::InvalidInput(format!(
-                            "note id {note_id} is not a valid UUID: {e}"
-                        ))),
-                    };
-                    if let Err(e) = claim_result {
-                        tracing::warn!(
-                            note_id = %note_id,
-                            error = %e,
-                            "outbox loop: failed to claim external_id; skipping"
-                        );
-                        continue;
-                    }
-                    mid
-                }
-            };
-
-            // Build and send the envelope.
-            let mut env = ChannelEnvelope::new(
-                format!("email:{mailbox}"),
-                format!("email:{recipient}"),
-                content,
-            )
-            .with_subject(subject)
-            .with_message_id(message_id.clone());
-
-            if let Some(tid) = thread_id {
-                env = env.with_correlation(tid);
-            }
-            if let Some(irt) = in_reply_to {
-                env = env.with_in_reply_to(irt);
-            }
-            if let Some(refs) = references {
-                env = env.with_references(refs);
-            }
-
-            match email_channel.send(env).await {
-                Ok(()) => {
-                    let delivered_at = Utc::now().to_rfc3339();
-                    let mark_result = registry
-                        .dispatch(
-                            "update",
-                            json!({
-                                "namespace": ingest_namespace,
-                                "id": note_id,
-                                "properties": { "delivered_at": delivered_at },
-                            }),
-                        )
-                        .await;
-                    match mark_result {
-                        Ok(_) => {
-                            tracing::info!(
-                                note_id = %note_id,
-                                recipient = %recipient,
-                                message_id = %message_id,
-                                "outbox loop: delivered"
-                            );
+        // Mint-before-send through the KG runtime's owner-only path. Generic
+        // `update` correctly refuses caller patches to `external_id`.
+        let message_id = match props.get("external_id").and_then(|value| value.as_str()) {
+            Some(external_id) if !external_id.is_empty() => external_id.to_string(),
+            _ => {
+                let message_id = format!("<{note_id}@{domain}>");
+                let claim_result = match uuid::Uuid::parse_str(&note_id) {
+                    Ok(uuid) => match runtime.authorize(namespace.clone()) {
+                        Ok(token) => {
+                            runtime
+                                .claim_outbound_message_external_id(
+                                    &token,
+                                    uuid,
+                                    message_id.clone(),
+                                )
+                                .await
                         }
-                        Err(e) => {
-                            tracing::warn!(
-                                note_id = %note_id,
-                                error = %e,
-                                "outbox loop: failed to set delivered_at (AT-LEAST-ONCE: will retry)"
-                            );
-                        }
-                    }
-                }
-                Err(e) => {
+                        Err(error) => Err(error),
+                    },
+                    Err(error) => Err(khive_runtime::RuntimeError::InvalidInput(format!(
+                        "note id {note_id} is not a valid UUID: {error}"
+                    ))),
+                };
+                if let Err(error) = claim_result {
                     tracing::warn!(
                         note_id = %note_id,
-                        recipient = %recipient,
-                        error = %e,
-                        "outbox loop: send failed; will retry next cycle"
+                        error = %error,
+                        "outbox loop: failed to claim external_id; skipping"
                     );
+                    continue;
+                }
+                message_id
+            }
+        };
+
+        let mut envelope = ChannelEnvelope::new(
+            format!("email:{mailbox}"),
+            format!("email:{recipient}"),
+            content,
+        )
+        .with_subject(subject)
+        .with_message_id(message_id.clone());
+        if let Some(thread_id) = thread_id {
+            envelope = envelope.with_correlation(thread_id);
+        }
+        if let Some(in_reply_to) = in_reply_to {
+            envelope = envelope.with_in_reply_to(in_reply_to);
+        }
+        if let Some(references) = references {
+            envelope = envelope.with_references(references);
+        }
+
+        match email_channel.send(envelope).await {
+            Ok(()) => {
+                let delivered_at = Utc::now().to_rfc3339();
+                match registry
+                    .dispatch(
+                        "update",
+                        json!({
+                            "namespace": ingest_namespace,
+                            "id": note_id,
+                            "properties": { "delivered_at": delivered_at },
+                        }),
+                    )
+                    .await
+                {
+                    Ok(_) => tracing::info!(
+                        note_id = %note_id,
+                        recipient = %recipient,
+                        message_id = %message_id,
+                        "outbox loop: delivered"
+                    ),
+                    Err(error) => tracing::warn!(
+                        note_id = %note_id,
+                        error = %error,
+                        "outbox loop: failed to set delivered_at (AT-LEAST-ONCE: will retry)"
+                    ),
                 }
             }
+            Err(error) => tracing::warn!(
+                note_id = %note_id,
+                recipient = %recipient,
+                error = %error,
+                "outbox loop: send failed; will retry next cycle"
+            ),
         }
     }
 }
@@ -2866,6 +2859,11 @@ pub fn build_server_from_multi_backend_registry(
         multi.per_pack_runtimes.get("kg").map(Arc::as_ref),
         multi.per_pack_runtimes.get("comm").map(Arc::as_ref),
     );
+    #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
+    let channel_outbox_runtime = multi
+        .per_pack_runtimes
+        .get("kg")
+        .map(|runtime| runtime.as_ref().clone());
     // Wire the main backend's pool for background WAL checkpointing. The pool is
     // only present for file-backed databases; in-memory backends return None here
     // so that checkpoint_once never runs on a non-WAL connection.
@@ -2888,7 +2886,9 @@ pub fn build_server_from_multi_backend_registry(
     .with_runtime(default_runtime);
 
     #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
-    let server = server.with_channel_loop_admission(channel_loop_admission);
+    let server = server
+        .with_channel_outbox_runtime(channel_outbox_runtime)
+        .with_channel_loop_admission(channel_loop_admission);
 
     let server = match coordinator {
         Some(c) => server.with_coordinator(c),
@@ -9209,6 +9209,176 @@ backend = "kg-backend"
                 .unwrap()
                 .clone();
             assert!(note_already_delivered(&props));
+        }
+    }
+
+    /// #1856 multi-backend regression: the owner-only `external_id` claim
+    /// must use the same KG-routed runtime as outbox list/update dispatch.
+    /// The default backend deliberately contains no message row; using its
+    /// runtime makes the claim fail and suppresses the external send.
+    #[cfg(feature = "channel-email")]
+    mod routed_email_outbox_tests {
+        use super::*;
+        use async_trait::async_trait;
+        use chrono::{DateTime, Utc};
+        use khive_channel::{Channel, ChannelEnvelope, ChannelError};
+        use khive_runtime::PackConfig;
+        use std::sync::Mutex;
+
+        #[derive(Default)]
+        struct RecordingChannel {
+            sent: Mutex<Vec<ChannelEnvelope>>,
+        }
+
+        #[async_trait]
+        impl Channel for RecordingChannel {
+            fn kind(&self) -> &'static str {
+                "email"
+            }
+
+            async fn send(&self, envelope: ChannelEnvelope) -> Result<(), ChannelError> {
+                self.sent.lock().unwrap().push(envelope);
+                Ok(())
+            }
+
+            async fn poll(
+                &self,
+                _since: DateTime<Utc>,
+            ) -> Result<Vec<ChannelEnvelope>, ChannelError> {
+                Ok(Vec::new())
+            }
+        }
+
+        #[tokio::test]
+        #[serial]
+        async fn kg_secondary_runtime_owns_external_id_claim_and_delivery_mark() {
+            let dir = tempfile::tempdir().unwrap();
+            let main_path = dir.path().join("main.db");
+            let kg_path = dir.path().join("kg-secondary.db");
+            let khive_cfg = KhiveConfig {
+                backends: vec![
+                    BackendConfig {
+                        name: BackendId::MAIN.to_string(),
+                        kind: BackendKind::Sqlite,
+                        path: Some(main_path.clone()),
+                        cache_mb: None,
+                        journal_mode: None,
+                        read_only: false,
+                    },
+                    BackendConfig {
+                        name: "kg-store".to_string(),
+                        kind: BackendKind::Sqlite,
+                        path: Some(kg_path.clone()),
+                        cache_mb: None,
+                        journal_mode: None,
+                        read_only: false,
+                    },
+                ],
+                packs: HashMap::from([
+                    (
+                        "kg".to_string(),
+                        PackConfig {
+                            backend: "kg-store".to_string(),
+                        },
+                    ),
+                    (
+                        "comm".to_string(),
+                        PackConfig {
+                            backend: "kg-store".to_string(),
+                        },
+                    ),
+                ]),
+                ..KhiveConfig::default()
+            };
+
+            let multi = build_registry_for_multi_backend_inner(
+                base_runtime_config_for_multi_backend(),
+                &khive_cfg,
+                None,
+            )
+            .expect("mixed-topology registry must build");
+            assert_eq!(
+                multi.per_pack_runtimes["kg"].backend_id().as_str(),
+                "kg-store"
+            );
+            let server = build_server_from_multi_backend_registry(multi, &khive_cfg, None);
+            let registry = server.verb_registry_clone();
+            let owner_runtime = server
+                .channel_outbox_runtime_clone()
+                .expect("email outbox must retain the KG-routed runtime");
+            assert_eq!(owner_runtime.backend_id().as_str(), "kg-store");
+
+            let send = registry
+                .dispatch(
+                    "comm.send",
+                    serde_json::json!({
+                        "to": "email:recipient@example.com",
+                        "subject": "routed owner claim",
+                        "content": "kg-secondary-outbox-probe",
+                    }),
+                )
+                .await
+                .expect("comm.send must create the outbound secondary row");
+            let note_id = send["full_id"]
+                .as_str()
+                .expect("comm.send returns full_id")
+                .to_string();
+
+            let channel = RecordingChannel::default();
+            let namespace = Namespace::parse("local").unwrap();
+            channel_outbox_once(
+                &channel,
+                &registry,
+                &owner_runtime,
+                &namespace,
+                "local",
+                "maintainer@example.com",
+                "example.com",
+                &["recipient@example.com".to_string()],
+            )
+            .await;
+            assert_eq!(channel.sent.lock().unwrap().len(), 1);
+
+            let note = registry
+                .dispatch("get", serde_json::json!({ "id": note_id }))
+                .await
+                .expect("KG-routed get must read the delivered secondary row");
+            assert!(
+                note["properties"]["external_id"]
+                    .as_str()
+                    .is_some_and(|value| !value.is_empty()),
+                "owner claim must persist external_id on the KG backend: {note}"
+            );
+            assert!(
+                note["properties"]["delivered_at"]
+                    .as_str()
+                    .is_some_and(|value| !value.is_empty()),
+                "successful send must persist delivered_at on the KG backend: {note}"
+            );
+
+            let main = rusqlite::Connection::open(&main_path).unwrap();
+            let main_count: i64 = main
+                .query_row(
+                    "SELECT COUNT(*) FROM notes WHERE content = 'kg-secondary-outbox-probe'",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(main_count, 0, "default backend must not own the message");
+
+            let kg = rusqlite::Connection::open(&kg_path).unwrap();
+            let (external_id, delivered_at): (String, String) = kg
+                .query_row(
+                    "SELECT json_extract(properties, '$.external_id'), \
+                            json_extract(properties, '$.delivered_at') \
+                     FROM notes WHERE content = 'kg-secondary-outbox-probe' \
+                       AND json_extract(properties, '$.direction') = 'outbound'",
+                    [],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )
+                .unwrap();
+            assert!(!external_id.is_empty());
+            assert!(!delivered_at.is_empty());
         }
     }
 

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -368,6 +368,15 @@ fn start_daemon_components_if_daemon(
     crate::components::start_daemon_components_with_schedule(server, schedule_rt)
 }
 
+/// Admit the schedule runtime to daemon supervision only when its own assigned
+/// backend is writable. This decision is deliberately per runtime: a read-only
+/// main backend must not disable a schedule pack routed to a writable secondary,
+/// while a writable main must not accidentally start a ticker for a schedule
+/// pack routed to a read-only secondary.
+fn writable_schedule_runtime(runtime: Option<KhiveRuntime>) -> Option<KhiveRuntime> {
+    runtime.filter(|runtime| !runtime.is_read_only())
+}
+
 /// Spawn the email channel polling + outbox loops if the `channel-email`
 /// feature is enabled and `KHIVE_EMAIL_*` config resolves. Non-fatal: logs a
 /// warning and returns on incomplete config. Only call this when
@@ -2407,12 +2416,13 @@ pub fn enforce_strict_actor_mode(
 
 /// Build a fully-configured server from parsed args (without serving).
 ///
-/// Returns, alongside the server, the resolved [`KhiveRuntime`] handle the
-/// `"schedule"` pack is bound to — `None` when the resolved pack set does
-/// not include `"schedule"` — for `start_daemon_components_if_daemon` to
-/// drain against (ADR-106). This is the SAME runtime the server itself
-/// dispatches through, never an independently re-resolved one (PR #782 —
-/// see `crates/khive-mcp/docs/api/pending-events.md`).
+/// Returns, alongside the server, the resolved writable [`KhiveRuntime`]
+/// handle the `"schedule"` pack is bound to. It is `None` when the resolved
+/// pack set omits `"schedule"` or that pack's own assigned backend is
+/// read-only, because every ticker pass begins with reclaim DML. This is the
+/// SAME runtime the server itself dispatches through, never an independently
+/// re-resolved one (PR #782 — see
+/// `crates/khive-mcp/docs/api/pending-events.md`).
 ///
 /// Thin wrapper over [`build_server_with_explicit_namespace`]: derives the
 /// `(namespace, namespace_explicit)` pair from a real CLI parse and, because
@@ -2534,12 +2544,14 @@ pub fn build_server_with_explicit_namespace(
                  Set KHIVE_ACTOR or --actor to this lambda's id."
             );
         }
-        let schedule_rt = runtime
-            .config()
-            .packs
-            .iter()
-            .any(|p| p == "schedule")
-            .then(|| runtime.clone());
+        let schedule_rt = writable_schedule_runtime(
+            runtime
+                .config()
+                .packs
+                .iter()
+                .any(|p| p == "schedule")
+                .then(|| runtime.clone()),
+        );
         let fmt = apply_env_output_format(khive_cfg.runtime.default_output_format);
         let server = KhiveMcpServer::new(runtime)
             .map(|s| s.with_default_output_format(fmt))
@@ -2554,10 +2566,12 @@ pub fn build_server_with_explicit_namespace(
         args.db.as_deref(),
         db_anchor.as_deref(),
     )?;
-    let schedule_rt = multi
-        .per_pack_runtimes
-        .get("schedule")
-        .map(|rt| (**rt).clone());
+    let schedule_rt = writable_schedule_runtime(
+        multi
+            .per_pack_runtimes
+            .get("schedule")
+            .map(|rt| (**rt).clone()),
+    );
     let server = build_server_from_multi_backend_registry(multi, &khive_cfg, None);
     Ok((server, schedule_rt))
 }
@@ -7866,6 +7880,192 @@ region = "us-east-1"
             "when the operator restricts --pack to exclude \"schedule\", the tick must have \
              nothing to drain against — never silently falling back to a runtime that can \
              dispatch through a pack the daemon was not configured to load"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    #[serial]
+    async fn default_read_only_server_omits_schedule_tick_and_warms_without_a_writer() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let seat_dir = tempfile::tempdir().expect("seat tempdir");
+        let _seat_env = SeatEnv::enter(seat_dir.path());
+        std::env::remove_var("KHIVE_DB");
+        std::env::remove_var("KHIVE_ACTOR");
+        std::env::remove_var("KHIVE_PACKS");
+        std::env::remove_var("KHIVE_REQUIRE_ATTRIBUTED_ACTOR");
+
+        let db = seat_dir.path().join("read-only-schedule.db");
+        KhiveRuntime::new(RuntimeConfig {
+            db_path: Some(db.clone()),
+            ..RuntimeConfig::no_embeddings()
+        })
+        .expect("create migrated snapshot source");
+        let mut permissions = std::fs::metadata(&db).unwrap().permissions();
+        permissions.set_mode(0o444);
+        std::fs::set_permissions(&db, permissions).unwrap();
+
+        use clap::Parser;
+        let args = Args::parse_from(["mcp", "--db", db.to_str().expect("utf8 path"), "--no-embed"]);
+
+        let (_server, schedule_rt) = build_server(&args).expect("read-only server must build");
+        assert!(
+            schedule_rt.is_none(),
+            "the default pack set must not return a writer-dependent ticker runtime for a snapshot"
+        );
+
+        // Read-only pools are intentionally omitted from `server.pool()` so
+        // checkpoint ownership cannot see them. Build the same default pack
+        // registry over a retained runtime clone to inspect its actual pool
+        // while exercising the identical `warm_all` implementation.
+        let runtime = KhiveRuntime::new_readonly(RuntimeConfig {
+            db_path: Some(db),
+            ..RuntimeConfig::no_embeddings()
+        })
+        .expect("retained read-only runtime");
+        let pool = runtime.backend().pool_arc();
+        let warm_server = KhiveMcpServer::new(runtime).expect("default read-only pack registry");
+        let before = pool.writer_acquisition_snapshot();
+        warm_server.warm_all().await;
+        assert_eq!(
+            pool.writer_acquisition_snapshot(),
+            before,
+            "default daemon pack warm must remain outside the read-only writer plane"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    #[serial]
+    async fn multi_backend_schedule_tick_and_warm_use_each_assigned_backend_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let seat_dir = tempfile::tempdir().expect("seat tempdir");
+        let _seat_env = SeatEnv::enter(seat_dir.path());
+        std::env::remove_var("KHIVE_DB");
+        std::env::remove_var("KHIVE_ACTOR");
+        std::env::remove_var("KHIVE_PACKS");
+        std::env::remove_var("KHIVE_REQUIRE_ATTRIBUTED_ACTOR");
+
+        let main_db = seat_dir.path().join("read-only-main.db");
+        let schedule_db = seat_dir.path().join("writable-schedule.db");
+        for path in [&main_db, &schedule_db] {
+            KhiveRuntime::new(RuntimeConfig {
+                db_path: Some(path.clone()),
+                ..RuntimeConfig::no_embeddings()
+            })
+            .expect("create migrated backend");
+        }
+        let mut permissions = std::fs::metadata(&main_db).unwrap().permissions();
+        permissions.set_mode(0o444);
+        std::fs::set_permissions(&main_db, permissions).unwrap();
+
+        let config_path = write_config(
+            seat_dir.path(),
+            &format!(
+                r#"
+[[backends]]
+name = "main"
+kind = "sqlite"
+path = "{main}"
+read_only = true
+
+[[backends]]
+name = "schedule-backend"
+kind = "sqlite"
+path = "{schedule}"
+
+[packs.schedule]
+backend = "schedule-backend"
+"#,
+                main = main_db.display(),
+                schedule = schedule_db.display(),
+            ),
+        );
+
+        use clap::Parser;
+        let args = Args::parse_from([
+            "mcp",
+            "--config",
+            config_path.to_str().expect("utf8 path"),
+            "--no-embed",
+            "--pack",
+            "kg",
+            "--pack",
+            "schedule",
+        ]);
+        let (server, schedule_rt) = build_server(&args).expect("mixed-mode server must build");
+        assert!(
+            schedule_rt.is_some(),
+            "a read-only main backend must not suppress schedule when schedule's own backend is writable"
+        );
+        let schedule_pool = schedule_rt
+            .as_ref()
+            .expect("writable schedule runtime")
+            .backend()
+            .pool_arc();
+        let schedule_before = schedule_pool.writer_acquisition_snapshot();
+        server.warm_all().await;
+        assert_eq!(
+            schedule_pool.writer_acquisition_snapshot(),
+            schedule_before,
+            "warming other packs must not add schedule-backend writer traffic"
+        );
+
+        let read_only_schedule_db = seat_dir.path().join("read-only-schedule-secondary.db");
+        KhiveRuntime::new(RuntimeConfig {
+            db_path: Some(read_only_schedule_db.clone()),
+            ..RuntimeConfig::no_embeddings()
+        })
+        .expect("create migrated read-only schedule source");
+        let mut permissions = std::fs::metadata(&read_only_schedule_db)
+            .unwrap()
+            .permissions();
+        permissions.set_mode(0o444);
+        std::fs::set_permissions(&read_only_schedule_db, permissions).unwrap();
+        let writable_main_db = seat_dir.path().join("writable-main.db");
+        KhiveRuntime::new(RuntimeConfig {
+            db_path: Some(writable_main_db.clone()),
+            ..RuntimeConfig::no_embeddings()
+        })
+        .expect("create migrated writable main");
+        let config_path = write_config(
+            seat_dir.path(),
+            &format!(
+                r#"
+[[backends]]
+name = "main"
+kind = "sqlite"
+path = "{main}"
+
+[[backends]]
+name = "schedule-backend"
+kind = "sqlite"
+path = "{schedule}"
+read_only = true
+
+[packs.schedule]
+backend = "schedule-backend"
+"#,
+                main = writable_main_db.display(),
+                schedule = read_only_schedule_db.display(),
+            ),
+        );
+        let args = Args::parse_from([
+            "mcp",
+            "--config",
+            config_path.to_str().expect("utf8 path"),
+            "--no-embed",
+            "--pack",
+            "kg",
+            "--pack",
+            "schedule",
+        ]);
+        let (_server, schedule_rt) = build_server(&args).expect("mixed-mode server must build");
+        assert!(
+            schedule_rt.is_none(),
+            "a writable main backend must not enable schedule when schedule's own backend is read-only"
         );
     }
 

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -6924,6 +6924,8 @@ region = "us-east-1"
         )
         .expect("seed exact-current snapshots");
         drop(seeded);
+        #[cfg(unix)]
+        freeze_snapshot_sidecars(&comm_path);
         let daemon = Args::parse_from(["mcp", "--daemon"]);
 
         let comm_snapshot = build_registry_for_multi_backend_inner(
@@ -6944,6 +6946,24 @@ region = "us-east-1"
             "list/update are backed by the writable kg runtime"
         );
         drop(server);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            freeze_snapshot_sidecars(&main_path);
+            // The second arm reopens comm writable, so its sidecars must thaw.
+            for suffix in ["-wal", "-shm"] {
+                let mut name = comm_path.file_name().expect("db file name").to_os_string();
+                name.push(suffix);
+                let sidecar = comm_path.parent().expect("db parent dir").join(name);
+                if sidecar.exists() {
+                    let mut permissions = std::fs::metadata(&sidecar)
+                        .expect("sidecar metadata")
+                        .permissions();
+                    permissions.set_mode(0o644);
+                    std::fs::set_permissions(&sidecar, permissions).expect("thaw sidecar");
+                }
+            }
+        }
 
         let kg_snapshot = build_registry_for_multi_backend_inner(
             base_runtime_config_for_multi_backend(),

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -8,9 +8,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use khive_runtime::{
-    config_from_env, parse_pack_list, run_migrations, runtime_config_from_khive_config,
-    BackendConfig, BackendId, BackendKind, ConnectionPool, KhiveConfig, KhiveRuntime, OutputFormat,
-    RuntimeConfig, StorageBackend,
+    config_from_env, parse_pack_list, runtime_config_from_khive_config, BackendConfig, BackendId,
+    BackendKind, ConnectionPool, KhiveConfig, KhiveRuntime, OutputFormat, RuntimeConfig,
+    StorageBackend,
 };
 
 use crate::args::{resolve_cli_namespace, Args};
@@ -2127,18 +2127,25 @@ fn build_registry_for_multi_backend_inner(
         let canonical = canonical_backend_path(backend_cfg)?;
         if let Some(ref canon) = canonical {
             if let Some(existing) = path_to_backend.get(canon) {
+                if existing.is_read_only() != backend_cfg.read_only {
+                    anyhow::bail!(
+                        "backend {} aliases {} but declares read_only={} while the same \
+                         physical database was already opened with read_only={}; every alias \
+                         of one database must use the same access mode",
+                        backend_cfg.name,
+                        canon.display(),
+                        backend_cfg.read_only,
+                        existing.is_read_only(),
+                    );
+                }
                 backends.insert(backend_cfg.name.clone(), existing.clone());
                 continue;
             }
         }
         let backend = open_backend(backend_cfg)?;
-        {
-            let mut writer = backend.pool().try_writer().map_err(|e| {
-                anyhow::anyhow!("backend {}: migration writer: {e}", backend_cfg.name)
-            })?;
-            run_migrations(writer.conn_mut())
-                .map_err(|e| anyhow::anyhow!("backend {}: migration: {e}", backend_cfg.name))?;
-        }
+        backend.prepare_core_schema().map_err(|e| {
+            anyhow::anyhow!("backend {}: schema preparation: {e}", backend_cfg.name)
+        })?;
         let arc = Arc::new(backend);
         if let Some(canon) = canonical {
             path_to_backend.insert(canon, arc.clone());
@@ -2229,10 +2236,11 @@ fn build_registry_for_multi_backend_inner(
 
     let gate = default_runtime.config().gate.clone();
     let default_namespace = default_runtime.config().default_namespace.clone();
-    let config_id = crate::server::compute_config_id_with_ann_fresh_tail(
+    let config_id = crate::server::compute_config_id_with_runtime_policies(
         default_runtime.config(),
         Some(khive_cfg),
         default_runtime.ann_fresh_tail_enabled(),
+        default_runtime.is_read_only(),
     );
     let visible_namespaces = default_runtime.config().visible_namespaces.clone();
 
@@ -2242,7 +2250,9 @@ fn build_registry_for_multi_backend_inner(
     builder.with_visible_namespaces(visible_namespaces);
     builder.with_actor_id(default_runtime.config().actor_id.clone());
 
-    if let Ok(tok) = default_runtime.authorize(khive_runtime::Namespace::local()) {
+    if default_runtime.is_read_only() {
+        builder.with_read_only_audit_store();
+    } else if let Ok(tok) = default_runtime.authorize(khive_runtime::Namespace::local()) {
         if let Ok(event_store) = default_runtime.events(&tok) {
             builder.with_event_store(event_store);
         }
@@ -2554,11 +2564,12 @@ pub fn build_server_with_explicit_namespace(
 
 /// Canonicalize a SQLite backend path for deduplication (ADR-028 §8).
 ///
-/// The database file may not exist yet at boot time, so we cannot call
-/// `std::fs::canonicalize` on the file itself. Instead we canonicalize the
-/// parent directory (which must exist after `open_backend` creates it) and
-/// rejoin the file name. `None` is returned for in-memory backends, which
-/// are never deduplicated.
+/// The database file may not exist yet at boot time, so this uses the shared
+/// no-side-effect path resolver rather than creating the parent as part of
+/// identity resolution. That distinction is mandatory for a missing
+/// read-only snapshot: boot must fail without materializing either the parent
+/// or database. `None` is returned for in-memory backends, which are never
+/// deduplicated.
 fn canonical_backend_path(cfg: &BackendConfig) -> anyhow::Result<Option<PathBuf>> {
     if cfg.kind == BackendKind::Memory {
         return Ok(None);
@@ -2567,28 +2578,9 @@ fn canonical_backend_path(cfg: &BackendConfig) -> anyhow::Result<Option<PathBuf>
         Some(p) => khive_runtime::expand_tilde(p),
         None => return Ok(None),
     };
-    let parent = path
-        .parent()
-        .ok_or_else(|| anyhow::anyhow!("backend {}: path has no parent directory", cfg.name))?;
-    let file_name = path
-        .file_name()
-        .ok_or_else(|| anyhow::anyhow!("backend {}: path has no file name", cfg.name))?;
-    // Create the parent so canonicalize succeeds even before the DB file is written.
-    std::fs::create_dir_all(parent).map_err(|e| {
-        anyhow::anyhow!(
-            "backend {}: cannot create parent dir {}: {e}",
-            cfg.name,
-            parent.display()
-        )
-    })?;
-    let canon_parent = parent.canonicalize().map_err(|e| {
-        anyhow::anyhow!(
-            "backend {}: cannot canonicalize parent dir {}: {e}",
-            cfg.name,
-            parent.display()
-        )
-    })?;
-    Ok(Some(canon_parent.join(file_name)))
+    canonical_path_no_side_effects(&path)
+        .map(Some)
+        .map_err(|e| anyhow::anyhow!("backend {}: cannot resolve path: {e}", cfg.name))
 }
 
 /// Bound on final-component symlink hops [`canonical_path_no_side_effects`]
@@ -2820,7 +2812,7 @@ fn secondary_file_backed_pools(multi: &MultiBackendRegistry) -> Vec<Arc<Connecti
     let mut pools = Vec::new();
     for rt in multi.per_pack_runtimes.values() {
         let backend = rt.backend();
-        if !backend.is_file_backed() {
+        if !backend.is_file_backed() || backend.is_read_only() {
             continue;
         }
         let pool = backend.pool_arc();
@@ -2886,7 +2878,7 @@ impl WiringSurface {
 /// constructor, so this derivation is no longer hand-copied at each call site
 /// (#601, #604).
 pub fn checkpoint_pool_for(main_backend: &StorageBackend) -> Option<Arc<ConnectionPool>> {
-    if main_backend.is_file_backed() {
+    if main_backend.is_file_backed() && !main_backend.is_read_only() {
         Some(main_backend.pool_arc())
     } else {
         None
@@ -2969,22 +2961,34 @@ fn open_backend(cfg: &BackendConfig) -> anyhow::Result<StorageBackend> {
                 )
             })?;
             let expanded = khive_runtime::expand_tilde(path);
-            if let Some(parent) = expanded.parent() {
-                std::fs::create_dir_all(parent).map_err(|e| {
-                    anyhow::anyhow!(
-                        "backend {}: cannot create parent dir {}: {e}",
-                        cfg.name,
-                        parent.display()
-                    )
-                })?;
+            if !cfg.read_only {
+                if let Some(parent) = expanded.parent() {
+                    std::fs::create_dir_all(parent).map_err(|e| {
+                        anyhow::anyhow!(
+                            "backend {}: cannot create parent dir {}: {e}",
+                            cfg.name,
+                            parent.display()
+                        )
+                    })?;
+                }
             }
             if cfg.read_only {
                 StorageBackend::sqlite_read_only(&expanded).map_err(|e| {
                     anyhow::anyhow!("backend {}: sqlite read-only open: {e}", cfg.name)
                 })
             } else {
-                StorageBackend::sqlite(&expanded)
-                    .map_err(|e| anyhow::anyhow!("backend {}: sqlite open: {e}", cfg.name))
+                let backend = StorageBackend::sqlite(&expanded)
+                    .map_err(|e| anyhow::anyhow!("backend {}: sqlite open: {e}", cfg.name))?;
+                if backend.is_read_only() {
+                    anyhow::bail!(
+                        "backend {}: path {} has no filesystem write bits; declare \
+                         `read_only = true` so backend topology and daemon config identity \
+                         describe the snapshot-inspection mode explicitly",
+                        cfg.name,
+                        expanded.display()
+                    );
+                }
+                Ok(backend)
             }
         }
     }
@@ -6400,6 +6404,72 @@ region = "us-east-1"
             result.is_err(),
             "write to a read-only backend must fail; got Ok(())"
         );
+        assert!(
+            checkpoint_pool_for(&ro).is_none(),
+            "read-only backends must not drive checkpoint or WAL sweep writers"
+        );
+    }
+
+    #[test]
+    fn read_only_backend_open_does_not_create_missing_parent_or_database() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("missing-parent");
+        let db_path = parent.join("missing.db");
+        let config = BackendConfig {
+            name: "archive".to_string(),
+            kind: BackendKind::Sqlite,
+            path: Some(db_path.clone()),
+            cache_mb: None,
+            journal_mode: None,
+            read_only: true,
+        };
+
+        let canonical = canonical_backend_path(&config)
+            .expect("read-only identity resolution must be lexical and side-effect free");
+        assert!(canonical.is_some());
+        assert!(
+            !parent.exists(),
+            "canonical backend identity must not create a missing read-only parent"
+        );
+
+        let error = open_backend(&config).expect_err("missing read-only snapshot must fail");
+        assert!(
+            error.to_string().contains("read-only open"),
+            "error must identify the read-only open: {error}"
+        );
+        assert!(!parent.exists(), "read-only boot must not create parents");
+        assert!(
+            !db_path.exists(),
+            "read-only boot must not create a database"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn multi_backend_requires_read_only_mode_to_be_declared_explicitly() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("chmod_snapshot.db");
+        drop(StorageBackend::sqlite(&db_path).expect("create snapshot source"));
+
+        let mut permissions = std::fs::metadata(&db_path).unwrap().permissions();
+        permissions.set_mode(0o444);
+        std::fs::set_permissions(&db_path, permissions).unwrap();
+
+        let config = BackendConfig {
+            name: "archive".to_string(),
+            kind: BackendKind::Sqlite,
+            path: Some(db_path),
+            cache_mb: None,
+            journal_mode: None,
+            read_only: false,
+        };
+        let error = open_backend(&config)
+            .expect_err("an undeclared multi-backend storage-mode change must fail closed");
+        let message = error.to_string();
+        assert!(message.contains("read_only = true"), "{message}");
+        assert!(message.contains("config identity"), "{message}");
     }
 
     /// RAII guard: redirects `HOME` and restores the prior value on drop.
@@ -6564,6 +6634,28 @@ region = "us-east-1"
                 "two backends with the same canonical path must share one Arc and boot ok; got: {e}"
             );
         }
+    }
+
+    #[test]
+    #[serial]
+    fn duplicate_sqlite_aliases_reject_conflicting_read_only_modes() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("shared-mode.db");
+        let mut khive_cfg = duplicate_sqlite_path_config(&db_path);
+        assert!(khive_cfg.backends.len() >= 2);
+        khive_cfg.backends[1].read_only = true;
+
+        let error = match build_server_multi_backend(
+            base_runtime_config_for_multi_backend(),
+            &khive_cfg,
+            None,
+        ) {
+            Ok(_) => panic!("one physical database cannot be both writable and read-only"),
+            Err(error) => error,
+        };
+        let message = error.to_string();
+        assert!(message.contains("same physical database"), "{message}");
+        assert!(message.contains("read_only"), "{message}");
     }
 
     /// Regression for #720: changing `HOME` after runtime-config resolution but

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -6494,7 +6494,10 @@ region = "us-east-1"
             "canonical backend identity must not create a missing read-only parent"
         );
 
-        let error = open_backend(&config).expect_err("missing read-only snapshot must fail");
+        let error = match open_backend(&config) {
+            Ok(_) => panic!("missing read-only snapshot must fail"),
+            Err(error) => error,
+        };
         assert!(
             error.to_string().contains("read-only open"),
             "error must identify the read-only open: {error}"
@@ -6527,8 +6530,10 @@ region = "us-east-1"
             journal_mode: None,
             read_only: false,
         };
-        let error = open_backend(&config)
-            .expect_err("an undeclared multi-backend storage-mode change must fail closed");
+        let error = match open_backend(&config) {
+            Ok(_) => panic!("an undeclared multi-backend storage-mode change must fail closed"),
+            Err(error) => error,
+        };
         let message = error.to_string();
         assert!(message.contains("read_only = true"), "{message}");
         assert!(message.contains("config identity"), "{message}");

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -6486,6 +6486,180 @@ region = "us-east-1"
         assert!(message.contains("config identity"), "{message}");
     }
 
+    #[test]
+    #[serial]
+    fn multi_backend_read_only_construction_and_pack_schema_paths_acquire_no_writer() {
+        use khive_runtime::PackConfig;
+
+        let dir = tempfile::tempdir().unwrap();
+        let main_path = dir.path().join("main-snapshot.db");
+        let comm_path = dir.path().join("comm-snapshot.db");
+        let config_for = |read_only: bool| KhiveConfig {
+            backends: vec![
+                BackendConfig {
+                    name: BackendId::MAIN.to_string(),
+                    kind: BackendKind::Sqlite,
+                    path: Some(main_path.clone()),
+                    cache_mb: None,
+                    journal_mode: None,
+                    read_only,
+                },
+                BackendConfig {
+                    name: "comm-store".to_string(),
+                    kind: BackendKind::Sqlite,
+                    path: Some(comm_path.clone()),
+                    cache_mb: None,
+                    journal_mode: None,
+                    read_only,
+                },
+            ],
+            packs: HashMap::from([(
+                "comm".to_string(),
+                PackConfig {
+                    backend: "comm-store".to_string(),
+                },
+            )]),
+            ..KhiveConfig::default()
+        };
+
+        let writable = build_registry_for_multi_backend_inner(
+            base_runtime_config_for_multi_backend(),
+            &config_for(false),
+            None,
+        )
+        .expect("prepare exact-current core and pack schemas");
+        drop(writable);
+
+        for path in [&main_path, &comm_path] {
+            let conn = rusqlite::Connection::open(path).unwrap();
+            let mode: String = conn
+                .pragma_update_and_check(None, "journal_mode", "DELETE", |row| row.get(0))
+                .unwrap();
+            assert_eq!(mode.to_ascii_lowercase(), "delete");
+        }
+
+        let snapshot = build_registry_for_multi_backend_inner(
+            base_runtime_config_for_multi_backend(),
+            &config_for(true),
+            None,
+        )
+        .expect("open both declared backends for inspection");
+
+        assert_eq!(
+            snapshot
+                .default_runtime
+                .backend()
+                .pool()
+                .writer_acquisition_snapshot(),
+            khive_db::pool::WriterAcquisitionSnapshot::default(),
+            "main snapshot construction, exact-ledger validation, and kg pack boot must stay \
+             writer-free"
+        );
+        assert!(
+            snapshot.default_runtime.backend().pool().max_readers() > 0,
+            "the main rollback-journal snapshot must retain a dedicated reader pool"
+        );
+        for (pack, runtime) in &snapshot.per_pack_runtimes {
+            assert_eq!(
+                runtime.backend().pool().writer_acquisition_snapshot(),
+                khive_db::pool::WriterAcquisitionSnapshot::default(),
+                "pack {pack:?} snapshot boot must keep its construction-inclusive writer \
+                 baseline at zero"
+            );
+            assert!(
+                runtime.backend().pool().max_readers() > 0,
+                "pack {pack:?} must read its rollback-journal snapshot through a dedicated \
+                 reader"
+            );
+        }
+    }
+
+    #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
+    #[test]
+    #[serial]
+    fn mixed_topology_channel_admission_follows_the_runtime_that_backs_each_loop() {
+        use clap::Parser;
+        use khive_runtime::PackConfig;
+
+        let dir = tempfile::tempdir().unwrap();
+        let main_path = dir.path().join("main-channel.db");
+        let comm_path = dir.path().join("comm-channel.db");
+        let config_for = |main_read_only: bool, comm_read_only: bool| KhiveConfig {
+            backends: vec![
+                BackendConfig {
+                    name: BackendId::MAIN.to_string(),
+                    kind: BackendKind::Sqlite,
+                    path: Some(main_path.clone()),
+                    cache_mb: None,
+                    journal_mode: None,
+                    read_only: main_read_only,
+                },
+                BackendConfig {
+                    name: "comm-store".to_string(),
+                    kind: BackendKind::Sqlite,
+                    path: Some(comm_path.clone()),
+                    cache_mb: None,
+                    journal_mode: None,
+                    read_only: comm_read_only,
+                },
+            ],
+            packs: HashMap::from([(
+                "comm".to_string(),
+                PackConfig {
+                    backend: "comm-store".to_string(),
+                },
+            )]),
+            ..KhiveConfig::default()
+        };
+
+        let seeded = build_registry_for_multi_backend_inner(
+            base_runtime_config_for_multi_backend(),
+            &config_for(false, false),
+            None,
+        )
+        .expect("seed exact-current snapshots");
+        drop(seeded);
+        let daemon = Args::parse_from(["mcp", "--daemon"]);
+
+        let comm_snapshot = build_registry_for_multi_backend_inner(
+            base_runtime_config_for_multi_backend(),
+            &config_for(false, true),
+            None,
+        )
+        .expect("writable kg plus read-only comm topology");
+        let server =
+            build_server_from_multi_backend_registry(comm_snapshot, &config_for(false, true), None);
+        let admission = channel_loop_plan(&server, &daemon);
+        assert!(
+            !admission.inbound_poll,
+            "comm.ingest/cursor/heartbeat are backed by the read-only comm runtime"
+        );
+        assert!(
+            admission.outbound_delivery,
+            "list/update are backed by the writable kg runtime"
+        );
+        drop(server);
+
+        let kg_snapshot = build_registry_for_multi_backend_inner(
+            base_runtime_config_for_multi_backend(),
+            &config_for(true, false),
+            None,
+        )
+        .expect("read-only kg plus writable comm topology");
+        let server =
+            build_server_from_multi_backend_registry(kg_snapshot, &config_for(true, false), None);
+        let admission = channel_loop_plan(&server, &daemon);
+        assert!(
+            admission.inbound_poll,
+            "comm.ingest/cursor/heartbeat are backed by the writable comm runtime"
+        );
+        assert!(
+            !admission.outbound_delivery,
+            "a read-only kg runtime cannot durably claim or mark delivery, so no external send \
+             task may start"
+        );
+    }
+
     /// RAII guard: redirects `HOME` and restores the prior value on drop.
     struct HomeGuard {
         original: Option<std::ffi::OsString>,
@@ -8874,6 +9048,47 @@ backend = "kg-backend"
             );
         }
 
+        #[test]
+        fn email_plan_gates_poll_and_outbox_on_daemon_role_and_backing_runtime_modes() {
+            use clap::Parser;
+
+            let dir = tempfile::tempdir().expect("temp dir");
+            let path = dir.path().join("email-read-only.db");
+            let config = RuntimeConfig {
+                db_path: Some(path),
+                packs: vec!["kg".to_string(), "comm".to_string()],
+                ..RuntimeConfig::no_embeddings()
+            };
+            KhiveRuntime::new(config.clone()).expect("seed exact-current snapshot");
+            let snapshot = KhiveRuntime::new_readonly(config).expect("open read-only snapshot");
+            let server = KhiveMcpServer::new(snapshot).expect("build snapshot server");
+
+            let daemon = Args::parse_from(["mcp", "--daemon"]);
+            let admitted = channel_loop_plan(&server, &daemon);
+            assert!(
+                !admitted.inbound_poll,
+                "email polling must not start when comm.ingest/cursor/heartbeat resolve to a \
+                 read-only runtime"
+            );
+            assert!(
+                !admitted.outbound_delivery,
+                "email delivery must not start when list/update resolve to a read-only runtime"
+            );
+
+            let writable = KhiveRuntime::memory().expect("writable runtime");
+            let server =
+                KhiveMcpServer::with_packs(writable, &["kg".to_string(), "comm".to_string()])
+                    .expect("build writable server");
+            let admitted = channel_loop_plan(&server, &daemon);
+            assert!(admitted.inbound_poll);
+            assert!(admitted.outbound_delivery);
+
+            let client = Args::parse_from(["mcp"]);
+            let admitted = channel_loop_plan(&server, &client);
+            assert!(!admitted.inbound_poll);
+            assert!(!admitted.outbound_delivery);
+        }
+
         #[tokio::test]
         #[serial]
         async fn daemon_role_gate_spawns_without_panic() {
@@ -8919,6 +9134,48 @@ backend = "kg-backend"
             // Client role: the wrapper must take the skip branch and never
             // attempt to construct an EmailChannel at all.
             spawn_email_channel_loops_if_daemon(&server, &args);
+        }
+    }
+
+    #[cfg(feature = "channel-telegram")]
+    mod telegram_channel_loop_admission_tests {
+        use super::*;
+
+        #[test]
+        fn telegram_plan_gates_poll_and_outbox_on_backing_runtime_modes() {
+            use clap::Parser;
+
+            let dir = tempfile::tempdir().expect("temp dir");
+            let path = dir.path().join("telegram-read-only.db");
+            let config = RuntimeConfig {
+                db_path: Some(path),
+                packs: vec!["kg".to_string(), "comm".to_string()],
+                ..RuntimeConfig::no_embeddings()
+            };
+            KhiveRuntime::new(config.clone()).expect("seed exact-current snapshot");
+            let snapshot = KhiveRuntime::new_readonly(config).expect("open read-only snapshot");
+            let server = KhiveMcpServer::new(snapshot).expect("build snapshot server");
+            let daemon = Args::parse_from(["mcp", "--daemon"]);
+
+            let admitted = channel_loop_plan(&server, &daemon);
+            assert!(
+                !admitted.inbound_poll,
+                "Telegram getUpdates must not start when comm.ingest resolves to a read-only \
+                 runtime"
+            );
+            assert!(
+                !admitted.outbound_delivery,
+                "Telegram sendMessage must not start when delivered_at cannot be durably \
+                 recorded by list/update's runtime"
+            );
+
+            let writable = KhiveRuntime::memory().expect("writable runtime");
+            let server =
+                KhiveMcpServer::with_packs(writable, &["kg".to_string(), "comm".to_string()])
+                    .expect("build writable server");
+            let admitted = channel_loop_plan(&server, &daemon);
+            assert!(admitted.inbound_poll);
+            assert!(admitted.outbound_delivery);
         }
     }
 

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -2906,21 +2906,12 @@ pub struct WiringSurface {
     /// The resolved ADR-078 default output format.
     pub output_format: OutputFormat,
     /// Whether the default ingest namespace passes the email loop's gate
-    /// preflight (#503/#602). This is only the authorization half of
-    /// admission; the runtime-mode fields below independently prevent tasks
-    /// backed by read-only runtimes from starting.
+    /// preflight (#503/#602). This captures only the existing public
+    /// authorization surface; runtime-mode admission remains private server
+    /// wiring and independently prevents read-only-backed tasks from starting.
     /// Only meaningful when the `channel-email` feature is compiled in.
     #[cfg(feature = "channel-email")]
     pub channel_loop_eligible: bool,
-    /// Runtime-mode half of channel-loop admission. These values deliberately
-    /// remain independent in mixed topologies: inbound `comm.*` writes and
-    /// outbound generic KG mutations can resolve to different backends.
-    #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
-    pub channel_inbound_poll_admitted: bool,
-    /// Whether the runtime serving generic `list`/`update` is writable, so an
-    /// external delivery can be durably claimed and marked complete.
-    #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
-    pub channel_outbound_delivery_admitted: bool,
 }
 
 impl WiringSurface {
@@ -2934,10 +2925,6 @@ impl WiringSurface {
                 &ingest_namespace_from_env(),
                 &server.verb_registry_clone(),
             ),
-            #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
-            channel_inbound_poll_admitted: server.channel_loop_admission().inbound_poll,
-            #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
-            channel_outbound_delivery_admitted: server.channel_loop_admission().outbound_delivery,
         }
     }
 }

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -5569,6 +5569,9 @@ region = "us-east-1"
         backend
             .prepare_core_schema()
             .expect("prepare exact-current migration ledger");
+        drop(backend);
+        #[cfg(unix)]
+        freeze_snapshot_sidecars(path);
     }
 
     fn blob_only_runtime_config() -> RuntimeConfig {
@@ -6704,6 +6707,8 @@ region = "us-east-1"
         ])
         .expect("DDL on rw backend");
         drop(rw);
+        #[cfg(unix)]
+        freeze_snapshot_sidecars(&db_path);
 
         // Re-open read-only and confirm writes fail.
         let ro = StorageBackend::sqlite_read_only(&db_path).expect("ro backend");

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -202,6 +202,19 @@ fn is_daemon_role(args: &Args) -> bool {
     args.daemon
 }
 
+/// Combine process role with the fixed runtime-mode admission captured when
+/// the server was built. A daemon flag alone never authorizes background
+/// writes: each loop is admitted only when the runtime serving its verbs is
+/// writable in the resolved single- or multi-backend topology.
+#[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
+fn channel_loop_plan(server: &KhiveMcpServer, args: &Args) -> crate::server::ChannelLoopAdmission {
+    if args.daemon {
+        server.channel_loop_admission()
+    } else {
+        crate::server::ChannelLoopAdmission::default()
+    }
+}
+
 /// Handle for the ADR-091 Amendment 2 Plank A session sweep task. Dropping
 /// the sender alone is NOT a sufficient shutdown contract (minor, ADR-091
 /// Amendment 2): the sweep task's own clean-shutdown heartbeat
@@ -332,23 +345,33 @@ async fn serve_holding_sweep(
     result
 }
 
-/// Spawn the email channel loops if — and only if — `args` indicates this
-/// process is the daemon (#602). Shared by both serve entrypoints (`run` and
-/// `serve_server`) so the role gate lives in exactly one place instead of
-/// being duplicated at each call site. Emits one `tracing::info!` line either
-/// way so the decision is visible at startup (seeds #606's health surface).
+/// Admit each email channel loop only when this is the daemon process and the
+/// runtime that backs that loop's verbs is writable. Shared by both serve
+/// entrypoints (`run` and `serve_server`) so neither role nor storage-mode
+/// gating can drift between single- and multi-backend boot paths.
 ///
 /// If no daemon is running, mail is simply not polled until one starts — that
 /// is the intended behavior, not a silent failure; the log line makes it
 /// observable.
 #[cfg(feature = "channel-email")]
 fn spawn_email_channel_loops_if_daemon(server: &KhiveMcpServer, args: &Args) {
-    if is_daemon_role(args) {
-        tracing::info!("email channel loops: spawning (daemon role)");
-        spawn_email_channel_loops(server);
-    } else {
+    let admission = channel_loop_plan(server, args);
+    if !is_daemon_role(args) {
         tracing::info!("email channel loops: skipped (client role; daemon owns channel loops)");
+        return;
     }
+    if !admission.inbound_poll && !admission.outbound_delivery {
+        tracing::info!(
+            "email channel loops: skipped (assigned comm and kg runtimes do not admit writes)"
+        );
+        return;
+    }
+    tracing::info!(
+        inbound_poll = admission.inbound_poll,
+        outbound_delivery = admission.outbound_delivery,
+        "email channel loops: applying daemon/runtime admission"
+    );
+    spawn_email_channel_loops(server, admission);
 }
 
 /// Start ADR-119 daemon components in daemon role only. Non-daemon roles
@@ -379,11 +402,14 @@ fn writable_schedule_runtime(runtime: Option<KhiveRuntime>) -> Option<KhiveRunti
 
 /// Spawn the email channel polling + outbox loops if the `channel-email`
 /// feature is enabled and `KHIVE_EMAIL_*` config resolves. Non-fatal: logs a
-/// warning and returns on incomplete config. Only call this when
-/// [`is_daemon_role`] is true — use [`spawn_email_channel_loops_if_daemon`],
-/// which both serve entrypoints (`run` and `serve_server`) call.
+/// warning and returns on incomplete config. Only call this with the
+/// role-and-runtime admission returned by [`channel_loop_plan`] — use
+/// [`spawn_email_channel_loops_if_daemon`], which both serve entrypoints call.
 #[cfg(feature = "channel-email")]
-fn spawn_email_channel_loops(server: &KhiveMcpServer) {
+fn spawn_email_channel_loops(
+    server: &KhiveMcpServer,
+    admission: crate::server::ChannelLoopAdmission,
+) {
     use khive_channel::ChannelRegistry;
     use khive_channel_email::EmailChannel;
     use std::sync::Arc;
@@ -416,41 +442,46 @@ fn spawn_email_channel_loops(server: &KhiveMcpServer) {
             let runtime_outbox = runtime.clone();
 
             let spawned = run_if_authorized(&ingest_ns, &verb_reg, || {
-                tokio::task::spawn(async move {
-                    if let Err(error) = ensure_channel_quarantine_storage(&verb_reg_poll).await {
-                        tracing::error!(
-                            error = %error,
-                            "email polling disabled: quarantine blob storage is unavailable"
-                        );
-                        return;
-                    }
-                    channel_poll_loop(
-                        ch_registry,
-                        verb_reg_poll,
-                        ingest_ns_clone,
-                        default_actor_clone,
-                    )
-                    .await;
-                });
-                match runtime_outbox {
-                    Some(rt) => {
-                        tokio::task::spawn(channel_outbox_loop(
-                            email_ch_clone,
-                            verb_reg_outbox,
-                            rt,
-                            ingest_ns_outbox,
-                            mailbox_clone,
-                            allowlist_clone,
-                        ));
-                        tracing::info!("email channel polling and outbox loops started");
-                    }
-                    None => {
-                        tracing::error!(
-                            "email polling started but the outbox loop was NOT started: server \
-                             has no default-backend runtime handle, which the outbox loop needs \
-                             to claim external_id on outbound notes; outbound mail will not be \
-                             sent"
-                        );
+                if admission.inbound_poll {
+                    tokio::task::spawn(async move {
+                        if let Err(error) = ensure_channel_quarantine_storage(&verb_reg_poll).await
+                        {
+                            tracing::error!(
+                                error = %error,
+                                "email polling disabled: quarantine blob storage is unavailable"
+                            );
+                            return;
+                        }
+                        channel_poll_loop(
+                            ch_registry,
+                            verb_reg_poll,
+                            ingest_ns_clone,
+                            default_actor_clone,
+                        )
+                        .await;
+                    });
+                    tracing::info!("email channel polling loop started");
+                }
+                if admission.outbound_delivery {
+                    match runtime_outbox {
+                        Some(rt) => {
+                            tokio::task::spawn(channel_outbox_loop(
+                                email_ch_clone,
+                                verb_reg_outbox,
+                                rt,
+                                ingest_ns_outbox,
+                                mailbox_clone,
+                                allowlist_clone,
+                            ));
+                            tracing::info!("email channel outbox loop started");
+                        }
+                        None => {
+                            tracing::error!(
+                                "email outbox loop was NOT started: server has no default-backend \
+                                 runtime handle, which the loop needs to claim external_id on \
+                                 outbound notes; outbound mail will not be sent"
+                            );
+                        }
                     }
                 }
             });
@@ -1564,32 +1595,34 @@ async fn channel_outbox_loop(
     }
 }
 
-/// Whether this process owns the Telegram channel loops. Mirrors
-/// [`is_daemon_role`]'s email-channel role gate (#602): channel loops are a
-/// daemon-role responsibility, never spawned per client process.
-#[cfg(feature = "channel-telegram")]
-fn is_telegram_daemon_role(args: &Args) -> bool {
-    args.daemon
-}
-
-/// Spawn the Telegram channel loops if — and only if — `args` indicates this
-/// process is the daemon. Mirrors
-/// [`spawn_email_channel_loops_if_daemon`]. If no daemon is running, Telegram
-/// is simply not polled until one starts.
+/// Apply the same independent daemon/runtime admission as the email adapter:
+/// Telegram polling follows the comm runtime, while outbound delivery follows
+/// the kg runtime that must durably mark `delivered_at`.
 #[cfg(feature = "channel-telegram")]
 fn spawn_telegram_channel_loops_if_daemon(server: &KhiveMcpServer, args: &Args) {
-    if is_telegram_daemon_role(args) {
-        tracing::info!("telegram channel loops: spawning (daemon role)");
-        spawn_telegram_channel_loops(server);
-    } else {
+    let admission = channel_loop_plan(server, args);
+    if !args.daemon {
         tracing::info!("telegram channel loops: skipped (client role; daemon owns channel loops)");
+        return;
     }
+    if !admission.inbound_poll && !admission.outbound_delivery {
+        tracing::info!(
+            "telegram channel loops: skipped (assigned comm and kg runtimes do not admit writes)"
+        );
+        return;
+    }
+    tracing::info!(
+        inbound_poll = admission.inbound_poll,
+        outbound_delivery = admission.outbound_delivery,
+        "telegram channel loops: applying daemon/runtime admission"
+    );
+    spawn_telegram_channel_loops(server, admission);
 }
 
 /// Spawn the Telegram channel polling + outbox loops if the `channel-telegram`
 /// feature is enabled and `KHIVE_TELEGRAM_*` config resolves. Non-fatal: logs
-/// a warning and returns on incomplete config. Only call this when
-/// [`is_telegram_daemon_role`] is true — use
+/// a warning and returns on incomplete config. Only call this with the
+/// role-and-runtime admission returned by [`channel_loop_plan`] — use
 /// [`spawn_telegram_channel_loops_if_daemon`].
 ///
 /// Unlike the email adapter, Telegram's poll offset is held in memory inside
@@ -1600,7 +1633,10 @@ fn spawn_telegram_channel_loops_if_daemon(server: &KhiveMcpServer, args: &Args) 
 /// this ADR explicitly does not require for Telegram's simpler getUpdates
 /// durability model.
 #[cfg(feature = "channel-telegram")]
-fn spawn_telegram_channel_loops(server: &KhiveMcpServer) {
+fn spawn_telegram_channel_loops(
+    server: &KhiveMcpServer,
+    admission: crate::server::ChannelLoopAdmission,
+) {
     use khive_channel_telegram::TelegramChannel;
     use std::sync::Arc;
 
@@ -1618,22 +1654,28 @@ fn spawn_telegram_channel_loops(server: &KhiveMcpServer) {
             let tg_ch_outbox = Arc::clone(&tg_ch);
 
             let spawned = run_if_authorized(&ingest_ns, &verb_reg, || {
-                tokio::task::spawn(async move {
-                    if let Err(error) = ensure_channel_quarantine_storage(&verb_reg_poll).await {
-                        tracing::error!(
-                            error = %error,
-                            "telegram polling disabled: quarantine blob storage is unavailable"
-                        );
-                        return;
-                    }
-                    telegram_poll_loop(tg_ch_poll, verb_reg_poll, ingest_ns_poll).await;
-                });
-                tokio::task::spawn(telegram_outbox_loop(
-                    tg_ch_outbox,
-                    verb_reg_outbox,
-                    ingest_ns_outbox,
-                ));
-                tracing::info!("telegram channel polling and outbox loops started");
+                if admission.inbound_poll {
+                    tokio::task::spawn(async move {
+                        if let Err(error) = ensure_channel_quarantine_storage(&verb_reg_poll).await
+                        {
+                            tracing::error!(
+                                error = %error,
+                                "telegram polling disabled: quarantine blob storage is unavailable"
+                            );
+                            return;
+                        }
+                        telegram_poll_loop(tg_ch_poll, verb_reg_poll, ingest_ns_poll).await;
+                    });
+                    tracing::info!("telegram channel polling loop started");
+                }
+                if admission.outbound_delivery {
+                    tokio::task::spawn(telegram_outbox_loop(
+                        tg_ch_outbox,
+                        verb_reg_outbox,
+                        ingest_ns_outbox,
+                    ));
+                    tracing::info!("telegram channel outbox loop started");
+                }
             });
             if !spawned {
                 tracing::error!(
@@ -2772,6 +2814,11 @@ pub fn build_server_from_multi_backend_registry(
     khive_cfg: &KhiveConfig,
     coordinator: Option<Arc<dyn crate::coordinator::CoordinatorService>>,
 ) -> KhiveMcpServer {
+    #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
+    let channel_loop_admission = crate::server::ChannelLoopAdmission::for_pack_runtimes(
+        multi.per_pack_runtimes.get("kg").map(Arc::as_ref),
+        multi.per_pack_runtimes.get("comm").map(Arc::as_ref),
+    );
     // Wire the main backend's pool for background WAL checkpointing. The pool is
     // only present for file-backed databases; in-memory backends return None here
     // so that checkpoint_once never runs on a non-WAL connection.
@@ -2792,6 +2839,9 @@ pub fn build_server_from_multi_backend_registry(
     .with_default_output_format(fmt)
     .with_secondary_pools(secondary_pools)
     .with_runtime(default_runtime);
+
+    #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
+    let server = server.with_channel_loop_admission(channel_loop_admission);
 
     let server = match coordinator {
         Some(c) => server.with_coordinator(c),
@@ -2855,15 +2905,22 @@ pub struct WiringSurface {
     pub has_checkpoint_pool: bool,
     /// The resolved ADR-078 default output format.
     pub output_format: OutputFormat,
-    /// Whether the default ingest namespace would authorize the email
-    /// channel loops to start if this process runs in the daemon role
-    /// (#503/#602). The actual spawn is arg-driven at `run`/`serve_server`
-    /// (#610), not construction time, but the *authorization* outcome is a
-    /// function of how the registry's gate was wired during construction —
-    /// this field is the construction-time state that decision reads.
+    /// Whether the default ingest namespace passes the email loop's gate
+    /// preflight (#503/#602). This is only the authorization half of
+    /// admission; the runtime-mode fields below independently prevent tasks
+    /// backed by read-only runtimes from starting.
     /// Only meaningful when the `channel-email` feature is compiled in.
     #[cfg(feature = "channel-email")]
     pub channel_loop_eligible: bool,
+    /// Runtime-mode half of channel-loop admission. These values deliberately
+    /// remain independent in mixed topologies: inbound `comm.*` writes and
+    /// outbound generic KG mutations can resolve to different backends.
+    #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
+    pub channel_inbound_poll_admitted: bool,
+    /// Whether the runtime serving generic `list`/`update` is writable, so an
+    /// external delivery can be durably claimed and marked complete.
+    #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
+    pub channel_outbound_delivery_admitted: bool,
 }
 
 impl WiringSurface {
@@ -2877,6 +2934,10 @@ impl WiringSurface {
                 &ingest_namespace_from_env(),
                 &server.verb_registry_clone(),
             ),
+            #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
+            channel_inbound_poll_admitted: server.channel_loop_admission().inbound_poll,
+            #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
+            channel_outbound_delivery_admitted: server.channel_loop_admission().outbound_delivery,
         }
     }
 }
@@ -9017,7 +9078,7 @@ backend = "kg-backend"
 
             // Must not panic: EmailChannel::from_env() fails closed on the missing
             // KHIVE_EMAIL_SMTP_HOST and the fn logs a warning and returns.
-            spawn_email_channel_loops(&server);
+            spawn_email_channel_loops(&server, server.channel_loop_admission());
         }
 
         /// Regression for #602: `spawn_email_channel_loops_if_daemon` is the
@@ -9101,11 +9162,11 @@ backend = "kg-backend"
                 default_namespace: Namespace::parse("test").unwrap(),
                 embedding_model: None,
                 additional_embedding_models: vec![],
-                packs: vec!["kg".to_string()],
+                packs: vec!["kg".to_string(), "comm".to_string()],
                 ..RuntimeConfig::default()
             };
             let runtime = KhiveRuntime::new(config).expect("in-memory runtime");
-            let server = KhiveMcpServer::new(runtime).expect("server builds with kg");
+            let server = KhiveMcpServer::new(runtime).expect("server builds with kg + comm");
 
             // Daemon role: the wrapper must take the spawn branch (still fails
             // closed on missing KHIVE_EMAIL_* — no network I/O — but must not

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -2152,6 +2152,50 @@ fn override_matches_declared_main_backend(
         == canonical_path_no_side_effects(std::path::Path::new(override_path))?)
 }
 
+/// Refuse a declared writable SQLite backend whose current filesystem mode is
+/// already read-only, without opening SQLite or creating any path.
+///
+/// The multi-backend boot path performs the same check after open so its
+/// captured runtime identity remains authoritative. Pre-open clients must run
+/// this narrower probe before daemon forwarding as well: a warm daemon may
+/// still hold a write-capable handle acquired before a later chmod, and the
+/// declaration-only topology fingerprint would otherwise route the request to
+/// that retained writer. A force-memory override supersedes every declared
+/// path and must skip this helper entirely at its call site.
+pub fn validate_declared_backend_access_modes(backends: &[BackendConfig]) -> anyhow::Result<()> {
+    for backend in backends {
+        if backend.kind != BackendKind::Sqlite || backend.read_only {
+            continue;
+        }
+        let Some(path) = backend.path.as_ref() else {
+            continue;
+        };
+        let expanded = khive_runtime::expand_tilde(path);
+        let metadata = match std::fs::metadata(&expanded) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(anyhow::anyhow!(
+                    "backend {}: cannot inspect filesystem access mode for {} before daemon \
+                     forwarding: {error}",
+                    backend.name,
+                    expanded.display(),
+                ));
+            }
+        };
+        if metadata.permissions().readonly() {
+            anyhow::bail!(
+                "backend {}: path {} has no filesystem write bits; declare `read_only = true` \
+                 so backend topology and daemon config identity describe the snapshot-inspection \
+                 mode explicitly (request was refused before daemon forwarding)",
+                backend.name,
+                expanded.display(),
+            );
+        }
+    }
+    Ok(())
+}
+
 fn build_registry_for_multi_backend_inner(
     mut base_config: RuntimeConfig,
     khive_cfg: &KhiveConfig,
@@ -2249,8 +2293,11 @@ fn build_registry_for_multi_backend_inner(
     // boot produces (`default_runtime` plus each per-pack runtime), so a
     // pack that later reads `KhiveRuntime::blob_store()` sees the same
     // selection regardless of which backend its own KG data lives on.
+    let blob_store_runtime = per_pack_runtimes_local
+        .get("blob")
+        .unwrap_or(&default_runtime);
     if let Some(store) =
-        install_resolved_blob_store(&default_runtime, khive_cfg, main_backend.as_ref())?
+        install_resolved_blob_store(blob_store_runtime, khive_cfg, main_backend.as_ref())?
     {
         for rt in per_pack_runtimes_local.values() {
             rt.install_blob_store(store.clone());
@@ -2972,7 +3019,7 @@ pub fn install_resolved_blob_store(
     khive_cfg: &KhiveConfig,
     backend: &StorageBackend,
 ) -> anyhow::Result<Option<Arc<dyn khive_storage::BlobStore>>> {
-    match khive_runtime::resolve_blob_store(khive_cfg, backend) {
+    match khive_runtime::resolve_blob_store_for_mode(khive_cfg, backend, rt.is_read_only()) {
         Ok(store) => {
             rt.install_blob_store(store.clone());
             Ok(Some(store))
@@ -5284,11 +5331,12 @@ region = "us-east-1"
     }
 
     impl ClearedKhiveEnvGuard {
-        const VARS: [&'static str; 4] = [
+        const VARS: [&'static str; 5] = [
             "KHIVE_DB",
             "KHIVE_ACTOR",
             "KHIVE_PACKS",
             "KHIVE_REQUIRE_ATTRIBUTED_ACTOR",
+            "KHIVE_BLOB_ROOT",
         ];
 
         fn clear() -> Self {
@@ -5494,6 +5542,184 @@ region = "us-east-1"
             Err(khive_storage::StorageError::CapacityFloor { .. }) => {}
             Err(other) => panic!("fs-default store must accept a write: {other:?}"),
         }
+    }
+
+    fn prepare_current_snapshot_source(path: &std::path::Path) {
+        let backend = StorageBackend::sqlite(path).expect("create snapshot source");
+        backend
+            .prepare_core_schema()
+            .expect("prepare exact-current migration ledger");
+    }
+
+    fn blob_only_runtime_config() -> RuntimeConfig {
+        RuntimeConfig {
+            packs: vec!["blob".to_string()],
+            ..base_runtime_config_for_multi_backend()
+        }
+    }
+
+    /// The default fs root is optional when no `[storage.blob]` section was
+    /// declared. A snapshot boot must not create that directory merely by
+    /// installing the blob pack, and `blob.put` must report the pack runtime's
+    /// read-only mode before attempting any physical store write.
+    #[tokio::test]
+    #[serial]
+    async fn read_only_single_backend_neither_creates_blob_root_nor_accepts_blob_put() {
+        let _env = ClearedKhiveEnvGuard::clear();
+        let dir = tempfile::tempdir().unwrap();
+        let main_path = dir.path().join("snapshot.db");
+        let blob_root = dir.path().join("blobs");
+        prepare_current_snapshot_source(&main_path);
+
+        let khive_cfg = KhiveConfig {
+            backends: vec![BackendConfig {
+                name: BackendId::MAIN.to_string(),
+                kind: BackendKind::Sqlite,
+                path: Some(main_path),
+                cache_mb: None,
+                journal_mode: None,
+                read_only: true,
+            }],
+            ..KhiveConfig::default()
+        };
+        let multi = build_registry_for_multi_backend(blob_only_runtime_config(), &khive_cfg, None)
+            .expect("read-only blob-pack registry must boot without creating a store");
+        assert!(
+            !blob_root.exists(),
+            "snapshot boot must not materialize the default FsBlobStore root"
+        );
+
+        let error = multi
+            .registry
+            .dispatch("blob.put", serde_json::json!({"bytes": "YQ=="}))
+            .await
+            .expect_err("blob.put must reject on its read-only pack runtime");
+        assert!(error.to_string().contains("read-only"), "{error}");
+        assert!(
+            !blob_root.exists(),
+            "the rejected put must remain side-effect free"
+        );
+    }
+
+    /// Mixed topology is governed by the runtime assigned to the blob pack,
+    /// not by the main audit backend. A writable main must not accidentally
+    /// make a read-only blob secondary writable or create its default fs root.
+    #[tokio::test]
+    #[serial]
+    async fn read_only_blob_secondary_refuses_put_beside_writable_main() {
+        use khive_runtime::PackConfig;
+
+        let _env = ClearedKhiveEnvGuard::clear();
+        let dir = tempfile::tempdir().unwrap();
+        let main_path = dir.path().join("main.db");
+        let archive_path = dir.path().join("blob-snapshot.db");
+        let blob_root = dir.path().join("blobs");
+        prepare_current_snapshot_source(&main_path);
+        prepare_current_snapshot_source(&archive_path);
+
+        let khive_cfg = KhiveConfig {
+            backends: vec![
+                BackendConfig {
+                    name: BackendId::MAIN.to_string(),
+                    kind: BackendKind::Sqlite,
+                    path: Some(main_path),
+                    cache_mb: None,
+                    journal_mode: None,
+                    read_only: false,
+                },
+                BackendConfig {
+                    name: "blob-snapshot".to_string(),
+                    kind: BackendKind::Sqlite,
+                    path: Some(archive_path),
+                    cache_mb: None,
+                    journal_mode: None,
+                    read_only: true,
+                },
+            ],
+            packs: HashMap::from([(
+                "blob".to_string(),
+                PackConfig {
+                    backend: "blob-snapshot".to_string(),
+                },
+            )]),
+            ..KhiveConfig::default()
+        };
+        let multi = build_registry_for_multi_backend(blob_only_runtime_config(), &khive_cfg, None)
+            .expect("mixed topology must boot");
+        let error = multi
+            .registry
+            .dispatch("blob.put", serde_json::json!({"bytes": "YQ=="}))
+            .await
+            .expect_err("read-only blob secondary must reject put");
+        assert!(error.to_string().contains("read-only"), "{error}");
+        assert!(
+            !blob_root.exists(),
+            "main writability must not create storage for a read-only blob pack"
+        );
+    }
+
+    /// Positive mixed-topology counterpart: a read-only main does not disable
+    /// a blob pack explicitly routed to a writable secondary.
+    #[tokio::test]
+    #[serial]
+    async fn writable_blob_secondary_accepts_put_beside_read_only_main() {
+        use khive_runtime::PackConfig;
+
+        let _env = ClearedKhiveEnvGuard::clear();
+        let dir = tempfile::tempdir().unwrap();
+        let main_path = dir.path().join("main-snapshot.db");
+        let blob_db = dir.path().join("blob-writable.db");
+        let blob_root = dir.path().join("writable-blobs");
+        prepare_current_snapshot_source(&main_path);
+        prepare_current_snapshot_source(&blob_db);
+
+        let khive_cfg = KhiveConfig {
+            backends: vec![
+                BackendConfig {
+                    name: BackendId::MAIN.to_string(),
+                    kind: BackendKind::Sqlite,
+                    path: Some(main_path),
+                    cache_mb: None,
+                    journal_mode: None,
+                    read_only: true,
+                },
+                BackendConfig {
+                    name: "blob-writable".to_string(),
+                    kind: BackendKind::Sqlite,
+                    path: Some(blob_db),
+                    cache_mb: None,
+                    journal_mode: None,
+                    read_only: false,
+                },
+            ],
+            packs: HashMap::from([(
+                "blob".to_string(),
+                PackConfig {
+                    backend: "blob-writable".to_string(),
+                },
+            )]),
+            storage: StorageSectionConfig {
+                blob: Some(BlobConfig::Fs {
+                    root: Some(blob_root.display().to_string()),
+                    floor_bytes: Some(0),
+                }),
+            },
+            ..KhiveConfig::default()
+        };
+        let multi = build_registry_for_multi_backend(blob_only_runtime_config(), &khive_cfg, None)
+            .expect("writable blob secondary must boot beside read-only main");
+        let result = multi
+            .registry
+            .dispatch("blob.put", serde_json::json!({"bytes": "YQ=="}))
+            .await;
+        assert!(
+            result.is_ok(),
+            "writable blob secondary must accept put: {result:?}"
+        );
+        assert!(
+            blob_root.exists(),
+            "writable blob storage may materialize its root"
+        );
     }
 
     /// Regression for ADR-073: a pack assigned to a secondary backend must

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -3507,6 +3507,26 @@ fn apply_config_pack_selection(
 mod tests {
     use super::*;
     use khive_runtime::{BlobConfig, Namespace, StorageSectionConfig};
+
+    // Freeze lingering `-wal`/`-shm` sidecars left by a writable fixture whose
+    // connections close asynchronously; read-only admission rejects a writable
+    // `-shm` as potentially live.
+    #[cfg(unix)]
+    fn freeze_snapshot_sidecars(path: &std::path::Path) {
+        use std::os::unix::fs::PermissionsExt;
+        for suffix in ["-wal", "-shm"] {
+            let mut name = path.file_name().expect("db file name").to_os_string();
+            name.push(suffix);
+            let sidecar = path.parent().expect("db parent dir").join(name);
+            if sidecar.exists() {
+                let mut permissions = std::fs::metadata(&sidecar)
+                    .expect("sidecar metadata")
+                    .permissions();
+                permissions.set_mode(0o444);
+                std::fs::set_permissions(&sidecar, permissions).expect("freeze sidecar");
+            }
+        }
+    }
     use serial_test::serial;
     use std::io::Write;
 
@@ -6747,6 +6767,7 @@ region = "us-east-1"
         let mut permissions = std::fs::metadata(&db_path).unwrap().permissions();
         permissions.set_mode(0o444);
         std::fs::set_permissions(&db_path, permissions).unwrap();
+        freeze_snapshot_sidecars(&db_path);
 
         let config = BackendConfig {
             name: "archive".to_string(),
@@ -8358,6 +8379,7 @@ region = "us-east-1"
         let mut permissions = std::fs::metadata(&db).unwrap().permissions();
         permissions.set_mode(0o444);
         std::fs::set_permissions(&db, permissions).unwrap();
+        freeze_snapshot_sidecars(&db);
 
         use clap::Parser;
         let args = Args::parse_from(["mcp", "--db", db.to_str().expect("utf8 path"), "--no-embed"]);
@@ -8413,6 +8435,7 @@ region = "us-east-1"
         let mut permissions = std::fs::metadata(&main_db).unwrap().permissions();
         permissions.set_mode(0o444);
         std::fs::set_permissions(&main_db, permissions).unwrap();
+        freeze_snapshot_sidecars(&main_db);
 
         let config_path = write_config(
             seat_dir.path(),
@@ -8477,6 +8500,7 @@ backend = "schedule-backend"
             .permissions();
         permissions.set_mode(0o444);
         std::fs::set_permissions(&read_only_schedule_db, permissions).unwrap();
+        freeze_snapshot_sidecars(&read_only_schedule_db);
         let writable_main_db = seat_dir.path().join("writable-main.db");
         KhiveRuntime::new(RuntimeConfig {
             db_path: Some(writable_main_db.clone()),

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -237,7 +237,9 @@ impl DispatchFailure {
 /// declaration, the backend topology (sorted backend list, explicit read-only
 /// modes, and pack→backend assignments) is folded into the fingerprint so that
 /// two configs differing only in routing or access mode produce different ids
-/// (ADR-049 / B-SHOULD-FIX-4).
+/// (ADR-049 / B-SHOULD-FIX-4). Delimiter-free topologies retain their legacy
+/// spelling; a topology containing reserved delimiter text uses an injective,
+/// escaped v2 encoding so path data can never impersonate access mode.
 ///
 /// When `khive_cfg` is `None` or its `backends` list is empty, a writable
 /// target remains byte-identical to what it would have been before this
@@ -300,16 +302,18 @@ fn configured_storage_read_only(
     })
 }
 
-/// Test-only storage-policy variant of [`compute_config_id`].
+/// Compute the daemon identity with an authoritative effective storage mode.
 ///
 /// A chmod-detected snapshot has the same configured path as its writable
 /// source but cannot safely share a warm daemon with it: the writable daemon
 /// would omit the audit advisory and could retain a write-capable file handle.
 /// Fold the effective main-backend mode into the existing `backend` component
 /// so the mismatch remains parseable as a structured backend mismatch without
-/// changing the legacy fingerprint for writable runtimes.
-#[cfg(test)]
-pub(crate) fn compute_config_id_with_storage_mode(
+/// changing the legacy fingerprint for writable runtimes. Pre-open callers
+/// that have already applied a storage override (for example, multi-backend
+/// `--db :memory:`) must use this form rather than re-reading the superseded
+/// declaration through [`compute_config_id`].
+pub fn compute_config_id_with_storage_mode(
     config: &RuntimeConfig,
     khive_cfg: Option<&khive_runtime::KhiveConfig>,
     storage_read_only: bool,
@@ -395,38 +399,119 @@ pub(crate) fn compute_config_id_with_runtime_policies(
     // with the pre-change fingerprint.
     let topology = khive_cfg
         .filter(|cfg| !cfg.backends.is_empty())
-        .map(|cfg| {
-            let mut backend_entries: Vec<String> = cfg
-                .backends
-                .iter()
-                .map(|b| {
-                    let path = b
-                        .path
-                        .as_deref()
-                        .map(canonical_fingerprint_path)
-                        .unwrap_or_else(|| ":memory:".to_string());
-                    let read_only = if b.read_only { ":read_only" } else { "" };
-                    format!("{}:{:?}:{}{}", b.name, b.kind, path, read_only)
-                })
-                .collect();
-            backend_entries.sort();
-
-            let mut pack_entries: Vec<String> = cfg
-                .packs
-                .iter()
-                .map(|(pack, pc)| format!("{}={}", pack, pc.backend))
-                .collect();
-            pack_entries.sort();
-
-            format!(
-                ";backends=[{}];pack_backends=[{}]",
-                backend_entries.join(","),
-                pack_entries.join(","),
-            )
-        })
+        .map(encode_backend_topology)
         .unwrap_or_default();
 
     format!("{base}{topology}")
+}
+
+/// Reserved syntax in the legacy topology spelling.
+///
+/// Keeping the legacy representation when every caller-controlled component
+/// excludes these bytes preserves existing warm-daemon identities without
+/// retaining its ambiguity. The v2 marker itself contains `|`, so a safe
+/// legacy value can never equal a v2 value.
+fn legacy_topology_component_is_safe(value: &str) -> bool {
+    !value
+        .bytes()
+        .any(|byte| matches!(byte, b':' | b',' | b'[' | b']' | b'=' | b';' | b'|'))
+}
+
+/// Percent-encode a v2 topology field so its payload can contain none of the
+/// structural `:`, `,`, or `=` delimiters. `%` itself is always escaped, making
+/// the mapping injective over the original UTF-8 bytes.
+fn escape_topology_component(value: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut escaped = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'/') {
+            escaped.push(byte as char);
+        } else {
+            escaped.push('%');
+            escaped.push(HEX[(byte >> 4) as usize] as char);
+            escaped.push(HEX[(byte & 0x0f) as usize] as char);
+        }
+    }
+    escaped
+}
+
+fn encode_backend_topology(cfg: &khive_runtime::KhiveConfig) -> String {
+    let mut legacy_safe = true;
+    let mut backend_rows: Vec<(String, String, String, bool)> = cfg
+        .backends
+        .iter()
+        .map(|backend| {
+            let kind = format!("{:?}", backend.kind);
+            let path = backend
+                .path
+                .as_deref()
+                .map(canonical_fingerprint_path)
+                .unwrap_or_else(|| ":memory:".to_string());
+            legacy_safe &= legacy_topology_component_is_safe(&backend.name)
+                && legacy_topology_component_is_safe(&kind)
+                && backend
+                    .path
+                    .is_none_or(|_| legacy_topology_component_is_safe(&path));
+            (backend.name.clone(), kind, path, backend.read_only)
+        })
+        .collect();
+    backend_rows.sort();
+
+    let mut pack_rows: Vec<(String, String)> = cfg
+        .packs
+        .iter()
+        .map(|(pack, pack_config)| {
+            legacy_safe &= legacy_topology_component_is_safe(pack)
+                && legacy_topology_component_is_safe(&pack_config.backend);
+            (pack.clone(), pack_config.backend.clone())
+        })
+        .collect();
+    pack_rows.sort();
+
+    let (backends, pack_backends) = if legacy_safe {
+        let backends = backend_rows
+            .iter()
+            .map(|(name, kind, path, is_read_only)| {
+                let read_only = if *is_read_only { ":read_only" } else { "" };
+                format!("{name}:{kind}:{path}{read_only}")
+            })
+            .collect::<Vec<_>>()
+            .join(",");
+        let pack_backends = pack_rows
+            .iter()
+            .map(|(pack, backend)| format!("{pack}={backend}"))
+            .collect::<Vec<_>>()
+            .join(",");
+        (backends, pack_backends)
+    } else {
+        let backends = backend_rows
+            .iter()
+            .map(|(name, kind, path, read_only)| {
+                let mode = if *read_only { "r" } else { "w" };
+                format!(
+                    "{}:{}:{}:{mode}",
+                    escape_topology_component(name),
+                    escape_topology_component(kind),
+                    escape_topology_component(path),
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(",");
+        let pack_backends = pack_rows
+            .iter()
+            .map(|(pack, backend)| {
+                format!(
+                    "{}={}",
+                    escape_topology_component(pack),
+                    escape_topology_component(backend),
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(",");
+        (format!("v2|{backends}"), format!("v2|{pack_backends}"))
+    };
+
+    format!(";backends=[{backends}];pack_backends=[{pack_backends}]")
 }
 
 /// Resolve any path headed into `config_id` fingerprinting — a declared
@@ -4177,6 +4262,111 @@ mod tests {
             "two projects declaring the same relative backend path string from \
              different working directories must not share a config_id; both \
              produced: {id_a}"
+        );
+    }
+
+    /// A backend path is caller-controlled data, so the legacy `:read_only`
+    /// suffix must never be confusable with literal path text. Before this
+    /// regression, these two distinct archive backends produced the same
+    /// topology string and could therefore share the wrong warm daemon:
+    ///
+    /// - read-only `/.../archive.db`
+    /// - writable `/.../archive.db:read_only`
+    #[test]
+    fn config_id_does_not_confuse_read_only_mode_with_a_path_suffix() {
+        use khive_runtime::{BackendConfig, BackendId, BackendKind, KhiveConfig, PackConfig};
+
+        let dir = tempfile::tempdir().expect("topology collision tempdir");
+        let main_path = dir.path().join("main.db");
+        let archive_path = dir.path().join("archive.db");
+        let literal_suffix_path = dir.path().join("archive.db:read_only");
+        let runtime = RuntimeConfig {
+            db_path: Some(main_path.clone()),
+            packs: vec!["kg".to_string(), "knowledge".to_string()],
+            backend_id: BackendId::main(),
+            ..RuntimeConfig::no_embeddings()
+        };
+
+        let topology = |path, read_only| KhiveConfig {
+            backends: vec![
+                BackendConfig {
+                    name: "main".to_string(),
+                    kind: BackendKind::Sqlite,
+                    path: Some(main_path.clone()),
+                    cache_mb: None,
+                    journal_mode: None,
+                    read_only: false,
+                },
+                BackendConfig {
+                    name: "archive".to_string(),
+                    kind: BackendKind::Sqlite,
+                    path: Some(path),
+                    cache_mb: None,
+                    journal_mode: None,
+                    read_only,
+                },
+            ],
+            packs: std::collections::HashMap::from([(
+                "knowledge".to_string(),
+                PackConfig {
+                    backend: "archive".to_string(),
+                },
+            )]),
+            ..KhiveConfig::default()
+        };
+
+        let read_only_archive = topology(archive_path, true);
+        let writable_literal_suffix = topology(literal_suffix_path, false);
+
+        assert_ne!(
+            compute_config_id(&runtime, Some(&read_only_archive)),
+            compute_config_id(&runtime, Some(&writable_literal_suffix)),
+            "backend mode must be encoded as a field, not an ambiguous path suffix"
+        );
+    }
+
+    /// The collision fix is deliberately conditional: ordinary topology
+    /// components that contain no reserved syntax keep their existing daemon
+    /// identity, avoiding an unnecessary one-time fallback/restart for the
+    /// overwhelmingly common configuration shape.
+    #[test]
+    fn config_id_preserves_legacy_topology_spelling_when_delimiter_free() {
+        use khive_runtime::{BackendConfig, BackendId, BackendKind, KhiveConfig, PackConfig};
+
+        let dir = tempfile::tempdir().expect("legacy topology tempdir");
+        let main_path = dir.path().join("main.db");
+        let runtime = RuntimeConfig {
+            db_path: Some(main_path.clone()),
+            packs: vec!["kg".to_string()],
+            backend_id: BackendId::main(),
+            ..RuntimeConfig::no_embeddings()
+        };
+        let topology = KhiveConfig {
+            backends: vec![BackendConfig {
+                name: "main".to_string(),
+                kind: BackendKind::Sqlite,
+                path: Some(main_path.clone()),
+                cache_mb: None,
+                journal_mode: None,
+                read_only: false,
+            }],
+            packs: std::collections::HashMap::from([(
+                "kg".to_string(),
+                PackConfig {
+                    backend: "main".to_string(),
+                },
+            )]),
+            ..KhiveConfig::default()
+        };
+
+        let expected_suffix = format!(
+            ";backends=[main:Sqlite:{}];pack_backends=[kg=main]",
+            canonical_fingerprint_path(&main_path)
+        );
+        let config_id = compute_config_id(&runtime, Some(&topology));
+        assert!(
+            config_id.ends_with(&expected_suffix),
+            "delimiter-free topologies must retain their legacy fingerprint spelling; got {config_id}"
         );
     }
 

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -322,13 +322,17 @@ pub(crate) fn compute_config_id_with_storage_mode(
     )
 }
 
+/// Compute daemon identity from construction-captured runtime policies.
+///
+/// `storage_read_only` is authoritative. Re-probing filesystem permissions
+/// here could relabel a runtime that already retained a write-capable SQLite
+/// handle after a later chmod; only the pre-open wrappers above may probe.
 pub(crate) fn compute_config_id_with_runtime_policies(
     config: &RuntimeConfig,
     khive_cfg: Option<&khive_runtime::KhiveConfig>,
     ann_fresh_tail_enabled: bool,
     storage_read_only: bool,
 ) -> String {
-    let storage_read_only = storage_read_only || configured_storage_read_only(config, khive_cfg);
     let mut packs = config.packs.clone();
     packs.sort();
     let db = config
@@ -4258,6 +4262,63 @@ mod tests {
             compute_config_id_with_storage_mode(&runtime, None, true),
             "pre-open forwarding and opened-server identities must converge"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn runtime_owned_config_id_keeps_captured_writable_mode_after_post_open_chmod() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("runtime-mode tempdir");
+        let path = dir.path().join("post-open-chmod.db");
+        let config = RuntimeConfig {
+            db_path: Some(path.clone()),
+            embedding_model: None,
+            packs: Vec::new(),
+            ..RuntimeConfig::default()
+        };
+        let runtime = KhiveRuntime::new(config).expect("open writable runtime");
+        assert!(
+            !runtime.is_read_only(),
+            "runtime must capture writable mode"
+        );
+        let captured_writable_id = compute_config_id_with_runtime_policies(
+            runtime.config(),
+            None,
+            runtime.ann_fresh_tail_enabled(),
+            runtime.is_read_only(),
+        );
+
+        let original_mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        let mut permissions = std::fs::metadata(&path).unwrap().permissions();
+        permissions.set_mode(0o444);
+        std::fs::set_permissions(&path, permissions).unwrap();
+
+        let pre_open_read_only_id = compute_config_id(runtime.config(), None);
+        assert!(
+            pre_open_read_only_id.contains(&format!(
+                "backend={:?}:read_only",
+                runtime.config().backend_id
+            )),
+            "a new runtime must detect the chmod-read-only snapshot: {pre_open_read_only_id}"
+        );
+
+        let server = KhiveMcpServer::new(runtime).expect("build server from opened runtime");
+        assert_eq!(
+            server.config_id(),
+            captured_writable_id,
+            "runtime-owned identity must trust the access mode captured when its SQLite pool opened"
+        );
+        assert_ne!(
+            server.config_id(),
+            pre_open_read_only_id,
+            "an already-open writable engine must not advertise the pre-open read-only identity"
+        );
+
+        drop(server);
+        let mut permissions = std::fs::metadata(&path).unwrap().permissions();
+        permissions.set_mode(original_mode);
+        std::fs::set_permissions(&path, permissions).unwrap();
     }
 
     /// The same collision, one layer up the resolution chain: `--db`/`KHIVE_DB`

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -485,6 +485,44 @@ fn build_verb_catalog(verbs: impl IntoIterator<Item = (String, String, String)>)
     out
 }
 
+/// Runtime-mode admission for transport background work.
+///
+/// The inbound tasks dispatch only `comm.*` verbs (`comm.ingest`, heartbeat,
+/// and cursor operations), so their write authority is the comm pack's actual
+/// assigned runtime. The outbound tasks scan and mutate notes through the kg
+/// pack's generic `list`/`update` verbs, so they must not perform an external
+/// send unless that runtime can durably record the claim and `delivered_at`.
+/// Keeping the two decisions separate preserves mixed-backend topologies.
+#[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct ChannelLoopAdmission {
+    pub(crate) inbound_poll: bool,
+    pub(crate) outbound_delivery: bool,
+}
+
+#[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
+impl ChannelLoopAdmission {
+    fn for_single_runtime(runtime: &KhiveRuntime, packs: &[String]) -> Self {
+        let comm_loaded = packs.iter().any(|pack| pack == "comm");
+        let kg_loaded = packs.iter().any(|pack| pack == "kg");
+        let writable = !runtime.is_read_only();
+        Self {
+            inbound_poll: comm_loaded && writable,
+            outbound_delivery: comm_loaded && kg_loaded && writable,
+        }
+    }
+
+    pub(crate) fn for_pack_runtimes(
+        kg: Option<&KhiveRuntime>,
+        comm: Option<&KhiveRuntime>,
+    ) -> Self {
+        Self {
+            inbound_poll: comm.is_some_and(|runtime| !runtime.is_read_only()),
+            outbound_delivery: comm.is_some() && kg.is_some_and(|runtime| !runtime.is_read_only()),
+        }
+    }
+}
+
 /// MCP server that dispatches all verbs through a [`VerbRegistry`].
 #[derive(Clone)]
 pub struct KhiveMcpServer {
@@ -527,6 +565,12 @@ pub struct KhiveMcpServer {
     /// Shared by server clones but never persisted, so a replacement process
     /// cannot inherit a plausible-looking heartbeat from its predecessor.
     schedule_ticker_last_tick_micros: Arc<AtomicI64>,
+    /// Per-verb-runtime write admission for email and Telegram background
+    /// tasks. CLI daemon role is necessary but not sufficient: snapshot
+    /// runtimes must never poll into a failing ingest path or send externally
+    /// when delivery state cannot be durably marked.
+    #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
+    channel_loop_admission: ChannelLoopAdmission,
 }
 
 /// Failure reason inside a [`PackRegError`].
@@ -630,6 +674,8 @@ impl KhiveMcpServer {
     // deref for no real benefit.
     #[allow(clippy::result_large_err)]
     pub fn with_packs(runtime: KhiveRuntime, packs: &[String]) -> Result<Self, PackRegError> {
+        #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
+        let channel_loop_admission = ChannelLoopAdmission::for_single_runtime(&runtime, packs);
         let gate = runtime.config().gate.clone();
         let default_namespace = runtime.config().default_namespace.clone();
         let config_id = compute_config_id_with_runtime_policies(
@@ -716,6 +762,8 @@ impl KhiveMcpServer {
             default_output_format: OutputFormat::Json,
             schedule_ticker_last_tick_micros: Arc::new(AtomicI64::new(0)),
             runtime: Some(runtime),
+            #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
+            channel_loop_admission,
         })
     }
 
@@ -739,6 +787,8 @@ impl KhiveMcpServer {
             default_output_format: OutputFormat::Json,
             schedule_ticker_last_tick_micros: Arc::new(AtomicI64::new(0)),
             runtime: None,
+            #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
+            channel_loop_admission: ChannelLoopAdmission::default(),
         }
     }
 
@@ -761,6 +811,8 @@ impl KhiveMcpServer {
             default_output_format: OutputFormat::Json,
             schedule_ticker_last_tick_micros: Arc::new(AtomicI64::new(0)),
             runtime: None,
+            #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
+            channel_loop_admission: ChannelLoopAdmission::default(),
         }
     }
 
@@ -781,6 +833,20 @@ impl KhiveMcpServer {
     pub fn with_default_output_format(mut self, fmt: OutputFormat) -> Self {
         self.default_output_format = fmt;
         self
+    }
+
+    /// Attach the runtime-derived channel admission computed by the
+    /// multi-backend builder after pack routing has been resolved.
+    #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
+    pub(crate) fn with_channel_loop_admission(mut self, admission: ChannelLoopAdmission) -> Self {
+        self.channel_loop_admission = admission;
+        self
+    }
+
+    /// Return the fixed boot-time admission for channel background tasks.
+    #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
+    pub(crate) fn channel_loop_admission(&self) -> ChannelLoopAdmission {
+        self.channel_loop_admission
     }
 
     /// Attach a cross-backend coordinator (ADR-029 Phase 2).

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -631,14 +631,20 @@ pub struct KhiveMcpServer {
     /// deployments. `None` in single-backend mode — all dispatch goes through the
     /// `VerbRegistry` unchanged (zero-change invariant).
     coordinator: Option<Arc<dyn CoordinatorService>>,
-    /// The default-backend `KhiveRuntime` this server was built from, kept so
-    /// background daemon tasks (e.g. the email outbox loop) can reach
-    /// non-wire owner APIs — such as the ADR-124-sanctioned store-level
-    /// property claim — that have no verb surface and so cannot go through
-    /// `registry.dispatch`. `None` only for servers built via
+    /// The default-backend `KhiveRuntime` this server was built from, retained
+    /// for non-wire background APIs that are genuinely default-backend scoped.
+    /// Pack-routed owner operations must use their dedicated runtime handle
+    /// below instead of assuming this one owns the row. `None` only for servers built via
     /// [`Self::from_registry`]/[`Self::from_registry_with_meta`] without an
     /// explicit [`Self::with_runtime`] call (test-only construction paths).
     runtime: Option<KhiveRuntime>,
+    /// Runtime that owns KG-routed outbox notes. The email loop's
+    /// `external_id` claim is deliberately non-wire, so it cannot rely on the
+    /// registry to route that one mutation. In a multi-backend topology this
+    /// may differ from `runtime` (the default backend); retaining the exact KG
+    /// runtime keeps list, owner claim, and delivered-at update on one store.
+    #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
+    channel_outbox_runtime: Option<KhiveRuntime>,
     /// Pool arc for the WAL checkpoint background task. `None` for in-memory
     /// or registry-only servers that have no persistent database.
     pool: Option<Arc<ConnectionPool>>,
@@ -853,6 +859,8 @@ impl KhiveMcpServer {
             secondary_pools: Vec::new(),
             default_output_format: OutputFormat::Json,
             schedule_ticker_last_tick_micros: Arc::new(AtomicI64::new(0)),
+            #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
+            channel_outbox_runtime: Some(runtime.clone()),
             runtime: Some(runtime),
             #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
             channel_loop_admission,
@@ -880,6 +888,8 @@ impl KhiveMcpServer {
             schedule_ticker_last_tick_micros: Arc::new(AtomicI64::new(0)),
             runtime: None,
             #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
+            channel_outbox_runtime: None,
+            #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
             channel_loop_admission: ChannelLoopAdmission::default(),
         }
     }
@@ -904,6 +914,8 @@ impl KhiveMcpServer {
             schedule_ticker_last_tick_micros: Arc::new(AtomicI64::new(0)),
             runtime: None,
             #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
+            channel_outbox_runtime: None,
+            #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
             channel_loop_admission: ChannelLoopAdmission::default(),
         }
     }
@@ -913,7 +925,21 @@ impl KhiveMcpServer {
     /// the same `default_runtime` it already resolved while building the
     /// registry.
     pub fn with_runtime(mut self, runtime: KhiveRuntime) -> Self {
+        #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
+        if self.channel_outbox_runtime.is_none() {
+            self.channel_outbox_runtime = Some(runtime.clone());
+        }
         self.runtime = Some(runtime);
+        self
+    }
+
+    /// Attach the exact KG-routed runtime that owns outbox note properties.
+    /// Multi-backend boot overrides the default-runtime fallback installed by
+    /// [`Self::with_runtime`]; single-backend construction already points both
+    /// handles at the same runtime.
+    #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
+    pub(crate) fn with_channel_outbox_runtime(mut self, runtime: Option<KhiveRuntime>) -> Self {
+        self.channel_outbox_runtime = runtime;
         self
     }
 
@@ -979,13 +1005,12 @@ impl KhiveMcpServer {
         self.registry.clone()
     }
 
-    /// Clone the default-backend `KhiveRuntime`, if this server was built with
-    /// one, for use by background tasks that need a non-wire owner API (e.g.
-    /// the email outbox loop's `external_id` claim). `KhiveRuntime` is
-    /// internally `Arc`-wrapped so this clone is cheap.
+    /// Clone the KG-routed `KhiveRuntime` retained for background tasks that
+    /// need a non-wire owner API (the email outbox loop's `external_id`
+    /// claim). `KhiveRuntime` is internally `Arc`-wrapped so this is cheap.
     #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
-    pub(crate) fn runtime_clone(&self) -> Option<KhiveRuntime> {
-        self.runtime.clone()
+    pub(crate) fn channel_outbox_runtime_clone(&self) -> Option<KhiveRuntime> {
+        self.channel_outbox_runtime.clone()
     }
 
     /// Route a `link` or `search` verb through the coordinator when in multi-backend mode.

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -266,8 +266,10 @@ pub fn compute_config_id(
 
 /// Compute the daemon identity with an already-snapshotted ADR-118 policy.
 ///
-/// Runtime-owning call sites use this form so an environment mutation after
-/// construction cannot make the fingerprint disagree with serving behavior.
+/// Test-only compatibility wrapper for exercising one already-snapshotted
+/// policy. Runtime-owning call sites pass both captured policies through
+/// [`compute_config_id_with_runtime_policies`].
+#[cfg(test)]
 pub(crate) fn compute_config_id_with_ann_fresh_tail(
     config: &RuntimeConfig,
     khive_cfg: Option<&khive_runtime::KhiveConfig>,
@@ -298,7 +300,7 @@ fn configured_storage_read_only(
     })
 }
 
-/// Runtime-aware variant of [`compute_config_id`].
+/// Test-only storage-policy variant of [`compute_config_id`].
 ///
 /// A chmod-detected snapshot has the same configured path as its writable
 /// source but cannot safely share a warm daemon with it: the writable daemon
@@ -306,6 +308,7 @@ fn configured_storage_read_only(
 /// Fold the effective main-backend mode into the existing `backend` component
 /// so the mismatch remains parseable as a structured backend mismatch without
 /// changing the legacy fingerprint for writable runtimes.
+#[cfg(test)]
 pub(crate) fn compute_config_id_with_storage_mode(
     config: &RuntimeConfig,
     khive_cfg: Option<&khive_runtime::KhiveConfig>,

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -3252,6 +3252,26 @@ mod tests {
     use khive_runtime::Namespace;
     use khive_storage::{EventFilter, PageRequest};
     use serial_test::serial;
+
+    // Freeze lingering `-wal`/`-shm` sidecars left by a writable fixture whose
+    // connections close asynchronously; read-only admission rejects a writable
+    // `-shm` as potentially live.
+    #[cfg(unix)]
+    fn freeze_snapshot_sidecars(path: &std::path::Path) {
+        use std::os::unix::fs::PermissionsExt;
+        for suffix in ["-wal", "-shm"] {
+            let mut name = path.file_name().expect("db file name").to_os_string();
+            name.push(suffix);
+            let sidecar = path.parent().expect("db parent dir").join(name);
+            if sidecar.exists() {
+                let mut permissions = std::fs::metadata(&sidecar)
+                    .expect("sidecar metadata")
+                    .permissions();
+                permissions.set_mode(0o444);
+                std::fs::set_permissions(&sidecar, permissions).expect("freeze sidecar");
+            }
+        }
+    }
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
 
@@ -4466,6 +4486,7 @@ mod tests {
         let mut permissions = std::fs::metadata(&path).unwrap().permissions();
         permissions.set_mode(0o444);
         std::fs::set_permissions(&path, permissions).unwrap();
+        freeze_snapshot_sidecars(&path);
 
         let detected = compute_config_id(&runtime, None);
         assert_ne!(writable, detected);
@@ -4509,6 +4530,7 @@ mod tests {
         let mut permissions = std::fs::metadata(&path).unwrap().permissions();
         permissions.set_mode(0o444);
         std::fs::set_permissions(&path, permissions).unwrap();
+        freeze_snapshot_sidecars(&path);
 
         let pre_open_read_only_id = compute_config_id(runtime.config(), None);
         assert!(

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -224,9 +224,9 @@ impl DispatchFailure {
 /// Fingerprint the engine-coherence parts of a resolved [`RuntimeConfig`].
 ///
 /// Two servers produce the same id iff they can safely share one warm engine:
-/// same pack set (order-independent), same storage target, same embedders, same
-/// backend topology/routing, and same construction-baked fresh-tail, outbound,
-/// and git-write policies.
+/// same pack set (order-independent), same storage target and effective access
+/// mode, same embedders, same backend topology/routing, and same
+/// construction-baked fresh-tail, outbound, and git-write policies.
 /// Identity fields (`namespace`, `actor_id`, `visible_namespaces`) are carried
 /// per request in the daemon frame and must never enter this key. The daemon
 /// compares this against each forwarded request's `config_id` and rejects
@@ -234,12 +234,16 @@ impl DispatchFailure {
 /// execute through the broader default daemon.
 ///
 /// When `khive_cfg` is supplied and contains a non-empty `[[backends]]`
-/// declaration, the backend topology (sorted backend list and pack→backend
-/// assignments) is folded into the fingerprint so that two configs differing
-/// only in pack routing produce different ids (ADR-049 / B-SHOULD-FIX-4).
+/// declaration, the backend topology (sorted backend list, explicit read-only
+/// modes, and pack→backend assignments) is folded into the fingerprint so that
+/// two configs differing only in routing or access mode produce different ids
+/// (ADR-049 / B-SHOULD-FIX-4).
 ///
-/// When `khive_cfg` is `None` or its `backends` list is empty, the fingerprint
-/// is byte-identical to what it would have been before this parameter was added.
+/// When `khive_cfg` is `None` or its `backends` list is empty, a writable
+/// target remains byte-identical to what it would have been before this
+/// parameter was added. An existing path with no filesystem write bits gains
+/// the read-only backend marker before the runtime opens it, so forwarding and
+/// server fingerprints converge.
 ///
 /// `config.db_path` and each declared backend path are canonicalized against
 /// the process's current working directory before entering the fingerprint. A
@@ -252,10 +256,11 @@ pub fn compute_config_id(
     config: &RuntimeConfig,
     khive_cfg: Option<&khive_runtime::KhiveConfig>,
 ) -> String {
-    compute_config_id_with_ann_fresh_tail(
+    compute_config_id_with_runtime_policies(
         config,
         khive_cfg,
         khive_runtime::ann_fresh_tail_enabled_from_env(),
+        configured_storage_read_only(config, khive_cfg),
     )
 }
 
@@ -268,6 +273,59 @@ pub(crate) fn compute_config_id_with_ann_fresh_tail(
     khive_cfg: Option<&khive_runtime::KhiveConfig>,
     ann_fresh_tail_enabled: bool,
 ) -> String {
+    compute_config_id_with_runtime_policies(
+        config,
+        khive_cfg,
+        ann_fresh_tail_enabled,
+        configured_storage_read_only(config, khive_cfg),
+    )
+}
+
+fn configured_storage_read_only(
+    config: &RuntimeConfig,
+    khive_cfg: Option<&khive_runtime::KhiveConfig>,
+) -> bool {
+    if let Some(main) = khive_cfg
+        .filter(|cfg| !cfg.backends.is_empty())
+        .and_then(|cfg| cfg.backends.iter().find(|backend| backend.name == "main"))
+    {
+        return main.kind == khive_runtime::BackendKind::Sqlite && main.read_only;
+    }
+
+    config.db_path.as_ref().is_some_and(|path| {
+        std::fs::metadata(khive_runtime::expand_tilde(path))
+            .is_ok_and(|metadata| metadata.permissions().readonly())
+    })
+}
+
+/// Runtime-aware variant of [`compute_config_id`].
+///
+/// A chmod-detected snapshot has the same configured path as its writable
+/// source but cannot safely share a warm daemon with it: the writable daemon
+/// would omit the audit advisory and could retain a write-capable file handle.
+/// Fold the effective main-backend mode into the existing `backend` component
+/// so the mismatch remains parseable as a structured backend mismatch without
+/// changing the legacy fingerprint for writable runtimes.
+pub(crate) fn compute_config_id_with_storage_mode(
+    config: &RuntimeConfig,
+    khive_cfg: Option<&khive_runtime::KhiveConfig>,
+    storage_read_only: bool,
+) -> String {
+    compute_config_id_with_runtime_policies(
+        config,
+        khive_cfg,
+        khive_runtime::ann_fresh_tail_enabled_from_env(),
+        storage_read_only,
+    )
+}
+
+pub(crate) fn compute_config_id_with_runtime_policies(
+    config: &RuntimeConfig,
+    khive_cfg: Option<&khive_runtime::KhiveConfig>,
+    ann_fresh_tail_enabled: bool,
+    storage_read_only: bool,
+) -> String {
+    let storage_read_only = storage_read_only || configured_storage_read_only(config, khive_cfg);
     let mut packs = config.packs.clone();
     packs.sort();
     let db = config
@@ -307,14 +365,19 @@ pub(crate) fn compute_config_id_with_ann_fresh_tail(
     }
     let git_write = format!("{:x}", git_write_hasher.finalize());
 
+    let backend = if storage_read_only {
+        format!("{:?}:read_only", config.backend_id)
+    } else {
+        format!("{:?}", config.backend_id)
+    };
     let base = format!(
-        "packs=[{}];db={};embed={};extra=[{}];fresh_tail={};backend={:?};outbound=[{}];git_write={}",
+        "packs=[{}];db={};embed={};extra=[{}];fresh_tail={};backend={};outbound=[{}];git_write={}",
         packs.join(","),
         db,
         primary,
         extra.join(","),
         ann_fresh_tail_enabled,
-        config.backend_id,
+        backend,
         outbound.join(","),
         git_write,
     );
@@ -335,7 +398,8 @@ pub(crate) fn compute_config_id_with_ann_fresh_tail(
                         .as_deref()
                         .map(canonical_fingerprint_path)
                         .unwrap_or_else(|| ":memory:".to_string());
-                    format!("{}:{:?}:{}", b.name, b.kind, path)
+                    let read_only = if b.read_only { ":read_only" } else { "" };
+                    format!("{}:{:?}:{}{}", b.name, b.kind, path, read_only)
                 })
                 .collect();
             backend_entries.sort();
@@ -568,10 +632,11 @@ impl KhiveMcpServer {
     pub fn with_packs(runtime: KhiveRuntime, packs: &[String]) -> Result<Self, PackRegError> {
         let gate = runtime.config().gate.clone();
         let default_namespace = runtime.config().default_namespace.clone();
-        let config_id = compute_config_id_with_ann_fresh_tail(
+        let config_id = compute_config_id_with_runtime_policies(
             runtime.config(),
             None,
             runtime.ann_fresh_tail_enabled(),
+            runtime.is_read_only(),
         );
         let visible_namespaces = runtime.config().visible_namespaces.clone();
         let actor_id = runtime.config().actor_id.clone();
@@ -580,8 +645,11 @@ impl KhiveMcpServer {
         builder.with_default_namespace(default_namespace.as_str());
         builder.with_visible_namespaces(visible_namespaces);
         builder.with_actor_id(actor_id);
-        // Wire the EventStore into the registry for audit persistence.
-        if let Ok(tok) = runtime.authorize(khive_runtime::Namespace::local()) {
+        // A read-only snapshot deliberately retains no EventStore handle; the
+        // registry exposes an advisory beside each successful result instead.
+        if runtime.is_read_only() {
+            builder.with_read_only_audit_store();
+        } else if let Ok(tok) = runtime.authorize(khive_runtime::Namespace::local()) {
             if let Ok(event_store) = runtime.events(&tok) {
                 builder.with_event_store(event_store);
             }
@@ -633,7 +701,7 @@ impl KhiveMcpServer {
         registry.apply_schema_plans(runtime.backend());
         // Capture the pool arc for the WAL checkpoint task. Only available for
         // file-backed databases; in-memory backends return None here.
-        let pool = if runtime.backend().is_file_backed() {
+        let pool = if runtime.backend().is_file_backed() && !runtime.is_read_only() {
             Some(runtime.backend().pool_arc())
         } else {
             None
@@ -2520,6 +2588,8 @@ impl KhiveMcpServer {
             )
             .await;
 
+        attach_audit_persistence_advisories(&mut result, &self.registry);
+
         if strict_refusals {
             attach_strict_refusal_reasons(&mut result);
         }
@@ -2548,6 +2618,62 @@ impl KhiveMcpServer {
             &self.registry,
             (origin == DispatchOrigin::Daemon).then_some(self.config_id.as_str()),
         ))
+    }
+}
+
+/// Attach a registry-level audit advisory to successful operation entries
+/// without changing their canonical `result` values.
+///
+/// Help introspection is excluded because it short-circuits before the
+/// gate/audit lifecycle and therefore would not append an audit row.
+fn attach_audit_persistence_advisories(response: &mut Value, registry: &VerbRegistry) {
+    let Some(advisory) = registry.audit_persistence_advisory() else {
+        return;
+    };
+    let Some(results) = response.get_mut("results").and_then(Value::as_array_mut) else {
+        return;
+    };
+
+    for entry in results {
+        if entry.get("ok").and_then(Value::as_bool) != Some(true) {
+            continue;
+        }
+        let tool = entry.get("tool").and_then(Value::as_str);
+        let is_help = entry.get("result").is_some_and(|result| {
+            let identifiers = result.get("identifier_resolution");
+            result.get("verb").and_then(Value::as_str) == tool
+                && result.get("pack").is_some_and(Value::is_string)
+                && result.get("description").is_some_and(Value::is_string)
+                && result.get("category").is_some_and(Value::is_string)
+                && identifiers
+                    .and_then(|value| value.get("full_uuid"))
+                    .is_some_and(Value::is_string)
+                && identifiers
+                    .and_then(|value| value.get("short_prefix"))
+                    .is_some_and(Value::is_string)
+                && identifiers
+                    .and_then(|value| value.get("parameter_rule"))
+                    .is_some_and(Value::is_string)
+        });
+        if is_help {
+            continue;
+        }
+
+        if let Some(map) = entry.as_object_mut() {
+            if let Some(existing) = map.get_mut("advisories") {
+                if let Some(advisories) = existing.as_array_mut() {
+                    let code = advisory.get("code");
+                    if !advisories.iter().any(|item| item.get("code") == code) {
+                        advisories.push(advisory.clone());
+                    }
+                }
+            } else {
+                map.insert(
+                    "advisories".to_string(),
+                    Value::Array(vec![advisory.clone()]),
+                );
+            }
+        }
     }
 }
 
@@ -2800,6 +2926,7 @@ fn frame_budget_omission(entry: &Value) -> Value {
         "status",
         "partial",
         "missing_backends",
+        "advisories",
     ] {
         if let Some(value) = entry.get(key) {
             omitted.insert(key.to_string(), value.clone());
@@ -3441,6 +3568,49 @@ mod tests {
     }
 
     #[test]
+    fn read_only_audit_advisory_decorates_success_but_not_help_or_error() {
+        let mut builder = VerbRegistryBuilder::new();
+        builder.with_read_only_audit_store();
+        let registry = builder.build().expect("registry builds");
+        let mut response = json!({
+            "results": [
+                {"ok": true, "tool": "stats", "result": {"entities": 0}},
+                {"ok": true, "tool": "list", "result": {"items": []}},
+                {"ok": true, "tool": "stats", "result": {
+                    "verb": "stats", "pack": "kg", "description": "help", "category": "assertive",
+                    "identifier_resolution": {
+                        "full_uuid": "canonical", "short_prefix": "prefix",
+                        "parameter_rule": "strict"
+                    }
+                }},
+                {"ok": false, "tool": "create", "error": "read-only"}
+            ],
+            "summary": {"total": 4, "succeeded": 3, "failed": 1, "aborted": 0},
+            "status": "partial"
+        });
+
+        attach_audit_persistence_advisories(&mut response, &registry);
+
+        assert_eq!(
+            response["results"][0]["advisories"][0]["code"],
+            khive_runtime::AUDIT_PERSISTENCE_SKIPPED_READ_ONLY
+        );
+        assert_eq!(
+            response["results"][1]["advisories"][0]["code"],
+            khive_runtime::AUDIT_PERSISTENCE_SKIPPED_READ_ONLY
+        );
+        assert!(response["results"][1]["result"]["items"].is_array());
+        assert!(response["results"][2].get("advisories").is_none());
+        assert!(response["results"][3].get("advisories").is_none());
+
+        let omitted = frame_budget_omission(&response["results"][0]);
+        assert!(
+            omitted.get("advisories").is_some(),
+            "frame-budget degradation must preserve the warning"
+        );
+    }
+
+    #[test]
     fn frame_budget_omission_preserves_search_degradation_advisory() {
         let omitted = frame_budget_omission(&json!({
             "ok": true,
@@ -3934,6 +4104,87 @@ mod tests {
             "two projects declaring the same relative backend path string from \
              different working directories must not share a config_id; both \
              produced: {id_a}"
+        );
+    }
+
+    #[test]
+    fn config_id_separates_effective_read_only_storage_modes() {
+        use khive_runtime::{BackendId, BackendKind, KhiveConfig, Namespace};
+
+        let dir = tempfile::tempdir().expect("config-mode tempdir");
+        let runtime = RuntimeConfig {
+            db_path: Some(dir.path().join("khive-config-mode.db")),
+            default_namespace: Namespace::local(),
+            embedding_model: None,
+            packs: vec!["kg".to_string()],
+            backend_id: BackendId::main(),
+            ..RuntimeConfig::default()
+        };
+
+        let writable = compute_config_id(&runtime, None);
+        assert_eq!(
+            writable,
+            compute_config_id_with_storage_mode(&runtime, None, false),
+            "the writable fingerprint must remain byte-identical"
+        );
+        let detected_read_only = compute_config_id_with_storage_mode(&runtime, None, true);
+        assert_ne!(
+            writable, detected_read_only,
+            "a chmod-detected snapshot must not reuse a write-capable warm daemon"
+        );
+        assert!(detected_read_only.contains(&format!("backend={:?}:read_only", runtime.backend_id)));
+
+        let writable_topology = KhiveConfig {
+            backends: vec![khive_runtime::BackendConfig {
+                name: "main".to_string(),
+                kind: BackendKind::Sqlite,
+                path: runtime.db_path.clone(),
+                cache_mb: None,
+                journal_mode: None,
+                read_only: false,
+            }],
+            ..KhiveConfig::default()
+        };
+        let mut read_only_topology = writable_topology.clone();
+        read_only_topology.backends[0].read_only = true;
+        assert_ne!(
+            compute_config_id(&runtime, Some(&writable_topology)),
+            compute_config_id(&runtime, Some(&read_only_topology)),
+            "declared multi-backend read_only mode is part of backend topology"
+        );
+        assert_eq!(
+            compute_config_id(&runtime, Some(&read_only_topology)),
+            compute_config_id_with_storage_mode(&runtime, Some(&read_only_topology), true),
+            "the pre-open client and opened read-only server must fingerprint identically"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn config_id_auto_detects_chmod_read_only_single_backend() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("config-mode tempdir");
+        let path = dir.path().join("chmod-snapshot.db");
+        std::fs::write(&path, b"snapshot identity fixture").expect("create fixture");
+        let runtime = RuntimeConfig {
+            db_path: Some(path.clone()),
+            packs: vec!["kg".to_string()],
+            ..RuntimeConfig::default()
+        };
+        let writable = compute_config_id(&runtime, None);
+
+        let mut permissions = std::fs::metadata(&path).unwrap().permissions();
+        permissions.set_mode(0o444);
+        std::fs::set_permissions(&path, permissions).unwrap();
+
+        let detected = compute_config_id(&runtime, None);
+        assert_ne!(writable, detected);
+        assert!(detected.contains("backend=main:read_only"), "{detected}");
+        assert_eq!(
+            detected,
+            compute_config_id_with_storage_mode(&runtime, None, true),
+            "pre-open forwarding and opened-server identities must converge"
         );
     }
 

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -451,6 +451,7 @@ fn encode_backend_topology(cfg: &khive_runtime::KhiveConfig) -> String {
                 && legacy_topology_component_is_safe(&kind)
                 && backend
                     .path
+                    .as_ref()
                     .is_none_or(|_| legacy_topology_component_is_safe(&path));
             (backend.name.clone(), kind, path, backend.read_only)
         })

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -4246,7 +4246,10 @@ mod tests {
 
         let detected = compute_config_id(&runtime, None);
         assert_ne!(writable, detected);
-        assert!(detected.contains("backend=main:read_only"), "{detected}");
+        assert!(
+            detected.contains(&format!("backend={:?}:read_only", runtime.backend_id)),
+            "{detected}"
+        );
         assert_eq!(
             detected,
             compute_config_id_with_storage_mode(&runtime, None, true),

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -171,6 +171,21 @@ async fn seeded_read_only_snapshot_server() -> (tempfile::TempDir, KhiveMcpServe
     let mut permissions = std::fs::metadata(&path).unwrap().permissions();
     permissions.set_mode(0o444);
     std::fs::set_permissions(&path, permissions).unwrap();
+    // Freeze lingering `-wal`/`-shm` sidecars left by the writable fixture's
+    // asynchronously closing connections; read-only admission rejects a
+    // writable `-shm` as potentially live.
+    for suffix in ["-wal", "-shm"] {
+        let mut name = path.file_name().expect("db file name").to_os_string();
+        name.push(suffix);
+        let sidecar = path.parent().expect("db parent dir").join(name);
+        if sidecar.exists() {
+            let mut sidecar_permissions = std::fs::metadata(&sidecar)
+                .expect("sidecar metadata")
+                .permissions();
+            sidecar_permissions.set_mode(0o444);
+            std::fs::set_permissions(&sidecar, sidecar_permissions).expect("freeze sidecar");
+        }
+    }
 
     let runtime = KhiveRuntime::new(config)
         .expect("normal boot must detect and validate the read-only snapshot");

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -131,12 +131,8 @@ async fn agent_one(
     Ok(first["result"].clone())
 }
 
-/// Issue #1602: normal runtime boot detects a chmod-read-only SQLite snapshot,
-/// keeps assertive verbs usable, and surfaces the deliberately skipped audit
-/// append beside each canonical result. The same backend still rejects writes.
 #[cfg(unix)]
-#[tokio::test]
-async fn chmod_read_only_snapshot_serves_stats_and_list_with_audit_advisory() {
+async fn seeded_read_only_snapshot_server() -> (tempfile::TempDir, KhiveMcpServer) {
     use std::os::unix::fs::PermissionsExt;
 
     use khive_mcp::tools::request::RequestParams;
@@ -180,10 +176,22 @@ async fn chmod_read_only_snapshot_serves_stats_and_list_with_audit_advisory() {
         .expect("normal boot must detect and validate the read-only snapshot");
     assert!(runtime.is_read_only());
     let server = KhiveMcpServer::new(runtime).expect("read-only server builds");
+    (dir, server)
+}
+
+/// Issue #1602: normal runtime boot detects a chmod-read-only SQLite snapshot,
+/// keeps assertive verbs usable, and surfaces the deliberately skipped audit
+/// append beside each canonical result. The same backend still rejects writes.
+#[cfg(unix)]
+#[tokio::test]
+async fn chmod_read_only_snapshot_serves_stats_and_clamped_list_with_audit_advisory() {
+    use khive_mcp::tools::request::RequestParams;
+
+    let (_dir, server) = seeded_read_only_snapshot_server().await;
 
     let reads = server
         .dispatch_request_local(RequestParams {
-            ops: r#"[stats(), list(kind="entity")]"#.to_string(),
+            ops: r#"[stats(), list(kind="entity", limit=501)]"#.to_string(),
             presentation: Some("verbose".to_string()),
             presentation_per_op: None,
             save_to: None,
@@ -204,6 +212,9 @@ async fn chmod_read_only_snapshot_serves_stats_and_list_with_audit_advisory() {
         "list's stable envelope must be preserved: {}",
         results[1]
     );
+    assert_eq!(results[1]["result"]["requested_limit"], json!(501));
+    assert_eq!(results[1]["result"]["effective_limit"], json!(500));
+    assert_eq!(results[1]["result"]["limit_clamped"], json!(true));
     for entry in results {
         assert_eq!(
             entry["advisories"][0]["code"],
@@ -237,6 +248,47 @@ async fn chmod_read_only_snapshot_serves_stats_and_list_with_audit_advisory() {
         mutation_error.contains("read-only") || mutation_error.contains("readonly"),
         "mutating verbs must remain rejected: {mutation}"
     );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn chmod_read_only_snapshot_default_list_keeps_array_and_sibling_audit_advisory() {
+    use khive_mcp::tools::request::RequestParams;
+
+    let (_dir, server) = seeded_read_only_snapshot_server().await;
+    let response = server
+        .dispatch_request_local(RequestParams {
+            ops: r#"list(kind="entity")"#.to_string(),
+            presentation: None,
+            presentation_per_op: None,
+            save_to: None,
+            format: Some("json".to_string()),
+            format_per_op: None,
+            request_id: None,
+        })
+        .await
+        .expect("default-presentation read dispatch");
+    let response: Value = serde_json::from_str(&response).expect("read response JSON");
+    let entry = &response["results"][0];
+
+    assert_eq!(entry["ok"], json!(true), "list must succeed: {response}");
+    assert_eq!(entry["tool"], json!("list"));
+    let items = entry["result"]
+        .as_array()
+        .expect("within-cap list must preserve main's bare-array result");
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["name"], json!("snapshot entity"));
+    assert_eq!(items[0]["id"].as_str().map(str::len), Some(8));
+    assert_eq!(
+        entry["advisories"][0]["code"],
+        json!(khive_runtime::AUDIT_PERSISTENCE_SKIPPED_READ_ONLY)
+    );
+    assert!(
+        entry["result"].get("advisories").is_none(),
+        "the transport advisory must remain outside the verb-owned array"
+    );
+    assert_eq!(response["summary"]["succeeded"], json!(1));
+    assert_eq!(response["status"], json!("success"));
 }
 
 // ── server info / surface shape ──────────────────────────────────────────────

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -131,6 +131,114 @@ async fn agent_one(
     Ok(first["result"].clone())
 }
 
+/// Issue #1602: normal runtime boot detects a chmod-read-only SQLite snapshot,
+/// keeps assertive verbs usable, and surfaces the deliberately skipped audit
+/// append beside each canonical result. The same backend still rejects writes.
+#[cfg(unix)]
+#[tokio::test]
+async fn chmod_read_only_snapshot_serves_stats_and_list_with_audit_advisory() {
+    use std::os::unix::fs::PermissionsExt;
+
+    use khive_mcp::tools::request::RequestParams;
+
+    disable_daemon();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("read_only_snapshot.db");
+    let config = RuntimeConfig {
+        db_path: Some(path.clone()),
+        default_namespace: Namespace::local(),
+        embedding_model: None,
+        additional_embedding_models: vec![],
+        packs: vec!["kg".to_string()],
+        ..RuntimeConfig::default()
+    };
+
+    {
+        let runtime = KhiveRuntime::new(config.clone()).expect("writable snapshot source");
+        let server = KhiveMcpServer::new(runtime).expect("writable server");
+        let seeded = server
+            .dispatch_request_local(RequestParams {
+                ops: r#"create(kind="concept", name="snapshot entity")"#.to_string(),
+                presentation: Some("verbose".to_string()),
+                presentation_per_op: None,
+                save_to: None,
+                format: Some("json".to_string()),
+                format_per_op: None,
+                request_id: None,
+            })
+            .await
+            .expect("seed dispatch");
+        let seeded: Value = serde_json::from_str(&seeded).expect("seed response JSON");
+        assert_eq!(seeded["results"][0]["ok"], json!(true), "{seeded}");
+    }
+
+    let mut permissions = std::fs::metadata(&path).unwrap().permissions();
+    permissions.set_mode(0o444);
+    std::fs::set_permissions(&path, permissions).unwrap();
+
+    let runtime = KhiveRuntime::new(config)
+        .expect("normal boot must detect and validate the read-only snapshot");
+    assert!(runtime.is_read_only());
+    let server = KhiveMcpServer::new(runtime).expect("read-only server builds");
+
+    let reads = server
+        .dispatch_request_local(RequestParams {
+            ops: r#"[stats(), list(kind="entity")]"#.to_string(),
+            presentation: Some("verbose".to_string()),
+            presentation_per_op: None,
+            save_to: None,
+            format: Some("json".to_string()),
+            format_per_op: None,
+            request_id: None,
+        })
+        .await
+        .expect("read dispatch");
+    let reads: Value = serde_json::from_str(&reads).expect("read response JSON");
+    let results = reads["results"].as_array().expect("results array");
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0]["ok"], json!(true), "stats must succeed: {reads}");
+    assert_eq!(results[0]["result"]["entities"], json!(1));
+    assert_eq!(results[1]["ok"], json!(true), "list must succeed: {reads}");
+    assert!(
+        results[1]["result"]["items"].is_array(),
+        "list's stable envelope must be preserved: {}",
+        results[1]
+    );
+    for entry in results {
+        assert_eq!(
+            entry["advisories"][0]["code"],
+            json!(khive_runtime::AUDIT_PERSISTENCE_SKIPPED_READ_ONLY),
+            "successful read must surface the skipped audit write: {entry}"
+        );
+        assert!(
+            entry["result"].get("advisories").is_none(),
+            "advisory belongs beside the result, not inside its verb-owned shape"
+        );
+    }
+
+    let mutation = server
+        .dispatch_request_local(RequestParams {
+            ops: r#"create(kind="concept", name="must fail")"#.to_string(),
+            presentation: Some("verbose".to_string()),
+            presentation_per_op: None,
+            save_to: None,
+            format: Some("json".to_string()),
+            format_per_op: None,
+            request_id: None,
+        })
+        .await
+        .expect("mutation returns a per-op error envelope");
+    let mutation: Value = serde_json::from_str(&mutation).expect("mutation response JSON");
+    assert_eq!(mutation["results"][0]["ok"], json!(false));
+    let mutation_error = mutation["results"][0]["error"]
+        .to_string()
+        .to_ascii_lowercase();
+    assert!(
+        mutation_error.contains("read-only") || mutation_error.contains("readonly"),
+        "mutating verbs must remain rejected: {mutation}"
+    );
+}
+
 // ── server info / surface shape ──────────────────────────────────────────────
 
 #[tokio::test]

--- a/crates/khive-pack-blob/src/handlers.rs
+++ b/crates/khive-pack-blob/src/handlers.rs
@@ -143,6 +143,11 @@ pub(crate) async fn handle_put(
     _token: &NamespaceToken,
     params: Value,
 ) -> Result<Value, RuntimeError> {
+    if runtime.is_read_only() {
+        return Err(RuntimeError::InvalidInput(
+            "blob.put is unavailable because the blob pack runtime is read-only".to_string(),
+        ));
+    }
     let store = blob_store(runtime)?;
 
     let b64 = params.get("bytes").and_then(Value::as_str).ok_or_else(|| {

--- a/crates/khive-pack-kg/docs/api/pack-lifecycle.md
+++ b/crates/khive-pack-kg/docs/api/pack-lifecycle.md
@@ -12,9 +12,12 @@ embedder warmup is attributed to the daemon principal instead of remaining invis
 event plane. A mint failure only removes this pass's telemetry — the warmup itself still
 runs.
 
-Every `warm()` call emits exactly one `PhaseStarted` and one terminal event
-(`PhaseCompleted`/`PhaseCancelled`) — this phase-span contract is regression-covered
-end to end.
+Every writable-runtime `warm()` call emits exactly one `PhaseStarted` and one
+terminal event (`PhaseCompleted`/`PhaseCancelled`) — this phase-span contract is
+regression-covered end to end. On an ADR-028 A2 read-only snapshot the embedder
+warm still runs, but phase persistence is deliberately absent: the shared
+emitter returns before resolving an `EventStore`, so warm never enters a writer
+path merely to produce best-effort telemetry.
 
 ## Entity-type validator installation
 

--- a/crates/khive-pack-knowledge/docs/api/vamana.md
+++ b/crates/khive-pack-knowledge/docs/api/vamana.md
@@ -27,6 +27,13 @@ serialization logic. These
 responsibilities are tightly coupled through the shared `AnnState` and cannot be split
 without obscuring the generation-fenced install and warm-ownership lock protocol.
 
+`warm_known_snapshots` is not a read-only lifecycle: classification may register
+a missing consumer, replay and checkpoint a tail, or publish a rebuild. The
+pack therefore omits this ANN warm when its assigned runtime is an ADR-028 A2
+read-only snapshot. Request-time exact/vector fallback remains available from
+the already-materialized snapshot tables; no rejected writer path is used as a
+substitute for warm persistence.
+
 ## Fresh-tail serving (ADR-118)
 
 `knowledge.search` and `knowledge.suggest` capture ANN candidates and the loaded bridge's

--- a/crates/khive-pack-knowledge/src/knowledge/vamana.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/vamana.rs
@@ -1855,6 +1855,16 @@ async fn force_cold_after_registry_loss(
     ann: &SharedAnn,
     key: &AnnKey,
 ) -> FreshTailOutcome {
+    if rt.is_read_only() {
+        // Registry loss normally publishes the cross-process `-1` rebuild
+        // fence. A frozen snapshot cannot acquire that authority, so evict
+        // only process-local candidates and remain on the FTS path.
+        clear_namespace(ann, &key.namespace).await;
+        return FreshTailOutcome::Replace {
+            candidates: Vec::new(),
+            source_exhausted: true,
+        };
+    }
     // Publish the cross-process fence before yielding or evicting local state.
     // A peer checkpoint therefore cannot compact/publish through the gap while
     // this process is transitioning its loaded bridge to Cold.
@@ -2631,6 +2641,12 @@ pub(crate) async fn warm_known_snapshots(rt: &KhiveRuntime, ann: &SharedAnn) {
 /// `Warming`/`Ready` states suppress duplicates; `Failed` remains retryable by
 /// the next search.
 pub(crate) fn ensure_ann_background(rt: &KhiveRuntime, token: &NamespaceToken, ann: &SharedAnn) {
+    // Searches against a frozen snapshot may use FTS, an already-loaded
+    // bridge, and the load-only fresh-tail leg, but must not turn a cache miss
+    // into consumer registration or checkpoint publication.
+    if rt.is_read_only() {
+        return;
+    }
     let model = rt.default_embedder_name().to_string();
     if model.is_empty() {
         return;
@@ -3122,6 +3138,46 @@ mod tests {
             "registry loss must publish the cross-process rebuild sentinel"
         );
         assert!(force_rebuild_required(&ann, &key));
+    }
+
+    #[tokio::test]
+    async fn read_only_fresh_tail_registry_loss_stays_process_local() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = khive_runtime::RuntimeConfig {
+            db_path: Some(dir.path().join("read-only-fresh-tail.db")),
+            ..khive_runtime::RuntimeConfig::no_embeddings()
+        };
+        drop(KhiveRuntime::new(config.clone()).expect("migrate snapshot source"));
+        let rt = KhiveRuntime::new_readonly(config).expect("open snapshot read-only");
+        let ann = new_shared();
+        let namespace = "local";
+        let model = "read-only-fresh-tail-model";
+        let key = AnnKey::new(namespace, model);
+        let before = rt.backend().pool().writer_acquisition_snapshot();
+
+        let outcome = force_cold_after_registry_loss(&rt, &ann, &key).await;
+
+        assert!(matches!(
+            outcome,
+            FreshTailOutcome::Replace { ref candidates, source_exhausted: true }
+                if candidates.is_empty()
+        ));
+        assert_eq!(
+            read_own_watermark(&rt, namespace, model)
+                .await
+                .expect("registry read"),
+            None,
+            "read-only registry loss must not publish a rebuild sentinel"
+        );
+        assert!(
+            !force_rebuild_required(&ann, &key),
+            "read-only registry loss must not claim local rebuild authority"
+        );
+        assert_eq!(
+            rt.backend().pool().writer_acquisition_snapshot(),
+            before,
+            "read-only fresh-tail degradation must not acquire a writer"
+        );
     }
 
     #[tokio::test]

--- a/crates/khive-pack-knowledge/src/knowledge/vamana.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/vamana.rs
@@ -3148,6 +3148,23 @@ mod tests {
             ..khive_runtime::RuntimeConfig::no_embeddings()
         };
         drop(KhiveRuntime::new(config.clone()).expect("migrate snapshot source"));
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let db_path = config.db_path.as_ref().expect("db path");
+            for suffix in ["-wal", "-shm"] {
+                let mut name = db_path.file_name().expect("db file name").to_os_string();
+                name.push(suffix);
+                let sidecar = db_path.parent().expect("db parent dir").join(name);
+                if sidecar.exists() {
+                    let mut permissions = std::fs::metadata(&sidecar)
+                        .expect("sidecar metadata")
+                        .permissions();
+                    permissions.set_mode(0o444);
+                    std::fs::set_permissions(&sidecar, permissions).expect("freeze sidecar");
+                }
+            }
+        }
         let rt = KhiveRuntime::new_readonly(config).expect("open snapshot read-only");
         let ann = new_shared();
         let namespace = "local";

--- a/crates/khive-pack-knowledge/src/pack.rs
+++ b/crates/khive-pack-knowledge/src/pack.rs
@@ -652,6 +652,24 @@ mod tests {
         };
         drop(KhiveRuntime::new(config.clone()).expect("migrate snapshot source"));
 
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let db_path = config.db_path.as_ref().expect("db path");
+            for suffix in ["-wal", "-shm"] {
+                let mut name = db_path.file_name().expect("db file name").to_os_string();
+                name.push(suffix);
+                let sidecar = db_path.parent().expect("db parent dir").join(name);
+                if sidecar.exists() {
+                    let mut permissions = std::fs::metadata(&sidecar)
+                        .expect("sidecar metadata")
+                        .permissions();
+                    permissions.set_mode(0o444);
+                    std::fs::set_permissions(&sidecar, permissions).expect("freeze sidecar");
+                }
+            }
+        }
+
         let read_only = KhiveRuntime::new_readonly(config).expect("open snapshot read-only");
         let token = read_only
             .authorize(Namespace::local())

--- a/crates/khive-pack-knowledge/src/pack.rs
+++ b/crates/khive-pack-knowledge/src/pack.rs
@@ -126,7 +126,12 @@ impl PackRuntime for KnowledgePack {
     }
 
     async fn warm(&self) {
-        crate::knowledge::vamana::warm_known_snapshots(&self.runtime, &self.ann).await;
+        // Vamana warm may register a missing ANN consumer or publish a rebuilt
+        // checkpoint. A snapshot runtime keeps only the pure embedder warm
+        // below; it must not enter a writer-bearing ANN lifecycle.
+        if !self.runtime.is_read_only() {
+            crate::knowledge::vamana::warm_known_snapshots(&self.runtime, &self.ann).await;
+        }
         if !self.runtime.default_embedder_name().is_empty() {
             let runtime = self.runtime.clone();
             // ADR-103 Amendment 1 Part 2: the phase span brackets ONLY this
@@ -594,7 +599,8 @@ impl PackByIdResolver for KnowledgePack {
 #[cfg(test)]
 mod tests {
     use khive_runtime::pack::PackRuntime;
-    use khive_runtime::{KhiveRuntime, Namespace};
+    use khive_runtime::{KhiveRuntime, Namespace, RuntimeConfig};
+    use lattice_embed::EmbeddingModel;
 
     use super::KnowledgePack;
 
@@ -632,6 +638,41 @@ mod tests {
              (configured-only branch must not fire, and warm_known_snapshots must not \
              independently emit): {:?}",
             page.items
+        );
+    }
+
+    #[tokio::test]
+    async fn read_only_knowledge_cache_miss_does_not_start_ann_writer_lifecycle() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = RuntimeConfig {
+            db_path: Some(dir.path().join("read-only-knowledge-ann.db")),
+            embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
+            additional_embedding_models: vec![],
+            ..RuntimeConfig::no_embeddings()
+        };
+        drop(KhiveRuntime::new(config.clone()).expect("migrate snapshot source"));
+
+        let read_only = KhiveRuntime::new_readonly(config).expect("open snapshot read-only");
+        let token = read_only
+            .authorize(Namespace::local())
+            .expect("authorize local");
+        let pack = KnowledgePack::new(read_only.clone());
+        let key = crate::knowledge::vamana::AnnKey::new(
+            token.namespace().as_str(),
+            read_only.default_embedder_name(),
+        );
+        let before = read_only.backend().pool().writer_acquisition_snapshot();
+
+        crate::knowledge::vamana::ensure_ann_background(&read_only, &token, &pack.ann);
+
+        assert!(
+            !crate::knowledge::vamana::is_warming_not_loaded(&pack.ann, &key),
+            "a read-only search cache miss must not claim or spawn an ANN warm slot"
+        );
+        assert_eq!(
+            read_only.backend().pool().writer_acquisition_snapshot(),
+            before,
+            "read-only ANN admission must not acquire a writer"
         );
     }
 }

--- a/crates/khive-pack-memory/docs/api/pack-integration.md
+++ b/crates/khive-pack-memory/docs/api/pack-integration.md
@@ -14,7 +14,7 @@ Verb categories are intentional: recall and its dotted stages are assertive; rem
 
 ## Warm phase
 
-`PackRuntime::warm` schedules ANN warming for registered embedding models, then runs an FTS population guard. The guard compares live base rows with unified FTS rows and warns when a database with more than 100 rows has less than half represented in FTS. It never hard-fails boot and skips legitimately new or empty databases. This detects the V3-to-V4 migration failure mode where empty unified tables stranded recall until manual reindexing.
+`PackRuntime::warm` schedules ANN warming for registered embedding models, then runs an FTS population guard. ANN warm is writer-bearing: it may register a consumer, publish a checkpoint, and compact a tail. It is therefore skipped when this pack's assigned runtime is an ADR-028 A2 read-only snapshot, and a recall-time cache miss likewise falls through to the exact sqlite-vec reader instead of scheduling a detached rebuild. The FTS population guard is genuinely load-only and still runs there. The guard compares live base rows with unified FTS rows and warns when a database with more than 100 rows has less than half represented in FTS. It never hard-fails boot and skips legitimately new or empty databases. This detects the V3-to-V4 migration failure mode where empty unified tables stranded recall until manual reindexing.
 
 ## Note-mutation hook
 

--- a/crates/khive-pack-memory/src/ann.rs
+++ b/crates/khive-pack-memory/src/ann.rs
@@ -672,7 +672,11 @@ pub(crate) async fn ensure_ann_background(
     ann: &SharedAnn,
     model: &str,
 ) -> bool {
-    if model.is_empty() {
+    // Request-time recall and mutation hooks share this entry point with
+    // daemon warm. A snapshot may use an already-loaded bridge or the exact
+    // sqlite-vec fallback, but it must never enqueue registration,
+    // checkpoint, or compaction work against its read-only backend.
+    if rt.is_read_only() || model.is_empty() {
         return false;
     }
     let key = AnnKey::from_token(model);

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -1282,6 +1282,13 @@ async fn collect_model_ann_hits_inner(
     let mut model_ann_degrade_reason: Option<String> = None;
     let initial_raw_hits: Option<(Vec<(Uuid, f32)>, u64)> = match search_result {
         Ok(Some(hits_and_seq)) => Some(hits_and_seq),
+        Ok(None) if runtime.is_read_only() => {
+            // Daemon warm deliberately leaves ANN state cold for a snapshot,
+            // and the request path must not replace that omitted lifecycle
+            // with a detached writer-bearing rebuild. Fall through to the
+            // exact sqlite-vec reader below.
+            None
+        }
         Ok(None) => {
             let (done_tx, done_rx) = tokio::sync::oneshot::channel();
             let rt_detached = runtime.clone();

--- a/crates/khive-pack-memory/src/pack.rs
+++ b/crates/khive-pack-memory/src/pack.rs
@@ -400,7 +400,13 @@ impl PackRuntime for MemoryPack {
     }
 
     async fn warm(&self) {
-        crate::ann::warm_existing_memory_indexes(&self.runtime, &self.ann).await;
+        // ANN warm is not a read-only operation: a missing consumer is first
+        // registered as pending, and a cold/stale segment can checkpoint and
+        // compact. Snapshot inspection must not enter that lifecycle. The FTS
+        // population check below is genuinely load-only and remains useful.
+        if !self.runtime.is_read_only() {
+            crate::ann::warm_existing_memory_indexes(&self.runtime, &self.ann).await;
+        }
         fts_population_guard(&self.runtime).await;
     }
 
@@ -635,6 +641,97 @@ async fn fts_population_guard(rt: &KhiveRuntime) {
                  Fix: run `kkernel reindex --no-knowledge` to repopulate {fts_table}."
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod read_only_warm_tests {
+    use super::*;
+
+    use crate::test_support::HashVecProvider;
+    use khive_runtime::RuntimeConfig;
+    use khive_storage::types::{SqlStatement, SqlValue};
+
+    #[tokio::test]
+    async fn read_only_warm_keeps_ann_lifecycle_out_of_the_writer_plane() {
+        const MODEL: &str = "read-only-warm-model";
+        const DIMS: usize = 8;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("read-only-memory-warm.db");
+        let cfg = RuntimeConfig {
+            db_path: Some(path),
+            ..RuntimeConfig::no_embeddings()
+        };
+
+        let writable = KhiveRuntime::new(cfg.clone()).expect("writable snapshot source");
+        writable.register_embedder(HashVecProvider {
+            model_name: MODEL.to_owned(),
+            dims: DIMS,
+        });
+        let token = writable
+            .authorize(khive_runtime::Namespace::local())
+            .expect("authorize local");
+        writable
+            .vectors_for_model(&token, MODEL)
+            .expect("materialize optional vector table");
+        let mut writer = writable.sql().writer().await.expect("seed writer");
+        writer
+            .execute(SqlStatement {
+                sql: "INSERT INTO ann_consumer_watermark \
+                      (consumer, namespace, embedding_model, watermark) \
+                      VALUES (?1, ?2, ?3, 0)"
+                    .into(),
+                params: vec![
+                    SqlValue::Text("memory-notes:note.content".into()),
+                    SqlValue::Text("*".into()),
+                    SqlValue::Text(MODEL.into()),
+                ],
+                label: Some("seed_read_only_warm_consumer".into()),
+            })
+            .await
+            .expect("seed active consumer");
+        drop(writer);
+
+        // `vectors_for_model` and `SqlAccess::writer` lazily spawn the
+        // file-backed pool's shared writer task. Own its one-shot join before
+        // dropping the runtime, then wait for the queue and close-time WAL
+        // work to settle before reopening the same file read-only. Otherwise
+        // this regression can observe fixture teardown instead of the
+        // read-only warm path it is meant to discriminate.
+        let writer_join = writable.backend().pool().take_writer_task_join();
+        drop(token);
+        drop(writable);
+        if let Some(join) = writer_join {
+            tokio::time::timeout(std::time::Duration::from_secs(5), join)
+                .await
+                .expect("writable fixture writer task must drain before read-only reopen")
+                .expect("writable fixture writer task must not panic");
+        }
+
+        let read_only = KhiveRuntime::new_readonly(cfg).expect("read-only snapshot runtime");
+        read_only.register_embedder(HashVecProvider {
+            model_name: MODEL.to_owned(),
+            dims: DIMS,
+        });
+        let before = read_only.backend().pool().writer_acquisition_snapshot();
+
+        let pack = MemoryPack::new(read_only.clone());
+        pack.warm().await;
+        let read_token = read_only
+            .authorize(khive_runtime::Namespace::local())
+            .expect("authorize read-only local");
+        assert!(
+            !crate::ann::ensure_ann_background(&read_only, &read_token, &pack.ann, MODEL).await,
+            "a read-only recall cache miss must not enqueue a writer-bearing ANN task"
+        );
+
+        assert_eq!(
+            read_only.backend().pool().writer_acquisition_snapshot(),
+            before,
+            "daemon warm must not acquire a writer for ANN registration, checkpoint, or \
+             optional-table inspection on a read-only runtime"
+        );
     }
 }
 

--- a/crates/khive-pack-session/src/pack.rs
+++ b/crates/khive-pack-session/src/pack.rs
@@ -87,6 +87,12 @@ impl PackRuntime for SessionPack {
     }
 
     async fn warm(&self) {
+        // Mirror services ingest external sessions and therefore write notes.
+        // A snapshot-inspection runtime may expose session read verbs, but it
+        // must never launch a background mirror against its read-only backend.
+        if self.runtime.is_read_only() {
+            return;
+        }
         let config = crate::mirror::MirrorConfig::from_env();
         if !config.enabled
             && !config.codex_enabled

--- a/crates/khive-runtime/docs/design.md
+++ b/crates/khive-runtime/docs/design.md
@@ -182,7 +182,9 @@
 ### Persistent Daemon (ADR-049)
 
 - `khived` is a persistent warm runtime over a Unix socket
-- `PackRuntime::warm` is invoked on every registered pack during daemon startup
+- `PackRuntime::warm` is invoked on every registered pack during daemon startup;
+  each hook follows its own assigned backend mode, suppressing writer-bearing
+  work for read-only snapshot runtimes (ADR-028 A2)
 
 ### Namespace Token Contract (ADR-050)
 

--- a/crates/khive-runtime/docs/protocol.md
+++ b/crates/khive-runtime/docs/protocol.md
@@ -31,6 +31,18 @@ MCP request(ops=...) → khive_request::parse_request → Vec<ParsedOp>
       → DispatchHook::on_dispatch(event) [if configured]
 ```
 
+When the configured main backend is read-only, the registry intentionally
+holds no `EventStore`: a known-failing append is not attempted. Successful
+non-help operation entries instead carry an `advisories` array beside their
+canonical `result`, with code `audit_persistence_skipped_read_only`. Failed and
+aborted entries receive no such advisory because they do not claim a successful
+operation whose audit persistence was skipped.
+
+Read-only versus writable main-backend mode is engine-coherence state, not
+request identity. It is folded into the warm-daemon `config_id`, so a snapshot
+inspection request cannot be served by a daemon that retained a write-capable
+handle to the same database path.
+
 ## Verb Visibility Contract
 
 - `Visibility::Verb` — callable via MCP `request` surface, advertised in `help=true` envelopes.
@@ -93,12 +105,13 @@ For subhandlers, the envelope additionally carries `"visibility": "internal"` an
 
 ## Failure Modes
 
-| Condition                        | Error                                              |
-| --------------------------------- | --------------------------------------------------- |
-| Unknown verb                      | `RuntimeError::UnknownVerb("unknown verb ...")`    |
-| Gate deny                         | `RuntimeError::PermissionDenied { verb, reason }`  |
-| Pack not loaded                   | `RuntimeError::UnknownVerb` (unknown verb path)    |
-| Malformed explicit namespace      | `RuntimeError::InvalidInput` (non-string `namespace`, rejected before gate) |
+| Condition                                             | Error                                                                       |
+| ----------------------------------------------------- | --------------------------------------------------------------------------- |
+| Unknown verb                                          | `RuntimeError::UnknownVerb("unknown verb ...")`                             |
+| Gate deny                                             | `RuntimeError::PermissionDenied { verb, reason }`                           |
+| Pack not loaded                                       | `RuntimeError::UnknownVerb` (unknown verb path)                             |
+| Malformed explicit namespace                          | `RuntimeError::InvalidInput` (non-string `namespace`, rejected before gate) |
+| Read-only audit backend after a successful inspection | Success plus `audit_persistence_skipped_read_only` advisory                 |
 
 `RuntimeError::NamespaceMismatch` is a historical/rejected variant from a pre-Rev-6
 design where by-ID lookups compared `record.namespace == caller_namespace`; it is not

--- a/crates/khive-runtime/src/blob.rs
+++ b/crates/khive-runtime/src/blob.rs
@@ -8,9 +8,13 @@
 
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use khive_db::stores::blob_s3::{S3BlobStore, S3BlobStoreConfig};
 use khive_db::{SqliteError, StorageBackend};
-use khive_storage::BlobStore;
+use khive_storage::{
+    BlobOrphanSweepConfig, BlobOrphanSweepResult, BlobStore, ContentRef, SqlAccess,
+    StorageCapability, StorageError, StorageResult,
+};
 
 use crate::engine_config::BlobConfig;
 use crate::KhiveConfig;
@@ -53,6 +57,104 @@ pub fn resolve_blob_store(
             let store = S3BlobStore::new(s3_cfg)?;
             Ok(Arc::new(store))
         }
+    }
+}
+
+/// Resolve the configured store for one pack runtime's effective access mode.
+///
+/// A read-only runtime retains `get`/`exists`/`size` against an already-present
+/// fs root (or a configured S3 store), but boot never creates the default fs
+/// root and the wrapper rejects every physical mutator. The mode belongs to the
+/// runtime assigned to the `blob` pack; a mixed topology must not infer it from
+/// the main audit backend.
+pub fn resolve_blob_store_for_mode(
+    cfg: &KhiveConfig,
+    backend: &StorageBackend,
+    read_only: bool,
+) -> Result<Arc<dyn BlobStore>, SqliteError> {
+    if !read_only {
+        return resolve_blob_store(cfg, backend);
+    }
+
+    let inner: Arc<dyn BlobStore> = match &cfg.storage.blob {
+        None => backend.blob_store_read_only(None, None)?,
+        Some(BlobConfig::Fs { root, floor_bytes }) => {
+            let root_path = root.as_ref().map(std::path::PathBuf::from);
+            backend.blob_store_read_only(root_path.as_deref(), *floor_bytes)?
+        }
+        Some(BlobConfig::S3 {
+            bucket,
+            region,
+            endpoint,
+            prefix,
+            allow_http,
+        }) => {
+            let mut s3_cfg = S3BlobStoreConfig::new(bucket.clone(), region.clone());
+            if let Some(endpoint) = endpoint {
+                s3_cfg = s3_cfg.with_endpoint(endpoint.clone());
+            }
+            if let Some(prefix) = prefix {
+                s3_cfg = s3_cfg.with_prefix(prefix.clone());
+            }
+            if let Some(allow_http) = allow_http {
+                s3_cfg = s3_cfg.with_allow_http(*allow_http);
+            }
+            Arc::new(S3BlobStore::new(s3_cfg)?)
+        }
+    };
+    Ok(Arc::new(ReadOnlyBlobStore { inner }))
+}
+
+#[derive(Debug)]
+struct ReadOnlyBlobStore {
+    inner: Arc<dyn BlobStore>,
+}
+
+impl ReadOnlyBlobStore {
+    fn mutation_error(operation: &'static str) -> StorageError {
+        StorageError::Unsupported {
+            capability: StorageCapability::Blob,
+            operation: operation.into(),
+            message: "blob storage is read-only for this pack runtime".to_string(),
+        }
+    }
+}
+
+#[async_trait]
+impl BlobStore for ReadOnlyBlobStore {
+    async fn put(&self, _bytes: Vec<u8>) -> StorageResult<ContentRef> {
+        Err(Self::mutation_error("put"))
+    }
+
+    async fn get(&self, content_ref: &ContentRef) -> StorageResult<Vec<u8>> {
+        self.inner.get(content_ref).await
+    }
+
+    async fn exists(&self, content_ref: &ContentRef) -> StorageResult<bool> {
+        self.inner.exists(content_ref).await
+    }
+
+    async fn size(&self, content_ref: &ContentRef) -> StorageResult<Option<u64>> {
+        self.inner.size(content_ref).await
+    }
+
+    async fn delete(&self, _content_ref: &ContentRef) -> StorageResult<bool> {
+        Err(Self::mutation_error("delete"))
+    }
+
+    async fn orphan_sweep(
+        &self,
+        _config: &BlobOrphanSweepConfig,
+    ) -> StorageResult<BlobOrphanSweepResult> {
+        Err(Self::mutation_error("orphan_sweep"))
+    }
+
+    async fn transactional_orphan_sweep(
+        &self,
+        _sql: &dyn SqlAccess,
+        _dry_run: bool,
+    ) -> StorageResult<BlobOrphanSweepResult> {
+        Err(Self::mutation_error("transactional_orphan_sweep"))
     }
 }
 

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -52,7 +52,7 @@ pub use atomic_runner::{
     run_atomic_unit, AtomicOpFailure, AtomicOpPlan, AtomicRunOutcome, AtomicRunnerError,
     CommittedPostCommitEffects,
 };
-pub use blob::resolve_blob_store;
+pub use blob::{resolve_blob_store, resolve_blob_store_for_mode};
 pub use build_info::{BuildInfo, BUILD_INFO, BUILD_VERSION};
 pub use config::{ann_fresh_tail_enabled_from_env, process_ref_from_env};
 pub use cost_unit::{base_resource_payload, cost_unit_for_dispatch, resource_payload};

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -112,7 +112,7 @@ pub use pack::{
     NoteKindSpec, NoteLifecycleSpec, PackByIdResolver, PackFactory, PackInstall, PackLoadError,
     PackRegistration, PackRegistry, PackRuntime, PackSchemaCollisionError, PackSchemaPlan,
     ParamDef, RequestIdentity, SchemaPlan, VerbCategory, VerbPresentationPolicy, VerbRegistry,
-    VerbRegistryBuilder, VerifiedActor, Visibility,
+    VerbRegistryBuilder, VerifiedActor, Visibility, AUDIT_PERSISTENCE_SKIPPED_READ_ONLY,
 };
 pub use phase_events::{emit_phase_event, is_benign_shutdown_cancellation};
 pub use portability::{ImportSummary, KgArchive};

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -8372,6 +8372,22 @@ mod help_tests {
             let writable = khive_db::StorageBackend::sqlite(&path).expect("writable backend");
             writable.prepare_core_schema().expect("current schema");
         }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            for suffix in ["-wal", "-shm"] {
+                let mut name = path.file_name().expect("db file name").to_os_string();
+                name.push(suffix);
+                let sidecar = path.parent().expect("db parent dir").join(name);
+                if sidecar.exists() {
+                    let mut permissions = std::fs::metadata(&sidecar)
+                        .expect("sidecar metadata")
+                        .permissions();
+                    permissions.set_mode(0o444);
+                    std::fs::set_permissions(&sidecar, permissions).expect("freeze sidecar");
+                }
+            }
+        }
         let backend = khive_db::StorageBackend::sqlite_read_only(&path).expect("read-only backend");
         let empty_map: HashMap<&str, &khive_db::StorageBackend> = HashMap::new();
 

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -41,6 +41,10 @@ use crate::validation::ValidationRule;
 /// [`VerbRegistry::pack_owned_note_kinds`].
 pub const GENERIC_CRUD_PACK: &str = "kg";
 
+/// Stable advisory code emitted when a successful inspection cannot persist
+/// its dispatch audit because the configured audit backend is read-only.
+pub const AUDIT_PERSISTENCE_SKIPPED_READ_ONLY: &str = "audit_persistence_skipped_read_only";
+
 const FULL_UUID_IDENTIFIER_HELP: &str = "A complete UUID spelling accepted by the consuming \
     parameter directly names one globally unique record; direct UUID lookup is not a namespace \
     search. Strict identifier responses use canonical lowercase dashed UUIDs.";
@@ -460,6 +464,9 @@ pub struct VerbRegistryBuilder {
     /// registry does not depend on the full `KhiveRuntime` surface — only the
     /// audit-persistence capability is needed here.
     event_store: Option<Arc<dyn EventStore>>,
+    /// The configured audit backend is intentionally read-only, so dispatch
+    /// omits the known-failing append and the transport surfaces an advisory.
+    audit_store_read_only: bool,
     /// Optional post-dispatch hook.
     ///
     /// When set, every successful pack dispatch calls `hook.on_dispatch(view)`
@@ -479,6 +486,7 @@ impl VerbRegistryBuilder {
             visible_namespaces: vec![],
             actor_id: None,
             event_store: None,
+            audit_store_read_only: false,
             dispatch_hook: None,
         }
     }
@@ -568,6 +576,18 @@ impl VerbRegistryBuilder {
     /// a durable receipt and therefore fails safely when no store is configured.
     pub fn with_event_store(&mut self, store: Arc<dyn EventStore>) -> &mut Self {
         self.event_store = Some(store);
+        self.audit_store_read_only = false;
+        self
+    }
+
+    /// Mark audit persistence unavailable because its backend is read-only.
+    ///
+    /// No `EventStore` is retained, so dispatch never attempts a write that is
+    /// known to fail. Successful request entries expose a machine-readable
+    /// advisory without changing their canonical verb result shape.
+    pub fn with_read_only_audit_store(&mut self) -> &mut Self {
+        self.event_store = None;
+        self.audit_store_read_only = true;
         self
     }
 
@@ -688,6 +708,7 @@ impl VerbRegistryBuilder {
             visible_namespaces: self.visible_namespaces,
             actor_id: self.actor_id,
             event_store: self.event_store,
+            audit_store_read_only: self.audit_store_read_only,
             dispatch_hook: self.dispatch_hook,
             available_verbs: Arc::new(available_verbs),
             reference_ring: Arc::new(crate::reference_ring::ReferenceRing::new()),
@@ -867,6 +888,9 @@ pub struct VerbRegistry {
     actor_id: Option<String>,
     /// Audit event sink — `None` means tracing-only (v0.2 default).
     event_store: Option<Arc<dyn EventStore>>,
+    /// Distinguishes ordinary tracing-only construction from a sink omitted
+    /// deliberately because its configured backend is read-only.
+    audit_store_read_only: bool,
     /// Post-dispatch hook: `None` means no real-time observation.
     dispatch_hook: Option<Arc<dyn DispatchHook>>,
     /// Names of all `Visibility::Verb` handlers across all packs, precomputed
@@ -1197,10 +1221,28 @@ impl VerbRegistry {
     /// `dispatch` (e.g. the email channel poll loop) append best-effort
     /// lifecycle events to the same sink gate-check audit rows use, without
     /// threading a second `Option<Arc<dyn EventStore>>` field through every
-    /// caller. `None` means tracing-only, matching the registry's own
-    /// audit-persistence default.
+    /// caller. `None` means either the historical tracing-only default or an
+    /// intentionally read-only audit backend; callers that need to distinguish
+    /// those cases use [`Self::audit_persistence_advisory`].
     pub fn event_store(&self) -> Option<Arc<dyn EventStore>> {
         self.event_store.clone()
+    }
+
+    /// Advisory for a dispatch whose configured audit sink is read-only.
+    ///
+    /// The MCP transport places this beside successful per-operation results;
+    /// `None` means audit persistence is configured normally or was never
+    /// configured at all.
+    pub fn audit_persistence_advisory(&self) -> Option<Value> {
+        self.audit_store_read_only.then(|| {
+            serde_json::json!({
+                "code": AUDIT_PERSISTENCE_SKIPPED_READ_ONLY,
+                "severity": "warning",
+                "component": "audit_event_store",
+                "reason": "read_only_backend",
+                "message": "operation completed, but its dispatch audit event was not persisted because the audit backend is read-only",
+            })
+        })
     }
 
     /// Return the help schema envelope for a verb.
@@ -2528,6 +2570,12 @@ impl VerbRegistry {
     /// rest from loading. Callers that need hard-failure semantics should call
     /// `all_schema_plans()` and apply each plan individually.
     pub fn apply_schema_plans(&self, backend: &khive_db::StorageBackend) {
+        if backend.is_read_only() {
+            tracing::info!(
+                "skipping pack schema plans because the backend is read-only; snapshot schema is used as-is"
+            );
+            return;
+        }
         for plan in self.all_schema_plans() {
             if plan.is_empty() {
                 continue;
@@ -2586,6 +2634,13 @@ impl VerbRegistry {
                 .get(pack_name)
                 .copied()
                 .unwrap_or(default_backend);
+            if backend.is_read_only() {
+                tracing::info!(
+                    pack = pack_name,
+                    "skipping pack schema plan because its assigned backend is read-only"
+                );
+                continue;
+            }
             let backend_ptr = std::sync::Arc::as_ptr(&backend.pool_arc()) as *const ();
 
             // Pre-scan DDL for table names and detect collisions before applying.

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -2634,13 +2634,6 @@ impl VerbRegistry {
                 .get(pack_name)
                 .copied()
                 .unwrap_or(default_backend);
-            if backend.is_read_only() {
-                tracing::info!(
-                    pack = pack_name,
-                    "skipping pack schema plan because its assigned backend is read-only"
-                );
-                continue;
-            }
             let backend_ptr = std::sync::Arc::as_ptr(&backend.pool_arc()) as *const ();
 
             // Pre-scan DDL for table names and detect collisions before applying.
@@ -2661,6 +2654,14 @@ impl VerbRegistry {
                         }
                     }
                 }
+            }
+
+            if backend.is_read_only() {
+                tracing::info!(
+                    pack = pack_name,
+                    "skipping pack schema plan because its assigned backend is read-only"
+                );
+                continue;
             }
 
             backend
@@ -8360,6 +8361,54 @@ mod help_tests {
         assert!(
             msg.contains("collision_table"),
             "collision error must name the table; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn apply_schema_plans_with_map_read_only_collision_is_an_error_without_writes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("read_only_schema_collision.db");
+        {
+            let writable = khive_db::StorageBackend::sqlite(&path).expect("writable backend");
+            writable.prepare_core_schema().expect("current schema");
+        }
+        let backend = khive_db::StorageBackend::sqlite_read_only(&path).expect("read-only backend");
+        let empty_map: HashMap<&str, &khive_db::StorageBackend> = HashMap::new();
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register_boxed(Box::new(SchemaPack {
+            pack_name: "pack_alpha",
+            statements: &["CREATE TABLE IF NOT EXISTS collision_table (id INTEGER PRIMARY KEY)"],
+        }));
+        builder.register_boxed(Box::new(SchemaPack {
+            pack_name: "pack_beta",
+            statements: &["CREATE TABLE IF NOT EXISTS collision_table (id INTEGER PRIMARY KEY)"],
+        }));
+        let registry = builder.build().expect("registry builds");
+        let writes_before = backend.pool().writer_acquisition_snapshot();
+
+        let result = registry.apply_schema_plans_with_map(&empty_map, &backend);
+
+        let err = result.expect_err(
+            "read-only topology must reject the same cross-pack collision as writable topology",
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("pack_alpha"),
+            "collision error must name first pack; got: {msg}"
+        );
+        assert!(
+            msg.contains("pack_beta"),
+            "collision error must name second pack; got: {msg}"
+        );
+        assert!(
+            msg.contains("collision_table"),
+            "collision error must name the table; got: {msg}"
+        );
+        assert_eq!(
+            backend.pool().writer_acquisition_snapshot(),
+            writes_before,
+            "read-only collision validation must not acquire a writer"
         );
     }
 }

--- a/crates/khive-runtime/src/phase_events.rs
+++ b/crates/khive-runtime/src/phase_events.rs
@@ -51,6 +51,12 @@ pub async fn emit_phase_event<P: serde::Serialize>(
     kind: khive_types::EventKind,
     payload: P,
 ) {
+    // A snapshot-inspection runtime has no durable audit sink by contract.
+    // Returning before store resolution is stronger than merely swallowing a
+    // rejected append: no writer-bearing EventStore path is entered at all.
+    if rt.is_read_only() {
+        return;
+    }
     // Best-effort exactly like ADR-094's other lifecycle-event emitters: a
     // backend that cannot resolve an `EventStore` for this token's namespace
     // is treated as an unconfigured audit sink, not an error to propagate.
@@ -84,6 +90,54 @@ pub async fn emit_phase_event<P: serde::Serialize>(
             event_kind = %kind.name(),
             label,
             "ADR-103 phase-span event append failed"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::RuntimeConfig;
+
+    struct MustNotSerialize;
+
+    impl serde::Serialize for MustNotSerialize {
+        fn serialize<S>(&self, _serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            panic!("a read-only phase event must return before payload serialization")
+        }
+    }
+
+    #[tokio::test]
+    async fn read_only_phase_event_returns_before_store_or_payload_work() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = RuntimeConfig {
+            db_path: Some(dir.path().join("read-only-phase-events.db")),
+            ..RuntimeConfig::no_embeddings()
+        };
+        drop(KhiveRuntime::new(config.clone()).expect("migrate snapshot source"));
+        let runtime = KhiveRuntime::new_readonly(config).expect("open snapshot read-only");
+        let token = runtime
+            .authorize(crate::Namespace::local())
+            .expect("authorize local");
+        let before = runtime.backend().pool().writer_acquisition_snapshot();
+
+        emit_phase_event(
+            &runtime,
+            &token,
+            "read-only.phase-test",
+            khive_types::EventKind::PhaseStarted,
+            MustNotSerialize,
+        )
+        .await;
+
+        assert_eq!(
+            runtime.backend().pool().writer_acquisition_snapshot(),
+            before,
+            "read-only phase suppression must not enter the writer plane"
         );
     }
 }

--- a/crates/khive-runtime/src/phase_events.rs
+++ b/crates/khive-runtime/src/phase_events.rs
@@ -119,6 +119,23 @@ mod tests {
             ..RuntimeConfig::no_embeddings()
         };
         drop(KhiveRuntime::new(config.clone()).expect("migrate snapshot source"));
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let db_path = config.db_path.as_ref().expect("db path");
+            for suffix in ["-wal", "-shm"] {
+                let mut name = db_path.file_name().expect("db file name").to_os_string();
+                name.push(suffix);
+                let sidecar = db_path.parent().expect("db parent dir").join(name);
+                if sidecar.exists() {
+                    let mut permissions = std::fs::metadata(&sidecar)
+                        .expect("sidecar metadata")
+                        .permissions();
+                    permissions.set_mode(0o444);
+                    std::fs::set_permissions(&sidecar, permissions).expect("freeze sidecar");
+                }
+            }
+        }
         let runtime = KhiveRuntime::new_readonly(config).expect("open snapshot read-only");
         let token = runtime
             .authorize(crate::Namespace::local())

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -1401,6 +1401,11 @@ mod tests {
         let runtime = KhiveRuntime::new(read_only_config)
             .expect("read-only boot must validate instead of migrating/registering");
         assert!(runtime.is_read_only());
+        assert_eq!(
+            runtime.backend().pool().writer_acquisition_snapshot(),
+            khive_db::pool::WriterAcquisitionSnapshot::default(),
+            "the construction-inclusive acquisition baseline must stay at zero"
+        );
         assert!(
             runtime
                 .list_embedding_models(None)
@@ -1433,6 +1438,12 @@ mod tests {
 
         let runtime = KhiveRuntime::new_readonly(config).expect("explicit read-only boot");
         assert!(runtime.is_read_only());
+        assert_eq!(
+            runtime.backend().pool().writer_acquisition_snapshot(),
+            khive_db::pool::WriterAcquisitionSnapshot::default(),
+            "explicit read-only construction must validate through a reader without ever \
+             acquiring the writer"
+        );
     }
 
     /// A `~/`-prefixed `--db`/`KHIVE_DB` override must resolve, boot, and

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -168,13 +168,13 @@ impl KhiveRuntime {
             }
             None => StorageBackend::memory()?,
         };
-        // Migrations must run before any pack handler touches the DB; idempotent;
-        // failure aborts construction with a clear error.
-        {
-            let mut writer = backend.pool().try_writer()?;
-            khive_db::run_migrations(writer.conn_mut())?;
+        // Writable backends migrate before handlers touch the DB. A detected
+        // read-only snapshot is validated at the current schema version without
+        // attempting migration DDL.
+        backend.prepare_core_schema()?;
+        if !backend.is_read_only() {
+            register_configured_embedding_models(&backend, &config)?;
         }
-        register_configured_embedding_models(&backend, &config)?;
         let (registry, default_embedder_name) = build_embedder_registry(&config);
         Ok(Self {
             backend: Arc::new(backend),
@@ -196,19 +196,17 @@ impl KhiveRuntime {
 
     /// Open a runtime for read-only inspection (no model registration, no DB creation).
     ///
-    /// Runs migrations (idempotent) but skips `register_configured_embedding_models`,
-    /// so `engine list` / `engine status` cannot mutate the registry as a side effect.
-    /// Returns `None` when `db_path` is `None` and the default DB does not exist.
+    /// File-backed databases are opened with SQLite read-only/query-only flags
+    /// and must already be at this build's current schema version. No migrations
+    /// or configured-model registration writes are attempted. A `None` path
+    /// retains the historical ephemeral in-memory behavior for tests.
     pub fn new_readonly(config: RuntimeConfig) -> RuntimeResult<Self> {
         let ann_fresh_tail_enabled = crate::config::ann_fresh_tail_enabled_from_env();
         let backend = match &config.db_path {
-            Some(path) => StorageBackend::sqlite(path)?,
+            Some(path) => StorageBackend::sqlite_read_only(path)?,
             None => StorageBackend::memory()?,
         };
-        {
-            let mut writer = backend.pool().try_writer()?;
-            khive_db::run_migrations(writer.conn_mut())?;
-        }
+        backend.prepare_core_schema()?;
         let (registry, default_embedder_name) = build_embedder_registry(&config);
         Ok(Self {
             backend: Arc::new(backend),
@@ -239,8 +237,10 @@ impl KhiveRuntime {
     /// `default_namespace` via the config builder pattern if non-defaults are needed.
     pub fn from_backend(backend: Arc<StorageBackend>, config: RuntimeConfig) -> Self {
         let ann_fresh_tail_enabled = crate::config::ann_fresh_tail_enabled_from_env();
-        if let Err(err) = register_configured_embedding_models(&backend, &config) {
-            tracing::warn!(error = %err, "failed to register configured embedding models");
+        if !backend.is_read_only() {
+            if let Err(err) = register_configured_embedding_models(&backend, &config) {
+                tracing::warn!(error = %err, "failed to register configured embedding models");
+            }
         }
         let (registry, default_embedder_name) = build_embedder_registry(&config);
         Self {
@@ -377,6 +377,12 @@ impl KhiveRuntime {
     /// Return a reference to the underlying storage backend.
     pub fn backend(&self) -> &StorageBackend {
         &self.backend
+    }
+
+    /// Whether this runtime's bound backend is explicitly or filesystem-mode
+    /// detected read-only.
+    pub fn is_read_only(&self) -> bool {
+        self.backend.is_read_only()
     }
 
     /// Return the directory containing the backend's database file, or `None`
@@ -1346,6 +1352,81 @@ mod tests {
         let rt = KhiveRuntime::new(config).expect("file runtime should create");
         assert!(path.exists());
         assert_eq!(rt.config().default_namespace.as_str(), "test");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn normal_boot_detects_read_only_snapshot_and_skips_model_registration() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("read_only_runtime.db");
+        let base = RuntimeConfig {
+            git_write: Default::default(),
+            db_path: Some(path.clone()),
+            default_namespace: Namespace::local(),
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            gate: Arc::new(AllowAllGate),
+            packs: vec!["kg".to_string()],
+            backend_id: BackendId::main(),
+            brain_profile: None,
+            visible_namespaces: vec![],
+            allowed_outbound_namespaces: vec![],
+            actor_id: None,
+        };
+        {
+            let writable = KhiveRuntime::new(base.clone()).expect("create migrated snapshot");
+            assert!(writable
+                .list_embedding_models(None)
+                .await
+                .expect("registry query")
+                .is_empty());
+        }
+
+        let mut permissions = std::fs::metadata(&path).unwrap().permissions();
+        permissions.set_mode(0o444);
+        std::fs::set_permissions(&path, permissions).unwrap();
+
+        let read_only_config = RuntimeConfig {
+            embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
+            ..base
+        };
+        let runtime = KhiveRuntime::new(read_only_config)
+            .expect("read-only boot must validate instead of migrating/registering");
+        assert!(runtime.is_read_only());
+        assert!(
+            runtime
+                .list_embedding_models(None)
+                .await
+                .expect("read-only registry query")
+                .is_empty(),
+            "configured models must remain in-memory only during read-only boot"
+        );
+    }
+
+    #[test]
+    fn explicit_readonly_constructor_uses_read_only_pool_even_on_writable_file_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("explicit_read_only_runtime.db");
+        let config = RuntimeConfig {
+            git_write: Default::default(),
+            db_path: Some(path.clone()),
+            default_namespace: Namespace::local(),
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            gate: Arc::new(AllowAllGate),
+            packs: vec!["kg".to_string()],
+            backend_id: BackendId::main(),
+            brain_profile: None,
+            visible_namespaces: vec![],
+            allowed_outbound_namespaces: vec![],
+            actor_id: None,
+        };
+        KhiveRuntime::new(config.clone()).expect("create migrated database");
+
+        let runtime = KhiveRuntime::new_readonly(config).expect("explicit read-only boot");
+        assert!(runtime.is_read_only());
     }
 
     /// A `~/`-prefixed `--db`/`KHIVE_DB` override must resolve, boot, and

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -1393,6 +1393,21 @@ mod tests {
         let mut permissions = std::fs::metadata(&path).unwrap().permissions();
         permissions.set_mode(0o444);
         std::fs::set_permissions(&path, permissions).unwrap();
+        // A lingering writable `-shm` from the writable fixture's asynchronous
+        // connection close is rejected by read-only admission as potentially
+        // live; freeze any sidecars into the documented frozen-snapshot form.
+        for suffix in ["-wal", "-shm"] {
+            let mut name = path.file_name().expect("db file name").to_os_string();
+            name.push(suffix);
+            let sidecar = path.parent().expect("db parent dir").join(name);
+            if sidecar.exists() {
+                let mut sidecar_permissions = std::fs::metadata(&sidecar)
+                    .expect("sidecar metadata")
+                    .permissions();
+                sidecar_permissions.set_mode(0o444);
+                std::fs::set_permissions(&sidecar, sidecar_permissions).expect("freeze sidecar");
+            }
+        }
 
         let read_only_config = RuntimeConfig {
             embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -1069,6 +1069,12 @@ impl KhiveRuntime {
         model_name: &str,
         duration_us: i64,
     ) {
+        // Lazy embedder construction can happen during daemon warm or an
+        // assertive request. A snapshot has no durable audit sink, so do not
+        // resolve an EventStore merely to attempt a known-rejected append.
+        if self.is_read_only() {
+            return;
+        }
         let Ok(store) = self.events(token) else {
             return;
         };

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -1450,6 +1450,22 @@ mod tests {
             actor_id: None,
         };
         KhiveRuntime::new(config.clone()).expect("create migrated database");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            for suffix in ["-wal", "-shm"] {
+                let mut name = path.file_name().expect("db file name").to_os_string();
+                name.push(suffix);
+                let sidecar = path.parent().expect("db parent dir").join(name);
+                if sidecar.exists() {
+                    let mut permissions = std::fs::metadata(&sidecar)
+                        .expect("sidecar metadata")
+                        .permissions();
+                    permissions.set_mode(0o444);
+                    std::fs::set_permissions(&sidecar, permissions).expect("freeze sidecar");
+                }
+            }
+        }
 
         let runtime = KhiveRuntime::new_readonly(config).expect("explicit read-only boot");
         assert!(runtime.is_read_only());

--- a/crates/kkernel/src/cli.rs
+++ b/crates/kkernel/src/cli.rs
@@ -970,6 +970,25 @@ mod tests {
         })
         .await
         .expect("migrate creates the database");
+        // SQLite connection close is deferred, so the migrate above can leave
+        // writable `-wal`/`-shm` sidecars behind at this point; the read-only
+        // inspection below accepts only the frozen snapshot form.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            for suffix in ["-wal", "-shm"] {
+                let mut name = path.file_name().expect("db file name").to_os_string();
+                name.push(suffix);
+                let sidecar = path.parent().expect("db parent dir").join(name);
+                if sidecar.exists() {
+                    let mut permissions = std::fs::metadata(&sidecar)
+                        .expect("sidecar metadata")
+                        .permissions();
+                    permissions.set_mode(0o444);
+                    std::fs::set_permissions(&sidecar, permissions).expect("freeze sidecar");
+                }
+            }
+        }
         let before = std::fs::read(&path).expect("read db before check");
         // strict passes only when the db is already current — proves the read sees V1.
         cmd_db_check(DbCheckArgs {

--- a/crates/kkernel/src/code_audit.rs
+++ b/crates/kkernel/src/code_audit.rs
@@ -1695,6 +1695,35 @@ crate-b = 1
         }
     }
 
+    #[cfg(unix)]
+    fn freeze_snapshot_sidecars(path: &Path) {
+        use std::os::unix::fs::PermissionsExt;
+        for suffix in ["-wal", "-shm"] {
+            let mut name = path.file_name().expect("db file name").to_os_string();
+            name.push(suffix);
+            let sidecar = path.parent().expect("db parent dir").join(name);
+            if sidecar.exists() {
+                let mut permissions = std::fs::metadata(&sidecar)
+                    .expect("sidecar metadata")
+                    .permissions();
+                permissions.set_mode(0o444);
+                std::fs::set_permissions(&sidecar, permissions).expect("freeze sidecar");
+            }
+        }
+    }
+
+    /// `generate_report` behind the frozen-snapshot form its read-only open
+    /// accepts. SQLite connection close is deferred, so a fixture seeded and
+    /// dropped just above can still hold writable `-wal`/`-shm` sidecars when
+    /// the report's read-only open runs; freeze them at the read boundary
+    /// (not inside the seeder — several tests reopen the fixture writably to
+    /// add rows after seeding).
+    async fn frozen_generate_report(request: &AuditRequest) -> Result<AuditReport> {
+        #[cfg(unix)]
+        freeze_snapshot_sidecars(&request.map_db);
+        generate_report(request).await
+    }
+
     #[tokio::test]
     async fn layering_violation_flags_upward_dependency() {
         let tmp = tempfile::TempDir::new().unwrap();
@@ -1702,7 +1731,9 @@ crate-b = 1
         build_fixture(&db, [0, 1]).await;
         let policy = test_policy(tmp.path());
 
-        let report = generate_report(&base_request(db, policy)).await.unwrap();
+        let report = frozen_generate_report(&base_request(db, policy))
+            .await
+            .unwrap();
         // crate-a (rank 0) depends_on crate-b (rank 1): a lower-ranked,
         // more-foundational crate depending on a higher-ranked crate is the
         // violating direction. The reverse edge in the fixture (crate-b ->
@@ -1743,7 +1774,7 @@ crate-b = 1
 
         let mut with_dev = base_request(tmp.path().join("map.db"), test_policy(tmp.path()));
         with_dev.include_dev_dependencies = true;
-        let report_with_dev = generate_report(&with_dev).await.unwrap();
+        let report_with_dev = frozen_generate_report(&with_dev).await.unwrap();
         let unmapped = report_with_dev
             .signals
             .iter()
@@ -1759,7 +1790,9 @@ crate-b = 1
         build_fixture(&db, [0, 1]).await;
         let policy = test_policy(tmp.path());
 
-        let report = generate_report(&base_request(db, policy)).await.unwrap();
+        let report = frozen_generate_report(&base_request(db, policy))
+            .await
+            .unwrap();
         let project_cycle = report.signals.iter().any(|s| {
             s.id == "dependency_cycle"
                 && s.subject_id.starts_with("project_production:")
@@ -1798,7 +1831,9 @@ crate-b = 1
         build_fixture(&db, [0, 1]).await;
         let policy = test_policy(tmp.path());
 
-        let report = generate_report(&base_request(db, policy)).await.unwrap();
+        let report = frozen_generate_report(&base_request(db, policy))
+            .await
+            .unwrap();
 
         // Subject is now the module's own ID (not its display name), so the
         // two same-named `crate_a::lib` modules each get an independent,
@@ -1839,7 +1874,9 @@ crate-b = 1
         build_fixture(&db, [0, 1]).await;
         let policy = test_policy(tmp.path());
 
-        let report = generate_report(&base_request(db, policy)).await.unwrap();
+        let report = frozen_generate_report(&base_request(db, policy))
+            .await
+            .unwrap();
         // crate-a itself carries no `unresolved_specifiers` property; the
         // one unresolved import lives on its `crate_a::orphan` MODULE
         // (source_ingest.rs:776-784). The pre-fix code read only the
@@ -1884,7 +1921,9 @@ crate-b = 1
 "#,
         );
 
-        let report = generate_report(&base_request(db, policy)).await.unwrap();
+        let report = frozen_generate_report(&base_request(db, policy))
+            .await
+            .unwrap();
         let orphan = report
             .signals
             .iter()
@@ -1907,7 +1946,9 @@ crate-b = 1
         build_fixture(&db, [0, 1]).await;
         let policy = test_policy(tmp.path());
 
-        let report = generate_report(&base_request(db, policy)).await.unwrap();
+        let report = frozen_generate_report(&base_request(db, policy))
+            .await
+            .unwrap();
         for id in ["churn_hotspot", "dead_file", "orphan_test_file"] {
             assert!(
                 report
@@ -1930,14 +1971,14 @@ crate-b = 1
 
         let db_a = tmp.path().join("map_a.db");
         build_fixture(&db_a, [0, 1]).await;
-        let report_a = generate_report(&base_request(db_a, policy.clone()))
+        let report_a = frozen_generate_report(&base_request(db_a, policy.clone()))
             .await
             .unwrap();
         let json_a = serde_json::to_string_pretty(&report_a).unwrap();
 
         let db_b = tmp.path().join("map_b.db");
         build_fixture(&db_b, [1, 0]).await;
-        let report_b = generate_report(&base_request(db_b, policy.clone()))
+        let report_b = frozen_generate_report(&base_request(db_b, policy.clone()))
             .await
             .unwrap();
         let json_b = serde_json::to_string_pretty(&report_b).unwrap();
@@ -1949,7 +1990,9 @@ crate-b = 1
 
         let db_c = tmp.path().join("map_c.db");
         build_fixture(&db_c, [0, 1]).await;
-        let report_c = generate_report(&base_request(db_c, policy)).await.unwrap();
+        let report_c = frozen_generate_report(&base_request(db_c, policy))
+            .await
+            .unwrap();
         let json_c = serde_json::to_string_pretty(&report_c).unwrap();
         assert_eq!(
             json_a, json_c,
@@ -2050,7 +2093,9 @@ cargo-dev-dep = 1
 undeclared-dep = 1
 "#,
         );
-        let report = generate_report(&base_request(db, policy)).await.unwrap();
+        let report = frozen_generate_report(&base_request(db, policy))
+            .await
+            .unwrap();
 
         let flagged: Vec<&Signal> = report
             .signals
@@ -2075,7 +2120,7 @@ undeclared-dep = 1
         let tmp = tempfile::TempDir::new().unwrap();
         let db = tmp.path().join("does-not-exist.db");
         let policy = test_policy(tmp.path());
-        let err = generate_report(&base_request(db, policy))
+        let err = frozen_generate_report(&base_request(db, policy))
             .await
             .unwrap_err();
         assert!(err.to_string().contains("does not exist"));
@@ -2098,7 +2143,9 @@ undeclared-dep = 1
 
         // H1: a partial map missing an entire table must still produce a
         // report — not abort the whole command.
-        let report = generate_report(&base_request(db, policy)).await.unwrap();
+        let report = frozen_generate_report(&base_request(db, policy))
+            .await
+            .unwrap();
         assert!(report
             .errors
             .iter()
@@ -2144,7 +2191,9 @@ undeclared-dep = 1
         }
         let policy = test_policy(tmp.path());
 
-        let report = generate_report(&base_request(db, policy)).await.unwrap();
+        let report = frozen_generate_report(&base_request(db, policy))
+            .await
+            .unwrap();
         assert!(report
             .errors
             .iter()
@@ -2183,7 +2232,9 @@ undeclared-dep = 1
         // must not suppress them — only the dependency-kind-classification
         // signals (layering, manifest/import mismatch, dependency cycles)
         // may degrade.
-        let report = generate_report(&base_request(db, policy)).await.unwrap();
+        let report = frozen_generate_report(&base_request(db, policy))
+            .await
+            .unwrap();
         assert!(report
             .errors
             .iter()
@@ -2272,7 +2323,9 @@ undeclared-dep = 1
         // ONLY that column must not suppress them — only the signals that
         // read `id` (layering, manifest/import mismatch, dependency cycles)
         // may degrade.
-        let report = generate_report(&base_request(db, policy)).await.unwrap();
+        let report = frozen_generate_report(&base_request(db, policy))
+            .await
+            .unwrap();
         assert!(report
             .errors
             .iter()

--- a/crates/kkernel/src/code_ingest.rs
+++ b/crates/kkernel/src/code_ingest.rs
@@ -509,11 +509,13 @@ fn preflight_secret_gate(batch: &CodeIngestBatch) -> Result<()> {
 /// ordinary WAL shared-memory maintenance on open, which creates or updates
 /// the `-shm` sidecar next to whatever path it is pointed at. Opening the
 /// target path directly would therefore still touch it. Instead, the
-/// database file (and its `-wal` sidecar, if one exists — an existing WAL
-/// file holds uncheckpointed rows that a plain copy of the main db file
-/// alone would miss) are copied into a scratch temp directory first, and
-/// the read-only checks run against that copy. No migrations run and no
-/// embedding models are registered, unlike `KhiveRuntime::new`.
+/// database file (and its `-wal`/`-shm` sidecars, if present — an existing
+/// WAL file holds uncheckpointed rows that a plain copy of the main db file
+/// alone would miss, and the read-only open requires the shared-memory
+/// index beside a non-empty WAL) are copied into a scratch temp directory
+/// and marked read-only, and the checks run against that frozen copy. No
+/// migrations run and no embedding models are registered, unlike
+/// `KhiveRuntime::new`.
 async fn dry_run_report(
     db_path: Option<&Path>,
     batch: &CodeIngestBatch,
@@ -605,6 +607,36 @@ fn open_read_only_snapshot(db_path: &Path) -> Result<(StorageBackend, tempfile::
         std::fs::copy(&wal_path, &snapshot_wal)
             .with_context(|| format!("failed to snapshot {} for dry-run", wal_path.display()))?;
     }
+    // The read-only open below refuses a non-empty WAL sidecar with no
+    // shared-memory index beside it (immutable mode would drop committed
+    // frames) and refuses a writable one (a live index is not a snapshot).
+    // Carry the `-shm` beside the WAL copy and mark both copies read-only:
+    // this private point-in-time copy is exactly the frozen snapshot form
+    // that open accepts. `fs::copy` preserves the source's (writable)
+    // permission bits, so the freeze is required, not decorative.
+    let shm_path = shm_sidecar_path(db_path);
+    if shm_path.exists() {
+        let snapshot_shm = shm_sidecar_path(&snapshot_db);
+        std::fs::copy(&shm_path, &snapshot_shm)
+            .with_context(|| format!("failed to snapshot {} for dry-run", shm_path.display()))?;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        for sidecar in [
+            wal_sidecar_path(&snapshot_db),
+            shm_sidecar_path(&snapshot_db),
+        ] {
+            if sidecar.exists() {
+                let mut permissions = std::fs::metadata(&sidecar)
+                    .with_context(|| format!("stat snapshot sidecar {}", sidecar.display()))?
+                    .permissions();
+                permissions.set_mode(0o444);
+                std::fs::set_permissions(&sidecar, permissions)
+                    .with_context(|| format!("freeze snapshot sidecar {}", sidecar.display()))?;
+            }
+        }
+    }
 
     let backend =
         StorageBackend::sqlite_read_only(&snapshot_db).map_err(|e| anyhow::anyhow!("{e}"))?;
@@ -615,6 +647,14 @@ fn open_read_only_snapshot(db_path: &Path) -> Result<(StorageBackend, tempfile::
 fn wal_sidecar_path(db_path: &Path) -> PathBuf {
     let mut name = db_path.as_os_str().to_owned();
     name.push("-wal");
+    PathBuf::from(name)
+}
+
+/// The `-shm` shared-memory index path SQLite uses alongside a WAL-mode
+/// database file.
+fn shm_sidecar_path(db_path: &Path) -> PathBuf {
+    let mut name = db_path.as_os_str().to_owned();
+    name.push("-shm");
     PathBuf::from(name)
 }
 

--- a/crates/kkernel/src/engine.rs
+++ b/crates/kkernel/src/engine.rs
@@ -277,7 +277,12 @@ mod tests {
     fn temp_db() -> (TempDir, Option<std::path::PathBuf>) {
         let tmp = TempDir::new().expect("temp dir");
         let path = tmp.path().join("engine_test.db");
-        std::fs::File::create(&path).expect("create empty db file");
+        let runtime = KhiveRuntime::new(RuntimeConfig {
+            db_path: Some(path.clone()),
+            ..RuntimeConfig::no_embeddings()
+        })
+        .expect("create and migrate engine test database");
+        drop(runtime);
         (tmp, Some(path))
     }
 

--- a/crates/kkernel/src/engine.rs
+++ b/crates/kkernel/src/engine.rs
@@ -283,6 +283,26 @@ mod tests {
         })
         .expect("create and migrate engine test database");
         drop(runtime);
+        // SQLite connection close is deferred, so the drop above can leave
+        // writable `-wal`/`-shm` sidecars behind; the commands under test
+        // open this database read-only, which accepts only the frozen
+        // snapshot form. No engine test writes after this point.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            for suffix in ["-wal", "-shm"] {
+                let mut name = path.file_name().expect("db file name").to_os_string();
+                name.push(suffix);
+                let sidecar = path.parent().expect("db parent dir").join(name);
+                if sidecar.exists() {
+                    let mut permissions = std::fs::metadata(&sidecar)
+                        .expect("sidecar metadata")
+                        .permissions();
+                    permissions.set_mode(0o444);
+                    std::fs::set_permissions(&sidecar, permissions).expect("freeze sidecar");
+                }
+            }
+        }
         (tmp, Some(path))
     }
 

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -47,9 +47,9 @@ use khive_mcp::serve::{
     normalize_redundant_db_override_with_source, reject_conflicting_db_override_with_source,
     RuntimeConfigInputs,
 };
-#[cfg(unix)]
-use khive_mcp::server::compute_config_id;
 use khive_mcp::server::KhiveMcpServer;
+#[cfg(unix)]
+use khive_mcp::server::{compute_config_id, compute_config_id_with_storage_mode};
 use khive_mcp::tools::request::RequestParams;
 #[cfg(unix)]
 use khive_runtime::{daemon::PROTOCOL_VERSION, DaemonRequestFrame};
@@ -1970,8 +1970,10 @@ async fn run_exec_inline_with_forward(
     // correctly rejects it. A matching concrete override is redundant, so its
     // fingerprint and captured construction anchor are normalized to the same
     // values used when no override is supplied.
-    if !khive_cfg.backends.is_empty() {
-        normalize_redundant_db_override_with_source(
+    let force_memory = if khive_cfg.backends.is_empty() {
+        false
+    } else {
+        let force_memory = normalize_redundant_db_override_with_source(
             &mut cfg,
             db_context.raw.as_deref(),
             &khive_cfg.backends,
@@ -1980,7 +1982,8 @@ async fn run_exec_inline_with_forward(
         if matches!(db_context.raw.as_deref(), Some(path) if path != ":memory:") {
             db_context.anchor = cfg.db_path.clone();
         }
-    }
+        force_memory
+    };
 
     disclose_resolved_database(&cfg, &khive_cfg);
 
@@ -2006,8 +2009,16 @@ async fn run_exec_inline_with_forward(
                 .map(|ns| ns.as_str().to_string())
                 .collect(),
             // Fold the SAME backends topology the daemon folds (`Some(&khive_cfg)`)
-            // instead of `None` — see the `khive_cfg` load above.
-            config_id: compute_config_id(&cfg, Some(&khive_cfg)),
+            // instead of `None` — see the `khive_cfg` load above. A force-memory
+            // override also supplies the effective writable mode explicitly:
+            // the declaration can say `main.read_only = true`, but the runtime
+            // the child opens is writable memory and fingerprints that captured
+            // mode after construction.
+            config_id: if force_memory {
+                compute_config_id_with_storage_mode(&cfg, Some(&khive_cfg), false)
+            } else {
+                compute_config_id(&cfg, Some(&khive_cfg))
+            },
             protocol_version: PROTOCOL_VERSION,
             probe_only: false,
             metrics_only: false,
@@ -5314,6 +5325,106 @@ id = "lambda:fallback"
             Some(":memory:".to_string()),
             "the daemon spawn seam must receive the raw --db override so a spawned daemon \
              can be constructed with the same ephemeral in-memory storage"
+        );
+    }
+
+    /// A declared read-only SQLite `main` backend becomes a writable memory
+    /// backend when `--db :memory:` forces the whole topology ephemeral. The
+    /// pre-open exec frame must fingerprint that effective runtime mode, not
+    /// the superseded declaration, or the freshly spawned daemon rejects its
+    /// very first request as a config mismatch.
+    #[cfg(unix)]
+    #[tokio::test]
+    #[serial]
+    async fn force_memory_exec_frame_matches_opened_read_only_topology_runtime() {
+        std::env::remove_var("KHIVE_EMBEDDING_MODEL");
+        std::env::remove_var("KHIVE_ADDITIONAL_EMBEDDING_MODELS");
+        std::env::remove_var("KHIVE_ACTOR");
+        std::env::remove_var("KHIVE_REQUIRE_ATTRIBUTED_ACTOR");
+        std::env::remove_var("KHIVE_DB");
+        let (prev_home, _home_dir) = isolate_home_for_test();
+        SPY_CAPTURED_CONFIG_ID.with(|captured| *captured.borrow_mut() = None);
+
+        let fixture = tempfile::tempdir().expect("force-memory config tempdir");
+        let config_path = fixture.path().join("read-only-topology.toml");
+        let declared_main = fixture.path().join("declared-main.db");
+        let declared_archive = fixture.path().join("declared-archive.db");
+        std::fs::write(
+            &config_path,
+            format!(
+                r#"
+[[backends]]
+name = "main"
+kind = "sqlite"
+path = "{}"
+read_only = true
+
+[[backends]]
+name = "archive"
+kind = "sqlite"
+path = "{}"
+"#,
+                declared_main.display(),
+                declared_archive.display(),
+            ),
+        )
+        .expect("write read-only topology config");
+
+        let cfg = resolve_runtime_config(RuntimeConfigInputs {
+            db: Some(":memory:"),
+            config: Some(&config_path),
+            namespace: Namespace::local(),
+            namespace_explicit: true,
+            actor_explicit: false,
+            no_embed: true,
+            packs: Some(vec!["kg".to_string()]),
+            brain_profile: None,
+        })
+        .expect("resolve force-memory exec config");
+        assert_eq!(
+            cfg.db_path, None,
+            "the force-memory anchor must be in-memory"
+        );
+
+        let result = run_exec_inline_with_forward(
+            "stats()".to_string(),
+            cfg.clone(),
+            None,
+            None,
+            None,
+            ExecDbContext {
+                raw: Some(":memory:".to_string()),
+                anchor: None,
+                config: Some(config_path.clone()),
+            },
+            false,
+            spy_capture_config_and_succeed,
+        )
+        .await;
+        assert!(result.is_ok(), "force-memory dispatch failed: {result:?}");
+
+        let frame_config_id = SPY_CAPTURED_CONFIG_ID
+            .with(|captured| captured.borrow_mut().take())
+            .expect("spy must capture the forwarded config id");
+        let khive_cfg = KhiveConfig::load_with_home_fallback(Some(&config_path), None)
+            .expect("load force-memory topology")
+            .expect("explicit config must exist");
+        let opened =
+            khive_mcp::serve::build_registry_for_multi_backend(cfg, &khive_cfg, Some(":memory:"))
+                .expect("force-memory runtime must build");
+        restore_home(prev_home);
+
+        assert!(
+            !opened.default_runtime.is_read_only(),
+            "force-memory replaces the declared read-only SQLite main with writable memory"
+        );
+        assert_eq!(
+            frame_config_id, opened.config_id,
+            "the pre-open exec frame and opened force-memory runtime must have identical config ids"
+        );
+        assert!(
+            !declared_main.exists() && !declared_archive.exists(),
+            "force-memory parity setup must not materialize either declared SQLite path"
         );
     }
 

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -45,7 +45,7 @@ use khive_mcp::serve::{
     apply_env_output_format, build_server_multi_backend_with_db_anchor, config_discovery_db_anchor,
     enforce_strict_actor_mode, install_resolved_blob_store,
     normalize_redundant_db_override_with_source, reject_conflicting_db_override_with_source,
-    RuntimeConfigInputs,
+    validate_declared_backend_access_modes, RuntimeConfigInputs,
 };
 use khive_mcp::server::KhiveMcpServer;
 #[cfg(unix)]
@@ -1984,6 +1984,10 @@ async fn run_exec_inline_with_forward(
         }
         force_memory
     };
+
+    if !force_memory {
+        validate_declared_backend_access_modes(&khive_cfg.backends)?;
+    }
 
     disclose_resolved_database(&cfg, &khive_cfg);
 
@@ -5425,6 +5429,193 @@ path = "{}"
         assert!(
             !declared_main.exists() && !declared_archive.exists(),
             "force-memory parity setup must not materialize either declared SQLite path"
+        );
+    }
+
+    #[cfg(unix)]
+    fn write_writable_multi_backend_config(
+        config_path: &Path,
+        main_path: &Path,
+        secondary_path: &Path,
+    ) {
+        std::fs::write(
+            config_path,
+            format!(
+                r#"
+[[backends]]
+name = "main"
+kind = "sqlite"
+path = "{}"
+
+[[backends]]
+name = "archive"
+kind = "sqlite"
+path = "{}"
+"#,
+                main_path.display(),
+                secondary_path.display(),
+            ),
+        )
+        .unwrap();
+    }
+
+    #[cfg(unix)]
+    fn chmod_read_only(path: &Path) {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut permissions = std::fs::metadata(path).unwrap().permissions();
+        permissions.set_mode(0o444);
+        std::fs::set_permissions(path, permissions).unwrap();
+    }
+
+    #[cfg(unix)]
+    fn runtime_config_for_explicit_multi_backend(
+        config_path: &Path,
+        db: Option<&str>,
+    ) -> RuntimeConfig {
+        resolve_runtime_config(RuntimeConfigInputs {
+            db,
+            config: Some(config_path),
+            namespace: Namespace::local(),
+            namespace_explicit: true,
+            actor_explicit: false,
+            no_embed: true,
+            packs: Some(vec!["kg".to_string()]),
+            brain_profile: None,
+        })
+        .unwrap()
+    }
+
+    /// A client must not reuse a daemon that retained a write-capable handle
+    /// after the declared main file was chmod'd into snapshot mode. The
+    /// filesystem-mode refusal belongs before the forwarding seam.
+    #[cfg(unix)]
+    #[tokio::test]
+    #[serial]
+    async fn multi_backend_main_chmod_refuses_before_daemon_forward() {
+        std::env::remove_var("KHIVE_DB");
+        std::env::remove_var("KHIVE_REQUIRE_ATTRIBUTED_ACTOR");
+        SPY_CAPTURED_CONFIG_ID.with(|captured| *captured.borrow_mut() = None);
+
+        let fixture = tempfile::tempdir().unwrap();
+        let config_path = fixture.path().join("khive.toml");
+        let main_path = fixture.path().join("main.db");
+        let archive_path = fixture.path().join("archive.db");
+        std::fs::write(&main_path, b"main snapshot fixture").unwrap();
+        std::fs::write(&archive_path, b"archive fixture").unwrap();
+        chmod_read_only(&main_path);
+        write_writable_multi_backend_config(&config_path, &main_path, &archive_path);
+
+        let result = run_exec_inline_with_forward(
+            "stats()".to_string(),
+            runtime_config_for_explicit_multi_backend(&config_path, None),
+            None,
+            None,
+            None,
+            ExecDbContext {
+                raw: None,
+                anchor: None,
+                config: Some(config_path),
+            },
+            false,
+            spy_capture_config_and_succeed,
+        )
+        .await;
+
+        let error = result.expect_err("an undeclared main snapshot mode must fail closed");
+        assert!(error.to_string().contains("read_only = true"), "{error}");
+        assert!(
+            SPY_CAPTURED_CONFIG_ID.with(|captured| captured.borrow().is_none()),
+            "the retained writable daemon must never receive the frame"
+        );
+    }
+
+    /// The topology fingerprint includes secondary modes too; apply the same
+    /// pre-forward refusal to every declared SQLite backend, not only `main`.
+    #[cfg(unix)]
+    #[tokio::test]
+    #[serial]
+    async fn multi_backend_secondary_chmod_refuses_before_daemon_forward() {
+        std::env::remove_var("KHIVE_DB");
+        std::env::remove_var("KHIVE_REQUIRE_ATTRIBUTED_ACTOR");
+        SPY_CAPTURED_CONFIG_ID.with(|captured| *captured.borrow_mut() = None);
+
+        let fixture = tempfile::tempdir().unwrap();
+        let config_path = fixture.path().join("khive.toml");
+        let main_path = fixture.path().join("main.db");
+        let archive_path = fixture.path().join("archive.db");
+        std::fs::write(&main_path, b"main fixture").unwrap();
+        std::fs::write(&archive_path, b"archive snapshot fixture").unwrap();
+        chmod_read_only(&archive_path);
+        write_writable_multi_backend_config(&config_path, &main_path, &archive_path);
+
+        let result = run_exec_inline_with_forward(
+            "stats()".to_string(),
+            runtime_config_for_explicit_multi_backend(&config_path, None),
+            None,
+            None,
+            None,
+            ExecDbContext {
+                raw: None,
+                anchor: None,
+                config: Some(config_path),
+            },
+            false,
+            spy_capture_config_and_succeed,
+        )
+        .await;
+
+        let error = result.expect_err("an undeclared secondary snapshot mode must fail closed");
+        assert!(error.to_string().contains("archive"), "{error}");
+        assert!(
+            SPY_CAPTURED_CONFIG_ID.with(|captured| captured.borrow().is_none()),
+            "the retained writable daemon must never receive the frame"
+        );
+    }
+
+    /// `--db :memory:` supersedes every declared file. Its pre-open/runtime
+    /// parity must therefore skip filesystem-mode checks on those unused paths.
+    #[cfg(unix)]
+    #[tokio::test]
+    #[serial]
+    async fn force_memory_skips_declared_chmod_preflight_and_forwards() {
+        std::env::remove_var("KHIVE_DB");
+        std::env::remove_var("KHIVE_REQUIRE_ATTRIBUTED_ACTOR");
+        SPY_CAPTURED_CONFIG_ID.with(|captured| *captured.borrow_mut() = None);
+
+        let fixture = tempfile::tempdir().unwrap();
+        let config_path = fixture.path().join("khive.toml");
+        let main_path = fixture.path().join("main.db");
+        let archive_path = fixture.path().join("archive.db");
+        std::fs::write(&main_path, b"unused main snapshot fixture").unwrap();
+        std::fs::write(&archive_path, b"unused archive snapshot fixture").unwrap();
+        chmod_read_only(&main_path);
+        chmod_read_only(&archive_path);
+        write_writable_multi_backend_config(&config_path, &main_path, &archive_path);
+
+        let result = run_exec_inline_with_forward(
+            "stats()".to_string(),
+            runtime_config_for_explicit_multi_backend(&config_path, Some(":memory:")),
+            None,
+            None,
+            None,
+            ExecDbContext {
+                raw: Some(":memory:".to_string()),
+                anchor: None,
+                config: Some(config_path),
+            },
+            false,
+            spy_capture_config_and_succeed,
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "force-memory forwarding must remain valid: {result:?}"
+        );
+        assert!(
+            SPY_CAPTURED_CONFIG_ID.with(|captured| captured.borrow().is_some()),
+            "the force-memory frame must reach the forwarding seam"
         );
     }
 

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -5466,6 +5466,21 @@ path = "{}"
         let mut permissions = std::fs::metadata(path).unwrap().permissions();
         permissions.set_mode(0o444);
         std::fs::set_permissions(path, permissions).unwrap();
+
+        // A writable fixture's connections can close asynchronously and leave
+        // `-wal`/`-shm` sidecars behind; read-only admission rejects a writable
+        // `-shm` as potentially live. Freeze any lingering sidecars so the
+        // snapshot takes the documented frozen form.
+        for suffix in ["-wal", "-shm"] {
+            let mut name = path.file_name().unwrap().to_os_string();
+            name.push(suffix);
+            let sidecar = path.parent().unwrap().join(name);
+            if sidecar.exists() {
+                let mut sidecar_permissions = std::fs::metadata(&sidecar).unwrap().permissions();
+                sidecar_permissions.set_mode(0o444);
+                std::fs::set_permissions(&sidecar, sidecar_permissions).unwrap();
+            }
+        }
     }
 
     #[cfg(unix)]

--- a/docs/adr/ADR-015-schema-migrations.md
+++ b/docs/adr/ADR-015-schema-migrations.md
@@ -146,6 +146,7 @@ above remains the historical pre-consolidation record.
 |     V16 | ADR-019 / #1474    | gtd_dependency_cycle_guards        | shipped |
 |     V17 | ADR-142 / #1700    | agents_ddl                         | shipped |
 |     V18 | #1479              | ann_consumer_pending               | shipped |
+|     V19 | #1649              | list_cursor_backfill_repair        | shipped |
 
 > **V9 record (2026-07-18)**: `entities_name_ci_index` (ADR-104) ships in the `MIGRATIONS`
 > array as `009-entities-name-ci-index.sql`; its status here was `claimed`, stale from ADR-104,
@@ -170,11 +171,18 @@ above remains the historical pre-consolidation record.
 > direct-storage, and atomic-unit writers. The migration does not rewrite or reject existing
 > rows while installing the triggers.
 
-> **V17 record (2026-08-01)**: `ann_consumer_pending` adds timestamped lifecycle
+> **V17 record (2026-08-01, ADR-142 / #1700)**: `agents_ddl` adds the
+> agent-process registry and its supporting indexes.
+
+> **V18 record (2026-08-01, #1479)**: `ann_consumer_pending` adds timestamped lifecycle
 > metadata for the closed ANN pending watermark `-2` and translates legacy
 > zero-watermark registrations into a one-day pending grace window. Successful
 > checkpoints, including a valid checkpoint at `S = 0`, atomically remove the
 > metadata; only never-activated pending rows are eligible for retirement.
+
+> **V19 record (2026-08-08, #1649)**: `list_cursor_backfill_repair` repairs the
+> known V13/V14 list-cursor divergence and normalizes those two ledger names.
+> No other divergence is repairable by inference.
 
 > **Invariant**: ADR number order and migration version order are independent. Migration versions reflect schema ledger assignment order. A migration may only depend on schema created by earlier versions.
 
@@ -301,8 +309,11 @@ CREATE TABLE IF NOT EXISTS _schema_migrations (
 ```
 
 The table records which migrations have been applied. `run_migrations` reads
-the highest applied version and runs only newer migrations. Idempotent calls
-are no-ops.
+the highest applied version and runs only newer migrations. Once known repair
+migrations have run, both writable boot and read-only snapshot validation
+require the rows to be the exact contiguous canonical `(version, name)` prefix:
+matching `MAX(version)` does not hide a missing middle row, an unknown version,
+or a renamed migration. Idempotent calls are no-ops.
 
 ### Atomicity per migration
 

--- a/docs/adr/ADR-016-request-dsl.md
+++ b/docs/adr/ADR-016-request-dsl.md
@@ -426,6 +426,41 @@ Response envelope:
 After parsing succeeds, `results.length == summary.total == input ops count`.
 Order preserves input order regardless of parallel completion order.
 
+#### Transport-owned per-operation advisories (2026-08-09 amendment)
+
+A successful per-operation envelope MAY carry an `advisories` array beside
+`result`:
+
+```json
+{
+  "ok": true,
+  "tool": "stats",
+  "result": { "entities": 42 },
+  "advisories": [
+    {
+      "code": "audit_persistence_skipped_read_only",
+      "severity": "warning",
+      "component": "audit_event_store",
+      "reason": "read_only_backend",
+      "message": "operation completed, but its dispatch audit event was not persisted because the audit backend is read-only"
+    }
+  ]
+}
+```
+
+`advisories` is transport-owned metadata about delivery or execution context;
+it is not part of the verb-owned canonical `result`, does not change `ok` or
+the batch summary, and MUST NOT be injected into `result`. Advisory objects
+have stable `code`, `severity`, `component`, `reason`, and `message` fields.
+Presentation and output-format transforms apply only to `result`, so callers
+receive advisory objects unchanged. Frame-budget degradation preserves the
+array even if an oversized `result` is replaced by `result_omitted`.
+
+The first governed advisory is
+`audit_persistence_skipped_read_only` (ADR-028 Amendment A2). It appears on
+successful non-help operations when the configured audit backend is
+read-only. Failed, aborted, and help-introspection entries do not carry it.
+
 ### Gate enforcement
 
 Per ADR-003, gate enforcement is part of the agent-binary (`khive-mcp`)

--- a/docs/adr/ADR-028-pack-scoped-backends.md
+++ b/docs/adr/ADR-028-pack-scoped-backends.md
@@ -608,14 +608,26 @@ slot.
 
 Boot and access obey these rules:
 
-1. The snapshot must already exist and its core schema version must equal this
-   build's latest migration. Boot validates that fact without writes; a schema
-   behind or ahead fails with instructions to migrate a writable copy or use a
-   compatible build.
+1. The snapshot must already exist and its core migration ledger must be the
+   exact contiguous canonical sequence through this build's latest migration.
+   Matching only `MAX(version)` is insufficient: missing middle rows, foreign
+   versions, renamed rows, behind ledgers, and ahead ledgers all fail without
+   writes and with an actionable compatibility diagnostic.
 2. Boot does not register embedding models, apply pack-auxiliary schema, start a
-   writer task, checkpoint, or schedule a WAL sweep for that backend.
+   writer task, checkpoint, or schedule a WAL sweep for that backend. Daemon
+   warm hooks remain per-pack-runtime aware: writer-bearing ANN warm and session
+   mirroring are suppressed on a read-only assigned backend, and warm phase
+   telemetry and lazy embedder-initialization telemetry perform no event append
+   there. The schedule ticker is admitted
+   only when the schedule pack's own assigned backend is writable; a read-only
+   main does not disable a schedule pack routed to a writable secondary, nor
+   does a writable main enable a read-only schedule secondary.
 3. Store acquisition does not run lazy DDL or repair DML. A requested optional
-   store table must already exist in the snapshot.
+   vector, sparse, or text-search table must already exist in the snapshot and
+   is checked through a reader connection, never the pool's query-only writer
+   slot. An ANN cache miss does not enqueue registration, rebuild, checkpoint,
+   or compaction work: memory recall uses its exact sqlite-vec reader fallback,
+   while knowledge search retains its FTS and load-only fresh-tail paths.
 4. Mutation semantics are unchanged: DDL and DML remain rejected by the SQLite
    open flags and `query_only`, regardless of verb metadata.
 5. When the main audit backend is read-only, the registry deliberately omits the

--- a/docs/adr/ADR-028-pack-scoped-backends.md
+++ b/docs/adr/ADR-028-pack-scoped-backends.md
@@ -612,7 +612,11 @@ Boot and access obey these rules:
    exact contiguous canonical sequence through this build's latest migration.
    Matching only `MAX(version)` is insufficient: missing middle rows, foreign
    versions, renamed rows, behind ledgers, and ahead ledgers all fail without
-   writes and with an actionable compatibility diagnostic.
+   writes and with an actionable compatibility diagnostic. Validation checks
+   out a reader before any writer acquisition. A file-backed read-only pool
+   keeps at least one genuine read-only reader even when the snapshot uses a
+   rollback journal rather than WAL; `reader()` never aliases that inspection
+   onto the query-only writer slot.
 2. Boot does not register embedding models, apply pack-auxiliary schema, start a
    writer task, checkpoint, or schedule a WAL sweep for that backend. Daemon
    warm hooks remain per-pack-runtime aware: writer-bearing ANN warm and session
@@ -621,7 +625,13 @@ Boot and access obey these rules:
    there. The schedule ticker is admitted
    only when the schedule pack's own assigned backend is writable; a read-only
    main does not disable a schedule pack routed to a writable secondary, nor
-   does a writable main enable a read-only schedule secondary.
+   does a writable main enable a read-only schedule secondary. Feature-enabled
+   email and Telegram tasks apply the same per-runtime rule in addition to the
+   daemon-role gate: inbound polling is admitted only when the runtime serving
+   `comm.ingest`/heartbeat/cursor verbs is writable, while outbound delivery is
+   admitted only when the runtime serving generic `list`/`update` can durably
+   claim and mark delivery. The two decisions remain independent in a mixed
+   topology, and neither adapter polls or sends before its decision passes.
 3. Store acquisition does not run lazy DDL or repair DML. A requested optional
    vector, sparse, or text-search table must already exist in the snapshot and
    is checked through a reader connection, never the pool's query-only writer

--- a/docs/adr/ADR-028-pack-scoped-backends.md
+++ b/docs/adr/ADR-028-pack-scoped-backends.md
@@ -616,7 +616,16 @@ Boot and access obey these rules:
    out a reader before any writer acquisition. A file-backed read-only pool
    keeps at least one genuine read-only reader even when the snapshot uses a
    rollback journal rather than WAL; `reader()` never aliases that inspection
-   onto the query-only writer slot.
+   onto the query-only writer slot. Persistent-WAL inspection also leaves the
+   source files and directory unchanged. A clean checkpointed main file with no
+   sidecars uses an encoded read-only `immutable=1` URI solely to prevent
+   SQLite from creating fresh `-wal`/`-shm`. If committed frames remain, the
+   frozen snapshot must include both `-wal` and a filesystem-read-only `-shm`;
+   ordinary read-only WAL semantics then preserve frame visibility. A
+   non-empty `-wal` without that index is rejected before open because
+   immutable SQLite would omit the committed frames, and a writable `-shm` is
+   rejected as potentially live. Rollback-journal databases never use
+   immutable mode and retain SQLite change detection.
 2. Boot does not register embedding models, apply pack-auxiliary schema, start a
    writer task, checkpoint, or schedule a WAL sweep for that backend. Daemon
    warm hooks remain per-pack-runtime aware: writer-bearing ANN warm and session
@@ -632,6 +641,11 @@ Boot and access obey these rules:
    admitted only when the runtime serving generic `list`/`update` can durably
    claim and mark delivery. The two decisions remain independent in a mixed
    topology, and neither adapter polls or sends before its decision passes.
+   Filesystem blob-store construction is gated by the runtime assigned to the
+   `blob` pack as well: a read-only blob runtime opens only an existing root,
+   never materializes the default directory, and rejects put/delete/sweep
+   mutators. A writable blob secondary beside a read-only main remains
+   writable, while a read-only blob secondary beside a writable main does not.
 3. Store acquisition does not run lazy DDL or repair DML. A requested optional
    vector, sparse, or text-search table must already exist in the snapshot and
    is checked through a reader connection, never the pool's query-only writer

--- a/docs/adr/ADR-028-pack-scoped-backends.md
+++ b/docs/adr/ADR-028-pack-scoped-backends.md
@@ -591,3 +591,48 @@ let runtime     = if pack_cfg.backend != BackendId::MAIN {
 
 All other ADR-028 mechanics (TOML shape, 1:1 pack-to-backend assignment, schema collision
 detection, declaration-order application, cross-pack composition) are unchanged.
+
+## Amendment A2: Read-only backends are snapshot-inspection runtimes (2026-08-09)
+
+ADR-028 names `archive` as a read-only storage profile but did not define a
+write-free boot and request lifecycle. A runtime cannot claim read-only support
+if opening a store, registering a configured embedding model, applying pack
+schema, or appending the dispatch audit row still acquires the SQLite writer.
+
+The SQLite implementation therefore treats a read-only backend as an existing
+snapshot-inspection runtime. Read-only mode is selected either by an explicit
+backend option or, for normal single-backend boot, by detecting that an existing
+database file has no filesystem write bits. The pool opens every connection
+with SQLite read-only flags and additionally applies `query_only` to its writer
+slot.
+
+Boot and access obey these rules:
+
+1. The snapshot must already exist and its core schema version must equal this
+   build's latest migration. Boot validates that fact without writes; a schema
+   behind or ahead fails with instructions to migrate a writable copy or use a
+   compatible build.
+2. Boot does not register embedding models, apply pack-auxiliary schema, start a
+   writer task, checkpoint, or schedule a WAL sweep for that backend.
+3. Store acquisition does not run lazy DDL or repair DML. A requested optional
+   store table must already exist in the snapshot.
+4. Mutation semantics are unchanged: DDL and DML remain rejected by the SQLite
+   open flags and `query_only`, regardless of verb metadata.
+5. When the main audit backend is read-only, the registry deliberately omits the
+   `EventStore` instead of attempting a known-failing append. Every successful
+   non-help MCP operation carries an envelope-level advisory with stable code
+   `audit_persistence_skipped_read_only`; the verb-owned `result` is unchanged.
+   Error entries do not claim that an audit write was skipped.
+6. The effective main-backend mode is part of the warm-daemon engine identity,
+   and each declared backend's explicit `read_only` mode is part of the
+   topology fingerprint. A chmod-detected single-backend snapshot therefore
+   cannot forward through a daemon that retained a writable handle to the same
+   path. Multi-backend configurations must declare `read_only = true`
+   explicitly when a SQLite path has no write bits; boot rejects an undeclared
+   mode change instead of fingerprinting it as writable.
+
+This mode is for offline analysis of frozen snapshots. It provides neither a
+durable dispatch audit trail nor durable accounting and says so on every
+successful operation. Deployments that require ADR-103/ADR-133 audit durability
+must use a writable audit backend. These constraints preserve ADR-028's physical
+isolation and do not weaken any mutation path.

--- a/docs/adr/ADR-045-verb-response-presentation.md
+++ b/docs/adr/ADR-045-verb-response-presentation.md
@@ -250,6 +250,13 @@ pub fn present_response(
 Pack handlers are unaware of mode. Tests against handler outputs always check
 verbose shape — golden outputs don't need to be mode-aware.
 
+ADR-016's optional envelope-level `advisories` array is outside the handler
+result and therefore outside every presentation and output-format transform.
+The runtime may add that transport-owned array after result presentation; its
+objects remain byte-for-byte machine-readable in Agent, Verbose, and Human
+modes. This preserves the central invariant here: presentation changes only a
+successful envelope's `result`, never sibling envelope metadata.
+
 ### 5. Handler invariants
 
 Handlers MUST:

--- a/docs/adr/ADR-080-session-pack-oss-storage-mechanism.md
+++ b/docs/adr/ADR-080-session-pack-oss-storage-mechanism.md
@@ -205,7 +205,10 @@ the M2 milestone of the session pack build (issue #350, PR #368) with the Claude
 source, gained the Codex CLI source in PR #375, and gains the ChatGPT export source with
 the 2026-07-02 amendment. The 2026-08-01 amendment adds claude.ai data exports as a
 separate fourth source. The mirror is disabled by default and never writes to, moves, or
-deletes the files it reads.
+deletes the files it reads. Here "read-only" describes the transcript sources,
+not the khive sink: the mirror writes auxiliary rows and cursor state. ADR-028
+Amendment A2 therefore suppresses this warm hook when the session pack's own
+assigned backend is a read-only snapshot.
 
 #### Mirror sources — closed set
 

--- a/docs/adr/ADR-083-session-pack-t1-verbs.md
+++ b/docs/adr/ADR-083-session-pack-t1-verbs.md
@@ -242,6 +242,9 @@ transcripts into three auxiliary tables (`sessions`, `session_messages`,
 `session_mirror_cursor`) declared through the pack's `SCHEMA_PLAN`
 (`SESSION_SCHEMA_PLAN_STMTS`, the ADR-028 mechanism). It shipped as the pack's M2 milestone
 (issue #350, PR #368), gained the Codex CLI source in PR #375, and is disabled by default.
+"Read-only" refers to the transcript inputs. The mirror's auxiliary-table sink
+is writer-bearing, so ADR-028 Amendment A2 disables it when the session pack is
+assigned to a read-only snapshot backend.
 
 The T1 verb surface and the session mirror are additive, not a replacement. This is a deliberate
 design ruling. T1's four verbs read and write `kind=session` notes in the shared `notes` table.

--- a/docs/adr/ADR-096-warm-daemon-per-request-identity.md
+++ b/docs/adr/ADR-096-warm-daemon-per-request-identity.md
@@ -529,3 +529,21 @@ there is no local retry that could duplicate a message.
    the actor; for hosted tenants it may need explicit per-connection scoping. Whether it must be
    threaded on the frame or derived Gate-side from the connection principal is **deferred to the
    future Gate-binding ADR** (§Acceptance conditions), since it only bites at the hosted bar.
+
+---
+
+## Amendment 4: read-only storage mode is engine coherence (2026-08-09)
+
+The engine-coherence definition above includes the effective access mode of the
+main SQLite backend and every declared backend's explicit `read_only` mode. A
+database path alone is insufficient: a daemon that opened the file while it was
+writable may retain a write-capable handle after the file is chmod-read-only,
+and it cannot truthfully serve the snapshot-inspection contract or its audit
+persistence advisory.
+
+Writable fingerprints remain byte-identical. A read-only main runtime adds its
+effective mode to the existing `backend` component, so structured mismatch
+diagnostics continue to report `backend`; declared per-backend modes live in the
+existing topology component. A mismatch remains a hard reject before verb
+dispatch and follows the ordinary local fallback path. Identity-derived frame
+fields remain excluded exactly as specified above.

--- a/docs/adr/ADR-103-resource-attribution-model.md
+++ b/docs/adr/ADR-103-resource-attribution-model.md
@@ -677,6 +677,13 @@ embed warmup call proceeds unaffected by the authorization outcome. This preserv
 infallible: any errors are logged internally, not propagated to the caller"
 (`crates/khive-runtime/src/pack.rs:230-231`).
 
+ADR-028 Amendment A2 narrows the persistence side of this rule for read-only
+snapshot runtimes: the embedder warm invocation may still run, but the shared
+phase emitter returns before `EventStore` resolution and emits no start or
+terminal row. A known-rejected append is not considered read-only telemetry;
+it would still enter a writer-bearing path. Writable runtimes retain the exact
+pair contract above.
+
 This is Stage 1 work: it extends Decision (c) with two additional emission sites, and
 requires no `work_class` enum amendment, no `EventKind` amendment, and no schema
 migration. It is a wiring gap in two `warm()` implementations, closed by reusing an

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -155,6 +155,32 @@ its siblings (chain failures do abort the remainder of the chain):
 `aborted` counts ops skipped after an earlier failure in a `|` chain; it is always 0 for
 parallel batches, since parallel failures do not cascade.
 
+A successful entry can also carry a transport-owned `advisories` array beside `result`.
+These warnings describe execution context without changing the verb's canonical result or
+the batch summary. Presentation and output-format transforms apply only to `result`, and
+frame-budget degradation preserves advisories. For example, inspecting a read-only snapshot
+returns normal verb data while making the missing durable dispatch audit explicit:
+
+```json
+{
+  "ok": true,
+  "tool": "stats",
+  "result": { "entities": 42 },
+  "advisories": [
+    {
+      "code": "audit_persistence_skipped_read_only",
+      "severity": "warning",
+      "component": "audit_event_store",
+      "reason": "read_only_backend",
+      "message": "operation completed, but its dispatch audit event was not persisted because the audit backend is read-only"
+    }
+  ]
+}
+```
+
+That advisory appears on successful non-help operations only. Failed, aborted, and
+`help=true` entries do not claim that an audit write was skipped.
+
 ---
 
 ## `kg` pack — 20 verbs

--- a/docs/guide/sessions-and-ingest.md
+++ b/docs/guide/sessions-and-ingest.md
@@ -132,7 +132,9 @@ the process that invokes them during startup through
 not run that daemon warm path. So, like the email channel loops described in
 [Communication and Email](communication.md), running `kkernel mcp --daemon`
 is what actually starts background ingestion; a stdio session never spawns
-its own mirror poller.
+its own mirror poller. A daemon whose session pack is assigned to an ADR-028 A2
+read-only snapshot also suppresses the mirror: its polling loop eventually
+writes session rows and cursor state, so it is not a snapshot-inspection task.
 
 | Variable                         | Default                  |
 | -------------------------------- | ------------------------ |

--- a/docs/multi-backend.md
+++ b/docs/multi-backend.md
@@ -333,11 +333,25 @@ SQLite file has no filesystem write bits. Explicit read-only configuration
 does not create a missing database or its parent directory.
 
 Read-only boot is an inspection path, not a migration path. It requires the
-snapshot's core schema to match the build's latest migration exactly and emits
-an actionable error for snapshots that are behind or ahead. It skips configured
+snapshot's core migration ledger to be the exact contiguous canonical sequence
+through the build's latest migration; a missing middle row or foreign version
+is rejected even when `MAX(version)` matches. It skips configured
 embedding-model registration, lazy store-schema/repair writes, pack schema
-application, writer-task startup, checkpointing, and WAL sweeps. Prepare and
-migrate a writable copy before inspection if validation fails.
+application, writer-task startup, checkpointing, and WAL sweeps. Optional
+vector, sparse, and text tables are checked through reader connections and must
+already exist. Read-only ANN cache misses do not enqueue registration or
+rebuild work; memory uses exact sqlite-vec fallback and knowledge retains FTS
+plus its load-only fresh-tail path. Prepare and migrate a writable copy before
+inspection if validation fails.
+
+Daemon background work follows the assigned backend, not a blanket main-mode
+switch. Writer-bearing memory/knowledge ANN warm and session mirroring do not
+run for a read-only pack runtime, and warm phase telemetry does not append to a
+read-only event store; neither does lazy embedder-initialization telemetry. The
+schedule ticker is omitted only when the schedule
+pack's own runtime is read-only: it remains enabled on a writable secondary
+beside a read-only main, and remains disabled on a read-only secondary beside a
+writable main.
 
 The explicit `read_only` value participates in the backend-topology portion of
 the warm-daemon `config_id`. In multi-backend configuration it must agree with

--- a/docs/multi-backend.md
+++ b/docs/multi-backend.md
@@ -308,9 +308,12 @@ protocol-version mismatch, never for config-id drift.
 
 ### Full schema on every backend
 
-Every declared backend receives the full khive schema via `run_migrations()` at
-startup. Packs do not write to tables outside their substrate; the schema is
-applied uniformly for simplicity. There is no per-backend schema trimming.
+Every writable declared backend receives the full khive schema via
+`run_migrations()` at startup. Packs do not write to tables outside their
+substrate; the schema is applied uniformly for simplicity. There is no
+per-backend schema trimming. A read-only backend is validated against the
+build's exact current core-schema version instead; boot never attempts a
+migration or pack-auxiliary DDL against it.
 
 ### Canonical-path deduplication
 
@@ -322,11 +325,52 @@ backends are never deduplicated (each gets its own in-process database).
 
 ### Read-only backends
 
-Setting `read_only = true` opens reader connections with
-`SQLITE_OPEN_READ_ONLY` and applies `PRAGMA query_only = ON` to the writer slot,
-so any write attempt (DDL or DML) through that backend returns an error. The
-regression test `read_only_backend_rejects_writes` in
-`crates/khive-mcp/src/serve.rs` verifies this behavior.
+Setting `read_only = true` opens every connection with
+`SQLITE_OPEN_READ_ONLY` and also applies `PRAGMA query_only = ON` to the pool's
+writer slot, so any write attempt (DDL or DML) through that backend returns an
+error. Normal single-backend boot also selects this mode when an existing
+SQLite file has no filesystem write bits. Explicit read-only configuration
+does not create a missing database or its parent directory.
+
+Read-only boot is an inspection path, not a migration path. It requires the
+snapshot's core schema to match the build's latest migration exactly and emits
+an actionable error for snapshots that are behind or ahead. It skips configured
+embedding-model registration, lazy store-schema/repair writes, pack schema
+application, writer-task startup, checkpointing, and WAL sweeps. Prepare and
+migrate a writable copy before inspection if validation fails.
+
+The explicit `read_only` value participates in the backend-topology portion of
+the warm-daemon `config_id`. In multi-backend configuration it must agree with
+the file mode: a path with no filesystem write bits and `read_only = false` is
+rejected with a remedy to declare the inspection mode. Normal single-backend
+boot can detect that mode from the existing file and folds the effective mode
+into the same fingerprint, preventing a read-only client from reusing a daemon
+that opened the path while it was writable.
+
+Because the main event store is itself read-only, successful MCP operations do
+not attempt the per-dispatch audit append. Each successful non-help operation
+instead carries a stable machine-readable warning beside its canonical result:
+
+```json
+{
+  "ok": true,
+  "tool": "stats",
+  "result": { "entities": 42 },
+  "advisories": [
+    {
+      "code": "audit_persistence_skipped_read_only",
+      "severity": "warning",
+      "component": "audit_event_store",
+      "reason": "read_only_backend"
+    }
+  ]
+}
+```
+
+The warning does not weaken mutation checks: mutating verbs still return a
+per-operation error from the read-only SQLite contract. Operators that require
+durable audit or accounting must use a writable backend; this inspection mode
+does not claim those durability guarantees.
 
 ### Cross-backend link and federated search
 

--- a/docs/multi-backend.md
+++ b/docs/multi-backend.md
@@ -332,6 +332,17 @@ error. Normal single-backend boot also selects this mode when an existing
 SQLite file has no filesystem write bits. Explicit read-only configuration
 does not create a missing database or its parent directory.
 
+Persistent-WAL inspection is physically source-side-effect free. A clean,
+checkpointed WAL database with no sidecars is opened through an encoded
+read-only immutable URI so SQLite cannot materialize fresh `-wal`/`-shm`
+files. A complete frozen snapshot that still has committed WAL frames must
+include both `-wal` and a filesystem-read-only `-shm`; it is opened with
+ordinary read-only WAL semantics so those frames remain visible. A non-empty
+`-wal` without that frozen index is rejected before SQLite opens (immutable
+mode would silently omit the committed frames), as is any writable `-shm`
+(evidence of potentially live shared state). Rollback-journal databases never
+use immutable mode and retain SQLite locking and change detection.
+
 Read-only boot is an inspection path, not a migration path. It requires the
 snapshot's core migration ledger to be the exact contiguous canonical sequence
 through the build's latest migration; a missing middle row or foreign version
@@ -355,6 +366,13 @@ schedule ticker is omitted only when the schedule
 pack's own runtime is read-only: it remains enabled on a writable secondary
 beside a read-only main, and remains disabled on a read-only secondary beside a
 writable main.
+
+Blob storage follows the runtime assigned to the `blob` pack by the same rule.
+A read-only blob runtime opens only an already-existing filesystem root, never
+creates the default `blobs/` directory, and rejects `blob.put` plus lower-level
+delete/sweep mutators. This remains true for a read-only blob secondary beside
+a writable main; conversely, a writable blob secondary beside a read-only main
+retains normal puts.
 
 Feature-enabled email and Telegram background work is also admitted by the
 runtime that serves each loop's verbs, not by `--daemon` alone. Inbound polling

--- a/docs/multi-backend.md
+++ b/docs/multi-backend.md
@@ -335,9 +335,12 @@ does not create a missing database or its parent directory.
 Read-only boot is an inspection path, not a migration path. It requires the
 snapshot's core migration ledger to be the exact contiguous canonical sequence
 through the build's latest migration; a missing middle row or foreign version
-is rejected even when `MAX(version)` matches. It skips configured
-embedding-model registration, lazy store-schema/repair writes, pack schema
-application, writer-task startup, checkpointing, and WAL sweeps. Optional
+is rejected even when `MAX(version)` matches. Core-ledger and optional-table
+inspection use genuine read-only reader connections. This remains true for a
+rollback-journal snapshot: a read-only file pool retains a dedicated reader
+instead of degrading `reader()` onto its query-only writer slot. It skips
+configured embedding-model registration, lazy store-schema/repair writes, pack
+schema application, writer-task startup, checkpointing, and WAL sweeps. Optional
 vector, sparse, and text tables are checked through reader connections and must
 already exist. Read-only ANN cache misses do not enqueue registration or
 rebuild work; memory uses exact sqlite-vec fallback and knowledge retains FTS
@@ -352,6 +355,16 @@ schedule ticker is omitted only when the schedule
 pack's own runtime is read-only: it remains enabled on a writable secondary
 beside a read-only main, and remains disabled on a read-only secondary beside a
 writable main.
+
+Feature-enabled email and Telegram background work is also admitted by the
+runtime that serves each loop's verbs, not by `--daemon` alone. Inbound polling
+requires the assigned `comm` runtime to be writable because it dispatches
+`comm.ingest`, heartbeat, and cursor writes. Outbound delivery requires the
+assigned `kg` runtime to be writable because it uses generic `list`/`update` to
+claim and mark a message; otherwise no external send task starts, avoiding a
+send followed by an inevitably failed `delivered_at` write. These gates are
+independent, so a mixed topology can admit one direction without admitting the
+other.
 
 The explicit `read_only` value participates in the backend-topology portion of
 the warm-daemon `config_id`. In multi-backend configuration it must agree with

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -214,7 +214,7 @@ phase_tests_doc() {
 }
 
 phase_channel_email() {
-    echo "=== Channel-Email Feature Tests (channel-email feature) ==="
+    echo "=== Channel Feature Tests (email + Telegram features) ==="
     # `--workspace` alone never runs any of the several `#[cfg(feature =
     # "channel-email")]` test modules in khive-mcp (ADR-094 channel lifecycle
     # sequencing, issue #449 cursor_commit gating, bootstrap-floor regressions,
@@ -222,8 +222,11 @@ phase_channel_email() {
     # name filter here (`channel_lifecycle`) ran only one of those modules and
     # silently skipped the rest, including the daemon's durable-cursor
     # regression tests. Run the whole crate under the feature, unfiltered, so
-    # every one of those modules fails CI on a regression.
-    cargo test -p khive-mcp --features channel-email
+    # every one of those modules fails CI on a regression. Keep Telegram in
+    # the same feature job: its poll/outbox admission is equally capable of
+    # external side effects and must execute tests, not merely type-check in
+    # the all-features clippy pass.
+    cargo test -p khive-mcp --features channel-email,channel-telegram
 }
 
 run_daemon_recovery_repeats() {


### PR DESCRIPTION
## Summary

- detect chmod-read-only SQLite snapshots during normal single-backend boot and honor explicit multi-backend read-only declarations
- validate current schema and acquire existing stores without migrations, lazy DDL, repair DML, model registration, writer tasks, checkpoints, or WAL sweeps
- return successful read results unchanged with a stable envelope-level warning when the read-only audit sink cannot persist the dispatch event

## Snapshot contract

Read-only boot requires an existing snapshot whose core migration version and closed migration-name ledger exactly match this build. Behind or ahead snapshots fail with an actionable writable-copy/compatible-build remedy; validation itself performs no writes. SQLite read-only flags plus `query_only` continue to reject every mutation regardless of verb metadata.

The effective main access mode and every declared backend's explicit mode participate in warm-daemon identity. Client-side fingerprinting detects the chmod mode before forwarding, so a snapshot request cannot reuse a daemon that retained a write-capable handle to the same path. Missing explicit read-only paths create neither their parent nor a database, and aliases of one physical database cannot declare conflicting modes.

Successful non-help entries carry `advisories[0].code = "audit_persistence_skipped_read_only"` beside the canonical `result`. The warning survives presentation, output formatting, save-file output, and frame-budget degradation without changing operation or batch status. Failed, aborted, and help-introspection entries do not claim that a successful operation skipped audit persistence.

## Verification

- independent exact-head review: completed at `22af9bd91503f4e0e6988f1e61ed453924ec8150`; one-line borrow fix applied at `f7b801edbce6b7edb95b014df68a264962a233a9`
- exact-head full CI: running at `f7b801edbce6b7edb95b014df68a264962a233a9` (link added on completion)
- direct Rust and Deno formatting checks
- ADR-reference, JSON-data, SQL, stub-marker, and diff checks
- chmod snapshot stats/list/create integration regression
- current/behind/ahead/foreign-ledger schema validation regressions
- single/multi-backend config-identity, missing-path, alias-mode, and checkpoint exclusions

Fixes #1602

AI-assisted contribution: implemented and reviewed with Codex.

