### PR TITLE
docs(adr): record ADR-121 as accepted

### DIFF
--- a/docs/adr/ADR-121-attachments-first-class.md
+++ b/docs/adr/ADR-121-attachments-first-class.md
@@ -1,6 +1,6 @@
 # ADR-121: Attachments — Role-Keyed Blob Renditions as a First-Class Substrate Property
 
-**Status**: proposed\
+**Status**: accepted\
 **Date**: 2026-07-23\
 **Authors**: khive maintainers\
 **Depends on**:


### PR DESCRIPTION
Dedicated status-flip PR per the catalog rule in docs/adr/README.md.

- **Ratifying artifact**: maintainer design review sign-off (contract-level ADR, single-subsystem scope), recorded **2026-08-10T04:29:08Z** against the file's current text at main.
- **Final ratified text**: commit `c32ea3541063ca5626058dd52e9d5f419f7f2181` ("docs(adr): reword ADR-121 boundary line to conform to the identifier ban"), landed **2026-08-02T06:28:26Z**.
- **Postdating check**: `ratified_at` 2026-08-10T04:29:08Z > `final_text_merged_at` 2026-08-02T06:28:26Z — the sign-off covers the final text.

The diff is one line; the file keeps its own status formatting.