### PR TITLE
feat(kg-editor): expose configured analysis catalog

### DIFF
--- a/apps/kg-editor/README.md
+++ b/apps/kg-editor/README.md
@@ -95,17 +95,26 @@ server-private materialized report without placing it under `public/`:
 
 ```bash
 KHIVE_SHOWCASE_ANALYSIS_ROOT=/absolute/path/to/analyses \
-KHIVE_SHOWCASE_ANALYSIS_IDS=khive \
+KHIVE_SHOWCASE_ANALYSES='[{"analysis_id":"khive","canonical_url":"https://github.com/ohdearquant/khive"}]' \
 npm run dev
 ```
 
 The report must be located at
-`$KHIVE_SHOWCASE_ANALYSIS_ROOT/khive/khive.repo.v1.json`. Fetch it at
-`/api/showcase/analyses/khive`. IDs are a closed operator allowlist; the route rejects
-symlinks, reports above 8 MiB, malformed bundles, and unknown IDs. It never opens
-SQLite or starts a repository process. Responses deliberately omit server paths and
-carry `X-Khive-Analysis-Source: khive-db-snapshot` plus the analysis ID and a canonical
-byte ETag.
+`$KHIVE_SHOWCASE_ANALYSIS_ROOT/khive/khive.repo.v1.json`. Discover configured entries at
+`/api/showcase/analyses`, then fetch this report at
+`/api/showcase/analyses/khive`. `KHIVE_SHOWCASE_ANALYSES` is a strict JSON array of one
+to 64 `{analysis_id, canonical_url}` objects. IDs and normalized repository URLs must
+both be unique; one invalid entry makes the entire catalog unavailable. The catalog is
+sorted by analysis ID and exposes only those two public fields. It does not scan the
+analysis root or read a report.
+
+The report route rejects symlinks, reports above 8 MiB, malformed bundles, unknown IDs,
+and bundles whose normalized `meta.repository.canonical_url` does not match the URL
+configured for that ID. It never opens SQLite or starts a repository process. Responses
+deliberately omit server paths and carry
+`X-Khive-Analysis-Source: khive-db-snapshot` plus the analysis ID and a canonical byte
+ETag. Both API routes use `private, no-store` and `nosniff` responses; an absent or
+invalid operator catalog returns a sanitized 404.
 
 The analysis root and its parent must be owned by the operator and unavailable for
 untrusted local writes. Promoted analysis directories are immutable: build into a fresh
@@ -114,7 +123,7 @@ containment and file identity after opening and reads at most 8 MiB plus one sen
 byte.
 
 This is a pinned DB-backed snapshot, not a live mutable query and not arbitrary URL
-ingest. See ADR-147 Amendment 1 and the repository-showcase CLI guide.
+ingest. See ADR-147 Amendments 1–2 and the repository-showcase CLI guide.
 
 ## Adapter boundary
 

--- a/apps/kg-editor/src/app/api/showcase/analyses/[id]/route.test.ts
+++ b/apps/kg-editor/src/app/api/showcase/analyses/[id]/route.test.ts
@@ -5,6 +5,9 @@ import { dirname, resolve } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createShowcaseAnalysisGet } from "@/lib/server/showcase-analysis-route";
+import {
+  ShowcaseAnalysisError,
+} from "@/lib/server/materialized-showcase-source";
 
 const goldenPath = resolve(
   process.cwd(),
@@ -18,7 +21,13 @@ async function configuredAnalysis() {
   const report = resolve(root, "khive", "khive.repo.v1.json");
   await mkdir(dirname(report), { recursive: true });
   await writeFile(report, await readFile(goldenPath));
-  return { root, ids: new Set(["khive"]) };
+  return {
+    root,
+    entries: [{
+      analysis_id: "khive",
+      canonical_url: "https://github.com/ohdearquant/khive",
+    }],
+  };
 }
 
 afterEach(async () => {
@@ -63,7 +72,10 @@ describe("GET /api/showcase/analyses/[id]", () => {
   it("returns a stable sanitized error envelope for an unknown id", async () => {
     const registry = {
       root: "/a/server/private/path/that/must/not/be-read",
-      ids: new Set(["khive"]),
+      entries: [{
+        analysis_id: "khive",
+        canonical_url: "https://github.com/ohdearquant/khive",
+      }],
     };
     const loadAnalysis = vi.fn();
     const get = createShowcaseAnalysisGet(() => registry, loadAnalysis);
@@ -86,5 +98,39 @@ describe("GET /api/showcase/analyses/[id]", () => {
     });
     expect(body).not.toContain(registry.root);
     expect(loadAnalysis).not.toHaveBeenCalled();
+  });
+
+  it("sanitizes a configured report that fails identity validation", async () => {
+    const registry = {
+      root: "/a/server/private/path/that/must/not-be-returned",
+      entries: [{
+        analysis_id: "khive",
+        canonical_url: "https://github.com/operator/private-repository",
+      }],
+    };
+    const get = createShowcaseAnalysisGet(
+      () => registry,
+      async () => {
+        throw new ShowcaseAnalysisError("ANALYSIS_INVALID");
+      },
+    );
+
+    const response = await get(
+      new Request("http://localhost/api/showcase/analyses/khive"),
+      { params: Promise.resolve({ id: "khive" }) },
+    );
+
+    expect(response.status).toBe(500);
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+    const body = await response.text();
+    expect(JSON.parse(body)).toEqual({
+      error: {
+        code: "ANALYSIS_INVALID",
+        message: "This repository analysis did not pass validation.",
+      },
+    });
+    expect(body).not.toContain(registry.root);
+    expect(body).not.toContain(registry.entries[0].canonical_url);
   });
 });

--- a/apps/kg-editor/src/app/api/showcase/analyses/route.test.ts
+++ b/apps/kg-editor/src/app/api/showcase/analyses/route.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createShowcaseAnalysisCatalogGet,
+} from "@/lib/server/showcase-analysis-route";
+import {
+  ShowcaseAnalysisError,
+  type ShowcaseAnalysisRegistry,
+} from "@/lib/server/materialized-showcase-source";
+
+describe("GET /api/showcase/analyses", () => {
+  it("returns a strict deterministic v1 catalog without private fields", async () => {
+    const registry: ShowcaseAnalysisRegistry = {
+      root: "/server/private/analyses",
+      entries: [
+        {
+          analysis_id: "zeta",
+          canonical_url: "https://github.com/example/zeta",
+        },
+        {
+          analysis_id: "alpha",
+          canonical_url: "https://github.com/example/alpha",
+        },
+      ],
+    };
+    const loadRegistry = vi.fn(() => registry);
+    const get = createShowcaseAnalysisCatalogGet(loadRegistry);
+
+    const response = await get();
+
+    expect(loadRegistry).toHaveBeenCalledOnce();
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(response.headers.get("content-type")).toBe(
+      "application/json; charset=utf-8",
+    );
+    const body = await response.text();
+    expect(body).toBe(
+      '{"schema_version":"khive.showcase.catalog.v1","entries":' +
+        '[{"analysis_id":"alpha","canonical_url":' +
+        '"https://github.com/example/alpha"},{"analysis_id":"zeta",' +
+        '"canonical_url":"https://github.com/example/zeta"}]}',
+    );
+    expect(body).not.toContain(registry.root);
+  });
+
+  it("returns a sanitized private 404 when the catalog is unconfigured", async () => {
+    const get = createShowcaseAnalysisCatalogGet(() => {
+      throw new ShowcaseAnalysisError("NOT_CONFIGURED");
+    });
+
+    const response = await get();
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "NOT_CONFIGURED",
+        message: "This repository analysis is not configured.",
+      },
+    });
+  });
+});

--- a/apps/kg-editor/src/app/api/showcase/analyses/route.ts
+++ b/apps/kg-editor/src/app/api/showcase/analyses/route.ts
@@ -1,0 +1,8 @@
+import {
+  createShowcaseAnalysisCatalogGet,
+} from "@/lib/server/showcase-analysis-route";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export const GET = createShowcaseAnalysisCatalogGet();

--- a/apps/kg-editor/src/lib/server/materialized-showcase-source.test.ts
+++ b/apps/kg-editor/src/lib/server/materialized-showcase-source.test.ts
@@ -42,19 +42,129 @@ afterEach(async () => {
 });
 
 describe("materialized showcase analysis source", () => {
-  it("resolves only an explicit closed analysis-id registry", () => {
+  it("resolves a normalized, deterministic explicit analysis registry", () => {
     const root = "/server/private/analyses";
     expect(resolveShowcaseAnalysisRegistry({
       KHIVE_SHOWCASE_ANALYSIS_ROOT: root,
-      KHIVE_SHOWCASE_ANALYSIS_IDS: "khive, example-2",
-    })).toEqual({ root, ids: new Set(["khive", "example-2"]) });
+      KHIVE_SHOWCASE_ANALYSES: JSON.stringify([
+        {
+          analysis_id: "khive",
+          canonical_url:
+            "http://www.github.com/ohdearquant/khive.git?tab=readme",
+        },
+        {
+          analysis_id: "example-2",
+          canonical_url: "https://github.com/example/two/",
+        },
+      ]),
+    })).toEqual({
+      root,
+      entries: [
+        {
+          analysis_id: "example-2",
+          canonical_url: "https://github.com/example/two",
+        },
+        {
+          analysis_id: "khive",
+          canonical_url: "https://github.com/ohdearquant/khive",
+        },
+      ],
+    });
+  });
 
+  it("fails closed on malformed, non-strict, empty, or oversized registries", () => {
+    const root = "/server/private/analyses";
+    const entries = Array.from({ length: 65 }, (_, index) => ({
+      analysis_id: `repo-${index}`,
+      canonical_url: `https://github.com/example/repo-${index}`,
+    }));
+
+    for (
+      const configured of [
+        "not json",
+        "{}",
+        "[]",
+        JSON.stringify([{
+          analysis_id: "khive",
+          canonical_url: "https://github.com/ohdearquant/khive",
+          path: "/private/report.json",
+        }]),
+        JSON.stringify([{
+          analysis_id: "../khive",
+          canonical_url: "https://github.com/ohdearquant/khive",
+        }]),
+        JSON.stringify([{
+          analysis_id: "khive",
+          canonical_url: "file:///server/private/khive",
+        }]),
+        JSON.stringify(entries),
+      ]
+    ) {
+      expect(() =>
+        resolveShowcaseAnalysisRegistry({
+          KHIVE_SHOWCASE_ANALYSIS_ROOT: root,
+          KHIVE_SHOWCASE_ANALYSES: configured,
+        })
+      ).toThrow(ShowcaseAnalysisError);
+    }
+  });
+
+  it("fails closed when ids or normalized repository URLs collide", () => {
+    const root = "/server/private/analyses";
+    const configurations = [
+      [
+        {
+          analysis_id: "khive",
+          canonical_url: "https://github.com/ohdearquant/khive",
+        },
+        {
+          analysis_id: "khive",
+          canonical_url: "https://github.com/example/other",
+        },
+      ],
+      [
+        {
+          analysis_id: "khive",
+          canonical_url: "https://github.com/ohdearquant/khive",
+        },
+        {
+          analysis_id: "khive-alias",
+          canonical_url: "http://www.github.com/ohdearquant/khive.git",
+        },
+      ],
+    ];
+
+    for (const entries of configurations) {
+      expect(() =>
+        resolveShowcaseAnalysisRegistry({
+          KHIVE_SHOWCASE_ANALYSIS_ROOT: root,
+          KHIVE_SHOWCASE_ANALYSES: JSON.stringify(entries),
+        })
+      ).toThrow(ShowcaseAnalysisError);
+    }
+  });
+
+  it("does not accept the removed id-only allowlist", () => {
     expect(() =>
       resolveShowcaseAnalysisRegistry({
-        KHIVE_SHOWCASE_ANALYSIS_ROOT: root,
-        KHIVE_SHOWCASE_ANALYSIS_IDS: "khive,../escape",
+        KHIVE_SHOWCASE_ANALYSIS_ROOT: "/server/private/analyses",
+        KHIVE_SHOWCASE_ANALYSIS_IDS: "khive",
       })
     ).toThrow(ShowcaseAnalysisError);
+  });
+
+  it("requires an absolute operator-owned analysis root", () => {
+    for (const root of [undefined, "", "relative/analyses"]) {
+      expect(() =>
+        resolveShowcaseAnalysisRegistry({
+          KHIVE_SHOWCASE_ANALYSIS_ROOT: root,
+          KHIVE_SHOWCASE_ANALYSES: JSON.stringify([{
+            analysis_id: "khive",
+            canonical_url: "https://github.com/ohdearquant/khive",
+          }]),
+        })
+      ).toThrow(ShowcaseAnalysisError);
+    }
   });
 
   it("loads and validates a server-private DB-produced snapshot", async () => {
@@ -64,7 +174,13 @@ describe("materialized showcase analysis source", () => {
 
     const result = await loadMaterializedShowcaseAnalysis(
       "khive",
-      { root, ids: new Set(["khive"]) },
+      {
+        root,
+        entries: [{
+          analysis_id: "khive",
+          canonical_url: "https://github.com/ohdearquant/khive",
+        }],
+      },
     );
 
     expect(result.bundle.schema_version).toBe("khive.repo.v1");
@@ -78,10 +194,36 @@ describe("materialized showcase analysis source", () => {
     for (const id of ["unknown", "../khive", "khive/../../escape"]) {
       await expect(loadMaterializedShowcaseAnalysis(
         id,
-        { root, ids: new Set(["khive"]) },
+        {
+          root,
+          entries: [{
+            analysis_id: "khive",
+            canonical_url: "https://github.com/ohdearquant/khive",
+          }],
+        },
       )).rejects.toMatchObject({ code: "NOT_CONFIGURED" });
     }
   });
+
+  it(
+    "rejects a valid bundle whose repository URL is not configured for its id",
+    async () => {
+      const root = await temporaryRoot();
+      await writeAnalysis(root, "khive", await readFile(goldenPath));
+
+      await expect(loadMaterializedShowcaseAnalysis(
+        "khive",
+        {
+          root,
+          entries: [{
+            analysis_id: "khive",
+            canonical_url: "https://github.com/example/different-repository",
+          }],
+        },
+      )).rejects.toMatchObject({ code: "ANALYSIS_INVALID" });
+    },
+    20_000,
+  );
 
   it.runIf(process.platform !== "win32")(
     "refuses a symlinked report even when it resolves under the configured root",
@@ -95,7 +237,13 @@ describe("materialized showcase analysis source", () => {
 
       await expect(loadMaterializedShowcaseAnalysis(
         "khive",
-        { root, ids: new Set(["khive"]) },
+        {
+          root,
+          entries: [{
+            analysis_id: "khive",
+            canonical_url: "https://github.com/ohdearquant/khive",
+          }],
+        },
       )).rejects.toMatchObject({ code: "ANALYSIS_INVALID" });
     },
   );
@@ -110,7 +258,13 @@ describe("materialized showcase analysis source", () => {
 
       await expect(loadMaterializedShowcaseAnalysis(
         "khive",
-        { root, ids: new Set(["khive"]) },
+        {
+          root,
+          entries: [{
+            analysis_id: "khive",
+            canonical_url: "https://github.com/ohdearquant/khive",
+          }],
+        },
       )).rejects.toMatchObject({ code: "ANALYSIS_INVALID" });
     },
   );
@@ -122,14 +276,26 @@ describe("materialized showcase analysis source", () => {
 
     await expect(loadMaterializedShowcaseAnalysis(
       "large",
-      { root, ids: new Set(["large"]) },
+      {
+        root,
+        entries: [{
+          analysis_id: "large",
+          canonical_url: "https://github.com/example/large",
+        }],
+      },
     )).rejects.toMatchObject({ code: "ANALYSIS_TOO_LARGE" });
 
     let error: unknown;
     try {
       await loadMaterializedShowcaseAnalysis(
         "invalid",
-        { root, ids: new Set(["invalid"]) },
+        {
+          root,
+          entries: [{
+            analysis_id: "invalid",
+            canonical_url: "https://github.com/example/invalid",
+          }],
+        },
       );
     } catch (caught) {
       error = caught;

--- a/apps/kg-editor/src/lib/server/materialized-showcase-source.ts
+++ b/apps/kg-editor/src/lib/server/materialized-showcase-source.ts
@@ -4,8 +4,10 @@ import { type FileHandle, lstat, open, realpath } from "node:fs/promises";
 import { isAbsolute, relative, resolve } from "node:path";
 
 import { parseRepoBundle, type RepoBundle } from "@/lib/repo-bundle";
+import { normalizeRepositoryUrl } from "@/lib/showcase-registry";
 
 export const SHOWCASE_ANALYSIS_MAX_BYTES = 8 * 1024 * 1024;
+export const SHOWCASE_ANALYSIS_MAX_ENTRIES = 64;
 const ANALYSIS_REPORT_NAME = "khive.repo.v1.json";
 const analysisIdPattern = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/;
 
@@ -45,9 +47,14 @@ export class ShowcaseAnalysisError extends Error {
   }
 }
 
+export type ShowcaseAnalysisCatalogEntry = Readonly<{
+  analysis_id: string;
+  canonical_url: string;
+}>;
+
 export type ShowcaseAnalysisRegistry = Readonly<{
   root: string;
-  ids: ReadonlySet<string>;
+  entries: readonly ShowcaseAnalysisCatalogEntry[];
 }>;
 
 export type MaterializedShowcaseAnalysis = Readonly<{
@@ -58,17 +65,63 @@ export type MaterializedShowcaseAnalysis = Readonly<{
 
 type Environment = Readonly<Record<string, string | undefined>>;
 
-function configuredAnalysisIds(value: string | undefined): ReadonlySet<string> {
-  const ids = new Set(
-    (value ?? "")
-      .split(",")
-      .map((id) => id.trim())
-      .filter(Boolean),
-  );
-  if (ids.size === 0 || [...ids].some((id) => !analysisIdPattern.test(id))) {
+function configuredAnalyses(
+  value: string | undefined,
+): readonly ShowcaseAnalysisCatalogEntry[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value ?? "");
+  } catch {
     throw new ShowcaseAnalysisError("NOT_CONFIGURED");
   }
-  return ids;
+  if (
+    !Array.isArray(parsed) || parsed.length === 0 ||
+    parsed.length > SHOWCASE_ANALYSIS_MAX_ENTRIES
+  ) {
+    throw new ShowcaseAnalysisError("NOT_CONFIGURED");
+  }
+
+  const entries: ShowcaseAnalysisCatalogEntry[] = [];
+  const ids = new Set<string>();
+  const urls = new Set<string>();
+  for (const candidate of parsed) {
+    if (
+      !candidate || typeof candidate !== "object" ||
+      Array.isArray(candidate) ||
+      Object.keys(candidate).sort().join(",") !==
+        "analysis_id,canonical_url"
+    ) {
+      throw new ShowcaseAnalysisError("NOT_CONFIGURED");
+    }
+    const analysisId = Reflect.get(candidate, "analysis_id");
+    const canonicalUrl = Reflect.get(candidate, "canonical_url");
+    if (
+      typeof analysisId !== "string" ||
+      !analysisIdPattern.test(analysisId) ||
+      typeof canonicalUrl !== "string"
+    ) {
+      throw new ShowcaseAnalysisError("NOT_CONFIGURED");
+    }
+    const normalizedUrl = normalizeRepositoryUrl(canonicalUrl);
+    if (
+      !normalizedUrl.ok || ids.has(analysisId) || urls.has(normalizedUrl.value)
+    ) {
+      throw new ShowcaseAnalysisError("NOT_CONFIGURED");
+    }
+    ids.add(analysisId);
+    urls.add(normalizedUrl.value);
+    entries.push({
+      analysis_id: analysisId,
+      canonical_url: normalizedUrl.value,
+    });
+  }
+  return entries.sort((left, right) =>
+    left.analysis_id < right.analysis_id
+      ? -1
+      : left.analysis_id > right.analysis_id
+      ? 1
+      : 0
+  );
 }
 
 export function resolveShowcaseAnalysisRegistry(
@@ -80,8 +133,16 @@ export function resolveShowcaseAnalysisRegistry(
   }
   return {
     root,
-    ids: configuredAnalysisIds(environment.KHIVE_SHOWCASE_ANALYSIS_IDS),
+    entries: configuredAnalyses(environment.KHIVE_SHOWCASE_ANALYSES),
   };
+}
+
+export function configuredShowcaseAnalysis(
+  id: string,
+  registry: ShowcaseAnalysisRegistry,
+): ShowcaseAnalysisCatalogEntry | undefined {
+  if (!analysisIdPattern.test(id)) return undefined;
+  return registry.entries.find((entry) => entry.analysis_id === id);
 }
 
 function isContainedPath(root: string, candidate: string): boolean {
@@ -156,7 +217,8 @@ export async function loadMaterializedShowcaseAnalysis(
   id: string,
   registry: ShowcaseAnalysisRegistry = resolveShowcaseAnalysisRegistry(),
 ): Promise<MaterializedShowcaseAnalysis> {
-  if (!analysisIdPattern.test(id) || !registry.ids.has(id)) {
+  const configured = configuredShowcaseAnalysis(id, registry);
+  if (!configured) {
     throw new ShowcaseAnalysisError("NOT_CONFIGURED");
   }
 
@@ -212,6 +274,16 @@ export async function loadMaterializedShowcaseAnalysis(
     const json = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
     bundle = parseRepoBundle(JSON.parse(json));
   } catch {
+    throw new ShowcaseAnalysisError("ANALYSIS_INVALID");
+  }
+  const bundleUrl = normalizeRepositoryUrl(
+    bundle.meta.repository.canonical_url,
+  );
+  const configuredUrl = normalizeRepositoryUrl(configured.canonical_url);
+  if (
+    !bundleUrl.ok || !configuredUrl.ok ||
+    bundleUrl.value !== configuredUrl.value
+  ) {
     throw new ShowcaseAnalysisError("ANALYSIS_INVALID");
   }
 

--- a/apps/kg-editor/src/lib/server/showcase-analysis-route.ts
+++ b/apps/kg-editor/src/lib/server/showcase-analysis-route.ts
@@ -1,4 +1,5 @@
 import {
+  configuredShowcaseAnalysis,
   loadMaterializedShowcaseAnalysis,
   type MaterializedShowcaseAnalysis,
   resolveShowcaseAnalysisRegistry,
@@ -35,7 +36,7 @@ export function createShowcaseAnalysisGet(
     const { id } = await context.params;
     try {
       const registry = await loadRegistry();
-      if (!registry.ids.has(id)) {
+      if (!configuredShowcaseAnalysis(id, registry)) {
         throw new ShowcaseAnalysisError("NOT_CONFIGURED");
       }
       const analysis = await loadAnalysis(id, registry);
@@ -49,6 +50,49 @@ export function createShowcaseAnalysisGet(
           "x-khive-analysis-source": "khive-db-snapshot",
         },
       });
+    } catch (error) {
+      const safeError = error instanceof ShowcaseAnalysisError
+        ? error
+        : new ShowcaseAnalysisError("ANALYSIS_UNAVAILABLE");
+      return Response.json(showcaseAnalysisErrorBody(safeError), {
+        status: safeError.status,
+        headers: responseHeaders,
+      });
+    }
+  };
+}
+
+export function createShowcaseAnalysisCatalogGet(
+  loadRegistry: RegistryLoader = resolveShowcaseAnalysisRegistry,
+) {
+  return async function get(): Promise<Response> {
+    try {
+      const registry = await loadRegistry();
+      const entries = registry.entries
+        .map(({ analysis_id, canonical_url }) => ({
+          analysis_id,
+          canonical_url,
+        }))
+        .sort((left, right) =>
+          left.analysis_id < right.analysis_id
+            ? -1
+            : left.analysis_id > right.analysis_id
+            ? 1
+            : 0
+        );
+      return new Response(
+        JSON.stringify({
+          schema_version: "khive.showcase.catalog.v1",
+          entries,
+        }),
+        {
+          status: 200,
+          headers: {
+            ...responseHeaders,
+            "content-type": "application/json; charset=utf-8",
+          },
+        },
+      );
     } catch (error) {
       const safeError = error instanceof ShowcaseAnalysisError
         ? error

--- a/crates/kkernel/docs/repo-showcase.md
+++ b/crates/kkernel/docs/repo-showcase.md
@@ -136,3 +136,24 @@ kkernel repo build \
 
 KG Studio receives only the opaque `khive` ID. It never receives the paths above and
 does not run this command in response to a browser request.
+
+Configure the server with an explicit ID-to-repository binding:
+
+```bash
+KHIVE_SHOWCASE_ANALYSIS_ROOT=<analysis-root> \
+KHIVE_SHOWCASE_ANALYSES='[{"analysis_id":"khive","canonical_url":"https://github.com/ohdearquant/khive"}]' \
+npm run dev
+```
+
+`KHIVE_SHOWCASE_ANALYSES` accepts one to 64 strict objects. Both the ID and normalized
+repository URL must be unique across the array; malformed JSON, unknown fields, invalid
+IDs or URLs, and duplicate bindings make the complete catalog unavailable. The legacy
+ID-only allowlist is not accepted because an ID without a repository identity cannot
+bind the materialized report to operator intent.
+
+`GET /api/showcase/analyses` returns the sorted
+`khive.showcase.catalog.v1` catalog. It exposes only `analysis_id` and `canonical_url`,
+does not enumerate the analysis root, and does not read reports, databases, or process
+state. `GET /api/showcase/analyses/khive` reads the explicit bounded report and rejects
+it when the bundle's normalized repository URL differs from the configured URL. Both
+routes return sanitized, private, non-cacheable responses.

--- a/docs/adr/ADR-147-repo-showcase-bundle.md
+++ b/docs/adr/ADR-147-repo-showcase-bundle.md
@@ -323,3 +323,47 @@ in TypeScript. The server boundary can land independently while the static adapt
 remains the default. This amendment does not authorize request-time `repo export`,
 arbitrary-URL ingestion, or direct browser/Next.js access to SQLite. Those remain slice
 2 and require the queueing, sandboxing, resource-limit, and abuse-control design in D4.
+
+## Amendment 2 — Operator-configured analysis catalog (2026-08-14)
+
+Amendment 1 allowed an operator to name completed materialized reports by opaque ID, but
+an ID-only allowlist left two missing contracts: a browser could not discover the
+configured set without an out-of-band static registry, and the report route did not bind
+an ID to the repository identity inside the loaded bundle. This amendment closes both
+gaps without adding discovery of server-private storage.
+
+The operator configuration is `KHIVE_SHOWCASE_ANALYSES`, a JSON array of strict
+`{analysis_id, canonical_url}` objects. It contains one to 64 entries. Analysis IDs use
+the Amendment 1 closed ID grammar. Repository URLs pass the same normalization used by
+the showcase lookup: HTTP and HTTPS inputs canonicalize to HTTPS, host names are
+case-normalized, the GitHub `www` alias and a terminal `.git` suffix are removed, and
+query, fragment, and trailing-slash variations do not create new identities. Both
+analysis ID and normalized URL are unique across the array. Malformed JSON, a non-array,
+an empty or oversized array, unknown object fields, an invalid ID or URL, or either kind
+of duplicate makes the whole configuration unavailable. The former
+`KHIVE_SHOWCASE_ANALYSIS_IDS` setting is not a compatibility surface.
+
+`GET /api/showcase/analyses` returns this exact deterministic envelope, ordered by
+`analysis_id`:
+
+```json
+{
+  "schema_version": "khive.showcase.catalog.v1",
+  "entries": [{ "analysis_id": "khive", "canonical_url": "https://github.com/ohdearquant/khive" }]
+}
+```
+
+Each entry contains exactly `analysis_id` and `canonical_url`. No server path, report
+metadata, database state, build state, or operator-only field is present. Catalog
+handling parses the bounded explicit configuration only: it does not enumerate the
+analysis root, read a report, open SQLite, or execute a process. The response is JSON
+with `Cache-Control: private, no-store` and `X-Content-Type-Options: nosniff`. Missing or
+invalid configuration returns Amendment 1's sanitized `NOT_CONFIGURED` 404 envelope.
+
+The existing `GET /api/showcase/analyses/[id]` route additionally resolves the configured
+entry before any filesystem access. After its existing bounded, symlink-resistant read
+and closed `khive.repo.v1` validation, it normalizes
+`meta.repository.canonical_url` and requires equality with that entry's configured URL.
+A mismatch is `ANALYSIS_INVALID`; neither URL nor a private path is reflected in the
+error. Request-time clone, export, SQLite access, process execution, directory scanning,
+and arbitrary URL ingest remain forbidden.


### PR DESCRIPTION
## Summary

- expose a deterministic khive.showcase.catalog.v1 endpoint from a strict operator-owned configuration
- bound the catalog to 64 unique analysis IDs and normalized repository URLs, failing the complete configuration closed
- bind each loaded khive.repo.v1 report URL to its configured analysis identity while preserving the existing snapshot filesystem defenses
- document the contract in ADR-147 Amendment 2, the KG editor README, and the repository-showcase operator guide

## Stack

Depends on #1937. This is a follow-up stacked on codex/kg-editor-live-snapshot; it does not close a separate issue.

## Validation

- npm test — 15 files, 80 tests passed
- npm run typecheck — passed
- npm run lint — passed with zero errors and three pre-existing repo-showcase warnings
- npm run check:showcase — passed
- npx next build --webpack — passed; both analysis routes are dynamic
- production localhost smoke — catalog 200, configured report 200, unknown analysis sanitized 404
- independent read-only source review — APPROVE with no correctness, security, Next 16, or documentation findings

## Environment note

The default Turbopack build cannot traverse this isolated worktree dependency setup because node_modules is an ignored symlink to another worktree (points out of the filesystem root). The production webpack build passes; this is an environment-only worktree limitation, not a source failure.