### PR TITLE
fix(pack-code): validate ingest args and report observed languages

### DIFF
--- a/crates/khive-pack-code/docs/code-ontology.md
+++ b/crates/khive-pack-code/docs/code-ontology.md
@@ -78,7 +78,10 @@ The pack depends on `kg`, registers the finding hook and vocabulary, and contrib
 database, with an opt-in L2 Rust symbol tier. Its optional `tiers` array accepts `l1`, `l1.5`, and
 `l2`. Omission or `null` preserves the L1+L1.5 default with L2 disabled; an empty array performs no
 map writes. When L2 is disabled, its five report counters are omitted so the existing default
-report shape is unchanged. `findings.json` ingestion is an admin CLI path through `kkernel
+report shape is unchanged. Arguments are deserialized through a closed typed schema (`path`, `db`,
+`languages`, and `tiers`), so unknown names fail before filesystem or database access. The report's
+sorted `languages` array names languages actually observed by a selected tier, not the caller's
+requested filter. `findings.json` ingestion is an admin CLI path through `kkernel
 code-ingest`, not an MCP operation. Its v2 finding identity is repository/project-scoped and carries
 a deterministic v1 UUID witness without rewriting legacy curated rows. Unknown dispatch attempts fail
 with `RuntimeError::InvalidInput` rather than silently succeeding.

--- a/crates/khive-pack-code/src/handlers.rs
+++ b/crates/khive-pack-code/src/handlers.rs
@@ -9,6 +9,7 @@ use std::collections::BTreeSet;
 use std::path::PathBuf;
 
 use chrono::Utc;
+use serde::Deserialize;
 use serde_json::Value;
 
 use khive_runtime::{KhiveRuntime, Namespace, RuntimeConfig, RuntimeError};
@@ -20,6 +21,15 @@ use crate::CodePack;
 
 const VALID_TIERS: &[&str] = &["l1", "l1.5", "l2"];
 
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CodeIngestParams {
+    path: String,
+    db: Option<String>,
+    languages: Option<Vec<String>>,
+    tiers: Option<Vec<String>>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct TierSelection {
     pub enable_l1: bool,
@@ -27,27 +37,48 @@ pub(crate) struct TierSelection {
     pub enable_l2: bool,
 }
 
-pub(crate) fn parse_tiers(value: Option<&Value>) -> Result<TierSelection, RuntimeError> {
-    let Some(value) = value.filter(|value| !value.is_null()) else {
+fn parse_params(params: Value) -> Result<CodeIngestParams, RuntimeError> {
+    serde_json::from_value(params).map_err(|error| {
+        RuntimeError::InvalidInput(format!("invalid code.ingest arguments: {error}"))
+    })
+}
+
+fn parse_languages(entries: Option<&[String]>) -> Result<BTreeSet<&'static str>, RuntimeError> {
+    let Some(entries) = entries else {
+        return Ok(LANGUAGES.iter().copied().collect());
+    };
+    let mut languages = BTreeSet::new();
+    for language in entries {
+        let canonical = LANGUAGES
+            .iter()
+            .find(|candidate| **candidate == language.as_str())
+            .copied()
+            .ok_or_else(|| {
+                RuntimeError::InvalidInput(format!(
+                    "unknown language {language:?}; valid: {}",
+                    LANGUAGES.join(", ")
+                ))
+            })?;
+        languages.insert(canonical);
+    }
+    Ok(languages)
+}
+
+pub(crate) fn parse_tiers(entries: Option<&[String]>) -> Result<TierSelection, RuntimeError> {
+    let Some(entries) = entries else {
         return Ok(TierSelection {
             enable_l1: true,
             enable_l1_5: true,
             enable_l2: false,
         });
     };
-    let entries = value
-        .as_array()
-        .ok_or_else(|| RuntimeError::InvalidInput("tiers must be an array of strings".into()))?;
     let mut selection = TierSelection {
         enable_l1: false,
         enable_l1_5: false,
         enable_l2: false,
     };
-    for entry in entries {
-        let tier = entry
-            .as_str()
-            .ok_or_else(|| RuntimeError::InvalidInput("tiers entries must be strings".into()))?;
-        match tier {
+    for tier in entries {
+        match tier.as_str() {
             "l1" => selection.enable_l1 = true,
             "l1.5" => selection.enable_l1_5 = true,
             "l2" => selection.enable_l2 = true,
@@ -64,49 +95,23 @@ pub(crate) fn parse_tiers(value: Option<&Value>) -> Result<TierSelection, Runtim
 
 impl CodePack {
     pub(crate) async fn handle_ingest(&self, params: Value) -> Result<Value, RuntimeError> {
-        let path_raw = params
-            .get("path")
-            .and_then(Value::as_str)
-            .ok_or_else(|| RuntimeError::InvalidInput("code.ingest requires path".into()))?;
-        let path = PathBuf::from(path_raw);
+        let CodeIngestParams {
+            path: path_raw,
+            db,
+            languages,
+            tiers,
+        } = parse_params(params)?;
+        let languages = parse_languages(languages.as_deref())?;
+        let tiers = parse_tiers(tiers.as_deref())?;
+        let path = PathBuf::from(&path_raw);
         if !path.is_dir() {
             return Err(RuntimeError::InvalidInput(format!(
                 "path {path_raw:?} does not exist or is not a directory"
             )));
         }
 
-        let languages: BTreeSet<&'static str> = match params.get("languages") {
-            None | Some(Value::Null) => LANGUAGES.iter().copied().collect(),
-            Some(v) => {
-                let arr = v.as_array().ok_or_else(|| {
-                    RuntimeError::InvalidInput("languages must be an array of strings".into())
-                })?;
-                let mut set = BTreeSet::new();
-                for entry in arr {
-                    let s = entry.as_str().ok_or_else(|| {
-                        RuntimeError::InvalidInput("languages entries must be strings".into())
-                    })?;
-                    let canonical =
-                        LANGUAGES
-                            .iter()
-                            .find(|l| **l == s)
-                            .copied()
-                            .ok_or_else(|| {
-                                RuntimeError::InvalidInput(format!(
-                                    "unknown language {s:?}; valid: {}",
-                                    LANGUAGES.join(", ")
-                                ))
-                            })?;
-                    set.insert(canonical);
-                }
-                set
-            }
-        };
-        let tiers = parse_tiers(params.get("tiers"))?;
-
-        let db_param = params.get("db").and_then(Value::as_str);
         let runtime_db_path = self.runtime.config().db_path.clone();
-        let db_path = resolve_target_db(db_param, &path, runtime_db_path.as_deref())
+        let db_path = resolve_target_db(db.as_deref(), &path, runtime_db_path.as_deref())
             .map_err(RuntimeError::InvalidInput)?;
 
         let config = RuntimeConfig {
@@ -147,7 +152,7 @@ impl CodePack {
 mod tests {
     use serde_json::json;
 
-    use super::{parse_tiers, TierSelection};
+    use super::{parse_params, parse_tiers, TierSelection};
 
     #[test]
     fn tiers_default_to_l1_and_l1_5() {
@@ -158,16 +163,13 @@ mod tests {
         };
 
         assert_eq!(parse_tiers(None).unwrap(), expected);
-        assert_eq!(
-            parse_tiers(Some(&serde_json::Value::Null)).unwrap(),
-            expected
-        );
     }
 
     #[test]
     fn tiers_accept_an_empty_selection() {
+        let tiers = Vec::new();
         assert_eq!(
-            parse_tiers(Some(&json!([]))).unwrap(),
+            parse_tiers(Some(&tiers)).unwrap(),
             TierSelection {
                 enable_l1: false,
                 enable_l1_5: false,
@@ -206,14 +208,15 @@ mod tests {
         ];
 
         for (tier, expected) in cases {
-            assert_eq!(parse_tiers(Some(&json!([tier]))).unwrap(), expected);
+            assert_eq!(parse_tiers(Some(&[tier.to_string()])).unwrap(), expected);
         }
     }
 
     #[test]
     fn tiers_deduplicate_entries_and_ignore_input_order() {
+        let tiers = ["l2", "l1.5", "l1", "l2"].map(str::to_string);
         assert_eq!(
-            parse_tiers(Some(&json!(["l2", "l1.5", "l1", "l2"]))).unwrap(),
+            parse_tiers(Some(&tiers)).unwrap(),
             TierSelection {
                 enable_l1: true,
                 enable_l1_5: true,
@@ -224,25 +227,19 @@ mod tests {
 
     #[test]
     fn tiers_reject_a_scalar_value() {
-        let scalar = parse_tiers(Some(&json!("l2"))).unwrap_err();
-        assert_eq!(
-            scalar.to_string(),
-            "invalid input: tiers must be an array of strings"
-        );
+        let scalar = parse_params(json!({"path": ".", "tiers": "l2"})).unwrap_err();
+        assert!(scalar.to_string().contains("invalid type: string"));
     }
 
     #[test]
     fn tiers_reject_non_string_entries() {
-        let non_string = parse_tiers(Some(&json!(["l1", 2]))).unwrap_err();
-        assert_eq!(
-            non_string.to_string(),
-            "invalid input: tiers entries must be strings"
-        );
+        let non_string = parse_params(json!({"path": ".", "tiers": ["l1", 2]})).unwrap_err();
+        assert!(non_string.to_string().contains("invalid type: integer"));
     }
 
     #[test]
     fn tiers_reject_unknown_values() {
-        let unknown = parse_tiers(Some(&json!(["L2"]))).unwrap_err();
+        let unknown = parse_tiers(Some(&["L2".to_string()])).unwrap_err();
         assert_eq!(
             unknown.to_string(),
             "invalid input: unknown tier \"L2\"; valid: l1, l1.5, l2"

--- a/crates/khive-pack-code/src/source_ingest.rs
+++ b/crates/khive-pack-code/src/source_ingest.rs
@@ -111,6 +111,8 @@ pub struct CodeSourceIngestReport {
     /// A successful ingest indexes every non-blocked entity upsert, so generic
     /// KG `search` and query-anchored `context` can read the resulting map.
     pub fts_indexed: u64,
+    /// Sorted, deduplicated languages observed in manifests or source files
+    /// accepted by at least one selected tier during this pass.
     pub languages: Vec<String>,
     /// Per-manifest / per-file failures that did not abort the pass (fail
     /// loud without silently dropping the rest of the run).
@@ -149,6 +151,13 @@ pub struct CodeSourceIngestOptions<'a> {
     /// L2 symbol/call-edge persistence tier (this module). Wire default
     /// `false` — opt-in only.
     pub enable_l2: bool,
+}
+
+fn record_observed_language(report: &mut CodeSourceIngestReport, language: &str) {
+    if !report.languages.iter().any(|observed| observed == language) {
+        report.languages.push(language.to_string());
+        report.languages.sort();
+    }
 }
 
 const IMPORT_DEPENDENCY_KIND: &str = "import";
@@ -1448,7 +1457,6 @@ pub async fn run_code_ingest(
 
     let snapshot = source_snapshot(opts.path).await;
     let mut report = CodeSourceIngestReport {
-        languages: opts.languages.iter().map(|s| s.to_string()).collect(),
         source_revision: snapshot.revision.clone(),
         l2: opts.enable_l2.then(CodeSourceIngestL2Report::default),
         ..Default::default()
@@ -1477,6 +1485,7 @@ pub async fn run_code_ingest(
         Vec::new()
     };
     for manifest in &manifests {
+        record_observed_language(&mut report, manifest.language);
         for (dependency, _kind, scope) in &manifest.dependencies {
             manifest_scopes
                 .entry((
@@ -1657,6 +1666,9 @@ async fn run_import_scan(
         return Ok(());
     }
     files.sort();
+    if !files.is_empty() {
+        record_observed_language(report, language);
+    }
 
     for file in files {
         let Some(file_dir) = file.parent() else {
@@ -2941,6 +2953,9 @@ async fn run_l2_sweep(
             skipped.display()
         ));
         report.files_dropped_without_source_path += 1;
+    }
+    if !files.is_empty() {
+        record_observed_language(report, LANGUAGE);
     }
 
     for file in files {

--- a/crates/khive-pack-code/src/vocab.rs
+++ b/crates/khive-pack-code/src/vocab.rs
@@ -33,8 +33,8 @@ pub(crate) static CODE_HANDLERS: [HandlerDef; 1] = [HandlerDef {
             name: "languages",
             param_type: "array of string",
             required: false,
-            description: "Restrict ingest to a subset of rust | python | typescript. Defaults \
-                           to all three (auto-detected from manifests found under path).",
+            description: "Restrict ingest to a subset of rust | python | typescript. Omission \
+                           accepts all three; the report lists only languages observed under path.",
         },
         ParamDef {
             name: "tiers",

--- a/crates/khive-pack-code/tests/source_ingest_l2.rs
+++ b/crates/khive-pack-code/tests/source_ingest_l2.rs
@@ -717,6 +717,57 @@ async fn wire_omitted_tiers_defaults_to_l1_and_l1_5() {
     );
 }
 
+#[tokio::test]
+async fn wire_unknown_arguments_are_rejected_before_db_open() {
+    let root = TempDir::new().expect("tempdir");
+    write_l2_symbol_fixture(root.path(), "pkg_unknown_arg");
+    let db = root.path().join("unknown-arg.db");
+    let reg = registry(KhiveRuntime::memory().expect("memory runtime"));
+
+    let error = dispatch(
+        &reg,
+        "code.ingest",
+        json!({
+            "path": root.path().join("pkg_unknown_arg").to_string_lossy(),
+            "db": db.to_string_lossy(),
+            "zzz_not_a_real_param": "banana",
+        }),
+    )
+    .await
+    .expect_err("unknown arguments must be rejected");
+
+    let message = error.to_string();
+    assert!(message.contains("unknown field"), "{message}");
+    for expected in ["zzz_not_a_real_param", "path", "db", "languages", "tiers"] {
+        assert!(message.contains(expected), "{message}");
+    }
+    assert!(
+        !db.exists(),
+        "argument validation must run before the target database is opened"
+    );
+}
+
+#[tokio::test]
+async fn wire_report_languages_describe_observed_sources() {
+    let root = TempDir::new().expect("tempdir");
+    write_l2_symbol_fixture(root.path(), "pkg_observed_language");
+    let db = root.path().join("observed-language.db");
+    let reg = registry(KhiveRuntime::memory().expect("memory runtime"));
+
+    let report = dispatch(
+        &reg,
+        "code.ingest",
+        json!({
+            "path": root.path().join("pkg_observed_language").to_string_lossy(),
+            "db": db.to_string_lossy(),
+        }),
+    )
+    .await
+    .expect("default ingest succeeds");
+
+    assert_eq!(report["languages"], json!(["rust"]));
+}
+
 /// Explicit `null` tiers behaves identically to omitted.
 #[tokio::test]
 async fn wire_null_tiers_defaults_to_l1_and_l1_5() {

--- a/crates/khive-pack-code/tests/source_ingest_l2.rs
+++ b/crates/khive-pack-code/tests/source_ingest_l2.rs
@@ -841,6 +841,7 @@ async fn wire_empty_tiers_write_no_map_rows() {
 
     assert!(result.get("symbols_created").is_none());
     assert!(result.get("symbol_parse_failures").is_none());
+    assert_eq!(result["languages"], json!([]));
     let target = rt_at(&db);
     assert_eq!(entity_count(&target).await, 0);
     assert_eq!(edge_count(&target).await, 0);

--- a/docs/adr/ADR-085-code-pack.md
+++ b/docs/adr/ADR-085-code-pack.md
@@ -1595,3 +1595,26 @@ Acceptance:
 3. Repeated same-repository input and changes only to `observed_at` retain stable v2 UUIDs.
 4. A v2 note exposes its schema version, repository, project UUID, and parseable deterministic v1
    UUID witness; ingest does not mutate or claim an existing v1 row.
+
+## Amendment 7 (2026-08-11): strict ingest arguments and observed languages
+
+`code.ingest` now validates its complete public argument object before any filesystem or database
+access. The closed argument set is `path`, `db`, `languages`, and `tiers`; deserialization rejects
+every unknown field by name and reports the accepted field names. This brings the code-pack tranche
+of the public verb surface into the same typo-detecting posture as the typed KG, GTD, memory, comm,
+knowledge, brain, schedule, and session handlers. Git- and blob-pack argument strictness remains a
+separate implementation tranche.
+
+The request's `languages` value remains an allow-list: omission permits every supported language,
+while an explicit array restricts discovery. The success report's `languages` field no longer
+echoes that allow-list. It is the sorted, deduplicated set actually observed by at least one selected
+tier: a discovered manifest counts for L1/L1.5, a discovered source file counts for L1.5, and an
+accepted Rust source file counts for L2. A language with no accepted manifest or source file is
+absent, and selecting no tiers reports an empty set.
+
+Acceptance:
+
+1. A valid call carrying an unknown argument fails before its target database is created, and the
+   error names both the unknown argument and the four accepted fields.
+2. An omitted language filter over a Rust-only fixture reports exactly `["rust"]`, never the full
+   supported-language allow-list.

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -2130,15 +2130,19 @@ becomes known.
 | ----------- | --------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `path`      | string          | yes      | Folder to ingest — a monorepo subtree (a single crate/package) is first-class, not a special case of whole-repo ingest.                                                                                                                      |
 | `db`        | string          | no       | Target map database path. Defaults to `<path>/.khive/code-map.db`. The shared production database — its default `$HOME/.khive/khive.db` location and the calling server's actual configured database — is always rejected, with no override. |
-| `languages` | array\<string\> | no       | Restrict ingest to a subset of `rust` \| `python` \| `typescript`. Defaults to all three (auto-detected from manifests found under `path`).                                                                                                  |
+| `languages` | array\<string\> | no       | Restrict ingest to a subset of `rust` \| `python` \| `typescript`. Omission accepts all three; the success report lists only languages observed under `path`.                                                                                |
+| `tiers`     | array\<string\> | no       | Select any of `l1` \| `l1.5` \| `l2`. Defaults to L1 and L1.5; L2 is opt-in and currently scans Rust sources only.                                                                                                                           |
 
 ```
 request(ops="code.ingest(path=\"/repo/crates/my-crate\")")
 ```
 
-The success report includes `fts_indexed`, the number of entity documents written to the map's
-full-text index. Entity and FTS writes are a single success postcondition for this verb: an FTS
-failure makes the ingest fail rather than returning a structurally populated but unsearchable map.
+The argument object is closed: unknown names are rejected before filesystem or database access.
+The success report's sorted `languages` array describes languages observed by a selected tier,
+rather than echoing the caller's filter. It also includes `fts_indexed`, the number of entity
+documents written to the map's full-text index. Entity and FTS writes are a single success
+postcondition for this verb: an FTS failure makes the ingest fail rather than returning a
+structurally populated but unsearchable map.
 
 The map database uses the ordinary khive schema. To explore it with the generic KG read verbs,
 select it as a backend in a dedicated config:

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -2109,10 +2109,10 @@ request(ops="git.commit(repo=\"/abs/path/repo\", message=\"fix: thing\") | git.p
 
 ## `code` pack — 1 verb
 
-Deterministic source-code map ingest (ADR-085 Amendment 2, PR #1039). Optional; load
-with `KHIVE_PACKS=kg,code`. Also registers the `finding` note kind used by the
-`kkernel code-ingest` admin CLI's `findings.json` batch ingest (not reachable via this
-MCP verb surface).
+Deterministic source-code map ingest (ADR-085 Amendment 2, PR #1039). Loaded by default;
+set `KHIVE_PACKS=kg,code` to select only the base and code packs. Also registers the
+`finding` note kind used by the `kkernel code-ingest` admin CLI's `findings.json` batch
+ingest (not reachable via this MCP verb surface).
 
 ### `code.ingest` — Commissive
 


### PR DESCRIPTION
Addresses the code-pack tranche of #1691.

- deserialize code.ingest through a closed typed parameter boundary before filesystem or SQLite access
- reject unknown fields deterministically
- report sorted languages actually observed in accepted L1/L1.5/L2 inputs instead of echoing the requested filter
- document the default-loaded code pack contract

Validation in progress locally; targeted wire regressions are green. Full CI will run on this draft PR.

Refs #1691