### PR TITLE
feat(storage): add bounded verified blob reads (ADR-160 phase 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -623,6 +623,11 @@ jobs:
       # Keep this still-new lane fast; widen alongside the `cargo check` step above.
       - name: khive-db walpin Windows FFI tests
         run: cargo test -p khive-db --lib walpin
+      # ADR-160 Phase 1: compile-only coverage cannot validate the Windows
+      # no-reparse, handle-pinned bounded blob read. Keep this lane focused on
+      # one normal-path test until the broader Windows suite is affordable.
+      - name: khive-db bounded blob read Windows test
+        run: cargo test -p khive-db --lib bounded_verified_get_accepts_exact_and_portable_maximum_limits
 
   coverage-ratchet:
     name: Coverage ratchet

--- a/crates/khive-db/src/stores/blob.rs
+++ b/crates/khive-db/src/stores/blob.rs
@@ -12,14 +12,16 @@
 
 use std::collections::HashMap;
 use std::fs;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex as StdMutex, OnceLock};
 use std::time::{Duration, SystemTime};
 
 use async_trait::async_trait;
 
-use khive_storage::blob::{BlobOrphanSweepConfig, BlobOrphanSweepResult, BlobStore, ContentRef};
+use khive_storage::blob::{
+    BlobOrphanSweepConfig, BlobOrphanSweepResult, BlobStore, ContentRef, MAX_BLOB_WHOLE_BYTES,
+};
 use khive_storage::error::StorageError;
 use khive_storage::types::{SqlRow, SqlStatement, SqlValue, StorageResult};
 use khive_storage::{AtomicUnitOp, SqlAccess, StorageCapability};
@@ -280,6 +282,157 @@ fn unlink_blob_shard_file_no_follow(root: &Path, content_ref: &ContentRef) -> st
         }
     }
     fs::remove_file(shard2.join(hex))
+}
+
+/// Open one blob leaf without following any root/shard/leaf symlink and
+/// return the single handle that must remain the authority for metadata,
+/// bounded bytes, and digest verification.
+#[cfg(unix)]
+fn open_blob_shard_file_no_follow(
+    root: &Path,
+    content_ref: &ContentRef,
+) -> std::io::Result<std::fs::File> {
+    use std::os::unix::io::{AsRawFd, FromRawFd};
+
+    let hex = content_ref.as_str();
+    let root_dir = open_dir_no_follow(root)?;
+    let shard1_dir = openat_dir_no_follow(root_dir.as_raw_fd(), &hex[0..2])?;
+    let shard2_dir = openat_dir_no_follow(shard1_dir.as_raw_fd(), &hex[2..4])?;
+    let c_name = std::ffi::CString::new(hex)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))?;
+
+    // O_NONBLOCK keeps a planted FIFO/device-like entry from hanging the
+    // worker before fstat can reject it; it does not alter regular-file I/O.
+    // O_NOFOLLOW rejects a symlink leaf, while the two openat directory
+    // handles above pin and verify every intermediate component.
+    let fd = unsafe {
+        libc::openat(
+            shard2_dir.as_raw_fd(),
+            c_name.as_ptr(),
+            libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK,
+        )
+    };
+    if fd < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // SAFETY: `fd` is newly returned and uniquely owned here.
+    let file = unsafe { std::fs::File::from_raw_fd(fd) };
+    if !file.metadata()?.file_type().is_file() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "refusing to read a blob leaf that is not a regular file",
+        ));
+    }
+    Ok(file)
+}
+
+#[cfg(windows)]
+fn open_blob_shard_file_no_follow(
+    root: &Path,
+    content_ref: &ContentRef,
+) -> std::io::Result<std::fs::File> {
+    use std::fs::OpenOptions;
+    use std::os::windows::ffi::OsStringExt;
+    use std::os::windows::fs::OpenOptionsExt;
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Storage::FileSystem::GetFinalPathNameByHandleW;
+
+    const FILE_SHARE_READ: u32 = 0x1;
+    const FILE_SHARE_WRITE: u32 = 0x2;
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x0200_0000;
+    const FINAL_PATH_FLAGS: u32 = 0x0;
+
+    fn open_dir_pinned_no_follow(path: &Path) -> std::io::Result<std::fs::File> {
+        let dir = OpenOptions::new()
+            .read(true)
+            // Omitting FILE_SHARE_DELETE pins this checked component against
+            // rename/removal until the leaf is open and verified.
+            .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
+            .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT)
+            .open(path)?;
+        let file_type = dir.metadata()?.file_type();
+        if file_type.is_symlink() || !file_type.is_dir() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!(
+                    "refusing to read a blob through non-directory or reparse-point component: {}",
+                    path.display()
+                ),
+            ));
+        }
+        Ok(dir)
+    }
+
+    fn final_path_by_handle(file: &std::fs::File) -> std::io::Result<PathBuf> {
+        let mut buf: Vec<u16> = vec![0; 512];
+        loop {
+            let len = unsafe {
+                GetFinalPathNameByHandleW(
+                    file.as_raw_handle() as _,
+                    buf.as_mut_ptr(),
+                    buf.len() as u32,
+                    FINAL_PATH_FLAGS,
+                )
+            };
+            if len == 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            let len = len as usize;
+            if len <= buf.len() {
+                buf.truncate(len);
+                return Ok(PathBuf::from(std::ffi::OsString::from_wide(&buf)));
+            }
+            buf.resize(len, 0);
+        }
+    }
+
+    let hex = content_ref.as_str();
+    let shard1 = root.join(&hex[0..2]);
+    let shard2 = shard1.join(&hex[2..4]);
+    let root_pin = open_dir_pinned_no_follow(root)?;
+    let _shard1_pin = open_dir_pinned_no_follow(&shard1)?;
+    let _shard2_pin = open_dir_pinned_no_follow(&shard2)?;
+    let expected = final_path_by_handle(&root_pin)?
+        .join(&hex[0..2])
+        .join(&hex[2..4])
+        .join(hex);
+
+    let target = OpenOptions::new()
+        .read(true)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(shard2.join(hex))?;
+    let file_type = target.metadata()?.file_type();
+    if file_type.is_symlink() || !file_type.is_file() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "refusing to read a blob leaf that is not a regular file",
+        ));
+    }
+    let resolved = final_path_by_handle(&target)?;
+    if resolved != expected {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "refusing blob read: handle resolved outside the verified blob root (expected {}, resolved {})",
+                expected.display(),
+                resolved.display()
+            ),
+        ));
+    }
+    Ok(target)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn open_blob_shard_file_no_follow(
+    _root: &Path,
+    _content_ref: &ContentRef,
+) -> std::io::Result<std::fs::File> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "bounded verified blob reads require handle-relative no-follow file APIs",
+    ))
 }
 
 #[cfg(unix)]
@@ -1252,6 +1405,10 @@ impl FsBlobStore {
     /// reads while remaining side-effect free; mutation is fenced by the
     /// runtime's read-only wrapper.
     pub fn open_existing(root: PathBuf, floor_bytes: u64) -> Result<Self, SqliteError> {
+        // Preserve existing support for configured symlink spellings without
+        // carrying that mutable indirection into handle-relative reads. The
+        // bounded reader deliberately opens its stored root with NOFOLLOW.
+        let root = root.canonicalize()?;
         let metadata = fs::metadata(&root)?;
         if !metadata.is_dir() {
             return Err(SqliteError::InvalidData(format!(
@@ -1347,6 +1504,103 @@ impl BlobStore for FsBlobStore {
         })
         .await
         .map_err(|e| StorageError::driver(StorageCapability::Blob, "get", e))?
+    }
+
+    async fn get_bounded_verified(
+        &self,
+        content_ref: &ContentRef,
+        max_bytes: u64,
+    ) -> StorageResult<Vec<u8>> {
+        // Argument validation is deliberately outside `spawn_blocking`: an
+        // invalid portable-envelope request must fail before any backend work
+        // is scheduled or the filesystem is touched (ADR-160 D2).
+        if max_bytes > MAX_BLOB_WHOLE_BYTES {
+            return Err(StorageError::InvalidInput {
+                capability: StorageCapability::Blob,
+                operation: "get_bounded_verified".into(),
+                message: format!(
+                    "max_bytes {max_bytes} exceeds the {MAX_BLOB_WHOLE_BYTES}-byte portable whole-buffer envelope"
+                ),
+            });
+        }
+
+        let root = self.root.clone();
+        let content_ref = content_ref.clone();
+        #[cfg(test)]
+        let read_hook = bounded_read_sync_hook::take(&root);
+        tokio::task::spawn_blocking(move || {
+            // Open exactly once. Both metadata and bytes below come from this
+            // no-follow handle, so replacing the path after open cannot
+            // switch the integrity authority underneath the read.
+            let mut file = open_blob_shard_file_no_follow(&root, &content_ref).map_err(|e| {
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    StorageError::NotFound {
+                        capability: StorageCapability::Blob,
+                        resource: "blob",
+                        key: content_ref.to_string(),
+                    }
+                } else if e.kind() == std::io::ErrorKind::Unsupported {
+                    StorageError::Unsupported {
+                        capability: StorageCapability::Blob,
+                        operation: "get_bounded_verified".into(),
+                        message: e.to_string(),
+                    }
+                } else {
+                    map_io_err(e, "get_bounded_verified.open")
+                }
+            })?;
+
+            let metadata_bytes = file
+                .metadata()
+                .map_err(|e| map_io_err(e, "get_bounded_verified.metadata"))?
+                .len();
+            #[cfg(test)]
+            if let Some(hook) = &read_hook {
+                let _ = hook.reached.send(());
+                let _ = hook.release.recv();
+            }
+            if metadata_bytes > max_bytes {
+                return Err(StorageError::BlobTooLarge {
+                    content_ref,
+                    max_bytes,
+                    observed_at_least: metadata_bytes,
+                });
+            }
+
+            // Read at most one sentinel byte beyond the caller's limit. The
+            // +1 is safe because max_bytes was already bounded to 64 MiB.
+            let mut bytes = Vec::with_capacity(metadata_bytes as usize);
+            (&mut file)
+                .take(max_bytes + 1)
+                .read_to_end(&mut bytes)
+                .map_err(|e| map_io_err(e, "get_bounded_verified.read"))?;
+            let actual_bytes = bytes.len() as u64;
+            if actual_bytes > max_bytes {
+                return Err(StorageError::BlobTooLarge {
+                    content_ref,
+                    max_bytes,
+                    observed_at_least: actual_bytes,
+                });
+            }
+            if metadata_bytes != actual_bytes {
+                return Err(StorageError::BlobSizeMismatch {
+                    content_ref,
+                    metadata_bytes,
+                    actual_bytes,
+                });
+            }
+
+            let actual = ContentRef::from_digest_bytes(blake3::hash(&bytes).as_bytes());
+            if actual != content_ref {
+                return Err(StorageError::BlobDigestMismatch {
+                    expected: content_ref,
+                    actual,
+                });
+            }
+            Ok(bytes)
+        })
+        .await
+        .map_err(|e| StorageError::driver(StorageCapability::Blob, "get_bounded_verified", e))?
     }
 
     async fn exists(&self, content_ref: &ContentRef) -> StorageResult<bool> {
@@ -1670,6 +1924,55 @@ mod sync_hook {
     }
 }
 
+/// Test-only pause after a bounded read has opened its authoritative handle
+/// and captured handle metadata, but before its first byte read. This makes
+/// append/truncate/path-replacement races deterministic without timing sleeps
+/// and is deliberately separate from the put/GC lock hook above.
+#[cfg(test)]
+mod bounded_read_sync_hook {
+    use std::collections::{HashMap, VecDeque};
+    use std::path::{Path, PathBuf};
+    use std::sync::mpsc::{Receiver, Sender};
+    use std::sync::{Mutex as StdMutex, OnceLock};
+
+    pub(super) struct Hook {
+        pub(super) reached: Sender<()>,
+        pub(super) release: Receiver<()>,
+    }
+
+    fn registry() -> &'static StdMutex<HashMap<PathBuf, VecDeque<Hook>>> {
+        static REGISTRY: OnceLock<StdMutex<HashMap<PathBuf, VecDeque<Hook>>>> = OnceLock::new();
+        REGISTRY.get_or_init(|| StdMutex::new(HashMap::new()))
+    }
+
+    pub(super) fn install(root: &Path) -> (Receiver<()>, Sender<()>) {
+        let canonical = root
+            .canonicalize()
+            .expect("root must exist before installing a bounded-read hook");
+        let (reached_tx, reached_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        registry()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .entry(canonical)
+            .or_default()
+            .push_back(Hook {
+                reached: reached_tx,
+                release: release_rx,
+            });
+        (reached_rx, release_tx)
+    }
+
+    pub(super) fn take(root: &Path) -> Option<Hook> {
+        let canonical = root.canonicalize().ok()?;
+        registry()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get_mut(&canonical)
+            .and_then(VecDeque::pop_front)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1815,6 +2118,243 @@ mod tests {
         let content_ref = store.put(bytes.clone()).await.unwrap();
         let fetched = store.get(&content_ref).await.unwrap();
         assert_eq!(fetched, bytes);
+    }
+
+    #[tokio::test]
+    async fn bounded_verified_get_accepts_exact_and_portable_maximum_limits() {
+        let (_dir, store) = store(0);
+        let bytes = b"bounded fs blob".to_vec();
+        let content_ref = store.put(bytes.clone()).await.unwrap();
+
+        assert_eq!(
+            store
+                .get_bounded_verified(&content_ref, bytes.len() as u64)
+                .await
+                .unwrap(),
+            bytes
+        );
+        assert_eq!(
+            store
+                .get_bounded_verified(&content_ref, MAX_BLOB_WHOLE_BYTES)
+                .await
+                .unwrap(),
+            bytes
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn bounded_verified_get_resolves_a_configured_symlink_root_once() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("blob-target");
+        fs::create_dir(&target).unwrap();
+        let configured = dir.path().join("blob-configured");
+        symlink(&target, &configured).unwrap();
+
+        let store = FsBlobStore::new(configured, 0).unwrap();
+        assert_eq!(store.root(), target.canonicalize().unwrap());
+        let bytes = b"symlink-configured root".to_vec();
+        let content_ref = store.put(bytes.clone()).await.unwrap();
+        assert_eq!(
+            store
+                .get_bounded_verified(&content_ref, bytes.len() as u64)
+                .await
+                .unwrap(),
+            bytes
+        );
+    }
+
+    #[tokio::test]
+    async fn bounded_verified_get_rejects_same_size_digest_corruption() {
+        let (_dir, store) = store(0);
+        let expected_bytes = b"expected".to_vec();
+        let actual_bytes = b"mutated!".to_vec();
+        let expected = store.put(expected_bytes).await.unwrap();
+        let actual = ContentRef::from_digest_bytes(blake3::hash(&actual_bytes).as_bytes());
+        fs::write(shard_path(store.root(), &expected), actual_bytes).unwrap();
+
+        let err = store.get_bounded_verified(&expected, 8).await.unwrap_err();
+        assert!(matches!(
+            err,
+            StorageError::BlobDigestMismatch {
+                expected: ref got_expected,
+                actual: ref got_actual,
+            } if got_expected == &expected && got_actual == &actual
+        ));
+    }
+
+    #[tokio::test]
+    async fn bounded_verified_get_stops_at_max_plus_one_after_file_growth() {
+        let (_dir, store) = store(0);
+        let store = Arc::new(store);
+        let content_ref = store.put(b"abcd".to_vec()).await.unwrap();
+        let path = shard_path(store.root(), &content_ref);
+        let (reached, release) = bounded_read_sync_hook::install(store.root());
+
+        let read_store = Arc::clone(&store);
+        let read_ref = content_ref.clone();
+        let read = tokio::spawn(async move { read_store.get_bounded_verified(&read_ref, 4).await });
+        assert!(
+            recv_blocking(reached).await,
+            "read must reach the metadata seam"
+        );
+        let mut writer = fs::OpenOptions::new().append(true).open(&path).unwrap();
+        writer.write_all(b"efgh-poison-tail").unwrap();
+        writer.flush().unwrap();
+        release.send(()).unwrap();
+
+        let err = read.await.unwrap().unwrap_err();
+        assert!(matches!(
+            err,
+            StorageError::BlobTooLarge {
+                content_ref: ref got,
+                max_bytes: 4,
+                observed_at_least: 5,
+            } if got == &content_ref
+        ));
+    }
+
+    #[tokio::test]
+    async fn bounded_verified_get_reports_growth_within_limit_as_size_mismatch() {
+        let (_dir, store) = store(0);
+        let store = Arc::new(store);
+        let content_ref = store.put(b"abcd".to_vec()).await.unwrap();
+        let path = shard_path(store.root(), &content_ref);
+        let (reached, release) = bounded_read_sync_hook::install(store.root());
+
+        let read_store = Arc::clone(&store);
+        let read_ref = content_ref.clone();
+        let read = tokio::spawn(async move { read_store.get_bounded_verified(&read_ref, 8).await });
+        assert!(
+            recv_blocking(reached).await,
+            "read must reach the metadata seam"
+        );
+        let mut writer = fs::OpenOptions::new().append(true).open(&path).unwrap();
+        writer.write_all(b"ef").unwrap();
+        writer.flush().unwrap();
+        release.send(()).unwrap();
+
+        let err = read.await.unwrap().unwrap_err();
+        assert!(matches!(
+            err,
+            StorageError::BlobSizeMismatch {
+                content_ref: ref got,
+                metadata_bytes: 4,
+                actual_bytes: 6,
+            } if got == &content_ref
+        ));
+    }
+
+    #[tokio::test]
+    async fn bounded_verified_get_reports_truncation_as_size_mismatch() {
+        let (_dir, store) = store(0);
+        let store = Arc::new(store);
+        let content_ref = store.put(b"abcd".to_vec()).await.unwrap();
+        let path = shard_path(store.root(), &content_ref);
+        let (reached, release) = bounded_read_sync_hook::install(store.root());
+
+        let read_store = Arc::clone(&store);
+        let read_ref = content_ref.clone();
+        let read = tokio::spawn(async move { read_store.get_bounded_verified(&read_ref, 4).await });
+        assert!(
+            recv_blocking(reached).await,
+            "read must reach the metadata seam"
+        );
+        let mut writer = fs::OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .open(&path)
+            .unwrap();
+        writer.write_all(b"abc").unwrap();
+        writer.flush().unwrap();
+        release.send(()).unwrap();
+
+        let err = read.await.unwrap().unwrap_err();
+        assert!(matches!(
+            err,
+            StorageError::BlobSizeMismatch {
+                content_ref: ref got,
+                metadata_bytes: 4,
+                actual_bytes: 3,
+            } if got == &content_ref
+        ));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn bounded_verified_get_keeps_the_opened_inode_when_the_path_is_replaced() {
+        let (_dir, store) = store(0);
+        let store = Arc::new(store);
+        let original = b"original".to_vec();
+        let replacement = b"replaced".to_vec();
+        let content_ref = store.put(original.clone()).await.unwrap();
+        let path = shard_path(store.root(), &content_ref);
+        let moved_path = path.with_extension("opened-inode");
+        let max_bytes = original.len() as u64;
+        let (reached, release) = bounded_read_sync_hook::install(store.root());
+
+        let read_store = Arc::clone(&store);
+        let read_ref = content_ref.clone();
+        let read =
+            tokio::spawn(
+                async move { read_store.get_bounded_verified(&read_ref, max_bytes).await },
+            );
+        assert!(
+            recv_blocking(reached).await,
+            "read must reach the metadata seam"
+        );
+        fs::rename(&path, &moved_path).unwrap();
+        fs::write(&path, replacement).unwrap();
+        release.send(()).unwrap();
+
+        assert_eq!(read.await.unwrap().unwrap(), original);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn bounded_verified_get_refuses_a_symlink_leaf() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = FsBlobStore::new(dir.path().join("blobs"), 0).unwrap();
+        let outside_bytes = b"outside but digest matching".to_vec();
+        let content_ref = ContentRef::from_digest_bytes(blake3::hash(&outside_bytes).as_bytes());
+        let outside = dir.path().join("outside");
+        fs::write(&outside, &outside_bytes).unwrap();
+        let leaf = shard_path(store.root(), &content_ref);
+        fs::create_dir_all(leaf.parent().unwrap()).unwrap();
+        symlink(&outside, &leaf).unwrap();
+
+        let err = store
+            .get_bounded_verified(&content_ref, outside_bytes.len() as u64)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, StorageError::Driver { .. }), "got {err:?}");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn bounded_verified_get_refuses_a_symlinked_shard_component() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = FsBlobStore::new(dir.path().join("blobs"), 0).unwrap();
+        let outside_bytes = b"outside through shard link".to_vec();
+        let content_ref = ContentRef::from_digest_bytes(blake3::hash(&outside_bytes).as_bytes());
+        let hex = content_ref.as_str();
+        let outside_shard1 = dir.path().join("outside-shard1");
+        let outside_shard2 = outside_shard1.join(&hex[2..4]);
+        fs::create_dir_all(&outside_shard2).unwrap();
+        fs::write(outside_shard2.join(hex), &outside_bytes).unwrap();
+        symlink(&outside_shard1, store.root().join(&hex[0..2])).unwrap();
+
+        let err = store
+            .get_bounded_verified(&content_ref, outside_bytes.len() as u64)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, StorageError::Driver { .. }), "got {err:?}");
     }
 
     #[tokio::test]

--- a/crates/khive-db/src/stores/blob_s3.rs
+++ b/crates/khive-db/src/stores/blob_s3.rs
@@ -1,7 +1,7 @@
 //! S3-compatible `BlobStore` backend (ADR-111 Amendment 2).
 //!
-//! Second implementation of the unchanged `khive_storage::blob::BlobStore`
-//! trait, beside `FsBlobStore` (`stores::blob`). Same content-addressed CAS
+//! S3 implementation of the `khive_storage::blob::BlobStore` trait, beside
+//! `FsBlobStore` (`stores::blob`). Same content-addressed CAS
 //! contract — `ContentRef`, dedup-on-identical-bytes, offline-maintenance-only
 //! `delete`/`orphan_sweep` — over an S3-compatible object store via the
 //! `object_store` crate's `aws` feature. No provider type crosses the
@@ -19,7 +19,9 @@ use object_store::{
     Error as ObjectStoreError, ObjectMeta, ObjectStore, ObjectStoreExt, PutMode, PutPayload,
 };
 
-use khive_storage::blob::{BlobOrphanSweepConfig, BlobOrphanSweepResult, BlobStore, ContentRef};
+use khive_storage::blob::{
+    BlobOrphanSweepConfig, BlobOrphanSweepResult, BlobStore, ContentRef, MAX_BLOB_WHOLE_BYTES,
+};
 use khive_storage::error::StorageError;
 use khive_storage::types::StorageResult;
 use khive_storage::StorageCapability;
@@ -31,7 +33,7 @@ use crate::error::SqliteError;
 /// `put` rejects a larger buffer; `get` checks metadata before collecting a
 /// larger response. A streaming amendment is required before khive supports
 /// larger blobs.
-pub const MAX_OBJECT_BYTES: u64 = 64 * 1024 * 1024;
+pub const MAX_OBJECT_BYTES: u64 = MAX_BLOB_WHOLE_BYTES;
 
 /// Default object-key prefix when a caller doesn't override it.
 pub const DEFAULT_PREFIX: &str = "blobs";
@@ -544,6 +546,103 @@ impl BlobStore for S3BlobStore {
         }
     }
 
+    async fn get_bounded_verified(
+        &self,
+        content_ref: &ContentRef,
+        max_bytes: u64,
+    ) -> StorageResult<Vec<u8>> {
+        // Reject an invalid portable-envelope request before constructing or
+        // polling a provider future. This ordering is observable through the
+        // backend-spy conformance test (ADR-160 D2).
+        if max_bytes > MAX_BLOB_WHOLE_BYTES {
+            return Err(StorageError::InvalidInput {
+                capability: StorageCapability::Blob,
+                operation: "get_bounded_verified".into(),
+                message: format!(
+                    "max_bytes {max_bytes} exceeds the {MAX_BLOB_WHOLE_BYTES}-byte portable whole-buffer envelope"
+                ),
+            });
+        }
+
+        let key = self.shard_key(content_ref);
+        // One absolute provider deadline spans both GET setup and every body
+        // poll; the body does not receive a fresh timeout window.
+        let deadline = tokio::time::Instant::now() + self.request_timeout;
+        let result = match tokio::time::timeout_at(deadline, self.client.get(&key)).await {
+            Ok(Ok(result)) => result,
+            Ok(Err(ObjectStoreError::NotFound { .. })) => {
+                return Err(StorageError::NotFound {
+                    capability: StorageCapability::Blob,
+                    resource: "blob",
+                    key: content_ref.to_string(),
+                });
+            }
+            Ok(Err(other)) => {
+                return Err(map_object_store_err(other, "get_bounded_verified"));
+            }
+            Err(_elapsed) => return Err(timeout_error("get_bounded_verified")),
+        };
+
+        let metadata_bytes = result.meta.size;
+        if metadata_bytes > max_bytes {
+            return Err(StorageError::BlobTooLarge {
+                content_ref: content_ref.clone(),
+                max_bytes,
+                observed_at_least: metadata_bytes,
+            });
+        }
+
+        let mut stream = result.into_stream();
+        let consume = async {
+            let mut bytes = Vec::with_capacity(metadata_bytes as usize);
+            loop {
+                match stream.next().await {
+                    Some(Ok(chunk)) => {
+                        let observed_at_least =
+                            (bytes.len() as u64).saturating_add(chunk.len() as u64);
+                        // Check before append: a false-small metadata value
+                        // cannot make the local Vec grow beyond max_bytes.
+                        if observed_at_least > max_bytes {
+                            return Err(StorageError::BlobTooLarge {
+                                content_ref: content_ref.clone(),
+                                max_bytes,
+                                observed_at_least,
+                            });
+                        }
+                        bytes.extend_from_slice(&chunk);
+                    }
+                    Some(Err(e)) => {
+                        return Err(map_object_store_err(e, "get_bounded_verified"));
+                    }
+                    None => break,
+                }
+            }
+
+            let actual_bytes = bytes.len() as u64;
+            if metadata_bytes != actual_bytes {
+                return Err(StorageError::BlobSizeMismatch {
+                    content_ref: content_ref.clone(),
+                    metadata_bytes,
+                    actual_bytes,
+                });
+            }
+
+            let actual = ContentRef::from_digest_bytes(blake3::hash(&bytes).as_bytes());
+            if actual != *content_ref {
+                return Err(StorageError::BlobDigestMismatch {
+                    expected: content_ref.clone(),
+                    actual,
+                });
+            }
+            Ok(bytes)
+        };
+
+        match tokio::time::timeout_at(deadline, consume).await {
+            Ok(result) => result,
+            Err(_elapsed) => Err(timeout_error("get_bounded_verified")),
+        }
+    }
+
     async fn exists(&self, content_ref: &ContentRef) -> StorageResult<bool> {
         let key = self.shard_key(content_ref);
         match tokio::time::timeout(self.request_timeout, self.client.head(&key)).await {
@@ -1017,7 +1116,12 @@ mod tests {
             /// granting each phase a fresh window.
             get_pre_delay: Mutex<Option<Duration>>,
             pub put_calls: AtomicUsize,
+            /// Total `get_opts` calls, retained for existing retry/error
+            /// tests whose script is shared by GET and HEAD.
             pub get_calls: AtomicUsize,
+            pub head_calls: AtomicUsize,
+            pub body_get_calls: AtomicUsize,
+            pub body_polls: Arc<AtomicUsize>,
             pub delete_calls: Arc<AtomicUsize>,
             /// How long a `Hang` outcome sleeps before resolving --
             /// deliberately far longer than the test's configured
@@ -1044,6 +1148,9 @@ mod tests {
                     get_pre_delay: Mutex::new(None),
                     put_calls: AtomicUsize::new(0),
                     get_calls: AtomicUsize::new(0),
+                    head_calls: AtomicUsize::new(0),
+                    body_get_calls: AtomicUsize::new(0),
+                    body_polls: Arc::new(AtomicUsize::new(0)),
                     delete_calls: Arc::new(AtomicUsize::new(0)),
                     hang_delay: Duration::from_secs(3600),
                 }
@@ -1134,11 +1241,12 @@ mod tests {
                 unimplemented!("not exercised by these tests")
             }
 
-            async fn get_opts(
-                &self,
-                location: &ObjectPath,
-                _opts: GetOptions,
-            ) -> Result<GetResult> {
+            async fn get_opts(&self, location: &ObjectPath, opts: GetOptions) -> Result<GetResult> {
+                if opts.head {
+                    self.head_calls.fetch_add(1, Ordering::SeqCst);
+                } else {
+                    self.body_get_calls.fetch_add(1, Ordering::SeqCst);
+                }
                 let outcome = Self::next_outcome(&self.get_script, &self.get_calls);
                 if matches!(outcome, Outcome::Hang) {
                     tokio::time::sleep(self.hang_delay).await;
@@ -1148,17 +1256,25 @@ mod tests {
                     tokio::time::sleep(delay).await;
                 }
                 let override_body = self.get_body_override.lock().unwrap().clone();
+                let body_polls = Arc::clone(&self.body_polls);
                 outcome_to_result(&outcome, || {
                     let (reported_size, body_chunks, per_chunk_delay) =
                         override_body.unwrap_or((0, Vec::new(), Duration::ZERO));
-                    let chunks: Vec<Result<Bytes>> = body_chunks.into_iter().map(Ok).collect();
                     let body_stream = if per_chunk_delay.is_zero() {
-                        stream::iter(chunks).boxed()
+                        stream::iter(body_chunks.into_iter().map(move |chunk| {
+                            body_polls.fetch_add(1, Ordering::SeqCst);
+                            Ok(chunk)
+                        }))
+                        .boxed()
                     } else {
-                        stream::iter(chunks)
-                            .then(move |c| async move {
-                                tokio::time::sleep(per_chunk_delay).await;
-                                c
+                        stream::iter(body_chunks)
+                            .then(move |chunk| {
+                                let body_polls = Arc::clone(&body_polls);
+                                async move {
+                                    body_polls.fetch_add(1, Ordering::SeqCst);
+                                    tokio::time::sleep(per_chunk_delay).await;
+                                    Ok(chunk)
+                                }
                             })
                             .boxed()
                     };
@@ -1342,6 +1458,265 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn bounded_get_rejects_invalid_limit_before_provider_work() {
+        let (fake, store) = fake_store(vec![], vec![Outcome::Hang]);
+        let content_ref = ContentRef::from_hex("b".repeat(64)).unwrap();
+        let err = store
+            .get_bounded_verified(&content_ref, MAX_BLOB_WHOLE_BYTES + 1)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, StorageError::InvalidInput { .. }),
+            "got {err:?}"
+        );
+        assert_eq!(
+            fake.get_calls.load(Ordering::SeqCst),
+            0,
+            "argument validation must not construct or poll a provider GET"
+        );
+    }
+
+    #[tokio::test]
+    async fn bounded_get_not_found_precedes_object_inspection() {
+        let (_fake, store) = fake_store(vec![], vec![Outcome::NotFound]);
+        let content_ref = ContentRef::from_hex("b".repeat(64)).unwrap();
+        let err = store
+            .get_bounded_verified(&content_ref, 0)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, StorageError::NotFound { .. }), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn bounded_get_accepts_a_digest_matching_body_at_the_exact_limit() {
+        let body = b"verified body".to_vec();
+        let content_ref = ContentRef::from_digest_bytes(blake3::hash(&body).as_bytes());
+        let fake = Arc::new(
+            FakeObjectStore::new(vec![], vec![Outcome::Ok]).with_get_body_chunks(
+                body.len() as u64,
+                vec![
+                    Bytes::from(body[..4].to_vec()),
+                    Bytes::from(body[4..].to_vec()),
+                ],
+            ),
+        );
+        let store = S3BlobStore::from_client_for_test(
+            Arc::clone(&fake) as Arc<dyn ObjectStore>,
+            "blobs",
+            3,
+            Duration::from_secs(1),
+            Duration::from_millis(1),
+        )
+        .unwrap();
+
+        let result = store
+            .get_bounded_verified(&content_ref, body.len() as u64)
+            .await
+            .unwrap();
+        assert_eq!(result, body);
+        assert_eq!(fake.body_get_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(fake.head_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn bounded_get_rejects_over_limit_metadata_before_consuming_body() {
+        let fake = Arc::new(
+            FakeObjectStore::new(vec![], vec![Outcome::Ok])
+                .with_get_body_chunks(5, vec![Bytes::from_static(b"x")]),
+        );
+        let store = S3BlobStore::from_client_for_test(
+            Arc::clone(&fake) as Arc<dyn ObjectStore>,
+            "blobs",
+            3,
+            Duration::from_secs(1),
+            Duration::from_millis(1),
+        )
+        .unwrap();
+        let content_ref = ContentRef::from_hex("c".repeat(64)).unwrap();
+
+        let err = store
+            .get_bounded_verified(&content_ref, 4)
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            StorageError::BlobTooLarge {
+                content_ref: ref got,
+                max_bytes: 4,
+                observed_at_least: 5,
+            } if got == &content_ref
+        ));
+        assert_eq!(
+            fake.body_polls.load(Ordering::SeqCst),
+            0,
+            "over-limit metadata must refuse before the body stream is polled"
+        );
+    }
+
+    #[tokio::test]
+    async fn bounded_get_stops_false_small_metadata_at_the_actual_byte_limit() {
+        let fake = Arc::new(
+            FakeObjectStore::new(vec![], vec![Outcome::Ok]).with_get_body_chunks(
+                1,
+                vec![
+                    Bytes::from_static(b"abc"),
+                    Bytes::from_static(b"de"),
+                    Bytes::from_static(b"must-not-be-polled"),
+                ],
+            ),
+        );
+        let store = S3BlobStore::from_client_for_test(
+            Arc::clone(&fake) as Arc<dyn ObjectStore>,
+            "blobs",
+            3,
+            Duration::from_secs(1),
+            Duration::from_millis(1),
+        )
+        .unwrap();
+        let content_ref = ContentRef::from_hex("d".repeat(64)).unwrap();
+
+        let err = store
+            .get_bounded_verified(&content_ref, 4)
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            StorageError::BlobTooLarge {
+                content_ref: ref got,
+                max_bytes: 4,
+                observed_at_least: 5,
+            } if got == &content_ref
+        ));
+        assert_eq!(
+            fake.body_polls.load(Ordering::SeqCst),
+            2,
+            "the stream must stop at the first chunk that crosses the limit"
+        );
+    }
+
+    #[tokio::test]
+    async fn bounded_get_reports_metadata_body_size_mismatch_before_digest() {
+        let fake = Arc::new(
+            FakeObjectStore::new(vec![], vec![Outcome::Ok])
+                .with_get_body_chunks(3, vec![Bytes::from_static(b"four")]),
+        );
+        let store = S3BlobStore::from_client_for_test(
+            Arc::clone(&fake) as Arc<dyn ObjectStore>,
+            "blobs",
+            3,
+            Duration::from_secs(1),
+            Duration::from_millis(1),
+        )
+        .unwrap();
+        let content_ref = ContentRef::from_hex("e".repeat(64)).unwrap();
+
+        let err = store
+            .get_bounded_verified(&content_ref, 4)
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            StorageError::BlobSizeMismatch {
+                content_ref: ref got,
+                metadata_bytes: 3,
+                actual_bytes: 4,
+            } if got == &content_ref
+        ));
+    }
+
+    #[tokio::test]
+    async fn bounded_get_reports_truncated_body_size_mismatch_before_digest() {
+        let fake = Arc::new(
+            FakeObjectStore::new(vec![], vec![Outcome::Ok])
+                .with_get_body_chunks(5, vec![Bytes::from_static(b"four")]),
+        );
+        let store = S3BlobStore::from_client_for_test(
+            Arc::clone(&fake) as Arc<dyn ObjectStore>,
+            "blobs",
+            3,
+            Duration::from_secs(1),
+            Duration::from_millis(1),
+        )
+        .unwrap();
+        let content_ref = ContentRef::from_hex("e".repeat(64)).unwrap();
+
+        let err = store
+            .get_bounded_verified(&content_ref, 5)
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            StorageError::BlobSizeMismatch {
+                content_ref: ref got,
+                metadata_bytes: 5,
+                actual_bytes: 4,
+            } if got == &content_ref
+        ));
+    }
+
+    #[tokio::test]
+    async fn bounded_get_reports_digest_mismatch_only_after_size_consistency() {
+        let expected_bytes = b"expected";
+        let actual_bytes = b"mutated!";
+        let expected = ContentRef::from_digest_bytes(blake3::hash(expected_bytes).as_bytes());
+        let actual = ContentRef::from_digest_bytes(blake3::hash(actual_bytes).as_bytes());
+        let fake = Arc::new(
+            FakeObjectStore::new(vec![], vec![Outcome::Ok]).with_get_body_chunks(
+                actual_bytes.len() as u64,
+                vec![Bytes::from_static(actual_bytes)],
+            ),
+        );
+        let store = S3BlobStore::from_client_for_test(
+            Arc::clone(&fake) as Arc<dyn ObjectStore>,
+            "blobs",
+            3,
+            Duration::from_secs(1),
+            Duration::from_millis(1),
+        )
+        .unwrap();
+
+        let err = store
+            .get_bounded_verified(&expected, actual_bytes.len() as u64)
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            StorageError::BlobDigestMismatch {
+                expected: ref got_expected,
+                actual: ref got_actual,
+            } if got_expected == &expected && got_actual == &actual
+        ));
+    }
+
+    #[tokio::test]
+    async fn bounded_get_deadline_spans_provider_get_and_body_consumption() {
+        let chunks = vec![
+            Bytes::from_static(b"12345678"),
+            Bytes::from_static(b"abcdefgh"),
+        ];
+        let fake = Arc::new(
+            FakeObjectStore::new(vec![], vec![Outcome::Ok])
+                .with_get_pre_delay(Duration::from_millis(80))
+                .with_get_body_chunks_delayed(16, chunks, Duration::from_millis(50)),
+        );
+        let store = S3BlobStore::from_client_for_test(
+            Arc::clone(&fake) as Arc<dyn ObjectStore>,
+            "blobs",
+            3,
+            Duration::from_millis(150),
+            Duration::from_millis(1),
+        )
+        .unwrap();
+        let content_ref = ContentRef::from_hex("f".repeat(64)).unwrap();
+
+        let err = store
+            .get_bounded_verified(&content_ref, 16)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, StorageError::Timeout { .. }), "got {err:?}");
+    }
+
+    #[tokio::test]
     async fn get_rejects_body_larger_than_reported_metadata_size() {
         // ADR-111 Amendment 2: `get` must check the
         // running total against the cap BEFORE appending a chunk, not
@@ -1380,9 +1755,10 @@ mod tests {
         // must succeed — confirming the check-before-append reorder didn't
         // shift the ceiling off-by-one.
         let exact = vec![b'x'; MAX_OBJECT_BYTES as usize];
+        let exact_len = exact.len();
         let fake = Arc::new(
             FakeObjectStore::new(vec![], vec![Outcome::Ok])
-                .with_get_body_chunks(MAX_OBJECT_BYTES, vec![Bytes::from(exact.clone())]),
+                .with_get_body_chunks(MAX_OBJECT_BYTES, vec![Bytes::from(exact)]),
         );
         let store = S3BlobStore::from_client_for_test(
             Arc::clone(&fake) as Arc<dyn ObjectStore>,
@@ -1394,7 +1770,7 @@ mod tests {
         .unwrap();
         let content_ref = ContentRef::from_hex("e".repeat(64)).unwrap();
         let bytes = store.get(&content_ref).await.unwrap();
-        assert_eq!(bytes.len(), exact.len());
+        assert_eq!(bytes.len(), exact_len);
     }
 
     #[tokio::test]

--- a/crates/khive-db/tests/blob_conformance.rs
+++ b/crates/khive-db/tests/blob_conformance.rs
@@ -8,12 +8,156 @@
 //! explicit message everywhere else, since it needs a live S3-compatible
 //! endpoint to mean anything.
 
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 
+use async_trait::async_trait;
 use futures::stream::StreamExt;
 use khive_db::stores::blob::FsBlobStore;
 use khive_db::stores::blob_s3::{S3BlobStore, S3BlobStoreConfig};
-use khive_storage::blob::{BlobOrphanSweepConfig, BlobStore, ContentRef};
+use khive_storage::blob::{BlobOrphanSweepConfig, BlobStore, ContentRef, MAX_BLOB_WHOLE_BYTES};
+use khive_storage::{StorageCapability, StorageError, StorageResult};
+
+/// Scriptable in-memory backend used to keep the required method honest for
+/// test/future implementations, including metadata/body corruption that a
+/// normal content-addressed `put` cannot create.
+#[derive(Debug, Default)]
+struct FixtureBlobStore {
+    objects: Mutex<HashMap<ContentRef, (u64, Vec<u8>)>>,
+    bounded_backend_calls: AtomicUsize,
+}
+
+impl FixtureBlobStore {
+    fn insert_raw(&self, content_ref: ContentRef, metadata_bytes: u64, body: Vec<u8>) {
+        self.objects
+            .lock()
+            .unwrap()
+            .insert(content_ref, (metadata_bytes, body));
+    }
+
+    fn not_found(content_ref: &ContentRef) -> StorageError {
+        StorageError::NotFound {
+            capability: StorageCapability::Blob,
+            resource: "blob",
+            key: content_ref.to_string(),
+        }
+    }
+}
+
+#[async_trait]
+impl BlobStore for FixtureBlobStore {
+    async fn put(&self, bytes: Vec<u8>) -> StorageResult<ContentRef> {
+        let content_ref = ContentRef::from_digest_bytes(blake3::hash(&bytes).as_bytes());
+        self.objects
+            .lock()
+            .unwrap()
+            .insert(content_ref.clone(), (bytes.len() as u64, bytes));
+        Ok(content_ref)
+    }
+
+    async fn get(&self, content_ref: &ContentRef) -> StorageResult<Vec<u8>> {
+        self.objects
+            .lock()
+            .unwrap()
+            .get(content_ref)
+            .map(|(_, body)| body.clone())
+            .ok_or_else(|| Self::not_found(content_ref))
+    }
+
+    async fn get_bounded_verified(
+        &self,
+        content_ref: &ContentRef,
+        max_bytes: u64,
+    ) -> StorageResult<Vec<u8>> {
+        if max_bytes > MAX_BLOB_WHOLE_BYTES {
+            return Err(StorageError::InvalidInput {
+                capability: StorageCapability::Blob,
+                operation: "get_bounded_verified".into(),
+                message: "maximum exceeds portable envelope".into(),
+            });
+        }
+        self.bounded_backend_calls.fetch_add(1, Ordering::SeqCst);
+        let guard = self.objects.lock().unwrap();
+        let (metadata_bytes, body) = guard
+            .get(content_ref)
+            .ok_or_else(|| Self::not_found(content_ref))?;
+        if *metadata_bytes > max_bytes {
+            return Err(StorageError::BlobTooLarge {
+                content_ref: content_ref.clone(),
+                max_bytes,
+                observed_at_least: *metadata_bytes,
+            });
+        }
+        if body.len() as u64 > max_bytes {
+            return Err(StorageError::BlobTooLarge {
+                content_ref: content_ref.clone(),
+                max_bytes,
+                observed_at_least: max_bytes + 1,
+            });
+        }
+        if *metadata_bytes != body.len() as u64 {
+            return Err(StorageError::BlobSizeMismatch {
+                content_ref: content_ref.clone(),
+                metadata_bytes: *metadata_bytes,
+                actual_bytes: body.len() as u64,
+            });
+        }
+        let actual = ContentRef::from_digest_bytes(blake3::hash(body).as_bytes());
+        if actual != *content_ref {
+            return Err(StorageError::BlobDigestMismatch {
+                expected: content_ref.clone(),
+                actual,
+            });
+        }
+        Ok(body.clone())
+    }
+
+    async fn exists(&self, content_ref: &ContentRef) -> StorageResult<bool> {
+        Ok(self.objects.lock().unwrap().contains_key(content_ref))
+    }
+
+    async fn size(&self, content_ref: &ContentRef) -> StorageResult<Option<u64>> {
+        Ok(self
+            .objects
+            .lock()
+            .unwrap()
+            .get(content_ref)
+            .map(|(metadata_bytes, _)| *metadata_bytes))
+    }
+
+    async fn delete(&self, content_ref: &ContentRef) -> StorageResult<bool> {
+        Ok(self.objects.lock().unwrap().remove(content_ref).is_some())
+    }
+
+    async fn orphan_sweep(
+        &self,
+        config: &BlobOrphanSweepConfig,
+    ) -> StorageResult<khive_storage::BlobOrphanSweepResult> {
+        let mut objects = self.objects.lock().unwrap();
+        let orphaned: Vec<ContentRef> = objects
+            .keys()
+            .filter(|content_ref| !config.live_refs.contains(*content_ref))
+            .cloned()
+            .collect();
+        let scanned = objects.len() as u64;
+        if !config.dry_run {
+            for content_ref in &orphaned {
+                objects.remove(content_ref);
+            }
+        }
+        Ok(khive_storage::BlobOrphanSweepResult {
+            scanned,
+            deleted: if config.dry_run {
+                0
+            } else {
+                orphaned.len() as u64
+            },
+            would_delete: orphaned.len() as u64,
+            grace_period_skipped: 0,
+        })
+    }
+}
 
 async fn assert_conforms(store: Arc<dyn BlobStore>) {
     let bytes = b"khive blob conformance suite".to_vec();
@@ -33,10 +177,72 @@ async fn assert_conforms(store: Arc<dyn BlobStore>) {
     let round_tripped = store.get(&ref_a).await.expect("get");
     assert_eq!(round_tripped, bytes);
 
+    // ADR-160 D2: the required whole-buffer read succeeds exactly at the
+    // caller's actual-byte limit and returns only digest-verified bytes.
+    let verified = store
+        .get_bounded_verified(&ref_a, bytes.len() as u64)
+        .await
+        .expect("bounded verified get at the exact limit");
+    assert_eq!(verified, bytes);
+
+    // The first byte beyond the caller's limit is refused with the same
+    // typed result on every backend. For this normally-published object the
+    // authoritative metadata knows the complete observed size.
+    let too_small_max = bytes.len() as u64 - 1;
+    let err = store
+        .get_bounded_verified(&ref_a, too_small_max)
+        .await
+        .expect_err("bounded get below the object size must refuse");
+    match err {
+        StorageError::BlobTooLarge {
+            content_ref,
+            max_bytes,
+            observed_at_least,
+        } => {
+            assert_eq!(content_ref, ref_a);
+            assert_eq!(max_bytes, too_small_max);
+            assert_eq!(observed_at_least, bytes.len() as u64);
+        }
+        other => panic!("expected BlobTooLarge, got {other:?}"),
+    }
+
+    // max_bytes=0 is a real boundary, not a synonym for "unbounded".
+    let empty_ref = store.put(Vec::new()).await.expect("put empty object");
+    assert_eq!(
+        store
+            .get_bounded_verified(&empty_ref, 0)
+            .await
+            .expect("empty object at a zero-byte limit"),
+        Vec::<u8>::new()
+    );
+    assert!(matches!(
+        store.get_bounded_verified(&ref_a, 0).await,
+        Err(StorageError::BlobTooLarge {
+            max_bytes: 0,
+            observed_at_least,
+            ..
+        }) if observed_at_least >= 1
+    ));
+
     // A content ref that was never written does not exist and 404s on get.
     let never_written = ContentRef::from_digest_bytes(&[0xAB; 32]);
     assert!(!store.exists(&never_written).await.expect("exists (absent)"));
     assert!(store.get(&never_written).await.is_err());
+    assert!(matches!(
+        store
+            .get_bounded_verified(&never_written, MAX_BLOB_WHOLE_BYTES)
+            .await,
+        Err(StorageError::NotFound { .. })
+    ));
+
+    // Argument validation has deterministic precedence over not-found and
+    // must happen before a backend lookup.
+    assert!(matches!(
+        store
+            .get_bounded_verified(&never_written, MAX_BLOB_WHOLE_BYTES + 1)
+            .await,
+        Err(StorageError::InvalidInput { .. })
+    ));
 
     // orphan_sweep dry-run against an empty live set reports would_delete
     // for the object we just wrote, without touching it.
@@ -60,6 +266,84 @@ async fn assert_conforms(store: Arc<dyn BlobStore>) {
         .delete(&ref_a)
         .await
         .expect("second delete is a no-op"));
+    assert!(store.delete(&empty_ref).await.expect("delete empty object"));
+}
+
+#[tokio::test]
+async fn scripted_fixture_blob_store_conforms() {
+    let store: Arc<dyn BlobStore> = Arc::new(FixtureBlobStore::default());
+    assert_conforms(store).await;
+}
+
+#[tokio::test]
+async fn scripted_fixture_pins_corruption_and_error_precedence() {
+    let store = FixtureBlobStore::default();
+    let missing = ContentRef::from_hex("a".repeat(64)).unwrap();
+    assert!(matches!(
+        store
+            .get_bounded_verified(&missing, MAX_BLOB_WHOLE_BYTES + 1)
+            .await,
+        Err(StorageError::InvalidInput { .. })
+    ));
+    assert_eq!(
+        store.bounded_backend_calls.load(Ordering::SeqCst),
+        0,
+        "invalid argument must win before fixture backend work"
+    );
+
+    let metadata_oversize = ContentRef::from_hex("b".repeat(64)).unwrap();
+    store.insert_raw(metadata_oversize.clone(), 5, b"bad".to_vec());
+    assert!(matches!(
+        store.get_bounded_verified(&metadata_oversize, 4).await,
+        Err(StorageError::BlobTooLarge {
+            observed_at_least: 5,
+            ..
+        })
+    ));
+
+    let streamed_oversize = ContentRef::from_hex("c".repeat(64)).unwrap();
+    store.insert_raw(streamed_oversize.clone(), 1, b"12345".to_vec());
+    assert!(matches!(
+        store.get_bounded_verified(&streamed_oversize, 4).await,
+        Err(StorageError::BlobTooLarge {
+            observed_at_least: 5,
+            ..
+        })
+    ));
+
+    // A size mismatch wins before the intentionally-wrong digest.
+    let size_mismatch = ContentRef::from_hex("d".repeat(64)).unwrap();
+    store.insert_raw(size_mismatch.clone(), 3, b"four".to_vec());
+    assert!(matches!(
+        store.get_bounded_verified(&size_mismatch, 4).await,
+        Err(StorageError::BlobSizeMismatch {
+            metadata_bytes: 3,
+            actual_bytes: 4,
+            ..
+        })
+    ));
+
+    let truncated_body = ContentRef::from_hex("e".repeat(64)).unwrap();
+    store.insert_raw(truncated_body.clone(), 5, b"four".to_vec());
+    assert!(matches!(
+        store.get_bounded_verified(&truncated_body, 5).await,
+        Err(StorageError::BlobSizeMismatch {
+            metadata_bytes: 5,
+            actual_bytes: 4,
+            ..
+        })
+    ));
+
+    let expected = ContentRef::from_digest_bytes(blake3::hash(b"expected").as_bytes());
+    let actual = ContentRef::from_digest_bytes(blake3::hash(b"mutated!").as_bytes());
+    store.insert_raw(expected.clone(), 8, b"mutated!".to_vec());
+    assert!(matches!(
+        store.get_bounded_verified(&expected, 8).await,
+        Err(StorageError::BlobDigestMismatch {
+            expected: got_expected,
+            actual: got_actual,
+        }) if got_expected == expected && got_actual == actual
+    ));
 }
 
 #[tokio::test]

--- a/crates/khive-pack-moodboard/src/handlers.rs
+++ b/crates/khive-pack-moodboard/src/handlers.rs
@@ -651,6 +651,19 @@ mod tests {
             Ok(Vec::new())
         }
 
+        async fn get_bounded_verified(
+            &self,
+            content_ref: &ContentRef,
+            max_bytes: u64,
+        ) -> khive_storage::types::StorageResult<Vec<u8>> {
+            self.get_calls.fetch_add(1, Ordering::SeqCst);
+            Err(khive_storage::StorageError::BlobTooLarge {
+                content_ref: content_ref.clone(),
+                max_bytes,
+                observed_at_least: MAX_OBJECT_BYTES as u64 + 1,
+            })
+        }
+
         async fn exists(
             &self,
             _content_ref: &ContentRef,

--- a/crates/khive-runtime/src/blob.rs
+++ b/crates/khive-runtime/src/blob.rs
@@ -130,6 +130,16 @@ impl BlobStore for ReadOnlyBlobStore {
         self.inner.get(content_ref).await
     }
 
+    async fn get_bounded_verified(
+        &self,
+        content_ref: &ContentRef,
+        max_bytes: u64,
+    ) -> StorageResult<Vec<u8>> {
+        self.inner
+            .get_bounded_verified(content_ref, max_bytes)
+            .await
+    }
+
     async fn exists(&self, content_ref: &ContentRef) -> StorageResult<bool> {
         self.inner.exists(content_ref).await
     }
@@ -163,8 +173,58 @@ mod tests {
     use super::*;
     use crate::engine_config::StorageSectionConfig;
 
+    #[derive(Debug, Default)]
+    struct RecordingReadStore {
+        bounded_call: std::sync::Mutex<Option<(ContentRef, u64)>>,
+    }
+
+    #[async_trait]
+    impl BlobStore for RecordingReadStore {
+        async fn put(&self, _bytes: Vec<u8>) -> StorageResult<ContentRef> {
+            panic!("put is not used by the read-only delegation test")
+        }
+
+        async fn get(&self, _content_ref: &ContentRef) -> StorageResult<Vec<u8>> {
+            panic!("legacy get must not service a bounded read")
+        }
+
+        async fn get_bounded_verified(
+            &self,
+            content_ref: &ContentRef,
+            max_bytes: u64,
+        ) -> StorageResult<Vec<u8>> {
+            *self.bounded_call.lock().unwrap() = Some((content_ref.clone(), max_bytes));
+            Ok(b"verified".to_vec())
+        }
+
+        async fn exists(&self, _content_ref: &ContentRef) -> StorageResult<bool> {
+            Ok(true)
+        }
+
+        async fn size(&self, _content_ref: &ContentRef) -> StorageResult<Option<u64>> {
+            Ok(Some(8))
+        }
+
+        async fn delete(&self, _content_ref: &ContentRef) -> StorageResult<bool> {
+            panic!("delete is not used by the read-only delegation test")
+        }
+    }
+
     fn memory_backend() -> StorageBackend {
         StorageBackend::memory().expect("memory backend should create")
+    }
+
+    #[tokio::test]
+    async fn read_only_store_delegates_the_bounded_verified_read_unchanged() {
+        let inner = Arc::new(RecordingReadStore::default());
+        let store = ReadOnlyBlobStore {
+            inner: Arc::clone(&inner) as Arc<dyn BlobStore>,
+        };
+        let content_ref = ContentRef::from_hex("a".repeat(64)).unwrap();
+
+        let bytes = store.get_bounded_verified(&content_ref, 17).await.unwrap();
+        assert_eq!(bytes, b"verified");
+        assert_eq!(*inner.bounded_call.lock().unwrap(), Some((content_ref, 17)));
     }
 
     #[test]

--- a/crates/khive-storage/docs/api/blob-store.md
+++ b/crates/khive-storage/docs/api/blob-store.md
@@ -31,6 +31,26 @@ to the same bytes.
 vector instead of pulling in the `blake3` crate, since khive-storage has zero
 heavy dependencies (ADR-005).
 
+## `BlobStore::get_bounded_verified`
+
+Whole-buffer reads declare an actual-byte maximum and use the required
+`get_bounded_verified(content_ref, max_bytes)` backend primitive. The maximum
+may be zero and cannot exceed `MAX_BLOB_WHOLE_BYTES` (64 MiB); larger objects
+require a future streaming contract. There is deliberately no default built
+from `size()` plus `get()`: metadata can provide an early refusal and an
+integrity witness, but cannot bound or authenticate a later read.
+
+A backend returns bytes only after the authoritative object reaches EOF at or
+below the declared limit, its opened-handle/GET metadata agrees with the final
+length, and BLAKE3 of those bytes equals the requested `ContentRef`. Failures
+are ordered: invalid maximum, not found, `BlobTooLarge`,
+`BlobSizeMismatch`, then `BlobDigestMismatch`. No partial or digest-mismatched
+buffer reaches the caller.
+
+The legacy unbounded `get` remains temporarily during ADR-160's staged consumer
+migration. It is not an implementation primitive for bounded reads and is
+removed with the final migrated consumer in Phase 3.
+
 ## `BlobStore::delete` — concurrency hazard
 
 `delete` performs an unconditional physical removal with **no coordination

--- a/crates/khive-storage/docs/api/error-taxonomy.md
+++ b/crates/khive-storage/docs/api/error-taxonomy.md
@@ -63,6 +63,30 @@ this variant is nevertheless a Rust source-compatibility change for downstream
 code that exhaustively matches every variant; those matches must add a
 `WriterTaskTerminated` arm.
 
+## Bounded blob read failures
+
+`BlobTooLarge`, `BlobSizeMismatch`, and `BlobDigestMismatch` are typed
+fail-closed outcomes of `BlobStore::get_bounded_verified`. All three report
+`Some(StorageCapability::Blob)` from `capability()` and are non-retryable by
+default. Their owned `ContentRef` fields preserve validated content-addressed
+identity; no raw or malformed digest string enters the backend contract.
+
+This addition is intentionally Rust source-breaking: `BlobStore` gains a
+required method with no default, and `StorageError` is a public enum without
+`#[non_exhaustive]`. Downstream implementations must provide
+`get_bounded_verified`; exhaustive error matches must add arms for all three
+new variants. The existing `get` method remains available during the staged
+ADR-160 migration and is removed only after every production consumer moves to
+the bounded runtime path.
+
+`BlobTooLarge.observed_at_least` is a lower bound, not always a verified final
+size. It may come from same-object metadata that caused an early refusal or
+from the byte prefix that first crossed the caller's limit.
+`BlobSizeMismatch` wins over digest validation once a bounded body reaches EOF,
+and `BlobDigestMismatch` is evaluated only for a metadata-consistent complete
+body. None of these variants carries bytes or changes the existing flattened
+runtime/MCP error envelope.
+
 ## Typed writer-pool checkout timeout source
 
 `khive-db` retains `SqliteError::WriterPoolCheckoutTimeout` as the typed source

--- a/crates/khive-storage/src/blob.rs
+++ b/crates/khive-storage/src/blob.rs
@@ -20,6 +20,13 @@ use crate::types::StorageResult;
 /// Number of hex characters in a BLAKE3-256 digest (32 bytes -> 64 hex chars).
 const CONTENT_REF_HEX_LEN: usize = 64;
 
+/// Portable v1 ceiling for a whole-buffer blob operation (64 MiB).
+///
+/// Callers needing larger objects require a future streaming contract. A
+/// [`BlobStore::get_bounded_verified`] request above this limit is invalid
+/// even when the selected backend could otherwise satisfy it.
+pub const MAX_BLOB_WHOLE_BYTES: u64 = 64 * 1024 * 1024;
+
 /// An opaque, content-addressed reference to a stored blob.
 ///
 /// Backed by a lowercase-hex BLAKE3 digest of the blob's bytes: identical
@@ -163,6 +170,25 @@ pub trait BlobStore: Send + Sync + std::fmt::Debug + 'static {
     /// Returns `StorageError::NotFound` (capability `Blob`) if no object
     /// exists for this reference.
     async fn get(&self, content_ref: &ContentRef) -> StorageResult<Vec<u8>>;
+
+    /// Fetch at most `max_bytes` from `content_ref` and verify its BLAKE3
+    /// digest before returning any bytes.
+    ///
+    /// `max_bytes` may be zero (only an empty object can then succeed) and
+    /// must not exceed [`MAX_BLOB_WHOLE_BYTES`]. Implementations must enforce
+    /// the limit while reading the authoritative object, not by composing a
+    /// metadata-only [`Self::size`] check with the unbounded [`Self::get`]
+    /// compatibility method. A successful result is complete, no larger than
+    /// the declared maximum, metadata-size-consistent, and digest-matched to
+    /// `content_ref`.
+    ///
+    /// The unbounded `get` method remains temporarily while ADR-160's
+    /// consumers migrate and is removed with the final consumer in Phase 3.
+    async fn get_bounded_verified(
+        &self,
+        content_ref: &ContentRef,
+        max_bytes: u64,
+    ) -> StorageResult<Vec<u8>>;
 
     /// Whether an object currently exists for `content_ref`.
     async fn exists(&self, content_ref: &ContentRef) -> StorageResult<bool>;

--- a/crates/khive-storage/src/error.rs
+++ b/crates/khive-storage/src/error.rs
@@ -6,6 +6,7 @@ use std::fmt;
 
 use thiserror::Error;
 
+use crate::blob::ContentRef;
 use crate::capability::StorageCapability;
 
 /// What is known about one request when its single-writer execution seam
@@ -74,6 +75,38 @@ pub enum StorageError {
         capability: StorageCapability,
         operation: Cow<'static, str>,
         message: String,
+    },
+
+    /// The authoritative object is larger than the caller's declared
+    /// whole-buffer limit. `observed_at_least` is either opened-object
+    /// metadata used for early refusal or the running byte count that first
+    /// crossed the limit; metadata is not treated as the actual-byte bound.
+    #[error(
+        "blob {content_ref} exceeds the {max_bytes}-byte read limit (observed at least {observed_at_least} bytes)"
+    )]
+    BlobTooLarge {
+        content_ref: ContentRef,
+        max_bytes: u64,
+        observed_at_least: u64,
+    },
+
+    /// The complete bounded body disagreed with metadata obtained from the
+    /// same opened object / GET response.
+    #[error(
+        "blob {content_ref} metadata reports {metadata_bytes} bytes but the complete body contains {actual_bytes} bytes"
+    )]
+    BlobSizeMismatch {
+        content_ref: ContentRef,
+        metadata_bytes: u64,
+        actual_bytes: u64,
+    },
+
+    /// The complete, size-consistent bounded body did not hash to the
+    /// requested content-addressed reference.
+    #[error("blob digest mismatch: expected {expected}, computed {actual}")]
+    BlobDigestMismatch {
+        expected: ContentRef,
+        actual: ContentRef,
     },
 
     #[error("pool failure during {operation}: {message}")]
@@ -193,6 +226,9 @@ impl StorageError {
             | Self::IndexMaintenance { capability, .. }
             | Self::Driver { capability, .. }
             | Self::CapacityFloor { capability, .. } => Some(*capability),
+            Self::BlobTooLarge { .. }
+            | Self::BlobSizeMismatch { .. }
+            | Self::BlobDigestMismatch { .. } => Some(StorageCapability::Blob),
             Self::Pool { .. }
             | Self::Timeout { .. }
             | Self::Transaction { .. }
@@ -350,6 +386,33 @@ mod tests {
                 error.to_string(),
                 format!("writer task terminated (request_state={request_state})")
             );
+        }
+    }
+
+    #[test]
+    fn blob_integrity_errors_are_blob_scoped_and_not_retryable() {
+        let requested = crate::blob::ContentRef::from_hex("a".repeat(64)).unwrap();
+        let actual = crate::blob::ContentRef::from_hex("b".repeat(64)).unwrap();
+        let errors = [
+            StorageError::BlobTooLarge {
+                content_ref: requested.clone(),
+                max_bytes: 8,
+                observed_at_least: 9,
+            },
+            StorageError::BlobSizeMismatch {
+                content_ref: requested.clone(),
+                metadata_bytes: 7,
+                actual_bytes: 8,
+            },
+            StorageError::BlobDigestMismatch {
+                expected: requested,
+                actual,
+            },
+        ];
+
+        for error in errors {
+            assert_eq!(error.capability(), Some(StorageCapability::Blob));
+            assert!(!error.is_retryable());
         }
     }
 

--- a/crates/khive-storage/src/lib.rs
+++ b/crates/khive-storage/src/lib.rs
@@ -19,7 +19,9 @@ pub mod usage;
 pub mod vectors;
 
 pub use agent::AgentStore;
-pub use blob::{BlobOrphanSweepConfig, BlobOrphanSweepResult, BlobStore, ContentRef};
+pub use blob::{
+    BlobOrphanSweepConfig, BlobOrphanSweepResult, BlobStore, ContentRef, MAX_BLOB_WHOLE_BYTES,
+};
 pub use capability::StorageCapability;
 pub use entity::{Entity, EntityFilter, EntityStore};
 pub use error::{StorageError, WriterTaskRequestState};


### PR DESCRIPTION
## Stack / merge gate

- Depends on #2001 (ADR-160 Phase 0).
- Base is `codex/adr-160-phase-0-gate-fail-closed`; this PR cannot merge ahead of Phase 0.
- Implements **only ADR-160 Phase 1**.
- ADR-160 was accepted on `main` in `135c3d46` (#2005). Keep this PR draft until its parent-stack order and Claude review are satisfied.

## What changed

- Add the required `BlobStore::get_bounded_verified` contract, the portable 64 MiB envelope, and typed too-large / size-mismatch / digest-mismatch failures.
- Fs: resolve the configured root once, open root/shards/leaf without following links, pin one regular-file handle, read at most `max + 1`, then enforce size-before-BLAKE3 precedence.
- S3: one GET, zero HEAD, one absolute GET+body deadline, metadata early refusal, pre-append cumulative bounds, EOF size consistency, then BLAKE3.
- Update the read-only decorator and test fixtures without migrating any production consumer.
- Add shared fixture conformance, adversarial Fs/S3 cases, and a focused Windows execution lane.

## Resource-safety invariants

- `max_bytes > 64 MiB` fails before backend/provider work.
- Metadata is only an early-refusal hint and integrity witness, never authority for returned bytes.
- Oversize, truncated, grown, path-swapped, symlinked, or digest-mismatched objects never escape as successful bytes.
- Legacy unbounded `get` remains unchanged in this phase; runtime admission, cancellation supervision, consumer migration, and deletion of `get` are intentionally deferred to Phases 2–3.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -j4 --workspace --all-targets`
- `cargo clippy -j4 --workspace --all-targets -- -D warnings`
- affected-crate Clippy rerun after final review fixes
- Fs bounded suite: 9/9
- S3 bounded suite: 9/9
- shared blob conformance: 5/5
- storage/runtime/moodboard targeted suites
- full workspace run reached one unrelated `khive-mcp` Unix-socket timing failure; its exact isolated rerun passed (403 sibling tests passed in that package run)

Two independent static review passes report no remaining merge blockers.