### PR TITLE
fix(db): enforce strict writer routing across stores

### DIFF
--- a/crates/khive-db/docs/api/graph.md
+++ b/crates/khive-db/docs/api/graph.md
@@ -9,17 +9,19 @@ endpoint-existence guards that back `link`'s atomic-unit safety.
 
 See `crates/khive-db/src/stores/graph.rs` — private method `with_writer`.
 
-Routes a single-row write through the pool-wide `WriterTask` when
-`KHIVE_WRITE_QUEUE=1` and a handle is available; otherwise falls back to the
-legacy standalone-connection / pool-mutex path. This is the ONE routing
+Resolves the pool-wide `WriterTask` at write time and routes through it when
+available; a handle missed by construction outside Tokio is refreshed here.
+Strict routing fails closed when no handle is available. Compatibility mode
+falls back to the legacy standalone-connection / pool-mutex path and emits a
+`direct_route:graph_general_write` violation when the file-backed queue is
+enabled. This is the ONE routing
 point for every `with_writer` caller in this store (`upsert_edge`,
 `delete_edge`, `purge_incident_edges`). `f` must be DML-only — on the
 flag-on path it runs inside the WriterTask's own transaction, so a bare
 `BEGIN IMMEDIATE` would violate SQLite's nested-transaction rule.
-`upsert_edges` (the batch method) does its own flag check and returns early
-on `Some`, so its fallback call into this helper only ever executes on the
-flag-off path (`self.writer_task` is `None` by construction whenever that
-call is reached) — no double-routing.
+`upsert_edges` and guarded batch/transaction paths perform the same write-time
+lookup before falling through this helper. A non-strict `None` records only at
+the actual fallback seam; strict mode never reaches it.
 
 ## `edge_insert_guarded_by_endpoints_statement` — commit-time endpoint guard (ADR-099 §B3)
 

--- a/crates/khive-db/docs/api/pool.md
+++ b/crates/khive-db/docs/api/pool.md
@@ -47,6 +47,29 @@ writer task would let concurrent migrated stores over the same pool spawn
 independent writer connections that contend with each other at `BEGIN
 IMMEDIATE`, defeating the point of ADR-067 Component A.
 
+## `ConnectionPool::writer_task_for_write` — write-time store routing (#1847)
+
+Store construction is synchronous and can happen before a Tokio runtime is
+entered. A constructor may therefore cache no writer-task handle even though a
+later write runs inside a runtime where the pool can spawn (or retrieve) its
+single task. Every SQLite-backed store resolves through
+`writer_task_for_write` at the write seam, including transaction-owning and
+batch entry points, so a construction-time `None` is never a permanent routing
+decision.
+
+When `write_routing_strict` is enabled, a missing handle fails closed: a
+missing runtime preserves `StorageError::WriterTaskNoRuntime`, while an
+explicitly disabled or degraded queue returns a typed `StorageError::Pool`
+naming the operation. In compatibility mode, a caller may use its legacy
+standalone/pool-mutex writer only after this lookup returns `None`; that exact
+fallback emits a store-specific `direct_route_violation` when the file-backed
+queue is enabled.
+
+This routing hardening does **not** flip the strict-mode default. ADR-135 F2
+and ADR-136 D2 still require production A/B evidence and a release gate before
+`write_routing_strict` can become the default; until that evidence is accepted,
+`KHIVE_WRITE_ROUTING=strict` remains opt-in.
+
 ## Test coverage notes
 
 ### `writer_guard_transaction_registers_during_closure_only`

--- a/crates/khive-db/docs/api/text.md
+++ b/crates/khive-db/docs/api/text.md
@@ -10,25 +10,25 @@ of MATCH-expression syntax errors and false-negative matches.
 
 See `crates/khive-db/src/stores/text.rs` — private method `with_writer`.
 
-Routes a single-row write through the pool-wide `WriterTask` when
-`KHIVE_WRITE_QUEUE=1` and a handle is available; otherwise falls back to the
-legacy standalone-connection / pool-mutex path.
+Resolves the pool-wide `WriterTask` at write time and routes through it when
+available; a handle missed by construction outside Tokio is refreshed here.
+Strict routing fails closed when no handle is available. Compatibility mode
+falls back to the legacy standalone-connection / pool-mutex path and emits a
+store-specific direct-route violation when the file-backed queue is enabled.
 
 This is the routing point for `with_writer` callers whose closure is
 DML-only (`delete_document`/`fts_delete`, `rebuild`/`fts_rebuild`): on the
 flag-on path the closure runs inside the WriterTask's own transaction, so a
 bare `BEGIN IMMEDIATE` would violate SQLite's nested-transaction rule.
-`upsert_document`/`upsert_documents` (the single-doc and batch write
-methods) do their own flag check and return early on `Some`, so their
-fallback calls into this helper only ever execute on the flag-off path
-(`self.writer_task` is `None` by construction whenever those calls are
-reached) — no double-routing.
+`upsert_document`/`upsert_documents` (the single-doc and batch write methods)
+perform the same write-time lookup before falling through this helper. A
+non-strict `None` records only at the actual fallback seam; strict mode never
+reaches it.
 
-`rename_namespace` (`#[allow(dead_code)]`, no production caller — see
-ADR-067's `BEGIN IMMEDIATE` site inventory, EXEMPT) manages its own manual
-transaction and calls `with_writer_unmanaged` instead of this helper —
-routing its closure through the WriterTask would nest a bare `BEGIN
-IMMEDIATE` inside the WriterTask's own transaction.
+`rename_namespace` submits its DML-only read/delete/reinsert body through the
+WriterTask when available, with the task owning the enclosing transaction. Its
+compatibility fallback alone calls `with_writer_unmanaged` and supplies the
+legacy explicit transaction; strict routing refuses before that fallback.
 
 ## FTS5 query sanitization pipeline
 

--- a/crates/khive-db/docs/api/vectors.md
+++ b/crates/khive-db/docs/api/vectors.md
@@ -11,26 +11,28 @@ pins down; public-item contracts stay complete in their own doc-comments.
 See `crates/khive-db/src/stores/vectors.rs` — private methods `with_writer`,
 `with_writer_unmanaged`.
 
-`with_writer` routes a single-row write through the pool-wide `WriterTask`
-when `KHIVE_WRITE_QUEUE=1` and a handle is available; otherwise it falls
-back to the legacy pool-mutex path (`with_writer_unmanaged`).
+`with_writer` resolves the pool-wide `WriterTask` at write time and routes
+through it when available; a handle missed by construction outside Tokio is
+refreshed here. Strict routing fails closed when no handle is available.
+Compatibility mode falls back to the legacy pool-mutex path
+(`with_writer_unmanaged`) and emits a store-specific direct-route violation
+when the file-backed queue is enabled.
 
-This is the routing point for callers whose closure is DML-only
-(`delete`/`vec_delete`, `delete_subjects`/`vec_delete_subjects`): on the
-flag-on path the closure runs inside the WriterTask's own transaction, so a
-bare `BEGIN IMMEDIATE` (or an inner `conn.unchecked_transaction()`) would
-violate SQLite's nested-transaction rule. `insert`/`update` (which need
-their own delete-then-insert atomicity), `insert_batch` (the batch method),
-and `orphan_sweep` (ADR-067 Amendment 1) each do their own flag check and
-return early on `Some`, routing a DML-only closure directly through the
-WriterTask instead — their fallback calls into `with_writer` only ever
-execute on the flag-off path (`self.writer_task` is `None` by construction
-whenever those calls are reached), so there is no double-routing.
+This is the routing point for DML-only `delete` and the compatibility
+fallbacks of `insert`/`update`/`insert_batch`. On the queue path the closure
+runs inside the WriterTask's own transaction, so a bare `BEGIN IMMEDIATE` (or
+an inner `conn.unchecked_transaction()`) would violate SQLite's
+nested-transaction rule. Those replacement/batch operations, plus
+`delete_subjects` and `orphan_sweep`, first perform their own write-time lookup
+and submit a DML-only closure directly through the WriterTask. On a non-strict
+`None`, they fall through to the matching legacy helper and record only at the
+actual fallback seam; strict mode never reaches it.
 
-`with_writer_unmanaged` bypasses the WriterTask channel unconditionally
-regardless of `KHIVE_WRITE_QUEUE`. Reserved for closures that manage their
-own transaction — those cannot be sent through the WriterTask channel, which
-already wraps every request in its own transaction. The flag-off paths for
+`with_writer_unmanaged` bypasses the WriterTask channel unconditionally and is
+therefore reachable only after the shared write-time routing decision.
+Reserved for compatibility closures that manage their own transaction — those
+cannot be sent through the WriterTask channel, which already wraps every
+request in its own transaction. The fallback paths for
 `delete_subjects` and `orphan_sweep` use it with
 `Transaction::new_unchecked` (their own `BEGIN IMMEDIATE`); their flag-on
 paths route DML-only closures directly through the WriterTask instead, since

--- a/crates/khive-db/docs/api/writer-task.md
+++ b/crates/khive-db/docs/api/writer-task.md
@@ -64,12 +64,10 @@ successful response cannot race ahead of its telemetry sample.
 
 See `crates/khive-db/src/writer_task.rs` — private fn `run_writer_task`.
 
-A `BEGIN IMMEDIATE` failure (for example, `SQLITE_BUSY` from lock
-contention with an unmigrated writer path still holding the pool's writer
-mutex — reachable while any write path outside the routed-call
-classification table in `writer_task.rs`'s module docs still opens its own
-writer; strict routing per ADR-136 D1 has not landed) replies the request's
-error via `AnyWriteRequest::reply_error` without ever invoking the
+A `BEGIN IMMEDIATE` failure (for example, `SQLITE_BUSY` from an explicitly
+exempt writer or a non-strict compatibility fallback still holding another
+writer connection) replies the request's error via
+`AnyWriteRequest::reply_error` without ever invoking the
 request's operation closure via `AnyWriteRequest::execute_and_reply`.
 For transaction-wrapped requests, the scoped `writer_task_tx` registry span
 is dropped before the oneshot reply wakes the caller, both after a completed
@@ -78,6 +76,12 @@ therefore cannot still observe that request as an open SQL transaction.
 There is no watchdog/retry story for a failed `BEGIN` (ADR-067
 Component D remains future work); the connection simply tries
 `BEGIN IMMEDIATE` fresh on the next request.
+
+Request-path stores refresh a missing construction-time handle at write time.
+Strict routing therefore fails closed before any store fallback, and a
+non-strict fallback emits a store-specific `direct_route_violation`. The
+strict-default flip is intentionally outside this tranche: ADR-135 F2 and
+ADR-136 D2 still gate it on accepted production A/B and release evidence.
 
 Exits normally when every `WriterTaskHandle` clone is dropped and the channel
 closes (`rx.recv()` returns `None`). A panic while executing a request, a failed

--- a/crates/khive-db/docs/design.md
+++ b/crates/khive-db/docs/design.md
@@ -94,12 +94,21 @@ stores would open independent connections that contend with each other at
 `BEGIN IMMEDIATE`, defeating the purpose of a write queue. `ConnectionPool`
 lazily spawns a single `WriterTask` behind a `OnceLock`: the first caller to
 need it runs the init closure, every later caller (from any store, any
-namespace) receives a clone of the same handle. When `KHIVE_WRITE_QUEUE=1`,
-store methods route single-row DML through this shared `WriterTask` instead
-of taking the pool mutex directly; `orphan_sweep` and other closures that
-manage their own transaction bypass the queue via the "unmanaged" path
-instead, since a transaction-owning closure cannot be sent through a channel
-that already wraps every request in its own transaction.
+namespace) receives a clone of the same handle. Store methods resolve that
+handle again at write time, so construction before a Tokio runtime cannot
+permanently cache a queue bypass. Single-row, batch, and transaction-owning
+operations submit DML-only closures through the shared task; the task owns the
+outer transaction. A non-strict compatibility fallback may still use the
+legacy standalone/pool-mutex writer and records a store-specific
+`direct_route_violation`. Strict mode refuses that fallback before it opens a
+direct writer.
+
+Strict routing remains opt-in. Flipping its default is separately gated by
+ADR-135 F2 and ADR-136 D2 production A/B evidence plus the release gate; this
+write-time routing hardening does not claim that evidence. The unified helper
+covers the SQLite store layer; remaining runtime-orchestration direct-writer
+call sites stay in #1847's follow-up inventory rather than being silently
+classified as complete.
 
 See `crates/khive-db/docs/api/pool.md` and `crates/khive-db/docs/api/vectors.md`
 for the per-function routing rules and the tests that pin them down.

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -79,10 +79,11 @@ pub struct PoolConfig {
     /// ADR-135 Amendment 1 and ADR-136 D1/D2 — the strict-routing default
     /// flip has NOT happened.
     ///
-    /// The set of routed write paths is the classification table in
-    /// `writer_task.rs` (module docs), not any single store; routing does
-    /// not yet claim ADR-067's single-writer guarantee — unmigrated write
-    /// paths still open their own writers until strict routing lands.
+    /// The store layer resolves all of its routed write paths at write time;
+    /// the classification table in `writer_task.rs` remains the authoritative
+    /// inventory. This tranche does not claim the repository-wide
+    /// single-writer guarantee: direct runtime-orchestration call sites remain
+    /// #1847 follow-up work, and the strict default is still evidence-gated.
     ///
     /// `None` means the caller expressed no preference: [`ConnectionPool::new`]
     /// resolves it once `path` is known, defaulting to `true` for file-backed
@@ -104,12 +105,13 @@ pub struct PoolConfig {
     /// Overridable via `KHIVE_WRITE_QUEUE_CAPACITY`. Default: 256 pending
     /// operations (ADR-067 Component A recommended default).
     pub write_queue_capacity: usize,
-    /// ADR-136 D1: when `true`, every write path that would otherwise
-    /// silently degrade to the legacy pool-mutex/standalone-connection path
-    /// on a missing or failed `WriterTask` handle instead returns an error.
-    /// Exercises the completed routing (ADR-135 F2's strict-routing
-    /// precondition) without changing behavior for callers that never set
-    /// the env var.
+    /// ADR-136 D1: when `true`, every covered store write path that would
+    /// otherwise silently degrade to the legacy pool-mutex/standalone-
+    /// connection path on a missing or failed `WriterTask` handle instead
+    /// returns an error.
+    /// Exercises the store-layer routing tranche toward ADR-135 F2's
+    /// strict-routing precondition without changing behavior for callers that
+    /// never set the env var.
     ///
     /// Overridable via `KHIVE_WRITE_ROUTING` (value `"strict"`,
     /// case-insensitive; anything else, or unset, leaves this `false`).
@@ -932,6 +934,52 @@ impl ConnectionPool {
                 }
             })
             .clone())
+    }
+
+    /// Resolve the writer task for a store write at the moment the write is
+    /// issued, rather than trusting only a handle cached by a synchronous
+    /// store constructor. Construction can legitimately run before Tokio is
+    /// entered, in which case `writer_task_handle()` returns
+    /// `WriterTaskNoRuntime` without caching a terminal `None`.
+    ///
+    /// Strict routing makes every missing handle fail closed here. The
+    /// caller remains responsible for recording a non-strict direct fallback
+    /// at the exact fallback seam with [`Self::record_direct_route`].
+    pub(crate) fn writer_task_for_write(
+        &self,
+        cached: Option<&WriterTaskHandle>,
+        operation: &'static str,
+    ) -> Result<Option<WriterTaskHandle>, StorageError> {
+        let handle = match cached {
+            Some(handle) => Some(handle.clone()),
+            None => match self.writer_task_handle() {
+                Ok(handle) => handle,
+                Err(error) if self.config.write_routing_strict => return Err(error),
+                Err(_) => None,
+            },
+        };
+
+        if handle.is_none() && self.config.write_routing_strict {
+            return Err(StorageError::Pool {
+                operation: operation.into(),
+                message: "strict write routing requires a writer-task handle; no handle is \
+                          available, so the direct writer fallback was refused"
+                    .into(),
+            });
+        }
+        Ok(handle)
+    }
+
+    /// Record one actual compatibility fallback around the writer task. A
+    /// file-backed pool with the queue enabled should never reach this seam
+    /// in strict mode because [`Self::writer_task_for_write`] refuses first.
+    pub(crate) fn record_direct_route(&self, site: crate::timeout_sink::Site) {
+        if self.write_queue_active() {
+            crate::timeout_sink::emit_direct_route_violation(
+                &crate::timeout_sink::db_label(self),
+                site,
+            );
+        }
     }
 
     /// Test-only: how many times the writer-task init closure actually ran.
@@ -2969,6 +3017,28 @@ mod tests {
             0,
             "the guard must reject before ever attempting tokio::spawn"
         );
+    }
+
+    /// #1847: strict store routing must preserve the typed missing-runtime
+    /// failure instead of collapsing it into a direct-writer fallback.
+    #[test]
+    fn strict_writer_task_for_write_preserves_missing_runtime_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let pool = ConnectionPool::new(PoolConfig {
+            path: Some(dir.path().join("strict_writer_task_no_runtime.db")),
+            write_queue_enabled: Some(true),
+            write_routing_strict: true,
+            ..PoolConfig::default()
+        })
+        .expect("file-backed pool should open");
+
+        let result = pool.writer_task_for_write(None, "strict_test_write");
+
+        assert!(
+            matches!(result, Err(StorageError::WriterTaskNoRuntime)),
+            "strict routing must preserve WriterTaskNoRuntime, got {result:?}"
+        );
+        assert_eq!(pool.writer_task_spawn_count(), 0);
     }
 
     /// Join-handle lifecycle: a spawn-configured pool stores exactly one

--- a/crates/khive-db/src/stores/agents.rs
+++ b/crates/khive-db/src/stores/agents.rs
@@ -210,6 +210,9 @@ pub struct SqlAgentStore {
 
 impl SqlAgentStore {
     pub fn new(pool: Arc<ConnectionPool>, is_file_backed: bool) -> Self {
+        // Construction may happen before Tokio is entered. A missing handle
+        // is therefore only a cache hint; every write re-resolves it and
+        // applies strict/compatibility policy at the actual write seam.
         let writer_task = pool.writer_task_handle().ok().flatten();
         Self {
             pool,
@@ -230,17 +233,27 @@ impl SqlAgentStore {
             .map_err(|e| map_sqlite_err(e, "open_agent_reader"))
     }
 
+    fn current_writer_task(
+        &self,
+        operation: &'static str,
+    ) -> Result<Option<WriterTaskHandle>, StorageError> {
+        self.pool
+            .writer_task_for_write(self.writer_task.as_ref(), operation)
+    }
+
     async fn with_writer<F, R>(&self, op: &'static str, f: F) -> Result<R, StorageError>
     where
         F: FnOnce(&rusqlite::Connection) -> Result<R, rusqlite::Error> + Send + 'static,
         R: Send + 'static,
     {
-        if let Some(writer_task) = &self.writer_task {
+        if let Some(writer_task) = self.current_writer_task(op)? {
             return writer_task
                 .send_bounded(move |conn| f(conn).map_err(|e| map_err(e, op)))
                 .await;
         }
 
+        self.pool
+            .record_direct_route(crate::timeout_sink::Site::DirectRouteAgentGeneralWrite);
         if self.is_file_backed {
             let conn = self.open_standalone_writer()?;
             tokio::task::spawn_blocking(move || f(&conn).map_err(|e| map_err(e, op)))
@@ -283,6 +296,19 @@ impl SqlAgentStore {
 impl AgentStore for SqlAgentStore {
     async fn insert(&self, record: &AgentRecord) -> Result<(), StorageError> {
         let record = record.clone();
+
+        // The provider-session pre-check and INSERT must share one write
+        // transaction. The WriterTask already supplies that transaction, so
+        // submit only the DML body on the queue path; the compatibility path
+        // below retains its explicit BEGIN/COMMIT wrapper.
+        if let Some(writer_task) = self.current_writer_task("agent_insert")? {
+            return writer_task
+                .send_bounded(move |conn| {
+                    insert_agent_dml(conn, &record).map_err(|error| map_err(error, "agent_insert"))
+                })
+                .await;
+        }
+
         self.with_writer("agent_insert", move |conn| {
             conn.execute_batch("BEGIN IMMEDIATE")?;
             if let Err(e) = insert_agent_dml(conn, &record) {

--- a/crates/khive-db/src/stores/agents_tests.rs
+++ b/crates/khive-db/src/stores/agents_tests.rs
@@ -49,6 +49,40 @@ async fn test_insert_and_get() {
     assert_eq!(fetched.owner_visible_namespaces, vec!["local".to_string()]);
 }
 
+/// #1847: the writer task owns the transaction around the agent ledger's
+/// provider-session pre-check plus insert. Sending the legacy BEGIN wrapper
+/// through the queue would deterministically fail as a nested transaction.
+#[tokio::test]
+async fn agent_insert_uses_writer_task_owned_transaction() {
+    let dir = tempfile::tempdir().unwrap();
+    let pool = Arc::new(
+        ConnectionPool::new(PoolConfig {
+            path: Some(dir.path().join("agent-writer-task-transaction.db")),
+            write_queue_enabled: Some(true),
+            ..PoolConfig::default()
+        })
+        .unwrap(),
+    );
+    {
+        let writer = pool.writer().unwrap();
+        writer.conn().execute_batch(AGENTS_DDL).unwrap();
+    }
+    let before = pool.writer_acquisition_snapshot();
+    let store = SqlAgentStore::new(Arc::clone(&pool), true);
+
+    store
+        .insert(&make_record("agent-queued", "actor-a"))
+        .await
+        .expect("agent insert must use the writer task's existing transaction");
+
+    let after = pool.writer_acquisition_snapshot();
+    assert_eq!(
+        after.writer_task_acquisitions,
+        before.writer_task_acquisitions + 1,
+        "agent insert must acquire the shared writer task exactly once"
+    );
+}
+
 #[tokio::test]
 async fn test_get_missing_returns_none() {
     let store = setup_memory_store();
@@ -264,4 +298,39 @@ async fn test_terminate_all_non_terminal_boot_scan() {
     let c = store.get("agent-c").await.unwrap().unwrap();
     assert_eq!(c.terminal_reason, Some(TerminalReason::Completed));
     assert_eq!(c.state_changed_at, 1_000);
+}
+
+/// #1847: the agent-process ledger was added after the original strict-route
+/// census. It must fail closed like every other store when strict routing is
+/// requested without a writer-task handle.
+#[test]
+fn agent_write_strict_routing_fails_closed_without_writer_task() {
+    let dir = tempfile::tempdir().unwrap();
+    let pool = Arc::new(
+        ConnectionPool::new(PoolConfig {
+            path: Some(dir.path().join("agent-strict-routing.db")),
+            write_queue_enabled: Some(false),
+            write_routing_strict: true,
+            ..PoolConfig::default()
+        })
+        .unwrap(),
+    );
+    {
+        let writer = pool.writer().unwrap();
+        writer.conn().execute_batch(AGENTS_DDL).unwrap();
+    }
+    let store = SqlAgentStore::new(pool, true);
+
+    let error = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(store.insert(&make_record("agent-strict", "actor-a")))
+        .expect_err("strict routing must refuse the standalone writer fallback");
+    assert!(
+        matches!(
+            &error,
+            StorageError::Pool { operation, .. } if operation == "agent_insert"
+        ),
+        "strict routing must return the typed operation error, got: {error:?}"
+    );
+    assert!(error.to_string().contains("strict"), "got: {error}");
 }

--- a/crates/khive-db/src/stores/entity.rs
+++ b/crates/khive-db/src/stores/entity.rs
@@ -153,8 +153,9 @@ impl SqlEntityStore {
         // fallback remains possible: a missing writer task — whether
         // explicitly disabled, spawn degraded (e.g. in-memory pool), or no
         // Tokio runtime was available at this first access (ADR-067
-        // Component A runtime-handle guard) — degrades to the legacy
-        // pool-mutex path rather than failing construction.
+        // Component A runtime-handle guard) — is cached without failing
+        // construction. Every write re-resolves it; strict mode refuses a
+        // remaining miss and compatibility mode may use the legacy path.
         let writer_task = pool.writer_task_handle().ok().flatten();
 
         Self {
@@ -170,9 +171,18 @@ impl SqlEntityStore {
             .map_err(|error| map_sqlite_err(error, "open_entity_reader"))
     }
 
+    fn current_writer_task(
+        &self,
+        operation: &'static str,
+    ) -> Result<Option<WriterTaskHandle>, StorageError> {
+        self.pool
+            .writer_task_for_write(self.writer_task.as_ref(), operation)
+    }
+
     /// Route a single-row write through the pool-wide `WriterTask` when
-    /// `KHIVE_WRITE_QUEUE=1` and a handle is available; otherwise fall back
-    /// to the legacy pool-mutex path.
+    /// the write queue is enabled and a handle is available. Strict mode
+    /// refuses a missing handle; compatibility mode falls back to the legacy
+    /// pool-mutex path.
     ///
     /// ADR-067 Component A (Fork C slice 2): this is the ONE routing point
     /// for every `with_writer` caller in this store — `upsert_entity`,
@@ -181,22 +191,23 @@ impl SqlEntityStore {
     /// DML-only (a single statement, no bare `BEGIN IMMEDIATE`): on the
     /// flag-on path it runs inside the WriterTask's own transaction, and a
     /// nested `BEGIN IMMEDIATE` would violate SQLite's nested-transaction
-    /// rule. `upsert_entities` (the batch method) does its OWN flag check
-    /// and returns early on `Some`, so its fallback call into this helper
-    /// only ever executes on the flag-off path (`self.writer_task` is
-    /// `None` by construction whenever that call is reached) — no
-    /// double-routing.
+    /// rule. `upsert_entities` (the batch method) performs the same write-time
+    /// lookup first; a non-strict `None` then falls through this helper, which
+    /// records the actual compatibility fallback. Strict mode returns before
+    /// either direct-writer seam is reached.
     async fn with_writer<F, R>(&self, op: &'static str, f: F) -> Result<R, StorageError>
     where
         F: FnOnce(&rusqlite::Connection) -> Result<R, rusqlite::Error> + Send + 'static,
         R: Send + 'static,
     {
-        if let Some(writer_task) = &self.writer_task {
+        if let Some(writer_task) = self.current_writer_task(op)? {
             return writer_task
                 .send_bounded(move |conn| f(conn).map_err(|e| map_err(e, op)))
                 .await;
         }
 
+        self.pool
+            .record_direct_route(crate::timeout_sink::Site::DirectRouteEntity);
         let pool = Arc::clone(&self.pool);
         tokio::task::spawn_blocking(move || {
             let guard = pool.try_writer().map_err(|e| map_sqlite_err(e, op))?;
@@ -575,7 +586,7 @@ impl EntityStore for SqlEntityStore {
         // owns the transaction and `WriteRequest::execute_and_reply` owns
         // the commit/rollback decision (a bare BEGIN IMMEDIATE inside this
         // closure would violate SQLite's nested-transaction rule).
-        if let Some(writer_task) = &self.writer_task {
+        if let Some(writer_task) = self.current_writer_task("upsert_entities")? {
             return writer_task
                 .send_bounded(move |conn| {
                     batch_upsert_entities(conn, &entities, attempted)

--- a/crates/khive-db/src/stores/entity_tests.rs
+++ b/crates/khive-db/src/stores/entity_tests.rs
@@ -1569,3 +1569,79 @@ async fn cursor_kind_filter_returns_records() {
         .unwrap();
     assert_eq!(offset_page.items.len(), concept_ids.len());
 }
+
+/// #1847: construction is synchronous and may happen before a Tokio runtime
+/// exists. A file-backed store must refresh its missing construction-time
+/// handle at write time; otherwise this batch silently takes the legacy
+/// pool-writer path even though the queue is enabled.
+#[test]
+fn batch_write_refreshes_writer_task_after_construction_outside_runtime() {
+    assert!(tokio::runtime::Handle::try_current().is_err());
+
+    let dir = tempfile::tempdir().unwrap();
+    let pool = Arc::new(
+        ConnectionPool::new(PoolConfig {
+            path: Some(dir.path().join("entity-late-writer-task.db")),
+            write_queue_enabled: Some(true),
+            ..PoolConfig::default()
+        })
+        .unwrap(),
+    );
+    {
+        let writer = pool.writer().unwrap();
+        writer.conn().execute_batch(ENTITIES_DDL).unwrap();
+    }
+    let store = Arc::new(SqlEntityStore::new(Arc::clone(&pool), true));
+
+    tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(async move {
+            let writer_task = pool
+                .writer_task_handle()
+                .unwrap()
+                .expect("file-backed pool must spawn its writer task inside the runtime");
+            let (started_tx, started_rx) = oneshot::channel::<()>();
+            let (release_tx, release_rx) = oneshot::channel::<()>();
+            let occupier = {
+                let writer_task = writer_task.clone();
+                tokio::spawn(async move {
+                    writer_task
+                        .send(move |_conn| {
+                            let _ = started_tx.send(());
+                            let _ = release_rx.blocking_recv();
+                            Ok::<(), StorageError>(())
+                        })
+                        .await
+                })
+            };
+            started_rx.await.unwrap();
+
+            let write = {
+                let store = Arc::clone(&store);
+                tokio::spawn(async move {
+                    store
+                        .upsert_entities(vec![
+                            make_entity("default", "concept", "late-a"),
+                            make_entity("default", "concept", "late-b"),
+                        ])
+                        .await
+                })
+            };
+            let mut saw_enqueued = false;
+            for _ in 0..100 {
+                if writer_task.queue_depth() >= 1 {
+                    saw_enqueued = true;
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+
+            release_tx.send(()).unwrap();
+            occupier.await.unwrap().unwrap();
+            write.await.unwrap().unwrap();
+            assert!(
+                saw_enqueued,
+                "batch write bypassed the queue after construction cached no runtime handle"
+            );
+        });
+}

--- a/crates/khive-db/src/stores/event.rs
+++ b/crates/khive-db/src/stores/event.rs
@@ -48,10 +48,10 @@ impl SqlEventStore {
         namespace: impl Into<String>,
     ) -> Self {
         // Enabled by default for file-backed pools; explicit off/degraded
-        // fallback remains possible (ADR-067 Component A, mirrors
-        // entity.rs policy): a missing writer task degrades to the legacy
-        // pool-mutex / standalone-connection path rather than failing
-        // construction.
+        // construction remains synchronous (ADR-067 Component A, mirrors
+        // entity.rs policy): a missing writer task is cached without failing
+        // construction. Every write re-resolves it and applies
+        // strict/compatibility policy then.
         let writer_task = pool.writer_task_handle().ok().flatten();
         Self {
             pool,
@@ -73,15 +73,24 @@ impl SqlEventStore {
             .map_err(|e| map_sqlite_err(e, "open_event_reader"))
     }
 
+    fn current_writer_task(
+        &self,
+        operation: &'static str,
+    ) -> Result<Option<WriterTaskHandle>, StorageError> {
+        self.pool
+            .writer_task_for_write(self.writer_task.as_ref(), operation)
+    }
+
     /// Route a single-row write through the pool-wide `WriterTask` when
-    /// `KHIVE_WRITE_QUEUE=1` and a handle is available; otherwise fall back
-    /// to the legacy standalone-connection / pool-mutex path (ADR-067
-    /// Component A, Fork C slice 2).
+    /// the write queue is enabled and a handle is available. Strict mode
+    /// refuses a missing handle; compatibility mode falls back to the legacy
+    /// standalone-connection / pool-mutex path (ADR-067 Component A, Fork C
+    /// slice 2).
     ///
-    /// `append_event`/`append_events` do their own flag check and return
-    /// early on `Some`, so their fallback calls into this helper only ever
-    /// execute on the flag-off path (`self.writer_task` is `None` by
-    /// construction whenever those calls are reached) — no double-routing.
+    /// `append_event`/`append_events` perform the same write-time lookup
+    /// first; a non-strict `None` then falls through this helper, which
+    /// records the actual compatibility fallback. Strict mode returns before
+    /// the direct-writer seam.
     /// `f` must be DML-only on the flag-on path (no bare `BEGIN IMMEDIATE`)
     /// since it runs inside the WriterTask's own transaction.
     async fn with_writer<F, R>(&self, op: &'static str, f: F) -> Result<R, StorageError>
@@ -89,12 +98,14 @@ impl SqlEventStore {
         F: FnOnce(&rusqlite::Connection) -> Result<R, rusqlite::Error> + Send + 'static,
         R: Send + 'static,
     {
-        if let Some(writer_task) = &self.writer_task {
+        if let Some(writer_task) = self.current_writer_task(op)? {
             return writer_task
                 .send_bounded(move |conn| f(conn).map_err(|e| map_err(e, op)))
                 .await;
         }
 
+        self.pool
+            .record_direct_route(crate::timeout_sink::Site::DirectRouteEventGeneralWrite);
         if self.is_file_backed {
             let conn = self.open_standalone_writer()?;
             let db = crate::timeout_sink::db_label(&self.pool);
@@ -1004,7 +1015,7 @@ impl EventStore for SqlEventStore {
         // curation, mutation events — is covered without per-call-site
         // instrumentation. The enclosing per-dispatch audit row is appended
         // only after the usage snapshot is frozen, so it never counts itself.
-        if let Some(writer_task) = &self.writer_task {
+        if let Some(writer_task) = self.current_writer_task("append_event")? {
             return writer_task
                 .send_bounded(move |conn| {
                     insert_event_with_observations(conn, &event)
@@ -1046,7 +1057,7 @@ impl EventStore for SqlEventStore {
         // all-or-nothing semantics (first failed insert aborts the whole
         // batch) — the WriterTask's run loop owns the enclosing transaction
         // and issues the ROLLBACK on `Err`.
-        if let Some(writer_task) = &self.writer_task {
+        if let Some(writer_task) = self.current_writer_task("append_events")? {
             return writer_task
                 .send_bounded(move |conn| {
                     batch_append_events_dml(conn, &events, attempted)

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -499,10 +499,10 @@ impl SqlGraphStore {
         namespace: impl Into<String>,
     ) -> Self {
         // Enabled by default for file-backed pools; explicit off/degraded
-        // fallback remains possible (ADR-067 Component A, mirrors
-        // entity.rs policy): a missing writer task degrades to the legacy
-        // pool-mutex / standalone-connection path rather than failing
-        // construction.
+        // construction remains synchronous (ADR-067 Component A, mirrors
+        // entity.rs policy): a missing writer task is cached without failing
+        // construction. Every write re-resolves it and applies
+        // strict/compatibility policy then.
         let writer_task = pool.writer_task_handle().ok().flatten();
 
         Self {
@@ -525,22 +525,33 @@ impl SqlGraphStore {
             .map_err(|e| map_sqlite_err(e, "open_graph_reader"))
     }
 
+    fn current_writer_task(
+        &self,
+        operation: &'static str,
+    ) -> Result<Option<WriterTaskHandle>, StorageError> {
+        self.pool
+            .writer_task_for_write(self.writer_task.as_ref(), operation)
+    }
+
     /// Route a single-row write through the pool-wide `WriterTask` when
-    /// `KHIVE_WRITE_QUEUE=1` and a handle is available; otherwise fall back
-    /// to the legacy standalone-connection / pool-mutex path (ADR-067
-    /// Component A, Fork C slice 2). `f` must be DML-only. See
+    /// the write queue is enabled and a handle is available. Strict mode
+    /// refuses a missing handle; compatibility mode falls back to the legacy
+    /// standalone-connection / pool-mutex path (ADR-067 Component A, Fork C
+    /// slice 2). `f` must be DML-only. See
     /// `crates/khive-db/docs/api/graph.md` for the per-caller routing rules.
     async fn with_writer<F, R>(&self, op: &'static str, f: F) -> Result<R, StorageError>
     where
         F: FnOnce(&rusqlite::Connection) -> Result<R, rusqlite::Error> + Send + 'static,
         R: Send + 'static,
     {
-        if let Some(writer_task) = &self.writer_task {
+        if let Some(writer_task) = self.current_writer_task(op)? {
             return writer_task
                 .send_bounded(move |conn| f(conn).map_err(|e| map_err(e, op)))
                 .await;
         }
 
+        self.pool
+            .record_direct_route(crate::timeout_sink::Site::DirectRouteGraphGeneralWrite);
         if self.is_file_backed {
             let conn = self.open_standalone_writer()?;
             let db = crate::timeout_sink::db_label(&self.pool);
@@ -1292,7 +1303,7 @@ impl GraphStore for SqlGraphStore {
         // IMMEDIATE/COMMIT/ROLLBACK here, since the WriterTask's run loop
         // owns the transaction (a bare BEGIN IMMEDIATE here would violate
         // SQLite's nested-transaction rule).
-        if let Some(writer_task) = &self.writer_task {
+        if let Some(writer_task) = self.current_writer_task("upsert_edges")? {
             return writer_task
                 .send_bounded(move |conn| {
                     batch_upsert_edges(conn, &edges, attempted)
@@ -1352,7 +1363,7 @@ impl GraphStore for SqlGraphStore {
         // insert and the missing-endpoint probe below already run inside
         // one write-locked transaction; a bare `BEGIN IMMEDIATE` here would
         // violate SQLite's nested-transaction rule.
-        if let Some(writer_task) = &self.writer_task {
+        if let Some(writer_task) = self.current_writer_task("upsert_edge_guarded")? {
             return writer_task
                 .send_bounded(move |conn| {
                     edge_insert_guarded(conn, &statement, source_id, target_id)
@@ -1400,7 +1411,7 @@ impl GraphStore for SqlGraphStore {
         // Same WriterTask routing as `upsert_edges` — the guard's pre-check
         // runs inside the WriterTask's own `BEGIN IMMEDIATE`, so a missing
         // endpoint is caught before any `INSERT` in this batch runs at all.
-        if let Some(writer_task) = &self.writer_task {
+        if let Some(writer_task) = self.current_writer_task("upsert_edges_guarded")? {
             return writer_task
                 .send_bounded(move |conn| {
                     batch_upsert_edges_guarded(conn, &edges, attempted)

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -286,8 +286,8 @@ impl SqlNoteStore {
         // fallback remains possible (ADR-067 Component A, mirrors
         // entity.rs policy): a missing writer task — explicitly disabled,
         // spawn degraded, or no Tokio runtime available at this first
-        // access — degrades to the legacy pool-mutex path rather than
-        // failing construction.
+        // access — is cached without failing construction. Every write
+        // re-resolves it and applies strict/compatibility policy then.
         let writer_task = pool.writer_task_handle().ok().flatten();
 
         Self {
@@ -303,20 +303,28 @@ impl SqlNoteStore {
             .map_err(|error| map_sqlite_err(error, "open_note_reader"))
     }
 
+    fn current_writer_task(
+        &self,
+        operation: &'static str,
+    ) -> Result<Option<WriterTaskHandle>, StorageError> {
+        self.pool
+            .writer_task_for_write(self.writer_task.as_ref(), operation)
+    }
+
     /// Route a single-row write through the pool-wide `WriterTask` when
-    /// `KHIVE_WRITE_QUEUE=1` and a handle is available; otherwise fall back
-    /// to the legacy pool-mutex path (ADR-067 Component A, Fork C slice 2).
+    /// the write queue is enabled and a handle is available. Strict mode
+    /// refuses a missing handle; compatibility mode falls back to the legacy
+    /// pool-mutex path (ADR-067 Component A, Fork C slice 2).
     ///
     /// This is the routing point for single-statement `with_writer` callers
     /// in this store (`update_note_properties`, `set_note_property`,
     /// `delete_note`). `f` must be DML-only — on the flag-on path it runs
     /// inside the WriterTask's own transaction, so a bare `BEGIN IMMEDIATE`
     /// would violate SQLite's nested-transaction rule. `upsert_notes` (the
-    /// batch method) does its own flag check and returns early on `Some`, so
-    /// its fallback call into this helper only ever executes on the flag-off
-    /// path
-    /// (`self.writer_task` is `None` by construction whenever that call is
-    /// reached) — no double-routing. Callers whose `f` issues more than one
+    /// batch method) performs the same write-time lookup first; a non-strict
+    /// `None` then falls through this helper, which records the actual
+    /// compatibility fallback. Strict mode returns before the direct-writer
+    /// seam. Callers whose `f` issues more than one
     /// DML statement that must land atomically together (`upsert_note`,
     /// `try_insert_note`, `patch_note_property_atomic`) use
     /// [`Self::with_writer_tx`] instead — see its doc comment (khive #827,
@@ -326,12 +334,14 @@ impl SqlNoteStore {
         F: FnOnce(&rusqlite::Connection) -> Result<R, rusqlite::Error> + Send + 'static,
         R: Send + 'static,
     {
-        if let Some(writer_task) = &self.writer_task {
+        if let Some(writer_task) = self.current_writer_task(op)? {
             return writer_task
                 .send_bounded(move |conn| f(conn).map_err(|e| map_err(e, op)))
                 .await;
         }
 
+        self.pool
+            .record_direct_route(crate::timeout_sink::Site::DirectRouteNote);
         let pool = Arc::clone(&self.pool);
         tokio::task::spawn_blocking(move || {
             let guard = pool.try_writer().map_err(|e| map_sqlite_err(e, op))?;
@@ -366,10 +376,12 @@ impl SqlNoteStore {
         F: FnOnce(&rusqlite::Connection) -> Result<R, StorageError> + Send + 'static,
         R: Send + 'static,
     {
-        if let Some(writer_task) = &self.writer_task {
+        if let Some(writer_task) = self.current_writer_task(op)? {
             return writer_task.send_bounded(f).await;
         }
 
+        self.pool
+            .record_direct_route(crate::timeout_sink::Site::DirectRouteNote);
         let pool = Arc::clone(&self.pool);
         tokio::task::spawn_blocking(move || {
             let guard = pool.try_writer().map_err(|e| map_sqlite_err(e, op))?;

--- a/crates/khive-db/src/stores/note_tests.rs
+++ b/crates/khive-db/src/stores/note_tests.rs
@@ -1943,3 +1943,79 @@ async fn upsert_note_reports_configured_write_queue_admission_deadline() {
         "a queue-rejected note write must never execute after capacity returns"
     );
 }
+
+/// #1847: the transaction-owning note path must not trust a `None` writer
+/// handle cached while the store was constructed outside Tokio. The queue
+/// depth makes the routing assertion independent of SQLite lock timing.
+#[test]
+fn transactional_write_refreshes_writer_task_after_construction_outside_runtime() {
+    assert!(tokio::runtime::Handle::try_current().is_err());
+
+    let dir = tempfile::tempdir().unwrap();
+    let pool = Arc::new(
+        ConnectionPool::new(PoolConfig {
+            path: Some(dir.path().join("note-late-writer-task.db")),
+            write_queue_enabled: Some(true),
+            ..PoolConfig::default()
+        })
+        .unwrap(),
+    );
+    {
+        let writer = pool.writer().unwrap();
+        writer.conn().execute_batch(NOTES_DDL).unwrap();
+    }
+    let store = Arc::new(SqlNoteStore::new(Arc::clone(&pool), true));
+
+    tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(async move {
+            let writer_task = pool
+                .writer_task_handle()
+                .unwrap()
+                .expect("file-backed pool must spawn its writer task inside the runtime");
+            let (started_tx, started_rx) = tokio::sync::oneshot::channel::<()>();
+            let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+            let occupier = {
+                let writer_task = writer_task.clone();
+                tokio::spawn(async move {
+                    writer_task
+                        .send(move |_conn| {
+                            let _ = started_tx.send(());
+                            let _ = release_rx.blocking_recv();
+                            Ok::<(), StorageError>(())
+                        })
+                        .await
+                })
+            };
+            started_rx.await.unwrap();
+
+            let write = {
+                let store = Arc::clone(&store);
+                tokio::spawn(async move {
+                    store
+                        .upsert_note(make_note(
+                            "default",
+                            "observation",
+                            "late transactional write",
+                        ))
+                        .await
+                })
+            };
+            let mut saw_enqueued = false;
+            for _ in 0..100 {
+                if writer_task.queue_depth() >= 1 {
+                    saw_enqueued = true;
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+
+            release_tx.send(()).unwrap();
+            occupier.await.unwrap().unwrap();
+            write.await.unwrap().unwrap();
+            assert!(
+                saw_enqueued,
+                "transactional note write bypassed the queue after construction cached no handle"
+            );
+        });
+}

--- a/crates/khive-db/src/stores/sparse.rs
+++ b/crates/khive-db/src/stores/sparse.rs
@@ -211,10 +211,10 @@ impl SqliteSparseStore {
         namespace: String,
     ) -> Result<Self, SqliteError> {
         let table_name = format!("sparse_{}", model_key);
-        // Enabled by default for file-backed pools; explicit off/degraded
-        // fallback remains possible (ADR-067 Component A, mirrors
-        // entity.rs policy): a missing writer task degrades to the legacy
-        // pool-mutex path rather than failing construction.
+        // Enabled by default for file-backed pools. Construction stays
+        // synchronous (ADR-067 Component A, mirrors entity.rs policy): a
+        // missing writer task is cached without failing construction. Every
+        // write re-resolves it and applies strict/compatibility policy then.
         let writer_task = pool.writer_task_handle().ok().flatten();
         Ok(Self {
             pool,
@@ -225,30 +225,40 @@ impl SqliteSparseStore {
         })
     }
 
+    fn current_writer_task(
+        &self,
+        operation: &'static str,
+    ) -> Result<Option<WriterTaskHandle>, StorageError> {
+        self.pool
+            .writer_task_for_write(self.writer_task.as_ref(), operation)
+    }
+
     /// Route a single-row write through the pool-wide `WriterTask` when
-    /// `KHIVE_WRITE_QUEUE=1` and a handle is available; otherwise fall back
-    /// to the legacy pool-mutex path (ADR-067 Component A, Fork C slice 2).
+    /// the write queue is enabled and a handle is available. Strict mode
+    /// refuses a missing handle; compatibility mode falls back to the legacy
+    /// pool-mutex path (ADR-067 Component A, Fork C slice 2).
     ///
     /// This is the ONE routing point for every `with_writer` caller in this
     /// store (`upsert_sparse_vector`, `delete_sparse_subject`). `f` must be
     /// DML-only — on the flag-on path it runs inside the WriterTask's own
     /// transaction, so a bare `BEGIN IMMEDIATE` would violate SQLite's
     /// nested-transaction rule. `insert_sparse_batch` (the batch method)
-    /// does its own flag check and returns early on `Some`, so its
-    /// fallback call into this helper only ever executes on the flag-off
-    /// path (`self.writer_task` is `None` by construction whenever that
-    /// call is reached) — no double-routing.
+    /// performs the same write-time lookup first; a non-strict `None` then
+    /// falls through this helper, which records the actual compatibility
+    /// fallback. Strict mode returns before the direct-writer seam.
     async fn with_writer<F, R>(&self, op: &'static str, f: F) -> Result<R, StorageError>
     where
         F: FnOnce(&rusqlite::Connection) -> Result<R, rusqlite::Error> + Send + 'static,
         R: Send + 'static,
     {
-        if let Some(writer_task) = &self.writer_task {
+        if let Some(writer_task) = self.current_writer_task(op)? {
             return writer_task
                 .send_bounded(move |conn| f(conn).map_err(|e| map_err(e, op)))
                 .await;
         }
 
+        self.pool
+            .record_direct_route(crate::timeout_sink::Site::DirectRouteSparseGeneralWrite);
         let pool = Arc::clone(&self.pool);
         tokio::task::spawn_blocking(move || {
             let guard = pool.try_writer().map_err(|e| map_sqlite_err(e, op))?;
@@ -345,7 +355,7 @@ impl SqliteSparseStore {
         // through the pool-wide WriterTask. DML-only closure — no BEGIN
         // IMMEDIATE/COMMIT/ROLLBACK here, since the WriterTask's run loop
         // owns the transaction.
-        if let Some(writer_task) = &self.writer_task {
+        if let Some(writer_task) = self.current_writer_task("sparse_insert_batch")? {
             let table2 = table.clone();
             return writer_task
                 .send_bounded(move |conn| {

--- a/crates/khive-db/src/stores/text.rs
+++ b/crates/khive-db/src/stores/text.rs
@@ -23,39 +23,6 @@ use crate::pool::ConnectionPool;
 use crate::sql_bridge::bind_params;
 use crate::writer_task::WriterTaskHandle;
 
-/// ADR-136 D1 gate 3: called immediately before a `with_writer_unmanaged`
-/// fallback so this store's one remaining direct-writer call site
-/// (`rename_namespace`) fails closed under strict routing instead of
-/// silently bypassing an enabled queue. Under non-strict routing this is a
-/// no-op except for a `direct_route_violation` sink row when the queue is
-/// enabled (ADR-136 D1 gate 6c) — observable, but not yet fatal. Mirrors
-/// `stores::vectors::refuse_direct_route_if_strict`; kept as a separate copy
-/// rather than a shared export to avoid coupling the two stores' internals.
-fn refuse_direct_route_if_strict(
-    pool: &ConnectionPool,
-    site: crate::timeout_sink::Site,
-    op: &'static str,
-) -> Result<(), StorageError> {
-    if pool.config().write_routing_strict {
-        return Err(StorageError::Pool {
-            operation: op.into(),
-            message: "KHIVE_WRITE_ROUTING=strict but no writer-task handle is available; \
-                      refusing to fall back to a direct connection"
-                .into(),
-        });
-    }
-    if pool.write_queue_active() {
-        // In-memory pools never spawn a writer task by documented design
-        // (explicit `Some(true)` degrades), so a violation row there would
-        // be noise, not signal.
-        crate::timeout_sink::emit_direct_route_violation(
-            &crate::timeout_sink::db_label(pool),
-            site,
-        );
-    }
-    Ok(())
-}
-
 /// The exact `DELETE` this store's `delete_document` issues, for a given
 /// FTS table (ADR-099 B3 r6 structural cut — see `entity.rs`'s sibling
 /// block). `table` must already be a trusted, sanitized table name (this
@@ -161,10 +128,10 @@ impl Fts5TextSearch {
     pub(crate) fn new(pool: Arc<ConnectionPool>, is_file_backed: bool, table_key: String) -> Self {
         let table_name = format!("fts_{}", table_key);
         // Enabled by default for file-backed pools; explicit off/degraded
-        // fallback remains possible (ADR-067 Component A, mirrors
-        // entity.rs policy): a missing writer task degrades to the legacy
-        // pool-mutex / standalone-connection path rather than failing
-        // construction.
+        // construction remains synchronous (ADR-067 Component A, mirrors
+        // entity.rs policy): a missing writer task is cached without failing
+        // construction. Every write re-resolves it and applies
+        // strict/compatibility policy then.
         let writer_task = pool.writer_task_handle().ok().flatten();
         Self {
             pool,
@@ -193,18 +160,21 @@ impl Fts5TextSearch {
     /// `Err(WriterTaskNoRuntime)`, which construction collapses via
     /// `.ok().flatten()`) — every later write, even ones running inside a
     /// runtime, would otherwise silently keep bypassing an enabled queue.
-    /// `ConnectionPool::writer_task_handle()` is a cheap `OnceCell` read once
-    /// resolved, so re-checking here costs nothing on the hot path.
-    fn current_writer_task(&self) -> Option<WriterTaskHandle> {
-        self.writer_task
-            .clone()
-            .or_else(|| self.pool.writer_task_handle().ok().flatten())
+    /// The pool helper also enforces strict fail-closed routing and preserves
+    /// a typed `WriterTaskNoRuntime` error when no runtime is available.
+    fn current_writer_task(
+        &self,
+        operation: &'static str,
+    ) -> Result<Option<WriterTaskHandle>, StorageError> {
+        self.pool
+            .writer_task_for_write(self.writer_task.as_ref(), operation)
     }
 
     /// Route a single-row write through the pool-wide `WriterTask` when
-    /// `KHIVE_WRITE_QUEUE=1` and a handle is available; otherwise fall back
-    /// to the legacy standalone-connection / pool-mutex path (ADR-067
-    /// Component A, Fork C slice 2). See `crates/khive-db/docs/api/text.md`
+    /// the write queue is enabled and a handle is available. Strict mode
+    /// refuses a missing handle; compatibility mode falls back to the legacy
+    /// standalone-connection / pool-mutex path (ADR-067 Component A, Fork C
+    /// slice 2). See `crates/khive-db/docs/api/text.md`
     /// for the per-caller routing rules (which methods bypass this via
     /// `with_writer_unmanaged` and why).
     async fn with_writer<F, R>(&self, op: &'static str, f: F) -> Result<R, StorageError>
@@ -212,17 +182,14 @@ impl Fts5TextSearch {
         F: FnOnce(&rusqlite::Connection) -> Result<R, rusqlite::Error> + Send + 'static,
         R: Send + 'static,
     {
-        if let Some(writer_task) = self.current_writer_task() {
+        if let Some(writer_task) = self.current_writer_task(op)? {
             return writer_task
                 .send_bounded(move |conn| f(conn).map_err(|e| map_err(e, op)))
                 .await;
         }
 
-        refuse_direct_route_if_strict(
-            &self.pool,
-            crate::timeout_sink::Site::DirectRouteFtsGeneralWrite,
-            op,
-        )?;
+        self.pool
+            .record_direct_route(crate::timeout_sink::Site::DirectRouteFtsGeneralWrite);
         self.with_writer_unmanaged(op, f).await
     }
 
@@ -802,13 +769,14 @@ impl TextSearch for Fts5TextSearch {
         // ADR-067 Component A: when the write queue is enabled, route
         // through the pool-wide WriterTask. DML-only closure — no BEGIN
         // IMMEDIATE/COMMIT/ROLLBACK here, since the WriterTask's run loop
-        // owns the transaction. `current_writer_task()` (ADR-136 D1 gate 3
+        // owns the transaction. `current_writer_task("fts_upsert")`
+        // (ADR-136 D1 gate 3
         // amendment) re-checks past a construction-time `None` cache so a
         // handle that only became available later is still used here rather
         // than falling to `with_writer`'s BEGIN-IMMEDIATE-wrapped closure
         // below (that closure is not safe to send through the queue, which
         // already wraps its own transaction).
-        if let Some(writer_task) = self.current_writer_task() {
+        if let Some(writer_task) = self.current_writer_task("fts_upsert")? {
             let table2 = table.clone();
             return writer_task
                 .send_bounded(move |conn| {
@@ -850,10 +818,10 @@ impl TextSearch for Fts5TextSearch {
         // through the pool-wide WriterTask. DML-only closure (the per-row
         // `SAVEPOINT fts_upsert_doc` is preserved unchanged — only the OUTER
         // BEGIN IMMEDIATE/COMMIT is removed, since the WriterTask's run loop
-        // owns the enclosing transaction). `current_writer_task()` re-checks
+        // owns the enclosing transaction). `current_writer_task` re-checks
         // past a construction-time `None` cache — see `upsert_document`'s
         // matching note.
-        if let Some(writer_task) = self.current_writer_task() {
+        if let Some(writer_task) = self.current_writer_task("fts_upsert_batch")? {
             let table2 = table.clone();
             return writer_task
                 .send_bounded(move |conn| {
@@ -1485,7 +1453,7 @@ impl Fts5TextSearch {
         // closing the TOCTOU window the pre-migration path had (its SELECT
         // ran before its own `BEGIN IMMEDIATE`, so a writer landing between
         // the two could resurrect a stale row or lose one mid-rename).
-        if let Some(writer_task) = &self.writer_task {
+        if let Some(writer_task) = self.current_writer_task("fts_rename_namespace")? {
             let table2 = table.clone();
             return writer_task
                 .send_bounded(move |conn| {
@@ -1495,11 +1463,8 @@ impl Fts5TextSearch {
                 .await;
         }
 
-        refuse_direct_route_if_strict(
-            &self.pool,
-            crate::timeout_sink::Site::DirectRouteFtsRenameNamespace,
-            "fts_rename_namespace",
-        )?;
+        self.pool
+            .record_direct_route(crate::timeout_sink::Site::DirectRouteFtsRenameNamespace);
 
         let origin = self.pool.origin();
         self.with_writer_unmanaged("fts_rename_namespace", move |conn| {

--- a/crates/khive-db/src/stores/text_tests.rs
+++ b/crates/khive-db/src/stores/text_tests.rs
@@ -2527,7 +2527,7 @@ async fn test_search_rank_within_cap_counts_two_fts_passes() {
 /// `upsert_documents_routes_through_writer_task_when_flag_enabled` above (a
 /// `writer_task_spawn_count() == 1` assertion alone is a false positive:
 /// `upsert_document` setup calls already spawn/use the task). Red-proof:
-/// reverting the `if let Some(writer_task) = &self.writer_task` branch in
+/// reverting the `current_writer_task("fts_rename_namespace")` branch in
 /// `rename_namespace` (forcing every call through `with_writer_unmanaged`)
 /// makes `saw_enqueued` stay `false` and this test fail — see the impl
 /// report for the exact revert/run/restore transcript.
@@ -2663,7 +2663,7 @@ async fn rename_namespace_strict_routing_fails_closed_without_writer_task() {
 /// Deliberately `#[test]`, not `#[tokio::test]`: construction must happen
 /// with no ambient runtime, which a `#[tokio::test]` function body would
 /// not give it (the whole test body already runs on a Tokio worker thread).
-/// Red-proof: reverting `with_writer`'s `self.current_writer_task()` check
+/// Red-proof: reverting `with_writer`'s `self.current_writer_task(op)` check
 /// back to `&self.writer_task` makes `saw_enqueued` stay `false` and this
 /// test fail — the write takes the direct-connection path immediately
 /// instead of ever appearing in the writer task's channel.

--- a/crates/khive-db/src/stores/vectors.rs
+++ b/crates/khive-db/src/stores/vectors.rs
@@ -22,37 +22,6 @@ use crate::error::SqliteError;
 use crate::pool::ConnectionPool;
 use crate::sql_bridge::bind_params;
 
-/// ADR-136 D1 gate 3: called immediately before a `with_writer_unmanaged`
-/// fallback so this store's two remaining direct-writer call sites
-/// (`vec_delete_subjects`, `orphan_sweep`) fail closed under strict routing
-/// instead of silently bypassing an enabled queue. Under non-strict routing
-/// this is a no-op except for a `direct_route_violation` sink row when the
-/// queue is enabled (ADR-136 D1 gate 6c) — observable, but not yet fatal.
-fn refuse_direct_route_if_strict(
-    pool: &ConnectionPool,
-    site: crate::timeout_sink::Site,
-    op: &'static str,
-) -> Result<(), StorageError> {
-    if pool.config().write_routing_strict {
-        return Err(StorageError::Pool {
-            operation: op.into(),
-            message: "KHIVE_WRITE_ROUTING=strict but no writer-task handle is available; \
-                      refusing to fall back to a direct connection"
-                .into(),
-        });
-    }
-    if pool.write_queue_active() {
-        // In-memory pools never spawn a writer task by documented design
-        // (explicit `Some(true)` degrades), so a violation row there would
-        // be noise, not signal.
-        crate::timeout_sink::emit_direct_route_violation(
-            &crate::timeout_sink::db_label(pool),
-            site,
-        );
-    }
-    Ok(())
-}
-
 /// The exact `DELETE` this store's `delete` issues, for a given vector table
 /// (ADR-099 B3 r6 structural cut — see `stores::entity`'s sibling block).
 /// `table` must already be a trusted, sanitized table name (mirrors
@@ -325,10 +294,10 @@ impl SqliteVecStore {
     ) -> Result<Self, SqliteError> {
         validate_model_key(&model_key)?;
         let table_name = format!("vec_{}", model_key);
-        // Enabled by default for file-backed pools; explicit off/degraded
-        // fallback remains possible (ADR-067 Component A, mirrors
-        // entity.rs policy): a missing writer task degrades to the legacy
-        // pool-mutex path rather than failing construction.
+        // Enabled by default for file-backed pools. Construction stays
+        // synchronous (ADR-067 Component A, mirrors entity.rs policy): a
+        // missing writer task is cached without failing construction. Every
+        // write re-resolves it and applies strict/compatibility policy then.
         let writer_task = pool.writer_task_handle().ok().flatten();
         Ok(Self {
             pool,
@@ -355,12 +324,14 @@ impl SqliteVecStore {
     /// `Err(WriterTaskNoRuntime)`, which construction collapses via
     /// `.ok().flatten()`) — every later write, even ones running inside a
     /// runtime, would otherwise silently keep bypassing an enabled queue.
-    /// `ConnectionPool::writer_task_handle()` is a cheap `OnceCell` read once
-    /// resolved, so re-checking here costs nothing on the hot path.
-    fn current_writer_task(&self) -> Option<crate::writer_task::WriterTaskHandle> {
-        self.writer_task
-            .clone()
-            .or_else(|| self.pool.writer_task_handle().ok().flatten())
+    /// The pool helper also enforces strict fail-closed routing and preserves
+    /// a typed `WriterTaskNoRuntime` error when no runtime is available.
+    fn current_writer_task(
+        &self,
+        operation: &'static str,
+    ) -> Result<Option<crate::writer_task::WriterTaskHandle>, StorageError> {
+        self.pool
+            .writer_task_for_write(self.writer_task.as_ref(), operation)
     }
 
     /// Route a single-row DML-only write through the pool-wide `WriterTask`
@@ -371,17 +342,14 @@ impl SqliteVecStore {
         F: FnOnce(&rusqlite::Connection) -> Result<R, rusqlite::Error> + Send + 'static,
         R: Send + 'static,
     {
-        if let Some(writer_task) = self.current_writer_task() {
+        if let Some(writer_task) = self.current_writer_task(op)? {
             return writer_task
                 .send_bounded(move |conn| f(conn).map_err(|e| map_err(e, op)))
                 .await;
         }
 
-        refuse_direct_route_if_strict(
-            &self.pool,
-            crate::timeout_sink::Site::DirectRouteVecGeneralWrite,
-            op,
-        )?;
+        self.pool
+            .record_direct_route(crate::timeout_sink::Site::DirectRouteVecGeneralWrite);
         self.with_writer_unmanaged(op, f).await
     }
 
@@ -458,7 +426,7 @@ impl SqliteVecStore {
         }
 
         let failpoint_flag = current_failpoint();
-        if let Some(writer_task) = self.current_writer_task() {
+        if let Some(writer_task) = self.current_writer_task(operation)? {
             let table_for_write = table.clone();
             let namespace_for_write = namespace.clone();
             let field_for_write = field.clone();
@@ -1043,7 +1011,7 @@ impl VectorStore for SqliteVecStore {
         // `SAVEPOINT vec_batch_record` is preserved unchanged — only the
         // OUTER BEGIN IMMEDIATE/COMMIT is removed, since the WriterTask's
         // run loop owns the enclosing transaction).
-        if let Some(writer_task) = self.current_writer_task() {
+        if let Some(writer_task) = self.current_writer_task("vec_insert_batch")? {
             let table2 = table.clone();
             let store_embedding_model2 = store_embedding_model.clone();
             return writer_task
@@ -1129,7 +1097,7 @@ impl VectorStore for SqliteVecStore {
         // named SAVEPOINT rather than `conn.unchecked_transaction()`,
         // which would attempt a nested `BEGIN` and fail under the
         // WriterTask's already-open transaction.
-        if let Some(writer_task) = self.current_writer_task() {
+        if let Some(writer_task) = self.current_writer_task("vec_update")? {
             let table2 = table.clone();
             let namespace2 = namespace.clone();
             let field2 = field.clone();
@@ -1395,7 +1363,7 @@ impl VectorStore for SqliteVecStore {
         // The WriterTask owns one BEGIN IMMEDIATE/COMMIT/ROLLBACK around each
         // request. Submit the complete chunk loop as one DML-only request so a
         // failure in any chunk makes the task roll back the complete input.
-        if let Some(writer_task) = &self.writer_task {
+        if let Some(writer_task) = self.current_writer_task("vec_delete_subjects")? {
             let table_for_error = table.clone();
             return writer_task
                 .send_bounded(move |conn| {
@@ -1413,11 +1381,8 @@ impl VectorStore for SqliteVecStore {
         // outermost SAVEPOINT. `Transaction` rolls back on early DML errors and
         // also when COMMIT fails while SQLite leaves the transaction open,
         // preventing a poisoned transaction from returning to the pool.
-        refuse_direct_route_if_strict(
-            &self.pool,
-            crate::timeout_sink::Site::DirectRouteVecDeleteSubjects,
-            "vec_delete_subjects",
-        )?;
+        self.pool
+            .record_direct_route(crate::timeout_sink::Site::DirectRouteVecDeleteSubjects);
         let table_for_error = table.clone();
         let origin = self.pool.origin();
         self.with_writer_unmanaged("vec_delete_subjects", move |conn| {
@@ -1531,7 +1496,7 @@ impl VectorStore for SqliteVecStore {
         // IMMEDIATE` here would violate SQLite's nested-transaction rule and
         // fail with `SQLITE_ERROR: cannot start a transaction within a
         // transaction` (ADR-067 lines 271-276).
-        if let Some(writer_task) = &self.writer_task {
+        if let Some(writer_task) = self.current_writer_task("orphan_sweep")? {
             let table2 = table.clone();
             let ns_json2 = ns_json.clone();
             let kind_json2 = kind_json.clone();
@@ -1555,11 +1520,8 @@ impl VectorStore for SqliteVecStore {
         // Explicitly disabled or degraded fallback path: byte-for-byte unchanged from pre-ADR-067
         // behavior — the closure owns its own transaction via
         // `Transaction::new_unchecked`.
-        refuse_direct_route_if_strict(
-            &self.pool,
-            crate::timeout_sink::Site::DirectRouteOrphanSweep,
-            "orphan_sweep",
-        )?;
+        self.pool
+            .record_direct_route(crate::timeout_sink::Site::DirectRouteOrphanSweep);
         let origin = self.pool.origin();
         self.with_writer_unmanaged("orphan_sweep", move |conn| {
             // `Transaction::new_unchecked` issues `BEGIN IMMEDIATE` and RAII-manages
@@ -4854,8 +4816,8 @@ mod write_queue_tests {
     /// `orphan_sweep_routes_through_writer_task_when_flag_enabled` above (a
     /// `writer_task_spawn_count() == 1` assertion alone is a false positive:
     /// `SqliteVecStore::new` and the setup insert already spawn/use the
-    /// task). Red-proof: reverting the `if let Some(writer_task) =
-    /// &self.writer_task` branch in `vec_delete_subjects` (forcing every
+    /// task). Red-proof: reverting the
+    /// `current_writer_task("vec_delete_subjects")` branch (forcing every
     /// call through `with_writer_unmanaged`) makes `saw_enqueued` stay
     /// `false` and this test fail — see the impl report for the exact
     /// revert/run/restore transcript.
@@ -5073,10 +5035,10 @@ mod write_queue_tests {
     /// happen with no ambient runtime, which a `#[tokio::test]` function
     /// body would not give it (the whole test body already runs on a Tokio
     /// worker thread). Red-proof: reverting `with_writer`'s
-    /// `self.current_writer_task()` check back to `&self.writer_task` makes
-    /// `saw_enqueued` stay `false` and this test fail — the write takes the
-    /// direct-connection path immediately instead of ever appearing in the
-    /// writer task's channel.
+    /// `self.current_writer_task(operation)` check back to the cached handle
+    /// makes `saw_enqueued` stay `false` and this test fail — the write takes
+    /// the direct-connection path immediately instead of ever appearing in
+    /// the writer task's channel.
     #[test]
     fn general_write_routes_through_writer_task_when_store_built_outside_runtime() {
         crate::extension::ensure_extensions_loaded();

--- a/crates/khive-db/src/timeout_sink.rs
+++ b/crates/khive-db/src/timeout_sink.rs
@@ -261,6 +261,18 @@ pub(crate) enum Site {
     /// `with_writer_unmanaged` fallback, taken while the write queue is
     /// enabled (ADR-136 D1 gate 3 amendment — the general vector write path).
     DirectRouteVecGeneralWrite,
+    /// `stores::entity::SqlEntityStore`'s pool-writer fallback.
+    DirectRouteEntity,
+    /// `stores::note::SqlNoteStore`'s pool-writer fallback.
+    DirectRouteNote,
+    /// `stores::graph::SqlGraphStore`'s standalone/pool-writer fallback.
+    DirectRouteGraphGeneralWrite,
+    /// `stores::event::SqlEventStore`'s standalone/pool-writer fallback.
+    DirectRouteEventGeneralWrite,
+    /// `stores::sparse::SqliteSparseStore`'s pool-writer fallback.
+    DirectRouteSparseGeneralWrite,
+    /// `stores::agents::SqlAgentStore`'s standalone/pool-writer fallback.
+    DirectRouteAgentGeneralWrite,
 }
 
 impl Site {
@@ -278,6 +290,12 @@ impl Site {
             Site::DirectRouteFtsRenameNamespace => "direct_route:fts_rename_namespace",
             Site::DirectRouteFtsGeneralWrite => "direct_route:fts_general_write",
             Site::DirectRouteVecGeneralWrite => "direct_route:vec_general_write",
+            Site::DirectRouteEntity => "direct_route:entity",
+            Site::DirectRouteNote => "direct_route:note",
+            Site::DirectRouteGraphGeneralWrite => "direct_route:graph_general_write",
+            Site::DirectRouteEventGeneralWrite => "direct_route:event_general_write",
+            Site::DirectRouteSparseGeneralWrite => "direct_route:sparse_general_write",
+            Site::DirectRouteAgentGeneralWrite => "direct_route:agent_general_write",
         }
     }
 }
@@ -1092,6 +1110,28 @@ pub(crate) fn maybe_emit_busy(db: &str, site: Site, err: &rusqlite::Error) {
 mod tests {
     use super::*;
     use std::thread;
+
+    #[test]
+    fn store_direct_route_sites_have_stable_names() {
+        assert_eq!(Site::DirectRouteEntity.as_str(), "direct_route:entity");
+        assert_eq!(Site::DirectRouteNote.as_str(), "direct_route:note");
+        assert_eq!(
+            Site::DirectRouteGraphGeneralWrite.as_str(),
+            "direct_route:graph_general_write"
+        );
+        assert_eq!(
+            Site::DirectRouteEventGeneralWrite.as_str(),
+            "direct_route:event_general_write"
+        );
+        assert_eq!(
+            Site::DirectRouteSparseGeneralWrite.as_str(),
+            "direct_route:sparse_general_write"
+        );
+        assert_eq!(
+            Site::DirectRouteAgentGeneralWrite.as_str(),
+            "direct_route:agent_general_write"
+        );
+    }
 
     #[test]
     fn resolve_log_dir_prefers_explicit_override() {

--- a/crates/khive-db/src/writer_task.rs
+++ b/crates/khive-db/src/writer_task.rs
@@ -33,6 +33,13 @@
 //! | Recovery (`walpin` beacon/sidecar bookkeeping) | None — file-level bookkeeping (PID beacons, heartbeats) alongside the database, not a SQL connection against it | No | N/A — never acquires a database writer connection |
 //! | Top-level maintenance (`VACUUM` via `execute_script_top_level`/`WriterTaskHandle::send_top_level`) | `WriterTaskHandle`, skipping the per-request `BEGIN IMMEDIATE`/`COMMIT` wrap only | Yes | Routed through the SAME single writer owner as every other queued request — only the transaction wrap is skipped, never the queue |
 //!
+//! Store constructors may run outside Tokio and temporarily cache no handle;
+//! every store request-path write refreshes through
+//! `ConnectionPool::writer_task_for_write` at execution time. Strict routing
+//! refuses a missing handle, while the explicit compatibility fallback emits
+//! its store-specific violation at the actual direct-writer seam. The strict
+//! default itself remains gated by ADR-135 F2 / ADR-136 D2 evidence.
+//!
 //! A `direct_route_violation` sink row (`timeout_sink::emit_direct_route_violation`,
 //! ADR-136 D1 gate 6c) is emitted ONLY for the first row's degrade path — a
 //! `SqlAccess`-reachable write that bypassed an enabled queue. The other four


### PR DESCRIPTION
Refs #1847.

This reviewable store tranche closes silent WriterTask bypasses without prematurely flipping the global strict-routing default:

- refreshes writer-task handles at write time across entity, note, graph, event, text, sparse, vector, and agent stores
- covers batch and transaction-owning entry points, including stores built outside a Tokio runtime
- fails closed in strict mode when no queue handle is available
- preserves compatibility routing with store-specific direct-route telemetry
- removes a nested BEGIN from the queue-backed agent ledger path while retaining the compatibility transaction

The default flip remains gated by ADR-135 F2 / ADR-136 D2 production evidence. Remaining direct runtime seams in curation/operations are intentionally tracked as follow-up scope.

Verification so far: independent source review APPROVE; rustfmt, diff check, and cached-handle structural census pass. No local Cargo build was run; this PR stays draft while the remote matrix runs.