### PR TITLE
docs(adr): mark ADR-160 accepted

### DIFF
--- a/docs/adr/ADR-160-shared-pack-infrastructure.md
+++ b/docs/adr/ADR-160-shared-pack-infrastructure.md
@@ -1,6 +1,6 @@
 # ADR-160: Shared Pack Infrastructure Program
 
-**Status**: proposed\
+**Status**: accepted\
 **Date**: 2026-08-16\
 **Authors**: khive maintainers\
 **Depends on**:


### PR DESCRIPTION
Reconciles ADR-160's status header with its merged state: the program document landed on main with the header still reading proposed. One-line docs-only change.