### PR TITLE
fix(db): surface retryable writer lock contention

### DIFF
--- a/crates/khive-db/docs/api/writer-task.md
+++ b/crates/khive-db/docs/api/writer-task.md
@@ -75,9 +75,13 @@ For transaction-wrapped requests, the scoped `writer_task_tx` registry span
 is dropped before the oneshot reply wakes the caller, both after a completed
 transaction and after a failed `BEGIN`. A caller that has observed its reply
 therefore cannot still observe that request as an open SQL transaction.
-There is no watchdog/retry story for a failed `BEGIN` (ADR-067
-Component D remains future work); the connection simply tries
-`BEGIN IMMEDIATE` fresh on the next request.
+When the raw SQLite code is `SQLITE_BUSY` or `SQLITE_LOCKED`, the caller
+receives `StorageError::WriterTaskBusy` with the connection's configured busy
+timeout. This is retryable because the operation closure never ran; it does
+not mean queue admission failed. Any other `BEGIN` error retains the generic
+pool failure. The connection tries `BEGIN IMMEDIATE` fresh on the next request,
+so transient contention does not retire the writer task. Automatic internal
+retry remains outside this seam.
 
 Exits normally when every `WriterTaskHandle` clone is dropped and the channel
 closes (`rx.recv()` returns `None`). A panic while executing a request, a failed

--- a/crates/khive-db/src/writer_task.rs
+++ b/crates/khive-db/src/writer_task.rs
@@ -556,6 +556,19 @@ fn writer_task_terminated(request_state: WriterTaskRequestState) -> StorageError
     StorageError::WriterTaskTerminated { request_state }
 }
 
+fn writer_task_begin_error(error: rusqlite::Error, busy_timeout: Duration) -> StorageError {
+    if crate::timeout_sink::is_busy_or_locked(&error) {
+        StorageError::WriterTaskBusy {
+            timeout_ms: u64::try_from(busy_timeout.as_millis()).unwrap_or(u64::MAX),
+        }
+    } else {
+        StorageError::Pool {
+            operation: "writer_task_begin".into(),
+            message: error.to_string(),
+        }
+    }
+}
+
 /// Sender half of the write queue. Cheaply cloneable (wraps an
 /// `mpsc::Sender`) — every migrated store that shares one writer task holds
 /// a clone of this handle.
@@ -824,6 +837,7 @@ pub fn spawn(pool: &ConnectionPool, capacity: usize) -> Result<WriterTaskHandle,
     // ownership boundary instead.
     let conn = pool.open_standalone_writer_untracked()?;
     let acquisition_counters = pool.writer_acquisition_counters();
+    let busy_timeout = pool.config().busy_timeout;
     let origin = pool.origin();
     let backend_key = writer_db_key(pool);
     let db = crate::timeout_sink::db_label(pool);
@@ -834,6 +848,7 @@ pub fn spawn(pool: &ConnectionPool, capacity: usize) -> Result<WriterTaskHandle,
         origin,
         db.clone(),
         acquisition_counters,
+        busy_timeout,
     ));
     // Stored on the pool (not returned) so the handle's clone-and-share
     // contract stays untouched; see ConnectionPool::take_writer_task_join
@@ -883,6 +898,7 @@ async fn run_writer_task(
     origin: khive_storage::tx_registry::TxOrigin,
     db: String,
     acquisition_counters: Arc<WriterAcquisitionCounters>,
+    busy_timeout: Duration,
 ) {
     while let Some(request) = rx.recv().await {
         // The bounded-channel wait ends at this exact dequeue boundary.
@@ -955,10 +971,7 @@ async fn run_writer_task(
                         drop(tx_span);
                         sealed::Sealed::reply_error_after_begin(
                             request,
-                            StorageError::Pool {
-                                operation: "writer_task_begin".into(),
-                                message: e.to_string(),
-                            },
+                            writer_task_begin_error(e, busy_timeout),
                             queue_wait,
                             transaction_acquire,
                         );
@@ -1008,6 +1021,29 @@ mod tests {
     use crate::pool::PoolConfig;
     use rusqlite::hooks::{AuthAction, AuthContext, Authorization, TransactionOperation};
     use serial_test::serial;
+
+    #[test]
+    fn begin_error_classification_is_code_based_and_narrow() {
+        for code in [rusqlite::ffi::SQLITE_BUSY, rusqlite::ffi::SQLITE_LOCKED] {
+            let error = rusqlite::Error::SqliteFailure(
+                rusqlite::ffi::Error::new(code),
+                Some("rendered text is irrelevant".to_string()),
+            );
+            assert!(matches!(
+                writer_task_begin_error(error, Duration::from_millis(175)),
+                StorageError::WriterTaskBusy { timeout_ms: 175 }
+            ));
+        }
+
+        let structural = rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_CONSTRAINT),
+            Some("database is locked".to_string()),
+        );
+        assert!(matches!(
+            writer_task_begin_error(structural, Duration::from_millis(175)),
+            StorageError::Pool { ref operation, .. } if operation == "writer_task_begin"
+        ));
+    }
     use std::future::Future;
     use std::pin::Pin;
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -1299,14 +1335,27 @@ mod tests {
         lock_holder.conn().execute_batch("ROLLBACK").unwrap();
         drop(lock_holder);
 
+        handle
+            .send(|conn| {
+                conn.execute("INSERT INTO t (id, v) VALUES (100, 'next-request')", [])
+                    .map_err(|e| StorageError::Pool {
+                        operation: "test_insert_after_busy".into(),
+                        message: e.to_string(),
+                    })
+            })
+            .await
+            .expect("transient contention must not retire the writer task");
+
         let reader = pool.reader().expect("reader");
         let count: i64 = reader
             .conn()
-            .query_row("SELECT COUNT(*) FROM t WHERE id = 99", [], |row| row.get(0))
+            .query_row("SELECT COUNT(*) FROM t WHERE id IN (99, 100)", [], |row| {
+                row.get(0)
+            })
             .unwrap();
         assert_eq!(
-            count, 0,
-            "no row must have landed from the request whose BEGIN IMMEDIATE failed"
+            count, 1,
+            "the failed request must not land, while the next request commits on the same task"
         );
     }
 

--- a/crates/khive-db/src/writer_task.rs
+++ b/crates/khive-db/src/writer_task.rs
@@ -1221,9 +1221,9 @@ mod tests {
         assert!(
             matches!(
                 &reply,
-                Err(StorageError::Pool { operation, .. }) if operation == "writer_task_begin"
+                Err(StorageError::WriterTaskBusy { timeout_ms }) if *timeout_ms == 150
             ),
-            "expected writer_task_begin failure, got {reply:?}"
+            "expected typed retryable writer-task contention, got {reply:?}"
         );
         assert!(!op_ran.load(Ordering::SeqCst));
         assert!(
@@ -1283,10 +1283,9 @@ mod tests {
         assert!(
             matches!(
                 &result,
-                Err(StorageError::Pool { operation, .. }) if operation == "writer_task_begin"
+                Err(StorageError::WriterTaskBusy { timeout_ms }) if *timeout_ms == 150
             ),
-            "expected a writer_task_begin Pool error on BEGIN IMMEDIATE \
-             failure, got {result:?}"
+            "expected a typed retryable error on contended BEGIN IMMEDIATE, got {result:?}"
         );
         assert!(
             !op_ran.load(Ordering::SeqCst),

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -1931,17 +1931,16 @@ fn coordinator_search_visibility(
 }
 
 /// Preserve the established flat-string payload for ordinary runtime errors,
-/// while carrying pre-execution write-admission failures (ADR-135 F6 writer-
-/// pool checkout timeout; #1382/#1643 write-queue saturation) structurally,
-/// and marked retryable, through every MCP execution mode. Both admission
-/// failures happen before SQLite executes the request, so retrying is safe:
-/// there is no partial side effect to roll back.
+/// while carrying every typed safe-retry write failure structurally through
+/// every MCP execution mode. Pool checkout and queue saturation happen before
+/// admission; writer-task BEGIN contention happens after queue acceptance but
+/// before the operation closure runs. None can leave a partial side effect.
 fn runtime_error_value(error: RuntimeError) -> Value {
     match error {
         RuntimeError::Khive(k) => serde_json::to_value(&k)
             .unwrap_or_else(|_| json!({"kind": "internal", "message": k.to_string()})),
         other => {
-            let Some(context) = other.admission_failure_context() else {
+            let Some(context) = other.retryable_failure_context() else {
                 return json!(other.to_string());
             };
             let timeout_ms = u64::try_from(context.timeout.as_millis()).unwrap_or(u64::MAX);
@@ -2279,8 +2278,9 @@ it (or summary) rather than relying on the absence of a top-level error.
 
 A parallel write-heavy batch is best-effort, not atomic: `results` ordering is
 not a commit prefix (an earlier entry succeeding implies nothing about a later
-one, or vice versa), and one entry's admission failure (e.g. `retryable:
-true`, `code: "writer_pool_checkout_timeout"` or `"writer_queue_saturated"`)
+one, or vice versa), and one entry's safe-retry failure (e.g. `retryable:
+true`, `code: "writer_pool_checkout_timeout"`, `"writer_queue_saturated"`,
+or `"writer_task_begin_busy"`)
 never rolls back a sibling that already committed. Inspect each result
 entry's own `ok` field rather than assuming batch-level atomicity.
 

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -1847,6 +1847,13 @@ impl khive_types::Pack for ErrorInjectPack {
             category: VerbCategory::Assertive,
             params: &[],
         },
+        HandlerDef {
+            name: "writer_task_busy",
+            description: "returns a typed writer-task BEGIN contention error",
+            visibility: Visibility::Verb,
+            category: VerbCategory::Assertive,
+            params: &[],
+        },
     ];
 }
 
@@ -1888,6 +1895,11 @@ impl PackRuntime for ErrorInjectPack {
         if verb == "write_queue_full" {
             return Err(RuntimeError::Storage(
                 khive_storage::StorageError::WriteQueueFull { timeout_ms: 175 },
+            ));
+        }
+        if verb == "writer_task_busy" {
+            return Err(RuntimeError::Storage(
+                khive_storage::StorageError::WriterTaskBusy { timeout_ms: 175 },
             ));
         }
         let err = KhiveError::unavailable("downstream service offline")
@@ -2063,6 +2075,42 @@ async fn write_queue_full_survives_storage_runtime_and_mcp_wire() -> anyhow::Res
             "retry_after_ms": 175,
         }),
         "the exact wire contract must preserve stage, deadline, retryability, and ADR-131:251's scope/retry_after_ms for queue saturation"
+    );
+
+    Ok(())
+}
+
+/// A writer task that exhausts SQLite's busy timeout before entering its
+/// request transaction has not invoked the operation and is therefore safe
+/// to retry. Keep that proof structured through the MCP boundary.
+#[tokio::test]
+async fn writer_task_busy_survives_storage_runtime_and_mcp_wire() -> anyhow::Result<()> {
+    let client = connect_error_inject().await?;
+    let result = call(
+        &client,
+        "request",
+        serde_json::json!({"ops": "writer_task_busy()"}),
+    )
+    .await?;
+    let body: serde_json::Value = serde_json::from_str(&first_text(&result))?;
+    let first = &body["results"][0];
+
+    assert_eq!(first["ok"], false, "expected op failure: {first}");
+    assert_eq!(
+        first["error"],
+        serde_json::json!({
+            "kind": "unavailable",
+            "code": "writer_task_begin_busy",
+            "stage": "writer_task_begin_busy",
+            "message": "storage: writer task could not begin within 175ms because SQLite remained busy; request was not executed",
+            "retryable": true,
+            "timeout_ms": 175,
+            "capability": serde_json::Value::Null,
+            "operation": "writer_task_begin",
+            "scope": serde_json::Value::Null,
+            "retry_after_ms": serde_json::Value::Null,
+        }),
+        "BEGIN contention must remain distinguishable and safely retryable"
     );
 
     Ok(())

--- a/crates/khive-pack-comm/docs/api/message-lifecycle.md
+++ b/crates/khive-pack-comm/docs/api/message-lifecycle.md
@@ -22,6 +22,13 @@ full `outbound_id` as `details.outbound_id`, so an automated caller can read
 the correlation id back out of the MCP error object instead of parsing prose,
 and use it for an exact `comm.delivered` lookup before retry.
 
+`WriterTaskBusy` is preserved unchanged. In that case the queue accepted the
+request but SQLite never entered the transaction and the dual-write operation
+never ran, so the failed `comm.send`/`comm.reply` operation is safe to retry.
+It carries no `outbound_id` and does not instruct the caller to use
+`comm.delivered`. In a chain or parallel batch, retry only that failed per-op
+entry; successful sibling operations may already have committed.
+
 ## `message.rs::dual_write_message`
 
 Writes an outbound copy (caller namespace) and an inbound copy (recipient

--- a/crates/khive-pack-comm/src/message.rs
+++ b/crates/khive-pack-comm/src/message.rs
@@ -813,6 +813,17 @@ mod tests {
         assert!(!annotated.to_string().contains("outbound_id="));
     }
 
+    #[test]
+    fn writer_begin_contention_is_retryable_without_delivery_probe() {
+        let error = RuntimeError::Storage(StorageError::WriterTaskBusy { timeout_ms: 175 });
+        let annotated = attach_outbound_id_to_ambiguous_write(Uuid::new_v4(), error);
+
+        assert!(matches!(
+            annotated,
+            RuntimeError::Storage(StorageError::WriterTaskBusy { timeout_ms: 175 })
+        ));
+    }
+
     #[tokio::test]
     async fn dual_write_versions_both_copies_and_stamps_optional_process_provenance() {
         use khive_runtime::{AllowAllGate, BackendId, RuntimeConfig};

--- a/crates/khive-runtime/src/error.rs
+++ b/crates/khive-runtime/src/error.rs
@@ -17,6 +17,10 @@ pub const WRITER_POOL_CHECKOUT_TIMEOUT_STAGE: &str = "writer_pool_checkout_timeo
 /// accepted the request within its configured deadline (#1382, #1643).
 pub const WRITER_QUEUE_SATURATED_STAGE: &str = "writer_queue_saturated";
 
+/// Stable wire code/stage for SQLite write-lock contention after the writer
+/// queue accepted a request but before its operation closure ran.
+pub const WRITER_TASK_BEGIN_BUSY_STAGE: &str = "writer_task_begin_busy";
+
 /// Stable ADR-131:251 `scope` discriminator carried on a
 /// [`WRITER_QUEUE_SATURATED_STAGE`] failure — distinguishes write-queue
 /// admission saturation from other `unavailable` failure kinds that share
@@ -54,6 +58,41 @@ pub struct AdmissionFailureContext {
     /// `Some(timeout_ms)` for [`WRITER_QUEUE_SATURATED_STAGE`]; `None`
     /// otherwise.
     pub retry_after_ms: Option<u64>,
+}
+
+/// Structured context for a failure that is proven safe to retry.
+///
+/// This includes the two pre-admission failures above and writer-task BEGIN
+/// contention after queue acceptance but before operation execution. Callers
+/// must inspect `scope`: only `writer_admission` means the queue never
+/// accepted the operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RetryableFailureContext {
+    /// Stable wire stage/code.
+    pub stage: &'static str,
+    /// Configured wait that ended before execution.
+    pub timeout: Duration,
+    /// Storage capability when the failure is capability-scoped.
+    pub capability: Option<khive_storage::StorageCapability>,
+    /// Storage operation when known.
+    pub operation: Option<String>,
+    /// Admission scope only when the queue never accepted the operation.
+    pub scope: Option<&'static str>,
+    /// Server backoff hint when a governing contract defines one.
+    pub retry_after_ms: Option<u64>,
+}
+
+impl From<AdmissionFailureContext> for RetryableFailureContext {
+    fn from(context: AdmissionFailureContext) -> Self {
+        Self {
+            stage: context.stage,
+            timeout: context.timeout,
+            capability: context.capability,
+            operation: context.operation,
+            scope: context.scope,
+            retry_after_ms: context.retry_after_ms,
+        }
+    }
 }
 
 /// Typed disposition for a channel message whose `comm.ingest` write failed.
@@ -391,13 +430,13 @@ impl RuntimeError {
     /// Classify a failed inbound channel write without inspecting rendered
     /// error text.
     ///
-    /// Existing typed admission failures remain retryable. Secret detection is
+    /// Existing typed safe-retry failures remain retryable. Secret detection is
     /// the first deterministic policy refusal and is permanent. `None` from
-    /// [`Self::admission_failure_context`] is deliberately not interpreted as
+    /// [`Self::retryable_failure_context`] is deliberately not interpreted as
     /// permanent: every other variant starts in the bounded `Unknown` bucket.
     pub fn channel_ingest_failure_class(&self) -> ChannelIngestFailureClass {
         let reason = self.variant_name();
-        if self.admission_failure_context().is_some() {
+        if self.retryable_failure_context().is_some() {
             ChannelIngestFailureClass::Retryable { reason }
         } else if matches!(self, Self::SecretDetected(_)) {
             ChannelIngestFailureClass::Permanent { reason }
@@ -502,6 +541,25 @@ impl RuntimeError {
         }
         None
     }
+
+    /// Recover every typed failure for which this process can prove that
+    /// retrying the one failed operation cannot duplicate a side effect.
+    pub fn retryable_failure_context(&self) -> Option<RetryableFailureContext> {
+        if let Some(context) = self.admission_failure_context() {
+            return Some(context.into());
+        }
+        let Self::Storage(khive_storage::StorageError::WriterTaskBusy { timeout_ms }) = self else {
+            return None;
+        };
+        Some(RetryableFailureContext {
+            stage: WRITER_TASK_BEGIN_BUSY_STAGE,
+            timeout: Duration::from_millis(*timeout_ms),
+            capability: None,
+            operation: Some("writer_task_begin".to_string()),
+            scope: None,
+            retry_after_ms: None,
+        })
+    }
 }
 
 /// Resolve an FTS text-leg search result, failing loud on parser syntax
@@ -559,6 +617,7 @@ impl From<khive_types::KhiveError> for RuntimeError {
 mod channel_ingest_failure_class_tests {
     use super::{ChannelIngestFailureClass, RuntimeError};
     use crate::secret_gate::SecretMatch;
+    use std::time::Duration;
 
     #[test]
     fn secret_detected_is_permanent_by_typed_variant_not_display_text() {
@@ -596,9 +655,8 @@ mod channel_ingest_failure_class_tests {
             ChannelIngestFailureClass::Retryable { reason: "Storage" }
         );
 
-        let begin_busy = RuntimeError::Storage(
-            khive_storage::StorageError::WriterTaskBusy { timeout_ms: 175 },
-        );
+        let begin_busy =
+            RuntimeError::Storage(khive_storage::StorageError::WriterTaskBusy { timeout_ms: 175 });
         let context = begin_busy
             .retryable_failure_context()
             .expect("contended BEGIN must remain typed and retryable");

--- a/crates/khive-runtime/src/error.rs
+++ b/crates/khive-runtime/src/error.rs
@@ -596,6 +596,22 @@ mod channel_ingest_failure_class_tests {
             ChannelIngestFailureClass::Retryable { reason: "Storage" }
         );
 
+        let begin_busy = RuntimeError::Storage(
+            khive_storage::StorageError::WriterTaskBusy { timeout_ms: 175 },
+        );
+        let context = begin_busy
+            .retryable_failure_context()
+            .expect("contended BEGIN must remain typed and retryable");
+        assert_eq!(context.stage, "writer_task_begin_busy");
+        assert_eq!(context.timeout, Duration::from_millis(175));
+        assert_eq!(context.operation.as_deref(), Some("writer_task_begin"));
+        assert_eq!(context.scope, None);
+        assert_eq!(context.retry_after_ms, None);
+        assert_eq!(
+            begin_busy.channel_ingest_failure_class(),
+            ChannelIngestFailureClass::Retryable { reason: "Storage" }
+        );
+
         let unknown = RuntimeError::InvalidInput(
             "write blocked: SecretDetected text must not affect classification".to_string(),
         );

--- a/crates/khive-storage/docs/api/error-taxonomy.md
+++ b/crates/khive-storage/docs/api/error-taxonomy.md
@@ -74,6 +74,21 @@ the wrapper's `capability`/`operation`. Its `message` field keeps the historical
 rendering for compatibility. This timeout occurs before SQLite executes and
 must not be classified as `SQLITE_BUSY` or checkpoint starvation.
 
+## Typed writer-task BEGIN contention
+
+`StorageError::WriterTaskBusy { timeout_ms }` means the writer queue accepted
+and dequeued the request, but SQLite returned `SQLITE_BUSY` or `SQLITE_LOCKED`
+until the connection's configured busy timeout expired. The writer task never
+invoked the request operation, so retrying that one failed operation is safe.
+The variant is capability-neutral and `is_retryable()` returns `true`.
+
+MCP preserves this proof with `code`/`stage` set to
+`writer_task_begin_busy`, `operation: "writer_task_begin"`, and
+`retryable: true`. Its `scope` and `retry_after_ms` are null: unlike
+`writer_queue_saturated`, the queue did accept this request, and no separate
+backoff policy is defined. Other `BEGIN IMMEDIATE` failures retain the generic
+pool error and are not promoted by rendered-message matching.
+
 ## `is_fts5_syntax_error`
 
 `TextSearch::search` returns the same `Driver` variant for a malformed MATCH

--- a/crates/khive-storage/src/error.rs
+++ b/crates/khive-storage/src/error.rs
@@ -315,6 +315,17 @@ mod tests {
     }
 
     #[test]
+    fn writer_task_busy_is_retryable_without_claiming_queue_rejection() {
+        let error = StorageError::WriterTaskBusy { timeout_ms: 175 };
+        assert!(error.is_retryable());
+        assert_eq!(
+            error.to_string(),
+            "writer task could not begin within 175ms because SQLite remained busy; request was not executed"
+        );
+        assert_eq!(error.capability(), None);
+    }
+
+    #[test]
     fn writer_task_terminated_is_uncapability_scoped_and_not_retryable() {
         for request_state in [
             WriterTaskRequestState::NotStarted,

--- a/crates/khive-storage/src/error.rs
+++ b/crates/khive-storage/src/error.rs
@@ -118,6 +118,15 @@ pub enum StorageError {
     #[error("write queue full: timed out after {timeout_ms}ms waiting for writer task capacity")]
     WriteQueueFull { timeout_ms: u64 },
 
+    /// SQLite refused the writer task's `BEGIN IMMEDIATE` with
+    /// `SQLITE_BUSY`/`SQLITE_LOCKED` until the configured busy timeout. The
+    /// queue accepted the request, but its operation closure was never
+    /// invoked, so retrying that one failed operation is safe.
+    #[error(
+        "writer task could not begin within {timeout_ms}ms because SQLite remained busy; request was not executed"
+    )]
+    WriterTaskBusy { timeout_ms: u64 },
+
     /// A single-writer execution seam has terminated permanently. This is the
     /// historical writer-task variant and display name; the fail-closed
     /// pool-mutex fallback also uses it when transaction finalization becomes
@@ -188,6 +197,7 @@ impl StorageError {
             | Self::Timeout { .. }
             | Self::Transaction { .. }
             | Self::WriteQueueFull { .. }
+            | Self::WriterTaskBusy { .. }
             | Self::WriterTaskTerminated { .. }
             | Self::Internal(..)
             | Self::WriterTaskNoRuntime => None,
@@ -202,6 +212,7 @@ impl StorageError {
                 | Self::Timeout { .. }
                 | Self::Transaction { .. }
                 | Self::WriteQueueFull { .. }
+                | Self::WriterTaskBusy { .. }
         )
     }
 

--- a/docs/adr/ADR-067-write-owner-daemon.md
+++ b/docs/adr/ADR-067-write-owner-daemon.md
@@ -806,3 +806,21 @@ a transaction is retired, queued requests are failed as `NotStarted`, and no
 top-level request is allowed to run. This pre-dispatch check is load-bearing:
 top-level requests skip `BEGIN IMMEDIATE` and would otherwise execute inside a
 stale transaction left by the prior failure.
+
+## Amendment 4 (2026-08-11): Retry-safe writer-lock contention
+
+A failed writer-task `BEGIN IMMEDIATE` is classified by SQLite result code.
+`SQLITE_BUSY` and `SQLITE_LOCKED` return
+`StorageError::WriterTaskBusy { timeout_ms }`, where `timeout_ms` is the
+connection's configured busy timeout. The queue already accepted the request,
+but the operation closure never ran, so retrying that one failed operation
+cannot duplicate a write. The writer task remains live and serves the next
+request normally.
+
+MCP carries this proof as `writer_task_begin_busy` with `retryable: true` and
+`operation: "writer_task_begin"`. It must not use the ADR-131
+`writer_admission` scope or queue-admission retry hint, because those fields
+mean the queue never accepted the request. Non-busy/non-locked BEGIN failures
+remain generic pool errors. `comm.send` preserves this typed retryable result
+without adding an outbound delivery probe: `comm.delivered` remains reserved
+for `SideEffectsUnknown`, where a write may already have committed.


### PR DESCRIPTION
## Summary

- classify only SQLite `BUSY`/`LOCKED` failures from the writer task's `BEGIN IMMEDIATE` as a dedicated `StorageError::WriterTaskBusy`
- preserve the exact configured SQLite busy timeout and emit a stable `writer_task_begin_busy` MCP result with `retryable: true`
- keep structural/non-contention BEGIN failures on the existing generic path and keep transient contention from retiring the writer task
- preserve `comm.send` delivery semantics: safe pre-operation contention receives no `outbound_id`/`comm.delivered` advice, while genuinely ambiguous outcomes remain unchanged

## Root cause

The writer queue accepted and dequeued a request, but a contended `BEGIN IMMEDIATE` failure was flattened into a generic pool string. The request operation never ran, yet callers could not distinguish this safe-to-retry condition from a structural failure or an ambiguous post-write outcome.

## Contract

The structured result uses `code`/`stage = writer_task_begin_busy`, `operation = writer_task_begin`, and the connection's configured `timeout_ms`. `scope` and `retry_after_ms` remain null because the queue did accept the request; ADR-131's `writer_admission` scope means the opposite. In a chain or parallel batch, callers retry only the failed per-op entry because successful siblings may already have committed.

## Validation

- RED: the storage test failed because `StorageError::WriterTaskBusy` did not exist
- real SQLite lock-contention regression: operation closure does not run, no failed row lands, and the same writer task commits the next request after the lock is released
- code-based `SQLITE_BUSY`/`SQLITE_LOCKED` classification with a rendered-text negative control
- `cargo check --manifest-path crates/Cargo.toml --workspace --all-targets --all-features`
- direct Rust/Deno format checks and `git diff --check`

Additional focused MCP/comm runtime tests are compiled by the workspace check and will continue on this draft branch.

Fixes #1890.
