### PR TITLE
fix(atomic): preserve committed post-processing outcomes

### DIFF
--- a/crates/khive-mcp/docs/save-sink.md
+++ b/crates/khive-mcp/docs/save-sink.md
@@ -22,6 +22,13 @@ defined in `crates/kkernel/docs/usage.md`. For `kkernel exec --strict
 manifest projection, canonical JSONL rows, and checksum all describe the same
 classified data.
 
+For an atomic ops-file envelope, `write_envelope` also copies the complete
+top-level `atomic` object into the stdout manifest. This unit-level commit and
+retry contract cannot be reconstructed from independent JSONL rows. In
+particular, a manifest for a committed-but-degraded unit retains
+`atomic.committed=true`, `atomic.status="committed_degraded"`, its typed
+`atomic.degradations`, and `atomic.retryable=false` unchanged.
+
 `write_and_manifest` derives that projection from its in-memory envelope.
 Incremental callers pass their already-bounded `summary.failures` projection to
 `finish`; the sink promotes exactly those entries to top-level `failures`
@@ -90,3 +97,10 @@ is known in those cases, so the ordinary manifest is the correct reconciliation
 record and no aborted manifest is emitted. Callers reconcile
 the manifest before applying the per-op/idempotency contracts to a retry;
 atomic ops-files retain their separate all-or-nothing database contract.
+
+Atomic execution also has a distinct post-commit sink-failure boundary. If a
+row write, flush, or final rename fails after the database unit committed, the
+CLI cannot return a manifest for an unpublished file. It instead prints the
+original result envelope augmented with a `save_file_publish` degradation and
+`retryable=false`, then exits non-zero for the sink failure. That non-zero exit
+does not roll back or make the already-durable atomic unit safe to replay.

--- a/crates/khive-mcp/src/save_sink.rs
+++ b/crates/khive-mcp/src/save_sink.rs
@@ -262,10 +262,15 @@ impl JsonlSaveSink {
             .and_then(Value::as_array)
             .cloned()
             .unwrap_or_else(|| failure_projection(results));
+        // Atomic execution has a second, commit-authoritative status surface
+        // in addition to the ordinary result summary.  Keep that block in the
+        // stdout manifest: the JSONL rows alone cannot tell an automation that
+        // a post-commit degradation is non-retryable.
+        let atomic = results_envelope.get("atomic").cloned();
         for row in results {
             self.write_row(row)?;
         }
-        self.finish_with_failures(summary, failures)
+        self.finish_with_failures(summary, failures, atomic)
     }
 
     /// Publish the complete JSONL file and return its ordinary manifest.
@@ -275,13 +280,14 @@ impl JsonlSaveSink {
             .and_then(Value::as_array)
             .cloned()
             .unwrap_or_default();
-        self.finish_with_failures(summary, failures)
+        self.finish_with_failures(summary, failures, None)
     }
 
     fn finish_with_failures(
         mut self,
         summary: Value,
         failures: Vec<Value>,
+        atomic: Option<Value>,
     ) -> anyhow::Result<Value> {
         self.temp
             .as_file_mut()
@@ -320,6 +326,9 @@ impl JsonlSaveSink {
         if !failures.is_empty() {
             manifest["failures"] = Value::Array(failures);
         }
+        if let Some(atomic) = atomic {
+            manifest["atomic"] = atomic;
+        }
         Ok(manifest)
     }
 }
@@ -353,7 +362,7 @@ fn failure_projection(results: &[Value]) -> Vec<Value> {
 ///
 /// Layout of `results_envelope`:
 /// ```json
-/// { "results": [ {"ok": bool, "tool": str, "result": ...}, ... ], "summary": {...} }
+/// { "results": [ {"ok": bool, "tool": str, "result": ...}, ... ], "summary": {...}, "atomic": {...} }
 /// ```
 ///
 /// Each entry in `results` becomes one line of JSONL. The manifest returned is:
@@ -365,9 +374,13 @@ fn failure_projection(results: &[Value]) -> Vec<Value> {
 ///   "schema_fingerprint": "<sha256 of sorted field names>",
 ///   "checksum": "<sha256 of file bytes>",
 ///   "summary": { ... },
+///   "atomic": { ... },
 ///   "failures": [ {"op_index": 0, "tool": "...", "error": ..., "reason": "..."} ]
 /// }
 /// ```
+///
+/// `atomic` is copied unchanged when the input envelope has that block and is
+/// omitted for ordinary non-atomic result envelopes.
 ///
 /// `failures` is omitted for an all-successful result. It is a compact
 /// projection rather than the full result payload: callers still need stable
@@ -451,6 +464,42 @@ mod tests {
         assert_eq!(manifest["failures"][0]["tool"], json!("get"));
         assert_eq!(manifest["failures"][0]["error"], json!("not found"));
         assert_eq!(manifest["failures"][0]["reason"], json!("entity-not-found"));
+    }
+
+    #[test]
+    fn atomic_manifest_preserves_committed_degradation_contract() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("atomic.jsonl");
+        let mut envelope = make_envelope(vec![json!({
+            "ok": true,
+            "tool": "update",
+            "op_index": 0,
+            "result": null,
+            "status": "committed_degraded",
+            "retryable": false
+        })]);
+        envelope["atomic"] = json!({
+            "committed": true,
+            "rolled_back": false,
+            "status": "committed_degraded",
+            "retryable": false,
+            "degradations": [{
+                "stage": "post_commit_reindex",
+                "op_index": null,
+                "tool": null,
+                "error": "injected post-commit failure"
+            }]
+        });
+
+        let manifest = write_and_manifest(&envelope, &path, false).unwrap();
+
+        assert_eq!(manifest["atomic"], envelope["atomic"]);
+        assert_eq!(manifest["atomic"]["committed"], true);
+        assert_eq!(manifest["atomic"]["retryable"], false);
+        assert_eq!(
+            manifest["atomic"]["degradations"][0]["stage"],
+            "post_commit_reindex"
+        );
     }
 
     #[test]

--- a/crates/khive-pack-kg/docs/design.md
+++ b/crates/khive-pack-kg/docs/design.md
@@ -66,7 +66,9 @@ It is the first-party pack shipped with the khive binary.
    regardless of caller namespace (ADR-007). Note verbs use the caller namespace.
 5. Proposals follow the state machine:
    `open -> approved -> applying -> applied` or `open -> withdrawn`.
-   The `applying` state is transient and blocks concurrent withdraw.
+   The `applying` state blocks concurrent withdraw and replay. It is normally
+   transient, but remains as the reconciliation state when base changes commit
+   and a post-commit reindex or created-record read fails.
 
 ## Failure Modes
 
@@ -78,6 +80,11 @@ It is the first-party pack shipped with the khive binary.
   relations for the specific entity-kind pair.
 - **Proposal CAS miss**: returns success with `cas_hit: false`; no duplicate
   events are emitted.
+- **Proposal post-commit degradation**: once the atomic runner reports
+  `Committed`, a reindex or created-record resolution failure emits neither a
+  `ProposalApplied { Failed }` event nor an `applying -> approved` revert. The
+  durable graph changes remain visible and the proposal stays `applying` for
+  operator reconciliation; another worker pass skips it instead of replaying.
 
 ## Edge rules and the `context` verb
 

--- a/crates/khive-pack-kg/src/apply_worker/tests.rs
+++ b/crates/khive-pack-kg/src/apply_worker/tests.rs
@@ -1,6 +1,8 @@
 use super::*;
 use async_trait::async_trait;
-use khive_runtime::{EmbedderProvider, KhiveRuntime, Namespace, VerbRegistryBuilder};
+use khive_runtime::{
+    EdgeListFilter, EmbedderProvider, KhiveRuntime, Namespace, VerbRegistryBuilder,
+};
 use khive_storage::types::{PageRequest, SqlStatement, SqlValue};
 use khive_types::{Id128, NoteDraft, ProposalChangeset, ProposalCreatedPayload};
 use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService, MAX_TEXT_BYTES};
@@ -82,6 +84,41 @@ async fn ensure_schema(rt: &KhiveRuntime) {
         })
         .await
         .expect("create table");
+}
+
+async fn replace_fts_entities_with_incompatible_table(rt: &KhiveRuntime) {
+    let sql = rt.sql();
+    let mut writer = sql.writer().await.expect("writer for FTS fault setup");
+    writer
+        .execute_script(
+            "DROP TABLE fts_entities; \
+             CREATE TABLE fts_entities (broken_column TEXT);"
+                .to_string(),
+        )
+        .await
+        .expect("replace FTS table to inject post-commit reindex failure");
+}
+
+async fn install_committed_edge_resolution_fault(rt: &KhiveRuntime) {
+    let sql = rt.sql();
+    let mut writer = sql
+        .writer()
+        .await
+        .expect("writer for edge-resolution fault setup");
+    writer
+        .execute_script(
+            "CREATE TRIGGER test_rewrite_committed_edge \
+             AFTER INSERT ON graph_edges \
+             WHEN NEW.relation = 'extends' \
+             BEGIN \
+               UPDATE graph_edges \
+               SET relation = 'variant_of', updated_at = updated_at + 1 \
+               WHERE namespace = NEW.namespace AND id = NEW.id; \
+             END;"
+                .to_string(),
+        )
+        .await
+        .expect("install edge-resolution fault trigger");
 }
 
 async fn insert_projection_row(
@@ -316,6 +353,267 @@ async fn apply_worker_returns_atomic_update_truncation_report() {
 
     assert_eq!(report.truncated, 1);
     assert!(report.discarded_bytes > 0);
+}
+
+#[tokio::test]
+async fn committed_post_commit_failure_stays_applying_and_is_not_replayed() {
+    let (rt, tok) = setup();
+    ensure_schema(&rt).await;
+    let entity = rt
+        .create_entity(
+            &tok,
+            "concept",
+            None,
+            "CommittedBeforeReindexFailure",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .expect("create entity");
+    let proposal_id = Uuid::new_v4();
+    seed_proposal_created_event(
+        &rt,
+        &tok,
+        proposal_id,
+        ProposalChangeset::UpdateEntity {
+            id: Id128::from_u128(entity.id.as_u128()),
+            patch: khive_types::ProposalEntityPatch {
+                name: Some("CommittedAfterReindexFailure".to_string()),
+                description: None,
+                properties: None,
+                tags: None,
+            },
+        },
+    )
+    .await;
+    insert_projection_row(&rt, &tok, proposal_id, "approved").await;
+
+    // The base entity plan never touches FTS. An incompatible ordinary table
+    // occupies the name so the store's IF NOT EXISTS setup cannot repair it;
+    // the real deferred reindex fails only after run_atomic_unit reports
+    // Committed.
+    replace_fts_entities_with_incompatible_table(&rt).await;
+
+    let registry = build_registry(&rt);
+    let worker = ProposalApplyWorker::new(rt.clone());
+    worker
+        .maybe_apply(&tok, proposal_id, &registry, None)
+        .await
+        .expect("committed degradation is reconciled, not returned as retryable failure");
+
+    let committed = rt
+        .get_entity(&tok, entity.id)
+        .await
+        .expect("committed entity row");
+    assert_eq!(committed.name, "CommittedAfterReindexFailure");
+    let committed_updated_at = committed.updated_at;
+
+    let projection = ProposalsProjectionWorker::new(rt.clone());
+    let row = projection
+        .get_proposal_row(&tok, proposal_id)
+        .await
+        .expect("get proposal row")
+        .expect("proposal row");
+    assert_eq!(
+        row.status, "applying",
+        "durable mutation requiring reconciliation must never return to approved"
+    );
+
+    let event_store = rt.events(&tok).expect("event store");
+    let applied_events = event_store
+        .query_events(
+            EventFilter {
+                kinds: vec![EventKind::ProposalApplied],
+                payload_proposal_id: Some(proposal_id),
+                ..Default::default()
+            },
+            PageRequest {
+                offset: 0,
+                limit: 10,
+            },
+        )
+        .await
+        .expect("query applied events");
+    assert!(
+        applied_events.items.is_empty(),
+        "post-commit degradation must publish neither Failed nor premature Success"
+    );
+
+    worker
+        .maybe_apply(&tok, proposal_id, &registry, None)
+        .await
+        .expect("repeated worker pass must skip applying proposal");
+    let after_repeat = rt
+        .get_entity(&tok, entity.id)
+        .await
+        .expect("entity after repeated worker pass");
+    assert_eq!(after_repeat.name, "CommittedAfterReindexFailure");
+    assert_eq!(
+        after_repeat.updated_at, committed_updated_at,
+        "an applying proposal must not replay its durable changeset"
+    );
+    let applied_events = event_store
+        .query_events(
+            EventFilter {
+                kinds: vec![EventKind::ProposalApplied],
+                payload_proposal_id: Some(proposal_id),
+                ..Default::default()
+            },
+            PageRequest {
+                offset: 0,
+                limit: 10,
+            },
+        )
+        .await
+        .expect("query applied events after repeat");
+    assert!(applied_events.items.is_empty());
+}
+
+#[tokio::test]
+async fn committed_created_record_resolution_failure_is_not_reverted_or_replayed() {
+    let (rt, tok) = setup();
+    ensure_schema(&rt).await;
+    let source = rt
+        .create_entity(
+            &tok,
+            "concept",
+            None,
+            "ResolutionFaultSource",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .expect("create source");
+    let target = rt
+        .create_entity(
+            &tok,
+            "concept",
+            None,
+            "ResolutionFaultTarget",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .expect("create target");
+    let proposal_id = Uuid::new_v4();
+    seed_proposal_created_event(
+        &rt,
+        &tok,
+        proposal_id,
+        ProposalChangeset::AddEdge {
+            source: Id128::from_u128(source.id.as_u128()),
+            target: Id128::from_u128(target.id.as_u128()),
+            relation: khive_types::EdgeRelation::Extends,
+            weight: Some(1.0),
+        },
+    )
+    .await;
+    insert_projection_row(&rt, &tok, proposal_id, "approved").await;
+
+    // The trigger runs inside the real atomic commit and rewrites only the
+    // just-inserted natural key. The edge remains durably present, while the
+    // post-commit lookup by the requested key deterministically returns none.
+    install_committed_edge_resolution_fault(&rt).await;
+
+    let registry = build_registry(&rt);
+    let worker = ProposalApplyWorker::new(rt.clone());
+    worker
+        .maybe_apply(&tok, proposal_id, &registry, None)
+        .await
+        .expect("created-record reconciliation failure is non-retryable");
+
+    let edges = rt
+        .list_edges(
+            &tok,
+            EdgeListFilter {
+                source_id: Some(source.id),
+                ..Default::default()
+            },
+            10,
+            0,
+        )
+        .await
+        .expect("list committed edge");
+    assert_eq!(edges.len(), 1, "the base edge insert must be durable");
+    assert_eq!(edges[0].relation.as_str(), "variant_of");
+    let committed_updated_at = edges[0].updated_at;
+
+    let projection = ProposalsProjectionWorker::new(rt.clone());
+    let row = projection
+        .get_proposal_row(&tok, proposal_id)
+        .await
+        .expect("get proposal row")
+        .expect("proposal row");
+    assert_eq!(row.status, "applying");
+
+    let event_store = rt.events(&tok).expect("event store");
+    let applied_events = event_store
+        .query_events(
+            EventFilter {
+                kinds: vec![EventKind::ProposalApplied],
+                payload_proposal_id: Some(proposal_id),
+                ..Default::default()
+            },
+            PageRequest {
+                offset: 0,
+                limit: 10,
+            },
+        )
+        .await
+        .expect("query applied events");
+    assert!(
+        applied_events.items.is_empty(),
+        "resolution degradation must emit neither Failed nor Success"
+    );
+
+    worker
+        .maybe_apply(&tok, proposal_id, &registry, None)
+        .await
+        .expect("repeated worker pass must skip applying proposal");
+    let edges_after_repeat = rt
+        .list_edges(
+            &tok,
+            EdgeListFilter {
+                source_id: Some(source.id),
+                ..Default::default()
+            },
+            10,
+            0,
+        )
+        .await
+        .expect("list edge after repeated worker pass");
+    assert_eq!(edges_after_repeat.len(), 1);
+    assert_eq!(edges_after_repeat[0].updated_at, committed_updated_at);
+    let row = projection
+        .get_proposal_row(&tok, proposal_id)
+        .await
+        .expect("get proposal row after repeat")
+        .expect("proposal row after repeat");
+    assert_eq!(
+        row.status, "applying",
+        "a replay attempt would fail/revert this injected write"
+    );
+    let applied_events = event_store
+        .query_events(
+            EventFilter {
+                kinds: vec![EventKind::ProposalApplied],
+                payload_proposal_id: Some(proposal_id),
+                ..Default::default()
+            },
+            PageRequest {
+                offset: 0,
+                limit: 10,
+            },
+        )
+        .await
+        .expect("query applied events after repeat");
+    assert!(
+        applied_events.items.is_empty(),
+        "repeat must emit neither the success nor failure a replay would produce"
+    );
 }
 
 #[tokio::test]

--- a/crates/khive-pack-kg/src/apply_worker/worker.rs
+++ b/crates/khive-pack-kg/src/apply_worker/worker.rs
@@ -42,6 +42,36 @@ pub(super) enum PendingCreatedRecord {
     },
 }
 
+#[derive(Clone, Copy, Debug)]
+enum ReconciliationStage {
+    PostCommitReindex,
+    CreatedRecordResolution,
+}
+
+impl ReconciliationStage {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::PostCommitReindex => "post_commit_reindex",
+            Self::CreatedRecordResolution => "created_record_resolution",
+        }
+    }
+}
+
+enum ApplyChangesetOutcome {
+    Applied {
+        created_records: Vec<Uuid>,
+        embedding_truncation: EmbeddingTruncationReport,
+    },
+    /// Base DML is durable, but the worker cannot safely publish success yet.
+    /// Keeping the proposal in `applying` makes repeated worker invocations a
+    /// no-op and leaves a stable operator-reconciliation state.
+    CommittedNeedsReconciliation {
+        stage: ReconciliationStage,
+        error: RuntimeError,
+        embedding_truncation: EmbeddingTruncationReport,
+    },
+}
+
 /// Worker that applies approved proposal changesets.
 pub struct ProposalApplyWorker {
     pub(crate) runtime: KhiveRuntime,
@@ -58,7 +88,9 @@ impl ProposalApplyWorker {
         }
     }
 
-    /// Check approval threshold; apply changeset if met. Errors emit `ProposalApplied { Failed }`.
+    /// Check approval threshold; apply changeset if met. Failures known to be
+    /// pre-commit emit `ProposalApplied { Failed }`; post-commit failures leave
+    /// the proposal in `applying` for reconciliation and are never replayed.
     pub async fn maybe_apply(
         &self,
         token: &NamespaceToken,
@@ -148,13 +180,32 @@ impl ProposalApplyWorker {
             .await;
 
         let embedding_truncation = match apply_result {
-            Ok((created_records, embedding_truncation)) => {
+            Ok(ApplyChangesetOutcome::Applied {
+                created_records,
+                embedding_truncation,
+            }) => {
                 let created_ids: Vec<Id128> = created_records
                     .iter()
                     .map(|id| Id128::from_u128(id.as_u128()))
                     .collect();
                 self.finalize_apply_success(token, proposal_id, created_ids)
                     .await;
+                embedding_truncation
+            }
+            Ok(ApplyChangesetOutcome::CommittedNeedsReconciliation {
+                stage,
+                error,
+                embedding_truncation,
+            }) => {
+                tracing::error!(
+                    proposal_id = %proposal_id,
+                    stage = stage.as_str(),
+                    error = %error,
+                    committed = true,
+                    retryable = false,
+                    "ProposalApplyWorker: proposal changeset committed but post-commit work \
+                     failed; leaving projection in 'applying' for operator reconciliation"
+                );
                 embedding_truncation
             }
             Err(e) => {
@@ -218,13 +269,17 @@ impl ProposalApplyWorker {
         Ok(payload.changeset)
     }
 
+    /// Apply one prepared changeset. `Err` is reserved for failures before a
+    /// durable atomic outcome is observed. Once the atomic runner reports
+    /// `Committed`, every later failure is returned as
+    /// `CommittedNeedsReconciliation` so the caller cannot emit Failed/revert.
     async fn apply_changeset(
         &self,
         token: &NamespaceToken,
         changeset: &ProposalChangeset,
         registry: &VerbRegistry,
         budget: &mut WriteBudget,
-    ) -> Result<(Vec<Uuid>, EmbeddingTruncationReport), RuntimeError> {
+    ) -> Result<ApplyChangesetOutcome, RuntimeError> {
         match self
             .prepare_changeset(token, changeset, registry, budget)
             .await?
@@ -238,19 +293,37 @@ impl ProposalApplyWorker {
                     .map_err(|error| RuntimeError::Storage(error.0))?;
                 match outcome {
                     AtomicRunOutcome::Committed { post_commit } => {
-                        let outcomes = apply_post_commit_effects_with_report(
+                        let outcomes = match apply_post_commit_effects_with_report(
                             &self.runtime,
                             token,
                             post_commit,
                         )
-                        .await?;
+                        .await
+                        {
+                            Ok(outcomes) => outcomes,
+                            Err(error) => {
+                                return Ok(ApplyChangesetOutcome::CommittedNeedsReconciliation {
+                                    stage: ReconciliationStage::PostCommitReindex,
+                                    error,
+                                    embedding_truncation: EmbeddingTruncationReport::default(),
+                                });
+                            }
+                        };
                         let mut embedding_truncation = EmbeddingTruncationReport::default();
                         for outcome in outcomes {
                             embedding_truncation.merge(outcome.truncation);
                         }
-                        let created_records =
-                            self.resolve_created_records(token, created_records).await?;
-                        Ok((created_records, embedding_truncation))
+                        match self.resolve_created_records(token, created_records).await {
+                            Ok(created_records) => Ok(ApplyChangesetOutcome::Applied {
+                                created_records,
+                                embedding_truncation,
+                            }),
+                            Err(error) => Ok(ApplyChangesetOutcome::CommittedNeedsReconciliation {
+                                stage: ReconciliationStage::CreatedRecordResolution,
+                                error,
+                                embedding_truncation,
+                            }),
+                        }
                     }
                     AtomicRunOutcome::RolledBack {
                         failed_op_index,
@@ -272,7 +345,10 @@ impl ProposalApplyWorker {
                         false,
                     )
                     .await?;
-                Ok((vec![], summary.embedding_truncation))
+                Ok(ApplyChangesetOutcome::Applied {
+                    created_records: vec![],
+                    embedding_truncation: summary.embedding_truncation,
+                })
             }
         }
     }

--- a/crates/kkernel/docs/design.md
+++ b/crates/kkernel/docs/design.md
@@ -128,15 +128,23 @@ It runs, in order:
    update whose embedding input was bounded carries the same per-result `warnings` advisory as
    the canonical non-atomic handler.
 
-The commit pass is the retry-safety boundary. Once it returns `Committed`, a reindex or canonical
-result-rendering failure cannot turn the command back into `Err`: the base DML is already durable.
-The command instead returns success with `atomic.committed=true`,
+The commit pass is the retry-safety boundary. Once it returns `Committed`, a reindex, canonical
+result-rendering, or save-file publication failure cannot make the database mutation retryable:
+the base DML is already durable. Reindex and rendering failures return success with
+`atomic.committed=true`,
 `atomic.status="committed_degraded"`, `atomic.retryable=false`, and typed entries in
 `atomic.degradations` (`post_commit_reindex` or `result_rendering`). A render-degraded operation
 keeps `ok=true` and the committed summary count, carries `result=null`, and repeats the typed
 non-retry marker on that result entry. This prevents automation from replaying the mutation while
 still making index repair or result re-read work explicit. An ordinary committed run and every
 pre-commit/rollback shape remain unchanged.
+
+`--save-file` preflights its sibling temp file before execution. On successful publication, the
+stdout manifest preserves the envelope's complete top-level `atomic` block. A write, flush, or
+rename failure after commit instead appends the `save_file_publish` degradation, prints the full
+committed/non-retryable envelope to stdout, and then returns `Err` so the file request still exits
+non-zero. That error is about the sink only; the stdout commit fact is authoritative and forbids
+replay.
 
 Preflight and prepare failures cross back to `exec.rs` as a typed `AtomicExecFailure` containing
 the unchanged terminal message plus a result envelope over the real ops-file entries. The shared

--- a/crates/kkernel/docs/design.md
+++ b/crates/kkernel/docs/design.md
@@ -128,6 +128,16 @@ It runs, in order:
    update whose embedding input was bounded carries the same per-result `warnings` advisory as
    the canonical non-atomic handler.
 
+The commit pass is the retry-safety boundary. Once it returns `Committed`, a reindex or canonical
+result-rendering failure cannot turn the command back into `Err`: the base DML is already durable.
+The command instead returns success with `atomic.committed=true`,
+`atomic.status="committed_degraded"`, `atomic.retryable=false`, and typed entries in
+`atomic.degradations` (`post_commit_reindex` or `result_rendering`). A render-degraded operation
+keeps `ok=true` and the committed summary count, carries `result=null`, and repeats the typed
+non-retry marker on that result entry. This prevents automation from replaying the mutation while
+still making index repair or result re-read work explicit. An ordinary committed run and every
+pre-commit/rollback shape remain unchanged.
+
 Preflight and prepare failures cross back to `exec.rs` as a typed `AtomicExecFailure` containing
 the unchanged terminal message plus a result envelope over the real ops-file entries. The shared
 refusal annotator emits `verb-refused` for unknown/unloaded preflight entries,

--- a/crates/kkernel/docs/usage.md
+++ b/crates/kkernel/docs/usage.md
@@ -173,6 +173,15 @@ not-committed result without changing the atomic path's existing process-exit
 semantics. Ordinary validation, transport, storage, and authorization-gate
 failures remain unclassified unless `--strict` supplies the aggregate reason.
 
+After `atomic.committed=true`, the write must not be replayed. If deferred
+reindexing or canonical result rendering then fails, the command exits
+successfully with `atomic.status="committed_degraded"`,
+`atomic.retryable=false`, and one or more typed `atomic.degradations` entries.
+Treat `post_commit_reindex` as an index-repair requirement and
+`result_rendering` as a result re-read requirement; neither means the mutation
+failed. A render-degraded result remains `ok=true` with `result=null` and its
+own non-retryable degradation marker.
+
 When an explicit `--db` conflicts with a selected multi-backend config,
 dispatch does not begin. The command emits
 `error.code = "database_override_conflict"` with

--- a/crates/kkernel/docs/usage.md
+++ b/crates/kkernel/docs/usage.md
@@ -182,6 +182,13 @@ Treat `post_commit_reindex` as an index-repair requirement and
 failed. A render-degraded result remains `ok=true` with `result=null` and its
 own non-retryable degradation marker.
 
+When `--atomic` and `--save-file` are combined, a successful stdout manifest
+preserves that complete top-level `atomic` block. If JSONL write, flush, or
+final publication fails after commit, stdout is instead the full atomic
+envelope with `stage="save_file_publish"`, `committed=true`, and
+`retryable=false`; the process then exits non-zero because the requested file
+was not published. Reconcile from stdout and do not replay the durable unit.
+
 When an explicit `--db` conflicts with a selected multi-backend config,
 dispatch does not begin. The command emits
 `error.code = "database_override_conflict"` with

--- a/crates/kkernel/src/atomic_apply.rs
+++ b/crates/kkernel/src/atomic_apply.rs
@@ -107,6 +107,81 @@ impl std::fmt::Display for AtomicExecFailure {
 
 impl std::error::Error for AtomicExecFailure {}
 
+#[derive(Clone, Debug)]
+struct AtomicDegradation {
+    stage: &'static str,
+    op_index: Option<usize>,
+    tool: Option<String>,
+    error: String,
+}
+
+impl AtomicDegradation {
+    fn post_commit_reindex(error: anyhow::Error) -> Self {
+        Self {
+            stage: "post_commit_reindex",
+            op_index: None,
+            tool: None,
+            error: format!("post-commit reindex after atomic unit commit: {error:#}"),
+        }
+    }
+
+    fn result_rendering(op_index: usize, tool: &str, error: anyhow::Error) -> Self {
+        Self {
+            stage: "result_rendering",
+            op_index: Some(op_index),
+            tool: Some(tool.to_string()),
+            error: format!(
+                "op {op_index} (`{tool}`) committed but result rendering failed: {error:#}"
+            ),
+        }
+    }
+
+    fn as_json(&self) -> Value {
+        json!({
+            "stage": self.stage,
+            "op_index": self.op_index,
+            "tool": self.tool.as_deref(),
+            "error": self.error.as_str(),
+        })
+    }
+}
+
+fn committed_atomic_block(degradations: &[AtomicDegradation]) -> Value {
+    let mut atomic = json!({
+        "committed": true,
+        "rolled_back": false,
+        "failed_op_index": Value::Null,
+        "error": Value::Null,
+    });
+    if !degradations.is_empty() {
+        atomic["status"] = json!("committed_degraded");
+        atomic["retryable"] = json!(false);
+        atomic["degradations"] = Value::Array(
+            degradations
+                .iter()
+                .map(AtomicDegradation::as_json)
+                .collect(),
+        );
+    }
+    atomic
+}
+
+fn committed_degraded_result_entry(
+    op_index: usize,
+    tool: &str,
+    degradation: &AtomicDegradation,
+) -> Value {
+    json!({
+        "ok": true,
+        "tool": tool,
+        "op_index": op_index,
+        "result": Value::Null,
+        "status": "committed_degraded",
+        "retryable": false,
+        "degradation": degradation.as_json(),
+    })
+}
+
 fn atomic_failure_error(
     ops: &[OpsFileEntry],
     message: String,
@@ -226,8 +301,10 @@ fn add_post_commit_embedding_warning(
 /// (`{"results", "summary", "atomic"}`) on success or a rolled-back run; the
 /// `Err` cases are typed preflight/prepare failures, the op-count guard, an
 /// unsupported multi-backend config, or a genuine `atomic_unit` seam failure
-/// (`AtomicRunnerError`). Preflight and prepare failures happen before any
-/// target write and retain a per-operation envelope for the CLI boundary.
+/// (`AtomicRunnerError`). Post-commit reindex and result-rendering failures
+/// instead return a committed, non-retryable degraded envelope. Preflight and
+/// prepare failures happen before any target write and retain a per-operation
+/// envelope for the CLI boundary.
 pub(crate) async fn execute_atomic_ops_file(
     ops: Vec<OpsFileEntry>,
     cfg: RuntimeConfig,
@@ -377,14 +454,27 @@ pub(crate) async fn execute_atomic_ops_file(
             // never fails an already-committed atomic unit, but is visible.
             let gtd_audit_outcomes =
                 apply_gtd_audit_post_commit_effects(&runtime, post_commit.as_slice()).await;
+            let mut degradations = Vec::new();
             let embedding_outcomes =
-                khive_runtime::atomic_prepare::apply_post_commit_effects_with_report(
+                match khive_runtime::atomic_prepare::apply_post_commit_effects_with_report(
                     &runtime,
                     &token,
                     post_commit,
                 )
                 .await
-                .context("post-commit reindex after atomic unit commit")?;
+                {
+                    Ok(outcomes) => outcomes,
+                    Err(error) => {
+                        let degradation =
+                            AtomicDegradation::post_commit_reindex(anyhow::Error::new(error));
+                        tracing::warn!(
+                            error = %degradation.error,
+                            "atomic unit committed but post-commit reindex failed"
+                        );
+                        degradations.push(degradation);
+                        Vec::new()
+                    }
+                };
             // ADR-099 B3: render each committed op's
             // canonical-shaped `result` payload (ADR-099 D4 requires
             // `results[i].result`; the pre-fix envelope carried only
@@ -392,7 +482,7 @@ pub(crate) async fn execute_atomic_ops_file(
             // safe post-commit, same reasoning as the reindex pass above.
             let mut results: Vec<Value> = Vec::with_capacity(ops.len());
             for (idx, op) in ops.iter().enumerate() {
-                let mut result = build_op_result(
+                let rendered = build_op_result(
                     &runtime,
                     &token,
                     &op.tool,
@@ -401,34 +491,39 @@ pub(crate) async fn execute_atomic_ops_file(
                     &plans[idx],
                     &gtd_audit_outcomes,
                 )
-                .await
-                .with_context(|| {
-                    format!(
-                        "op {idx} (`{}`) committed but result rendering failed",
-                        op.tool
-                    )
-                })?;
-                let embedding_effect = match &plans[idx] {
-                    AtomicOpPlan::Update(plan) => Some(plan.post_commit()),
-                    _ => None,
-                };
-                add_post_commit_embedding_warning(
-                    &mut result,
-                    embedding_effect,
-                    &embedding_outcomes,
-                );
-                results
-                    .push(json!({"ok": true, "tool": op.tool, "op_index": idx, "result": result}));
+                .await;
+                match rendered {
+                    Ok(mut result) => {
+                        let embedding_effect = match &plans[idx] {
+                            AtomicOpPlan::Update(plan) => Some(plan.post_commit()),
+                            _ => None,
+                        };
+                        add_post_commit_embedding_warning(
+                            &mut result,
+                            embedding_effect,
+                            &embedding_outcomes,
+                        );
+                        results.push(
+                            json!({"ok": true, "tool": op.tool, "op_index": idx, "result": result}),
+                        );
+                    }
+                    Err(error) => {
+                        let degradation = AtomicDegradation::result_rendering(idx, &op.tool, error);
+                        tracing::warn!(
+                            error = %degradation.error,
+                            op_index = idx,
+                            tool = %op.tool,
+                            "atomic unit committed but operation result rendering failed"
+                        );
+                        results.push(committed_degraded_result_entry(idx, &op.tool, &degradation));
+                        degradations.push(degradation);
+                    }
+                }
             }
             json!({
                 "results": results,
                 "summary": {"total": total, "succeeded": total, "failed": 0},
-                "atomic": {
-                    "committed": true,
-                    "rolled_back": false,
-                    "failed_op_index": Value::Null,
-                    "error": Value::Null,
-                },
+                "atomic": committed_atomic_block(&degradations),
             })
         }
         AtomicRunOutcome::RolledBack {
@@ -1235,7 +1330,10 @@ async fn prepare_gtd_complete(
 /// `kkernel::exec::tests::atomic_update_unknown_field_is_rejected_and_does_not_mutate_row`.
 #[cfg(test)]
 mod validate_atomic_args_tests {
-    use super::{add_post_commit_embedding_warning, validate_atomic_args, PostCommitEffect, Uuid};
+    use super::{
+        add_post_commit_embedding_warning, committed_atomic_block, committed_degraded_result_entry,
+        validate_atomic_args, AtomicDegradation, PostCommitEffect, Uuid,
+    };
     use serde_json::json;
 
     #[test]
@@ -1292,6 +1390,40 @@ mod validate_atomic_args_tests {
         let expected = json!([khive_runtime::retrieval::EMBEDDING_INPUT_TRUNCATED_WARNING]);
         assert_eq!(first_result["warnings"], expected);
         assert_eq!(second_result["warnings"], expected);
+    }
+
+    #[test]
+    fn committed_reindex_failure_is_typed_degraded_and_non_retryable() {
+        let degradation =
+            AtomicDegradation::post_commit_reindex(anyhow::anyhow!("fts maintenance unavailable"));
+        let atomic = committed_atomic_block(std::slice::from_ref(&degradation));
+
+        assert_eq!(atomic["committed"], true);
+        assert_eq!(atomic["rolled_back"], false);
+        assert_eq!(atomic["status"], "committed_degraded");
+        assert_eq!(atomic["retryable"], false);
+        assert_eq!(atomic["degradations"][0]["stage"], "post_commit_reindex");
+        assert!(atomic["degradations"][0]["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("fts maintenance unavailable")));
+    }
+
+    #[test]
+    fn committed_render_failure_keeps_operation_successful_and_non_retryable() {
+        let degradation = AtomicDegradation::result_rendering(
+            2,
+            "link",
+            anyhow::anyhow!("committed edge read failed"),
+        );
+        let result = committed_degraded_result_entry(2, "link", &degradation);
+
+        assert_eq!(result["ok"], true);
+        assert_eq!(result["result"], serde_json::Value::Null);
+        assert_eq!(result["status"], "committed_degraded");
+        assert_eq!(result["retryable"], false);
+        assert_eq!(result["degradation"]["stage"], "result_rendering");
+        assert_eq!(result["degradation"]["op_index"], 2);
+        assert_eq!(result["degradation"]["tool"], "link");
     }
 
     #[test]

--- a/crates/kkernel/src/atomic_apply.rs
+++ b/crates/kkernel/src/atomic_apply.rs
@@ -136,6 +136,15 @@ impl AtomicDegradation {
         }
     }
 
+    fn save_file_publish(error: &anyhow::Error) -> Self {
+        Self {
+            stage: "save_file_publish",
+            op_index: None,
+            tool: None,
+            error: format!("atomic unit committed but save-file publication failed: {error:#}"),
+        }
+    }
+
     fn as_json(&self) -> Value {
         json!({
             "stage": self.stage,
@@ -144,6 +153,36 @@ impl AtomicDegradation {
             "error": self.error.as_str(),
         })
     }
+}
+
+/// Attach a failed post-commit `--save-file` publication to the authoritative
+/// atomic envelope. Returns `true` only when the envelope represents a durable
+/// commit; rolled-back envelopes still get printed by the caller but must not
+/// be mislabeled as committed degradation.
+pub(crate) fn record_save_file_publish_failure(
+    envelope: &mut Value,
+    error: &anyhow::Error,
+) -> bool {
+    let Some(atomic) = envelope.get_mut("atomic").and_then(Value::as_object_mut) else {
+        return false;
+    };
+    if atomic.get("committed").and_then(Value::as_bool) != Some(true) {
+        return false;
+    }
+
+    let degradation = AtomicDegradation::save_file_publish(error).as_json();
+    atomic.insert(
+        "status".to_string(),
+        Value::String("committed_degraded".to_string()),
+    );
+    atomic.insert("retryable".to_string(), Value::Bool(false));
+    match atomic.get_mut("degradations") {
+        Some(Value::Array(degradations)) => degradations.push(degradation),
+        _ => {
+            atomic.insert("degradations".to_string(), Value::Array(vec![degradation]));
+        }
+    }
+    true
 }
 
 fn committed_atomic_block(degradations: &[AtomicDegradation]) -> Value {
@@ -1330,10 +1369,7 @@ async fn prepare_gtd_complete(
 /// `kkernel::exec::tests::atomic_update_unknown_field_is_rejected_and_does_not_mutate_row`.
 #[cfg(test)]
 mod validate_atomic_args_tests {
-    use super::{
-        add_post_commit_embedding_warning, committed_atomic_block, committed_degraded_result_entry,
-        validate_atomic_args, AtomicDegradation, PostCommitEffect, Uuid,
-    };
+    use super::{add_post_commit_embedding_warning, validate_atomic_args, PostCommitEffect, Uuid};
     use serde_json::json;
 
     #[test]
@@ -1390,40 +1426,6 @@ mod validate_atomic_args_tests {
         let expected = json!([khive_runtime::retrieval::EMBEDDING_INPUT_TRUNCATED_WARNING]);
         assert_eq!(first_result["warnings"], expected);
         assert_eq!(second_result["warnings"], expected);
-    }
-
-    #[test]
-    fn committed_reindex_failure_is_typed_degraded_and_non_retryable() {
-        let degradation =
-            AtomicDegradation::post_commit_reindex(anyhow::anyhow!("fts maintenance unavailable"));
-        let atomic = committed_atomic_block(std::slice::from_ref(&degradation));
-
-        assert_eq!(atomic["committed"], true);
-        assert_eq!(atomic["rolled_back"], false);
-        assert_eq!(atomic["status"], "committed_degraded");
-        assert_eq!(atomic["retryable"], false);
-        assert_eq!(atomic["degradations"][0]["stage"], "post_commit_reindex");
-        assert!(atomic["degradations"][0]["error"]
-            .as_str()
-            .is_some_and(|error| error.contains("fts maintenance unavailable")));
-    }
-
-    #[test]
-    fn committed_render_failure_keeps_operation_successful_and_non_retryable() {
-        let degradation = AtomicDegradation::result_rendering(
-            2,
-            "link",
-            anyhow::anyhow!("committed edge read failed"),
-        );
-        let result = committed_degraded_result_entry(2, "link", &degradation);
-
-        assert_eq!(result["ok"], true);
-        assert_eq!(result["result"], serde_json::Value::Null);
-        assert_eq!(result["status"], "committed_degraded");
-        assert_eq!(result["retryable"], false);
-        assert_eq!(result["degradation"]["stage"], "result_rendering");
-        assert_eq!(result["degradation"]["op_index"], 2);
-        assert_eq!(result["degradation"]["tool"], "link");
     }
 
     #[test]

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -2153,6 +2153,45 @@ fn build_local_fallback_server(
     }
 }
 
+struct AtomicSavePublishFailure {
+    stdout: String,
+    error: anyhow::Error,
+}
+
+/// Render the authoritative atomic stdout value. A save sink is preflighted
+/// before execution, but its writes/flush/rename necessarily happen after the
+/// database outcome is known. If that publication fails after a commit, keep
+/// the process failure while returning a reconciliation envelope that makes
+/// the durable, non-retryable outcome explicit.
+fn render_atomic_output(
+    envelope: &mut serde_json::Value,
+    save_sink: Option<khive_mcp::save_sink::JsonlSaveSink>,
+) -> std::result::Result<String, AtomicSavePublishFailure> {
+    let Some(save_sink) = save_sink else {
+        return Ok(serde_json::to_string_pretty(envelope).expect("serialize atomic envelope"));
+    };
+
+    match save_sink.write_envelope(envelope) {
+        Ok(manifest) => {
+            Ok(serde_json::to_string(&manifest).expect("serialize atomic save manifest"))
+        }
+        Err(error) => {
+            let committed = crate::atomic_apply::record_save_file_publish_failure(envelope, &error);
+            let stdout = serde_json::to_string_pretty(envelope)
+                .expect("serialize atomic save failure reconciliation envelope");
+            let error = if committed {
+                error.context(
+                    "atomic database changes committed but --save-file publication failed; \
+                     do not replay the mutation (inspect stdout for reconciliation details)",
+                )
+            } else {
+                error.context("atomic --save-file publication failed")
+            };
+            Err(AtomicSavePublishFailure { stdout, error })
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn run_exec_ops_file(
     path: PathBuf,
@@ -2260,11 +2299,15 @@ async fn run_exec_ops_file(
                 }
             };
         annotate_and_emit_refusals(&mut envelope, strict);
-        let output = if let Some(save_sink) = save_sink {
-            let manifest = save_sink.write_envelope(&envelope)?;
-            serde_json::to_string(&manifest).expect("serialize atomic save manifest")
-        } else {
-            serde_json::to_string_pretty(&envelope).expect("serialize atomic envelope")
+        let output = match render_atomic_output(&mut envelope, save_sink) {
+            Ok(output) => output,
+            Err(failure) => {
+                // stdout is the machine reconciliation channel. Emit it before
+                // returning the non-zero sink error so callers never infer that
+                // silence means the atomic database unit is safe to replay.
+                println!("{}", failure.stdout);
+                return Err(failure.error);
+            }
         };
         println!("{output}");
         return Ok(());
@@ -2300,6 +2343,7 @@ mod tests {
     use clap::Parser;
     use serial_test::serial;
     use tempfile::NamedTempFile;
+    use uuid::Uuid;
 
     // ── collect_op_failures: per-op error surfacing (#1228) ───────────────────
 
@@ -6372,6 +6416,20 @@ backend = "sessions"
         }
     }
 
+    async fn replace_fts_entities_with_incompatible_table(db_path: &str) {
+        let runtime = KhiveRuntime::new(atomic_cfg(db_path)).expect("runtime for FTS fault setup");
+        let sql = runtime.sql();
+        let mut writer = sql.writer().await.expect("writer for FTS fault setup");
+        writer
+            .execute_script(
+                "DROP TABLE fts_entities; \
+                 CREATE TABLE fts_entities (broken_column TEXT);"
+                    .to_string(),
+            )
+            .await
+            .expect("replace FTS table to inject post-commit reindex failure");
+    }
+
     #[tokio::test]
     async fn atomic_kg_only_config_keeps_gtd_hook_and_lifecycle_execution() {
         let db_file = NamedTempFile::new().expect("temp db");
@@ -6500,6 +6558,125 @@ backend = "sessions"
         let y_resp = dispatch_json(&server, &format!(r#"get(id="{y_id}")"#)).await;
         assert_eq!(x_resp["results"][0]["result"]["name"], "AtomicX-renamed");
         assert_eq!(y_resp["results"][0]["result"]["name"], "AtomicY-renamed");
+    }
+
+    #[tokio::test]
+    async fn atomic_post_commit_reindex_failure_returns_committed_non_retryable_envelope() {
+        let db_file = NamedTempFile::new().expect("temp db");
+        let db_path = db_file.path().to_str().expect("utf8").to_string();
+        let entity_id = {
+            let server = isolated_server(&db_path);
+            let response = dispatch_json(
+                &server,
+                r#"create(kind="concept", name="PostCommitReindexBefore")"#,
+            )
+            .await;
+            response["results"][0]["result"]["id"]
+                .as_str()
+                .expect("entity id")
+                .to_string()
+        };
+
+        // Migration state remains current, but an incompatible ordinary table
+        // occupies the post-commit FTS name. Store initialization cannot
+        // recreate the virtual table through IF NOT EXISTS; prepare and base
+        // DML do not touch it, so the failure occurs at the real reindex seam.
+        replace_fts_entities_with_incompatible_table(&db_path).await;
+
+        let envelope = crate::atomic_apply::execute_atomic_ops_file(
+            vec![atomic_op(
+                "update",
+                serde_json::json!({"id": entity_id, "name": "PostCommitReindexAfter"}),
+            )],
+            atomic_cfg(&db_path),
+            &KhiveConfig::default(),
+            khive_types::pack::ATOMIC_MAX_OPS_DEFAULT,
+        )
+        .await
+        .expect("post-commit failure must return a reconciliation envelope");
+
+        assert_eq!(envelope["atomic"]["committed"], true, "{envelope}");
+        assert_eq!(
+            envelope["atomic"]["status"], "committed_degraded",
+            "{envelope}"
+        );
+        assert_eq!(envelope["atomic"]["retryable"], false, "{envelope}");
+        assert_eq!(
+            envelope["atomic"]["degradations"][0]["stage"], "post_commit_reindex",
+            "{envelope}"
+        );
+        assert_eq!(envelope["summary"]["succeeded"], 1, "{envelope}");
+
+        let runtime =
+            KhiveRuntime::new(atomic_cfg(&db_path)).expect("runtime for committed-row check");
+        let token = runtime.authorize(Namespace::local()).expect("authorize");
+        let entity = runtime
+            .get_entity(&token, Uuid::parse_str(&entity_id).unwrap())
+            .await
+            .expect("committed entity row");
+        assert_eq!(entity.name, "PostCommitReindexAfter");
+    }
+
+    #[tokio::test]
+    async fn atomic_result_read_failure_keeps_later_committed_delete_non_retryable() {
+        let db_file = NamedTempFile::new().expect("temp db");
+        let db_path = db_file.path().to_str().expect("utf8").to_string();
+        let entity_id = {
+            let server = isolated_server(&db_path);
+            let response = dispatch_json(
+                &server,
+                r#"create(kind="concept", name="RenderThenDelete")"#,
+            )
+            .await;
+            response["results"][0]["result"]["id"]
+                .as_str()
+                .expect("entity id")
+                .to_string()
+        };
+
+        // Both plans prepare against the same live row. The unit then updates
+        // and hard-deletes it atomically. Rendering op 0 performs its real
+        // post-commit read and cannot find the row removed by op 1.
+        let envelope = crate::atomic_apply::execute_atomic_ops_file(
+            vec![
+                atomic_op(
+                    "update",
+                    serde_json::json!({"id": entity_id, "name": "NeverRendered"}),
+                ),
+                atomic_op("delete", serde_json::json!({"id": entity_id, "hard": true})),
+            ],
+            atomic_cfg(&db_path),
+            &KhiveConfig::default(),
+            khive_types::pack::ATOMIC_MAX_OPS_DEFAULT,
+        )
+        .await
+        .expect("render failure after commit must be a reconciliation envelope");
+
+        assert_eq!(envelope["atomic"]["committed"], true, "{envelope}");
+        assert_eq!(
+            envelope["atomic"]["status"], "committed_degraded",
+            "{envelope}"
+        );
+        assert_eq!(envelope["atomic"]["retryable"], false, "{envelope}");
+        assert_eq!(
+            envelope["atomic"]["degradations"][0]["stage"], "result_rendering",
+            "{envelope}"
+        );
+        assert_eq!(envelope["results"][0]["ok"], true, "{envelope}");
+        assert_eq!(
+            envelope["results"][0]["status"], "committed_degraded",
+            "{envelope}"
+        );
+        assert_eq!(envelope["results"][0]["retryable"], false, "{envelope}");
+        assert_eq!(envelope["results"][1]["result"]["deleted"], true);
+
+        let runtime =
+            KhiveRuntime::new(atomic_cfg(&db_path)).expect("runtime for deleted-row check");
+        let token = runtime.authorize(Namespace::local()).expect("authorize");
+        let deleted = runtime
+            .get_entity(&token, Uuid::parse_str(&entity_id).unwrap())
+            .await;
+        assert!(deleted.is_err(), "hard delete must remain committed");
     }
 
     /// Acceptance test 1b: a mid-unit failure rolls the WHOLE unit back —
@@ -6650,6 +6827,56 @@ backend = "sessions"
         assert_eq!(
             std::fs::read_to_string(save_path).unwrap().lines().count(),
             2
+        );
+    }
+
+    #[test]
+    fn atomic_save_persist_failure_returns_committed_reconciliation_stdout() {
+        let output_dir = tempfile::tempdir().unwrap();
+        let save_path = output_dir.path().join("publish-race.jsonl");
+        let sink = khive_mcp::save_sink::JsonlSaveSink::new(&save_path, false)
+            .expect("preflight save sink");
+        // Deterministic post-preflight publication failure: a directory wins
+        // the destination path after the sibling temp file has been created,
+        // so row writes and flush succeed but the final atomic rename fails.
+        std::fs::create_dir(&save_path).expect("occupy destination with a directory");
+        let mut envelope = serde_json::json!({
+            "results": [{
+                "ok": true,
+                "tool": "update",
+                "op_index": 0,
+                "result": {"id": Uuid::new_v4()}
+            }],
+            "summary": {"total": 1, "succeeded": 1, "failed": 0},
+            "atomic": {
+                "committed": true,
+                "rolled_back": false,
+                "failed_op_index": null,
+                "error": null
+            }
+        });
+
+        let failure = render_atomic_output(&mut envelope, Some(sink))
+            .expect_err("persist failure must remain a non-zero CLI outcome");
+        let stdout: serde_json::Value =
+            serde_json::from_str(&failure.stdout).expect("structured stdout envelope");
+
+        assert_eq!(stdout["atomic"]["committed"], true, "{stdout}");
+        assert_eq!(stdout["atomic"]["status"], "committed_degraded", "{stdout}");
+        assert_eq!(stdout["atomic"]["retryable"], false, "{stdout}");
+        assert_eq!(
+            stdout["atomic"]["degradations"][0]["stage"], "save_file_publish",
+            "{stdout}"
+        );
+        assert!(
+            stdout["atomic"]["degradations"][0]["error"]
+                .as_str()
+                .is_some_and(|error| error.contains("persist temp file")),
+            "{stdout}"
+        );
+        assert!(
+            format!("{:#}", failure.error).contains("do not replay the mutation"),
+            "terminal error must point automation at reconciliation"
         );
     }
 

--- a/docs/adr/ADR-046-event-sourced-proposals.md
+++ b/docs/adr/ADR-046-event-sourced-proposals.md
@@ -295,21 +295,24 @@ background worker:
 - successful `ProposalApplied` → atomically UPDATE status='applied' (CAS:
   `WHERE status='applying'`) and INSERT the success event; a missed CAS or update
   error publishes no success event
-- failed `ProposalApplied` → INSERT the failure event, then best-effort revert
-  status from 'applying' to 'approved'
+- apply failure known to precede a durable changeset commit → INSERT the
+  failure event, then best-effort revert status from 'applying' to 'approved'
 - `ProposalWithdrawn` → UPDATE status='withdrawn'
 
-**`applying` — transient in-flight state (V18 amendment):** The apply worker
+**`applying` — in-flight or reconciliation state (V18 plus 2026-08-11 amendment):** The apply worker
 atomically transitions status from `'approved'` to `'applying'` (a CAS UPDATE)
 before executing any KG mutations. This prevents a concurrent `withdraw` from
 landing while the apply is in progress — `withdraw`'s own CAS requires
 `status NOT IN ('applied', 'applying', 'withdrawn', 'rejected')`, so it fails
 with an error when the apply worker holds `'applying'`. The apply worker
 transitions to `'applied'` and inserts the success event in one transaction, or
-reverts to `'approved'` on failure so the proposal is not permanently stuck.
+reverts to `'approved'` only when failure is known to precede the durable
+changeset commit. A failure after that commit leaves `'applying'` as the
+non-replayable reconciliation state.
 The success event INSERT is conditional on the transition changing exactly one
 row, so a missed CAS cannot publish success. `'applying'` is never written to
-the event log — it is a purely transient projection state.
+the event log — it is a projection-only state, normally transient but retained
+when a durable apply needs post-commit reconciliation.
 
 Hard-state (status != 'open' | 'changes_requested') rows are retained for
 audit. A `proposal_cleanup` operator command is deferred; future work must
@@ -351,8 +354,9 @@ Call flow:
 2. `reviewed_and_emit` atomically advances `proposals_open` and inserts `ProposalReviewed`.
 3. On `Approve`, `ProposalApplyWorker::maybe_apply` claims `approved` to `applying`
    and applies the changeset. Success atomically marks `applied` and inserts
-   `ProposalApplied`; failure inserts `ProposalApplied { Failed }` and then
-   reverts to `approved`.
+   `ProposalApplied`; a failure known to be pre-commit inserts
+   `ProposalApplied { Failed }` and then reverts to `approved`. A post-commit
+   maintenance/read failure leaves `applying` for reconciliation.
 
 Future async worker wiring, if added, must filter by `EventKind::ProposalReviewed`,
 not by verb string. Current v1 code calls the worker directly from `handle_review`.
@@ -374,8 +378,10 @@ On each approved review handled by `handle_review`, `ProposalApplyWorker::maybe_
      currently rejected before this stage — see the current-restriction note above)
 4. On success, calls `applied_and_emit`, which executes the `applying` →
    `applied` CAS and the conditional `ProposalApplied { Success { created_records } }`
-   INSERT in one write transaction. On failure, emits
-   `ProposalApplied { Failed { error } }` and best-effort reverts to `approved`.
+   INSERT in one write transaction. On failure known to precede a durable
+   changeset commit, emits `ProposalApplied { Failed { error } }` and
+   best-effort reverts to `approved`. After `Committed`, later failures emit no
+   failed event and do not revert.
 
 Authorization (ADR-018) checks the apply attempt. The worker's actor identity
 is (Fix 9):
@@ -468,16 +474,17 @@ verbs and the apply worker each have policy hooks:
 
 ### 9. Failure modes
 
-| Condition                                         | Behavior                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
-| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Proposer withdraws after Approve but before Apply | If `withdraw` arrives before the apply worker claims `'applying'`: `ProposalWithdrawn` emitted; worker sees status≠'approved' (pre-apply CAS fails); skips KG mutations; no `ProposalApplied` emitted. If `withdraw` arrives after the apply worker claims `'applying'`: `withdraw` CAS finds status='applying' and returns an error — the withdraw is rejected. KG mutations proceed and `ProposalApplied` is emitted normally.                                                                                                                                                                                                                                                                        |
-| Apply fails (validation, network, etc.)           | `ProposalApplied { Failed }` emitted; status is reverted from `'applying'` back to `'approved'` (best-effort CAS) so the proposal is not permanently stuck. Apply retry is deferred to a follow-up ADR. v1 behavior: failed applies return to `'approved'`; operators may issue a new `propose` (with `parent_id` referencing the failed proposal) to retry. Direct re-emission of `apply` events is not supported in v1.                                                                                                                                                                                                                                                                               |
-| Apply policy denied                               | Same as Apply fails with `error = "denied by policy"`. Operator adjusts policy and issues a new `propose` (with `parent_id`) to retry; direct `apply` re-emission is not supported in v1.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| Success finalization CAS misses or errors         | The transaction publishes no `ProposalApplied { Success }` event. A failed batch leaves the projection at `applying`; committed KG mutations remain visible, but event consumers cannot observe success while projection readers still see a non-applied proposal. The condition is logged for operator reconciliation.                                                                                                                                                                                                                                                                                                                                                                                 |
-| Reviewer reverses Approve to Reject               | Each review is its own event; the worker uses the latest decision per reviewer. If a previously-approved proposal hits Reject before Apply fires, status moves to 'rejected'.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| Two reviewers race (both Approve simultaneously)  | Each `review(approve)` call invokes the apply worker synchronously after `reviewed_and_emit`. The `reviewed_and_emit` CAS serializes concurrent reviews at the projection layer; the apply worker’s `approved → applying` CAS ensures only one invocation executes the changeset. The worker checks `proposals_open.status` before applying; if already `applied` or `applying`, it returns without re-executing.                                                                                                                                                                                                                                                                                       |
-| Proposal expires                                  | A background sweep (TBD: cron-style, not v1) emits `ProposalWithdrawn` with `by = "system:expiry"` on proposals past their `expiry` timestamp.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
-| Stale-target conflict (Fix 6)                     | An `UpdateEntity` or `MergeEntities` proposal targets a specific entity ID. Between propose-time and apply-time the entity may be independently modified. v1 default: **last-writer-wins** — the proposal applies its patch unconditionally. Optional: proposals may include `expected_version: Option<u64>` in the payload (if entity versioning is introduced via ADR-014 amendment). The apply worker would then check `current_version == expected_version` and emit `ProposalApplied { Failed { error: "stale: target was modified since proposal", current_version, expected_version } }` on mismatch. v1 does NOT introduce entity versioning; this knob is gated on a future ADR-014 amendment. |
+| Condition                                                       | Behavior                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Proposer withdraws after Approve but before Apply               | If `withdraw` arrives before the apply worker claims `'applying'`: `ProposalWithdrawn` emitted; worker sees status≠'approved' (pre-apply CAS fails); skips KG mutations; no `ProposalApplied` emitted. If `withdraw` arrives after the apply worker claims `'applying'`: `withdraw` CAS finds status='applying' and returns an error — the withdraw is rejected. KG mutations proceed and `ProposalApplied` is emitted normally.                                                                                                                                                                                                                                                                        |
+| Apply fails before commit (validation, prepare, rollback, etc.) | `ProposalApplied { Failed }` emitted; status is reverted from `'applying'` back to `'approved'` (best-effort CAS) so the proposal is not permanently stuck. Apply retry is deferred to a follow-up ADR. v1 behavior: failed applies return to `'approved'`; operators may issue a new `propose` (with `parent_id` referencing the failed proposal) to retry. Direct re-emission of `apply` events is not supported in v1.                                                                                                                                                                                                                                                                               |
+| Post-commit reindex or created-record resolution fails          | No `ProposalApplied { Failed }` event is emitted and the projection is not reverted. The graph mutation is already durable, so the proposal remains `applying` as an explicit reconciliation state. A repeated worker pass sees status != `approved` and skips the changeset, preventing replay. The condition is logged with `committed=true`, `retryable=false`, and a typed stage.                                                                                                                                                                                                                                                                                                                   |
+| Apply policy denied                                             | Same as a pre-commit apply failure with `error = "denied by policy"`. Operator adjusts policy and issues a new `propose` (with `parent_id`) to retry; direct `apply` re-emission is not supported in v1.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| Success finalization CAS misses or errors                       | The transaction publishes no `ProposalApplied { Success }` event. A failed batch leaves the projection at `applying`; committed KG mutations remain visible, but event consumers cannot observe success while projection readers still see a non-applied proposal. The condition is logged for operator reconciliation.                                                                                                                                                                                                                                                                                                                                                                                 |
+| Reviewer reverses Approve to Reject                             | Each review is its own event; the worker uses the latest decision per reviewer. If a previously-approved proposal hits Reject before Apply fires, status moves to 'rejected'.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| Two reviewers race (both Approve simultaneously)                | Each `review(approve)` call invokes the apply worker synchronously after `reviewed_and_emit`. The `reviewed_and_emit` CAS serializes concurrent reviews at the projection layer; the apply worker’s `approved → applying` CAS ensures only one invocation executes the changeset. The worker checks `proposals_open.status` before applying; if already `applied` or `applying`, it returns without re-executing.                                                                                                                                                                                                                                                                                       |
+| Proposal expires                                                | A background sweep (TBD: cron-style, not v1) emits `ProposalWithdrawn` with `by = "system:expiry"` on proposals past their `expiry` timestamp.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| Stale-target conflict (Fix 6)                                   | An `UpdateEntity` or `MergeEntities` proposal targets a specific entity ID. Between propose-time and apply-time the entity may be independently modified. v1 default: **last-writer-wins** — the proposal applies its patch unconditionally. Optional: proposals may include `expected_version: Option<u64>` in the payload (if entity versioning is introduced via ADR-014 amendment). The apply worker would then check `current_version == expected_version` and emit `ProposalApplied { Failed { error: "stale: target was modified since proposal", current_version, expected_version } }` on mismatch. v1 does NOT introduce entity versioning; this knob is gated on a future ADR-014 amendment. |
 
 ### 10. CLI / MCP surface summary
 
@@ -627,8 +634,8 @@ supersede, compound). Future arms add to the enum via additive semver bumps.
 ### Migration
 
 The `proposals_open` projection table was created in migration V15 in
-`crates/khive-db/src/migrations.rs`. The `applying` transient status and
-its CAS invariants were added in V18.
+`crates/khive-db/src/migrations.rs`. The `applying` projection status and its
+CAS invariants were added in V18.
 
 A `VersionedMigration` in `crates/khive-db/src/migrations.rs`:
 
@@ -793,3 +800,26 @@ is not part of this finalization transaction, but success never becomes external
 visible while `proposals_open` remains `applying`. Because this path bypasses the
 `EventStore::append_event` seam, it increments ADR-103 `event_rows` exactly once
 after and only after the two-row atomic batch succeeds.
+
+## Amendment (2026-08-11): durable apply reconciliation boundary
+
+`AtomicRunOutcome::Committed` is the proposal apply worker's irreversible
+retry-safety boundary. After that outcome is observed, failure of deferred
+reindexing or committed-created-record resolution MUST NOT flow through the
+ordinary apply-failure branch: it emits no `ProposalApplied { Failed }`, does
+not run the `applying -> approved` revert, and is not eligible for automatic
+replay.
+
+Instead, the worker logs a typed reconciliation stage
+(`post_commit_reindex` or `created_record_resolution`) with `committed=true`
+and `retryable=false`, and leaves `proposals_open.status='applying'`. This is a
+deliberate durable reconciliation state, not evidence that base DML is still in
+flight. The normal worker entry guard only claims `approved`, so another pass
+cannot execute the changeset again. Operator reconciliation may repair the
+derived index or recover the created-record identifiers and then perform the
+existing atomic success finalization; it must never reapply the base mutation.
+
+Failures before a committed outcome is observed retain the existing contract:
+emit `ProposalApplied { Failed }` and best-effort revert to `approved`. A
+rolled-back atomic unit is therefore retryable under the proposal workflow; a
+committed unit with incomplete post-processing is not.

--- a/docs/adr/ADR-099-bulk-apply-atomic-units.md
+++ b/docs/adr/ADR-099-bulk-apply-atomic-units.md
@@ -647,9 +647,9 @@ implementation was restructured to the seam this ADR mandates:
 ## Amendment 2 (2026-08-11) — committed post-processing degradation is non-retryable
 
 The successful commit is the irreversible retry-safety boundary. Once the commit pass returns
-`AtomicRunOutcome::Committed`, neither deferred index maintenance nor canonical result rendering
-may convert the invocation into an error that invites replay. The base DML is already durable at
-that point.
+`AtomicRunOutcome::Committed`, neither deferred index maintenance, canonical result rendering, nor
+publication of an optional `--save-file` may produce an outcome that invites replay. The base DML
+is already durable at that point.
 
 A post-commit reindex or result-rendering failure therefore returns the ordinary successful
 `results` and `summary` envelope with the D4 atomic facts preserved:
@@ -671,12 +671,22 @@ also carries these additive fields:
 }
 ```
 
-The closed stage spellings in this amendment are `post_commit_reindex` and `result_rendering`.
+The closed stage spellings in this amendment are `post_commit_reindex`, `result_rendering`, and
+`save_file_publish`.
 For a rendering failure, the affected result entry remains `ok=true` because its mutation
 committed; it carries `result=null`, `status="committed_degraded"`, `retryable=false`, and the same
 typed degradation object with its `op_index` and `tool`. `summary.succeeded` continues to count
 durable mutations, not successful presentation reads. Other committed results are still rendered,
 so one failed read does not erase the outcomes that remain available.
+
+With `--save-file`, a successful publication returns the ordinary manifest and copies the entire
+top-level `atomic` object from the execution envelope unchanged. The JSONL rows are not sufficient
+reconciliation evidence because they cannot carry this unit-level commit fact. If a row write,
+flush, or final rename fails after the database commit, the destination is not claimed as
+published; the CLI first writes the full execution envelope to stdout with a
+`save_file_publish` degradation and `retryable=false`, then exits non-zero for the requested file
+failure. The non-zero status reports output-publication failure, not mutation failure. Automation
+MUST inspect stdout and MUST NOT replay a unit whose envelope says `committed=true`.
 
 The reindex stage remains best-effort as D3 already requires. Its failure means the derived search
 index may need repair; it does not mean the source row update failed. Full success, pre-commit

--- a/docs/adr/ADR-099-bulk-apply-atomic-units.md
+++ b/docs/adr/ADR-099-bulk-apply-atomic-units.md
@@ -641,3 +641,44 @@ implementation was restructured to the seam this ADR mandates:
    (kind-vs-substrate NotFound shape on `update`; the `link`
    target-backend conflict arm) are obsolete: both paths now execute the same code, so
    the divergences no longer exist and no compensating documentation is required.
+
+---
+
+## Amendment 2 (2026-08-11) — committed post-processing degradation is non-retryable
+
+The successful commit is the irreversible retry-safety boundary. Once the commit pass returns
+`AtomicRunOutcome::Committed`, neither deferred index maintenance nor canonical result rendering
+may convert the invocation into an error that invites replay. The base DML is already durable at
+that point.
+
+A post-commit reindex or result-rendering failure therefore returns the ordinary successful
+`results` and `summary` envelope with the D4 atomic facts preserved:
+`committed=true`, `rolled_back=false`, `failed_op_index=null`, and `error=null`. The `atomic` object
+also carries these additive fields:
+
+```json
+{
+  "status": "committed_degraded",
+  "retryable": false,
+  "degradations": [
+    {
+      "stage": "post_commit_reindex",
+      "op_index": null,
+      "tool": null,
+      "error": "<diagnostic>"
+    }
+  ]
+}
+```
+
+The closed stage spellings in this amendment are `post_commit_reindex` and `result_rendering`.
+For a rendering failure, the affected result entry remains `ok=true` because its mutation
+committed; it carries `result=null`, `status="committed_degraded"`, `retryable=false`, and the same
+typed degradation object with its `op_index` and `tool`. `summary.succeeded` continues to count
+durable mutations, not successful presentation reads. Other committed results are still rendered,
+so one failed read does not erase the outcomes that remain available.
+
+The reindex stage remains best-effort as D3 already requires. Its failure means the derived search
+index may need repair; it does not mean the source row update failed. Full success, pre-commit
+failure, and rollback envelopes are unchanged. This is a CLI-only additive contract and does not
+change the MCP `request` wire surface.

--- a/docs/adr/ADR-102-tiered-validate-and-merge.md
+++ b/docs/adr/ADR-102-tiered-validate-and-merge.md
@@ -201,6 +201,24 @@ D4 defines. This is additive to ADR-020's CLI surface — no existing verb's beh
 and the `commit` verb is scoped to this ADR's own local, non-remote repository (D6), not to
 the project-repository-embedded `.khive/kg/` layout ADR-020 §1 otherwise describes.
 
+### Amendment (2026-08-11): reviewed apply commit boundary
+
+The tier-2 reviewed path inherits ADR-046's proposal-worker state machine and
+the atomic change-set runner's durable outcome. Once that runner reports
+`AtomicRunOutcome::Committed`, the live graph write has landed even if deferred
+index maintenance or created-record resolution subsequently fails. Such a
+failure is a reconciliation condition, not a rejected review or a failed live
+write.
+
+The reviewed proposal therefore remains `applying`; the worker emits neither
+`ProposalApplied { Failed }` nor an `applying -> approved` revert. A repeated
+worker pass must skip it rather than replaying the approved change-set. The
+operator repairs the typed post-commit stage and resumes success finalization
+from the durable state. Only failures known to precede commit, including an
+atomic rollback, use the ordinary failed/revert path. This boundary preserves
+the tier-2 audit gate without turning a derived-index or reconciliation read
+failure into a duplicate live mutation.
+
 ---
 
 ## Consequences

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -586,7 +586,10 @@ failure list and use `--strict` when any failed op must produce a non-zero exit.
 against an idle daemon or in a maintenance window. A plan-level rollback prints
 `atomic.committed=false` but currently exits zero even with `--strict`; inspect that field rather
 than relying on process status. Admissibility, prepare, and atomic-unit seam errors instead exit
-non-zero before printing an atomic result envelope. For combined non-atomic
+non-zero before printing an atomic result envelope. A deferred reindex or result-rendering failure
+after commit is different: it exits zero with `atomic.committed=true`,
+`atomic.status="committed_degraded"`, and `atomic.retryable=false`; repair or re-read as directed by
+the typed `atomic.degradations` stage, and do not replay the durable mutation. For combined non-atomic
 `--ops-file --save-file`, file publication is atomic but database chunks commit incrementally.
 Every exit after dispatch prints a reconciliation manifest: success uses the ordinary shape; a
 failure before the manifest is finalized uses `status="aborted"`, lists confirmed

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -589,7 +589,12 @@ than relying on process status. Admissibility, prepare, and atomic-unit seam err
 non-zero before printing an atomic result envelope. A deferred reindex or result-rendering failure
 after commit is different: it exits zero with `atomic.committed=true`,
 `atomic.status="committed_degraded"`, and `atomic.retryable=false`; repair or re-read as directed by
-the typed `atomic.degradations` stage, and do not replay the durable mutation. For combined non-atomic
+the typed `atomic.degradations` stage, and do not replay the durable mutation. With atomic
+`--save-file`, a successful manifest preserves that entire `atomic` block. A sink write, flush, or
+rename failure after commit prints the full envelope with
+`atomic.degradations[].stage="save_file_publish"` and `atomic.retryable=false`, then exits non-zero;
+the exit reports file-publication failure, while `atomic.committed=true` remains authoritative and
+forbids replay. For combined non-atomic
 `--ops-file --save-file`, file publication is atomic but database chunks commit incrementally.
 Every exit after dispatch prints a reconciliation manifest: success uses the ordinary shape; a
 failure before the manifest is finalized uses `status="aborted"`, lists confirmed


### PR DESCRIPTION
Fixes #1752.

This keeps durable atomic commits distinguishable from post-commit degradation:

- returns committed_degraded / retryable=false for reindex and per-op render failures
- preserves the atomic reconciliation contract in save-file manifests
- prints the committed envelope before reporting a post-commit save publish failure
- leaves proposal apply reconciliation in applying after committed post-hook failures, without reverting or replaying
- replaces helper-only coverage with real FTS, render, filesystem persistence, manifest, and proposal-worker fault regressions

Accepted ADR-046, ADR-099, ADR-102 and operator docs are aligned.

Verification so far: independent source review APPROVE; rustfmt, Deno fmt, diff check, ADR-ref lint, and stub-marker lint pass. Six focused Rust tests are queued serially behind the active #1897 build; this PR remains draft until they pass.