### PR TITLE
fix(db): publish checkpoint ownership after configuration

### DIFF
--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -1794,7 +1794,8 @@ pub async fn run_checkpoint_task(
         tracing::warn!(
             error = %e,
             "checkpoint task could not re-apply the ownership pragma on the pooled writer; \
-             writer connections keep the bounded autocheckpoint fallback until reopened"
+             writer connections keep the bounded autocheckpoint fallback unless ownership is \
+             claimed later"
         );
     }
     if let Err(e) = pool.propagate_checkpoint_claim_to_writer_task().await {

--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -3771,7 +3771,14 @@ mod tests {
         );
 
         let legacy_conn = pool.legacy_conn();
-        let held_writer = legacy_conn.lock();
+        let (held_tx, held_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let holder = tokio::task::spawn_blocking(move || {
+            let _held_writer = legacy_conn.lock();
+            held_tx.send(()).expect("signal held pooled writer");
+            release_rx.recv().expect("release held pooled writer");
+        });
+        held_rx.await.expect("pooled writer holder started");
         let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
         drop(shutdown_tx);
         run_checkpoint_task(
@@ -3792,7 +3799,8 @@ mod tests {
             crate::pool::FALLBACK_WAL_AUTOCHECKPOINT_PAGES,
             "failed pooled-writer claim must not partially propagate ownership"
         );
-        drop(held_writer);
+        release_tx.send(()).expect("release pooled writer");
+        holder.await.expect("pooled writer holder joined");
     }
 
     #[tokio::test]

--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -1790,20 +1790,24 @@ pub async fn run_checkpoint_task(
     // running checkpoint task never claim and keep SQLite's bounded WAL
     // reclamation. A failed claim leaves connections on the bounded fallback
     // — safe, just not the low-latency posture — so it warns and continues.
-    if let Err(e) = pool.claim_checkpoint_ownership() {
-        tracing::warn!(
-            error = %e,
-            "checkpoint task could not re-apply the ownership pragma on the pooled writer; \
-             writer connections keep the bounded autocheckpoint fallback unless ownership is \
-             claimed later"
-        );
-    }
-    if let Err(e) = pool.propagate_checkpoint_claim_to_writer_task().await {
-        tracing::warn!(
-            error = %e,
-            "checkpoint task could not reach the writer task's connection; it keeps the \
-             bounded autocheckpoint fallback"
-        );
+    match pool.claim_checkpoint_ownership() {
+        Ok(()) => {
+            if let Err(e) = pool.propagate_checkpoint_claim_to_writer_task().await {
+                tracing::warn!(
+                    error = %e,
+                    "checkpoint task could not reach the writer task's connection; it keeps the \
+                     bounded autocheckpoint fallback"
+                );
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "checkpoint task could not re-apply the ownership pragma on the pooled writer; \
+                 writer connections keep the bounded autocheckpoint fallback unless ownership is \
+                 claimed later"
+            );
+        }
     }
     let mut interval = tokio::time::interval(config.interval);
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -2959,6 +2963,7 @@ fn query_wal_pages(conn: &rusqlite::Connection) -> u64 {
 mod tests {
     use super::*;
     use crate::pool::PoolConfig;
+    use crate::writer_task::WriterTaskHandle;
     use rusqlite::hooks::{AuthAction, Authorization};
     use serial_test::serial;
     use tracing::field::{Field, Visit};
@@ -3199,6 +3204,19 @@ mod tests {
             ..PoolConfig::default()
         };
         Arc::new(ConnectionPool::new(cfg).expect("pool open"))
+    }
+
+    async fn writer_task_wal_autocheckpoint_pages(handle: &WriterTaskHandle) -> u32 {
+        handle
+            .send_top_level(|conn| {
+                conn.pragma_query_value(None, "wal_autocheckpoint", |row| row.get::<_, u32>(0))
+                    .map_err(|error| khive_storage::error::StorageError::Pool {
+                        operation: "test_wal_autocheckpoint".into(),
+                        message: error.to_string(),
+                    })
+            })
+            .await
+            .expect("query writer-task connection pragma")
     }
 
     /// Test helper: open the same dedicated standalone connection
@@ -3727,6 +3745,54 @@ mod tests {
             .pragma_query_value(None, "wal_autocheckpoint", |row| row.get(0))
             .expect("read reopened autocheckpoint setting");
         assert_eq!(reopened, 0);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    #[serial(checkpoint_skip_metrics)]
+    async fn failed_checkpoint_claim_keeps_existing_writer_task_on_fallback() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("failed_claim_writer_task.db");
+        let pool = Arc::new(
+            ConnectionPool::new(PoolConfig {
+                path: Some(path),
+                checkout_timeout: Duration::from_millis(1),
+                write_queue_enabled: Some(true),
+                ..PoolConfig::default()
+            })
+            .expect("pool open"),
+        );
+        let writer_task = pool
+            .writer_task_handle()
+            .expect("writer-task resolution")
+            .expect("writer task enabled");
+        assert_eq!(
+            writer_task_wal_autocheckpoint_pages(&writer_task).await,
+            crate::pool::FALLBACK_WAL_AUTOCHECKPOINT_PAGES
+        );
+
+        let legacy_conn = pool.legacy_conn();
+        let held_writer = legacy_conn.lock();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
+        drop(shutdown_tx);
+        run_checkpoint_task(
+            Arc::clone(&pool),
+            CheckpointConfig {
+                interval: Duration::from_secs(60),
+                ..CheckpointConfig::default()
+            },
+            None,
+            shutdown_rx,
+            true,
+        )
+        .await;
+
+        assert_eq!(pool.writer_acquisition_snapshot().timeouts, 1);
+        assert_eq!(
+            writer_task_wal_autocheckpoint_pages(&writer_task).await,
+            crate::pool::FALLBACK_WAL_AUTOCHECKPOINT_PAGES,
+            "failed pooled-writer claim must not partially propagate ownership"
+        );
+        drop(held_writer);
     }
 
     #[tokio::test]

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -152,6 +152,7 @@ impl CheckpointOwnershipGate {
         state
     }
 
+    #[cfg(test)]
     fn wal_autocheckpoint_pages(&self) -> u32 {
         let state = self.settled_state();
         match state.phase {
@@ -1223,6 +1224,7 @@ impl ConnectionPool {
     /// Effective `PRAGMA wal_autocheckpoint` for a writer-capable connection
     /// opened right now: `0` once a dedicated checkpoint owner has claimed
     /// the pool, the bounded fallback otherwise.
+    #[cfg(test)]
     pub(crate) fn effective_wal_autocheckpoint_pages(&self) -> u32 {
         self.checkpoint_ownership.wal_autocheckpoint_pages()
     }

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -47,9 +47,29 @@ struct CheckpointOwnershipState {
     connection_waiters: usize,
 }
 
+#[cfg(test)]
+struct CheckpointConnectionConfigPause {
+    selected: std::sync::Barrier,
+    resume: std::sync::Barrier,
+}
+
+#[cfg(test)]
+impl CheckpointConnectionConfigPause {
+    fn new() -> Self {
+        Self {
+            selected: std::sync::Barrier::new(2),
+            resume: std::sync::Barrier::new(2),
+        }
+    }
+}
+
 struct CheckpointOwnershipGate {
     state: Mutex<CheckpointOwnershipState>,
     changed: Condvar,
+    #[cfg(test)]
+    connection_config_pause: Mutex<Option<Arc<CheckpointConnectionConfigPause>>>,
+    #[cfg(test)]
+    claim_lock_observed: Mutex<Option<std::sync::mpsc::SyncSender<bool>>>,
 }
 
 impl CheckpointOwnershipGate {
@@ -61,12 +81,34 @@ impl CheckpointOwnershipGate {
                 connection_waiters: 0,
             }),
             changed: Condvar::new(),
+            #[cfg(test)]
+            connection_config_pause: Mutex::new(None),
+            #[cfg(test)]
+            claim_lock_observed: Mutex::new(None),
         }
     }
 
     /// Join an in-flight claim, or become the one caller that configures it.
     /// Returns `false` when another caller has already completed the claim.
     fn begin_claim(&self) -> bool {
+        #[cfg(test)]
+        let claim_lock_observed = self.claim_lock_observed.lock().take();
+        #[cfg(test)]
+        let mut state = if let Some(observed) = claim_lock_observed {
+            match self.state.try_lock() {
+                Some(state) => {
+                    let _ = observed.send(false);
+                    state
+                }
+                None => {
+                    let _ = observed.send(true);
+                    self.state.lock()
+                }
+            }
+        } else {
+            self.state.lock()
+        };
+        #[cfg(not(test))]
         let mut state = self.state.lock();
         loop {
             match state.phase {
@@ -92,12 +134,7 @@ impl CheckpointOwnershipGate {
         self.changed.notify_all();
     }
 
-    /// Wait for an in-flight claim before selecting the connection-local
-    /// autocheckpoint posture. The condition variable makes the claim's
-    /// publication and every standalone open that encounters `Claiming` one
-    /// ordered decision: that open cannot retain the fallback after a
-    /// successful claim or lose the fallback after a failed one.
-    fn wal_autocheckpoint_pages(&self) -> u32 {
+    fn settled_state(&self) -> parking_lot::MutexGuard<'_, CheckpointOwnershipState> {
         let mut state = self.state.lock();
         while state.phase == CheckpointOwnership::Claiming {
             #[cfg(test)]
@@ -112,11 +149,37 @@ impl CheckpointOwnershipGate {
                 self.changed.notify_all();
             }
         }
+        state
+    }
+
+    fn wal_autocheckpoint_pages(&self) -> u32 {
+        let state = self.settled_state();
         match state.phase {
             CheckpointOwnership::Unclaimed => FALLBACK_WAL_AUTOCHECKPOINT_PAGES,
             CheckpointOwnership::Claimed => 0,
             CheckpointOwnership::Claiming => unreachable!("claim wait must settle the state"),
         }
+    }
+
+    /// Wait for any in-flight claim, select the resulting posture, and retain
+    /// the gate until SQLite has applied that connection-local PRAGMA. A claim
+    /// therefore linearizes entirely before or after this configuration,
+    /// never between its state sample and side effect.
+    fn configure_wal_autocheckpoint(&self, conn: &Connection) -> Result<(), SqliteError> {
+        let state = self.settled_state();
+        let pages = match state.phase {
+            CheckpointOwnership::Unclaimed => FALLBACK_WAL_AUTOCHECKPOINT_PAGES,
+            CheckpointOwnership::Claimed => 0,
+            CheckpointOwnership::Claiming => unreachable!("claim wait must settle the state"),
+        };
+        #[cfg(test)]
+        if let Some(pause) = self.connection_config_pause.lock().take() {
+            pause.selected.wait();
+            pause.resume.wait();
+        }
+        conn.pragma_update(None, "wal_autocheckpoint", pages)?;
+        drop(state);
+        Ok(())
     }
 }
 
@@ -1150,11 +1213,8 @@ impl ConnectionPool {
                 | OpenFlags::SQLITE_OPEN_URI,
         )?;
         conn.busy_timeout(self.config.busy_timeout)?;
-        conn.pragma_update(
-            None,
-            "wal_autocheckpoint",
-            self.effective_wal_autocheckpoint_pages(),
-        )?;
+        self.checkpoint_ownership
+            .configure_wal_autocheckpoint(&conn)?;
         conn.pragma_update(None, "foreign_keys", "ON")?;
         conn.pragma_update(None, "synchronous", "NORMAL")?;
         Ok(conn)
@@ -2703,6 +2763,59 @@ mod tests {
             0,
             "a writer open concurrent with a successful claim must inherit claimed ownership"
         );
+    }
+
+    #[test]
+    fn standalone_fallback_application_linearizes_before_claim_publication() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("checkpoint_open_before_claim.db");
+        let pool = Arc::new(
+            ConnectionPool::new(PoolConfig {
+                path: Some(path),
+                checkout_timeout: Duration::from_secs(5),
+                write_queue_enabled: Some(false),
+                ..PoolConfig::default()
+            })
+            .expect("pool open"),
+        );
+        let pause = Arc::new(CheckpointConnectionConfigPause::new());
+        *pool.checkpoint_ownership.connection_config_pause.lock() = Some(Arc::clone(&pause));
+
+        let open_pool = Arc::clone(&pool);
+        let open_thread = thread::spawn(move || {
+            let conn = open_pool
+                .open_standalone_writer()
+                .expect("standalone writer opens");
+            wal_autocheckpoint_pages(&conn)
+        });
+        pause.selected.wait();
+        assert!(
+            pool.checkpoint_ownership.state.try_lock().is_none(),
+            "standalone selection must retain the ownership gate until its PRAGMA is applied"
+        );
+
+        let (claim_observed_tx, claim_observed_rx) = std::sync::mpsc::sync_channel(0);
+        *pool.checkpoint_ownership.claim_lock_observed.lock() = Some(claim_observed_tx);
+        let claim_pool = Arc::clone(&pool);
+        let claim_thread = thread::spawn(move || claim_pool.claim_checkpoint_ownership());
+        assert!(
+            claim_observed_rx
+                .recv()
+                .expect("claim reports whether it observed gate contention"),
+            "the claim must attempt the gate between fallback selection and PRAGMA application"
+        );
+        pause.resume.wait();
+
+        assert_eq!(
+            open_thread.join().expect("standalone-open thread joins"),
+            FALLBACK_WAL_AUTOCHECKPOINT_PAGES,
+            "an open linearized before the claim keeps the fallback"
+        );
+        claim_thread
+            .join()
+            .expect("claim thread joins")
+            .expect("claim succeeds after standalone configuration");
+        assert_eq!(pool.effective_wal_autocheckpoint_pages(), 0);
     }
 
     #[test]

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -1103,14 +1103,15 @@ impl ConnectionPool {
     /// of growing its WAL without bound.
     ///
     /// Read-only pools record the claim but have no writer-capable
-    /// connections to reconfigure.
+    /// connections to reconfigure. Writable pools publish the claim only after
+    /// the pooled writer is configured successfully; a failed attempt keeps
+    /// the bounded fallback active and remains retryable.
     pub fn claim_checkpoint_ownership(&self) -> Result<(), SqliteError> {
-        self.checkpoint_owner_claimed.store(true, Ordering::Release);
-        if self.config.read_only {
-            return Ok(());
+        if !self.config.read_only {
+            let writer = self.writer()?;
+            writer.conn().pragma_update(None, "wal_autocheckpoint", 0)?;
         }
-        let writer = self.writer()?;
-        writer.conn().pragma_update(None, "wal_autocheckpoint", 0)?;
+        self.checkpoint_owner_claimed.store(true, Ordering::Release);
         Ok(())
     }
 
@@ -2550,6 +2551,50 @@ mod tests {
             FALLBACK_WAL_AUTOCHECKPOINT_PAGES,
             "an unclaimed in-memory pool keeps the bounded fallback"
         );
+    }
+
+    #[test]
+    fn failed_checkpoint_ownership_claim_keeps_fallback_and_can_be_retried() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("checkpoint_claim_retry.db");
+        let pool = ConnectionPool::new(PoolConfig {
+            path: Some(path),
+            checkout_timeout: Duration::from_millis(1),
+            write_queue_enabled: Some(false),
+            ..PoolConfig::default()
+        })
+        .expect("pool open");
+
+        let legacy_conn = pool.legacy_conn();
+        let held_writer = legacy_conn.lock();
+        let error = pool
+            .claim_checkpoint_ownership()
+            .expect_err("the held pooled writer must make the claim time out");
+        assert!(matches!(
+            error,
+            SqliteError::WriterPoolCheckoutTimeout { .. }
+        ));
+        assert_eq!(
+            pool.effective_wal_autocheckpoint_pages(),
+            FALLBACK_WAL_AUTOCHECKPOINT_PAGES,
+            "a failed claim must leave later writer connections fallback-safe"
+        );
+
+        let fallback_writer = pool
+            .open_standalone_writer()
+            .expect("standalone writer after failed claim");
+        assert_eq!(
+            wal_autocheckpoint_pages(&fallback_writer),
+            FALLBACK_WAL_AUTOCHECKPOINT_PAGES
+        );
+        drop(fallback_writer);
+
+        drop(held_writer);
+        pool.claim_checkpoint_ownership()
+            .expect("the ownership claim remains retryable");
+        assert_eq!(pool.effective_wal_autocheckpoint_pages(), 0);
+        let writer = pool.writer().expect("pooled writer after successful retry");
+        assert_eq!(wal_autocheckpoint_pages(writer.conn()), 0);
     }
 
     #[test]

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -1,6 +1,6 @@
 //! Connection pool for SQLite: one exclusive writer, N concurrent readers.
 use crossbeam_queue::ArrayQueue;
-use parking_lot::Mutex;
+use parking_lot::{Condvar, Mutex};
 use rusqlite::hooks::{AuthContext, Authorization};
 use rusqlite::{Connection, OpenFlags};
 use std::fs;
@@ -33,6 +33,92 @@ const DEFAULT_WRITE_QUEUE_CAPACITY: usize = 256;
 /// ownership claim ([`ConnectionPool::claim_checkpoint_ownership`]), which a
 /// runtime may make only when it really runs the scheduled checkpoint task.
 pub(crate) const FALLBACK_WAL_AUTOCHECKPOINT_PAGES: u32 = 4_000;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CheckpointOwnership {
+    Unclaimed,
+    Claiming,
+    Claimed,
+}
+
+struct CheckpointOwnershipState {
+    phase: CheckpointOwnership,
+    #[cfg(test)]
+    connection_waiters: usize,
+}
+
+struct CheckpointOwnershipGate {
+    state: Mutex<CheckpointOwnershipState>,
+    changed: Condvar,
+}
+
+impl CheckpointOwnershipGate {
+    fn new() -> Self {
+        Self {
+            state: Mutex::new(CheckpointOwnershipState {
+                phase: CheckpointOwnership::Unclaimed,
+                #[cfg(test)]
+                connection_waiters: 0,
+            }),
+            changed: Condvar::new(),
+        }
+    }
+
+    /// Join an in-flight claim, or become the one caller that configures it.
+    /// Returns `false` when another caller has already completed the claim.
+    fn begin_claim(&self) -> bool {
+        let mut state = self.state.lock();
+        loop {
+            match state.phase {
+                CheckpointOwnership::Unclaimed => {
+                    state.phase = CheckpointOwnership::Claiming;
+                    self.changed.notify_all();
+                    return true;
+                }
+                CheckpointOwnership::Claiming => self.changed.wait(&mut state),
+                CheckpointOwnership::Claimed => return false,
+            }
+        }
+    }
+
+    fn finish_claim(&self, succeeded: bool) {
+        let mut state = self.state.lock();
+        debug_assert_eq!(state.phase, CheckpointOwnership::Claiming);
+        state.phase = if succeeded {
+            CheckpointOwnership::Claimed
+        } else {
+            CheckpointOwnership::Unclaimed
+        };
+        self.changed.notify_all();
+    }
+
+    /// Wait for an in-flight claim before selecting the connection-local
+    /// autocheckpoint posture. The condition variable makes the claim's
+    /// publication and every standalone open that encounters `Claiming` one
+    /// ordered decision: that open cannot retain the fallback after a
+    /// successful claim or lose the fallback after a failed one.
+    fn wal_autocheckpoint_pages(&self) -> u32 {
+        let mut state = self.state.lock();
+        while state.phase == CheckpointOwnership::Claiming {
+            #[cfg(test)]
+            {
+                state.connection_waiters += 1;
+                self.changed.notify_all();
+            }
+            self.changed.wait(&mut state);
+            #[cfg(test)]
+            {
+                state.connection_waiters -= 1;
+                self.changed.notify_all();
+            }
+        }
+        match state.phase {
+            CheckpointOwnership::Unclaimed => FALLBACK_WAL_AUTOCHECKPOINT_PAGES,
+            CheckpointOwnership::Claimed => 0,
+            CheckpointOwnership::Claiming => unreachable!("claim wait must settle the state"),
+        }
+    }
+}
 
 fn deny_retired_writer(_context: AuthContext<'_>) -> Authorization {
     Authorization::Deny
@@ -304,15 +390,15 @@ fn validate_write_admission_deadline(deadline_ms: u64) -> Result<(), SqliteError
 /// never alias a read onto the query-only writer slot.
 pub struct ConnectionPool {
     writer: Arc<Mutex<Connection>>,
-    /// Whether a dedicated checkpoint owner (the ADR-091 scheduled task) has
-    /// claimed routine WAL reclamation for this pool. Until claimed, every
+    /// Three-state gate for whether the ADR-091 scheduled task has claimed
+    /// routine WAL reclamation for this pool. Until claimed, every
     /// writer-capable connection keeps a bounded SQLite autocheckpoint
     /// ([`FALLBACK_WAL_AUTOCHECKPOINT_PAGES`]) so a writable pool without a
     /// checkpoint task cannot grow its WAL without bound. After
     /// [`Self::claim_checkpoint_ownership`], writer-capable connections open
     /// with `wal_autocheckpoint = 0` and routine checkpoint I/O stays off
     /// application commit paths.
-    checkpoint_owner_claimed: AtomicBool,
+    checkpoint_ownership: CheckpointOwnershipGate,
     /// Fail-closed guard for the legacy pool-mutex writer. A transaction
     /// owner retires this connection after a body panic or when it cannot
     /// prove that finalization restored autocommit mode; subsequent checkouts
@@ -589,7 +675,7 @@ impl ConnectionPool {
 
         let pool = Self {
             writer: Arc::new(Mutex::new(writer)),
-            checkpoint_owner_claimed: AtomicBool::new(false),
+            checkpoint_ownership: CheckpointOwnershipGate::new(),
             pooled_writer_retired: AtomicBool::new(false),
             writer_acquisition_counters: Arc::new(WriterAcquisitionCounters::default()),
             readers,
@@ -1078,11 +1164,7 @@ impl ConnectionPool {
     /// opened right now: `0` once a dedicated checkpoint owner has claimed
     /// the pool, the bounded fallback otherwise.
     pub(crate) fn effective_wal_autocheckpoint_pages(&self) -> u32 {
-        if self.checkpoint_owner_claimed.load(Ordering::Acquire) {
-            0
-        } else {
-            FALLBACK_WAL_AUTOCHECKPOINT_PAGES
-        }
+        self.checkpoint_ownership.wal_autocheckpoint_pages()
     }
 
     /// Claim routine WAL-checkpoint ownership for this pool.
@@ -1107,12 +1189,18 @@ impl ConnectionPool {
     /// the pooled writer is configured successfully; a failed attempt keeps
     /// the bounded fallback active and remains retryable.
     pub fn claim_checkpoint_ownership(&self) -> Result<(), SqliteError> {
-        if !self.config.read_only {
-            let writer = self.writer()?;
-            writer.conn().pragma_update(None, "wal_autocheckpoint", 0)?;
+        if !self.checkpoint_ownership.begin_claim() {
+            return Ok(());
         }
-        self.checkpoint_owner_claimed.store(true, Ordering::Release);
-        Ok(())
+        let result = (|| {
+            if !self.config.read_only {
+                let writer = self.writer()?;
+                writer.conn().pragma_update(None, "wal_autocheckpoint", 0)?;
+            }
+            Ok(())
+        })();
+        self.checkpoint_ownership.finish_claim(result.is_ok());
+        result
     }
 
     /// Flip an already-running writer task's long-lived connection to the
@@ -2550,6 +2638,70 @@ mod tests {
             wal_autocheckpoint_pages(memory_writer.conn()),
             FALLBACK_WAL_AUTOCHECKPOINT_PAGES,
             "an unclaimed in-memory pool keeps the bounded fallback"
+        );
+    }
+
+    #[test]
+    fn standalone_writer_waits_for_checkpoint_claim_resolution() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("checkpoint_claim_race.db");
+        let pool = Arc::new(
+            ConnectionPool::new(PoolConfig {
+                path: Some(path),
+                checkout_timeout: Duration::from_secs(5),
+                write_queue_enabled: Some(false),
+                ..PoolConfig::default()
+            })
+            .expect("pool open"),
+        );
+
+        let legacy_conn = pool.legacy_conn();
+        let held_writer = legacy_conn.lock();
+        let claim_start = Arc::new(std::sync::Barrier::new(2));
+        let claim_pool = Arc::clone(&pool);
+        let claim_thread_start = Arc::clone(&claim_start);
+        let claim_thread = thread::spawn(move || {
+            claim_thread_start.wait();
+            claim_pool.claim_checkpoint_ownership()
+        });
+        claim_start.wait();
+
+        {
+            let mut state = pool.checkpoint_ownership.state.lock();
+            while state.phase != CheckpointOwnership::Claiming {
+                pool.checkpoint_ownership.changed.wait(&mut state);
+            }
+        }
+
+        let open_start = Arc::new(std::sync::Barrier::new(2));
+        let open_pool = Arc::clone(&pool);
+        let open_thread_start = Arc::clone(&open_start);
+        let open_thread = thread::spawn(move || {
+            open_thread_start.wait();
+            let conn = open_pool
+                .open_standalone_writer()
+                .expect("standalone writer after claim resolution");
+            wal_autocheckpoint_pages(&conn)
+        });
+        open_start.wait();
+
+        {
+            let mut state = pool.checkpoint_ownership.state.lock();
+            while state.connection_waiters == 0 {
+                pool.checkpoint_ownership.changed.wait(&mut state);
+            }
+            assert_eq!(state.phase, CheckpointOwnership::Claiming);
+        }
+
+        drop(held_writer);
+        claim_thread
+            .join()
+            .expect("claim thread joins")
+            .expect("claim succeeds");
+        assert_eq!(
+            open_thread.join().expect("standalone-open thread joins"),
+            0,
+            "a writer open concurrent with a successful claim must inherit claimed ownership"
         );
     }
 


### PR DESCRIPTION
Fixes #1901.

Checkpoint ownership is now published only after the pooled writer is acquired and PRAGMA wal_autocheckpoint=0 succeeds. A failed claim therefore leaves the bounded SQLite fallback active and remains safely retryable instead of advertising an owner that never came online.

The regression holds legacy_conn beyond writer checkout timeout, verifies a later standalone writer still uses FALLBACK_WAL_AUTOCHECKPOINT_PAGES, then retries the ownership claim successfully.

Static verification: rustfmt, ADR-ref lint, stub-marker lint, SQL lint, JSON guard, and diff check pass. No local Cargo build was run because another active Claude build is consuming shared disk; the remote matrix is the build gate.