### PR TITLE
feat(runtime): add ADR-160 shared blob hydration

### DIFF
--- a/crates/khive-mcp/docs/api/daemon-lifecycle.md
+++ b/crates/khive-mcp/docs/api/daemon-lifecycle.md
@@ -123,9 +123,9 @@ as stable, full SHA-256 identifiers rather than the path- and topology-bearing
 fingerprints used for the equality check. A configuration mismatch also carries
 `config_mismatch_field`, naming the first differing fingerprint field without
 emitting either field value. Its ordered vocabulary follows the production fingerprint:
-`packs`, `db`, `embed`, `extra`, `fresh_tail`, `backend`, `outbound`, `git_write`,
-`backends`, then `pack_backends`. The wire equality check and fallback decision still use
-the original full fingerprints.
+`packs`, `db`, `embed`, `extra`, `fresh_tail`, `blob_hydration_bytes`, `backend`,
+`outbound`, `git_write`, `backends`, then `pack_backends`. The wire equality check and
+fallback decision still use the original full fingerprints.
 
 The `khive_strict_daemon_fallback` marker on a strict-fallback rejection's
 `McpError` (#947) lets `request()` in `server.rs` distinguish "the daemon was

--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -213,6 +213,7 @@ struct ConfigIdFields<'a> {
     embed: &'a str,
     extra: &'a str,
     fresh_tail: &'a str,
+    blob_hydration_bytes: &'a str,
     backend: &'a str,
     outbound: &'a str,
     git_write: &'a str,
@@ -236,6 +237,12 @@ fn parse_config_id(config_id: &str) -> Option<ConfigIdFields<'_>> {
     let (rest, outbound) = rest.rsplit_once(";outbound=[")?;
     let outbound = outbound.strip_suffix(']')?;
     let (rest, backend) = rest.rsplit_once(";backend=")?;
+    // Parse pre-ADR-160 fingerprints too so an incumbent from the preceding
+    // release reports the newly construction-baked budget as the mismatch,
+    // rather than degrading an otherwise recognizable identity to `unknown`.
+    let (rest, blob_hydration_bytes) = rest
+        .rsplit_once(";blob_hydration_bytes=")
+        .unwrap_or((rest, "<legacy-absent>"));
     let (rest, fresh_tail) = rest.rsplit_once(";fresh_tail=")?;
     let (rest, extra) = rest.rsplit_once(";extra=[")?;
     let extra = extra.strip_suffix(']')?;
@@ -247,6 +254,7 @@ fn parse_config_id(config_id: &str) -> Option<ConfigIdFields<'_>> {
         embed,
         extra,
         fresh_tail,
+        blob_hydration_bytes,
         backend,
         outbound,
         git_write,
@@ -273,6 +281,8 @@ fn first_config_mismatch_field(client: &str, daemon: Option<&str>) -> &'static s
         "extra"
     } else if client.fresh_tail != daemon.fresh_tail {
         "fresh_tail"
+    } else if client.blob_hydration_bytes != daemon.blob_hydration_bytes {
+        "blob_hydration_bytes"
     } else if client.backend != daemon.backend {
         "backend"
     } else if client.outbound != daemon.outbound {
@@ -2635,9 +2645,9 @@ mod tests {
     #[test]
     fn first_config_mismatch_field_follows_fingerprint_order() {
         let client = "packs=[kg];db=/private/client.db;embed=none;extra=[];fresh_tail=true;\
-                      backend=main;outbound=[];git_write=client-policy";
+                      blob_hydration_bytes=268435456;backend=main;outbound=[];git_write=client-policy";
         let daemon = "packs=[kg,gtd];db=/private/daemon.db;embed=none;extra=[];fresh_tail=true;\
-                      backend=main;outbound=[];git_write=daemon-policy";
+                      blob_hydration_bytes=268435456;backend=main;outbound=[];git_write=daemon-policy";
 
         assert_eq!(first_config_mismatch_field(client, Some(daemon)), "packs");
     }
@@ -2651,6 +2661,33 @@ mod tests {
         assert_eq!(
             first_config_mismatch_field(&enabled, Some(&disabled)),
             "fresh_tail"
+        );
+    }
+
+    #[test]
+    fn first_config_mismatch_field_names_blob_hydration_budget_from_computed_ids() {
+        let config = RuntimeConfig::no_embeddings();
+        let mut changed = config.clone();
+        changed.blob_hydration_bytes /= 2;
+        let client = crate::server::compute_config_id_with_ann_fresh_tail(&config, None, true);
+        let daemon = crate::server::compute_config_id_with_ann_fresh_tail(&changed, None, true);
+
+        assert_eq!(
+            first_config_mismatch_field(&client, Some(&daemon)),
+            "blob_hydration_bytes"
+        );
+    }
+
+    #[test]
+    fn legacy_config_id_reports_the_new_blob_budget_as_its_first_mismatch() {
+        let legacy = "packs=[kg];db=:memory:;embed=none;extra=[];fresh_tail=true;\
+                      backend=main;outbound=[];git_write=policy";
+        let current = "packs=[kg];db=:memory:;embed=none;extra=[];fresh_tail=true;\
+                       blob_hydration_bytes=268435456;backend=main;outbound=[];git_write=policy";
+
+        assert_eq!(
+            first_config_mismatch_field(current, Some(legacy)),
+            "blob_hydration_bytes"
         );
     }
 
@@ -2670,8 +2707,8 @@ mod tests {
 
     #[test]
     fn first_config_mismatch_field_names_backend_topology_without_values() {
-        let base = "packs=[kg];db=:memory:;embed=none;extra=[];fresh_tail=true;backend=main;\
-                    outbound=[];git_write=policy";
+        let base = "packs=[kg];db=:memory:;embed=none;extra=[];fresh_tail=true;\
+                    blob_hydration_bytes=268435456;backend=main;outbound=[];git_write=policy";
         let client =
             format!("{base};backends=[main:Sqlite:/private/client.db];pack_backends=[kg=main]");
         let daemon =
@@ -2704,10 +2741,10 @@ mod tests {
         reset_fallback_counters();
         let client =
             "packs=[kg];db=/private/client-topology/main.db;embed=none;extra=[];fresh_tail=true;\
-                      backend=main;outbound=[];git_write=same-policy";
+                      blob_hydration_bytes=268435456;backend=main;outbound=[];git_write=same-policy";
         let daemon =
             "packs=[kg];db=/private/daemon-topology/main.db;embed=none;extra=[];fresh_tail=true;\
-                      backend=main;outbound=[];git_write=same-policy";
+                      blob_hydration_bytes=268435456;backend=main;outbound=[];git_write=same-policy";
         let response = DaemonResponseFrame {
             ok: false,
             result: None,

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -9,8 +9,8 @@ use std::sync::Arc;
 
 use khive_runtime::{
     config_from_env, parse_pack_list, runtime_config_from_khive_config, BackendConfig, BackendId,
-    BackendKind, ConnectionPool, KhiveConfig, KhiveRuntime, OutputFormat, RuntimeConfig,
-    StorageBackend,
+    BackendKind, BlobHydrator, ConnectionPool, KhiveConfig, KhiveRuntime, OutputFormat,
+    RuntimeConfig, StorageBackend,
 };
 
 use crate::args::{resolve_cli_namespace, Args};
@@ -2288,19 +2288,19 @@ fn build_registry_for_multi_backend_inner(
         cfg
     });
 
-    // ADR-111 Amendment 2: resolve the config-selected `BlobStore` once
-    // against the main backend and install it on every runtime handle this
-    // boot produces (`default_runtime` plus each per-pack runtime), so a
-    // pack that later reads `KhiveRuntime::blob_store()` sees the same
-    // selection regardless of which backend its own KG data lives on.
+    // ADR-160 D3: resolve the config-selected `BlobStore` once, pair it with
+    // exactly one aggregate hydration budget, and install the same immutable
+    // hydrator `Arc` on every runtime handle this boot produces. `core()`
+    // clones share each runtime's one-shot slot, so they see this same pair.
     let blob_store_runtime = per_pack_runtimes_local
         .get("blob")
         .unwrap_or(&default_runtime);
-    if let Some(store) =
+    if let Some(hydrator) =
         install_resolved_blob_store(blob_store_runtime, khive_cfg, main_backend.as_ref())?
     {
+        default_runtime.install_blob_hydrator(Arc::clone(&hydrator))?;
         for rt in per_pack_runtimes_local.values() {
-            rt.install_blob_store(store.clone());
+            rt.install_blob_hydrator(Arc::clone(&hydrator))?;
         }
     }
 
@@ -3004,8 +3004,9 @@ pub fn checkpoint_pool_for(main_backend: &StorageBackend) -> Option<Arc<Connecti
 /// Resolve `khive.toml`'s `[storage.blob]` selection against `backend` and
 /// install it on `rt` (ADR-111 Amendment 2's boot-wiring requirement).
 ///
-/// Returns the resolved store on success so multi-backend callers can also
-/// install it on every per-pack runtime without re-resolving it.
+/// Returns the resolved store/hydration pair on success so multi-backend
+/// callers can install the exact same aggregate budget on every runtime
+/// without re-resolving or reconstructing it.
 ///
 /// An **explicit** `[storage.blob]` section that fails to resolve (an `s3`
 /// backend with no AWS credentials in the environment, an invalid prefix,
@@ -3025,11 +3026,12 @@ pub fn install_resolved_blob_store(
     rt: &KhiveRuntime,
     khive_cfg: &KhiveConfig,
     backend: &StorageBackend,
-) -> anyhow::Result<Option<Arc<dyn khive_storage::BlobStore>>> {
+) -> anyhow::Result<Option<Arc<BlobHydrator>>> {
     match khive_runtime::resolve_blob_store_for_mode(khive_cfg, backend, rt.is_read_only()) {
         Ok(store) => {
-            rt.install_blob_store(store.clone());
-            Ok(Some(store))
+            let hydrator = Arc::new(BlobHydrator::new(store, rt.config().blob_hydration_bytes)?);
+            rt.install_blob_hydrator(Arc::clone(&hydrator))?;
+            Ok(Some(hydrator))
         }
         Err(e) if khive_cfg.storage.blob.is_none() => {
             tracing::debug!(
@@ -5499,6 +5501,103 @@ region = "us-east-1"
                 "pack {pack_name:?}: expected the installed store to be an S3BlobStore, got: {debug}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn multi_backend_boot_shares_one_hydrator_across_default_core_blob_and_moodboard() {
+        let blob_root = tempfile::tempdir().expect("blob root");
+        let khive_cfg = KhiveConfig {
+            backends: vec![BackendConfig {
+                name: "main".to_string(),
+                kind: BackendKind::Memory,
+                path: None,
+                cache_mb: None,
+                journal_mode: None,
+                read_only: false,
+            }],
+            storage: StorageSectionConfig {
+                blob: Some(BlobConfig::Fs {
+                    root: Some(blob_root.path().to_string_lossy().into_owned()),
+                    floor_bytes: Some(0),
+                }),
+            },
+            ..KhiveConfig::default()
+        };
+        let mut base_cfg = base_runtime_config_for_multi_backend();
+        base_cfg.packs = vec!["kg".into(), "blob".into(), "moodboard".into()];
+        base_cfg.blob_hydration_bytes = khive_storage::MAX_BLOB_WHOLE_BYTES;
+
+        let multi = build_registry_for_multi_backend(base_cfg, &khive_cfg, None)
+            .expect("multi-backend registry build");
+        let expected = multi
+            .default_runtime
+            .blob_hydrator()
+            .expect("default runtime hydrator");
+        assert_eq!(expected.budget_bytes(), khive_storage::MAX_BLOB_WHOLE_BYTES);
+
+        for pack_name in ["kg", "blob", "moodboard"] {
+            let runtime = multi
+                .per_pack_runtimes
+                .get(pack_name)
+                .unwrap_or_else(|| panic!("missing {pack_name} runtime"));
+            let installed = runtime
+                .blob_hydrator()
+                .unwrap_or_else(|| panic!("missing {pack_name} hydrator"));
+            assert!(
+                Arc::ptr_eq(&installed, &expected),
+                "{pack_name} must share the default runtime's aggregate budget"
+            );
+            let core = runtime.core().blob_hydrator().expect("core hydrator");
+            assert!(
+                Arc::ptr_eq(&core, &expected),
+                "{pack_name}.core() must share the same aggregate budget"
+            );
+        }
+
+        let blob_runtime = multi.per_pack_runtimes.get("blob").expect("blob runtime");
+        let moodboard_runtime = multi
+            .per_pack_runtimes
+            .get("moodboard")
+            .expect("moodboard runtime");
+        let content_ref = blob_runtime
+            .blob_store()
+            .expect("raw store")
+            .put(vec![b'x'])
+            .await
+            .expect("publish contention fixture");
+
+        let held = blob_runtime
+            .core()
+            .blob_hydrator()
+            .expect("blob core hydrator")
+            .hydrate_verified(&content_ref, khive_storage::MAX_BLOB_WHOLE_BYTES)
+            .await
+            .expect("reserve the full shared budget");
+
+        let contender_hydrator = moodboard_runtime
+            .blob_hydrator()
+            .expect("moodboard hydrator");
+        let contender_ref = content_ref.clone();
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+        let mut contender = tokio::spawn(async move {
+            let _ = entered_tx.send(());
+            contender_hydrator.hydrate_verified(&contender_ref, 1).await
+        });
+        entered_rx.await.expect("contender entered task");
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(25), &mut contender)
+                .await
+                .is_err(),
+            "moodboard hydration must wait while blob/core holds the shared budget"
+        );
+
+        drop(held);
+        let contender_blob = tokio::time::timeout(std::time::Duration::from_secs(1), contender)
+            .await
+            .expect("contender should wake when the shared lease drops")
+            .expect("contender task")
+            .expect("contender hydration");
+        assert_eq!(contender_blob.bytes(), b"x");
     }
 
     /// Guards the ADR-111 Amendment 2 fs-default promise (`docs/adr/ADR-111-blob-store.md:538-541`):
@@ -10501,7 +10600,9 @@ backend = "kg-backend"
                 khive_db::stores::blob::FsBlobStore::new(blob_dir.path().to_path_buf(), 0)
                     .expect("fs blob store");
             let runtime = KhiveRuntime::memory().expect("in-memory runtime");
-            runtime.install_blob_store(Arc::new(blob_store));
+            runtime
+                .install_blob_store(Arc::new(blob_store))
+                .expect("install blob store");
             let mut builder = VerbRegistryBuilder::new();
             builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
             builder.register(khive_pack_comm::CommPack::new(runtime.clone()));

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -434,7 +434,8 @@ impl DispatchFailure {
 /// Two servers produce the same id iff they can safely share one warm engine:
 /// same pack set (order-independent), same storage target and effective access
 /// mode, same embedders, same backend topology/routing, and same
-/// construction-baked fresh-tail, outbound, and git-write policies.
+/// construction-baked fresh-tail, blob-hydration, outbound, and git-write
+/// policies.
 /// Identity fields (`namespace`, `actor_id`, `visible_namespaces`) are carried
 /// per request in the daemon frame and must never enter this key. The daemon
 /// compares this against each forwarded request's `config_id` and rejects
@@ -590,12 +591,13 @@ pub(crate) fn compute_config_id_with_runtime_policies(
         format!("{:?}", config.backend_id)
     };
     let base = format!(
-        "packs=[{}];db={};embed={};extra=[{}];fresh_tail={};backend={};outbound=[{}];git_write={}",
+        "packs=[{}];db={};embed={};extra=[{}];fresh_tail={};blob_hydration_bytes={};backend={};outbound=[{}];git_write={}",
         packs.join(","),
         db,
         primary,
         extra.join(","),
         ann_fresh_tail_enabled,
+        config.blob_hydration_bytes,
         backend,
         outbound.join(","),
         git_write,
@@ -3830,6 +3832,43 @@ mod tests {
             compute_config_id_with_ann_fresh_tail(&config, None, true),
             compute_config_id_with_ann_fresh_tail(&config, None, false),
             "opposite fresh-tail policies must not share one warm daemon"
+        );
+    }
+
+    #[test]
+    fn config_id_treats_absent_and_explicit_default_blob_hydration_budget_as_equivalent() {
+        use khive_runtime::engine_config::RuntimeSectionConfig;
+        use khive_runtime::{runtime_config_from_khive_config, KhiveConfig};
+
+        let base = RuntimeConfig::no_embeddings();
+        let absent = runtime_config_from_khive_config(&KhiveConfig::default(), base.clone());
+        let explicit = runtime_config_from_khive_config(
+            &KhiveConfig {
+                runtime: RuntimeSectionConfig {
+                    blob_hydration_bytes: Some(base.blob_hydration_bytes),
+                    ..RuntimeSectionConfig::default()
+                },
+                ..KhiveConfig::default()
+            },
+            base,
+        );
+
+        assert_eq!(
+            compute_config_id_with_ann_fresh_tail(&absent, None, true),
+            compute_config_id_with_ann_fresh_tail(&explicit, None, true)
+        );
+    }
+
+    #[test]
+    fn config_id_differs_when_resolved_blob_hydration_budget_differs() {
+        let config = RuntimeConfig::no_embeddings();
+        let mut changed = config.clone();
+        changed.blob_hydration_bytes /= 2;
+
+        assert_ne!(
+            compute_config_id_with_ann_fresh_tail(&config, None, true),
+            compute_config_id_with_ann_fresh_tail(&changed, None, true),
+            "different resident-blob admission budgets must not share one warm daemon"
         );
     }
 

--- a/crates/khive-pack-blob/tests/integration.rs
+++ b/crates/khive-pack-blob/tests/integration.rs
@@ -15,7 +15,9 @@ fn build_registry() -> (VerbRegistry, KhiveRuntime, tempfile::TempDir) {
     let store = FsBlobStore::new(dir.path().to_path_buf(), 0).expect("fs blob store");
 
     let runtime = KhiveRuntime::memory().expect("in-memory runtime");
-    runtime.install_blob_store(std::sync::Arc::new(store));
+    runtime
+        .install_blob_store(std::sync::Arc::new(store))
+        .expect("install blob store");
 
     let mut builder = VerbRegistryBuilder::new();
     builder.register(BlobPack::new(runtime.clone()));

--- a/crates/khive-pack-brain/src/fold_gate.rs
+++ b/crates/khive-pack-brain/src/fold_gate.rs
@@ -523,6 +523,7 @@ mod tests {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             db_path: Some(db_path),
+            blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
             embedding_model: None,
             additional_embedding_models: vec![],
@@ -629,6 +630,7 @@ mod tests {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             db_path: Some(db_path),
+            blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
             embedding_model: None,
             additional_embedding_models: vec![],

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -2396,6 +2396,7 @@ fn make_pack_with_actor(actor_id: &str) -> (BrainPack, KhiveRuntime) {
     let rt = KhiveRuntime::new(khive_runtime::RuntimeConfig {
         git_write: Default::default(),
         db_path: None,
+        blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
         embedding_model: None,
         additional_embedding_models: vec![],

--- a/crates/khive-pack-brain/tests/resolve_actor.rs
+++ b/crates/khive-pack-brain/tests/resolve_actor.rs
@@ -14,6 +14,7 @@ fn runtime_with_actor(actor_id: Option<&str>) -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         db_path: None,
+        blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
         embedding_model: None,
         additional_embedding_models: vec![],

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -3125,6 +3125,7 @@ mod tests {
         let runtime = super::KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             db_path: None,
+            blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::parse(&ns).unwrap(),
             embedding_model: None,
             additional_embedding_models: vec![],
@@ -3645,6 +3646,7 @@ mod tests {
         let runtime = super::KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             db_path: None,
+            blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::parse(&ns).unwrap(),
             embedding_model: None,
             additional_embedding_models: vec![],
@@ -3760,6 +3762,7 @@ mod tests {
             let runtime = super::KhiveRuntime::new(RuntimeConfig {
                 git_write: Default::default(),
                 db_path: None,
+                blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
                 default_namespace: Namespace::parse(&ns).unwrap(),
                 embedding_model: None,
                 additional_embedding_models: vec![],

--- a/crates/khive-pack-comm/src/message.rs
+++ b/crates/khive-pack-comm/src/message.rs
@@ -454,6 +454,7 @@ mod tests {
         let runtime = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             db_path: None,
+            blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::parse(&sender_ns).unwrap(),
             embedding_model: None,
             additional_embedding_models: vec![],
@@ -530,6 +531,7 @@ mod tests {
         let runtime = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             db_path: None,
+            blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::parse(ns).unwrap(),
             embedding_model: None,
             additional_embedding_models: vec![],
@@ -671,6 +673,7 @@ mod tests {
         let runtime = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             db_path: None,
+            blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::parse(&sender_ns).unwrap(),
             embedding_model: None,
             additional_embedding_models: vec![],
@@ -831,6 +834,7 @@ mod tests {
         let runtime = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             db_path: None,
+            blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
             embedding_model: None,
             additional_embedding_models: vec![],

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -3809,6 +3809,7 @@ fn build_crossns_registry(
     let config = RuntimeConfig {
         git_write: Default::default(),
         db_path: None,
+        blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::parse(dispatch_ns).unwrap(),
         embedding_model: None,
         additional_embedding_models: vec![],
@@ -4909,6 +4910,7 @@ fn build_actor_registry(
     let config = RuntimeConfig {
         git_write: Default::default(),
         db_path: None,
+        blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
         embedding_model: None,
         additional_embedding_models: vec![],
@@ -5251,6 +5253,7 @@ async fn t_c2_gate_receives_configured_actor_not_anonymous() {
     let config = RuntimeConfig {
         git_write: Default::default(),
         db_path: None,
+        blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
         embedding_model: None,
         additional_embedding_models: vec![],
@@ -5403,6 +5406,7 @@ async fn i199_anonymous_inbox_cannot_read_messages_addressed_to_other_actor() {
     let config_anon = RuntimeConfig {
         git_write: Default::default(),
         db_path: None,
+        blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
         embedding_model: None,
         additional_embedding_models: vec![],

--- a/crates/khive-pack-comm/tests/probe.rs
+++ b/crates/khive-pack-comm/tests/probe.rs
@@ -1011,6 +1011,7 @@ async fn probe_backfills_pre_existing_messages_across_v6_to_v7_upgrade() {
     let config = RuntimeConfig {
         git_write: Default::default(),
         db_path: Some(path.clone()),
+        blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
         embedding_model: None,
         additional_embedding_models: vec![],
@@ -1194,6 +1195,7 @@ async fn probe_repairs_partial_notes_seq_left_by_original_v7_on_reopen() {
     let config = RuntimeConfig {
         git_write: Default::default(),
         db_path: Some(path.clone()),
+        blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
         embedding_model: None,
         additional_embedding_models: vec![],

--- a/crates/khive-pack-git/tests/acceptance.rs
+++ b/crates/khive-pack-git/tests/acceptance.rs
@@ -7271,6 +7271,7 @@ async fn ingest_over_cap_commit_embedding_is_semantically_retrievable() {
     let rt = KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         db_path: None,
+        blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
         embedding_model: Some(MODEL),
         additional_embedding_models: vec![],

--- a/crates/khive-pack-knowledge/benches/knowledge_bench.rs
+++ b/crates/khive-pack-knowledge/benches/knowledge_bench.rs
@@ -21,6 +21,7 @@ fn build_runtime() -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         db_path: None,
+        blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
         embedding_model: None,
         additional_embedding_models: vec![],

--- a/crates/khive-pack-knowledge/benches/search_latency.rs
+++ b/crates/khive-pack-knowledge/benches/search_latency.rs
@@ -28,6 +28,7 @@ fn rt_with_embedder() -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         db_path: None,
+        blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
         embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
         additional_embedding_models: vec![],

--- a/crates/khive-pack-knowledge/src/handlers.rs
+++ b/crates/khive-pack-knowledge/src/handlers.rs
@@ -929,6 +929,7 @@ mod tests {
         let rt = KhiveRuntime::new(khive_runtime::RuntimeConfig {
             git_write: Default::default(),
             db_path: None,
+            blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
             embedding_model: None,
             additional_embedding_models: vec![],

--- a/crates/khive-pack-knowledge/src/knowledge/ann_degrade_tests.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/ann_degrade_tests.rs
@@ -171,6 +171,7 @@ fn rt_with_fake_embedder() -> KhiveRuntime {
     let rt = KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         db_path: None,
+        blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
         embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
         additional_embedding_models: vec![],
@@ -191,6 +192,7 @@ fn rt_with_controlled_ranking(fail_fresh_rerank: bool) -> KhiveRuntime {
     let rt = KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         db_path: None,
+        blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
         embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
         additional_embedding_models: vec![],
@@ -215,6 +217,7 @@ fn file_rt_with_fake_embedder(db_path: std::path::PathBuf) -> KhiveRuntime {
     let rt = KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         db_path: Some(db_path),
+        blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
         embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
         additional_embedding_models: vec![],

--- a/crates/khive-pack-knowledge/src/knowledge/suggest_ranking_tests.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/suggest_ranking_tests.rs
@@ -168,6 +168,7 @@ fn rt_with_fixture_embedder() -> KhiveRuntime {
     let rt = KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         db_path: None,
+        blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
         embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
         additional_embedding_models: vec![],

--- a/crates/khive-pack-knowledge/src/knowledge/vamana.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/vamana.rs
@@ -4256,6 +4256,7 @@ mod tests {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             db_path,
+            blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
             embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
             additional_embedding_models: vec![],

--- a/crates/khive-pack-knowledge/tests/bench.rs
+++ b/crates/khive-pack-knowledge/tests/bench.rs
@@ -28,6 +28,7 @@ fn rt_with_embedder() -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         db_path: None,
+        blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
         embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
         additional_embedding_models: vec![],

--- a/crates/khive-pack-knowledge/tests/feedback.rs
+++ b/crates/khive-pack-knowledge/tests/feedback.rs
@@ -22,6 +22,7 @@ fn make_rt(brain_profile: Option<String>, with_brain: bool) -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         db_path: None,
+        blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         embedding_model: None,
         additional_embedding_models: vec![],
         packs,
@@ -38,6 +39,7 @@ fn make_rt_with_actor(actor: &str) -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         db_path: None,
+        blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
         embedding_model: None,
         additional_embedding_models: vec![],

--- a/crates/khive-pack-knowledge/tests/fixes.rs
+++ b/crates/khive-pack-knowledge/tests/fixes.rs
@@ -1630,6 +1630,7 @@ fn rt_with_default_embedder() -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         db_path: None,
+        blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
         embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
         additional_embedding_models: vec![],
@@ -2305,6 +2306,7 @@ mod embed_failure_tests {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             db_path: None,
+            blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
             embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
             additional_embedding_models: vec![],
@@ -2491,6 +2493,7 @@ mod embed_failure_tests {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             db_path: None,
+            blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
             embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
             additional_embedding_models: vec![EmbeddingModel::ParaphraseMultilingualMiniLmL12V2],
@@ -2805,6 +2808,7 @@ mod ann_bypass_regression {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             db_path: None,
+            blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
             embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
             additional_embedding_models: vec![],
@@ -3402,6 +3406,7 @@ mod edit_inline_reembed {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             db_path: None,
+            blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
             embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
             additional_embedding_models: vec![],
@@ -3805,6 +3810,7 @@ mod ann_type_filter_regression {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             db_path: None,
+            blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
             embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
             additional_embedding_models: vec![],
@@ -4209,6 +4215,7 @@ mod compose_explain_sections {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             db_path: None,
+            blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
             embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
             additional_embedding_models: vec![],

--- a/crates/khive-pack-knowledge/tests/integration.rs
+++ b/crates/khive-pack-knowledge/tests/integration.rs
@@ -1809,6 +1809,7 @@ async fn index_reembed_paging_sweep_covers_equal_created_at_in_order() {
     let rt = KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         db_path: None,
+        blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
         embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
         additional_embedding_models: vec![],
@@ -3965,6 +3966,7 @@ mod kg_blend {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             db_path: None,
+            blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
             embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
             additional_embedding_models: vec![],
@@ -4593,6 +4595,7 @@ mod kg_blend {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             db_path: None,
+            blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
             embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
             additional_embedding_models: vec![],

--- a/crates/khive-pack-knowledge/tests/search_candidate_refill.rs
+++ b/crates/khive-pack-knowledge/tests/search_candidate_refill.rs
@@ -144,6 +144,7 @@ fn runtime_with_embedder() -> KhiveRuntime {
     let runtime = KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         db_path: None,
+        blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
         embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
         additional_embedding_models: vec![],

--- a/crates/khive-pack-moodboard/src/handlers.rs
+++ b/crates/khive-pack-moodboard/src/handlers.rs
@@ -937,7 +937,9 @@ mod tests {
 
         let root = tempfile::tempdir().unwrap();
         let blob_store = Arc::new(FsBlobStore::new(root.path().to_path_buf(), 0).unwrap());
-        runtime.install_blob_store(blob_store.clone());
+        runtime
+            .install_blob_store(blob_store.clone())
+            .expect("install blob store");
         let primary_ref = blob_store.put(b"primary".to_vec()).await.unwrap();
         let extra_ref = blob_store.put(b"extra".to_vec()).await.unwrap();
         let mut primary_entity =
@@ -1000,7 +1002,9 @@ mod tests {
             .expect("authorize");
         let root = tempfile::tempdir().unwrap();
         let blob_store = Arc::new(FsBlobStore::new(root.path().to_path_buf(), 0).unwrap());
-        pack.runtime().install_blob_store(blob_store.clone());
+        pack.runtime()
+            .install_blob_store(blob_store.clone())
+            .expect("install blob store");
         let query_ref = blob_store
             .put(b"core query original".to_vec())
             .await
@@ -1109,7 +1113,9 @@ mod tests {
         let descriptor = DescriptorIdentity::fixture(4);
         let root = tempfile::tempdir().unwrap();
         let blob_store = Arc::new(FsBlobStore::new(root.path().to_path_buf(), 0).unwrap());
-        runtime.install_blob_store(blob_store.clone());
+        runtime
+            .install_blob_store(blob_store.clone())
+            .expect("install blob store");
         let live_ref = blob_store.put(b"live original".to_vec()).await.unwrap();
         let stale = Uuid::new_v4();
         let live = Entity::new(token.namespace().as_str(), "artifact", "live candidate")
@@ -1180,7 +1186,9 @@ mod tests {
         let token = runtime.authorize(Namespace::local()).expect("authorize");
         let root = tempfile::tempdir().unwrap();
         let blob_store = Arc::new(FsBlobStore::new(root.path().to_path_buf(), 0).unwrap());
-        runtime.install_blob_store(blob_store.clone());
+        runtime
+            .install_blob_store(blob_store.clone())
+            .expect("install blob store");
         let content_ref = blob_store
             .put(b"same original bytes".to_vec())
             .await

--- a/crates/khive-pack-moodboard/src/preference_handlers.rs
+++ b/crates/khive-pack-moodboard/src/preference_handlers.rs
@@ -1594,6 +1594,7 @@ mod tests {
         KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             db_path: Some(db_path.to_path_buf()),
+            blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
             embedding_model: None,
             additional_embedding_models: vec![],
@@ -1651,7 +1652,9 @@ mod tests {
         let blob_root = temp.path().join("blobs");
         let runtime = persistent_runtime(&db_path, "alice");
         let blob_store = Arc::new(FsBlobStore::new(blob_root.clone(), 0).unwrap());
-        runtime.install_blob_store(blob_store.clone());
+        runtime
+            .install_blob_store(blob_store.clone())
+            .expect("install blob store");
         let token = runtime.authorize(Namespace::local()).unwrap();
         let content_ref = blob_store
             .put(b"moodboard candidate raster bytes".to_vec())
@@ -1871,7 +1874,9 @@ mod tests {
         let blob_root = temp.path().join("blobs");
         let runtime = persistent_runtime(&db_path, "alice");
         let blob_store = Arc::new(FsBlobStore::new(blob_root.clone(), 0).unwrap());
-        runtime.install_blob_store(blob_store.clone());
+        runtime
+            .install_blob_store(blob_store.clone())
+            .expect("install blob store");
         let token = runtime.authorize(Namespace::local()).unwrap();
         let scope = PreferenceScope {
             namespace: "local".to_string(),
@@ -2006,7 +2011,9 @@ mod tests {
         drop(blob_store);
 
         let restarted = persistent_runtime(&db_path, "alice");
-        restarted.install_blob_store(Arc::new(FsBlobStore::new(blob_root, 0).unwrap()));
+        restarted
+            .install_blob_store(Arc::new(FsBlobStore::new(blob_root, 0).unwrap()))
+            .expect("install blob store");
         let restarted_token = restarted.authorize(Namespace::local()).unwrap();
         let loaded = load_preference_model(&restarted, &restarted_token, model_id, &scope)
             .await

--- a/crates/khive-pack-moodboard/tests/integration.rs
+++ b/crates/khive-pack-moodboard/tests/integration.rs
@@ -253,7 +253,9 @@ async fn attributed_serve_randomizes_occurrences_and_judgment_is_immutable() {
     let runtime = KhiveRuntime::memory().expect("memory runtime");
     let root = tempfile::tempdir().expect("blob root");
     let blob_store = Arc::new(FsBlobStore::new(root.path().to_path_buf(), 0).expect("blob store"));
-    runtime.install_blob_store(blob_store.clone());
+    runtime
+        .install_blob_store(blob_store.clone())
+        .expect("install blob store");
     let setup_token = runtime
         .authorize(Namespace::parse("moodboard-source").expect("source namespace"))
         .expect("setup token");
@@ -505,7 +507,9 @@ async fn public_training_publishes_calibrated_fann_and_preference_stays_nonconfo
     let (runtime, moodboard_runtime) = core_and_moodboard_runtimes();
     let root = tempfile::tempdir().expect("blob root");
     let blob_store = Arc::new(FsBlobStore::new(root.path().to_path_buf(), 0).expect("blob store"));
-    moodboard_runtime.install_blob_store(blob_store.clone());
+    moodboard_runtime
+        .install_blob_store(blob_store.clone())
+        .expect("install blob store");
     let setup_token = runtime.authorize(Namespace::local()).expect("setup token");
     let board_fingerprint = "a".repeat(64);
     let descriptor_fingerprint = "b".repeat(64);

--- a/crates/khive-pack-session/src/mirror/ingest.rs
+++ b/crates/khive-pack-session/src/mirror/ingest.rs
@@ -1104,6 +1104,7 @@ mod tests {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             db_path: Some(db_path),
+            blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
             embedding_model: None,
             additional_embedding_models: vec![],

--- a/crates/khive-pack-session/src/mirror/service.rs
+++ b/crates/khive-pack-session/src/mirror/service.rs
@@ -2626,6 +2626,7 @@ mod cursor_retry_tests {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             db_path: Some(db_path),
+            blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
             embedding_model: None,
             additional_embedding_models: vec![],

--- a/crates/khive-pack-session/tests/integration.rs
+++ b/crates/khive-pack-session/tests/integration.rs
@@ -22,6 +22,7 @@ fn file_rt(db_path: std::path::PathBuf) -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         db_path: Some(db_path),
+        blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
         embedding_model: None,
         additional_embedding_models: vec![],

--- a/crates/khive-runtime/README.md
+++ b/crates/khive-runtime/README.md
@@ -9,6 +9,10 @@ verb-dispatch machinery that lets packs (`kg`, `gtd`, `memory`, …) extend the 
 - **`KhiveRuntime`** — a cloneable handle wrapping a `khive-db::StorageBackend` with
   namespace-scoped accessors for every storage capability, plus a lazily-configured
   embedder registry
+- **`BlobHydrator`** — one store-paired, runtime-shared weighted byte budget for
+  bounded, digest-verified whole-blob reads. Its non-cloneable `VerifiedBlob`
+  keeps admission until callers finish using the borrowed bytes, and tracked
+  supervisors keep native work visible to daemon drain after request cancellation
 - **`VerbRegistry` / `VerbRegistryBuilder`** — registers packs (`PackRuntime` impls),
   an authorization `Gate`, an actor identity, and dispatches verbs by name
 - **`PackRuntime` trait** — the object-safe runtime counterpart to `khive-types::Pack`;
@@ -68,9 +72,9 @@ let result = registry
                         │
               StorageBackend (khive-db)
                         │
-     ┌──────────────────┼──────────────────────┐
-authorize(ns)     entities/graph/notes/…   embedder(name)
-     │             (khive-storage traits)  (lattice-embed)
+     ┌──────────────────┼─────────────────────────────┐
+authorize(ns)     entities/graph/notes/…   BlobHydrator / embedder(name)
+     │             (khive-storage traits)  (bounded bytes / lattice-embed)
      ▼
 NamespaceToken ──── VerbRegistryBuilder::register(pack) × N
                          │

--- a/crates/khive-runtime/docs/design.md
+++ b/crates/khive-runtime/docs/design.md
@@ -20,6 +20,24 @@
 - The audit payload field holds the full `AuditEvent` envelope (not a bare verb result)
 - Top-level event fields follow the ADR-004/ADR-005 schema
 
+### Shared Blob Hydration (ADR-160 D3)
+
+- Each installed `BlobStore` is paired with one immutable, runtime-owned
+  `Arc<BlobHydrator>`; default, core, and pack runtime handles sharing that
+  store receive the same hydrator and therefore one aggregate byte budget
+- Admission reserves the caller's declared whole-object maximum before backend
+  I/O. `[runtime] blob_hydration_bytes` defaults to 256 MiB and startup rejects
+  values below the portable 64 MiB object envelope
+- `VerifiedBlob` exposes borrowed bytes and retains its weighted lease until
+  drop; it has no clone or owned-byte extraction API
+- A tracked supervisor owns admitted backend work. Request cancellation drops
+  only the waiter, while capacity remains charged until native work ends; daemon
+  drain observes the supervisor through ADR-119 background-task accounting
+- Raw store access remains temporarily available for mutation, stat, existence,
+  and compatibility with the still-unmigrated whole-buffer readers. ADR-160
+  Phase 3 routes those production reads through `BlobHydrator` and removes the
+  raw read surface
+
 ### Namespace Strategy (Rev 6) (ADR-007)
 
 - Namespace is attribution and gate-policy input, not a storage partition; it is not a

--- a/crates/khive-runtime/src/blob.rs
+++ b/crates/khive-runtime/src/blob.rs
@@ -17,7 +17,160 @@ use khive_storage::{
 };
 
 use crate::engine_config::BlobConfig;
-use crate::KhiveConfig;
+use crate::{KhiveConfig, RuntimeError, RuntimeResult};
+
+/// Default process-local admission budget for resident verified blob buffers.
+pub const DEFAULT_BLOB_HYDRATION_BYTES: u64 = 4 * khive_storage::MAX_BLOB_WHOLE_BYTES;
+
+/// Runtime-owned bounded blob hydration with weighted raw-byte admission.
+#[derive(Debug)]
+pub struct BlobHydrator {
+    store: Arc<dyn BlobStore>,
+    admission: Arc<tokio::sync::Semaphore>,
+    budget_bytes: u64,
+}
+
+impl BlobHydrator {
+    /// Pair one store with one aggregate byte budget.
+    pub fn new(store: Arc<dyn BlobStore>, budget_bytes: u64) -> RuntimeResult<Self> {
+        if budget_bytes < khive_storage::MAX_BLOB_WHOLE_BYTES {
+            return Err(RuntimeError::InvalidInput(format!(
+                "blob hydration budget must be at least {} bytes, got {budget_bytes}",
+                khive_storage::MAX_BLOB_WHOLE_BYTES
+            )));
+        }
+        let permits = usize::try_from(budget_bytes).map_err(|_| {
+            RuntimeError::InvalidInput(format!(
+                "blob hydration budget {budget_bytes} does not fit this platform"
+            ))
+        })?;
+        if permits > tokio::sync::Semaphore::MAX_PERMITS {
+            return Err(RuntimeError::InvalidInput(format!(
+                "blob hydration budget {budget_bytes} exceeds the runtime maximum {}",
+                tokio::sync::Semaphore::MAX_PERMITS
+            )));
+        }
+        Ok(Self {
+            store,
+            admission: Arc::new(tokio::sync::Semaphore::new(permits)),
+            budget_bytes,
+        })
+    }
+
+    /// Return the resolved aggregate admission budget.
+    pub fn budget_bytes(&self) -> u64 {
+        self.budget_bytes
+    }
+
+    /// Clone the paired store for metadata and mutation paths.
+    ///
+    /// Whole-buffer production reads must use [`Self::hydrate_verified`].
+    pub(crate) fn store(&self) -> Arc<dyn BlobStore> {
+        Arc::clone(&self.store)
+    }
+
+    /// Hydrate one complete digest-verified object under weighted admission.
+    pub async fn hydrate_verified(
+        &self,
+        content_ref: &ContentRef,
+        max_bytes: u64,
+    ) -> RuntimeResult<VerifiedBlob> {
+        if max_bytes > khive_storage::MAX_BLOB_WHOLE_BYTES {
+            return Err(RuntimeError::InvalidInput(format!(
+                "blob hydration max_bytes must not exceed {} bytes, got {max_bytes}",
+                khive_storage::MAX_BLOB_WHOLE_BYTES
+            )));
+        }
+
+        let acquire = Arc::clone(&self.admission).acquire_many_owned(max_bytes as u32);
+        let admission =
+            khive_storage::await_request_read_phase("blob_hydration_admission", acquire)
+                .await?
+                .map_err(|error| {
+                    RuntimeError::Internal(format!("blob hydration admission closed: {error}"))
+                })?;
+
+        let (sender, receiver) = tokio::sync::oneshot::channel::<RuntimeResult<VerifiedBlob>>();
+        let store = Arc::clone(&self.store);
+        let content_ref = content_ref.clone();
+        crate::track_background_task(async move {
+            // The tracked supervisor itself owns backend work and the lease.
+            // Dropping a request only drops `receiver`; the supervisor stays
+            // visible to daemon drain until the backend future actually ends.
+            let result = match store.get_bounded_verified(&content_ref, max_bytes).await {
+                Ok(bytes) => Ok(VerifiedBlob {
+                    bytes,
+                    _admission: admission,
+                }),
+                Err(error) => Err(RuntimeError::Storage(error)),
+            };
+            let _ = sender.send(result);
+        });
+
+        khive_storage::await_request_read_phase("blob_hydration", receiver)
+            .await?
+            .map_err(|_| {
+                RuntimeError::Internal(
+                    "blob hydration supervisor ended without delivering a result".to_string(),
+                )
+            })?
+    }
+}
+
+/// One verified raw blob buffer and its aggregate admission lease.
+///
+/// The wrapper intentionally has no `Clone` or owned-byte extraction API.
+/// Borrowed bytes may still be copied under the caller's own allocation budget.
+///
+/// ```compile_fail
+/// use khive_runtime::VerifiedBlob;
+///
+/// fn clone_verified(blob: &VerifiedBlob) {
+///     let _ = <VerifiedBlob as Clone>::clone(blob);
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use khive_runtime::VerifiedBlob;
+///
+/// fn extract_owned(blob: VerifiedBlob) -> Vec<u8> {
+///     blob.into_bytes()
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use khive_runtime::VerifiedBlob;
+///
+/// fn access_private_storage(blob: &VerifiedBlob) -> usize {
+///     blob.bytes.len()
+/// }
+/// ```
+pub struct VerifiedBlob {
+    bytes: Vec<u8>,
+    _admission: tokio::sync::OwnedSemaphorePermit,
+}
+
+impl VerifiedBlob {
+    /// Borrow the verified bytes without releasing weighted admission.
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
+impl AsRef<[u8]> for VerifiedBlob {
+    fn as_ref(&self) -> &[u8] {
+        self.bytes()
+    }
+}
+
+impl std::fmt::Debug for VerifiedBlob {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("VerifiedBlob")
+            .field("len", &self.bytes.len())
+            .finish_non_exhaustive()
+    }
+}
 
 /// Resolve the `BlobStore` this `backend` should use, per `cfg.storage.blob`.
 ///
@@ -172,6 +325,7 @@ impl BlobStore for ReadOnlyBlobStore {
 mod tests {
     use super::*;
     use crate::engine_config::StorageSectionConfig;
+    use serial_test::serial;
 
     #[derive(Debug, Default)]
     struct RecordingReadStore {
@@ -225,6 +379,531 @@ mod tests {
         let bytes = store.get_bounded_verified(&content_ref, 17).await.unwrap();
         assert_eq!(bytes, b"verified");
         assert_eq!(*inner.bounded_call.lock().unwrap(), Some((content_ref, 17)));
+    }
+
+    #[derive(Debug)]
+    struct HydrationReadStore {
+        calls: std::sync::atomic::AtomicUsize,
+        bytes: Vec<u8>,
+        first_started: std::sync::Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+        first_release: Option<Arc<tokio::sync::Semaphore>>,
+        fail_first: bool,
+        panic_first: bool,
+    }
+
+    impl HydrationReadStore {
+        fn immediate(bytes: Vec<u8>) -> Arc<Self> {
+            Arc::new(Self {
+                calls: std::sync::atomic::AtomicUsize::new(0),
+                bytes,
+                first_started: std::sync::Mutex::new(None),
+                first_release: None,
+                fail_first: false,
+                panic_first: false,
+            })
+        }
+
+        fn blocking_first(
+            bytes: Vec<u8>,
+        ) -> (
+            Arc<Self>,
+            tokio::sync::oneshot::Receiver<()>,
+            Arc<tokio::sync::Semaphore>,
+        ) {
+            let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+            let release = Arc::new(tokio::sync::Semaphore::new(0));
+            (
+                Arc::new(Self {
+                    calls: std::sync::atomic::AtomicUsize::new(0),
+                    bytes,
+                    first_started: std::sync::Mutex::new(Some(started_tx)),
+                    first_release: Some(Arc::clone(&release)),
+                    fail_first: false,
+                    panic_first: false,
+                }),
+                started_rx,
+                release,
+            )
+        }
+
+        fn blocking_first_panic(
+            bytes: Vec<u8>,
+        ) -> (
+            Arc<Self>,
+            tokio::sync::oneshot::Receiver<()>,
+            Arc<tokio::sync::Semaphore>,
+        ) {
+            let (store, started, release) = Self::blocking_first(bytes);
+            let store = Arc::try_unwrap(store).expect("new fixture has one owner");
+            (
+                Arc::new(Self {
+                    panic_first: true,
+                    ..store
+                }),
+                started,
+                release,
+            )
+        }
+
+        fn blocking_first_error(
+            bytes: Vec<u8>,
+        ) -> (
+            Arc<Self>,
+            tokio::sync::oneshot::Receiver<()>,
+            Arc<tokio::sync::Semaphore>,
+        ) {
+            let (store, started, release) = Self::blocking_first(bytes);
+            let store = Arc::try_unwrap(store).expect("new fixture has one owner");
+            (
+                Arc::new(Self {
+                    fail_first: true,
+                    ..store
+                }),
+                started,
+                release,
+            )
+        }
+
+        fn calls(&self) -> usize {
+            self.calls.load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait]
+    impl BlobStore for HydrationReadStore {
+        async fn put(&self, _bytes: Vec<u8>) -> StorageResult<ContentRef> {
+            panic!("put is not used by hydrator tests")
+        }
+
+        async fn get(&self, _content_ref: &ContentRef) -> StorageResult<Vec<u8>> {
+            panic!("legacy get must not service hydration")
+        }
+
+        async fn get_bounded_verified(
+            &self,
+            content_ref: &ContentRef,
+            _max_bytes: u64,
+        ) -> StorageResult<Vec<u8>> {
+            let call = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            if call == 0 {
+                if let Some(started) = self.first_started.lock().unwrap().take() {
+                    let _ = started.send(());
+                }
+                if let Some(release) = &self.first_release {
+                    release
+                        .clone()
+                        .acquire_owned()
+                        .await
+                        .expect("test release semaphore stays open")
+                        .forget();
+                }
+                if self.fail_first {
+                    return Err(StorageError::BlobDigestMismatch {
+                        expected: content_ref.clone(),
+                        actual: ContentRef::from_hex("b".repeat(64))
+                            .expect("fixture digest is canonical"),
+                    });
+                }
+                assert!(!self.panic_first, "injected hydration backend panic");
+            }
+            Ok(self.bytes.clone())
+        }
+
+        async fn exists(&self, _content_ref: &ContentRef) -> StorageResult<bool> {
+            panic!("exists is not used by hydrator tests")
+        }
+
+        async fn size(&self, _content_ref: &ContentRef) -> StorageResult<Option<u64>> {
+            panic!("size is not used by hydrator tests")
+        }
+
+        async fn delete(&self, _content_ref: &ContentRef) -> StorageResult<bool> {
+            panic!("delete is not used by hydrator tests")
+        }
+    }
+
+    async fn wait_for_hydration_calls(store: &HydrationReadStore, expected: usize) {
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while store.calls() != expected {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("hydration backend call count should advance");
+    }
+
+    async fn wait_for_background_task_count(expected: usize) {
+        for _ in 0..10_000 {
+            if crate::background_task_count() == expected {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(crate::background_task_count(), expected);
+    }
+
+    #[tokio::test]
+    async fn hydrator_rejects_an_invalid_maximum_before_admission_or_backend_work() {
+        let store = HydrationReadStore::immediate(b"x".to_vec());
+        let hydrator = BlobHydrator::new(
+            Arc::clone(&store) as Arc<dyn BlobStore>,
+            khive_storage::MAX_BLOB_WHOLE_BYTES,
+        )
+        .unwrap();
+        let content_ref = ContentRef::from_hex("a".repeat(64)).unwrap();
+
+        let error = hydrator
+            .hydrate_verified(&content_ref, khive_storage::MAX_BLOB_WHOLE_BYTES + 1)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, crate::RuntimeError::InvalidInput(_)));
+        assert_eq!(store.calls(), 0);
+    }
+
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn zero_maximum_and_idle_portable_maximum_are_both_admissible() {
+        let before = crate::background_task_count();
+        let empty_store = HydrationReadStore::immediate(Vec::new());
+        let empty_hydrator = BlobHydrator::new(
+            Arc::clone(&empty_store) as Arc<dyn BlobStore>,
+            khive_storage::MAX_BLOB_WHOLE_BYTES,
+        )
+        .unwrap();
+        let content_ref = ContentRef::from_hex("a".repeat(64)).unwrap();
+
+        let empty = empty_hydrator
+            .hydrate_verified(&content_ref, 0)
+            .await
+            .expect("zero is a valid declared maximum");
+        assert!(empty.bytes().is_empty());
+        drop(empty);
+
+        let max_store = HydrationReadStore::immediate(b"bounded".to_vec());
+        let max_hydrator = BlobHydrator::new(
+            Arc::clone(&max_store) as Arc<dyn BlobStore>,
+            khive_storage::MAX_BLOB_WHOLE_BYTES,
+        )
+        .unwrap();
+        let max = max_hydrator
+            .hydrate_verified(&content_ref, khive_storage::MAX_BLOB_WHOLE_BYTES)
+            .await
+            .expect("an idle minimum-size budget admits every valid maximum");
+        assert_eq!(max.bytes(), b"bounded");
+        drop(max);
+        wait_for_background_task_count(before).await;
+    }
+
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn cancelling_a_waiter_retains_admission_until_backend_completion() {
+        let before = crate::background_task_count();
+        let (store, first_started, first_release) =
+            HydrationReadStore::blocking_first(b"x".to_vec());
+        let hydrator = Arc::new(
+            BlobHydrator::new(
+                Arc::clone(&store) as Arc<dyn BlobStore>,
+                khive_storage::MAX_BLOB_WHOLE_BYTES,
+            )
+            .unwrap(),
+        );
+        let content_ref = ContentRef::from_hex("a".repeat(64)).unwrap();
+
+        let first_hydrator = Arc::clone(&hydrator);
+        let first_ref = content_ref.clone();
+        let first = tokio::spawn(async move {
+            first_hydrator
+                .hydrate_verified(&first_ref, khive_storage::MAX_BLOB_WHOLE_BYTES)
+                .await
+        });
+        first_started.await.expect("first backend read must start");
+        assert_eq!(crate::background_task_count(), before + 1);
+
+        first.abort();
+        assert!(first.await.unwrap_err().is_cancelled());
+
+        let second_hydrator = Arc::clone(&hydrator);
+        let second_ref = content_ref.clone();
+        let second =
+            tokio::spawn(async move { second_hydrator.hydrate_verified(&second_ref, 1).await });
+        assert_eq!(hydrator.admission.available_permits(), 0);
+        assert_eq!(
+            store.calls(),
+            1,
+            "cancelled waiters must not release admission held by native work"
+        );
+
+        first_release.add_permits(1);
+        let verified = tokio::time::timeout(std::time::Duration::from_secs(1), second)
+            .await
+            .expect("second waiter should acquire after native completion")
+            .expect("second waiter task should not panic")
+            .expect("second hydration should succeed");
+        assert_eq!(verified.bytes(), b"x");
+        drop(verified);
+        wait_for_hydration_calls(&store, 2).await;
+
+        wait_for_background_task_count(before).await;
+    }
+
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn verified_blob_retains_its_weighted_lease_until_drop() {
+        let before = crate::background_task_count();
+        let store = HydrationReadStore::immediate(b"x".to_vec());
+        let hydrator = Arc::new(
+            BlobHydrator::new(
+                Arc::clone(&store) as Arc<dyn BlobStore>,
+                khive_storage::MAX_BLOB_WHOLE_BYTES,
+            )
+            .unwrap(),
+        );
+        let content_ref = ContentRef::from_hex("a".repeat(64)).unwrap();
+
+        let first = hydrator
+            .hydrate_verified(&content_ref, khive_storage::MAX_BLOB_WHOLE_BYTES)
+            .await
+            .unwrap();
+        assert_eq!(first.bytes(), b"x");
+
+        let second_hydrator = Arc::clone(&hydrator);
+        let second_ref = content_ref.clone();
+        let second =
+            tokio::spawn(async move { second_hydrator.hydrate_verified(&second_ref, 1).await });
+        assert_eq!(hydrator.admission.available_permits(), 0);
+        assert_eq!(
+            store.calls(),
+            1,
+            "borrowed access must not release the original raw-buffer lease"
+        );
+
+        drop(first);
+        let second = tokio::time::timeout(std::time::Duration::from_secs(1), second)
+            .await
+            .expect("dropping VerifiedBlob should release its lease")
+            .expect("second waiter task should not panic")
+            .expect("second hydration should succeed");
+        assert_eq!(second.bytes(), b"x");
+        drop(second);
+        wait_for_background_task_count(before).await;
+    }
+
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn cancelling_while_queued_starts_no_backend_work() {
+        let before = crate::background_task_count();
+        let store = HydrationReadStore::immediate(b"x".to_vec());
+        let hydrator = Arc::new(
+            BlobHydrator::new(
+                Arc::clone(&store) as Arc<dyn BlobStore>,
+                khive_storage::MAX_BLOB_WHOLE_BYTES,
+            )
+            .unwrap(),
+        );
+        let content_ref = ContentRef::from_hex("a".repeat(64)).unwrap();
+        let first = hydrator
+            .hydrate_verified(&content_ref, khive_storage::MAX_BLOB_WHOLE_BYTES)
+            .await
+            .unwrap();
+
+        let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+        let queued_hydrator = Arc::clone(&hydrator);
+        let queued_ref = content_ref.clone();
+        let queued = tokio::spawn(async move {
+            khive_storage::scope_request_read_cancellation(cancel_rx, async move {
+                let _ = entered_tx.send(());
+                queued_hydrator.hydrate_verified(&queued_ref, 1).await
+            })
+            .await
+        });
+        entered_rx.await.expect("queued request must be polled");
+        cancel_tx.send(true).unwrap();
+
+        let error = queued.await.unwrap().unwrap_err();
+        assert!(matches!(
+            error,
+            RuntimeError::Storage(StorageError::Timeout { .. })
+        ));
+        assert_eq!(hydrator.admission.available_permits(), 0);
+        assert_eq!(store.calls(), 1, "queued cancellation must start no I/O");
+        drop(first);
+        wait_for_background_task_count(before).await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    #[serial(background_tasks)]
+    async fn caller_deadline_drops_only_the_waiter_until_backend_completion() {
+        let before = crate::background_task_count();
+        let (store, first_started, first_release) =
+            HydrationReadStore::blocking_first(b"x".to_vec());
+        let hydrator = Arc::new(
+            BlobHydrator::new(
+                Arc::clone(&store) as Arc<dyn BlobStore>,
+                khive_storage::MAX_BLOB_WHOLE_BYTES,
+            )
+            .unwrap(),
+        );
+        let content_ref = ContentRef::from_hex("a".repeat(64)).unwrap();
+        let timed_hydrator = Arc::clone(&hydrator);
+        let timed_ref = content_ref.clone();
+        let timed = tokio::spawn(async move {
+            khive_storage::scope_request_read_deadline(
+                std::time::Duration::from_secs(1),
+                timed_hydrator.hydrate_verified(&timed_ref, khive_storage::MAX_BLOB_WHOLE_BYTES),
+            )
+            .await
+        });
+        first_started.await.expect("backend work must start");
+        tokio::time::advance(std::time::Duration::from_secs(1)).await;
+
+        let error = timed.await.unwrap().unwrap_err();
+        assert!(matches!(
+            error,
+            RuntimeError::Storage(StorageError::Timeout { .. })
+        ));
+        assert_eq!(crate::background_task_count(), before + 1);
+
+        let second_hydrator = Arc::clone(&hydrator);
+        let second_ref = content_ref.clone();
+        let second =
+            tokio::spawn(async move { second_hydrator.hydrate_verified(&second_ref, 1).await });
+        assert_eq!(hydrator.admission.available_permits(), 0);
+        assert_eq!(store.calls(), 1);
+
+        first_release.add_permits(1);
+        let verified = second.await.unwrap().unwrap();
+        assert_eq!(verified.bytes(), b"x");
+        drop(verified);
+        wait_for_hydration_calls(&store, 2).await;
+        wait_for_background_task_count(before).await;
+    }
+
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn distinct_hydrators_have_independent_admission_budgets() {
+        let before = crate::background_task_count();
+        let (blocked_store, started, release) = HydrationReadStore::blocking_first(b"one".to_vec());
+        let independent_store = HydrationReadStore::immediate(b"two".to_vec());
+        let blocked = Arc::new(
+            BlobHydrator::new(
+                Arc::clone(&blocked_store) as Arc<dyn BlobStore>,
+                khive_storage::MAX_BLOB_WHOLE_BYTES,
+            )
+            .unwrap(),
+        );
+        let independent = BlobHydrator::new(
+            Arc::clone(&independent_store) as Arc<dyn BlobStore>,
+            khive_storage::MAX_BLOB_WHOLE_BYTES,
+        )
+        .unwrap();
+        let content_ref = ContentRef::from_hex("a".repeat(64)).unwrap();
+
+        let blocked_hydrator = Arc::clone(&blocked);
+        let blocked_ref = content_ref.clone();
+        let in_flight = tokio::spawn(async move {
+            blocked_hydrator
+                .hydrate_verified(&blocked_ref, khive_storage::MAX_BLOB_WHOLE_BYTES)
+                .await
+        });
+        started.await.expect("first store must enter backend work");
+
+        let verified = independent
+            .hydrate_verified(&content_ref, khive_storage::MAX_BLOB_WHOLE_BYTES)
+            .await
+            .expect("a different store must retain an independent budget");
+        assert_eq!(verified.bytes(), b"two");
+        drop(verified);
+
+        release.add_permits(1);
+        drop(in_flight.await.unwrap().unwrap());
+        wait_for_background_task_count(before).await;
+    }
+
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn typed_backend_failure_holds_then_releases_admission() {
+        let before = crate::background_task_count();
+        let (store, started, release) =
+            HydrationReadStore::blocking_first_error(b"recovered".to_vec());
+        let hydrator = Arc::new(
+            BlobHydrator::new(
+                Arc::clone(&store) as Arc<dyn BlobStore>,
+                khive_storage::MAX_BLOB_WHOLE_BYTES,
+            )
+            .unwrap(),
+        );
+        let content_ref = ContentRef::from_hex("a".repeat(64)).unwrap();
+
+        let failing_hydrator = Arc::clone(&hydrator);
+        let failing_ref = content_ref.clone();
+        let failing = tokio::spawn(async move {
+            failing_hydrator
+                .hydrate_verified(&failing_ref, khive_storage::MAX_BLOB_WHOLE_BYTES)
+                .await
+        });
+        started.await.expect("failing backend work must start");
+
+        let retry_hydrator = Arc::clone(&hydrator);
+        let retry_ref = content_ref.clone();
+        let retry =
+            tokio::spawn(async move { retry_hydrator.hydrate_verified(&retry_ref, 1).await });
+        assert_eq!(hydrator.admission.available_permits(), 0);
+        assert_eq!(store.calls(), 1);
+
+        release.add_permits(1);
+        let error = failing.await.unwrap().unwrap_err();
+        assert!(matches!(
+            error,
+            RuntimeError::Storage(StorageError::BlobDigestMismatch { .. })
+        ));
+
+        let verified = retry.await.unwrap().unwrap();
+        assert_eq!(verified.bytes(), b"recovered");
+        assert_eq!(store.calls(), 2);
+        drop(verified);
+        wait_for_background_task_count(before).await;
+    }
+
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn backend_panic_closes_the_reply_and_restores_admission() {
+        let before = crate::background_task_count();
+        let (store, started, release) =
+            HydrationReadStore::blocking_first_panic(b"recovered".to_vec());
+        let hydrator = Arc::new(
+            BlobHydrator::new(
+                Arc::clone(&store) as Arc<dyn BlobStore>,
+                khive_storage::MAX_BLOB_WHOLE_BYTES,
+            )
+            .unwrap(),
+        );
+        let content_ref = ContentRef::from_hex("a".repeat(64)).unwrap();
+
+        let panicking_hydrator = Arc::clone(&hydrator);
+        let panicking_ref = content_ref.clone();
+        let panicking = tokio::spawn(async move {
+            panicking_hydrator
+                .hydrate_verified(&panicking_ref, khive_storage::MAX_BLOB_WHOLE_BYTES)
+                .await
+        });
+        started.await.expect("panicking backend work must start");
+        assert_eq!(crate::background_task_count(), before + 1);
+        release.add_permits(1);
+
+        let error = panicking.await.unwrap().unwrap_err();
+        assert!(matches!(error, RuntimeError::Internal(_)));
+        wait_for_background_task_count(before).await;
+
+        let recovered = hydrator
+            .hydrate_verified(&content_ref, khive_storage::MAX_BLOB_WHOLE_BYTES)
+            .await
+            .expect("backend panic must not leak admission");
+        assert_eq!(recovered.bytes(), b"recovered");
+        assert_eq!(store.calls(), 2);
+        drop(recovered);
+        wait_for_background_task_count(before).await;
     }
 
     #[test]

--- a/crates/khive-runtime/src/config.rs
+++ b/crates/khive-runtime/src/config.rs
@@ -253,6 +253,13 @@ pub struct RuntimeConfig {
     /// Defaults to the shipped production set returned by
     /// [`RuntimeConfig::built_in_packs`].
     pub packs: Vec<String>,
+    /// Resolved aggregate admission budget for resident digest-verified blob
+    /// buffers (ADR-160 D3), in raw bytes.
+    ///
+    /// `[runtime].blob_hydration_bytes` may raise or lower the built-in 256 MiB
+    /// value, but config validation guarantees enough room for one maximum-size
+    /// whole-blob read.
+    pub blob_hydration_bytes: u64,
     /// Identifies this runtime's backend in a multi-backend deployment.
     ///
     /// Set by the boot path when constructing per-pack runtimes from `khive.toml`.
@@ -365,6 +372,7 @@ impl Default for RuntimeConfig {
             additional_embedding_models,
             gate: Arc::new(AllowAllGate),
             packs,
+            blob_hydration_bytes: crate::blob::DEFAULT_BLOB_HYDRATION_BYTES,
             backend_id: BackendId::main(),
             brain_profile,
             visible_namespaces: vec![],
@@ -703,6 +711,10 @@ pub fn runtime_config_from_khive_config(
         .or_else(|| base.actor_id.clone());
 
     let git_write = khive_cfg.git_write.clone();
+    let blob_hydration_bytes = khive_cfg
+        .runtime
+        .blob_hydration_bytes
+        .unwrap_or(base.blob_hydration_bytes);
 
     if khive_cfg.engines.is_empty() {
         return RuntimeConfig {
@@ -712,6 +724,7 @@ pub fn runtime_config_from_khive_config(
             allowed_outbound_namespaces,
             actor_id,
             git_write,
+            blob_hydration_bytes,
             ..base
         };
     }
@@ -747,6 +760,7 @@ pub fn runtime_config_from_khive_config(
         allowed_outbound_namespaces,
         actor_id,
         git_write,
+        blob_hydration_bytes,
         ..base
     }
 }
@@ -957,6 +971,14 @@ mod no_embeddings_tests {
         assert!(
             configured_embedding_models(&config).is_empty(),
             "no_embeddings() must yield zero configured embedders"
+        );
+    }
+
+    #[test]
+    fn blob_hydration_default_is_four_portable_whole_objects() {
+        assert_eq!(
+            RuntimeConfig::default().blob_hydration_bytes,
+            4 * khive_storage::MAX_BLOB_WHOLE_BYTES
         );
     }
 

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -838,7 +838,7 @@ struct BackgroundTaskGuard {
 impl Drop for BackgroundTaskGuard {
     fn drop(&mut self) {
         self.counter
-            .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+            .fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
     }
 }
 
@@ -852,7 +852,7 @@ pub fn track_background_task<F>(fut: F)
 where
     F: std::future::Future<Output = ()> + Send + 'static,
 {
-    background_tasks().fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    background_tasks().fetch_add(1, std::sync::atomic::Ordering::SeqCst);
     let guard = BackgroundTaskGuard {
         counter: background_tasks().clone(),
     };
@@ -865,7 +865,7 @@ where
 /// Current count of in-flight tasks started via [`track_background_task`].
 /// Exposed for tests; `drain()` reads the shared counter directly.
 pub fn background_task_count() -> usize {
-    background_tasks().load(std::sync::atomic::Ordering::Relaxed)
+    background_tasks().load(std::sync::atomic::Ordering::SeqCst)
 }
 
 /// Process-wide daemon shutdown signal (ADR-119).
@@ -1272,7 +1272,7 @@ struct ActiveConnectionGuard {
 #[cfg(unix)]
 impl ActiveConnectionGuard {
     fn claim(active: Arc<std::sync::atomic::AtomicUsize>) -> Self {
-        active.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        active.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         Self { active }
     }
 }
@@ -1281,7 +1281,7 @@ impl ActiveConnectionGuard {
 impl Drop for ActiveConnectionGuard {
     fn drop(&mut self) {
         self.active
-            .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+            .fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
     }
 }
 
@@ -2039,7 +2039,10 @@ async fn drain_with_timeout(
     timeout: std::time::Duration,
 ) -> bool {
     use std::sync::atomic::Ordering;
-    let remaining = || active.load(Ordering::Relaxed) + background_task_count();
+    // One sequentially-consistent order spans connection handoff and tracked
+    // task publication. Drain must not observe an ended connection and a
+    // stale pre-publication background count as two simultaneous zeroes.
+    let remaining = || active.load(Ordering::SeqCst) + background_task_count();
     if remaining() == 0 {
         return true;
     }
@@ -2047,7 +2050,7 @@ async fn drain_with_timeout(
     while remaining() > 0 {
         if tokio::time::Instant::now() >= deadline {
             tracing::warn!(
-                remaining_connections = active.load(Ordering::Relaxed),
+                remaining_connections = active.load(Ordering::SeqCst),
                 remaining_background_tasks = background_task_count(),
                 "drain timeout reached; forcing shutdown"
             );
@@ -2151,6 +2154,72 @@ mod khive_root_tests {
 mod tests {
     use super::*;
     use serial_test::serial;
+
+    #[derive(Debug)]
+    struct DrainBlockingBlobStore {
+        started: std::sync::Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+        release: Arc<tokio::sync::Semaphore>,
+    }
+
+    #[async_trait]
+    impl khive_storage::BlobStore for DrainBlockingBlobStore {
+        async fn put(
+            &self,
+            _bytes: Vec<u8>,
+        ) -> khive_storage::StorageResult<khive_storage::ContentRef> {
+            panic!("put is not used by the hydration drain test")
+        }
+
+        async fn get(
+            &self,
+            _content_ref: &khive_storage::ContentRef,
+        ) -> khive_storage::StorageResult<Vec<u8>> {
+            panic!("legacy get must not service hydration")
+        }
+
+        async fn get_bounded_verified(
+            &self,
+            _content_ref: &khive_storage::ContentRef,
+            _max_bytes: u64,
+        ) -> khive_storage::StorageResult<Vec<u8>> {
+            if let Some(started) = self
+                .started
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .take()
+            {
+                let _ = started.send(());
+            }
+            self.release
+                .clone()
+                .acquire_owned()
+                .await
+                .expect("test release semaphore remains open")
+                .forget();
+            Ok(b"late result".to_vec())
+        }
+
+        async fn exists(
+            &self,
+            _content_ref: &khive_storage::ContentRef,
+        ) -> khive_storage::StorageResult<bool> {
+            panic!("exists is not used by the hydration drain test")
+        }
+
+        async fn size(
+            &self,
+            _content_ref: &khive_storage::ContentRef,
+        ) -> khive_storage::StorageResult<Option<u64>> {
+            panic!("size is not used by the hydration drain test")
+        }
+
+        async fn delete(
+            &self,
+            _content_ref: &khive_storage::ContentRef,
+        ) -> khive_storage::StorageResult<bool> {
+            panic!("delete is not used by the hydration drain test")
+        }
+    }
 
     struct AppendCompletionEventStore {
         inner: Arc<dyn khive_storage::EventStore>,
@@ -2610,6 +2679,57 @@ mod tests {
             done.is_ok(),
             "drain() must return once the tracked background task finishes"
         );
+    }
+
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn drain_waits_for_hydration_after_its_last_request_waiter_is_cancelled() {
+        let before = background_task_count();
+        let active = std::sync::atomic::AtomicUsize::new(0);
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let release = Arc::new(tokio::sync::Semaphore::new(0));
+        let store = Arc::new(DrainBlockingBlobStore {
+            started: std::sync::Mutex::new(Some(started_tx)),
+            release: Arc::clone(&release),
+        });
+        let hydrator = Arc::new(
+            crate::BlobHydrator::new(
+                store as Arc<dyn khive_storage::BlobStore>,
+                khive_storage::MAX_BLOB_WHOLE_BYTES,
+            )
+            .expect("minimum hydration budget is valid"),
+        );
+        let content_ref =
+            khive_storage::ContentRef::from_hex("a".repeat(64)).expect("fixture content ref");
+
+        let request_hydrator = Arc::clone(&hydrator);
+        let request = tokio::spawn(async move {
+            request_hydrator
+                .hydrate_verified(&content_ref, khive_storage::MAX_BLOB_WHOLE_BYTES)
+                .await
+        });
+        started_rx.await.expect("backend work must begin");
+        request.abort();
+        assert!(request.await.unwrap_err().is_cancelled());
+        assert_eq!(background_task_count(), before + 1);
+
+        let draining = drain_with_timeout(&active, std::time::Duration::from_secs(5));
+        tokio::pin!(draining);
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(150), &mut draining)
+                .await
+                .is_err(),
+            "drain must remain pending while cancelled-request hydration still runs"
+        );
+
+        release.add_permits(1);
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_secs(5), draining)
+                .await
+                .expect("drain should finish after native hydration ends"),
+            "hydration should finish inside the drain window"
+        );
+        assert_eq!(background_task_count(), before);
     }
 
     // See the `#[serial(background_tasks)]` note on

--- a/crates/khive-runtime/src/engine_config.rs
+++ b/crates/khive-runtime/src/engine_config.rs
@@ -73,6 +73,11 @@ pub enum ConfigError {
     #[error("[[git_write.allowed]] entry {repo:?}: {reason}")]
     InvalidGitWriteEntry { repo: String, reason: String },
 
+    #[error(
+        "[runtime] blob_hydration_bytes must be between {min} and {max} bytes inclusive; got {value}"
+    )]
+    InvalidBlobHydrationBytes { value: u64, min: u64, max: u64 },
+
     #[error("the explicitly selected config file does not exist: {path}")]
     ExplicitConfigMissing { path: PathBuf },
 
@@ -414,9 +419,10 @@ pub struct KhiveConfig {
 
 /// `[runtime]` section in `khive.toml`.
 ///
-/// Carries runtime knobs that mirror the CLI flag / env var tier.
-/// All fields are optional; absent keys fall through to env vars or built-in
-/// defaults.
+/// Carries runtime knobs resolved during process construction. Most mirror a
+/// CLI flag / environment tier; field documentation calls out exceptions.
+/// All fields are optional and preserve their already-resolved base value when
+/// absent.
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct RuntimeSectionConfig {
     /// Packs to load when neither `--pack` nor `KHIVE_PACKS` selects them.
@@ -441,6 +447,15 @@ pub struct RuntimeSectionConfig {
     /// Accepted values: `"json"` (default), `"auto"`, `"table"`.
     #[serde(default)]
     pub default_output_format: Option<OutputFormat>,
+
+    /// Aggregate process-local admission budget for digest-verified blob
+    /// hydration (ADR-160 D3), in raw bytes.
+    ///
+    /// This knob has no environment-variable counterpart. When absent, the
+    /// resolved runtime keeps its built-in 256 MiB default (or a value supplied
+    /// directly through `RuntimeConfig`).
+    #[serde(default)]
+    pub blob_hydration_bytes: Option<u64>,
 }
 
 impl KhiveConfig {
@@ -677,6 +692,14 @@ impl KhiveConfig {
                 return Err(ConfigError::UnsupportedTopLevelDb {
                     value: value.to_string(),
                 });
+            }
+        }
+
+        if let Some(value) = self.runtime.blob_hydration_bytes {
+            let min = khive_storage::MAX_BLOB_WHOLE_BYTES;
+            let max = tokio::sync::Semaphore::MAX_PERMITS as u64;
+            if value < min || value > max {
+                return Err(ConfigError::InvalidBlobHydrationBytes { value, min, max });
             }
         }
 
@@ -1168,6 +1191,92 @@ model = "paraphrase-multilingual-minilm-l12-v2"
             .expect("file should be found");
         assert!(cfg.engines.is_empty());
         cfg.validate().expect("empty config should be valid");
+    }
+
+    #[test]
+    fn runtime_blob_hydration_budget_parses_and_resolves_before_engine_early_return() {
+        use crate::runtime::runtime_config_from_khive_config;
+        use crate::RuntimeConfig;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_toml(
+            &dir,
+            r#"
+[runtime]
+blob_hydration_bytes = 134217728
+"#,
+        );
+        let cfg = KhiveConfig::load(Some(&path))
+            .expect("load should succeed")
+            .expect("file should be found");
+
+        assert_eq!(cfg.runtime.blob_hydration_bytes, Some(134_217_728));
+        let resolved = runtime_config_from_khive_config(&cfg, RuntimeConfig::default());
+        assert_eq!(resolved.blob_hydration_bytes, 134_217_728);
+    }
+
+    #[test]
+    fn runtime_blob_hydration_budget_below_one_whole_blob_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let value = khive_storage::MAX_BLOB_WHOLE_BYTES - 1;
+        let path = write_toml(
+            &dir,
+            &format!("[runtime]\nblob_hydration_bytes = {value}\n"),
+        );
+
+        let err = KhiveConfig::load(Some(&path)).expect_err("undersized budget must fail closed");
+        assert!(
+            matches!(
+                err,
+                ConfigError::InvalidBlobHydrationBytes {
+                    value: actual,
+                    min,
+                    ..
+                } if actual == value && min == khive_storage::MAX_BLOB_WHOLE_BYTES
+            ),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn runtime_blob_hydration_budget_accepts_the_inclusive_portable_minimum() {
+        let dir = tempfile::tempdir().unwrap();
+        let value = khive_storage::MAX_BLOB_WHOLE_BYTES;
+        let path = write_toml(
+            &dir,
+            &format!("[runtime]\nblob_hydration_bytes = {value}\n"),
+        );
+
+        let cfg = KhiveConfig::load(Some(&path))
+            .expect("the inclusive minimum must be valid")
+            .expect("config should exist");
+        assert_eq!(cfg.runtime.blob_hydration_bytes, Some(value));
+    }
+
+    #[test]
+    fn runtime_blob_hydration_budget_above_semaphore_capacity_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let max = tokio::sync::Semaphore::MAX_PERMITS as u64;
+        let value = max
+            .checked_add(1)
+            .expect("tokio maximum fits below u64::MAX");
+        let path = write_toml(
+            &dir,
+            &format!("[runtime]\nblob_hydration_bytes = {value}\n"),
+        );
+
+        let err = KhiveConfig::load(Some(&path)).expect_err("oversized budget must fail closed");
+        assert!(
+            matches!(
+                err,
+                ConfigError::InvalidBlobHydrationBytes {
+                    value: actual,
+                    max: actual_max,
+                    ..
+                } if actual == value && actual_max == max
+            ),
+            "got {err:?}"
+        );
     }
 
     #[test]

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -52,7 +52,10 @@ pub use atomic_runner::{
     run_atomic_unit, AtomicOpFailure, AtomicOpPlan, AtomicRunOutcome, AtomicRunnerError,
     CommittedPostCommitEffects,
 };
-pub use blob::{resolve_blob_store, resolve_blob_store_for_mode};
+pub use blob::{
+    resolve_blob_store, resolve_blob_store_for_mode, BlobHydrator, VerifiedBlob,
+    DEFAULT_BLOB_HYDRATION_BYTES,
+};
 pub use build_info::{BuildInfo, BUILD_INFO, BUILD_VERSION};
 pub use config::{ann_fresh_tail_enabled_from_env, process_ref_from_env};
 pub use cost_unit::{base_resource_payload, cost_unit_for_dispatch, resource_payload};

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -4,7 +4,7 @@
 //! live in `super::config` and are re-exported from here.
 
 use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, OnceLock, RwLock};
 
 use khive_db::StorageBackend;
 #[cfg(test)]
@@ -214,15 +214,13 @@ pub struct KhiveRuntime {
     /// properties survive a `merge` unchanged. Empty until installed (bare
     /// runtime), which leaves both rules inert.
     pack_owned_note_kinds: Arc<RwLock<Vec<String>>>,
-    /// The config-resolved `BlobStore` (ADR-111 Amendment 2), installed by
-    /// the boot path (`khive-mcp`'s single- and multi-backend startup paths)
-    /// via [`install_blob_store`](Self::install_blob_store) once `khive.toml`'s
-    /// `[storage.blob]` selection has been resolved through
-    /// `khive_runtime::resolve_blob_store`. `None` until installed — every
-    /// constructor here defaults it unset rather than eagerly resolving a
-    /// filesystem default, because many callers (unit tests, `memory()`) use
-    /// an in-memory backend with no blob root configured at all.
-    blob_store: Arc<RwLock<Option<Arc<dyn khive_storage::BlobStore>>>>,
+    /// The immutable runtime-owned store/hydration pair (ADR-160 D3).
+    ///
+    /// Boot resolves one store and constructs exactly one shared hydrator,
+    /// then installs that same `Arc` on every runtime handle. The one-shot
+    /// slot rejects replacement so pack runtimes cannot silently split the
+    /// aggregate byte budget after startup. Bare runtimes leave it unset.
+    blob_hydrator: Arc<OnceLock<Arc<crate::blob::BlobHydrator>>>,
     /// Pack-registered custom fusion executors (ADR-012), keyed by the name
     /// carried in `FusionStrategy::Custom { name, .. }`.
     ///
@@ -275,7 +273,7 @@ impl KhiveRuntime {
             note_mutation_hook: Arc::new(RwLock::new(None)),
             note_write_validator: Arc::new(RwLock::new(None)),
             pack_owned_note_kinds: Arc::new(RwLock::new(Vec::new())),
-            blob_store: Arc::new(RwLock::new(None)),
+            blob_hydrator: Arc::new(OnceLock::new()),
             fusion_executors: Arc::new(RwLock::new(HashMap::new())),
         })
     }
@@ -308,7 +306,7 @@ impl KhiveRuntime {
             note_mutation_hook: Arc::new(RwLock::new(None)),
             note_write_validator: Arc::new(RwLock::new(None)),
             pack_owned_note_kinds: Arc::new(RwLock::new(Vec::new())),
-            blob_store: Arc::new(RwLock::new(None)),
+            blob_hydrator: Arc::new(OnceLock::new()),
             fusion_executors: Arc::new(RwLock::new(HashMap::new())),
         })
     }
@@ -344,7 +342,7 @@ impl KhiveRuntime {
             note_mutation_hook: Arc::new(RwLock::new(None)),
             note_write_validator: Arc::new(RwLock::new(None)),
             pack_owned_note_kinds: Arc::new(RwLock::new(Vec::new())),
-            blob_store: Arc::new(RwLock::new(None)),
+            blob_hydrator: Arc::new(OnceLock::new()),
             fusion_executors: Arc::new(RwLock::new(HashMap::new())),
         }
     }
@@ -406,7 +404,7 @@ impl KhiveRuntime {
                     note_mutation_hook: self.note_mutation_hook.clone(),
                     note_write_validator: self.note_write_validator.clone(),
                     pack_owned_note_kinds: self.pack_owned_note_kinds.clone(),
-                    blob_store: self.blob_store.clone(),
+                    blob_hydrator: self.blob_hydrator.clone(),
                     fusion_executors: self.fusion_executors.clone(),
                 }
             }
@@ -889,17 +887,76 @@ impl KhiveRuntime {
         }
     }
 
-    /// Install the config-resolved `BlobStore` (ADR-111 Amendment 2).
+    /// Install an already-paired blob hydrator into this runtime.
     ///
-    /// Called by the boot path (`khive-mcp`'s single- and multi-backend
-    /// startup paths, `crates/khive-mcp/src/serve.rs`) once
-    /// `khive_runtime::resolve_blob_store` has selected the backend
-    /// `khive.toml`'s `[storage.blob]` section requests. Idempotent: a later
-    /// call overwrites the previous handle.
-    pub fn install_blob_store(&self, store: Arc<dyn khive_storage::BlobStore>) {
-        if let Ok(mut guard) = self.blob_store.write() {
-            *guard = Some(store);
+    /// Reinstalling the exact same `Arc` is idempotent. A different pair is
+    /// rejected: replacing it would split or reset the aggregate admission
+    /// budget while requests may still hold leases.
+    pub fn install_blob_hydrator(
+        &self,
+        hydrator: Arc<crate::blob::BlobHydrator>,
+    ) -> RuntimeResult<()> {
+        if hydrator.budget_bytes() != self.config.blob_hydration_bytes {
+            return Err(RuntimeError::InvalidInput(format!(
+                "blob hydrator budget {} does not match this runtime's resolved budget {}",
+                hydrator.budget_bytes(),
+                self.config.blob_hydration_bytes
+            )));
         }
+        if let Some(current) = self.blob_hydrator.get() {
+            return if Arc::ptr_eq(current, &hydrator) {
+                Ok(())
+            } else {
+                Err(RuntimeError::InvalidInput(
+                    "a different blob hydrator is already installed".to_string(),
+                ))
+            };
+        }
+
+        match self.blob_hydrator.set(hydrator) {
+            Ok(()) => Ok(()),
+            Err(candidate) => {
+                let current = self.blob_hydrator.get().ok_or_else(|| {
+                    RuntimeError::Internal(
+                        "blob hydrator install raced without a visible winner".to_string(),
+                    )
+                })?;
+                if Arc::ptr_eq(current, &candidate) {
+                    Ok(())
+                } else {
+                    Err(RuntimeError::InvalidInput(
+                        "a different blob hydrator is already installed".to_string(),
+                    ))
+                }
+            }
+        }
+    }
+
+    /// Pair and install a store using this runtime's resolved hydration budget.
+    ///
+    /// Boot paths that own multiple runtimes should instead construct one
+    /// [`crate::BlobHydrator`] and call [`Self::install_blob_hydrator`] with
+    /// the same `Arc` on every handle.
+    pub fn install_blob_store(
+        &self,
+        store: Arc<dyn khive_storage::BlobStore>,
+    ) -> RuntimeResult<()> {
+        if let Some(current) = self.blob_hydrator.get() {
+            let current_store = current.store();
+            if Arc::ptr_eq(&current_store, &store) {
+                return Ok(());
+            }
+        }
+        let hydrator = Arc::new(crate::blob::BlobHydrator::new(
+            store,
+            self.config.blob_hydration_bytes,
+        )?);
+        self.install_blob_hydrator(hydrator)
+    }
+
+    /// Return the installed shared blob hydrator, if boot configured one.
+    pub fn blob_hydrator(&self) -> Option<Arc<crate::blob::BlobHydrator>> {
+        self.blob_hydrator.get().cloned()
     }
 
     /// Return the installed `BlobStore`, if the boot path resolved and
@@ -907,7 +964,7 @@ impl KhiveRuntime {
     /// installed — e.g. a bare/test runtime constructed without going
     /// through the `khive-mcp` boot path.
     pub fn blob_store(&self) -> Option<Arc<dyn khive_storage::BlobStore>> {
-        self.blob_store.read().ok().and_then(|guard| guard.clone())
+        self.blob_hydrator.get().map(|hydrator| hydrator.store())
     }
 
     /// Install the pack-aggregated valid entity and note kinds.
@@ -1478,10 +1535,86 @@ mod tests {
     use khive_gate::GateRef;
     use serial_test::serial;
 
+    fn test_blob_hydrator() -> (tempfile::TempDir, Arc<crate::BlobHydrator>) {
+        let root = tempfile::tempdir().expect("blob root");
+        let store = Arc::new(
+            khive_db::stores::blob::FsBlobStore::new(root.path().to_path_buf(), 0)
+                .expect("fs blob store"),
+        );
+        let hydrator = Arc::new(
+            crate::BlobHydrator::new(store, crate::DEFAULT_BLOB_HYDRATION_BYTES)
+                .expect("blob hydrator"),
+        );
+        (root, hydrator)
+    }
+
     #[test]
     fn memory_runtime_creates_successfully() {
         let rt = KhiveRuntime::memory().expect("memory runtime should create");
         assert!(rt.config().db_path.is_none());
+    }
+
+    #[test]
+    fn installed_blob_hydrator_is_shared_by_clone_and_core_handles() {
+        let main_backend = Arc::new(StorageBackend::memory().expect("main backend"));
+        let pack_backend = Arc::new(StorageBackend::memory().expect("pack backend"));
+        let mut config = RuntimeConfig::no_embeddings();
+        config.backend_id = BackendId::new("assets");
+        let runtime = KhiveRuntime::from_backend(pack_backend, config)
+            .with_core_backend(Arc::clone(&main_backend));
+        let (_root, hydrator) = test_blob_hydrator();
+
+        runtime
+            .install_blob_hydrator(Arc::clone(&hydrator))
+            .expect("first install");
+
+        for handle in [runtime.clone(), runtime.core()] {
+            let installed = handle.blob_hydrator().expect("installed hydrator");
+            assert!(Arc::ptr_eq(&installed, &hydrator));
+        }
+    }
+
+    #[test]
+    fn blob_hydrator_install_is_idempotent_but_rejects_replacement() {
+        let runtime = KhiveRuntime::memory().expect("runtime");
+        let (_first_root, first) = test_blob_hydrator();
+        let (_second_root, second) = test_blob_hydrator();
+
+        runtime
+            .install_blob_hydrator(Arc::clone(&first))
+            .expect("first install");
+        runtime
+            .install_blob_hydrator(Arc::clone(&first))
+            .expect("same Arc reinstall is idempotent");
+
+        let error = runtime
+            .install_blob_hydrator(second)
+            .expect_err("a different hydrator must not replace the installed pair");
+        assert!(error.to_string().contains("already installed"));
+        assert!(Arc::ptr_eq(
+            &runtime.blob_hydrator().expect("original remains"),
+            &first
+        ));
+    }
+
+    #[test]
+    fn blob_hydrator_install_rejects_a_budget_that_disagrees_with_runtime_identity() {
+        let runtime = KhiveRuntime::memory().expect("runtime");
+        let root = tempfile::tempdir().expect("blob root");
+        let store = Arc::new(
+            khive_db::stores::blob::FsBlobStore::new(root.path().to_path_buf(), 0)
+                .expect("fs blob store"),
+        );
+        let mismatched = Arc::new(
+            crate::BlobHydrator::new(store, khive_storage::MAX_BLOB_WHOLE_BYTES)
+                .expect("minimum blob budget"),
+        );
+
+        let error = runtime
+            .install_blob_hydrator(mismatched)
+            .expect_err("live admission must match the construction-baked config identity");
+        assert!(matches!(error, RuntimeError::InvalidInput(_)));
+        assert!(runtime.blob_hydrator().is_none());
     }
 
     #[test]
@@ -1541,6 +1674,7 @@ mod tests {
         let config = RuntimeConfig {
             git_write: Default::default(),
             db_path: Some(path),
+            blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
             embedding_model: None,
             additional_embedding_models: vec![],
@@ -1565,6 +1699,7 @@ mod tests {
         let config = RuntimeConfig {
             git_write: Default::default(),
             db_path: None,
+            blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
             embedding_model: None,
             additional_embedding_models: vec![],
@@ -1587,6 +1722,7 @@ mod tests {
         let config = RuntimeConfig {
             git_write: Default::default(),
             db_path: Some(path.clone()),
+            blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::parse("test").unwrap(),
             embedding_model: None,
             additional_embedding_models: vec![],
@@ -1613,6 +1749,7 @@ mod tests {
         let base = RuntimeConfig {
             git_write: Default::default(),
             db_path: Some(path.clone()),
+            blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
             embedding_model: None,
             additional_embedding_models: vec![],
@@ -1681,6 +1818,7 @@ mod tests {
         let config = RuntimeConfig {
             git_write: Default::default(),
             db_path: Some(path.clone()),
+            blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
             embedding_model: None,
             additional_embedding_models: vec![],
@@ -1762,6 +1900,7 @@ mod tests {
             let make_config = |db_path: std::path::PathBuf| RuntimeConfig {
                 git_write: Default::default(),
                 db_path: Some(db_path),
+                blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
                 default_namespace: Namespace::local(),
                 embedding_model: None,
                 additional_embedding_models: vec![],
@@ -1807,6 +1946,7 @@ mod tests {
         let config = RuntimeConfig {
             git_write: Default::default(),
             db_path: None,
+            blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
             embedding_model: None,
             additional_embedding_models: vec![],
@@ -1972,6 +2112,7 @@ mod tests {
         let base = RuntimeConfig {
             git_write: Default::default(),
             db_path: None,
+            blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
             embedding_model: None,
             additional_embedding_models: vec![],
@@ -1997,6 +2138,7 @@ mod tests {
         let base = RuntimeConfig {
             git_write: Default::default(),
             db_path: None,
+            blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::parse("lambda:base").unwrap(),
             embedding_model: None,
             additional_embedding_models: vec![],
@@ -2030,6 +2172,7 @@ mod tests {
         let base = RuntimeConfig {
             git_write: Default::default(),
             db_path: None,
+            blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::parse("lambda:base").unwrap(),
             embedding_model: None,
             additional_embedding_models: vec![],
@@ -2055,6 +2198,7 @@ mod tests {
         let base = RuntimeConfig {
             git_write: Default::default(),
             db_path: None,
+            blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
             embedding_model: None,
             additional_embedding_models: vec![],
@@ -2215,6 +2359,7 @@ mod tests {
         RuntimeConfig {
             git_write: Default::default(),
             db_path: None,
+            blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
             embedding_model: None,
             additional_embedding_models: vec![],
@@ -2292,6 +2437,7 @@ mod tests {
         let main_config = RuntimeConfig {
             git_write: Default::default(),
             db_path: None,
+            blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
             embedding_model: None,
             additional_embedding_models: vec![],
@@ -2429,6 +2575,7 @@ mod tests {
             RuntimeConfig {
                 git_write: Default::default(),
                 db_path: None,
+                blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
                 default_namespace: Namespace::local(),
                 embedding_model: None,
                 additional_embedding_models: vec![],

--- a/crates/khive-runtime/tests/integration.rs
+++ b/crates/khive-runtime/tests/integration.rs
@@ -75,7 +75,8 @@ async fn entity_create_with_content_ref_roundtrip() {
     let blob_store = std::sync::Arc::new(
         khive_db::stores::blob::FsBlobStore::new(temp.path().to_path_buf(), 0).unwrap(),
     );
-    rt.install_blob_store(blob_store.clone());
+    rt.install_blob_store(blob_store.clone())
+        .expect("install blob store");
     let content_ref = blob_store.put(b"asset bytes".to_vec()).await.unwrap();
 
     let entity = rt
@@ -103,7 +104,8 @@ async fn entity_create_with_content_ref_rejects_unpublished_blob() {
     let temp = tempfile::tempdir().unwrap();
     rt.install_blob_store(std::sync::Arc::new(
         khive_db::stores::blob::FsBlobStore::new(temp.path().to_path_buf(), 0).unwrap(),
-    ));
+    ))
+    .expect("install blob store");
     let missing = ContentRef::from_digest_bytes(&[7; 32]);
 
     let error = rt
@@ -1928,6 +1930,7 @@ async fn file_backed_runtime_persists() {
         let config = RuntimeConfig {
             git_write: Default::default(),
             db_path: Some(path.clone()),
+            blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
             embedding_model: None,
             gate: std::sync::Arc::new(khive_runtime::AllowAllGate),
@@ -1951,6 +1954,7 @@ async fn file_backed_runtime_persists() {
         let config = RuntimeConfig {
             git_write: Default::default(),
             db_path: Some(path.clone()),
+            blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
             embedding_model: None,
             gate: std::sync::Arc::new(khive_runtime::AllowAllGate),
@@ -2572,6 +2576,7 @@ mod embedder_registry_tests {
         KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             db_path: None,
+            blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
             embedding_model: None,
             additional_embedding_models: vec![],
@@ -2724,6 +2729,7 @@ mod embedder_registry_tests {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             db_path: None,
+            blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
             embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
             additional_embedding_models: vec![EmbeddingModel::ParaphraseMultilingualMiniLmL12V2],

--- a/docs/khive-config-example.toml
+++ b/docs/khive-config-example.toml
@@ -82,6 +82,11 @@
 # Keep "json" if anything parses khive's output.
 # default_output_format = "json"
 
+# Aggregate admission budget for resident, digest-verified whole-blob buffers
+# (ADR-160). Default: 268435456 (256 MiB). Values below 67108864 (64 MiB)
+# are rejected because every valid portable blob request must be reservable.
+# blob_hydration_bytes = 268435456
+
 # ── [gate] — reserved authorization surface ───────────────────────────────────────
 #
 # Do not add a live [gate] table. The accepted design uses store-held caller grants


### PR DESCRIPTION
## Summary
- add runtime-owned `BlobHydrator` with weighted declared-byte admission and a non-`Clone` `VerifiedBlob` lease
- supervise admitted backend reads through ADR-119 tracked tasks so waiter cancellation/deadline neither releases capacity early nor hides native work from daemon drain
- pair each installed `BlobStore` with one immutable hydrator shared across default/core/all pack runtimes
- add `[runtime] blob_hydration_bytes` (256 MiB default, 64 MiB minimum) and include its resolved value in daemon configuration identity
- keep Phase 3 consumer migration intentionally out of scope

Most pack-file changes only add the new required `RuntimeConfig` default or handle fallible store installation.

## Stack
- base: #2004 / `codex/adr-160-phase-1-blob-contract`
- depends on Phase 0 #2001 and Phase 1 #2004
- ADR-160 Phase 2 only
- ADR-160 was accepted on `main` in `135c3d46` (#2005); keep draft until parent-stack order and Claude review are satisfied

## Resource-safety invariants
- a maximum above 64 MiB is rejected before admission or backend I/O
- request cancellation/deadline drops only the waiter
- the tracked supervisor owns the backend future plus admission until native completion, or transfers the lease to `VerifiedBlob`
- daemon drain observes hydration supervisors
- actual hydrator budget must equal `RuntimeConfig` and its daemon `config_id`
- different stores remain independent; shared runtime handles contend on one budget

## Verification
- `RUSTC_WRAPPER= cargo check -j4 --workspace --all-targets`
- `RUSTC_WRAPPER= cargo clippy -j4 -p khive-runtime -p khive-mcp --all-targets -- -D warnings`
- `RUSTC_WRAPPER= cargo test -j4 -p khive-runtime`
- full `khive-mcp`: 409 unit + 142 integration tests
- `RUSTC_WRAPPER= cargo test -j4 -p khive-pack-blob -p khive-pack-moodboard`
- focused cancellation/deadline/panic/drain/config/sharing tests
- `cargo fmt --all -- --check`
- `git diff --check`

## Phase boundary
No production consumer moves in this PR. Blob GET, moodboard source/preference helpers, unbounded `BlobStore::get`, the blob-pack semaphore, and moodboard decoded/raster preprocessing admission remain for Phase 3's atomic consumer closure.