### PR TITLE
fix(knowledge): preserve atom finalized flag across upserts

### DIFF
--- a/crates/khive-pack-knowledge/src/knowledge/crud.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/crud.rs
@@ -162,8 +162,11 @@ impl KnowledgeHandlers {
                     .execute(SqlStatement {
                         // Promote draft -> reviewed when this upsert finalizes the atom.
                         // Never demote an already reviewed row, and leave status
-                        // untouched when not finalizing.
-                        sql: "UPDATE knowledge_atoms SET name=?1, content=?2, tags=?3, properties=?4, source_uri=?5, source_type=?6, finalized=?7, status = CASE WHEN ?7 = 1 AND status = 'draft' THEN 'reviewed' ELSE status END, updated_at=?8 WHERE id=?9 AND namespace=?10".into(),
+                        // untouched when not finalizing. finalized=COALESCE(?7, finalized)
+                        // preserves the existing flag when the caller omits it; SQLite's
+                        // `NULL = 1` evaluates to NULL (falsy), so an omitted field also
+                        // leaves the status CASE on its ELSE branch.
+                        sql: "UPDATE knowledge_atoms SET name=?1, content=?2, tags=?3, properties=?4, source_uri=?5, source_type=?6, finalized=COALESCE(?7, finalized), status = CASE WHEN ?7 = 1 AND status = 'draft' THEN 'reviewed' ELSE status END, updated_at=?8 WHERE id=?9 AND namespace=?10".into(),
                         params: vec![
                             SqlValue::Text(atom_in.name.clone()),
                             SqlValue::Text(content.clone()),
@@ -171,7 +174,7 @@ impl KnowledgeHandlers {
                             props_json.as_ref().map_or(SqlValue::Null, |p| SqlValue::Text(p.clone())),
                             source_uri.map_or(SqlValue::Null, |s| SqlValue::Text(s.to_string())),
                             source_type.map_or(SqlValue::Null, |s| SqlValue::Text(s.to_string())),
-                            SqlValue::Integer(atom_in.finalized.unwrap_or(false) as i64),
+                            atom_in.finalized.map_or(SqlValue::Null, |f| SqlValue::Integer(f as i64)),
                             SqlValue::Integer(now),
                             SqlValue::Text(id),
                             SqlValue::Text(ns.clone()),

--- a/crates/khive-pack-knowledge/src/knowledge/crud.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/crud.rs
@@ -165,8 +165,10 @@ impl KnowledgeHandlers {
                         // untouched when not finalizing. finalized=COALESCE(?7, finalized)
                         // preserves the existing flag when the caller omits it; SQLite's
                         // `NULL = 1` evaluates to NULL (falsy), so an omitted field also
-                        // leaves the status CASE on its ELSE branch.
-                        sql: "UPDATE knowledge_atoms SET name=?1, content=?2, tags=?3, properties=?4, source_uri=?5, source_type=?6, finalized=COALESCE(?7, finalized), status = CASE WHEN ?7 = 1 AND status = 'draft' THEN 'reviewed' ELSE status END, updated_at=?8 WHERE id=?9 AND namespace=?10".into(),
+                        // leaves the status CASE on its ELSE branch. source_uri/source_type
+                        // use the same COALESCE shape so an omitted field preserves the
+                        // existing attribution instead of clobbering it with NULL.
+                        sql: "UPDATE knowledge_atoms SET name=?1, content=?2, tags=?3, properties=?4, source_uri=COALESCE(?5, source_uri), source_type=COALESCE(?6, source_type), finalized=COALESCE(?7, finalized), status = CASE WHEN ?7 = 1 AND status = 'draft' THEN 'reviewed' ELSE status END, updated_at=?8 WHERE id=?9 AND namespace=?10".into(),
                         params: vec![
                             SqlValue::Text(atom_in.name.clone()),
                             SqlValue::Text(content.clone()),

--- a/crates/khive-pack-knowledge/src/vocab.rs
+++ b/crates/khive-pack-knowledge/src/vocab.rs
@@ -232,7 +232,7 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 20] = [
     },
     HandlerDef {
         name: "knowledge.search",
-        description: "TF-IDF ranked search over the atom teaching corpus ONLY — knowledge graph entities and notes are a disjoint corpus and are never returned here; use the kg pack's `search` verb for those. Embedding rerank applies by default when an embedder is configured. Draft and deprecated atoms are excluded by default; pass include_drafts=true to include drafts (deprecated remain excluded). Score bands: score>=0.46 reliably on-target, 0.42<=score<0.46 mixed quality, score<0.42 mostly off-target.",
+        description: "TF-IDF ranked search over the atom teaching corpus ONLY — knowledge graph entities and notes are a disjoint corpus and are never returned here; use the kg pack's `search` verb for those. Embedding rerank applies by default when an embedder is configured. Draft and deprecated atoms are excluded by default; pass include_drafts=true to include drafts (deprecated remain excluded). Scores are squash-normalized to [0,1); absolute score is not a presence signal — use result rank for presence/coverage checks.",
         visibility: Visibility::Verb,
         category: VerbCategory::Assertive,
         params: &[
@@ -282,7 +282,7 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 20] = [
                 name: "min_score",
                 param_type: "number",
                 required: false,
-                description: "Minimum score threshold (default 0.0). Score bands: score>=0.46 reliable, 0.42<=score<0.46 mixed, score<0.42 mostly off-target.",
+                description: "Minimum score threshold (default 0.0). Scores are squash-normalized to [0,1); absolute score is not a presence signal — use result rank for presence/coverage checks.",
             },
             ParamDef {
                 name: "weights",

--- a/crates/khive-pack-knowledge/tests/fixes.rs
+++ b/crates/khive-pack-knowledge/tests/fixes.rs
@@ -1318,6 +1318,113 @@ async fn upsert_finalizing_does_not_demote_non_draft_status() {
     );
 }
 
+// ── #1980: upsert UPDATE path must preserve finalized when the caller omits it ──
+
+#[tokio::test]
+async fn upsert_omitting_finalized_preserves_existing_flag() {
+    let f = pack(rt());
+
+    // Initial insert: finalized=true.
+    f.dispatch(
+        "knowledge.upsert_atoms",
+        json!({ "atoms": [{ "slug": "preserve-atom", "name": "Preserve", "content": "body dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity", "finalized": true }] }),
+    )
+    .await
+    .expect("insert finalized");
+
+    // Re-upsert the SAME slug WITHOUT the finalized field: the flag must be preserved,
+    // not silently reset to false (COALESCE(?7, finalized) — regression test for #1980).
+    f.dispatch(
+        "knowledge.upsert_atoms",
+        json!({ "atoms": [{ "slug": "preserve-atom", "name": "Preserve V2", "content": "body v2 dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity" }] }),
+    )
+    .await
+    .expect("re-upsert without finalized");
+
+    let row = f
+        .sql_query_one(
+            "SELECT finalized FROM knowledge_atoms WHERE slug=?1",
+            vec![SqlValue::Text("preserve-atom".into())],
+        )
+        .await
+        .expect("atom row");
+    assert_eq!(
+        row_i64(&row, "finalized"),
+        Some(1),
+        "omitting finalized on re-upsert must preserve the existing true flag"
+    );
+}
+
+#[tokio::test]
+async fn upsert_explicit_finalized_false_clears_flag() {
+    let f = pack(rt());
+
+    f.dispatch(
+        "knowledge.upsert_atoms",
+        json!({ "atoms": [{ "slug": "demote-atom", "name": "Demote", "content": "body dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity", "finalized": true }] }),
+    )
+    .await
+    .expect("insert finalized");
+
+    // Explicit finalized=false is a deliberate demote and must still work.
+    f.dispatch(
+        "knowledge.upsert_atoms",
+        json!({ "atoms": [{ "slug": "demote-atom", "name": "Demote V2", "content": "body v2 dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity", "finalized": false }] }),
+    )
+    .await
+    .expect("re-upsert with explicit false");
+
+    let row = f
+        .sql_query_one(
+            "SELECT finalized FROM knowledge_atoms WHERE slug=?1",
+            vec![SqlValue::Text("demote-atom".into())],
+        )
+        .await
+        .expect("atom row");
+    assert_eq!(
+        row_i64(&row, "finalized"),
+        Some(0),
+        "explicit finalized=false on re-upsert must clear the flag"
+    );
+}
+
+#[tokio::test]
+async fn upsert_explicit_finalized_true_on_draft_sets_flag_and_promotes_status() {
+    let f = pack(rt());
+
+    f.dispatch(
+        "knowledge.upsert_atoms",
+        json!({ "atoms": [{ "slug": "promote-atom", "name": "Promote", "content": "body dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity" }] }),
+    )
+    .await
+    .expect("insert draft");
+
+    f.dispatch(
+        "knowledge.upsert_atoms",
+        json!({ "atoms": [{ "slug": "promote-atom", "name": "Promote V2", "content": "body v2 dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity", "finalized": true }] }),
+    )
+    .await
+    .expect("re-upsert with explicit true");
+
+    let row = f
+        .sql_query_one(
+            "SELECT finalized, status FROM knowledge_atoms WHERE slug=?1",
+            vec![SqlValue::Text("promote-atom".into())],
+        )
+        .await
+        .expect("atom row");
+    assert_eq!(
+        row_i64(&row, "finalized"),
+        Some(1),
+        "explicit finalized=true on re-upsert must set the flag"
+    );
+    assert_eq!(
+        row_text(&row, "status").as_deref(),
+        Some("reviewed"),
+        "explicit finalized=true on a draft must promote status to reviewed"
+    );
+}
+
 // ── FTS5 MATCH escaping regression ───────────────────────────────────────────
 
 #[tokio::test]

--- a/crates/khive-pack-knowledge/tests/fixes.rs
+++ b/crates/khive-pack-knowledge/tests/fixes.rs
@@ -1425,6 +1425,109 @@ async fn upsert_explicit_finalized_true_on_draft_sets_flag_and_promotes_status()
     );
 }
 
+// ── #1985: upsert UPDATE path must preserve source_uri/source_type when omitted ──
+
+#[tokio::test]
+async fn upsert_omitting_source_fields_preserves_existing_values() {
+    let f = pack(rt());
+
+    // Initial insert carries source_uri/source_type.
+    f.dispatch(
+        "knowledge.upsert_atoms",
+        json!({ "atoms": [{
+            "slug": "preserve-source-atom",
+            "name": "Preserve Source",
+            "content": "body dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity",
+            "source_uri": "https://example.com/doc",
+            "source_type": "import"
+        }] }),
+    )
+    .await
+    .expect("insert with source fields");
+
+    // Re-upsert the SAME slug WITHOUT source_uri/source_type: both must be
+    // preserved, not silently NULLed (COALESCE(?5, source_uri) /
+    // COALESCE(?6, source_type) — regression test for #1985).
+    f.dispatch(
+        "knowledge.upsert_atoms",
+        json!({ "atoms": [{
+            "slug": "preserve-source-atom",
+            "name": "Preserve Source V2",
+            "content": "body v2 dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity"
+        }] }),
+    )
+    .await
+    .expect("re-upsert without source fields");
+
+    let row = f
+        .sql_query_one(
+            "SELECT source_uri, source_type, created_at FROM knowledge_atoms WHERE slug=?1",
+            vec![SqlValue::Text("preserve-source-atom".into())],
+        )
+        .await
+        .expect("atom row");
+    assert_eq!(
+        row_text(&row, "source_uri").as_deref(),
+        Some("https://example.com/doc"),
+        "omitting source_uri on re-upsert must preserve the existing value"
+    );
+    assert_eq!(
+        row_text(&row, "source_type").as_deref(),
+        Some("import"),
+        "omitting source_type on re-upsert must preserve the existing value"
+    );
+}
+
+#[tokio::test]
+async fn upsert_explicit_source_fields_replace_existing_values() {
+    let f = pack(rt());
+
+    f.dispatch(
+        "knowledge.upsert_atoms",
+        json!({ "atoms": [{
+            "slug": "replace-source-atom",
+            "name": "Replace Source",
+            "content": "body dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity",
+            "source_uri": "https://example.com/old",
+            "source_type": "import"
+        }] }),
+    )
+    .await
+    .expect("insert with source fields");
+
+    // Explicit new values on re-upsert must still replace the existing ones.
+    f.dispatch(
+        "knowledge.upsert_atoms",
+        json!({ "atoms": [{
+            "slug": "replace-source-atom",
+            "name": "Replace Source V2",
+            "content": "body v2 dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity",
+            "source_uri": "https://example.com/new",
+            "source_type": "manual"
+        }] }),
+    )
+    .await
+    .expect("re-upsert with explicit source fields");
+
+    let row = f
+        .sql_query_one(
+            "SELECT source_uri, source_type FROM knowledge_atoms WHERE slug=?1",
+            vec![SqlValue::Text("replace-source-atom".into())],
+        )
+        .await
+        .expect("atom row");
+    assert_eq!(
+        row_text(&row, "source_uri").as_deref(),
+        Some("https://example.com/new"),
+        "explicit source_uri on re-upsert must replace the existing value"
+    );
+    assert_eq!(
+        row_text(&row, "source_type").as_deref(),
+        Some("manual"),
+        "explicit source_type on re-upsert must replace the existing value"
+    );
+}
+
 // ── FTS5 MATCH escaping regression ───────────────────────────────────────────
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Three defects in the knowledge pack, filed as #1980, #1982, and #1985:

1. **`finalized` flag erasure on re-upsert.** The `upsert_atoms` UPDATE
   path unconditionally wrote `finalized=?7`, bound from
   `finalized.unwrap_or(false)`. Any re-upsert against an existing slug
   that omitted the `finalized` field silently reset it to `false`,
   even for atoms that had previously been finalized. The INSERT path
   was already correct (no prior row to erase).
2. **Stale score-band guidance.** The `knowledge.search` and
   `min_score` parameter descriptions cited `score>=0.46` /
   `0.42<=score<0.46` bands as separating on-topic from off-topic
   results. Those bands were calibrated against raw TF-IDF scores
   before a later `s/(s+1)` score-squash normalization was introduced;
   the squash compresses all scores into `[0,1)`, and on-topic hits now
   land in the same 0.4-0.5 band as off-topic queries served through
   the full-scan fallback. The bands no longer separate anything.
3. **`source_uri`/`source_type` erasure on re-upsert.** Same class of
   bug as #1980, same UPDATE statement: `source_uri=?5,
   source_type=?6` were bound `NULL` whenever the caller's payload
   omitted the fields, and the plain assignment then overwrote any
   previously-recorded source attribution. A re-upsert of an existing
   slug supplying only `name`/`content` cleared both fields on a row
   that had them set from a prior insert.

## Fixes

1. `crates/khive-pack-knowledge/src/knowledge/crud.rs`: the UPDATE SQL
   now uses `finalized = COALESCE(?7, finalized)`, with `?7` bound as
   `NULL` when the caller omits the field (instead of coercing to
   `0`). An omitted field now preserves the existing value; explicit
   `true`/`false` still set/clear it as before. The
   draft→reviewed status-promotion `CASE` is unaffected, since
   `NULL = 1` evaluates falsy in SQLite. The INSERT path and the
   hardcoded `upsert_domains` mirror-atom path are unchanged — both
   were already correct.
2. `crates/khive-pack-knowledge/src/vocab.rs`: replaced the stale
   score-band sentence in both the `knowledge.search` description and
   the `min_score` parameter description with guidance to use result
   rank, not absolute score, for presence/coverage checks. No scoring
   behavior changed.
3. `crates/khive-pack-knowledge/src/knowledge/crud.rs`: the same UPDATE
   statement now uses `source_uri = COALESCE(?5, source_uri)`,
   `source_type = COALESCE(?6, source_type)` — same shape as the
   `finalized` fix. An omitted field preserves the existing
   attribution; an explicit value still replaces it. The INSERT path
   is unchanged.

Other `0.46`/`0.42` band references were found in
`crates/khive-pack-knowledge/README.md`, `docs/guide/api-reference.md`,
and `docs/adr/ADR-047-knowledge-pack.md` (prose docs, not code
descriptions) — left for a separate documentation change.

## Test plan

- [x] `cargo test -p khive-pack-knowledge` — full crate green across
      the unit-test binary and all integration suites (fixes.rs,
      param_strictness.rs, search_candidate_refill.rs, and the rest)
- [x] `cargo clippy -p khive-pack-knowledge --all-targets -- -D
      warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Added three regression tests in `tests/fixes.rs` for the
      `finalized` fix: omitting `finalized` on re-upsert preserves the
      existing flag (proved red on the pre-fix UPDATE SQL, green after
      the fix); explicit `finalized=false` still clears the flag;
      explicit `finalized=true` on a draft still sets the flag and
      promotes status to `reviewed`.
- [x] Added two regression tests in `tests/fixes.rs` for the
      `source_uri`/`source_type` fix: omitting both fields on
      re-upsert preserves the existing values (proved red on the
      pre-fix UPDATE SQL, green after the fix); explicit new values on
      re-upsert still replace the existing ones.

Fixes #1980
Fixes #1985
Refs #1982
