### PR TITLE
perf(db): bound WAL-pin holder census cadence

### DIFF
--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -545,6 +545,25 @@ fn tx_age_thresholds_from_env(
     (warn_secs, max_age_secs)
 }
 
+#[cfg(unix)]
+const DEFAULT_WALPIN_FULL_SCAN_INTERVAL: Duration = Duration::from_secs(30);
+
+#[cfg(unix)]
+#[derive(Debug, Clone)]
+struct CachedWalpinAttribution {
+    report: crate::walpin::WalpinReport,
+    census: Result<crate::walpin::CensusResult, String>,
+    captured_at: Instant,
+}
+
+#[cfg(unix)]
+#[derive(Debug)]
+enum WalpinFullScanPlan {
+    Refresh,
+    Cached(CachedWalpinAttribution),
+    Suppressed,
+}
+
 /// Mutable escalation state carried across ticks by the caller (ADR-091 Plank 2).
 ///
 /// Kept separate from [`CheckpointConfig`] because it is *state*, not
@@ -568,6 +587,16 @@ pub struct TruncateState {
     /// the daemon's faster checkpoint cadence or a local environment override.
     #[cfg(unix)]
     legacy_walpin_fallback_interval: Duration,
+    /// Minimum spacing between full sidecar/OS-holder enumeration attempts.
+    /// The attempt timestamp advances before blocking work starts, so an I/O
+    /// failure or worker panic cannot turn sustained pressure into a hot retry
+    /// loop. A successful report is retained only for diagnostic reuse.
+    #[cfg(unix)]
+    walpin_full_scan_interval: Duration,
+    #[cfg(unix)]
+    walpin_full_scan_last_attempt: Option<Instant>,
+    #[cfg(unix)]
+    walpin_cached_attribution: Option<CachedWalpinAttribution>,
     /// Whether the no-progress attribution arm already attempted the one
     /// bounded sidecar enumeration allowed for this checkpoint tick.
     #[cfg(unix)]
@@ -581,6 +610,12 @@ impl Default for TruncateState {
             consecutive_failures: 0,
             #[cfg(unix)]
             legacy_walpin_fallback_interval: DEFAULT_SESSION_SWEEP_INTERVAL,
+            #[cfg(unix)]
+            walpin_full_scan_interval: DEFAULT_WALPIN_FULL_SCAN_INTERVAL,
+            #[cfg(unix)]
+            walpin_full_scan_last_attempt: None,
+            #[cfg(unix)]
+            walpin_cached_attribution: None,
             #[cfg(unix)]
             sidecar_attribution_attempted_this_tick: false,
         }
@@ -596,6 +631,14 @@ impl TruncateState {
         }
     }
 
+    #[cfg(all(test, unix))]
+    fn with_walpin_full_scan_cadence(interval: Duration) -> Self {
+        Self {
+            walpin_full_scan_interval: interval,
+            ..Self::default()
+        }
+    }
+
     #[cfg(unix)]
     fn begin_tick(&mut self) {
         self.sidecar_attribution_attempted_this_tick = false;
@@ -604,6 +647,48 @@ impl TruncateState {
     #[cfg(unix)]
     fn housekeeping_due(&self) -> bool {
         !self.sidecar_attribution_attempted_this_tick
+            && self.walpin_full_scan_due_at(Instant::now())
+    }
+
+    #[cfg(unix)]
+    fn walpin_full_scan_due_at(&self, now: Instant) -> bool {
+        self.walpin_full_scan_last_attempt.is_none_or(|last| {
+            now.saturating_duration_since(last) >= self.walpin_full_scan_interval
+        })
+    }
+
+    #[cfg(unix)]
+    fn claim_walpin_full_scan_at(&mut self, now: Instant) -> bool {
+        if !self.walpin_full_scan_due_at(now) {
+            return false;
+        }
+        self.walpin_full_scan_last_attempt = Some(now);
+        true
+    }
+
+    #[cfg(unix)]
+    fn plan_walpin_attribution_at(&mut self, now: Instant) -> WalpinFullScanPlan {
+        if self.claim_walpin_full_scan_at(now) {
+            WalpinFullScanPlan::Refresh
+        } else if let Some(cached) = self.walpin_cached_attribution.clone() {
+            WalpinFullScanPlan::Cached(cached)
+        } else {
+            WalpinFullScanPlan::Suppressed
+        }
+    }
+
+    #[cfg(unix)]
+    fn cache_walpin_attribution(
+        &mut self,
+        report: crate::walpin::WalpinReport,
+        census: Result<crate::walpin::CensusResult, String>,
+        captured_at: Instant,
+    ) {
+        self.walpin_cached_attribution = Some(CachedWalpinAttribution {
+            report,
+            census,
+            captured_at,
+        });
     }
 }
 
@@ -977,25 +1062,30 @@ impl WalpinSidecarState {
     /// and report memory are capped, and all blocking filesystem operations
     /// stay off the async runtime worker.
     #[cfg(unix)]
-    async fn reap_dead_entries_bounded(&self, legacy_fallback_interval: Duration) {
+    async fn reap_dead_entries_bounded(
+        &self,
+        legacy_fallback_interval: Duration,
+    ) -> Option<crate::walpin::WalpinReport> {
         let dir = self.dir.clone();
         let result = tokio::task::spawn_blocking(move || {
             crate::walpin::housekeep_live(&dir, legacy_fallback_interval)
         })
         .await;
         match result {
-            Ok(Ok(_)) => {}
+            Ok(Ok(report)) => Some(report),
             Ok(Err(e)) => {
                 tracing::warn!(
                     error = %e,
                     "ADR-091 Amendment 6: bounded walpin sidecar cleanup failed"
                 );
+                None
             }
             Err(join_err) => {
                 tracing::warn!(
                     error = %join_err,
                     "ADR-091 Amendment 6: walpin sidecar cleanup task panicked"
                 );
+                None
             }
         }
     }
@@ -1969,10 +2059,22 @@ pub async fn run_checkpoint_task(
             sidecar
                 .observe(oldest_tx.clone(), config.tx_warn_secs)
                 .await;
-            if truncate_state.housekeeping_due() {
-                sidecar
+            if truncate_state.housekeeping_due()
+                && truncate_state.claim_walpin_full_scan_at(Instant::now())
+            {
+                if let Some(report) = sidecar
                     .reap_dead_entries_bounded(legacy_walpin_fallback_interval)
-                    .await;
+                    .await
+                {
+                    truncate_state.cache_walpin_attribution(
+                        report,
+                        Err(
+                            "OS holder census is unavailable for a housekeeping-only scan"
+                                .to_string(),
+                        ),
+                        Instant::now(),
+                    );
+                }
             }
         }
 
@@ -2368,8 +2470,7 @@ fn maybe_truncate(
     }
 
     #[cfg(unix)]
-    let holder_attribution =
-        capture_walpin_attribution_request(pool, truncate_state.legacy_walpin_fallback_interval);
+    let holder_attribution = capture_walpin_attribution_request(pool, truncate_state);
     #[cfg(unix)]
     let mut sidecar_attribution = None;
     #[cfg(not(unix))]
@@ -2640,10 +2741,28 @@ fn note_truncate_outcome(
 /// `spawn_blocking` by [`complete_walpin_attribution`].
 #[cfg(unix)]
 #[derive(Debug)]
-struct WalpinAttributionRequest {
-    dir: PathBuf,
-    census: Result<crate::walpin::CensusResult, String>,
-    legacy_fallback_interval: Duration,
+enum WalpinAttributionRequest {
+    Fresh {
+        dir: PathBuf,
+        census: Result<crate::walpin::CensusResult, String>,
+        legacy_fallback_interval: Duration,
+    },
+    Cached(CachedWalpinAttribution),
+    Suppressed,
+}
+
+#[cfg(unix)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WalpinReportFreshness {
+    Fresh,
+    Cached { age: Duration },
+}
+
+#[cfg(unix)]
+impl WalpinReportFreshness {
+    fn is_fresh(self) -> bool {
+        self == Self::Fresh
+    }
 }
 
 /// Non-Unix placeholder keeps the synchronous core's outcome shape stable;
@@ -2695,16 +2814,21 @@ impl std::fmt::Display for WalpinAttributionFailure {
 #[cfg(unix)]
 fn capture_walpin_attribution_request(
     pool: &ConnectionPool,
-    legacy_fallback_interval: Duration,
+    state: &mut TruncateState,
 ) -> Option<WalpinAttributionRequest> {
     let path = pool.canonical_path()?;
     if !crate::walpin::sidecar_enabled(true) {
         return None;
     }
-    Some(WalpinAttributionRequest {
-        dir: crate::walpin::sidecar_dir_for(path),
-        census: crate::walpin::census_holders(path).map_err(|error| error.to_string()),
-        legacy_fallback_interval,
+    let legacy_fallback_interval = state.legacy_walpin_fallback_interval;
+    Some(match state.plan_walpin_attribution_at(Instant::now()) {
+        WalpinFullScanPlan::Refresh => WalpinAttributionRequest::Fresh {
+            dir: crate::walpin::sidecar_dir_for(path),
+            census: crate::walpin::census_holders(path).map_err(|error| error.to_string()),
+            legacy_fallback_interval,
+        },
+        WalpinFullScanPlan::Cached(cached) => WalpinAttributionRequest::Cached(cached),
+        WalpinFullScanPlan::Suppressed => WalpinAttributionRequest::Suppressed,
     })
 }
 
@@ -2721,24 +2845,65 @@ async fn complete_walpin_attribution(
     let Some(request) = request else {
         return Ok(false);
     };
-    state.sidecar_attribution_attempted_this_tick = true;
+    match request {
+        WalpinAttributionRequest::Suppressed => Ok(false),
+        WalpinAttributionRequest::Cached(cached) => {
+            log_walpin_sidecar_report(
+                &cached.report,
+                cached.census,
+                WalpinReportFreshness::Cached {
+                    age: Instant::now().saturating_duration_since(cached.captured_at),
+                },
+            );
+            Ok(true)
+        }
+        WalpinAttributionRequest::Fresh {
+            dir,
+            census,
+            legacy_fallback_interval,
+        } => {
+            state.sidecar_attribution_attempted_this_tick = true;
+            if state.walpin_full_scan_last_attempt.is_none() {
+                state.walpin_full_scan_last_attempt = Some(Instant::now());
+            }
+            let fallback = state.walpin_cached_attribution.clone();
+            let result = tokio::task::spawn_blocking(move || {
+                #[cfg(test)]
+                walpin_attribution_test_sync::before_enumeration(&dir);
+                crate::walpin::enumerate_live(&dir, legacy_fallback_interval)
+            })
+            .await
+            .map_err(|error| WalpinAttributionFailure::Worker(error.to_string()))
+            .and_then(|result| {
+                result.map_err(|error| WalpinAttributionFailure::Enumeration(error.to_string()))
+            });
 
-    let WalpinAttributionRequest {
-        dir,
-        census,
-        legacy_fallback_interval,
-    } = request;
-    let report = tokio::task::spawn_blocking(move || {
-        #[cfg(test)]
-        walpin_attribution_test_sync::before_enumeration(&dir);
-        crate::walpin::enumerate_live(&dir, legacy_fallback_interval)
-    })
-    .await
-    .map_err(|error| WalpinAttributionFailure::Worker(error.to_string()))?
-    .map_err(|error| WalpinAttributionFailure::Enumeration(error.to_string()))?;
-
-    log_walpin_sidecar_report(&report, census);
-    Ok(true)
+            match result {
+                Ok(report) => {
+                    let captured_at = Instant::now();
+                    log_walpin_sidecar_report(
+                        &report,
+                        census.clone(),
+                        WalpinReportFreshness::Fresh,
+                    );
+                    state.cache_walpin_attribution(report, census, captured_at);
+                    Ok(true)
+                }
+                Err(error) => {
+                    if let Some(cached) = fallback {
+                        log_walpin_sidecar_report(
+                            &cached.report,
+                            cached.census,
+                            WalpinReportFreshness::Cached {
+                                age: Instant::now().saturating_duration_since(cached.captured_at),
+                            },
+                        );
+                    }
+                    Err(error)
+                }
+            }
+        }
+    }
 }
 
 /// When a TRUNCATE attempt makes no progress, enumerate the walpin sidecar and
@@ -2759,6 +2924,7 @@ async fn complete_walpin_attribution(
 fn log_walpin_sidecar_report(
     report: &crate::walpin::WalpinReport,
     census: Result<crate::walpin::CensusResult, String>,
+    freshness: WalpinReportFreshness,
 ) {
     #[cfg(test)]
     walpin_attribution_test_sync::report_used();
@@ -2776,6 +2942,7 @@ fn log_walpin_sidecar_report(
             walpin_oldest_tx_label = hb.oldest_tx_label.as_deref().unwrap_or("<unlabeled>"),
             walpin_attribution_basis = hb.attribution_basis.as_deref().unwrap_or("<unspecified>"),
             walpin_attribution_evidence_backed = hb.attribution_is_evidence_backed(),
+            walpin_attribution_fresh = freshness.is_fresh(),
             walpin_health = "reporting",
             "ADR-091 Amendment 2 Plank B: live cross-process WAL-pin attribution report"
         );
@@ -2784,10 +2951,19 @@ fn log_walpin_sidecar_report(
         tracing::debug!(
             walpin_pid = pid,
             walpin_health = "registered_silent",
+            walpin_attribution_fresh = freshness.is_fresh(),
             "ADR-091 Amendment 2 Plank B: process affirmatively reports no over-threshold span"
         );
     }
     let mut unknown_pids: Vec<u32> = report.unknown_pids().collect();
+    if let WalpinReportFreshness::Cached { age } = freshness {
+        tracing::warn!(
+            walpin_cache_age_ms = age.as_millis() as u64,
+            "cached WAL-pin attribution is diagnostic-only; fully-attributed \
+             conclusion is not licensed"
+        );
+        unknown_pids.push(0);
+    }
 
     // The sidecar directory alone can only speak for PIDs that wrote
     // something there. Widen the universe to every PID the OS reports as
@@ -2853,6 +3029,8 @@ fn log_walpin_sidecar_report(
         }
     }
 
+    unknown_pids.sort_unstable();
+    unknown_pids.dedup();
     if !unknown_pids.is_empty() {
         tracing::warn!(
             ?unknown_pids,
@@ -3245,6 +3423,100 @@ mod tests {
         }
     }
 
+    #[test]
+    #[cfg(unix)]
+    fn walpin_full_scan_cadence_refreshes_first_then_reuses_until_boundary() {
+        let cadence = Duration::from_secs(30);
+        let started_at = Instant::now();
+        let mut state = TruncateState::with_walpin_full_scan_cadence(cadence);
+
+        assert!(matches!(
+            state.plan_walpin_attribution_at(started_at),
+            WalpinFullScanPlan::Refresh
+        ));
+        state.cache_walpin_attribution(
+            crate::walpin::WalpinReport::default(),
+            Ok(crate::walpin::CensusResult::default()),
+            started_at,
+        );
+
+        assert!(matches!(
+            state.plan_walpin_attribution_at(started_at + cadence - Duration::from_nanos(1)),
+            WalpinFullScanPlan::Cached(_)
+        ));
+        assert!(matches!(
+            state.plan_walpin_attribution_at(started_at + cadence),
+            WalpinFullScanPlan::Refresh
+        ));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn walpin_full_scan_failure_retries_only_after_cadence() {
+        let cadence = Duration::from_secs(30);
+        let started_at = Instant::now();
+        let mut state = TruncateState::with_walpin_full_scan_cadence(cadence);
+
+        assert!(matches!(
+            state.plan_walpin_attribution_at(started_at),
+            WalpinFullScanPlan::Refresh
+        ));
+        // No cache update models either an enumeration error or a panicked
+        // blocking worker. The attempt itself still owns the cadence slot.
+        assert!(matches!(
+            state.plan_walpin_attribution_at(started_at + cadence - Duration::from_nanos(1)),
+            WalpinFullScanPlan::Suppressed
+        ));
+        assert!(matches!(
+            state.plan_walpin_attribution_at(started_at + cadence),
+            WalpinFullScanPlan::Refresh
+        ));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn cached_walpin_report_is_diagnostic_only_even_when_fully_attributed() {
+        let report = crate::walpin::WalpinReport::default();
+        assert!(
+            report.fully_attributed(),
+            "the fixture must otherwise license the sharp conclusion"
+        );
+        let buffer = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let subscriber = CaptureSubscriber {
+            events: std::sync::Arc::clone(&buffer),
+        };
+
+        tracing::subscriber::with_default(subscriber, || {
+            log_walpin_sidecar_report(
+                &report,
+                Ok(crate::walpin::CensusResult::default()),
+                WalpinReportFreshness::Cached {
+                    age: Duration::from_secs(1),
+                },
+            );
+        });
+
+        let events = buffer.lock().unwrap();
+        assert!(
+            events.iter().any(|event| {
+                event.message.as_deref()
+                    == Some(
+                        "cached WAL-pin attribution is diagnostic-only; fully-attributed \
+                         conclusion is not licensed",
+                    )
+            }),
+            "cached attribution must declare its fail-closed status: {events:?}"
+        );
+        assert!(
+            !events.iter().any(|event| {
+                event.message.as_deref().is_some_and(|message| {
+                    message.starts_with("ADR-091 Amendment 2 Plank B: every live PID is reporting")
+                })
+            }),
+            "cached attribution must never authorize the fully-attributed conclusion: {events:?}"
+        );
+    }
+
     struct ReaderProcess {
         child: std::process::Child,
         _stdout: std::io::BufReader<std::process::ChildStdout>,
@@ -3460,7 +3732,7 @@ mod tests {
 
         let runtime_thread = std::thread::current().id();
         let mut state = TruncateState::default();
-        let request = Some(WalpinAttributionRequest {
+        let request = Some(WalpinAttributionRequest::Fresh {
             dir: sidecar_dir,
             census: Ok(crate::walpin::CensusResult::default()),
             legacy_fallback_interval: DEFAULT_SESSION_SWEEP_INTERVAL,
@@ -3518,7 +3790,7 @@ mod tests {
         let _hook_guard = WalpinAttributionHookGuard;
 
         let mut state = TruncateState::default();
-        let request = Some(WalpinAttributionRequest {
+        let request = Some(WalpinAttributionRequest::Fresh {
             dir: sidecar_dir,
             census: Ok(crate::walpin::CensusResult::default()),
             legacy_fallback_interval: DEFAULT_SESSION_SWEEP_INTERVAL,

--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -559,7 +559,9 @@ struct CachedWalpinAttribution {
 #[cfg(unix)]
 #[derive(Debug)]
 enum WalpinFullScanPlan {
-    Refresh,
+    Refresh {
+        previous_last_attempt: Option<Instant>,
+    },
     Cached(CachedWalpinAttribution),
     Suppressed,
 }
@@ -668,13 +670,21 @@ impl TruncateState {
 
     #[cfg(unix)]
     fn plan_walpin_attribution_at(&mut self, now: Instant) -> WalpinFullScanPlan {
-        if self.claim_walpin_full_scan_at(now) {
-            WalpinFullScanPlan::Refresh
+        if self.walpin_full_scan_due_at(now) {
+            let previous_last_attempt = self.walpin_full_scan_last_attempt.replace(now);
+            WalpinFullScanPlan::Refresh {
+                previous_last_attempt,
+            }
         } else if let Some(cached) = self.walpin_cached_attribution.clone() {
             WalpinFullScanPlan::Cached(cached)
         } else {
             WalpinFullScanPlan::Suppressed
         }
+    }
+
+    #[cfg(unix)]
+    fn restore_walpin_full_scan_reservation(&mut self, previous_last_attempt: Option<Instant>) {
+        self.walpin_full_scan_last_attempt = previous_last_attempt;
     }
 
     #[cfg(unix)]
@@ -1341,6 +1351,28 @@ impl WalpinSidecarState {
             self.wrote = false;
         }
     }
+}
+
+#[cfg(unix)]
+async fn run_walpin_housekeeping_if_due(
+    sidecar: &WalpinSidecarState,
+    state: &mut TruncateState,
+    legacy_fallback_interval: Duration,
+) -> bool {
+    if !state.housekeeping_due() || !state.claim_walpin_full_scan_at(Instant::now()) {
+        return false;
+    }
+    if let Some(report) = sidecar
+        .reap_dead_entries_bounded(legacy_fallback_interval)
+        .await
+    {
+        state.cache_walpin_attribution(
+            report,
+            Err("OS holder census is unavailable for a housekeeping-only scan".to_string()),
+            Instant::now(),
+        );
+    }
+    true
 }
 
 fn now_epoch_secs() -> i64 {
@@ -2059,23 +2091,12 @@ pub async fn run_checkpoint_task(
             sidecar
                 .observe(oldest_tx.clone(), config.tx_warn_secs)
                 .await;
-            if truncate_state.housekeeping_due()
-                && truncate_state.claim_walpin_full_scan_at(Instant::now())
-            {
-                if let Some(report) = sidecar
-                    .reap_dead_entries_bounded(legacy_walpin_fallback_interval)
-                    .await
-                {
-                    truncate_state.cache_walpin_attribution(
-                        report,
-                        Err(
-                            "OS holder census is unavailable for a housekeeping-only scan"
-                                .to_string(),
-                        ),
-                        Instant::now(),
-                    );
-                }
-            }
+            let _ = run_walpin_housekeeping_if_due(
+                sidecar,
+                &mut truncate_state,
+                legacy_walpin_fallback_interval,
+            )
+            .await;
         }
 
         // Skipped ticks leave crossing state unchanged — a busy tick must not
@@ -2470,7 +2491,7 @@ fn maybe_truncate(
     }
 
     #[cfg(unix)]
-    let holder_attribution = capture_walpin_attribution_request(pool, truncate_state);
+    let mut holder_attribution = capture_walpin_attribution_request(pool, truncate_state);
     #[cfg(unix)]
     let mut sidecar_attribution = None;
     #[cfg(not(unix))]
@@ -2522,7 +2543,7 @@ fn maybe_truncate(
                     // core is called directly from `run_checkpoint_task` on a
                     // Tokio worker. Hand the immutable request back to that
                     // async owner for an awaited `spawn_blocking` pass.
-                    sidecar_attribution = holder_attribution;
+                    sidecar_attribution = holder_attribution.take();
                 }
                 log_wal_pin_depth(conn);
             }
@@ -2534,6 +2555,14 @@ fn maybe_truncate(
             log_tx_registry_snapshot_warn(wal_pages_before);
             note_truncate_outcome(config, wal_pages_before, truncate_state);
         }
+    }
+    #[cfg(unix)]
+    if let Some(WalpinAttributionRequest::Fresh {
+        previous_last_attempt,
+        ..
+    }) = holder_attribution.as_ref()
+    {
+        truncate_state.restore_walpin_full_scan_reservation(*previous_last_attempt);
     }
     sidecar_attribution
 }
@@ -2746,6 +2775,7 @@ enum WalpinAttributionRequest {
         dir: PathBuf,
         census: Result<crate::walpin::CensusResult, String>,
         legacy_fallback_interval: Duration,
+        previous_last_attempt: Option<Instant>,
     },
     Cached(CachedWalpinAttribution),
     Suppressed,
@@ -2822,10 +2852,13 @@ fn capture_walpin_attribution_request(
     }
     let legacy_fallback_interval = state.legacy_walpin_fallback_interval;
     Some(match state.plan_walpin_attribution_at(Instant::now()) {
-        WalpinFullScanPlan::Refresh => WalpinAttributionRequest::Fresh {
+        WalpinFullScanPlan::Refresh {
+            previous_last_attempt,
+        } => WalpinAttributionRequest::Fresh {
             dir: crate::walpin::sidecar_dir_for(path),
             census: crate::walpin::census_holders(path).map_err(|error| error.to_string()),
             legacy_fallback_interval,
+            previous_last_attempt,
         },
         WalpinFullScanPlan::Cached(cached) => WalpinAttributionRequest::Cached(cached),
         WalpinFullScanPlan::Suppressed => WalpinAttributionRequest::Suppressed,
@@ -2861,6 +2894,7 @@ async fn complete_walpin_attribution(
             dir,
             census,
             legacy_fallback_interval,
+            previous_last_attempt: _,
         } => {
             state.sidecar_attribution_attempted_this_tick = true;
             if state.walpin_full_scan_last_attempt.is_none() {
@@ -3432,7 +3466,7 @@ mod tests {
 
         assert!(matches!(
             state.plan_walpin_attribution_at(started_at),
-            WalpinFullScanPlan::Refresh
+            WalpinFullScanPlan::Refresh { .. }
         ));
         state.cache_walpin_attribution(
             crate::walpin::WalpinReport::default(),
@@ -3446,7 +3480,7 @@ mod tests {
         ));
         assert!(matches!(
             state.plan_walpin_attribution_at(started_at + cadence),
-            WalpinFullScanPlan::Refresh
+            WalpinFullScanPlan::Refresh { .. }
         ));
     }
 
@@ -3459,7 +3493,7 @@ mod tests {
 
         assert!(matches!(
             state.plan_walpin_attribution_at(started_at),
-            WalpinFullScanPlan::Refresh
+            WalpinFullScanPlan::Refresh { .. }
         ));
         // No cache update models either an enumeration error or a panicked
         // blocking worker. The attempt itself still owns the cadence slot.
@@ -3469,7 +3503,7 @@ mod tests {
         ));
         assert!(matches!(
             state.plan_walpin_attribution_at(started_at + cadence),
-            WalpinFullScanPlan::Refresh
+            WalpinFullScanPlan::Refresh { .. }
         ));
     }
 
@@ -3515,6 +3549,105 @@ mod tests {
             }),
             "cached attribution must never authorize the fully-attributed conclusion: {events:?}"
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    #[cfg(unix)]
+    #[serial(checkpoint_skip_metrics, khive_walpin_sidecar_env)]
+    async fn progressing_truncate_releases_full_scan_reservation_to_housekeeping() {
+        let _env_guard = crate::walpin::EnvVarGuard::capture("KHIVE_WALPIN_SIDECAR");
+        std::env::set_var("KHIVE_WALPIN_SIDECAR", "1");
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("walpin-progress-reservation.db");
+        let pool = file_pool(&path);
+        {
+            let writer = pool.try_writer().unwrap();
+            writer
+                .conn()
+                .execute_batch("CREATE TABLE t (x INTEGER); INSERT INTO t VALUES (1);")
+                .unwrap();
+        }
+        let conn = checkpoint_conn(&pool);
+        let mut state = TruncateState::default();
+        let config = CheckpointConfig {
+            truncate_high_water_pages: 0,
+            truncate_min_interval: Duration::ZERO,
+            ..CheckpointConfig::default()
+        };
+
+        assert!(
+            maybe_truncate(&pool, &conn, &config, u64::MAX, &mut state).is_none(),
+            "a progressing TRUNCATE must not schedule no-progress attribution"
+        );
+        assert!(
+            state.housekeeping_due(),
+            "unused pre-TRUNCATE reservation must be restored before housekeeping"
+        );
+        let sidecar =
+            WalpinSidecarState::new(pool.canonical_path(), true, "daemon", config.interval)
+                .expect("file-backed test sidecar");
+        assert!(
+            run_walpin_housekeeping_if_due(&sidecar, &mut state, DEFAULT_SESSION_SWEEP_INTERVAL,)
+                .await,
+            "the production housekeeping arm must consume one full scan"
+        );
+        assert!(state.walpin_cached_attribution.is_some());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    #[cfg(unix)]
+    #[serial(checkpoint_skip_metrics, khive_walpin_sidecar_env)]
+    async fn erroring_truncate_releases_full_scan_reservation_to_housekeeping() {
+        let _env_guard = crate::walpin::EnvVarGuard::capture("KHIVE_WALPIN_SIDECAR");
+        std::env::set_var("KHIVE_WALPIN_SIDECAR", "1");
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("walpin-error-reservation.db");
+        let pool = file_pool(&path);
+        {
+            let writer = pool.try_writer().unwrap();
+            writer
+                .conn()
+                .execute_batch("CREATE TABLE t (x INTEGER); INSERT INTO t VALUES (1);")
+                .unwrap();
+        }
+        let conn = checkpoint_conn(&pool);
+        conn.authorizer(Some(
+            |context: rusqlite::hooks::AuthContext<'_>| match context.action {
+                AuthAction::Pragma { pragma_name, .. }
+                    if pragma_name.eq_ignore_ascii_case("wal_checkpoint") =>
+                {
+                    Authorization::Deny
+                }
+                _ => Authorization::Allow,
+            },
+        ))
+        .unwrap();
+        let mut state = TruncateState::default();
+        let config = CheckpointConfig {
+            truncate_high_water_pages: 0,
+            truncate_min_interval: Duration::ZERO,
+            ..CheckpointConfig::default()
+        };
+
+        assert!(
+            maybe_truncate(&pool, &conn, &config, u64::MAX, &mut state).is_none(),
+            "an erroring TRUNCATE must not schedule no-progress attribution"
+        );
+        conn.authorizer(None::<fn(rusqlite::hooks::AuthContext<'_>) -> Authorization>)
+            .unwrap();
+        assert!(
+            state.housekeeping_due(),
+            "failed TRUNCATE must restore its unused full-scan reservation"
+        );
+        let sidecar =
+            WalpinSidecarState::new(pool.canonical_path(), true, "daemon", config.interval)
+                .expect("file-backed test sidecar");
+        assert!(
+            run_walpin_housekeeping_if_due(&sidecar, &mut state, DEFAULT_SESSION_SWEEP_INTERVAL,)
+                .await,
+            "the production housekeeping arm must consume one full scan"
+        );
+        assert!(state.walpin_cached_attribution.is_some());
     }
 
     struct ReaderProcess {
@@ -3736,6 +3869,7 @@ mod tests {
             dir: sidecar_dir,
             census: Ok(crate::walpin::CensusResult::default()),
             legacy_fallback_interval: DEFAULT_SESSION_SWEEP_INTERVAL,
+            previous_last_attempt: None,
         });
         let completion = tokio::spawn(async move {
             let result = complete_walpin_attribution(request, &mut state).await;
@@ -3794,6 +3928,7 @@ mod tests {
             dir: sidecar_dir,
             census: Ok(crate::walpin::CensusResult::default()),
             legacy_fallback_interval: DEFAULT_SESSION_SWEEP_INTERVAL,
+            previous_last_attempt: None,
         });
 
         let error = complete_walpin_attribution(request, &mut state)
@@ -3884,7 +4019,7 @@ mod tests {
             .find("complete_walpin_attribution(")
             .expect("awaited attribution completion");
         let housekeeping = task
-            .find("reap_dead_entries_bounded(legacy_walpin_fallback_interval)")
+            .find("run_walpin_housekeeping_if_due(")
             .expect("fallback housekeeping");
         let outcome = task
             .find("observe_checkpoint_pressure_tick(")
@@ -3892,6 +4027,15 @@ mod tests {
         assert!(
             checkpoint < completion && completion < housekeeping && housekeeping < outcome,
             "tick ordering must be checkpoint -> awaited attribution -> housekeeping decision -> outcome"
+        );
+        let housekeeping_helper = section(
+            source,
+            "async fn run_walpin_housekeeping_if_due(",
+            "fn now_epoch_secs()",
+        );
+        assert!(
+            housekeeping_helper.contains("reap_dead_entries_bounded(legacy_fallback_interval)"),
+            "the ordered housekeeping arm must retain the bounded full scan"
         );
 
         // The outcome decision itself moved into the extracted per-tick


### PR DESCRIPTION
## What changed

- share one 30-second full-enumeration cadence between ordinary WAL-pin housekeeping and TRUNCATE no-progress attribution
- cache the last successful report for intermediate diagnostics without treating cached evidence as current attribution
- reserve the cadence slot before blocking work starts, so enumeration failures and worker panics retry only after the interval
- add focused tests for first scan, interval suppression, boundary refresh, failure retry cadence, and cached-report fail-closed behavior

## Why

Repeated `enumerate_live_bounded` walks amplified CPU load during sustained WAL pressure. This keeps the checkpoint retry loop unchanged while bounding the expensive process/sidecar census.

Cached evidence is deliberately diagnostic-only: even a cached report whose entries are otherwise fully attributed receives an unresolved sentinel and cannot license the sharper fully-attributed conclusion.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `git diff --check`
- source invariants for the 30-second gate, cached path, and fail-closed sentinel
- no local Cargo build/test in this first draft; remote CI is the build/test authority for this disk-guarded campaign

Fixes #1924
