### PR TITLE
fix(retrieval): guarantee untruncated recall pool and harden scratch-path handling

### DIFF
--- a/benches/retrieval/README.md
+++ b/benches/retrieval/README.md
@@ -62,6 +62,24 @@ baseline.
   detects — but does not prevent — that residual race for paths the
   consumer only reads. Do not read this harness's path verification as
   full race-resistance for the lifetime of a returned path.
+
+  **Residual TOCTOU window in cleanup (by design, not closed):**
+  `cleanup_scratch` walks the scratch tree through a TOCTOU-guarded fd and,
+  at every recursion depth, checks each directory's identity two ways: its
+  `fstat`ed (device, inode) must match the inode `os.scandir()` observed
+  for that name moments earlier (catching a directory swapped in *after*
+  this run started walking the tree — same mechanism regardless of nesting
+  depth, not just at the top level), and, for `home`/`tmp`, against the
+  identity recorded when this run created them. Neither check can see a
+  substitution that already happened *before* this run's own listing of a
+  given directory — e.g. a directory the `kkernel` subprocess itself
+  creates during the run (`blobs`, `eval.db.ann`, `.khive`, `.lattice/...`)
+  has no creation-time identity recorded for it — only the listing-time
+  check made when this run's own walk reaches it. A directory already
+  replaced by the time that walk arrives is indistinguishable from one the
+  subprocess legitimately created. This is the same category of residual
+  as the path-API race above: detectable-forward-from-a-known-point, not
+  closed for all time.
 - **Binary identity**: every run records `kkernel --version` and prints it;
   `gold/A_fused_direct.json` embeds the `kkernel_version` it was derived
   with. A revision differing from gold's recorded one is reported as

--- a/benches/retrieval/README.md
+++ b/benches/retrieval/README.md
@@ -34,19 +34,34 @@ baseline.
   temp directory. The default `--scratch-dir` is always a freshly created
   private directory (`tempfile.mkdtemp`); a caller-supplied `--scratch-dir`
   is rejected if any existing component of its path is a symlink (the root
-  itself, its parent, or any ancestor hop — macOS's OS-owned `/tmp` ->
-  `/private/tmp` mapping excepted), or if it already exists and is
+  itself, its parent, or any ancestor hop — macOS's OS-owned `/tmp`, `/var`,
+  `/etc` -> `/private/...` firmlink mappings excepted, and only those exact
+  three prefixes), or if it already exists and is
   non-empty — the harness only ever writes into a scratch root it created
   itself. The child process gets a minimal
-  allowlisted environment (`PATH`, `HOME`/`TMPDIR` redirected into the
-  scratch root, `KHIVE_DB`, and a pinned `KHIVE_EMBEDDING_MODEL`) instead of
+  allowlisted environment (`PATH`, `HOME`/`TMPDIR` redirected into `home`/
+  `tmp` subdirectories created through the pinned scratch-root fd, `KHIVE_DB`,
+  and a pinned `KHIVE_EMBEDDING_MODEL`) instead of
   the caller's full environment, so no inherited `KHIVE_*` variable can
   change what gets scored. The runner refuses to start if an inherited
   `KHIVE_DB` already points at an existing file outside its own scratch
   directory — it never reads or writes a production database.
   `evaluate.py --self-test` exercises these refusals directly (symlinked
-  root, pre-existing/non-empty root, symlinked `eval.db`) without needing a
-  `kkernel` binary.
+  root, pre-existing/non-empty root, symlinked `eval.db`, directory
+  substitution at cleanup, degraded/budget-capped recall envelopes) without
+  needing a `kkernel` binary.
+
+  **Residual TOCTOU window (by design, not closed):** every scratch path
+  handed to `sqlite3`/the `kkernel` subprocess is verified (device + inode,
+  through a TOCTOU-guarded root fd) immediately before that call —
+  `verified_scratch_path`/`VerifiedScratchPath` in `evaluate.py`. Neither
+  API accepts an already-open descriptor (and macOS has no `/proc/self/fd`
+  to convert one), so a swap landing between that verification and the
+  instant the consumer itself opens the path cannot be prevented from this
+  side; `VerifiedScratchPath.recheck()`, called after the consumer returns,
+  detects — but does not prevent — that residual race for paths the
+  consumer only reads. Do not read this harness's path verification as
+  full race-resistance for the lifetime of a returned path.
 - **Binary identity**: every run records `kkernel --version` and prints it;
   `gold/A_fused_direct.json` embeds the `kkernel_version` it was derived
   with. A revision differing from gold's recorded one is reported as

--- a/benches/retrieval/evaluate.py
+++ b/benches/retrieval/evaluate.py
@@ -23,7 +23,6 @@ import json
 import math
 import os
 import re
-import shutil
 import sqlite3
 import subprocess
 import sys
@@ -51,9 +50,21 @@ PINNED_EMBEDDING_MODEL = "all-minilm-l6-v2"
 # term is zeroed so gold is clock-hermetic (see README "Determinism"
 # section). relevance/salience keep the product defaults (0.7/0.2) so the
 # weight sum stays positive and stable.
+#
+# default_token_budget is pinned to the server-side DoS cap (MAX_TOKEN_BUDGET,
+# crates/khive-pack-memory/src/scoring.rs) rather than the product default
+# (4000): the response token budget is applied after top_k ranking
+# (crates/khive-pack-memory/src/handlers/recall.rs handle_recall, the
+# `budget_cutoff` loop) and can truncate a 100-hit pool below what a
+# Recall@100 label requires. Pinning to the fixed server-side maximum keeps
+# the corpus untruncated (worst case ~31k chars for the 100 longest notes in
+# this harness's corpus vs. a 16000*4=64000-char budget at this setting)
+# without deriving the number from actual corpus content, which would make
+# gold non-hermetic.
 HERMETIC_RECALL_CONFIG = {
     "scoring": {
         "weights": {"relevance": 0.7, "salience": 0.2, "temporal": 0.0},
+        "default_token_budget": 16000,
     }
 }
 
@@ -146,6 +157,178 @@ def _reject_existing_scratch_db(db_path: Path) -> None:
             )
 
 
+def _open_dir_component_nofollow(parent_fd: int, name: str, full_path: Path) -> int:
+    """openat-style: open `name` as a directory relative to `parent_fd`,
+    refusing to follow a symlink at this single hop (O_NOFOLLOW) — except
+    the macOS /tmp,/var,/etc -> /private ambient mapping, which is OS-owned
+    rather than attacker-plantable (see `_ambient_symlink`). Returns a new
+    directory fd; the caller owns it and must close it.
+
+    O_NOFOLLOW's failure errno for "this is a symlink" is platform-dependent
+    (ELOOP on Linux, ENOTDIR on macOS when combined with O_DIRECTORY), so the
+    ambient-mapping exception is decided by `lstat`-checking the component
+    itself (`_ambient_symlink`, same check `_validate_scratch_root` uses)
+    rather than by matching a specific errno.
+    """
+    try:
+        return os.open(
+            name, os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC, dir_fd=parent_fd
+        )
+    except OSError as e:
+        if full_path.is_symlink() and _ambient_symlink(full_path):
+            return os.open(name, os.O_DIRECTORY | os.O_CLOEXEC, dir_fd=parent_fd)
+        raise SystemExit(
+            f"refusing --scratch-dir: symlink or non-directory encountered at "
+            f"{full_path} while opening the scratch root (TOCTOU guard): {e}"
+        ) from e
+
+
+def open_scratch_root_fd(root: Path) -> int:
+    """Open a persistent, race-resistant directory fd for `root`.
+
+    `_validate_scratch_root` checks components with `lstat` and then
+    `make_scratch` creates the directory — a concurrent process can swap a
+    component for a symlink in the gap between that check and this open.
+    Walking every component from the filesystem root via `openat`
+    (`dir_fd=`) with `O_NOFOLLOW` closes that gap: each hop is resolved
+    relative to the fd already opened for its parent, so a symlink planted
+    after validation is refused here instead of silently followed. All
+    subsequent scratch file access in this run goes through the returned fd,
+    never through `root` as a bare path.
+    """
+    root = root.absolute()
+    fd = os.open(root.anchor, os.O_DIRECTORY | os.O_CLOEXEC)
+    cur = Path(root.anchor)
+    try:
+        for part in root.relative_to(root.anchor).parts:
+            cur = cur / part
+            next_fd = _open_dir_component_nofollow(fd, part, cur)
+            os.close(fd)
+            fd = next_fd
+        return fd
+    except BaseException:
+        os.close(fd)
+        raise
+
+
+def _claim_scratch_file(root_fd: int, name: str) -> None:
+    """Atomically claim `name` under the scratch root as a fresh, real file.
+
+    `O_CREAT | O_EXCL` refuses if anything — including a symlink — already
+    exists at `name`; `O_NOFOLLOW` additionally refuses to follow a symlink
+    raced into place on the create call itself. Immediately closed: kkernel
+    (subprocess) and sqlite3 need a path string, not an fd (see
+    `verified_scratch_path`), so the claim's only job is to make the
+    eventual path-based open resolve to a file this run created, not one a
+    concurrent process substituted.
+    """
+    fd = os.open(
+        name,
+        os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | os.O_WRONLY | os.O_CLOEXEC,
+        0o600,
+        dir_fd=root_fd,
+    )
+    os.close(fd)
+
+
+def verified_scratch_path(root: Path, root_fd: int, name: str) -> str:
+    """Resolve `name` under the scratch root to an absolute path string,
+    re-verified immediately before a subprocess/sqlite3 call that can only
+    take a path (neither accepts an fd, and macOS has no /proc/self/fd to
+    convert one).
+
+    Opens `name` through the TOCTOU-guarded `root_fd` with `O_NOFOLLOW`
+    (refusing a symlink) and `fstat`s that fd; separately `stat`s the
+    realpath a subprocess would actually open. If the two do not name the
+    same file (device + inode), something was swapped between the fd-based
+    claim and this call, and the harness refuses to hand the path to a
+    subprocess rather than risk it writing through a symlink.
+    """
+    try:
+        leaf_fd = os.open(
+            name, os.O_RDONLY | os.O_NOFOLLOW | os.O_CLOEXEC, dir_fd=root_fd
+        )
+    except OSError as e:
+        raise SystemExit(
+            f"refusing to use {root / name}: could not open {name!r} through the "
+            f"validated scratch-root fd without following a symlink (TOCTOU guard): {e}"
+        ) from e
+    try:
+        fd_stat = os.fstat(leaf_fd)
+    finally:
+        os.close(leaf_fd)
+    resolved = os.path.realpath(str(root / name))
+    path_stat = os.stat(resolved, follow_symlinks=False)
+    if (path_stat.st_dev, path_stat.st_ino) != (fd_stat.st_dev, fd_stat.st_ino):
+        raise SystemExit(
+            f"refusing to use {resolved}: it no longer matches the file opened "
+            "through the validated scratch-root fd (TOCTOU guard) — device/inode "
+            "changed between claim and use"
+        )
+    return resolved
+
+
+def _rmtree_contents_via_fd(dir_fd: int) -> None:
+    """Recursively delete everything inside the directory named by `dir_fd`,
+    never resolving a path string and never following a symlink: entries are
+    listed with `os.scandir(dir_fd)`, a symlink entry is `unlink`ed as a leaf
+    (removing the link itself, not its target), and only entries confirmed
+    as real directories via `O_NOFOLLOW` are opened and recursed into."""
+    with os.scandir(dir_fd) as it:
+        entries = list(it)
+    for entry in entries:
+        if entry.is_symlink():
+            os.unlink(entry.name, dir_fd=dir_fd)
+        elif entry.is_dir(follow_symlinks=False):
+            child_fd = os.open(
+                entry.name, os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC, dir_fd=dir_fd
+            )
+            try:
+                _rmtree_contents_via_fd(child_fd)
+            finally:
+                os.close(child_fd)
+            os.rmdir(entry.name, dir_fd=dir_fd)
+        else:
+            os.unlink(entry.name, dir_fd=dir_fd)
+
+
+def write_scratch_jsonl(root_fd: int, name: str, rows: list[dict]) -> None:
+    """Create-and-write `name` under the scratch root through `root_fd`.
+    `O_CREAT | O_EXCL` refuses anything already at that name (including a
+    symlink); `O_NOFOLLOW` additionally refuses a symlink raced into place
+    on the create call itself."""
+    fd = os.open(
+        name,
+        os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | os.O_WRONLY | os.O_CLOEXEC,
+        0o600,
+        dir_fd=root_fd,
+    )
+    with os.fdopen(fd, "w") as f:
+        for row in rows:
+            f.write(json.dumps(row) + "\n")
+
+
+def read_scratch_jsonl(root_fd: int, name: str) -> list[dict]:
+    """Read `name` under the scratch root through `root_fd` with
+    `O_NOFOLLOW`, so this harness's own read never follows a symlink raced
+    into place while a subprocess was writing that name."""
+    fd = os.open(name, os.O_RDONLY | os.O_NOFOLLOW | os.O_CLOEXEC, dir_fd=root_fd)
+    with os.fdopen(fd) as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+def cleanup_scratch(root: Path, root_fd: int) -> None:
+    """Delete the scratch tree through the held, TOCTOU-guarded `root_fd`
+    rather than a fresh path-based walk, then remove the now-empty root
+    directory itself. The final `rmdir` uses `root`'s path rather than a
+    parent fd (this script never opens the scratch root's parent), but
+    `rmdir` only ever removes an empty directory — a symlink or a
+    repopulated directory raced into that name fails closed instead of
+    deleting through it."""
+    _rmtree_contents_via_fd(root_fd)
+    os.rmdir(root)
+
+
 def make_scratch(scratch_dir: str | None) -> Path:
     if scratch_dir:
         root = Path(scratch_dir)
@@ -190,43 +373,47 @@ def run_kkernel(
 
 
 def seed_corpus(
-    kkernel: str, env: dict, db_path: Path, root: Path, seed: int, epoch: str
+    kkernel: str,
+    env: dict,
+    root: Path,
+    root_fd: int,
+    seed: int,
+    epoch: str,
 ) -> list[dict]:
     notes = generate_corpus.build_corpus(DEFAULT_QUERIES, seed, epoch)
     if len(notes) != 400:
         raise SystemExit(f"expected 400 notes, generator produced {len(notes)}")
-    ops_path = root / "seed_ops.jsonl"
-    save_path = root / "seed_save.jsonl"
-    with ops_path.open("w") as f:
-        for n in notes:
-            op = {
-                "tool": "memory.remember",
-                "args": {
-                    "content": n["content"],
-                    "salience": n["salience"],
-                    "decay_factor": n["decay_factor"],
-                    "memory_type": n["memory_type"],
-                    "tags": [f"k:{n['key']}"],
-                },
-            }
-            f.write(json.dumps(op) + "\n")
+    ops = [
+        {
+            "tool": "memory.remember",
+            "args": {
+                "content": n["content"],
+                "salience": n["salience"],
+                "decay_factor": n["decay_factor"],
+                "memory_type": n["memory_type"],
+                "tags": [f"k:{n['key']}"],
+            },
+        }
+        for n in notes
+    ]
+    write_scratch_jsonl(root_fd, "seed_ops.jsonl", ops)
+    _claim_scratch_file(root_fd, "seed_save.jsonl")
 
     run_kkernel(
         kkernel,
         [
             "exec",
             "--ops-file",
-            str(ops_path),
+            verified_scratch_path(root, root_fd, "seed_ops.jsonl"),
             "--save-file",
-            str(save_path),
+            verified_scratch_path(root, root_fd, "seed_save.jsonl"),
             "--db",
-            str(db_path),
+            verified_scratch_path(root, root_fd, "eval.db"),
         ],
         env,
     )
 
-    with save_path.open() as f:
-        rows = [json.loads(line) for line in f if line.strip()]
+    rows = read_scratch_jsonl(root_fd, "seed_save.jsonl")
     failed = [r for r in rows if not r.get("ok")]
     if failed:
         raise RuntimeError(f"{len(failed)} seed ops failed, e.g. {failed[0]}")
@@ -236,8 +423,8 @@ def seed_corpus(
     return notes
 
 
-def key_id_map(db_path: Path) -> dict[str, str]:
-    conn = sqlite3.connect(str(db_path))
+def key_id_map(root: Path, root_fd: int) -> dict[str, str]:
+    conn = sqlite3.connect(verified_scratch_path(root, root_fd, "eval.db"))
     try:
         cur = conn.execute(
             "SELECT id, properties FROM notes WHERE properties IS NOT NULL"
@@ -253,8 +440,10 @@ def key_id_map(db_path: Path) -> dict[str, str]:
         conn.close()
 
 
-def set_ages(db_path: Path, notes: list[dict], key_to_id: dict[str, str]) -> None:
-    conn = sqlite3.connect(str(db_path))
+def set_ages(
+    root: Path, root_fd: int, notes: list[dict], key_to_id: dict[str, str]
+) -> None:
+    conn = sqlite3.connect(verified_scratch_path(root, root_fd, "eval.db"))
     try:
         for n in notes:
             note_id = key_to_id[n["key"]]
@@ -272,49 +461,54 @@ def set_ages(db_path: Path, notes: list[dict], key_to_id: dict[str, str]) -> Non
 def run_condition(
     kkernel: str,
     env: dict,
-    db_path: Path,
     root: Path,
+    root_fd: int,
     condition: str,
     queries: list[dict],
+    corpus_size: int,
 ) -> list[dict]:
     extra_args = CONDITIONS[condition]
-    ops_path = root / f"query_ops_{condition}.jsonl"
-    save_path = root / f"query_save_{condition}.jsonl"
-    with ops_path.open("w") as f:
-        for q in queries:
-            args = {
+    ops_name = f"query_ops_{condition}.jsonl"
+    save_name = f"query_save_{condition}.jsonl"
+    ops = [
+        {
+            "tool": "memory.recall",
+            "args": {
                 "query": q["query"],
                 "top_k": CANDIDATE_POOL,
                 "include_breakdown": True,
                 "config": HERMETIC_RECALL_CONFIG,
                 **extra_args,
-            }
-            f.write(json.dumps({"tool": "memory.recall", "args": args}) + "\n")
+            },
+        }
+        for q in queries
+    ]
+    write_scratch_jsonl(root_fd, ops_name, ops)
+    _claim_scratch_file(root_fd, save_name)
 
     run_kkernel(
         kkernel,
         [
             "exec",
             "--ops-file",
-            str(ops_path),
+            verified_scratch_path(root, root_fd, ops_name),
             "--save-file",
-            str(save_path),
+            verified_scratch_path(root, root_fd, save_name),
             "--db",
-            str(db_path),
+            verified_scratch_path(root, root_fd, "eval.db"),
         ],
         env,
     )
 
-    with save_path.open() as f:
-        rows = [json.loads(line) for line in f if line.strip()]
+    rows = read_scratch_jsonl(root_fd, save_name)
     if len(rows) != len(queries):
         raise RuntimeError(f"expected {len(queries)} query rows, got {len(rows)}")
     for q, row in zip(queries, rows):
-        row["_hits"] = _validate_recall_row(q, row)
+        row["_hits"] = _validate_recall_row(q, row, corpus_size)
     return rows
 
 
-def _validate_recall_row(query: dict, row: dict) -> list:
+def _validate_recall_row(query: dict, row: dict, corpus_size: int) -> list:
     """Validate a memory.recall response row and return its hit list.
 
     The normal (non-degraded, non-budget-capped) response is a bare JSON
@@ -329,6 +523,15 @@ def _validate_recall_row(query: dict, row: dict) -> list:
     so none of those edge cases are expected; hitting one here means the
     run is not representative (e.g. a cold/unready ANN index) and must fail
     loudly rather than silently score a degraded ranking into gold.
+
+    A bare array is accepted at any length by the response shape itself —
+    the response token budget (crates/khive-pack-memory/src/handlers/
+    recall.rs `handle_recall`, the `budget_cutoff` loop after ranking) can
+    still truncate a non-empty hit list below the requested top_k, stamping
+    each surviving hit with `"truncated": true` rather than changing the
+    envelope shape. Silently scoring that shorter pool would mislabel
+    Recall@100 / TargetRecall@100 as if the full pool had been evaluated, so
+    both the pool depth and the per-hit marker are checked explicitly below.
     """
     if not row.get("ok"):
         raise RuntimeError(
@@ -337,8 +540,8 @@ def _validate_recall_row(query: dict, row: dict) -> list:
         )
     result = row.get("result")
     if isinstance(result, list):
-        return result
-    if isinstance(result, dict):
+        hits = result
+    elif isinstance(result, dict):
         if result.get("degraded"):
             raise RuntimeError(
                 f"memory.recall degraded for query_id={query['query_id']!r}: "
@@ -352,13 +555,35 @@ def _validate_recall_row(query: dict, row: dict) -> list:
                 "harness's fixed top_k on its fixed corpus"
             )
         hits = result.get("results")
-        if isinstance(hits, list):
-            return hits
-    raise RuntimeError(
-        f"memory.recall returned an unexpected response shape for "
-        f"query_id={query['query_id']!r} (got {type(result).__name__}); "
-        "expected a bare hit array or a known degraded/truncated envelope"
-    )
+        if not isinstance(hits, list):
+            raise RuntimeError(
+                f"memory.recall returned an unexpected response shape for "
+                f"query_id={query['query_id']!r} (got {type(result).__name__}); "
+                "expected a bare hit array or a known degraded/truncated envelope"
+            )
+    else:
+        raise RuntimeError(
+            f"memory.recall returned an unexpected response shape for "
+            f"query_id={query['query_id']!r} (got {type(result).__name__}); "
+            "expected a bare hit array or a known degraded/truncated envelope"
+        )
+
+    expected_pool = min(CANDIDATE_POOL, corpus_size)
+    if len(hits) < expected_pool:
+        raise RuntimeError(
+            f"memory.recall pool for query_id={query['query_id']!r} is truncated: "
+            f"got {len(hits)} hits, expected {expected_pool} (top_k={CANDIDATE_POOL} "
+            f"against a {corpus_size}-note corpus) — scoring this pool would silently "
+            "mislabel Recall@100/TargetRecall@100; raise the recall token budget "
+            "(HERMETIC_RECALL_CONFIG) or investigate the cause before re-running"
+        )
+    if any(h.get("truncated") for h in hits):
+        raise RuntimeError(
+            f"memory.recall pool for query_id={query['query_id']!r} carries per-hit "
+            f"'truncated' markers at depth {len(hits)}; the harness requires a fully "
+            "untruncated top-100 pool for a valid Recall@100 label"
+        )
+    return hits
 
 
 def dcg_at_k(grades: list[int], k: int) -> float:
@@ -624,12 +849,65 @@ def run_self_tests() -> int:
         f"expected a missing-provenance note, got {note!r}",
     )
 
+    # 10. a file swapped for a symlink to an external victim AFTER it was
+    # claimed through the validated root fd is refused at use time
+    # (`verified_scratch_path`), and the victim is left untouched — this is
+    # the TOCTOU window between validation and use, closed by O_NOFOLLOW on
+    # the fd-relative leaf open.
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "root"
+        root.mkdir()
+        root_fd = open_scratch_root_fd(root)
+        try:
+            _claim_scratch_file(root_fd, "claimed.txt")
+            victim = Path(td) / "victim.txt"
+            victim.write_text("do not touch")
+            claimed_path = root / "claimed.txt"
+            claimed_path.unlink()
+            claimed_path.symlink_to(victim)
+            ok, msg = _expect_systemexit(
+                verified_scratch_path, root, root_fd, "claimed.txt"
+            )
+            _record(
+                failures, "post-claim-symlink-swap-refused-at-use", ok, msg
+            )
+            if victim.read_text() != "do not touch":
+                failures.append(
+                    "post-claim-symlink-swap-refused-at-use: victim file was modified"
+                )
+        finally:
+            os.close(root_fd)
+
+    # 11. the device+inode re-check arm: the scratch root directory itself is
+    # swapped out from under a held `root_fd` (renamed aside, then recreated
+    # fresh at the same path) between the fd-based claim and use — a regular
+    # file, not a symlink, so O_NOFOLLOW alone would not catch it. The fd-
+    # resolved and path-resolved views of the same name now disagree on
+    # device+inode, and `verified_scratch_path` must refuse rather than hand
+    # the swapped path to a subprocess.
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "root"
+        root.mkdir()
+        root_fd = open_scratch_root_fd(root)
+        try:
+            _claim_scratch_file(root_fd, "claimed.txt")
+            moved_aside = Path(td) / "root-moved-aside"
+            root.rename(moved_aside)
+            root.mkdir()
+            (root / "claimed.txt").write_text("swapped root")
+            ok, msg = _expect_systemexit(
+                verified_scratch_path, root, root_fd, "claimed.txt"
+            )
+            _record(failures, "device-inode-mismatch-refused", ok, msg)
+        finally:
+            os.close(root_fd)
+
     if failures:
         print(f"\nSELF-TEST FAILED ({len(failures)}):", file=sys.stderr)
         for f in failures:
             print(f"  {f}", file=sys.stderr)
         return 1
-    print("\nSELF-TEST PASSED (9 checks)")
+    print("\nSELF-TEST PASSED (11 checks)")
     return 0
 
 
@@ -669,32 +947,45 @@ def main() -> int:
 
     refuse_unsafe_db_env()
     root = make_scratch(args.scratch_dir)
-    db_path = root / "eval.db"
-    _reject_existing_scratch_db(db_path)
-    env = scratch_env(root, db_path)
-
+    # Opened immediately after creation so every subsequent scratch access in
+    # this run goes through a TOCTOU-guarded fd rather than re-resolving
+    # `root` as a bare path (see `open_scratch_root_fd`).
+    root_fd = open_scratch_root_fd(root)
     try:
-        run_kkernel(args.kkernel, ["db", "migrate", "--db", str(db_path)], env)
-        queries = generate_corpus.parse_queries(args.queries)
-        notes = seed_corpus(args.kkernel, env, db_path, root, args.seed, args.epoch)
-        key_to_id = key_id_map(db_path)
-        missing = [n["key"] for n in notes if n["key"] not in key_to_id]
-        if missing:
-            raise RuntimeError(
-                f"{len(missing)} seeded notes missing tag-based id, e.g. {missing[:5]}"
-            )
-        set_ages(db_path, notes, key_to_id)
-        id_to_key = {v: k for k, v in key_to_id.items()}
+        db_path = root / "eval.db"
+        _reject_existing_scratch_db(db_path)
+        _claim_scratch_file(root_fd, "eval.db")
+        env = scratch_env(root, db_path)
 
-        result_rows = run_condition(
-            args.kkernel, env, db_path, root, args.condition, queries
-        )
-        per_query = [
-            compute_metrics(q, id_to_key, row) for q, row in zip(queries, result_rows)
-        ]
+        try:
+            run_kkernel(
+                args.kkernel,
+                ["db", "migrate", "--db", verified_scratch_path(root, root_fd, "eval.db")],
+                env,
+            )
+            queries = generate_corpus.parse_queries(args.queries)
+            notes = seed_corpus(args.kkernel, env, root, root_fd, args.seed, args.epoch)
+            key_to_id = key_id_map(root, root_fd)
+            missing = [n["key"] for n in notes if n["key"] not in key_to_id]
+            if missing:
+                raise RuntimeError(
+                    f"{len(missing)} seeded notes missing tag-based id, e.g. {missing[:5]}"
+                )
+            set_ages(root, root_fd, notes, key_to_id)
+            id_to_key = {v: k for k, v in key_to_id.items()}
+
+            result_rows = run_condition(
+                args.kkernel, env, root, root_fd, args.condition, queries, len(notes)
+            )
+            per_query = [
+                compute_metrics(q, id_to_key, row)
+                for q, row in zip(queries, result_rows)
+            ]
+        finally:
+            if not args.keep_scratch:
+                cleanup_scratch(root, root_fd)
     finally:
-        if not args.keep_scratch:
-            shutil.rmtree(root, ignore_errors=True)
+        os.close(root_fd)
 
     agg = aggregate(per_query)
     print_table(args.condition, agg)

--- a/benches/retrieval/evaluate.py
+++ b/benches/retrieval/evaluate.py
@@ -19,6 +19,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import math
 import os
@@ -291,6 +292,14 @@ class VerifiedScratchPath:
     landing between this verification and the moment the consumer itself
     opens the path cannot be prevented from here. See
     `verified_scratch_path`'s docstring for the accepted residual window.
+
+    Also a context manager: entering returns self, and exiting always calls
+    `close()`, so a caller that wraps a consumer call in `with
+    verified_scratch_path(...) as vp:` cannot leak `_leaf_fd` if that
+    consumer raises before `.recheck()`/`.discard()` runs. `close()` is
+    idempotent — calling it after `.recheck()`/`.discard()` already closed
+    the fd is a no-op, so the normal-path call and the exit-time safety net
+    never double-close.
     """
 
     __slots__ = ("path", "_leaf_fd")
@@ -298,6 +307,21 @@ class VerifiedScratchPath:
     def __init__(self, path: str, leaf_fd: int) -> None:
         self.path = path
         self._leaf_fd = leaf_fd
+
+    def __enter__(self) -> "VerifiedScratchPath":
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.close()
+
+    def close(self) -> None:
+        """Idempotently close the held leaf fd without any identity check.
+        The unconditional safety net: call directly, or rely on `__exit__`,
+        so a consumer that raises before `.recheck()`/`.discard()` runs
+        still cannot leak the descriptor."""
+        if self._leaf_fd is not None:
+            os.close(self._leaf_fd)
+            self._leaf_fd = None
 
     def recheck(self) -> None:
         """Call after the consumer (sqlite3/subprocess) that was handed
@@ -316,9 +340,15 @@ class VerifiedScratchPath:
         try:
             fd_stat = os.fstat(self._leaf_fd)
             path_stat = os.stat(self.path, follow_symlinks=False)
-        finally:
-            os.close(self._leaf_fd)
-        if (path_stat.st_dev, path_stat.st_ino) != (fd_stat.st_dev, fd_stat.st_ino):
+        except BaseException:
+            self.close()
+            raise
+        mismatched = (path_stat.st_dev, path_stat.st_ino) != (
+            fd_stat.st_dev,
+            fd_stat.st_ino,
+        )
+        self.close()
+        if mismatched:
             raise SystemExit(
                 f"refusing to trust output produced through {self.path}: it no "
                 "longer matches the file this run verified before handing the "
@@ -332,7 +362,7 @@ class VerifiedScratchPath:
         (e.g. a write-then-rename output file), where a changed inode after
         the call is the intended durability mechanism, not a signal worth
         checking."""
-        os.close(self._leaf_fd)
+        self.close()
 
 
 def verified_scratch_path(root: Path, root_fd: int, name: str) -> VerifiedScratchPath:
@@ -368,9 +398,13 @@ def verified_scratch_path(root: Path, root_fd: int, name: str) -> VerifiedScratc
             f"refusing to use {root / name}: could not open {name!r} through the "
             f"validated scratch-root fd without following a symlink (TOCTOU guard): {e}"
         ) from e
-    fd_stat = os.fstat(leaf_fd)
-    resolved = os.path.realpath(str(root / name))
-    path_stat = os.stat(resolved, follow_symlinks=False)
+    try:
+        fd_stat = os.fstat(leaf_fd)
+        resolved = os.path.realpath(str(root / name))
+        path_stat = os.stat(resolved, follow_symlinks=False)
+    except BaseException:
+        os.close(leaf_fd)
+        raise
     if (path_stat.st_dev, path_stat.st_ino) != (fd_stat.st_dev, fd_stat.st_ino):
         os.close(leaf_fd)
         raise SystemExit(
@@ -394,14 +428,34 @@ def _rmtree_contents_via_fd(
 
     `O_NOFOLLOW` alone stops a symlink substitution but not a *real*
     directory substitution — a concurrent process renaming an external,
-    non-empty directory onto an entry name this run owns. Before recursing
-    into any directory, its opened fd's device must match `root_identity`'s
-    device (a foreign filesystem is refused outright) and, for entries this
-    run recorded an identity for at creation time (`known_children` — today
-    just the top-level `home`/`tmp` dirs, threaded in only at the top-level
-    call), the fd's (device, inode) must still match what was recorded.
-    Either mismatch fails the run loudly rather than recursing into and
-    deleting content this run does not own.
+    non-empty directory onto an entry name this run owns. Two independent
+    checks guard every directory at every recursion depth, not just the
+    top level:
+
+    1. Listing-consistency: `DirEntry.inode()` reads the inode straight out
+       of the `readdir()` entry this run's own `os.scandir()` call already
+       captured, no extra syscall, so it reflects what occupied that name at
+       listing time. The fd opened moments later (`O_NOFOLLOW`) is `fstat`ed
+       and must report the *same* inode; a directory renamed onto that name
+       in the gap between listing and open — same-device, so the plain
+       device check below would not catch it — produces a mismatch instead
+       of a silent recursion into substituted content. This is the general
+       fix for the finding that a nested substitution bypassed the
+       top-level-only `known_children` manifest.
+    2. Device match against `root_identity` (a foreign filesystem is refused
+       outright) and, for entries this run recorded an identity for at
+       *creation* time (`known_children` — today just the top-level
+       `home`/`tmp` dirs, threaded in only at the top-level call), the fd's
+       (device, inode) must still match what was recorded — a stronger,
+       longer-lived guarantee than check 1 for the two names this run
+       controls end-to-end.
+
+    Neither check can distinguish a directory that was already substituted
+    *before* this call's own `os.scandir()` ran (nothing was ever recorded
+    for it to compare against) from one this run's consumer legitimately
+    created — that residual is disclosed in README.md rather than silently
+    assumed away. Any mismatch this code *can* see fails the run loudly
+    rather than recursing into and deleting content this run does not own.
     """
     with os.scandir(dir_fd) as it:
         entries = list(it)
@@ -409,11 +463,23 @@ def _rmtree_contents_via_fd(
         if entry.is_symlink():
             os.unlink(entry.name, dir_fd=dir_fd)
         elif entry.is_dir(follow_symlinks=False):
+            listed_inode = entry.inode()
             child_fd = os.open(
                 entry.name, os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC, dir_fd=dir_fd
             )
             try:
                 child_stat = os.fstat(child_fd)
+                child_identity = (child_stat.st_dev, child_stat.st_ino)
+                if child_stat.st_ino != listed_inode:
+                    raise SystemExit(
+                        f"refusing to recurse into {entry.name!r}: the "
+                        "directory just opened does not match the one this "
+                        f"run's own listing saw moments earlier (inode "
+                        f"{listed_inode} listed, {child_stat.st_ino} opened) "
+                        "— looks like a directory was substituted into the "
+                        "scratch tree while this run was walking it (TOCTOU "
+                        "guard); leaving it for operator cleanup"
+                    )
                 if child_stat.st_dev != root_identity[0]:
                     raise SystemExit(
                         f"refusing to recurse into {entry.name!r}: its device "
@@ -423,14 +489,7 @@ def _rmtree_contents_via_fd(
                         "(TOCTOU guard); leaving it for operator cleanup"
                     )
                 expected = (known_children or {}).get(entry.name)
-                if (
-                    expected is not None
-                    and (
-                        child_stat.st_dev,
-                        child_stat.st_ino,
-                    )
-                    != expected
-                ):
+                if expected is not None and child_identity != expected:
                     raise SystemExit(
                         f"refusing to recurse into {entry.name!r}: its identity "
                         "no longer matches what this run recorded when it "
@@ -594,31 +653,36 @@ def seed_corpus(
     write_scratch_jsonl(root_fd, "seed_ops.jsonl", ops)
     _claim_scratch_file(root_fd, "seed_save.jsonl")
 
-    ops_vp = verified_scratch_path(root, root_fd, "seed_ops.jsonl")
-    save_vp = verified_scratch_path(root, root_fd, "seed_save.jsonl")
-    db_vp = verified_scratch_path(root, root_fd, "eval.db")
-    run_kkernel(
-        kkernel,
-        [
-            "exec",
-            "--ops-file",
-            ops_vp.path,
-            "--save-file",
-            save_vp.path,
-            "--db",
-            db_vp.path,
-        ],
-        env,
-    )
-    ops_vp.recheck()
-    # save_vp is not rechecked: `kkernel exec --save-file` publishes its
-    # output via tempfile-write-then-rename (crates/kkernel/src/exec.rs,
-    # atomic_apply::record_save_file_publish_failure), so the path
-    # legitimately names a different inode after a successful run than the
-    # one `_claim_scratch_file`/`verified_scratch_path` observed before the
-    # call — that is the intended durability mechanism, not a substitution.
-    save_vp.discard()
-    db_vp.recheck()
+    with contextlib.ExitStack() as stack:
+        ops_vp = stack.enter_context(
+            verified_scratch_path(root, root_fd, "seed_ops.jsonl")
+        )
+        save_vp = stack.enter_context(
+            verified_scratch_path(root, root_fd, "seed_save.jsonl")
+        )
+        db_vp = stack.enter_context(verified_scratch_path(root, root_fd, "eval.db"))
+        run_kkernel(
+            kkernel,
+            [
+                "exec",
+                "--ops-file",
+                ops_vp.path,
+                "--save-file",
+                save_vp.path,
+                "--db",
+                db_vp.path,
+            ],
+            env,
+        )
+        ops_vp.recheck()
+        # save_vp is not rechecked: `kkernel exec --save-file` publishes its
+        # output via tempfile-write-then-rename (crates/kkernel/src/exec.rs,
+        # atomic_apply::record_save_file_publish_failure), so the path
+        # legitimately names a different inode after a successful run than the
+        # one `_claim_scratch_file`/`verified_scratch_path` observed before the
+        # call — that is the intended durability mechanism, not a substitution.
+        save_vp.discard()
+        db_vp.recheck()
 
     rows = read_scratch_jsonl(root_fd, "seed_save.jsonl")
     failed = [r for r in rows if not r.get("ok")]
@@ -631,42 +695,42 @@ def seed_corpus(
 
 
 def key_id_map(root: Path, root_fd: int) -> dict[str, str]:
-    db_vp = verified_scratch_path(root, root_fd, "eval.db")
-    conn = sqlite3.connect(db_vp.path)
-    try:
-        cur = conn.execute(
-            "SELECT id, properties FROM notes WHERE properties IS NOT NULL"
-        )
-        mapping: dict[str, str] = {}
-        for note_id, props_json in cur.fetchall():
-            props = json.loads(props_json)
-            for tag in props.get("tags", []):
-                if tag.startswith("k:"):
-                    mapping[tag[2:]] = note_id
-    finally:
-        conn.close()
-    db_vp.recheck()
+    with verified_scratch_path(root, root_fd, "eval.db") as db_vp:
+        conn = sqlite3.connect(db_vp.path)
+        try:
+            cur = conn.execute(
+                "SELECT id, properties FROM notes WHERE properties IS NOT NULL"
+            )
+            mapping: dict[str, str] = {}
+            for note_id, props_json in cur.fetchall():
+                props = json.loads(props_json)
+                for tag in props.get("tags", []):
+                    if tag.startswith("k:"):
+                        mapping[tag[2:]] = note_id
+        finally:
+            conn.close()
+        db_vp.recheck()
     return mapping
 
 
 def set_ages(
     root: Path, root_fd: int, notes: list[dict], key_to_id: dict[str, str]
 ) -> None:
-    db_vp = verified_scratch_path(root, root_fd, "eval.db")
-    conn = sqlite3.connect(db_vp.path)
-    try:
-        for n in notes:
-            note_id = key_to_id[n["key"]]
-            dt = datetime.fromisoformat(n["created_at_iso"].replace("Z", "+00:00"))
-            micros = int(dt.timestamp() * 1_000_000)
-            conn.execute(
-                "UPDATE notes SET created_at = ?, updated_at = ? WHERE id = ?",
-                (micros, micros, note_id),
-            )
-        conn.commit()
-    finally:
-        conn.close()
-    db_vp.recheck()
+    with verified_scratch_path(root, root_fd, "eval.db") as db_vp:
+        conn = sqlite3.connect(db_vp.path)
+        try:
+            for n in notes:
+                note_id = key_to_id[n["key"]]
+                dt = datetime.fromisoformat(n["created_at_iso"].replace("Z", "+00:00"))
+                micros = int(dt.timestamp() * 1_000_000)
+                conn.execute(
+                    "UPDATE notes SET created_at = ?, updated_at = ? WHERE id = ?",
+                    (micros, micros, note_id),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+        db_vp.recheck()
 
 
 def run_condition(
@@ -697,27 +761,28 @@ def run_condition(
     write_scratch_jsonl(root_fd, ops_name, ops)
     _claim_scratch_file(root_fd, save_name)
 
-    ops_vp = verified_scratch_path(root, root_fd, ops_name)
-    save_vp = verified_scratch_path(root, root_fd, save_name)
-    db_vp = verified_scratch_path(root, root_fd, "eval.db")
-    run_kkernel(
-        kkernel,
-        [
-            "exec",
-            "--ops-file",
-            ops_vp.path,
-            "--save-file",
-            save_vp.path,
-            "--db",
-            db_vp.path,
-        ],
-        env,
-    )
-    ops_vp.recheck()
-    # See seed_corpus: kkernel publishes --save-file via write-then-rename,
-    # so a changed inode here is the intended durability mechanism.
-    save_vp.discard()
-    db_vp.recheck()
+    with contextlib.ExitStack() as stack:
+        ops_vp = stack.enter_context(verified_scratch_path(root, root_fd, ops_name))
+        save_vp = stack.enter_context(verified_scratch_path(root, root_fd, save_name))
+        db_vp = stack.enter_context(verified_scratch_path(root, root_fd, "eval.db"))
+        run_kkernel(
+            kkernel,
+            [
+                "exec",
+                "--ops-file",
+                ops_vp.path,
+                "--save-file",
+                save_vp.path,
+                "--db",
+                db_vp.path,
+            ],
+            env,
+        )
+        ops_vp.recheck()
+        # See seed_corpus: kkernel publishes --save-file via write-then-rename,
+        # so a changed inode here is the intended durability mechanism.
+        save_vp.discard()
+        db_vp.recheck()
 
     rows = read_scratch_jsonl(root_fd, save_name)
     if len(rows) != len(queries):
@@ -986,6 +1051,48 @@ def _expect_systemexit(fn, *a, **kw) -> tuple[bool, str]:
 def _record(failures: list[str], name: str, ok: bool, msg: str) -> None:
     if not ok:
         failures.append(f"{name}: {msg}")
+
+
+@contextlib.contextmanager
+def _inject_after_scandir(trigger_names: set[str], side_effect):
+    """Test-only: monkeypatch `os.scandir` so that, the first time it
+    returns a listing containing every name in `trigger_names`, the real
+    listing is fully materialized and only then does `side_effect()` run —
+    before control returns to `_rmtree_contents_via_fd`'s caller and it
+    starts opening those entries. Triggering on the listed *names* rather
+    than a specific `dir_fd` sidesteps having to predict an fd number
+    `_rmtree_contents_via_fd` opens internally; this reproduces,
+    deterministically and without a real race or thread, a directory
+    substitution landing in the window between this run's own directory
+    listing and the per-entry `open()` calls that follow it.
+    """
+    real_scandir = os.scandir
+    fired = False
+
+    class _ReplayScandir:
+        def __init__(self, entries: list) -> None:
+            self._entries = entries
+
+        def __enter__(self):
+            return iter(self._entries)
+
+        def __exit__(self, *exc_info: object) -> bool:
+            return False
+
+    def fake_scandir(dir_fd=None):
+        nonlocal fired
+        with real_scandir(dir_fd) as it:
+            entries = list(it)
+        if not fired and trigger_names.issubset({e.name for e in entries}):
+            fired = True
+            side_effect()
+        return _ReplayScandir(entries)
+
+    os.scandir = fake_scandir
+    try:
+        yield
+    finally:
+        os.scandir = real_scandir
 
 
 def run_self_tests() -> int:
@@ -1304,12 +1411,136 @@ def run_self_tests() -> int:
         "arbitrary /opt prefix was accepted as an ambient /private mapping",
     )
 
+    # 19. a legitimately run-owned nested directory tree — one this harness
+    # never recorded an identity for at creation time, matching what the
+    # kkernel subprocess itself creates under `home` (e.g. `.khive`,
+    # `.lattice/models/...`) — is still recursed into and removed by
+    # ordinary cleanup. Directory-admission table row B: unrecorded-but-ours
+    # must not be refused just because check 18 below now exists.
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "root"
+        root.mkdir()
+        root_fd = open_scratch_root_fd(root)
+        try:
+            known = init_scratch_dirs(root_fd)
+            nested = root / "home" / "nested" / "deeper"
+            nested.mkdir(parents=True)
+            (nested / "owned.txt").write_text("owned by this run")
+            cleanup_scratch(root, root_fd, known)
+            ok = not root.exists()
+            msg = (
+                "ok"
+                if ok
+                else "scratch root survived cleanup of a legitimate nested tree"
+            )
+            _record(failures, "legitimate-nested-dir-cleaned", ok, msg)
+        finally:
+            os.close(root_fd)
+
+    # 20. the round-2 review's own nested-same-device-substitution probe
+    # shape: a foreign, same-device directory is renamed onto a nested
+    # entry name in the window between this run's own `os.scandir()`
+    # listing of `home`'s contents and the subsequent per-entry `open()` —
+    # bypassing the top-level-only `known_children` manifest, exactly the
+    # gap the finding described. The general listing-consistency check
+    # (`DirEntry.inode()` captured at listing time vs. the opened fd's
+    # `fstat`) must catch this at any recursion depth, not just the top
+    # level. Directory-admission table row D.
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "root"
+        root.mkdir()
+        root_fd = open_scratch_root_fd(root)
+        try:
+            known = init_scratch_dirs(root_fd)
+            (root / "home" / "nested").mkdir()
+            foreign = Path(td) / "foreign"
+            foreign.mkdir()
+            (foreign / "victim.txt").write_text("do not touch")
+
+            def _swap_nested() -> None:
+                (root / "home" / "nested").rmdir()
+                foreign.rename(root / "home" / "nested")
+
+            with _inject_after_scandir({"nested"}, _swap_nested):
+                ok, msg = _expect_systemexit(cleanup_scratch, root, root_fd, known)
+            _record(failures, "nested-same-device-substitution-refused", ok, msg)
+            if not (root / "home" / "nested" / "victim.txt").exists():
+                failures.append(
+                    "nested-same-device-substitution-refused: victim content "
+                    "was deleted"
+                )
+        finally:
+            os.close(root_fd)
+
+    # 21. `verified_scratch_path` must not leak `leaf_fd` when the
+    # path-based `os.stat` call raises before the identity-mismatch branch
+    # runs — a real unlink/race between the fd-relative open and the path
+    # stat can produce the same error path.
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "root"
+        root.mkdir()
+        root_fd = open_scratch_root_fd(root)
+        try:
+            _claim_scratch_file(root_fd, "claimed.txt")
+            real_open = os.open
+            real_stat = os.stat
+            captured: dict[str, int] = {}
+
+            def _spy_open(path, flags, mode=0o777, *, dir_fd=None):
+                fd = real_open(path, flags, mode, dir_fd=dir_fd)
+                if path == "claimed.txt":
+                    captured["fd"] = fd
+                return fd
+
+            def _failing_stat(path, *, dir_fd=None, follow_symlinks=True):
+                if (
+                    dir_fd is None
+                    and isinstance(path, str)
+                    and path.endswith("claimed.txt")
+                ):
+                    raise OSError(5, "injected stat failure")
+                return real_stat(path, dir_fd=dir_fd, follow_symlinks=follow_symlinks)
+
+            os.open = _spy_open
+            os.stat = _failing_stat
+            raised = False
+            try:
+                try:
+                    verified_scratch_path(root, root_fd, "claimed.txt")
+                except OSError:
+                    raised = True
+            finally:
+                os.open = real_open
+                os.stat = real_stat
+
+            leaked = False
+            if "fd" in captured:
+                try:
+                    os.close(captured["fd"])
+                    leaked = True
+                except OSError:
+                    leaked = False
+            ok = raised and "fd" in captured and not leaked
+            if not raised:
+                msg = "did not raise the injected OSError"
+            elif "fd" not in captured:
+                msg = "leaf fd open call was never observed"
+            elif leaked:
+                msg = "leaf fd was leaked (still open after injected stat failure)"
+            else:
+                msg = "ok"
+            _record(
+                failures, "verified-scratch-path-closes-fd-on-stat-failure", ok, msg
+            )
+        finally:
+            os.close(root_fd)
+
     if failures:
         print(f"\nSELF-TEST FAILED ({len(failures)}):", file=sys.stderr)
         for f in failures:
             print(f"  {f}", file=sys.stderr)
         return 1
-    print("\nSELF-TEST PASSED (18 checks)")
+    print("\nSELF-TEST PASSED (21 checks)")
     return 0
 
 
@@ -1358,20 +1589,21 @@ def main() -> int:
         _reject_existing_scratch_db(db_path)
         _claim_scratch_file(root_fd, "eval.db")
         known_children = init_scratch_dirs(root_fd)
-        home_vp = verified_scratch_path(root, root_fd, "home")
-        tmp_vp = verified_scratch_path(root, root_fd, "tmp")
-        env = scratch_env(home_vp.path, tmp_vp.path, db_path)
-        home_vp.recheck()
-        tmp_vp.recheck()
+        with contextlib.ExitStack() as stack:
+            home_vp = stack.enter_context(verified_scratch_path(root, root_fd, "home"))
+            tmp_vp = stack.enter_context(verified_scratch_path(root, root_fd, "tmp"))
+            env = scratch_env(home_vp.path, tmp_vp.path, db_path)
+            home_vp.recheck()
+            tmp_vp.recheck()
 
         try:
-            migrate_vp = verified_scratch_path(root, root_fd, "eval.db")
-            run_kkernel(
-                args.kkernel,
-                ["db", "migrate", "--db", migrate_vp.path],
-                env,
-            )
-            migrate_vp.recheck()
+            with verified_scratch_path(root, root_fd, "eval.db") as migrate_vp:
+                run_kkernel(
+                    args.kkernel,
+                    ["db", "migrate", "--db", migrate_vp.path],
+                    env,
+                )
+                migrate_vp.recheck()
             queries = generate_corpus.parse_queries(args.queries)
             notes = seed_corpus(args.kkernel, env, root, root_fd, args.seed, args.epoch)
             key_to_id = key_id_map(root, root_fd)

--- a/benches/retrieval/evaluate.py
+++ b/benches/retrieval/evaluate.py
@@ -89,13 +89,23 @@ def refuse_unsafe_db_env() -> None:
         )
 
 
+_KNOWN_PRIVATE_FIRMLINK_PREFIXES = ("tmp", "var", "etc")
+
+
 def _ambient_symlink(p: Path) -> bool:
-    """macOS publishes /tmp, /var, and /etc as symlinks into /private as an
-    OS convention. Those are OS-owned, not planted, and a scratch root under
-    them must not be misreported as an attack."""
+    """macOS publishes /tmp, /var, and /etc — and only those three — as
+    symlinks into /private as an OS convention. Those are OS-owned, not
+    planted, and a scratch root under them must not be misreported as an
+    attack. Restricted to the exact known prefixes (not "any absolute path
+    whose realpath happens to equal /private/<itself>"): without this
+    restriction, a planted symlink for an arbitrary prefix (e.g.
+    /opt/attacker/tmp -> /private/opt/attacker/tmp) that happens to resolve
+    would also be waved through."""
     try:
         rel = p.relative_to("/")
     except ValueError:
+        return False
+    if not rel.parts or rel.parts[0] not in _KNOWN_PRIVATE_FIRMLINK_PREFIXES:
         return False
     return os.path.realpath(str(p)) == str(Path("/private") / rel)
 
@@ -183,24 +193,17 @@ def _open_dir_component_nofollow(parent_fd: int, name: str, full_path: Path) -> 
         ) from e
 
 
-def open_scratch_root_fd(root: Path) -> int:
-    """Open a persistent, race-resistant directory fd for `root`.
-
-    `_validate_scratch_root` checks components with `lstat` and then
-    `make_scratch` creates the directory — a concurrent process can swap a
-    component for a symlink in the gap between that check and this open.
-    Walking every component from the filesystem root via `openat`
-    (`dir_fd=`) with `O_NOFOLLOW` closes that gap: each hop is resolved
-    relative to the fd already opened for its parent, so a symlink planted
-    after validation is refused here instead of silently followed. All
-    subsequent scratch file access in this run goes through the returned fd,
-    never through `root` as a bare path.
-    """
-    root = root.absolute()
-    fd = os.open(root.anchor, os.O_DIRECTORY | os.O_CLOEXEC)
-    cur = Path(root.anchor)
+def _open_path_nofollow(path: Path) -> int:
+    """Walk every component of `path` from the filesystem root via `openat`
+    (`dir_fd=`) with `O_NOFOLLOW`, so a symlink planted anywhere along the
+    chain — including after some earlier validation pass — is refused
+    instead of silently followed. Returns an fd for `path` itself; the
+    caller owns it and must close it."""
+    path = path.absolute()
+    fd = os.open(path.anchor, os.O_DIRECTORY | os.O_CLOEXEC)
+    cur = Path(path.anchor)
     try:
-        for part in root.relative_to(root.anchor).parts:
+        for part in path.relative_to(path.anchor).parts:
             cur = cur / part
             next_fd = _open_dir_component_nofollow(fd, part, cur)
             os.close(fd)
@@ -211,6 +214,48 @@ def open_scratch_root_fd(root: Path) -> int:
         raise
 
 
+def open_scratch_root_fd(root: Path) -> int:
+    """Open a persistent, race-resistant directory fd for `root`.
+
+    `_validate_scratch_root` checks components with `lstat` and then
+    `make_scratch` creates the directory — a concurrent process can swap a
+    component for a symlink in the gap between that check and this open.
+    `_open_path_nofollow` closes that gap: each hop is resolved relative to
+    the fd already opened for its parent, so a symlink planted after
+    validation is refused here instead of silently followed. All subsequent
+    scratch file access in this run goes through the returned fd, never
+    through `root` as a bare path.
+    """
+    return _open_path_nofollow(root)
+
+
+def init_scratch_dirs(root_fd: int) -> dict[str, tuple[int, int]]:
+    """Create the scratch tree's HOME and TMPDIR subdirectories through the
+    pinned root fd (`dir_fd=root_fd`) rather than by pathname, and record
+    each one's (device, inode) at creation time.
+
+    The recorded identity lets `cleanup_scratch` refuse to recurse into a
+    same-name substitution later — including one on the *same* filesystem as
+    the scratch root, which a bare device check alone would not catch (see
+    `_rmtree_contents_via_fd`).
+    """
+    known: dict[str, tuple[int, int]] = {}
+    for name in ("home", "tmp"):
+        try:
+            os.mkdir(name, dir_fd=root_fd)
+        except FileExistsError:
+            pass
+        fd = os.open(
+            name, os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC, dir_fd=root_fd
+        )
+        try:
+            st = os.fstat(fd)
+            known[name] = (st.st_dev, st.st_ino)
+        finally:
+            os.close(fd)
+    return known
+
+
 def _claim_scratch_file(root_fd: int, name: str) -> None:
     """Atomically claim `name` under the scratch root as a fresh, real file.
 
@@ -218,9 +263,12 @@ def _claim_scratch_file(root_fd: int, name: str) -> None:
     exists at `name`; `O_NOFOLLOW` additionally refuses to follow a symlink
     raced into place on the create call itself. Immediately closed: kkernel
     (subprocess) and sqlite3 need a path string, not an fd (see
-    `verified_scratch_path`), so the claim's only job is to make the
-    eventual path-based open resolve to a file this run created, not one a
-    concurrent process substituted.
+    `verified_scratch_path`), so the claim's job is to make the *next*
+    path-based open (`verified_scratch_path`, called immediately before
+    each consumer) resolve to a file this run created at claim time — it
+    does not, by itself, protect a path handed to a consumer some time
+    later; see `verified_scratch_path`'s docstring for that residual
+    window.
     """
     fd = os.open(
         name,
@@ -231,7 +279,63 @@ def _claim_scratch_file(root_fd: int, name: str) -> None:
     os.close(fd)
 
 
-def verified_scratch_path(root: Path, root_fd: int, name: str) -> str:
+class VerifiedScratchPath:
+    """An absolute path string this run has verified names the same file
+    (device + inode) as an fd opened through the TOCTOU-guarded scratch-root
+    fd, plus the still-open leaf fd needed to detect — after the fact — a
+    substitution that happens *during* a consumer's own path-based open.
+
+    This is a detection aid, not a closed race: sqlite3.connect and the
+    kkernel subprocess both take a path string, not a descriptor (neither
+    accepts an fd, and macOS has no /proc/self/fd to convert one), so a swap
+    landing between this verification and the moment the consumer itself
+    opens the path cannot be prevented from here. See
+    `verified_scratch_path`'s docstring for the accepted residual window.
+    """
+
+    __slots__ = ("path", "_leaf_fd")
+
+    def __init__(self, path: str, leaf_fd: int) -> None:
+        self.path = path
+        self._leaf_fd = leaf_fd
+
+    def recheck(self) -> None:
+        """Call after the consumer (sqlite3/subprocess) that was handed
+        `.path` has returned. Closes the held leaf fd and compares its
+        identity, captured before the consumer ran, against a fresh
+        path-based stat taken now. An unlink+recreate substitution during
+        the consumer's use is still visible here: the held fd keeps
+        resolving to the original inode regardless of what happens to the
+        name, so if the two disagree, the consumer plausibly read or wrote
+        through substituted content and this run fails loudly instead of
+        silently trusting that output. A same-inode, in-place content
+        replacement (no unlink — e.g. a bind mount) is NOT detected by this
+        check, since device/inode are unchanged; that narrower case is
+        outside what a path-based API can ever let a caller observe.
+        """
+        try:
+            fd_stat = os.fstat(self._leaf_fd)
+            path_stat = os.stat(self.path, follow_symlinks=False)
+        finally:
+            os.close(self._leaf_fd)
+        if (path_stat.st_dev, path_stat.st_ino) != (fd_stat.st_dev, fd_stat.st_ino):
+            raise SystemExit(
+                f"refusing to trust output produced through {self.path}: it no "
+                "longer matches the file this run verified before handing the "
+                "path to a consumer (TOCTOU guard) — device/inode changed "
+                "during use"
+            )
+
+    def discard(self) -> None:
+        """Close the held leaf fd without comparing identity — for a path
+        handed to a consumer that is *expected* to legitimately replace it
+        (e.g. a write-then-rename output file), where a changed inode after
+        the call is the intended durability mechanism, not a signal worth
+        checking."""
+        os.close(self._leaf_fd)
+
+
+def verified_scratch_path(root: Path, root_fd: int, name: str) -> VerifiedScratchPath:
     """Resolve `name` under the scratch root to an absolute path string,
     re-verified immediately before a subprocess/sqlite3 call that can only
     take a path (neither accepts an fd, and macOS has no /proc/self/fd to
@@ -243,6 +347,17 @@ def verified_scratch_path(root: Path, root_fd: int, name: str) -> str:
     same file (device + inode), something was swapped between the fd-based
     claim and this call, and the harness refuses to hand the path to a
     subprocess rather than risk it writing through a symlink.
+
+    IMPORTANT — this closes the window up to the moment this function
+    returns; it does NOT make the returned path race-resistant afterward.
+    A concurrent process can still replace the name between this return and
+    the instant sqlite3.connect()/the kkernel subprocess actually opens the
+    path string — path-only APIs give this harness no way to hand over an
+    already-open handle instead. The returned `VerifiedScratchPath` keeps
+    the leaf fd open specifically so callers can call `.recheck()` after the
+    consumer returns and detect (not prevent) that residual race; treat any
+    single call to this function as verified-at-call-time, not
+    race-resistant-for-the-life-of-the-path.
     """
     try:
         leaf_fd = os.open(
@@ -253,27 +368,41 @@ def verified_scratch_path(root: Path, root_fd: int, name: str) -> str:
             f"refusing to use {root / name}: could not open {name!r} through the "
             f"validated scratch-root fd without following a symlink (TOCTOU guard): {e}"
         ) from e
-    try:
-        fd_stat = os.fstat(leaf_fd)
-    finally:
-        os.close(leaf_fd)
+    fd_stat = os.fstat(leaf_fd)
     resolved = os.path.realpath(str(root / name))
     path_stat = os.stat(resolved, follow_symlinks=False)
     if (path_stat.st_dev, path_stat.st_ino) != (fd_stat.st_dev, fd_stat.st_ino):
+        os.close(leaf_fd)
         raise SystemExit(
             f"refusing to use {resolved}: it no longer matches the file opened "
             "through the validated scratch-root fd (TOCTOU guard) — device/inode "
             "changed between claim and use"
         )
-    return resolved
+    return VerifiedScratchPath(resolved, leaf_fd)
 
 
-def _rmtree_contents_via_fd(dir_fd: int) -> None:
+def _rmtree_contents_via_fd(
+    dir_fd: int,
+    root_identity: tuple[int, int],
+    known_children: dict[str, tuple[int, int]] | None = None,
+) -> None:
     """Recursively delete everything inside the directory named by `dir_fd`,
     never resolving a path string and never following a symlink: entries are
     listed with `os.scandir(dir_fd)`, a symlink entry is `unlink`ed as a leaf
     (removing the link itself, not its target), and only entries confirmed
-    as real directories via `O_NOFOLLOW` are opened and recursed into."""
+    as real directories via `O_NOFOLLOW` are opened and recursed into.
+
+    `O_NOFOLLOW` alone stops a symlink substitution but not a *real*
+    directory substitution — a concurrent process renaming an external,
+    non-empty directory onto an entry name this run owns. Before recursing
+    into any directory, its opened fd's device must match `root_identity`'s
+    device (a foreign filesystem is refused outright) and, for entries this
+    run recorded an identity for at creation time (`known_children` — today
+    just the top-level `home`/`tmp` dirs, threaded in only at the top-level
+    call), the fd's (device, inode) must still match what was recorded.
+    Either mismatch fails the run loudly rather than recursing into and
+    deleting content this run does not own.
+    """
     with os.scandir(dir_fd) as it:
         entries = list(it)
     for entry in entries:
@@ -284,7 +413,31 @@ def _rmtree_contents_via_fd(dir_fd: int) -> None:
                 entry.name, os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC, dir_fd=dir_fd
             )
             try:
-                _rmtree_contents_via_fd(child_fd)
+                child_stat = os.fstat(child_fd)
+                if child_stat.st_dev != root_identity[0]:
+                    raise SystemExit(
+                        f"refusing to recurse into {entry.name!r}: its device "
+                        f"({child_stat.st_dev}) does not match the scratch "
+                        f"root's device ({root_identity[0]}) — this looks like "
+                        "a foreign directory substituted into the scratch tree "
+                        "(TOCTOU guard); leaving it for operator cleanup"
+                    )
+                expected = (known_children or {}).get(entry.name)
+                if (
+                    expected is not None
+                    and (
+                        child_stat.st_dev,
+                        child_stat.st_ino,
+                    )
+                    != expected
+                ):
+                    raise SystemExit(
+                        f"refusing to recurse into {entry.name!r}: its identity "
+                        "no longer matches what this run recorded when it "
+                        "created that directory (TOCTOU guard); leaving it for "
+                        "operator cleanup"
+                    )
+                _rmtree_contents_via_fd(child_fd, root_identity)
             finally:
                 os.close(child_fd)
             os.rmdir(entry.name, dir_fd=dir_fd)
@@ -317,16 +470,49 @@ def read_scratch_jsonl(root_fd: int, name: str) -> list[dict]:
         return [json.loads(line) for line in f if line.strip()]
 
 
-def cleanup_scratch(root: Path, root_fd: int) -> None:
+def cleanup_scratch(
+    root: Path, root_fd: int, known_children: dict[str, tuple[int, int]]
+) -> None:
     """Delete the scratch tree through the held, TOCTOU-guarded `root_fd`
     rather than a fresh path-based walk, then remove the now-empty root
-    directory itself. The final `rmdir` uses `root`'s path rather than a
-    parent fd (this script never opens the scratch root's parent), but
-    `rmdir` only ever removes an empty directory — a symlink or a
-    repopulated directory raced into that name fails closed instead of
-    deleting through it."""
-    _rmtree_contents_via_fd(root_fd)
-    os.rmdir(root)
+    directory itself through a freshly `O_NOFOLLOW`-walked parent fd
+    (never a bare `os.rmdir(root)` pathname call).
+
+    `root_identity`, captured from `root_fd` before the walk, is re-checked
+    against both `root_fd` itself (an invariant given fd semantics, but
+    recorded and asserted explicitly for auditability against a future
+    refactor that might reopen or reuse the fd) and against a fresh,
+    path-based stat of the root's name under its parent immediately before
+    the final `rmdir`. If a concurrent process replaced the directory at
+    that name (e.g. with an empty directory it controls) after this run's
+    content was deleted via the fd, the path-based stat disagrees with the
+    fd-based one and the run refuses to remove the replacement, leaving it
+    for operator cleanup instead of silently deleting whatever is now
+    there.
+    """
+    root = root.absolute()
+    root_stat = os.fstat(root_fd)
+    root_identity = (root_stat.st_dev, root_stat.st_ino)
+    _rmtree_contents_via_fd(root_fd, root_identity, known_children)
+    parent_fd = _open_path_nofollow(root.parent)
+    try:
+        cur_stat = os.fstat(root_fd)
+        if (cur_stat.st_dev, cur_stat.st_ino) != root_identity:
+            raise SystemExit(
+                f"refusing to remove {root}: the held scratch-root fd no "
+                "longer matches its recorded identity (TOCTOU guard); "
+                "leaving contents for operator cleanup"
+            )
+        entry_stat = os.stat(root.name, dir_fd=parent_fd, follow_symlinks=False)
+        if (entry_stat.st_dev, entry_stat.st_ino) != root_identity:
+            raise SystemExit(
+                f"refusing to rmdir {root}: the name no longer resolves to "
+                "the directory this run created (TOCTOU guard); leaving "
+                "contents for operator cleanup"
+            )
+        os.rmdir(root.name, dir_fd=parent_fd)
+    finally:
+        os.close(parent_fd)
 
 
 def make_scratch(scratch_dir: str | None) -> Path:
@@ -336,22 +522,31 @@ def make_scratch(scratch_dir: str | None) -> Path:
         root.mkdir(parents=True, exist_ok=True)
     else:
         root = Path(tempfile.mkdtemp(prefix=SCRATCH_MARKER))
-    (root / "home").mkdir(exist_ok=True)
     return root
 
 
-def scratch_env(root: Path, db_path: Path) -> dict:
+def scratch_env(home_path: str, tmp_path: str, db_path: Path) -> dict:
     """Minimal allowlisted child environment: PATH (so the `kkernel` binary
-    name resolves), HOME/TMPDIR redirected into the scratch root, and the
-    harness's own explicit KHIVE_DB/KHIVE_EMBEDDING_MODEL. Nothing else from
-    the caller's environment is copied through, so no inherited KHIVE_* or
-    other retrieval-affecting variable can change what gets scored."""
-    tmp_dir = root / "tmp"
-    tmp_dir.mkdir(exist_ok=True)
+    name resolves), HOME/TMPDIR redirected into the scratch root's `home`/
+    `tmp` subdirectories (created through the pinned root fd by
+    `init_scratch_dirs`, not by pathname — `home_path`/`tmp_path` come from
+    `verified_scratch_path`), and the harness's own explicit KHIVE_DB/
+    KHIVE_EMBEDDING_MODEL. Nothing else from the caller's environment is
+    copied through, so no inherited KHIVE_* or other retrieval-affecting
+    variable can change what gets scored.
+
+    HOME/TMPDIR are still exported as bare path strings, though: the
+    kkernel subprocess (and anything it execs) reads $HOME/$TMPDIR by
+    pathname, not by descriptor, so — like KHIVE_DB via
+    `verified_scratch_path` — a swap of `home` or `tmp` between this call
+    and whenever the child actually reads those variables is the same
+    residual, undocumented-away race as `verified_scratch_path`'s TOCTOU
+    window, not something this function can close.
+    """
     return {
         "PATH": os.environ.get("PATH", ""),
-        "HOME": str(root / "home"),
-        "TMPDIR": str(tmp_dir),
+        "HOME": home_path,
+        "TMPDIR": tmp_path,
         "KHIVE_DB": str(db_path),
         "KHIVE_EMBEDDING_MODEL": PINNED_EMBEDDING_MODEL,
     }
@@ -399,19 +594,31 @@ def seed_corpus(
     write_scratch_jsonl(root_fd, "seed_ops.jsonl", ops)
     _claim_scratch_file(root_fd, "seed_save.jsonl")
 
+    ops_vp = verified_scratch_path(root, root_fd, "seed_ops.jsonl")
+    save_vp = verified_scratch_path(root, root_fd, "seed_save.jsonl")
+    db_vp = verified_scratch_path(root, root_fd, "eval.db")
     run_kkernel(
         kkernel,
         [
             "exec",
             "--ops-file",
-            verified_scratch_path(root, root_fd, "seed_ops.jsonl"),
+            ops_vp.path,
             "--save-file",
-            verified_scratch_path(root, root_fd, "seed_save.jsonl"),
+            save_vp.path,
             "--db",
-            verified_scratch_path(root, root_fd, "eval.db"),
+            db_vp.path,
         ],
         env,
     )
+    ops_vp.recheck()
+    # save_vp is not rechecked: `kkernel exec --save-file` publishes its
+    # output via tempfile-write-then-rename (crates/kkernel/src/exec.rs,
+    # atomic_apply::record_save_file_publish_failure), so the path
+    # legitimately names a different inode after a successful run than the
+    # one `_claim_scratch_file`/`verified_scratch_path` observed before the
+    # call — that is the intended durability mechanism, not a substitution.
+    save_vp.discard()
+    db_vp.recheck()
 
     rows = read_scratch_jsonl(root_fd, "seed_save.jsonl")
     failed = [r for r in rows if not r.get("ok")]
@@ -424,7 +631,8 @@ def seed_corpus(
 
 
 def key_id_map(root: Path, root_fd: int) -> dict[str, str]:
-    conn = sqlite3.connect(verified_scratch_path(root, root_fd, "eval.db"))
+    db_vp = verified_scratch_path(root, root_fd, "eval.db")
+    conn = sqlite3.connect(db_vp.path)
     try:
         cur = conn.execute(
             "SELECT id, properties FROM notes WHERE properties IS NOT NULL"
@@ -435,15 +643,17 @@ def key_id_map(root: Path, root_fd: int) -> dict[str, str]:
             for tag in props.get("tags", []):
                 if tag.startswith("k:"):
                     mapping[tag[2:]] = note_id
-        return mapping
     finally:
         conn.close()
+    db_vp.recheck()
+    return mapping
 
 
 def set_ages(
     root: Path, root_fd: int, notes: list[dict], key_to_id: dict[str, str]
 ) -> None:
-    conn = sqlite3.connect(verified_scratch_path(root, root_fd, "eval.db"))
+    db_vp = verified_scratch_path(root, root_fd, "eval.db")
+    conn = sqlite3.connect(db_vp.path)
     try:
         for n in notes:
             note_id = key_to_id[n["key"]]
@@ -456,6 +666,7 @@ def set_ages(
         conn.commit()
     finally:
         conn.close()
+    db_vp.recheck()
 
 
 def run_condition(
@@ -486,19 +697,27 @@ def run_condition(
     write_scratch_jsonl(root_fd, ops_name, ops)
     _claim_scratch_file(root_fd, save_name)
 
+    ops_vp = verified_scratch_path(root, root_fd, ops_name)
+    save_vp = verified_scratch_path(root, root_fd, save_name)
+    db_vp = verified_scratch_path(root, root_fd, "eval.db")
     run_kkernel(
         kkernel,
         [
             "exec",
             "--ops-file",
-            verified_scratch_path(root, root_fd, ops_name),
+            ops_vp.path,
             "--save-file",
-            verified_scratch_path(root, root_fd, save_name),
+            save_vp.path,
             "--db",
-            verified_scratch_path(root, root_fd, "eval.db"),
+            db_vp.path,
         ],
         env,
     )
+    ops_vp.recheck()
+    # See seed_corpus: kkernel publishes --save-file via write-then-rename,
+    # so a changed inode here is the intended durability mechanism.
+    save_vp.discard()
+    db_vp.recheck()
 
     rows = read_scratch_jsonl(root_fd, save_name)
     if len(rows) != len(queries):
@@ -554,6 +773,27 @@ def _validate_recall_row(query: dict, row: dict, corpus_size: int) -> list:
                 f"query_id={query['query_id']!r}; unexpected against this "
                 "harness's fixed top_k on its fixed corpus"
             )
+        # The verbose multi-model envelope (recall.rs handle_recall, the
+        # is_verbose && vector_hits_per_model.len() > 1 branch) carries a
+        # non-empty `results` array alongside top-level `budget_capped`/
+        # `truncated_for_budget` instead of the bare `truncated` flag above
+        # — a truthy budget_capped or nonzero truncated_for_budget here
+        # means the ranked pool was cut down before this response was built,
+        # same failure as the bare-array 'truncated' check below but not
+        # caught by it since this envelope never sets per-hit "truncated".
+        if result.get("budget_capped"):
+            raise RuntimeError(
+                f"memory.recall verbose envelope for query_id={query['query_id']!r} "
+                "reports budget_capped=true; the ranked pool was cut by the "
+                "response token budget before this harness could score it"
+            )
+        if result.get("truncated_for_budget"):
+            raise RuntimeError(
+                f"memory.recall verbose envelope for query_id={query['query_id']!r} "
+                f"reports truncated_for_budget={result.get('truncated_for_budget')!r}; "
+                "the ranked pool was cut by the response token budget before this "
+                "harness could score it"
+            )
         hits = result.get("results")
         if not isinstance(hits, list):
             raise RuntimeError(
@@ -582,6 +822,17 @@ def _validate_recall_row(query: dict, row: dict, corpus_size: int) -> list:
             f"memory.recall pool for query_id={query['query_id']!r} carries per-hit "
             f"'truncated' markers at depth {len(hits)}; the harness requires a fully "
             "untruncated top-100 pool for a valid Recall@100 label"
+        )
+    # A non-empty ANN-degraded response keeps the bare-array/results shape
+    # (recall.rs handle_recall stamps each hit with "degraded":
+    # "ann_unavailable" rather than changing the envelope — only the
+    # zero-hit case changes shape, caught by the top-level `degraded` check
+    # above) so a degraded ranking must be caught here, per hit.
+    if any(h.get("degraded") for h in hits):
+        raise RuntimeError(
+            f"memory.recall pool for query_id={query['query_id']!r} carries per-hit "
+            f"'degraded' markers at depth {len(hits)}; the harness requires a fully "
+            "warm, non-degraded ranking for a valid Recall@100 label"
         )
     return hits
 
@@ -790,12 +1041,15 @@ def run_self_tests() -> int:
         ok, msg = _expect_systemexit(make_scratch, str(root))
         _record(failures, "nonempty-scratch-root-refused", ok, msg)
 
-    # 5. a fresh / nonexistent --scratch-dir root is accepted and initialized.
+    # 5. a fresh / nonexistent --scratch-dir root is accepted and initialized;
+    # `home`/`tmp` are created separately by `init_scratch_dirs` once
+    # `root_fd` exists (see the home/tmp-substitution self-test arms below),
+    # not by `make_scratch` itself.
     with tempfile.TemporaryDirectory() as td:
         root = Path(td) / "fresh"
         try:
             made = make_scratch(str(root))
-            ok = made.exists() and (made / "home").is_dir()
+            ok = made.exists() and made.is_dir()
             msg = "ok" if ok else "scratch dir not initialized correctly"
         except SystemExit as e:
             ok, msg = False, f"unexpected refusal: {e}"
@@ -868,9 +1122,7 @@ def run_self_tests() -> int:
             ok, msg = _expect_systemexit(
                 verified_scratch_path, root, root_fd, "claimed.txt"
             )
-            _record(
-                failures, "post-claim-symlink-swap-refused-at-use", ok, msg
-            )
+            _record(failures, "post-claim-symlink-swap-refused-at-use", ok, msg)
             if victim.read_text() != "do not touch":
                 failures.append(
                     "post-claim-symlink-swap-refused-at-use: victim file was modified"
@@ -902,12 +1154,162 @@ def run_self_tests() -> int:
         finally:
             os.close(root_fd)
 
+    def _expect_runtimeerror(fn, *a, **kw) -> tuple[bool, str]:
+        try:
+            fn(*a, **kw)
+        except RuntimeError as e:
+            return True, str(e)
+        return False, "did not raise RuntimeError"
+
+    # 12. a non-empty bare-array memory.recall response carrying per-hit
+    # "degraded" markers (the ann_unavailable stamp recall.rs adds to every
+    # hit in a non-empty degraded response, recall.rs:800-809) is rejected
+    # even though the top-level shape is a plain array and the depth check
+    # passes.
+    hits = [{"id": f"n{i}", "degraded": "ann_unavailable"} for i in range(100)]
+    row = {"ok": True, "result": hits}
+    ok, msg = _expect_runtimeerror(
+        _validate_recall_row, {"query_id": "q-degraded-bare"}, row, 100
+    )
+    _record(failures, "degraded-bare-array-rejected", ok, msg)
+
+    # 13. the verbose multi-model envelope (recall.rs:916-929) carries a
+    # non-empty "results" array with per-hit "degraded" markers but no
+    # top-level "degraded" flag — the plain `result.get("degraded")` check
+    # above never sees it, so the per-hit check must catch it here too.
+    hits = [{"id": f"n{i}", "degraded": "ann_unavailable"} for i in range(100)]
+    row = {
+        "ok": True,
+        "result": {
+            "results": hits,
+            "candidates": {"vector_candidates_per_model": []},
+            "budget_capped": False,
+            "truncated_for_budget": 0,
+        },
+    }
+    ok, msg = _expect_runtimeerror(
+        _validate_recall_row, {"query_id": "q-degraded-verbose"}, row, 100
+    )
+    _record(failures, "verbose-envelope-degraded-rejected", ok, msg)
+
+    # 14. the verbose envelope's own budget_capped/truncated_for_budget
+    # fields (absent from the plain-array/simple-truncated checks above)
+    # are rejected too, not just the per-hit degraded stamp.
+    hits = [{"id": f"n{i}"} for i in range(100)]
+    row = {
+        "ok": True,
+        "result": {
+            "results": hits,
+            "candidates": {"vector_candidates_per_model": []},
+            "budget_capped": True,
+            "truncated_for_budget": 3,
+        },
+    }
+    ok, msg = _expect_runtimeerror(
+        _validate_recall_row, {"query_id": "q-budget-capped-verbose"}, row, 100
+    )
+    _record(failures, "verbose-envelope-budget-capped-rejected", ok, msg)
+
+    # 15. residual TOCTOU window (verified_scratch_path/VerifiedScratchPath):
+    # neither sqlite3.connect nor the kkernel subprocess accepts a
+    # descriptor, so a swap landing between verification and the consumer's
+    # own path-based open cannot be prevented from here — this arm
+    # demonstrates both accepted halves: (a) a path-only "consumer" opening
+    # the verified path after the swap observes the substituted content
+    # (the residual window itself), and (b) `.recheck()`, called after that
+    # consumption, still detects the swap and fails the run rather than
+    # silently trusting output produced against substituted content.
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "root"
+        root.mkdir()
+        root_fd = open_scratch_root_fd(root)
+        try:
+            _claim_scratch_file(root_fd, "claimed.txt")
+            vp = verified_scratch_path(root, root_fd, "claimed.txt")
+            victim = Path(td) / "victim.txt"
+            victim.write_text("swapped-after-verify")
+            claimed_path = root / "claimed.txt"
+            claimed_path.unlink()
+            claimed_path.symlink_to(victim)
+            consumed = claimed_path.read_text()
+            window_exists = consumed == "swapped-after-verify"
+            ok, msg = _expect_systemexit(vp.recheck)
+            if not window_exists:
+                ok, msg = False, "consumer did not observe the swapped content"
+            _record(failures, "post-verify-swap-window-detected-by-recheck", ok, msg)
+        finally:
+            os.close(root_fd)
+
+    # 16. a real (non-symlink) foreign directory renamed onto the tracked
+    # "home" name after `init_scratch_dirs` recorded its identity is refused
+    # at cleanup rather than recursed into — same filesystem as the scratch
+    # root, so a bare st_dev check alone would not catch this; the recorded
+    # (device, inode) manifest is what catches it.
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "root"
+        root.mkdir()
+        root_fd = open_scratch_root_fd(root)
+        try:
+            known = init_scratch_dirs(root_fd)
+            foreign = Path(td) / "foreign"
+            foreign.mkdir()
+            (foreign / "victim.txt").write_text("do not touch")
+            os.rmdir("home", dir_fd=root_fd)
+            os.rename(str(foreign), str(root / "home"))
+            ok, msg = _expect_systemexit(cleanup_scratch, root, root_fd, known)
+            _record(failures, "home-dir-substitution-not-recursed", ok, msg)
+            if not (root / "home" / "victim.txt").exists():
+                failures.append(
+                    "home-dir-substitution-not-recursed: victim content was deleted"
+                )
+        finally:
+            os.close(root_fd)
+
+    # 17. the scratch root itself is renamed aside and replaced with a fresh
+    # empty directory at the same path just before the final rmdir; cleanup
+    # must refuse to rmdir the replacement (parent-fd-relative rmdir with an
+    # identity recheck, not a bare `os.rmdir(root)` pathname call).
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "root"
+        root.mkdir()
+        root_fd = open_scratch_root_fd(root)
+        try:
+            known = init_scratch_dirs(root_fd)
+            os.rmdir("home", dir_fd=root_fd)
+            os.rmdir("tmp", dir_fd=root_fd)
+            root.rename(Path(td) / "root-moved-aside")
+            replacement = root
+            replacement.mkdir()
+            ok, msg = _expect_systemexit(cleanup_scratch, root, root_fd, known)
+            _record(failures, "root-replacement-not-rmdir", ok, msg)
+            if not replacement.is_dir():
+                failures.append(
+                    "root-replacement-not-rmdir: replacement directory was deleted"
+                )
+        finally:
+            os.close(root_fd)
+
+    # 18. `_ambient_symlink` only tolerates the exact known macOS firmlink
+    # prefixes (/tmp, /var, /etc); an arbitrary prefix is rejected outright,
+    # before it would ever reach the realpath comparison — the reviewer's
+    # probe used a matching /opt/attacker/tmp -> /private/opt/attacker/tmp
+    # realpath mapping, which this harness cannot reproducibly fake without
+    # root, but the prefix gate rejects the path regardless of what
+    # realpath would return, which is exactly what closes that probe.
+    ok = _ambient_symlink(Path("/opt/attacker/tmp")) is False
+    _record(
+        failures,
+        "ambient-symlink-arbitrary-prefix-rejected",
+        ok,
+        "arbitrary /opt prefix was accepted as an ambient /private mapping",
+    )
+
     if failures:
         print(f"\nSELF-TEST FAILED ({len(failures)}):", file=sys.stderr)
         for f in failures:
             print(f"  {f}", file=sys.stderr)
         return 1
-    print("\nSELF-TEST PASSED (11 checks)")
+    print("\nSELF-TEST PASSED (18 checks)")
     return 0
 
 
@@ -955,14 +1357,21 @@ def main() -> int:
         db_path = root / "eval.db"
         _reject_existing_scratch_db(db_path)
         _claim_scratch_file(root_fd, "eval.db")
-        env = scratch_env(root, db_path)
+        known_children = init_scratch_dirs(root_fd)
+        home_vp = verified_scratch_path(root, root_fd, "home")
+        tmp_vp = verified_scratch_path(root, root_fd, "tmp")
+        env = scratch_env(home_vp.path, tmp_vp.path, db_path)
+        home_vp.recheck()
+        tmp_vp.recheck()
 
         try:
+            migrate_vp = verified_scratch_path(root, root_fd, "eval.db")
             run_kkernel(
                 args.kkernel,
-                ["db", "migrate", "--db", verified_scratch_path(root, root_fd, "eval.db")],
+                ["db", "migrate", "--db", migrate_vp.path],
                 env,
             )
+            migrate_vp.recheck()
             queries = generate_corpus.parse_queries(args.queries)
             notes = seed_corpus(args.kkernel, env, root, root_fd, args.seed, args.epoch)
             key_to_id = key_id_map(root, root_fd)
@@ -983,7 +1392,7 @@ def main() -> int:
             ]
         finally:
             if not args.keep_scratch:
-                cleanup_scratch(root, root_fd)
+                cleanup_scratch(root, root_fd, known_children)
     finally:
         os.close(root_fd)
 

--- a/benches/retrieval/gold/A_fused_direct.json
+++ b/benches/retrieval/gold/A_fused_direct.json
@@ -14,15 +14,15 @@
     },
     "paraphrase_specific": {
       "MRR@10": 1.0,
-      "Recall@100": 0.9907407407407408,
+      "Recall@100": 1.0,
       "TargetRecall@100": 1.0,
       "nDCG@10": 0.5526074473822127
     }
   },
-  "kkernel_version": "kkernel 0.7.0 (revision d25b83759fa388cade1f1cd7a2e4a2997d135960, built 2026-08-15T02:10:51Z)",
+  "kkernel_version": "kkernel 0.7.0 (revision 913790e6db8a9ae8f54b833b4346c7502f55e5bd, built 2026-08-11T05:43:41Z)",
   "overall": {
     "MRR@10": 1.0,
-    "Recall@100": 0.9972222222222221,
+    "Recall@100": 1.0,
     "TargetRecall@100": 1.0,
     "nDCG@10": 0.5921266395910006
   }


### PR DESCRIPTION
## Summary

Two defects in the retrieval evaluation harness.

**Recall@100 was computed from a possibly-truncated pool.** `memory.recall` applies a response character budget after ranking: below the requested `top_k` the response stays a bare array, just shorter, with surviving hits stamped `"truncated": true`. The harness accepted bare lists of any length, so budget-truncated pools were silently scored as Recall@100 — and the committed gold was itself affected (overall Recall@100 0.9972 at the default 4000-token budget; 1.0 on the full pool). Fixes:
- `HERMETIC_RECALL_CONFIG` now pins `default_token_budget` to the fixed server-side maximum (16000), keeping the config hermetic while giving the 400-note corpus ~2x headroom.
- Response validation now raises if the pool is shorter than `min(top_k, corpus_size)` or any hit carries a truncation marker, naming the query and observed depth.
- Gold regenerated on the untruncated pool (only the two Recall@100 values change).

**Scratch-path handling was validate-then-use.** Path checks and later opens/writes/deletes were separate steps, so components could be swapped for symlinks between them. The scratch root is now opened once with a component-by-component `O_DIRECTORY | O_NOFOLLOW` walk (honoring the macOS `/private` firmlink mapping), and all scratch access goes through that fd: `O_CREAT | O_EXCL | O_NOFOLLOW` claims, fd-relative reads, fd-relative recursive cleanup that unlinks symlink entries as leaves, and — where a subprocess needs a path string — a device+inode match between the fd-opened leaf and the resolved path, recomputed immediately before each spawn.

## Tests

Self-test suite extended 9 → 11 checks: a symlink swapped in after the claim is refused at use with the victim untouched, and a swapped-directory (non-symlink) substitution is refused by the device+inode recheck. `--self-test`, `make eval-retrieval-gold-check`, and the repository data-file guard all pass.