### PR TITLE
docs(adr): retire unallocated and withdrawn ADR numbers

### DIFF
--- a/docs/adr/ADR-060-number-retired.md
+++ b/docs/adr/ADR-060-number-retired.md
@@ -1,11 +1,12 @@
-# ADR-060: Number Retired — Never Allocated
+# ADR-060: Number Retired — v0-Series Record Archived
 
-**Status**: Withdrawn — number retired without a design record (2026-08-11).
+**Status**: Withdrawn — number retired (2026-08-16).
 
-No record was ever authored under ADR-060 in this repository's history (verified against the
-full commit history, including deleted paths). Numbering advanced past it during concurrent
-allocation and the skip was never reconciled. This file retires the number so the catalog stays
-contiguous and future allocation cannot reuse it against an ambiguous history.
+A v0-series record was authored under this number: `ADR-060-verb-surface-speech-acts.md`
+(illocutionary verb classification, PR #151). It was archived, with the rest of the v0 series,
+when the v1 series became canonical (PR #310); the text remains available in git history. No
+v1-series record was ever authored under ADR-060. This file retires the number so the catalog
+stays contiguous and future allocation cannot reuse it against an ambiguous history.
 
-**Date**: 2026-08-11
+**Date**: 2026-08-16
 **Authors**: khive maintainers

--- a/docs/adr/ADR-060-number-retired.md
+++ b/docs/adr/ADR-060-number-retired.md
@@ -1,0 +1,11 @@
+# ADR-060: Number Retired — Never Allocated
+
+**Status**: Withdrawn — number retired without a design record (2026-08-11).
+
+No record was ever authored under ADR-060 in this repository's history (verified against the
+full commit history, including deleted paths). Numbering advanced past it during concurrent
+allocation and the skip was never reconciled. This file retires the number so the catalog stays
+contiguous and future allocation cannot reuse it against an ambiguous history.
+
+**Date**: 2026-08-11
+**Authors**: khive maintainers

--- a/docs/adr/ADR-064-number-retired.md
+++ b/docs/adr/ADR-064-number-retired.md
@@ -1,0 +1,11 @@
+# ADR-064: Number Retired — Never Allocated
+
+**Status**: Withdrawn — number retired without a design record (2026-08-11).
+
+No record was ever authored under ADR-064 in this repository's history (verified against the
+full commit history, including deleted paths). Numbering advanced past it during concurrent
+allocation and the skip was never reconciled. This file retires the number so the catalog stays
+contiguous and future allocation cannot reuse it against an ambiguous history.
+
+**Date**: 2026-08-11
+**Authors**: khive maintainers

--- a/docs/adr/ADR-064-number-retired.md
+++ b/docs/adr/ADR-064-number-retired.md
@@ -1,11 +1,13 @@
-# ADR-064: Number Retired — Never Allocated
+# ADR-064: Number Retired — v0-Series Record Archived
 
-**Status**: Withdrawn — number retired without a design record (2026-08-11).
+**Status**: Withdrawn — number retired (2026-08-16).
 
-No record was ever authored under ADR-064 in this repository's history (verified against the
-full commit history, including deleted paths). Numbering advanced past it during concurrent
-allocation and the skip was never reconciled. This file retires the number so the catalog stays
-contiguous and future allocation cannot reuse it against an ambiguous history.
+A v0-series record was authored under this number: `ADR-064-brain-architecture.md`
+(brain architecture and event-driven auto-tuning, PRs #150 and #157). It was archived, with the
+rest of the v0 series, when the v1 series became canonical (PR #310); the text remains available
+in git history. No v1-series record was ever authored under ADR-064. This file retires the number
+so the catalog stays contiguous and future allocation cannot reuse it against an ambiguous
+history.
 
-**Date**: 2026-08-11
+**Date**: 2026-08-16
 **Authors**: khive maintainers

--- a/docs/adr/ADR-065-number-retired.md
+++ b/docs/adr/ADR-065-number-retired.md
@@ -1,0 +1,11 @@
+# ADR-065: Number Retired — Never Allocated
+
+**Status**: Withdrawn — number retired without a design record (2026-08-11).
+
+No record was ever authored under ADR-065 in this repository's history (verified against the
+full commit history, including deleted paths). Numbering advanced past it during concurrent
+allocation and the skip was never reconciled. This file retires the number so the catalog stays
+contiguous and future allocation cannot reuse it against an ambiguous history.
+
+**Date**: 2026-08-11
+**Authors**: khive maintainers

--- a/docs/adr/ADR-065-number-retired.md
+++ b/docs/adr/ADR-065-number-retired.md
@@ -1,11 +1,14 @@
-# ADR-065: Number Retired — Never Allocated
+# ADR-065: Number Retired — Draft Archived
 
-**Status**: Withdrawn — number retired without a design record (2026-08-11).
+**Status**: Withdrawn — number retired (2026-08-16).
 
-No record was ever authored under ADR-065 in this repository's history (verified against the
-full commit history, including deleted paths). Numbering advanced past it during concurrent
-allocation and the skip was never reconciled. This file retires the number so the catalog stays
-contiguous and future allocation cannot reuse it against an ambiguous history.
+A draft was authored under this number: `ADR-065-plugin-intent-routing.md` (PR #248). It was
+archived when the v1 series became canonical (PR #310); the text remains available in git
+history. Accepted [ADR-069](ADR-069-subject-model.md) cites "draft ADR-065" in its discussion of
+the `depends_on` concept-to-concept edge rule; those citations refer to this archived draft, not
+to a v1-series record. No v1-series record was ever authored under ADR-065. This file retires the
+number so the catalog stays contiguous and future allocation cannot reuse it against an ambiguous
+history.
 
-**Date**: 2026-08-11
+**Date**: 2026-08-16
 **Authors**: khive maintainers

--- a/docs/adr/ADR-070-comprehensive-event-capture.md
+++ b/docs/adr/ADR-070-comprehensive-event-capture.md
@@ -1,0 +1,12 @@
+# ADR-070: Comprehensive Event Capture — Reference-Based, Read+Write, Default-On
+
+**Status**: Withdrawn — reserved by a draft that was not pursued (2026-08-11).
+
+The number was reserved on 2026-06-25 by a draft proposing reference-based capture of both read
+and write operations into the event substrate, default-on, amending ADR-004 (observable fields),
+ADR-018 (gate audit pairing), and ADR-022 (emission scope). The draft never reached review and
+was not pursued. The number is burned — a successor proposal on event-capture scope takes a
+fresh number.
+
+**Date**: 2026-08-11
+**Authors**: khive maintainers

--- a/docs/adr/ADR-077-number-retired.md
+++ b/docs/adr/ADR-077-number-retired.md
@@ -1,11 +1,12 @@
-# ADR-077: Number Retired — Never Allocated
+# ADR-077: Number Retired — v0-Series Record Archived
 
-**Status**: Withdrawn — number retired without a design record (2026-08-11).
+**Status**: Withdrawn — number retired (2026-08-16).
 
-No record was ever authored under ADR-077 in this repository's history (verified against the
-full commit history, including deleted paths). Numbering advanced past it during concurrent
-allocation and the skip was never reconciled. This file retires the number so the catalog stays
-contiguous and future allocation cannot reuse it against an ambiguous history.
+A v0-series record was authored under this number: `ADR-077-rust-binary-packaging.md`, added
+alongside the Rust admin-binary work tracked in issue #174. It was archived, with the rest of the
+v0 series, when the v1 series became canonical (PR #310); the text remains available in git
+history. No v1-series record was ever authored under ADR-077. This file retires the number so the
+catalog stays contiguous and future allocation cannot reuse it against an ambiguous history.
 
-**Date**: 2026-08-11
+**Date**: 2026-08-16
 **Authors**: khive maintainers

--- a/docs/adr/ADR-077-number-retired.md
+++ b/docs/adr/ADR-077-number-retired.md
@@ -1,0 +1,11 @@
+# ADR-077: Number Retired — Never Allocated
+
+**Status**: Withdrawn — number retired without a design record (2026-08-11).
+
+No record was ever authored under ADR-077 in this repository's history (verified against the
+full commit history, including deleted paths). Numbering advanced past it during concurrent
+allocation and the skip was never reconciled. This file retires the number so the catalog stays
+contiguous and future allocation cannot reuse it against an ambiguous history.
+
+**Date**: 2026-08-11
+**Authors**: khive maintainers

--- a/docs/adr/ADR-097-number-retired.md
+++ b/docs/adr/ADR-097-number-retired.md
@@ -1,0 +1,11 @@
+# ADR-097: Number Retired — Never Allocated
+
+**Status**: Withdrawn — number retired without a design record (2026-08-11).
+
+No record was ever authored under ADR-097 in this repository's history (verified against the
+full commit history, including deleted paths). Numbering advanced past it during concurrent
+allocation and the skip was never reconciled. This file retires the number so the catalog stays
+contiguous and future allocation cannot reuse it against an ambiguous history.
+
+**Date**: 2026-08-11
+**Authors**: khive maintainers

--- a/docs/adr/ADR-098-number-retired.md
+++ b/docs/adr/ADR-098-number-retired.md
@@ -1,0 +1,11 @@
+# ADR-098: Number Retired — Never Allocated
+
+**Status**: Withdrawn — number retired without a design record (2026-08-11).
+
+No record was ever authored under ADR-098 in this repository's history (verified against the
+full commit history, including deleted paths). Numbering advanced past it during concurrent
+allocation and the skip was never reconciled. This file retires the number so the catalog stays
+contiguous and future allocation cannot reuse it against an ambiguous history.
+
+**Date**: 2026-08-11
+**Authors**: khive maintainers

--- a/docs/adr/ADR-116-memory-ann-generation-coherence.md
+++ b/docs/adr/ADR-116-memory-ann-generation-coherence.md
@@ -1,0 +1,12 @@
+# ADR-116: Durable Per-Model Generation Coherence for the Memory ANN Warm Path
+
+**Status**: Withdrawn — proposal closed without merge (2026-08-11).
+
+ADR-116 proposed durable per-model generation coherence for memory-pack ANN freshness across
+processes, covering persisted memory-ANN snapshots and the SQLite write/migration contract. It
+was submitted as PR #1080, iterated through six review rounds, and the PR was closed without
+merge on 2026-07-22. The full drafted text remains available in that PR's history. The number is
+burned — a successor proposal on ANN generation coherence takes a fresh number.
+
+**Date**: 2026-08-11
+**Authors**: khive maintainers

--- a/docs/adr/ADR-126-number-retired.md
+++ b/docs/adr/ADR-126-number-retired.md
@@ -1,0 +1,11 @@
+# ADR-126: Number Retired — Never Allocated
+
+**Status**: Withdrawn — number retired without a design record (2026-08-11).
+
+No record was ever authored under ADR-126 in this repository's history (verified against the
+full commit history, including deleted paths). Numbering advanced past it during concurrent
+allocation and the skip was never reconciled. This file retires the number so the catalog stays
+contiguous and future allocation cannot reuse it against an ambiguous history.
+
+**Date**: 2026-08-11
+**Authors**: khive maintainers

--- a/docs/adr/ADR-132-number-retired.md
+++ b/docs/adr/ADR-132-number-retired.md
@@ -1,0 +1,11 @@
+# ADR-132: Number Retired — Never Allocated
+
+**Status**: Withdrawn — number retired without a design record (2026-08-11).
+
+No record was ever authored under ADR-132 in this repository's history (verified against the
+full commit history, including deleted paths). Numbering advanced past it during concurrent
+allocation and the skip was never reconciled. This file retires the number so the catalog stays
+contiguous and future allocation cannot reuse it against an ambiguous history.
+
+**Date**: 2026-08-11
+**Authors**: khive maintainers

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -75,12 +75,12 @@ The same head-binding governs review: a verdict authorizes only the exact commit
 | [ADR-057](ADR-057-comm-actor-addressed-delivery.md)                     | Comm Actor-Addressed Delivery                                                                              |
 | [ADR-058](ADR-058-brain-posterior-read-path.md)                         | Brain Posterior Read Path — Wiring Profile Posteriors into Recall Ranking                                  |
 | [ADR-059](ADR-059-namespace-write-tiers.md)                             | Namespace Write Tiers and Cross-Namespace Link Access Control                                              |
-| [ADR-060](ADR-060-number-retired.md)                                    | Number Retired — Never Allocated                                                                           |
+| [ADR-060](ADR-060-number-retired.md)                                    | Number Retired — v0-Series Record Archived                                                                 |
 | [ADR-061](ADR-061-pack-extensible-by-id-resolution.md)                  | Pack-Extensible by-ID Resolution                                                                           |
 | [ADR-062](ADR-062-fts-ann-consolidation.md)                             | FTS and ANN Consolidation -- Unified Search Tables (Schema V4)                                             |
 | [ADR-063](ADR-063-comm-principal-model.md)                              | Comm Pack Principal Model and Remote Backend Isolation                                                     |
-| [ADR-064](ADR-064-number-retired.md)                                    | Number Retired — Never Allocated                                                                           |
-| [ADR-065](ADR-065-number-retired.md)                                    | Number Retired — Never Allocated                                                                           |
+| [ADR-064](ADR-064-number-retired.md)                                    | Number Retired — v0-Series Record Archived                                                                 |
+| [ADR-065](ADR-065-number-retired.md)                                    | Number Retired — Draft Archived                                                                            |
 | [ADR-066](ADR-066-autonomous-merge-pipeline.md)                         | Autonomous Merge Pipeline — Gate Wall as Reviewer                                                          |
 | [ADR-067](ADR-067-write-owner-daemon.md)                                | Write-Owner Daemon — Single-Writer Task and Write Queue                                                    |
 | [ADR-068](ADR-068-process-isolation-topology.md)                        | Per-Process Isolation Topology                                                                             |
@@ -92,7 +92,7 @@ The same head-binding governs review: a verdict authorizes only the exact commit
 | [ADR-074](ADR-074-graph-aware-recall.md)                                | Graph-Aware Recall — Graph-Proximity Signal in Memory Retrieval                                            |
 | [ADR-075](ADR-075-owl-rdf-interoperability.md)                          | OWL/RDF Interoperability -- Publishing the khive Vocabulary and Aligning with External Ontologies          |
 | [ADR-076](ADR-076-relation-calculability-and-system-role.md)            | Relation-Set Calculability — System Role and the Non-Redundancy Certificate                                |
-| [ADR-077](ADR-077-number-retired.md)                                    | Number Retired — Never Allocated                                                                           |
+| [ADR-077](ADR-077-number-retired.md)                                    | Number Retired — v0-Series Record Archived                                                                 |
 | [ADR-078](ADR-078-output-format-shape-aware-rendering.md)               | Output Format and Shape-Aware Rendering                                                                    |
 | [ADR-079](ADR-079-ann-persistence-warm-path-integration.md)             | ANN Persistence Warm-Path Integration — Wiring v2 Persistence into the Daemon                              |
 | [ADR-080](ADR-080-session-pack-oss-storage-mechanism.md)                | Session Pack — OSS Storage Mechanism                                                                       |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -75,19 +75,24 @@ The same head-binding governs review: a verdict authorizes only the exact commit
 | [ADR-057](ADR-057-comm-actor-addressed-delivery.md)                     | Comm Actor-Addressed Delivery                                                                              |
 | [ADR-058](ADR-058-brain-posterior-read-path.md)                         | Brain Posterior Read Path — Wiring Profile Posteriors into Recall Ranking                                  |
 | [ADR-059](ADR-059-namespace-write-tiers.md)                             | Namespace Write Tiers and Cross-Namespace Link Access Control                                              |
+| [ADR-060](ADR-060-number-retired.md)                                    | Number Retired — Never Allocated                                                                           |
 | [ADR-061](ADR-061-pack-extensible-by-id-resolution.md)                  | Pack-Extensible by-ID Resolution                                                                           |
 | [ADR-062](ADR-062-fts-ann-consolidation.md)                             | FTS and ANN Consolidation -- Unified Search Tables (Schema V4)                                             |
 | [ADR-063](ADR-063-comm-principal-model.md)                              | Comm Pack Principal Model and Remote Backend Isolation                                                     |
+| [ADR-064](ADR-064-number-retired.md)                                    | Number Retired — Never Allocated                                                                           |
+| [ADR-065](ADR-065-number-retired.md)                                    | Number Retired — Never Allocated                                                                           |
 | [ADR-066](ADR-066-autonomous-merge-pipeline.md)                         | Autonomous Merge Pipeline — Gate Wall as Reviewer                                                          |
 | [ADR-067](ADR-067-write-owner-daemon.md)                                | Write-Owner Daemon — Single-Writer Task and Write Queue                                                    |
 | [ADR-068](ADR-068-process-isolation-topology.md)                        | Per-Process Isolation Topology                                                                             |
 | [ADR-069](ADR-069-subject-model.md)                                     | The Subject Model -- Domain-Ontology Ingestion and Map Pipeline                                            |
+| [ADR-070](ADR-070-comprehensive-event-capture.md)                       | Comprehensive Event Capture — Reference-Based, Read+Write, Default-On                                      |
 | [ADR-071](ADR-071-backend-pluggable-runtime.md)                         | Backend-Pluggable Runtime — Polystore Restoration                                                          |
 | [ADR-072](ADR-072-subject-ontologyspec-as-data.md)                      | Subject OntologySpec as Runtime Data -- Verbless Verticals and Pack Retirement                             |
 | [ADR-073](ADR-073-pack-core-backend-accessor.md)                        | Pack Core-Backend Accessor                                                                                 |
 | [ADR-074](ADR-074-graph-aware-recall.md)                                | Graph-Aware Recall — Graph-Proximity Signal in Memory Retrieval                                            |
 | [ADR-075](ADR-075-owl-rdf-interoperability.md)                          | OWL/RDF Interoperability -- Publishing the khive Vocabulary and Aligning with External Ontologies          |
 | [ADR-076](ADR-076-relation-calculability-and-system-role.md)            | Relation-Set Calculability — System Role and the Non-Redundancy Certificate                                |
+| [ADR-077](ADR-077-number-retired.md)                                    | Number Retired — Never Allocated                                                                           |
 | [ADR-078](ADR-078-output-format-shape-aware-rendering.md)               | Output Format and Shape-Aware Rendering                                                                    |
 | [ADR-079](ADR-079-ann-persistence-warm-path-integration.md)             | ANN Persistence Warm-Path Integration — Wiring v2 Persistence into the Daemon                              |
 | [ADR-080](ADR-080-session-pack-oss-storage-mechanism.md)                | Session Pack — OSS Storage Mechanism                                                                       |
@@ -107,6 +112,8 @@ The same head-binding governs review: a verdict authorizes only the exact commit
 | [ADR-094](ADR-094-lifecycle-telemetry-events.md)                        | Sequencing-Assertable Lifecycle Telemetry Events                                                           |
 | [ADR-095](ADR-095-verb-surface-consolidation.md)                        | Verb-Surface Consolidation and Field-Validation Governance                                                 |
 | [ADR-096](ADR-096-warm-daemon-per-request-identity.md)                  | warm daemon per-request identity — serving many attribution identities over one shared backend             |
+| [ADR-097](ADR-097-number-retired.md)                                    | Number Retired — Never Allocated                                                                           |
+| [ADR-098](ADR-098-number-retired.md)                                    | Number Retired — Never Allocated                                                                           |
 | [ADR-099](ADR-099-bulk-apply-atomic-units.md)                           | Cross-Op Atomicity for Bulk Apply — Prepared Write Plans over the Single-Writer Seam                       |
 | [ADR-100](ADR-100-store-backup-replication.md)                          | Store backup and replication                                                                               |
 | [ADR-101](ADR-101-kg-changeset-model.md)                                | KG Change-Set Model — Producer-Agnostic Op-List with Stage-Time Stable IDs                                 |
@@ -124,6 +131,7 @@ The same head-binding governs review: a verdict authorizes only the exact commit
 | [ADR-113](ADR-113-identifier-continuity.md)                             | Identifier Continuity — Merged-Entity Redirect Resolution and Split Endpoint-Move                          |
 | [ADR-114](ADR-114-code-audit-derived-report.md)                         | Code-Audit Derived Report, Not Agent Findings                                                              |
 | [ADR-115](ADR-115-secret-gate-content-manifest-exemption.md)            | Exact-Content Manifest Exemption for the Write Secret Gate                                                 |
+| [ADR-116](ADR-116-memory-ann-generation-coherence.md)                   | Durable Per-Model Generation Coherence for the Memory ANN Warm Path                                        |
 | [ADR-117](ADR-117-session-continuity-search.md)                         | Session Continuity — Cross-Session Search and Remote Ingestion                                             |
 | [ADR-117a](ADR-117a-session-identity-tenant-isolation.md)               | Session Identity and Tenant Isolation                                                                      |
 | [ADR-118](ADR-118-fresh-tail-recall-visibility.md)                      | Fresh-Tail Exact Leg — Read-Your-Writes Visibility for Vector Recall                                       |
@@ -134,11 +142,13 @@ The same head-binding governs review: a verdict authorizes only the exact commit
 | [ADR-123](ADR-123-comm-forward.md)                                      | comm.forward — Provenance-Preserving Message Forwarding                                                    |
 | [ADR-124](ADR-124-note-write-identity.md)                               | Note-Write Identity — Deriving Pack-Owned Identity Properties at the Write                                 |
 | [ADR-125](ADR-125-reserved-property-keys.md)                            | Reserved property keys on pack-owned note kinds                                                            |
+| [ADR-126](ADR-126-number-retired.md)                                    | Number Retired — Never Allocated                                                                           |
 | [ADR-127](ADR-127-authenticated-actor-and-grant-primitive.md)           | Authenticated actor and grant primitive                                                                    |
 | [ADR-128](ADR-128-custody-party-pairs-and-slot-authenticity.md)         | Custody party-pairs and slot authenticity                                                                  |
 | [ADR-129](ADR-129-fail-closed-gate-default.md)                          | Fail-closed authorization gate default                                                                     |
 | [ADR-130](ADR-130-search-response-completeness-and-ranking-evidence.md) | Search response completeness and ranking evidence                                                          |
 | [ADR-131](ADR-131-batch-write-admission-control.md)                     | Admission control for parallel write batches                                                               |
+| [ADR-132](ADR-132-number-retired.md)                                    | Number Retired — Never Allocated                                                                           |
 | [ADR-133](ADR-133-incidental-writes-off-the-request-hot-path.md)        | Reduce writer acquisitions on the request path                                                             |
 | [ADR-134](ADR-134-store-durability-posture.md)                          | Store durability posture, and the obligation it carries for accounting records                             |
 | [ADR-135](ADR-135-write-scaling-demand-before-ownership.md)             | Scale SQLite writes by reducing writer demand before changing ownership                                    |


### PR DESCRIPTION
Fills the ten gaps in the ADR numbering sequence (060, 064, 065, 070, 077, 097, 098, 116, 126, 132) with tombstone records, following the ADR-059 burned-number precedent, so the catalog is contiguous and retired numbers cannot be reused against an ambiguous history.

- Eight numbers were never allocated in this repository's history (verified against the full commit history including deleted paths); each gets a short retirement record.
- ADR-070 was reserved by a 2026-06-25 event-capture draft that never reached review; the number is burned.
- ADR-116 was proposed in PR #1080 and closed without merge on 2026-07-22; the number is burned and the drafted text remains available in that PR's history.
- Catalog rows added for all ten; `scripts/lint-adr-refs.sh` passes.

Docs-only change; no code paths touched.