### PR TITLE
docs(adr): fix self-contradictory pipeline order in ADR-078 shape detection

### DIFF
--- a/docs/adr/ADR-078-output-format-shape-aware-rendering.md
+++ b/docs/adr/ADR-078-output-format-shape-aware-rendering.md
@@ -471,8 +471,9 @@ resolution, when `default_output_format` is still `None`.
 
 ### Shape detection sequence
 
-The shape detector operates on the final post-presentation `serde_json::Value`, before the
-redundancy-reduction pass runs. Detection precedence:
+The shape detector operates on the final post-presentation `serde_json::Value` after the
+redundancy-reduction pass has run (or on the unreduced value when that pass is skipped — see the
+next subsection). Detection precedence:
 
 1. If the pack has registered a bespoke renderer for this verb and this format, invoke it.
 2. If the value contains a key whose value is a JSON array of two or more objects sharing a


### PR DESCRIPTION
Two adjacent Implementation subsections of ADR-078 stated the rendering pipeline order in opposite directions: the shape-detection subsection said detection runs before the redundancy-reduction pass, while the redundancy-reduction subsection said the reductions are applied before shape detection. The orders are observably different — the reductions drop keys (full_id, echoed properties children, default namespace) that the record-array detector keys on, so the same payload can classify differently under the two readings.

The shipped implementation applies the reduction pass first: `render_format` in `crates/khive-runtime/src/presentation.rs` reduces the value (unless the pass is skipped for `format=json` or verbose presentation) and then dispatches shape detection on the reduced value. This change corrects the shape-detection sentence to match the implementation and cross-references the skip condition. No code changes.