### PR TITLE
docs(adr): record ADR-117a as accepted

### DIFF
--- a/docs/adr/ADR-117a-session-identity-tenant-isolation.md
+++ b/docs/adr/ADR-117a-session-identity-tenant-isolation.md
@@ -1,6 +1,6 @@
 # ADR-117a: Session Identity and Tenant Isolation
 
-**Status**: proposed
+**Status**: accepted
 **Date**: 2026-07-19
 **Authors**: khive maintainers
 **Implements**: [ADR-117](ADR-117-session-continuity-search.md) D1, D2, D4 (the direction ADR names


### PR DESCRIPTION
Dedicated status-flip PR per the catalog rule in docs/adr/README.md.

- **Ratifying artifact**: maintainer design review sign-off of the landed text (contract-level ADR scoped to the session subsystem), recorded **2026-08-10T05:14:49Z**, naming the final-text commit explicitly.
- **Final ratified text**: commit `59839cc25664ddbbfca9c060bf895ce6e455cde0` ("docs(adr): qualify stale fail-open references in ADR-117 and ADR-117a"), landed **2026-08-10T05:12:40Z**.
- **Postdating check**: `ratified_at` 2026-08-10T05:14:49Z > `final_text_merged_at` 2026-08-10T05:12:40Z — the sign-off covers the final text.

The diff is one line; the file keeps its own status formatting.