### PR TITLE
fix(moodboard): align Lattice provenance with 0.9.0

### DIFF
--- a/crates/khive-pack-moodboard/src/model.rs
+++ b/crates/khive-pack-moodboard/src/model.rs
@@ -86,7 +86,7 @@ impl DescriptorIdentity {
             checkpoint_sha256,
             inference: InferenceIdentity {
                 provider: "lattice-embed",
-                version: "0.8.0",
+                version: "0.9.0",
             },
             preprocessing: PreprocessingIdentity {
                 revision: PREPROCESSING_REVISION,
@@ -1248,7 +1248,7 @@ mod tests {
         assert_eq!(value["schema_version"], SCHEMA_VERSION);
         assert_eq!(value["dimensions"], 4);
         assert_eq!(value["prompt"]["revision"], PROMPT_REVISION);
-        assert_eq!(value["inference"]["version"], "0.8.0");
+        assert_eq!(value["inference"]["version"], "0.9.0");
     }
 
     #[test]
@@ -1260,7 +1260,7 @@ mod tests {
             checkpoint_sha256: "1".repeat(64),
             inference: InferenceIdentity {
                 provider: "lattice-embed",
-                version: "0.8.0",
+                version: "0.9.0",
             },
             preprocessing: PreprocessingIdentity {
                 revision: PREPROCESSING_REVISION,
@@ -1280,11 +1280,11 @@ mod tests {
         let fingerprint = sha256_hex(&canonical_json_bytes(&core).unwrap());
         assert_eq!(
             fingerprint,
-            "32d7e52301b0383e0d4db0b145809ad789dc04c8db6b4ac2af8c14a2d68dce7a"
+            "b57fb3cf43da387cde12425e6d7d442af269ba37ecabfbe4c975cb80abdf56e5"
         );
         assert_eq!(
             format!("moodboard_{fingerprint}_4"),
-            "moodboard_32d7e52301b0383e0d4db0b145809ad789dc04c8db6b4ac2af8c14a2d68dce7a_4"
+            "moodboard_b57fb3cf43da387cde12425e6d7d442af269ba37ecabfbe4c975cb80abdf56e5_4"
         );
 
         let production_prompt =
@@ -1295,26 +1295,26 @@ mod tests {
         );
         assert_eq!(
             production_prompt.fingerprint,
-            "2f5dca0e2eed947ef1ed1a6fb2af12206ce1838b7778678f2a99fea576b2310a"
+            "5d62815b1b662fa926c58aaaf58553e3d842b615cd90f431fe6e7c1bd782ea0b"
         );
         assert_eq!(
             production_prompt.model_key,
-            "moodboard_2f5dca0e2eed947ef1ed1a6fb2af12206ce1838b7778678f2a99fea576b2310a_4"
+            "moodboard_5d62815b1b662fa926c58aaaf58553e3d842b615cd90f431fe6e7c1bd782ea0b_4"
         );
 
-        let indexed_qwen_08 = DescriptorIdentity::build(
+        let indexed_qwen_09 = DescriptorIdentity::build(
             "hf-Qwen-Qwen3.5-0.8B-2fc06364715b967f1860aea9cf38778875588b17".to_string(),
             "6dca0d0e661696b36985cbce8f89e1a91377822065de31eac94e90a0e45d43d3".to_string(),
             1024,
         )
         .unwrap();
         assert_eq!(
-            indexed_qwen_08.fingerprint,
-            "40be6f4ae97057e6a0b5c0d011db6e5a37f26c46b787df3e19ddf0fec1e3c9b9"
+            indexed_qwen_09.fingerprint,
+            "bd91f5bf961eb429a6f57b6c16bafde9eeea249d799b1ff0d31e32cf05e5bc8f"
         );
         assert_eq!(
-            indexed_qwen_08.model_key,
-            "moodboard_40be6f4ae97057e6a0b5c0d011db6e5a37f26c46b787df3e19ddf0fec1e3c9b9_1024"
+            indexed_qwen_09.model_key,
+            "moodboard_bd91f5bf961eb429a6f57b6c16bafde9eeea249d799b1ff0d31e32cf05e5bc8f_1024"
         );
     }
 

--- a/crates/khive-pack-moodboard/src/preference.rs
+++ b/crates/khive-pack-moodboard/src/preference.rs
@@ -1,6 +1,6 @@
 //! Governed pairwise-preference feature, training, calibration, and FANN model contracts.
 //!
-//! `lattice-fann` 0.7.1's `BackpropTrainer` optimizes MSE.  This module therefore
+//! `lattice-fann` 0.9.0's `BackpropTrainer` optimizes MSE.  This module therefore
 //! fits the Bradley--Terry logistic objective directly in deterministic `f64`,
 //! then materializes the learned zero-intercept 10 -> 1 linear head as a FANN
 //! network.  FANN owns the persisted binary representation and every served
@@ -29,7 +29,7 @@ pub(crate) const RANDOMIZATION_REVISION: &str = "moodboard-side-v1";
 pub(crate) const PAIR_SPLIT_REVISION: &str = "moodboard-pair-split-v1";
 pub(crate) const TRAINING_REVISION: &str = "moodboard-logistic-bce-l2-v1";
 pub(crate) const MODEL_FAMILY: &str = "pairwise_zero_intercept_logistic";
-pub(crate) const FANN_CRATE_VERSION: &str = "0.7.1";
+pub(crate) const FANN_CRATE_VERSION: &str = "0.9.0";
 pub(crate) const FANN_FORMAT: &str = "FANN binary v1";
 
 pub(crate) const MIN_TRAIN_DECISIVE_GROUPS: usize = 64;
@@ -1675,7 +1675,12 @@ pub(crate) mod tests {
         let data = prepare_training_data(&sufficient_records(false), &scope).unwrap();
         let mut trained = train_model(&data, scope).unwrap();
         trained.bundle.fann.network_content_ref = "f".repeat(64);
+        assert_eq!(trained.bundle.fann.crate_version, "0.9.0");
         validate_loaded_bundle(&trained.bundle).unwrap();
+
+        let mut prior_fann_version = trained.bundle.clone();
+        prior_fann_version.fann.crate_version = "0.7.1".to_string();
+        assert!(validate_loaded_bundle(&prior_fann_version).is_err());
 
         let mut wrong_schema = trained.bundle.clone();
         wrong_schema.scope.feature_schema_id = "0".repeat(64);

--- a/docs/adr/ADR-148-moodboard-visual-retrieval-pack.md
+++ b/docs/adr/ADR-148-moodboard-visual-retrieval-pack.md
@@ -20,7 +20,7 @@ provider, while a visual descriptor must be derived from decoded raster bytes un
 explicit preprocessing contract. A separate application database would duplicate Khive's
 asset, provenance, namespace, and retrieval responsibilities.
 
-The Qwen3.5 pooled descriptor available in `lattice-embed` 0.8.0 is experimental retrieval
+The Qwen3.5 pooled descriptor available in `lattice-embed` 0.9.0 is experimental retrieval
 machinery. Its own contract says retrieval quality for the base instruct checkpoint is
 unvalidated. This pack must expose that machinery honestly, not market it as a state-of-the-art
 style model or collapse compatibility, cohesion, diversity, and uncertainty into one score.
@@ -65,7 +65,7 @@ Every response contains a nested `descriptor` object with this closed v1 shape:
   "model_name": "qwen3.5-vlm-pooled-visual",
   "model_revision": "<operator-pinned revision>",
   "checkpoint_sha256": "<64 lowercase hexadecimal characters>",
-  "inference": { "provider": "lattice-embed", "version": "0.8.0" },
+  "inference": { "provider": "lattice-embed", "version": "0.9.0" },
   "preprocessing": {
     "revision": "moodboard-qwen35-srgb-pad32-max448-v1",
     "max_side": 448,
@@ -109,8 +109,8 @@ paths, non-file entries, and more than 100000 files fail closed. This deliberate
 directory identity includes auxiliary files and layout as well as all configuration, tokenizer,
 manifest, and resolved weight bytes. A one-byte mutation cannot reuse the vector table identity.
 
-The published pack graph directly and exactly pins both `lattice-embed = "=0.8.0"` and its
-inference engine `lattice-inference = "=0.8.0"`, matching `inference.version`; a lock refresh cannot
+The published pack graph directly and exactly pins both `lattice-embed = "=0.9.0"` and its
+inference engine `lattice-inference = "=0.9.0"`, matching `inference.version`; a lock refresh cannot
 silently float the transitive math implementation under the same descriptor fingerprint.
 
 Each response also carries top-level `experimental: true`. Exact result shapes are:
@@ -332,26 +332,33 @@ and ignored real-checkpoint characterization tests. `KHIVE_MOODBOARD_MODEL_DIR` 
 expected attestation checked against the always-computed canonical digest.
 
 The load-free characterization successfully derived a 2048-dimensional descriptor from a local
-Qwen3.5-2B fixture. Inference did not start for that fixture because it contains a single
-`model.safetensors`, while `lattice-embed` 0.8.0 requires `model.safetensors.index.json` or
-`quantize_index.json` to locate `model.visual.*` tensors. This remains an explicit upstream
-checkpoint-layout friction ([lattice#1381](https://github.com/ohdearquant/lattice/issues/1381)).
+Qwen3.5-2B fixture. The historical 0.8.0 inference attempt did not start because that fixture
+contains a single `model.safetensors`, while that release required
+`model.safetensors.index.json` or `quantize_index.json` to locate `model.visual.*` tensors.
+`lattice-embed` 0.9.0 now supports the unindexed single-file layout; the upstream friction in
+[lattice#1381](https://github.com/ohdearquant/lattice/issues/1381) was resolved by the merged
+[lattice#1385](https://github.com/ohdearquant/lattice/pull/1385).
 
-The same ignored inference gate passed against the materialized indexed Qwen3.5-0.8B fixture with
-operator revision
-`hf-Qwen-Qwen3.5-0.8B-2fc06364715b967f1860aea9cf38778875588b17`. Published
-`lattice-embed` 0.8.0 produced a 1024-dimensional descriptor with checkpoint digest
+The same ignored inference gate historically passed with `lattice-embed` 0.8.0 against the
+materialized indexed Qwen3.5-0.8B fixture with operator revision
+`hf-Qwen-Qwen3.5-0.8B-2fc06364715b967f1860aea9cf38778875588b17`. That run produced a
+1024-dimensional descriptor with checkpoint digest
 `6dca0d0e661696b36985cbce8f89e1a91377822065de31eac94e90a0e45d43d3`, fingerprint
 `40be6f4ae97057e6a0b5c0d011db6e5a37f26c46b787df3e19ddf0fec1e3c9b9`, and model key
 `moodboard_40be6f4ae97057e6a0b5c0d011db6e5a37f26c46b787df3e19ddf0fec1e3c9b9_1024`.
+Under the current 0.9.0 contract, the unchanged checkpoint bytes map to fingerprint
+`bd91f5bf961eb429a6f57b6c16bafde9eeea249d799b1ff0d31e32cf05e5bc8f` and model key
+`moodboard_bd91f5bf961eb429a6f57b6c16bafde9eeea249d799b1ff0d31e32cf05e5bc8f_1024`; those values
+are descriptor-identity goldens, not evidence of a fresh real-checkpoint inference run.
 Before the private-snapshot hardening amendment, load-free descriptor discovery took 98,776 ms and
 cold load plus post-load verification took 297,380 ms; those timings are a historical direct-source
 baseline and do not include the new copy lifecycle. Three serialized inferences took 279,305 ms,
 294,164 ms, and 170,919 ms. The output L2 norm was
 `1.000000047`, repeat maximum coordinate delta `0`, and trailing-prompt maximum coordinate delta
-`0`. These timings characterize that contended local debug-build run, not a performance
-commitment. The result characterizes the pinned implementation and confirms the prompt-independent
-causal layout; it is not retrieval-quality evidence.
+`0`. These timings and numerical observations characterize that contended historical 0.8.0
+debug-build run, not the current 0.9.0 math or a performance commitment. They are not
+retrieval-quality evidence; the current inference identity requires a fresh characterization
+before equivalent numerical claims may be made for 0.9.0.
 
 ## References
 

--- a/docs/adr/ADR-149-moodboard-preference-learning.md
+++ b/docs/adr/ADR-149-moodboard-preference-learning.md
@@ -15,7 +15,7 @@ statistic.
 
 Khive already provides the necessary durable boundaries: actor-attributed namespace tokens,
 append-only events, artifact entities, and `BlobStore`. `lattice-fann` provides a compact governed
-network representation and CPU inference. Its 0.7.1 `BackpropTrainer`, however, computes MSE; it
+network representation and CPU inference. Its 0.9.0 `BackpropTrainer`, however, computes MSE; it
 does not expose Bradley--Terry binary cross-entropy. Calling that trainer a pairwise logistic
 learner would be mathematically false.
 
@@ -184,7 +184,7 @@ exactly one `lattice_fann::Layer`:
 
 That `Network` is the governed representation. Calibration and test metrics use logits from its
 actual FANN `forward` path after `float32` materialization. The workspace and pack dependency pin
-`lattice-fann = "=0.7.1"`.
+`lattice-fann = "=0.9.0"`.
 
 Temperature is selected on decisive calibration groups by a deterministic 128-iteration
 golden-section search over log-temperature `[-4,4]`. The indifference half-band is selected from
@@ -264,7 +264,7 @@ can build.
 | Alternative                                  | Why rejected                                                                                                                              |
 | -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
 | Treat cosine similarity as preference        | It has no interaction grounding and conflates retrieval geometry with human judgment.                                                     |
-| Train with `BackpropTrainer` and call it BCE | Version 0.7.1 hard-codes MSE, so the claimed objective would be false.                                                                    |
+| Train with `BackpropTrainer` and call it BCE | Version 0.9.0 hard-codes MSE, so the claimed objective would be false.                                                                    |
 | Store only JSON weights                      | It would not exercise or govern the requested FANN serialization and inference path.                                                      |
 | Use individual-event random split            | Side-reversed or repeated unordered pairs would leak across train/calibration/test.                                                       |
 | Fold ties into label `0.5`                   | It changes the decisive Bradley--Terry likelihood and hides the separate indifference decision.                                           |


### PR DESCRIPTION
## Why

Khive main exactly pins `lattice-embed`, `lattice-inference`, and `lattice-fann` 0.9.0, but the Moodboard pack still published a 0.8.0 visual-descriptor identity and a 0.7.1 FANN-bundle identity. That mismatch made current outputs claim the wrong implementation and could reuse the wrong named vector space.

## What changed

- publish `lattice-embed` 0.9.0 in the closed visual-descriptor identity
- regenerate descriptor fingerprints and model keys for the existing cross-language goldens
- publish and require `lattice-fann` 0.9.0 in preference bundles
- prove that a prior 0.7.1 bundle fails closed on load
- align ADR-148 and ADR-149 with the exact Cargo pins
- record the merged single-file checkpoint support from lattice#1385
- keep historical 0.8.0 inference measurements explicitly historical; the new 0.9.0 values are identity goldens, not a claimed fresh inference run

This intentionally selects a new descriptor fingerprint and named vector table. It does not add a compatibility shim.

## TDD evidence

RED before implementation:

- `descriptor_is_deterministic_and_closed`: expected 0.9.0, received 0.8.0
- `wrong_or_uncalibrated_bundle_identity_fails_closed`: expected 0.9.0, received 0.7.1

GREEN:

- `cargo test -p khive-pack-moodboard --all-targets` — 50 unit passed, 2 real-checkpoint tests ignored by their existing environment gate, 9 integration passed
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `make fmt-check`
- `make docs-check`

The descriptor goldens were independently recomputed with canonical `jq` plus SHA-256 and Python `json.dumps(sort_keys=True, separators=(comma, colon))`; both produced the same digests.

## Explicit non-claim

A fresh real-checkpoint inference characterization on lattice 0.9.0 is not part of this provenance-only correction. The existing ignored real-checkpoint tests remain gated by `KHIVE_MOODBOARD_*`. A full `cargo test --workspace` run showed no failures through the completed suites but was manually stopped in the long CLI integration tail, so it is not claimed as complete.
