### PR TITLE
docs(runtime): move narrative comments into crate docs, trim inline chatter

### DIFF
--- a/crates/khive-runtime/docs/api/secret_gate.md
+++ b/crates/khive-runtime/docs/api/secret_gate.md
@@ -295,6 +295,116 @@ Bare base64 tokens of those lengths WITHOUT the `sha<N>-` prefix are NOT allowli
 without the prefix, so the explicit prefix is required to avoid false-negative credential
 escapes.
 
+## check_entropy_heuristic — per-token flagging sequence
+
+For each token, in order:
+
+1. **UUID / content-hash near trigger.** Both exact-shape checkers (`is_uuid_canonical`,
+   `is_base64_content_hash`) require the WHOLE candidate to match, so `value_candidates` is used
+   instead of the raw token to reach a credential glued to storage syntax (`api_key=<uuid>`,
+   `(<uuid>)`, `{"api_key":"<uuid>"}`, a doubled assignment, a trailing sentence period, or a
+   label itself containing `:`/`=`) — `strip_delimiters` only trims outer punctuation, not an
+   internal separator from an assignment form. `value_candidates` is used only for this pair of
+   checks; it does not replace `token` for entropy, hex, or structured-identifier checks, none of
+   which require an exact shape match. This is a small bounded iteration over separator positions
+   in one token, not an allocation-heavy scan. Off-trigger, a UUID or content hash is allowlisted
+   outright.
+2. **Pure hex off-trigger** is allowlisted (git SHA, checksum digests). Trigger-adjacent hex
+   requires an explicit VCS coordinate marker (`commit`, `revision`, `rev`, `sha`) to earn the
+   same exemption, and only when the surrounding clause carries no credential label (`api key
+   value is commit <hex>` is a labeled credential wearing a marker, not a VCS citation). The
+   exemption is a flag over the hex-credential-shape checks only, never an early skip of fragment
+   reconstruction — an exempted anchor that skipped reconstruction would let a marker-adjacent
+   fragment hide a split credential. The bare-marker-word form (`commit <hex>`) is skipped
+   entirely via `continue`, since a fixed marker word is not attacker-controlled material and
+   letting it anchor fragment reconstruction would re-accumulate its own legitimate neighboring
+   revision; the hex value itself is a separate token checked on its own iteration.
+3. **Hex credential shape near trigger.** The entropy heuristic cannot catch hex API keys (AWS
+   secret access key, Stripe test keys): hex's alphabet maxes at log2(16) = 4.0 bits/char, always
+   below `ENTROPY_THRESHOLD` (4.5). A credential-shaped hex token (32/40/64/128 chars,
+   `HEX_CREDENTIAL_LENGTHS`) near a trigger word is flagged directly.
+4. **Per-run hex/entropy re-check (issue #1044).** A genuine credential can dilute below the
+   whole-token-average checks above when it shares a whitespace token with low-entropy filler
+   segments (`vault/<payload>/rotate.md`). Decomposing the token on every non-alphanumeric
+   separator (the same split `is_structured_identifier` uses) and re-running the hex-length and
+   entropy checks against each run independently closes that gap. Only `MIN_ENTROPY_LEN`+ runs
+   are considered — the #1040 measurement corpus confirmed no real path false positive contains a
+   single run that long. This does not touch the `is_structured_identifier` exemption itself,
+   which stays scoped to `!near_trigger`; a run this long clearing its own check is evidence
+   independent of that exemption's word-shape rule.
+5. **Normalized hex concatenation (issue #1062).** The per-run loop above still misses a
+   credential hex payload split into multiple runs each individually below `MIN_ENTROPY_LEN`
+   (e.g. two 20-char hex runs joined by `/`). Concatenating consecutive pure-hex runs (dropping
+   separators) and re-checking the combined length against `HEX_CREDENTIAL_LENGTHS` closes this
+   without widening the allowlist.
+6. **Multi-fragment bridge (issue #1062, Unicode variant).** A non-ASCII separator (e.g. U+200B)
+   is a tokenizer delimiter, so it splits the payload into separate tokens instead of leaving it
+   inside one — the concatenation check above never sees the halves together. Bridging only one
+   adjacent pair and bounding the gap by raw byte length is insufficient (repeating the delimiter
+   defeats a byte-length bound, and a three-way split defeats single-pair bridging).
+   `bridge_fragment_chain` fixes both by walking outward in both directions across a bounded
+   chain of fragments (see [Bridge fragment reconstruction](#bridge-fragment-reconstruction)); a
+   delimiter-only token between two gaps is transparent to the walk (absorbed as glue, see
+   `is_delimiter_only_token`). Every fragment found while extending from the anchor must itself
+   be bridge-fragment-shaped (alphanumeric, `MIN_BRIDGE_FRAGMENT_LEN`+) — this stops the walk at
+   a short trigger/glue word (`key`, `api`, `for`) rather than dragging prose into the
+   reconstruction. The anchor itself is included unconditionally, so a shape exemption able to
+   admit a long non-fragment anchor must run after this reconstruction, not before.
+
+   **Actual guarantee** (narrower than "every three-or-more-way split is reconstructed"):
+   coverage extends to splits of up to `MAX_BRIDGE_FRAGMENTS` real fragments (each individually
+   meeting `MIN_BRIDGE_FRAGMENT_LEN`), where a single gap between two fragments may be any byte
+   length but spans at most `MAX_BRIDGE_GLUE_TOKENS` delimiter-only tokens per probe direction. A
+   split into more fragments, into fragments individually below the length floor, or across more
+   glue tokens in one gap, is an accepted residual limitation of the local-neighborhood bound —
+   per ADR-096 / ADR-115 this gate is accidental-persistence hygiene on a single-principal
+   same-uid host, not defense against a same-uid adversary hand-splitting a credential to evade
+   it (that adversary can write the DB directly). This module does not itself establish that the
+   host is same-uid; it inherits that from the daemon's peer-credential check
+   (`khive-runtime/src/daemon.rs`, refusal of any peer uid other than its own before the first
+   frame is read) — if that refusal is ever removed or weakened, this residual limitation stops
+   being residual. See the `allows_seven_way_hex_split_beyond_fragment_cap_documented_limitation`
+   and `allows_six_way_sub_floor_hex_split_documented_limitation` tests.
+
+   The bridged chain is checked two ways: `contains_normalized_hex_credential` over fragments
+   joined by a plain space (a non-alphanumeric separator, so it accumulates only genuinely
+   adjacent hex runs the same way it does for one token's internal `/`-split runs), and
+   separately the fragments concatenated WITHOUT a separator against the same whole-token entropy
+   decision a single-token high-entropy candidate must clear — this catches a
+   base64/base64url-shaped credential split by the same delimiter mechanism, which isn't pure hex
+   so the hex-length check alone misses it. A vcs-exempt anchor skips reconstruction from itself
+   (else the chain would re-accumulate the anchor's own legitimate 40-hex and re-flag every
+   benign marker-adjacent revision); a genuinely split credential hiding one fragment behind a
+   marker is still caught because every OTHER fragment anchors its own chain and accumulates the
+   exempted fragment's hex into the total (`blocks_split_hex_credential_with_marker_adjacent_fragment`).
+7. **File-path exemption** (`is_plausible_file_path`, gated by `has_clause_credential_label`)
+   applies after all of the above, never before — a path-shaped anchor must not be able to skip a
+   chain that would otherwise reconstruct a blocked credential.
+8. **Structured-identifier exemption** off-trigger only — must come after the UUID/content-hash
+   and hex-credential-token checks (neither of which it weakens) and before the entropy
+   computation, since an identifier can exceed `ENTROPY_THRESHOLD` on Shannon entropy alone.
+
+## Bridge fragment reconstruction
+
+`bridge_fragment_chain` checks whether a trigger-adjacent short token is one piece of a
+delimiter-split credential by walking outward and concatenating neighboring fragments.
+`MAX_BRIDGE_FRAGMENTS` bounds the walk by FRAGMENT COUNT, deliberately not by gap byte length: a
+byte-length gap bound is defeated by repeating the delimiter (e.g. three U+200B in a row instead
+of one), while a fragment count cannot be bypassed that way since repeating a delimiter inside a
+single gap never creates a new fragment. Each extension consumes one real fragment plus up to
+`MAX_BRIDGE_GLUE_TOKENS` delimiter-only glue tokens crossed to reach it, and the walk stops the
+moment a gap contains an ASCII alphanumeric character — this keeps reconstruction to a small
+local neighborhood rather than a document-wide scan, even for a document seeded with a long run
+of punctuation-only tokens (`--- --- --- ...`).
+
+`MIN_BRIDGE_FRAGMENT_LEN` is the shortest bare token treated as a plausible fragment (the
+`is_bridge_candidate` check in `check_entropy_heuristic`). Below this length, common short words
+(`dead`, `beef`, `cafe`, or their base64-alphabet equivalents) would let ordinary prose feed the
+bridge checks. It applies equally to hex and generic alphanumeric fragments — a
+base64/base64url-shaped credential half is exactly as plausible a bridge candidate as a hex half;
+the entropy/length decision made over the reconstructed chain, not this floor, is what keeps
+ordinary short prose fragments from being flagged.
+
 ## is_structured_identifier
 
 A structured identifier decomposes into two or more maximal ASCII-alphanumeric "runs" separated

--- a/crates/khive-runtime/docs/operations.md
+++ b/crates/khive-runtime/docs/operations.md
@@ -1,0 +1,92 @@
+# Operations — Design Notes
+
+`operations.rs` composes storage capabilities into the runtime's user-facing verbs (create, get,
+list, search, link, traverse, query, recall, etc.). This document collects design rationale that
+doesn't belong as inline comments: why the file isn't split into submodules, and the fault-injection
+testing infrastructure it hosts. The in-source comments carry only short pointers here.
+
+## Why this file is not split into submodules
+
+All verbs share internal helpers (namespace checks, edge validation, canonical-endpoint logic)
+that require `pub(crate)` access — splitting into submodules would require `pub(crate)`
+re-exports across every helper or circular dependencies, and inline tests exercise those private
+helpers directly. Split plan: once the verb surface stabilises post-retrieval-refactor, group by
+substrate (entity, note, edge, search) into submodules under an `operations/` directory.
+
+## Fault-injection arm migration
+
+Namespace-targeted fault injection uses scoped guards. The former `arm_fts_fail`,
+`arm_fts_fail_many`, `arm_fts_fail_many_partial`, and `arm_vector_fail` names were removed in
+favor of their `_scoped` variants so stale statement-form calls fail to compile. Statement-form
+arming cannot be preserved because dropping the returned guard at the semicolon disarms an
+unconsumed injection.
+
+## Concurrency and correctness notes
+
+### atomic_hard_delete_with_edge_purge
+
+The endpoint row delete and the incident-edge cascade used to run as two independently-committing
+storage calls. A concurrent guarded write (`upsert_edge_guarded`/`upsert_edges_guarded`) landing
+between them could see the endpoint still live, insert a fresh edge against it, and then survive
+the cascade that already ran — a durably dangling edge with no second purge. Routing both
+statements through one `run_atomic_unit` call closes the window: since every write (this one and
+the guarded insert) funnels through the same single-writer queue, a concurrent guarded write
+either fully commits before this unit starts (and its edge is then swept by the purge below, in
+the same transaction as the row delete) or fully commits after this unit has already committed
+(and its own endpoint-existence check then sees the endpoint gone and refuses the write) — there
+is no state in which it can observe the endpoint alive with edges already purged.
+
+### merge_traversal_paths_by_root
+
+`traverse` queries every namespace in the token's visible set independently — including
+namespaces that don't own the root at all, which still contribute a root-only entry when
+`include_roots` is set — and each per-namespace call already enforces `limit` on its own results.
+Concatenating them naively would let a root visible in N namespaces return up to N * limit nodes,
+would keep whichever namespace's copy of a shared node happened to arrive first (wrong
+depth/`via_edge` when that wasn't the shortest path, non-BFS ordering), and would rebuild a
+seen-set from scratch per namespace (quadratic in namespace count). The merge keys by
+`(root_id, node_id)`, keeps the node's shallowest depth and the `via_edge` that produced it
+(first-namespace-processed wins ties at equal depth — deterministic but not otherwise decidable
+which tied edge is "more correct"), reorders BFS-style (ascending depth), and re-applies `limit`
+to the merged non-root node count.
+
+### update_edge_symmetric_dml
+
+DML text is the single source of truth shared with the atomic `prepare_update_edge` symmetric
+branch (`khive_db::stores::graph::EDGE_SYMMETRIC_CONFLICT_PROBE_SQL` /
+`EDGE_SYMMETRIC_DELETE_NONCANONICAL_SQL` / `EDGE_SYMMETRIC_UPDATE_INPLACE_SQL`): this function
+binds them against `rusqlite::params!` (it runs inside an existing transaction on a borrowed
+`&rusqlite::Connection`), while the atomic path binds the same text via `SqlValue` plan params —
+see the constants' doc comment in `khive-db` for why a single bridge type isn't used for both.
+
+## Fault-injection static state
+
+Several `thread_local!`/`static` items in this file back the test-only fault-injection surface
+(`cfg(any(test, feature = "fault-injection"))`), gated out of production/published binaries.
+External integration test crates enable it via `khive-runtime = { ..., features =
+["fault-injection"] }`.
+
+- `LINK_FAIL_AFTER` (test-only): failure injection for `create_note_inner`.
+- `VECTOR_FAIL_AFTER`: count-targetable vector-INSERT fault. When set to `N` (N > 0), the next N
+  vector insert calls (entity or note, single- or multi-model) succeed and the (N+1)-th returns an
+  injected error, then the counter resets to 0. `thread_local!` gives per-thread isolation
+  (`#[tokio::test]` uses a current-thread runtime, so there's no thread migration mid-test),
+  letting a test fail one specific model's insert in a multi-model fan-out without depending on
+  `VECTOR_FAIL_NS`'s namespace match.
+- `FTS_FAIL_NS` / `VECTOR_FAIL_NS` / `ENTITY_COMPENSATION_FAIL_NS` / `FTS_FAIL_MANY_NS` /
+  `FTS_FAIL_MANY_PARTIAL_NS`: namespace-keyed one-shot arm sets, not a single `Option<String>`
+  slot. `create_note_inner` and `create_entity_inner` share `FTS_FAIL_NS`/`VECTOR_FAIL_NS`, and a
+  single-slot design let a concurrently running test's `arm_fts_fail_scoped(other_ns)` overwrite
+  this test's armed namespace before its own create call consumed it, so the intended injection
+  silently never fired (#1095). Keying by namespace fixes that at the root — arming `ns_B` inserts
+  `ns_B` without evicting `ns_A`. These are process-wide (not thread-local) so a caller may arm on
+  one OS thread and run the triggering `create_note`/`create_entity` on another (e.g. via
+  `tokio::spawn` on a multi-thread runtime); the check-and-remove under the mutex lock keeps
+  exactly-once semantics even under concurrent same-namespace creates. `FTS_FAIL_MANY_NS` /
+  `FTS_FAIL_MANY_PARTIAL_NS` are separate from `FTS_FAIL_NS` so `create_note_inner` and
+  `create_many` tests cannot disarm each other (#1263) — the "partial" variant returns
+  `Ok(BatchWriteSummary)` with `failed > 0` so the `summary.failed > 0` rollback branch is
+  exercised, distinct from the hard-`Err` variant.
+- `ENTITY_COMPENSATION_FAIL_NS`: entity-create compensation failure injection. The matching
+  compensation skips only the entity-row delete; FTS/vector cleanup still runs so tests can
+  inspect the exact residual state and combined error contract.

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -1,21 +1,7 @@
-// FILE SIZE JUSTIFICATION: operations.rs is the single coherent surface for all
-// runtime verb implementations (create, get, list, search, link, traverse, query,
-// recall, etc.). All verbs share internal helpers (namespace checks, edge validation,
-// canonical-endpoint logic) that require pub(crate) access — splitting into submodules
-// would require pub(crate) re-exports across every helper or circular dependencies.
-// Inline tests exercise those private helpers directly. Split plan: once the verb
-// surface stabilises post-retrieval-refactor, group by substrate (entity,
-// note, edge, search) into submodules under an `operations/` directory.
+// See docs/operations.md#why-this-file-is-not-split-into-submodules.
 //! High-level operations composing storage capabilities into user-facing verbs.
 //!
-//! # Fault-injection arm migration
-//!
-//! Namespace-targeted fault injection uses scoped guards. The former
-//! `arm_fts_fail`, `arm_fts_fail_many`, `arm_fts_fail_many_partial`, and
-//! `arm_vector_fail` names were removed in favor of their `_scoped` variants so
-//! stale statement-form calls fail to compile. Statement-form arming cannot be
-//! preserved because dropping the returned guard at the semicolon disarms an
-//! unconsumed injection.
+//! Fault-injection arming uses scoped guards only — see docs/operations.md#fault-injection-arm-migration.
 
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -50,24 +36,12 @@ use crate::curation::{entity_fts_document, note_embedding_text_ref, note_fts_doc
 use crate::error::{GuardedWriteFailure, RuntimeError, RuntimeResult};
 use crate::runtime::{KhiveRuntime, NamespaceToken};
 
-// Test-only failure injection for `create_note_inner`. Namespace-targeted so only
-// calls for the armed namespace fire, avoiding cross-test races without `#[serial]`.
-// Gated behind `cfg(any(test, feature = "fault-injection"))` so no lock acquisitions
-// or injection surface exist in production/published binaries. External integration
-// test crates enable it via a dev-dependency: khive-runtime = { ..., features = ["fault-injection"] }
+// Test-only fault-injection state; see docs/operations.md#fault-injection-static-state.
 #[cfg(test)]
 std::thread_local! {
     static LINK_FAIL_AFTER: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 
-// Count-targetable vector-INSERT fault injection: when set to N (N > 0), the next N
-// vector insert calls (entity or note, single- or multi-model) succeed and the
-// (N+1)-th returns an injected error, then the counter resets to 0.
-// `thread_local!` provides per-thread isolation (`#[tokio::test]` uses a
-// current-thread runtime, so there is no thread migration mid-test), letting a
-// test fail one specific model's insert in a multi-model fan-out and giving any
-// caller whose test suite shares a default namespace a deterministic, race-free
-// injection instead of depending on `VECTOR_FAIL_NS`'s namespace match.
 #[cfg(any(test, feature = "fault-injection"))]
 std::thread_local! {
     static VECTOR_FAIL_AFTER: std::cell::Cell<Option<usize>> =
@@ -75,28 +49,14 @@ std::thread_local! {
 }
 
 /// Arm the count-targetable vector-INSERT fault: let `n` inserts succeed, then fail
-/// the next one (entity or note, single- or multi-model). Set `n = 0` to fail
-/// immediately on the first insert. Thread-local, so unlike `arm_vector_fail_scoped`
-/// it cannot be won or disarmed by a concurrently-running test on another
-/// thread — prefer this one whenever the caller cannot guarantee it is the
-/// only test writing into the namespace it cares about.
-/// Available when compiled with `cfg(test)` or `feature = "fault-injection"`.
+/// the next one. See docs/operations.md#fault-injection-static-state.
 #[cfg(any(test, feature = "fault-injection"))]
 pub fn arm_vector_fail_after(n: usize) {
     VECTOR_FAIL_AFTER.with(|cell| cell.set(Some(n)));
 }
 
-// Namespace-keyed one-shot arms, not a single `Option<String>` slot:
-// `create_note_inner` and `create_entity_inner` share this flag, and a
-// single-slot design let a concurrently running test's `arm_fts_fail_scoped(other_ns)`
-// overwrite this test's armed namespace before its own create call consumed
-// it, so the intended injection silently never fired (#1095). Keying by
-// namespace fixes that at the root — arming `ns_B` inserts `ns_B` without
-// evicting `ns_A`. Process-wide (not thread-local) so a caller may arm on
-// one OS thread and run the triggering `create_note`/`create_entity` on
-// another (e.g. via `tokio::spawn` on a multi-thread runtime); the
-// check-and-remove under the mutex lock keeps exactly-once semantics even
-// under concurrent same-namespace creates.
+// Namespace-keyed one-shot arm sets — see docs/operations.md#fault-injection-static-state
+// (rationale for keying by namespace instead of a single Option<String> slot, #1095).
 #[cfg(any(test, feature = "fault-injection"))]
 type FaultArmSet = std::sync::Mutex<std::collections::HashMap<String, std::sync::Arc<()>>>;
 #[cfg(any(test, feature = "fault-injection"))]
@@ -104,26 +64,20 @@ const MAX_FAULT_ARMS: usize = 64;
 #[cfg(any(test, feature = "fault-injection"))]
 static FTS_FAIL_NS: std::sync::LazyLock<FaultArmSet> =
     std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
-// Vector insertion failures use the same namespace-keyed one-shot semantics.
 #[cfg(any(test, feature = "fault-injection"))]
 static VECTOR_FAIL_NS: std::sync::LazyLock<FaultArmSet> =
     std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
-/// Entity-create compensation failure injection. The matching compensation
-/// skips only the entity-row delete; FTS/vector cleanup still runs so tests can
-/// inspect the exact residual state and combined error contract.
+/// Entity-create compensation failure injection; see docs/operations.md#fault-injection-static-state.
 #[cfg(any(test, feature = "fault-injection"))]
 static ENTITY_COMPENSATION_FAIL_NS: std::sync::LazyLock<FaultArmSet> =
     std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
-/// FTS failure injection for `create_many` — separate from `FTS_FAIL_NS` so that
-/// create_note_inner and create_many tests cannot disarm each other. Namespace-keyed
-/// set (not a single `Option<String>` slot) for the same reason as `VECTOR_FAIL_NS` (#1263).
+/// `create_many` FTS failure injection, kept separate from `FTS_FAIL_NS` (#1263); see
+/// docs/operations.md#fault-injection-static-state.
 #[cfg(any(test, feature = "fault-injection"))]
 static FTS_FAIL_MANY_NS: std::sync::LazyLock<FaultArmSet> =
     std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
-/// FTS partial-failure injection for `create_many` — returns `Ok(BatchWriteSummary)`
-/// with `failed > 0` so that the `summary.failed > 0` rollback branch is exercised.
-/// Distinct from `FTS_FAIL_MANY_NS` which injects a hard `Err`. Namespace-keyed set
-/// for the same reason as `VECTOR_FAIL_NS` (#1263).
+/// `create_many` FTS partial-failure injection (exercises the `summary.failed > 0` rollback
+/// branch); see docs/operations.md#fault-injection-static-state.
 #[cfg(any(test, feature = "fault-injection"))]
 static FTS_FAIL_MANY_PARTIAL_NS: std::sync::LazyLock<FaultArmSet> =
     std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
@@ -618,20 +572,14 @@ fn accepted_pack_relations_for_pattern_entities(
 
 /// All `(source_kind, target_kind)` entity-kind pairs — restricted to the closed
 /// 8-kind base [`khive_types::EntityKind`] taxonomy — that accept `relation`
-/// under the composed base allowlist plus pack `EDGE_RULES`.
-///
-/// Reuses [`base_entity_rule_allows`] and [`accepted_pack_relations_for_pattern_entities`]
-/// (the pattern-side, unconstrained-`None` counterpart of the functions the live
-/// validator consults) over the closed kind set, rather than re-deriving a
-/// parallel table — issue #543 precedent, applied to GQL query-pattern hint
-/// derivation (issue #593).
-///
-/// Pack rules are skipped when `crate::pack::is_special_relation` is true
-/// (supersedes / supports / refutes): the live validator's special-relation branch
-/// (`validate_edge_relation_endpoints`, this file) resolves those relations
-/// before `pack_rule_allows` is ever reached, so a pack `EDGE_RULES` entry for
-/// one of them is never actually enforced (see `pack.rs`'s
-/// `edge_endpoint_table` doc comment for the authoritative statement of this).
+/// under the composed base allowlist plus pack `EDGE_RULES`. Reuses
+/// [`base_entity_rule_allows`] and [`accepted_pack_relations_for_pattern_entities`]
+/// over the closed kind set rather than re-deriving a parallel table (for GQL
+/// query-pattern hint derivation). Pack rules are skipped when
+/// `crate::pack::is_special_relation` is true (supersedes/supports/refutes):
+/// those relations are resolved by the live validator's special-relation branch
+/// before `pack_rule_allows` is ever reached — see `pack.rs`'s
+/// `edge_endpoint_table` doc comment.
 fn accepted_entity_kind_pairs_for_relation(
     pack_rules: &[EdgeEndpointRule],
     relation: EdgeRelation,
@@ -1046,27 +994,10 @@ fn note_graph_name(note: &Note) -> String {
         .unwrap_or_else(|| format!("[{}]", note.kind))
 }
 
-/// Collapse per-namespace `GraphPath`s from [`KhiveRuntime::traverse`] down to
-/// exactly one entry per distinct `root_id`.
-///
-/// `traverse` queries every namespace in the token's visible set
-/// independently — including namespaces that don't own the root at all,
-/// which still contribute a root-only entry when `include_roots` is set —
-/// and each of those per-namespace calls already enforces `limit` on its own
-/// results. Concatenating them naively before this function would let a root
-/// visible in N namespaces return up to N * limit nodes, would keep
-/// whichever namespace's copy of a shared node happened to arrive first
-/// (wrong depth/`via_edge` when that wasn't the shortest path, and
-/// non-BFS ordering), and would rebuild a seen-set from scratch per
-/// namespace (quadratic in namespace count).
-///
-/// This merges by `(root_id, node_id)` keeping the node's shallowest depth
-/// and the `via_edge` that produced it (first-namespace-processed wins ties
-/// at equal depth — namespace processing order is deterministic but which
-/// tied edge is "more correct" is not otherwise decidable), reorders the
-/// merged result BFS-style (ascending depth), and re-applies `limit` to the
-/// merged non-root node count so the response honors the contract each
-/// individual namespace call already tried to.
+/// Collapse per-namespace `GraphPath`s from [`KhiveRuntime::traverse`] down to exactly
+/// one entry per distinct `root_id`, merging by `(root_id, node_id)` (shallowest depth
+/// wins), BFS-ordering the result, and re-applying `limit`. See
+/// docs/operations.md#merge_traversal_paths_by_root for why naive concatenation is unsound.
 fn merge_traversal_paths_by_root(paths: Vec<GraphPath>, limit: Option<u32>) -> Vec<GraphPath> {
     let mut order: Vec<Uuid> = Vec::new();
     let mut merged: HashMap<Uuid, GraphPath> = HashMap::new();
@@ -4419,33 +4350,17 @@ impl KhiveRuntime {
         Ok(None)
     }
 
-    /// Hard-delete a single graph node (entity, note, or edge-as-node row)
-    /// AND purge its incident edges in ONE write transaction.
-    ///
-    /// The endpoint row delete and the incident-edge cascade used
-    /// to run as two independently-committing storage calls. A concurrent
-    /// guarded write (`upsert_edge_guarded`/`upsert_edges_guarded`) landing
-    /// between them could see the endpoint still live, insert a fresh edge
-    /// against it, and then survive the cascade that already ran — a
-    /// durably dangling edge with no second purge. Routing both statements
-    /// through one [`run_atomic_unit`] call closes the window: since every
-    /// write (this one and the guarded insert) funnels through the same
-    /// single-writer queue, a concurrent guarded write either fully commits
-    /// before this unit starts (and its edge is then swept by the purge
-    /// below, in the same transaction as the row delete) or fully commits
-    /// after this unit has already committed (and its own endpoint-existence
-    /// check then sees the endpoint gone and refuses the write) — there is
-    /// no state in which it can observe the endpoint alive with edges
-    /// already purged.
+    /// Hard-delete a single graph node (entity, note, or edge-as-node row) AND purge its
+    /// incident edges in ONE write transaction — closes a race where a concurrent guarded
+    /// write could insert a fresh edge against the endpoint between two separately
+    /// committed calls; see docs/operations.md#atomic_hard_delete_with_edge_purge.
     ///
     /// `row_statement` is the exact hard-delete `DELETE` for the target row
     /// (entity, note, or edge). Before the incident-edge purge, the same plan
     /// appends any ADR-002 lineage-loss warnings from the still-present edge
     /// rows, so the warning payload and cascade commit or roll back together.
-    /// Returns `Ok(true)` if the row was deleted,
-    /// `Ok(false)` if it no longer existed (lost a race with a concurrent
-    /// delete of the same row) — never an error for that case, matching the
-    /// non-atomic bool-returning shape callers had before this fix.
+    /// Returns `Ok(true)` if the row was deleted, `Ok(false)` if it no longer
+    /// existed (lost a race with a concurrent delete of the same row).
     async fn atomic_hard_delete_with_edge_purge(
         &self,
         row_statement: SqlStatement,
@@ -5062,12 +4977,9 @@ impl KhiveRuntime {
     pub const EDGE_LIST_MAX_LIMIT: u32 = 1000;
 
     /// List edges matching `filter`, paging by `offset`. `limit` is capped at
-    /// [`Self::EDGE_LIST_MAX_LIMIT`]; defaults to 100.
-    ///
-    /// `offset` pages through the full matching set (previously hard-coded to
-    /// 0, so every page returned the same first rows). For
-    /// O(1)-at-depth walks over large edge populations, prefer
-    /// [`Self::list_edges_after`] instead of paging offset deep.
+    /// [`Self::EDGE_LIST_MAX_LIMIT`]; defaults to 100. For O(1)-at-depth walks
+    /// over large edge populations, prefer [`Self::list_edges_after`] instead
+    /// of paging offset deep.
     pub async fn list_edges(
         &self,
         token: &NamespaceToken,
@@ -5271,17 +5183,8 @@ impl KhiveRuntime {
     /// Returns `Ok(Some(existing_id))` when a canonical conflict was absorbed (the
     /// requested edge was deleted, the existing canonical row left untouched per
     /// ADR-039 DO NOTHING), or `Ok(None)` when the requested edge was updated in
-    /// place.
-    ///
-    /// DML text is the single source of truth shared with the atomic
-    /// `prepare_update_edge` symmetric branch:
-    /// [`khive_db::stores::graph::EDGE_SYMMETRIC_CONFLICT_PROBE_SQL`] /
-    /// `EDGE_SYMMETRIC_DELETE_NONCANONICAL_SQL` /
-    /// `EDGE_SYMMETRIC_UPDATE_INPLACE_SQL` — this function binds them against
-    /// `rusqlite::params!` (it runs inside an existing transaction on a
-    /// borrowed `&rusqlite::Connection`), the atomic path binds the same text
-    /// via `SqlValue` plan params; see the constants' doc comment in
-    /// `khive-db` for why a single bridge type isn't used for both.
+    /// place. Shares its DML text with the atomic `prepare_update_edge` symmetric
+    /// branch — see docs/operations.md#update_edge_symmetric_dml.
     #[allow(clippy::too_many_arguments)]
     fn update_edge_symmetric_dml(
         conn: &rusqlite::Connection,
@@ -6582,15 +6485,10 @@ mod tests {
         assert!((updated.weight - 0.5).abs() < 0.001);
     }
 
-    /// Regression test: `update_edge_symmetric_dml` previously stored
-    /// `updated_at` via `chrono::Utc::now().timestamp()` (SECONDS) while every
-    /// other `graph_edges` write path (`edge_upsert_statement`,
-    /// `edge_soft_delete_statement`) uses `timestamp_micros()`: a genuine
-    /// pre-existing bug, found while unifying this raw-SQL path with the
-    /// atomic builder (which already used `timestamp_micros()` correctly)
-    /// onto the shared `EDGE_SYMMETRIC_*_SQL` text. A seconds value misread as
-    /// microseconds round-trips to a date a few minutes after the Unix epoch,
-    /// not "now".
+    /// `updated_at` on this path must use `timestamp_micros()`, matching every other
+    /// `graph_edges` write path (`edge_upsert_statement`, `edge_soft_delete_statement`);
+    /// a seconds value misread as microseconds round-trips to a date a few minutes
+    /// after the Unix epoch, not "now".
     #[tokio::test]
     async fn update_edge_symmetric_relation_stores_microsecond_updated_at() {
         let rt = rt();
@@ -9251,21 +9149,12 @@ mod tests {
     }
 
     // ---- file-backed, both write-queue configs ----
-    //
-    // The six tests above run against `KhiveRuntime::memory()` and race
-    // delete against the guarded write via `tokio::join!` with no explicit
-    // ordering control, so the scheduler could run them fully sequentially
-    // on one thread without ever exercising real interleaving, and neither
-    // the file-backed storage path nor `write_queue_enabled: Some(true)`
-    // (`KHIVE_WRITE_QUEUE=1`, the `WriterTask`-routed write path in
-    // `SqlGraphStore`) is covered at all. The four tests below close both
-    // gaps: file-backed databases, one run with the writer queue off
-    // (default) and one with it on, each provably forcing the guarded write
-    // to land on one specific side of the delete — fully committed before
-    // the delete starts (swept by the delete's cascade) and attempted only
-    // after the delete has already committed (refused by the guard) — via
-    // plain `.await` sequencing rather than a race whose outcome the test
-    // does not control.
+    // The six tests above race delete against the guarded write via `tokio::join!` with
+    // no ordering control, so the scheduler could run them fully sequentially without
+    // exercising real interleaving, and neither the file-backed storage path nor
+    // `write_queue_enabled: Some(true)` (`KHIVE_WRITE_QUEUE=1`) is covered. The four
+    // tests below force the guarded write to land on one specific side of the delete via
+    // plain `.await` sequencing instead of an uncontrolled race.
 
     fn file_backed_runtime(
         dir: &tempfile::TempDir,
@@ -10014,7 +9903,6 @@ mod tests {
 
     // ---- supersedes same-substrate contract ----
 
-    // Headline regression: note→note supersedes must succeed (was wrongly rejected before this fix).
     #[tokio::test]
     async fn link_supersedes_note_to_note_succeeds() {
         let rt = rt();
@@ -10448,7 +10336,6 @@ mod tests {
         );
     }
 
-    // Sanity: annotates note→edge still succeeds (unchanged path not broken by this fix).
     #[tokio::test]
     async fn link_annotates_note_to_edge_still_succeeds_after_fix() {
         let rt = rt();
@@ -12508,12 +12395,9 @@ mod tests {
         );
     }
 
-    // ── Traversal across namespace labels now succeeds ────────────────────────
-    //
-    // Previously, traverse with ns_b token + ns_a root was silently empty
-    // because substrate_exists_in_ns → get_entity rejected cross-namespace lookups.
-    // Now: get_entity finds any entity by UUID; traverse finds the root and
-    // returns paths scoped to the graph store's namespace filter for ns_b.
+    // get_entity finds any entity by UUID; traverse finds the root and returns paths
+    // scoped to the graph store's namespace filter for ns_b, even when the token's
+    // namespace differs from the root's.
     #[tokio::test]
     async fn traverse_cross_namespace_root_is_accepted() {
         use khive_storage::types::TraversalOptions;

--- a/crates/khive-runtime/src/secret_gate.rs
+++ b/crates/khive-runtime/src/secret_gate.rs
@@ -606,40 +606,16 @@ const TRIGGER_WINDOW: usize = 120;
 /// [`contains_normalized_hex_credential`].
 const HEX_CREDENTIAL_LENGTHS: &[usize] = &[32, 40, 64, 128];
 
-/// Largest number of tokenizer fragments (inclusive of the anchor token)
-/// [`bridge_fragment_chain`] will concatenate when checking whether a
-/// trigger-adjacent short token is one piece of a delimiter-split credential.
-/// The bound is on FRAGMENT COUNT, deliberately NOT on gap byte length:
-/// a byte-length gap bound is defeated outright by
-/// repeating the delimiter (e.g. three U+200B in a row instead of one), while
-/// a fragment count cannot be bypassed that way — repeating the delimiter
-/// inside a single gap never creates a new fragment. This still bounds the
-/// reconstruction to a small local neighborhood (never a document-wide scan):
-/// each extension consumes one real fragment plus up to
-/// [`MAX_BRIDGE_GLUE_TOKENS`] delimiter-only glue tokens crossed to reach it,
-/// and the walk stops the moment a gap contains an ASCII alphanumeric character.
+/// Max fragments [`bridge_fragment_chain`] concatenates per credential (fragment-count bound,
+/// not gap byte length — see docs/api/secret_gate.md#bridge-fragment-reconstruction).
 const MAX_BRIDGE_FRAGMENTS: usize = 6;
 
-/// Maximum number of delimiter-only tokens (see [`is_delimiter_only_token`])
-/// the walk may absorb as glue, in ONE direction, while searching for the
-/// next real fragment across them. Glue tokens do
-/// not count against [`MAX_BRIDGE_FRAGMENTS`] — they carry none of the
-/// credential's own characters — but the search across them still needs its
-/// own bound, or a document seeded with a long run of punctuation-only
-/// tokens (`--- --- --- ...`) could turn the walk into a document-wide scan
-/// instead of the small local neighborhood the module doc promises.
+/// Max delimiter-only glue tokens absorbed per direction while bridging fragments; see
+/// docs/api/secret_gate.md#bridge-fragment-reconstruction.
 const MAX_BRIDGE_GLUE_TOKENS: usize = 6;
 
-/// Shortest bare token treated as a plausible FRAGMENT of a separator-split
-/// credential (see the `is_bridge_candidate` check in
-/// [`check_entropy_heuristic`]). Below this, common short words (`dead`,
-/// `beef`, `cafe`, or their base64-alphabet equivalents) would let ordinary
-/// prose feed the bridge checks. Applies to hex AND generic alphanumeric
-/// fragments alike — a
-/// base64/base64url-shaped credential half is exactly as plausible a bridge
-/// candidate as a hex half; the entropy/length decision made over the
-/// reconstructed chain, not this floor, is what keeps ordinary short prose
-/// fragments from being flagged.
+/// Shortest bare token treated as a plausible bridge fragment; see
+/// docs/api/secret_gate.md#bridge-fragment-reconstruction.
 const MIN_BRIDGE_FRAGMENT_LEN: usize = 8;
 
 /// Largest index `<= i` that lies on a UTF-8 char boundary of `s`. Stable
@@ -658,13 +634,10 @@ fn floor_char_boundary(s: &str, i: usize) -> usize {
 /// `text`. This lets [`mask_secrets`] advance past an earlier redaction without
 /// losing a trigger word that sat to the left of it.
 fn check_entropy_heuristic(text: &str, from: usize) -> Option<(&str, &'static str)> {
-    // Tokenize into maximal ASCII non-whitespace runs, recording each run's byte
-    // offset.  Non-ASCII characters are delimiters (alongside ASCII whitespace):
-    // real base64/hex/base64url credentials are ASCII, so splitting on non-ASCII
-    // isolates an ASCII credential glued to CJK text/punctuation/fullwidth
-    // whitespace, while a run of natural-language CJK yields no ASCII run long
-    // enough to trip the length floor below.  On pure-ASCII input this is
-    // identical to `split_ascii_whitespace`.
+    // Tokenize into maximal ASCII non-whitespace runs; non-ASCII chars are also
+    // delimiters (see docs/api/secret_gate.md#module-level-detection-algorithm,
+    // "non-ASCII token delimiting"). Identical to `split_ascii_whitespace` on
+    // pure-ASCII input.
     let tokens: Vec<(usize, &str)> = text
         .split(|c: char| c.is_ascii_whitespace() || !c.is_ascii())
         .filter(|t| !t.is_empty())
@@ -683,20 +656,9 @@ fn check_entropy_heuristic(text: &str, from: usize) -> Option<(&str, &'static st
         if token_offset < from {
             continue;
         }
-        // A token below MIN_ENTROPY_LEN is still let through when it is
-        // itself a plausible FRAGMENT of a separator-split credential (a
-        // bare alphanumeric run of at least MIN_BRIDGE_FRAGMENT_LEN) — see
-        // the normalized-hex-concatenation and fragment-chain-bridge checks
-        // below. Gating on hex-only fragments would let a base64/base64url-shaped
-        // credential half through untouched: neither half of a Unicode-split
-        // base64-like secret is pure hex, so both would be skipped here before
-        // ever reaching the near-trigger checks. Gating on "any alphanumeric run"
-        // instead of
-        // "any run" still keeps ordinary prose out: a token containing
-        // spaces, punctuation, or other separators already split into
-        // smaller pieces by the tokenizer above, and the bridge/entropy
-        // decision applied to the reconstructed chain below is what actually
-        // filters unrelated short fragments — not this length floor.
+        // A token below MIN_ENTROPY_LEN still passes through when it's a plausible
+        // bridge FRAGMENT (see docs/api/secret_gate.md#bridge-fragment-reconstruction);
+        // gating on alphanumeric runs (not hex-only) covers base64/base64url halves too.
         let is_bridge_candidate = is_bridge_fragment_shape(token);
         if token.len() < MIN_ENTROPY_LEN && !is_bridge_candidate {
             continue;
@@ -714,45 +676,16 @@ fn check_entropy_heuristic(text: &str, from: usize) -> Option<(&str, &'static st
         let raw_start = tok_offset - window_start;
         let raw_end = raw_start + raw_token.len();
 
-        // A high-entropy candidate must not provide its own surrounding
-        // trigger context. This matters for paths whose slugs contain a real
-        // trigger token, such as `ADR-051-cli-auth-and-kg-git-workflow.md`.
-        // Search the prose on either side independently, then preserve inline
-        // credential shapes through a focused assignment/config check.
+        // Must not provide its own trigger context (e.g. a path slug like
+        // `ADR-051-cli-auth-and-kg-git-workflow.md`); see
+        // docs/api/secret_gate.md#check_entropy_heuristic--per-token-flagging-sequence.
         let near_trigger = contains_trigger(&window[..raw_start])
             || contains_trigger(&window[raw_end..])
             || has_inline_credential_trigger(raw_token);
 
-        // UUID canonical form and sha-prefixed base64 content hashes (SRI /
-        // npm lockfile integrity) are allowlisted only outside trigger
-        // context. Near a trigger, both shapes fall through to detection
-        // below instead of being silently passed.
-        //
-        // A UUID's own character entropy cannot be relied on to catch it once
-        // it falls through: hex digits cap at log2(16) = 4.0 bits/char, which
-        // never reaches ENTROPY_THRESHOLD (4.5) regardless of token length.
-        // The explicit checks immediately below are what actually block a
-        // UUID-shaped or hash-shaped token in trigger context; letting it run
-        // into the generic entropy computation at the bottom of this loop
-        // would silently readmit it. A corpus replay of ~19k real notes/docs
-        // measured exactly one benign token (an internal task `area_id` UUID
-        // co-occurring with the word "auth" inside `authorized_write`) newly
-        // blocked by this rule — an accepted false positive, not a systemic
-        // regression.
-        //
-        // Both exact-shape checkers require the WHOLE token to match, so a
-        // credential glued to ordinary storage syntax (`api_key=<uuid>`,
-        // `(<uuid>)`, `{"api_key":"<uuid>"}`, a trailing sentence period,
-        // a doubled assignment, or a label itself containing `:`/`=`)
-        // would otherwise never reach them: `strip_delimiters` above only
-        // trims `"'`:=,;` at the token's OUTER ends, not braces/parens, and
-        // not an internal `=`/`:` from an assignment form. `value_candidates`
-        // enumerates every plausible value extraction from those glued forms
-        // specifically for this pair of checks — it does not replace `token`
-        // for any other check in this loop (entropy, hex, structured-
-        // identifier), none of which require an exact shape match. This is a
-        // small bounded iteration over separator positions in one token, not
-        // an allocation-heavy scan.
+        // Step 1 (see doc: per-token flagging sequence). UUID/content-hash checks fall
+        // through to detection near a trigger rather than being silently passed —
+        // hex-shaped entropy alone (<=4.0 bits/char) can never reach ENTROPY_THRESHOLD.
         if near_trigger && value_candidates(token).any(is_uuid_canonical) {
             return Some((token, "uuid-near-trigger"));
         }
@@ -763,31 +696,14 @@ fn check_entropy_heuristic(text: &str, from: usize) -> Option<(&str, &'static st
             continue;
         }
 
-        // Pure hex tokens (git SHA, checksum digests) are allowlisted when they
-        // are not near a trigger. Trigger-adjacent Git revisions require an
-        // explicit VCS coordinate marker.
+        // Step 2. Pure hex off-trigger is allowlisted; trigger-adjacent hex needs an
+        // explicit VCS coordinate marker (see doc).
         if !near_trigger && is_pure_hex(token) {
             continue;
         }
 
-        // A 40-hex value attached to a VCS coordinate marker (`commit`,
-        // `revision`, `rev`, `sha`) is a public VCS coordinate, not a
-        // credential — but ONLY when the surrounding clause carries no
-        // credential label ("api key value is commit <hex>" is a labeled
-        // credential wearing a marker). The exemption is a flag, not an early
-        // `continue`: it must skip ONLY the hex-credential-shape checks
-        // below, never fragment reconstruction — an exempted anchor that
-        // skipped reconstruction would let a marker-adjacent fragment hide a
-        // split credential (the same anchor-ordering rule the file-path
-        // exemption pins via
-        // `blocks_unicode_split_hex_credential_with_path_shaped_anchor`).
-        // Marker-word form: the token IS a bare `commit`/`revision`/`rev`/
-        // `sha` whose next token is the 40-hex value. A fixed marker word is
-        // not attacker-controlled credential material, so a full `continue`
-        // is safe here — without it the marker would anchor fragment
-        // reconstruction and re-accumulate its own legitimate neighboring
-        // revision. The hex value itself is a separate token and receives
-        // the full check sequence on its own iteration.
+        // VCS-marker exemption is a flag over the hex-credential-shape checks only,
+        // never an early skip of fragment reconstruction below (see doc).
         if is_vcs_marker_before_hex(text, raw_token)
             && !has_clause_credential_label(
                 text,
@@ -807,14 +723,8 @@ fn check_entropy_heuristic(text: &str, from: usize) -> Option<(&str, &'static st
                 ClauseValueKind::VcsReference,
             );
 
-        // Hex API keys (AWS secret access key, Stripe test keys, random hex
-        // tokens) are pure hex yet are real credentials.  The entropy heuristic
-        // cannot catch them — hex alphabet maxes at log2(16) = 4.0 bits/char,
-        // which is always below ENTROPY_THRESHOLD (4.5).  A credential-shaped
-        // hex token (32 / 40 / 64 / 128 chars) near a trigger word is always
-        // flagged. Generic "sha" or "hash" prose does not rescue a token;
-        // `is_git_revision_reference` requires a 40-hex value attached to a
-        // VCS coordinate marker.
+        // Step 3. Hex API keys aren't caught by the entropy heuristic (hex tops out at
+        // 4.0 bits/char, below ENTROPY_THRESHOLD 4.5); flag credential-shaped hex directly.
         if !vcs_reference_exempt
             && near_trigger
             && is_pure_hex(token)
@@ -823,28 +733,13 @@ fn check_entropy_heuristic(text: &str, from: usize) -> Option<(&str, &'static st
             return Some((token, "hex-credential-token"));
         }
 
-        // A genuine credential can be diluted below the WHOLE-TOKEN-AVERAGE
-        // entropy/hex checks above by low-entropy filler segments sharing the
-        // same whitespace token (issue #1044) — e.g. a 40-char hex payload or
-        // a random run as one `/`-delimited path segment among several short
-        // filler segments (`vault/<payload>/rotate.md`,
-        // `a/b/c/d/<payload>/e/f.rs`). Decomposing on every non-alphanumeric
-        // separator — the same run split `is_structured_identifier` uses —
-        // and re-running the hex-credential-length and entropy checks against
-        // each individual run independently of its surrounding filler closes
-        // that gap. Only `MIN_ENTROPY_LEN`+ runs are considered, so short
-        // natural-language path segments (the common case, verified against
-        // the #1040 measurement corpus: none of its real path false positives
-        // contain a single run this long) never trip it. This does NOT touch
-        // the `is_structured_identifier` exemption itself, which stays scoped
-        // to `!near_trigger` per the module doc's soundness argument — a run
-        // this long clearing its own entropy/hex check is evidence independent
-        // of that exemption's word-shape rule.
+        // Step 4 (issue #1044): a credential can dilute below the whole-token-average
+        // checks above via low-entropy filler sharing its whitespace token
+        // (`vault/<payload>/rotate.md`); re-check each `/`-split run independently.
+        // See doc for the #1040 corpus rationale behind the MIN_ENTROPY_LEN floor.
         if near_trigger {
-            // `vcs_reference_exempt` also covers the single-token forms these
-            // per-token shape checks would re-flag (`rev:<hex>` is one token
-            // whose 40-hex run and normalized-hex accumulation both match);
-            // it does NOT cover fragment reconstruction below.
+            // vcs_reference_exempt also covers single-token forms below (`rev:<hex>`);
+            // it does not cover fragment reconstruction.
             for run in token.split(|c: char| !c.is_ascii_alphanumeric()) {
                 if run.len() < MIN_ENTROPY_LEN {
                     continue;
@@ -860,101 +755,19 @@ fn check_entropy_heuristic(text: &str, from: usize) -> Option<(&str, &'static st
                 }
             }
 
-            // #1062: the per-run loop above still misses a credential hex
-            // payload split into MULTIPLE runs each individually below
-            // MIN_ENTROPY_LEN — e.g. `0123456789abcdef0123/456789abcdef01234567`
-            // (two 20-char hex runs joined by `/`): neither run alone reaches
-            // the 24-char floor or a HEX_CREDENTIAL_LENGTHS value, the whole
-            // token is not pure hex (the `/` breaks it), and the whole-token
-            // entropy is capped below ENTROPY_THRESHOLD by the small
-            // hex-plus-separator alphabet. Concatenating consecutive pure-hex
-            // runs (dropping the separators) and re-checking the combined
-            // length against the same HEX_CREDENTIAL_LENGTHS allowlist closes
-            // this gap without widening the allowlist itself. Bounded to the
-            // runs inside this one token, not a document-wide scan.
+            // Step 5 (#1062): concatenate consecutive pure-hex runs (dropping
+            // separators) and re-check against HEX_CREDENTIAL_LENGTHS — catches a
+            // hex payload split into multiple sub-floor runs. See doc.
             if !vcs_reference_exempt && contains_normalized_hex_credential(token) {
                 return Some((token, "hex-credential-token"));
             }
 
-            // Unicode/multi-fragment variant of the same bypass (#1062): a
-            // non-ASCII separator (e.g. U+200B) is a TOKENIZER delimiter (see
-            // the tokenizer comment above `tokens`), so it splits the payload
-            // into SEPARATE tokens instead of surviving inside one — the
-            // concatenation check above never sees the halves together.
-            // Bridging only ONE adjacent pair (`idx` with `idx + 1`, or `idx`
-            // with `idx - 1`) and bounding the gap by raw byte length is
-            // insufficient: repeating the delimiter (e.g. three U+200B in a
-            // row) exceeds any small fixed byte-length gap bound, and a
-            // three-token split means no single adjacent pair ever reaches
-            // the full credential length. `bridge_fragment_chain` fixes both:
-            // it walks outward in BOTH directions across a bounded CHAIN of
-            // fragments (MAX_BRIDGE_FRAGMENTS, not a byte-length gap), so
-            // repeating the delimiter cannot buy an attacker anything. A
-            // delimiter-only token sitting between two Unicode gaps (`---`
-            // glue) is itself transparent to the walk — see
-            // [`is_delimiter_only_token`] — so it is absorbed as gap material
-            // rather than treated as a chain-terminating non-fragment token.
-            // Every token found while extending from the anchor must itself
-            // be [`is_bridge_fragment_shape`] (alphanumeric,
-            // MIN_BRIDGE_FRAGMENT_LEN+): this is what stops the walk at a
-            // short trigger/glue word (`key`, `api`, `for`, 3-4 chars) rather
-            // than dragging prose into the reconstruction. The anchor is
-            // included unconditionally, so shape exemptions that can admit a
-            // long non-fragment anchor must run after this reconstruction.
-            //
-            // ACTUAL GUARANTEE (not "every three-or-more-way split is
-            // reconstructed", which this function does NOT provide):
-            // reconstruction covers splits of
-            // up to MAX_BRIDGE_FRAGMENTS real fragments (each individually
-            // meeting MIN_BRIDGE_FRAGMENT_LEN), where a single gap between
-            // two fragments may be any byte length but spans at most
-            // MAX_BRIDGE_GLUE_TOKENS delimiter-only intermediary tokens per
-            // probe direction. A split into MORE than MAX_BRIDGE_FRAGMENTS
-            // real fragments, into fragments individually below
-            // MIN_BRIDGE_FRAGMENT_LEN, or across MORE than
-            // MAX_BRIDGE_GLUE_TOKENS delimiter-only tokens in one gap, is an
-            // accepted residual limitation of the local-neighborhood bound,
-            // not a soundness gap to close here: per ADR-096 / ADR-115, this
-            // gate is accidental-persistence hygiene on a single-principal
-            // same-uid host, not defense against a same-uid adversary
-            // hand-splitting a credential to evade it — that adversary can
-            // write the DB directly. This module does not itself establish
-            // that the host is same-uid; it inherits that from the daemon's
-            // accept-site refusal of any peer uid other than its own
-            // (`khive-runtime/src/daemon.rs`, peer-credential check before the
-            // first frame is read). If that refusal is ever removed or
-            // weakened, the residual limitation documented here stops being
-            // residual. See
-            // `allows_seven_way_hex_split_beyond_fragment_cap_documented_limitation`
-            // and `allows_six_way_sub_floor_hex_split_documented_limitation`.
-            //
-            // The chain is checked two ways. `contains_normalized_hex_credential`
-            // runs over the fragments joined by a plain space — a non-
-            // alphanumeric separator the function already treats as a run
-            // boundary, so it accumulates only genuinely-adjacent hex runs
-            // exactly as it does for a single token's internal `/`-split
-            // runs. Separately, the fragments are
-            // concatenated WITHOUT a separator and the SAME whole-token
-            // entropy decision a genuine single-token high-entropy candidate
-            // must clear is applied to that reconstruction — this catches
-            // the case where a base64/base64url-shaped credential split by the same
-            // tokenizer-delimiter mechanism is not pure hex, so the
-            // hex-length check alone never catches it, but its reconstructed
-            // entropy does. Unrelated short fragments near a trigger (e.g.
-            // two short git SHAs cited in the same sentence) either fail the
-            // per-fragment shape gate or reconstruct to well under
-            // MIN_ENTROPY_LEN, so they stay allowed; see
-            // `blocks_separator_split_three_way_hex_credential_mixed_case`
-            // and `allows_unrelated_short_fragments_cited_near_a_trigger_word`.
-            // A vcs-exempt anchor skips reconstruction FROM ITSELF: the chain
-            // would re-accumulate the anchor's own legitimate 40-hex (any
-            // adjacent prose word is fragment-shaped enough to open a chain)
-            // and re-flag every benign marker-adjacent revision. A genuinely
-            // split credential hiding one fragment behind a marker is still
-            // caught: every OTHER fragment anchors its own chain, walks both
-            // directions, and accumulates the exempted fragment's hex into
-            // the total (see
-            // `blocks_split_hex_credential_with_marker_adjacent_fragment`).
+            // Step 6 (#1062, Unicode variant): bridge fragments split across non-ASCII
+            // tokenizer delimiters (e.g. U+200B) via `bridge_fragment_chain`, which walks
+            // both directions across a bounded chain (MAX_BRIDGE_FRAGMENTS,
+            // MAX_BRIDGE_GLUE_TOKENS) rather than one adjacent pair — see
+            // docs/api/secret_gate.md#check_entropy_heuristic--per-token-flagging-sequence
+            // for the exact guarantee and its accepted residual (same-uid-host) limits.
             if !vcs_reference_exempt && tokens.len() > 1 {
                 let fragments = bridge_fragment_chain(&tokens, text, idx);
                 if fragments.len() > 1 {
@@ -984,15 +797,9 @@ fn check_entropy_heuristic(text: &str, from: usize) -> Option<(&str, &'static st
             }
         }
 
-        // Other structured identifiers (branch names, doc slugs, snake_case
-        // identifiers) are exempted from the entropy check — see the module
-        // doc and `is_structured_identifier`. Must come after the
-        // UUID/content-hash and hex-credential-token checks above (neither of
-        // which it weakens) and before the entropy computation, since a
-        // identifier can exceed ENTROPY_THRESHOLD on Shannon entropy alone.
-        // This general exemption applies only outside trigger context; the
-        // narrower file-path exemption above also requires the absence of an
-        // immediate credential label.
+        // Step 8: structured-identifier exemption, off-trigger only. Must run after the
+        // UUID/hex checks and before the entropy computation (an identifier can exceed
+        // ENTROPY_THRESHOLD on Shannon entropy alone).
         if !near_trigger && is_structured_identifier(token) {
             continue;
         }
@@ -2880,18 +2687,9 @@ mod tests {
     }
 
     // ── Hex allowlist is not applied when trigger context is present ────────
-    //
-    // Pure hex strings have a theoretical maximum entropy of log2(16) = 4.0 bits/char,
-    // which is below the ENTROPY_THRESHOLD of 4.5.  That means pure hex tokens cannot
-    // reach the entropy threshold and will never be flagged by the heuristic alone.
-    //
-    // However, the hex allowlist was previously applied BEFORE the trigger window was
-    // computed, meaning a future threshold reduction or edge case could silently
-    // skip credential-context hex.  The fix: compute trigger context first; only
-    // apply the hex allowlist when NOT near a trigger.  The tests below verify the
-    // structural change is in place by confirming that non-pure-hex high-entropy
-    // tokens near triggers are caught (showing the trigger path is live), and that
-    // purely hex tokens near triggers still correctly pass (entropy too low to flag).
+    // Pure hex tops out at log2(16) = 4.0 bits/char, below ENTROPY_THRESHOLD (4.5), so
+    // the entropy heuristic alone never flags it. The hex allowlist must only apply
+    // when NOT near a trigger; the tests below guard that ordering.
 
     #[test]
     fn hex_near_key_blocked_in_credential_context() {
@@ -4082,25 +3880,12 @@ mod tests {
     }
 
     // ── Credential-labeled structured identifiers remain blocked ────────────
-    //
-    // Narrower fixes that keep some exemption alive in trigger context (e.g.
-    // requiring a trailing file-extension run, or requiring >= 2 path-shaped
-    // runs with a low average per-run letters-only entropy) are all
-    // attacker-defeatable: a random credential can be extension-suffixed, or
-    // split/padded into short runs that drive each run's own entropy toward
-    // its length ceiling (log2(run_len)), which real short path words already
-    // sit at. Shannon entropy over an attacker-chosen run boundary cannot
-    // distinguish "distinct letters that spell an English word" from
-    // "distinct letters chosen adversarially" — both hit the same
-    // log2(length) ceiling — an upper bound shared by every string of that
-    // length, not a claim that entropy is content-independent at a fixed
-    // length (two different N-character strings can and do score
-    // differently; neither is distinguishable from the other by a threshold
-    // alone once both sit near that shared ceiling). So no aggregation is
-    // sound. Plausible file paths are therefore exempt only after their
-    // individual runs have passed the entropy and normalized-hex checks, and
-    // only when the path is not immediately labeled as a credential value.
-    // The tests below guard that credential-label boundary.
+    // Shannon entropy over an attacker-chosen run boundary cannot distinguish an
+    // English word from adversarially-chosen letters at the same length ceiling
+    // (log2(run_len)), so no run-shape exemption is sound near a trigger. File paths
+    // are exempt only after their runs pass the entropy/hex checks AND the path is
+    // not immediately labeled as a credential value. The tests below guard that
+    // credential-label boundary.
 
     #[test]
     fn blocks_separator_secret_access_key_bypass() {
@@ -4363,18 +4148,10 @@ mod tests {
 
     #[test]
     fn blocks_punctuation_glue_between_two_unicode_gaps() {
-        // Two 20-char hex fragments separated by a
-        // punctuation-only token (`---`) sandwiched between two U+200B
-        // gaps. `adjacent_gap_is_bridgeable` already accepts any
-        // non-alphanumeric GAP between tokens; before this fix, `---` was
-        // tokenized as its own TOKEN (not gap text), failed
-        // `is_bridge_fragment_shape` (not alphanumeric), and stopped the
-        // walk before it ever reached the second hex fragment — the two
-        // real fragments were never joined, contradicting the bridge's own
-        // stated intent that delimiter-only material is transparent to
-        // reconstruction. `is_delimiter_only_token` now lets the walk
-        // absorb `---` as glue and continue to the fragment on its far
-        // side, without counting it against `MAX_BRIDGE_FRAGMENTS`.
+        // Two 20-char hex fragments separated by a punctuation-only token (`---`)
+        // sandwiched between two U+200B gaps: `is_delimiter_only_token` must let the
+        // walk absorb `---` as glue (without counting it against MAX_BRIDGE_FRAGMENTS)
+        // rather than stopping at it as a non-fragment token.
         let content = "api key 0123456789abcdef0123\u{200B}---\u{200B}456789abcdef01234567";
         assert!(
             check(content).is_err(),
@@ -5088,19 +4865,9 @@ mod tests {
     }
 
     // ── Underscore is a BOUNDARY for bare TRIGGER_WORDS, not a continuation ─
-    //
-    // Bare TRIGGER_WORDS are word-boundary-aware, but underscore must be
-    // treated as a boundary rather than a word character (continuation) for
-    // this set specifically: the opposite of `has_standalone_token`'s rule
-    // for `token`. Treating underscore as a continuation would silently drop
-    // detection of extremely common underscore-joined credential-config
-    // compounds (`SECRET_KEY=`, `auth_token=`, `signing_key=`,
-    // `session_secret_...`), since `secret`/`key`/`auth` would never be
-    // bounded by `_` under that rule. Fixed by treating `_` as a boundary for
-    // the bare `TRIGGER_WORDS` check specifically (see `contains_word`'s
-    // `underscore_is_word_char` parameter), while leaving
-    // `has_standalone_token`'s `token`-specific underscore-as-continuation
-    // rule (the `tokenizer`/`next_token`/`token_count` exemption) unchanged.
+    // Opposite of `has_standalone_token`'s rule for `token`: treating underscore as a
+    // boundary here is what keeps `SECRET_KEY=`/`auth_token=`/`signing_key=` detected
+    // (`contains_word`'s `underscore_is_word_char` parameter controls this per caller).
 
     #[test]
     fn blocks_secret_key_assignment_when_underscore_bounds_trigger() {
@@ -5304,18 +5071,12 @@ mod corpus_replay {
         }
     }
 
-    /// Generates the sanitized aggregate corpus manifest checked in at
-    /// `tests/data/secret_gate_corpus_manifest.md` (#1062): per-
-    /// detector block counts plus a sha256 of each blocked candidate's
-    /// content — never the candidate text itself, so the manifest carries no
-    /// production data. This is a POINT-IN-TIME generator, not a CI check:
-    /// re-run it manually (`KHIVE_REPLAY_DB=... cargo test -p khive-runtime
-    /// --release -- --ignored --nocapture generate_corpus_manifest`) and
-    /// hand-update the checked-in file when the detector set changes enough
-    /// to warrant a fresh snapshot. `replay_against_corpus` above stays the
-    /// human-readable spot-check with a few truncated samples; this is the
-    /// reproducible-evidence counterpart the #1040/#1056 drop rationale in
-    /// the PR body cites.
+    /// Generates the sanitized corpus manifest at
+    /// `tests/data/secret_gate_corpus_manifest.md`: per-detector block counts plus a
+    /// sha256 of each blocked candidate, never the candidate text itself. Point-in-time
+    /// generator, not a CI check — re-run manually (`KHIVE_REPLAY_DB=... cargo test -p
+    /// khive-runtime --release -- --ignored --nocapture generate_corpus_manifest`) and
+    /// hand-update the checked-in file when the detector set changes.
     #[test]
     #[ignore]
     fn generate_corpus_manifest() {


### PR DESCRIPTION
First pass of a comment-to-docs alignment series. Extracts design narratives from `khive-runtime`'s two comment-densest files into structured crate docs and trims the inline comments to constraint one-liners.

- `crates/khive-runtime/docs/operations.md` (new): module-split rationale, fault-injection static-state design, and concurrency/correctness notes for `atomic_hard_delete_with_edge_purge`, `merge_traversal_paths_by_root`, and `update_edge_symmetric_dml`.
- `crates/khive-runtime/docs/api/secret_gate.md` (extended): bridge-fragment reconstruction rationale and the full per-token detection sequence for `check_entropy_heuristic`.
- `secret_gate.rs`: 1368 → 1129 comment lines. `operations.rs`: 2040 → 1924 (partial pass; a follow-up will cover the remainder).
- Comment and doc lines only — no executable code, signatures, attributes, or test logic changed (verified by filtering the diff for non-comment changed lines: none).
- Gates: `cargo fmt -p khive-runtime --check` and `RUSTDOCFLAGS="-D warnings" cargo doc -p khive-runtime --no-deps` both pass.