### PR TITLE
feat(kg-editor): add shared ontology legend

### DIFF
--- a/apps/kg-editor/src/app/globals.css
+++ b/apps/kg-editor/src/app/globals.css
@@ -41,6 +41,8 @@
   --ontology-unknown: #7c8795;
   --shadow: 0 16px 45px rgba(26, 37, 47, 0.07);
   --shadow-small: 0 4px 18px rgba(28, 39, 49, 0.06);
+  --selection-ring: rgba(20, 32, 51, 0.12);
+  --selection-ring-accent: rgba(20, 125, 98, 0.12);
   --radius: 12px;
   --space-1: 2px;
   --space-2: 4px;
@@ -97,6 +99,8 @@
     --ontology-unknown: #b9b7ae;
     --shadow: 0 16px 45px rgba(0, 0, 0, 0.45);
     --shadow-small: 0 4px 18px rgba(0, 0, 0, 0.35);
+    --selection-ring: rgba(233, 228, 217, 0.22);
+    --selection-ring-accent: rgba(120, 214, 183, 0.24);
   }
 }
 
@@ -130,6 +134,8 @@
   --ontology-unknown: #b9b7ae;
   --shadow: 0 16px 45px rgba(0, 0, 0, 0.45);
   --shadow-small: 0 4px 18px rgba(0, 0, 0, 0.35);
+  --selection-ring: rgba(233, 228, 217, 0.22);
+  --selection-ring-accent: rgba(120, 214, 183, 0.24);
 }
 
 * {
@@ -1745,7 +1751,7 @@ i.context,
 
 .edge-label.selected {
   border-color: var(--ontology-edge-hue, var(--ink));
-  box-shadow: 0 0 0 2px rgba(20, 32, 51, 0.12);
+  box-shadow: 0 0 0 2px var(--selection-ring);
 }
 
 .graph-edge-summary li button {

--- a/apps/kg-editor/src/app/globals.css
+++ b/apps/kg-editor/src/app/globals.css
@@ -20,6 +20,25 @@
   --amber-pale: #fff3d7;
   --red: #b24a4a;
   --red-pale: #fbe9e8;
+  --ontology-concept: #7256b1;
+  --ontology-document: #356d96;
+  --ontology-dataset: #087b77;
+  --ontology-project: #167357;
+  --ontology-person: #9a6914;
+  --ontology-org: #9b4d2f;
+  --ontology-artifact: #8a4d86;
+  --ontology-service: #2f7290;
+  --ontology-resource: #6f6547;
+  --ontology-observation: #4f6d7a;
+  --ontology-insight: #7a589d;
+  --ontology-question: #9b6514;
+  --ontology-decision: #3c7563;
+  --ontology-reference: #596fa3;
+  --ontology-edge-neutral: #697780;
+  --ontology-support: #147d62;
+  --ontology-refute: #b24a4a;
+  --ontology-derived: #7158bc;
+  --ontology-unknown: #7c8795;
   --shadow: 0 16px 45px rgba(26, 37, 47, 0.07);
   --shadow-small: 0 4px 18px rgba(28, 39, 49, 0.06);
   --radius: 12px;
@@ -82,6 +101,95 @@ kbd {
   white-space: nowrap;
   width: 1px;
 }
+
+.ontology-kind-mark,
+.ontology-relation-mark,
+.ontology-derived-mark,
+.ontology-legend {
+  align-items: center;
+  display: inline-flex;
+}
+
+.ontology-kind-mark {
+  color: var(--ontology-kind-hue);
+  gap: 4px;
+}
+
+.ontology-kind-mark svg {
+  flex: 0 0 auto;
+  height: 1em;
+  width: 1em;
+}
+
+.ontology-relation-mark {
+  color: var(--ontology-edge-hue);
+  gap: 4px;
+}
+
+.ontology-relation-mark b,
+.ontology-derived-mark b {
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 1.15em;
+  line-height: 1;
+}
+
+.ontology-derived-mark {
+  color: var(--ontology-derived);
+  gap: 4px;
+}
+
+.ontology-legend {
+  flex-wrap: wrap;
+  gap: 6px 10px;
+}
+
+.ontology-legend > span {
+  font-size: 9px;
+  white-space: nowrap;
+}
+
+svg line.ontology-edge {
+  stroke: var(--ontology-edge-hue);
+  stroke-linecap: round;
+  stroke-width: 1.3px;
+}
+
+svg line.ontology-edge[data-edge-treatment="quiet-solid"] { opacity: 0.72; }
+svg line.ontology-edge[data-edge-treatment="directional"] { stroke-dasharray: 7 2; }
+svg line.ontology-edge[data-edge-treatment="dotted"] { stroke-dasharray: 1 3; }
+svg line.ontology-edge[data-edge-treatment="assertive-solid"] { stroke-width: 1.8px; }
+svg line.ontology-edge[data-edge-treatment="undirected"] { stroke-dasharray: 6 2 1 2; }
+svg line.ontology-edge[data-edge-treatment="recessive-dashed"] { opacity: 0.62; stroke-dasharray: 3 4; }
+svg line.ontology-edge[data-edge-treatment="epistemic"] { stroke-dasharray: 8 2; stroke-width: 1.6px; }
+svg line.ontology-edge[data-edge-variant="secondary"] { stroke-dashoffset: 2; }
+svg line.ontology-edge[data-edge-variant="tertiary"] { stroke-dashoffset: 4; }
+svg line.ontology-edge[data-edge-variant="quaternary"] { stroke-dashoffset: 6; }
+svg line.ontology-edge[data-edge-origin="derived"] { stroke-dasharray: 2 2; }
+
+.ontology-edge-glyph {
+  dominant-baseline: central;
+  fill: var(--ontology-edge-hue);
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 3px;
+  paint-order: stroke;
+  stroke: var(--surface-strong);
+  stroke-width: 0.7px;
+  text-anchor: middle;
+}
+
+.ontology-direction-glyph {
+  dominant-baseline: central;
+  fill: var(--ontology-edge-hue);
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 5px;
+  font-weight: 800;
+  paint-order: stroke;
+  stroke: var(--surface-strong);
+  stroke-width: 0.8px;
+  text-anchor: middle;
+}
+
+.ontology-derived-glyph { fill: var(--ontology-derived); }
 
 .app-shell {
   min-height: 100vh;
@@ -1018,6 +1126,9 @@ i.context,
   color: var(--blue);
 }
 
+.substrate-chip.ontology-kind-mark { color: var(--ontology-kind-hue); }
+.substrate-chip.ontology-relation-mark { color: var(--ontology-edge-hue); }
+
 .tier-pill {
   padding: 4px 8px;
 }
@@ -1400,6 +1511,18 @@ i.context,
   gap: 10px;
 }
 
+.graph-legend-block {
+  display: grid;
+  gap: 7px;
+  justify-items: end;
+  max-width: min(62%, 620px);
+}
+
+.graph-ontology-legend {
+  color: var(--ink-faint);
+  justify-content: flex-end;
+}
+
 .graph-stage {
   background:
     linear-gradient(rgba(36, 56, 50, 0.03) 1px, transparent 1px),
@@ -1434,12 +1557,11 @@ i.context,
 }
 
 .graph-lines .added line {
-  stroke: #6cae98;
+  opacity: 1;
 }
 
 .graph-lines .modified line {
-  stroke: #c3a15c;
-  stroke-dasharray: 5 4;
+  opacity: 0.82;
 }
 
 .graph-node {
@@ -1464,7 +1586,7 @@ i.context,
 }
 
 .graph-node.selected {
-  border-color: var(--green);
+  border-color: var(--ontology-kind-hue);
 }
 
 .graph-node.added {
@@ -1480,9 +1602,10 @@ i.context,
 }
 
 .node-kind {
-  color: var(--ink-faint);
-  display: block;
+  color: var(--ontology-kind-hue);
+  display: flex;
   font-size: 8px;
+  gap: 4px;
   margin-bottom: 3px;
   text-transform: uppercase;
 }
@@ -1505,6 +1628,11 @@ i.context,
   position: absolute;
   transform: translate(-50%, -50%);
   z-index: 3;
+}
+
+.edge-label .ontology-relation-mark {
+  display: inline-flex;
+  font-size: inherit;
 }
 
 .edge-label.modified {
@@ -1560,6 +1688,14 @@ i.context,
   font-size: 10px;
   line-height: 1.45;
   margin: 5px 0 0;
+}
+
+.node-inspector-kind {
+  color: var(--ontology-kind-hue);
+  display: inline-flex;
+  float: left;
+  font-size: 15px;
+  margin: 0 6px 2px 0;
 }
 
 .node-inspector code {

--- a/apps/kg-editor/src/app/globals.css
+++ b/apps/kg-editor/src/app/globals.css
@@ -42,6 +42,94 @@
   --shadow: 0 16px 45px rgba(26, 37, 47, 0.07);
   --shadow-small: 0 4px 18px rgba(28, 39, 49, 0.06);
   --radius: 12px;
+  --space-1: 2px;
+  --space-2: 4px;
+  --space-3: 6px;
+  --space-4: 8px;
+  --space-5: 10px;
+  --space-6: 14px;
+  --font-size-micro: 8px;
+  --font-size-2xs: 9px;
+  --font-size-xs: 10px;
+  --font-size-sm: 11px;
+  --font-size-icon: 14px;
+  --font-size-icon-lg: 15px;
+  --ontology-glyph-size: 3px;
+  --ontology-glyph-size-lg: 5px;
+  --ontology-stroke-thin: 1.3px;
+  --ontology-stroke-bold: 1.8px;
+  --ontology-stroke-epistemic: 1.6px;
+  --ontology-glyph-stroke: 0.7px;
+  --ontology-glyph-stroke-lg: 0.8px;
+}
+
+/* ADR-151 D1-D2: dark-first token remap for the shared surface/ontology
+   layer. OS preference is honored via prefers-color-scheme; an explicit
+   data-theme attribute always wins over it. */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --ink: #e8e6df;
+    --ink-soft: #b9b7ae;
+    --ink-faint: #8b8980;
+    --canvas: #17140f;
+    --surface: #1f1c16;
+    --surface-strong: #262219;
+    --line: #35312a;
+    --line-strong: #47423a;
+    --ontology-concept: #a68ee0;
+    --ontology-document: #6fa8d6;
+    --ontology-dataset: #3fc7c0;
+    --ontology-project: #4fd0a0;
+    --ontology-person: #e0b354;
+    --ontology-org: #e08a5e;
+    --ontology-artifact: #d08bcb;
+    --ontology-service: #5fb0d0;
+    --ontology-resource: #c7bd94;
+    --ontology-observation: #8fb0bd;
+    --ontology-insight: #b79bd9;
+    --ontology-question: #e0b354;
+    --ontology-decision: #6fd0b3;
+    --ontology-reference: #9aacd9;
+    --ontology-edge-neutral: #9aa4ab;
+    --ontology-support: #4fd0a0;
+    --ontology-refute: #e08a8a;
+    --ontology-derived: #a68ee0;
+    --ontology-unknown: #b9b7ae;
+    --shadow: 0 16px 45px rgba(0, 0, 0, 0.45);
+    --shadow-small: 0 4px 18px rgba(0, 0, 0, 0.35);
+  }
+}
+
+[data-theme="dark"] {
+  --ink: #e8e6df;
+  --ink-soft: #b9b7ae;
+  --ink-faint: #8b8980;
+  --canvas: #17140f;
+  --surface: #1f1c16;
+  --surface-strong: #262219;
+  --line: #35312a;
+  --line-strong: #47423a;
+  --ontology-concept: #a68ee0;
+  --ontology-document: #6fa8d6;
+  --ontology-dataset: #3fc7c0;
+  --ontology-project: #4fd0a0;
+  --ontology-person: #e0b354;
+  --ontology-org: #e08a5e;
+  --ontology-artifact: #d08bcb;
+  --ontology-service: #5fb0d0;
+  --ontology-resource: #c7bd94;
+  --ontology-observation: #8fb0bd;
+  --ontology-insight: #b79bd9;
+  --ontology-question: #e0b354;
+  --ontology-decision: #6fd0b3;
+  --ontology-reference: #9aacd9;
+  --ontology-edge-neutral: #9aa4ab;
+  --ontology-support: #4fd0a0;
+  --ontology-refute: #e08a8a;
+  --ontology-derived: #a68ee0;
+  --ontology-unknown: #b9b7ae;
+  --shadow: 0 16px 45px rgba(0, 0, 0, 0.45);
+  --shadow-small: 0 4px 18px rgba(0, 0, 0, 0.35);
 }
 
 * {
@@ -112,7 +200,7 @@ kbd {
 
 .ontology-kind-mark {
   color: var(--ontology-kind-hue);
-  gap: 4px;
+  gap: var(--space-2);
 }
 
 .ontology-kind-mark svg {
@@ -123,11 +211,10 @@ kbd {
 
 .ontology-relation-mark {
   color: var(--ontology-edge-hue);
-  gap: 4px;
+  gap: var(--space-2);
 }
 
-.ontology-relation-mark b,
-.ontology-derived-mark b {
+.ontology-relation-mark b {
   font-family: "SFMono-Regular", Consolas, monospace;
   font-size: 1.15em;
   line-height: 1;
@@ -135,32 +222,47 @@ kbd {
 
 .ontology-derived-mark {
   color: var(--ontology-derived);
-  gap: 4px;
+  gap: var(--space-2);
+}
+
+.ontology-derived-glyph-icon {
+  fill: none;
+  flex: 0 0 auto;
+  height: 1em;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.5;
+  width: 1em;
+}
+
+.ontology-mark-dim {
+  opacity: 0.5;
 }
 
 .ontology-legend {
   flex-wrap: wrap;
-  gap: 6px 10px;
+  gap: var(--space-3) var(--space-5);
 }
 
 .ontology-legend > span {
-  font-size: 9px;
+  font-size: var(--font-size-2xs);
   white-space: nowrap;
 }
 
 svg line.ontology-edge {
   stroke: var(--ontology-edge-hue);
   stroke-linecap: round;
-  stroke-width: 1.3px;
+  stroke-width: var(--ontology-stroke-thin);
 }
 
 svg line.ontology-edge[data-edge-treatment="quiet-solid"] { opacity: 0.72; }
 svg line.ontology-edge[data-edge-treatment="directional"] { stroke-dasharray: 7 2; }
 svg line.ontology-edge[data-edge-treatment="dotted"] { stroke-dasharray: 1 3; }
-svg line.ontology-edge[data-edge-treatment="assertive-solid"] { stroke-width: 1.8px; }
+svg line.ontology-edge[data-edge-treatment="assertive-solid"] { stroke-width: var(--ontology-stroke-bold); }
 svg line.ontology-edge[data-edge-treatment="undirected"] { stroke-dasharray: 6 2 1 2; }
 svg line.ontology-edge[data-edge-treatment="recessive-dashed"] { opacity: 0.62; stroke-dasharray: 3 4; }
-svg line.ontology-edge[data-edge-treatment="epistemic"] { stroke-dasharray: 8 2; stroke-width: 1.6px; }
+svg line.ontology-edge[data-edge-treatment="epistemic"] { stroke-dasharray: 8 2; stroke-width: var(--ontology-stroke-epistemic); }
 svg line.ontology-edge[data-edge-variant="secondary"] { stroke-dashoffset: 2; }
 svg line.ontology-edge[data-edge-variant="tertiary"] { stroke-dashoffset: 4; }
 svg line.ontology-edge[data-edge-variant="quaternary"] { stroke-dashoffset: 6; }
@@ -170,10 +272,10 @@ svg line.ontology-edge[data-edge-origin="derived"] { stroke-dasharray: 2 2; }
   dominant-baseline: central;
   fill: var(--ontology-edge-hue);
   font-family: "SFMono-Regular", Consolas, monospace;
-  font-size: 3px;
+  font-size: var(--ontology-glyph-size);
   paint-order: stroke;
   stroke: var(--surface-strong);
-  stroke-width: 0.7px;
+  stroke-width: var(--ontology-glyph-stroke);
   text-anchor: middle;
 }
 
@@ -181,11 +283,11 @@ svg line.ontology-edge[data-edge-origin="derived"] { stroke-dasharray: 2 2; }
   dominant-baseline: central;
   fill: var(--ontology-edge-hue);
   font-family: "SFMono-Regular", Consolas, monospace;
-  font-size: 5px;
+  font-size: var(--ontology-glyph-size-lg);
   font-weight: 800;
   paint-order: stroke;
   stroke: var(--surface-strong);
-  stroke-width: 0.8px;
+  stroke-width: var(--ontology-glyph-stroke-lg);
   text-anchor: middle;
 }
 
@@ -1513,7 +1615,7 @@ i.context,
 
 .graph-legend-block {
   display: grid;
-  gap: 7px;
+  gap: var(--space-4);
   justify-items: end;
   max-width: min(62%, 620px);
 }
@@ -1604,9 +1706,9 @@ i.context,
 .node-kind {
   color: var(--ontology-kind-hue);
   display: flex;
-  font-size: 8px;
-  gap: 4px;
-  margin-bottom: 3px;
+  font-size: var(--font-size-micro);
+  gap: var(--space-2);
+  margin-bottom: var(--space-1);
   text-transform: uppercase;
 }
 
@@ -1621,12 +1723,13 @@ i.context,
   border: 1px solid var(--line);
   border-radius: 999px;
   color: var(--ink-soft);
+  cursor: pointer;
   font-family: "SFMono-Regular", Consolas, monospace;
   font-size: 7px;
   padding: 3px 6px;
-  pointer-events: none;
   position: absolute;
   transform: translate(-50%, -50%);
+  transition: border-color 140ms ease, box-shadow 140ms ease;
   z-index: 3;
 }
 
@@ -1638,6 +1741,28 @@ i.context,
 .edge-label.modified {
   background: var(--amber-pale);
   border-color: #ecd59c;
+}
+
+.edge-label.selected {
+  border-color: var(--ontology-edge-hue, var(--ink));
+  box-shadow: 0 0 0 2px rgba(20, 32, 51, 0.12);
+}
+
+.graph-edge-summary li button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+}
+
+.graph-edge-summary li button.selected {
+  outline: 2px solid var(--ontology-edge-hue, var(--ink));
+  outline-offset: 2px;
+}
+
+.edge-inspector {
+  margin-top: var(--space-4);
 }
 
 .graph-edge-summary {
@@ -1694,8 +1819,8 @@ i.context,
   color: var(--ontology-kind-hue);
   display: inline-flex;
   float: left;
-  font-size: 15px;
-  margin: 0 6px 2px 0;
+  font-size: var(--font-size-icon-lg);
+  margin: 0 var(--space-3) var(--space-1) 0;
 }
 
 .node-inspector code {
@@ -2537,12 +2662,15 @@ i.context,
   }
 
   .graph-edge-summary li {
+    font-size: 9px;
+  }
+
+  .graph-edge-summary li button {
     align-items: center;
     background: #f7f8f5;
     border: 1px solid var(--line);
     border-radius: 7px;
     display: grid;
-    font-size: 9px;
     gap: 7px;
     grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr) auto;
     padding: 7px 8px;

--- a/apps/kg-editor/src/app/layout.tsx
+++ b/apps/kg-editor/src/app/layout.tsx
@@ -13,8 +13,11 @@ export const metadata: Metadata = {
 };
 
 export const viewport: Viewport = {
-  colorScheme: "light",
-  themeColor: "#f5f3ee",
+  colorScheme: "light dark",
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#f5f3ee" },
+    { media: "(prefers-color-scheme: dark)", color: "#17140f" },
+  ],
 };
 
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {

--- a/apps/kg-editor/src/app/showcase.css
+++ b/apps/kg-editor/src/app/showcase.css
@@ -459,6 +459,12 @@
 .repo-graph-toolbar button { cursor: pointer; font-size: 14px; width: 30px; }
 .repo-graph-toolbar output { align-items: center; display: inline-flex; justify-content: center; min-width: 46px; padding: 0 5px; }
 
+.repo-ontology-legend {
+  border-bottom: 1px solid var(--repo-border);
+  color: var(--repo-muted);
+  padding: 7px 14px;
+}
+
 .repo-graph-stage {
   background:
     linear-gradient(rgba(20, 32, 51, 0.025) 1px, transparent 1px),
@@ -481,7 +487,7 @@
 
 .repo-graph-stage svg.repo-edges { height: 100%; inset: 0; position: absolute; width: 100%; }
 .repo-edges line { stroke: #b5c3bc; stroke-width: 1.2; }
-.repo-edges line.derived { stroke: var(--repo-violet); stroke-dasharray: 4 3; }
+.repo-edges .ontology-edge-glyph { stroke: var(--repo-paper); }
 .repo-graph-node {
   background: white;
   border: 1px solid #cfd8d3;
@@ -497,16 +503,23 @@
   z-index: 2;
 }
 .repo-graph-node:hover,
-.repo-graph-node.selected { border-color: var(--repo-green); box-shadow: 0 0 0 3px rgba(20, 125, 98, 0.12); }
+.repo-graph-node.selected { border-color: var(--ontology-kind-hue); box-shadow: 0 0 0 3px rgba(20, 125, 98, 0.12); }
 .repo-graph-node.history.selected { border-color: var(--repo-violet); box-shadow: 0 0 0 3px rgba(113, 88, 188, 0.12); }
 .repo-graph-node span,
 .repo-graph-node strong { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .repo-graph-node span { color: var(--repo-muted); font-size: 9px; text-transform: uppercase; }
 .repo-graph-node strong { font-size: 11px; margin-top: 2px; }
+.repo-graph-node > .repo-node-kind-icon {
+  color: var(--ontology-kind-hue);
+  display: inline-flex;
+  float: left;
+  font-size: 14px;
+  margin-right: 5px;
+}
 
 .repo-inspector { border-top: 1px solid var(--repo-border); padding: 13px 15px; }
 .repo-inspector-heading { gap: 8px; }
-.repo-inspector-heading svg { color: var(--repo-green); height: 15px; width: 15px; }
+.repo-inspector-heading svg { color: var(--ontology-kind-hue); height: 15px; width: 15px; }
 .repo-inspector-heading div { flex: 1; min-width: 0; }
 .repo-inspector-heading span,
 .repo-inspector-heading strong { display: block; }
@@ -535,6 +548,8 @@
 .repo-edge-list code { color: var(--repo-muted); font-size: 9px; overflow: hidden; text-overflow: ellipsis; }
 .repo-edge-list span { color: var(--repo-green); font-size: 10px; }
 .repo-edge-list em { color: var(--repo-violet); font-size: 9px; font-style: normal; }
+.repo-edge-list .ontology-relation-mark { color: var(--ontology-edge-hue); display: inline-flex; }
+.repo-edge-list .ontology-derived-mark { display: inline-flex; font-size: inherit; }
 
 .repo-list { max-height: 520px; overflow: auto; }
 .repo-list-row {

--- a/apps/kg-editor/src/app/showcase.css
+++ b/apps/kg-editor/src/app/showcase.css
@@ -503,7 +503,7 @@
   z-index: 2;
 }
 .repo-graph-node:hover,
-.repo-graph-node.selected { border-color: var(--ontology-kind-hue); box-shadow: 0 0 0 3px rgba(20, 125, 98, 0.12); }
+.repo-graph-node.selected { border-color: var(--ontology-kind-hue); box-shadow: 0 0 0 3px var(--selection-ring-accent); }
 .repo-graph-node.history.selected { border-color: var(--repo-violet); box-shadow: 0 0 0 3px rgba(113, 88, 188, 0.12); }
 .repo-graph-node span,
 .repo-graph-node strong { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }

--- a/apps/kg-editor/src/app/showcase.css
+++ b/apps/kg-editor/src/app/showcase.css
@@ -462,7 +462,7 @@
 .repo-ontology-legend {
   border-bottom: 1px solid var(--repo-border);
   color: var(--repo-muted);
-  padding: 7px 14px;
+  padding: var(--space-4) var(--space-6);
 }
 
 .repo-graph-stage {
@@ -513,8 +513,8 @@
   color: var(--ontology-kind-hue);
   display: inline-flex;
   float: left;
-  font-size: 14px;
-  margin-right: 5px;
+  font-size: var(--font-size-icon);
+  margin-right: var(--space-3);
 }
 
 .repo-inspector { border-top: 1px solid var(--repo-border); padding: 13px 15px; }

--- a/apps/kg-editor/src/components/ontology-mark.test.ts
+++ b/apps/kg-editor/src/components/ontology-mark.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { edgeDirectionMark } from "@/components/ontology-mark";
+import { edgeLegendFor } from "@/lib/ontology-legend";
+
+describe("ontology marks", () => {
+  it("keeps direction cues in the visible edge span", () => {
+    const mark = edgeDirectionMark(
+      edgeLegendFor("supports"),
+      { x: 0, y: 0 },
+      { x: 100, y: 50 },
+    );
+
+    expect(mark).toMatchObject({ x: 68, y: 34 });
+  });
+});

--- a/apps/kg-editor/src/components/ontology-mark.test.tsx
+++ b/apps/kg-editor/src/components/ontology-mark.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { OntologyLegend } from "@/components/ontology-mark";
+import {
+  EDGE_RELATIONS,
+  ENTITY_KINDS,
+  NOTE_KINDS,
+} from "@/lib/ontology-legend";
+
+describe("OntologyLegend", () => {
+  it("renders the complete closed vocabulary by default", () => {
+    const { container } = render(<OntologyLegend />);
+
+    const entityMarks = ENTITY_KINDS.map((kind) =>
+      container.querySelector(`.ontology-kind-mark[data-kind="${kind}"]`)
+    );
+    const noteMarks = NOTE_KINDS.map((kind) =>
+      container.querySelector(`.ontology-kind-mark[data-kind="${kind}"]`)
+    );
+    const relationMarks = EDGE_RELATIONS.map((relation) =>
+      container.querySelector(
+        `.ontology-relation-mark[data-relation="${relation}"]`,
+      )
+    );
+
+    expect(entityMarks.filter(Boolean)).toHaveLength(9);
+    expect(noteMarks.filter(Boolean)).toHaveLength(5);
+    expect(relationMarks.filter(Boolean)).toHaveLength(17);
+    expect(container.querySelectorAll(".ontology-derived-mark")).toHaveLength(
+      1,
+    );
+    expect(screen.getByLabelText("Ontology legend")).toHaveTextContent(
+      "Derived",
+    );
+  });
+
+  it("dims identities absent from the current graph without removing them", () => {
+    const { container } = render(
+      <OntologyLegend
+        presentEntityKinds={["concept"]}
+        presentRelations={["contains"]}
+      />,
+    );
+
+    expect(
+      container.querySelector('.ontology-kind-mark[data-kind="concept"]'),
+    ).not.toHaveClass("ontology-mark-dim");
+    expect(
+      container.querySelector('.ontology-kind-mark[data-kind="document"]'),
+    ).toHaveClass("ontology-mark-dim");
+    expect(
+      container.querySelector(
+        '.ontology-relation-mark[data-relation="contains"]',
+      ),
+    ).not.toHaveClass("ontology-mark-dim");
+    expect(
+      container.querySelector(
+        '.ontology-relation-mark[data-relation="depends_on"]',
+      ),
+    ).toHaveClass("ontology-mark-dim");
+    expect(
+      container.querySelectorAll(".ontology-kind-mark[data-kind]"),
+    ).toHaveLength(14);
+  });
+});

--- a/apps/kg-editor/src/components/ontology-mark.tsx
+++ b/apps/kg-editor/src/components/ontology-mark.tsx
@@ -1,0 +1,249 @@
+import {
+  Bookmark,
+  BookOpen,
+  Building2,
+  Circle,
+  CircleHelp,
+  Database,
+  Eye,
+  FileText,
+  FolderKanban,
+  Lightbulb,
+  type LucideIcon,
+  Package,
+  ServerCog,
+  Signpost,
+  Sparkles,
+  User,
+} from "lucide-react";
+import type { CSSProperties } from "react";
+
+import {
+  DERIVED_EDGE_MARK,
+  type EdgeLegendEntry,
+  edgeLegendFor,
+  entityLegendFor,
+  isNoteKind,
+  type KindLegendEntry,
+  noteLegendFor,
+  type OntologyIconName,
+} from "@/lib/ontology-legend";
+
+const iconComponents = {
+  lightbulb: Lightbulb,
+  "file-text": FileText,
+  database: Database,
+  "folder-kanban": FolderKanban,
+  user: User,
+  building: Building2,
+  package: Package,
+  "server-cog": ServerCog,
+  "book-open": BookOpen,
+  eye: Eye,
+  sparkles: Sparkles,
+  "circle-help": CircleHelp,
+  signpost: Signpost,
+  bookmark: Bookmark,
+  circle: Circle,
+} satisfies Record<OntologyIconName, LucideIcon>;
+
+type OntologyStyle = CSSProperties & {
+  "--ontology-kind-hue"?: string;
+  "--ontology-edge-hue"?: string;
+};
+
+function classes(...values: Array<string | false | undefined>): string {
+  return values.filter(Boolean).join(" ");
+}
+
+export function kindHueStyle(entry: KindLegendEntry): OntologyStyle {
+  return { "--ontology-kind-hue": entry.hue };
+}
+
+export function edgeHueStyle(entry: EdgeLegendEntry): OntologyStyle {
+  return { "--ontology-edge-hue": entry.hue };
+}
+
+export function edgeDirectionMark(
+  entry: EdgeLegendEntry,
+  source: { x: number; y: number },
+  target: { x: number; y: number },
+): { x: number; y: number; transform: string } | null {
+  if (!entry.directed || (source.x === target.x && source.y === target.y)) {
+    return null;
+  }
+  const x = source.x + (target.x - source.x) * 0.82;
+  const y = source.y + (target.y - source.y) * 0.82;
+  const angle = Math.atan2(target.y - source.y, target.x - source.x) * 180 /
+    Math.PI;
+  return { x, y, transform: `rotate(${angle} ${x} ${y})` };
+}
+
+function KindMark({
+  entry,
+  rawKind,
+  className,
+  showLabel,
+}: {
+  entry: KindLegendEntry;
+  rawKind: string;
+  className?: string;
+  showLabel: boolean;
+}) {
+  const Icon = iconComponents[entry.icon];
+  return (
+    <span
+      aria-label={showLabel ? undefined : entry.label}
+      className={classes("ontology-kind-mark", className)}
+      data-kind={rawKind}
+      style={kindHueStyle(entry)}
+      title={entry.label === "Unsupported kind"
+        ? `${entry.label}: ${rawKind}`
+        : undefined}
+    >
+      <Icon aria-hidden="true" strokeWidth={1.5} />
+      {showLabel && <span>{entry.label}</span>}
+    </span>
+  );
+}
+
+export function EntityKindMark({
+  kind,
+  className,
+  showLabel = true,
+}: {
+  kind: string;
+  className?: string;
+  showLabel?: boolean;
+}) {
+  return (
+    <KindMark
+      entry={entityLegendFor(kind)}
+      rawKind={kind}
+      className={className}
+      showLabel={showLabel}
+    />
+  );
+}
+
+export function NoteKindMark({
+  kind,
+  className,
+  showLabel = true,
+}: {
+  kind: string;
+  className?: string;
+  showLabel?: boolean;
+}) {
+  return (
+    <KindMark
+      entry={noteLegendFor(kind)}
+      rawKind={kind}
+      className={className}
+      showLabel={showLabel}
+    />
+  );
+}
+
+export function OntologyKindMark({
+  kind,
+  className,
+  showLabel = true,
+}: {
+  kind: string;
+  className?: string;
+  showLabel?: boolean;
+}) {
+  return isNoteKind(kind)
+    ? <NoteKindMark kind={kind} className={className} showLabel={showLabel} />
+    : (
+      <EntityKindMark
+        kind={kind}
+        className={className}
+        showLabel={showLabel}
+      />
+    );
+}
+
+export function RelationMark({
+  relation,
+  className,
+  showLabel = true,
+}: {
+  relation: string;
+  className?: string;
+  showLabel?: boolean;
+}) {
+  const entry = edgeLegendFor(relation);
+  return (
+    <span
+      aria-label={showLabel ? undefined : entry.label}
+      className={classes("ontology-relation-mark", className)}
+      data-edge-family={entry.family}
+      data-relation={relation}
+      data-edge-treatment={entry.treatment}
+      data-edge-variant={entry.variant}
+      style={edgeHueStyle(entry)}
+      title={entry.label === "Unsupported relation"
+        ? `${entry.label}: ${relation}`
+        : `${entry.family} · ${entry.label}`}
+    >
+      <b aria-hidden="true">{entry.glyph}</b>
+      {showLabel && <span>{entry.label}</span>}
+    </span>
+  );
+}
+
+export function DerivedEdgeMark({
+  className,
+  label = DERIVED_EDGE_MARK.label,
+}: {
+  className?: string;
+  label?: string;
+}) {
+  return (
+    <span
+      className={classes("ontology-derived-mark", className)}
+      title={DERIVED_EDGE_MARK.geometry}
+    >
+      <b aria-hidden="true">{DERIVED_EDGE_MARK.glyph}</b>
+      <span>{label}</span>
+    </span>
+  );
+}
+
+function unique(values: readonly string[]): string[] {
+  return [...new Set(values)];
+}
+
+export function OntologyLegend({
+  entityKinds = [],
+  noteKinds = [],
+  relations = [],
+  includeDerived = false,
+  className,
+}: {
+  entityKinds?: readonly string[];
+  noteKinds?: readonly string[];
+  relations?: readonly string[];
+  includeDerived?: boolean;
+  className?: string;
+}) {
+  return (
+    <div
+      className={classes("ontology-legend", className)}
+      aria-label="Ontology legend"
+    >
+      {unique(entityKinds).map((kind) => (
+        <EntityKindMark kind={kind} key={`entity-${kind}`} />
+      ))}
+      {unique(noteKinds).map((kind) => (
+        <NoteKindMark kind={kind} key={`note-${kind}`} />
+      ))}
+      {unique(relations).map((relation) => (
+        <RelationMark relation={relation} key={`relation-${relation}`} />
+      ))}
+      {includeDerived && <DerivedEdgeMark />}
+    </div>
+  );
+}

--- a/apps/kg-editor/src/components/ontology-mark.tsx
+++ b/apps/kg-editor/src/components/ontology-mark.tsx
@@ -20,12 +20,15 @@ import type { CSSProperties } from "react";
 
 import {
   DERIVED_EDGE_MARK,
+  EDGE_RELATIONS,
   type EdgeLegendEntry,
   edgeLegendFor,
+  ENTITY_KINDS,
   entityLegendFor,
   isNoteKind,
   type KindLegendEntry,
   noteLegendFor,
+  NOTE_KINDS,
   type OntologyIconName,
 } from "@/lib/ontology-legend";
 
@@ -209,44 +212,76 @@ export function DerivedEdgeMark({
       className={classes("ontology-derived-mark", className)}
       title={DERIVED_EDGE_MARK.geometry}
     >
-      <b aria-hidden="true">{DERIVED_EDGE_MARK.glyph}</b>
+      <svg
+        aria-hidden="true"
+        className="ontology-derived-glyph-icon"
+        viewBox="0 0 24 24"
+      >
+        <polygon points="12,3 21,12 12,21 3,12" />
+      </svg>
       <span>{label}</span>
     </span>
   );
 }
 
-function unique(values: readonly string[]): string[] {
-  return [...new Set(values)];
+function dimClass(present: Set<string> | null, value: string): string | undefined {
+  return present && !present.has(value) ? "ontology-mark-dim" : undefined;
 }
 
+/**
+ * Renders the complete closed ontology (9 entity kinds, 17 relations, 5 note
+ * kinds, plus the derived-edge mark) per ADR-153 D1/D5 — the legend is a
+ * permanent, complete on-canvas affordance, not a per-graph subset. Passing
+ * `presentEntityKinds` / `presentNoteKinds` / `presentRelations` highlights
+ * which identities occur in the current graph by dimming the rest; it never
+ * removes an identity from the render.
+ */
 export function OntologyLegend({
-  entityKinds = [],
-  noteKinds = [],
-  relations = [],
-  includeDerived = false,
+  presentEntityKinds,
+  presentNoteKinds,
+  presentRelations,
   className,
 }: {
-  entityKinds?: readonly string[];
-  noteKinds?: readonly string[];
-  relations?: readonly string[];
-  includeDerived?: boolean;
+  presentEntityKinds?: readonly string[];
+  presentNoteKinds?: readonly string[];
+  presentRelations?: readonly string[];
   className?: string;
 }) {
+  const presentEntitySet = presentEntityKinds
+    ? new Set(presentEntityKinds)
+    : null;
+  const presentNoteSet = presentNoteKinds ? new Set(presentNoteKinds) : null;
+  const presentRelationSet = presentRelations
+    ? new Set(presentRelations)
+    : null;
+
   return (
     <div
       className={classes("ontology-legend", className)}
       aria-label="Ontology legend"
     >
-      {unique(entityKinds).map((kind) => (
-        <EntityKindMark kind={kind} key={`entity-${kind}`} />
+      {ENTITY_KINDS.map((kind) => (
+        <EntityKindMark
+          kind={kind}
+          key={`entity-${kind}`}
+          className={dimClass(presentEntitySet, kind)}
+        />
       ))}
-      {unique(noteKinds).map((kind) => (
-        <NoteKindMark kind={kind} key={`note-${kind}`} />
+      {NOTE_KINDS.map((kind) => (
+        <NoteKindMark
+          kind={kind}
+          key={`note-${kind}`}
+          className={dimClass(presentNoteSet, kind)}
+        />
       ))}
-      {unique(relations).map((relation) => (
-        <RelationMark relation={relation} key={`relation-${relation}`} />
+      {EDGE_RELATIONS.map((relation) => (
+        <RelationMark
+          relation={relation}
+          key={`relation-${relation}`}
+          className={dimClass(presentRelationSet, relation)}
+        />
       ))}
-      {includeDerived && <DerivedEdgeMark />}
+      <DerivedEdgeMark />
     </div>
   );
 }

--- a/apps/kg-editor/src/components/ontology-mark.tsx
+++ b/apps/kg-editor/src/components/ontology-mark.tsx
@@ -72,8 +72,11 @@ export function edgeDirectionMark(
   if (!entry.directed || (source.x === target.x && source.y === target.y)) {
     return null;
   }
-  const x = source.x + (target.x - source.x) * 0.82;
-  const y = source.y + (target.y - source.y) * 0.82;
+  // Keep the direction cue in the open edge span. Both graph canvases draw
+  // center-to-center beneath opaque node cards, so a cue near the target is
+  // hidden on short edges even though the SVG marker is present.
+  const x = source.x + (target.x - source.x) * 0.68;
+  const y = source.y + (target.y - source.y) * 0.68;
   const angle = Math.atan2(target.y - source.y, target.x - source.x) * 180 /
     Math.PI;
   return { x, y, transform: `rotate(${angle} ${x} ${y})` };

--- a/apps/kg-editor/src/components/showcase/repo-showcase.test.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase.test.tsx
@@ -31,10 +31,10 @@ describe("repository showcase", () => {
   it("uses the shared ontology legend and marks exporter-derived edges geometrically", () => {
     const { container } = render(<RepoShowcase bundle={golden()} />);
 
-    expect(screen.getByLabelText("Ontology legend")).toHaveTextContent(/Project.*Concept.*Contains.*Derived/i);
+    expect(screen.getByLabelText("Ontology legend")).toHaveTextContent(/Concept.*Project.*Contains.*Derived/i);
     expect(container.querySelector('line[data-edge-origin="derived"]')).toHaveAttribute("marker-end", "url(#showcase-ontology-arrow)");
     expect(container.querySelector(".ontology-direction-glyph")?.getAttribute("transform")).toMatch(/^rotate\(/);
-    expect(container.querySelector(".ontology-derived-glyph")).toHaveTextContent("◇");
+    expect(container.querySelector("polygon.ontology-derived-glyph")).toBeInTheDocument();
   });
 
   it("navigates from a module to its precomputed commits and back to modules", async () => {

--- a/apps/kg-editor/src/components/showcase/repo-showcase.test.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase.test.tsx
@@ -28,6 +28,15 @@ describe("repository showcase", () => {
     }
   });
 
+  it("uses the shared ontology legend and marks exporter-derived edges geometrically", () => {
+    const { container } = render(<RepoShowcase bundle={golden()} />);
+
+    expect(screen.getByLabelText("Ontology legend")).toHaveTextContent(/Project.*Concept.*Contains.*Derived/i);
+    expect(container.querySelector('line[data-edge-origin="derived"]')).toHaveAttribute("marker-end", "url(#showcase-ontology-arrow)");
+    expect(container.querySelector(".ontology-direction-glyph")?.getAttribute("transform")).toMatch(/^rotate\(/);
+    expect(container.querySelector(".ontology-derived-glyph")).toHaveTextContent("◇");
+  });
+
   it("navigates from a module to its precomputed commits and back to modules", async () => {
     const bundle = golden();
     const user = userEvent.setup();

--- a/apps/kg-editor/src/components/showcase/repo-showcase.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase.tsx
@@ -33,7 +33,7 @@ import {
   OntologyLegend,
   RelationMark,
 } from "@/components/ontology-mark";
-import { DERIVED_EDGE_MARK, edgeLegendFor, entityLegendFor } from "@/lib/ontology-legend";
+import { edgeLegendFor, entityLegendFor } from "@/lib/ontology-legend";
 import type {
   RepoBundle,
   RepoModule,
@@ -76,6 +76,11 @@ const UI_ROW_LIMIT = 200;
 const UI_TREEMAP_LIMIT = 180;
 const UI_RESIDUAL_LIMIT = 80;
 const UI_GRAPH_EDGE_LIMIT = 50;
+
+function derivedDiamondPoints(x: number, y: number): string {
+  const r = 1.1;
+  return `${x},${y - r} ${x + r},${y} ${x},${y + r} ${x - r},${y}`;
+}
 
 function formatNumber(value: number): string {
   return new Intl.NumberFormat("en", { notation: value >= 10_000 ? "compact" : "standard" }).format(value);
@@ -284,9 +289,8 @@ function StructureGraph({ bundle, moduleById }: { bundle: RepoBundle; moduleById
         </div>
         <OntologyLegend
           className="repo-ontology-legend"
-          entityKinds={["project", "concept"]}
-          includeDerived={displayedEdges.some((edge) => edge.origin === "derived")}
-          relations={displayedEdges.map((edge) => edge.relation)}
+          presentEntityKinds={["project", "concept"]}
+          presentRelations={displayedEdges.map((edge) => edge.relation)}
         />
         <div className="repo-graph-stage" aria-label={capability.views.structure_graph.label}>
           <div className="repo-graph-viewport" style={{ transform: `scale(${zoom})` }}>
@@ -337,13 +341,13 @@ function StructureGraph({ bundle, moduleById }: { bundle: RepoBundle; moduleById
                       >›</text>
                     )}
                     {edge.origin === "derived" && (
-                      <text
-                        className="ontology-edge-glyph ontology-derived-glyph"
-                        x={source.x + (target.x - source.x) * 0.4}
-                        y={source.y + (target.y - source.y) * 0.4}
-                      >
-                        {DERIVED_EDGE_MARK.glyph}
-                      </text>
+                      <polygon
+                        className="ontology-derived-glyph"
+                        points={derivedDiamondPoints(
+                          source.x + (target.x - source.x) * 0.4,
+                          source.y + (target.y - source.y) * 0.4,
+                        )}
+                      />
                     )}
                   </g>
                 );

--- a/apps/kg-editor/src/components/showcase/repo-showcase.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase.tsx
@@ -24,6 +24,16 @@ import {
 } from "lucide-react";
 import { useMemo, useState } from "react";
 
+import {
+  DerivedEdgeMark,
+  edgeDirectionMark,
+  edgeHueStyle,
+  EntityKindMark,
+  kindHueStyle,
+  OntologyLegend,
+  RelationMark,
+} from "@/components/ontology-mark";
+import { DERIVED_EDGE_MARK, edgeLegendFor, entityLegendFor } from "@/lib/ontology-legend";
 import type {
   RepoBundle,
   RepoModule,
@@ -241,6 +251,7 @@ function StructureGraph({ bundle, moduleById }: { bundle: RepoBundle; moduleById
   const nodeWidth = (id: string) => 92 + ((degrees.get(id) ?? 0) / maxDegree) * 46;
   const selectedModule = displayedModules.find((item) => item.id === selectedId);
   const selectedPackage = displayedPackages.find((item) => item.id === selectedId);
+  const selectedEntityKind = selectedModule ? "concept" : "project";
   const visibleLabel = new Map<string, string>([
     [graph.repository.id, graph.repository.label],
     ...displayedPackages.map((item) => [item.id, item.name] as const),
@@ -271,29 +282,88 @@ function StructureGraph({ bundle, moduleById }: { bundle: RepoBundle; moduleById
             <button type="button" aria-label={`${capability.views.structure_graph.label} +`} onClick={() => setZoom((value) => Math.min(1.5, value + 0.25))}>+</button>
           </div>
         </div>
+        <OntologyLegend
+          className="repo-ontology-legend"
+          entityKinds={["project", "concept"]}
+          includeDerived={displayedEdges.some((edge) => edge.origin === "derived")}
+          relations={displayedEdges.map((edge) => edge.relation)}
+        />
         <div className="repo-graph-stage" aria-label={capability.views.structure_graph.label}>
           <div className="repo-graph-viewport" style={{ transform: `scale(${zoom})` }}>
             <svg className="repo-edges" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
+              <defs>
+                <marker id="showcase-ontology-arrow" markerHeight="6" markerWidth="6" orient="auto" refX="5" refY="3" viewBox="0 0 6 6">
+                  <path d="M 0 0 L 6 3 L 0 6 z" fill="context-stroke" />
+                </marker>
+              </defs>
               {displayedEdges.map((edge) => {
                 const source = positions.get(edge.source);
                 const target = positions.get(edge.target);
                 if (!source || !target) return null;
-                return <line key={edge.id} className={edge.origin} x1={source.x} y1={source.y} x2={target.x} y2={target.y} vectorEffect="non-scaling-stroke" />;
+                const legend = edgeLegendFor(edge.relation);
+                const direction = edgeDirectionMark(legend, source, target);
+                return (
+                  <g key={edge.id}>
+                    <line
+                      className="ontology-edge"
+                      data-edge-family={legend.family}
+                      data-edge-origin={edge.origin}
+                      data-edge-treatment={legend.treatment}
+                      data-edge-variant={legend.variant}
+                      markerEnd={legend.directed ? "url(#showcase-ontology-arrow)" : undefined}
+                      style={edgeHueStyle(legend)}
+                      x1={source.x}
+                      y1={source.y}
+                      x2={target.x}
+                      y2={target.y}
+                      vectorEffect="non-scaling-stroke"
+                    />
+                    <text
+                      className="ontology-edge-glyph"
+                      data-edge-directed={legend.directed}
+                      style={edgeHueStyle(legend)}
+                      x={(source.x + target.x) / 2}
+                      y={(source.y + target.y) / 2}
+                    >
+                      {legend.glyph}
+                    </text>
+                    {direction && (
+                      <text
+                        className="ontology-direction-glyph"
+                        style={edgeHueStyle(legend)}
+                        transform={direction.transform}
+                        x={direction.x}
+                        y={direction.y}
+                      >›</text>
+                    )}
+                    {edge.origin === "derived" && (
+                      <text
+                        className="ontology-edge-glyph ontology-derived-glyph"
+                        x={source.x + (target.x - source.x) * 0.4}
+                        y={source.y + (target.y - source.y) * 0.4}
+                      >
+                        {DERIVED_EDGE_MARK.glyph}
+                      </text>
+                    )}
+                  </g>
+                );
               })}
             </svg>
             <button
               className={`repo-graph-node ${selectedId === graph.repository.id ? "selected" : ""}`}
-              style={{ left: "50%", top: "9%", width: `${nodeWidth(graph.repository.id)}px` }}
+              style={{ left: "50%", top: "9%", width: `${nodeWidth(graph.repository.id)}px`, ...kindHueStyle(entityLegendFor("project")) }}
               type="button"
               aria-pressed={selectedId === graph.repository.id}
               onClick={() => setSelectedId(graph.repository.id)}
             >
+              <EntityKindMark className="repo-node-kind-icon" kind="project" showLabel={false} />
               <span>{labels.node_types.repository}</span><strong>{graph.repository.label}</strong>
             </button>
             {displayedPackages.map((item) => {
               const position = positions.get(item.id)!;
               return (
-                <button className={`repo-graph-node ${selectedId === item.id ? "selected" : ""}`} style={{ left: `${position.x}%`, top: `${position.y}%`, width: `${nodeWidth(item.id)}px` }} type="button" aria-pressed={selectedId === item.id} key={item.id} onClick={() => setSelectedId(item.id)}>
+                <button className={`repo-graph-node ${selectedId === item.id ? "selected" : ""}`} style={{ left: `${position.x}%`, top: `${position.y}%`, width: `${nodeWidth(item.id)}px`, ...kindHueStyle(entityLegendFor("project")) }} type="button" aria-pressed={selectedId === item.id} key={item.id} onClick={() => setSelectedId(item.id)}>
+                  <EntityKindMark className="repo-node-kind-icon" kind="project" showLabel={false} />
                   <span>{labels.node_types.package}</span><strong>{item.name}</strong>
                 </button>
               );
@@ -301,7 +371,8 @@ function StructureGraph({ bundle, moduleById }: { bundle: RepoBundle; moduleById
             {displayedModules.map((item) => {
               const position = positions.get(item.id)!;
               return (
-                <button className={`repo-graph-node ${selectedId === item.id ? "selected" : ""}`} style={{ left: `${position.x}%`, top: `${position.y}%`, width: `${nodeWidth(item.id)}px` }} type="button" aria-pressed={selectedId === item.id} key={item.id} onClick={() => setSelectedId(item.id)}>
+                <button className={`repo-graph-node ${selectedId === item.id ? "selected" : ""}`} style={{ left: `${position.x}%`, top: `${position.y}%`, width: `${nodeWidth(item.id)}px`, ...kindHueStyle(entityLegendFor("concept")) }} type="button" aria-pressed={selectedId === item.id} key={item.id} onClick={() => setSelectedId(item.id)}>
+                  <EntityKindMark className="repo-node-kind-icon" kind="concept" showLabel={false} />
                   <span>{labels.node_types.module}</span><strong>{item.module_path}</strong>
                 </button>
               );
@@ -310,7 +381,7 @@ function StructureGraph({ bundle, moduleById }: { bundle: RepoBundle; moduleById
         </div>
         <div className="repo-inspector">
           <div className="repo-inspector-heading">
-            <CircleDot aria-hidden="true" />
+            <EntityKindMark kind={selectedEntityKind} showLabel={false} />
             <div>
               <span>{selectedModule ? labels.node_types.module : selectedPackage ? labels.node_types.package : labels.node_types.repository}</span>
               <strong>{selectedModule?.module_path ?? selectedPackage?.name ?? graph.repository.label}</strong>
@@ -325,7 +396,7 @@ function StructureGraph({ bundle, moduleById }: { bundle: RepoBundle; moduleById
         <ul className="repo-edge-list" aria-label={capability.views.structure_graph.label}>
           {displayedEdges.map((edge) => (
             <li key={`${edge.id}-accessible`}>
-              <code>{visibleLabel.get(edge.source) ?? edge.source}</code><span>{edge.relation}</span><code>{visibleLabel.get(edge.target) ?? edge.target}</code><em>{edge.origin === "derived" ? labels.derived : labels.ingested}</em>
+              <code>{visibleLabel.get(edge.source) ?? edge.source}</code><RelationMark relation={edge.relation} /><code>{visibleLabel.get(edge.target) ?? edge.target}</code><em>{edge.origin === "derived" ? <DerivedEdgeMark label={labels.derived} /> : labels.ingested}</em>
             </li>
           ))}
         </ul>

--- a/apps/kg-editor/src/components/studio.test.tsx
+++ b/apps/kg-editor/src/components/studio.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 
 import { Studio } from "@/components/studio";
 import { atlasReviewFixture } from "@/lib/fixtures/atlas-review";
-import { REVIEW_IMPORT_MAX_BYTES } from "@/lib/review-bundle";
+import { REVIEW_IMPORT_MAX_BYTES, type ReviewReport } from "@/lib/review-bundle";
 
 describe("KG Studio", () => {
   it("makes the no-write and unavailable capability boundary visible", () => {
@@ -17,14 +17,73 @@ describe("KG Studio", () => {
 
   it("navigates from semantic diff to the affected graph", async () => {
     const user = userEvent.setup();
-    render(<Studio initialBundle={atlasReviewFixture} />);
+    const { container } = render(<Studio initialBundle={atlasReviewFixture} />);
 
     await user.click(screen.getAllByRole("button", { name: /affected graph/i })[0]);
     expect(screen.getByRole("heading", { name: "Affected subgraph" })).toBeVisible();
     expect(screen.getByRole("button", { name: /Assertion-level provenance/i })).toBeVisible();
+    expect(screen.getByLabelText("Ontology legend")).toHaveTextContent(/Concept.*Document.*Unsupported kind/i);
+    expect(container.querySelector('[data-kind="domain"]')).toHaveAttribute("title", "Unsupported kind: domain");
+    expect(container.querySelector('line[data-edge-family="epistemic"]')).toBeInTheDocument();
+    expect(container.querySelector('line[data-edge-family="epistemic"]')).toHaveAttribute("marker-end", "url(#studio-ontology-arrow)");
+    expect(container.querySelector(".ontology-direction-glyph")).toHaveTextContent("›");
+    expect(container.querySelector(".ontology-direction-glyph")?.getAttribute("transform")).toMatch(/^rotate\(/);
     expect(
       screen.getByRole("region", { name: "Affected graph relationships" }),
     ).toHaveTextContent(/introduced_by · 1\.00/i);
+  });
+
+  it("dispatches retrieval note kinds through the note legend", async () => {
+    const user = userEvent.setup();
+    const { container } = render(<Studio initialBundle={atlasReviewFixture} />);
+
+    await user.click(screen.getAllByRole("button", { name: /Khive context/i })[0]);
+    expect(container.querySelector('[data-kind="observation"]')).toHaveTextContent("Observation");
+    expect(container.querySelector('[data-kind="observation"]')).not.toHaveTextContent("Unsupported kind");
+  });
+
+  it("uses explicit entity_kind in core review operation lists", async () => {
+    const user = userEvent.setup();
+    const operation = {
+      ...atlasReviewFixture.change_set.operations[0],
+      after: { kind: "entity", entity_kind: "concept", name: "Canonical concept" },
+    };
+    const report: ReviewReport = {
+      schema_version: "khive.review.v1",
+      review_kind: "changeset",
+      capability: {
+        source: "cli",
+        mutability: "read_only",
+        no_writes: true,
+        git_reads: false,
+        khive_reads: true,
+        github_writes: false,
+        wasm: false,
+        persistence: false,
+        unavailable_actions: ["apply", "commit", "push", "publish", "persist_review"],
+      },
+      change_set: { envelope: atlasReviewFixture.change_set.envelope, operations: [operation] },
+      tier_summary: {
+        ...atlasReviewFixture.tier_summary,
+        operations: 1,
+        tier_1: 1,
+        tier_2: 0,
+        highest_tier: "tier_1",
+        requires_independent_review: false,
+      },
+      validation: atlasReviewFixture.validation,
+      findings: [],
+      review_gate: atlasReviewFixture.review_gate,
+    };
+    const serialized = JSON.stringify(report);
+    const imported = new File([serialized], "core-review.json", { type: "application/json" });
+    Object.defineProperty(imported, "text", { value: () => Promise.resolve(serialized) });
+    const { container } = render(<Studio initialBundle={atlasReviewFixture} />);
+
+    await user.upload(container.querySelector<HTMLInputElement>('input[type="file"]')!, imported);
+
+    expect(await screen.findByRole("heading", { name: "Attributed change-set review" })).toBeVisible();
+    expect(container.querySelector('.core-operation-list [data-kind="concept"]')).toHaveTextContent("Concept");
   });
 
   it("refuses same-family approval and records no approval state", async () => {

--- a/apps/kg-editor/src/components/studio.test.tsx
+++ b/apps/kg-editor/src/components/studio.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 
@@ -21,8 +21,9 @@ describe("KG Studio", () => {
 
     await user.click(screen.getAllByRole("button", { name: /affected graph/i })[0]);
     expect(screen.getByRole("heading", { name: "Affected subgraph" })).toBeVisible();
-    expect(screen.getByRole("button", { name: /Assertion-level provenance/i })).toBeVisible();
-    expect(screen.getByLabelText("Ontology legend")).toHaveTextContent(/Concept.*Document.*Unsupported kind/i);
+    expect(screen.getAllByRole("button", { name: /Assertion-level provenance/i })[0]).toBeVisible();
+    expect(screen.getByLabelText("Ontology legend")).toHaveTextContent(/Concept.*Document.*Dataset.*Project.*Person.*Organization.*Artifact.*Service.*Resource/i);
+    expect(screen.getByLabelText("Ontology legend")).toHaveTextContent(/Derived/i);
     expect(container.querySelector('[data-kind="domain"]')).toHaveAttribute("title", "Unsupported kind: domain");
     expect(container.querySelector('line[data-edge-family="epistemic"]')).toBeInTheDocument();
     expect(container.querySelector('line[data-edge-family="epistemic"]')).toHaveAttribute("marker-end", "url(#studio-ontology-arrow)");
@@ -31,6 +32,22 @@ describe("KG Studio", () => {
     expect(
       screen.getByRole("region", { name: "Affected graph relationships" }),
     ).toHaveTextContent(/introduced_by · 1\.00/i);
+  });
+
+  it("makes graph edges addressable with a shared selection and contextual inspector", async () => {
+    const user = userEvent.setup();
+    render(<Studio initialBundle={atlasReviewFixture} />);
+
+    await user.click(screen.getAllByRole("button", { name: /affected graph/i })[0]);
+    const edgeSummaryRegion = screen.getByRole("region", { name: "Affected graph relationships" });
+    const edgeRow = within(edgeSummaryRegion).getAllByRole("button")[0];
+
+    edgeRow.focus();
+    expect(edgeRow).toHaveFocus();
+
+    await user.click(edgeRow);
+    expect(edgeRow).toHaveAttribute("aria-pressed", "true");
+    expect(document.querySelector(".edge-inspector")).toBeInTheDocument();
   });
 
   it("dispatches retrieval note kinds through the note legend", async () => {

--- a/apps/kg-editor/src/components/studio.tsx
+++ b/apps/kg-editor/src/components/studio.tsx
@@ -447,11 +447,26 @@ function ChangesView({ bundle, query, onQuery }: { bundle: ReviewBundle; query: 
   );
 }
 
+type GraphSelection = { type: "node" | "edge"; id: string };
+
 function GraphView({ bundle }: { bundle: ReviewBundle }) {
-  const [selectedId, setSelectedId] = useState(bundle.graph.nodes.items[0]?.id ?? "");
-  const selected = bundle.graph.nodes.items.find((node) => node.id === selectedId) ?? bundle.graph.nodes.items[0];
+  const [selection, setSelection] = useState<GraphSelection>({
+    type: "node",
+    id: bundle.graph.nodes.items[0]?.id ?? "",
+  });
 
   const nodeById = useMemo(() => new Map(bundle.graph.nodes.items.map((node) => [node.id, node])), [bundle.graph.nodes.items]);
+  const edgeById = useMemo(() => new Map(bundle.graph.edges.items.map((edge) => [edge.id, edge])), [bundle.graph.edges.items]);
+
+  const selectNode = (id: string) => setSelection({ type: "node", id });
+  const selectEdge = (id: string) => setSelection({ type: "edge", id });
+
+  const selected = selection.type === "node"
+    ? bundle.graph.nodes.items.find((node) => node.id === selection.id) ?? bundle.graph.nodes.items[0]
+    : undefined;
+  const selectedEdge = selection.type === "edge" ? edgeById.get(selection.id) : undefined;
+  const selectedEdgeSource = selectedEdge ? nodeById.get(selectedEdge.source) : undefined;
+  const selectedEdgeTarget = selectedEdge ? nodeById.get(selectedEdge.target) : undefined;
 
   return (
     <div className="view-stack">
@@ -468,8 +483,8 @@ function GraphView({ bundle }: { bundle: ReviewBundle }) {
           </div>
           <OntologyLegend
             className="graph-ontology-legend"
-            entityKinds={bundle.graph.nodes.items.map((node) => node.kind)}
-            relations={bundle.graph.edges.items.map((edge) => edge.relation)}
+            presentEntityKinds={bundle.graph.nodes.items.map((node) => node.kind)}
+            presentRelations={bundle.graph.edges.items.map((edge) => edge.relation)}
           />
         </div>
       </div>
@@ -527,10 +542,10 @@ function GraphView({ bundle }: { bundle: ReviewBundle }) {
         {bundle.graph.nodes.items.map((node) => (
           <button
             type="button"
-            className={`graph-node ${node.state} ${node.id === selectedId ? "selected" : ""}`}
+            className={`graph-node ${node.state} ${selection.type === "node" && node.id === selection.id ? "selected" : ""}`}
             style={{ left: `${node.x}%`, top: `${node.y}%`, ...kindHueStyle(entityLegendFor(node.kind)) }}
             key={node.id}
-            onClick={() => setSelectedId(node.id)}
+            onClick={() => selectNode(node.id)}
           >
             <EntityKindMark className="node-kind" kind={node.kind} />
             <strong>{node.label}</strong>
@@ -541,13 +556,16 @@ function GraphView({ bundle }: { bundle: ReviewBundle }) {
           const target = nodeById.get(edge.target);
           if (!source || !target) return null;
           return (
-            <span
+            <button
+              type="button"
               key={`${edge.id}-label`}
-              className={`edge-label ${edge.state}`}
+              className={`edge-label ${edge.state} ${selection.type === "edge" && edge.id === selection.id ? "selected" : ""}`}
               style={{ left: `${(source.x + target.x) / 2}%`, top: `${(source.y + target.y) / 2}%` }}
+              aria-pressed={selection.type === "edge" && edge.id === selection.id}
+              onClick={() => selectEdge(edge.id)}
             >
               <RelationMark relation={edge.relation} /> · {edge.weight.toFixed(2)}
-            </span>
+            </button>
           );
         })}
       </div>
@@ -560,10 +578,17 @@ function GraphView({ bundle }: { bundle: ReviewBundle }) {
             if (!source || !target) return null;
             return (
               <li key={`${edge.id}-summary`}>
-                <strong>{source.label}</strong>
-                <span><RelationMark relation={edge.relation} /><span className="visually-hidden">{edge.relation}</span> · {edge.weight.toFixed(2)}</span>
-                <strong>{target.label}</strong>
-                <em>{edge.state}</em>
+                <button
+                  type="button"
+                  className={selection.type === "edge" && edge.id === selection.id ? "selected" : ""}
+                  aria-pressed={selection.type === "edge" && edge.id === selection.id}
+                  onClick={() => selectEdge(edge.id)}
+                >
+                  <strong>{source.label}</strong>
+                  <span><RelationMark relation={edge.relation} /><span className="visually-hidden">{edge.relation}</span> · {edge.weight.toFixed(2)}</span>
+                  <strong>{target.label}</strong>
+                  <em>{edge.state}</em>
+                </button>
               </li>
             );
           })}
@@ -579,6 +604,18 @@ function GraphView({ bundle }: { bundle: ReviewBundle }) {
             <p>{selected.description}</p>
           </div>
           <code>{shortHash(selected.id)}</code>
+        </div>
+      )}
+      {selectedEdge && selectedEdgeSource && selectedEdgeTarget && (
+        <div className="node-inspector edge-inspector" style={edgeHueStyle(edgeLegendFor(selectedEdge.relation))}>
+          <div className={`node-state-dot ${selectedEdge.state}`} />
+          <div>
+            <RelationMark className="node-inspector-kind" relation={selectedEdge.relation} showLabel={false} />
+            <span>{edgeLegendFor(selectedEdge.relation).label} · {selectedEdge.state}</span>
+            <strong>{selectedEdgeSource.label} → {selectedEdgeTarget.label}</strong>
+            <p>Weight {selectedEdge.weight.toFixed(2)}</p>
+          </div>
+          <code>{shortHash(selectedEdge.id)}</code>
         </div>
       )}
       <PageNotice page={bundle.graph.nodes} label="Graph nodes" />

--- a/apps/kg-editor/src/components/studio.tsx
+++ b/apps/kg-editor/src/components/studio.tsx
@@ -38,6 +38,17 @@ import {
 import { useMemo, useRef, useState } from "react";
 
 import {
+  edgeDirectionMark,
+  edgeHueStyle,
+  EntityKindMark,
+  kindHueStyle,
+  NoteKindMark,
+  OntologyKindMark,
+  OntologyLegend,
+  RelationMark,
+} from "@/components/ontology-mark";
+import { edgeLegendFor, entityLegendFor } from "@/lib/ontology-legend";
+import {
   isReviewReport,
   parseReviewInput,
   REVIEW_IMPORT_MAX_BYTES,
@@ -345,6 +356,26 @@ function FieldDiff({ field }: { field: ReviewChange["fields"][number] }) {
   );
 }
 
+function ChangeOntologyMark({ change }: { change: ReviewChange }) {
+  const valueAt = (path: string) => {
+    const field = change.fields.find((candidate) => candidate.path === path);
+    return field?.after ?? field?.before;
+  };
+  if (change.substrate === "entity") {
+    const value = valueAt("entity_kind") ?? valueAt("kind");
+    const kind = typeof value === "string" ? value : "entity";
+    return <EntityKindMark className="substrate-chip" kind={kind} />;
+  }
+  if (change.substrate === "note") {
+    const value = valueAt("note_kind") ?? valueAt("kind");
+    const kind = typeof value === "string" ? value : "note";
+    return <NoteKindMark className="substrate-chip" kind={kind} />;
+  }
+  const value = valueAt("relation");
+  const relation = typeof value === "string" ? value : "edge";
+  return <RelationMark className="substrate-chip edge" relation={relation} />;
+}
+
 function ChangeCard({ change, selected, onSelect }: { change: ReviewChange; selected: boolean; onSelect: () => void }) {
   return (
     <article className={`change-card ${change.change} ${selected ? "selected" : ""}`}>
@@ -356,7 +387,7 @@ function ChangeCard({ change, selected, onSelect }: { change: ReviewChange; sele
           <strong>{change.title}</strong>
           <span>{change.subtitle}</span>
         </div>
-        <span className={`substrate-chip ${change.substrate}`}>{change.substrate}</span>
+        <ChangeOntologyMark change={change} />
         <TierPill tier={change.tier} />
         <ChevronDown className={selected ? "rotated" : ""} aria-hidden="true" />
       </button>
@@ -429,22 +460,66 @@ function GraphView({ bundle }: { bundle: ReviewBundle }) {
           <span className="eyebrow">Bounded 2-hop context</span>
           <h2>Affected subgraph</h2>
         </div>
-        <div className="graph-legend">
-          <span><i className="added" /> Added</span>
-          <span><i className="modified" /> Changed</span>
-          <span><i className="context" /> Context</span>
+        <div className="graph-legend-block">
+          <div className="graph-legend">
+            <span><i className="added" /> Added</span>
+            <span><i className="modified" /> Changed</span>
+            <span><i className="context" /> Context</span>
+          </div>
+          <OntologyLegend
+            className="graph-ontology-legend"
+            entityKinds={bundle.graph.nodes.items.map((node) => node.kind)}
+            relations={bundle.graph.edges.items.map((edge) => edge.relation)}
+          />
         </div>
       </div>
       <div className="graph-stage">
         <svg className="graph-lines" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
+          <defs>
+            <marker id="studio-ontology-arrow" markerHeight="6" markerWidth="6" orient="auto" refX="5" refY="3" viewBox="0 0 6 6">
+              <path d="M 0 0 L 6 3 L 0 6 z" fill="context-stroke" />
+            </marker>
+          </defs>
           {bundle.graph.edges.items.map((edge) => {
             const source = nodeById.get(edge.source);
             const target = nodeById.get(edge.target);
             if (!source || !target) return null;
+            const legend = edgeLegendFor(edge.relation);
+            const direction = edgeDirectionMark(legend, source, target);
             return (
               <g key={edge.id} className={edge.state}>
-                <line x1={source.x} y1={source.y} x2={target.x} y2={target.y} vectorEffect="non-scaling-stroke" />
-                <circle cx={(source.x + target.x) / 2} cy={(source.y + target.y) / 2} r="1.2" vectorEffect="non-scaling-stroke" />
+                <line
+                  className="ontology-edge"
+                  data-edge-family={legend.family}
+                  data-edge-treatment={legend.treatment}
+                  data-edge-variant={legend.variant}
+                  data-edge-origin="ingested"
+                  markerEnd={legend.directed ? "url(#studio-ontology-arrow)" : undefined}
+                  style={edgeHueStyle(legend)}
+                  x1={source.x}
+                  y1={source.y}
+                  x2={target.x}
+                  y2={target.y}
+                  vectorEffect="non-scaling-stroke"
+                />
+                <text
+                  className="ontology-edge-glyph"
+                  data-edge-directed={legend.directed}
+                  style={edgeHueStyle(legend)}
+                  x={(source.x + target.x) / 2}
+                  y={(source.y + target.y) / 2}
+                >
+                  {legend.glyph}
+                </text>
+                {direction && (
+                  <text
+                    className="ontology-direction-glyph"
+                    style={edgeHueStyle(legend)}
+                    transform={direction.transform}
+                    x={direction.x}
+                    y={direction.y}
+                  >›</text>
+                )}
               </g>
             );
           })}
@@ -453,11 +528,11 @@ function GraphView({ bundle }: { bundle: ReviewBundle }) {
           <button
             type="button"
             className={`graph-node ${node.state} ${node.id === selectedId ? "selected" : ""}`}
-            style={{ left: `${node.x}%`, top: `${node.y}%` }}
+            style={{ left: `${node.x}%`, top: `${node.y}%`, ...kindHueStyle(entityLegendFor(node.kind)) }}
             key={node.id}
             onClick={() => setSelectedId(node.id)}
           >
-            <span className="node-kind">{node.kind}</span>
+            <EntityKindMark className="node-kind" kind={node.kind} />
             <strong>{node.label}</strong>
           </button>
         ))}
@@ -471,7 +546,7 @@ function GraphView({ bundle }: { bundle: ReviewBundle }) {
               className={`edge-label ${edge.state}`}
               style={{ left: `${(source.x + target.x) / 2}%`, top: `${(source.y + target.y) / 2}%` }}
             >
-              {edge.relation} · {edge.weight.toFixed(2)}
+              <RelationMark relation={edge.relation} /> · {edge.weight.toFixed(2)}
             </span>
           );
         })}
@@ -486,7 +561,7 @@ function GraphView({ bundle }: { bundle: ReviewBundle }) {
             return (
               <li key={`${edge.id}-summary`}>
                 <strong>{source.label}</strong>
-                <span>{edge.relation} · {edge.weight.toFixed(2)}</span>
+                <span><RelationMark relation={edge.relation} /><span className="visually-hidden">{edge.relation}</span> · {edge.weight.toFixed(2)}</span>
                 <strong>{target.label}</strong>
                 <em>{edge.state}</em>
               </li>
@@ -495,10 +570,11 @@ function GraphView({ bundle }: { bundle: ReviewBundle }) {
         </ul>
       </section>
       {selected && (
-        <div className="node-inspector">
+        <div className="node-inspector" style={kindHueStyle(entityLegendFor(selected.kind))}>
           <div className={`node-state-dot ${selected.state}`} />
           <div>
-            <span>{selected.kind} · {selected.state}</span>
+            <EntityKindMark className="node-inspector-kind" kind={selected.kind} showLabel={false} />
+            <span>{entityLegendFor(selected.kind).label} · {selected.state}</span>
             <strong>{selected.label}</strong>
             <p>{selected.description}</p>
           </div>
@@ -603,7 +679,7 @@ function RetrievalView({ bundle }: { bundle: ReviewBundle }) {
       {mode === "search" && (
         <div className="retrieval-results">
           {bundle.retrieval.search.items.map((result, index) => (
-            <article key={result.id}><span className="result-rank">{index + 1}</span><div><strong>{result.title}</strong><span>{result.kind} · score {result.score}</span><p>{result.snippet}</p></div><code>{result.id}</code></article>
+            <article key={result.id}><span className="result-rank">{index + 1}</span><div><strong>{result.title}</strong><span><OntologyKindMark kind={result.kind} /> · score {result.score}</span><p>{result.snippet}</p></div><code>{result.id}</code></article>
           ))}
         </div>
       )}
@@ -619,8 +695,8 @@ function RetrievalView({ bundle }: { bundle: ReviewBundle }) {
           {bundle.retrieval.traversal.items.map((node, index) => (
             <div className={`traversal-row depth-${node.depth}`} key={`${node.id}-${index}`}>
               <span className="traversal-line" aria-hidden="true" />
-              <span className="traversal-node"><Circle /></span>
-              <div><strong>{node.name}</strong><span>{node.kind}{node.via ? ` · ${node.via}` : " · root"}</span></div>
+              <span className="traversal-node"><EntityKindMark kind={node.kind} showLabel={false} /></span>
+              <div><strong>{node.name}</strong><span><EntityKindMark kind={node.kind} />{node.via ? <> · <RelationMark relation={node.via} /></> : " · root"}</span></div>
               <code>{node.id}</code>
             </div>
           ))}
@@ -763,6 +839,28 @@ function ViewSurface({ activeView, bundle, query, onQuery }: { activeView: View;
   return <ChangesView bundle={bundle} query={query} onQuery={onQuery} />;
 }
 
+function OperationOntologyMark({
+  operation,
+}: {
+  operation: ReviewReport["change_set"]["operations"][number];
+}) {
+  const record = operation.after ?? operation.before;
+  const stringField = (...names: string[]) => {
+    for (const name of names) {
+      const value = record?.[name];
+      if (typeof value === "string") return value;
+    }
+    return undefined;
+  };
+  if (operation.target === "entity") {
+    return <EntityKindMark className="substrate-chip" kind={stringField("entity_kind", "kind") ?? "entity"} />;
+  }
+  if (operation.target === "note") {
+    return <NoteKindMark className="substrate-chip" kind={stringField("note_kind", "kind") ?? "note"} />;
+  }
+  return <RelationMark className="substrate-chip edge" relation={stringField("relation") ?? "edge"} />;
+}
+
 function CoreReviewStudio({
   report,
   onImport,
@@ -825,7 +923,7 @@ function CoreReviewStudio({
                     <div className="change-summary core-operation-summary">
                       <span className="change-sign">{operation.index + 1}</span>
                       <div className="change-title"><strong>{operation.summary}</strong><span>{operation.reason}</span></div>
-                      <span className={`substrate-chip ${operation.target}`}>{operation.target}</span>
+                      <OperationOntologyMark operation={operation} />
                       <TierPill tier={operation.tier} />
                     </div>
                     <div className="change-detail core-operation-detail">

--- a/apps/kg-editor/src/lib/ontology-legend.test.ts
+++ b/apps/kg-editor/src/lib/ontology-legend.test.ts
@@ -1,0 +1,135 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  DERIVED_EDGE_MARK,
+  EDGE_RELATION_FAMILIES,
+  EDGE_RELATION_LEGEND,
+  EDGE_RELATIONS,
+  ENTITY_KIND_LEGEND,
+  ENTITY_KINDS,
+  NOTE_KIND_LEGEND,
+  NOTE_KINDS,
+} from "@/lib/ontology-legend";
+
+const vocabSource = readFileSync(
+  resolve(process.cwd(), "../../crates/khive-pack-kg/src/vocab.rs"),
+  "utf8",
+);
+const edgeSource = readFileSync(
+  resolve(process.cwd(), "../../crates/khive-types/src/edge.rs"),
+  "utf8",
+);
+
+function rustStringConst(
+  source: string,
+  scope: string,
+  name: string,
+): string[] {
+  const scopeStart = source.indexOf(`impl ${scope} {`);
+  const declaration = source.indexOf(`const ${name}`, scopeStart);
+  const arrayStart = source.indexOf("&[", declaration);
+  const arrayEnd = source.indexOf("];", arrayStart);
+  if (scopeStart < 0 || declaration < 0 || arrayStart < 0 || arrayEnd < 0) {
+    throw new Error(`could not locate ${scope}::${name}`);
+  }
+  return [...source.slice(arrayStart, arrayEnd).matchAll(/"([a-z_]+)"/g)].map((
+    match,
+  ) => match[1]);
+}
+
+function rustEnumVariants(source: string, name: string): string[] {
+  const body = source.match(
+    new RegExp(`pub enum ${name} \\{([\\s\\S]*?)\\n\\}`),
+  )?.[1];
+  if (!body) throw new Error(`could not locate enum ${name}`);
+  return [...body.matchAll(/^\s*([A-Z][A-Za-z0-9]+),$/gm)].map((match) =>
+    match[1].toLowerCase()
+  );
+}
+
+function rustRelationFamilies(source: string): Record<string, string> {
+  const start = source.indexOf("pub const fn category(&self)");
+  const end = source.indexOf("/// Canonical snake_case name", start);
+  if (start < 0 || end < 0) {
+    throw new Error("could not locate EdgeRelation::category");
+  }
+  const result: Record<string, string> = {};
+  const arms = source.slice(start, end).matchAll(
+    /(Self::[A-Za-z]+(?:\s*\|\s*Self::[A-Za-z]+)*)\s*=>\s*(?:\{\s*)?EdgeCategory::([A-Za-z]+)/g,
+  );
+  for (const arm of arms) {
+    const family = arm[2].toLowerCase();
+    for (const variant of arm[1].matchAll(/Self::([A-Za-z]+)/g)) {
+      const relation = variant[1].replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+        .toLowerCase();
+      result[relation] = family;
+    }
+  }
+  return result;
+}
+
+describe("ontology legend", () => {
+  it("exactly covers the base ontology", () => {
+    const canonicalEntities = rustStringConst(
+      vocabSource,
+      "EntityKind",
+      "NAMES",
+    );
+    const canonicalRelations = rustStringConst(
+      edgeSource,
+      "EdgeRelation",
+      "VALID_NAMES",
+    );
+    const canonicalNotes = rustStringConst(vocabSource, "NoteKind", "NAMES");
+    const canonicalFamilies = rustEnumVariants(edgeSource, "EdgeCategory");
+
+    expect([...ENTITY_KINDS]).toEqual(canonicalEntities);
+    expect([...EDGE_RELATIONS]).toEqual(canonicalRelations);
+    expect([...NOTE_KINDS]).toEqual(canonicalNotes);
+    expect(Object.keys(ENTITY_KIND_LEGEND)).toEqual(canonicalEntities);
+    expect(Object.keys(EDGE_RELATION_LEGEND)).toEqual(canonicalRelations);
+    expect(Object.keys(NOTE_KIND_LEGEND)).toEqual(canonicalNotes);
+    expect(Object.keys(EDGE_RELATION_FAMILIES)).toEqual(canonicalFamilies);
+  });
+
+  it("assigns every relation to its authoritative family", () => {
+    const canonicalRelationFamilies = rustRelationFamilies(edgeSource);
+    const registered = Object.fromEntries(
+      Object.entries(EDGE_RELATION_FAMILIES).flatMap(([family, relations]) =>
+        relations.map((relation) => [relation, family])
+      ),
+    );
+    const rendered = Object.fromEntries(
+      Object.entries(EDGE_RELATION_LEGEND).map((
+        [relation, entry],
+      ) => [relation, entry.family]),
+    );
+    expect(registered).toEqual(canonicalRelationFamilies);
+    expect(rendered).toEqual(canonicalRelationFamilies);
+    for (const [family, relations] of Object.entries(EDGE_RELATION_FAMILIES)) {
+      for (const relation of relations) {
+        expect(EDGE_RELATION_LEGEND[relation].family).toBe(family);
+      }
+    }
+  });
+
+  it("keeps every distinction legible without hue", () => {
+    expect(
+      new Set(Object.values(ENTITY_KIND_LEGEND).map((entry) => entry.icon))
+        .size,
+    ).toBe(9);
+    expect(
+      new Set(Object.values(NOTE_KIND_LEGEND).map((entry) => entry.icon)).size,
+    ).toBe(5);
+    expect(
+      new Set(Object.values(EDGE_RELATION_LEGEND).map((entry) => entry.glyph))
+        .size,
+    ).toBe(17);
+    expect(DERIVED_EDGE_MARK).toMatchObject({
+      geometry: "diamond",
+      glyph: "◇",
+    });
+  });
+});

--- a/apps/kg-editor/src/lib/ontology-legend.ts
+++ b/apps/kg-editor/src/lib/ontology-legend.ts
@@ -1,0 +1,389 @@
+export const ENTITY_KINDS = [
+  "concept",
+  "document",
+  "dataset",
+  "project",
+  "person",
+  "org",
+  "artifact",
+  "service",
+  "resource",
+] as const;
+
+export const EDGE_RELATIONS = [
+  "contains",
+  "part_of",
+  "instance_of",
+  "extends",
+  "variant_of",
+  "introduced_by",
+  "supersedes",
+  "derived_from",
+  "precedes",
+  "depends_on",
+  "enables",
+  "implements",
+  "competes_with",
+  "composed_with",
+  "annotates",
+  "supports",
+  "refutes",
+] as const;
+
+export const NOTE_KINDS = [
+  "observation",
+  "insight",
+  "question",
+  "decision",
+  "reference",
+] as const;
+
+export const EDGE_RELATION_FAMILY_NAMES = [
+  "structure",
+  "derivation",
+  "provenance",
+  "temporal",
+  "dependency",
+  "implementation",
+  "lateral",
+  "annotation",
+  "epistemic",
+] as const;
+
+export type EntityKind = (typeof ENTITY_KINDS)[number];
+export type EdgeRelation = (typeof EDGE_RELATIONS)[number];
+export type NoteKind = (typeof NOTE_KINDS)[number];
+export type EdgeRelationFamily = (typeof EDGE_RELATION_FAMILY_NAMES)[number];
+
+export const EDGE_RELATION_FAMILIES = {
+  structure: ["contains", "part_of", "instance_of"],
+  derivation: ["extends", "variant_of", "introduced_by", "supersedes"],
+  provenance: ["derived_from"],
+  temporal: ["precedes"],
+  dependency: ["depends_on", "enables"],
+  implementation: ["implements"],
+  lateral: ["competes_with", "composed_with"],
+  annotation: ["annotates"],
+  epistemic: ["supports", "refutes"],
+} as const satisfies Record<EdgeRelationFamily, readonly EdgeRelation[]>;
+
+export type OntologyIconName =
+  | "lightbulb"
+  | "file-text"
+  | "database"
+  | "folder-kanban"
+  | "user"
+  | "building"
+  | "package"
+  | "server-cog"
+  | "book-open"
+  | "eye"
+  | "sparkles"
+  | "circle-help"
+  | "signpost"
+  | "bookmark"
+  | "circle";
+
+export type KindLegendEntry = Readonly<{
+  label: string;
+  icon: OntologyIconName;
+  hue: string;
+}>;
+
+export const ENTITY_KIND_LEGEND = {
+  concept: {
+    label: "Concept",
+    icon: "lightbulb",
+    hue: "var(--ontology-concept)",
+  },
+  document: {
+    label: "Document",
+    icon: "file-text",
+    hue: "var(--ontology-document)",
+  },
+  dataset: {
+    label: "Dataset",
+    icon: "database",
+    hue: "var(--ontology-dataset)",
+  },
+  project: {
+    label: "Project",
+    icon: "folder-kanban",
+    hue: "var(--ontology-project)",
+  },
+  person: { label: "Person", icon: "user", hue: "var(--ontology-person)" },
+  org: { label: "Organization", icon: "building", hue: "var(--ontology-org)" },
+  artifact: {
+    label: "Artifact",
+    icon: "package",
+    hue: "var(--ontology-artifact)",
+  },
+  service: {
+    label: "Service",
+    icon: "server-cog",
+    hue: "var(--ontology-service)",
+  },
+  resource: {
+    label: "Resource",
+    icon: "book-open",
+    hue: "var(--ontology-resource)",
+  },
+} as const satisfies Record<EntityKind, KindLegendEntry>;
+
+export const NOTE_KIND_LEGEND = {
+  observation: {
+    label: "Observation",
+    icon: "eye",
+    hue: "var(--ontology-observation)",
+  },
+  insight: {
+    label: "Insight",
+    icon: "sparkles",
+    hue: "var(--ontology-insight)",
+  },
+  question: {
+    label: "Question",
+    icon: "circle-help",
+    hue: "var(--ontology-question)",
+  },
+  decision: {
+    label: "Decision",
+    icon: "signpost",
+    hue: "var(--ontology-decision)",
+  },
+  reference: {
+    label: "Reference",
+    icon: "bookmark",
+    hue: "var(--ontology-reference)",
+  },
+} as const satisfies Record<NoteKind, KindLegendEntry>;
+
+export type EdgeLineTreatment =
+  | "quiet-solid"
+  | "directional"
+  | "dotted"
+  | "assertive-solid"
+  | "undirected"
+  | "recessive-dashed"
+  | "epistemic";
+
+export type EdgeLegendEntry = Readonly<{
+  label: string;
+  family: EdgeRelationFamily;
+  glyph: string;
+  treatment: EdgeLineTreatment;
+  variant: "primary" | "secondary" | "tertiary" | "quaternary";
+  hue: string;
+  directed: boolean;
+}>;
+
+const neutralEdge = "var(--ontology-edge-neutral)";
+
+export const EDGE_RELATION_LEGEND = {
+  contains: {
+    label: "Contains",
+    family: "structure",
+    glyph: "C",
+    treatment: "quiet-solid",
+    variant: "primary",
+    hue: neutralEdge,
+    directed: true,
+  },
+  part_of: {
+    label: "Part of",
+    family: "structure",
+    glyph: "P",
+    treatment: "quiet-solid",
+    variant: "secondary",
+    hue: neutralEdge,
+    directed: true,
+  },
+  instance_of: {
+    label: "Instance of",
+    family: "structure",
+    glyph: "I",
+    treatment: "quiet-solid",
+    variant: "tertiary",
+    hue: neutralEdge,
+    directed: true,
+  },
+  extends: {
+    label: "Extends",
+    family: "derivation",
+    glyph: "E",
+    treatment: "directional",
+    variant: "primary",
+    hue: neutralEdge,
+    directed: true,
+  },
+  variant_of: {
+    label: "Variant of",
+    family: "derivation",
+    glyph: "V",
+    treatment: "directional",
+    variant: "secondary",
+    hue: neutralEdge,
+    directed: true,
+  },
+  introduced_by: {
+    label: "Introduced by",
+    family: "derivation",
+    glyph: "IB",
+    treatment: "directional",
+    variant: "tertiary",
+    hue: neutralEdge,
+    directed: true,
+  },
+  supersedes: {
+    label: "Supersedes",
+    family: "derivation",
+    glyph: "S",
+    treatment: "directional",
+    variant: "quaternary",
+    hue: neutralEdge,
+    directed: true,
+  },
+  derived_from: {
+    label: "Derived from",
+    family: "provenance",
+    glyph: "DF",
+    treatment: "directional",
+    variant: "primary",
+    hue: neutralEdge,
+    directed: true,
+  },
+  precedes: {
+    label: "Precedes",
+    family: "temporal",
+    glyph: "T",
+    treatment: "dotted",
+    variant: "primary",
+    hue: neutralEdge,
+    directed: true,
+  },
+  depends_on: {
+    label: "Depends on",
+    family: "dependency",
+    glyph: "DO",
+    treatment: "assertive-solid",
+    variant: "primary",
+    hue: neutralEdge,
+    directed: true,
+  },
+  enables: {
+    label: "Enables",
+    family: "dependency",
+    glyph: "EN",
+    treatment: "assertive-solid",
+    variant: "secondary",
+    hue: neutralEdge,
+    directed: true,
+  },
+  implements: {
+    label: "Implements",
+    family: "implementation",
+    glyph: "IM",
+    treatment: "directional",
+    variant: "primary",
+    hue: neutralEdge,
+    directed: true,
+  },
+  competes_with: {
+    label: "Competes with",
+    family: "lateral",
+    glyph: "CW",
+    treatment: "undirected",
+    variant: "primary",
+    hue: neutralEdge,
+    directed: false,
+  },
+  composed_with: {
+    label: "Composed with",
+    family: "lateral",
+    glyph: "CO",
+    treatment: "undirected",
+    variant: "secondary",
+    hue: neutralEdge,
+    directed: false,
+  },
+  annotates: {
+    label: "Annotates",
+    family: "annotation",
+    glyph: "A",
+    treatment: "recessive-dashed",
+    variant: "primary",
+    hue: neutralEdge,
+    directed: true,
+  },
+  supports: {
+    label: "Supports",
+    family: "epistemic",
+    glyph: "+",
+    treatment: "epistemic",
+    variant: "primary",
+    hue: "var(--ontology-support)",
+    directed: true,
+  },
+  refutes: {
+    label: "Refutes",
+    family: "epistemic",
+    glyph: "−",
+    treatment: "epistemic",
+    variant: "secondary",
+    hue: "var(--ontology-refute)",
+    directed: true,
+  },
+} as const satisfies Record<EdgeRelation, EdgeLegendEntry>;
+
+export const DERIVED_EDGE_MARK = {
+  label: "Derived",
+  glyph: "◇",
+  geometry: "diamond",
+  hue: "var(--ontology-derived)",
+} as const;
+
+const UNKNOWN_KIND_LEGEND: KindLegendEntry = {
+  label: "Unsupported kind",
+  icon: "circle",
+  hue: "var(--ontology-unknown)",
+};
+
+const UNKNOWN_EDGE_LEGEND: EdgeLegendEntry = {
+  label: "Unsupported relation",
+  family: "annotation",
+  glyph: "?",
+  treatment: "recessive-dashed",
+  variant: "primary",
+  hue: "var(--ontology-unknown)",
+  directed: true,
+};
+
+function hasOwn<T extends object>(value: T, key: PropertyKey): key is keyof T {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+export function isEntityKind(value: string): value is EntityKind {
+  return hasOwn(ENTITY_KIND_LEGEND, value);
+}
+
+export function isNoteKind(value: string): value is NoteKind {
+  return hasOwn(NOTE_KIND_LEGEND, value);
+}
+
+export function isEdgeRelation(value: string): value is EdgeRelation {
+  return hasOwn(EDGE_RELATION_LEGEND, value);
+}
+
+export function entityLegendFor(kind: string): KindLegendEntry {
+  return isEntityKind(kind) ? ENTITY_KIND_LEGEND[kind] : UNKNOWN_KIND_LEGEND;
+}
+
+export function noteLegendFor(kind: string): KindLegendEntry {
+  return isNoteKind(kind) ? NOTE_KIND_LEGEND[kind] : UNKNOWN_KIND_LEGEND;
+}
+
+export function edgeLegendFor(relation: string): EdgeLegendEntry {
+  return isEdgeRelation(relation)
+    ? EDGE_RELATION_LEGEND[relation]
+    : UNKNOWN_EDGE_LEGEND;
+}


### PR DESCRIPTION
## Summary

- define the complete shared entity, note, relation-family, relation, and derived-edge visual legend
- wire the shared marks into Studio graph/list/inspector and repository showcase graph
- verify completeness against the authoritative Rust ontology sources and preserve grayscale-readable distinctions

## Verification

- ontology contract tests: 3/3 passed during TDD
- `deno fmt` on new TypeScript files
- `git diff --check`
- remote CI requested for the full app dependency matrix

Fixes #1885