### PR TITLE
fix(kkernel): read tombstone assertions through a writable backend

### DIFF
--- a/crates/kkernel/src/code_ingest.rs
+++ b/crates/kkernel/src/code_ingest.rs
@@ -856,8 +856,15 @@ mod tests {
         }
     }
 
+    /// Read back the three tombstone markers through an ordinary writable
+    /// backend's reader connection. The read-only constructor is not usable
+    /// here: it refuses a database whose WAL `-shm` sidecar is still
+    /// writable, and this fixture's earlier ingest and tombstone writers
+    /// legitimately leave that sidecar behind. The production dry-run path
+    /// satisfies that guard by snapshot-copying and freezing sidecars; this
+    /// assertion needs only three scalar reads on the live fixture file.
     async fn assert_mapped_batch_remains_tombstoned(db: &Path, batch: &CodeIngestBatch) {
-        let backend = StorageBackend::sqlite_read_only(db).expect("open tombstone reader");
+        let backend = StorageBackend::sqlite(db).expect("open tombstone reader");
         let sql = backend.sql();
         let mut reader = sql.reader().await.expect("acquire tombstone reader");
 


### PR DESCRIPTION
Main's ubuntu shard 2 is failing on code_ingest_never_reactivates_consumed_tombstone_ids: the test read tombstone markers back through StorageBackend::sqlite_read_only, which refuses a database whose WAL -shm sidecar is writable. That guard postdates the test's branch point, so the test was green on its branch and red on the merged tree. The assertion needs only three scalar reads on the live fixture file; it now uses an ordinary backend's reader connection. Verified locally: the unmodified test reproduces the exact guard refusal, the fixed test passes.