### PR TITLE
docs(adr): recursion and invalidation-write verification arms; ADR-157/159 accepted

### DIFF
--- a/docs/adr/ADR-046-event-sourced-proposals.md
+++ b/docs/adr/ADR-046-event-sourced-proposals.md
@@ -1139,14 +1139,17 @@ reviewer test.
   natural-key upsert selects an actively governed incumbent fails the
   apply with the stale-preimage contract, appends no decision row, and
   leaves the incumbent's projection row untouched.
-- A recursion pair on the A1 classification: a proposal whose only
-  governance-bearing step is nested at depth two or more —
-  `Compound([Compound([AddEdge{supersedes, …}])])` — is treated as
-  governance-bearing by every propose-time and review-time check: the
-  propose-time rejection shapes fire on the nested form, and a
-  provider-denied reviewer's approve is refused exactly as for the flat
-  form. Mutation control on the same pair: a classifier restricted to the
-  outer variant (any shallow, non-recursive evaluation) must redden both
-  halves — the nested proposal is admitted at propose time and the denied
-  reviewer's approve lands — proving the recursive evaluation of A1 is
-  load-bearing rather than incidental.
+- A recursion pair on the A1 classification, two distinct proposals since
+  the rejected shapes and the governance-bearing class are disjoint by
+  A1: (i) a proposal whose only step is one of the propose-time rejection
+  shapes nested at depth two or more — for example a cross-namespace
+  memory-supersedes inside `Compound([Compound([AddEdge{…}])])` — is
+  refused at propose time with the same typed error as its flat form;
+  (ii) a proposal whose only governance-bearing step is nested at the
+  same depth is classified governance-bearing, so a provider-denied
+  reviewer's approve is refused exactly as for the flat form. Mutation
+  control on the pair: a classifier restricted to the outer variant (any
+  shallow, non-recursive evaluation) must redden both — the nested
+  rejected shape is admitted at propose time, and the denied reviewer's
+  approve lands on the nested governance-bearing proposal — proving the
+  recursive evaluation of A1 is load-bearing rather than incidental.

--- a/docs/adr/ADR-046-event-sourced-proposals.md
+++ b/docs/adr/ADR-046-event-sourced-proposals.md
@@ -1139,3 +1139,14 @@ reviewer test.
   natural-key upsert selects an actively governed incumbent fails the
   apply with the stale-preimage contract, appends no decision row, and
   leaves the incumbent's projection row untouched.
+- A recursion pair on the A1 classification: a proposal whose only
+  governance-bearing step is nested at depth two or more —
+  `Compound([Compound([AddEdge{supersedes, …}])])` — is treated as
+  governance-bearing by every propose-time and review-time check: the
+  propose-time rejection shapes fire on the nested form, and a
+  provider-denied reviewer's approve is refused exactly as for the flat
+  form. Mutation control on the same pair: a classifier restricted to the
+  outer variant (any shallow, non-recursive evaluation) must redden both
+  halves — the nested proposal is admitted at propose time and the denied
+  reviewer's approve lands — proving the recursive evaluation of A1 is
+  load-bearing rather than incidental.

--- a/docs/adr/ADR-157-supersession-chain-canonicalization.md
+++ b/docs/adr/ADR-157-supersession-chain-canonicalization.md
@@ -1,6 +1,6 @@
 # ADR-157: Canonicalize Verified Supersession Chains Before Memory Recall Scoring
 
-**Status**: proposed
+**Status**: accepted
 **Date**: 2026-08-15
 **Scope**: the `memory.recall` serving predicate for supersession chain-head
 substitution, its degradation contract, its activation gate, and the bounded

--- a/docs/adr/ADR-159-edge-governance-provenance.md
+++ b/docs/adr/ADR-159-edge-governance-provenance.md
@@ -1,6 +1,6 @@
 # ADR-159: Durable Edge-Governance Provenance for Supersession Canonicalization
 
-**Status**: Proposed
+**Status**: Accepted
 **Date**: 2026-08-15
 **Depends on**: ADR-002 (edge ontology), ADR-007 (namespace), ADR-013 (note kinds), ADR-014 (curation), ADR-017 (pack standard), ADR-018 (authorization gate), ADR-039 (note merge), ADR-046 (event-sourced proposals), ADR-055 (epistemic edges)
 **Consumed by**: ADR-157 (supersession chain canonicalization, in flight), a forthcoming ADR-046 amendment
@@ -550,6 +550,18 @@ recorded in § Context.)
 - Per-store activation test: activating governance on one store leaves a
   second store's state untouched and its edges ungoverned.
 - Query-plan and latency gates from the measurements above.
+- Invalidation-write mutation control: with the invalidation triggers
+  present and well-formed as far as the activation gate can observe, no-op
+  only the invalidation-row append (marker deletion retained), state the
+  expected reddened arms before the run, and re-run the rebuild and
+  same-key-resurrection arms. Both must fail by the spent decision
+  reactivating — not by an activation-gate refusal, which would leave the
+  rebuild-path assertion unreachable rather than falsified. The fixture
+  must isolate the ledger as the sole resurrection defense: the recurred
+  preimage satisfies the preimage and liveness rechecks by construction
+  (§3, same-key resurrection), so the append is load-bearing exactly
+  where every other mechanism passes, and an arm that stays green under
+  this mutant is measuring one of the other mechanisms instead.
 
 ## Implementation fences
 

--- a/docs/adr/ADR-159-edge-governance-provenance.md
+++ b/docs/adr/ADR-159-edge-governance-provenance.md
@@ -554,7 +554,9 @@ recorded in § Context.)
   present and well-formed as far as the activation gate can observe, no-op
   only the invalidation-row append while retaining the marker deletion —
   constructible without touching the monitored trigger DDL, for example
-  by a `BEFORE INSERT` trigger on the ledger that raises `IGNORE` — state
+  by a `BEFORE INSERT` trigger on `edge_governance_invalidations` that
+  raises `IGNORE`; the decision log is a separate table (§1), so the
+  setup phase's decision inserts are unaffected — state
   the expected reddened arm before the run, and re-run the rebuild test.
   It must fail by the spent decision reactivating on the rebuild step —
   not by an activation-gate refusal, which would leave the rebuild-path

--- a/docs/adr/ADR-159-edge-governance-provenance.md
+++ b/docs/adr/ADR-159-edge-governance-provenance.md
@@ -552,16 +552,22 @@ recorded in § Context.)
 - Query-plan and latency gates from the measurements above.
 - Invalidation-write mutation control: with the invalidation triggers
   present and well-formed as far as the activation gate can observe, no-op
-  only the invalidation-row append (marker deletion retained), state the
-  expected reddened arms before the run, and re-run the rebuild and
-  same-key-resurrection arms. Both must fail by the spent decision
-  reactivating — not by an activation-gate refusal, which would leave the
-  rebuild-path assertion unreachable rather than falsified. The fixture
-  must isolate the ledger as the sole resurrection defense: the recurred
-  preimage satisfies the preimage and liveness rechecks by construction
-  (§3, same-key resurrection), so the append is load-bearing exactly
-  where every other mechanism passes, and an arm that stays green under
-  this mutant is measuring one of the other mechanisms instead.
+  only the invalidation-row append while retaining the marker deletion —
+  constructible without touching the monitored trigger DDL, for example
+  by a `BEFORE INSERT` trigger on the ledger that raises `IGNORE` — state
+  the expected reddened arm before the run, and re-run the rebuild test.
+  It must fail by the spent decision reactivating on the rebuild step —
+  not by an activation-gate refusal, which would leave the rebuild-path
+  assertion unreachable rather than falsified. The rebuild test is the
+  arm this mutant isolates: its same-key resurrection restores the exact
+  original preimage, so the preimage and liveness rechecks pass by
+  construction (§3) and only the ledger separates the incarnations. The
+  resurrection rows of the regression matrix are not expected to redden
+  by reactivation — without a rebuild step no path re-inserts an active
+  marker — and may catch the mutant only through a direct
+  ledger-row-appended assertion; an implementation whose rebuild test
+  stays green under this mutant is measuring one of the other mechanisms
+  instead.
 
 ## Implementation fences
 


### PR DESCRIPTION
Docs-only follow-up to the ADR-157/159/046 series, adding the two verification arms identified during that series' review as landed-without-a-named-test:

**ADR-046 §A6 — recursion pair.** A1 specifies that governance-bearing classification recurses through `Compound` nesting, but no arm exercised it. The new arm names two distinct proposals (A1's rejected shapes and its governance-bearing class are disjoint): a nested rejected shape must refuse at propose time as its flat form does, and a nested governance-bearing step must require reviewer authority at review time. A shallow outer-variant classifier must redden both, proving the recursive evaluation is load-bearing.

**ADR-159 §Verification — invalidation-write mutation control.** §3 states the invalidation ledger row is load-bearing for same-key resurrection, but the existing rebuild arm only exercises the path where the append works, and the activation test covers trigger drop/alter through the serving-side gate — under which a rebuild-path assertion can become unreachable rather than red. The new clause requires an isolating mutant (monitored trigger DDL untouched; the append to `edge_governance_invalidations` alone no-opped, e.g. via a `BEFORE INSERT ... RAISE(IGNORE)` trigger on that table — the decision log is a separate table, so setup-phase decision inserts are unaffected) and requires the rebuild test to fail by spent-decision reactivation on its rebuild step, with the expected reddened arm stated before the run.

**Status flips.** ADR-157 and ADR-159 headers move to accepted. The acceptance events occurred in the order the documents' ordering clauses mandate, and are on the public record as the sequence of merges to main: ADR-159 first (merge commit c807de1c), the ADR-046 amendment second (merge commit 6ecd5374), ADR-157 last (merge commit 3a96f1b1). These flips record that completed sequence — the pre-flip state, in which the merged, in-effect amendment referenced a still-Proposed ADR-159, was the inconsistency.

No code changes.