### PR TITLE
docs(adr): pack artifact ingest and named-vector restart semantics (ADR-155, ADR-156)

### DIFF
--- a/docs/adr/ADR-155-pack-artifact-ingest-blobstore.md
+++ b/docs/adr/ADR-155-pack-artifact-ingest-blobstore.md
@@ -1,0 +1,95 @@
+# ADR-155: Pack Artifact Ingest over BlobStore
+
+**Status**: proposed
+**Date**: 2026-08-14
+**Authors**: khive maintainers
+**Depends on**:
+
+- ADR-111 (Blob Store) — the `BlobStore` content-addressed storage trait and the
+  `blob.put` / `blob.get` / `blob.stat` verb surface
+- ADR-017 (Pack Standard) — pack-owned entity subtypes
+- ADR-148 (Moodboard Visual Retrieval Pack) — the first implementation of this contract
+
+## Context
+
+ADR-111 specifies the BlobStore trait and its generic verb surface, but it does not say how a
+_pack_ should anchor its own typed artifact entities to stored bytes. The moodboard pack built
+that pattern for visual assets: original bytes go into the content-addressed store, a typed
+`artifact` entity carries the returned `ContentRef`, and every later read re-verifies the bytes
+against that identity. The pattern is general — any pack that ingests external media (images,
+documents, recordings, model bundles) faces the same four questions: what is the canonical
+identity of the bytes, how are duplicates handled, what guarantees a read returns the bytes
+that were written, and what happens when no store is installed.
+
+Today the answers live only in `khive-pack-moodboard` handler code. A second media-ingesting
+pack would either re-derive them or diverge silently. This record makes the contract normative
+so future packs implement it rather than reinvent it.
+
+## Decision
+
+A pack that stores external bytes and registers typed artifact entities for them MUST follow
+this contract:
+
+**D1 — ContentRef is the canonical identity of the original bytes.** The pack stores the raw
+decoded bytes via `BlobStore::put` and records the returned BLAKE3 `ContentRef` on the entity.
+Derived representations (thumbnails, embeddings, normalized forms) never replace the original
+bytes' identity; they are separate records that reference it.
+
+**D2 — Deduplication is by ContentRef, before entity creation.** Ingest queries for an existing
+entity carrying the same `content_ref` and returns it instead of creating a duplicate. The
+store's own idempotent put (identical content, same ref, no re-write) handles the byte layer;
+this decision extends the same idempotence to the entity layer.
+
+**D3 — Every read back is a verified read.** When a pack hydrates stored bytes to act on them,
+it re-verifies the BLAKE3 digest against the recorded `ContentRef` before use. A mismatch is an
+integrity error surfaced to the caller, never silently tolerated. Digest verification lives on
+the read path by design: that is where the bytes are already in hand.
+
+**D4 — Source reads are bounded.** Reads of stored source bytes carry an explicit size bound
+chosen by the pack for its media class. A blob exceeding the bound is a typed refusal, not an
+unbounded allocation.
+
+**D5 — Absent store fails closed with a typed refusal.** A pack verb that requires the
+BlobStore returns a typed unconfigured error naming the missing capability when no store is
+installed. It does not degrade to storing bytes inline, writing to scratch paths, or silently
+skipping persistence.
+
+**D6 — The artifact entity is self-describing.** The entity's properties record at minimum a
+`schema_version` for the pack's artifact shape and the media metadata needed to interpret the
+bytes without fetching them (for visual assets: media type and pixel dimensions).
+
+## Consequences
+
+- Ingest is idempotent end to end: repeated ingest of identical bytes converges on one blob and
+  one entity.
+- Corruption anywhere between write and read is detected at the read seam, the only place it
+  can be detected cheaply.
+- A pack's artifact entities remain interpretable from the graph alone (D6), while the bytes
+  stay in the store.
+- Packs pay a digest re-computation on every source read (D3). For the media sizes bounded by
+  D4 this is negligible against the read itself.
+
+## Alternatives considered
+
+**Trust-on-read (no digest re-verification).** Rejected: the store is content-addressed at
+write time only; filesystem corruption or an operator replacing files under the store root
+would otherwise propagate silently into derived computations.
+
+**Entity-layer dedup by perceptual or semantic similarity.** Rejected for the ingest contract:
+identity here means byte identity. Near-duplicate handling is a retrieval-layer concern and
+varies per pack.
+
+**Inline bytes on the entity when the store is absent.** Rejected: it forks the persistence
+model on a configuration accident and violates the graph/bytes separation ADR-111 establishes.
+
+## Non-claims
+
+This record does not govern retrieval quality, embedding identity, or vector storage — those
+are ADR-148 (for moodboard) and the named-vector durability record (ADR-156). It does not add
+verbs; the generic blob verb surface remains ADR-111's.
+
+## References
+
+- `crates/khive-pack-moodboard/src/handlers.rs` — reference implementation: dedup-by-ref entity
+  creation, bounded verified source reads, typed unconfigured refusal
+- ADR-111 (Blob Store) — trait, verbs, idempotent put

--- a/docs/adr/ADR-155-pack-artifact-ingest-blobstore.md
+++ b/docs/adr/ADR-155-pack-artifact-ingest-blobstore.md
@@ -36,7 +36,11 @@ Derived representations (thumbnails, embeddings, normalized forms) never replace
 bytes' identity; they are separate records that reference it.
 
 **D2 — Deduplication is by ContentRef, before entity creation.** Ingest queries for an existing
-entity carrying the same `content_ref` and returns it instead of creating a duplicate. The
+entity carrying the same `content_ref` and returns it instead of creating a duplicate. This
+carries the ADR-148 idempotence boundary unchanged: the lookup-before-create critical section
+is process-wide, so the one-entity guarantee holds within a single Khive process; separate
+processes can still race and create duplicates because `entities.content_ref` is indexed but
+not unique. This record does not tighten that boundary. The
 store's own idempotent put (identical content, same ref, no re-write) handles the byte layer;
 this decision extends the same idempotence to the entity layer.
 
@@ -46,8 +50,13 @@ integrity error surfaced to the caller, never silently tolerated. Digest verific
 the read path by design: that is where the bytes are already in hand.
 
 **D4 — Source reads are bounded.** Reads of stored source bytes carry an explicit size bound
-chosen by the pack for its media class. A blob exceeding the bound is a typed refusal, not an
-unbounded allocation.
+chosen by the pack for its media class. Under the current `BlobStore` capability the bound is
+enforced by a size preflight before the read and a length check after it; the read itself
+returns a whole buffer, so a store whose object grows between preflight and read is detected
+only after the allocation. An over-bound object is a typed refusal in either case. A
+backend-enforced bounded or streaming read, which would close the preflight/read race and make
+the refusal precede allocation, is a `khive-storage` capability extension deferred to its own
+record.
 
 **D5 — Absent store fails closed with a typed refusal.** A pack verb that requires the
 BlobStore returns a typed unconfigured error naming the missing capability when no store is
@@ -60,8 +69,9 @@ bytes without fetching them (for visual assets: media type and pixel dimensions)
 
 ## Consequences
 
-- Ingest is idempotent end to end: repeated ingest of identical bytes converges on one blob and
-  one entity.
+- Ingest is idempotent end to end within one Khive process: repeated ingest of identical bytes
+  converges on one blob and one entity. Across processes the blob layer still converges (the
+  store's put is content-addressed), but entity creation can race per the ADR-148 boundary.
 - Corruption anywhere between write and read is detected at the read seam, the only place it
   can be detected cheaply.
 - A pack's artifact entities remain interpretable from the graph alone (D6), while the bytes

--- a/docs/adr/ADR-156-named-vector-restart-durability.md
+++ b/docs/adr/ADR-156-named-vector-restart-durability.md
@@ -21,11 +21,13 @@ questions that matter operationally: which parts survive a restart, which are re
 guarantees results are identical before and after, and what the read path does when a stored
 hit's backing artifact has since disappeared.
 
-Restart semantics have been exercised end to end for the preference-model and blob lifecycle
-(a serving process restarted between training and inference, with exact-equality checks on the
-results). The named-vector reopen path — index, restart, search, exact hit and score equality —
-is not yet covered by such a test; for that path this record states the intended contract, and
-acceptance of this ADR gates on a persistent reopen test with exact hit and score assertions.
+Restart durability has been exercised for the preference-model and blob lifecycle: a persisted
+model bundle and its blob-backed artifacts are loaded by a recreated runtime and produce a
+valid prediction. That test demonstrates load-after-restart, not result equality — it records
+no pre-restart prediction to compare against. The named-vector reopen path — index, restart,
+search, exact hit and score equality — is likewise not yet covered; for both, this record
+states the intended contract, and acceptance of this ADR gates on a persistent reopen test
+with exact hit and score assertions.
 
 ## Decision
 

--- a/docs/adr/ADR-156-named-vector-restart-durability.md
+++ b/docs/adr/ADR-156-named-vector-restart-durability.md
@@ -1,0 +1,98 @@
+# ADR-156: Named-Vector Search Restart and Durability Semantics
+
+**Status**: proposed
+**Date**: 2026-08-14
+**Authors**: khive maintainers
+**Depends on**:
+
+- ADR-148 (Moodboard Visual Retrieval Pack) — descriptor identity and the first named-vector
+  consumer
+- ADR-155 (Pack Artifact Ingest over BlobStore) — the artifact identity the read path
+  cross-checks
+- ADR-005 (Storage Capability Traits) — the `VectorStore` seam
+
+## Context
+
+Named vector spaces bind a physical sqlite-vec table (`vec_{model_key}`) to an immutable
+descriptor identity: a fingerprint over model name, revision, checkpoint digest, preprocessing
+configuration, prompt, pooling strategy, dimensions, and normalization. The moodboard pack
+introduced the mechanism; nothing yet states what a process restart means for it. The
+questions that matter operationally: which parts survive a restart, which are re-derived, what
+guarantees results are identical before and after, and what the read path does when a stored
+hit's backing artifact has since disappeared.
+
+These semantics were exercised end to end (a serving process was restarted between indexing
+and search, and between training and inference, with exact-equality checks on the results) but
+the contract lives only in test code. This record states it normatively.
+
+## Decision
+
+**D1 — Vector tables are durable; identity binding is re-derived, never stored as mutable
+configuration.** The `vec_{model_key}` tables and their rows persist in the database across
+restarts. The mapping from descriptor identity to table name is a pure function of the
+identity's canonical form (fingerprint plus dimensions). A restarted process recomputes the
+same `model_key` from the same configured identity and lands on the same table. There is no
+stored pointer that can drift from the identity it names.
+
+**D2 — A changed identity selects a new space; it never mutates an old one.** Any change to an
+identity field (a new checkpoint digest, a different pooling strategy, changed dimensions)
+produces a different fingerprint, hence a different `model_key`, hence a different physical
+table. Existing vectors are untouched and remain queryable under their original identity.
+Upgrades are therefore additive: old and new spaces coexist, and retiring an old space is an
+explicit curation act, not a side effect of reconfiguration.
+
+**D3 — Model state is process-local and reloads from configuration at boot.** Inference
+weights are not stored in the database. A restarted process reloads the checkpoint from its
+configured path, and the identity fields that participate in the fingerprint (revision,
+checkpoint digest) guarantee that a _different_ checkpoint at the same path cannot silently
+write into the old space — it lands in a new one per D2.
+
+**D4 — Restart exactness for search.** For an unchanged store and an unchanged descriptor
+identity, a search issued after a restart returns the same hits with the same scores as before
+it. This follows from D1–D3 plus the retrieval design: exact brute-force cosine over the named
+table with deterministic score conversion, no approximate index whose in-memory build state
+could differ across processes. Consumers may rely on it; a violation is a defect, not drift to
+be tolerated.
+
+**D5 — Read-path orphan policy: skip, do not error, never re-rank.** A hit whose backing
+artifact bytes are no longer resolvable (blob removed, entity soft-deleted) is dropped during
+result materialization. The remaining hits keep their store-assigned order; materialization
+never re-scores or re-ranks. Orphaned rows are a curation concern; the read path's only duty
+is to not present results it cannot back with bytes.
+
+## Consequences
+
+- Operators may restart serving processes freely between indexing and query; no re-indexing or
+  warm-up invariant is implied for exact-search named spaces.
+- Rolling a model forward is safe by construction (D2) at the cost of disk growth per retained
+  space; reclaiming old spaces needs an explicit curation path.
+- The orphan policy (D5) means result counts can shrink below the requested `top_k` when the
+  store has been curated; callers must not treat a short page as an error.
+- D4 is stated for exact search. A future approximate index behind the same seam must either
+  meet it or amend this record with its weaker guarantee before shipping.
+
+## Alternatives considered
+
+**Storing the identity-to-table binding as configuration rows.** Rejected: a stored binding is
+a second copy of the identity that can drift from it; the pure-function derivation cannot.
+
+**Erroring on orphaned hits.** Rejected: it turns routine curation of old artifacts into
+search outages for unrelated queries.
+
+**Backfilling or re-ranking around dropped orphans.** Rejected: materialization would then
+return results the ranking stage never saw in that order, breaking the filter-before-rank
+property of the retrieval design.
+
+## Non-claims
+
+This record does not cover the retrieval scoring design itself (ADR-148), embedding compute
+placement, or ANN index persistence for the knowledge corpus (ADR-079's territory). It states
+restart semantics for exact-search named vector spaces only.
+
+## References
+
+- `crates/khive-db/src/stores/vectors.rs` — one instance per `vec_{model_key}` table;
+  namespace and model predicates applied before rank projection
+- `crates/khive-pack-moodboard/src/model.rs` — descriptor identity fingerprint and
+  `NamedVectorIdentity` derivation
+- `crates/khive-pack-moodboard/src/handlers.rs` — result materialization and orphan skip

--- a/docs/adr/ADR-156-named-vector-restart-durability.md
+++ b/docs/adr/ADR-156-named-vector-restart-durability.md
@@ -21,9 +21,11 @@ questions that matter operationally: which parts survive a restart, which are re
 guarantees results are identical before and after, and what the read path does when a stored
 hit's backing artifact has since disappeared.
 
-These semantics were exercised end to end (a serving process was restarted between indexing
-and search, and between training and inference, with exact-equality checks on the results) but
-the contract lives only in test code. This record states it normatively.
+Restart semantics have been exercised end to end for the preference-model and blob lifecycle
+(a serving process restarted between training and inference, with exact-equality checks on the
+results). The named-vector reopen path — index, restart, search, exact hit and score equality —
+is not yet covered by such a test; for that path this record states the intended contract, and
+acceptance of this ADR gates on a persistent reopen test with exact hit and score assertions.
 
 ## Decision
 
@@ -41,18 +43,25 @@ table. Existing vectors are untouched and remain queryable under their original 
 Upgrades are therefore additive: old and new spaces coexist, and retiring an old space is an
 explicit curation act, not a side effect of reconfiguration.
 
-**D3 — Model state is process-local and reloads from configuration at boot.** Inference
-weights are not stored in the database. A restarted process reloads the checkpoint from its
-configured path, and the identity fields that participate in the fingerprint (revision,
+**D3 — Model state is process-local and reloads from configuration on first use after a
+restart.** Inference weights are not stored in the database. A restarted process reloads the
+checkpoint from its configured path lazily, when the first verb needing it runs; the first
+request after a restart therefore pays the load, and a load failure surfaces on that request
+rather than at boot. The identity fields that participate in the fingerprint (revision,
 checkpoint digest) guarantee that a _different_ checkpoint at the same path cannot silently
 write into the old space — it lands in a new one per D2.
 
 **D4 — Restart exactness for search.** For an unchanged store and an unchanged descriptor
-identity, a search issued after a restart returns the same hits with the same scores as before
-it. This follows from D1–D3 plus the retrieval design: exact brute-force cosine over the named
-table with deterministic score conversion, no approximate index whose in-memory build state
-could differ across processes. Consumers may rely on it; a violation is a defect, not drift to
-be tolerated.
+identity, a search issued after a restart returns the same scores as before it, and the same
+hits wherever the ordering is total. This follows from D1–D3 plus the retrieval design: exact
+brute-force cosine over the named table with deterministic score conversion, no approximate
+index whose in-memory build state could differ across processes. The known gap in totality:
+the store query orders by distance and truncates at the candidate limit without a tie-break,
+so equal-distance rows at the truncation boundary can produce different hit sets. Full
+same-hits exactness under ties requires a total order (distance, then subject id) applied in
+the store query before the limit; until that lands, consumers may rely on score exactness
+unconditionally and on hit-set exactness only in the absence of boundary ties. A violation
+outside that carve-out is a defect, not drift to be tolerated.
 
 **D5 — Read-path orphan policy: skip, do not error, never re-rank.** A hit whose backing
 artifact bytes are no longer resolvable (blob removed, entity soft-deleted) is dropped during

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -161,6 +161,8 @@ The same head-binding governs review: a verdict authorizes only the exact commit
 | [ADR-152](ADR-152-kg-editor-interaction-grammar.md)                     | kg-editor Interaction Grammar — Navigation, History, and Review Conversation                               |
 | [ADR-153](ADR-153-typed-graph-visual-encoding.md)                       | Typed Graph Visual Encoding                                                                                |
 | [ADR-154](ADR-154-sqlite-disk-reserve-admission.md)                     | SQLite Disk-Reserve Admission Before Logical Writes                                                        |
+| [ADR-155](ADR-155-pack-artifact-ingest-blobstore.md)                    | Pack Artifact Ingest over BlobStore                                                                        |
+| [ADR-156](ADR-156-named-vector-restart-durability.md)                   | Named-Vector Search Restart and Durability Semantics                                                       |
 
 <!-- END GENERATED ADR CATALOG -->
 


### PR DESCRIPTION
Two proposed records making shipped mechanisms normative:

- **ADR-155 — Pack Artifact Ingest over BlobStore**: the contract for packs anchoring typed artifact entities to content-addressed bytes: ContentRef as canonical identity, dedup by ref before entity creation, BLAKE3-verified bounded reads on every hydration, typed unconfigured refusal when no store is installed, self-describing entity properties. Generalizes the pattern the moodboard pack implements so future media-ingesting packs implement one contract instead of re-deriving it.
- **ADR-156 — Named-Vector Search Restart and Durability Semantics**: what survives a process restart for named vector spaces and what is re-derived: durable vec tables with identity binding recomputed as a pure function of descriptor identity, identity changes select new spaces additively, restart-exact search for exact-cosine spaces, and a skip-only orphan policy at result materialization.

Docs-only. ADR catalog rows added; adr-ref lint and deno fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)