### PR TITLE
docs(adr): kg-editor design language, interaction grammar, and typed graph visual encoding (ADR-151..153)

### DIFF
--- a/docs/adr/ADR-151-kg-editor-design-language.md
+++ b/docs/adr/ADR-151-kg-editor-design-language.md
@@ -94,7 +94,10 @@ Automated gates (token lint, contrast computation, icon contract test, `next bui
 necessary and not sufficient. A change that touches visual surface area ships with
 screenshots of the running app in the PR — dense view and reading view, both themes — and
 the review criterion is D1's stated character. Green CI with an unstyled or off-character
-page is a known failure class; the screenshot is the gate that catches it.
+page is a known failure class; the screenshot is the gate that catches it. The
+both-themes-both-densities screenshot requirement lives in the repository's PR template as
+a checklist item, so the gate survives contributor turnover rather than depending on
+reviewers remembering this clause.
 
 ## Consequences
 

--- a/docs/adr/ADR-151-kg-editor-design-language.md
+++ b/docs/adr/ADR-151-kg-editor-design-language.md
@@ -1,0 +1,114 @@
+# ADR-151: kg-editor Design Language and Token Contract
+
+**Status**: Proposed\
+**Date**: 2026-08-10\
+**Authors**: khive maintainers\
+**Related**: [ADR-145](ADR-145-local-first-kg-workbench.md),
+[ADR-147](ADR-147-repo-showcase-bundle.md)
+
+## Context
+
+`apps/kg-editor` now carries two product verticals over one component base: the ADR-147
+repository showcase (default route, ten analysis views) and the ADR-145 KG review workbench
+(`/review`). ADR-147 explicitly counts component transfer between the two lanes as a consequence
+of its design, and ADR-146 (in flight) will add a third consumer of the same rendering
+components.
+
+Both governing ADRs are data and trust contracts. Neither says a word about visual language.
+Today every view invents its own spacing, color, icon treatment, and empty-state shape, and
+nothing stops the app from drifting toward the generic admin-template look that data-heavy
+tools default to. With three lanes sharing components, visual drift compounds: the same entity
+rendered two ways reads as two different products.
+
+A design language is enforceable only if it is written down as a contract with testable
+clauses. This ADR is that contract. It intentionally binds aesthetics the way ADR-145 binds
+trust boundaries: specific, checkable, and fail-closed where a machine can check, with the
+judgment calls named as review criteria rather than left implicit.
+
+## Decision
+
+### D1 — One design language, dark-first, across both verticals
+
+The showcase and the workbench share a single design language. Component-level styling is
+expressed exclusively through the shared token set (D2); a view may compose tokens but MUST NOT
+introduce literal color, radius, shadow, or type values. The base theme is dark; a light theme
+is a token remap, not a component rewrite.
+
+The intended character, stated as a review criterion: restrained, warm, and material. Premium
+through meaning and restraint, not gloss. Dense where the user scans, generous where the user
+reads or edits. The failure modes this clause exists to reject are equally specific: flat
+generic admin-template surfaces, sterile minimalism, decorative gradients without informational
+content, and stock-dashboard visual noise.
+
+### D2 — Token contract
+
+All visual constants live in one token layer (CSS custom properties, mapped into Tailwind
+theme config so utilities resolve to tokens):
+
+- **Surfaces**: a near-black warm neutral base (not pure `#000`, not a cold blue-gray), with
+  at most three elevation steps. Elevation is expressed by surface value and hairline borders,
+  not drop shadows.
+- **Accent**: one warm accent family (stone/amber range) used for primary actions, focus, and
+  selection. Semantic colors (success, warning, error, epistemic support/refute) are their own
+  tokens and are never reused for decoration.
+- **Text contrast floors**, validated against the base surface: primary text at full strength;
+  secondary text at a minimum of 0.7 alpha-equivalent; muted/metadata text at a minimum of
+  0.5 alpha-equivalent. These floors are validated on dense data tables at 1x zoom, never on
+  isolated swatches — a value that passes on a swatch and fails on a table fails.
+- **Type**: one UI family and one monospace family. Identifiers, hashes, paths, counts, and
+  code render in monospace. Type scale is a token ramp; components do not set raw sizes.
+- **Spacing and radius**: a single spacing ramp and a single radius ramp; tables and dense
+  lists use the compact end, reading and editing surfaces use the generous end.
+
+Enforcement: a lint gate fails any component stylesheet or class string carrying a literal
+color value outside the token layer, and an automated contrast check computes the effective
+contrast of text tokens over surface tokens in both themes.
+
+### D3 — One SVG contract
+
+Every icon in the application follows one contract: `viewBox="0 0 24 24"`, 1.5px stroke,
+round caps and joins, literal shapes over abstract glyphs. Icons from different sources that
+disagree in stroke weight or corner treatment read as two different products inside one
+window; a lint test asserts the contract over the icon directory, and rail icons and body
+icons come from the same set.
+
+### D4 — Density, scanability, and generous editing space
+
+Dense surfaces (tables, change lists, graph legends) optimize for scanability: uniform row
+shape, monospace identifiers, columns before prose. Reading and editing surfaces (an entity
+card, a rule finding's evidence, a review comment) get generous space — the dominant element
+of an editing view fills the view, full-height where the content is the point. Cramped modal
+editors over dense backgrounds are rejected; editing happens in space, not in a keyhole.
+
+### D5 — Zero states invite action
+
+Every empty state names what belongs there and carries the primary action to create or load
+it, phrased as an invitation, with exactly one primary CTA. A bare glyph and a sentence is a
+failure. Distinct states remain distinct per ADR-145/147: _empty_ ("known to contain no
+items"), _unavailable_ (capability absent), _truncated_ (bounded), and _loading_ each have
+their own visual treatment, and none of them is collapsed into another.
+
+### D6 — Acceptance is visual, on the running app
+
+Automated gates (token lint, contrast computation, icon contract test, `next build`) are
+necessary and not sufficient. A change that touches visual surface area ships with
+screenshots of the running app in the PR — dense view and reading view, both themes — and
+the review criterion is D1's stated character. Green CI with an unstyled or off-character
+page is a known failure class; the screenshot is the gate that catches it.
+
+## Consequences
+
+- Aesthetic drift becomes a reviewable defect with named criteria instead of a matter of
+  taste re-litigated per PR.
+- The token layer is a one-time migration cost for existing views; after it, theme work and
+  the ADR-146 lane inherit the language for free.
+- The contract constrains contributors who would prefer a component library's defaults; that
+  is the point, and the escape hatch is amending this ADR, not overriding a token locally.
+
+## Acceptance criteria
+
+- Token layer exists; no component carries literal color values (lint-enforced).
+- Contrast floors hold computationally in both themes and visually on the densest table.
+- Icon lint passes over the full icon set.
+- All four empty-state classes render distinctly in both verticals.
+- A visual review with screenshots accompanies every surface-touching PR.

--- a/docs/adr/ADR-152-kg-editor-interaction-grammar.md
+++ b/docs/adr/ADR-152-kg-editor-interaction-grammar.md
@@ -1,0 +1,95 @@
+# ADR-152: kg-editor Interaction Grammar — Navigation, History, and Review Conversation
+
+**Status**: Proposed\
+**Date**: 2026-08-10\
+**Authors**: khive maintainers\
+**Related**: [ADR-145](ADR-145-local-first-kg-workbench.md),
+[ADR-147](ADR-147-repo-showcase-bundle.md),
+[ADR-151](ADR-151-kg-editor-design-language.md)
+
+## Context
+
+The showcase and the workbench are both exploration tools over bounded projections of large
+graphs. Exploration UIs fail in predictable ways: navigation trails grow without bound,
+history fragments into per-type pages, review data renders as walls of undifferentiated
+rows, and half the surface is reachable only by mouse. ADR-151 governs how surfaces look;
+this ADR governs how they behave.
+
+The unifying principle: borrow interaction metaphors users already own — the browser's
+back/forward stack, the email client's thread list and conversation stream, version-control
+history — instead of inventing navigation. An interface a user can predict from muscle
+memory beats a novel one that must be learned, and interfaces here are judged by
+scanability and predictability before visual novelty.
+
+## Decision
+
+### D1 — Browser-grade navigation, no unbounded trails
+
+Graph and view exploration maintains a history stack with back/forward controls that behave
+exactly like the browser's, and integrates with the actual browser history where routing
+allows. Breadcrumb trails that append per navigation step are rejected: any trail visible at
+once is bounded to the containment path of the current focus (e.g., project → package →
+module), never the user's walk history. The walk lives in the stack, reachable through
+back/forward.
+
+### D2 — One unified History timeline
+
+Each vertical presents one chronological history surface, not separate pages per record
+type. In the workbench, review activity — change-set operations, validation runs, review
+events, conversation — interleaves on one timeline with type facets as _filters over the one
+timeline_, never as separate destinations. In the showcase, the cadence view is likewise one
+timeline faceted by series. Splitting history by type forces the user to reassemble
+chronology in their head; that reassembly is the tool's job.
+
+### D3 — Review reads as a thread
+
+The change-set review surface uses the email shape: a scannable list pane (one row per
+reviewable unit — bounded, uniform, monospace identifiers) and a conversation pane where the
+selected unit's content streams chronologically — operations, findings, evidence, and
+review annotations in order. The list answers "what needs my attention"; the thread answers
+"what is the story of this one." Both ADR-145 review variants render through this shape.
+
+### D4 — Selection drives a contextual inspector
+
+One selection model spans graph views, lists, and timelines: selecting any addressable
+object (node, edge, change row, finding, commit) binds the inspector panel to it. The
+inspector is contextual — its content is the selection's type-specific card — never a static
+rail that renders the same regardless of focus. Empty selection shows the current scope's
+summary card, which per ADR-151 D5 invites the next action.
+
+### D5 — Keyboard-first operation
+
+Every navigational and review action is reachable by keyboard. A command palette
+(Cmd/Ctrl-K) exposes navigation targets, view switches, and non-destructive actions by
+name. List and timeline surfaces support j/k-style row traversal and Enter-to-open.
+Focus order follows visual order; the palette and traversal are tested, not aspirational.
+
+### D6 — Boundedness is a first-class interaction
+
+ADR-145 D9 and ADR-147 D6 make truncation and availability wire-level facts. This ADR makes
+them interactions: a truncation badge on any bounded surface states the bound and the total
+when known, and where a wider bound exists server-side, the badge is the affordance that
+requests the next page. Unavailable capabilities render their reason on demand (per ADR-145,
+e.g. the same-family review refusal explains itself). No control silently does nothing: an
+action that cannot proceed states why where the user clicked.
+
+## Consequences
+
+- Navigation and history behavior become testable contracts (stack semantics, single
+  timeline, keyboard reachability) instead of per-view improvisation.
+- The thread shape constrains how future conversation/comment enrichments land in ADR-145's
+  `pull_request` variant: they extend the stream, not a new pane.
+- Command palette and keyboard traversal add up-front cost to every new surface; the
+  compounding return is that power users never leave the keyboard.
+
+## Acceptance criteria
+
+- Back/forward traverse the exploration history across graph, list, and timeline views;
+  no UI element accumulates unbounded navigation state.
+- Each vertical has exactly one history timeline; type filters filter it in place.
+- The workbench review route renders list-plus-thread and both `khive.review.v1` variants
+  flow through it.
+- Every interactive surface passes a keyboard-only walkthrough; the palette reaches every
+  named view.
+- Truncated, unavailable, empty, and loading states each surface their reason or bound at
+  the point of interaction, covered by component tests.

--- a/docs/adr/ADR-153-typed-graph-visual-encoding.md
+++ b/docs/adr/ADR-153-typed-graph-visual-encoding.md
@@ -1,0 +1,108 @@
+# ADR-153: Typed Graph Visual Encoding
+
+**Status**: Proposed\
+**Date**: 2026-08-10\
+**Authors**: khive maintainers\
+**Related**: [ADR-001](ADR-001-entity-kind-taxonomy.md),
+[ADR-002](ADR-002-edge-ontology.md),
+[ADR-013](ADR-013-note-kind-taxonomy.md),
+[ADR-055](ADR-055-epistemic-edge-relations.md),
+[ADR-145](ADR-145-local-first-kg-workbench.md),
+[ADR-147](ADR-147-repo-showcase-bundle.md),
+[ADR-151](ADR-151-kg-editor-design-language.md)
+
+## Context
+
+khive's ontology is closed: 9 entity kinds, 17 edge relations in named families, 5 note
+kinds. That closure is the product's central bet, and it is also a rendering opportunity no
+generic graph library exploits: a closed vocabulary can have a _complete_ visual encoding,
+where every kind and relation has one stable visual identity and a reader who has learned
+the legend once can read any khive graph anywhere — showcase, workbench, or any future
+surface.
+
+Today each graph view chooses its own colors and line styles ad hoc. The same
+`depends_on` edge renders differently across views, derived exporter edges (ADR-147 D5)
+are visually indistinguishable from ingested ones, and epistemic relations (ADR-055) carry
+no visual semantics at all. Nothing distinguishes an encoding decision from a styling
+accident.
+
+## Decision
+
+### D1 — A complete, closed visual vocabulary
+
+The encoding covers the full ontology and only the ontology; it is amended when the
+ontology is amended (ADR-001/002/013 process), never extended ad hoc by a view.
+
+- **Entity kinds (9)**: each kind has a stable pairing of icon (per the ADR-151 SVG
+  contract) and hue. The pairing is defined once in a shared legend module consumed by
+  every graph, list, and inspector surface.
+- **Edge relations (17)**: line treatment is assigned per ADR-002 _family_, with
+  relation-level differentiation inside a family only where the family has more than one
+  member on screen: structure (contains/part_of/instance_of) as quiet solid lines;
+  derivation and provenance as directional treatments; dependency
+  (depends_on/enables) as the assertive solid family; lateral symmetric relations
+  (competes_with/composed_with) as undirected treatments; `annotates` as the recessive
+  dashed treatment; epistemic `supports`/`refutes` (ADR-055) as the one place semantic
+  color applies to edges — the support/refute tokens from ADR-151 D2, since their meaning
+  is evaluative, not structural.
+- **Note kinds (5)**: notes render as satellite chips off their anchor, tinted by kind,
+  visually subordinate to entities.
+- **Derived vs ingested**: an exporter-derived edge (ADR-147 D5) always carries a visible
+  derivation mark distinguishing it from ingested assertions. A reader must never mistake
+  a computed join for a stored claim.
+
+### D2 — Level-of-detail ladder
+
+Graph views render along a bounded ladder: cluster/overview (packages or kind-clusters,
+aggregate counts on super-nodes) → mid (entities with icons and labels for the focus
+neighborhood) → detail (full cards in the inspector, not on the canvas). Zoom and expansion
+move along the ladder under the wire-level budgets of ADR-145 D9 / ADR-147; a collapsed
+super-node states its contained count, and expansion beyond budget surfaces the truncation
+interaction of ADR-152 D6. Node sizing encodes exactly one declared quantity per view
+(degree, dependent count, or churn — named in the view's legend), never an undeclared mix.
+
+### D3 — Focus and overlay semantics
+
+Selection focuses the subgraph: the selected node, its neighbors at the declared hop bound,
+and their edges render at full strength; the remainder dims to context (within ADR-151
+contrast floors — dimmed is still readable). Analytical overlays (hotspot quadrant
+membership, hidden-coupling pairs, ownership concentration from ADR-147 aggregates) tint
+or badge nodes _on top of_ the base encoding and are exclusive: one overlay at a time,
+named in the legend while active. Overlays never repaint the kind hue — kind identity
+survives every overlay.
+
+### D4 — Deterministic layout
+
+Same bundle, same view parameters, same layout: layout algorithms run with fixed seeds and
+stable input ordering (the deterministic ordering the bundles already guarantee). Review
+reproducibility depends on it — two reviewers of one change-set see one picture, and
+screenshot-based visual regression becomes possible. Force-directed animation may run at
+interaction time, but the settled state is the deterministic one.
+
+### D5 — Encoding is never hue alone
+
+Every distinction the encoding makes survives grayscale: kind pairs icon with hue, edge
+families pair line treatment with any color, epistemic edges pair color with a directional
+glyph, derivation marks are geometric. The legend is a permanent, compact on-canvas
+affordance, not documentation.
+
+## Consequences
+
+- The legend module becomes a single point of truth consumed by three lanes (showcase,
+  workbench, ADR-146), ending per-view encoding drift; it is also a natural showcase asset —
+  the encoding itself demonstrates the ontology.
+- Ontology amendments acquire a small additional cost: a new kind or relation ships with
+  its visual identity. That coupling is deliberate; an unrenderable kind is an incomplete
+  addition.
+- Deterministic layout trades some aesthetic freedom of force simulation for
+  reproducibility; the trade is correct for a review tool.
+
+## Acceptance criteria
+
+- A shared legend module enumerates all 9 + 17 + 5 identities plus the derived-edge mark;
+  a completeness test fails when the ontology and the legend disagree.
+- Derived edges are visually distinct from ingested edges in every graph view.
+- Rendering the same golden bundle twice yields identical settled layouts (asserted by
+  serialized position snapshot).
+- A grayscale render of the legend remains fully distinguishable.
+- Each analytical overlay renders exclusively, with the active overlay named on-canvas.

--- a/docs/adr/ADR-153-typed-graph-visual-encoding.md
+++ b/docs/adr/ADR-153-typed-graph-visual-encoding.md
@@ -74,7 +74,9 @@ survives every overlay.
 ### D4 — Deterministic layout
 
 Same bundle, same view parameters, same layout: layout algorithms run with fixed seeds and
-stable input ordering (the deterministic ordering the bundles already guarantee). Review
+stable input ordering (the deterministic ordering the bundles already guarantee). The seed
+is defined once in the shared legend module and consumed by every view; a per-view seed
+would let determinism fragment silently as views are added. Review
 reproducibility depends on it — two reviewers of one change-set see one picture, and
 screenshot-based visual regression becomes possible. Force-directed animation may run at
 interaction time, but the settled state is the deterministic one.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -157,6 +157,9 @@ The same head-binding governs review: a verdict authorizes only the exact commit
 | [ADR-148](ADR-148-moodboard-visual-retrieval-pack.md)                   | Moodboard Visual Retrieval Pack                                                                            |
 | [ADR-149](ADR-149-moodboard-preference-learning.md)                     | Moodboard Pairwise Preference Learning                                                                     |
 | [ADR-150](ADR-150-single-write-owner-topology.md)                       | Single Write-Owner Topology — Bounded Admission, Read Admission, and Query Interruption                    |
+| [ADR-151](ADR-151-kg-editor-design-language.md)                         | kg-editor Design Language and Token Contract                                                               |
+| [ADR-152](ADR-152-kg-editor-interaction-grammar.md)                     | kg-editor Interaction Grammar — Navigation, History, and Review Conversation                               |
+| [ADR-153](ADR-153-typed-graph-visual-encoding.md)                       | Typed Graph Visual Encoding                                                                                |
 
 <!-- END GENERATED ADR CATALOG -->
 


### PR DESCRIPTION
Proposes three design-layer ADRs for `apps/kg-editor`. ADR-145 and ADR-147 govern the app's data and trust contracts; nothing governs how the product looks and behaves, and with a third lane (ADR-146) about to share the same components, visual and interaction drift compound.

- **ADR-151 — Design language and token contract.** One dark-first language across both verticals: a single token layer (lint-enforced, no literal color values in components), computed text-contrast floors validated on dense tables, one SVG icon contract, density/scanability rules, a zero-state contract distinguishing empty/unavailable/truncated/loading, and visual acceptance on the running app with screenshots.
- **ADR-152 — Interaction grammar.** Browser-grade back/forward navigation with no unbounded trails, one unified history timeline per vertical (facets filter, never fragment), the email list-plus-thread shape for change-set review, one selection model driving a contextual inspector, keyboard-first operation with a command palette, and truncation/availability as first-class interactions.
- **ADR-153 — Typed graph visual encoding.** A complete visual vocabulary for the closed ontology (9 entity kinds, 17 relations by family, 5 note kinds), derived-vs-ingested edge marking, a bounded level-of-detail ladder, exclusive analytical overlays, deterministic seeded layout for reproducible review, and no distinction carried by hue alone.

Docs only; no code changes. Implementation slices will be filed as issues referencing these ADRs.
