### PR TITLE
test(runtime): add fail-closed writer census scaffold

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -39,6 +39,9 @@ phase_lint() {
 
     echo "=== Local Build Artifact Verification Tests ==="
     python3 "$SCRIPT_DIR/tests/test_verify_local_artifact.py"
+
+    echo "=== Writer Census Contract Tests ==="
+    python3 "$SCRIPT_DIR/tests/test_writer_census.py"
 }
 
 phase_no_stubs_scan() {

--- a/scripts/data/writer-census-v1.json
+++ b/scripts/data/writer-census-v1.json
@@ -1,0 +1,235 @@
+{
+  "schema_version": "khive.writer-census.manifest.v1",
+  "source_revision": "288b9eee1f471d505e7f5de33e121c58773a10af",
+  "pack_set": [
+    "kg",
+    "gtd",
+    "memory",
+    "brain",
+    "comm",
+    "schedule",
+    "knowledge",
+    "session",
+    "git",
+    "code",
+    "workspace",
+    "blob"
+  ],
+  "inventory": {
+    "kg": [
+      "create",
+      "get",
+      "list",
+      "stats",
+      "update",
+      "delete",
+      "merge",
+      "search",
+      "link",
+      "neighbors",
+      "traverse",
+      "context",
+      "query",
+      "propose",
+      "review",
+      "withdraw",
+      "resolve",
+      "whoami",
+      "db_diagnostics",
+      "verbs"
+    ],
+    "gtd": [
+      "gtd.assign",
+      "gtd.next",
+      "gtd.complete",
+      "gtd.tasks",
+      "gtd.transition"
+    ],
+    "memory": [
+      "memory.remember",
+      "memory.feedback",
+      "memory.recall",
+      "memory.prune",
+      "memory.vacuum"
+    ],
+    "brain": [
+      "brain.event_counts",
+      "brain.profiles",
+      "brain.profile",
+      "brain.resolve",
+      "brain.activate",
+      "brain.deactivate",
+      "brain.archive",
+      "brain.reset",
+      "brain.feedback",
+      "brain.auto_feedback",
+      "brain.mark_turn",
+      "brain.bind",
+      "brain.unbind",
+      "brain.bindings",
+      "brain.create_profile",
+      "brain.register_adapter"
+    ],
+    "comm": [
+      "comm.send",
+      "comm.delivered",
+      "comm.inbox",
+      "comm.read",
+      "comm.mark_read",
+      "comm.unread",
+      "comm.reply",
+      "comm.thread",
+      "comm.health",
+      "comm.probe"
+    ],
+    "schedule": [
+      "schedule.remind",
+      "schedule.schedule",
+      "schedule.agenda",
+      "schedule.cancel"
+    ],
+    "knowledge": [
+      "knowledge.upsert_atoms",
+      "knowledge.upsert_domains",
+      "knowledge.get",
+      "knowledge.list",
+      "knowledge.delete_atoms",
+      "knowledge.stats",
+      "knowledge.index",
+      "knowledge.fold",
+      "knowledge.search",
+      "knowledge.suggest",
+      "knowledge.compose",
+      "knowledge.edit",
+      "knowledge.import",
+      "knowledge.challenge",
+      "knowledge.adjudicate",
+      "knowledge.learn",
+      "knowledge.cite",
+      "knowledge.topic",
+      "knowledge.feedback"
+    ],
+    "session": [
+      "session.store",
+      "session.list",
+      "session.resume",
+      "session.export"
+    ],
+    "git": [
+      "git.digest",
+      "git.commit",
+      "git.branch",
+      "git.push"
+    ],
+    "code": [
+      "code.ingest"
+    ],
+    "workspace": [],
+    "blob": [
+      "blob.put",
+      "blob.get",
+      "blob.stat"
+    ]
+  },
+  "control": {
+    "verb": "comm.read",
+    "required_classification": "WRITER"
+  },
+  "defaults": {
+    "classification": "UNKNOWN",
+    "reason": "intrinsic handler writer trace is not complete in tranche 1",
+    "paths": [
+      {
+        "classification": "WRITER-COND",
+        "condition": "event_store_configured",
+        "kind": "dispatch_audit",
+        "symbol": "VerbRegistry::dispatch_with_identity -> EventStore::append_event",
+        "evidence": {
+          "path": "crates/khive-runtime/src/pack.rs",
+          "required_patterns": [
+            "async fn append_audit_event_best_effort(",
+            "store.append_event(event).await"
+          ]
+        }
+      }
+    ]
+  },
+  "internal_handlers": {
+    "brain.record_serve": {
+      "classification": "WRITER-COND",
+      "reason": "non-empty serve batches acquire SqlWriter once",
+      "paths": [
+        {
+          "classification": "WRITER-COND",
+          "condition": "target_ids_non_empty",
+          "kind": "sqlite",
+          "symbol": "serve_ledger::record_serves -> SqlAccess::writer",
+          "evidence": {
+            "path": "crates/khive-pack-brain/src/serve_ledger.rs",
+            "required_patterns": [
+              "pub(crate) async fn record_serves(",
+              "let mut writer = sql.writer().await"
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "overrides": {
+    "comm.read": {
+      "classification": "WRITER",
+      "reason": "a valid inbound target attempts an atomic read-flag update",
+      "paths": [
+        {
+          "classification": "WRITER",
+          "kind": "sqlite",
+          "symbol": "mark_read_target -> NoteStore::try_patch_note_property",
+          "evidence": {
+            "path": "crates/khive-pack-comm/src/handlers.rs",
+            "required_patterns": [
+              "async fn mark_read_target(",
+              ".try_patch_note_property("
+            ]
+          }
+        }
+      ]
+    },
+    "memory.recall": {
+      "classification": "UNKNOWN",
+      "reason": "direct handler trace is incomplete; one nested writer is recorded",
+      "paths": [],
+      "nested_dispatches": [
+        {
+          "condition": "brain pack registered and recall returns target ids",
+          "target": "brain.record_serve",
+          "via_registry": true
+        }
+      ]
+    },
+    "blob.put": {
+      "classification": "UNKNOWN",
+      "reason": "object-store mutation is known but the shared SQLite writer path is untraced",
+      "paths": []
+    },
+    "code.ingest": {
+      "classification": "UNKNOWN",
+      "reason": "dedicated map-database writer path is not reconciled with the shared writer census",
+      "paths": []
+    },
+    "git.branch": {
+      "classification": "UNKNOWN",
+      "reason": "external git mutation remains outside the completed SQLite writer trace",
+      "paths": []
+    },
+    "git.commit": {
+      "classification": "UNKNOWN",
+      "reason": "external git mutation remains outside the completed SQLite writer trace",
+      "paths": []
+    },
+    "git.push": {
+      "classification": "UNKNOWN",
+      "reason": "external git mutation remains outside the completed SQLite writer trace",
+      "paths": []
+    }
+  }
+}

--- a/scripts/tests/test_writer_census.py
+++ b/scripts/tests/test_writer_census.py
@@ -234,7 +234,7 @@ class WriterCensusTests(unittest.TestCase):
         self.assertNotIn("entries", report)
         self.assertIn("comm.read", " ".join(report["errors"]))
 
-    def test_unreachable_observed_revision_voids_run_via_control(self):
+    def test_unreachable_observed_revision_fails_closed(self):
         report = self.census.build_report(
             manifest(),
             inventory(
@@ -247,23 +247,64 @@ class WriterCensusTests(unittest.TestCase):
 
         self.assertEqual(report["status"], "VOID")
         self.assertNotIn("entries", report)
-        self.assertIn("control", " ".join(report["errors"]))
+        self.assertIn(
+            "does not resolve to a commit", " ".join(report["errors"])
+        )
+
+    def test_tree_object_observed_revision_fails_closed(self):
+        tree_revision = subprocess.run(
+            ["git", "rev-parse", "HEAD^{tree}"],
+            cwd=REPO_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        self.assertNotEqual(tree_revision, SOURCE_REVISION)
+
+        report = self.census.build_report(
+            manifest(),
+            inventory(
+                ("comm", "comm.read"),
+                ("memory", "memory.recall"),
+                packs=("comm", "memory", "brain"),
+            ),
+            observed_revision=tree_revision,
+        )
+
+        self.assertEqual(report["status"], "VOID")
+        self.assertNotIn("entries", report)
+        self.assertIn(
+            "does not resolve to a commit", " ".join(report["errors"])
+        )
 
     def test_revision_mismatch_reverifies_evidence_at_observed_revision(self):
         if PARENT_REVISION is None:
             self.skipTest("HEAD~1 unavailable (shallow clone)")
         pinned_elsewhere = manifest()
         pinned_elsewhere["source_revision"] = PARENT_REVISION
-        report = self.census.build_report(
-            pinned_elsewhere,
-            inventory(
-                ("comm", "comm.read"),
-                ("memory", "memory.recall"),
-                packs=("comm", "memory", "brain"),
-            ),
-            observed_revision=SOURCE_REVISION,
-        )
+        verified_at: list[str] = []
+        original_verify = self.census._verify_path_evidence
 
+        def recording_verify(path, repo_root, revision):
+            verified_at.append(revision)
+            return original_verify(path, repo_root, revision)
+
+        self.census._verify_path_evidence = recording_verify
+        try:
+            report = self.census.build_report(
+                pinned_elsewhere,
+                inventory(
+                    ("comm", "comm.read"),
+                    ("memory", "memory.recall"),
+                    packs=("comm", "memory", "brain"),
+                ),
+                observed_revision=SOURCE_REVISION,
+            )
+        finally:
+            self.census._verify_path_evidence = original_verify
+
+        self.assertTrue(verified_at)
+        self.assertEqual(set(verified_at), {SOURCE_REVISION})
         self.assertEqual(report["status"], "OK")
         self.assertEqual(report["control"]["status"], "PASS")
         self.assertIn(

--- a/scripts/tests/test_writer_census.py
+++ b/scripts/tests/test_writer_census.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Contract tests for the fail-closed writer-path census."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "writer_census.py"
+SOURCE_REVISION = subprocess.run(
+    ["git", "rev-parse", "HEAD"],
+    cwd=REPO_ROOT,
+    check=True,
+    capture_output=True,
+    text=True,
+).stdout.strip()
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("writer_census", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def inventory(
+    *verbs: tuple[str, str], packs: tuple[str, ...] = ()
+) -> list[dict]:
+    by_pack: dict[str, list[dict]] = {pack: [] for pack in packs}
+    for pack, verb in verbs:
+        by_pack.setdefault(pack, []).append(
+            {"name": verb, "visibility": "verb"}
+        )
+    return [
+        {"name": pack, "verbs": entries}
+        for pack, entries in sorted(by_pack.items())
+    ]
+
+
+def manifest(*, control_classification: str = "WRITER") -> dict:
+    return {
+        "schema_version": "khive.writer-census.manifest.v1",
+        "source_revision": SOURCE_REVISION,
+        "pack_set": ["comm", "memory", "brain"],
+        "inventory": {
+            "comm": ["comm.read"],
+            "memory": ["memory.recall"],
+            "brain": [],
+        },
+        "control": {
+            "verb": "comm.read",
+            "required_classification": "WRITER",
+        },
+        "defaults": {
+            "classification": "UNKNOWN",
+            "reason": "handler trace incomplete",
+            "paths": [
+                {
+                    "classification": "WRITER-COND",
+                    "condition": "event_store_configured",
+                    "kind": "dispatch_audit",
+                    "symbol": "VerbRegistry::dispatch_with_identity",
+                    "evidence": {
+                        "path": "crates/khive-runtime/src/pack.rs",
+                        "required_patterns": [
+                            "async fn append_audit_event_best_effort(",
+                            "store.append_event(event).await",
+                        ],
+                    },
+                }
+            ],
+        },
+        "internal_handlers": {
+            "brain.record_serve": {
+                "classification": "WRITER",
+                "reason": "serve ledger batch acquires SqlWriter",
+                "paths": [
+                    {
+                        "classification": "WRITER",
+                        "kind": "sqlite",
+                        "symbol": "serve_ledger::record_serves -> SqlAccess::writer",
+                        "evidence": {
+                            "path": "crates/khive-pack-brain/src/serve_ledger.rs",
+                            "required_patterns": [
+                                "pub(crate) async fn record_serves(",
+                                "let mut writer = sql.writer().await",
+                            ],
+                        },
+                    }
+                ],
+            }
+        },
+        "overrides": {
+            "comm.read": {
+                "classification": control_classification,
+                "reason": "read flag mutation attempts a SQLite write",
+                "paths": [
+                    {
+                        "classification": "WRITER",
+                        "kind": "sqlite",
+                        "symbol": "mark_read_target -> try_patch_note_property",
+                        "evidence": {
+                            "path": "crates/khive-pack-comm/src/handlers.rs",
+                            "required_patterns": [
+                                "async fn mark_read_target(",
+                                ".try_patch_note_property(",
+                            ],
+                        },
+                    }
+                ],
+            },
+            "memory.recall": {
+                "classification": "UNKNOWN",
+                "reason": "direct handler trace incomplete",
+                "nested_dispatches": [
+                    {
+                        "condition": "brain pack registered and results non-empty",
+                        "target": "brain.record_serve",
+                        "via_registry": True,
+                    }
+                ],
+            },
+        },
+    }
+
+
+class WriterCensusTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.census = load_module()
+
+    def test_missing_manifest_entry_fails_closed_and_output_is_stable(self):
+        data = manifest()
+        data["inventory"]["memory"] = []
+        del data["overrides"]["memory.recall"]
+        live = inventory(
+            ("comm", "comm.read"),
+            ("memory", "memory.recall"),
+            packs=("comm", "memory", "brain"),
+        )
+
+        first = self.census.build_report(
+            data, live, observed_revision=SOURCE_REVISION
+        )
+        second = self.census.build_report(
+            data, live, observed_revision=SOURCE_REVISION
+        )
+
+        self.assertEqual(first["status"], "OK")
+        by_verb = {entry["verb"]: entry for entry in first["entries"]}
+        self.assertEqual(by_verb["memory.recall"]["classification"], "UNKNOWN")
+        self.assertEqual(
+            by_verb["memory.recall"]["reason"], "manifest entry missing"
+        )
+        self.assertEqual(
+            self.census.canonical_json(first), self.census.canonical_json(second)
+        )
+
+    def test_missing_known_positive_voids_run_without_a_table(self):
+        report = self.census.build_report(
+            manifest(control_classification="UNKNOWN"),
+            inventory(
+                ("comm", "comm.read"),
+                ("memory", "memory.recall"),
+                packs=("comm", "memory", "brain"),
+            ),
+            observed_revision=SOURCE_REVISION,
+        )
+
+        self.assertEqual(report["status"], "VOID")
+        self.assertNotIn("entries", report)
+        self.assertNotIn("summary", report)
+        self.assertIn("comm.read", " ".join(report["errors"]))
+
+    def test_nested_dispatch_is_resolved_in_the_public_row(self):
+        report = self.census.build_report(
+            manifest(),
+            inventory(
+                ("comm", "comm.read"),
+                ("memory", "memory.recall"),
+                packs=("comm", "memory", "brain"),
+            ),
+            observed_revision=SOURCE_REVISION,
+        )
+
+        recall = next(
+            entry for entry in report["entries"] if entry["verb"] == "memory.recall"
+        )
+        self.assertEqual(recall["classification"], "UNKNOWN")
+        nested = recall["nested_dispatches"]
+        self.assertEqual(len(nested), 1)
+        self.assertEqual(nested[0]["target"], "brain.record_serve")
+        self.assertEqual(nested[0]["resolved_classification"], "WRITER")
+        self.assertEqual(
+            {path["symbol"] for path in nested[0]["writer_paths"]},
+            {
+                "VerbRegistry::dispatch_with_identity",
+                "serve_ledger::record_serves -> SqlAccess::writer",
+            },
+        )
+
+    def test_stale_known_positive_evidence_voids_run(self):
+        data = manifest()
+        data["overrides"]["comm.read"]["paths"][0]["evidence"][
+            "required_patterns"
+        ].append("this pattern cannot exist in the pinned source")
+
+        report = self.census.build_report(
+            data,
+            inventory(
+                ("comm", "comm.read"),
+                ("memory", "memory.recall"),
+                packs=("comm", "memory", "brain"),
+            ),
+            observed_revision=SOURCE_REVISION,
+            repo_root=REPO_ROOT,
+        )
+
+        self.assertEqual(report["status"], "VOID")
+        self.assertNotIn("entries", report)
+        self.assertIn("comm.read", " ".join(report["errors"]))
+
+    def test_artifact_revision_mismatch_voids_run(self):
+        report = self.census.build_report(
+            manifest(),
+            inventory(
+                ("comm", "comm.read"),
+                ("memory", "memory.recall"),
+                packs=("comm", "memory", "brain"),
+            ),
+            observed_revision="b" * 40,
+        )
+
+        self.assertEqual(report["status"], "VOID")
+        self.assertNotIn("entries", report)
+        self.assertIn("revision", " ".join(report["errors"]))
+
+    def test_ci_lint_phase_runs_writer_census_contracts(self):
+        ci = (REPO_ROOT / "scripts" / "ci.sh").read_text()
+        self.assertIn(
+            'python3 "$SCRIPT_DIR/tests/test_writer_census.py"', ci
+        )
+
+    def test_closed_vocabulary_rejects_unreviewed_classification(self):
+        data = manifest()
+        data["overrides"]["comm.read"]["classification"] = "MAYBE"
+
+        with self.assertRaisesRegex(self.census.CensusError, "MAYBE"):
+            self.census.build_report(
+                data,
+                inventory(
+                    ("comm", "comm.read"),
+                    ("memory", "memory.recall"),
+                    packs=("comm", "memory", "brain"),
+                ),
+                observed_revision=SOURCE_REVISION,
+            )
+
+    def test_non_string_classification_fails_closed(self):
+        data = manifest()
+        data["defaults"]["classification"] = []
+
+        with self.assertRaisesRegex(self.census.CensusError, "classification"):
+            self.census.build_report(
+                data,
+                inventory(
+                    ("comm", "comm.read"),
+                    ("memory", "memory.recall"),
+                    packs=("comm", "memory", "brain"),
+                ),
+                observed_revision=SOURCE_REVISION,
+            )
+
+    def test_writer_cond_requires_a_named_condition(self):
+        data = manifest()
+        data["defaults"]["paths"][0]["condition"] = "  "
+
+        with self.assertRaisesRegex(self.census.CensusError, "condition"):
+            self.census.build_report(
+                data,
+                inventory(
+                    ("comm", "comm.read"),
+                    ("memory", "memory.recall"),
+                    packs=("comm", "memory", "brain"),
+                ),
+                observed_revision=SOURCE_REVISION,
+            )
+
+    def test_no_writer_cannot_survive_verified_writer_evidence(self):
+        data = manifest()
+        data["overrides"]["memory.recall"] = {
+            "classification": "NO-WRITER",
+            "reason": "synthetic false read-only claim",
+            "trace_complete": True,
+            "paths": [],
+        }
+
+        report = self.census.build_report(
+            data,
+            inventory(
+                ("comm", "comm.read"),
+                ("memory", "memory.recall"),
+                packs=("comm", "memory", "brain"),
+            ),
+            observed_revision=SOURCE_REVISION,
+        )
+
+        recall = next(
+            entry for entry in report["entries"] if entry["verb"] == "memory.recall"
+        )
+        self.assertEqual(recall["classification"], "UNKNOWN")
+        self.assertIn("contradicted", recall["reason"])
+
+    def test_baseline_keeps_untraced_external_paths_unknown(self):
+        baseline = json.loads(
+            (REPO_ROOT / "scripts" / "data" / "writer-census-v1.json").read_text()
+        )
+        unknown = {
+            "blob.put",
+            "code.ingest",
+            "git.branch",
+            "git.commit",
+            "git.push",
+        }
+        self.assertEqual(
+            {
+                verb
+                for verb in unknown
+                if baseline["overrides"][verb]["classification"] == "UNKNOWN"
+            },
+            unknown,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_writer_census.py
+++ b/scripts/tests/test_writer_census.py
@@ -19,6 +19,14 @@ SOURCE_REVISION = subprocess.run(
     capture_output=True,
     text=True,
 ).stdout.strip()
+_parent = subprocess.run(
+    ["git", "rev-parse", "--verify", "HEAD~1"],
+    cwd=REPO_ROOT,
+    check=False,
+    capture_output=True,
+    text=True,
+)
+PARENT_REVISION = _parent.stdout.strip() if _parent.returncode == 0 else None
 
 
 def load_module():
@@ -226,7 +234,7 @@ class WriterCensusTests(unittest.TestCase):
         self.assertNotIn("entries", report)
         self.assertIn("comm.read", " ".join(report["errors"]))
 
-    def test_artifact_revision_mismatch_voids_run(self):
+    def test_unreachable_observed_revision_voids_run_via_control(self):
         report = self.census.build_report(
             manifest(),
             inventory(
@@ -239,7 +247,72 @@ class WriterCensusTests(unittest.TestCase):
 
         self.assertEqual(report["status"], "VOID")
         self.assertNotIn("entries", report)
-        self.assertIn("revision", " ".join(report["errors"]))
+        self.assertIn("control", " ".join(report["errors"]))
+
+    def test_revision_mismatch_reverifies_evidence_at_observed_revision(self):
+        if PARENT_REVISION is None:
+            self.skipTest("HEAD~1 unavailable (shallow clone)")
+        pinned_elsewhere = manifest()
+        pinned_elsewhere["source_revision"] = PARENT_REVISION
+        report = self.census.build_report(
+            pinned_elsewhere,
+            inventory(
+                ("comm", "comm.read"),
+                ("memory", "memory.recall"),
+                packs=("comm", "memory", "brain"),
+            ),
+            observed_revision=SOURCE_REVISION,
+        )
+
+        self.assertEqual(report["status"], "OK")
+        self.assertEqual(report["control"]["status"], "PASS")
+        self.assertIn(
+            "re-verified at the observed revision",
+            " ".join(report["warnings"]),
+        )
+
+    def test_absent_observed_revision_still_voids_run(self):
+        report = self.census.build_report(
+            manifest(),
+            inventory(
+                ("comm", "comm.read"),
+                ("memory", "memory.recall"),
+                packs=("comm", "memory", "brain"),
+            ),
+            observed_revision=None,
+        )
+
+        self.assertEqual(report["status"], "VOID")
+        self.assertIn("absent or invalid", " ".join(report["errors"]))
+
+    def test_no_writer_without_surviving_evidence_fails_closed(self):
+        stripped = manifest()
+        stripped["overrides"]["memory.recall"] = {
+            "classification": "NO-WRITER",
+            "reason": "declared read-only",
+            "trace_complete": True,
+            "inherit_default_paths": False,
+            "paths": [],
+        }
+        report = self.census.build_report(
+            manifest=stripped,
+            observed_inventory=inventory(
+                ("comm", "comm.read"),
+                ("memory", "memory.recall"),
+                packs=("comm", "memory", "brain"),
+            ),
+            observed_revision=SOURCE_REVISION,
+        )
+
+        self.assertEqual(report["status"], "OK")
+        entry = next(
+            row for row in report["entries"] if row["verb"] == "memory.recall"
+        )
+        self.assertEqual(entry["classification"], "UNKNOWN")
+        self.assertIn(
+            "no verified read-only evidence",
+            entry["reason"],
+        )
 
     def test_ci_lint_phase_runs_writer_census_contracts(self):
         ci = (REPO_ROOT / "scripts" / "ci.sh").read_text()

--- a/scripts/writer_census.py
+++ b/scripts/writer_census.py
@@ -275,6 +275,16 @@ def _sorted_paths(paths: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return sorted(paths, key=canonical_json)
 
 
+def _revision_is_commit(repo_root: Path, revision: str) -> bool:
+    completed = subprocess.run(
+        ["git", "-C", str(repo_root), "cat-file", "-t", revision],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return completed.returncode == 0 and completed.stdout.strip() == "commit"
+
+
 def _verify_path_evidence(
     path: dict[str, Any], repo_root: Path, revision: str
 ) -> tuple[dict[str, Any], str | None]:
@@ -499,6 +509,11 @@ def build_report(
     ):
         errors.append(
             "observed artifact revision is absent or invalid; census is void"
+        )
+    elif not _revision_is_commit(repo_root, observed_revision):
+        errors.append(
+            "observed artifact revision does not resolve to a commit; "
+            "census is void"
         )
     elif observed_revision != checked["source_revision"]:
         evidence_revision = observed_revision

--- a/scripts/writer_census.py
+++ b/scripts/writer_census.py
@@ -1,0 +1,668 @@
+#!/usr/bin/env python3
+"""Render a stable, fail-closed writer-path census from pack introspection."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+from typing import Any
+
+
+SCHEMA = "khive.writer-census.manifest.v1"
+REPORT_SCHEMA = "khive.writer-census.report.v1"
+CLASSIFICATIONS = frozenset(
+    {"WRITER", "WRITER-COND", "NO-WRITER", "UNKNOWN"}
+)
+DEFAULT_MANIFEST = Path(__file__).with_name("data") / "writer-census-v1.json"
+DEFAULT_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class CensusError(ValueError):
+    """The manifest or observed inventory cannot produce a sound census."""
+
+
+def canonical_json(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n"
+
+
+def _classification(value: Any, context: str) -> str:
+    if not isinstance(value, str) or value not in CLASSIFICATIONS:
+        raise CensusError(
+            f"{context}: invalid classification {value!r}; expected one of "
+            f"{sorted(CLASSIFICATIONS)}"
+        )
+    return value
+
+
+def _string_list(value: Any, context: str) -> list[str]:
+    if not isinstance(value, list) or any(
+        not isinstance(item, str) or not item for item in value
+    ):
+        raise CensusError(f"{context}: expected a list of non-empty strings")
+    if len(value) != len(set(value)):
+        raise CensusError(f"{context}: duplicate values are not allowed")
+    return value
+
+
+def _validate_path(path: Any, context: str) -> dict[str, Any]:
+    if not isinstance(path, dict):
+        raise CensusError(f"{context}: writer path must be an object")
+    normalized = dict(path)
+    normalized["classification"] = _classification(
+        normalized.get("classification"), f"{context}.classification"
+    )
+    for field in ("kind", "symbol"):
+        if not isinstance(normalized.get(field), str) or not normalized[field]:
+            raise CensusError(f"{context}.{field}: expected a non-empty string")
+    if normalized["classification"] == "WRITER-COND" and (
+        not isinstance(normalized.get("condition"), str)
+        or not normalized["condition"].strip()
+    ):
+        raise CensusError(
+            f"{context}.condition: WRITER-COND paths must name their condition"
+        )
+    if normalized["classification"] != "UNKNOWN":
+        evidence = normalized.get("evidence")
+        if not isinstance(evidence, dict):
+            raise CensusError(
+                f"{context}.evidence: known writer paths require pinned source evidence"
+            )
+        evidence_path = evidence.get("path")
+        if (
+            not isinstance(evidence_path, str)
+            or not evidence_path
+            or Path(evidence_path).is_absolute()
+            or ".." in Path(evidence_path).parts
+        ):
+            raise CensusError(
+                f"{context}.evidence.path: expected a repository-relative path"
+            )
+        _string_list(
+            evidence.get("required_patterns"),
+            f"{context}.evidence.required_patterns",
+        )
+    return normalized
+
+
+def _validate_entry(entry: Any, context: str) -> dict[str, Any]:
+    if not isinstance(entry, dict):
+        raise CensusError(f"{context}: expected an object")
+    normalized = dict(entry)
+    normalized["classification"] = _classification(
+        normalized.get("classification"), f"{context}.classification"
+    )
+    if not isinstance(normalized.get("reason"), str) or not normalized["reason"]:
+        raise CensusError(f"{context}.reason: expected a non-empty string")
+    paths = normalized.get("paths", [])
+    if not isinstance(paths, list):
+        raise CensusError(f"{context}.paths: expected a list")
+    normalized["paths"] = [
+        _validate_path(path, f"{context}.paths[{index}]")
+        for index, path in enumerate(paths)
+    ]
+    nested = normalized.get("nested_dispatches", [])
+    if not isinstance(nested, list):
+        raise CensusError(f"{context}.nested_dispatches: expected a list")
+    for index, dispatch in enumerate(nested):
+        if not isinstance(dispatch, dict):
+            raise CensusError(
+                f"{context}.nested_dispatches[{index}]: expected an object"
+            )
+        for field in ("target", "condition"):
+            if not isinstance(dispatch.get(field), str) or not dispatch[field]:
+                raise CensusError(
+                    f"{context}.nested_dispatches[{index}].{field}: "
+                    "expected a non-empty string"
+                )
+        if dispatch.get("via_registry") is not True:
+            raise CensusError(
+                f"{context}.nested_dispatches[{index}].via_registry: "
+                "nested dispatches in v1 must explicitly traverse the registry"
+            )
+    if normalized["classification"] == "WRITER" and not any(
+        path["classification"] == "WRITER" for path in normalized["paths"]
+    ):
+        raise CensusError(
+            f"{context}: WRITER classification requires a WRITER path"
+        )
+    if (
+        normalized["classification"] == "NO-WRITER"
+        and normalized.get("trace_complete") is not True
+    ):
+        raise CensusError(
+            f"{context}: NO-WRITER requires trace_complete=true; absence of "
+            "evidence is UNKNOWN"
+        )
+    return normalized
+
+
+def _validate_manifest(manifest: Any) -> dict[str, Any]:
+    if not isinstance(manifest, dict):
+        raise CensusError("manifest: expected an object")
+    if manifest.get("schema_version") != SCHEMA:
+        raise CensusError(
+            f"manifest.schema_version: expected {SCHEMA!r}, got "
+            f"{manifest.get('schema_version')!r}"
+        )
+    revision = manifest.get("source_revision")
+    if not isinstance(revision, str) or re.fullmatch(r"[0-9a-f]{40}", revision) is None:
+        raise CensusError(
+            "manifest.source_revision: expected a lowercase 40-hex commit"
+        )
+    pack_set = _string_list(manifest.get("pack_set"), "manifest.pack_set")
+    inventory = manifest.get("inventory")
+    if not isinstance(inventory, dict):
+        raise CensusError("manifest.inventory: expected an object")
+    if set(inventory) != set(pack_set):
+        raise CensusError(
+            "manifest.inventory keys must exactly match manifest.pack_set"
+        )
+    public_owner: dict[str, str] = {}
+    for pack in pack_set:
+        for verb in _string_list(
+            inventory[pack], f"manifest.inventory.{pack}"
+        ):
+            if verb in public_owner:
+                raise CensusError(
+                    f"manifest.inventory: verb {verb!r} appears in both "
+                    f"{public_owner[verb]!r} and {pack!r}"
+                )
+            public_owner[verb] = pack
+
+    defaults = _validate_entry(manifest.get("defaults"), "manifest.defaults")
+    if defaults["classification"] != "UNKNOWN":
+        raise CensusError(
+            "manifest.defaults.classification must be UNKNOWN so untraced "
+            "handlers fail closed"
+        )
+    internal_raw = manifest.get("internal_handlers", {})
+    overrides_raw = manifest.get("overrides", {})
+    if not isinstance(internal_raw, dict) or not isinstance(overrides_raw, dict):
+        raise CensusError("manifest handlers and overrides must be objects")
+    internal = {
+        name: _validate_entry(entry, f"manifest.internal_handlers.{name}")
+        for name, entry in internal_raw.items()
+    }
+    overrides = {
+        name: _validate_entry(entry, f"manifest.overrides.{name}")
+        for name, entry in overrides_raw.items()
+    }
+    unknown_overrides = sorted(set(overrides) - set(public_owner))
+    if unknown_overrides:
+        raise CensusError(
+            "manifest.overrides names verbs outside the pinned inventory: "
+            + ", ".join(unknown_overrides)
+        )
+
+    control = manifest.get("control")
+    if not isinstance(control, dict):
+        raise CensusError("manifest.control: expected an object")
+    control_verb = control.get("verb")
+    if not isinstance(control_verb, str) or not control_verb:
+        raise CensusError("manifest.control.verb: expected a non-empty string")
+    required = _classification(
+        control.get("required_classification"),
+        "manifest.control.required_classification",
+    )
+
+    normalized = dict(manifest)
+    normalized["pack_set"] = pack_set
+    normalized["public_owner"] = public_owner
+    normalized["defaults"] = defaults
+    normalized["internal_handlers"] = internal
+    normalized["overrides"] = overrides
+    normalized["control"] = {
+        "verb": control_verb,
+        "required_classification": required,
+    }
+    return normalized
+
+
+def _observed_inventory(
+    raw: Any, pack_set: list[str]
+) -> tuple[dict[str, str], list[str]]:
+    if not isinstance(raw, list):
+        raise CensusError("observed inventory: expected `kkernel pack list` JSON")
+    selected = set(pack_set)
+    seen_packs: set[str] = set()
+    owner: dict[str, str] = {}
+    for pack in raw:
+        if not isinstance(pack, dict) or not isinstance(pack.get("name"), str):
+            raise CensusError("observed inventory: each pack must name itself")
+        pack_name = pack["name"]
+        if pack_name not in selected:
+            continue
+        if pack_name in seen_packs:
+            raise CensusError(f"observed inventory: duplicate pack {pack_name!r}")
+        seen_packs.add(pack_name)
+        verbs = pack.get("verbs")
+        if not isinstance(verbs, list):
+            raise CensusError(
+                f"observed inventory pack {pack_name!r}: verbs must be a list"
+            )
+        for raw_verb in verbs:
+            if isinstance(raw_verb, str):
+                verb = raw_verb
+                visibility = "verb"
+            elif isinstance(raw_verb, dict):
+                verb = raw_verb.get("name")
+                visibility = raw_verb.get("visibility", "verb")
+            else:
+                raise CensusError(
+                    f"observed inventory pack {pack_name!r}: malformed verb"
+                )
+            if visibility != "verb":
+                continue
+            if not isinstance(verb, str) or not verb:
+                raise CensusError(
+                    f"observed inventory pack {pack_name!r}: verb needs a name"
+                )
+            if verb in owner:
+                raise CensusError(
+                    f"observed inventory: public verb {verb!r} has duplicate owners"
+                )
+            owner[verb] = pack_name
+    missing_packs = sorted(selected - seen_packs)
+    return owner, missing_packs
+
+
+def _sorted_paths(paths: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return sorted(paths, key=canonical_json)
+
+
+def _verify_path_evidence(
+    path: dict[str, Any], repo_root: Path, revision: str
+) -> tuple[dict[str, Any], str | None]:
+    if path["classification"] == "UNKNOWN":
+        return path, None
+    evidence = path["evidence"]
+    completed = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo_root),
+            "show",
+            f"{revision}:{evidence['path']}",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        failure = (
+            f"cannot read {evidence['path']!r} at pinned revision {revision}"
+        )
+    else:
+        missing = [
+            pattern
+            for pattern in evidence["required_patterns"]
+            if pattern not in completed.stdout
+        ]
+        failure = (
+            f"pinned evidence {evidence['path']!r} is missing patterns {missing!r}"
+            if missing
+            else None
+        )
+    if failure is None:
+        return path, None
+    failed = dict(path)
+    failed["classification"] = "UNKNOWN"
+    failed["evidence_error"] = failure
+    return failed, failure
+
+
+def _verified_paths(
+    paths: list[dict[str, Any]],
+    repo_root: Path,
+    revision: str,
+    owner: str,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    verified: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    for path in paths:
+        checked, failure = _verify_path_evidence(path, repo_root, revision)
+        verified.append(checked)
+        if failure is not None:
+            warnings.append(f"{owner}: {failure}")
+    return _sorted_paths(verified), warnings
+
+
+def _effective_classification(
+    declared: str, paths: list[dict[str, Any]]
+) -> str:
+    if declared == "WRITER" and not any(
+        path["classification"] == "WRITER" for path in paths
+    ):
+        return "UNKNOWN"
+    if declared == "WRITER-COND" and not any(
+        path["classification"] == "WRITER-COND" for path in paths
+    ):
+        return "UNKNOWN"
+    if declared == "NO-WRITER" and any(
+        path["classification"] in {"WRITER", "WRITER-COND"}
+        for path in paths
+    ):
+        return "UNKNOWN"
+    return declared
+
+
+def _public_entry(
+    manifest: dict[str, Any],
+    verb: str,
+    pack: str,
+    pinned: bool,
+    repo_root: Path,
+) -> tuple[dict[str, Any], list[str]]:
+    warnings: list[str] = []
+    if not pinned:
+        return (
+            {
+                "classification": "UNKNOWN",
+                "nested_dispatches": [],
+                "pack": pack,
+                "reason": "manifest entry missing",
+                "verb": verb,
+                "writer_paths": [],
+            },
+            [f"observed verb {verb!r} is absent from the pinned manifest"],
+        )
+
+    defaults = manifest["defaults"]
+    override = manifest["overrides"].get(verb)
+    selected = override if override is not None else defaults
+    paths = list(defaults["paths"])
+    if override is not None:
+        if override.get("inherit_default_paths", True):
+            paths.extend(override["paths"])
+        else:
+            paths = list(override["paths"])
+    paths, evidence_warnings = _verified_paths(
+        paths, repo_root, manifest["source_revision"], verb
+    )
+    warnings.extend(evidence_warnings)
+
+    nested_rows: list[dict[str, Any]] = []
+    for dispatch in selected.get("nested_dispatches", []):
+        target = dispatch["target"]
+        target_entry = manifest["internal_handlers"].get(target)
+        target_paths = list(manifest["defaults"]["paths"])
+        if target_entry is None:
+            resolved = "UNKNOWN"
+            warnings.append(
+                f"nested dispatch target {target!r} from {verb!r} is unclassified"
+            )
+        else:
+            target_paths.extend(target_entry["paths"])
+            target_paths, target_warnings = _verified_paths(
+                target_paths,
+                repo_root,
+                manifest["source_revision"],
+                f"{verb} -> {target}",
+            )
+            warnings.extend(target_warnings)
+            resolved = _effective_classification(
+                target_entry["classification"], target_paths
+            )
+        nested_rows.append(
+            {
+                "condition": dispatch["condition"],
+                "resolved_classification": resolved,
+                "target": target,
+                "via_registry": True,
+                "writer_paths": target_paths,
+            }
+        )
+
+    all_writer_paths = paths + [
+        path
+        for nested in nested_rows
+        for path in nested["writer_paths"]
+    ]
+    declared = selected["classification"]
+    effective = _effective_classification(declared, all_writer_paths)
+    reason = selected["reason"]
+    if effective != declared:
+        if declared == "NO-WRITER":
+            reason = "declared NO-WRITER is contradicted by verified writer evidence"
+        else:
+            reason = f"declared {declared} lacks verified matching writer evidence"
+        warnings.append(f"{verb}: {reason}")
+
+    return (
+        {
+            "classification": effective,
+            "nested_dispatches": sorted(
+                nested_rows, key=lambda row: (row["target"], row["condition"])
+            ),
+            "pack": pack,
+            "reason": reason,
+            "verb": verb,
+            "writer_paths": _sorted_paths(paths),
+        },
+        warnings,
+    )
+
+
+def _void_report(
+    manifest: dict[str, Any],
+    errors: list[str],
+    warnings: list[str],
+    observed_revision: str | None,
+) -> dict[str, Any]:
+    return {
+        "errors": sorted(set(errors)),
+        "observed_revision": observed_revision,
+        "pack_set": sorted(manifest["pack_set"]),
+        "schema_version": REPORT_SCHEMA,
+        "source_revision": manifest["source_revision"],
+        "status": "VOID",
+        "warnings": sorted(set(warnings)),
+    }
+
+
+def build_report(
+    manifest: Any,
+    observed_inventory: Any,
+    *,
+    repo_root: Path = DEFAULT_REPO_ROOT,
+    observed_revision: str | None = None,
+) -> dict[str, Any]:
+    checked = _validate_manifest(manifest)
+    observed, missing_packs = _observed_inventory(
+        observed_inventory, checked["pack_set"]
+    )
+    errors = [
+        f"configured pack {pack!r} is absent from the observed inventory"
+        for pack in missing_packs
+    ]
+    if (
+        not isinstance(observed_revision, str)
+        or re.fullmatch(r"[0-9a-f]{40}", observed_revision) is None
+    ):
+        errors.append(
+            "observed artifact revision is absent or invalid; census is void"
+        )
+    elif observed_revision != checked["source_revision"]:
+        errors.append(
+            f"observed artifact revision {observed_revision} does not match "
+            f"manifest source revision {checked['source_revision']}; census is void"
+        )
+    warnings: list[str] = []
+    pinned_owner = checked["public_owner"]
+    entries: list[dict[str, Any]] = []
+    for verb, pack in sorted(observed.items()):
+        entry, entry_warnings = _public_entry(
+            checked, verb, pack, verb in pinned_owner, repo_root
+        )
+        entries.append(entry)
+        warnings.extend(entry_warnings)
+
+    for verb in sorted(set(pinned_owner) - set(observed)):
+        warnings.append(
+            f"pinned verb {verb!r} is absent from the observed inventory"
+        )
+
+    control = checked["control"]
+    control_entry = next(
+        (entry for entry in entries if entry["verb"] == control["verb"]), None
+    )
+    if control_entry is None:
+        errors.append(
+            f"known-positive control {control['verb']!r} is absent; census is void"
+        )
+    elif control_entry["classification"] != control["required_classification"]:
+        errors.append(
+            f"known-positive control {control['verb']!r} classified as "
+            f"{control_entry['classification']!r}, expected "
+            f"{control['required_classification']!r}; census is void"
+        )
+    elif not any(
+        path["classification"] == "WRITER"
+        for path in control_entry["writer_paths"]
+    ):
+        errors.append(
+            f"known-positive control {control['verb']!r} has no WRITER path; "
+            "census is void"
+        )
+
+    if errors:
+        return _void_report(checked, errors, warnings, observed_revision)
+
+    counts = {classification: 0 for classification in CLASSIFICATIONS}
+    for entry in entries:
+        counts[entry["classification"]] += 1
+    population = sorted((entry["pack"], entry["verb"]) for entry in entries)
+    population_hash = hashlib.sha256(
+        canonical_json(population).encode("utf-8")
+    ).hexdigest()
+    return {
+        "control": {
+            "classification": control_entry["classification"],
+            "status": "PASS",
+            "verb": control["verb"],
+        },
+        "entries": entries,
+        "observed_revision": observed_revision,
+        "pack_set": sorted(checked["pack_set"]),
+        "population_sha256": population_hash,
+        "schema_version": REPORT_SCHEMA,
+        "source_revision": checked["source_revision"],
+        "status": "OK",
+        "summary": {"counts": counts, "total": len(entries)},
+        "warnings": sorted(set(warnings)),
+    }
+
+
+def _load_json(path: Path) -> Any:
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _kkernel_revision(path: Path) -> str:
+    completed = subprocess.run(
+        [str(path), "--version"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    version = completed.stdout.strip()
+    match = re.search(r"\(revision ([0-9a-f]{40}),", version)
+    if completed.returncode != 0 or match is None:
+        detail = completed.stderr.strip() or version
+        raise CensusError(f"{path} --version has no exact revision: {detail}")
+    return match.group(1)
+
+
+def _inventory_from_kkernel(path: Path) -> tuple[Any, str]:
+    revision = _kkernel_revision(path)
+    completed = subprocess.run(
+        [str(path), "pack", "list"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise CensusError(
+            f"{path} pack list exited {completed.returncode}: {detail}"
+        )
+    try:
+        return json.loads(completed.stdout), revision
+    except json.JSONDecodeError as error:
+        raise CensusError(f"{path} pack list returned invalid JSON: {error}") from error
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compare a pinned writer-path manifest with an exact kkernel pack "
+            "inventory. Output is canonical JSON and contains no timestamps."
+        )
+    )
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=DEFAULT_REPO_ROOT,
+        help="Git repository containing the manifest's pinned source revision",
+    )
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument(
+        "--inventory",
+        type=Path,
+        help="JSON captured from `kkernel pack list`",
+    )
+    parser.add_argument(
+        "--inventory-revision",
+        help="40-hex revision of the artifact that produced --inventory",
+    )
+    source.add_argument(
+        "--kkernel",
+        type=Path,
+        help="exact kkernel artifact to invoke as `<path> pack list`",
+    )
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args(argv)
+    if args.inventory is not None and args.inventory_revision is None:
+        parser.error("--inventory requires --inventory-revision")
+    if args.kkernel is not None and args.inventory_revision is not None:
+        parser.error("--inventory-revision is only valid with --inventory")
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        manifest = _load_json(args.manifest)
+        if args.inventory is not None:
+            observed = _load_json(args.inventory)
+            observed_revision = args.inventory_revision
+        else:
+            observed, observed_revision = _inventory_from_kkernel(args.kkernel)
+        report = build_report(
+            manifest,
+            observed,
+            repo_root=args.repo_root,
+            observed_revision=observed_revision,
+        )
+    except (CensusError, OSError, json.JSONDecodeError) as error:
+        report = {
+            "errors": [str(error)],
+            "schema_version": REPORT_SCHEMA,
+            "status": "VOID",
+        }
+    rendered = canonical_json(report)
+    if args.output is None:
+        sys.stdout.write(rendered)
+    else:
+        args.output.write_text(rendered, encoding="utf-8")
+    return 0 if report["status"] == "OK" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/writer_census.py
+++ b/scripts/writer_census.py
@@ -348,6 +348,11 @@ def _effective_classification(
         for path in paths
     ):
         return "UNKNOWN"
+    if declared == "NO-WRITER" and (
+        not paths
+        or all(path["classification"] == "UNKNOWN" for path in paths)
+    ):
+        return "UNKNOWN"
     return declared
 
 
@@ -357,6 +362,7 @@ def _public_entry(
     pack: str,
     pinned: bool,
     repo_root: Path,
+    evidence_revision: str,
 ) -> tuple[dict[str, Any], list[str]]:
     warnings: list[str] = []
     if not pinned:
@@ -382,7 +388,7 @@ def _public_entry(
         else:
             paths = list(override["paths"])
     paths, evidence_warnings = _verified_paths(
-        paths, repo_root, manifest["source_revision"], verb
+        paths, repo_root, evidence_revision, verb
     )
     warnings.extend(evidence_warnings)
 
@@ -401,7 +407,7 @@ def _public_entry(
             target_paths, target_warnings = _verified_paths(
                 target_paths,
                 repo_root,
-                manifest["source_revision"],
+                evidence_revision,
                 f"{verb} -> {target}",
             )
             warnings.extend(target_warnings)
@@ -427,8 +433,13 @@ def _public_entry(
     effective = _effective_classification(declared, all_writer_paths)
     reason = selected["reason"]
     if effective != declared:
-        if declared == "NO-WRITER":
+        if declared == "NO-WRITER" and any(
+            path["classification"] in {"WRITER", "WRITER-COND"}
+            for path in all_writer_paths
+        ):
             reason = "declared NO-WRITER is contradicted by verified writer evidence"
+        elif declared == "NO-WRITER":
+            reason = "declared NO-WRITER carries no verified read-only evidence"
         else:
             reason = f"declared {declared} lacks verified matching writer evidence"
         warnings.append(f"{verb}: {reason}")
@@ -480,6 +491,8 @@ def build_report(
         f"configured pack {pack!r} is absent from the observed inventory"
         for pack in missing_packs
     ]
+    warnings: list[str] = []
+    evidence_revision = checked["source_revision"]
     if (
         not isinstance(observed_revision, str)
         or re.fullmatch(r"[0-9a-f]{40}", observed_revision) is None
@@ -488,16 +501,18 @@ def build_report(
             "observed artifact revision is absent or invalid; census is void"
         )
     elif observed_revision != checked["source_revision"]:
-        errors.append(
-            f"observed artifact revision {observed_revision} does not match "
-            f"manifest source revision {checked['source_revision']}; census is void"
+        evidence_revision = observed_revision
+        warnings.append(
+            f"observed artifact revision {observed_revision} differs from "
+            f"manifest source revision {checked['source_revision']}; every "
+            "evidence pattern was re-verified at the observed revision"
         )
-    warnings: list[str] = []
     pinned_owner = checked["public_owner"]
     entries: list[dict[str, Any]] = []
     for verb, pack in sorted(observed.items()):
         entry, entry_warnings = _public_entry(
-            checked, verb, pack, verb in pinned_owner, repo_root
+            checked, verb, pack, verb in pinned_owner, repo_root,
+            evidence_revision,
         )
         entries.append(entry)
         warnings.extend(entry_warnings)


### PR DESCRIPTION
## Summary

- commit a 91-verb baseline for the shipped 12-pack population, pinned to exact source revision `288b9eee1f471d505e7f5de33e121c58773a10af`
- add a canonical JSON census renderer with the closed `WRITER` / `WRITER-COND` / `NO-WRITER` / `UNKNOWN` vocabulary
- fail closed on missing entries, stale source evidence, malformed classifications, population drift, or artifact/source revision mismatch
- make `comm.read` a mandatory source-backed positive control: a missed writer path voids the run and suppresses the table
- represent the known `memory.recall -> brain.record_serve` nested dispatch, including both the nested dispatch audit and serve-ledger writer paths
- keep `blob.put`, `code.ingest`, and the three external git mutation verbs explicitly `UNKNOWN`

## Why

The prior writer census was a prose snapshot. It could not prove that two measurements covered the same verb population or that the classifier still detected a known writer. This tranche establishes the reproducible, machine-diffable and fail-closed foundation before filling in every handler trace and workload measurement.

## Scope

This is intentionally tranche 1, not acceptance closure. The baseline reports one source-proven `WRITER` and 90 `UNKNOWN` public verbs while retaining the common conditional audit path as path evidence. Follow-up work remains for the complete per-handler classification, crash injection, and fixed concurrent acquisition workload.

## Validation

- `python3 scripts/tests/test_writer_census.py` — 11 passed
- `python3 -m py_compile scripts/writer_census.py scripts/tests/test_writer_census.py`
- `sh scripts/ci.sh lint` component gates passed; writer-census tests are now part of this phase
- stale installed artifact (`913790e6...`) correctly returned canonical `VOID` / exit 2 against the pinned `288b9eee...` manifest
- canonical baseline render: 91 verbs, control PASS, zero warnings
- independent exact review: APPROVE, 0 findings

Full Cargo/workspace builds were not run for this Python/JSON-only tranche.

Refs #1406
