### PR TITLE
fix(storage): routine logical WAL and writer-stage telemetry (#1849)

### DIFF
--- a/crates/khive-db/docs/api/checkpoint.md
+++ b/crates/khive-db/docs/api/checkpoint.md
@@ -134,7 +134,8 @@ await with no further calls."
 ## Metrics read-surface (load/perf harness)
 
 See `crates/khive-db/src/checkpoint.rs` — the module-scoped `AtomicU64`
-statics (`LAST_WAL_PAGES`, `TRUNCATE_ATTEMPTS`, etc.) and their accessors.
+compatibility counters (`LAST_WAL_PAGES`, `TRUNCATE_ATTEMPTS`, etc.) plus the
+backend-keyed `RoutineWalObservation` registry.
 
 Mirrors the fallback-counter pattern in `khive-mcp/src/daemon.rs`
 (`FALLBACK_*` statics + their `pub(crate)` accessors): the checkpoint task is
@@ -145,6 +146,16 @@ atomics rather than a struct threaded through every `checkpoint_once`/
 existing test call site). Read-only surface: nothing here is ever reset
 outside `#[cfg(test)]`, and nothing reachable over the daemon wire can reset
 them either (see `khive_runtime::daemon::DaemonRequestFrame::metrics_only`).
+
+Each periodic tick issues exactly one routine `PRAGMA wal_checkpoint(PASSIVE)`
+and retains that row's `busy`, `log`, and `checkpointed` values. Logical
+backlog is `max(log - checkpointed, 0)`. The same tick stats the backend's
+physical `-wal` sidecar and records its byte allocation independently. This
+matters because PASSIVE can drain every logical frame while SQLite retains the
+sidecar's high-water allocation for reuse. `routine_wal_observation(pool)` is
+a pure backend-scoped memory read: a metrics scrape performs neither another
+checkpoint nor another filesystem stat, and a secondary backend cannot win a
+process-global race and masquerade as the main backend's sample (#1849).
 
 ## `run_checkpoint_task` — shutdown design history
 

--- a/crates/khive-db/docs/api/writer-task.md
+++ b/crates/khive-db/docs/api/writer-task.md
@@ -40,6 +40,26 @@ writer-task acquisition class once per dequeued top-level request or successful
 `PoolConfig::write_queue_capacity` resolves the default from
 `KHIVE_WRITE_QUEUE_CAPACITY`).
 
+## Writer-stage telemetry (#1849)
+
+Every completed writer-task request records a backend-scoped in-memory sample
+with four independent stages: `queue_wait_micros` starts before bounded-channel
+admission and ends when the drain loop dequeues the request;
+`transaction_acquire_micros` measures only `BEGIN IMMEDIATE`; `body_micros`
+measures the typed operation closure; and `commit_micros` measures only
+SQLite's `COMMIT`. `total_micros`, queue depth at entry, and observation time
+remain siblings. A top-level request has zero acquisition/commit stages; a
+request that fails before a stage runs likewise reports zero for that stage.
+Rollback/recovery work remains visible in the difference between the total
+and named stages rather than being falsely attributed to COMMIT.
+
+`last_writer_stage_observation(pool)` is a pure per-backend read used by the
+daemon metrics frame. When a request crosses the existing slow-write
+threshold, the durable `slow_write` sink row also carries the four stage
+fields (while retaining `elapsed_ms` and `queue_depth` for compatibility).
+Observation is completed before the oneshot reply wakes the caller, so a
+successful response cannot race ahead of its telemetry sample.
+
 ## `run_writer_task` — drain loop and failure modes
 
 See `crates/khive-db/src/writer_task.rs` — private fn `run_writer_task`.

--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -36,9 +36,10 @@
 //! from ordinary ticks, the dedicated-connection invariant, and why Plank 1
 //! is a sweep rather than the ADR's originally-described per-statement guard).
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 use crate::pool::ConnectionPool;
@@ -47,8 +48,8 @@ use crate::pool::ConnectionPool;
 // Read-only process-wide gauges (never reset outside #[cfg(test)]). See
 // crates/khive-db/docs/api/checkpoint.md#metrics-read-surface-loadperf-harness
 
-/// Last-observed WAL page count (`query_wal_pages`'s return value on its
-/// most recent call, from either `checkpoint_once` or `maybe_truncate`).
+/// Last-observed WAL page count (the routine PASSIVE row's `log` value, or a
+/// rare post-TRUNCATE observation from `maybe_truncate`).
 /// `u64::MAX` is the "never observed" sentinel — no checkpoint tick has run
 /// yet in this process — distinct from a genuine zero-page WAL.
 static LAST_WAL_PAGES: AtomicU64 = AtomicU64::new(u64::MAX);
@@ -79,6 +80,83 @@ static CHECKPOINT_CONSECUTIVE_SKIPS: AtomicU64 = AtomicU64::new(0);
 /// moment a skip occurs. `u64::MAX` is the "no skip has recorded a snapshot
 /// yet" sentinel, mirroring `LAST_WAL_PAGES`.
 static CHECKPOINT_LAST_SKIP_WAL_PAGES: AtomicU64 = AtomicU64::new(u64::MAX);
+
+/// One backend-scoped observation produced by the periodic checkpoint task's
+/// own PASSIVE pass. Logical frame counts and the physical `-wal` allocation
+/// are intentionally separate: SQLite may retain/reuse the sidecar after the
+/// logical backlog drains (#1849).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RoutineWalObservation {
+    pub busy: i64,
+    pub log_frames: u64,
+    pub checkpointed_frames: u64,
+    pub pending_frames: u64,
+    pub physical_wal_bytes: Option<u64>,
+    pub observed_at_unix_ms: u64,
+}
+
+/// Latest routine observation by canonical database identity. Checkpoint
+/// tasks fan out per backend, so a single process-global "last task wins"
+/// gauge would misattribute a secondary backend to the main metrics frame.
+static ROUTINE_WAL_OBSERVATIONS: OnceLock<Mutex<HashMap<String, RoutineWalObservation>>> =
+    OnceLock::new();
+
+fn routine_wal_observations() -> &'static Mutex<HashMap<String, RoutineWalObservation>> {
+    ROUTINE_WAL_OBSERVATIONS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn checkpoint_db_label(pool: &ConnectionPool) -> String {
+    pool.canonical_path()
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|| "memory".to_string())
+}
+
+fn observed_at_unix_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+fn physical_wal_bytes(pool: &ConnectionPool) -> Option<u64> {
+    let path = pool.canonical_path()?;
+    let mut sidecar = path.as_os_str().to_os_string();
+    sidecar.push("-wal");
+    std::fs::metadata(PathBuf::from(sidecar))
+        .ok()
+        .map(|metadata| metadata.len())
+}
+
+fn record_routine_wal_observation(
+    pool: &ConnectionPool,
+    raw: RawCheckpointObservation,
+) -> RoutineWalObservation {
+    let log_frames = raw.log_frames.max(0) as u64;
+    let checkpointed_frames = raw.checkpointed_frames.max(0) as u64;
+    let observation = RoutineWalObservation {
+        busy: raw.busy,
+        log_frames,
+        checkpointed_frames,
+        pending_frames: log_frames.saturating_sub(checkpointed_frames),
+        physical_wal_bytes: physical_wal_bytes(pool),
+        observed_at_unix_ms: observed_at_unix_ms(),
+    };
+    routine_wal_observations()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .insert(checkpoint_db_label(pool), observation.clone());
+    observation
+}
+
+/// Latest periodic checkpoint sample for this exact backend. This is a pure
+/// in-memory read: it never issues `wal_checkpoint` or stats the filesystem.
+pub fn routine_wal_observation(pool: &ConnectionPool) -> Option<RoutineWalObservation> {
+    routine_wal_observations()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .get(&checkpoint_db_label(pool))
+        .cloned()
+}
 
 /// Last-observed WAL page count, if any checkpoint tick has run yet in this
 /// process. Read surface for the daemon-frame metrics snapshot.
@@ -1955,13 +2033,35 @@ fn checkpoint_once_core(
 ) -> Result<CheckpointCoreOutcome, rusqlite::Error> {
     #[cfg(unix)]
     truncate_state.begin_tick();
-    let wal_pages = query_wal_pages(conn);
+    let raw_observation = match query_checkpoint_observation(conn) {
+        Ok(observation) => observation,
+        Err(e) => {
+            tracing::warn!(error = %e, "WAL checkpoint failed");
+            return Err(e);
+        }
+    };
+    let observation = record_routine_wal_observation(pool, raw_observation);
+    let wal_pages = observation.log_frames;
+    LAST_WAL_PAGES.store(wal_pages, Ordering::Relaxed);
+    note_checkpoint_observed(wal_pages);
 
-    if let Err(e) = conn.execute_batch("PRAGMA wal_checkpoint(PASSIVE)") {
-        tracing::warn!(error = %e, "WAL checkpoint failed");
-        return Err(e);
+    if raw_observation.busy != 0 {
+        tracing::debug!(
+            busy = raw_observation.busy,
+            wal_log_frames = raw_observation.log_frames,
+            wal_checkpointed_frames = raw_observation.checkpointed_frames,
+            wal_pending_frames = observation.pending_frames,
+            wal_physical_bytes = ?observation.physical_wal_bytes,
+            "WAL PASSIVE checkpoint reported incomplete progress"
+        );
     }
-    tracing::debug!(wal_pages, "WAL checkpoint issued");
+    tracing::debug!(
+        wal_pages,
+        wal_checkpointed_frames = observation.checkpointed_frames,
+        wal_pending_frames = observation.pending_frames,
+        wal_physical_bytes = ?observation.physical_wal_bytes,
+        "WAL checkpoint issued"
+    );
 
     let sidecar_attribution = maybe_truncate(pool, conn, config, wal_pages, truncate_state);
 
@@ -2561,21 +2661,36 @@ fn crossing_warn(now_above: bool, was_above: &mut bool) -> bool {
     fire
 }
 
-/// Query the current WAL frame count via `PRAGMA wal_checkpoint`.
+#[derive(Debug, Clone, Copy)]
+struct RawCheckpointObservation {
+    busy: i64,
+    log_frames: i64,
+    checkpointed_frames: i64,
+}
+
+/// Issue one PASSIVE checkpoint and retain the complete SQLite result row.
+/// This is the periodic task's one routine checkpoint call: the same row
+/// drives thresholds and the logical-backlog monitoring sample (#1849).
+fn query_checkpoint_observation(
+    conn: &rusqlite::Connection,
+) -> rusqlite::Result<RawCheckpointObservation> {
+    conn.query_row("PRAGMA wal_checkpoint(PASSIVE)", [], |row| {
+        Ok(RawCheckpointObservation {
+            busy: row.get(0)?,
+            log_frames: row.get(1)?,
+            checkpointed_frames: row.get(2)?,
+        })
+    })
+}
+
+/// Query the current WAL frame count with one PASSIVE checkpoint.
 ///
-/// The pragma returns a 3-column row `(busy, log, checkpointed)`, where `log`
-/// (column index 1) is the number of frames currently in the WAL file — the
-/// backlog the high-water threshold keys off. (Column 2 is `checkpointed`, the
-/// frames moved *by this call*, which is not the WAL size.) The no-arg pragma
-/// also performs a PASSIVE checkpoint as a side effect; the subsequent explicit
-/// `PRAGMA wal_checkpoint(PASSIVE)` in `checkpoint_once` is a deliberate second
-/// pass that can checkpoint any frames written between the two calls.
-///
-/// Returns 0 on any error (e.g. in-memory DB where WAL is not active, which
-/// reports `log = -1`).
+/// Used only for rare post-TRUNCATE outcome measurement. The ordinary
+/// periodic path calls [`query_checkpoint_observation`] directly and stores
+/// its complete row, avoiding the former double-checkpoint pass.
 fn query_wal_pages(conn: &rusqlite::Connection) -> u64 {
-    let pages = conn
-        .query_row("PRAGMA wal_checkpoint", [], |row| row.get::<_, i64>(1))
+    let pages = query_checkpoint_observation(conn)
+        .map(|observation| observation.log_frames)
         .unwrap_or(0)
         .max(0) as u64;
     // Metrics read-surface (load/perf harness): mirror every observation into
@@ -6114,16 +6229,18 @@ mod tests {
         let checkpoint_conn = pool.open_standalone_writer().unwrap();
         let pragma_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let pragma_calls_from_hook = Arc::clone(&pragma_calls);
-        checkpoint_conn.authorizer(Some(move |context| {
-            if matches!(
-                context.action,
-                AuthAction::Pragma { pragma_name, .. }
-                    if pragma_name.eq_ignore_ascii_case("wal_checkpoint")
-            ) {
-                pragma_calls_from_hook.fetch_add(1, Ordering::SeqCst);
-            }
-            Authorization::Allow
-        }));
+        checkpoint_conn
+            .authorizer(Some(move |context| {
+                if matches!(
+                    context.action,
+                    AuthAction::Pragma { pragma_name, .. }
+                        if pragma_name.eq_ignore_ascii_case("wal_checkpoint")
+                ) {
+                    pragma_calls_from_hook.fetch_add(1, Ordering::SeqCst);
+                }
+                Authorization::Allow
+            }))
+            .unwrap();
 
         checkpoint_once(
             &pool,
@@ -6132,7 +6249,9 @@ mod tests {
             &mut TruncateState::default(),
         )
         .unwrap();
-        checkpoint_conn.authorizer(None::<fn(_) -> _>);
+        checkpoint_conn
+            .authorizer(None::<fn(rusqlite::hooks::AuthContext<'_>) -> Authorization>)
+            .unwrap();
 
         assert_eq!(
             pragma_calls.load(Ordering::SeqCst),

--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -98,17 +98,19 @@ pub struct RoutineWalObservation {
 /// Latest routine observation by canonical database identity. Checkpoint
 /// tasks fan out per backend, so a single process-global "last task wins"
 /// gauge would misattribute a secondary backend to the main metrics frame.
-static ROUTINE_WAL_OBSERVATIONS: OnceLock<Mutex<HashMap<String, RoutineWalObservation>>> =
+static ROUTINE_WAL_OBSERVATIONS: OnceLock<Mutex<HashMap<Option<PathBuf>, RoutineWalObservation>>> =
     OnceLock::new();
 
-fn routine_wal_observations() -> &'static Mutex<HashMap<String, RoutineWalObservation>> {
+fn routine_wal_observations() -> &'static Mutex<HashMap<Option<PathBuf>, RoutineWalObservation>> {
     ROUTINE_WAL_OBSERVATIONS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-fn checkpoint_db_label(pool: &ConnectionPool) -> String {
-    pool.canonical_path()
-        .map(|path| path.display().to_string())
-        .unwrap_or_else(|| "memory".to_string())
+fn checkpoint_db_key_from_path(path: Option<&Path>) -> Option<PathBuf> {
+    path.map(Path::to_path_buf)
+}
+
+fn checkpoint_db_key(pool: &ConnectionPool) -> Option<PathBuf> {
+    checkpoint_db_key_from_path(pool.canonical_path())
 }
 
 fn observed_at_unix_ms() -> u64 {
@@ -144,7 +146,7 @@ fn record_routine_wal_observation(
     routine_wal_observations()
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .insert(checkpoint_db_label(pool), observation.clone());
+        .insert(checkpoint_db_key(pool), observation.clone());
     observation
 }
 
@@ -154,7 +156,7 @@ pub fn routine_wal_observation(pool: &ConnectionPool) -> Option<RoutineWalObserv
     routine_wal_observations()
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .get(&checkpoint_db_label(pool))
+        .get(&checkpoint_db_key(pool))
         .cloned()
 }
 
@@ -6179,6 +6181,29 @@ mod tests {
         // Either an explicit error or a nonsensical negative `log` value is
         // acceptable here — the requirement is just "does not panic".
         let _ = query_wal_pin_depth(writer.conn());
+    }
+
+    /// #1849: a canonical filesystem identity is an OS path, not a display
+    /// label. Distinct non-UTF-8 Unix paths can render to the same lossy
+    /// string and must still occupy distinct backend telemetry slots.
+    #[cfg(unix)]
+    #[test]
+    fn routine_wal_backend_key_preserves_non_utf8_path_bytes() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let path_a = PathBuf::from(OsString::from_vec(b"/tmp/khive-wal-\x80.db".to_vec()));
+        let path_b = PathBuf::from(OsString::from_vec(b"/tmp/khive-wal-\x81.db".to_vec()));
+        assert_eq!(
+            path_a.display().to_string(),
+            path_b.display().to_string(),
+            "fixture must reproduce the lossy display-label collision"
+        );
+        assert_ne!(
+            checkpoint_db_key_from_path(Some(&path_a)),
+            checkpoint_db_key_from_path(Some(&path_b)),
+            "backend keys must retain the canonical path's exact OS bytes"
+        );
     }
 
     /// #1849: the periodic checkpoint's own PASSIVE row is the monitoring

--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -2590,6 +2590,7 @@ fn query_wal_pages(conn: &rusqlite::Connection) -> u64 {
 mod tests {
     use super::*;
     use crate::pool::PoolConfig;
+    use rusqlite::hooks::{AuthAction, Authorization};
     use serial_test::serial;
     use tracing::field::{Field, Visit};
 
@@ -6063,5 +6064,110 @@ mod tests {
         // Either an explicit error or a nonsensical negative `log` value is
         // acceptable here — the requirement is just "does not panic".
         let _ = query_wal_pin_depth(writer.conn());
+    }
+
+    /// #1849: the periodic checkpoint's own PASSIVE row is the monitoring
+    /// sample. One tick must not issue the old no-arg probe followed by a
+    /// second PASSIVE, and the stored sample must distinguish logical
+    /// backlog from the physical sidecar high-water mark.
+    #[test]
+    #[serial(checkpoint_skip_metrics)]
+    fn routine_checkpoint_records_one_pass_logical_and_physical_wal_sample() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("routine_wal_sample.db");
+        let pool = file_pool(&path);
+
+        {
+            let writer = pool.try_writer().expect("writer");
+            writer
+                .conn()
+                .execute_batch(
+                    "PRAGMA wal_autocheckpoint=0; \
+                     CREATE TABLE t (id INTEGER PRIMARY KEY, payload TEXT); \
+                     INSERT INTO t VALUES (0, 'seed');",
+                )
+                .unwrap();
+        }
+
+        let reader = rusqlite::Connection::open_with_flags(
+            &path,
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+        )
+        .unwrap();
+        reader.execute_batch("BEGIN").unwrap();
+        let _: i64 = reader
+            .query_row("SELECT COUNT(*) FROM t", [], |row| row.get(0))
+            .unwrap();
+
+        {
+            let writer = pool.try_writer().expect("writer");
+            writer.conn().execute_batch("BEGIN IMMEDIATE").unwrap();
+            for id in 1..=256_i64 {
+                writer
+                    .conn()
+                    .execute("INSERT INTO t VALUES (?1, printf('%.*c', 2048, 'x'))", [id])
+                    .unwrap();
+            }
+            writer.conn().execute_batch("COMMIT").unwrap();
+        }
+
+        let checkpoint_conn = pool.open_standalone_writer().unwrap();
+        let pragma_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let pragma_calls_from_hook = Arc::clone(&pragma_calls);
+        checkpoint_conn.authorizer(Some(move |context| {
+            if matches!(
+                context.action,
+                AuthAction::Pragma { pragma_name, .. }
+                    if pragma_name.eq_ignore_ascii_case("wal_checkpoint")
+            ) {
+                pragma_calls_from_hook.fetch_add(1, Ordering::SeqCst);
+            }
+            Authorization::Allow
+        }));
+
+        checkpoint_once(
+            &pool,
+            &checkpoint_conn,
+            &CheckpointConfig::default(),
+            &mut TruncateState::default(),
+        )
+        .unwrap();
+        checkpoint_conn.authorizer(None::<fn(_) -> _>);
+
+        assert_eq!(
+            pragma_calls.load(Ordering::SeqCst),
+            1,
+            "one routine tick must issue exactly one PASSIVE checkpoint"
+        );
+        let pinned = routine_wal_observation(&pool).expect("routine sample");
+        assert!(pinned.log_frames > 0, "the test must create WAL frames");
+        assert!(
+            pinned.pending_frames > 0,
+            "the old reader must leave a logical backlog: {pinned:?}"
+        );
+        assert_eq!(
+            pinned.pending_frames,
+            pinned.log_frames.saturating_sub(pinned.checkpointed_frames)
+        );
+        assert!(
+            pinned.physical_wal_bytes.is_some_and(|bytes| bytes > 0),
+            "the physical sidecar high-water must be reported separately: {pinned:?}"
+        );
+
+        reader.execute_batch("COMMIT").unwrap();
+        checkpoint_once(
+            &pool,
+            &checkpoint_conn,
+            &CheckpointConfig::default(),
+            &mut TruncateState::default(),
+        )
+        .unwrap();
+        let drained = routine_wal_observation(&pool).expect("drained routine sample");
+        assert_eq!(drained.pending_frames, 0, "unpinned PASSIVE must drain");
+        assert!(
+            drained.physical_wal_bytes.is_some_and(|bytes| bytes > 0),
+            "PASSIVE may reuse rather than shrink the physical WAL; the two gauges must remain \
+             independently visible: {drained:?}"
+        );
     }
 }

--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -6255,7 +6255,7 @@ mod tests {
         let pragma_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let pragma_calls_from_hook = Arc::clone(&pragma_calls);
         checkpoint_conn
-            .authorizer(Some(move |context| {
+            .authorizer(Some(move |context: rusqlite::hooks::AuthContext<'_>| {
                 if matches!(
                     context.action,
                     AuthAction::Pragma { pragma_name, .. }

--- a/crates/khive-db/src/timeout_sink.rs
+++ b/crates/khive-db/src/timeout_sink.rs
@@ -133,7 +133,7 @@ const WRITE_DELAY_MS_OVERRIDE_ENV: &str = "KHIVE_WRITER_TIMEOUT_SINK_WRITE_DELAY
 /// caller-visible WAITING: under burst, contention now presents as latency,
 /// which the failure-shaped rows are structurally unable to record — a
 /// quiet sink no longer means an uncontended writer. The bound is on the
-/// whole send-to-reply span (enqueue wait + queue depth + execution), i.e.
+/// whole request span (queue wait + transaction stages), i.e.
 /// the quantity a blocked caller actually experiences.
 const SLOW_WRITE_THRESHOLD: Duration = Duration::from_secs(1);
 
@@ -293,7 +293,7 @@ impl Site {
 /// `"direct_route_violation"` (a direct writer acquisition bypassing an
 /// enabled queue, carries `site`), and `"slow_write"` (a queued write whose
 /// send-to-reply span met [`SLOW_WRITE_THRESHOLD`], carries `elapsed_ms` +
-/// `queue_depth`).
+/// `queue_depth` plus the four decomposed writer-stage durations).
 struct QueuedEvent {
     ts_utc: String,
     kind: &'static str,
@@ -303,6 +303,16 @@ struct QueuedEvent {
     timeout_ms: Option<u64>,
     elapsed_ms: Option<u64>,
     queue_depth: Option<u64>,
+    writer_stages: Option<WriterStageFields>,
+}
+
+#[derive(Clone, serde::Serialize)]
+struct WriterStageFields {
+    queue_wait_micros: u64,
+    transaction_acquire_micros: u64,
+    body_micros: u64,
+    commit_micros: u64,
+    total_micros: u64,
 }
 
 /// Process-global handle to the writer thread's inbox. Set at most once per
@@ -337,6 +347,8 @@ struct EventRecord<'a> {
     elapsed_ms: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     queue_depth: Option<u64>,
+    #[serde(flatten, skip_serializing_if = "Option::is_none")]
+    writer_stages: Option<WriterStageFields>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pid: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -353,6 +365,7 @@ fn build_line(
     timeout_ms: Option<u64>,
     elapsed_ms: Option<u64>,
     queue_depth: Option<u64>,
+    writer_stages: Option<WriterStageFields>,
     pid: Option<u32>,
     version: Option<&str>,
 ) -> String {
@@ -365,6 +378,7 @@ fn build_line(
         timeout_ms,
         elapsed_ms,
         queue_depth,
+        writer_stages,
         pid,
         version,
     };
@@ -393,6 +407,7 @@ fn build_line_now(
         site,
         error,
         timeout_ms,
+        None,
         None,
         None,
         pid,
@@ -629,6 +644,7 @@ fn write_event(sink: &mut AppendSink<File>, dropped: &AtomicU64, event: QueuedEv
         event.timeout_ms,
         event.elapsed_ms,
         event.queue_depth,
+        event.writer_stages,
         None,
         None,
     );
@@ -943,6 +959,7 @@ pub(crate) fn emit_timeout(db: &str, site: Site, error: &str, timeout_ms: Option
         timeout_ms,
         elapsed_ms: None,
         queue_depth: None,
+        writer_stages: None,
     };
     enqueue(&handle.sender, &handle.dropped, event);
 }
@@ -965,6 +982,7 @@ pub(crate) fn emit_queue_saturation(db: &str, timeout_ms: u64) {
         timeout_ms: Some(timeout_ms),
         elapsed_ms: None,
         queue_depth: None,
+        writer_stages: None,
     };
     enqueue(&handle.sender, &handle.dropped, event);
 }
@@ -986,6 +1004,7 @@ pub(crate) fn emit_writer_task_retirement(db: &str, reason: &str) {
         timeout_ms: None,
         elapsed_ms: None,
         queue_depth: None,
+        writer_stages: None,
     };
     enqueue(&handle.sender, &handle.dropped, event);
 }
@@ -1010,17 +1029,17 @@ pub(crate) fn emit_direct_route_violation(db: &str, site: Site) {
         timeout_ms: None,
         elapsed_ms: None,
         queue_depth: None,
+        writer_stages: None,
     };
     enqueue(&handle.sender, &handle.dropped, event);
 }
 
-/// Record a `slow_write` event: a queued write whose whole send-to-reply
-/// span (enqueue wait + queue depth + execution) met the slow-write
-/// threshold. Emitted by `WriterTaskHandle`'s send paths on completion —
-/// success or error alike, since the caller experienced the latency either
-/// way. `queue_depth` is the backlog snapshot taken when the send STARTED,
-/// so a reader can separate "queue was deep" from "one op was slow".
-pub(crate) fn emit_slow_write(db: &str, elapsed_ms: u64, queue_depth: usize) {
+/// Record a `slow_write` event: a queued write whose whole request span met
+/// the slow-write threshold. Emitted before the typed reply wakes the caller,
+/// for success or error alike. The compatibility `elapsed_ms`/`queue_depth`
+/// fields remain, while the microsecond stage fields distinguish admission,
+/// SQLite write-lock acquisition, operation body, and COMMIT (#1849).
+pub(crate) fn emit_slow_write(db: &str, stages: &crate::writer_task::WriterStageObservation) {
     let Some(handle) = SINK.get() else {
         return;
     };
@@ -1031,8 +1050,15 @@ pub(crate) fn emit_slow_write(db: &str, elapsed_ms: u64, queue_depth: usize) {
         site: None,
         error: None,
         timeout_ms: None,
-        elapsed_ms: Some(elapsed_ms),
-        queue_depth: Some(queue_depth as u64),
+        elapsed_ms: Some(stages.total_micros / 1_000),
+        queue_depth: Some(stages.queue_depth_at_entry),
+        writer_stages: Some(WriterStageFields {
+            queue_wait_micros: stages.queue_wait_micros,
+            transaction_acquire_micros: stages.transaction_acquire_micros,
+            body_micros: stages.body_micros,
+            commit_micros: stages.commit_micros,
+            total_micros: stages.total_micros,
+        }),
     };
     enqueue(&handle.sender, &handle.dropped, event);
 }
@@ -1113,6 +1139,13 @@ mod tests {
 
     #[test]
     fn slow_write_line_carries_elapsed_and_depth_and_omits_inapplicable_fields() {
+        let stages = WriterStageFields {
+            queue_wait_micros: 11,
+            transaction_acquire_micros: 22,
+            body_micros: 1_111_000,
+            commit_micros: 44,
+            total_micros: 1_234_000,
+        };
         let line = build_line(
             now_rfc3339(),
             "slow_write",
@@ -1122,6 +1155,7 @@ mod tests {
             None,
             Some(1234),
             Some(7),
+            Some(stages),
             None,
             None,
         );
@@ -1129,6 +1163,11 @@ mod tests {
         assert_eq!(parsed["kind"], "slow_write");
         assert_eq!(parsed["elapsed_ms"], 1234);
         assert_eq!(parsed["queue_depth"], 7);
+        assert_eq!(parsed["queue_wait_micros"], 11);
+        assert_eq!(parsed["transaction_acquire_micros"], 22);
+        assert_eq!(parsed["body_micros"], 1_111_000);
+        assert_eq!(parsed["commit_micros"], 44);
+        assert_eq!(parsed["total_micros"], 1_234_000);
         // Inapplicable fields are omitted, not null (existing sink contract).
         assert!(parsed.get("site").is_none());
         assert!(parsed.get("error").is_none());
@@ -1178,6 +1217,7 @@ mod tests {
             timeout_ms: Some(5),
             elapsed_ms: None,
             queue_depth: None,
+            writer_stages: None,
         };
 
         enqueue(&sender, &dropped, make_event());
@@ -1357,6 +1397,7 @@ mod tests {
                         timeout_ms: Some(i as u64),
                         elapsed_ms: None,
                         queue_depth: None,
+                        writer_stages: None,
                     };
                     enqueue(&sender, &dropped, event);
                 })
@@ -1380,6 +1421,7 @@ mod tests {
                 event.timeout_ms,
                 event.elapsed_ms,
                 event.queue_depth,
+                event.writer_stages,
                 None,
                 None,
             );

--- a/crates/khive-db/src/writer_task.rs
+++ b/crates/khive-db/src/writer_task.rs
@@ -867,10 +867,13 @@ async fn run_writer_task(
     acquisition_counters: Arc<WriterAcquisitionCounters>,
 ) {
     while let Some(request) = rx.recv().await {
+        // The bounded-channel wait ends at this exact dequeue boundary.
+        // Sampling inside the blocking closure would misattribute a saturated
+        // Tokio blocking pool to writer-queue contention (#1849).
+        let queue_wait = request.queue_wait();
         let origin = origin.clone();
         let acquisition_counters = Arc::clone(&acquisition_counters);
         let outcome = tokio::task::spawn_blocking(move || {
-            let queue_wait = request.queue_wait();
             // A top-level request deliberately skips BEGIN, so it would
             // silently join any transaction leaked by an earlier request.
             // Refuse every request before dispatch if the connection is not

--- a/crates/khive-db/src/writer_task.rs
+++ b/crates/khive-db/src/writer_task.rs
@@ -41,6 +41,7 @@
 use rusqlite::Connection;
 use std::collections::HashMap;
 use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, oneshot};
@@ -76,11 +77,20 @@ pub struct WriterStageObservation {
     pub observed_at_unix_ms: u64,
 }
 
-static WRITER_STAGE_OBSERVATIONS: OnceLock<Mutex<HashMap<String, WriterStageObservation>>> =
-    OnceLock::new();
+static WRITER_STAGE_OBSERVATIONS: OnceLock<
+    Mutex<HashMap<Option<PathBuf>, WriterStageObservation>>,
+> = OnceLock::new();
 
-fn writer_stage_observations() -> &'static Mutex<HashMap<String, WriterStageObservation>> {
+fn writer_stage_observations() -> &'static Mutex<HashMap<Option<PathBuf>, WriterStageObservation>> {
     WRITER_STAGE_OBSERVATIONS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn writer_db_key_from_path(path: Option<&Path>) -> Option<PathBuf> {
+    path.map(Path::to_path_buf)
+}
+
+fn writer_db_key(pool: &ConnectionPool) -> Option<PathBuf> {
+    writer_db_key_from_path(pool.canonical_path())
 }
 
 fn duration_micros(duration: Duration) -> u64 {
@@ -97,15 +107,15 @@ fn observed_at_unix_ms() -> u64 {
 /// Pure in-memory read of the most recently completed writer-task span for
 /// this exact backend. It acquires no SQLite connection and performs no I/O.
 pub fn last_writer_stage_observation(pool: &ConnectionPool) -> Option<WriterStageObservation> {
-    let db = crate::timeout_sink::db_label(pool);
     writer_stage_observations()
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .get(&db)
+        .get(&writer_db_key(pool))
         .cloned()
 }
 
 struct WriteTelemetry {
+    backend_key: Option<PathBuf>,
     db: String,
     submitted_at: Instant,
     queue_depth_at_entry: usize,
@@ -114,11 +124,13 @@ struct WriteTelemetry {
 
 impl WriteTelemetry {
     fn new(
+        backend_key: Option<PathBuf>,
         db: String,
         queue_depth_at_entry: usize,
         slow_write_threshold: Option<Duration>,
     ) -> Self {
         Self {
+            backend_key,
             db,
             submitted_at: Instant::now(),
             queue_depth_at_entry,
@@ -150,7 +162,7 @@ impl WriteTelemetry {
         writer_stage_observations()
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .insert(self.db.clone(), observation.clone());
+            .insert(self.backend_key, observation.clone());
 
         if self
             .slow_write_threshold
@@ -550,6 +562,9 @@ fn writer_task_terminated(request_state: WriterTaskRequestState) -> StorageError
 #[derive(Clone, Debug)]
 pub struct WriterTaskHandle {
     tx: mpsc::Sender<Box<dyn AnyWriteRequest + Send>>,
+    /// Exact canonical backend identity used by the in-memory stage registry.
+    /// Kept separate from `db`, whose lossy display form is logging-only.
+    backend_key: Option<PathBuf>,
     /// This handle's pool's writer-timeout sink identity (`timeout_sink::db_label`),
     /// captured at spawn so `send_with_timeout`'s `WriteQueueFull` path can
     /// report a `queue_saturation` sink row (ADR-136 D1 gate 6a) without
@@ -623,6 +638,7 @@ impl WriterTaskHandle {
     {
         let (reply_tx, reply_rx) = oneshot::channel();
         let telemetry = WriteTelemetry::new(
+            self.backend_key.clone(),
             self.db.clone(),
             self.queue_depth(),
             self.slow_write_threshold,
@@ -809,6 +825,7 @@ pub fn spawn(pool: &ConnectionPool, capacity: usize) -> Result<WriterTaskHandle,
     let conn = pool.open_standalone_writer_untracked()?;
     let acquisition_counters = pool.writer_acquisition_counters();
     let origin = pool.origin();
+    let backend_key = writer_db_key(pool);
     let db = crate::timeout_sink::db_label(pool);
     let (tx, rx) = mpsc::channel(capacity.max(1));
     let join = tokio::spawn(run_writer_task(
@@ -824,6 +841,7 @@ pub fn spawn(pool: &ConnectionPool, capacity: usize) -> Result<WriterTaskHandle,
     pool.set_writer_task_join(join);
     Ok(WriterTaskHandle {
         tx,
+        backend_key,
         db,
         slow_write_threshold: crate::timeout_sink::slow_write_threshold(),
         enqueue_timeout: std::time::Duration::from_millis(
@@ -1377,6 +1395,7 @@ mod tests {
         let (tx, _rx) = mpsc::channel::<Box<dyn AnyWriteRequest + Send>>(1);
         let handle = WriterTaskHandle {
             tx,
+            backend_key: None,
             db: "test".to_string(),
             slow_write_threshold: None,
             enqueue_timeout: Duration::from_secs(5),
@@ -1416,6 +1435,7 @@ mod tests {
         let (tx, _rx) = mpsc::channel::<Box<dyn AnyWriteRequest + Send>>(1);
         let handle = WriterTaskHandle {
             tx,
+            backend_key: None,
             db: "test".to_string(),
             slow_write_threshold: None,
             enqueue_timeout: Duration::from_secs(5),
@@ -1741,7 +1761,7 @@ mod tests {
             }),
             reply: reply_tx,
             top_level: true,
-            telemetry: WriteTelemetry::new("test".to_string(), 0, None),
+            telemetry: WriteTelemetry::new(None, "test".to_string(), 0, None),
         };
 
         let terminal_state = sealed::Sealed::execute_and_reply_top_level_reporting_terminal(
@@ -1786,7 +1806,7 @@ mod tests {
             }),
             reply: reply_tx,
             top_level: false,
-            telemetry: WriteTelemetry::new("test".to_string(), 0, None),
+            telemetry: WriteTelemetry::new(None, "test".to_string(), 0, None),
         };
 
         let terminal_state = sealed::Sealed::execute_and_reply_reporting_terminal(
@@ -1924,7 +1944,7 @@ mod tests {
             }),
             reply: reply_tx,
             top_level: false,
-            telemetry: WriteTelemetry::new("test".to_string(), 0, None),
+            telemetry: WriteTelemetry::new(None, "test".to_string(), 0, None),
         };
 
         let terminal_state = sealed::Sealed::execute_and_reply_reporting_terminal(
@@ -1969,7 +1989,7 @@ mod tests {
             }),
             reply: reply_tx,
             top_level: false,
-            telemetry: WriteTelemetry::new("test".to_string(), 0, None),
+            telemetry: WriteTelemetry::new(None, "test".to_string(), 0, None),
         };
 
         let terminal_state = sealed::Sealed::execute_and_reply_reporting_terminal(
@@ -2240,6 +2260,7 @@ mod tests {
 
         let handle = WriterTaskHandle {
             tx,
+            backend_key: None,
             db: "test".to_string(),
             slow_write_threshold: None,
             enqueue_timeout: Duration::from_secs(5),
@@ -2266,6 +2287,7 @@ mod tests {
         let (tx, mut rx) = mpsc::channel::<Box<dyn AnyWriteRequest + Send>>(1);
         let handle = WriterTaskHandle {
             tx,
+            backend_key: None,
             db: "test".to_string(),
             slow_write_threshold: None,
             enqueue_timeout: Duration::from_secs(5),
@@ -2290,6 +2312,30 @@ mod tests {
 
         assert_writer_task_terminal_state(result, WriterTaskRequestState::SideEffectsUnknown);
         assert!(!request_ran.load(Ordering::SeqCst));
+    }
+
+    /// #1849: writer telemetry uses the same canonical OS-path identity as
+    /// the pool. A lossy display string would merge these distinct backends.
+    #[cfg(unix)]
+    #[test]
+    fn writer_stage_backend_key_preserves_non_utf8_path_bytes() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let path_a =
+            std::path::PathBuf::from(OsString::from_vec(b"/tmp/khive-writer-\x80.db".to_vec()));
+        let path_b =
+            std::path::PathBuf::from(OsString::from_vec(b"/tmp/khive-writer-\x81.db".to_vec()));
+        assert_eq!(
+            path_a.display().to_string(),
+            path_b.display().to_string(),
+            "fixture must reproduce the lossy display-label collision"
+        );
+        assert_ne!(
+            writer_db_key_from_path(Some(&path_a)),
+            writer_db_key_from_path(Some(&path_b)),
+            "backend keys must retain the canonical path's exact OS bytes"
+        );
     }
 
     /// #1849: a deliberately slow transaction body with no queue backlog or

--- a/crates/khive-db/src/writer_task.rs
+++ b/crates/khive-db/src/writer_task.rs
@@ -2074,4 +2074,53 @@ mod tests {
         assert_writer_task_terminal_state(result, WriterTaskRequestState::SideEffectsUnknown);
         assert!(!request_ran.load(Ordering::SeqCst));
     }
+
+    /// #1849: a deliberately slow transaction body with no queue backlog or
+    /// lock contention must be attributed to `body`, not flattened into one
+    /// opaque send-to-reply duration.
+    #[tokio::test]
+    async fn writer_stage_sample_attributes_a_slow_body() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("writer_stage_sample.db");
+        let pool = file_pool(&path);
+        {
+            let writer = pool.try_writer().unwrap();
+            writer
+                .conn()
+                .execute_batch("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+                .unwrap();
+        }
+        let handle = spawn(&pool, 8).unwrap();
+
+        handle
+            .send(|conn| {
+                std::thread::sleep(Duration::from_millis(60));
+                conn.execute("INSERT INTO t VALUES (1)", [])
+                    .map_err(|error| StorageError::Pool {
+                        operation: "writer_stage_sample".into(),
+                        message: error.to_string(),
+                    })
+            })
+            .await
+            .unwrap();
+
+        let sample = last_writer_stage_observation(&pool).expect("writer stage sample");
+        assert!(
+            sample.body_micros >= 50_000,
+            "the synthetic delay must land in the body stage: {sample:?}"
+        );
+        assert!(
+            sample.body_micros > sample.queue_wait_micros,
+            "fast queueing must not receive the body's delay: {sample:?}"
+        );
+        assert!(
+            sample.body_micros > sample.transaction_acquire_micros,
+            "an uncontended BEGIN must not receive the body's delay: {sample:?}"
+        );
+        assert!(
+            sample.body_micros > sample.commit_micros,
+            "a fast COMMIT must not receive the body's delay: {sample:?}"
+        );
+        assert!(sample.observed_at_unix_ms > 0);
+    }
 }

--- a/crates/khive-db/src/writer_task.rs
+++ b/crates/khive-db/src/writer_task.rs
@@ -2337,4 +2337,60 @@ mod tests {
         );
         assert!(sample.observed_at_unix_ms > 0);
     }
+
+    /// #1849: bounded-channel queue wait ends when the drain loop receives
+    /// the request. Saturation in Tokio's blocking pool happens after that
+    /// boundary and must remain in `total - named_stages`, never be relabeled
+    /// as writer-queue contention.
+    #[test]
+    fn writer_queue_wait_excludes_blocking_pool_scheduling_delay() {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .max_blocking_threads(1)
+            .enable_all()
+            .build()
+            .expect("test runtime");
+
+        runtime.block_on(async {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("writer_dequeue_boundary.db");
+            let pool = file_pool(&path);
+            let handle = spawn(&pool, 8).unwrap();
+
+            let (blocker_started_tx, blocker_started_rx) = std_mpsc::sync_channel(0);
+            let (release_blocker_tx, release_blocker_rx) = std_mpsc::channel();
+            let blocker = tokio::task::spawn_blocking(move || {
+                blocker_started_tx.send(()).unwrap();
+                release_blocker_rx.recv().unwrap();
+            });
+            blocker_started_rx
+                .recv_timeout(Duration::from_secs(1))
+                .expect("sole blocking worker must be occupied");
+
+            let reply = handle
+                .enqueue(|_conn| Ok::<(), StorageError>(()))
+                .await
+                .expect("request must enter the bounded writer channel");
+            let dequeue_deadline = Instant::now() + Duration::from_secs(1);
+            while handle.queue_depth() != 0 {
+                assert!(
+                    Instant::now() < dequeue_deadline,
+                    "writer drain never dequeued the accepted request"
+                );
+                tokio::task::yield_now().await;
+            }
+
+            let scheduling_delay = Duration::from_millis(150);
+            tokio::time::sleep(scheduling_delay).await;
+            release_blocker_tx.send(()).unwrap();
+            blocker.await.unwrap();
+            reply.await.unwrap().unwrap();
+
+            let sample = last_writer_stage_observation(&pool).expect("writer stage sample");
+            assert!(
+                sample.total_micros.saturating_sub(sample.queue_wait_micros) >= 100_000,
+                "the post-dequeue blocking-pool delay must not inflate queue_wait: {sample:?}"
+            );
+        });
+    }
 }

--- a/crates/khive-db/src/writer_task.rs
+++ b/crates/khive-db/src/writer_task.rs
@@ -39,8 +39,10 @@
 //! rows are exempt by design and never emit that row.
 
 use rusqlite::Connection;
+use std::collections::HashMap;
 use std::panic::{catch_unwind, AssertUnwindSafe};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, oneshot};
 
 use khive_storage::error::{StorageError, WriterTaskRequestState};
@@ -58,6 +60,106 @@ use crate::pool::{ConnectionPool, WriterAcquisitionCounters};
 /// nested-transaction rule and return `SQLITE_ERROR: cannot start a
 /// transaction within a transaction` (ADR-067 lines 271-276).
 type WriteOp<R> = Box<dyn FnOnce(&Connection) -> Result<R, StorageError> + Send>;
+
+/// Latest completed writer-task span for one database, decomposed at the
+/// boundaries an operator can act on (#1849). A zero value means that phase
+/// did not run (top-level/early-failure request) or completed below the
+/// microsecond clock resolution; `total_micros` retains the full span.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WriterStageObservation {
+    pub queue_wait_micros: u64,
+    pub transaction_acquire_micros: u64,
+    pub body_micros: u64,
+    pub commit_micros: u64,
+    pub total_micros: u64,
+    pub queue_depth_at_entry: u64,
+    pub observed_at_unix_ms: u64,
+}
+
+static WRITER_STAGE_OBSERVATIONS: OnceLock<Mutex<HashMap<String, WriterStageObservation>>> =
+    OnceLock::new();
+
+fn writer_stage_observations() -> &'static Mutex<HashMap<String, WriterStageObservation>> {
+    WRITER_STAGE_OBSERVATIONS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn duration_micros(duration: Duration) -> u64 {
+    duration.as_micros().min(u128::from(u64::MAX)) as u64
+}
+
+fn observed_at_unix_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Pure in-memory read of the most recently completed writer-task span for
+/// this exact backend. It acquires no SQLite connection and performs no I/O.
+pub fn last_writer_stage_observation(pool: &ConnectionPool) -> Option<WriterStageObservation> {
+    let db = crate::timeout_sink::db_label(pool);
+    writer_stage_observations()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .get(&db)
+        .cloned()
+}
+
+struct WriteTelemetry {
+    db: String,
+    submitted_at: Instant,
+    queue_depth_at_entry: usize,
+    slow_write_threshold: Option<Duration>,
+}
+
+impl WriteTelemetry {
+    fn new(
+        db: String,
+        queue_depth_at_entry: usize,
+        slow_write_threshold: Option<Duration>,
+    ) -> Self {
+        Self {
+            db,
+            submitted_at: Instant::now(),
+            queue_depth_at_entry,
+            slow_write_threshold,
+        }
+    }
+
+    fn queue_wait(&self) -> Duration {
+        self.submitted_at.elapsed()
+    }
+
+    fn finish(
+        self,
+        queue_wait: Duration,
+        transaction_acquire: Duration,
+        body: Duration,
+        commit: Duration,
+    ) {
+        let total = self.submitted_at.elapsed();
+        let observation = WriterStageObservation {
+            queue_wait_micros: duration_micros(queue_wait),
+            transaction_acquire_micros: duration_micros(transaction_acquire),
+            body_micros: duration_micros(body),
+            commit_micros: duration_micros(commit),
+            total_micros: duration_micros(total),
+            queue_depth_at_entry: self.queue_depth_at_entry as u64,
+            observed_at_unix_ms: observed_at_unix_ms(),
+        };
+        writer_stage_observations()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert(self.db.clone(), observation.clone());
+
+        if self
+            .slow_write_threshold
+            .is_some_and(|threshold| total >= threshold)
+        {
+            crate::timeout_sink::emit_slow_write(&self.db, &observation);
+        }
+    }
+}
 
 /// One write request awaiting execution by the writer task.
 ///
@@ -77,6 +179,7 @@ pub struct WriteRequest<R: Send + 'static> {
     op: WriteOp<R>,
     reply: oneshot::Sender<Result<R, StorageError>>,
     top_level: bool,
+    telemetry: WriteTelemetry,
 }
 
 mod sealed {
@@ -89,12 +192,22 @@ mod sealed {
             self: Box<Self>,
             conn: &rusqlite::Connection,
             tx_span: Option<khive_storage::tx_registry::TxHandle>,
+            queue_wait: std::time::Duration,
+            transaction_acquire: std::time::Duration,
         ) -> Option<khive_storage::error::WriterTaskRequestState>;
 
         fn execute_and_reply_top_level_reporting_terminal(
             self: Box<Self>,
             conn: &rusqlite::Connection,
+            queue_wait: std::time::Duration,
         ) -> Option<khive_storage::error::WriterTaskRequestState>;
+
+        fn reply_error_after_begin(
+            self: Box<Self>,
+            err: khive_storage::error::StorageError,
+            queue_wait: std::time::Duration,
+            transaction_acquire: std::time::Duration,
+        );
     }
 }
 
@@ -146,6 +259,10 @@ pub trait AnyWriteRequest: sealed::Sealed + Send {
     /// [`Self::execute_and_reply_top_level`] (no transaction wrap) instead
     /// of [`Self::execute_and_reply`] (wrapped in `BEGIN IMMEDIATE`).
     fn is_top_level(&self) -> bool;
+
+    /// Time from the caller constructing this request (before bounded-channel
+    /// admission) until the writer task dequeued it.
+    fn queue_wait(&self) -> Duration;
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -189,46 +306,92 @@ pub(crate) fn execute_wrapped_transaction<R, F>(
 where
     F: FnOnce(&Connection) -> Result<R, StorageError>,
 {
-    match catch_unwind(AssertUnwindSafe(|| operation(conn))) {
-        Ok(Ok(value)) => match conn.execute_batch("COMMIT") {
-            Ok(()) if conn.is_autocommit() => (Ok(value), None),
-            Ok(()) => {
-                tracing::error!(
+    let profiled = execute_wrapped_transaction_profiled(conn, commit_operation, operation);
+    (profiled.result, profiled.terminal_state)
+}
+
+struct ProfiledWrappedTransaction<R> {
+    result: Result<R, StorageError>,
+    terminal_state: Option<WriterTaskRequestState>,
+    body: Duration,
+    commit: Duration,
+}
+
+fn execute_wrapped_transaction_profiled<R, F>(
+    conn: &Connection,
+    commit_operation: &'static str,
+    operation: F,
+) -> ProfiledWrappedTransaction<R>
+where
+    F: FnOnce(&Connection) -> Result<R, StorageError>,
+{
+    let body_started = Instant::now();
+    let operation_outcome = catch_unwind(AssertUnwindSafe(|| operation(conn)));
+    let body = body_started.elapsed();
+
+    match operation_outcome {
+        Ok(Ok(value)) => {
+            let commit_started = Instant::now();
+            let commit_outcome = conn.execute_batch("COMMIT");
+            let commit = commit_started.elapsed();
+            match commit_outcome {
+                Ok(()) if conn.is_autocommit() => ProfiledWrappedTransaction {
+                    result: Ok(value),
+                    terminal_state: None,
+                    body,
+                    commit,
+                },
+                Ok(()) => {
+                    tracing::error!(
                     "writer transaction: COMMIT returned success but the connection is still in \
                      a transaction; request side effects are unknown"
                 );
-                let request_state = WriterTaskRequestState::SideEffectsUnknown;
-                (
-                    Err(writer_task_terminated(request_state)),
-                    Some(request_state),
-                )
-            }
-            Err(commit_error) => match rollback_after_failure(conn, "commit failure") {
-                RollbackDisposition::RolledBack => (
-                    Err(StorageError::Pool {
-                        operation: commit_operation.into(),
-                        message: commit_error.to_string(),
-                    }),
-                    None,
-                ),
-                RollbackDisposition::SideEffectsUnknown => {
                     let request_state = WriterTaskRequestState::SideEffectsUnknown;
-                    (
-                        Err(writer_task_terminated(request_state)),
-                        Some(request_state),
-                    )
+                    ProfiledWrappedTransaction {
+                        result: Err(writer_task_terminated(request_state)),
+                        terminal_state: Some(request_state),
+                        body,
+                        commit,
+                    }
                 }
-            },
-        },
+                Err(commit_error) => match rollback_after_failure(conn, "commit failure") {
+                    RollbackDisposition::RolledBack => ProfiledWrappedTransaction {
+                        result: Err(StorageError::Pool {
+                            operation: commit_operation.into(),
+                            message: commit_error.to_string(),
+                        }),
+                        terminal_state: None,
+                        body,
+                        commit,
+                    },
+                    RollbackDisposition::SideEffectsUnknown => {
+                        let request_state = WriterTaskRequestState::SideEffectsUnknown;
+                        ProfiledWrappedTransaction {
+                            result: Err(writer_task_terminated(request_state)),
+                            terminal_state: Some(request_state),
+                            body,
+                            commit,
+                        }
+                    }
+                },
+            }
+        }
         Ok(Err(operation_error)) => {
             match rollback_after_failure(conn, "request operation failure") {
-                RollbackDisposition::RolledBack => (Err(operation_error), None),
+                RollbackDisposition::RolledBack => ProfiledWrappedTransaction {
+                    result: Err(operation_error),
+                    terminal_state: None,
+                    body,
+                    commit: Duration::ZERO,
+                },
                 RollbackDisposition::SideEffectsUnknown => {
                     let request_state = WriterTaskRequestState::SideEffectsUnknown;
-                    (
-                        Err(writer_task_terminated(request_state)),
-                        Some(request_state),
-                    )
+                    ProfiledWrappedTransaction {
+                        result: Err(writer_task_terminated(request_state)),
+                        terminal_state: Some(request_state),
+                        body,
+                        commit: Duration::ZERO,
+                    }
                 }
             }
         }
@@ -239,10 +402,12 @@ where
                     WriterTaskRequestState::SideEffectsUnknown
                 }
             };
-            (
-                Err(writer_task_terminated(request_state)),
-                Some(request_state),
-            )
+            ProfiledWrappedTransaction {
+                result: Err(writer_task_terminated(request_state)),
+                terminal_state: Some(request_state),
+                body,
+                commit: Duration::ZERO,
+            }
         }
     }
 }
@@ -252,29 +417,52 @@ impl<R: Send + 'static> sealed::Sealed for WriteRequest<R> {
         self: Box<Self>,
         conn: &Connection,
         tx_span: Option<khive_storage::tx_registry::TxHandle>,
+        queue_wait: Duration,
+        transaction_acquire: Duration,
     ) -> Option<WriterTaskRequestState> {
         // Keep the typed reply sender outside the unwind boundary. Calling
         // `(self.op)(conn)` directly would drop `self.reply` while unwinding,
         // leaving the active caller with only an untyped RecvError.
-        let WriteRequest { op, reply, .. } = *self;
-        let (result, terminal_state) = execute_wrapped_transaction(conn, "writer_task_commit", op);
+        let WriteRequest {
+            op,
+            reply,
+            telemetry,
+            ..
+        } = *self;
+        let profiled = execute_wrapped_transaction_profiled(conn, "writer_task_commit", op);
         // The reply wake can make the caller immediately observe the
         // committed/error result. Deregister the transaction span first so
         // tx_registry continues to mean "currently open SQL transaction",
         // never "a transaction whose caller has already resumed" (#1790).
         drop(tx_span);
+        telemetry.finish(
+            queue_wait,
+            transaction_acquire,
+            profiled.body,
+            profiled.commit,
+        );
         // The receiver may already be gone (caller dropped its future) —
         // that is not this task's problem to report.
-        let _ = reply.send(result);
-        terminal_state
+        let _ = reply.send(profiled.result);
+        profiled.terminal_state
     }
 
     fn execute_and_reply_top_level_reporting_terminal(
         self: Box<Self>,
         conn: &Connection,
+        queue_wait: Duration,
     ) -> Option<WriterTaskRequestState> {
-        let WriteRequest { op, reply, .. } = *self;
-        match catch_unwind(AssertUnwindSafe(|| op(conn))) {
+        let WriteRequest {
+            op,
+            reply,
+            telemetry,
+            ..
+        } = *self;
+        let body_started = Instant::now();
+        let outcome = catch_unwind(AssertUnwindSafe(|| op(conn)));
+        let body = body_started.elapsed();
+        telemetry.finish(queue_wait, Duration::ZERO, body, Duration::ZERO);
+        match outcome {
             Ok(outcome) if conn.is_autocommit() => {
                 // No COMMIT/ROLLBACK here: this request explicitly did not
                 // open a transaction, so there is nothing to close.
@@ -300,25 +488,55 @@ impl<R: Send + 'static> sealed::Sealed for WriteRequest<R> {
             }
         }
     }
+
+    fn reply_error_after_begin(
+        self: Box<Self>,
+        err: StorageError,
+        queue_wait: Duration,
+        transaction_acquire: Duration,
+    ) {
+        let WriteRequest {
+            reply, telemetry, ..
+        } = *self;
+        telemetry.finish(
+            queue_wait,
+            transaction_acquire,
+            Duration::ZERO,
+            Duration::ZERO,
+        );
+        let _ = reply.send(Err(err));
+    }
 }
 
 impl<R: Send + 'static> AnyWriteRequest for WriteRequest<R> {
     fn execute_and_reply(self: Box<Self>, conn: &Connection) {
-        let _ = sealed::Sealed::execute_and_reply_reporting_terminal(self, conn, None);
+        let queue_wait = self.queue_wait();
+        let _ = sealed::Sealed::execute_and_reply_reporting_terminal(
+            self,
+            conn,
+            None,
+            queue_wait,
+            Duration::ZERO,
+        );
     }
 
     fn execute_and_reply_top_level(self: Box<Self>, conn: &Connection) {
-        let _ = sealed::Sealed::execute_and_reply_top_level_reporting_terminal(self, conn);
+        let queue_wait = self.queue_wait();
+        let _ =
+            sealed::Sealed::execute_and_reply_top_level_reporting_terminal(self, conn, queue_wait);
     }
 
     fn reply_error(self: Box<Self>, err: StorageError) {
-        // Same "receiver may already be gone" reasoning as above — send and
-        // move on regardless of outcome.
-        let _ = self.reply.send(Err(err));
+        let queue_wait = self.queue_wait();
+        sealed::Sealed::reply_error_after_begin(self, err, queue_wait, Duration::ZERO);
     }
 
     fn is_top_level(&self) -> bool {
         self.top_level
+    }
+
+    fn queue_wait(&self) -> Duration {
+        self.telemetry.queue_wait()
     }
 }
 
@@ -404,10 +622,16 @@ impl WriterTaskHandle {
         F: FnOnce(&Connection) -> Result<R, StorageError> + Send + 'static,
     {
         let (reply_tx, reply_rx) = oneshot::channel();
+        let telemetry = WriteTelemetry::new(
+            self.db.clone(),
+            self.queue_depth(),
+            self.slow_write_threshold,
+        );
         let request = WriteRequest {
             op: Box::new(op),
             reply: reply_tx,
             top_level,
+            telemetry,
         };
 
         self.tx
@@ -429,13 +653,10 @@ impl WriterTaskHandle {
         R: Send + 'static,
         F: FnOnce(&Connection) -> Result<R, StorageError> + Send + 'static,
     {
-        let observation = self.begin_latency_observation();
         let reply_rx = self.enqueue(op).await?;
-        let result = reply_rx
+        reply_rx
             .await
-            .map_err(|_| writer_task_terminated(WriterTaskRequestState::SideEffectsUnknown))?;
-        self.finish_latency_observation(observation);
-        result
+            .map_err(|_| writer_task_terminated(WriterTaskRequestState::SideEffectsUnknown))?
     }
 
     /// Like [`Self::send`], but bounds the wait for the bounded channel to
@@ -461,7 +682,6 @@ impl WriterTaskHandle {
         R: Send + 'static,
         F: FnOnce(&Connection) -> Result<R, StorageError> + Send + 'static,
     {
-        let observation = self.begin_latency_observation();
         let reply_rx = match tokio::time::timeout(timeout, self.enqueue(op)).await {
             Ok(Ok(reply_rx)) => reply_rx,
             Ok(Err(e)) => return Err(e),
@@ -472,11 +692,9 @@ impl WriterTaskHandle {
             }
         };
 
-        let result = reply_rx
+        reply_rx
             .await
-            .map_err(|_| writer_task_terminated(WriterTaskRequestState::SideEffectsUnknown))?;
-        self.finish_latency_observation(observation);
-        result
+            .map_err(|_| writer_task_terminated(WriterTaskRequestState::SideEffectsUnknown))?
     }
 
     /// Like [`Self::send`], but bounds the enqueue-capacity wait with this
@@ -513,13 +731,10 @@ impl WriterTaskHandle {
         R: Send + 'static,
         F: FnOnce(&Connection) -> Result<R, StorageError> + Send + 'static,
     {
-        let observation = self.begin_latency_observation();
         let reply_rx = self.enqueue_inner(op, true).await?;
-        let result = reply_rx
+        reply_rx
             .await
-            .map_err(|_| writer_task_terminated(WriterTaskRequestState::SideEffectsUnknown))?;
-        self.finish_latency_observation(observation);
-        result
+            .map_err(|_| writer_task_terminated(WriterTaskRequestState::SideEffectsUnknown))?
     }
 
     /// Like [`Self::send_top_level`], but bounds the enqueue-capacity wait
@@ -531,7 +746,6 @@ impl WriterTaskHandle {
         R: Send + 'static,
         F: FnOnce(&Connection) -> Result<R, StorageError> + Send + 'static,
     {
-        let observation = self.begin_latency_observation();
         let reply_rx =
             match tokio::time::timeout(self.enqueue_timeout, self.enqueue_inner(op, true)).await {
                 Ok(Ok(reply_rx)) => reply_rx,
@@ -543,42 +757,9 @@ impl WriterTaskHandle {
                 }
             };
 
-        let result = reply_rx
+        reply_rx
             .await
-            .map_err(|_| writer_task_terminated(WriterTaskRequestState::SideEffectsUnknown))?;
-        self.finish_latency_observation(observation);
-        result
-    }
-
-    /// Snapshot the start instant and the queue backlog for one send, if
-    /// slow-write observation is enabled for this handle. The depth is
-    /// captured at send START — after completion the drain loop has already
-    /// consumed this request, so a completion-time read would systematically
-    /// understate the backlog the caller actually waited behind.
-    fn begin_latency_observation(&self) -> Option<(std::time::Instant, usize)> {
-        self.slow_write_threshold
-            .map(|_| (std::time::Instant::now(), self.queue_depth()))
-    }
-
-    /// Emit a `slow_write` sink row if this send's whole span met the
-    /// threshold. Called on the reply path — success or typed error alike,
-    /// since the caller experienced the latency either way. Never called
-    /// when the reply channel itself is severed (writer-task terminated),
-    /// which is reported through its own retirement row.
-    fn finish_latency_observation(&self, observation: Option<(std::time::Instant, usize)>) {
-        let (Some(threshold), Some((start, depth_at_entry))) =
-            (self.slow_write_threshold, observation)
-        else {
-            return;
-        };
-        let elapsed = start.elapsed();
-        if elapsed >= threshold {
-            crate::timeout_sink::emit_slow_write(
-                &self.db,
-                elapsed.as_millis() as u64,
-                depth_at_entry,
-            );
-        }
+            .map_err(|_| writer_task_terminated(WriterTaskRequestState::SideEffectsUnknown))?
     }
 
     /// Current write-queue backlog depth: requests enqueued but not yet
@@ -689,6 +870,7 @@ async fn run_writer_task(
         let origin = origin.clone();
         let acquisition_counters = Arc::clone(&acquisition_counters);
         let outcome = tokio::task::spawn_blocking(move || {
+            let queue_wait = request.queue_wait();
             // A top-level request deliberately skips BEGIN, so it would
             // silently join any transaction leaked by an earlier request.
             // Refuse every request before dispatch if the connection is not
@@ -712,19 +894,26 @@ async fn run_writer_task(
                 // this same drain loop, so the single-writer guarantee
                 // holds; only the transaction wrap is skipped.
                 acquisition_counters.record_writer_task_acquisition();
-                sealed::Sealed::execute_and_reply_top_level_reporting_terminal(request, &conn)
+                sealed::Sealed::execute_and_reply_top_level_reporting_terminal(
+                    request, &conn, queue_wait,
+                )
             } else {
                 let tx_span = khive_storage::tx_registry::register_scoped(
                     Some("writer_task_tx".to_string()),
                     origin,
                 );
-                match conn.execute_batch("BEGIN IMMEDIATE") {
+                let transaction_acquire_started = Instant::now();
+                let begin_outcome = conn.execute_batch("BEGIN IMMEDIATE");
+                let transaction_acquire = transaction_acquire_started.elapsed();
+                match begin_outcome {
                     Ok(()) => {
                         acquisition_counters.record_writer_task_acquisition();
                         sealed::Sealed::execute_and_reply_reporting_terminal(
                             request,
                             &conn,
                             Some(tx_span),
+                            queue_wait,
+                            transaction_acquire,
                         )
                     }
                     Err(e) => {
@@ -743,10 +932,15 @@ async fn run_writer_task(
                         // it before waking the caller for the same reply-side
                         // lifecycle guarantee as successful requests (#1790).
                         drop(tx_span);
-                        request.reply_error(StorageError::Pool {
-                            operation: "writer_task_begin".into(),
-                            message: e.to_string(),
-                        });
+                        sealed::Sealed::reply_error_after_begin(
+                            request,
+                            StorageError::Pool {
+                                operation: "writer_task_begin".into(),
+                                message: e.to_string(),
+                            },
+                            queue_wait,
+                            transaction_acquire,
+                        );
                         None
                     }
                 }
@@ -1544,11 +1738,13 @@ mod tests {
             }),
             reply: reply_tx,
             top_level: true,
+            telemetry: WriteTelemetry::new("test".to_string(), 0, None),
         };
 
         let terminal_state = sealed::Sealed::execute_and_reply_top_level_reporting_terminal(
             Box::new(request),
             &conn,
+            Duration::ZERO,
         );
         assert_eq!(
             terminal_state,
@@ -1587,10 +1783,16 @@ mod tests {
             }),
             reply: reply_tx,
             top_level: false,
+            telemetry: WriteTelemetry::new("test".to_string(), 0, None),
         };
 
-        let terminal_state =
-            sealed::Sealed::execute_and_reply_reporting_terminal(Box::new(request), &conn, None);
+        let terminal_state = sealed::Sealed::execute_and_reply_reporting_terminal(
+            Box::new(request),
+            &conn,
+            None,
+            Duration::ZERO,
+            Duration::ZERO,
+        );
         assert_eq!(
             terminal_state,
             Some(WriterTaskRequestState::SideEffectsUnknown)
@@ -1719,10 +1921,16 @@ mod tests {
             }),
             reply: reply_tx,
             top_level: false,
+            telemetry: WriteTelemetry::new("test".to_string(), 0, None),
         };
 
-        let terminal_state =
-            sealed::Sealed::execute_and_reply_reporting_terminal(Box::new(request), &conn, None);
+        let terminal_state = sealed::Sealed::execute_and_reply_reporting_terminal(
+            Box::new(request),
+            &conn,
+            None,
+            Duration::ZERO,
+            Duration::ZERO,
+        );
         assert_eq!(
             terminal_state,
             Some(WriterTaskRequestState::SideEffectsUnknown)
@@ -1758,10 +1966,16 @@ mod tests {
             }),
             reply: reply_tx,
             top_level: false,
+            telemetry: WriteTelemetry::new("test".to_string(), 0, None),
         };
 
-        let terminal_state =
-            sealed::Sealed::execute_and_reply_reporting_terminal(Box::new(request), &conn, None);
+        let terminal_state = sealed::Sealed::execute_and_reply_reporting_terminal(
+            Box::new(request),
+            &conn,
+            None,
+            Duration::ZERO,
+            Duration::ZERO,
+        );
         assert_eq!(
             terminal_state,
             Some(WriterTaskRequestState::SideEffectsUnknown)

--- a/crates/khive-runtime/docs/api/daemon.md
+++ b/crates/khive-runtime/docs/api/daemon.md
@@ -36,11 +36,15 @@ forever for a possibly-wedged holder — needs a deadline instead.
 ## build_metrics_snapshot
 
 `tx_registry` (ADR-091 Plank 0) is a process-global singleton reachable directly, with no plumbing
-through `dispatcher`. `wal_pages` and the TRUNCATE counters (ADR-091 Plank 2) are read from
-`khive_db::checkpoint`'s module-scoped atomics, updated wherever the checkpoint task already calls
-`query_wal_pages`/`note_truncate_outcome` — mirroring the fallback-counter pattern in
-`khive-mcp/src/daemon.rs` rather than threading a metrics handle through every checkpoint call
-site, since the checkpoint task itself is a fire-and-forget `tokio::spawn` with no handle retained
-anywhere this accept loop can reach. `write_queue_depth`/`_capacity` (ADR-067 Component A) come
-from the dispatcher's own pool, if any, and are `None` unless `KHIVE_WRITE_QUEUE=1` actually
-spawned a writer task.
+through `dispatcher`. TRUNCATE counters remain module-scoped atomics. The logical WAL fields
+(`wal_log_frames`, `wal_checkpointed_frames`, and `wal_pending_frames`) and
+`wal_physical_bytes` come from the dispatcher's exact pool's last routine PASSIVE tick; building a
+metrics frame does not issue an on-demand checkpoint or stat the sidecar. `wal_pages` remains the
+compatibility projection of `wal_log_frames`. The backend key is load-bearing in a multi-backend
+daemon: a secondary task's later tick cannot relabel its state as the main pool's sample.
+
+`write_queue_depth`/`_capacity` (ADR-067 Component A) come from the same pool and are `None`
+unless a writer task exists. The `write_last_*_micros` fields expose that task's latest completed
+queue-wait, transaction-acquisition, body, commit, and total stages, plus the observation time.
+All new fields are additive `serde(default)` metrics-only fields; older peers can omit them without
+changing request dispatch or the canonical verb result.

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -2892,6 +2892,11 @@ mod tests {
             snapshot.wal_pages.is_some(),
             "wal_pages must be observed after a real checkpoint tick, got {snapshot:?}"
         );
+        assert_eq!(snapshot.wal_log_frames, snapshot.wal_pages);
+        assert!(snapshot.wal_checkpointed_frames.is_some());
+        assert!(snapshot.wal_pending_frames.is_some());
+        assert!(snapshot.wal_physical_bytes.is_some());
+        assert!(snapshot.wal_observed_at_unix_ms.is_some());
         // The snapshot carries the checkpoint-pressure fields read-only
         // (no mutation path reachable through `MetricsSnapshot`/`DaemonRequestFrame`);
         // an observed tick (not a skip) must report a zero-length skip streak.

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -549,9 +549,9 @@ pub struct DaemonResponseFrame {
 ///
 /// Every field here is a **server-side** gauge reachable from `handle_conn`
 /// without any mutation: [`khive_storage::tx_registry`] (ADR-091 Plank 0,
-/// process-global singleton), the WAL checkpoint task's last-observed page
-/// count and TRUNCATE counters (`khive_db::checkpoint`), and the ADR-067
-/// Component A write queue depth (only when `KHIVE_WRITE_QUEUE=1`). There is
+/// process-global singleton), the main pool's backend-keyed routine WAL
+/// sample and process TRUNCATE counters (`khive_db::checkpoint`), and the
+/// ADR-067 Component A write queue depth/latest writer-stage sample. There is
 /// no reset reachable through this type or through [`DaemonRequestFrame`] —
 /// gauges out, nothing in.
 #[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
@@ -561,6 +561,22 @@ pub struct MetricsSnapshot {
     /// (for example, an in-memory dispatcher with no pool, or a daemon that
     /// just started and hasn't hit its first tick yet).
     pub wal_pages: Option<u64>,
+    /// Logical frames present in the WAL at the main backend's most recent
+    /// periodic PASSIVE checkpoint. Kept separate from physical allocation.
+    #[serde(default)]
+    pub wal_log_frames: Option<u64>,
+    /// Frames backfilled by that same periodic PASSIVE pass.
+    #[serde(default)]
+    pub wal_checkpointed_frames: Option<u64>,
+    /// Logical frames still pending after that pass (`log - checkpointed`).
+    #[serde(default)]
+    pub wal_pending_frames: Option<u64>,
+    /// Physical `-wal` sidecar bytes captured at the same routine tick.
+    #[serde(default)]
+    pub wal_physical_bytes: Option<u64>,
+    /// Wall-clock timestamp of the routine WAL sample, for staleness checks.
+    #[serde(default)]
+    pub wal_observed_at_unix_ms: Option<u64>,
     /// Total WAL TRUNCATE escalation attempts (ADR-091 Plank 2) made in this
     /// process's lifetime, regardless of whether they succeeded in reclaiming
     /// pages.
@@ -600,6 +616,25 @@ pub struct MetricsSnapshot {
     /// (`PoolConfig::write_queue_capacity`), gated the same as
     /// `write_queue_depth`.
     pub write_queue_capacity: Option<usize>,
+    /// Latest completed writer-task span: bounded-channel admission/backlog.
+    #[serde(default)]
+    pub write_last_queue_wait_micros: Option<u64>,
+    /// Latest completed writer-task span: `BEGIN IMMEDIATE` acquisition.
+    #[serde(default)]
+    pub write_last_transaction_acquire_micros: Option<u64>,
+    /// Latest completed writer-task span: application transaction body.
+    #[serde(default)]
+    pub write_last_body_micros: Option<u64>,
+    /// Latest completed writer-task span: SQLite COMMIT/fsync phase.
+    #[serde(default)]
+    pub write_last_commit_micros: Option<u64>,
+    /// Whole latest writer-task request span, retained for compatibility and
+    /// comparison with the decomposed stages.
+    #[serde(default)]
+    pub write_last_total_micros: Option<u64>,
+    /// Wall-clock timestamp of the writer-stage sample.
+    #[serde(default)]
+    pub write_last_observed_at_unix_ms: Option<u64>,
 }
 
 // ── framing ───────────────────────────────────────────────────────────────────
@@ -933,14 +968,32 @@ fn build_metrics_snapshot<D: DaemonDispatch>(dispatcher: &D) -> MetricsSnapshot 
             None => (None, None),
         };
 
-    let (write_queue_depth, write_queue_capacity) = dispatcher
-        .pool_for_checkpoint()
+    let checkpoint_pool = dispatcher.pool_for_checkpoint();
+    let routine_wal = checkpoint_pool
+        .as_deref()
+        .and_then(khive_db::checkpoint::routine_wal_observation);
+    let writer_stages = checkpoint_pool
+        .as_deref()
+        .and_then(khive_db::writer_task::last_writer_stage_observation);
+    let (write_queue_depth, write_queue_capacity) = checkpoint_pool
+        .as_ref()
         .and_then(|pool| pool.writer_task_handle().ok().flatten())
         .map(|handle| (Some(handle.queue_depth()), Some(handle.capacity())))
         .unwrap_or((None, None));
 
     MetricsSnapshot {
-        wal_pages: khive_db::checkpoint::last_observed_wal_pages(),
+        wal_pages: routine_wal.as_ref().map(|sample| sample.log_frames),
+        wal_log_frames: routine_wal.as_ref().map(|sample| sample.log_frames),
+        wal_checkpointed_frames: routine_wal
+            .as_ref()
+            .map(|sample| sample.checkpointed_frames),
+        wal_pending_frames: routine_wal.as_ref().map(|sample| sample.pending_frames),
+        wal_physical_bytes: routine_wal
+            .as_ref()
+            .and_then(|sample| sample.physical_wal_bytes),
+        wal_observed_at_unix_ms: routine_wal
+            .as_ref()
+            .map(|sample| sample.observed_at_unix_ms),
         wal_truncate_attempts: khive_db::checkpoint::truncate_attempts(),
         wal_truncate_consecutive_failures: khive_db::checkpoint::truncate_consecutive_failures(),
         wal_checkpoint_skipped_ticks: khive_db::checkpoint::checkpoint_skipped_ticks(),
@@ -951,6 +1004,18 @@ fn build_metrics_snapshot<D: DaemonDispatch>(dispatcher: &D) -> MetricsSnapshot 
         open_tx_count,
         write_queue_depth,
         write_queue_capacity,
+        write_last_queue_wait_micros: writer_stages
+            .as_ref()
+            .map(|sample| sample.queue_wait_micros),
+        write_last_transaction_acquire_micros: writer_stages
+            .as_ref()
+            .map(|sample| sample.transaction_acquire_micros),
+        write_last_body_micros: writer_stages.as_ref().map(|sample| sample.body_micros),
+        write_last_commit_micros: writer_stages.as_ref().map(|sample| sample.commit_micros),
+        write_last_total_micros: writer_stages.as_ref().map(|sample| sample.total_micros),
+        write_last_observed_at_unix_ms: writer_stages
+            .as_ref()
+            .map(|sample| sample.observed_at_unix_ms),
     }
 }
 
@@ -2904,6 +2969,59 @@ mod tests {
             snapshot.wal_checkpoint_consecutive_skips, 0,
             "an observed (non-skipped) tick must report zero consecutive skips, got {snapshot:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn metrics_snapshot_exposes_decomposed_writer_stages() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("metrics_writer_stage_test.db");
+        let pool = Arc::new(
+            ConnectionPool::new(khive_db::PoolConfig {
+                path: Some(path),
+                ..khive_db::PoolConfig::default()
+            })
+            .expect("pool open"),
+        );
+        {
+            let writer = pool.try_writer().unwrap();
+            writer
+                .conn()
+                .execute_batch("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+                .unwrap();
+        }
+        let handle = pool
+            .writer_task_handle()
+            .unwrap()
+            .expect("file-backed default writer task");
+        handle
+            .send(|conn| {
+                std::thread::sleep(std::time::Duration::from_millis(30));
+                conn.execute("INSERT INTO t VALUES (1)", [])
+                    .map_err(|error| khive_storage::error::StorageError::Pool {
+                        operation: "metrics_writer_stage_test".into(),
+                        message: error.to_string(),
+                    })
+            })
+            .await
+            .unwrap();
+
+        let dispatcher = MockDispatch {
+            namespace: "local".to_string(),
+            config_id: "cfg-writer-stages".to_string(),
+            dispatch_calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            pool: Some(pool),
+            dispatch_err: None,
+        };
+        let snapshot = build_metrics_snapshot(&dispatcher);
+        assert!(snapshot.write_last_queue_wait_micros.is_some());
+        assert!(snapshot.write_last_transaction_acquire_micros.is_some());
+        assert!(snapshot.write_last_commit_micros.is_some());
+        assert!(
+            snapshot.write_last_body_micros >= Some(25_000),
+            "synthetic delay must be attributed to the body: {snapshot:?}"
+        );
+        assert!(snapshot.write_last_total_micros >= snapshot.write_last_body_micros);
+        assert!(snapshot.write_last_observed_at_unix_ms.is_some());
     }
 
     /// Test 3: the tx-pin oracle. The registry is process-global, so an

--- a/docs/adr/ADR-091-wal-snapshot-lifetime.md
+++ b/docs/adr/ADR-091-wal-snapshot-lifetime.md
@@ -1207,3 +1207,34 @@ invoke `enumerate_live`. Its cleanup-derived `sidecar_listing_truncated` and
 `sidecar_entries_cleanup_would_reap` members are optional and omitted when enumeration did not
 run. A background checkpoint tick may independently perform its normal cleanup, but the
 diagnostic request itself never converts an unmeasured value into a clean-looking zero.
+
+### 2026-08-09 amendment (Amendment 7): routine logical WAL and writer-stage telemetry
+
+**Motivation.** Physical `-wal` bytes are an allocation high-water mark, not a logical backlog:
+SQLite can reset and reuse a large sidecar after every frame has been backfilled. Conversely, the
+old periodic path discarded most of the PASSIVE result and operational writer telemetry flattened
+queue admission, write-lock acquisition, application work, and COMMIT/fsync into one duration.
+Those shapes could not distinguish retained allocation from a pinned checkpoint boundary, or
+queue contention from a slow transaction body (#1849).
+
+**Routine WAL decision.** A normal checkpoint tick issues exactly one
+`PRAGMA wal_checkpoint(PASSIVE)` and retains its complete `(busy, log, checkpointed)` row. The
+former no-argument observation followed by an explicit PASSIVE second pass is removed. Thresholds
+continue to use `log`; `pending = max(log - checkpointed, 0)` is exposed independently. The same
+tick records physical sidecar bytes and an observation timestamp. Samples are keyed by canonical
+backend identity because checkpoint tasks fan out in multi-backend deployments. The daemon's
+metrics-only frame reads the sample for its own main pool and exposes `wal_log_frames`,
+`wal_checkpointed_frames`, `wal_pending_frames`, `wal_physical_bytes`, and sample time; `wal_pages`
+remains a compatibility alias for logical log frames. A scrape is a pure memory read and causes no
+additional checkpoint I/O or filesystem stat. The explicit `db_diagnostics` probe remains an
+on-demand, checkpoint-performing diagnostic with its existing contract.
+
+**Writer-stage decision.** Each writer-task request timestamps (1) construction before bounded
+channel admission through dequeue (`queue_wait`), (2) only `BEGIN IMMEDIATE`
+(`transaction_acquire`), (3) only the typed operation closure (`body`), and (4) only `COMMIT`.
+Backend-keyed latest-stage gauges and the existing slow-write row expose those microsecond fields,
+the total, queue depth, and observation time. Telemetry is published before the typed reply. A
+top-level request or a phase that never ran reports zero for the inapplicable phase; rollback and
+recovery time is not mislabeled as COMMIT and remains visible as total minus the named stages.
+This is observation only: no timing value changes admission, retry, rollback, checkpoint, or
+TRUNCATE behavior.


### PR DESCRIPTION
## Summary

Closes #1849.

Physical `-wal` bytes are an allocation high-water mark, not a logical backlog, and the
previous writer telemetry flattened queue admission, lock acquisition, application work, and
COMMIT into a single duration. This PR lands the observability contract specified in
ADR-091 Amendment 7:

- **Routine logical WAL telemetry**: the normal checkpoint tick issues exactly one
  `PRAGMA wal_checkpoint(PASSIVE)` and retains the full `(busy, log, checkpointed)` row,
  exposing `wal_log_frames`, `wal_checkpointed_frames`, `wal_pending_frames`,
  `wal_physical_bytes`, and the sample timestamp. `wal_pages` remains a compatibility alias.
  Scrapes are pure memory reads — no extra checkpoint I/O or filesystem stat.
- **Writer-stage telemetry**: each writer-task request separately times `queue_wait`
  (construction through dequeue), `transaction_acquire` (`BEGIN IMMEDIATE` only), `body`
  (the typed operation closure only), and `commit` (`COMMIT` only). Rollback/recovery time
  is never mislabeled as COMMIT and remains visible as total minus the named stages.
- **Exact canonical path keying**: backend telemetry registries key on the exact
  `Option<PathBuf>` rather than a lossy display string, so byte-distinct non-UTF-8 paths
  no longer collapse into one sample row. Fixtures assert the lossy-collision precondition.
- **Queue telemetry boundary**: queue-wait measurement stops at dequeue instead of
  bleeding into transaction acquisition.

Observation only: no timing value changes admission, retry, rollback, checkpoint, or
TRUNCATE behavior.

## Testing

- Regression tests for the exact-path registry keying (including non-UTF-8 collision
  fixtures) and the writer-stage boundaries.
- Full workspace gates run in CI at this head.
