### PR TITLE
fix(runtime): fail closed on gate errors

### DIFF
--- a/crates/khive-gate-rego/docs/api/policy-contract.md
+++ b/crates/khive-gate-rego/docs/api/policy-contract.md
@@ -74,9 +74,9 @@ assert!(gate.check(&req).unwrap().is_allow());
 
 ## Evaluation failures and fail-closed behavior
 
-Per ADR-018, a `GateError` returned from `Gate::check` is treated as a fail-open infrastructure
-failure by the dispatcher. `RegoGate` therefore converts policy evaluation uncertainty into an
-explicit `Ok(GateDecision::Deny)`:
+Per ADR-018 and ADR-129, a `GateError` returned from `Gate::check` is audited and refused as an
+infrastructure outage by the dispatcher. `RegoGate` converts policy evaluation uncertainty into
+an explicit `Ok(GateDecision::Deny)` so it remains distinguishable as a policy denial:
 
 - a poisoned engine mutex;
 - an evaluation error or missing rule;

--- a/crates/khive-gate-rego/docs/design.md
+++ b/crates/khive-gate-rego/docs/design.md
@@ -8,11 +8,11 @@ This crate is the reference Rego backend for the khive authorization gate define
 
 Key design decisions and constraints:
 
-- **Fail-open on dispatch errors.** When `Gate::check` returns `Err(GateError)`, the runtime
-  treats it as an infrastructure failure, logs a warning, and proceeds. This is the ADR-018
-  "fail-open on gate Err" behavior. To prevent unintended access, always declare a
-  `default decision := {"decision": "deny", ...}` so unmatched requests deny explicitly
-  rather than relying on the fail-open path.
+- **Fail-closed on dispatch errors.** When `Gate::check` returns `Err(GateError)`, the runtime
+  audits the infrastructure outage and returns `RuntimeError::GateUnavailable` without invoking
+  the operation. Policies should still declare a
+  `default decision := {"decision": "deny", ...}` so unmatched requests produce an explicit
+  policy denial instead of an infrastructure-outage response.
 
 - **Fail-closed on load errors.** Policy syntax/parse errors and empty policy directories are
   detected at construction time (`from_policy_str` / `from_dir` return `Err`), not at dispatch.
@@ -24,7 +24,7 @@ Key design decisions and constraints:
 
 - **Entrypoint validation at construction.** `try_with_entrypoint` rejects empty,
   whitespace-only, or non-`data.`-prefixed entrypoints before the gate is installed.
-  This prevents a misconfigured entrypoint from causing fail-open dispatch errors at runtime.
+  This prevents a misconfigured entrypoint from causing gate-unavailable dispatch errors at runtime.
   `with_entrypoint` is the infallible variant for programmatic use with already-validated paths.
 
 - **Deterministic policy load order.** `from_dir` sorts `.rego` files by name before loading,
@@ -35,6 +35,5 @@ Key design decisions and constraints:
 - The `README.md` and `docs/api/policy-contract.md` retain ADR-018 cross-references for external readers
   navigating from documentation to the authoritative design record. Only the `.rs` source files
   have had ADR citations removed.
-- The fail-open behavior described here matches the production runtime behavior in
-  `khive-runtime`. Any change to the gate error handling policy must be coordinated with
-  the runtime gate dispatch path.
+- The fail-closed behavior described here matches the production runtime behavior in
+  `khive-runtime`; gate-outage handling remains coordinated with the runtime dispatch path.

--- a/crates/khive-gate-rego/src/gate.rs
+++ b/crates/khive-gate-rego/src/gate.rs
@@ -159,7 +159,7 @@ impl Gate for RegoGate {
             engine.eval_rule(self.entrypoint.clone())
         };
 
-        // Gate errors are dispatcher-fail-open; policy evaluation uncertainty must deny.
+        // Keep policy evaluation uncertainty distinguishable from a gate infrastructure outage.
         let value = match result {
             Ok(v) => v,
             Err(e) => {

--- a/crates/khive-gate-rego/tests/integration.rs
+++ b/crates/khive-gate-rego/tests/integration.rs
@@ -122,8 +122,8 @@ fn malformed_policy_returns_policy_error() {
 fn missing_entrypoint_returns_deny_not_error() {
     // Compiles fine but has no `decision` rule — the default entrypoint
     // data.khive.gate.decision will be absent.  check() must return
-    // Ok(Deny) rather than Err so the runtime's fail-open Err branch is
-    // never reached.
+    // Ok(Deny) rather than Err so callers observe a policy denial rather than
+    // a gate infrastructure outage.
     let policy = r#"
         package khive.gate
         import rego.v1

--- a/crates/khive-gate/README.md
+++ b/crates/khive-gate/README.md
@@ -40,10 +40,12 @@ are both non-zero.
 - `GateDecision::Allow { obligations }` carries zero or more `Obligation` values
   (`Audit`, `RateLimit`, `Custom`) the runtime records on dispatch. `GateDecision::Deny
   { reason }` aborts dispatch — deny is authoritative and requires a non-empty reason.
-- `AuditEvent::from_check` builds the structured audit record (`actor`, `namespace`,
-  `verb`, `decision`, `obligations`, `gate_impl`, `session_id`) emitted once per gate
-  consultation. Its JSON projection is a stable public contract — field names don't
-  change without a new ADR.
+- `AuditEvent::from_check` builds the structured audit record for an explicit Allow or
+  Deny decision. `AuditEvent::gate_unavailable` builds the corresponding record when
+  `Gate::check` returns `GateError`; the runtime refuses dispatch without invoking the
+  operation. Both carry `actor`, `namespace`, `verb`, `decision`, `obligations`,
+  `gate_impl`, and `session_id`. Their JSON projection is a stable public contract —
+  field names don't change without a new ADR.
 - All wire types (`ActorRef`, `GateRequest`, `GateDecision`, `Obligation`) validate
   their invariants both at construction (`try_new` / `try_*` constructors) and at
   deserialization (custom `Deserialize` via a private `TryFrom<Raw*>` shape), so a

--- a/crates/khive-gate/docs/api/audit-events.md
+++ b/crates/khive-gate/docs/api/audit-events.md
@@ -5,15 +5,15 @@ tracing and, when configured, to the runtime event store.
 
 ## Stable JSON fields
 
-| Field | Meaning |
-| --- | --- |
-| `timestamp` | UTC consultation time, RFC 3339 in JSON |
-| `actor`, `namespace`, `verb` | request identity and operation |
-| `decision` | lowercase `"allow"` or `"deny"` |
-| `deny_reason` | present only for a denial |
-| `obligations` | policy obligations on allow; always `[]` on deny |
-| `gate_impl` | backend name from `Gate::impl_name` |
-| `session_id` | request-context correlation token when present |
+| Field                        | Meaning                                                                 |
+| ---------------------------- | ----------------------------------------------------------------------- |
+| `timestamp`                  | UTC consultation time, RFC 3339 in JSON                                 |
+| `actor`, `namespace`, `verb` | request identity and operation                                          |
+| `decision`                   | lowercase `"allow"`, `"deny"`, or `"gate_unavailable"`                  |
+| `deny_reason`                | present only for a denial                                               |
+| `obligations`                | policy obligations on allow; always `[]` on deny or gate unavailability |
+| `gate_impl`                  | backend name from `Gate::impl_name`                                     |
+| `session_id`                 | request-context correlation token when present                          |
 
 Field names are a public wire contract. Adding a field is compatible; removing or renaming one
 requires an architectural compatibility decision. `obligations` is always serialized so non-Rust
@@ -24,3 +24,10 @@ consumers never need to distinguish absence from an empty array.
 The constructor copies actor, namespace, verb, backend name, and optional session ID from the
 request, uses the request-context timestamp when supplied (stamping the current UTC time only when it is absent), and projects the decision. Allow carries its obligations and
 no deny reason; deny carries its reason and an empty obligation array.
+
+## `AuditEvent::gate_unavailable`
+
+The constructor preserves the request identity, namespace, verb, timestamp, optional session ID,
+and gate implementation while recording `decision="gate_unavailable"`, no deny reason, and an
+empty obligation array. Runtime dispatch persists this envelope with `EventOutcome::Error` before
+returning `RuntimeError::GateUnavailable` without invoking the operation.

--- a/crates/khive-gate/docs/api/gate-evaluation.md
+++ b/crates/khive-gate/docs/api/gate-evaluation.md
@@ -24,5 +24,7 @@ the sibling `khive-gate-rego` crate and downstream capability or wrapper impleme
 ## Error boundary
 
 `GateError::Policy` reports policy parsing or evaluation failures and `GateError::Internal` reports
-backend infrastructure faults. The dispatcher decides how errors affect availability; a gate that
-must fail closed should convert evaluation uncertainty into an explicit denial.
+backend infrastructure faults. The dispatcher audits every `GateError` as gate unavailability,
+returns `RuntimeError::GateUnavailable`, and never invokes the operation. An implementation should
+convert evaluation uncertainty into `Ok(GateDecision::Deny)` only when it intends to report an
+explicit policy refusal rather than an infrastructure outage.

--- a/crates/khive-gate/docs/design.md
+++ b/crates/khive-gate/docs/design.md
@@ -10,8 +10,8 @@ This crate implements the public types and default gate defined by ADR-018:
 
 - **`Gate` trait** — the authorization hook consulted before each verb dispatch.
   The `check` method returns `Ok(GateDecision)` or `Err(GateError)`. A `Deny`
-  decision blocks dispatch; an `Err` (infrastructure failure) is fail-open per
-  the ADR — dispatch proceeds with a tracing warning, no audit event emitted.
+  decision blocks dispatch with `PermissionDenied`; an `Err` (infrastructure
+  failure) is audited and blocks dispatch with `GateUnavailable`.
 
 - **`impl_name()`** — stable string identifier per `Gate` implementation.
   Default returns `std::any::type_name::<Self>()`. Concrete impls override for

--- a/crates/khive-gate/src/audit.rs
+++ b/crates/khive-gate/src/audit.rs
@@ -17,12 +17,12 @@ pub struct AuditEvent {
     pub namespace: String,
     /// Verb being dispatched.
     pub verb: String,
-    /// Gate outcome — `"allow"` or `"deny"`.
+    /// Gate outcome — `"allow"`, `"deny"`, or `"gate_unavailable"`.
     pub decision: AuditDecision,
     /// Deny reason, present only when `decision == "deny"`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub deny_reason: Option<String>,
-    /// Obligations on allow; always serialized and empty on deny.
+    /// Obligations on allow; always serialized and empty on deny or outage.
     #[serde(default)]
     pub obligations: Vec<Obligation>,
     /// Name of the gate implementation that produced this decision.
@@ -32,12 +32,13 @@ pub struct AuditEvent {
     pub session_id: Option<String>,
 }
 
-/// The outcome field of an [`AuditEvent`], serialised as `"allow"` / `"deny"`.
+/// The outcome field of an [`AuditEvent`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AuditDecision {
     Allow,
     Deny,
+    GateUnavailable,
 }
 
 impl AuditEvent {
@@ -61,6 +62,21 @@ impl AuditEvent {
             decision: audit_decision,
             deny_reason,
             obligations,
+            gate_impl: gate_impl.to_string(),
+            session_id: req.context.session_id.clone(),
+        }
+    }
+
+    /// Project a gate infrastructure failure into the stable audit envelope.
+    pub fn gate_unavailable(req: &crate::GateRequest, gate_impl: &str) -> Self {
+        Self {
+            timestamp: req.context.timestamp.unwrap_or_else(chrono::Utc::now),
+            actor: req.actor.clone(),
+            namespace: req.namespace.as_str().to_string(),
+            verb: req.verb.clone(),
+            decision: AuditDecision::GateUnavailable,
+            deny_reason: None,
+            obligations: Vec::new(),
             gate_impl: gate_impl.to_string(),
             session_id: req.context.session_id.clone(),
         }

--- a/crates/khive-gate/src/error.rs
+++ b/crates/khive-gate/src/error.rs
@@ -32,3 +32,53 @@ pub enum GateError {
     #[error("validation error: {0}")]
     Validation(#[from] GateValidationError),
 }
+
+impl GateError {
+    /// Stable, caller-safe classification of this error's failure category.
+    ///
+    /// This is what a `Gate::check` caller is permitted to forward to an
+    /// untrusted requester. It never includes this error's `Display` text:
+    /// a gate backend's error message can embed connection details,
+    /// addresses, or credentials, and that text must stay in server-side
+    /// logs only (log the full error separately with its `Display` impl).
+    ///
+    /// `Internal` is a transient backend-availability failure — safe to
+    /// retry. `Policy` and `Validation` are non-transient: the gate backend
+    /// is reachable but the request or its configured policy cannot be
+    /// evaluated, and retrying the identical request will not change the
+    /// outcome.
+    pub fn wire_reason(&self) -> &'static str {
+        match self {
+            Self::Internal(_) => "gate backend unavailable",
+            Self::Policy(_) => "gate policy evaluation failed",
+            Self::Validation(_) => "gate request validation failed",
+        }
+    }
+}
+
+#[cfg(test)]
+mod wire_reason_tests {
+    use super::{GateError, GateValidationError};
+
+    #[test]
+    fn wire_reason_never_echoes_backend_display_text() {
+        let canary = "postgres://svc:not-a-real-secret@internal-host";
+        let error = GateError::Internal(canary.to_string());
+
+        assert!(!error.wire_reason().contains(canary));
+        assert_eq!(error.wire_reason(), "gate backend unavailable");
+    }
+
+    #[test]
+    fn policy_and_internal_classify_into_distinguishable_stable_text() {
+        let internal = GateError::Internal("connection refused".to_string());
+        let policy = GateError::Policy("rule set has no allow clause".to_string());
+        let validation = GateError::Validation(GateValidationError::EmptyVerb);
+
+        assert_eq!(internal.wire_reason(), "gate backend unavailable");
+        assert_eq!(policy.wire_reason(), "gate policy evaluation failed");
+        assert_eq!(validation.wire_reason(), "gate request validation failed");
+        assert_ne!(internal.wire_reason(), policy.wire_reason());
+        assert_ne!(policy.wire_reason(), validation.wire_reason());
+    }
+}

--- a/crates/khive-gate/src/tests.rs
+++ b/crates/khive-gate/src/tests.rs
@@ -253,11 +253,33 @@ fn audit_event_allow_no_obligations() {
 }
 
 #[test]
+fn audit_event_gate_unavailable_path_has_no_deny_fields() {
+    let req = sample_request();
+    let ev = AuditEvent::gate_unavailable(&req, "FailingGate");
+
+    let json = serde_json::to_value(&ev).unwrap();
+
+    assert_eq!(json["decision"], "gate_unavailable");
+    assert_eq!(json["gate_impl"], "FailingGate");
+    assert!(json.get("deny_reason").is_none() || json["deny_reason"].is_null());
+    assert_eq!(
+        json["obligations"],
+        serde_json::Value::Array(Vec::new()),
+        "obligations must be an empty array when the gate is unavailable"
+    );
+
+    let back: AuditEvent = serde_json::from_value(json).unwrap();
+    assert_eq!(back.decision, AuditDecision::GateUnavailable);
+}
+
+#[test]
 fn audit_decision_serialises_as_snake_case() {
     let allow = serde_json::to_value(AuditDecision::Allow).unwrap();
     assert_eq!(allow, "allow");
     let deny = serde_json::to_value(AuditDecision::Deny).unwrap();
     assert_eq!(deny, "deny");
+    let unavailable = serde_json::to_value(AuditDecision::GateUnavailable).unwrap();
+    assert_eq!(unavailable, "gate_unavailable");
 }
 
 // ---- GATE-AUD-001: impl_name() default ----

--- a/crates/khive-gate/tests/integration.rs
+++ b/crates/khive-gate/tests/integration.rs
@@ -222,6 +222,8 @@ fn audit_decision_serialises_as_snake_case() {
     assert_eq!(allow, "allow");
     let deny = serde_json::to_value(AuditDecision::Deny).unwrap();
     assert_eq!(deny, "deny");
+    let unavailable = serde_json::to_value(AuditDecision::GateUnavailable).unwrap();
+    assert_eq!(unavailable, "gate_unavailable");
 }
 
 // ---- impl_name() default ----

--- a/crates/khive-runtime/README.md
+++ b/crates/khive-runtime/README.md
@@ -81,7 +81,7 @@ NamespaceToken ──── VerbRegistryBuilder::register(pack) × N
                     Gate::check  first pack whose handlers() match verb
                     (authoritative
                      Deny; errors
-                     fail open)
+                     fail closed)
 ```
 
 `dispatch` short-circuits to `describe_verb` when `params["help"] == true`, otherwise

--- a/crates/khive-runtime/docs/api/pack.md
+++ b/crates/khive-runtime/docs/api/pack.md
@@ -141,8 +141,7 @@ key for one successful digest result. The handler policy is `AlwaysVerbose`,
 so the default MCP presentation returns the exact stored `payload.result`
 without shortening UUIDs or dropping empty fields.
 
-No configured event store, no gate audit decision, malformed `project_id`,
-or append failure replaces the handler success with
+No configured event store, malformed `project_id`, or append failure replaces the handler success with
 `RuntimeError::Internal("git_digest_receipt_persist_failed: ...")`. The
 message tells the caller that writes may already have committed and reveals
 no storage/source/command detail. When receipt construction rejects malformed
@@ -151,6 +150,10 @@ is still appended once through the generic schema-v1 Error path; it is not
 silently consumed. A receipt append failure is not retried as a generic append
 against the same failing store. Handler errors and every other verb retain the
 ordinary best-effort audit path.
+
+A gate infrastructure error takes precedence over the receipt path: it writes the ordinary
+best-effort `gate_unavailable` Error audit and returns `RuntimeError::GateUnavailable` before the
+handler or intercepted operation can run.
 
 ## LinkAuditSuccessV2
 

--- a/crates/khive-runtime/docs/design.md
+++ b/crates/khive-runtime/docs/design.md
@@ -84,7 +84,8 @@
 
 ### ADR-018: Authorization Gate
 
-- Gate is consulted before every verb dispatch; gate infrastructure failures are fail-open
+- Gate is consulted before every verb dispatch; gate infrastructure failures are audited and
+  fail closed with `RuntimeError::GateUnavailable`
 - `GateDecision::Deny` is hard enforcement: the pack is never invoked on denial
 - Namespace token is minted at the dispatch boundary after gate approval
 - `namespace` is stripped from params before forwarding to pack handlers

--- a/crates/khive-runtime/docs/protocol.md
+++ b/crates/khive-runtime/docs/protocol.md
@@ -23,8 +23,9 @@ MCP request(ops=...) → khive_request::parse_request → Vec<ParsedOp>
   for each ParsedOp:
     VerbRegistry::dispatch(verb, params)
       → help=true? → describe_verb() [short-circuit, no gate]
-      → Gate::check(GateRequest) → Allow|Deny
+      → Gate::check(GateRequest) → Allow|Deny|Err
           Deny → RuntimeError::PermissionDenied [pack not invoked]
+          Err → RuntimeError::GateUnavailable [pack not invoked]
           Allow → first matching pack.dispatch(verb, params)
                   → RuntimeResult<Value>
       → EventStore::append(audit_event) [if configured]
@@ -93,7 +94,8 @@ For subhandlers, the envelope additionally carries `"visibility": "internal"` an
 ## Invariants
 
 - One pack per verb at boot: duplicate verb names across packs produce `RuntimeError::VerbCollision`.
-- Gate is consulted before every dispatch. Gate infrastructure errors are fail-open (ADR-018).
+- Gate is consulted before every dispatch. Gate infrastructure errors are audited and fail closed
+  with `RuntimeError::GateUnavailable` (ADR-018, ADR-129).
 - Namespace is attribution and gate-policy input (ADR-007 Rev 6, ADR-050): it is minted into
   the dispatch `NamespaceToken`'s read/write scope, not re-checked per record. By-ID
   operations (get, delete, update) resolve globally unique UUIDs without a namespace
@@ -109,6 +111,7 @@ For subhandlers, the envelope additionally carries `"visibility": "internal"` an
 | ----------------------------------------------------- | --------------------------------------------------------------------------- |
 | Unknown verb                                          | `RuntimeError::UnknownVerb("unknown verb ...")`                             |
 | Gate deny                                             | `RuntimeError::PermissionDenied { verb, reason }`                           |
+| Gate infrastructure error                             | `RuntimeError::GateUnavailable { verb, reason }`                            |
 | Pack not loaded                                       | `RuntimeError::UnknownVerb` (unknown verb path)                             |
 | Malformed explicit namespace                          | `RuntimeError::InvalidInput` (non-string `namespace`, rejected before gate) |
 | Read-only audit backend after a successful inspection | Success plus `audit_persistence_skipped_read_only` advisory                 |

--- a/crates/khive-runtime/src/error.rs
+++ b/crates/khive-runtime/src/error.rs
@@ -337,6 +337,14 @@ pub enum RuntimeError {
     #[error("permission denied for verb {verb:?}: {reason}")]
     PermissionDenied { verb: String, reason: String },
 
+    /// The configured gate could not produce an authorization decision.
+    ///
+    /// This is distinct from [`Self::PermissionDenied`]: the pack or
+    /// intercepted operation is never invoked, but the gate did not answer
+    /// with an explicit denial.
+    #[error("gate unavailable for verb {verb:?}: {reason}")]
+    GateUnavailable { verb: String, reason: String },
+
     /// A structured [`khive_types::KhiveError`] converted into the runtime
     /// layer. The full structured error is preserved so callers can inspect
     /// `kind`, `code`, `details`, and `retry_hint` without information loss.
@@ -485,6 +493,7 @@ impl RuntimeError {
             Self::VerbCollision { .. } => "VerbCollision",
             Self::ReservedEnvelopeParam { .. } => "ReservedEnvelopeParam",
             Self::PermissionDenied { .. } => "PermissionDenied",
+            Self::GateUnavailable { .. } => "GateUnavailable",
             Self::Khive(_) => "Khive",
             Self::NamespaceMismatch { .. } => "NamespaceMismatch",
             Self::AmbiguousPrefix { .. } => "AmbiguousPrefix",

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -550,8 +550,7 @@ impl VerbRegistryBuilder {
     ///
     /// Defaults to `AllowAllGate` if not set. `Deny` is authoritative — a deny
     /// decision aborts dispatch with `RuntimeError::PermissionDenied`. Gate
-    /// infrastructure errors fail open (logged via `tracing::warn!`, dispatch
-    /// proceeds).
+    /// infrastructure errors abort dispatch with `RuntimeError::GateUnavailable`.
     pub fn with_gate(&mut self, gate: GateRef) -> &mut Self {
         self.gate = gate;
         self
@@ -569,8 +568,8 @@ impl VerbRegistryBuilder {
     /// Set the `EventStore` used to persist audit events.
     ///
     /// When configured, every gate check appends one `Event` (substrate =
-    /// `Event`, outcome = `Success` on allow, `Denied` on deny) in addition to
-    /// the `tracing::info!` emission that was already present in v0.2.
+    /// `Event`, outcome = `Success` on allow, `Denied` on deny, or `Error` on
+    /// gate unavailability) in addition to the `tracing::info!` emission.
     ///
     /// Callers that do not set this field continue to use tracing-only emission
     /// (the v0.2 default), except `git.digest`: its successful response carries
@@ -1361,7 +1360,7 @@ impl VerbRegistry {
     ///
     /// Multi-backend transports use this to route an operation through a
     /// coordinator while retaining [`Self::dispatch_with_identity`]'s gate and
-    /// audit lifecycle. Deny is authoritative, gate errors fail open, and an
+    /// audit lifecycle. Deny is authoritative, gate errors fail closed, and an
     /// allowed audit is persisted after the intercepted operation resolves so
     /// its outcome and duration reflect the operation result. Successful
     /// `git.digest` interception uses the same strict durable-receipt exception
@@ -1436,8 +1435,9 @@ impl VerbRegistry {
                 Some(audit)
             }
             Err(err) => {
-                tracing::warn!(verb, error = %err, "gate check failed (fail-open)");
-                None
+                return Err(self
+                    .gate_unavailable_error(&gate_req, &err, request_id)
+                    .await);
             }
         };
 
@@ -1590,11 +1590,43 @@ impl VerbRegistry {
         Ok(GateRequest::new(actor, namespace, verb, params.clone()))
     }
 
+    async fn gate_unavailable_error(
+        &self,
+        gate_req: &GateRequest,
+        error: &khive_gate::GateError,
+        request_id: Option<u64>,
+    ) -> RuntimeError {
+        let audit = AuditEvent::gate_unavailable(gate_req, self.gate.impl_name());
+        tracing::info!(
+            audit_event = %serde_json::to_string(&audit)
+                .unwrap_or_else(|_| "{\"error\":\"serialize\"}".into()),
+            "gate.check"
+        );
+        tracing::warn!(
+            verb = %gate_req.verb,
+            error = %error,
+            "gate check failed (fail-closed)"
+        );
+        if let Some(store) = &self.event_store {
+            let event = build_audit_storage_event(
+                gate_req,
+                &audit,
+                EventOutcome::Error,
+                Some(crate::cost_unit::base_resource_payload(request_id)),
+            );
+            append_audit_event_best_effort(store, event, gate_req.verb.as_str()).await;
+        }
+        RuntimeError::GateUnavailable {
+            verb: gate_req.verb.clone(),
+            reason: error.to_string(),
+        }
+    }
+
     /// Dispatch a verb to the first pack that handles it.
     ///
     /// Routes through the gate, then invokes the matching pack handler. When
     /// `params["help"] == true`, short-circuits to `describe_verb` with no side effects.
-    /// Gate errors are fail-open. Full dispatch flow documented in `docs/protocol.md`.
+    /// Gate errors fail closed. Full dispatch flow documented in `docs/protocol.md`.
     ///
     /// Equivalent to `self.dispatch_with_identity(verb, params, None)` — uses
     /// this registry's construction-baked `default_namespace` / `actor_id` /
@@ -1652,7 +1684,7 @@ impl VerbRegistry {
         //
         // - Ok(Allow) → proceed to pack dispatch (tracing + optional EventStore).
         // - Ok(Deny) → emit audit, persist if store configured, return PermissionDenied.
-        // - Err(_) → warn via tracing, fail-open (no audit persisted).
+        // - Err(_) → emit an outage audit and return GateUnavailable.
         let (gate_blocked, mut deferred_audit) = match self.gate.check(&gate_req) {
             Ok(decision) => {
                 let is_deny = matches!(decision, GateDecision::Deny { .. });
@@ -1747,10 +1779,9 @@ impl VerbRegistry {
                 (reason, deferred)
             }
             Err(err) => {
-                // Gate infrastructure failure — fail-open.
-                // No decision was produced; no audit event is persisted.
-                tracing::warn!(verb, error = %err, "gate check failed (fail-open)");
-                (None, None)
+                return Err(self
+                    .gate_unavailable_error(&gate_req, &err, request_id)
+                    .await);
             }
         };
 
@@ -3304,6 +3335,54 @@ pub(crate) mod tests {
         }
     }
 
+    #[derive(Debug)]
+    struct GateErrorTrackingPack {
+        invoked: Arc<AtomicUsize>,
+    }
+
+    impl Pack for GateErrorTrackingPack {
+        const NAME: &'static str = "gate_error_tracking";
+        const NOTE_KINDS: &'static [&'static str] = &[];
+        const ENTITY_KINDS: &'static [&'static str] = &[];
+        const HANDLERS: &'static [HandlerDef] = &[HandlerDef {
+            name: "guarded",
+            description: "track whether gate-error dispatch reaches the handler",
+            visibility: Visibility::Verb,
+            category: VerbCategory::Assertive,
+            params: &[],
+        }];
+    }
+
+    #[async_trait]
+    impl PackRuntime for GateErrorTrackingPack {
+        fn name(&self) -> &str {
+            Self::NAME
+        }
+
+        fn note_kinds(&self) -> &'static [&'static str] {
+            Self::NOTE_KINDS
+        }
+
+        fn entity_kinds(&self) -> &'static [&'static str] {
+            Self::ENTITY_KINDS
+        }
+
+        fn handlers(&self) -> &'static [HandlerDef] {
+            Self::HANDLERS
+        }
+
+        async fn dispatch(
+            &self,
+            _verb: &str,
+            _params: Value,
+            _registry: &VerbRegistry,
+            _token: &NamespaceToken,
+        ) -> Result<Value, RuntimeError> {
+            self.invoked.fetch_add(1, Ordering::SeqCst);
+            Ok(serde_json::json!({"invoked": true}))
+        }
+    }
+
     /// A pack whose `dispatch` sleeps for a fixed, generous duration so
     /// `duration_us` regression tests (ADR-103 Stage 1) have a reliably
     /// nonzero, non-flaky measured dispatch time to assert against.
@@ -4638,9 +4717,9 @@ pub(crate) mod tests {
     /// fails closed rather than opening a security hole.
     /// `RegoGate::check` converts all evaluation failures (missing rule,
     /// undefined result, serialization error, poisoned engine) to
-    /// `Ok(GateDecision::Deny)`, so dispatch is blocked. The runtime's
-    /// fail-open `Err(_)` branch remains for non-evaluation gate errors
-    /// (e.g. infrastructure faults from other `Gate` implementations).
+    /// `Ok(GateDecision::Deny)`, so dispatch is blocked as a policy refusal.
+    /// Infrastructure faults from other `Gate` implementations remain
+    /// distinguishable as `RuntimeError::GateUnavailable`.
     #[tokio::test]
     async fn rego_gate_missing_entrypoint_returns_permission_denied() {
         use khive_gate_rego::RegoGate;
@@ -4648,8 +4727,8 @@ pub(crate) mod tests {
         // Policy defines `verdict` but NOT `data.khive.gate.decision` (the
         // default entrypoint).  Construction succeeds — from_policy_str does
         // not validate the default entrypoint.  check() must convert the
-        // missing-rule evaluation error to Ok(Deny) so the runtime denies
-        // the request rather than treating the Err as a fail-open signal.
+        // missing-rule evaluation error to Ok(Deny) so the runtime reports a
+        // policy refusal rather than a gate infrastructure outage.
         let policy = r#"
             package khive.gate
             import rego.v1
@@ -4930,6 +5009,51 @@ pub(crate) mod tests {
             audit.deny_reason.is_none(),
             "deny_reason must be None on Allow"
         );
+    }
+
+    #[test]
+    #[serial]
+    fn dispatch_tracing_emits_one_gate_check_event_when_gate_is_unavailable() {
+        #[derive(Debug)]
+        struct TracingUnavailableGate;
+        impl Gate for TracingUnavailableGate {
+            fn check(&self, _: &GateRequest) -> Result<GateDecision, GateError> {
+                Err(GateError::Internal("tracing gate broken".into()))
+            }
+
+            fn impl_name(&self) -> &'static str {
+                "TracingUnavailableGate"
+            }
+        }
+
+        let events = capture_dispatch_events(async {
+            let mut builder = VerbRegistryBuilder::new();
+            builder.register(AlphaPack);
+            builder.with_gate(Arc::new(TracingUnavailableGate));
+            let reg = builder.build().expect("registry builds");
+            let error = reg
+                .dispatch("list", Value::Null)
+                .await
+                .expect_err("gate outage must refuse dispatch");
+            assert!(matches!(error, RuntimeError::GateUnavailable { .. }));
+        });
+
+        let gate_events = gate_check_events_for(&events, "TracingUnavailableGate");
+        assert_eq!(
+            gate_events.len(),
+            1,
+            "exactly one gate.check tracing event per gate outage; got {gate_events:?}"
+        );
+        let payload = gate_events[0]
+            .audit_event
+            .as_ref()
+            .expect("gate outage trace must carry an audit_event field");
+        let audit: AuditEvent =
+            serde_json::from_str(payload).expect("audit_event payload must decode");
+        assert_eq!(audit.decision, AuditDecision::GateUnavailable);
+        assert!(audit.deny_reason.is_none());
+        assert!(audit.obligations.is_empty());
+        assert_eq!(audit.gate_impl, "TracingUnavailableGate");
     }
 
     // ---- Hard enforcement + EventStore persistence ----
@@ -5248,7 +5372,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn git_digest_gate_fail_open_cannot_bypass_the_receipt_contract() {
+    async fn git_digest_gate_unavailable_precedes_the_receipt_contract() {
         #[derive(Debug)]
         struct FailingGate;
         impl Gate for FailingGate {
@@ -5271,15 +5395,119 @@ pub(crate) mod tests {
         let err = registry
             .dispatch("git.digest", serde_json::json!({}))
             .await
-            .expect_err("no gate audit means no complete receipt");
+            .expect_err("gate unavailability must refuse before the handler or receipt path");
         assert!(matches!(
             err,
-            RuntimeError::Internal(ref message)
-                if message.starts_with("git_digest_receipt_persist_failed:")
+            RuntimeError::GateUnavailable { ref verb, ref reason }
+                if verb == "git.digest" && reason.contains("injected gate failure")
         ));
-        assert!(
-            store.events.lock().unwrap().is_empty(),
-            "a missing gate decision must not fabricate an audit receipt"
+        let event = only_git_digest_event(&store);
+        assert_eq!(event.outcome, EventOutcome::Error);
+        assert_eq!(event.payload["decision"], "gate_unavailable");
+        assert!(event.payload.get("result").is_none());
+    }
+
+    #[tokio::test]
+    async fn intercepted_gate_error_returns_typed_refusal_without_invoking_operation() {
+        #[derive(Debug)]
+        struct FailingGate;
+        impl Gate for FailingGate {
+            fn check(&self, _req: &GateRequest) -> Result<GateDecision, khive_gate::GateError> {
+                Err(khive_gate::GateError::Internal(
+                    "intercepted gate broken".into(),
+                ))
+            }
+        }
+
+        let invoked = Arc::new(AtomicUsize::new(0));
+        let invoked_by_operation = Arc::clone(&invoked);
+        let store = Arc::new(MemoryEventStore::default());
+        let mut builder = VerbRegistryBuilder::new();
+        builder.with_gate(Arc::new(FailingGate));
+        builder.with_event_store(store.clone());
+        let registry = builder.build().expect("registry builds");
+        let identity = RequestIdentity {
+            namespace: "identity-default".to_string(),
+            request_id: Some(1_600),
+            ..Default::default()
+        };
+
+        let err = registry
+            .dispatch_intercepted_with_identity(
+                "list",
+                &serde_json::json!({"namespace": "test-ns"}),
+                Some(&identity),
+                move |_namespace| {
+                    invoked_by_operation.fetch_add(1, Ordering::SeqCst);
+                    async move { Ok(serde_json::json!({"invoked": true})) }
+                },
+            )
+            .await
+            .expect_err("gate unavailability must refuse intercepted dispatch");
+
+        assert!(matches!(
+            err,
+            RuntimeError::GateUnavailable { ref verb, ref reason }
+                if verb == "list" && reason.contains("intercepted gate broken")
+        ));
+        assert_eq!(
+            invoked.load(Ordering::SeqCst),
+            0,
+            "intercepted operation must not run after a gate infrastructure error"
+        );
+
+        let events = store.events.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].verb, "list");
+        assert_eq!(events[0].namespace, "test-ns");
+        assert_eq!(events[0].outcome, EventOutcome::Error);
+        assert_eq!(events[0].payload["decision"], "gate_unavailable");
+        assert!(events[0].payload.get("deny_reason").is_none());
+        assert_eq!(events[0].payload["resource"]["work_class"], "interactive");
+        assert_eq!(events[0].payload["resource"]["request_id"], 1_600);
+        assert!(events[0].payload["resource"].get("cost_unit").is_none());
+    }
+
+    #[tokio::test]
+    async fn intercepted_deny_remains_distinct_and_does_not_invoke_operation() {
+        #[derive(Debug)]
+        struct DenyingGate;
+        impl Gate for DenyingGate {
+            fn check(&self, _req: &GateRequest) -> Result<GateDecision, GateError> {
+                Ok(GateDecision::deny("intercepted policy denied"))
+            }
+        }
+
+        let invoked = Arc::new(AtomicUsize::new(0));
+        let invoked_by_operation = Arc::clone(&invoked);
+        let store = Arc::new(MemoryEventStore::default());
+        let mut builder = VerbRegistryBuilder::new();
+        builder.with_gate(Arc::new(DenyingGate));
+        builder.with_event_store(store.clone());
+        let registry = builder.build().expect("registry builds");
+
+        let err = registry
+            .dispatch_intercepted_with_identity("list", &Value::Null, None, move |_namespace| {
+                invoked_by_operation.fetch_add(1, Ordering::SeqCst);
+                async move { Ok(serde_json::json!({"invoked": true})) }
+            })
+            .await
+            .expect_err("explicit gate denial must refuse intercepted dispatch");
+
+        assert!(matches!(
+            err,
+            RuntimeError::PermissionDenied { ref verb, ref reason }
+                if verb == "list" && reason == "intercepted policy denied"
+        ));
+        assert_eq!(invoked.load(Ordering::SeqCst), 0);
+
+        let events = store.events.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].outcome, EventOutcome::Denied);
+        assert_eq!(events[0].payload["decision"], "deny");
+        assert_eq!(
+            events[0].payload["deny_reason"],
+            "intercepted policy denied"
         );
     }
 
@@ -5789,7 +6017,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn gate_error_does_not_persist_to_event_store() {
+    async fn gate_error_returns_typed_refusal_without_invoking_pack() {
         #[derive(Debug)]
         struct FailingGate;
         impl Gate for FailingGate {
@@ -5799,23 +6027,91 @@ pub(crate) mod tests {
         }
 
         let store = Arc::new(MemoryEventStore::default());
+        let invoked = Arc::new(AtomicUsize::new(0));
         let mut builder = VerbRegistryBuilder::new();
-        builder.register(AlphaPack);
+        builder.register(GateErrorTrackingPack {
+            invoked: Arc::clone(&invoked),
+        });
         builder.with_gate(Arc::new(FailingGate));
         builder.with_event_store(store.clone());
         let reg = builder.build().expect("registry builds");
 
-        // Gate Err → fail-open, dispatch proceeds.
-        let res = reg.dispatch("list", Value::Null).await.unwrap();
+        let err = reg
+            .dispatch("guarded", Value::Null)
+            .await
+            .expect_err("gate unavailability must refuse normal dispatch");
+        assert!(matches!(
+            err,
+            RuntimeError::GateUnavailable { ref verb, ref reason }
+                if verb == "guarded" && reason.contains("gate broken")
+        ));
         assert_eq!(
-            res["pack"], "alpha",
-            "gate error must fail-open, not block dispatch"
+            invoked.load(Ordering::SeqCst),
+            0,
+            "pack handler must not run after a gate infrastructure error"
         );
 
         let count = store.count_events(EventFilter::default()).await.unwrap();
+        assert_eq!(count, 1, "gate infrastructure error must be audited");
+        let page = store
+            .query_events(
+                EventFilter::default(),
+                PageRequest {
+                    limit: 10,
+                    offset: 0,
+                },
+            )
+            .await
+            .unwrap();
+        let event = &page.items[0];
+        assert_eq!(event.verb, "guarded");
+        assert_eq!(event.outcome, EventOutcome::Error);
+        assert_eq!(event.payload["decision"], "gate_unavailable");
+        assert!(event.payload.get("deny_reason").is_none());
+        assert_eq!(event.payload["resource"]["work_class"], "interactive");
+        assert!(event.payload["resource"].get("cost_unit").is_none());
+    }
+
+    #[tokio::test]
+    #[serial(audit_append_failures)]
+    async fn gate_error_audit_failure_cannot_reopen_dispatch_or_replace_typed_error() {
+        #[derive(Debug)]
+        struct FailingGate;
+        impl Gate for FailingGate {
+            fn check(&self, _req: &GateRequest) -> Result<GateDecision, GateError> {
+                Err(GateError::Internal("gate still broken".into()))
+            }
+        }
+
+        let before = audit_append_failure_count();
+        let invoked = Arc::new(AtomicUsize::new(0));
+        let store = Arc::new(MemoryEventStore {
+            fail_appends: true,
+            ..MemoryEventStore::default()
+        });
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(GateErrorTrackingPack {
+            invoked: Arc::clone(&invoked),
+        });
+        builder.with_gate(Arc::new(FailingGate));
+        builder.with_event_store(store);
+        let registry = builder.build().expect("registry builds");
+
+        let error = registry
+            .dispatch("guarded", Value::Null)
+            .await
+            .expect_err("audit persistence failure must not reopen dispatch");
+
+        assert!(matches!(
+            error,
+            RuntimeError::GateUnavailable { ref verb, ref reason }
+                if verb == "guarded" && reason.contains("gate still broken")
+        ));
+        assert_eq!(invoked.load(Ordering::SeqCst), 0);
         assert_eq!(
-            count, 0,
-            "gate infrastructure error must NOT produce an audit event in EventStore"
+            audit_append_failure_count(),
+            before + 1,
+            "best-effort audit failure remains diagnostic without changing the refusal"
         );
     }
 

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -1618,7 +1618,12 @@ impl VerbRegistry {
         }
         RuntimeError::GateUnavailable {
             verb: gate_req.verb.clone(),
-            reason: error.to_string(),
+            // Caller-visible: a stable, classified reason derived from the
+            // `GateError` variant only. `error`'s `Display` text is logged
+            // above (server-side, via `tracing::warn!`) and must never be
+            // interpolated here — a gate backend's error message can embed
+            // connection details, addresses, or credentials.
+            reason: error.wire_reason().to_string(),
         }
     }
 
@@ -5399,7 +5404,9 @@ pub(crate) mod tests {
         assert!(matches!(
             err,
             RuntimeError::GateUnavailable { ref verb, ref reason }
-                if verb == "git.digest" && reason.contains("injected gate failure")
+                if verb == "git.digest"
+                    && reason == "gate backend unavailable"
+                    && !reason.contains("injected gate failure")
         ));
         let event = only_git_digest_event(&store);
         assert_eq!(event.outcome, EventOutcome::Error);
@@ -5448,7 +5455,9 @@ pub(crate) mod tests {
         assert!(matches!(
             err,
             RuntimeError::GateUnavailable { ref verb, ref reason }
-                if verb == "list" && reason.contains("intercepted gate broken")
+                if verb == "list"
+                    && reason == "gate backend unavailable"
+                    && !reason.contains("intercepted gate broken")
         ));
         assert_eq!(
             invoked.load(Ordering::SeqCst),
@@ -6043,7 +6052,9 @@ pub(crate) mod tests {
         assert!(matches!(
             err,
             RuntimeError::GateUnavailable { ref verb, ref reason }
-                if verb == "guarded" && reason.contains("gate broken")
+                if verb == "guarded"
+                    && reason == "gate backend unavailable"
+                    && !reason.contains("gate broken")
         ));
         assert_eq!(
             invoked.load(Ordering::SeqCst),
@@ -6105,7 +6116,9 @@ pub(crate) mod tests {
         assert!(matches!(
             error,
             RuntimeError::GateUnavailable { ref verb, ref reason }
-                if verb == "guarded" && reason.contains("gate still broken")
+                if verb == "guarded"
+                    && reason == "gate backend unavailable"
+                    && !reason.contains("gate still broken")
         ));
         assert_eq!(invoked.load(Ordering::SeqCst), 0);
         assert_eq!(
@@ -6113,6 +6126,95 @@ pub(crate) mod tests {
             before + 1,
             "best-effort audit failure remains diagnostic without changing the refusal"
         );
+    }
+
+    /// Regression for a credential-disclosure path: a gate backend's error
+    /// `Display` text can embed connection details (URLs, addresses, auth
+    /// material). That text must never reach `RuntimeError::GateUnavailable`
+    /// as observed by a dispatch caller — only the stable classified
+    /// `wire_reason()` may cross that boundary. The full error is still
+    /// logged server-side via `tracing::warn!` in `gate_unavailable_error`.
+    #[tokio::test]
+    async fn gate_unavailable_reason_never_carries_backend_error_text() {
+        const CANARY: &str = "postgres://svc:not-a-real-secret@internal-host";
+
+        #[derive(Debug)]
+        struct FailingGate;
+        impl Gate for FailingGate {
+            fn check(&self, _req: &GateRequest) -> Result<GateDecision, GateError> {
+                Err(GateError::Internal(CANARY.to_string()))
+            }
+        }
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(GateErrorTrackingPack {
+            invoked: Arc::new(AtomicUsize::new(0)),
+        });
+        builder.with_gate(Arc::new(FailingGate));
+        let registry = builder.build().expect("registry builds");
+
+        let err = registry
+            .dispatch("guarded", Value::Null)
+            .await
+            .expect_err("gate unavailability must refuse dispatch");
+
+        let RuntimeError::GateUnavailable { reason, .. } = &err else {
+            panic!("expected GateUnavailable, got {err:?}");
+        };
+        assert!(
+            !reason.contains(CANARY),
+            "caller-visible reason must not embed backend error text: {reason:?}"
+        );
+        assert!(
+            !reason.contains("svc") && !reason.contains("internal-host"),
+            "caller-visible reason must not embed backend error fragments: {reason:?}"
+        );
+        assert_eq!(reason, "gate backend unavailable");
+
+        // The full error, canary included, still reaches the server-side log.
+        let rendered = err.to_string();
+        assert!(
+            !rendered.contains(CANARY),
+            "top-level Display must not embed backend error text either: {rendered:?}"
+        );
+    }
+
+    /// Task 2 (ADR-129 gate-error classification): a `GateError::Policy`
+    /// failure — the gate backend is reachable but its configured policy
+    /// could not be evaluated — is a distinct, non-transient class from a
+    /// `GateError::Internal` backend-availability failure, and gets its own
+    /// stable reason text at the dispatch boundary.
+    #[tokio::test]
+    async fn gate_policy_error_classifies_distinctly_from_backend_unavailable() {
+        #[derive(Debug)]
+        struct PolicyBrokenGate;
+        impl Gate for PolicyBrokenGate {
+            fn check(&self, _req: &GateRequest) -> Result<GateDecision, GateError> {
+                Err(GateError::Policy(
+                    "rule set has no allow clause for this namespace".to_string(),
+                ))
+            }
+        }
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(GateErrorTrackingPack {
+            invoked: Arc::new(AtomicUsize::new(0)),
+        });
+        builder.with_gate(Arc::new(PolicyBrokenGate));
+        let registry = builder.build().expect("registry builds");
+
+        let err = registry
+            .dispatch("guarded", Value::Null)
+            .await
+            .expect_err("gate unavailability must refuse dispatch");
+
+        assert!(matches!(
+            err,
+            RuntimeError::GateUnavailable { ref verb, ref reason }
+                if verb == "guarded"
+                    && reason == "gate policy evaluation failed"
+                    && !reason.contains("rule set has no allow clause")
+        ));
     }
 
     #[tokio::test]

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -817,7 +817,17 @@ impl KhiveRuntime {
                 verb: "authorize".to_string(),
                 reason: "gate denied".to_string(),
             }),
-            Err(e) => Err(crate::RuntimeError::Internal(format!("gate error: {e}"))),
+            Err(e) => {
+                tracing::warn!(
+                    namespace = %ns.as_str(),
+                    error = %e,
+                    "authorize: gate check failed (fail-closed)"
+                );
+                Err(crate::RuntimeError::Internal(format!(
+                    "gate error: {}",
+                    e.wire_reason()
+                )))
+            }
         }
     }
 
@@ -874,7 +884,17 @@ impl KhiveRuntime {
                 verb: "authorize".to_string(),
                 reason: "gate denied".to_string(),
             }),
-            Err(e) => Err(crate::RuntimeError::Internal(format!("gate error: {e}"))),
+            Err(e) => {
+                tracing::warn!(
+                    namespace = %primary.as_str(),
+                    error = %e,
+                    "authorize_with_visibility: gate check failed (fail-closed)"
+                );
+                Err(crate::RuntimeError::Internal(format!(
+                    "gate error: {}",
+                    e.wire_reason()
+                )))
+            }
         }
     }
 

--- a/crates/kkernel/src/coordinator/tests.rs
+++ b/crates/kkernel/src/coordinator/tests.rs
@@ -1688,6 +1688,138 @@ async fn cross_backend_illegal_entity_pair_rejected_and_not_persisted() {
     );
 }
 
+// ---- T2c: Cross-backend link's authorize() gate error stays sanitized on the wire ----
+
+/// A gate that allows its first three checks — the test's own entity-setup
+/// authorize call, plus the two `locate_endpoint` probe-authorize calls
+/// `link_cross_backend` issues against this backend for the source and
+/// target ids before it authorizes the link itself — and then fails every
+/// subsequent check with a backend error carrying connection-string-shaped
+/// detail, simulating a gate backend outage discovered during
+/// `link_cross_backend`'s own `src_runtime.authorize(...)` call
+/// (`crates/kkernel/src/coordinator/dispatch.rs`).
+#[derive(Debug)]
+struct ErrorAfterSetupCallsGate {
+    cause: String,
+    calls: std::sync::atomic::AtomicUsize,
+}
+
+impl khive_runtime::Gate for ErrorAfterSetupCallsGate {
+    fn check(
+        &self,
+        _req: &khive_runtime::GateRequest,
+    ) -> Result<khive_runtime::GateDecision, khive_runtime::GateError> {
+        let call = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        if call < 3 {
+            Ok(khive_runtime::GateDecision::allow())
+        } else {
+            Err(khive_runtime::GateError::Internal(self.cause.clone()))
+        }
+    }
+}
+
+fn memory_runtime_gate_erroring_after_first_call_with(cause: String) -> Arc<KhiveRuntime> {
+    Arc::new(
+        KhiveRuntime::new(khive_runtime::RuntimeConfig {
+            db_path: None,
+            packs: vec!["kg".to_string()],
+            gate: Arc::new(ErrorAfterSetupCallsGate {
+                cause,
+                calls: std::sync::atomic::AtomicUsize::new(0),
+            }),
+            ..khive_runtime::RuntimeConfig::no_embeddings()
+        })
+        .expect("memory runtime with gate-erroring-after-setup-calls gate"),
+    )
+}
+
+/// Regression for the second production leak the round-2 review found: a
+/// `GateError` raised inside `link_cross_backend`'s own `authorize()` call on
+/// the source backend must never put backend `Display` text (which can embed
+/// connection strings or credentials) on the MCP-visible wire response. Only
+/// the stable classified `wire_reason()` may cross that boundary; the full
+/// error must still land in the server-side `tracing::warn!` emitted by
+/// `KhiveRuntime::authorize`.
+#[tokio::test]
+async fn t2c_cross_backend_link_authorize_gate_error_omits_backend_text_from_wire() {
+    const CANARY: &str = "postgres://svc:not-a-real-secret@internal-host";
+
+    let rt_main = memory_runtime_gate_erroring_after_first_call_with(CANARY.to_string());
+    let rt_lore = memory_runtime();
+
+    let mut registry = BackendRegistry::new();
+    registry.register(BackendId::new("main"), Arc::clone(&rt_main));
+    registry.register(BackendId::new("lore"), Arc::clone(&rt_lore));
+    let coord = SubstrateCoordinator::new(registry);
+    let ns = Namespace::local();
+
+    // Entity creation on "main" consumes the gate's first free `Allow` call.
+    let tok_main = rt_main.authorize(ns.clone()).expect("setup authorize");
+    let src = rt_main
+        .create_entity(
+            &tok_main,
+            "project",
+            None,
+            "SourceProject",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .expect("T2c: create source on main");
+
+    let tok_lore = rt_lore.authorize(ns.clone()).expect("setup authorize lore");
+    let tgt = rt_lore
+        .create_entity(
+            &tok_lore,
+            "concept",
+            None,
+            "TargetConcept",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .expect("T2c: create target on lore");
+
+    let captured = CoordinatorLogCapture::default();
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(MakeCoordinatorLogCapture(captured.clone()))
+        .with_ansi(false)
+        .without_time()
+        .finish();
+
+    let guard = tracing::subscriber::set_default(subscriber);
+    // The gate's three free `Allow` calls are already spent (entity setup,
+    // then `locate_endpoint`'s probe-authorize for source and target). The
+    // real `src_runtime.authorize(...)` inside `link_cross_backend` is the
+    // fourth call on "main" and now errors.
+    let result = coord
+        .link_cross_backend(&ns, src.id, tgt.id, EdgeRelation::Implements, 1.0, None)
+        .await;
+    drop(guard);
+    let logs = captured.contents();
+
+    let wire_err = result.expect_err("T2c: gate error during link must fail closed");
+    assert!(
+        !wire_err.contains(CANARY),
+        "T2c: MCP-visible link error must not embed backend error text: {wire_err:?}"
+    );
+    assert!(
+        !wire_err.contains("svc") && !wire_err.contains("internal-host"),
+        "T2c: MCP-visible link error must not embed backend error fragments: {wire_err:?}"
+    );
+    assert!(
+        wire_err.contains("gate backend unavailable"),
+        "T2c: MCP-visible link error must carry the stable classified reason: {wire_err:?}"
+    );
+
+    assert!(
+        logs.contains(CANARY),
+        "T2c: the full backend error must still reach the server-side log: {logs}"
+    );
+}
+
 // ---- T3: Fan-out merged from multiple backends ----
 
 /// T3: Fan-out entity search over two backends merges results from both.

--- a/crates/kkernel/src/coordinator/tests.rs
+++ b/crates/kkernel/src/coordinator/tests.rs
@@ -1733,7 +1733,7 @@ fn memory_runtime_gate_erroring_after_first_call_with(cause: String) -> Arc<Khiv
     )
 }
 
-/// Regression for the second production leak the round-2 review found: a
+/// Regression for a second production disclosure path: a
 /// `GateError` raised inside `link_cross_backend`'s own `authorize()` call on
 /// the source backend must never put backend `Display` text (which can embed
 /// connection strings or credentials) on the MCP-visible wire response. Only

--- a/crates/kkernel/src/coordinator/tests.rs
+++ b/crates/kkernel/src/coordinator/tests.rs
@@ -1690,14 +1690,16 @@ async fn cross_backend_illegal_entity_pair_rejected_and_not_persisted() {
 
 // ---- T2c: Cross-backend link's authorize() gate error stays sanitized on the wire ----
 
-/// A gate that allows its first three checks — the test's own entity-setup
-/// authorize call, plus the two `locate_endpoint` probe-authorize calls
-/// `link_cross_backend` issues against this backend for the source and
-/// target ids before it authorizes the link itself — and then fails every
-/// subsequent check with a backend error carrying connection-string-shaped
-/// detail, simulating a gate backend outage discovered during
-/// `link_cross_backend`'s own `src_runtime.authorize(...)` call
-/// (`crates/kkernel/src/coordinator/dispatch.rs`).
+/// A gate that allows its first four checks — the test's own entity-setup
+/// authorize call, the MCP dispatch's own top-level namespace authorize check
+/// (`VerbRegistry::dispatch_intercepted_with_metadata_with_identity`, which
+/// runs once before the coordinator ever sees the request), and the two
+/// `locate_endpoint` probe-authorize calls `link_cross_backend` issues
+/// against this backend for the source and target ids before it authorizes
+/// the link itself — and then fails every subsequent check with a backend
+/// error carrying connection-string-shaped detail, simulating a gate backend
+/// outage discovered during `link_cross_backend`'s own
+/// `src_runtime.authorize(...)` call (`crates/kkernel/src/coordinator/dispatch.rs`).
 #[derive(Debug)]
 struct ErrorAfterSetupCallsGate {
     cause: String,
@@ -1710,7 +1712,7 @@ impl khive_runtime::Gate for ErrorAfterSetupCallsGate {
         _req: &khive_runtime::GateRequest,
     ) -> Result<khive_runtime::GateDecision, khive_runtime::GateError> {
         let call = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-        if call < 3 {
+        if call < 4 {
             Ok(khive_runtime::GateDecision::allow())
         } else {
             Err(khive_runtime::GateError::Internal(self.cause.clone()))
@@ -1733,24 +1735,27 @@ fn memory_runtime_gate_erroring_after_first_call_with(cause: String) -> Arc<Khiv
     )
 }
 
-/// Regression for a second production disclosure path: a
+/// Regression for a second production disclosure path, exercised through the
+/// real MCP wire boundary rather than the coordinator's Rust API directly: a
 /// `GateError` raised inside `link_cross_backend`'s own `authorize()` call on
 /// the source backend must never put backend `Display` text (which can embed
-/// connection strings or credentials) on the MCP-visible wire response. Only
-/// the stable classified `wire_reason()` may cross that boundary; the full
-/// error must still land in the server-side `tracing::warn!` emitted by
-/// `KhiveRuntime::authorize`.
+/// connection strings or credentials) into the per-operation error a caller
+/// receives from `request(ops="link(...)")`. Only the stable classified
+/// `wire_reason()` may cross that boundary; the full error must still land in
+/// the server-side `tracing::warn!` emitted by `KhiveRuntime::authorize`.
+///
+/// Dispatches through `KhiveMcpServer::dispatch_request_local`, which routes
+/// `link` through `dispatch_via_coordinator_inner` ->
+/// `VerbRegistry::dispatch_intercepted_with_identity` ->
+/// `SubstrateCoordinatorService::link` -> `DispatchFailure::from_runtime` ->
+/// the serialized MCP response — the same chain a real MCP client's `link`
+/// call goes through in multi-backend mode.
 #[tokio::test]
 async fn t2c_cross_backend_link_authorize_gate_error_omits_backend_text_from_wire() {
     const CANARY: &str = "postgres://svc:not-a-real-secret@internal-host";
 
     let rt_main = memory_runtime_gate_erroring_after_first_call_with(CANARY.to_string());
     let rt_lore = memory_runtime();
-
-    let mut registry = BackendRegistry::new();
-    registry.register(BackendId::new("main"), Arc::clone(&rt_main));
-    registry.register(BackendId::new("lore"), Arc::clone(&rt_lore));
-    let coord = SubstrateCoordinator::new(registry);
     let ns = Namespace::local();
 
     // Entity creation on "main" consumes the gate's first free `Allow` call.
@@ -1782,6 +1787,8 @@ async fn t2c_cross_backend_link_authorize_gate_error_omits_backend_text_from_wir
         .await
         .expect("T2c: create target on lore");
 
+    let server = two_backend_server_with_packs(Arc::clone(&rt_main), Arc::clone(&rt_lore), &["kg"]);
+
     let captured = CoordinatorLogCapture::default();
     let subscriber = tracing_subscriber::fmt()
         .with_writer(MakeCoordinatorLogCapture(captured.clone()))
@@ -1790,17 +1797,43 @@ async fn t2c_cross_backend_link_authorize_gate_error_omits_backend_text_from_wir
         .finish();
 
     let guard = tracing::subscriber::set_default(subscriber);
-    // The gate's three free `Allow` calls are already spent (entity setup,
-    // then `locate_endpoint`'s probe-authorize for source and target). The
-    // real `src_runtime.authorize(...)` inside `link_cross_backend` is the
-    // fourth call on "main" and now errors.
-    let result = coord
-        .link_cross_backend(&ns, src.id, tgt.id, EdgeRelation::Implements, 1.0, None)
-        .await;
+    // The gate's four free `Allow` calls are already spent by this point:
+    // entity setup, this dispatch's own top-level namespace check, and
+    // `locate_endpoint`'s probe-authorize for source and target. The real
+    // `src_runtime.authorize(...)` inside `link_cross_backend` is the fifth
+    // call on "main" and now errors.
+    let ops = format!(
+        r#"link(source_id="{}", target_id="{}", relation="implements")"#,
+        src.id, tgt.id
+    );
+    let raw = server
+        .dispatch_request_local(khive_mcp::tools::request::RequestParams {
+            ops,
+            presentation: None,
+            presentation_per_op: None,
+            save_to: None,
+            format: None,
+            format_per_op: None,
+            request_id: None,
+        })
+        .await
+        .expect("T2c: dispatch must produce a response envelope");
     drop(guard);
     let logs = captured.contents();
 
-    let wire_err = result.expect_err("T2c: gate error during link must fail closed");
+    let response: serde_json::Value =
+        serde_json::from_str(&raw).expect("T2c: response must be valid JSON");
+    let op = &response["results"][0];
+    assert_eq!(
+        op["ok"].as_bool(),
+        Some(false),
+        "T2c: link op must fail closed on the wire: {response}"
+    );
+    let wire_err = op["error"]
+        .as_str()
+        .unwrap_or_else(|| panic!("T2c: MCP-visible error must be a string: {response}"))
+        .to_string();
+
     assert!(
         !wire_err.contains(CANARY),
         "T2c: MCP-visible link error must not embed backend error text: {wire_err:?}"

--- a/docs/adr/ADR-046-event-sourced-proposals.md
+++ b/docs/adr/ADR-046-event-sourced-proposals.md
@@ -7,7 +7,7 @@
 
 - ADR-014 (Curation Operations — apply step rides on existing curation primitives)
 - ADR-017 (Pack Standard — KG pack handler surface; async event-consumer worker registration is deferred)
-- ADR-018 (Authorization Gate — gates the apply step)
+- ADR-018 (Authorization Gate — gates the apply step; Gate-error posture is amended by ADR-129)
 - ADR-022 (Events Query Surface — proposals live as events)
 - ADR-032 (Brain Profile Orchestration — future proposal-event Fold design; no v1 consumer)
 - ADR-041 (Event Provenance Projection — open-proposal projection lives here)
@@ -1012,12 +1012,12 @@ amendment adds, for governance-bearing changesets only:
    dispatch with a typed error
    (`ReviewerNotAuthorized { proposal_id, actor_id }`) — parallel to
    `SelfApprovalForbidden`, before the handler runs and before any event
-   lands. **Admission errors fail closed for this class**: a resolver
-   failure, an authority-provider error, or an unavailable provider
-   refuses the dispatch exactly as a denial does; the base dispatch path's
-   fail-open treatment of Gate errors is explicitly overridden for
-   governance-bearing review dispatch, while ungoverned verbs keep their
-   existing behavior. On allow, stage 2 issues the endpoint-scoped
+   lands. **Admission errors fail closed for this class**: ADR-129 already
+   requires a stage-1 Gate infrastructure error to refuse dispatch, and a
+   resolver failure, authority-provider error, or unavailable provider in
+   stage 2 independently refuses exactly as a denial does. Neither failure
+   path invokes the handler; ungoverned verbs inherit ADR-129's base Gate
+   error posture. On allow, stage 2 issues the endpoint-scoped
    `AuthorityReceipt` and the dispatch site hands it to the handler
    in-process (item 2); the handler performs no authorization of its own.
 2. The receipt is runtime-internal and non-serializable (ADR-159 §2), and

--- a/docs/adr/ADR-068-process-isolation-topology.md
+++ b/docs/adr/ADR-068-process-isolation-topology.md
@@ -3,7 +3,8 @@
 **Status**: Proposed\
 **Date**: 2026-06-23\
 **Authors**: khive maintainers
-**Depends on**: ADR-007 (Namespace as Attribution), ADR-018 (Authorization Gate), ADR-049
+**Depends on**: ADR-007 (Namespace as Attribution), ADR-018 (Authorization Gate, as amended by
+ADR-129), ADR-049
 (khived daemon), ADR-057 (Comm Actor-Addressed Delivery)\
 **Amends (effective now)**: ADR-007 Rule 4 (TenantGate clause); ADR-018
 §"AllowAllGate" and §"Multi-tenant deployments" context bullet — see
@@ -240,7 +241,8 @@ traffic" recommendation for multi-actor deployments is satisfied by the process 
 rather than by a TenantGate implementation. When the per-actor-process topology is in use,
 AllowAllGate is not a misconfiguration.
 
-ADR-018 §"Hard enforcement" and §"Fail-open on gate Err" are unchanged and apply verbatim.
+ADR-018 §"Hard enforcement" and its ADR-129-amended fail-closed Gate-error contract apply verbatim.
+This supersedes this proposal's original reference to the pre-ADR-129 fail-open section.
 
 ---
 

--- a/docs/adr/ADR-109-sandboxed-kkernel-gateway.md
+++ b/docs/adr/ADR-109-sandboxed-kkernel-gateway.md
@@ -3,8 +3,8 @@
 **Status**: Proposed\
 **Date**: 2026-07-11\
 **Authors**: khive maintainers\
-**Depends on**: ADR-018 (Authorization Gate), ADR-016 (Request DSL), ADR-017 (Pack
-Standard), ADR-007 Rev 7 (Namespace as Attribution-Only)\
+**Depends on**: ADR-018 (Authorization Gate, as amended by ADR-129), ADR-016 (Request DSL),
+ADR-017 (Pack Standard), ADR-007 Rev 7 (Namespace as Attribution-Only)\
 **Related**: ADR-108 (Git Write Surface - composition point, Fork (d) below), ADR-085 (Code
 Pack - precedent for an admin-CLI-only surface distinct from the agent-facing MCP surface),
 khive-cloud API-key scope model (design input for Fork (b))
@@ -47,9 +47,9 @@ declared set of things and nothing else. Both need a surface with:
 - No filesystem-path-bearing arguments accepted (a sandboxed caller must not be able to
   direct khive to read or write an arbitrary host path).
 - Fail-closed behavior on anything outside the declared contract - an unrecognized verb, an
-  out-of-allowlist argument shape, or a Gate infrastructure error must deny, not fall
-  through to a permissive default the way ADR-018's base Gate fails open on infrastructure
-  errors.
+  out-of-allowlist argument shape, or a Gate infrastructure error must refuse. ADR-129 now
+  requires the base Gate to refuse infrastructure errors too; the gateway rule remains necessary
+  for its additional allowlist, argument-shape, namespace, and budget boundaries.
 
 This ADR specs a gateway **mode** for this third trust tier. How that mode is packaged
 (Fork (a)) and how the sandboxed caller authenticates (Fork (b)) were presented to design
@@ -109,9 +109,9 @@ resolved in place, with the full set of rulings summarized in the Resolutions se
 6. **Fail-closed on anything outside the contract.** Any of: an unrecognized verb, an
    argument shape that does not match the declared contract, a caller-supplied namespace
    override attempt, a Gate infrastructure error (`Err(GateError)`), or a rate/budget cap
-   exceeded - all result in denial. This explicitly reverses ADR-018's fail-open-on-`Err`
-   posture (see Rationale below) for the gateway path only; the base Gate's fail-open
-   behavior is unchanged for the operator and trusted-agent tiers.
+   exceeded - all result in denial or typed refusal. For Gate infrastructure errors this now
+   matches ADR-129's base fail-closed posture; the gateway-specific validation failures remain
+   additional refusals rather than a gateway-only reversal of the base Gate.
 
 ### Fork (a): Process boundary
 
@@ -230,7 +230,7 @@ rules 2, 4, 5, and 6 above that go beyond what `Obligation` enforcement does tod
 - Pro: reuses ADR-018's policy language and engine entirely; a capability grant and a
   general Gate policy are authored in the same language, reducing the number of
   configuration surfaces an operator must learn; Rego's `default decision := {"decision":
- "deny", ...}` pattern (already the documented fail-closed idiom in ADR-018's own example
+ "deny", ...}` pattern (the documented explicit-deny idiom in ADR-018's own example
   policy) is a natural fit for rule 6's fail-closed requirement.
 - Con: couples the gateway's capability model to Rego/regorus even for the simplest
   allowlist cases, where C1's flat format would suffice and be easier to audit at a glance;
@@ -380,8 +380,9 @@ the gateway path.
 ## References
 
 - ADR-018 - Authorization Gate; `Gate`, `GateRequest`, `GateDecision`, `Obligation`,
-  `PackGatePolicy`; this ADR's enforcement additions (rules 5 and 6) are explicit, scoped
-  deltas from ADR-018's declared-not-enforced `RateLimit` and fail-open-on-`Err` defaults
+  `PackGatePolicy`; this ADR's rate enforcement and gateway-specific validation refusals are
+  scoped additions. Gate infrastructure-error refusal is inherited from ADR-129, not a scoped
+  delta from ADR-018.
 - ADR-018 Amendment 1 - canonical verb identity; the allowlist check in rule 1 depends on
   the same canonicalization step to avoid an alias-based bypass
 - ADR-016 - Request DSL; the wire surface the gateway's pre-dispatch check intercepts

--- a/docs/adr/ADR-112-git-outbound-publish-verbs.md
+++ b/docs/adr/ADR-112-git-outbound-publish-verbs.md
@@ -4,9 +4,9 @@
 **Date**: 2026-07-13\
 **Authors**: khive maintainers\
 **Depends on**: ADR-088 (Git-Lifecycle Pack) and its Amendments 1-2 (`git.digest`), ADR-108
-(Git Write Surface Through khive, Phase B), ADR-018 (Authorization Gate), ADR-017 (Pack
-Standard), ADR-016 (Request DSL), ADR-004 (Substrate Observables - `Event` store used for
-audit), ADR-013 (Note Kind Taxonomy)\
+(Git Write Surface Through khive, Phase B), ADR-018 (Authorization Gate, as amended by ADR-129),
+ADR-017 (Pack Standard), ADR-016 (Request DSL), ADR-004 (Substrate Observables - `Event` store
+used for audit), ADR-013 (Note Kind Taxonomy)\
 **Related**: ADR-002 (Edge Ontology - `annotates`), ADR-007 Rev 7 (Namespace as
 Attribution-Only)
 
@@ -328,9 +328,9 @@ authorization, and hygiene scanning have completed:
 Verb dispatch passes through the Gate (ADR-018) at the registry boundary before the pack
 handler. For exactly `git.publish_issue`, `git.publish_comment`, `git.publish_pr`, and
 `git.publish_release`, that boundary **must use strict fail-closed Gate evaluation and
-publish-specific reason redaction**. These are verb-scoped overrides of ADR-018's general
-fail-open default for Gate errors and reason-preserving explicit denials (ADR-018 lines 32-34,
-71-74, 184-194, and 209-222); they do not change Gate behavior for any other verb.
+publish-specific reason redaction**. ADR-129 now makes Gate infrastructure errors fail closed for
+every dispatch; this proposal's verb-scoped additions are content-free reason replacement and the
+stronger audit-persistence rule below. They do not change Gate behavior for any other verb.
 
 For these four verbs, the registry owns a publish-specific redaction boundary immediately
 after `Gate::check` returns and before `AuditEvent::from_check`, tracing, Event construction
@@ -1511,10 +1511,11 @@ Four forks were presented for this design; each is resolved in place.
   candidate for future adoption by ADR-108 surfaces (for example, scanning a `git.commit`
   message) - not specified by this ADR, noted as a natural extension point.
 - ADR-018 - Authorization Gate; the dispatch-time authorization seam every verb, including
-  this ADR's four, passes through independent of the hygiene scan. ADR-112 makes two
-  verb-scoped exceptions for the four publish verbs: Gate errors fail closed, and both
-  Gate-provided explicit-denial reasons and error text are replaced at the registry boundary
-  with stable content-free reasons. All other verbs retain ADR-018 behavior.
+  this ADR's four, passes through independent of the hygiene scan. ADR-129 supplies the common
+  fail-closed Gate-error posture; ADR-112 additionally replaces both Gate-provided
+  explicit-denial reasons and error text at the registry boundary with stable content-free reasons
+  and requires persistence for the outage record. All other verbs retain ADR-018 as amended by
+  ADR-129.
 - ADR-017 - Pack Standard; `HandlerDef`, `PackRuntime::dispatch`, the mechanism these verbs
   register through.
 - ADR-016 - Request DSL; the wire surface these verbs are reachable through.

--- a/docs/adr/ADR-115-secret-gate-content-manifest-exemption.md
+++ b/docs/adr/ADR-115-secret-gate-content-manifest-exemption.md
@@ -4,10 +4,11 @@
 **Date**: 2026-07-16
 **Authors**: khive maintainers
 **Relates to**: [ADR-018](ADR-018-authorization-gate.md) (authorization Gate seam, rejected as
-the layer for this decision), [ADR-014](ADR-014-curation-operations.md) (curation operations,
-unaffected), [ADR-015](ADR-015-schema-migrations.md) (migration policy, if a durable event shape
-requires one), [ADR-096](ADR-096-warm-daemon-per-request-identity.md) (single-principal host-trust
-posture this ADR relies on and does not extend)
+the layer for this decision, with its Gate-error posture amended by ADR-129),
+[ADR-014](ADR-014-curation-operations.md) (curation operations, unaffected),
+[ADR-015](ADR-015-schema-migrations.md) (migration policy, if a durable event shape requires one),
+[ADR-096](ADR-096-warm-daemon-per-request-identity.md) (single-principal host-trust posture this ADR
+relies on and does not extend)
 
 ---
 
@@ -271,8 +272,9 @@ final outcome, and the persisted record id. It records no content and no detecto
 records also distinguish `exempted`, `manifest-invalid`, `audit-failed`, `stamp-failed`, and
 `record-write-failed` outcomes. This audit is part of the exemption control itself, not a general
 [ADR-018](ADR-018-authorization-gate.md) Gate audit event, and its failure semantics are independent
-of that ADR's fail-open infrastructure-error handling (see Fail-closed, below). An admitted exempted
-record must never exist without both its reserved stamp and a queryable audit event; if the
+of the Gate audit and infrastructure-error handling defined there and amended by ADR-129 (see
+Fail-closed, below). An admitted exempted record must never exist without both its reserved stamp and
+a queryable audit event; if the
 implementation cannot make this atomic in one transaction, it must use a transactional outbox or
 equivalent, and audit-persistence failure on this path blocks the write rather than proceeding.
 
@@ -291,10 +293,10 @@ what is shown).
 The exemption is a scoped carve-out from the existing heuristic path, not a replacement for it. Any
 error condition on the exemption path — missing, unreadable, malformed, stale, duplicate-conflicting,
 unsupported-algorithm, or unknown-version manifest; stamp-write failure; audit-persistence failure —
-degrades to the current, unchanged blocking behavior. It never degrades to allow. This applies even
-though [ADR-018](ADR-018-authorization-gate.md) treats Gate-infrastructure errors as fail-open;
-that policy governs the coarse authorization seam, not this content-level exemption, and this ADR
-does not adopt it here.
+degrades to the current, unchanged blocking behavior. It never degrades to allow. ADR-129 now also
+makes [ADR-018](ADR-018-authorization-gate.md) Gate-infrastructure errors fail closed, but that
+policy governs the coarse authorization seam, not this content-level exemption. The two layers
+refuse independently for different reasons.
 
 ---
 
@@ -494,10 +496,10 @@ patching individual manifest entries.
   no verified hash; making it content-aware would require threading the exact scanner input and a
   runtime field scope into the request, a recomputation/consumption step in every handler, and
   equivalent treatment of the `code.ingest` direct-write path — which reconstructs this ADR's design
-  after an added policy round trip, while also inheriting ADR-018's fail-open-on-infrastructure-error
-  semantics, which this exemption must not have. A future real Gate may still authorize who is
-  permitted to administer the exemption manifest; it must not decide whether submitted bytes match
-  an entry.
+  after an added policy round trip. ADR-129 has since made Gate infrastructure errors fail closed,
+  but the Gate still lacks the content evidence this exemption requires. A future real Gate may
+  still authorize who is permitted to administer the exemption manifest; it must not decide whether
+  submitted bytes match an entry.
 - **[ADR-014](ADR-014-curation-operations.md)**: curation operations (`update`, `delete`, `merge`)
   are unaffected by this ADR beyond the property-reservation requirement in Decision §4 — none of
   them may set or clear `khive:secret_gate` on the caller's behalf, and `merge` must carry the
@@ -516,9 +518,9 @@ patching individual manifest entries.
 
 - **At the [ADR-018](ADR-018-authorization-gate.md) Gate seam.** Rejected. The seam is coarse —
   verb, namespace, actor, source — and has no content access. Making it content-aware converges on
-  this ADR's own design plumbed through an extra policy round trip, while inheriting Gate's
-  fail-open-on-error semantics, which this exemption must not have. The shipping Gate is
-  `AllowAllGate`, so this option is also inert today.
+  this ADR's own design plumbed through an extra policy round trip. ADR-129 has removed the former
+  fail-open-on-error difference, but it does not give the Gate content-specific evidence. The
+  shipping Gate is `AllowAllGate`, so this option is also inert today.
 - **A new pre-handler attestation service.** Rejected for now. A dedicated component that
   recomputes hashes and consults the allowlist ahead of dispatch offers cleaner separation, but it
   is a new registry, lifecycle, cache, refresh protocol, and failure surface with no distinct trust

--- a/docs/adr/ADR-129-fail-closed-gate-default.md
+++ b/docs/adr/ADR-129-fail-closed-gate-default.md
@@ -13,13 +13,22 @@
   invariant with store-held caller grants and hierarchical subactor identity,
   delivering per-caller differentiation in per-view form
 
-> **Implementation status (2026-08-08):** This accepted staged design is not
-> fully shipped. The current runtime default remains `AllowAllGate`, and the
-> ADR-143 store-held caller-grant model has not been implemented. Because
-> silently accepting Amendment 2's now-superseded `[gate]` roster would claim
-> enforcement that does not exist, this build rejects every `[gate]` table at
-> configuration load. This note records implementation state only; it does not
-> change the accepted fail-closed decision or ADR-143's superseding design.
+> **Implementation status (2026-08-18):** This accepted staged design is
+> partially shipped. Stage 1a has landed: every `Gate::check` call-site in
+> `khive-runtime` — both `dispatch_with_identity` and
+> `dispatch_intercepted_with_identity` — now treats a `GateError` as a
+> refusal, returning `RuntimeError::GateUnavailable` without invoking the
+> pack handler, and the caller-visible `reason` on that refusal is a stable
+> classification derived from the `GateError` variant, never the gate
+> backend's own error text (which may embed connection details or
+> credentials and stays in the server-side log only). Stage 1b through
+> Stage 2 remain unshipped: the current runtime default is still
+> `AllowAllGate`, and the ADR-143 store-held caller-grant model has not been
+> implemented. Because silently accepting Amendment 2's now-superseded
+> `[gate]` roster would claim enforcement that does not exist, this build
+> rejects every `[gate]` table at configuration load. This note records
+> implementation state only; it does not change the accepted fail-closed
+> decision or ADR-143's superseding design.
 
 ## Context
 
@@ -40,14 +49,16 @@ deployment-specific policy layered at the deployment edge.
 Three facts about the current code shape the staging below; a decision that
 ignored them would not be implementable as written:
 
-1. **Two dispatch seams fail open today.**
-   `dispatch_intercepted_with_identity` documents "gate errors fail open" and,
-   on a `GateError`, logs and invokes the intercepted operation anyway
-   (`crates/khive-runtime/src/pack.rs:1153-1206`); the ordinary dispatch path
-   advertises the same contract in its public API doc and its error arm does
-   the same (`crates/khive-runtime/src/pack.rs:1315-1319,1463-1468`). Both are
-   masked by the permissive default — `AllowAllGate::check` cannot error — and
-   become live authorization bypasses the moment any fallible gate is wired.
+1. **Two dispatch seams failed open at the time this ADR was accepted.**
+   `dispatch_intercepted_with_identity` documented "gate errors fail open" and,
+   on a `GateError`, logged and invoked the intercepted operation anyway; the
+   ordinary dispatch path advertised the same contract in its public API doc
+   and its error arm did the same. Both were masked by the permissive
+   default — `AllowAllGate::check` cannot error — and would become live
+   authorization bypasses the moment any fallible gate was wired. Stage 1a
+   below closes this gap: both seams now return
+   `RuntimeError::GateUnavailable` without invoking the operation, and their
+   doc comments say so.
 2. **No runtime `Gate` implementation exists over the capability layer.**
    `RuntimeConfig` accepts a `GateRef`; `khive-runtime` depends on neither
    capability crate, and `khive-capability`'s validator requires
@@ -74,11 +85,15 @@ documented fail-open behaviour to returning a typed gate-unavailable error
 without invoking the operation: `dispatch_intercepted_with_identity` and the
 ordinary `dispatch_with_identity` path. Every changed seam's `GateError`
 documentation — doc comments and any prose contract that states fail-open
-behaviour (`crates/khive-runtime/src/pack.rs:1315-1319` today) — changes in
-the same commit as its behaviour; a seam whose code fails closed while its
-public doc still promises fail-open is a defect of this stage. Denials and
-gate-unavailable refusals remain distinguishable in errors and audit events.
-A regression test per seam pins both that the dispatch closure is never
+behaviour — changes in the same commit as its behaviour; a seam whose code
+fails closed while its public doc still promises fail-open is a defect of
+this stage. Denials and gate-unavailable refusals remain distinguishable in
+errors and audit events. The `reason` carried on `RuntimeError::GateUnavailable`
+is a stable classification derived from the `GateError` variant (e.g. backend
+unavailable vs. policy-evaluation failure) — never the gate backend's own
+`Display` text, which can embed connection details or credentials; the full
+error is logged server-side instead. A regression test per seam pins both
+that the dispatch closure is never
 invoked after a gate error and the typed gate-unavailable result the caller
 observes. This stage is a behaviour change only for gates that can error —
 the permissive default cannot — so it is safe to land ahead of the flip.


### PR DESCRIPTION
AI-assisted: Implemented by OpenAI Codex for maintainer review.

## Summary

Implements ADR-160 Phase 0 / ADR-129 Stage 1a at the two `VerbRegistry` dispatch seams:

- return typed `RuntimeError::GateUnavailable { verb, reason }` when `Gate::check` fails
- refuse before normal pack handlers or intercepted operations can run
- emit `decision="gate_unavailable"` with `EventOutcome::Error`, no `deny_reason`, and empty obligations
- keep audit persistence best-effort without allowing an append failure to reopen dispatch or replace the typed refusal
- preserve explicit `Deny` as `PermissionDenied` / `EventOutcome::Denied`
- align public runtime, gate, Rego, and dependent ADR prose with ADR-129's accepted fail-closed contract

## Root cause

Both normal and intercepted dispatch converted a `GateError` into “no gate decision” and continued execution. A fallible authorization backend could therefore become an authorization bypass.

## Regression guards

Tests pin:

- zero handler invocation on normal Gate failure
- zero closure entry on intercepted Gate failure
- typed error and outage audit shape at both seams
- explicit Deny/outage separation
- one structured `gate.check` trace
- audit append failure cannot reopen dispatch
- Gate failure takes precedence over the `git.digest` receipt path
- stable `gate_unavailable` audit wire encoding

## Scope boundary

This PR does not flip the default `AllowAllGate`, implement later ADR-160 phases, or broaden into the already-fail-closed `authorize*` token-minting APIs.

## Validation

- `cargo test --workspace`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --no-run`
- `cargo fmt --all --manifest-path crates/Cargo.toml -- --check`
- `deno fmt --check` on all changed Markdown
- `sh scripts/lint-adr-refs.sh` (376 files / 206 titled references)
- `git diff --check`
- `gitleaks protect --staged --redact --no-banner`

Three independent read-only review passes (dispatch/resource safety, public wire/provenance, and regression coverage/spec drift) returned PASS after the final doc corrections.