### PR TITLE
feat(storage): implement attachment cutover (ADR-160 Phase 4b)

### DIFF
--- a/crates/khive-db/README.md
+++ b/crates/khive-db/README.md
@@ -1,15 +1,15 @@
 # khive-db
 
-SQLite storage backend for the khive knowledge graph runtime: entity, note, event, and
-edge storage, FTS5 text search, and optional `sqlite-vec` vector storage over a
-WAL-mode connection pool.
+SQLite storage backend for the khive knowledge graph runtime: entity, note, event,
+edge, attachment, and content-addressed blob storage; FTS5 text search; and
+optional `sqlite-vec` vector storage over a WAL-mode connection pool.
 
 ## Features
 
 - **WAL-mode connection pool** — one writer, N concurrent readers (`ConnectionPool`)
 - **Capability-trait factories** — `StorageBackend` hands out `Arc<dyn EntityStore>`,
   `GraphStore`, `NoteStore`, `EventStore`, `VectorStore`, `SparseStore`, `TextSearch`,
-  and `SqlAccess` from `khive-storage`
+  `BlobStore`, `AttachmentStore`, and `SqlAccess` from `khive-storage`
 - **Forward-only versioned migrations** — `run_migrations` applies `MIGRATIONS` in
   order, tracked in `_schema_migrations`
 - **Legacy pack-scoped schema plans** — `ServiceSchemaPlan` / `apply_schema_plan` for
@@ -33,14 +33,19 @@ let backend = StorageBackend::sqlite("/path/to/khive.db")?;
 }
 
 let entities = backend.entities()?; // Arc<dyn khive_storage::EntityStore>
+let attachments = backend.attachments()?; // Arc<dyn khive_storage::AttachmentStore>
 let graph = backend.graph()?; // Arc<dyn khive_storage::GraphStore>
 let text = backend.text("entities_fts")?; // Arc<dyn khive_storage::TextSearch>
 let sql = backend.sql(); // Arc<dyn khive_storage::SqlAccess>, for pack-owned tables
 ```
 
-Each capability accessor (`entities`, `graph`, `notes`, `events`, `vectors`, `sparse`,
-`text`) applies its own DDL idempotently on first call, so callers never need a
-separate "create schema" step per store. Namespace-scoped variants
+Most legacy capability accessors (`entities`, `graph`, `notes`, `events`,
+`vectors`, `sparse`,
+`text`) apply their own DDL idempotently on first call. `attachments()` is the
+exception: it never installs schema on demand because the coordinated V21
+cutover owns table creation, GC fences, and legacy-column removal as one
+boot-gated operation. Callers never need a separate "create schema" step per
+store. Namespace-scoped variants
 (`entities_for_namespace`, `graph_for_namespace`, …) validate that the namespace is
 non-empty; the store itself remains namespace-agnostic — callers pass namespace on
 each query.
@@ -52,7 +57,7 @@ Two migration systems coexist, both defined in `migrations.rs`:
 - **Versioned** (`MIGRATIONS: &[VersionedMigration]`, applied by `run_migrations`) —
   the forward-only pipeline for core substrate tables (entities, notes, edges,
   events). `V1` is the consolidated fresh-start baseline loaded from
-  `sql/schema.sql`; `V2..V5` are incremental `.sql` files applied in order and
+  `sql/schema.sql`; later versions are incremental `.sql` files applied in order and
   tracked in `_schema_migrations`. A database whose recorded version is ahead of the
   latest known migration fails loudly rather than silently skipping the baseline.
 - **Legacy per-service** (`ServiceSchemaPlan` / `apply_schema_plan`) — used by packs
@@ -62,6 +67,21 @@ Schema DDL is authored in `crates/khive-db/sql/*.sql` and pulled in via
 `include_str!` — never hand-written as inline Rust string literals. Adding a
 migration means a new `.sql` file plus a new `VersionedMigration` entry; `V1` itself
 is never edited on an existing database.
+
+V21 is a coordinated Phase-4b exception to ordinary eager application. A
+zero-reference database may complete it atomically inside `run_migrations`; a
+legacy V20 database stops at V20 and requires the async MCP/kkernel host
+coordinator to hold the blob-GC owner, stage attachments, authenticate pack-owned
+roles, and finalize. The V21 ledger row is written only in that final transaction.
+
+Phase 4b may run only after the separately shipped Phase-4a transactional-GC
+epoch gate has converged across every process sharing the database/blob root and
+all pre-Phase-4a processes have been drained. Phase 4a leaves V20 untouched and
+refuses transactional GC on V20 or any incomplete/malformed V21 state in both
+dry-run and destructive modes; it does not create or backfill attachments.
+Before cutover, also quiesce every Phase-4a application reader/writer or prove
+it cannot access the database. Only a GC-only worker has narrow completed-V21
+compatibility; start Phase-4b serving after exact-current topology validation.
 
 ## Vector storage
 

--- a/crates/khive-db/docs/design.md
+++ b/crates/khive-db/docs/design.md
@@ -28,6 +28,28 @@
   production `_schema_migrations` table and must not change.
 - V20 adds durable `blob_gc_claims` plus entity INSERT/UPDATE trigger fences
   for ADR-091 Amendment 9's external-I/O-free transactional blob sweep.
+- After the separately released Phase-4a GC gate has converged fleet-wide and
+  every pre-Phase-4a process is drained, quiesce every Phase-4a application
+  reader/writer before Phase 4b/V21 stages role-keyed attachments under the
+  canonical database GC owner. A GC-only Phase-4a worker's completed-V21
+  compatibility is not general serving compatibility. Phase 4b
+  authenticates application-owned roles through the async host coordinator,
+  then atomically switches liveness/fences to attachments and drops
+  `entities.content_ref`. Pending/incomplete state never enables GC, and the
+  Phase-4b service fleet starts only after exact-current topology validation.
+
+### Attachments and Blob Liveness (ADR-111, ADR-121, ADR-160)
+
+- `stores/attachment.rs` implements `AttachmentStore`; entity role `content`
+  is projected into the compatibility `Entity.content_ref` response field.
+- Entity-plus-initial-attachments publication and entity/note hard-delete
+  cleanup are transactional. Soft deletion retains attachment liveness.
+- Transactional filesystem blob GC validates every attachment/claim ref,
+  anti-joins all attachment rows, and relies on attachment INSERT/UPDATE claim
+  fences. Its Phase-4a epoch gate accepts only an exact completed V21
+  ledger/marker/fence/schema combination; V20 and pending, incomplete, or
+  malformed states refuse dry-run and destructive sweep before filesystem or
+  claim mutation.
 
 ### Pack Standard — Pack-Auxiliary Schema (ADR-017)
 
@@ -129,7 +151,8 @@ process/advisory owner lock makes every pre-existing claim safely recoverable
 even after root relocation or database restore. Candidate recovery, claim,
 physical deletion, and cleanup proceed in batches of at most 128. Each claim
 and cleanup transaction is SQL-only and commits before filesystem deletion;
-entity triggers reject claimed references in every released-writer interval.
+attachment INSERT/UPDATE triggers reject claimed references in every
+released-writer interval.
 
 ## Consistency Notes
 

--- a/crates/khive-db/docs/migration.md
+++ b/crates/khive-db/docs/migration.md
@@ -20,6 +20,24 @@ The `run_migrations` function:
    migration and leaves the DB at the prior version
 5. Records the applied version, name, and timestamp in `_schema_migrations`
 
+V21 is the one application-assisted exception in rollout Phase 4b.
+`run_migrations` may complete it atomically only when no legacy content refs
+exist. Otherwise it stops at V20;
+the async host acquires the database GC owner, records durable `Incomplete`,
+authenticates pack-owned blob roles, and records V21 only in the exclusive
+final transaction. Restart resumes this state before serving or GC.
+
+Phase 4b has an operational prerequisite that is not encoded in the V20 ledger.
+Phase 4a first ships only the transactional-GC epoch gate: it leaves V20 schema
+and data untouched, and refuses V20 or any incomplete/malformed V21 state in
+both sweep modes. After that binary converges fleet-wide, every pre-Phase-4a
+process sharing the database/blob root must be drained before any Phase-4b host
+or admin migration is allowed to start V21. Phase-4a application-serving and
+read/write processes must also be quiesced, or proven unable to access the
+database, during cutover; only a GC-only Phase-4a worker is compatible with
+exact completed V21. Phase-4b serving starts after exact-current topology
+validation.
+
 ## Version numbering
 
 Versions form a contiguous sequence: 1, 2, 3, ... Gaps are rejected at
@@ -64,6 +82,9 @@ V1 baseline at v0.2.8. The live post-consolidation sequence is:
 - **V18**: Adds ANN consumer-pending lifecycle metadata.
 - **V19**: Repairs divergent V13/V14 migration names and cursor-sequence rows.
 - **V20**: Adds bounded blob-GC claims and entity write-fence triggers.
+- **V21 (Phase 4b)**: Adds first-class attachments, backfills role `content`,
+  switches blob GC claim fences to attachment writes, and drops
+  `entities.content_ref` after verified application backfill.
 
 The historical pre-consolidation allocation table remains in ADR-015 for
 provenance; its version numbers do not describe the live migration array.

--- a/crates/khive-db/sql/021-attachments-claim-fences.sql
+++ b/crates/khive-db/sql/021-attachments-claim-fences.sql
@@ -1,0 +1,20 @@
+-- V21 final claim fences.  These replace V20's entities.content_ref fences
+-- in the same exclusive transaction that drops the legacy column.
+
+CREATE TRIGGER attachments_reject_claimed_blob_insert
+BEFORE INSERT ON attachments
+WHEN EXISTS (
+    SELECT 1 FROM blob_gc_claims WHERE content_ref = NEW.content_ref
+)
+BEGIN
+    SELECT RAISE(ABORT, 'content_ref is reserved by an active blob sweep');
+END;
+
+CREATE TRIGGER attachments_reject_claimed_blob_update
+BEFORE UPDATE OF content_ref ON attachments
+WHEN EXISTS (
+    SELECT 1 FROM blob_gc_claims WHERE content_ref = NEW.content_ref
+)
+BEGIN
+    SELECT RAISE(ABORT, 'content_ref is reserved by an active blob sweep');
+END;

--- a/crates/khive-db/sql/021-attachments-stage.sql
+++ b/crates/khive-db/sql/021-attachments-stage.sql
@@ -1,0 +1,35 @@
+-- V21 stage 1: durable, resumable attachments-first cutover (ADR-121/ADR-160).
+--
+-- The boot coordinator executes this DDL while holding the canonical database
+-- GC owner.  It deliberately does not remove entities.content_ref or its V20
+-- claim fences.  Those remain authoritative until the application migrator
+-- has verified pack-owned roles and the final transaction commits.
+
+CREATE TABLE IF NOT EXISTS attachments (
+    record_uuid TEXT NOT NULL,
+    substrate   TEXT NOT NULL CHECK (substrate IN ('entity', 'note')),
+    role        TEXT NOT NULL CHECK (length(role) > 0),
+    content_ref TEXT NOT NULL
+        CHECK (
+            length(content_ref) = 64
+            AND content_ref NOT GLOB '*[^0-9a-f]*'
+        ),
+    media_type  TEXT,
+    size_bytes  INTEGER CHECK (size_bytes IS NULL OR size_bytes >= 0),
+    created_at  INTEGER NOT NULL,
+    PRIMARY KEY (record_uuid, role)
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_attachments_content_ref
+    ON attachments(content_ref);
+
+CREATE TABLE IF NOT EXISTS attachment_cutover_state (
+    singleton    INTEGER PRIMARY KEY CHECK (singleton = 1),
+    state        TEXT NOT NULL CHECK (state IN ('incomplete', 'complete')),
+    started_at   INTEGER NOT NULL,
+    completed_at INTEGER,
+    CHECK (
+        (state = 'incomplete' AND completed_at IS NULL)
+        OR (state = 'complete' AND completed_at IS NOT NULL)
+    )
+) STRICT;

--- a/crates/khive-db/sql/entities-ddl.sql
+++ b/crates/khive-db/sql/entities-ddl.sql
@@ -14,8 +14,7 @@ CREATE TABLE IF NOT EXISTS entities (
     updated_at     INTEGER NOT NULL,
     deleted_at     INTEGER,
     merged_into    TEXT,
-    merge_event_id TEXT,
-    content_ref    TEXT
+    merge_event_id TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_entities_namespace ON entities(namespace);
@@ -24,11 +23,6 @@ CREATE INDEX IF NOT EXISTS idx_entities_kind_entity_type ON entities(namespace, 
 CREATE INDEX IF NOT EXISTS idx_entities_name ON entities(namespace, name);
 CREATE INDEX IF NOT EXISTS idx_entities_created ON entities(created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_entities_merged_into ON entities(namespace, merged_into);
--- BlobStore content_ref reference (khive#292) — mirrors migration 010 for
--- callers that create the table via ensure_entities_schema() without ever
--- running the versioned migration chain (e.g. StorageBackend::memory() test
--- setups that apply ENTITIES_DDL directly).
-CREATE INDEX IF NOT EXISTS idx_entities_content_ref ON entities(content_ref) WHERE content_ref IS NOT NULL;
 
 -- Durable list-cursor insertion order. This mirrors migration V13 as a
 -- belt-and-suspenders path for fresh/direct store construction that applies

--- a/crates/khive-db/src/backend.rs
+++ b/crates/khive-db/src/backend.rs
@@ -1,8 +1,9 @@
 //! Concrete storage backend providing capability traits.
 //!
 //! `StorageBackend` owns a `ConnectionPool` and provides factory methods for all
-//! capability traits (`GraphStore`, `NoteStore`, `EventStore`, `VectorStore`,
-//! `TextSearch`, `SqlAccess`). File-backed for production; in-memory for tests.
+//! ten capability traits (`SqlAccess`, `NoteStore`, `EntityStore`, `GraphStore`,
+//! `EventStore`, `VectorStore`, `SparseStore`, `TextSearch`, `BlobStore`, and
+//! `AttachmentStore`). File-backed for production; in-memory for tests.
 
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -13,7 +14,7 @@ use rusqlite::OptionalExtension;
 use crate::error::SqliteError;
 use crate::pool::{ConnectionPool, PoolConfig};
 use crate::sql_bridge::SqlBridge;
-use crate::stores::{agents, blob, entity, event, graph, note, sparse, text, vectors};
+use crate::stores::{agents, attachment, blob, entity, event, graph, note, sparse, text, vectors};
 
 fn sqlite_table_exists(conn: &rusqlite::Connection, table: &str) -> Result<bool, SqliteError> {
     conn.query_row(
@@ -202,17 +203,137 @@ impl StorageBackend {
 
     /// Prepare the core schema for runtime boot.
     ///
-    /// Writable backends apply pending migrations. Read-only backends perform
-    /// a query-only compatibility check and require the snapshot to be at this
-    /// build's exact latest schema version.
+    /// Writable backends acquire the canonical database-GC owner before the
+    /// writer, apply the ordinary versioned prefix, and may finish V21 only
+    /// through its zero-legacy-reference fast path. A legacy V20 database
+    /// remains at V20 for the async host's application-assisted attachment
+    /// cutover; this method alone is not a serving boot gate.
+    /// Read-only backends perform a query-only compatibility check and require
+    /// the snapshot to be at this build's exact latest schema version.
     pub fn prepare_core_schema(&self) -> Result<u32, SqliteError> {
         if self.is_read_only() {
             let reader = self.pool.reader()?;
             crate::migrations::validate_schema_is_current(reader.conn())
         } else {
+            let latest = crate::migrations::MIGRATIONS
+                .last()
+                .map(|migration| migration.version)
+                .unwrap_or(0);
+            {
+                let reader = self.pool.reader()?;
+                let current = crate::migrations::read_schema_version(reader.conn())?;
+                if current >= latest {
+                    return crate::migrations::validate_schema_is_current(reader.conn());
+                }
+            }
+            let owner = crate::stores::blob::acquire_database_gc_owner_for_path_blocking(
+                self.pool.canonical_path().map(Path::to_path_buf),
+            )
+            .map_err(|error| {
+                SqliteError::InvalidData(format!(
+                    "failed to acquire database GC owner before schema preparation: {error}"
+                ))
+            })?;
             let mut writer = self.pool.try_writer()?;
-            crate::migrations::run_migrations(writer.conn_mut())
+            crate::migrations::run_migrations_with_database_gc_owner(writer.conn_mut(), &owner)
         }
+    }
+
+    /// Inspect the coordinated V21 attachment cutover state.
+    pub fn attachment_cutover_status(
+        &self,
+    ) -> Result<crate::migrations::AttachmentCutoverStatus, SqliteError> {
+        if self.is_read_only() {
+            let reader = self.pool.reader()?;
+            crate::migrations::attachment_cutover_status(reader.conn())
+        } else {
+            let writer = self.pool.try_writer()?;
+            crate::migrations::attachment_cutover_status(writer.conn())
+        }
+    }
+
+    fn require_attachment_cutover_owner(
+        &self,
+        owner: &crate::stores::blob::DatabaseGcOwnerGuard,
+    ) -> Result<(), SqliteError> {
+        let sql = self.sql();
+        let backend_path = sql.database_path();
+        if owner.database_path() != backend_path.as_deref() {
+            return Err(SqliteError::InvalidData(format!(
+                "attachment cutover GC owner targets {:?}, but this backend is {:?}",
+                owner.database_path(),
+                backend_path.as_deref()
+            )));
+        }
+        Ok(())
+    }
+
+    /// Commit resumable V21 stage 1 while the caller owns this database's GC
+    /// protocol. The owner must remain live through verified application
+    /// backfill and finalization.
+    pub fn stage_attachment_cutover(
+        &self,
+        owner: &crate::stores::blob::DatabaseGcOwnerGuard,
+    ) -> Result<(), SqliteError> {
+        self.require_attachment_cutover_owner(owner)?;
+        if self.is_read_only() {
+            return Err(SqliteError::InvalidData(
+                "cannot stage attachment cutover on a read-only backend".into(),
+            ));
+        }
+        let mut writer = self.pool.try_writer()?;
+        crate::migrations::stage_attachment_cutover(writer.conn_mut())
+    }
+
+    /// Atomically publish a verified batch of pack-owned attachment roles.
+    pub fn apply_verified_attachments(
+        &self,
+        owner: &crate::stores::blob::DatabaseGcOwnerGuard,
+        attachments: &[khive_storage::Attachment],
+    ) -> Result<(), SqliteError> {
+        self.require_attachment_cutover_owner(owner)?;
+        if self.is_read_only() {
+            return Err(SqliteError::InvalidData(
+                "cannot apply verified attachments on a read-only backend".into(),
+            ));
+        }
+        let mut writer = self.pool.try_writer()?;
+        let tx = writer
+            .conn_mut()
+            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+        for attachment in attachments {
+            attachment
+                .validate()
+                .map_err(|error| SqliteError::InvalidData(error.to_string()))?;
+            crate::migrations::apply_generic_verified_attachment(
+                &tx,
+                &attachment.record_uuid.to_string(),
+                attachment.substrate.as_str(),
+                &attachment.role,
+                &attachment.content_ref,
+                attachment.media_type.as_deref(),
+                attachment.size_bytes,
+                attachment.created_at,
+            )?;
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Atomically swap GC liveness/fences to attachments, remove the legacy
+    /// entity column, and record V21 while the canonical owner is held.
+    pub fn finalize_attachment_cutover(
+        &self,
+        owner: &crate::stores::blob::DatabaseGcOwnerGuard,
+    ) -> Result<(), SqliteError> {
+        self.require_attachment_cutover_owner(owner)?;
+        if self.is_read_only() {
+            return Err(SqliteError::InvalidData(
+                "cannot finalize attachment cutover on a read-only backend".into(),
+            ));
+        }
+        let mut writer = self.pool.try_writer()?;
+        crate::migrations::finalize_attachment_cutover(writer.conn_mut())
     }
 
     /// Get an EntityStore. Applies the entities DDL if not already present.
@@ -240,6 +361,19 @@ impl StorageBackend {
         }
 
         Ok(Arc::new(entity::SqlEntityStore::new(
+            Arc::clone(&self.pool),
+            self.is_file_backed,
+        )))
+    }
+
+    /// Get the role-keyed attachment store.
+    ///
+    /// Unlike the legacy capability accessors, this does not install DDL on
+    /// demand. The coordinated V21 core cutover owns creation of the table,
+    /// reference fences, GC liveness swap, and removal of the legacy entity
+    /// column as one boot-gated operation.
+    pub fn attachments(&self) -> Result<Arc<dyn khive_storage::AttachmentStore>, SqliteError> {
+        Ok(Arc::new(attachment::SqlAttachmentStore::new(
             Arc::clone(&self.pool),
             self.is_file_backed,
         )))

--- a/crates/khive-db/src/lib.rs
+++ b/crates/khive-db/src/lib.rs
@@ -48,8 +48,9 @@ pub use khive_storage::{
     DEFAULT_REQUEST_READ_TIMEOUT_SECS,
 };
 pub use migrations::{
-    inspect_schema_version, query_embedding_models, read_schema_version, run_migrations,
-    EmbeddingModelRegistryRecord, Migration, ServiceSchemaPlan, VersionedMigration, MIGRATIONS,
+    inspect_schema_is_current, inspect_schema_version, query_embedding_models, read_schema_version,
+    run_migrations, EmbeddingModelRegistryRecord, Migration, ServiceSchemaPlan, VersionedMigration,
+    MIGRATIONS,
 };
 pub use pool::{ConnectionPool, PoolConfig, ReaderGuard, WriterGuard};
 #[cfg(test)]

--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -6,9 +6,12 @@
 //! - **Versioned migrations** (`MIGRATIONS` / `run_migrations`): the forward-only
 //!   migration pipeline for the core tables.
 
-use rusqlite::Connection;
+use khive_storage::blob::ContentRef;
+use rusqlite::{Connection, OptionalExtension};
+use std::path::PathBuf;
 
 use crate::error::SqliteError;
+use crate::stores::blob::{try_acquire_database_gc_owner_for_path, DatabaseGcOwnerGuard};
 
 // =============================================================================
 // Legacy per-service migration API (preserved for backward compatibility)
@@ -141,6 +144,13 @@ const V19_UP: &str = include_str!("../sql/019-list-cursor-backfill-repair.sql");
 
 const V20_UP: &str = include_str!("../sql/020-blob-gc-claims.sql");
 
+const V21_STAGE_UP: &str = include_str!("../sql/021-attachments-stage.sql");
+
+const V21_ATTACHMENT_FENCES_UP: &str = include_str!("../sql/021-attachments-claim-fences.sql");
+
+/// Core schema version reserved for ADR-121's attachments-first cutover.
+pub const ATTACHMENT_CUTOVER_VERSION: u32 = 21;
+
 /// DDL for the `ann_write_log` delta table.
 ///
 /// Shared between migration V11 and the belt-and-suspenders creation in
@@ -171,7 +181,12 @@ pub const ANN_CONSUMER_PENDING_DDL: &str = include_str!("../sql/ann-consumer-pen
 /// the schema cannot silently diverge if the registry evolves.
 pub const EMBEDDING_MODELS_DDL: &str = include_str!("../sql/embedding-models-ddl.sql");
 
-/// All versioned migrations in ascending order, applied by `run_migrations`.
+/// Canonical versioned migration ledger in ascending order.
+///
+/// [`run_migrations`] applies the ordinary prefix and may complete V21 through
+/// its zero-legacy-reference fast path. A legacy V20 database records V21 only
+/// when [`finalize_attachment_cutover`] commits the application-assisted
+/// cutover.
 pub const MIGRATIONS: &[VersionedMigration] = &[
     VersionedMigration {
         version: 1,
@@ -273,7 +288,538 @@ pub const MIGRATIONS: &[VersionedMigration] = &[
         name: "blob_gc_claims",
         up: V20_UP,
     },
+    VersionedMigration {
+        version: ATTACHMENT_CUTOVER_VERSION,
+        name: "attachments_first_class",
+        // V21 is coordinated rather than an unconditional SQL migration.
+        // The runner special-cases it below; exposing the stage DDL here keeps
+        // the ledger entry self-describing for migration inspection tooling.
+        up: V21_STAGE_UP,
+    },
 ];
+
+/// Durable state of ADR-121's boot-gated, two-stage attachment cutover.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AttachmentCutoverStatus {
+    /// V20 is current and no stage marker has been committed.
+    Pending,
+    /// Stage 1 committed; boot must finish verified pack-owned attachments.
+    Incomplete,
+    /// V21, the attachment fences, and the attachment-only schema committed.
+    Complete,
+}
+
+fn schema_object_exists(
+    conn: &Connection,
+    object_type: &str,
+    name: &str,
+) -> Result<bool, SqliteError> {
+    conn.query_row(
+        "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type = ?1 AND name = ?2",
+        rusqlite::params![object_type, name],
+        |row| row.get(0),
+    )
+    .map_err(Into::into)
+}
+
+fn schema_column_exists(conn: &Connection, table: &str, column: &str) -> Result<bool, SqliteError> {
+    conn.query_row(
+        "SELECT COUNT(*) > 0 FROM pragma_table_info(?1) WHERE name = ?2",
+        rusqlite::params![table, column],
+        |row| row.get(0),
+    )
+    .map_err(Into::into)
+}
+
+fn require_attachment_schema_objects(
+    conn: &Connection,
+    objects: &[(&str, &str)],
+    phase: &str,
+) -> Result<(), SqliteError> {
+    for (object_type, name) in objects {
+        if !schema_object_exists(conn, object_type, name)? {
+            return Err(SqliteError::InvalidData(format!(
+                "attachment cutover {phase} state is missing {object_type} {name:?}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_incomplete_attachment_schema(conn: &Connection) -> Result<(), SqliteError> {
+    require_attachment_schema_objects(
+        conn,
+        &[
+            ("table", "attachments"),
+            ("index", "idx_attachments_content_ref"),
+        ],
+        "incomplete",
+    )?;
+    require_legacy_attachment_fences(conn)
+}
+
+fn validate_complete_attachment_schema(conn: &Connection) -> Result<(), SqliteError> {
+    require_attachment_schema_objects(
+        conn,
+        &[
+            ("table", "attachments"),
+            ("table", "blob_gc_claims"),
+            ("index", "idx_attachments_content_ref"),
+            ("index", "idx_blob_gc_claims_content_ref"),
+            ("trigger", "attachments_reject_claimed_blob_insert"),
+            ("trigger", "attachments_reject_claimed_blob_update"),
+        ],
+        "complete",
+    )?;
+    if schema_column_exists(conn, "entities", "content_ref")? {
+        return Err(SqliteError::InvalidData(
+            "attachment cutover is complete but entities.content_ref still exists".into(),
+        ));
+    }
+    for (object_type, name) in [
+        ("index", "idx_entities_content_ref"),
+        ("trigger", "entities_reject_claimed_blob_insert"),
+        ("trigger", "entities_reject_claimed_blob_update"),
+    ] {
+        if schema_object_exists(conn, object_type, name)? {
+            return Err(SqliteError::InvalidData(format!(
+                "attachment cutover is complete but legacy {object_type} {name:?} still exists"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Inspect the coordinated V21 state without mutating the connection.
+///
+/// The marker and migration ledger form one state machine. Impossible pairs
+/// fail closed instead of being guessed into a resumable state.
+pub fn attachment_cutover_status(
+    conn: &Connection,
+) -> Result<AttachmentCutoverStatus, SqliteError> {
+    let version = read_schema_version(conn)?;
+    let marker_table = schema_object_exists(conn, "table", "attachment_cutover_state")?;
+    if !marker_table {
+        if version >= ATTACHMENT_CUTOVER_VERSION {
+            return Err(SqliteError::InvalidData(format!(
+                "migration V{ATTACHMENT_CUTOVER_VERSION} is recorded but its attachment cutover marker is absent"
+            )));
+        }
+        if schema_object_exists(conn, "table", "attachments")? {
+            return Err(SqliteError::InvalidData(
+                "attachments table exists without the durable attachment cutover marker".into(),
+            ));
+        }
+        return Ok(AttachmentCutoverStatus::Pending);
+    }
+
+    let marker: Option<(String, Option<i64>)> = conn
+        .query_row(
+            "SELECT state, completed_at FROM attachment_cutover_state WHERE singleton = 1",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .optional()?;
+    match marker {
+        Some((state, None)) if state == "incomplete" => {
+            if version >= ATTACHMENT_CUTOVER_VERSION {
+                Err(SqliteError::InvalidData(format!(
+                    "attachment cutover is incomplete but migration V{ATTACHMENT_CUTOVER_VERSION} is already recorded"
+                )))
+            } else {
+                validate_incomplete_attachment_schema(conn)?;
+                Ok(AttachmentCutoverStatus::Incomplete)
+            }
+        }
+        Some((state, Some(_))) if state == "complete" => {
+            if version == ATTACHMENT_CUTOVER_VERSION {
+                validate_complete_attachment_schema(conn)?;
+                Ok(AttachmentCutoverStatus::Complete)
+            } else {
+                Err(SqliteError::InvalidData(format!(
+                    "attachment cutover is complete but schema ledger is at V{version}, expected V{ATTACHMENT_CUTOVER_VERSION}"
+                )))
+            }
+        }
+        Some((state, completed_at)) => Err(SqliteError::InvalidData(format!(
+            "invalid attachment cutover marker state {state:?} with completed_at={completed_at:?}"
+        ))),
+        None => Err(SqliteError::InvalidData(
+            "attachment cutover marker table exists without its singleton row".into(),
+        )),
+    }
+}
+
+fn require_legacy_attachment_fences(conn: &Connection) -> Result<(), SqliteError> {
+    if !schema_column_exists(conn, "entities", "content_ref")? {
+        return Err(SqliteError::InvalidData(
+            "attachment cutover requires legacy entities.content_ref until finalization".into(),
+        ));
+    }
+    for (object_type, name) in [
+        ("table", "blob_gc_claims"),
+        ("index", "idx_blob_gc_claims_content_ref"),
+        ("index", "idx_entities_content_ref"),
+        ("trigger", "entities_reject_claimed_blob_insert"),
+        ("trigger", "entities_reject_claimed_blob_update"),
+    ] {
+        if !schema_object_exists(conn, object_type, name)? {
+            return Err(SqliteError::InvalidData(format!(
+                "attachment cutover requires legacy {object_type} {name:?} until finalization"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_canonical_legacy_refs(conn: &Connection) -> Result<(), SqliteError> {
+    let invalid: Option<String> = conn
+        .query_row(
+            "SELECT id FROM entities \
+             WHERE content_ref IS NOT NULL \
+               AND (typeof(content_ref) <> 'text' \
+                 OR length(content_ref) <> 64 \
+                 OR content_ref GLOB '*[^0-9a-f]*') \
+             LIMIT 1",
+            [],
+            |row| row.get(0),
+        )
+        .optional()?;
+    if let Some(id) = invalid {
+        return Err(SqliteError::InvalidData(format!(
+            "entities.content_ref for record {id:?} is not a canonical 64-character lowercase hexadecimal ContentRef"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_canonical_attachment_and_claim_refs(conn: &Connection) -> Result<(), SqliteError> {
+    for (table, identity) in [
+        ("attachments", "record_uuid"),
+        ("blob_gc_claims", "root_key"),
+    ] {
+        let sql = format!(
+            "SELECT {identity} FROM {table} \
+             WHERE typeof(content_ref) <> 'text' \
+                OR length(content_ref) <> 64 \
+                OR content_ref GLOB '*[^0-9a-f]*' \
+             LIMIT 1"
+        );
+        let invalid: Option<String> = conn.query_row(&sql, [], |row| row.get(0)).optional()?;
+        if let Some(owner) = invalid {
+            return Err(SqliteError::InvalidData(format!(
+                "{table}.content_ref for {identity} {owner:?} is not canonical"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_attachment_record_owners(conn: &Connection) -> Result<(), SqliteError> {
+    let dangling: Option<(String, String)> = conn
+        .query_row(
+            "SELECT record_uuid, substrate FROM attachments AS attachment \
+             WHERE (substrate = 'entity' AND NOT EXISTS ( \
+                       SELECT 1 FROM entities WHERE id = attachment.record_uuid \
+                   )) \
+                OR (substrate = 'note' AND NOT EXISTS ( \
+                       SELECT 1 FROM notes WHERE id = attachment.record_uuid \
+                   )) \
+             LIMIT 1",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .optional()?;
+    if let Some((record_uuid, substrate)) = dangling {
+        return Err(SqliteError::InvalidData(format!(
+            "attachment role references absent {substrate} record {record_uuid:?}"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_legacy_content_backfill(conn: &Connection) -> Result<(), SqliteError> {
+    let conflict: Option<String> = conn
+        .query_row(
+            "SELECT entity.id FROM entities AS entity \
+             LEFT JOIN attachments AS attachment \
+               ON attachment.record_uuid = entity.id AND attachment.role = 'content' \
+             WHERE entity.content_ref IS NOT NULL \
+               AND (attachment.record_uuid IS NULL \
+                 OR attachment.substrate <> 'entity' \
+                 OR attachment.content_ref <> entity.content_ref) \
+             LIMIT 1",
+            [],
+            |row| row.get(0),
+        )
+        .optional()?;
+    if let Some(record_uuid) = conflict {
+        return Err(SqliteError::InvalidData(format!(
+            "legacy content attachment for entity {record_uuid:?} is missing or conflicts with entities.content_ref"
+        )));
+    }
+    Ok(())
+}
+
+fn stage_attachment_cutover_on_connection(conn: &Connection, now: i64) -> Result<(), SqliteError> {
+    require_legacy_attachment_fences(conn)?;
+    conn.execute_batch(V21_STAGE_UP)?;
+    validate_canonical_legacy_refs(conn)?;
+    validate_canonical_attachment_and_claim_refs(conn)?;
+
+    let conflict: Option<String> = conn
+        .query_row(
+            "SELECT entity.id FROM entities AS entity \
+             JOIN attachments AS attachment \
+               ON attachment.record_uuid = entity.id AND attachment.role = 'content' \
+             WHERE entity.content_ref IS NOT NULL \
+               AND (attachment.substrate <> 'entity' \
+                 OR attachment.content_ref <> entity.content_ref) \
+             LIMIT 1",
+            [],
+            |row| row.get(0),
+        )
+        .optional()?;
+    if let Some(record_uuid) = conflict {
+        return Err(SqliteError::InvalidData(format!(
+            "existing content attachment for entity {record_uuid:?} conflicts with entities.content_ref"
+        )));
+    }
+
+    conn.execute(
+        "INSERT INTO attachments \
+         (record_uuid, substrate, role, content_ref, media_type, size_bytes, created_at) \
+         SELECT id, 'entity', 'content', content_ref, NULL, NULL, created_at \
+         FROM entities WHERE content_ref IS NOT NULL \
+         ON CONFLICT(record_uuid, role) DO NOTHING",
+        [],
+    )?;
+    validate_legacy_content_backfill(conn)?;
+
+    // The caller holds the canonical database GC owner, so every preexisting
+    // claim is abandoned. Clearing happens before the durable incomplete
+    // marker is exposed and remains inside this one transaction.
+    conn.execute("DELETE FROM blob_gc_claims", [])?;
+    conn.execute(
+        "INSERT INTO attachment_cutover_state \
+         (singleton, state, started_at, completed_at) \
+         VALUES (1, 'incomplete', ?1, NULL) \
+         ON CONFLICT(singleton) DO NOTHING",
+        [now],
+    )?;
+    Ok(())
+}
+
+/// Commit stage 1 of the coordinated V21 migration.
+///
+/// The caller must hold [`crate::stores::blob::DatabaseGcOwnerGuard`] for the
+/// canonical database before entering this function and retain it through
+/// application backfill and finalization. This function owns one IMMEDIATE
+/// SQLite transaction; a failure leaves neither its DDL nor marker visible.
+pub fn stage_attachment_cutover(conn: &mut Connection) -> Result<(), SqliteError> {
+    match attachment_cutover_status(conn)? {
+        AttachmentCutoverStatus::Complete => return Ok(()),
+        AttachmentCutoverStatus::Pending | AttachmentCutoverStatus::Incomplete => {}
+    }
+    if read_schema_version(conn)? != ATTACHMENT_CUTOVER_VERSION - 1 {
+        return Err(SqliteError::InvalidData(format!(
+            "attachment cutover stage requires canonical V{} schema",
+            ATTACHMENT_CUTOVER_VERSION - 1
+        )));
+    }
+
+    let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+    let status = attachment_cutover_status(&tx)?;
+    if status == AttachmentCutoverStatus::Complete {
+        return Ok(());
+    }
+    stage_attachment_cutover_on_connection(&tx, chrono::Utc::now().timestamp_micros())?;
+    tx.commit()?;
+    Ok(())
+}
+
+/// Add one host-verified pack-owned attachment during V21 stage 2.
+///
+/// This helper is deliberately transaction-neutral: it neither begins nor
+/// commits a transaction. The boot coordinator can therefore apply the full
+/// verified vector in one caller-owned IMMEDIATE transaction while retaining
+/// the canonical database GC owner. Reapplying the same role and content is
+/// idempotent; a different substrate or digest for that role fails closed.
+#[allow(clippy::too_many_arguments)]
+pub fn apply_generic_verified_attachment(
+    conn: &Connection,
+    record_uuid: &str,
+    substrate: &str,
+    role: &str,
+    content_ref: &ContentRef,
+    media_type: Option<&str>,
+    size_bytes: Option<u64>,
+    created_at: i64,
+) -> Result<(), SqliteError> {
+    if attachment_cutover_status(conn)? != AttachmentCutoverStatus::Incomplete {
+        return Err(SqliteError::InvalidData(
+            "verified application attachments may only be applied while V21 cutover is incomplete"
+                .into(),
+        ));
+    }
+    if role.is_empty() || role.chars().any(char::is_control) {
+        return Err(SqliteError::InvalidData(
+            "attachment role must be non-empty and contain no control characters".into(),
+        ));
+    }
+    let size_bytes = size_bytes.map(i64::try_from).transpose().map_err(|_| {
+        SqliteError::InvalidData("attachment size_bytes exceeds SQLite INTEGER".into())
+    })?;
+    let owner_table = match substrate {
+        "entity" => "entities",
+        "note" => "notes",
+        other => {
+            return Err(SqliteError::InvalidData(format!(
+                "attachment substrate must be 'entity' or 'note', got {other:?}"
+            )))
+        }
+    };
+    let owner_sql = format!("SELECT COUNT(*) > 0 FROM {owner_table} WHERE id = ?1");
+    let owner_exists: bool = conn.query_row(&owner_sql, [record_uuid], |row| row.get(0))?;
+    if !owner_exists {
+        return Err(SqliteError::InvalidData(format!(
+            "cannot attach role {role:?}: {substrate} record {record_uuid:?} does not exist"
+        )));
+    }
+    let claimed: bool = conn.query_row(
+        "SELECT COUNT(*) > 0 FROM blob_gc_claims WHERE content_ref = ?1",
+        [content_ref.as_str()],
+        |row| row.get(0),
+    )?;
+    if claimed {
+        return Err(SqliteError::InvalidData(format!(
+            "cannot attach claimed content_ref {} during V21 cutover",
+            content_ref.as_str()
+        )));
+    }
+
+    let changed = conn.execute(
+        "INSERT INTO attachments \
+         (record_uuid, substrate, role, content_ref, media_type, size_bytes, created_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7) \
+         ON CONFLICT(record_uuid, role) DO UPDATE SET \
+             media_type = excluded.media_type, \
+             size_bytes = excluded.size_bytes, \
+             created_at = excluded.created_at \
+         WHERE attachments.substrate = excluded.substrate \
+           AND attachments.content_ref = excluded.content_ref",
+        rusqlite::params![
+            record_uuid,
+            substrate,
+            role,
+            content_ref.as_str(),
+            media_type,
+            size_bytes,
+            created_at,
+        ],
+    )?;
+    if changed == 0 {
+        return Err(SqliteError::InvalidData(format!(
+            "attachment role {role:?} for record {record_uuid:?} conflicts with an existing substrate or content_ref"
+        )));
+    }
+    Ok(())
+}
+
+fn finalize_attachment_cutover_on_connection(
+    conn: &Connection,
+    now: i64,
+) -> Result<(), SqliteError> {
+    require_legacy_attachment_fences(conn)?;
+    validate_canonical_legacy_refs(conn)?;
+    validate_canonical_attachment_and_claim_refs(conn)?;
+    validate_attachment_record_owners(conn)?;
+    validate_legacy_content_backfill(conn)?;
+
+    let remaining_claims: i64 =
+        conn.query_row("SELECT COUNT(*) FROM blob_gc_claims", [], |row| row.get(0))?;
+    if remaining_claims != 0 {
+        return Err(SqliteError::InvalidData(format!(
+            "attachment cutover cannot finalize while {remaining_claims} blob GC claim rows remain"
+        )));
+    }
+
+    let uncovered_model: Option<String> = conn
+        .query_row(
+            "SELECT model.id FROM entities AS model \
+             WHERE model.entity_type = 'moodboard_model' \
+               AND model.content_ref IS NOT NULL \
+               AND NOT EXISTS ( \
+                   SELECT 1 FROM attachments AS attachment \
+                   WHERE attachment.record_uuid = model.id \
+                     AND attachment.substrate = 'entity' \
+                     AND attachment.role = 'fann-network' \
+               ) \
+             LIMIT 1",
+            [],
+            |row| row.get(0),
+        )
+        .optional()?;
+    if let Some(record_uuid) = uncovered_model {
+        return Err(SqliteError::InvalidData(format!(
+            "moodboard_model {record_uuid:?} has legacy content but no verified 'fann-network' attachment"
+        )));
+    }
+
+    conn.execute_batch(V21_ATTACHMENT_FENCES_UP)?;
+    conn.execute_batch(
+        "DROP TRIGGER entities_reject_claimed_blob_insert; \
+         DROP TRIGGER entities_reject_claimed_blob_update; \
+         DROP INDEX idx_entities_content_ref; \
+         ALTER TABLE entities DROP COLUMN content_ref;",
+    )?;
+    conn.execute(
+        "UPDATE attachment_cutover_state \
+         SET state = 'complete', completed_at = ?1 \
+         WHERE singleton = 1 AND state = 'incomplete'",
+        [now],
+    )?;
+    Ok(())
+}
+
+fn record_attachment_cutover_migration(conn: &Connection, now: i64) -> Result<(), SqliteError> {
+    let migration = MIGRATIONS
+        .iter()
+        .find(|migration| migration.version == ATTACHMENT_CUTOVER_VERSION)
+        .expect("V21 migration must be registered");
+    conn.execute(
+        "INSERT INTO _schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3)",
+        rusqlite::params![migration.version, migration.name, now],
+    )?;
+    Ok(())
+}
+
+/// Atomically switch an explicitly staged database to attachment-only V21.
+///
+/// The caller must still hold the canonical database GC owner. The exclusive
+/// transition revalidates every legacy and attachment reference, verifies
+/// moodboard model role coverage, replaces the claim fences, removes the old
+/// column, marks the cutover complete, and records V21 in one transaction.
+pub fn finalize_attachment_cutover(conn: &mut Connection) -> Result<(), SqliteError> {
+    if attachment_cutover_status(conn)? == AttachmentCutoverStatus::Complete {
+        return Ok(());
+    }
+    let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Exclusive)?;
+    match attachment_cutover_status(&tx)? {
+        AttachmentCutoverStatus::Complete => return Ok(()),
+        AttachmentCutoverStatus::Pending => {
+            return Err(SqliteError::InvalidData(
+                "attachment cutover must complete stage 1 before finalization".into(),
+            ))
+        }
+        AttachmentCutoverStatus::Incomplete => {}
+    }
+    let now = chrono::Utc::now().timestamp_micros();
+    finalize_attachment_cutover_on_connection(&tx, now)?;
+    record_attachment_cutover_migration(&tx, now)?;
+    tx.commit()?;
+    Ok(())
+}
 
 /// Read the ordered migration ledger prefix without interpreting its rows.
 fn read_applied_migration_ledger(
@@ -382,8 +928,6 @@ fn validate_applied_migration_ledger(
 
 const MIGRATION_TRACKING_TABLE: &str = include_str!("../sql/schema-migrations-table.sql");
 
-/// Apply all unapplied migrations in order. Idempotent; each migration runs in its own transaction.
-/// Errors on non-contiguous version array or failed migration.
 /// Read the applied schema version from an open connection **without** running
 /// migrations. Returns 0 when the `_schema_migrations` ledger is absent (an
 /// un-migrated or empty database); any other failure (BUSY, IO) propagates —
@@ -412,6 +956,13 @@ pub fn read_schema_version(conn: &Connection) -> Result<u32, SqliteError> {
 pub fn inspect_schema_version(path: &std::path::Path) -> Result<u32, SqliteError> {
     let conn = crate::pool::open_read_only_snapshot_connection(path)?;
     read_schema_version(&conn)
+}
+
+/// Open `path` read-only and require the exact canonical current ledger and
+/// physical cutover state, without creating files or applying migrations.
+pub fn inspect_schema_is_current(path: &std::path::Path) -> Result<u32, SqliteError> {
+    let conn = crate::pool::open_read_only_snapshot_connection(path)?;
+    validate_schema_is_current(&conn)
 }
 
 /// Require an already-open database to match this build's latest core schema
@@ -449,6 +1000,13 @@ pub fn validate_schema_is_current(conn: &Connection) -> Result<u32, SqliteError>
     // must not accept a history that ordinary boot would reject merely because
     // it cannot repair it in place.
     validate_applied_migration_ledger(conn, current_version)?;
+    if current_version == ATTACHMENT_CUTOVER_VERSION
+        && attachment_cutover_status(conn)? != AttachmentCutoverStatus::Complete
+    {
+        return Err(SqliteError::InvalidData(
+            "read-only database has not completed the V21 attachment cutover".into(),
+        ));
+    }
 
     Ok(current_version)
 }
@@ -500,7 +1058,78 @@ pub(crate) mod test_sync {
     }
 }
 
+/// Apply the ordinary unapplied migration prefix in order.
+///
+/// The operation is idempotent and each ordinary migration runs in its own
+/// transaction. V21 is the application-assisted exception: a database with no
+/// legacy content references may complete V21 atomically here, while a legacy
+/// database stops successfully at V20 so the async host can stage, verify, and
+/// finalize the attachment cutover. Errors on a non-contiguous migration array,
+/// a non-canonical applied ledger, or a failed migration.
+fn canonical_connection_database_path(conn: &Connection) -> Result<Option<PathBuf>, SqliteError> {
+    let configured = conn.path().unwrap_or_default();
+    let raw_path = if configured.is_empty() {
+        conn.query_row(
+            "SELECT file FROM pragma_database_list WHERE name = 'main'",
+            [],
+            |row| row.get::<_, String>(0),
+        )?
+    } else {
+        configured.to_string()
+    };
+
+    if raw_path.is_empty() {
+        return Ok(None);
+    }
+    std::fs::canonicalize(&raw_path)
+        .map(Some)
+        .map_err(SqliteError::Io)
+}
+
+fn validate_database_gc_owner(
+    conn: &Connection,
+    owner: &DatabaseGcOwnerGuard,
+) -> Result<(), SqliteError> {
+    let connection_path = canonical_connection_database_path(conn)?;
+    if owner.database_path() != connection_path.as_deref() {
+        return Err(SqliteError::InvalidData(format!(
+            "database GC owner targets {:?}, but migration connection targets {:?}",
+            owner.database_path(),
+            connection_path.as_deref(),
+        )));
+    }
+    Ok(())
+}
+
 pub fn run_migrations(conn: &mut Connection) -> Result<u32, SqliteError> {
+    let database_path = canonical_connection_database_path(conn)?;
+    if let Some(database_path) = database_path {
+        // This raw API may have been handed a connection behind an opaque pool
+        // writer guard. Never wait here and invert the canonical
+        // owner-before-writer order; fail closed and direct production callers
+        // to `StorageBackend::prepare_core_schema` instead.
+        let owner = try_acquire_database_gc_owner_for_path(database_path).map_err(|error| {
+            SqliteError::InvalidData(format!(
+                "failed to acquire database GC owner before schema migration: {error}"
+            ))
+        })?;
+        return run_migrations_with_database_gc_owner(conn, &owner);
+    }
+
+    // A raw in-memory connection has no durable/cross-process GC domain. The
+    // production in-memory backend still uses the owner-aware path below.
+    run_migrations_with_busy_timeout(conn)
+}
+
+pub(crate) fn run_migrations_with_database_gc_owner(
+    conn: &mut Connection,
+    owner: &DatabaseGcOwnerGuard,
+) -> Result<u32, SqliteError> {
+    validate_database_gc_owner(conn, owner)?;
+    run_migrations_with_busy_timeout(conn)
+}
+
+fn run_migrations_with_busy_timeout(conn: &mut Connection) -> Result<u32, SqliteError> {
     // Concurrent boots (multiple processes migrating the same file) contend on
     // the write lock below; a short hot-path busy_timeout cannot wait out a
     // sibling's migration. Raise-only to a 5s floor — never reduce a caller
@@ -647,11 +1276,56 @@ fn run_migrations_locked(conn: &mut Connection) -> Result<u32, SqliteError> {
             continue;
         }
 
-        tx.execute_batch(migration.up)
-            .map_err(|e| SqliteError::Migration {
+        if migration.version == ATTACHMENT_CUTOVER_VERSION {
+            let status = attachment_cutover_status(&tx).map_err(|e| SqliteError::Migration {
                 version: migration.version,
                 error: e.to_string(),
             })?;
+            let legacy_refs: i64 = tx
+                .query_row(
+                    "SELECT COUNT(*) FROM entities WHERE content_ref IS NOT NULL",
+                    [],
+                    |row| row.get(0),
+                )
+                .map_err(|e| SqliteError::Migration {
+                    version: migration.version,
+                    error: e.to_string(),
+                })?;
+
+            // V21 belongs to the boot coordinator. Ordinary backend open may
+            // finish the degenerate zero-ref case atomically, but it must not
+            // expose a dual-source interval or eagerly stage a legacy DB.
+            if status == AttachmentCutoverStatus::Incomplete || legacy_refs != 0 {
+                drop(tx);
+                break;
+            }
+            if status != AttachmentCutoverStatus::Pending {
+                return Err(SqliteError::Migration {
+                    version: migration.version,
+                    error: format!("unexpected attachment cutover state {status:?}"),
+                });
+            }
+
+            let now = chrono::Utc::now().timestamp_micros();
+            stage_attachment_cutover_on_connection(&tx, now).map_err(|e| {
+                SqliteError::Migration {
+                    version: migration.version,
+                    error: e.to_string(),
+                }
+            })?;
+            finalize_attachment_cutover_on_connection(&tx, now).map_err(|e| {
+                SqliteError::Migration {
+                    version: migration.version,
+                    error: e.to_string(),
+                }
+            })?;
+        } else {
+            tx.execute_batch(migration.up)
+                .map_err(|e| SqliteError::Migration {
+                    version: migration.version,
+                    error: e.to_string(),
+                })?;
+        }
 
         // V19's repair contract includes normalizing the two known-divergent
         // recorded names. `_schema_migrations` is created and owned by this

--- a/crates/khive-db/src/migrations_tests.rs
+++ b/crates/khive-db/src/migrations_tests.rs
@@ -5,6 +5,25 @@ fn open_memory() -> Connection {
     Connection::open_in_memory().expect("in-memory connection")
 }
 
+fn migrate_through(conn: &mut Connection, through_version: u32) {
+    conn.execute_batch(MIGRATION_TRACKING_TABLE)
+        .expect("create migration ledger");
+    for migration in MIGRATIONS
+        .iter()
+        .filter(|migration| migration.version <= through_version)
+    {
+        let tx = conn.transaction().expect("begin historical migration");
+        tx.execute_batch(migration.up)
+            .expect("apply historical migration body");
+        tx.execute(
+            "INSERT INTO _schema_migrations (version, name, applied_at) VALUES (?1, ?2, 0)",
+            rusqlite::params![migration.version, migration.name],
+        )
+        .expect("record historical migration");
+        tx.commit().expect("commit historical migration");
+    }
+}
+
 fn table_exists(conn: &Connection, name: &str) -> bool {
     conn.query_row(
         "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name=?1",
@@ -1407,7 +1426,7 @@ fn v6_implicit_mass_upsert_on_conflict() {
 #[test]
 fn v10_adds_content_ref_column_and_partial_index() {
     let mut conn = open_memory();
-    run_migrations(&mut conn).expect("migrations should succeed");
+    migrate_through(&mut conn, 10);
     assert!(
         column_exists(&conn, "entities", "content_ref"),
         "V10 must add entities.content_ref"
@@ -1421,7 +1440,7 @@ fn v10_adds_content_ref_column_and_partial_index() {
 #[test]
 fn v10_content_ref_defaults_null_and_accepts_a_value() {
     let mut conn = open_memory();
-    run_migrations(&mut conn).expect("migrations should succeed");
+    migrate_through(&mut conn, 10);
 
     conn.execute(
         "INSERT INTO entities (id, namespace, kind, name, tags, created_at, updated_at) \
@@ -1904,38 +1923,52 @@ impl Drop for BarrierGuard {
     }
 }
 
-// khive#1212: two processes booting the same database file must both complete
-// migrations — the IMMEDIATE transaction serializes them and the under-lock
-// re-check makes the loser converge instead of failing on already-applied DDL.
+// khive#1212 + ADR-160: two boots of one file must both converge, with the
+// canonical database-GC owner acquired before either pool writer. The
+// pre-held owner makes both waiters deterministic and proves no V21 marker or
+// ledger mutation appears before ownership transfers.
 #[test]
 #[serial_test::serial(migration_contention)]
 fn concurrent_boots_converge() {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().join("concurrent-boot.db");
-    let _guard = BarrierGuard;
+    let backends = [
+        crate::StorageBackend::sqlite(&path).expect("open first backend"),
+        crate::StorageBackend::sqlite(&path).expect("open second backend"),
+    ];
+    let canonical = backends[0]
+        .pool()
+        .canonical_path()
+        .expect("file-backed canonical path")
+        .to_path_buf();
+    let owner =
+        crate::stores::blob::acquire_database_gc_owner_for_path_blocking(Some(canonical.clone()))
+            .expect("pre-hold database GC owner");
 
-    // Deterministic interleaving via the in-crate stale-read barrier: both
-    // threads must observe the empty ledger (version 0, no lock held) before
-    // either is released to compete for the IMMEDIATE write lock. The loser
-    // is thereby guaranteed to reach the under-lock re-check with a stale
-    // view, which the fast-forward counter asserts below.
-    let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
-    *test_sync::STALE_READ_BARRIER.lock().unwrap() = Some(barrier);
-    test_sync::LOCKED_FAST_FORWARDS.store(0, std::sync::atomic::Ordering::Relaxed);
-    test_sync::BUSY_OBSERVED.store(false, std::sync::atomic::Ordering::SeqCst);
-    test_sync::WINNER_COMMITTED.store(false, std::sync::atomic::Ordering::SeqCst);
-    test_sync::LOSER_SAW_WINNER_COMMIT.store(false, std::sync::atomic::Ordering::SeqCst);
-
-    let handles: Vec<_> = (0..2)
-        .map(|_| {
-            let path = path.clone();
-            std::thread::spawn(move || {
-                test_sync::PARTICIPATE.with(|p| p.set(true));
-                let mut conn = Connection::open(&path).expect("open");
-                run_migrations(&mut conn)
-            })
-        })
+    let handles: Vec<_> = backends
+        .into_iter()
+        .map(|backend| std::thread::spawn(move || backend.prepare_core_schema()))
         .collect();
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while crate::stores::blob::database_gc_waiter_count(Some(&canonical)) != 2
+        && std::time::Instant::now() < deadline
+    {
+        std::thread::yield_now();
+    }
+    assert_eq!(
+        crate::stores::blob::database_gc_waiter_count(Some(&canonical)),
+        2,
+        "both boot paths must wait behind the canonical owner before taking a writer"
+    );
+    let before = Connection::open(&path).expect("inspect pre-owner schema");
+    assert_eq!(
+        read_schema_version(&before).expect("read pre-owner ledger"),
+        0,
+        "schema must remain untouched while database-GC ownership is unavailable"
+    );
+    drop(before);
+    drop(owner);
 
     let latest = MIGRATIONS.last().expect("at least one migration").version;
     for handle in handles {
@@ -1945,31 +1978,6 @@ fn concurrent_boots_converge() {
             .expect("both concurrent boots must succeed");
         assert_eq!(version, latest);
     }
-    *test_sync::STALE_READ_BARRIER.lock().unwrap() = None;
-
-    // Both threads observed version 0 before either took the write lock, so
-    // the loser necessarily re-checked under the lock and fast-forwarded past
-    // the winner's applied migrations. This fails if either the IMMEDIATE
-    // behavior or the under-lock MAX(version) re-check regresses.
-    assert!(
-        test_sync::LOCKED_FAST_FORWARDS.load(std::sync::atomic::Ordering::Relaxed) >= 1,
-        "loser thread must observe the sibling's ledger under the write lock"
-    );
-
-    // SQLite itself reported a busy acquisition to the loser while the winner
-    // held the write lock: the winner does not commit until the loser's busy
-    // handler has fired, so this is observed contention, not an intended
-    // attempt. If IMMEDIATE regressed to deferred behavior, no busy signal
-    // occurs on BEGIN and this fails (that interleaving also fails outright
-    // on duplicate DDL).
-    assert!(
-        test_sync::BUSY_OBSERVED.load(std::sync::atomic::Ordering::SeqCst),
-        "SQLite must observe the loser's blocked BEGIN IMMEDIATE while the winner holds the lock"
-    );
-    assert!(
-        test_sync::LOSER_SAW_WINNER_COMMIT.load(std::sync::atomic::Ordering::SeqCst),
-        "loser's BEGIN IMMEDIATE must return only after the winner committed"
-    );
 
     let conn = Connection::open(&path).expect("reopen");
     let rows: u32 = conn
@@ -1982,6 +1990,45 @@ fn concurrent_boots_converge() {
         MIGRATIONS.len(),
         "exactly one ledger row per migration"
     );
+}
+
+#[test]
+#[serial_test::serial(migration_contention)]
+fn raw_file_migration_refuses_when_database_gc_owner_is_held() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("raw-owner-refusal.db");
+    drop(Connection::open(&path).expect("create raw migration database"));
+    let canonical = std::fs::canonicalize(&path).expect("canonical database path");
+    let owner = crate::stores::blob::acquire_database_gc_owner_for_path_blocking(Some(canonical))
+        .expect("hold database GC owner");
+    let (result_tx, result_rx) = std::sync::mpsc::channel();
+    let path_for_runner = path.clone();
+    let runner = std::thread::spawn(move || {
+        let mut conn = Connection::open(path_for_runner).expect("open raw migration connection");
+        let result = run_migrations(&mut conn)
+            .map(|_| "unexpected success".to_string())
+            .unwrap_or_else(|error| error.to_string());
+        let version = read_schema_version(&conn).expect("read post-refusal schema");
+        result_tx.send((result, version)).expect("report refusal");
+    });
+    let (error, version) = match result_rx.recv_timeout(std::time::Duration::from_secs(2)) {
+        Ok(result) => result,
+        Err(timeout) => {
+            drop(owner);
+            let _ = runner.join();
+            panic!("raw migration waited for database-GC ownership instead of refusing: {timeout}");
+        }
+    };
+    assert!(
+        error.contains("database GC owner"),
+        "unexpected refusal: {error}"
+    );
+    assert_eq!(
+        version, 0,
+        "raw refusal must occur before creating the migration ledger"
+    );
+    drop(owner);
+    runner.join().expect("raw migration runner joins");
 }
 
 // khive#1217 review blocking finding: the pre-lock ahead-of-latest guard runs
@@ -2088,7 +2135,7 @@ fn insert_v19_test_edge(conn: &Connection, id: &str, source_id: &str, target_id:
 #[test]
 fn v19_repairs_divergent_cursor_ledgers() {
     let mut conn = open_memory();
-    run_migrations(&mut conn).expect("fresh migrate to latest (includes V19)");
+    migrate_through(&mut conn, 18);
 
     // Populate rows that predate the divergence being simulated below.
     insert_v19_test_entity(&conn, "e1", 10);
@@ -2223,7 +2270,7 @@ fn post_v19_name_mismatch_fails_loud() {
 #[test]
 fn v20_blob_gc_claims_block_new_live_references_until_cleanup() {
     let mut conn = open_memory();
-    run_migrations(&mut conn).expect("fresh migrate to latest (includes V20)");
+    migrate_through(&mut conn, 20);
 
     assert!(
         table_exists(&conn, "blob_gc_claims"),
@@ -2289,4 +2336,252 @@ fn v20_blob_gc_claims_block_new_live_references_until_cleanup() {
         [claimed],
     )
     .expect("the reference becomes writable after claim cleanup");
+}
+
+// ── V21: coordinated attachments-first cutover (ADR-160 D4) ────────────────────
+
+#[test]
+fn v21_legacy_refs_remain_pending_until_explicit_stage_and_finalize() {
+    let mut conn = open_memory();
+    migrate_through(&mut conn, 20);
+    let content = khive_storage::blob::ContentRef::from_hex("a".repeat(64)).unwrap();
+    let model = khive_storage::blob::ContentRef::from_hex("b".repeat(64)).unwrap();
+    conn.execute(
+        "INSERT INTO entities \
+         (id, namespace, kind, entity_type, name, tags, created_at, updated_at, deleted_at, content_ref) \
+         VALUES ('doc', 'local', 'document', NULL, 'doc', '[]', 1, 1, 2, ?1), \
+                ('model', 'local', 'artifact', 'moodboard_model', 'model', '[]', 1, 1, NULL, ?2)",
+        rusqlite::params![content.as_str(), model.as_str()],
+    )
+    .unwrap();
+
+    assert_eq!(run_migrations(&mut conn).unwrap(), 20);
+    assert_eq!(
+        attachment_cutover_status(&conn).unwrap(),
+        AttachmentCutoverStatus::Pending
+    );
+    assert!(!table_exists(&conn, "attachments"));
+
+    conn.execute(
+        "INSERT INTO blob_gc_claims (root_key, content_ref, claimed_at) VALUES ('abandoned', ?1, 1)",
+        [content.as_str()],
+    )
+    .unwrap();
+    stage_attachment_cutover(&mut conn).unwrap();
+    assert_eq!(
+        attachment_cutover_status(&conn).unwrap(),
+        AttachmentCutoverStatus::Incomplete
+    );
+    assert!(column_exists(&conn, "entities", "content_ref"));
+    assert_eq!(read_schema_version(&conn).unwrap(), 20);
+    let backfilled: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM attachments WHERE role = 'content' AND record_uuid IN ('doc', 'model')",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(backfilled, 2, "stage must include soft-deleted entity rows");
+    assert_eq!(
+        conn.query_row("SELECT COUNT(*) FROM blob_gc_claims", [], |row| row
+            .get::<_, i64>(0))
+            .unwrap(),
+        0,
+        "exclusive stage owner clears abandoned claims"
+    );
+
+    assert_eq!(
+        run_migrations(&mut conn).unwrap(),
+        20,
+        "restart must remain resumable"
+    );
+    assert_eq!(
+        attachment_cutover_status(&conn).unwrap(),
+        AttachmentCutoverStatus::Incomplete
+    );
+
+    apply_generic_verified_attachment(
+        &conn,
+        "model",
+        "entity",
+        "fann-network",
+        &model,
+        Some("application/vnd.khive.fann+json"),
+        Some(123),
+        3,
+    )
+    .unwrap();
+    finalize_attachment_cutover(&mut conn).unwrap();
+    assert_eq!(read_schema_version(&conn).unwrap(), 21);
+    assert_eq!(
+        attachment_cutover_status(&conn).unwrap(),
+        AttachmentCutoverStatus::Complete
+    );
+    assert!(!column_exists(&conn, "entities", "content_ref"));
+    assert!(!index_exists(&conn, "idx_entities_content_ref"));
+    for trigger in [
+        "entities_reject_claimed_blob_insert",
+        "entities_reject_claimed_blob_update",
+    ] {
+        assert!(
+            !schema_object_exists(&conn, "trigger", trigger).unwrap(),
+            "finalization must remove legacy trigger {trigger}"
+        );
+    }
+    for trigger in [
+        "attachments_reject_claimed_blob_insert",
+        "attachments_reject_claimed_blob_update",
+    ] {
+        assert!(
+            schema_object_exists(&conn, "trigger", trigger).unwrap(),
+            "finalization must install attachment trigger {trigger}"
+        );
+    }
+}
+
+#[test]
+fn v21_empty_database_fast_path_is_atomic_and_complete() {
+    let mut conn = open_memory();
+    assert_eq!(run_migrations(&mut conn).unwrap(), 21);
+    assert_eq!(
+        attachment_cutover_status(&conn).unwrap(),
+        AttachmentCutoverStatus::Complete
+    );
+    assert!(table_exists(&conn, "attachments"));
+    assert!(!column_exists(&conn, "entities", "content_ref"));
+    assert_eq!(
+        conn.query_row(
+            "SELECT COUNT(*) FROM attachment_cutover_state WHERE state = 'incomplete'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap(),
+        0,
+        "the zero-ref fast path must expose no durable incomplete window"
+    );
+}
+
+#[test]
+fn v21_stage_rejects_invalid_refs_without_partial_schema_or_marker() {
+    let mut conn = open_memory();
+    migrate_through(&mut conn, 20);
+    conn.execute(
+        "INSERT INTO entities \
+         (id, namespace, kind, name, tags, created_at, updated_at, content_ref) \
+         VALUES ('bad', 'local', 'document', 'bad', '[]', 1, 1, 'NOT-CANONICAL')",
+        [],
+    )
+    .unwrap();
+
+    let error = stage_attachment_cutover(&mut conn)
+        .expect_err("invalid legacy refs must fail the coordinated stage");
+    assert!(
+        error.to_string().contains("canonical"),
+        "unexpected error: {error}"
+    );
+    assert_eq!(read_schema_version(&conn).unwrap(), 20);
+    assert!(
+        !table_exists(&conn, "attachments"),
+        "failed stage must roll back DDL"
+    );
+    assert!(!table_exists(&conn, "attachment_cutover_state"));
+    assert!(column_exists(&conn, "entities", "content_ref"));
+}
+
+#[test]
+fn v21_verified_attachment_conflict_preserves_the_staged_identity() {
+    let mut conn = open_memory();
+    migrate_through(&mut conn, 20);
+    let original = khive_storage::blob::ContentRef::from_hex("d".repeat(64)).unwrap();
+    let conflicting = khive_storage::blob::ContentRef::from_hex("e".repeat(64)).unwrap();
+    conn.execute(
+        "INSERT INTO entities \
+         (id, namespace, kind, name, tags, created_at, updated_at, content_ref) \
+         VALUES ('doc', 'local', 'document', 'doc', '[]', 1, 1, ?1)",
+        [original.as_str()],
+    )
+    .unwrap();
+    stage_attachment_cutover(&mut conn).unwrap();
+
+    let error = apply_generic_verified_attachment(
+        &conn,
+        "doc",
+        "entity",
+        "content",
+        &conflicting,
+        None,
+        None,
+        2,
+    )
+    .expect_err("one role cannot be rebound to a different verified digest");
+    assert!(
+        error.to_string().contains("conflicts"),
+        "unexpected error: {error}"
+    );
+    let retained: String = conn
+        .query_row(
+            "SELECT content_ref FROM attachments WHERE record_uuid = 'doc' AND role = 'content'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(retained, original.as_str());
+    assert_eq!(
+        attachment_cutover_status(&conn).unwrap(),
+        AttachmentCutoverStatus::Incomplete
+    );
+}
+
+#[test]
+fn v21_finalize_revalidates_model_coverage_and_attachment_claim_fences() {
+    let mut conn = open_memory();
+    migrate_through(&mut conn, 20);
+    let model = khive_storage::blob::ContentRef::from_hex("c".repeat(64)).unwrap();
+    conn.execute(
+        "INSERT INTO entities \
+         (id, namespace, kind, entity_type, name, tags, created_at, updated_at, content_ref) \
+         VALUES ('model', 'local', 'artifact', 'moodboard_model', 'model', '[]', 1, 1, ?1)",
+        [model.as_str()],
+    )
+    .unwrap();
+    stage_attachment_cutover(&mut conn).unwrap();
+
+    let error = finalize_attachment_cutover(&mut conn)
+        .expect_err("every extant model with content requires fann-network");
+    assert!(
+        error.to_string().contains("fann-network"),
+        "unexpected error: {error}"
+    );
+    assert_eq!(
+        attachment_cutover_status(&conn).unwrap(),
+        AttachmentCutoverStatus::Incomplete
+    );
+    assert!(column_exists(&conn, "entities", "content_ref"));
+
+    apply_generic_verified_attachment(
+        &conn,
+        "model",
+        "entity",
+        "fann-network",
+        &model,
+        None,
+        None,
+        2,
+    )
+    .unwrap();
+    finalize_attachment_cutover(&mut conn).unwrap();
+    conn.execute(
+        "INSERT INTO blob_gc_claims (root_key, content_ref, claimed_at) VALUES ('active', ?1, 3)",
+        [model.as_str()],
+    )
+    .unwrap();
+    let insert_error = conn
+        .execute(
+            "INSERT INTO attachments \
+             (record_uuid, substrate, role, content_ref, created_at) \
+             VALUES ('other', 'entity', 'content', ?1, 4)",
+            [model.as_str()],
+        )
+        .expect_err("an attachment cannot acquire a claimed digest");
+    assert!(insert_error.to_string().contains("active blob sweep"));
 }

--- a/crates/khive-db/src/stores/attachment.rs
+++ b/crates/khive-db/src/stores/attachment.rs
@@ -1,0 +1,301 @@
+//! SQL-backed `AttachmentStore` implementation.
+
+use std::str::FromStr;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rusqlite::OptionalExtension;
+use uuid::Uuid;
+
+use khive_storage::attachment::{
+    validate_attachment_role, Attachment, AttachmentStore, AttachmentSubstrate,
+};
+use khive_storage::error::StorageError;
+use khive_storage::types::{SqlStatement, SqlValue};
+use khive_storage::{ContentRef, StorageCapability};
+
+use crate::error::SqliteError;
+use crate::pool::ConnectionPool;
+use crate::sql_bridge::bind_params;
+use crate::writer_task::WriterTaskHandle;
+
+fn map_err(error: rusqlite::Error, operation: &'static str) -> StorageError {
+    StorageError::driver(StorageCapability::Attachments, operation, error)
+}
+
+fn map_sqlite_err(error: SqliteError, operation: &'static str) -> StorageError {
+    StorageError::driver(StorageCapability::Attachments, operation, error)
+}
+
+/// Build the canonical upsert for one already-validated attachment.
+pub fn attachment_upsert_statement(attachment: &Attachment) -> Result<SqlStatement, StorageError> {
+    attachment.validate()?;
+    let size_bytes = attachment
+        .size_bytes
+        .map(|size| {
+            i64::try_from(size).map_err(|_| StorageError::InvalidInput {
+                capability: StorageCapability::Attachments,
+                operation: "upsert_attachment".into(),
+                message: "attachment size_bytes must fit SQLite INTEGER".to_string(),
+            })
+        })
+        .transpose()?;
+    Ok(SqlStatement {
+        sql: "INSERT INTO attachments \
+              (record_uuid, substrate, role, content_ref, media_type, size_bytes, created_at) \
+              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7) \
+              ON CONFLICT(record_uuid, role) DO UPDATE SET \
+                substrate = excluded.substrate, \
+                content_ref = excluded.content_ref, \
+                media_type = excluded.media_type, \
+                size_bytes = excluded.size_bytes, \
+                created_at = excluded.created_at"
+            .to_string(),
+        params: vec![
+            SqlValue::Text(attachment.record_uuid.to_string()),
+            SqlValue::Text(attachment.substrate.as_str().to_string()),
+            SqlValue::Text(attachment.role.clone()),
+            SqlValue::Text(attachment.content_ref.to_string()),
+            attachment
+                .media_type
+                .clone()
+                .map_or(SqlValue::Null, SqlValue::Text),
+            size_bytes.map_or(SqlValue::Null, SqlValue::Integer),
+            SqlValue::Integer(attachment.created_at),
+        ],
+        label: Some("attachment-upsert".to_string()),
+    })
+}
+
+/// Build deletion of one role from one record.
+pub fn delete_attachment_statement(record_uuid: Uuid, role: &str) -> SqlStatement {
+    SqlStatement {
+        sql: "DELETE FROM attachments WHERE record_uuid = ?1 AND role = ?2".to_string(),
+        params: vec![
+            SqlValue::Text(record_uuid.to_string()),
+            SqlValue::Text(role.to_string()),
+        ],
+        label: Some("attachment-delete-role".to_string()),
+    }
+}
+
+/// Build deletion of every attachment owned by one record substrate.
+pub fn delete_record_attachments_statement(
+    record_uuid: Uuid,
+    substrate: AttachmentSubstrate,
+) -> SqlStatement {
+    SqlStatement {
+        sql: "DELETE FROM attachments WHERE record_uuid = ?1 AND substrate = ?2".to_string(),
+        params: vec![
+            SqlValue::Text(record_uuid.to_string()),
+            SqlValue::Text(substrate.as_str().to_string()),
+        ],
+        label: Some(format!("attachment-delete-record-{}", substrate.as_str())),
+    }
+}
+
+/// SQLite attachment store. Schema installation is owned by the coordinated
+/// core migration, not by this accessor.
+pub struct SqlAttachmentStore {
+    pool: Arc<ConnectionPool>,
+    is_file_backed: bool,
+    writer_task: Option<WriterTaskHandle>,
+}
+
+impl SqlAttachmentStore {
+    pub fn new(pool: Arc<ConnectionPool>, is_file_backed: bool) -> Self {
+        let writer_task = pool.writer_task_handle().ok().flatten();
+        Self {
+            pool,
+            is_file_backed,
+            writer_task,
+        }
+    }
+
+    fn current_writer_task(
+        &self,
+        operation: &'static str,
+    ) -> Result<Option<WriterTaskHandle>, StorageError> {
+        self.pool
+            .writer_task_for_write(self.writer_task.as_ref(), operation)
+    }
+
+    async fn with_writer<F, R>(&self, operation: &'static str, f: F) -> Result<R, StorageError>
+    where
+        F: FnOnce(&rusqlite::Connection) -> Result<R, rusqlite::Error> + Send + 'static,
+        R: Send + 'static,
+    {
+        if let Some(writer_task) = self.current_writer_task(operation)? {
+            return writer_task
+                .send_bounded(move |conn| f(conn).map_err(|error| map_err(error, operation)))
+                .await;
+        }
+
+        self.pool
+            .record_direct_route(crate::timeout_sink::Site::DirectRouteEntity);
+        let pool = Arc::clone(&self.pool);
+        tokio::task::spawn_blocking(move || {
+            let guard = pool
+                .try_writer()
+                .map_err(|error| map_sqlite_err(error, operation))?;
+            f(guard.conn()).map_err(|error| map_err(error, operation))
+        })
+        .await
+        .map_err(|error| StorageError::driver(StorageCapability::Attachments, operation, error))?
+    }
+
+    async fn with_reader<F, R>(&self, operation: &'static str, f: F) -> Result<R, StorageError>
+    where
+        F: FnOnce(&rusqlite::Connection) -> Result<R, rusqlite::Error> + Send + 'static,
+        R: Send + 'static,
+    {
+        if self.is_file_backed {
+            let pool = Arc::clone(&self.pool);
+            crate::read_cancellation::run_declared_interruptible_read(
+                StorageCapability::Attachments,
+                operation,
+                move |scope| {
+                    scope.ensure_active()?;
+                    let conn = pool
+                        .open_standalone_reader()
+                        .map_err(|error| map_sqlite_err(error, operation))?;
+                    scope.run(&conn, || {
+                        f(&conn).map_err(|error| map_err(error, operation))
+                    })
+                },
+            )
+            .await
+        } else {
+            let pool = Arc::clone(&self.pool);
+            crate::read_cancellation::run_declared_interruptible_read(
+                StorageCapability::Attachments,
+                operation,
+                move |scope| {
+                    let mut guard = pool
+                        .reader_until(|| scope.should_stop())
+                        .map_err(|error| map_sqlite_err(error, operation))?
+                        .ok_or_else(|| StorageError::Timeout {
+                            operation: operation.into(),
+                        })?;
+                    scope.run_pooled_reader(&mut guard, |conn| {
+                        f(conn).map_err(|error| map_err(error, operation))
+                    })
+                },
+            )
+            .await
+        }
+    }
+}
+
+fn conversion_error(
+    index: usize,
+    value_type: rusqlite::types::Type,
+    message: String,
+) -> rusqlite::Error {
+    rusqlite::Error::FromSqlConversionFailure(
+        index,
+        value_type,
+        Box::new(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            message,
+        )),
+    )
+}
+
+fn read_attachment(row: &rusqlite::Row<'_>) -> Result<Attachment, rusqlite::Error> {
+    let record_uuid_raw: String = row.get(0)?;
+    let substrate_raw: String = row.get(1)?;
+    let role: String = row.get(2)?;
+    let content_ref_raw: String = row.get(3)?;
+    let media_type: Option<String> = row.get(4)?;
+    let size_bytes_raw: Option<i64> = row.get(5)?;
+    let created_at: i64 = row.get(6)?;
+
+    let record_uuid = Uuid::parse_str(&record_uuid_raw)
+        .map_err(|error| conversion_error(0, rusqlite::types::Type::Text, error.to_string()))?;
+    let substrate = AttachmentSubstrate::from_str(&substrate_raw)
+        .map_err(|error| conversion_error(1, rusqlite::types::Type::Text, error))?;
+    validate_attachment_role(&role)
+        .map_err(|error| conversion_error(2, rusqlite::types::Type::Text, error.to_string()))?;
+    let content_ref = ContentRef::from_hex(content_ref_raw)
+        .map_err(|error| conversion_error(3, rusqlite::types::Type::Text, error))?;
+    let size_bytes = size_bytes_raw
+        .map(|size| {
+            u64::try_from(size).map_err(|_| {
+                conversion_error(
+                    5,
+                    rusqlite::types::Type::Integer,
+                    format!("attachment size_bytes must not be negative, got {size}"),
+                )
+            })
+        })
+        .transpose()?;
+
+    Ok(Attachment {
+        record_uuid,
+        substrate,
+        role,
+        content_ref,
+        media_type,
+        size_bytes,
+        created_at,
+    })
+}
+
+#[async_trait]
+impl AttachmentStore for SqlAttachmentStore {
+    async fn upsert_attachment(&self, attachment: Attachment) -> Result<(), StorageError> {
+        let statement = attachment_upsert_statement(&attachment)?;
+        self.with_writer("upsert_attachment", move |conn| {
+            let mut stmt = conn.prepare(&statement.sql)?;
+            bind_params(&mut stmt, &statement.params)?;
+            stmt.raw_execute()?;
+            Ok(())
+        })
+        .await
+    }
+
+    async fn get_attachment(
+        &self,
+        record_uuid: Uuid,
+        role: &str,
+    ) -> Result<Option<Attachment>, StorageError> {
+        validate_attachment_role(role)?;
+        let record_uuid = record_uuid.to_string();
+        let role = role.to_string();
+        self.with_reader("get_attachment", move |conn| {
+            conn.query_row(
+                "SELECT record_uuid, substrate, role, content_ref, media_type, size_bytes, created_at \
+                 FROM attachments WHERE record_uuid = ?1 AND role = ?2",
+                rusqlite::params![record_uuid, role],
+                read_attachment,
+            )
+            .optional()
+        })
+        .await
+    }
+
+    async fn list_attachments(&self, record_uuid: Uuid) -> Result<Vec<Attachment>, StorageError> {
+        let record_uuid = record_uuid.to_string();
+        self.with_reader("list_attachments", move |conn| {
+            let mut stmt = conn.prepare(
+                "SELECT record_uuid, substrate, role, content_ref, media_type, size_bytes, created_at \
+                 FROM attachments WHERE record_uuid = ?1 ORDER BY role ASC",
+            )?;
+            let rows = stmt.query_map([record_uuid], read_attachment)?;
+            rows.collect()
+        })
+        .await
+    }
+
+    async fn delete_attachment(&self, record_uuid: Uuid, role: &str) -> Result<bool, StorageError> {
+        validate_attachment_role(role)?;
+        let statement = delete_attachment_statement(record_uuid, role);
+        self.with_writer("delete_attachment", move |conn| {
+            let mut stmt = conn.prepare(&statement.sql)?;
+            bind_params(&mut stmt, &statement.params)?;
+            Ok(stmt.raw_execute()? > 0)
+        })
+        .await
+    }
+}

--- a/crates/khive-db/src/stores/blob.rs
+++ b/crates/khive-db/src/stores/blob.rs
@@ -578,7 +578,7 @@ where
     // refreshed to now: a prior orphan re-published through this path
     // restarts its publish-grace clock exactly as a fresh write would,
     // rather than keeping a stale mtime that lets the orphan sweep delete it
-    // out from under the caller's follow-up entity write (khive#1313). The
+    // out from under the caller's follow-up attachment write (khive#1313). The
     // caller already holds both the async and file-based publish advisory
     // locks for the duration of this call, so the refresh is serialized
     // against a concurrent sweep the same way an ordinary write is.
@@ -720,8 +720,8 @@ fn walk_blob_files(root: &Path) -> std::io::Result<Vec<(ContentRef, PathBuf)>> {
 /// Whether a candidate file is still inside its publish grace period and must
 /// be left alone regardless of liveness.
 ///
-/// `put`'s two-step client protocol (bytes land first, a *later* entity write
-/// commits the `content_ref`) means a blob can be physically on disk with
+/// `put`'s two-step client protocol (bytes land first, a *later* attachment
+/// write commits the `content_ref`) means a blob can be physically on disk with
 /// zero live references for a window entirely outside this store's control —
 /// the referencing write simply hasn't happened yet. A file whose mtime is
 /// younger than `grace_period` is therefore treated as not-yet-orphaned:
@@ -817,15 +817,14 @@ fn invalid_content_ref(message: String) -> StorageError {
     }
 }
 
-/// Whether this database carries the complete V20 `blob_gc_claims` fencing
-/// set: the claims table plus both entity triggers
-/// (`sql/020-blob-gc-claims.sql`).
+/// Whether this database carries the complete V21 attachment-only GC fencing
+/// set and durable completed cutover marker.
 ///
 /// `transactional_orphan_sweep` is reachable from any `SqlAccess` a caller
 /// hands it, including a `StorageBackend` constructed directly (e.g.
 /// `StorageBackend::memory()`/`sqlite()` used without `prepare_core_schema`)
 /// that never ran core migrations. The triggers are the fence that keeps a
-/// concurrent entity write from resurrecting a claimed digest in the
+/// concurrent attachment write from resurrecting a claimed digest in the
 /// released-writer window, so a database missing any element of the set
 /// cannot satisfy the fail-closed guarantee the
 /// [`BlobStore::transactional_orphan_sweep`] contract requires; the sweep
@@ -837,10 +836,15 @@ async fn blob_gc_fencing_complete(sql: &dyn SqlAccess) -> StorageResult<bool> {
         reader
             .query_scalar(SqlStatement {
                 sql: "SELECT COUNT(*) FROM sqlite_master \
-                      WHERE (type = 'table' AND name = 'blob_gc_claims') \
+                      WHERE (type = 'table' AND name IN ( \
+                                 'blob_gc_claims', 'attachments', \
+                                 'attachment_cutover_state')) \
+                         OR (type = 'index' AND name IN ( \
+                             'idx_blob_gc_claims_content_ref', \
+                             'idx_attachments_content_ref')) \
                          OR (type = 'trigger' AND name IN ( \
-                             'entities_reject_claimed_blob_insert', \
-                             'entities_reject_claimed_blob_update'))"
+                             'attachments_reject_claimed_blob_insert', \
+                             'attachments_reject_claimed_blob_update'))"
                     .to_string(),
                 params: vec![],
                 label: Some("blob_gc_fencing_complete".to_string()),
@@ -848,7 +852,62 @@ async fn blob_gc_fencing_complete(sql: &dyn SqlAccess) -> StorageResult<bool> {
             .await?,
         "blob_gc_fencing_complete",
     )?;
-    Ok(present == 3)
+    if present != 7 {
+        return Ok(false);
+    }
+
+    let legacy_objects = required_nonnegative_count(
+        reader
+            .query_scalar(SqlStatement {
+                sql: "SELECT \
+                        (SELECT COUNT(*) FROM pragma_table_info('entities') \
+                         WHERE name = 'content_ref') \
+                      + (SELECT COUNT(*) FROM sqlite_master \
+                         WHERE (type = 'index' AND name = 'idx_entities_content_ref') \
+                            OR (type = 'trigger' AND name IN ( \
+                                'entities_reject_claimed_blob_insert', \
+                                'entities_reject_claimed_blob_update')))"
+                    .to_string(),
+                params: vec![],
+                label: Some("blob_gc_legacy_fencing_absent".to_string()),
+            })
+            .await?,
+        "blob_gc_legacy_fencing_absent",
+    )?;
+    if legacy_objects != 0 {
+        return Ok(false);
+    }
+
+    let complete = required_nonnegative_count(
+        reader
+            .query_scalar(SqlStatement {
+                sql: "SELECT COUNT(*) FROM attachment_cutover_state AS cutover \
+                      WHERE cutover.singleton = 1 \
+                        AND cutover.state = 'complete' \
+                        AND cutover.completed_at IS NOT NULL \
+                        AND (SELECT COUNT(*) FROM _schema_migrations \
+                             WHERE version = 21 \
+                               AND name = 'attachments_first_class') = 1 \
+                        AND (SELECT MAX(version) FROM _schema_migrations) = 21"
+                    .to_string(),
+                params: vec![],
+                label: Some("blob_gc_cutover_complete".to_string()),
+            })
+            .await?,
+        "blob_gc_cutover_complete",
+    )?;
+    Ok(complete == 1)
+}
+
+fn unsupported_blob_gc_epoch() -> StorageError {
+    StorageError::Unsupported {
+        capability: StorageCapability::Blob,
+        operation: "transactional_orphan_sweep".into(),
+        message: "transactional blob GC requires a complete V21 attachment cutover with \
+                  the attachment claim-fencing set; refusing both report-only and \
+                  destructive sweep in this database epoch"
+            .into(),
+    }
 }
 
 /// The sentinel digest the fence probe claims. All zeros is canonical-form
@@ -857,16 +916,19 @@ async fn blob_gc_fencing_complete(sql: &dyn SqlAccess) -> StorageResult<bool> {
 const BLOB_GC_FENCE_PROBE_REF: &str =
     "0000000000000000000000000000000000000000000000000000000000000000";
 
-/// The RAISE(ABORT) message both V20 fencing triggers carry. The probe
+const BLOB_GC_FENCE_PROBE_SEED_REF: &str =
+    "1111111111111111111111111111111111111111111111111111111111111111";
+
+/// The RAISE(ABORT) message both V21 attachment fencing triggers carry. The probe
 /// requires the rejection to be OUR fence, not an incidental failure.
 const BLOB_GC_FENCE_TRIGGER_MESSAGE: &str = "content_ref is reserved by an active blob sweep";
 
-/// Prove the V20 fence actually fences, not merely that objects with the
+/// Prove the V21 fence actually fences, not merely that objects with the
 /// right NAMES exist in `sqlite_master`. Same-named no-op triggers (or a
 /// rewritten trigger body) would pass the name census while letting a
 /// claimed `content_ref` become live in the released-writer window, so the
 /// gate exercises the fence: inside one writer transaction it claims a
-/// sentinel digest, attempts the entity INSERT and the entity UPDATE that
+/// sentinel digest, attempts the attachment INSERT and attachment UPDATE that
 /// the triggers must reject, requires both to fail with the triggers' own
 /// RAISE message, and deletes every probe row before the unit commits. Any
 /// other outcome — either write accepted, or rejected for a different
@@ -911,13 +973,10 @@ async fn blob_gc_fence_probe_with_ids(
             // Ownership guard: the cleanup below deletes these ids
             // unconditionally, so the probe may only proceed when it can
             // prove every id is unclaimed in EVERY table cleanup touches.
-            // entities_seq is checked separately from entities because the
-            // ledger intentionally retains rows after entity hard deletion —
-            // a retained-only collision has no entities row to trip on.
             let preexisting = writer
                 .query_row(SqlStatement {
-                    sql: "SELECT (SELECT COUNT(*) FROM entities WHERE id IN (?1, ?2)) \
-                              + (SELECT COUNT(*) FROM entities_seq WHERE entity_id IN (?1, ?2)) \
+                    sql: "SELECT (SELECT COUNT(*) FROM attachments \
+                                   WHERE record_uuid IN (?1, ?2)) \
                               + (SELECT COUNT(*) FROM blob_gc_claims WHERE root_key = ?3)"
                         .to_string(),
                     params: vec![
@@ -963,9 +1022,9 @@ async fn blob_gc_fence_probe_with_ids(
 
             let insert_attempt = writer
                 .execute(SqlStatement {
-                    sql: "INSERT INTO entities \
-                          (id, namespace, kind, name, tags, created_at, updated_at, content_ref) \
-                          VALUES (?1, 'local', 'document', 'fence probe', '[]', 0, 0, ?2)"
+                    sql: "INSERT INTO attachments \
+                          (record_uuid, substrate, role, content_ref, created_at) \
+                          VALUES (?1, 'entity', 'content', ?2, 0)"
                         .to_string(),
                     params: vec![
                         SqlValue::Text(insert_id.clone()),
@@ -978,17 +1037,22 @@ async fn blob_gc_fence_probe_with_ids(
 
             writer
                 .execute(SqlStatement {
-                    sql: "INSERT INTO entities \
-                          (id, namespace, kind, name, tags, created_at, updated_at) \
-                          VALUES (?1, 'local', 'document', 'fence probe', '[]', 0, 0)"
+                    sql: "INSERT INTO attachments \
+                          (record_uuid, substrate, role, content_ref, created_at) \
+                          VALUES (?1, 'entity', 'content', ?2, 0)"
                         .to_string(),
-                    params: vec![SqlValue::Text(update_id.clone())],
+                    params: vec![
+                        SqlValue::Text(update_id.clone()),
+                        SqlValue::Text(BLOB_GC_FENCE_PROBE_SEED_REF.to_string()),
+                    ],
                     label: Some("blob_gc_fence_probe_update_arm_seed".to_string()),
                 })
                 .await?;
             let update_attempt = writer
                 .execute(SqlStatement {
-                    sql: "UPDATE entities SET content_ref = ?1 WHERE id = ?2".to_string(),
+                    sql: "UPDATE attachments SET content_ref = ?1 \
+                          WHERE record_uuid = ?2 AND role = 'content'"
+                        .to_string(),
                     params: vec![
                         SqlValue::Text(BLOB_GC_FENCE_PROBE_REF.to_string()),
                         SqlValue::Text(update_id.clone()),
@@ -999,25 +1063,15 @@ async fn blob_gc_fence_probe_with_ids(
             let update_fenced = fence_rejection(update_attempt);
 
             // Remove every probe row before this unit commits, including an
-            // entity row a dead fence let through and the list-sequence
-            // ledger rows the seed inserts created. The ledger rows were
-            // never visible outside this uncommitted transaction, so no
-            // cursor can have observed them.
+            // attachment row a dead fence let through.
             writer
                 .execute(SqlStatement {
-                    sql: "DELETE FROM entities WHERE id IN (?1, ?2)".to_string(),
+                    sql: "DELETE FROM attachments WHERE record_uuid IN (?1, ?2)".to_string(),
                     params: vec![
                         SqlValue::Text(insert_id.clone()),
                         SqlValue::Text(update_id.clone()),
                     ],
-                    label: Some("blob_gc_fence_probe_cleanup_entities".to_string()),
-                })
-                .await?;
-            writer
-                .execute(SqlStatement {
-                    sql: "DELETE FROM entities_seq WHERE entity_id IN (?1, ?2)".to_string(),
-                    params: vec![SqlValue::Text(insert_id), SqlValue::Text(update_id)],
-                    label: Some("blob_gc_fence_probe_cleanup_entities_seq".to_string()),
+                    label: Some("blob_gc_fence_probe_cleanup_attachments".to_string()),
                 })
                 .await?;
             writer
@@ -1045,14 +1099,14 @@ async fn blob_gc_fence_probe_with_ids(
                 operation: "transactional_orphan_sweep".into(),
                 message: format!(
                     "the V20 fencing triggers exist by name but did not reject a claimed \
-                     content_ref on the entity {arm} path; refusing unfenced deletion"
+                     content_ref on the attachment {arm} path; refusing unfenced deletion"
                 ),
             }),
             Err(other) => Err(StorageError::Unsupported {
                 capability: StorageCapability::Blob,
                 operation: "transactional_orphan_sweep".into(),
                 message: format!(
-                    "the blob GC fence probe could not verify the entity {arm} fence \
+                    "the blob GC fence probe could not verify the attachment {arm} fence \
                      (unexpected rejection: {other}); refusing unfenced deletion"
                 ),
             }),
@@ -1088,11 +1142,10 @@ async fn validate_blob_gc_evidence(sql: &dyn SqlAccess) -> StorageResult<()> {
 
     let invalid_live = reader
         .query_row(SqlStatement {
-            sql: "SELECT content_ref FROM entities \
-                  WHERE deleted_at IS NULL AND content_ref IS NOT NULL \
-                    AND (typeof(content_ref) <> 'text' \
+            sql: "SELECT content_ref FROM attachments \
+                  WHERE typeof(content_ref) <> 'text' \
                       OR length(content_ref) <> 64 \
-                      OR content_ref GLOB '*[^0-9a-f]*') \
+                      OR content_ref GLOB '*[^0-9a-f]*' \
                   LIMIT 1"
                 .to_string(),
             params: vec![],
@@ -1101,7 +1154,7 @@ async fn validate_blob_gc_evidence(sql: &dyn SqlAccess) -> StorageResult<()> {
         .await?;
     if invalid_live.is_some() {
         return Err(invalid_content_ref(
-            "entities.content_ref contained a non-canonical value".into(),
+            "attachments.content_ref contained a non-canonical value".into(),
         ));
     }
     Ok(())
@@ -1168,9 +1221,8 @@ async fn claim_blob_gc_batch(
                     .query_scalar(SqlStatement {
                         sql: "SELECT COUNT(*) FROM json_each(?1) AS candidate \
                               WHERE NOT EXISTS ( \
-                                SELECT 1 FROM entities \
-                                WHERE deleted_at IS NULL \
-                                  AND content_ref = candidate.value \
+                                SELECT 1 FROM attachments \
+                                WHERE content_ref = candidate.value \
                               )"
                         .to_string(),
                         params: vec![SqlValue::Text(grace_json)],
@@ -1186,9 +1238,8 @@ async fn claim_blob_gc_batch(
                         .query_scalar(SqlStatement {
                             sql: "SELECT COUNT(*) FROM json_each(?1) AS candidate \
                                   WHERE NOT EXISTS ( \
-                                    SELECT 1 FROM entities \
-                                    WHERE deleted_at IS NULL \
-                                      AND content_ref = candidate.value \
+                                    SELECT 1 FROM attachments \
+                                    WHERE content_ref = candidate.value \
                                   )"
                             .to_string(),
                             params: vec![SqlValue::Text(eligible_json)],
@@ -1210,9 +1261,8 @@ async fn claim_blob_gc_batch(
                           SELECT ?1, candidate.value, ?3 \
                           FROM json_each(?2) AS candidate \
                           WHERE NOT EXISTS ( \
-                            SELECT 1 FROM entities \
-                            WHERE deleted_at IS NULL \
-                              AND content_ref = candidate.value \
+                            SELECT 1 FROM attachments \
+                            WHERE content_ref = candidate.value \
                           )"
                     .to_string(),
                     params: vec![
@@ -1295,26 +1345,188 @@ fn sweep_blob_files(
 
 /// Process-wide database owner fence for transactional blob sweeps.
 ///
-/// Claims live in the database and their entity triggers are database-global,
+/// Claims live in the database and their attachment triggers are database-global,
 /// so a root-only lock is insufficient: two differently configured roots for
 /// one database must not recover each other's live claims. File-backed pools
 /// additionally take [`acquire_database_gc_lock`] for cross-process exclusion.
-type SweepLockMap = HashMap<Option<PathBuf>, Arc<tokio::sync::Mutex<()>>>;
+type SweepLockMap = HashMap<Option<PathBuf>, Arc<DatabaseGcProcessLock>>;
+
+#[derive(Debug, Default)]
+struct DatabaseGcProcessLock {
+    held: StdMutex<bool>,
+    released: std::sync::Condvar,
+    #[cfg(test)]
+    waiters: std::sync::atomic::AtomicUsize,
+}
+
+impl DatabaseGcProcessLock {
+    fn acquire(self: &Arc<Self>) -> DatabaseGcProcessGuard {
+        let mut held = self
+            .held
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        while *held {
+            #[cfg(test)]
+            self.waiters
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            held = self
+                .released
+                .wait(held)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            #[cfg(test)]
+            self.waiters
+                .fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+        }
+        *held = true;
+        DatabaseGcProcessGuard {
+            lock: Arc::clone(self),
+        }
+    }
+
+    fn try_acquire(self: &Arc<Self>) -> Option<DatabaseGcProcessGuard> {
+        let mut held = self
+            .held
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if *held {
+            return None;
+        }
+        *held = true;
+        Some(DatabaseGcProcessGuard {
+            lock: Arc::clone(self),
+        })
+    }
+}
+
+#[derive(Debug)]
+struct DatabaseGcProcessGuard {
+    lock: Arc<DatabaseGcProcessLock>,
+}
+
+impl Drop for DatabaseGcProcessGuard {
+    fn drop(&mut self) {
+        let mut held = self
+            .lock
+            .held
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        debug_assert!(*held, "database GC process owner released twice");
+        *held = false;
+        self.lock.released.notify_one();
+    }
+}
 
 fn database_sweep_locks() -> &'static StdMutex<SweepLockMap> {
     static REGISTRY: OnceLock<StdMutex<SweepLockMap>> = OnceLock::new();
     REGISTRY.get_or_init(|| StdMutex::new(HashMap::new()))
 }
 
-fn sweep_lock_for_database(database_path: Option<&Path>) -> Arc<tokio::sync::Mutex<()>> {
+fn sweep_lock_for_database(database_path: Option<&Path>) -> Arc<DatabaseGcProcessLock> {
     let key = database_path.map(Path::to_path_buf);
     let mut locks = database_sweep_locks()
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     locks
         .entry(key)
-        .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+        .or_insert_with(|| Arc::new(DatabaseGcProcessLock::default()))
         .clone()
+}
+
+#[cfg(test)]
+pub(crate) fn database_gc_waiter_count(database_path: Option<&Path>) -> usize {
+    sweep_lock_for_database(database_path)
+        .waiters
+        .load(std::sync::atomic::Ordering::SeqCst)
+}
+
+/// Exclusive canonical-database ownership shared by transactional blob GC and
+/// the boot-gated V21 attachment cutover.
+///
+/// The process-local mutex is acquired first and retained while the advisory
+/// file lock is acquired on a blocking thread. Moving the owned mutex guard
+/// into that closure makes cancellation safe: dropping the outer future cannot
+/// release process ownership while a blocking advisory acquisition continues.
+pub struct DatabaseGcOwnerGuard {
+    _process_guard: DatabaseGcProcessGuard,
+    _advisory_guard: Option<fs::File>,
+    database_path: Option<PathBuf>,
+}
+
+pub(crate) fn acquire_database_gc_owner_for_path_blocking(
+    database_path: Option<PathBuf>,
+) -> StorageResult<DatabaseGcOwnerGuard> {
+    let process_guard = sweep_lock_for_database(database_path.as_deref()).acquire();
+    let advisory_guard = acquire_database_gc_lock(database_path.as_deref())?;
+    Ok(DatabaseGcOwnerGuard {
+        _process_guard: process_guard,
+        _advisory_guard: advisory_guard,
+        database_path,
+    })
+}
+
+/// Try to acquire canonical database-GC ownership without waiting.
+///
+/// This is the fail-closed bridge for the legacy raw-connection migration API:
+/// a caller may already hold an opaque pooled writer guard, so waiting here
+/// could invert the canonical owner-before-writer order used by sweeps. The
+/// production backend boot path uses the blocking helper before writer
+/// checkout instead.
+pub(crate) fn try_acquire_database_gc_owner_for_path(
+    database_path: PathBuf,
+) -> StorageResult<DatabaseGcOwnerGuard> {
+    let process_guard = sweep_lock_for_database(Some(&database_path))
+        .try_acquire()
+        .ok_or_else(|| {
+            StorageError::Internal(format!(
+                "database GC owner for {} is already held; retry schema migration through the \
+                 coordinated backend boot path",
+                database_path.display()
+            ))
+        })?;
+    let lock_path = database_gc_lock_path(&database_path);
+    let advisory_guard = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
+        .map_err(|error| map_io_err(error, "database_gc_lock_open"))?;
+    fs4::FileExt::try_lock(&advisory_guard)
+        .map_err(|error| map_io_err(error.into(), "database_gc_lock_try_acquire"))?;
+    Ok(DatabaseGcOwnerGuard {
+        _process_guard: process_guard,
+        _advisory_guard: Some(advisory_guard),
+        database_path: Some(database_path),
+    })
+}
+
+impl std::fmt::Debug for DatabaseGcOwnerGuard {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("DatabaseGcOwnerGuard")
+            .field("database_path", &self.database_path)
+            .finish_non_exhaustive()
+    }
+}
+
+impl DatabaseGcOwnerGuard {
+    /// Canonical database path that keys this owner, or `None` for an
+    /// in-memory database whose process-local mutex is the complete fence.
+    pub fn database_path(&self) -> Option<&Path> {
+        self.database_path.as_deref()
+    }
+}
+
+/// Acquire the canonical database owner used by both V21 boot cutover and
+/// transactional blob sweep. Callers must retain the returned guard across
+/// every stage that must exclude the other protocol.
+pub async fn acquire_database_gc_owner(sql: &dyn SqlAccess) -> StorageResult<DatabaseGcOwnerGuard> {
+    let database_path = sql.database_path();
+    tokio::task::spawn_blocking(move || acquire_database_gc_owner_for_path_blocking(database_path))
+        .await
+        .map_err(|error| {
+            StorageError::driver(StorageCapability::Blob, "acquire_database_gc_owner", error)
+        })?
 }
 
 /// Process-wide registry of per-canonical-root write locks.
@@ -1377,7 +1589,7 @@ pub struct FsBlobStore {
     /// How long a blob with zero live references is left alone before an
     /// orphan sweep will delete it — see `within_publish_grace`. Bounds the
     /// window between `put` (bytes land, lock released) and the later,
-    /// separate entity write that commits a `content_ref` to it; it does not
+    /// separate attachment write that commits a `content_ref` to it; it does not
     /// close that window entirely; see `within_publish_grace` and
     /// `transactional_orphan_sweep`'s doc comment for the residual exposure.
     orphan_sweep_grace: Duration,
@@ -1390,7 +1602,7 @@ impl FsBlobStore {
 
     /// Default orphan-sweep publish grace period: 1 hour. Generous on
     /// purpose — it only needs to outlast the gap between a client's `put`
-    /// call returning and its follow-up entity write landing, not any
+    /// call returning and its follow-up attachment write landing, not any
     /// steady-state condition.
     pub const DEFAULT_ORPHAN_SWEEP_GRACE: Duration = Duration::from_secs(3600);
 
@@ -1635,24 +1847,24 @@ impl BlobStore for FsBlobStore {
         .map_err(|e| StorageError::driver(StorageCapability::Blob, "orphan_sweep", e))?
     }
 
-    // `put` and the entity write that later commits a `content_ref` to its
+    // `put` and the attachment write that later commits a `content_ref` to its
     // result are two separate steps of the client protocol -- the write
     // lock this method takes only serializes it against a concurrent `put`,
     // it is not held across the caller's own gap between finishing `put` and
-    // issuing that follow-up entity write. A blob can therefore be fully on
+    // issuing that follow-up attachment write. A blob can therefore be fully on
     // disk with zero live references purely because its referencing write
     // hasn't landed yet, not because it is actually orphaned.
     // `within_publish_grace` (via `orphan_sweep_grace`) is what protects that
     // window: a file younger than the grace period is left alone regardless
     // of liveness. Residual assumption: a client that waits longer than the
-    // grace period between `put` returning and its entity write committing
+    // grace period between `put` returning and its attachment write committing
     // is still exposed to this method deleting the blob out from under it --
     // callers with an unusually slow publish path should widen the grace
     // period (`FsBlobStore::with_orphan_sweep_grace`) accordingly.
     //
     // Cross-resource ordering (#1850): database/root ownership and filesystem
     // walk/metadata happen before SQL. Bounded SQL-only units recover abandoned
-    // rows and commit at most 128 fresh claims whose entity triggers fence new
+    // rows and commit at most 128 fresh claims whose attachment triggers fence new
     // live references; physical deletion happens after each COMMIT; a second
     // bounded SQL-only unit releases that batch. Owner/root locks span all
     // phases, but SQLite's single writer never spans external I/O.
@@ -1661,24 +1873,46 @@ impl BlobStore for FsBlobStore {
         sql: &dyn SqlAccess,
         dry_run: bool,
     ) -> StorageResult<BlobOrphanSweepResult> {
-        // Claims and their entity triggers are database-global. Serialize the
+        // The compatibility preflight deliberately precedes database/root
+        // ownership, lock-file creation, filesystem walking, probe claims,
+        // and abandoned-claim cleanup. V20 and staged/malformed V21 cannot
+        // represent the complete attachment liveness set, so report-only and
+        // destructive modes both refuse without mutation.
+        if !blob_gc_fencing_complete(sql).await? {
+            return Err(unsupported_blob_gc_epoch());
+        }
+
+        // Claims and their attachment triggers are database-global. Serialize the
         // whole cross-resource protocol by database before taking the root
         // locks, so differently configured roots cannot recover one another's
         // active claim batches. The OS lock is the crash-detecting owner:
         // acquiring it proves that every row left in this database is
         // abandoned, including rows copied by backup or left before a root
         // relocation.
-        let database_path = sql.database_path();
-        let database_guard = sweep_lock_for_database(database_path.as_deref())
-            .lock_owned()
-            .await;
+        let database_owner = acquire_database_gc_owner(sql).await?;
+        // Recheck under canonical ownership so external maintenance cannot
+        // swap the schema between preflight and the destructive protocol.
+        if !blob_gc_fencing_complete(sql).await? {
+            return Err(unsupported_blob_gc_epoch());
+        }
+        validate_blob_gc_evidence(sql).await?;
+        blob_gc_fence_probe(sql).await?;
+        if !dry_run {
+            loop {
+                let released = release_abandoned_blob_gc_claim_batch(sql).await?;
+                if released < BLOB_GC_CLAIM_BATCH_SIZE as u64 {
+                    break;
+                }
+            }
+        }
+
+        // Root ownership follows fully acquired database ownership. This is
+        // the ADR-111 canonical DB -> root order shared with boot cutover.
         let root_guard = self.write_lock.clone().lock_owned().await;
         let root = self.root.clone();
         let scan_root = root.clone();
-        let lock_database_path = database_path.clone();
         let grace_period = self.orphan_sweep_grace;
         let (write_guards, canonical_root, prepared) = tokio::task::spawn_blocking(move || {
-            let database_file_guard = acquire_database_gc_lock(lock_database_path.as_deref())?;
             let canonical_root = scan_root
                 .canonicalize()
                 .map_err(|e| map_io_err(e, "transactional_orphan_sweep_root"))?;
@@ -1687,12 +1921,7 @@ impl BlobStore for FsBlobStore {
                 .map_err(|e| map_io_err(e, "transactional_orphan_sweep_walk"))?;
             let prepared = prepare_transactional_sweep(candidates, grace_period);
             Ok::<_, StorageError>((
-                (
-                    database_guard,
-                    database_file_guard,
-                    root_guard,
-                    root_write_guard,
-                ),
+                (database_owner, root_guard, root_write_guard),
                 canonical_root,
                 prepared,
             ))
@@ -1706,27 +1935,6 @@ impl BlobStore for FsBlobStore {
             )
         })??;
         let root_key = blob_root_key(&canonical_root);
-        if !blob_gc_fencing_complete(sql).await? {
-            return Err(StorageError::Unsupported {
-                capability: StorageCapability::Blob,
-                operation: "transactional_orphan_sweep".into(),
-                message: "this database lacks the complete V20 blob_gc_claims fencing set \
-                          (claims table plus both entity triggers); refusing unfenced \
-                          deletion — run core migrations (prepare_core_schema) to enable \
-                          the sweep"
-                    .into(),
-            });
-        }
-        blob_gc_fence_probe(sql).await?;
-        validate_blob_gc_evidence(sql).await?;
-        if !dry_run {
-            loop {
-                let released = release_abandoned_blob_gc_claim_batch(sql).await?;
-                if released < BLOB_GC_CLAIM_BATCH_SIZE as u64 {
-                    break;
-                }
-            }
-        }
 
         let mut write_guards = write_guards;
         let mut result = prepared.result;
@@ -1985,6 +2193,42 @@ mod tests {
             database_gc_lock_path(&database),
             PathBuf::from(expected_lock_path)
         );
+    }
+
+    #[tokio::test]
+    async fn database_gc_owner_holds_process_and_advisory_fences_until_drop() {
+        let dir = tempfile::tempdir().unwrap();
+        let database = dir.path().join("owner.db");
+        let backend = crate::StorageBackend::sqlite(&database).unwrap();
+        let owner = acquire_database_gc_owner(backend.sql().as_ref())
+            .await
+            .unwrap();
+        let canonical_database = owner
+            .database_path()
+            .expect("file-backed owner path")
+            .to_path_buf();
+
+        assert!(
+            sweep_lock_for_database(Some(&canonical_database))
+                .try_acquire()
+                .is_none(),
+            "boot and sweep must share one process-local database owner"
+        );
+        let external = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(database_gc_lock_path(&canonical_database))
+            .unwrap();
+        assert!(
+            matches!(
+                fs4::FileExt::try_lock(&external),
+                Err(fs4::TryLockError::WouldBlock)
+            ),
+            "the reusable owner must also retain the cross-process advisory fence"
+        );
+
+        drop(owner);
+        fs4::FileExt::try_lock(&external).expect("owner drop releases advisory fence");
     }
 
     #[cfg(unix)]
@@ -2789,9 +3033,45 @@ mod tests {
         );
     }
 
-    /// The fencing gate must demand the complete V20 set, not just the
+    #[tokio::test]
+    async fn transactional_orphan_sweep_refuses_an_incomplete_cutover_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("khive.db");
+        let backend = std::sync::Arc::new(crate::StorageBackend::sqlite(&db_path).unwrap());
+        {
+            let mut writer = backend.pool().writer().unwrap();
+            crate::run_migrations(writer.conn_mut()).unwrap();
+            writer
+                .conn_mut()
+                .execute_batch(
+                    "UPDATE attachment_cutover_state \
+                     SET state = 'incomplete', completed_at = NULL WHERE singleton = 1; \
+                     DELETE FROM _schema_migrations WHERE version = 21;",
+                )
+                .unwrap();
+        }
+
+        let store = FsBlobStore::new(dir.path().join("blobs"), 0)
+            .unwrap()
+            .with_orphan_sweep_grace(Duration::ZERO);
+        let orphan = store
+            .put(b"incomplete-cutover orphan".to_vec())
+            .await
+            .unwrap();
+        let error = store
+            .transactional_orphan_sweep(backend.sql().as_ref(), false)
+            .await
+            .expect_err("sweep must refuse every durable incomplete marker");
+        assert!(matches!(error, StorageError::Unsupported { .. }));
+        assert!(
+            store.exists(&orphan).await.unwrap(),
+            "refused incomplete-state sweep must preserve every blob"
+        );
+    }
+
+    /// The fencing gate must demand the complete V21 set, not just the
     /// claims table: with a fencing trigger dropped, a claim no longer
-    /// blocks a concurrent entity write from resurrecting the digest, so
+    /// blocks a concurrent attachment write from resurrecting the digest, so
     /// the sweep must refuse exactly as it does with no migration at all.
     #[tokio::test]
     async fn transactional_orphan_sweep_refuses_with_incomplete_fencing_triggers() {
@@ -2803,7 +3083,7 @@ mod tests {
             crate::run_migrations(writer.conn_mut()).unwrap();
             writer
                 .conn_mut()
-                .execute_batch("DROP TRIGGER entities_reject_claimed_blob_update")
+                .execute_batch("DROP TRIGGER attachments_reject_claimed_blob_update")
                 .unwrap();
         }
 
@@ -2819,7 +3099,7 @@ mod tests {
         let error = store
             .transactional_orphan_sweep(sql.as_ref(), false)
             .await
-            .expect_err("sweep must refuse when any V20 fencing trigger is missing");
+            .expect_err("sweep must refuse when any V21 fencing trigger is missing");
         assert!(
             matches!(error, StorageError::Unsupported { .. }),
             "expected StorageError::Unsupported, got {error:?}"
@@ -2846,12 +3126,12 @@ mod tests {
             writer
                 .conn_mut()
                 .execute_batch(
-                    "DROP TRIGGER entities_reject_claimed_blob_insert; \
-                     DROP TRIGGER entities_reject_claimed_blob_update; \
-                     CREATE TRIGGER entities_reject_claimed_blob_insert \
-                     BEFORE INSERT ON entities BEGIN SELECT 0; END; \
-                     CREATE TRIGGER entities_reject_claimed_blob_update \
-                     BEFORE UPDATE OF content_ref, deleted_at ON entities \
+                    "DROP TRIGGER attachments_reject_claimed_blob_insert; \
+                     DROP TRIGGER attachments_reject_claimed_blob_update; \
+                     CREATE TRIGGER attachments_reject_claimed_blob_insert \
+                     BEFORE INSERT ON attachments BEGIN SELECT 0; END; \
+                     CREATE TRIGGER attachments_reject_claimed_blob_update \
+                     BEFORE UPDATE OF content_ref ON attachments \
                      BEGIN SELECT 0; END;",
                 )
                 .unwrap();
@@ -2886,10 +3166,8 @@ mod tests {
             .query_row(
                 "SELECT (SELECT COUNT(*) FROM blob_gc_claims \
                          WHERE root_key GLOB '__fence_probe-*') \
-                      + (SELECT COUNT(*) FROM entities \
-                         WHERE id GLOB '__blob-gc-fence-probe-*') \
-                      + (SELECT COUNT(*) FROM entities_seq \
-                         WHERE entity_id GLOB '__blob-gc-fence-probe-*')",
+                      + (SELECT COUNT(*) FROM attachments \
+                         WHERE record_uuid GLOB '__blob-gc-fence-probe-*')",
                 [],
                 |row| row.get(0),
             )
@@ -2898,7 +3176,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn fence_probe_refuses_id_collision_and_preserves_the_colliding_entity() {
+    async fn fence_probe_refuses_id_collision_and_preserves_the_colliding_attachment() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("khive.db");
         let backend = std::sync::Arc::new(crate::StorageBackend::sqlite(&db_path).unwrap());
@@ -2908,9 +3186,11 @@ mod tests {
             writer
                 .conn_mut()
                 .execute(
-                    "INSERT INTO entities \
-                     (id, namespace, kind, name, tags, created_at, updated_at) \
-                     VALUES ('victim-id', 'local', 'document', 'unrelated data', '[]', 7, 7)",
+                    "INSERT INTO attachments \
+                     (record_uuid, substrate, role, content_ref, media_type, created_at) \
+                     VALUES ('victim-id', 'entity', 'content', \
+                             '2222222222222222222222222222222222222222222222222222222222222222', \
+                             'application/test', 7)",
                     [],
                 )
                 .unwrap();
@@ -2931,20 +3211,21 @@ mod tests {
         );
 
         let reader = backend.pool().reader().unwrap();
-        let (name, created_at): (String, i64) = reader
+        let (media_type, created_at): (String, i64) = reader
             .conn()
             .query_row(
-                "SELECT name, created_at FROM entities WHERE id = 'victim-id'",
+                "SELECT media_type, created_at FROM attachments \
+                 WHERE record_uuid = 'victim-id' AND role = 'content'",
                 [],
                 |row| Ok((row.get(0)?, row.get(1)?)),
             )
-            .expect("the colliding entity must survive the refused probe untouched");
-        assert_eq!(name, "unrelated data");
+            .expect("the colliding attachment must survive the refused probe untouched");
+        assert_eq!(media_type, "application/test");
         assert_eq!(created_at, 7);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn fence_probe_refuses_retained_seq_collision_and_preserves_the_ledger_row() {
+    async fn fence_probe_does_not_touch_an_unrelated_retained_entity_sequence() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("khive.db");
         let backend = std::sync::Arc::new(crate::StorageBackend::sqlite(&db_path).unwrap());
@@ -2979,18 +3260,14 @@ mod tests {
         }
 
         let sql = backend.sql();
-        let error = super::blob_gc_fence_probe_with_ids(
+        super::blob_gc_fence_probe_with_ids(
             sql.as_ref(),
             "retained-id".to_string(),
             "retained-update-id".to_string(),
             "retained-claim-key".to_string(),
         )
         .await
-        .expect_err("the probe must refuse when an id collides with a retained ledger row");
-        assert!(
-            matches!(error, StorageError::Unsupported { .. }),
-            "expected StorageError::Unsupported, got {error:?}"
-        );
+        .expect("attachment probe has no reason to mutate an entity sequence row");
 
         let reader = backend.pool().reader().unwrap();
         let survivors: i64 = reader
@@ -3003,7 +3280,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             survivors, 1,
-            "the retained ledger row must survive the refused probe"
+            "the retained ledger row must survive the attachment probe"
         );
     }
 
@@ -3126,13 +3403,13 @@ mod tests {
             .expect("external filesystem work must not retain SQLite's writer lock");
 
         // The claim trigger is the cross-resource fence: while the file is
-        // selected for deletion, a concurrent entity writer cannot make it
+        // selected for deletion, a concurrent attachment writer cannot make it
         // newly live in the released-writer window.
         let claimed_err = unrelated
             .execute(
-                "INSERT INTO entities \
-                 (id, namespace, kind, name, tags, created_at, updated_at, content_ref) \
-                 VALUES ('racing-reference', 'local', 'document', 'racing', '[]', 1, 1, ?1)",
+                "INSERT INTO attachments \
+                 (record_uuid, substrate, role, content_ref, created_at) \
+                 VALUES ('racing-reference', 'entity', 'content', ?1, 1)",
                 [orphan.as_str()],
             )
             .expect_err("a claimed content_ref must fail closed before deletion");
@@ -3515,14 +3792,17 @@ mod tests {
             .unwrap();
 
         let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute_batch("PRAGMA ignore_check_constraints = ON")
+            .unwrap();
         conn.execute(
-            "INSERT INTO entities \
-             (id, namespace, kind, name, tags, created_at, updated_at, content_ref) \
-             VALUES ('corrupt-live', 'local', 'document', 'corrupt', '[]', 1, 1, \
-                     'not-a-content-ref')",
+            "INSERT INTO attachments \
+             (record_uuid, substrate, role, content_ref, created_at) \
+             VALUES ('corrupt-live', 'entity', 'content', 'not-a-content-ref', 1)",
             [],
         )
         .unwrap();
+        conn.execute_batch("PRAGMA ignore_check_constraints = OFF")
+            .unwrap();
         let live_error = store
             .transactional_orphan_sweep(backend.sql().as_ref(), false)
             .await
@@ -3533,8 +3813,11 @@ mod tests {
             "no file may be removed after corrupt live evidence"
         );
 
-        conn.execute("DELETE FROM entities WHERE id = 'corrupt-live'", [])
-            .unwrap();
+        conn.execute(
+            "DELETE FROM attachments WHERE record_uuid = 'corrupt-live'",
+            [],
+        )
+        .unwrap();
         let root_key = blob_root_key(&root.canonicalize().unwrap());
         conn.execute(
             "INSERT INTO blob_gc_claims (root_key, content_ref, claimed_at) \
@@ -3631,7 +3914,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn transactional_orphan_sweep_uses_only_non_deleted_entity_refs_as_live() {
+    async fn transactional_orphan_sweep_uses_all_attachment_refs_as_live() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("khive.db");
         let backend = crate::StorageBackend::sqlite(&db_path).unwrap();
@@ -3649,11 +3932,20 @@ mod tests {
             let writer = backend.pool().writer().unwrap();
             writer
                 .conn()
-                .execute(
+                .execute_batch(
                     "INSERT INTO entities \
-                     (id, namespace, kind, name, tags, created_at, updated_at, deleted_at, content_ref) \
-                     VALUES ('live', 'local', 'document', 'live', '[]', 1, 1, NULL, ?1), \
-                            ('deleted', 'local', 'document', 'deleted', '[]', 1, 1, 2, ?2)",
+                     (id, namespace, kind, name, tags, created_at, updated_at, deleted_at) \
+                     VALUES ('live', 'local', 'document', 'live', '[]', 1, 1, NULL), \
+                            ('deleted', 'local', 'document', 'deleted', '[]', 1, 1, 2);",
+                )
+                .unwrap();
+            writer
+                .conn()
+                .execute(
+                    "INSERT INTO attachments \
+                     (record_uuid, substrate, role, content_ref, created_at) \
+                     VALUES ('live', 'entity', 'content', ?1, 1), \
+                            ('deleted', 'entity', 'content', ?2, 1)",
                     rusqlite::params![live.as_str(), soft_deleted.as_str()],
                 )
                 .unwrap();
@@ -3663,7 +3955,7 @@ mod tests {
             .transactional_orphan_sweep(backend.sql().as_ref(), true)
             .await
             .unwrap();
-        assert_eq!(dry_run.would_delete, 2);
+        assert_eq!(dry_run.would_delete, 1);
         assert_eq!(dry_run.deleted, 0);
         assert!(store.exists(&soft_deleted).await.unwrap());
         assert!(store.exists(&orphan).await.unwrap());
@@ -3674,9 +3966,12 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.scanned, 3);
-        assert_eq!(result.deleted, 2);
+        assert_eq!(result.deleted, 1);
         assert!(store.exists(&live).await.unwrap());
-        assert!(!store.exists(&soft_deleted).await.unwrap());
+        assert!(
+            store.exists(&soft_deleted).await.unwrap(),
+            "soft delete retains attachment rows and their blobs"
+        );
         assert!(!store.exists(&orphan).await.unwrap());
     }
 
@@ -3684,12 +3979,12 @@ mod tests {
     async fn transactional_orphan_sweep_protects_a_freshly_published_blob_before_its_reference_commits(
     ) {
         // The exact two-step client protocol hazard: `put` completes and
-        // releases its write lock (step 1) while the entity write that will
-        // *later* commit a `content_ref` to this blob (step 2) has not
+        // releases its write lock (step 1) while the attachment write that will
+        // *later* commit a reference to this blob (step 2) has not
         // happened yet -- nothing in this store's locking serializes the
         // two, because they are separate calls the client makes with an
         // arbitrary gap in between. A sweep that lands in that gap must not
-        // delete the blob: `entities.content_ref` has no row for it yet
+        // delete the blob: `attachments.content_ref` has no row for it yet
         // purely because the referencing write hasn't landed, not because
         // it is actually orphaned. Without the publish-grace window this
         // reproduces khive#1313's dangling-reference defect: the blob file
@@ -3733,7 +4028,7 @@ mod tests {
             "a blob still inside its publish grace period must survive the sweep"
         );
 
-        // Step 2 now lands: the entity write commits content_ref to the
+        // Step 2 now lands: the attachment write commits content_ref to the
         // still-present blob.
         {
             let writer = backend.pool().writer().unwrap();
@@ -3741,8 +4036,17 @@ mod tests {
                 .conn()
                 .execute(
                     "INSERT INTO entities \
-                     (id, namespace, kind, name, tags, created_at, updated_at, deleted_at, content_ref) \
-                     VALUES ('e1', 'local', 'document', 'e1', '[]', 1, 1, NULL, ?1)",
+                     (id, namespace, kind, name, tags, created_at, updated_at) \
+                     VALUES ('e1', 'local', 'document', 'e1', '[]', 1, 1)",
+                    [],
+                )
+                .unwrap();
+            writer
+                .conn()
+                .execute(
+                    "INSERT INTO attachments \
+                     (record_uuid, substrate, role, content_ref, created_at) \
+                     VALUES ('e1', 'entity', 'content', ?1, 1)",
                     rusqlite::params![blob.as_str()],
                 )
                 .unwrap();
@@ -3815,15 +4119,24 @@ mod tests {
         );
         assert!(store.exists(&first).await.unwrap());
 
-        // The caller's follow-up entity write now lands.
+        // The caller's follow-up attachment write now lands.
         {
             let writer = backend.pool().writer().unwrap();
             writer
                 .conn()
                 .execute(
                     "INSERT INTO entities \
-                     (id, namespace, kind, name, tags, created_at, updated_at, deleted_at, content_ref) \
-                     VALUES ('e1', 'local', 'document', 'e1', '[]', 1, 1, NULL, ?1)",
+                     (id, namespace, kind, name, tags, created_at, updated_at) \
+                     VALUES ('e1', 'local', 'document', 'e1', '[]', 1, 1)",
+                    [],
+                )
+                .unwrap();
+            writer
+                .conn()
+                .execute(
+                    "INSERT INTO attachments \
+                     (record_uuid, substrate, role, content_ref, created_at) \
+                     VALUES ('e1', 'entity', 'content', ?1, 1)",
                     rusqlite::params![first.as_str()],
                 )
                 .unwrap();

--- a/crates/khive-db/src/stores/entity.rs
+++ b/crates/khive-db/src/stores/entity.rs
@@ -7,8 +7,9 @@ use async_trait::async_trait;
 use rusqlite::OptionalExtension;
 use uuid::Uuid;
 
+use khive_storage::attachment::{Attachment, AttachmentSubstrate};
 use khive_storage::entity::{Entity, EntityFilter};
-use khive_storage::error::StorageError;
+use khive_storage::error::{StorageError, WriterTaskRequestState};
 use khive_storage::types::{
     BatchWriteSummary, DeleteMode, Page, PageRequest, SeekCursor, SeekPage, SqlStatement, SqlValue,
 };
@@ -18,7 +19,8 @@ use khive_storage::StorageCapability;
 use crate::error::SqliteError;
 use crate::pool::ConnectionPool;
 use crate::sql_bridge::bind_params;
-use crate::writer_task::WriterTaskHandle;
+use crate::stores::attachment::{attachment_upsert_statement, delete_record_attachments_statement};
+use crate::writer_task::{execute_wrapped_transaction, WriterTaskHandle};
 
 fn map_err(e: rusqlite::Error, op: &'static str) -> StorageError {
     StorageError::driver(StorageCapability::Entities, op, e)
@@ -29,6 +31,14 @@ fn map_sqlite_err(e: SqliteError, op: &'static str) -> StorageError {
 }
 
 const NAMESPACE_COUNT_CHUNK_SIZE: usize = 500;
+
+const ENTITY_SELECT_COLUMNS: &str =
+    "entities.id, entities.namespace, entities.kind, entities.entity_type, entities.name, \
+     entities.description, entities.properties, entities.tags, entities.created_at, \
+     entities.updated_at, entities.deleted_at, entities.merged_into, entities.merge_event_id, \
+     (SELECT attachment.content_ref FROM attachments AS attachment \
+      WHERE attachment.record_uuid = entities.id \
+        AND attachment.substrate = 'entity' AND attachment.role = 'content') AS content_ref";
 
 // ---------------------------------------------------------------------------
 // Pure statement builders (ADR-099 B3 r6 structural cut)
@@ -54,8 +64,8 @@ pub fn entity_upsert_statement(entity: &Entity) -> SqlStatement {
     SqlStatement {
         sql: "INSERT OR REPLACE INTO entities \
               (id, namespace, kind, entity_type, name, description, properties, tags, \
-               created_at, updated_at, deleted_at, merged_into, merge_event_id, content_ref) \
-              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)"
+               created_at, updated_at, deleted_at, merged_into, merge_event_id) \
+              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)"
             .to_string(),
         params: vec![
             SqlValue::Text(entity.id.to_string()),
@@ -87,10 +97,6 @@ pub fn entity_upsert_statement(entity: &Entity) -> SqlStatement {
             },
             match entity.merge_event_id {
                 Some(u) => SqlValue::Text(u.to_string()),
-                None => SqlValue::Null,
-            },
-            match &entity.content_ref {
-                Some(c) => SqlValue::Text(c.clone()),
                 None => SqlValue::Null,
             },
         ],
@@ -209,6 +215,56 @@ impl SqlEntityStore {
         })
         .await
         .map_err(|e| StorageError::driver(StorageCapability::Entities, op, e))?
+    }
+
+    /// Route multi-statement entity mutations through one write transaction.
+    /// The writer task already supplies that transaction; the direct fallback
+    /// opens and closes its own fail-closed `BEGIN IMMEDIATE` unit.
+    async fn with_writer_tx<F, R>(&self, op: &'static str, f: F) -> Result<R, StorageError>
+    where
+        F: FnOnce(&rusqlite::Connection) -> Result<R, rusqlite::Error> + Send + 'static,
+        R: Send + 'static,
+    {
+        if let Some(writer_task) = self.current_writer_task(op)? {
+            return writer_task
+                .send_bounded(move |conn| f(conn).map_err(|error| map_err(error, op)))
+                .await;
+        }
+
+        self.pool
+            .record_direct_route(crate::timeout_sink::Site::DirectRouteEntity);
+        let pool = Arc::clone(&self.pool);
+        tokio::task::spawn_blocking(move || {
+            let guard = pool
+                .try_writer()
+                .map_err(|error| map_sqlite_err(error, op))?;
+            let conn = guard.conn();
+            if !conn.is_autocommit() {
+                pool.retire_pooled_writer(conn);
+                return Err(StorageError::WriterTaskTerminated {
+                    request_state: WriterTaskRequestState::SideEffectsUnknown,
+                });
+            }
+            if let Err(begin_error) = conn.execute_batch("BEGIN IMMEDIATE") {
+                if !conn.is_autocommit() {
+                    pool.retire_pooled_writer(conn);
+                    return Err(StorageError::WriterTaskTerminated {
+                        request_state: WriterTaskRequestState::SideEffectsUnknown,
+                    });
+                }
+                return Err(map_err(begin_error, op));
+            }
+
+            let (result, terminal_state) = execute_wrapped_transaction(conn, op, move |conn| {
+                f(conn).map_err(|error| map_err(error, op))
+            });
+            if terminal_state.is_some() {
+                pool.retire_pooled_writer(conn);
+            }
+            result
+        })
+        .await
+        .map_err(|error| StorageError::driver(StorageCapability::Entities, op, error))?
     }
 
     async fn with_reader<F, R>(&self, op: &'static str, f: F) -> Result<R, StorageError>
@@ -353,8 +409,8 @@ fn batch_upsert_entities(
         match conn.execute(
             "INSERT OR REPLACE INTO entities \
              (id, namespace, kind, entity_type, name, description, properties, tags, \
-              created_at, updated_at, deleted_at, merged_into, merge_event_id, content_ref) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
+              created_at, updated_at, deleted_at, merged_into, merge_event_id) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
             rusqlite::params![
                 id_str,
                 &entity.namespace,
@@ -369,7 +425,6 @@ fn batch_upsert_entities(
                 entity.deleted_at,
                 merged_into_str,
                 merge_event_id_str,
-                entity.content_ref,
             ],
         ) {
             Ok(_) => affected += 1,
@@ -585,6 +640,47 @@ impl EntityStore for SqlEntityStore {
         .await
     }
 
+    async fn upsert_entity_with_attachments(
+        &self,
+        entity: Entity,
+        attachments: Vec<Attachment>,
+    ) -> Result<(), StorageError> {
+        let entity_id = entity.id;
+        let entity_statement = entity_upsert_statement(&entity);
+        let mut attachment_statements = Vec::with_capacity(attachments.len());
+        for attachment in attachments {
+            attachment.validate()?;
+            if attachment.record_uuid != entity_id
+                || attachment.substrate != AttachmentSubstrate::Entity
+            {
+                return Err(StorageError::InvalidInput {
+                    capability: StorageCapability::Attachments,
+                    operation: "upsert_entity_with_attachments".into(),
+                    message: format!(
+                        "attachment {} must target entity {entity_id}",
+                        attachment.role
+                    ),
+                });
+            }
+            attachment_statements.push(attachment_upsert_statement(&attachment)?);
+        }
+
+        self.with_writer_tx("upsert_entity_with_attachments", move |conn| {
+            let mut entity_stmt = conn.prepare(&entity_statement.sql)?;
+            bind_params(&mut entity_stmt, &entity_statement.params)?;
+            entity_stmt.raw_execute()?;
+            drop(entity_stmt);
+
+            for statement in attachment_statements {
+                let mut stmt = conn.prepare(&statement.sql)?;
+                bind_params(&mut stmt, &statement.params)?;
+                stmt.raw_execute()?;
+            }
+            Ok(())
+        })
+        .await
+    }
+
     async fn upsert_entities(
         &self,
         entities: Vec<Entity>,
@@ -632,11 +728,11 @@ impl EntityStore for SqlEntityStore {
         let id_str = id.to_string();
 
         self.with_reader("get_entity", move |conn| {
-            let mut stmt = conn.prepare(
-                "SELECT id, namespace, kind, entity_type, name, description, properties, tags, \
-                 created_at, updated_at, deleted_at, merged_into, merge_event_id, content_ref \
-                 FROM entities WHERE id = ?1 AND deleted_at IS NULL",
-            )?;
+            let sql = format!(
+                "SELECT {ENTITY_SELECT_COLUMNS} FROM entities \
+                 WHERE entities.id = ?1 AND entities.deleted_at IS NULL"
+            );
+            let mut stmt = conn.prepare(&sql)?;
             let mut rows = stmt.query(rusqlite::params![id_str])?;
             match rows.next()? {
                 Some(row) => Ok(Some(read_entity(row)?)),
@@ -672,11 +768,20 @@ impl EntityStore for SqlEntityStore {
                 .await
             }
             DeleteMode::Hard => {
-                let statement = entity_hard_delete_statement(id);
-                self.with_writer("delete_entity_hard", move |conn| {
-                    let mut stmt = conn.prepare(&statement.sql)?;
-                    bind_params(&mut stmt, &statement.params)?;
-                    Ok(stmt.raw_execute()? > 0)
+                let entity_statement = entity_hard_delete_statement(id);
+                let attachment_statement =
+                    delete_record_attachments_statement(id, AttachmentSubstrate::Entity);
+                self.with_writer_tx("delete_entity_hard", move |conn| {
+                    let mut entity_stmt = conn.prepare(&entity_statement.sql)?;
+                    bind_params(&mut entity_stmt, &entity_statement.params)?;
+                    let deleted = entity_stmt.raw_execute()? > 0;
+                    drop(entity_stmt);
+                    if deleted {
+                        let mut attachment_stmt = conn.prepare(&attachment_statement.sql)?;
+                        bind_params(&mut attachment_stmt, &attachment_statement.params)?;
+                        attachment_stmt.raw_execute()?;
+                    }
+                    Ok(deleted)
                 })
                 .await
             }
@@ -769,8 +874,7 @@ impl EntityStore for SqlEntityStore {
             let limit_idx = data_params.len() - 1;
             let offset_idx = data_params.len();
 
-            let columns = "id, namespace, kind, entity_type, name, description, properties, tags, \
-                           created_at, updated_at, deleted_at, merged_into, merge_event_id, content_ref";
+            let columns = ENTITY_SELECT_COLUMNS;
             let data_sql = if filter.names_ci.is_empty() {
                 format!(
                     "SELECT {columns} FROM entities{where_sql} \
@@ -832,8 +936,7 @@ impl EntityStore for SqlEntityStore {
             params.push(Box::new(probe_limit_i64));
             let limit_idx = params.len();
 
-            let columns = "id, namespace, kind, entity_type, name, description, properties, tags, \
-                           created_at, updated_at, deleted_at, merged_into, merge_event_id, content_ref";
+            let columns = ENTITY_SELECT_COLUMNS;
             // CROSS JOIN is load-bearing for the unfiltered walk: SQLite must
             // drive the query from the sequence INTEGER PRIMARY KEY range
             // instead of scanning the namespace index and sorting all matches
@@ -881,11 +984,9 @@ impl EntityStore for SqlEntityStore {
         let id_str = id.to_string();
 
         self.with_reader("get_entity_including_deleted", move |conn| {
-            let mut stmt = conn.prepare(
-                "SELECT id, namespace, kind, entity_type, name, description, properties, tags, \
-                 created_at, updated_at, deleted_at, merged_into, merge_event_id, content_ref \
-                 FROM entities WHERE id = ?1",
-            )?;
+            let sql =
+                format!("SELECT {ENTITY_SELECT_COLUMNS} FROM entities WHERE entities.id = ?1");
+            let mut stmt = conn.prepare(&sql)?;
             let mut rows = stmt.query(rusqlite::params![id_str])?;
             match rows.next()? {
                 Some(row) => Ok(Some(read_entity(row)?)),

--- a/crates/khive-db/src/stores/entity_tests.rs
+++ b/crates/khive-db/src/stores/entity_tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::migrations::run_migrations;
 use crate::pool::PoolConfig;
+use khive_storage::{Attachment, AttachmentSubstrate, ContentRef};
 use std::time::Duration;
 use tokio::sync::oneshot;
 
@@ -12,10 +13,27 @@ fn setup_pool() -> Arc<ConnectionPool> {
     let pool = Arc::new(ConnectionPool::new(config).unwrap());
     {
         let writer = pool.writer().unwrap();
-        writer.conn().execute_batch(ENTITIES_DDL).unwrap();
+        writer
+            .conn()
+            .execute_batch(&format!("{ENTITIES_DDL}\n{TEST_ATTACHMENTS_DDL}"))
+            .unwrap();
     }
     pool
 }
+
+const TEST_ATTACHMENTS_DDL: &str = r#"
+CREATE TABLE attachments (
+    record_uuid TEXT NOT NULL,
+    substrate   TEXT NOT NULL CHECK (substrate IN ('entity', 'note')),
+    role        TEXT NOT NULL,
+    content_ref TEXT NOT NULL,
+    media_type  TEXT,
+    size_bytes  INTEGER,
+    created_at  INTEGER NOT NULL,
+    PRIMARY KEY (record_uuid, role)
+);
+CREATE INDEX idx_attachments_content_ref ON attachments(content_ref);
+"#;
 
 fn setup_memory_store() -> SqlEntityStore {
     SqlEntityStore::new(setup_pool(), false)
@@ -42,6 +60,18 @@ fn make_entity(namespace: &str, kind: &str, name: &str) -> Entity {
         merged_into: None,
         merge_event_id: None,
         content_ref: None,
+    }
+}
+
+fn content_attachment(record_uuid: Uuid, digest: &str) -> Attachment {
+    Attachment {
+        record_uuid,
+        substrate: AttachmentSubstrate::Entity,
+        role: "content".to_string(),
+        content_ref: ContentRef::from_hex(digest).expect("canonical content ref"),
+        media_type: Some("application/octet-stream".to_string()),
+        size_bytes: Some(42),
+        created_at: 123,
     }
 }
 
@@ -1077,7 +1107,10 @@ async fn upsert_entities_routes_through_writer_task_when_flag_enabled() {
     let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
     {
         let writer = pool.writer().unwrap();
-        writer.conn().execute_batch(ENTITIES_DDL).unwrap();
+        writer
+            .conn()
+            .execute_batch(&format!("{ENTITIES_DDL}\n{TEST_ATTACHMENTS_DDL}"))
+            .unwrap();
     }
 
     let store = SqlEntityStore::new(Arc::clone(&pool), true);
@@ -1151,7 +1184,10 @@ async fn multiple_stores_over_one_pool_share_a_single_writer_task() {
     let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
     {
         let writer = pool.writer().unwrap();
-        writer.conn().execute_batch(ENTITIES_DDL).unwrap();
+        writer
+            .conn()
+            .execute_batch(&format!("{ENTITIES_DDL}\n{TEST_ATTACHMENTS_DDL}"))
+            .unwrap();
     }
 
     // Three independent stores over the same pool, each resolving the
@@ -1209,7 +1245,10 @@ async fn concurrent_writes_across_all_migrated_stores_share_one_writer_task() {
     let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
     {
         let writer = pool.writer().unwrap();
-        writer.conn().execute_batch(ENTITIES_DDL).unwrap();
+        writer
+            .conn()
+            .execute_batch(&format!("{ENTITIES_DDL}\n{TEST_ATTACHMENTS_DDL}"))
+            .unwrap();
         crate::stores::note::ensure_notes_schema(writer.conn()).unwrap();
         crate::stores::graph::ensure_graph_schema(writer.conn()).unwrap();
     }
@@ -1365,7 +1404,10 @@ async fn upsert_entity_routes_through_writer_task_when_flag_enabled() {
     let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
     {
         let writer = pool.writer().unwrap();
-        writer.conn().execute_batch(ENTITIES_DDL).unwrap();
+        writer
+            .conn()
+            .execute_batch(&format!("{ENTITIES_DDL}\n{TEST_ATTACHMENTS_DDL}"))
+            .unwrap();
     }
 
     let store = Arc::new(SqlEntityStore::new(Arc::clone(&pool), true));
@@ -1442,17 +1484,20 @@ async fn upsert_entity_routes_through_writer_task_when_flag_enabled() {
     assert_eq!(fetched.unwrap().name, "RoPE");
 }
 
-// ── content_ref (khive#292) ─────────────────────────────────────────────────
+// ── attachment-backed content_ref projection ───────────────────────────────
 
 #[tokio::test]
 async fn test_content_ref_roundtrip() {
     let store = setup_memory_store();
 
     let digest = "a".repeat(64);
-    let entity = Entity::new("default", "document", "SourcePdf").with_content_ref(digest.clone());
+    let entity = Entity::new("default", "document", "SourcePdf");
     let id = entity.id;
 
-    store.upsert_entity(entity).await.unwrap();
+    store
+        .upsert_entity_with_attachments(entity, vec![content_attachment(id, &digest)])
+        .await
+        .unwrap();
 
     let fetched = store.get_entity(id).await.unwrap().unwrap();
     assert_eq!(fetched.content_ref, Some(digest));
@@ -1474,8 +1519,12 @@ async fn test_content_ref_defaults_to_none() {
 async fn test_content_ref_survives_query_entities() {
     let store = setup_memory_store_ns("blob_ns");
     let digest = "b".repeat(64);
-    let entity = Entity::new("blob_ns", "document", "QueriedPdf").with_content_ref(digest.clone());
-    store.upsert_entity(entity).await.unwrap();
+    let entity = Entity::new("blob_ns", "document", "QueriedPdf");
+    let id = entity.id;
+    store
+        .upsert_entity_with_attachments(entity, vec![content_attachment(id, &digest)])
+        .await
+        .unwrap();
 
     let page = store
         .query_entities("blob_ns", EntityFilter::default(), PageRequest::default())
@@ -1486,22 +1535,98 @@ async fn test_content_ref_survives_query_entities() {
 }
 
 #[tokio::test]
-async fn test_content_ref_survives_batch_upsert() {
+async fn entity_upserts_ignore_the_response_only_content_ref_projection() {
     let store = setup_memory_store();
     let digest = "c".repeat(64);
-    let entities = vec![
-        Entity::new("default", "document", "Batch1").with_content_ref(digest.clone()),
-        Entity::new("default", "document", "Batch2"),
-    ];
+    let mut projected = Entity::new("default", "document", "Batch1");
+    projected.content_ref = Some(digest);
+    let entities = vec![projected, Entity::new("default", "document", "Batch2")];
     let ids: Vec<Uuid> = entities.iter().map(|e| e.id).collect();
 
     let summary = store.upsert_entities(entities).await.unwrap();
     assert_eq!(summary.affected, 2);
 
     let with_ref = store.get_entity(ids[0]).await.unwrap().unwrap();
-    assert_eq!(with_ref.content_ref, Some(digest));
+    assert_eq!(with_ref.content_ref, None);
     let without_ref = store.get_entity(ids[1]).await.unwrap().unwrap();
     assert_eq!(without_ref.content_ref, None);
+}
+
+#[tokio::test]
+async fn entity_and_multiple_attachments_roll_back_as_one_unit() {
+    let pool = setup_pool();
+    let store = SqlEntityStore::new(pool.clone(), false);
+    let entity = Entity::new("default", "document", "Atomic");
+    let id = entity.id;
+    pool.writer()
+        .unwrap()
+        .conn()
+        .execute_batch(
+            "CREATE TRIGGER reject_second_attachment BEFORE INSERT ON attachments \
+             WHEN NEW.role = 'reject' BEGIN SELECT RAISE(ABORT, 'injected'); END;",
+        )
+        .unwrap();
+    let mut rejected = content_attachment(id, &"d".repeat(64));
+    rejected.role = "reject".to_string();
+
+    store
+        .upsert_entity_with_attachments(
+            entity,
+            vec![content_attachment(id, &"c".repeat(64)), rejected],
+        )
+        .await
+        .expect_err("second attachment failure must abort the unit");
+
+    assert!(store.get_entity(id).await.unwrap().is_none());
+    let count: i64 = pool
+        .reader()
+        .unwrap()
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM attachments WHERE record_uuid = ?1",
+            [id.to_string()],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(count, 0);
+}
+
+#[tokio::test]
+async fn entity_soft_delete_retains_attachments_and_hard_delete_removes_them() {
+    let pool = setup_pool();
+    let store = SqlEntityStore::new(pool.clone(), false);
+    let entity = Entity::new("default", "document", "Delete");
+    let id = entity.id;
+    store
+        .upsert_entity_with_attachments(entity, vec![content_attachment(id, &"e".repeat(64))])
+        .await
+        .unwrap();
+
+    assert!(store.delete_entity(id, DeleteMode::Soft).await.unwrap());
+    let retained: i64 = pool
+        .reader()
+        .unwrap()
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM attachments WHERE record_uuid = ?1",
+            [id.to_string()],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(retained, 1);
+
+    assert!(store.delete_entity(id, DeleteMode::Hard).await.unwrap());
+    let removed: i64 = pool
+        .reader()
+        .unwrap()
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM attachments WHERE record_uuid = ?1",
+            [id.to_string()],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(removed, 0);
 }
 
 /// #1656: a seek-cursor walk with an active `kind` filter must return every
@@ -1589,7 +1714,10 @@ fn batch_write_refreshes_writer_task_after_construction_outside_runtime() {
     );
     {
         let writer = pool.writer().unwrap();
-        writer.conn().execute_batch(ENTITIES_DDL).unwrap();
+        writer
+            .conn()
+            .execute_batch(&format!("{ENTITIES_DDL}\n{TEST_ATTACHMENTS_DDL}"))
+            .unwrap();
     }
     let store = Arc::new(SqlEntityStore::new(Arc::clone(&pool), true));
 

--- a/crates/khive-db/src/stores/mod.rs
+++ b/crates/khive-db/src/stores/mod.rs
@@ -4,6 +4,7 @@
 //! `khive-storage` capability traits against the shared connection pool.
 
 pub mod agents;
+pub mod attachment;
 pub mod blob;
 pub mod blob_s3;
 pub mod entity;

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -7,6 +7,7 @@ use async_trait::async_trait;
 use rusqlite::OptionalExtension;
 use uuid::Uuid;
 
+use khive_storage::attachment::AttachmentSubstrate;
 use khive_storage::error::{StorageError, WriterTaskRequestState};
 use khive_storage::note::{FilterOp, Note, NoteFilter, SortDir};
 use khive_storage::types::{
@@ -18,6 +19,7 @@ use khive_storage::StorageCapability;
 use crate::error::SqliteError;
 use crate::pool::ConnectionPool;
 use crate::sql_bridge::bind_params;
+use crate::stores::attachment::delete_record_attachments_statement;
 use crate::writer_task::{execute_wrapped_transaction, WriterTaskHandle};
 
 fn map_err(e: rusqlite::Error, op: &'static str) -> StorageError {
@@ -1226,11 +1228,20 @@ impl NoteStore for SqlNoteStore {
                 .await
             }
             DeleteMode::Hard => {
-                let statement = note_hard_delete_statement(id);
-                self.with_writer("delete_note_hard", move |conn| {
-                    let mut stmt = conn.prepare(&statement.sql)?;
-                    bind_params(&mut stmt, &statement.params)?;
-                    Ok(stmt.raw_execute()? > 0)
+                let note_statement = note_hard_delete_statement(id);
+                let attachment_statement =
+                    delete_record_attachments_statement(id, AttachmentSubstrate::Note);
+                self.with_writer_tx("delete_note_hard", move |conn| {
+                    let mut note_stmt = conn.prepare(&note_statement.sql)?;
+                    bind_params(&mut note_stmt, &note_statement.params)?;
+                    let deleted = note_stmt.raw_execute()? > 0;
+                    drop(note_stmt);
+                    if deleted {
+                        let mut attachment_stmt = conn.prepare(&attachment_statement.sql)?;
+                        bind_params(&mut attachment_stmt, &attachment_statement.params)?;
+                        attachment_stmt.raw_execute()?;
+                    }
+                    Ok(deleted)
                 })
                 .await
             }

--- a/crates/khive-db/src/stores/note_tests.rs
+++ b/crates/khive-db/src/stores/note_tests.rs
@@ -81,10 +81,26 @@ fn setup_pool() -> Arc<ConnectionPool> {
     let pool = Arc::new(ConnectionPool::new(config).unwrap());
     {
         let writer = pool.writer().unwrap();
-        writer.conn().execute_batch(NOTES_DDL).unwrap();
+        writer
+            .conn()
+            .execute_batch(&format!("{NOTES_DDL}\n{TEST_ATTACHMENTS_DDL}"))
+            .unwrap();
     }
     pool
 }
+
+const TEST_ATTACHMENTS_DDL: &str = r#"
+CREATE TABLE attachments (
+    record_uuid TEXT NOT NULL,
+    substrate   TEXT NOT NULL CHECK (substrate IN ('entity', 'note')),
+    role        TEXT NOT NULL,
+    content_ref TEXT NOT NULL,
+    media_type  TEXT,
+    size_bytes  INTEGER,
+    created_at  INTEGER NOT NULL,
+    PRIMARY KEY (record_uuid, role)
+);
+"#;
 
 fn setup_memory_store() -> SqlNoteStore {
     SqlNoteStore::new(setup_pool(), false)
@@ -199,6 +215,51 @@ async fn test_hard_delete() {
 
     let fetched = store.get_note(id).await.unwrap();
     assert!(fetched.is_none());
+}
+
+#[tokio::test]
+async fn note_soft_delete_retains_attachments_and_hard_delete_removes_them() {
+    let pool = setup_pool();
+    let store = SqlNoteStore::new(pool.clone(), false);
+    let note = make_note("default", "observation", "attached note");
+    let id = note.id;
+    store.upsert_note(note).await.unwrap();
+    pool.writer()
+        .unwrap()
+        .conn()
+        .execute(
+            "INSERT INTO attachments \
+             (record_uuid, substrate, role, content_ref, created_at) \
+             VALUES (?1, 'note', 'content', ?2, 123)",
+            rusqlite::params![id.to_string(), "a".repeat(64)],
+        )
+        .unwrap();
+
+    assert!(store.delete_note(id, DeleteMode::Soft).await.unwrap());
+    let retained: i64 = pool
+        .reader()
+        .unwrap()
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM attachments WHERE record_uuid = ?1",
+            [id.to_string()],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(retained, 1);
+
+    assert!(store.delete_note(id, DeleteMode::Hard).await.unwrap());
+    let removed: i64 = pool
+        .reader()
+        .unwrap()
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM attachments WHERE record_uuid = ?1",
+            [id.to_string()],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(removed, 0);
 }
 
 /// Namespace isolation: one store, two namespaces — each query sees only its own.

--- a/crates/khive-db/tests/attachment_store.rs
+++ b/crates/khive-db/tests/attachment_store.rs
@@ -1,0 +1,142 @@
+use std::sync::Arc;
+
+use khive_db::pool::{ConnectionPool, PoolConfig};
+use khive_db::stores::attachment::SqlAttachmentStore;
+use khive_storage::{Attachment, AttachmentStore, AttachmentSubstrate, ContentRef, StorageError};
+use uuid::Uuid;
+
+const ATTACHMENTS_DDL: &str = r#"
+CREATE TABLE attachments (
+    record_uuid TEXT NOT NULL,
+    substrate   TEXT NOT NULL CHECK (substrate IN ('entity', 'note')),
+    role        TEXT NOT NULL,
+    content_ref TEXT NOT NULL,
+    media_type  TEXT,
+    size_bytes  INTEGER,
+    created_at  INTEGER NOT NULL,
+    PRIMARY KEY (record_uuid, role)
+);
+CREATE INDEX idx_attachments_content_ref ON attachments(content_ref);
+"#;
+
+fn setup() -> (Arc<ConnectionPool>, SqlAttachmentStore) {
+    let pool = Arc::new(
+        ConnectionPool::new(PoolConfig {
+            path: None,
+            ..PoolConfig::default()
+        })
+        .expect("pool"),
+    );
+    pool.writer()
+        .expect("writer")
+        .conn()
+        .execute_batch(ATTACHMENTS_DDL)
+        .expect("attachment schema");
+    let store = SqlAttachmentStore::new(pool.clone(), false);
+    (pool, store)
+}
+
+fn attachment(record_uuid: Uuid, role: &str, byte: char) -> Attachment {
+    Attachment {
+        record_uuid,
+        substrate: AttachmentSubstrate::Entity,
+        role: role.to_string(),
+        content_ref: ContentRef::from_hex(byte.to_string().repeat(64)).expect("canonical ref"),
+        media_type: Some("application/octet-stream".to_string()),
+        size_bytes: Some(42),
+        created_at: 123,
+    }
+}
+
+#[tokio::test]
+async fn attachment_store_crud_is_role_keyed_and_stably_listed() {
+    let (_pool, store) = setup();
+    let record_uuid = Uuid::new_v4();
+    let content = attachment(record_uuid, "content", 'a');
+    let network = attachment(record_uuid, "fann-network", 'b');
+
+    store
+        .upsert_attachment(network.clone())
+        .await
+        .expect("insert network");
+    store
+        .upsert_attachment(content.clone())
+        .await
+        .expect("insert content");
+
+    assert_eq!(
+        store
+            .get_attachment(record_uuid, "content")
+            .await
+            .expect("get content"),
+        Some(content.clone())
+    );
+    assert_eq!(
+        store
+            .list_attachments(record_uuid)
+            .await
+            .expect("list attachments"),
+        vec![content.clone(), network]
+    );
+
+    let replacement = attachment(record_uuid, "content", 'c');
+    store
+        .upsert_attachment(replacement.clone())
+        .await
+        .expect("replace content role");
+    assert_eq!(
+        store
+            .get_attachment(record_uuid, "content")
+            .await
+            .expect("get replacement"),
+        Some(replacement)
+    );
+
+    assert!(store
+        .delete_attachment(record_uuid, "content")
+        .await
+        .expect("delete content"));
+    assert!(!store
+        .delete_attachment(record_uuid, "content")
+        .await
+        .expect("idempotent missing delete"));
+}
+
+#[tokio::test]
+async fn attachment_store_rejects_invalid_roles_before_sql() {
+    let (_pool, store) = setup();
+    let record_uuid = Uuid::new_v4();
+
+    let error = store
+        .upsert_attachment(attachment(record_uuid, "bad\nrole", 'd'))
+        .await
+        .expect_err("control-bearing role must fail");
+    assert!(matches!(error, StorageError::InvalidInput { .. }));
+
+    let error = store
+        .get_attachment(record_uuid, "")
+        .await
+        .expect_err("empty lookup role must fail");
+    assert!(matches!(error, StorageError::InvalidInput { .. }));
+}
+
+#[tokio::test]
+async fn attachment_store_rejects_corrupt_negative_size_rows() {
+    let (pool, store) = setup();
+    let record_uuid = Uuid::new_v4();
+    pool.writer()
+        .expect("writer")
+        .conn()
+        .execute(
+            "INSERT INTO attachments \
+             (record_uuid, substrate, role, content_ref, size_bytes, created_at) \
+             VALUES (?1, 'entity', 'content', ?2, -1, 123)",
+            rusqlite::params![record_uuid.to_string(), "e".repeat(64)],
+        )
+        .expect("corrupt fixture");
+
+    store
+        .get_attachment(record_uuid, "content")
+        .await
+        .expect_err("negative persisted size must fail closed");
+}

--- a/crates/khive-db/tests/contract.rs
+++ b/crates/khive-db/tests/contract.rs
@@ -1,8 +1,10 @@
 //! Contract tests for the sqlite backend (ADR-009 §backend-contract-tests).
 //!
-//! Exercises the eight storage capability traits (`SqlAccess`, `EntityStore`,
+//! Exercises the original eight storage capability traits (`SqlAccess`, `EntityStore`,
 //! `GraphStore`, `NoteStore`, `EventStore`, `VectorStore`, `SparseStore`,
 //! `TextSearch`) against both in-memory and file-backed SQLite backends.
+//! `BlobStore` and `AttachmentStore`, added later, have dedicated conformance
+//! suites in `blob_conformance.rs` and `attachment_store.rs`.
 //! The harness is structured to become a cross-backend conformance suite when
 //! a second backend ships (e.g. `khive-db-postgres`).
 

--- a/crates/khive-db/tests/contract/backend.rs
+++ b/crates/khive-db/tests/contract/backend.rs
@@ -22,11 +22,17 @@ use uuid::Uuid;
 // ---- Factory helpers ----
 
 fn memory_backend() -> StorageBackend {
-    StorageBackend::memory().expect("in-memory backend")
+    let backend = StorageBackend::memory().expect("in-memory backend");
+    backend
+        .prepare_core_schema()
+        .expect("prepare in-memory core schema");
+    backend
 }
 
 fn file_backend(dir: &tempfile::TempDir, name: &str) -> StorageBackend {
-    StorageBackend::sqlite(dir.path().join(name)).expect("file backend")
+    let backend = StorageBackend::sqlite(dir.path().join(name)).expect("file backend");
+    backend.prepare_core_schema().expect("prepare file schema");
+    backend
 }
 
 // ---- SqlAccess contract ----

--- a/crates/khive-mcp/README.md
+++ b/crates/khive-mcp/README.md
@@ -31,9 +31,14 @@ lifetime.
 
 ```rust
 use khive_mcp::server::KhiveMcpServer;
-use khive_runtime::{KhiveRuntime, RuntimeConfig};
+use khive_runtime::{KhiveConfig, RuntimeConfig};
 
-let runtime = KhiveRuntime::new(RuntimeConfig::default()).expect("valid config");
+let runtime = khive_mcp::serve::build_single_backend_runtime(
+    RuntimeConfig::default(),
+    &KhiveConfig::default(),
+)
+.await
+.expect("schema, attachment cutover, and runtime boot");
 let server = KhiveMcpServer::new(runtime).expect("known packs, deps satisfied");
 ```
 
@@ -42,6 +47,26 @@ an explicit pack list instead. Both fail fast with `PackRegError` (naming the un
 or missing dependency) rather than silently dropping packs. Once built, `serve_stdio(self)`
 consumes the server and serves over stdio — the path `StdioTransport::serve` and `kkernel
 mcp` both call.
+
+Production callers must obtain that runtime from the async host builders. They inventory
+secondaries, install the shared bounded hydrator, and finish the resumable V21 attachment/GC
+cutover before exposing a server. Direct `KhiveRuntime::from_backend` plus
+`KhiveMcpServer::new` is only for tests or a caller that has independently proved the backend is
+exact-current; it does not run the application-assisted migration.
+
+Those Phase-4b builders must not be deployed until the Phase-4a GC compatibility
+release has converged across every process sharing the database/blob root and
+all pre-Phase-4a processes are drained. Phase 4a makes no schema/data change; it
+only refuses transactional GC unless it sees an exact completed V21 epoch.
+Before cutover, every Phase-4a application-serving/read-write process must also
+be quiesced or unable to access the database. A GC-only worker's completed-V21
+compatibility is not general serving compatibility; start Phase-4b serving only
+after exact-current topology validation.
+
+The Phase-4b boot APIs are async source changes:
+`build_server{,_with_explicit_namespace}`,
+`build_registry_for_multi_backend{,_with_db_anchor}`, and
+`build_server_multi_backend{,_with_db_anchor}` must now be awaited.
 
 ## Where this sits
 

--- a/crates/khive-mcp/docs/design.md
+++ b/crates/khive-mcp/docs/design.md
@@ -40,6 +40,29 @@ decisions and rationale.
 - `register_embedders` is called on every pack after the registry is built so
   custom embedding providers are available before the first `remember`/`recall`.
 
+### Attachment Cutover Boot Gate (ADR-121, ADR-160 D4)
+
+- Phase-4b host boot assumes the mandatory deployment gate has already passed:
+  the separately released Phase-4a GC epoch gate has converged everywhere that
+  shares the database/blob root, and every pre-Phase-4a process has been drained
+  and restart-fenced. Every Phase-4a application-serving/read-write process is
+  also quiesced or unable to access the database during cutover. Phase 4a itself
+  leaves V20 schema/data untouched; only its GC-only worker is narrowly
+  compatible with exact completed V21.
+- Single- and multi-backend constructors are async host choke points. They keep
+  serving closed until the coordinated V21 attachment migration is complete.
+- Multi-backend boot opens and deduplicates all databases, prepares and
+  inventories secondaries first, and only then prepares main. Any legacy or
+  current attachment row on a secondary is an actionable boot error.
+- Main cutover resolves one shared `BlobHydrator`, acquires the same canonical
+  database ownership used by transactional blob GC, stages legacy `content`
+  roles, authenticates every moodboard bundle/event/FANN pair even when that
+  pack is disabled, publishes `fann-network`, and finalizes V21.
+- Pending/incomplete state is durable and resumable. No runtime, request, or GC
+  surface is exposed until finalization drops `entities.content_ref` and installs
+  attachment-only claim fences. The Phase-4b serving fleet starts only after
+  exact-current topology validation.
+
 ### Dynamic Pack Loading (ADR-027)
 
 - `builtin_pack_names()` is sourced from `PackRegistry::discovered_names()` so

--- a/crates/khive-mcp/src/attachment_cutover.rs
+++ b/crates/khive-mcp/src/attachment_cutover.rs
@@ -1,0 +1,512 @@
+//! Host-runtime coordination for ADR-121/ADR-160's V21 attachment cutover.
+
+use std::sync::Arc;
+
+use anyhow::Context as _;
+use khive_db::migrations::AttachmentCutoverStatus;
+use khive_runtime::{BlobHydrator, StorageBackend};
+use khive_storage::types::{SqlStatement, SqlValue};
+use khive_storage::{Attachment, AttachmentSubstrate};
+
+const FANN_NETWORK_ROLE: &str = "fann-network";
+
+enum CutoverMode {
+    Main,
+    EmptySecondary { backend_name: String },
+}
+
+impl CutoverMode {
+    fn secondary_name(&self) -> Option<&str> {
+        match self {
+            Self::Main => None,
+            Self::EmptySecondary { backend_name } => Some(backend_name),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test_sync {
+    use std::path::PathBuf;
+    use std::sync::{Arc, Mutex, OnceLock};
+
+    use khive_storage::SqlAccess;
+    use tokio::sync::Barrier;
+
+    struct Hook {
+        database_path: PathBuf,
+        barrier: Arc<Barrier>,
+    }
+
+    fn hook() -> &'static Mutex<Option<Hook>> {
+        static HOOK: OnceLock<Mutex<Option<Hook>>> = OnceLock::new();
+        HOOK.get_or_init(|| Mutex::new(None))
+    }
+
+    pub(super) fn install(database_path: PathBuf, barrier: Arc<Barrier>) {
+        *hook().lock().expect("cutover test hook lock") = Some(Hook {
+            database_path,
+            barrier,
+        });
+    }
+
+    pub(super) fn clear() {
+        *hook().lock().expect("cutover test hook lock") = None;
+    }
+
+    pub(super) async fn before_gc_owner(sql: &dyn SqlAccess) {
+        let barrier = hook()
+            .lock()
+            .expect("cutover test hook lock")
+            .as_ref()
+            .filter(|hook| sql.database_path().as_ref() == Some(&hook.database_path))
+            .map(|hook| Arc::clone(&hook.barrier));
+        if let Some(barrier) = barrier {
+            barrier.wait().await;
+        }
+    }
+}
+
+async fn scalar_count(
+    backend: &StorageBackend,
+    sql: &'static str,
+    label: &'static str,
+) -> anyhow::Result<u64> {
+    let sql_access = backend.sql();
+    let mut reader = sql_access
+        .reader()
+        .await
+        .with_context(|| format!("{label}: acquire SQL reader"))?;
+    match reader
+        .query_scalar(SqlStatement {
+            sql: sql.to_string(),
+            params: vec![],
+            label: Some(label.to_string()),
+        })
+        .await
+        .with_context(|| format!("{label}: execute count"))?
+    {
+        Some(SqlValue::Integer(count)) if count >= 0 => Ok(count as u64),
+        other => anyhow::bail!("{label}: invalid count result {other:?}"),
+    }
+}
+
+async fn cutover_status(backend: Arc<StorageBackend>) -> anyhow::Result<AttachmentCutoverStatus> {
+    tokio::task::spawn_blocking(move || backend.attachment_cutover_status())
+        .await
+        .context("attachment cutover status task panicked")?
+        .context("inspect attachment cutover status")
+}
+
+/// Reject attachment evidence on a non-main database before the main database
+/// exposes its durable incomplete marker.
+///
+/// Phase 4 deliberately chooses one liveness authority: attachment-bearing
+/// records are main-backend-only. This check includes recoverable soft-deleted
+/// legacy entities and already-completed attachment rows.
+pub(crate) async fn require_secondary_attachment_empty(
+    backend: Arc<StorageBackend>,
+    backend_name: &str,
+) -> anyhow::Result<()> {
+    let status = cutover_status(Arc::clone(&backend)).await?;
+    let legacy_refs = match status {
+        AttachmentCutoverStatus::Pending | AttachmentCutoverStatus::Incomplete => {
+            scalar_count(
+                backend.as_ref(),
+                "SELECT COUNT(*) FROM entities WHERE content_ref IS NOT NULL",
+                "secondary_legacy_attachment_count",
+            )
+            .await?
+        }
+        AttachmentCutoverStatus::Complete => 0,
+    };
+    let attachment_rows = match status {
+        AttachmentCutoverStatus::Pending => 0,
+        AttachmentCutoverStatus::Incomplete | AttachmentCutoverStatus::Complete => {
+            scalar_count(
+                backend.as_ref(),
+                "SELECT COUNT(*) FROM attachments",
+                "secondary_attachment_row_count",
+            )
+            .await?
+        }
+    };
+
+    if legacy_refs != 0 || attachment_rows != 0 {
+        anyhow::bail!(
+            "backend {backend_name:?} contains attachment-bearing records \
+             (legacy_refs={legacy_refs}, attachment_rows={attachment_rows}); V21 makes the \
+             main backend the sole attachment/GC liveness authority. Move or remove those \
+             recoverable records before retrying boot"
+        );
+    }
+    Ok(())
+}
+
+/// Finish one pending/incomplete database on the real host Tokio runtime.
+///
+/// The outer task is ADR-119 tracked and explicitly awaited. It owns the
+/// canonical DB GC guard across stage, async verified blob hydration, the one
+/// application-attachment transaction, and finalization. Blocking SQLite
+/// phases receive ownership of the guard, so caller cancellation cannot release
+/// it while native work is still running.
+pub(crate) async fn coordinate_attachment_cutover(
+    backend: Arc<StorageBackend>,
+    hydrator: Option<Arc<BlobHydrator>>,
+) -> anyhow::Result<()> {
+    coordinate_attachment_cutover_inner(backend, hydrator, CutoverMode::Main).await
+}
+
+/// Finish an interrupted empty secondary without ever making it an
+/// attachment-liveness authority.
+pub(crate) async fn coordinate_empty_secondary_attachment_cutover(
+    backend: Arc<StorageBackend>,
+    backend_name: &str,
+) -> anyhow::Result<()> {
+    coordinate_attachment_cutover_inner(
+        backend,
+        None,
+        CutoverMode::EmptySecondary {
+            backend_name: backend_name.to_string(),
+        },
+    )
+    .await
+}
+
+async fn coordinate_attachment_cutover_inner(
+    backend: Arc<StorageBackend>,
+    hydrator: Option<Arc<BlobHydrator>>,
+    mode: CutoverMode,
+) -> anyhow::Result<()> {
+    if cutover_status(Arc::clone(&backend)).await? == AttachmentCutoverStatus::Complete {
+        if let Some(backend_name) = mode.secondary_name() {
+            // Exact-current read-only snapshots must remain query-only: GC
+            // ownership creates an advisory lock file, but no mutation or
+            // legacy-column race is possible after the V21 drop. Inventory
+            // the immutable secondary and return without filesystem writes.
+            require_secondary_attachment_empty(backend, backend_name).await?;
+        }
+        return Ok(());
+    }
+
+    let handle = khive_runtime::daemon::spawn_tracked_task(async move {
+        let sql = backend.sql();
+        #[cfg(test)]
+        test_sync::before_gc_owner(sql.as_ref()).await;
+        let owner = khive_db::stores::blob::acquire_database_gc_owner(sql.as_ref())
+            .await
+            .context("acquire canonical database GC owner for V21")?;
+
+        let (backend, owner, already_complete) = tokio::task::spawn_blocking(move || {
+            // The optimistic check before task creation is not a lock. A
+            // sibling process may complete V21 while this boot waits for the
+            // canonical GC owner, so re-check under ownership before issuing
+            // any SQL that still names the legacy column.
+            if backend.attachment_cutover_status()? == AttachmentCutoverStatus::Complete {
+                return Ok::<_, anyhow::Error>((backend, owner, true));
+            }
+            backend
+                .stage_attachment_cutover(&owner)
+                .context("commit V21 attachment stage 1")?;
+            Ok::<_, anyhow::Error>((backend, owner, false))
+        })
+        .await
+        .context("V21 stage-1 blocking task panicked")??;
+        if already_complete {
+            if let Some(backend_name) = mode.secondary_name() {
+                require_secondary_attachment_empty(backend, backend_name).await?;
+            }
+            return Ok(());
+        }
+
+        let verified = if let Some(backend_name) = mode.secondary_name() {
+            // Revalidate after stage while the same GC owner remains held.
+            // A legacy writer that raced the earlier inventory is now either
+            // visible both as a legacy ref and a staged content attachment,
+            // or will be caught by finalization's exact backfill recheck.
+            require_secondary_attachment_empty(Arc::clone(&backend), backend_name).await?;
+            Vec::new()
+        } else {
+            let sql = backend.sql();
+            let legacy_model_count =
+                khive_pack_moodboard::legacy_preference_model_count(sql.as_ref())
+                    .await
+                    .context("count legacy moodboard preference models")?;
+            if legacy_model_count == 0 {
+                Vec::new()
+            } else {
+                let hydrator = hydrator.as_ref().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "V21 found {legacy_model_count} legacy moodboard preference model(s), but \
+                         no BlobHydrator is configured; configure [storage.blob] and retry boot"
+                    )
+                })?;
+                let verified = khive_pack_moodboard::verify_legacy_preference_attachments(
+                    sql.as_ref(),
+                    hydrator.as_ref(),
+                )
+                .await
+                .context("verify legacy moodboard bundle/event/FANN evidence")?;
+                if verified.len() as u64 != legacy_model_count {
+                    anyhow::bail!(
+                        "legacy moodboard verification returned {} attachment(s) for \
+                         {legacy_model_count} recoverable model(s)",
+                        verified.len()
+                    );
+                }
+                verified
+            }
+        };
+
+        let created_at = chrono::Utc::now().timestamp_micros();
+        let attachments = verified
+            .into_iter()
+            .map(|verified| Attachment {
+                record_uuid: verified.model_id,
+                substrate: AttachmentSubstrate::Entity,
+                role: FANN_NETWORK_ROLE.to_string(),
+                content_ref: verified.network_content_ref,
+                media_type: Some("application/octet-stream".to_string()),
+                size_bytes: Some(verified.size_bytes),
+                created_at,
+            })
+            .collect::<Vec<_>>();
+
+        tokio::task::spawn_blocking(move || {
+            backend
+                .apply_verified_attachments(&owner, &attachments)
+                .context("atomically apply verified pack-owned attachments")?;
+            backend
+                .finalize_attachment_cutover(&owner)
+                .context("finalize V21 attachment/GC cutover")?;
+            Ok::<_, anyhow::Error>(())
+        })
+        .await
+        .context("V21 finalization blocking task panicked")??;
+
+        Ok::<_, anyhow::Error>(())
+    });
+
+    handle
+        .await
+        .context("tracked V21 attachment migrator panicked")??;
+    Ok(())
+}
+
+/// Materialize the exact canonical V20 prefix without invoking V21.
+///
+/// Test-only upgrade fixture shared by coordinator and multi-backend boot
+/// regressions; this is not an alternate production migration path.
+#[cfg(test)]
+pub(crate) fn create_v20_database_fixture(
+    path: &std::path::Path,
+    entity_type: &str,
+    deleted_at: Option<i64>,
+) -> (uuid::Uuid, khive_storage::ContentRef) {
+    use khive_db::migrations::{ATTACHMENT_CUTOVER_VERSION, MIGRATIONS};
+
+    let mut conn = rusqlite::Connection::open(path).expect("open V20 fixture");
+    conn.execute_batch(
+        "CREATE TABLE _schema_migrations (\
+             version INTEGER PRIMARY KEY, \
+             name TEXT NOT NULL, \
+             applied_at INTEGER NOT NULL\
+         ) STRICT;",
+    )
+    .expect("create migration ledger");
+    for migration in MIGRATIONS
+        .iter()
+        .filter(|migration| migration.version < ATTACHMENT_CUTOVER_VERSION)
+    {
+        let tx = conn.transaction().expect("begin fixture migration");
+        tx.execute_batch(migration.up)
+            .unwrap_or_else(|error| panic!("apply V{}: {error}", migration.version));
+        tx.execute(
+            "INSERT INTO _schema_migrations (version, name, applied_at) \
+             VALUES (?1, ?2, ?3)",
+            rusqlite::params![
+                migration.version,
+                migration.name,
+                i64::from(migration.version)
+            ],
+        )
+        .unwrap_or_else(|error| panic!("record V{}: {error}", migration.version));
+        tx.commit().expect("commit fixture migration");
+    }
+
+    let id = uuid::Uuid::new_v4();
+    let content_ref =
+        khive_storage::ContentRef::from_hex("a".repeat(64)).expect("canonical fixture digest");
+    conn.execute(
+        "INSERT INTO entities (\
+             id, namespace, kind, entity_type, name, tags, created_at, updated_at, \
+             deleted_at, content_ref\
+         ) VALUES (?1, 'local', 'artifact', ?2, 'legacy fixture', '[]', 1, 1, ?3, ?4)",
+        rusqlite::params![
+            id.to_string(),
+            entity_type,
+            deleted_at,
+            content_ref.as_str()
+        ],
+    )
+    .expect("insert legacy attachment-bearing entity");
+    (id, content_ref)
+}
+
+#[cfg(test)]
+mod tests {
+    use khive_db::migrations::ATTACHMENT_CUTOVER_VERSION;
+    use khive_db::stores::blob::FsBlobStore;
+    use khive_storage::BlobStore as _;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn non_model_legacy_content_resumes_to_attachment_only_v21_without_a_blob_store() {
+        let temp = tempfile::tempdir().unwrap();
+        let db_path = temp.path().join("legacy.db");
+        let (entity_id, content_ref) = create_v20_database_fixture(&db_path, "visual_asset", None);
+        let backend = Arc::new(StorageBackend::sqlite(&db_path).unwrap());
+
+        assert_eq!(
+            backend.prepare_core_schema().unwrap(),
+            ATTACHMENT_CUTOVER_VERSION - 1,
+            "ordinary migration must stop before the coordinated legacy cutover"
+        );
+        coordinate_attachment_cutover(Arc::clone(&backend), None)
+            .await
+            .expect("non-model legacy content needs no BlobHydrator");
+        assert_eq!(
+            backend.attachment_cutover_status().unwrap(),
+            AttachmentCutoverStatus::Complete
+        );
+
+        let attachment = backend
+            .attachments()
+            .unwrap()
+            .get_attachment(entity_id, "content")
+            .await
+            .unwrap()
+            .expect("legacy content role must be backfilled");
+        assert_eq!(attachment.content_ref, content_ref);
+
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let legacy_columns: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('entities') WHERE name = 'content_ref'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(legacy_columns, 0, "final V21 must drop the legacy column");
+    }
+
+    #[tokio::test]
+    async fn legacy_model_without_hydrator_stays_incomplete_and_gc_refuses_to_run() {
+        let temp = tempfile::tempdir().unwrap();
+        let db_path = temp.path().join("legacy-model.db");
+        create_v20_database_fixture(&db_path, "moodboard_model", None);
+        let backend = Arc::new(StorageBackend::sqlite(&db_path).unwrap());
+        assert_eq!(
+            backend.prepare_core_schema().unwrap(),
+            ATTACHMENT_CUTOVER_VERSION - 1
+        );
+
+        let error = coordinate_attachment_cutover(Arc::clone(&backend), None)
+            .await
+            .expect_err("legacy model evidence requires configured blob hydration");
+        assert!(error.to_string().contains("no BlobHydrator is configured"));
+        assert_eq!(
+            backend.attachment_cutover_status().unwrap(),
+            AttachmentCutoverStatus::Incomplete,
+            "a failed application stage must remain durably resumable"
+        );
+
+        let store = FsBlobStore::new(temp.path().join("blobs"), 0).unwrap();
+        let sweep_error = store
+            .transactional_orphan_sweep(backend.sql().as_ref(), false)
+            .await
+            .expect_err("GC must not run over an incomplete dual representation");
+        assert!(sweep_error.to_string().contains("fencing"));
+    }
+
+    #[tokio::test]
+    async fn secondary_preflight_counts_soft_deleted_legacy_references() {
+        let temp = tempfile::tempdir().unwrap();
+        let db_path = temp.path().join("secondary.db");
+        create_v20_database_fixture(&db_path, "visual_asset", Some(2));
+        let backend = Arc::new(StorageBackend::sqlite(&db_path).unwrap());
+        assert_eq!(
+            backend.prepare_core_schema().unwrap(),
+            ATTACHMENT_CUTOVER_VERSION - 1
+        );
+
+        let error = require_secondary_attachment_empty(backend, "secondary")
+            .await
+            .expect_err("recoverable soft-deleted references still participate in liveness");
+        assert!(error.to_string().contains("legacy_refs=1"));
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn concurrent_boots_recheck_completion_after_waiting_for_gc_ownership() {
+        let temp = tempfile::tempdir().unwrap();
+        let db_path = temp.path().join("concurrent-boot.db");
+        create_v20_database_fixture(&db_path, "visual_asset", None);
+        let backend = Arc::new(StorageBackend::sqlite(&db_path).unwrap());
+        assert_eq!(
+            backend.prepare_core_schema().unwrap(),
+            ATTACHMENT_CUTOVER_VERSION - 1
+        );
+
+        let owner = khive_db::stores::blob::acquire_database_gc_owner(backend.sql().as_ref())
+            .await
+            .unwrap();
+        let barrier = Arc::new(tokio::sync::Barrier::new(3));
+        test_sync::install(
+            std::fs::canonicalize(&db_path).expect("canonical fixture database"),
+            Arc::clone(&barrier),
+        );
+        let first = tokio::spawn(coordinate_attachment_cutover(Arc::clone(&backend), None));
+        let second = tokio::spawn(coordinate_attachment_cutover(Arc::clone(&backend), None));
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), barrier.wait())
+            .await
+            .expect("both boot tasks must reach the per-database GC-owner hook");
+        test_sync::clear();
+        drop(owner);
+
+        first.await.unwrap().unwrap();
+        second.await.unwrap().unwrap();
+        assert_eq!(
+            backend.attachment_cutover_status().unwrap(),
+            AttachmentCutoverStatus::Complete
+        );
+    }
+
+    #[tokio::test]
+    async fn interrupted_secondary_revalidates_empty_after_staging() {
+        let temp = tempfile::tempdir().unwrap();
+        let db_path = temp.path().join("secondary-race.db");
+        create_v20_database_fixture(&db_path, "visual_asset", None);
+        let backend = Arc::new(StorageBackend::sqlite(&db_path).unwrap());
+        assert_eq!(
+            backend.prepare_core_schema().unwrap(),
+            ATTACHMENT_CUTOVER_VERSION - 1
+        );
+        let owner = khive_db::stores::blob::acquire_database_gc_owner(backend.sql().as_ref())
+            .await
+            .unwrap();
+        backend.stage_attachment_cutover(&owner).unwrap();
+        drop(owner);
+
+        let error =
+            coordinate_empty_secondary_attachment_cutover(Arc::clone(&backend), "secondary")
+                .await
+                .expect_err("a raced legacy reference must never become secondary liveness");
+        assert!(error.to_string().contains("attachment_rows=1"));
+        assert_eq!(
+            backend.attachment_cutover_status().unwrap(),
+            AttachmentCutoverStatus::Incomplete
+        );
+    }
+}

--- a/crates/khive-mcp/src/lib.rs
+++ b/crates/khive-mcp/src/lib.rs
@@ -4,6 +4,7 @@
 //! The binary frontend is `kkernel mcp`; this crate ships no binary of its own.
 
 pub mod args;
+mod attachment_cutover;
 pub mod components;
 pub mod coordinator;
 #[cfg(unix)]

--- a/crates/khive-mcp/src/pending_events.rs
+++ b/crates/khive-mcp/src/pending_events.rs
@@ -464,7 +464,7 @@ pub async fn run_pending_events_with_config(
     // emitting the documented JSON refusal envelope. Every other build
     // failure keeps the generic "pending-events: build server" provenance.
     let (server, schedule_rt) =
-        match crate::serve::build_server_with_explicit_namespace(&args, ns, true, false) {
+        match crate::serve::build_server_with_explicit_namespace(&args, ns, true, false).await {
             Ok(built) => built,
             Err(error) => {
                 if error
@@ -7000,9 +7000,9 @@ mod tests {
     /// `actor_explicit`, tripping the "genuinely explicit actor tier
     /// requesting anonymous" branch in `resolve_runtime_config` and silently
     /// discarding the configured `[actor] id`.
-    #[test]
+    #[tokio::test]
     #[serial_test::serial]
-    fn wrapper_seam_falls_through_to_project_actor_instead_of_clearing_it() {
+    async fn wrapper_seam_falls_through_to_project_actor_instead_of_clearing_it() {
         std::env::remove_var("KHIVE_ACTOR");
         std::env::remove_var("KHIVE_DB");
         std::env::remove_var("KHIVE_PACKS");
@@ -7032,6 +7032,7 @@ mod tests {
         // (`actor_explicit: false`).
         let (_server, schedule_rt) =
             crate::serve::build_server_with_explicit_namespace(&args, ns, true, false)
+                .await
                 .expect("build_server_with_explicit_namespace must succeed");
         let rt = schedule_rt.expect("\"schedule\" pack is in the default pack set");
         assert_eq!(
@@ -7049,9 +7050,9 @@ mod tests {
     /// present namespace value really does mean "the operator typed
     /// --namespace". This documents why `run_pending_events` must not reuse
     /// that entry point for a synthesized, non-CLI-parsed namespace default.
-    #[test]
+    #[tokio::test]
     #[serial_test::serial]
-    fn build_server_cli_seam_clears_actor_for_explicit_local_namespace() {
+    async fn build_server_cli_seam_clears_actor_for_explicit_local_namespace() {
         std::env::remove_var("KHIVE_ACTOR");
         std::env::remove_var("KHIVE_DB");
         std::env::remove_var("KHIVE_PACKS");
@@ -7075,8 +7076,9 @@ mod tests {
             resumed_generation: None,
         };
 
-        let (_server, schedule_rt) =
-            crate::serve::build_server(&args).expect("build_server must succeed");
+        let (_server, schedule_rt) = crate::serve::build_server(&args)
+            .await
+            .expect("build_server must succeed");
         let rt = schedule_rt.expect("\"schedule\" pack is in the default pack set");
         assert_eq!(
             rt.config().actor_id,

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -7,6 +7,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use anyhow::Context as _;
 use khive_runtime::{
     config_from_env, parse_pack_list, runtime_config_from_khive_config, BackendConfig, BackendId,
     BackendKind, BlobHydrator, ConnectionPool, KhiveConfig, KhiveRuntime, OutputFormat,
@@ -156,7 +157,7 @@ pub async fn run(args: Args, registry: &TransportRegistry) -> anyhow::Result<()>
     } else {
         khive_runtime::daemon::acquire_recovery_lock()
     };
-    let (server, schedule_rt) = build_server(&args)?;
+    let (server, schedule_rt) = build_server(&args).await?;
 
     #[cfg(feature = "channel-email")]
     spawn_email_channel_loops_if_daemon(&server, &args);
@@ -1968,6 +1969,12 @@ pub async fn serve_server(
 /// 1. Construct the `KhiveMcpServer` (via `from_registry_with_meta`), and
 /// 2. Build the `BackendRegistry` for the `SubstrateCoordinator`.
 ///
+/// This is an asynchronous host-boot boundary, not a pure registry constructor.
+/// Before it returns, every distinct secondary backend has been inventoried and
+/// the canonical main backend has completed the application-assisted V21
+/// attachment cutover. No runtime or attachment-only GC surface is exposed while
+/// that work is pending or incomplete.
+///
 /// This is a refactor-extraction of the registry-building logic from
 /// `build_server_multi_backend`, keeping the existing tests intact.
 ///
@@ -1979,16 +1986,21 @@ pub async fn serve_server(
 /// declared `main` backend is accepted as a no-op; any other concrete path is
 /// rejected rather than silently collapsing distinct declared backends onto one
 /// caller-supplied file.
-pub fn build_registry_for_multi_backend(
+pub async fn build_registry_for_multi_backend(
     base_config: RuntimeConfig,
     khive_cfg: &KhiveConfig,
     cli_db_override: Option<&str>,
 ) -> anyhow::Result<MultiBackendRegistry> {
     khive_runtime::assert_db_anchor_consistent(base_config.db_path.as_deref(), cli_db_override)?;
-    build_registry_for_multi_backend_inner(base_config, khive_cfg, cli_db_override)
+    build_registry_for_multi_backend_inner(base_config, khive_cfg, cli_db_override).await
 }
 
-pub fn build_registry_for_multi_backend_with_db_anchor(
+/// Build the coordinated multi-backend registry while checking a canonical
+/// database anchor captured earlier in config discovery.
+///
+/// This has the same secondary-inventory and V21-completion guarantee as
+/// [`build_registry_for_multi_backend`].
+pub async fn build_registry_for_multi_backend_with_db_anchor(
     base_config: RuntimeConfig,
     khive_cfg: &KhiveConfig,
     cli_db_override: Option<&str>,
@@ -2002,7 +2014,266 @@ pub fn build_registry_for_multi_backend_with_db_anchor(
     // once instead of at each caller.
     khive_runtime::assert_captured_db_anchor_consistent(base_config.db_path.as_deref(), db_anchor)?;
 
-    build_registry_for_multi_backend_inner(base_config, khive_cfg, cli_db_override)
+    build_registry_for_multi_backend_inner(base_config, khive_cfg, cli_db_override).await
+}
+
+/// One backend's schema result from [`migrate_configured_storage_topology`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackendSchemaMigrationStatus {
+    /// Configured backend name (`main` for the implicit single backend).
+    pub backend: String,
+    /// Applied canonical core-schema version after coordination.
+    pub applied_version: u32,
+    /// Whether this backend advanced only as a prerequisite for the selected
+    /// canonical-main target.
+    pub prerequisite: bool,
+}
+
+#[derive(Debug, Clone)]
+struct ConfiguredStorageTargetPlan {
+    effective_backends: Vec<BackendConfig>,
+    full_topology: bool,
+}
+
+fn effective_backend_configs(backends: &[BackendConfig], force_memory: bool) -> Vec<BackendConfig> {
+    backends
+        .iter()
+        .map(|backend| {
+            if force_memory {
+                BackendConfig {
+                    kind: BackendKind::Memory,
+                    path: None,
+                    ..backend.clone()
+                }
+            } else {
+                backend.clone()
+            }
+        })
+        .collect()
+}
+
+fn validate_effective_backend_alias_modes(backends: &[BackendConfig]) -> anyhow::Result<()> {
+    let mut physical_sqlite: HashMap<std::path::PathBuf, (&str, bool)> = HashMap::new();
+    for backend in backends {
+        let Some(canonical) = canonical_backend_path(backend)? else {
+            continue;
+        };
+        if let Some((first_name, first_read_only)) = physical_sqlite.get(&canonical) {
+            if *first_read_only != backend.read_only {
+                anyhow::bail!(
+                    "backend {} aliases {} (already declared by backend {}) but declares \
+                     read_only={} while the same physical database is declared read_only={}; \
+                     every alias of one database must use the same access mode",
+                    backend.name,
+                    canonical.display(),
+                    first_name,
+                    backend.read_only,
+                    first_read_only,
+                );
+            }
+        } else {
+            physical_sqlite.insert(canonical, (&backend.name, backend.read_only));
+        }
+    }
+    Ok(())
+}
+
+fn plan_configured_storage_targets(
+    khive_cfg: &KhiveConfig,
+    cli_db_override: Option<&str>,
+    target_backend: Option<&str>,
+) -> anyhow::Result<ConfiguredStorageTargetPlan> {
+    reject_conflicting_db_override_with_source(cli_db_override, &khive_cfg.backends, None)?;
+    let force_memory = cli_db_override == Some(":memory:");
+    let effective_backends = effective_backend_configs(&khive_cfg.backends, force_memory);
+    validate_effective_backend_alias_modes(&effective_backends)?;
+
+    let main = effective_backends
+        .iter()
+        .find(|backend| backend.name == BackendId::MAIN)
+        .ok_or_else(|| anyhow::anyhow!("configured topology has no \"main\" backend"))?;
+    let full_topology = match target_backend {
+        None => true,
+        Some(target) => {
+            let selected = effective_backends
+                .iter()
+                .find(|backend| backend.name == target)
+                .ok_or_else(|| {
+                    let defined = effective_backends
+                        .iter()
+                        .map(|backend| backend.name.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    anyhow::anyhow!("unknown backend {target:?}; defined backends: {defined}")
+                })?;
+            match (
+                canonical_backend_path(selected)?,
+                canonical_backend_path(main)?,
+            ) {
+                (Some(selected), Some(main)) => selected == main,
+                // A force-memory override intentionally creates one distinct
+                // ephemeral backend per configured name; only the literal
+                // main name is the canonical-main target in that mode.
+                (None, None) => selected.name == main.name,
+                _ => false,
+            }
+        }
+    };
+
+    Ok(ConfiguredStorageTargetPlan {
+        effective_backends,
+        full_topology,
+    })
+}
+
+/// Return the configured backend names a read-only schema check must inspect.
+///
+/// This shares the migration command's physical-alias planning. Selecting
+/// `main` (or a SQLite alias of it) therefore includes every secondary
+/// prerequisite; selecting an independent secondary inspects only that target.
+pub fn configured_storage_check_targets(
+    khive_cfg: &KhiveConfig,
+    cli_db_override: Option<&str>,
+    target_backend: Option<&str>,
+) -> anyhow::Result<Vec<String>> {
+    if khive_cfg.backends.is_empty() {
+        if let Some(target) = target_backend {
+            if target != BackendId::MAIN {
+                anyhow::bail!(
+                    "unknown backend {target:?}; the implicit single-backend topology contains \
+                     only \"main\""
+                );
+            }
+        }
+        return Ok(vec![BackendId::MAIN.to_string()]);
+    }
+
+    let plan = plan_configured_storage_targets(khive_cfg, cli_db_override, target_backend)?;
+    if plan.full_topology {
+        Ok(plan
+            .effective_backends
+            .into_iter()
+            .map(|backend| backend.name)
+            .collect())
+    } else {
+        Ok(vec![target_backend
+            .expect("a partial topology plan always has a selected target")
+            .to_string()])
+    }
+}
+
+/// Migrate storage without constructing pack runtimes or loading embedders.
+///
+/// When `[[backends]]` is present this executes the same deduplicated,
+/// secondary-first inventory and main V21 cutover barrier as normal MCP boot.
+/// With no declared topology it uses the single-backend boot coordinator. No
+/// runtime is exposed and no pack DDL is applied.
+pub async fn migrate_configured_storage_topology(
+    mut base_config: RuntimeConfig,
+    khive_cfg: &KhiveConfig,
+    cli_db_override: Option<&str>,
+    target_backend: Option<&str>,
+) -> anyhow::Result<Vec<BackendSchemaMigrationStatus>> {
+    if khive_cfg.backends.is_empty() {
+        if let Some(target) = target_backend {
+            if target != BackendId::MAIN {
+                anyhow::bail!(
+                    "unknown backend {target:?}; the implicit single-backend topology contains \
+                     only \"main\""
+                );
+            }
+        }
+        let backend = prepare_single_backend_for_schema_admin(&base_config, khive_cfg).await?;
+        let applied_version = read_applied_schema_version(backend.sql().as_ref()).await?;
+        return Ok(vec![BackendSchemaMigrationStatus {
+            backend: BackendId::MAIN.to_string(),
+            applied_version,
+            prerequisite: false,
+        }]);
+    }
+
+    let plan = plan_configured_storage_targets(khive_cfg, cli_db_override, target_backend)?;
+    if !plan.full_topology {
+        let target = target_backend.expect("a partial topology plan always has a target");
+        let _force_memory = normalize_redundant_db_override(
+            &mut base_config,
+            cli_db_override,
+            &khive_cfg.backends,
+        )?;
+        let selected = plan
+            .effective_backends
+            .iter()
+            .find(|backend| backend.name == target)
+            .expect("the planner validated the selected backend")
+            .clone();
+        let backend = Arc::new(open_backend(&selected)?);
+        prepare_core_schema_for_boot(Arc::clone(&backend), format!("backend {}", selected.name))
+            .await?;
+        crate::attachment_cutover::require_secondary_attachment_empty(
+            Arc::clone(&backend),
+            &selected.name,
+        )
+        .await?;
+        crate::attachment_cutover::coordinate_empty_secondary_attachment_cutover(
+            Arc::clone(&backend),
+            &selected.name,
+        )
+        .await?;
+        return Ok(vec![BackendSchemaMigrationStatus {
+            backend: selected.name,
+            applied_version: read_applied_schema_version(backend.sql().as_ref()).await?,
+            prerequisite: false,
+        }]);
+    }
+
+    let prepared = prepare_configured_storage_topology(
+        base_config,
+        khive_cfg,
+        cli_db_override,
+        StorageTopologyPurpose::SchemaAdministration,
+    )
+    .await?;
+    let selected_target = target_backend
+        .and_then(|target| prepared.backends.get(target))
+        .cloned();
+    let mut statuses = Vec::with_capacity(khive_cfg.backends.len());
+    for configured in &khive_cfg.backends {
+        let backend = prepared.backends.get(&configured.name).ok_or_else(|| {
+            anyhow::anyhow!(
+                "configured backend {:?} disappeared during schema coordination",
+                configured.name
+            )
+        })?;
+        statuses.push(BackendSchemaMigrationStatus {
+            backend: configured.name.clone(),
+            applied_version: read_applied_schema_version(backend.sql().as_ref()).await?,
+            prerequisite: selected_target
+                .as_ref()
+                .is_some_and(|selected| !Arc::ptr_eq(selected, backend)),
+        });
+    }
+    Ok(statuses)
+}
+
+async fn read_applied_schema_version(sql: &dyn khive_storage::SqlAccess) -> anyhow::Result<u32> {
+    use khive_storage::types::{SqlStatement, SqlValue};
+
+    let mut reader = sql
+        .reader()
+        .await
+        .map_err(|error| anyhow::anyhow!("open schema-version reader: {error}"))?;
+    let value = reader
+        .query_scalar(SqlStatement {
+            sql: "SELECT COALESCE(MAX(version), 0) FROM _schema_migrations".into(),
+            params: vec![],
+            label: Some("read_applied_schema_version".into()),
+        })
+        .await
+        .map_err(|error| anyhow::anyhow!("read applied schema version: {error}"))?;
+    match value {
+        Some(SqlValue::Integer(version)) if version >= 0 => Ok(version as u32),
+        other => anyhow::bail!("schema-version query returned an invalid value: {other:?}"),
+    }
 }
 
 /// Validate a `--db`/`KHIVE_DB` override against a non-empty `[[backends]]`
@@ -2196,29 +2467,59 @@ pub fn validate_declared_backend_access_modes(backends: &[BackendConfig]) -> any
     Ok(())
 }
 
-fn build_registry_for_multi_backend_inner(
+struct PreparedStorageTopology {
+    base_config: RuntimeConfig,
+    backends: HashMap<String, Arc<StorageBackend>>,
+    main_backend: Arc<StorageBackend>,
+    shared_hydrator: Option<Arc<BlobHydrator>>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum StorageTopologyPurpose {
+    Serving,
+    SchemaAdministration,
+}
+
+async fn schema_admin_requires_blob_hydrator(backend: Arc<StorageBackend>) -> anyhow::Result<bool> {
+    let status_backend = Arc::clone(&backend);
+    let status = tokio::task::spawn_blocking(move || status_backend.attachment_cutover_status())
+        .await
+        .context("schema-admin attachment status task panicked")?
+        .context("inspect schema-admin attachment status")?;
+    if status == khive_db::migrations::AttachmentCutoverStatus::Complete {
+        return Ok(false);
+    }
+
+    Ok(
+        khive_pack_moodboard::legacy_preference_model_count(backend.sql().as_ref())
+            .await
+            .context("count legacy moodboard models before resolving blob storage")?
+            != 0,
+    )
+}
+
+async fn prepare_configured_storage_topology(
     mut base_config: RuntimeConfig,
     khive_cfg: &KhiveConfig,
     cli_db_override: Option<&str>,
-) -> anyhow::Result<MultiBackendRegistry> {
+    purpose: StorageTopologyPurpose,
+) -> anyhow::Result<PreparedStorageTopology> {
     let force_memory =
         normalize_redundant_db_override(&mut base_config, cli_db_override, &khive_cfg.backends)?;
+    let effective_backends = effective_backend_configs(&khive_cfg.backends, force_memory);
+    // Validate every physical alias before opening the first database. A
+    // targeted admin command and full server boot must reject the same mixed
+    // read-only/read-write alias topology without creating a partial set of
+    // database files.
+    validate_effective_backend_alias_modes(&effective_backends)?;
 
-    // Open and migrate each declared backend, deduplicating SQLite backends by
-    // canonical path (ADR-028 §8).
+    // Open each declared backend, deduplicating SQLite backends by canonical
+    // path (ADR-028 §8). Schema preparation is deliberately deferred until
+    // after main is identified: every distinct secondary must be inventoried
+    // before main can atomically enable attachment-only GC at V21.
     let mut backends: HashMap<String, Arc<StorageBackend>> = HashMap::new();
     let mut path_to_backend: HashMap<std::path::PathBuf, Arc<StorageBackend>> = HashMap::new();
-    for backend_cfg in &khive_cfg.backends {
-        let owned_cfg = if force_memory {
-            BackendConfig {
-                kind: BackendKind::Memory,
-                path: None,
-                ..backend_cfg.clone()
-            }
-        } else {
-            backend_cfg.clone()
-        };
-        let backend_cfg = &owned_cfg;
+    for backend_cfg in &effective_backends {
         let canonical = canonical_backend_path(backend_cfg)?;
         if let Some(ref canon) = canonical {
             if let Some(existing) = path_to_backend.get(canon) {
@@ -2238,9 +2539,6 @@ fn build_registry_for_multi_backend_inner(
             }
         }
         let backend = open_backend(backend_cfg)?;
-        backend.prepare_core_schema().map_err(|e| {
-            anyhow::anyhow!("backend {}: schema preparation: {e}", backend_cfg.name)
-        })?;
         let arc = Arc::new(backend);
         if let Some(canon) = canonical {
             path_to_backend.insert(canon, arc.clone());
@@ -2257,6 +2555,120 @@ fn build_registry_for_multi_backend_inner(
             )
         })?
         .clone();
+
+    // ADR-160 D4 chooses one liveness authority: attachment-bearing records
+    // live only on main. Preflight every distinct secondary before main can
+    // expose a durable incomplete marker, then finish any empty interrupted
+    // V21 stage there so every runtime starts on one exact schema.
+    let mut checked_secondary = HashSet::new();
+    let mut unique_secondary = Vec::new();
+    for configured in &khive_cfg.backends {
+        let backend_name = configured.name.as_str();
+        let backend = backends.get(backend_name).ok_or_else(|| {
+            anyhow::anyhow!(
+                "configured backend {backend_name:?} disappeared during topology preparation"
+            )
+        })?;
+        if Arc::ptr_eq(backend, &main_backend) {
+            continue;
+        }
+        let identity = Arc::as_ptr(backend) as usize;
+        if checked_secondary.insert(identity) {
+            prepare_core_schema_for_boot(Arc::clone(backend), format!("backend {backend_name}"))
+                .await?;
+            crate::attachment_cutover::require_secondary_attachment_empty(
+                Arc::clone(backend),
+                backend_name,
+            )
+            .await?;
+            unique_secondary.push((backend_name.to_string(), Arc::clone(backend)));
+        }
+    }
+    for (backend_name, backend) in unique_secondary {
+        crate::attachment_cutover::coordinate_empty_secondary_attachment_cutover(
+            backend,
+            &backend_name,
+        )
+        .await?;
+    }
+
+    // Only now may main advance. In particular, a zero-ref V20 main must not
+    // take the ordinary atomic V21 fast path until every secondary has proved
+    // it anchors no process-shared blob.
+    prepare_core_schema_for_boot(Arc::clone(&main_backend), "backend main").await?;
+
+    // Serving always resolves the process-wide BlobStore/hydration pair.
+    // Core-only schema administration does so only when an unfinished V21
+    // cutover has legacy moodboard evidence to authenticate. Exact-current
+    // and non-moodboard migrations must remain independent of unused blob
+    // configuration (and side-effect free for read-only snapshots).
+    let resolve_hydrator = match purpose {
+        StorageTopologyPurpose::Serving => true,
+        StorageTopologyPurpose::SchemaAdministration => {
+            schema_admin_requires_blob_hydrator(Arc::clone(&main_backend)).await?
+        }
+    };
+    let shared_hydrator = if resolve_hydrator {
+        // Resolve before staging main: an explicit invalid [storage.blob]
+        // selection required for verified migration must fail without leaving
+        // a new incomplete marker. The blob pack's backend mode governs
+        // read-only wrapping during serving boot.
+        let blob_runtime_read_only = if base_config.packs.iter().any(|pack| pack == "blob") {
+            match khive_cfg.packs.get("blob") {
+                Some(pack) => backends
+                    .get(pack.backend.as_str())
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "[packs.blob].backend = {:?} references an unknown backend",
+                            pack.backend
+                        )
+                    })?
+                    .is_read_only(),
+                None => main_backend.is_read_only(),
+            }
+        } else {
+            main_backend.is_read_only()
+        };
+        resolve_blob_hydrator_for_boot(
+            &base_config,
+            khive_cfg,
+            main_backend.as_ref(),
+            blob_runtime_read_only,
+        )?
+    } else {
+        None
+    };
+    crate::attachment_cutover::coordinate_attachment_cutover(
+        Arc::clone(&main_backend),
+        shared_hydrator.clone(),
+    )
+    .await?;
+
+    Ok(PreparedStorageTopology {
+        base_config,
+        backends,
+        main_backend,
+        shared_hydrator,
+    })
+}
+
+async fn build_registry_for_multi_backend_inner(
+    base_config: RuntimeConfig,
+    khive_cfg: &KhiveConfig,
+    cli_db_override: Option<&str>,
+) -> anyhow::Result<MultiBackendRegistry> {
+    let PreparedStorageTopology {
+        base_config,
+        backends,
+        main_backend,
+        shared_hydrator,
+    } = prepare_configured_storage_topology(
+        base_config,
+        khive_cfg,
+        cli_db_override,
+        StorageTopologyPurpose::Serving,
+    )
+    .await?;
 
     let pack_names = &base_config.packs;
     let mut per_pack_runtimes_local: HashMap<String, KhiveRuntime> = HashMap::new();
@@ -2292,12 +2704,7 @@ fn build_registry_for_multi_backend_inner(
     // exactly one aggregate hydration budget, and install the same immutable
     // hydrator `Arc` on every runtime handle this boot produces. `core()`
     // clones share each runtime's one-shot slot, so they see this same pair.
-    let blob_store_runtime = per_pack_runtimes_local
-        .get("blob")
-        .unwrap_or(&default_runtime);
-    if let Some(hydrator) =
-        install_resolved_blob_store(blob_store_runtime, khive_cfg, main_backend.as_ref())?
-    {
+    if let Some(hydrator) = shared_hydrator {
         default_runtime.install_blob_hydrator(Arc::clone(&hydrator))?;
         for rt in per_pack_runtimes_local.values() {
             rt.install_blob_hydrator(Arc::clone(&hydrator))?;
@@ -2505,6 +2912,12 @@ pub fn enforce_strict_actor_mode(
 
 /// Build a fully-configured server from parsed args (without serving).
 ///
+/// This is the supported production boot path for a single-backend server. The
+/// returned future does not complete until bounded blob hydration is installed
+/// and any resumable V21 attachment cutover has reached `Complete`; callers must
+/// not replace it with direct `KhiveRuntime`/`KhiveMcpServer` construction for a
+/// legacy database.
+///
 /// Returns, alongside the server, the resolved writable [`KhiveRuntime`]
 /// handle the `"schedule"` pack is bound to. It is `None` when the resolved
 /// pack set omits `"schedule"` or that pack's own assigned backend is
@@ -2517,7 +2930,7 @@ pub fn enforce_strict_actor_mode(
 /// `(namespace, namespace_explicit)` pair from a real CLI parse and, because
 /// this is the genuine `--actor`/`--namespace` CLI flag path, also treats
 /// that explicitness as a real actor override.
-pub fn build_server(args: &Args) -> anyhow::Result<(KhiveMcpServer, Option<KhiveRuntime>)> {
+pub async fn build_server(args: &Args) -> anyhow::Result<(KhiveMcpServer, Option<KhiveRuntime>)> {
     let (cli_namespace_explicit, cli_namespace) =
         resolve_cli_namespace(args).map_err(|e| anyhow::anyhow!("{e}"))?;
     build_server_with_explicit_namespace(
@@ -2526,10 +2939,14 @@ pub fn build_server(args: &Args) -> anyhow::Result<(KhiveMcpServer, Option<Khive
         cli_namespace_explicit,
         cli_namespace_explicit,
     )
+    .await
 }
 
 /// Build a fully-configured server from parsed args plus an independently
 /// resolved `(namespace, namespace_explicit, actor_explicit)` triple.
+///
+/// Like [`build_server`], this is an asynchronous host-boot boundary and returns
+/// only after the attachment cutover is complete.
 ///
 /// Extracted from [`build_server`] (PR #782) so non-interactive-CLI callers
 /// (e.g. the `--pending-events` one-shot drain wrapper) can supply a
@@ -2541,7 +2958,7 @@ pub fn build_server(args: &Args) -> anyhow::Result<(KhiveMcpServer, Option<Khive
 /// that inference — pass `actor_explicit: false` while `namespace_explicit`
 /// is still `true` (the `kkernel exec` / `kkernel reindex` shape; see
 /// `RuntimeConfigInputs::actor_explicit`'s field doc).
-pub fn build_server_with_explicit_namespace(
+pub async fn build_server_with_explicit_namespace(
     args: &Args,
     namespace: khive_runtime::Namespace,
     namespace_explicit: bool,
@@ -2610,9 +3027,7 @@ pub fn build_server_with_explicit_namespace(
     tracing::info!(target: "khive.boot", "{}", resolved_database_disclosure(config.db_path.as_deref(), &khive_cfg.backends));
 
     if khive_cfg.backends.is_empty() {
-        // Single-backend path — identical to pre-ADR-028 behavior.
-        let runtime = KhiveRuntime::new(config)?;
-        install_resolved_blob_store(&runtime, &khive_cfg, runtime.backend())?;
+        let runtime = build_single_backend_runtime(config, &khive_cfg).await?;
         #[cfg(feature = "bench-embedder")]
         {
             for name in runtime.registered_embedding_model_names() {
@@ -2654,7 +3069,8 @@ pub fn build_server_with_explicit_namespace(
         &khive_cfg,
         args.db.as_deref(),
         db_anchor.as_deref(),
-    )?;
+    )
+    .await?;
     let schedule_rt = writable_schedule_runtime(
         multi
             .per_pack_runtimes
@@ -2802,6 +3218,11 @@ pub(crate) fn canonical_path_no_side_effects(path: &std::path::Path) -> anyhow::
 
 /// Build a fully-wired multi-backend `KhiveMcpServer` (ADR-028).
 ///
+/// Before this future resolves, all distinct secondary databases have passed the
+/// no-attachment-authority inventory and the canonical main database has reached
+/// V21 `Complete`. This ordering prevents a main-database GC sweep from becoming
+/// eligible while a secondary still carries legacy blob liveness.
+///
 /// Called only when `[[backends]]` is non-empty in `khive.toml`. Delegates
 /// registry assembly to [`build_registry_for_multi_backend`] and finishing
 /// (pool + output format) to [`build_server_from_multi_backend_registry`] —
@@ -2811,19 +3232,25 @@ pub(crate) fn canonical_path_no_side_effects(path: &std::path::Path) -> anyhow::
 /// `pub` so `kkernel`'s coordinator-attached boot path can be compared
 /// against it directly in the #603 parity regression test — both call sites
 /// must produce servers with an identical wiring surface for the same config.
-pub fn build_server_multi_backend(
+pub async fn build_server_multi_backend(
     base_config: RuntimeConfig,
     khive_cfg: &KhiveConfig,
     cli_db_override: Option<&str>,
 ) -> anyhow::Result<KhiveMcpServer> {
     khive_runtime::assert_db_anchor_consistent(base_config.db_path.as_deref(), cli_db_override)?;
-    let multi = build_registry_for_multi_backend_inner(base_config, khive_cfg, cli_db_override)?;
+    let multi =
+        build_registry_for_multi_backend_inner(base_config, khive_cfg, cli_db_override).await?;
     Ok(build_server_from_multi_backend_registry(
         multi, khive_cfg, None,
     ))
 }
 
-pub fn build_server_multi_backend_with_db_anchor(
+/// Build a coordinated multi-backend server while checking a canonical
+/// database anchor captured earlier in config discovery.
+///
+/// This has the same secondary-inventory and V21-completion guarantee as
+/// [`build_server_multi_backend`].
+pub async fn build_server_multi_backend_with_db_anchor(
     base_config: RuntimeConfig,
     khive_cfg: &KhiveConfig,
     cli_db_override: Option<&str>,
@@ -2837,7 +3264,8 @@ pub fn build_server_multi_backend_with_db_anchor(
         khive_cfg,
         cli_db_override,
         db_anchor,
-    )?;
+    )
+    .await?;
     Ok(build_server_from_multi_backend_registry(
         multi, khive_cfg, None,
     ))
@@ -3001,8 +3429,8 @@ pub fn checkpoint_pool_for(main_backend: &StorageBackend) -> Option<Arc<Connecti
     }
 }
 
-/// Resolve `khive.toml`'s `[storage.blob]` selection against `backend` and
-/// install it on `rt` (ADR-111 Amendment 2's boot-wiring requirement).
+/// Resolve `khive.toml`'s `[storage.blob]` selection against `backend`
+/// (ADR-111 Amendment 2's boot-wiring requirement).
 ///
 /// Returns the resolved store/hydration pair on success so multi-backend
 /// callers can install the exact same aggregate budget on every runtime
@@ -3018,31 +3446,128 @@ pub fn checkpoint_pool_for(main_backend: &StorageBackend) -> Option<Arc<Connecti
 /// nothing yet consumes it, and forcing a filesystem root onto every
 /// in-memory boot would be a behavior change nobody asked for.
 ///
-/// `pub` so `kkernel`'s `exec` local-dispatch fallback server (the
-/// single-backend branch of `build_local_fallback_server`) can install a
-/// `BlobStore` the same way the `serve` boot path does, instead of leaving
-/// `exec`'s in-process runtime without one (khive#1209).
-pub fn install_resolved_blob_store(
-    rt: &KhiveRuntime,
+fn resolve_blob_hydrator_for_boot(
+    config: &RuntimeConfig,
     khive_cfg: &KhiveConfig,
     backend: &StorageBackend,
+    read_only: bool,
 ) -> anyhow::Result<Option<Arc<BlobHydrator>>> {
-    match khive_runtime::resolve_blob_store_for_mode(khive_cfg, backend, rt.is_read_only()) {
-        Ok(store) => {
-            let hydrator = Arc::new(BlobHydrator::new(store, rt.config().blob_hydration_bytes)?);
-            rt.install_blob_hydrator(Arc::clone(&hydrator))?;
-            Ok(Some(hydrator))
-        }
-        Err(e) if khive_cfg.storage.blob.is_none() => {
+    match khive_runtime::resolve_blob_store_for_mode(khive_cfg, backend, read_only) {
+        Ok(store) => Ok(Some(Arc::new(BlobHydrator::new(
+            store,
+            config.blob_hydration_bytes,
+        )?))),
+        Err(error) if khive_cfg.storage.blob.is_none() => {
             tracing::debug!(
-                error = %e,
+                error = %error,
                 "no usable BlobStore for this backend and no [storage.blob] configured; \
                  leaving KhiveRuntime::blob_store() unset"
             );
             Ok(None)
         }
-        Err(e) => Err(anyhow::anyhow!("[storage.blob] configuration error: {e}")),
+        Err(error) => Err(anyhow::anyhow!(
+            "[storage.blob] configuration error: {error}"
+        )),
     }
+}
+
+/// Open, migrate, coordinate V21, and construct one single-backend runtime.
+///
+/// Both `serve` and `kkernel exec` use this real-host async choke point. The
+/// runtime is not exposed until the attachment/GC cutover is complete, and no
+/// temporary Tokio runtime or writer-task lifecycle domain is introduced.
+pub async fn build_single_backend_runtime(
+    config: RuntimeConfig,
+    khive_cfg: &KhiveConfig,
+) -> anyhow::Result<KhiveRuntime> {
+    let backend = Arc::new(open_single_backend(&config)?);
+    prepare_core_schema_for_boot(Arc::clone(&backend), "single backend").await?;
+
+    let hydrator = resolve_blob_hydrator_for_boot(
+        &config,
+        khive_cfg,
+        backend.as_ref(),
+        backend.is_read_only(),
+    )?;
+    crate::attachment_cutover::coordinate_attachment_cutover(
+        Arc::clone(&backend),
+        hydrator.clone(),
+    )
+    .await?;
+
+    let runtime = KhiveRuntime::from_prepared_backend(backend, config)?;
+    if let Some(hydrator) = hydrator {
+        runtime.install_blob_hydrator(hydrator)?;
+    }
+    Ok(runtime)
+}
+
+fn open_single_backend(config: &RuntimeConfig) -> anyhow::Result<StorageBackend> {
+    let backend = match &config.db_path {
+        Some(path) => {
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).map_err(|error| {
+                    anyhow::anyhow!(
+                        "cannot create database parent directory {}: {error}",
+                        parent.display()
+                    )
+                })?;
+            }
+            StorageBackend::sqlite(path)
+                .map_err(|error| anyhow::anyhow!("open single SQLite backend: {error}"))?
+        }
+        None => StorageBackend::memory()
+            .map_err(|error| anyhow::anyhow!("open single in-memory backend: {error}"))?,
+    };
+    Ok(backend)
+}
+
+async fn prepare_single_backend_for_schema_admin(
+    config: &RuntimeConfig,
+    khive_cfg: &KhiveConfig,
+) -> anyhow::Result<Arc<StorageBackend>> {
+    let backend = Arc::new(open_single_backend(config)?);
+    prepare_core_schema_for_boot(Arc::clone(&backend), "single backend").await?;
+
+    let hydrator = if schema_admin_requires_blob_hydrator(Arc::clone(&backend)).await? {
+        resolve_blob_hydrator_for_boot(config, khive_cfg, backend.as_ref(), backend.is_read_only())?
+    } else {
+        None
+    };
+    crate::attachment_cutover::coordinate_attachment_cutover(Arc::clone(&backend), hydrator)
+        .await?;
+    Ok(backend)
+}
+
+async fn prepare_core_schema_for_boot(
+    backend: Arc<StorageBackend>,
+    label: impl Into<String>,
+) -> anyhow::Result<u32> {
+    let label = label.into();
+    tokio::task::spawn_blocking(move || backend.prepare_core_schema())
+        .await
+        .map_err(|error| anyhow::anyhow!("{label}: schema preparation task panicked: {error}"))?
+        .map_err(|error| anyhow::anyhow!("{label}: schema preparation: {error}"))
+}
+
+/// Resolve and install blob hydration on an already prepared runtime.
+///
+/// This low-level compatibility helper does **not** run or validate the
+/// application-assisted V21 attachment cutover. Production host boot should use
+/// [`build_single_backend_runtime`], [`build_server`], or the async multi-backend
+/// builders instead. Calling this helper is sound only when `backend` is the
+/// runtime's backend and its attachment-cutover status is already `Complete`.
+pub fn install_resolved_blob_store(
+    rt: &KhiveRuntime,
+    khive_cfg: &KhiveConfig,
+    backend: &StorageBackend,
+) -> anyhow::Result<Option<Arc<BlobHydrator>>> {
+    let hydrator =
+        resolve_blob_hydrator_for_boot(rt.config(), khive_cfg, backend, rt.is_read_only())?;
+    if let Some(hydrator) = hydrator.as_ref() {
+        rt.install_blob_hydrator(Arc::clone(hydrator))?;
+    }
+    Ok(hydrator)
 }
 
 /// Construct one per-pack runtime, wiring `core_backend` for secondary-backend packs.
@@ -3516,6 +4041,44 @@ fn apply_config_pack_selection(
 mod tests {
     use super::*;
     use khive_runtime::{BlobConfig, Namespace, StorageSectionConfig};
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn schema_prepare_waits_for_gc_owner_off_the_async_worker() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let database = dir.path().join("owner-wait.db");
+        let backend = Arc::new(StorageBackend::sqlite(&database).expect("open backend"));
+        let owner = khive_db::stores::blob::acquire_database_gc_owner(backend.sql().as_ref())
+            .await
+            .expect("pre-hold database GC owner");
+        let released = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let released_by_task = Arc::clone(&released);
+
+        tokio::spawn(async move {
+            tokio::task::yield_now().await;
+            released_by_task.store(true, std::sync::atomic::Ordering::SeqCst);
+            drop(owner);
+        });
+
+        let version = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            prepare_core_schema_for_boot(Arc::clone(&backend), "owner wait regression"),
+        )
+        .await
+        .expect("current-thread runtime must keep scheduling while schema preparation waits")
+        .expect("schema preparation after owner release");
+
+        assert_eq!(
+            version,
+            khive_db::MIGRATIONS
+                .last()
+                .expect("migration ledger")
+                .version
+        );
+        assert!(
+            released.load(std::sync::atomic::Ordering::SeqCst),
+            "the owner-release task must run before schema preparation can complete"
+        );
+    }
 
     // Freeze lingering `-wal`/`-shm` sidecars left by a writable fixture whose
     // connections close asynchronously; read-only admission rejects a writable
@@ -4698,6 +5261,90 @@ id = "lambda:project-actor"
         }
     }
 
+    #[tokio::test]
+    async fn secondary_legacy_ref_blocks_before_zero_ref_main_can_enable_v21_gc() {
+        use khive_db::migrations::AttachmentCutoverStatus;
+        use khive_db::stores::blob::FsBlobStore;
+        use khive_storage::BlobStore as _;
+
+        let temp = tempfile::tempdir().unwrap();
+        let main_path = temp.path().join("main.db");
+        let secondary_path = temp.path().join("secondary.db");
+        let (main_entity, _) = crate::attachment_cutover::create_v20_database_fixture(
+            &main_path,
+            "visual_asset",
+            None,
+        );
+        rusqlite::Connection::open(&main_path)
+            .unwrap()
+            .execute(
+                "DELETE FROM entities WHERE id = ?1",
+                [main_entity.to_string()],
+            )
+            .unwrap();
+        let (secondary_entity, _) = crate::attachment_cutover::create_v20_database_fixture(
+            &secondary_path,
+            "visual_asset",
+            Some(2),
+        );
+
+        let store = FsBlobStore::new(temp.path().join("blobs"), 0).unwrap();
+        let bytes = b"secondary-owned legacy blob".to_vec();
+        let live_ref = store.put(bytes).await.unwrap();
+        rusqlite::Connection::open(&secondary_path)
+            .unwrap()
+            .execute(
+                "UPDATE entities SET content_ref = ?1 WHERE id = ?2",
+                rusqlite::params![live_ref.as_str(), secondary_entity.to_string()],
+            )
+            .unwrap();
+
+        let khive_cfg = KhiveConfig {
+            backends: vec![
+                BackendConfig {
+                    name: "main".to_string(),
+                    kind: BackendKind::Sqlite,
+                    path: Some(main_path.clone()),
+                    cache_mb: None,
+                    journal_mode: None,
+                    read_only: false,
+                },
+                BackendConfig {
+                    name: "secondary".to_string(),
+                    kind: BackendKind::Sqlite,
+                    path: Some(secondary_path),
+                    cache_mb: None,
+                    journal_mode: None,
+                    read_only: false,
+                },
+            ],
+            ..KhiveConfig::default()
+        };
+        let error = match build_registry_for_multi_backend(
+            base_runtime_config_for_multi_backend(),
+            &khive_cfg,
+            None,
+        )
+        .await
+        {
+            Ok(_) => panic!("secondary liveness must block main cutover"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("legacy_refs=1"));
+
+        let main = StorageBackend::sqlite(&main_path).unwrap();
+        assert_eq!(
+            main.attachment_cutover_status().unwrap(),
+            AttachmentCutoverStatus::Pending,
+            "secondary rejection must leave main at V20 without a marker"
+        );
+        store
+            .transactional_orphan_sweep(main.sql().as_ref(), false)
+            .await
+            .expect_err("a V20 main must refuse attachment-only GC");
+        assert!(store.exists(&live_ref).await.unwrap());
+    }
+
     /// Two in-memory backends — `main` plus a second named `secondary`.
     /// The `comm` pack is pinned to `secondary`; `kg` defaults to `main`.
     /// Positive test: `build_server_multi_backend` must return `Ok` and both
@@ -4743,6 +5390,7 @@ id = "lambda:project-actor"
         let base_cfg = base_runtime_config_for_multi_backend();
 
         let server = build_server_multi_backend(base_cfg, &khive_cfg, None)
+            .await
             .expect("multi-backend boot must succeed");
 
         // kg round-trip: create an entity on the main backend.
@@ -4828,6 +5476,7 @@ id = "lambda:project-actor"
         let base_cfg = base_runtime_config_for_multi_backend();
 
         let server = build_server_multi_backend(base_cfg, &khive_cfg, None)
+            .await
             .expect("multi-backend boot must succeed");
 
         let send_resp = server
@@ -4963,6 +5612,7 @@ id = "lambda:project-actor"
         let base_cfg = base_runtime_config_for_multi_backend();
 
         let multi = build_registry_for_multi_backend_inner(base_cfg, &khive_cfg, None)
+            .await
             .expect("multi-backend registry build must succeed");
 
         assert!(
@@ -5074,6 +5724,7 @@ id = "lambda:project-actor"
         base_cfg.packs = vec!["kg".to_string(), "brain".to_string()];
 
         let multi = build_registry_for_multi_backend(base_cfg, &khive_cfg, None)
+            .await
             .expect("multi-backend registry build must succeed");
 
         multi
@@ -5116,9 +5767,9 @@ id = "lambda:project-actor"
     /// itself is covered end-to-end by `kkernel`'s own
     /// `multi_backend_boot_paths_share_identical_wiring_surface` test, which
     /// exercises the actual coordinator branch.
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn kkernel_multi_backend_path_wires_pool_for_file_backed_main() {
+    async fn kkernel_multi_backend_path_wires_pool_for_file_backed_main() {
         let dir = tempfile::tempdir().expect("temp dir");
         let main_path = dir.path().join("main.db");
 
@@ -5137,6 +5788,7 @@ id = "lambda:project-actor"
         let base_cfg = base_runtime_config_for_multi_backend();
 
         let multi = build_registry_for_multi_backend(base_cfg, &khive_cfg, None)
+            .await
             .expect("multi-backend registry build must succeed");
         let server = build_server_from_multi_backend_registry(multi, &khive_cfg, None);
 
@@ -5150,9 +5802,9 @@ id = "lambda:project-actor"
     /// (checkpoint_once must never run on a non-WAL, in-memory connection). Also
     /// exercises `build_server_from_multi_backend_registry` — see the note on the
     /// sibling test above.
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn kkernel_multi_backend_path_leaves_pool_none_for_in_memory_main() {
+    async fn kkernel_multi_backend_path_leaves_pool_none_for_in_memory_main() {
         let khive_cfg = KhiveConfig {
             backends: vec![BackendConfig {
                 name: "main".to_string(),
@@ -5168,6 +5820,7 @@ id = "lambda:project-actor"
         let base_cfg = base_runtime_config_for_multi_backend();
 
         let multi = build_registry_for_multi_backend(base_cfg, &khive_cfg, None)
+            .await
             .expect("multi-backend registry build must succeed");
         let server = build_server_from_multi_backend_registry(multi, &khive_cfg, None);
 
@@ -5186,9 +5839,9 @@ id = "lambda:project-actor"
     // themselves, proving the boot path resolves and installs the configured
     // `S3BlobStore` rather than silently keeping the default `FsBlobStore`.
 
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn single_backend_boot_wires_configured_s3_blob_store() {
+    async fn single_backend_boot_wires_configured_s3_blob_store() {
         std::env::remove_var("KHIVE_DB");
         std::env::remove_var("KHIVE_ACTOR");
         std::env::remove_var("KHIVE_PACKS");
@@ -5220,7 +5873,7 @@ region = "us-east-1"
             config_path.to_str().expect("utf8 path"),
         ]);
 
-        let result = build_server(&args);
+        let result = build_server(&args).await;
 
         match prev_access_key {
             Some(v) => std::env::set_var("AWS_ACCESS_KEY_ID", v),
@@ -5242,9 +5895,9 @@ region = "us-east-1"
         );
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn multi_backend_boot_wires_configured_s3_blob_store() {
+    async fn multi_backend_boot_wires_configured_s3_blob_store() {
         let prev_access_key = std::env::var("AWS_ACCESS_KEY_ID").ok();
         let prev_secret_key = std::env::var("AWS_SECRET_ACCESS_KEY").ok();
         std::env::remove_var("AWS_ACCESS_KEY_ID");
@@ -5272,7 +5925,7 @@ region = "us-east-1"
         };
         let base_cfg = base_runtime_config_for_multi_backend();
 
-        let result = build_registry_for_multi_backend(base_cfg, &khive_cfg, None);
+        let result = build_registry_for_multi_backend(base_cfg, &khive_cfg, None).await;
 
         match prev_access_key {
             Some(v) => std::env::set_var("AWS_ACCESS_KEY_ID", v),
@@ -5411,9 +6064,9 @@ region = "us-east-1"
     /// via a temporary `khive.toml` + parsed `Args`, selecting the `schedule`
     /// pack so its already-installed runtime (`:1847`) is returned for
     /// inspection.
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn single_backend_boot_installs_s3_blob_store_on_successful_selection() {
+    async fn single_backend_boot_installs_s3_blob_store_on_successful_selection() {
         let _env = ClearedKhiveEnvGuard::clear();
         let _creds = DummyAwsCredsGuard::set();
 
@@ -5441,7 +6094,7 @@ region = "us-east-1"
             config_path.to_str().expect("utf8 path"),
         ]);
 
-        let (_server, schedule_rt) = build_server(&args).expect(
+        let (_server, schedule_rt) = build_server(&args).await.expect(
             "valid dummy AWS credentials must resolve and install an S3BlobStore through the \
              real single-backend boot path",
         );
@@ -5463,9 +6116,9 @@ region = "us-east-1"
     /// with valid (dummy) AWS credentials present, the multi-backend startup
     /// path must resolve the configured `S3BlobStore` once (`:1567`) and
     /// install it on every per-pack runtime this boot produces.
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn multi_backend_boot_installs_s3_blob_store_on_successful_selection() {
+    async fn multi_backend_boot_installs_s3_blob_store_on_successful_selection() {
         let _creds = DummyAwsCredsGuard::set();
 
         let khive_cfg = KhiveConfig {
@@ -5485,6 +6138,7 @@ region = "us-east-1"
         let base_cfg = base_runtime_config_for_multi_backend();
 
         let multi = build_registry_for_multi_backend(base_cfg, &khive_cfg, None)
+            .await
             .expect("valid dummy AWS credentials must resolve through the multi-backend path");
 
         assert!(
@@ -5528,6 +6182,7 @@ region = "us-east-1"
         base_cfg.blob_hydration_bytes = khive_storage::MAX_BLOB_WHOLE_BYTES;
 
         let multi = build_registry_for_multi_backend(base_cfg, &khive_cfg, None)
+            .await
             .expect("multi-backend registry build");
         let expected = multi
             .default_runtime
@@ -5631,6 +6286,7 @@ region = "us-east-1"
         ]);
 
         let (_server, schedule_rt) = build_server(&args)
+            .await
             .expect("absent [storage.blob] must resolve the fs default through the real single-backend boot path");
         let runtime = schedule_rt
             .expect("the schedule pack was selected so its installed runtime must be returned");
@@ -5676,6 +6332,14 @@ region = "us-east-1"
             .prepare_core_schema()
             .expect("prepare exact-current migration ledger");
         drop(backend);
+        let gc_lock = std::path::PathBuf::from(format!(
+            "{}.khive-blob-gc.lock",
+            path.as_os_str().to_string_lossy()
+        ));
+        if gc_lock.exists() {
+            std::fs::remove_file(&gc_lock)
+                .expect("snapshot fixture must start without a writable GC-lock sidecar");
+        }
         #[cfg(unix)]
         freeze_snapshot_sidecars(path);
     }
@@ -5685,6 +6349,75 @@ region = "us-east-1"
             packs: vec!["blob".to_string()],
             ..base_runtime_config_for_multi_backend()
         }
+    }
+
+    /// Schema administration does not construct a serving runtime. Once the
+    /// attachment cutover is already complete, an otherwise-valid read-only
+    /// snapshot therefore must not need (or materialize) its configured blob
+    /// backend merely to report a no-op migration.
+    #[tokio::test]
+    #[serial]
+    async fn exact_current_read_only_schema_admin_skips_unused_blob_resolution() {
+        let _env = ClearedKhiveEnvGuard::clear();
+        let dir = tempfile::tempdir().expect("temp dir");
+        let main_path = dir.path().join("snapshot.db");
+        let missing_blob_root = dir.path().join("must-not-be-created");
+        let gc_lock = std::path::PathBuf::from(format!(
+            "{}.khive-blob-gc.lock",
+            main_path.as_os_str().to_string_lossy()
+        ));
+        prepare_current_snapshot_source(&main_path);
+        let before = std::fs::read(&main_path).expect("read exact-current snapshot");
+
+        let khive_cfg = KhiveConfig {
+            backends: vec![BackendConfig {
+                name: BackendId::MAIN.to_string(),
+                kind: BackendKind::Sqlite,
+                path: Some(main_path.clone()),
+                cache_mb: None,
+                journal_mode: None,
+                read_only: true,
+            }],
+            storage: StorageSectionConfig {
+                blob: Some(BlobConfig::Fs {
+                    root: Some(missing_blob_root.display().to_string()),
+                    floor_bytes: Some(0),
+                }),
+            },
+            ..KhiveConfig::default()
+        };
+
+        let statuses = migrate_configured_storage_topology(
+            base_runtime_config_for_multi_backend(),
+            &khive_cfg,
+            None,
+            Some(BackendId::MAIN),
+        )
+        .await
+        .expect("an exact-current admin migration must not resolve unused blob storage");
+
+        assert_eq!(statuses.len(), 1);
+        assert_eq!(statuses[0].backend, BackendId::MAIN);
+        assert_eq!(
+            statuses[0].applied_version,
+            khive_db::MIGRATIONS
+                .last()
+                .expect("migration ledger")
+                .version
+        );
+        assert_eq!(
+            std::fs::read(&main_path).expect("re-read exact-current snapshot"),
+            before,
+            "a no-op read-only migration must preserve database bytes"
+        );
+        assert!(
+            !missing_blob_root.exists(),
+            "schema administration must not materialize an unused blob root"
+        );
+        assert!(
+            !gc_lock.exists(),
+            "an exact-current no-op must not acquire write-side GC ownership"
+        );
     }
 
     /// The default fs root is optional when no `[storage.blob]` section was
@@ -5712,6 +6445,7 @@ region = "us-east-1"
             ..KhiveConfig::default()
         };
         let multi = build_registry_for_multi_backend(blob_only_runtime_config(), &khive_cfg, None)
+            .await
             .expect("read-only blob-pack registry must boot without creating a store");
         assert!(
             !blob_root.exists(),
@@ -5742,9 +6476,15 @@ region = "us-east-1"
         let dir = tempfile::tempdir().unwrap();
         let main_path = dir.path().join("main.db");
         let archive_path = dir.path().join("blob-snapshot.db");
+        let archive_gc_lock = {
+            let mut path = archive_path.as_os_str().to_os_string();
+            path.push(".khive-blob-gc.lock");
+            std::path::PathBuf::from(path)
+        };
         let blob_root = dir.path().join("blobs");
         prepare_current_snapshot_source(&main_path);
         prepare_current_snapshot_source(&archive_path);
+        assert!(!archive_gc_lock.exists());
 
         let khive_cfg = KhiveConfig {
             backends: vec![
@@ -5774,6 +6514,7 @@ region = "us-east-1"
             ..KhiveConfig::default()
         };
         let multi = build_registry_for_multi_backend(blob_only_runtime_config(), &khive_cfg, None)
+            .await
             .expect("mixed topology must boot");
         let error = multi
             .registry
@@ -5784,6 +6525,10 @@ region = "us-east-1"
         assert!(
             !blob_root.exists(),
             "main writability must not create storage for a read-only blob pack"
+        );
+        assert!(
+            !archive_gc_lock.exists(),
+            "an exact-current read-only secondary must be inventoried without acquiring a write-side GC lock file"
         );
     }
 
@@ -5836,6 +6581,7 @@ region = "us-east-1"
             ..KhiveConfig::default()
         };
         let multi = build_registry_for_multi_backend(blob_only_runtime_config(), &khive_cfg, None)
+            .await
             .expect("writable blob secondary must boot beside read-only main");
         let result = multi
             .registry
@@ -5859,9 +6605,9 @@ region = "us-east-1"
     /// returned the secondary-backend handle — silently defeating the ADR-073 contract.
     /// Both boot paths now delegate to `build_pack_runtime`, which applies the wiring in
     /// one place and prevents any future path from drifting.
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn secondary_pack_runtime_core_resolves_to_main_after_build_registry() {
+    async fn secondary_pack_runtime_core_resolves_to_main_after_build_registry() {
         use khive_runtime::PackConfig;
 
         let khive_cfg = KhiveConfig {
@@ -5899,6 +6645,7 @@ region = "us-east-1"
         let base_cfg = base_runtime_config_for_multi_backend();
 
         let result = build_registry_for_multi_backend(base_cfg, &khive_cfg, None)
+            .await
             .expect("multi-backend registry must boot");
 
         let comm_rt = result
@@ -5932,10 +6679,10 @@ region = "us-east-1"
     /// dedup this replaced would have kept both `Arc<ConnectionPool>`
     /// instances distinct, letting two `SweepBackend`s race on one
     /// heartbeat file.
-    #[test]
+    #[tokio::test]
     #[serial]
     #[cfg(unix)]
-    fn secondary_pools_dedup_by_canonical_identity_across_alias_spellings() {
+    async fn secondary_pools_dedup_by_canonical_identity_across_alias_spellings() {
         use khive_runtime::PackConfig;
 
         let dir = tempfile::tempdir().unwrap();
@@ -5992,6 +6739,7 @@ region = "us-east-1"
 
         let base_cfg = base_runtime_config_for_multi_backend();
         let multi = build_registry_for_multi_backend(base_cfg, &khive_cfg, None)
+            .await
             .expect("multi-backend registry with alias-spelled backends must boot");
 
         let secondary = secondary_file_backed_pools(&multi);
@@ -6030,9 +6778,9 @@ region = "us-east-1"
     /// `Some(":memory:")` as `cli_db_override` must force every declared backend
     /// in-memory for this invocation, and the declared sqlite paths must never be
     /// created on disk.
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn memory_override_forces_all_backends_in_memory_and_never_creates_sqlite_file() {
+    async fn memory_override_forces_all_backends_in_memory_and_never_creates_sqlite_file() {
         use khive_runtime::PackConfig;
 
         let dir = tempfile::tempdir().unwrap();
@@ -6073,7 +6821,7 @@ region = "us-east-1"
 
         let base_cfg = base_runtime_config_for_multi_backend();
 
-        let result = build_registry_for_multi_backend(base_cfg, &khive_cfg, Some(":memory:"));
+        let result = build_registry_for_multi_backend(base_cfg, &khive_cfg, Some(":memory:")).await;
         if let Err(ref e) = result {
             panic!(
                 "--db :memory: override must force both declared sqlite backends \
@@ -6129,9 +6877,9 @@ region = "us-east-1"
         }
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn concrete_db_override_matching_declared_main_backend_path_is_accepted() {
+    async fn concrete_db_override_matching_declared_main_backend_path_is_accepted() {
         let dir = tempfile::tempdir().unwrap();
         let main_path = dir.path().join("main.db");
         let nested = dir.path().join("nested");
@@ -6146,7 +6894,8 @@ region = "us-east-1"
             ..base_runtime_config_for_multi_backend()
         };
 
-        let result = build_registry_for_multi_backend(base_cfg, &khive_cfg, Some(override_value));
+        let result =
+            build_registry_for_multi_backend(base_cfg, &khive_cfg, Some(override_value)).await;
 
         if let Err(error) = result {
             panic!(
@@ -6309,10 +7058,11 @@ region = "us-east-1"
     /// reports `false` for a dangling one, so it never resolved the link and
     /// compared the literal alias path against the literal target path
     /// instead, rejecting a legitimate no-op override as ambiguous.
-    #[test]
+    #[tokio::test]
     #[serial]
     #[cfg(unix)]
-    fn concrete_db_override_matching_declared_main_backend_via_dangling_symlink_is_accepted() {
+    async fn concrete_db_override_matching_declared_main_backend_via_dangling_symlink_is_accepted()
+    {
         let dir = tempfile::tempdir().unwrap();
         let target_path = dir.path().join("target.db");
         let link_path = dir.path().join("link.db");
@@ -6329,7 +7079,8 @@ region = "us-east-1"
             ..base_runtime_config_for_multi_backend()
         };
 
-        let result = build_registry_for_multi_backend(base_cfg, &khive_cfg, Some(override_value));
+        let result =
+            build_registry_for_multi_backend(base_cfg, &khive_cfg, Some(override_value)).await;
 
         if let Err(error) = result {
             panic!(
@@ -6472,9 +7223,9 @@ region = "us-east-1"
     /// `[[backends]]` is ambiguous (which of N declared backends should it apply
     /// to?) and must fail loud with a selectable-config remedy rather than
     /// silently collapsing distinct backends onto one path.
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn concrete_db_override_with_backends_declared_is_rejected() {
+    async fn concrete_db_override_with_backends_declared_is_rejected() {
         use khive_runtime::PackConfig;
 
         let khive_cfg = KhiveConfig {
@@ -6522,7 +7273,8 @@ region = "us-east-1"
             base_cfg,
             &khive_cfg,
             Some("/tmp/some-explicit-override.db"),
-        );
+        )
+        .await;
         assert!(
             result.is_err(),
             "a concrete --db path override combined with declared [[backends]] must \
@@ -6595,6 +7347,7 @@ region = "us-east-1"
         };
 
         let server = build_server_multi_backend(base_cfg, &khive_cfg, None)
+            .await
             .expect("multi-backend boot must succeed");
 
         let dispatch = |ops: String| {
@@ -6649,9 +7402,9 @@ region = "us-east-1"
     /// Negative test: `[[backends]]` is declared but there is no entry named
     /// `"main"`. `build_server_multi_backend` must return an error whose
     /// message mentions `"main"` so operators know what to fix.
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn multi_backend_missing_main_returns_error_mentioning_main() {
+    async fn multi_backend_missing_main_returns_error_mentioning_main() {
         let khive_cfg = KhiveConfig {
             backends: vec![BackendConfig {
                 name: "secondary".to_string(), // intentionally NOT "main"
@@ -6667,7 +7420,7 @@ region = "us-east-1"
 
         let base_cfg = base_runtime_config_for_multi_backend();
 
-        let result = build_server_multi_backend(base_cfg, &khive_cfg, None);
+        let result = build_server_multi_backend(base_cfg, &khive_cfg, None).await;
         assert!(
             result.is_err(),
             "missing main backend must produce an error"
@@ -6687,9 +7440,9 @@ region = "us-east-1"
     /// instead of silently falling back to `main`. `build_registry_for_multi_backend`
     /// must return an `Err` mentioning the pack, the requested backend, and the
     /// defined backends.
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn multi_backend_registry_rejects_undefined_pack_backend() {
+    async fn multi_backend_registry_rejects_undefined_pack_backend() {
         use khive_runtime::PackConfig;
 
         let khive_cfg = KhiveConfig {
@@ -6716,7 +7469,7 @@ region = "us-east-1"
 
         let base_cfg = base_runtime_config_for_multi_backend();
 
-        let result = build_registry_for_multi_backend(base_cfg, &khive_cfg, None);
+        let result = build_registry_for_multi_backend(base_cfg, &khive_cfg, None).await;
         assert!(
             result.is_err(),
             "an undeclared configured pack backend must be a startup error, not a silent \
@@ -6745,9 +7498,9 @@ region = "us-east-1"
     /// Same regression as `multi_backend_registry_rejects_undefined_pack_backend`
     /// but through the `build_server_multi_backend` public builder, which has its
     /// own independent per-pack backend resolution loop.
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn multi_backend_server_rejects_undefined_pack_backend() {
+    async fn multi_backend_server_rejects_undefined_pack_backend() {
         use khive_runtime::PackConfig;
 
         let khive_cfg = KhiveConfig {
@@ -6774,7 +7527,7 @@ region = "us-east-1"
 
         let base_cfg = base_runtime_config_for_multi_backend();
 
-        let result = build_server_multi_backend(base_cfg, &khive_cfg, None);
+        let result = build_server_multi_backend(base_cfg, &khive_cfg, None).await;
         assert!(
             result.is_err(),
             "an undeclared configured pack backend must be a startup error, not a silent \
@@ -6897,9 +7650,9 @@ region = "us-east-1"
         assert!(message.contains("config identity"), "{message}");
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn multi_backend_read_only_construction_and_pack_schema_paths_acquire_no_writer() {
+    async fn multi_backend_read_only_construction_and_pack_schema_paths_acquire_no_writer() {
         use khive_runtime::PackConfig;
 
         let dir = tempfile::tempdir().unwrap();
@@ -6938,8 +7691,29 @@ region = "us-east-1"
             &config_for(false),
             None,
         )
+        .await
         .expect("prepare exact-current core and pack schemas");
+        let mut writer_joins = Vec::new();
+        if let Some(join) = writable
+            .default_runtime
+            .backend()
+            .pool()
+            .take_writer_task_join()
+        {
+            writer_joins.push(join);
+        }
+        for runtime in writable.per_pack_runtimes.values() {
+            if let Some(join) = runtime.backend().pool().take_writer_task_join() {
+                writer_joins.push(join);
+            }
+        }
         drop(writable);
+        for join in writer_joins {
+            tokio::time::timeout(std::time::Duration::from_secs(5), join)
+                .await
+                .expect("writer task must settle before freezing the snapshot")
+                .expect("writer task exits cleanly");
+        }
 
         for path in [&main_path, &comm_path] {
             let conn = rusqlite::Connection::open(path).unwrap();
@@ -6954,6 +7728,7 @@ region = "us-east-1"
             &config_for(true),
             None,
         )
+        .await
         .expect("open both declared backends for inspection");
 
         assert_eq!(
@@ -6986,9 +7761,9 @@ region = "us-east-1"
     }
 
     #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn mixed_topology_channel_admission_follows_the_runtime_that_backs_each_loop() {
+    async fn mixed_topology_channel_admission_follows_the_runtime_that_backs_each_loop() {
         use clap::Parser;
         use khive_runtime::PackConfig;
 
@@ -7028,6 +7803,7 @@ region = "us-east-1"
             &config_for(false, false),
             None,
         )
+        .await
         .expect("seed exact-current snapshots");
         drop(seeded);
         #[cfg(unix)]
@@ -7039,6 +7815,7 @@ region = "us-east-1"
             &config_for(false, true),
             None,
         )
+        .await
         .expect("writable kg plus read-only comm topology");
         let server =
             build_server_from_multi_backend_registry(comm_snapshot, &config_for(false, true), None);
@@ -7076,6 +7853,7 @@ region = "us-east-1"
             &config_for(true, false),
             None,
         )
+        .await
         .expect("read-only kg plus writable comm topology");
         let server =
             build_server_from_multi_backend_registry(kg_snapshot, &config_for(true, false), None);
@@ -7149,6 +7927,121 @@ region = "us-east-1"
         }
     }
 
+    #[tokio::test]
+    async fn targeted_secondary_rejects_conflicting_physical_alias_modes_before_open() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let aliased = dir.path().join("must-not-be-created.db");
+        let khive_cfg = KhiveConfig {
+            backends: vec![
+                BackendConfig {
+                    name: BackendId::MAIN.to_string(),
+                    kind: BackendKind::Memory,
+                    path: None,
+                    cache_mb: None,
+                    journal_mode: None,
+                    read_only: false,
+                },
+                BackendConfig {
+                    name: "archive-ro".to_string(),
+                    kind: BackendKind::Sqlite,
+                    path: Some(aliased.clone()),
+                    cache_mb: None,
+                    journal_mode: None,
+                    read_only: true,
+                },
+                BackendConfig {
+                    name: "archive-rw".to_string(),
+                    kind: BackendKind::Sqlite,
+                    path: Some(aliased.clone()),
+                    cache_mb: None,
+                    journal_mode: None,
+                    read_only: false,
+                },
+            ],
+            ..KhiveConfig::default()
+        };
+
+        let error = migrate_configured_storage_topology(
+            base_runtime_config_for_multi_backend(),
+            &khive_cfg,
+            None,
+            Some("archive-rw"),
+        )
+        .await
+        .expect_err("targeted migration must apply full-topology alias validation");
+        assert!(error.to_string().contains("same access mode"), "{error:#}");
+        assert!(
+            !aliased.exists(),
+            "alias validation must fail before opening or creating the selected database"
+        );
+    }
+
+    #[tokio::test]
+    async fn main_alias_target_marks_physical_target_names_not_prerequisite() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let main = dir.path().join("main.db");
+        let secondary = dir.path().join("secondary.db");
+        let khive_cfg = KhiveConfig {
+            backends: vec![
+                BackendConfig {
+                    name: BackendId::MAIN.to_string(),
+                    kind: BackendKind::Sqlite,
+                    path: Some(main.clone()),
+                    cache_mb: None,
+                    journal_mode: None,
+                    read_only: false,
+                },
+                BackendConfig {
+                    name: "main-alias".to_string(),
+                    kind: BackendKind::Sqlite,
+                    path: Some(main),
+                    cache_mb: None,
+                    journal_mode: None,
+                    read_only: false,
+                },
+                BackendConfig {
+                    name: "secondary".to_string(),
+                    kind: BackendKind::Sqlite,
+                    path: Some(secondary),
+                    cache_mb: None,
+                    journal_mode: None,
+                    read_only: false,
+                },
+            ],
+            ..KhiveConfig::default()
+        };
+
+        let statuses = migrate_configured_storage_topology(
+            base_runtime_config_for_multi_backend(),
+            &khive_cfg,
+            None,
+            Some("main-alias"),
+        )
+        .await
+        .expect("an alias of main must run the full prerequisite topology");
+        let status = |name: &str| {
+            statuses
+                .iter()
+                .find(|status| status.backend == name)
+                .unwrap_or_else(|| panic!("missing status for {name}"))
+        };
+        assert!(!status(BackendId::MAIN).prerequisite);
+        assert!(!status("main-alias").prerequisite);
+        assert!(status("secondary").prerequisite);
+    }
+
+    #[test]
+    fn force_memory_makes_a_file_alias_target_independent_from_main() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let khive_cfg = duplicate_sqlite_path_config(&dir.path().join("unused.db"));
+        assert_eq!(
+            configured_storage_check_targets(&khive_cfg, Some(":memory:"), Some("alias"))
+                .expect("forced-memory target plan"),
+            vec!["alias".to_string()],
+            "forced-memory configured names are distinct ephemeral databases"
+        );
+    }
+
     fn memory_main_backend_config() -> KhiveConfig {
         KhiveConfig {
             backends: vec![BackendConfig {
@@ -7173,73 +8066,75 @@ region = "us-east-1"
         }
     }
 
-    #[test]
-    fn legacy_registry_rejects_mismatched_explicit_db_override() {
+    #[tokio::test]
+    async fn legacy_registry_rejects_mismatched_explicit_db_override() {
         let base_cfg = RuntimeConfig {
             db_path: Some(PathBuf::from("/tmp/khive-resolved.db")),
             ..base_runtime_config_for_multi_backend()
         };
 
-        assert_db_anchor_drift(build_registry_for_multi_backend(
-            base_cfg,
-            &memory_main_backend_config(),
-            Some("/tmp/khive-raw.db"),
-        ));
+        assert_db_anchor_drift(
+            build_registry_for_multi_backend(
+                base_cfg,
+                &memory_main_backend_config(),
+                Some("/tmp/khive-raw.db"),
+            )
+            .await,
+        );
     }
 
-    #[test]
-    fn legacy_server_rejects_mismatched_explicit_db_override() {
+    #[tokio::test]
+    async fn legacy_server_rejects_mismatched_explicit_db_override() {
         let base_cfg = RuntimeConfig {
             db_path: Some(PathBuf::from("/tmp/khive-resolved.db")),
             ..base_runtime_config_for_multi_backend()
         };
 
-        assert_db_anchor_drift(build_server_multi_backend(
-            base_cfg,
-            &memory_main_backend_config(),
-            Some("/tmp/khive-raw.db"),
-        ));
+        assert_db_anchor_drift(
+            build_server_multi_backend(
+                base_cfg,
+                &memory_main_backend_config(),
+                Some("/tmp/khive-raw.db"),
+            )
+            .await,
+        );
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn legacy_registry_rejects_unset_db_after_home_changes() {
+    async fn legacy_registry_rejects_unset_db_after_home_changes() {
         let first_home = tempfile::tempdir().unwrap();
         let _home_guard = HomeGuard::redirect_to(first_home.path());
         let base_cfg = base_runtime_config_for_multi_backend();
         let second_home = tempfile::tempdir().unwrap();
         std::env::set_var("HOME", second_home.path());
 
-        assert_db_anchor_drift(build_registry_for_multi_backend(
-            base_cfg,
-            &memory_main_backend_config(),
-            None,
-        ));
+        assert_db_anchor_drift(
+            build_registry_for_multi_backend(base_cfg, &memory_main_backend_config(), None).await,
+        );
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn legacy_server_rejects_unset_db_after_home_changes() {
+    async fn legacy_server_rejects_unset_db_after_home_changes() {
         let first_home = tempfile::tempdir().unwrap();
         let _home_guard = HomeGuard::redirect_to(first_home.path());
         let base_cfg = base_runtime_config_for_multi_backend();
         let second_home = tempfile::tempdir().unwrap();
         std::env::set_var("HOME", second_home.path());
 
-        assert_db_anchor_drift(build_server_multi_backend(
-            base_cfg,
-            &memory_main_backend_config(),
-            None,
-        ));
+        assert_db_anchor_drift(
+            build_server_multi_backend(base_cfg, &memory_main_backend_config(), None).await,
+        );
     }
 
     /// B-SHOULD-FIX-2 (data safety): Two [[backends]] entries whose sqlite paths
     /// canonicalize to the same file must share a single Arc<StorageBackend> and
     /// run migrations only once. Verified by using two names that differ only by
     /// `./` prefix while pointing at the same absolute path.
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn duplicate_sqlite_paths_deduplicated_to_single_backend() {
+    async fn duplicate_sqlite_paths_deduplicated_to_single_backend() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("shared.db");
         let khive_cfg = duplicate_sqlite_path_config(&db_path);
@@ -7247,7 +8142,7 @@ region = "us-east-1"
         let base_cfg = base_runtime_config_for_multi_backend();
 
         // Must boot successfully (dedup prevents double-migration / SQLITE_BUSY).
-        let result = build_server_multi_backend(base_cfg, &khive_cfg, None);
+        let result = build_server_multi_backend(base_cfg, &khive_cfg, None).await;
         if let Err(ref e) = result {
             panic!(
                 "two backends with the same canonical path must share one Arc and boot ok; got: {e}"
@@ -7255,9 +8150,9 @@ region = "us-east-1"
         }
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn duplicate_sqlite_aliases_reject_conflicting_read_only_modes() {
+    async fn duplicate_sqlite_aliases_reject_conflicting_read_only_modes() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("shared-mode.db");
         let mut khive_cfg = duplicate_sqlite_path_config(&db_path);
@@ -7268,7 +8163,9 @@ region = "us-east-1"
             base_runtime_config_for_multi_backend(),
             &khive_cfg,
             None,
-        ) {
+        )
+        .await
+        {
             Ok(_) => panic!("one physical database cannot be both writable and read-only"),
             Err(error) => error,
         };
@@ -7280,9 +8177,9 @@ region = "us-east-1"
     /// Regression for #720: changing `HOME` after runtime-config resolution but
     /// before multi-backend registry construction must not change the database
     /// anchor used by the consistency guard.
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn multi_backend_boot_uses_anchor_captured_by_runtime_config() {
+    async fn multi_backend_boot_uses_anchor_captured_by_runtime_config() {
         let first_home = tempfile::tempdir().unwrap();
         let _home_guard = HomeGuard::redirect_to(first_home.path());
         let config_path = first_home.path().join("config.toml");
@@ -7310,7 +8207,8 @@ region = "us-east-1"
             &khive_cfg,
             None,
             db_anchor.as_deref(),
-        );
+        )
+        .await;
         if let Err(error) = result {
             panic!(
                 "multi-backend construction must retain the anchor captured by \
@@ -7330,9 +8228,9 @@ region = "us-east-1"
     /// Passing `Some(":memory:")` as `cli_db_override` must force every
     /// declared backend in-memory for this invocation, and the declared sqlite
     /// paths must never be created on disk.
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn memory_override_forces_all_backends_in_memory_and_never_creates_sqlite_file_via_build_server_multi_backend(
+    async fn memory_override_forces_all_backends_in_memory_and_never_creates_sqlite_file_via_build_server_multi_backend(
     ) {
         use khive_runtime::PackConfig;
 
@@ -7374,7 +8272,7 @@ region = "us-east-1"
 
         let base_cfg = base_runtime_config_for_multi_backend();
 
-        let result = build_server_multi_backend(base_cfg, &khive_cfg, Some(":memory:"));
+        let result = build_server_multi_backend(base_cfg, &khive_cfg, Some(":memory:")).await;
         if let Err(ref e) = result {
             panic!(
                 "--db :memory: override must force both declared sqlite backends \
@@ -7399,9 +8297,10 @@ region = "us-east-1"
     /// should it apply to?) and must fail loud on the `build_server_multi_backend`
     /// path too, with a selectable-config remedy rather than silently
     /// collapsing distinct backends onto one path.
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn concrete_db_override_with_backends_declared_is_rejected_via_build_server_multi_backend() {
+    async fn concrete_db_override_with_backends_declared_is_rejected_via_build_server_multi_backend(
+    ) {
         use khive_runtime::PackConfig;
 
         let khive_cfg = KhiveConfig {
@@ -7449,7 +8348,8 @@ region = "us-east-1"
             base_cfg,
             &khive_cfg,
             Some("/tmp/some-explicit-override.db"),
-        );
+        )
+        .await;
         assert!(
             result.is_err(),
             "a concrete --db path override combined with declared [[backends]] must \
@@ -7611,6 +8511,7 @@ region = "us-east-1"
         let base_cfg = base_runtime_config_for_multi_backend();
 
         let server = build_server_multi_backend(base_cfg, &khive_cfg, None)
+            .await
             .expect("multi-backend boot must succeed");
 
         let dispatch = |ops: String| {
@@ -8408,9 +9309,9 @@ region = "us-east-1"
     // in the test-runner's environment cannot silently change the resolved
     // config out from under the assertion.
 
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn build_server_schedule_tick_uses_the_configured_backend_not_the_home_default() {
+    async fn build_server_schedule_tick_uses_the_configured_backend_not_the_home_default() {
         let seat_dir = tempfile::tempdir().expect("seat tempdir");
         let _seat_env = SeatEnv::enter(seat_dir.path());
         std::env::remove_var("KHIVE_DB");
@@ -8423,7 +9324,9 @@ region = "us-east-1"
         use clap::Parser;
         let args = Args::parse_from(["mcp", "--db", configured_db.to_str().expect("utf8 path")]);
 
-        let (_server, schedule_rt) = build_server(&args).expect("build_server must succeed");
+        let (_server, schedule_rt) = build_server(&args)
+            .await
+            .expect("build_server must succeed");
         let rt = schedule_rt
             .expect("the default pack set includes \"schedule\" — a runtime must be returned");
 
@@ -8435,9 +9338,9 @@ region = "us-east-1"
         );
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn build_server_schedule_tick_uses_the_configured_actor_identity() {
+    async fn build_server_schedule_tick_uses_the_configured_actor_identity() {
         let seat_dir = tempfile::tempdir().expect("seat tempdir");
         let _seat_env = SeatEnv::enter(seat_dir.path());
         std::env::remove_var("KHIVE_DB");
@@ -8454,7 +9357,9 @@ region = "us-east-1"
             "lambda:adr106-tick-actor",
         ]);
 
-        let (_server, schedule_rt) = build_server(&args).expect("build_server must succeed");
+        let (_server, schedule_rt) = build_server(&args)
+            .await
+            .expect("build_server must succeed");
         let rt = schedule_rt.expect("schedule pack is loaded by default");
 
         assert_eq!(
@@ -8465,9 +9370,10 @@ region = "us-east-1"
         );
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn build_server_schedule_tick_is_none_when_schedule_pack_is_not_in_the_restricted_pack_set() {
+    async fn build_server_schedule_tick_is_none_when_schedule_pack_is_not_in_the_restricted_pack_set(
+    ) {
         let seat_dir = tempfile::tempdir().expect("seat tempdir");
         let _seat_env = SeatEnv::enter(seat_dir.path());
         std::env::remove_var("KHIVE_DB");
@@ -8479,7 +9385,9 @@ region = "us-east-1"
         // Restrict to a pack set that deliberately excludes "schedule".
         let args = Args::parse_from(["mcp", "--db", ":memory:", "--pack", "kg"]);
 
-        let (_server, schedule_rt) = build_server(&args).expect("build_server must succeed");
+        let (_server, schedule_rt) = build_server(&args)
+            .await
+            .expect("build_server must succeed");
         assert!(
             schedule_rt.is_none(),
             "when the operator restricts --pack to exclude \"schedule\", the tick must have \
@@ -8515,7 +9423,9 @@ region = "us-east-1"
         use clap::Parser;
         let args = Args::parse_from(["mcp", "--db", db.to_str().expect("utf8 path"), "--no-embed"]);
 
-        let (_server, schedule_rt) = build_server(&args).expect("read-only server must build");
+        let (_server, schedule_rt) = build_server(&args)
+            .await
+            .expect("read-only server must build");
         assert!(
             schedule_rt.is_none(),
             "the default pack set must not return a writer-dependent ticker runtime for a snapshot"
@@ -8602,7 +9512,9 @@ backend = "schedule-backend"
             "--pack",
             "schedule",
         ]);
-        let (server, schedule_rt) = build_server(&args).expect("mixed-mode server must build");
+        let (server, schedule_rt) = build_server(&args)
+            .await
+            .expect("mixed-mode server must build");
         assert!(
             schedule_rt.is_some(),
             "a read-only main backend must not suppress schedule when schedule's own backend is writable"
@@ -8670,7 +9582,9 @@ backend = "schedule-backend"
             "--pack",
             "schedule",
         ]);
-        let (_server, schedule_rt) = build_server(&args).expect("mixed-mode server must build");
+        let (_server, schedule_rt) = build_server(&args)
+            .await
+            .expect("mixed-mode server must build");
         assert!(
             schedule_rt.is_none(),
             "a writable main backend must not enable schedule when schedule's own backend is read-only"
@@ -8699,9 +9613,9 @@ backend = "schedule-backend"
         );
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn build_server_schedule_tick_runtime_satisfies_strict_actor_mode_like_the_live_server() {
+    async fn build_server_schedule_tick_runtime_satisfies_strict_actor_mode_like_the_live_server() {
         // Regression for the exact "strict actor mode can make every tick
         // fail" scenario this fix addressed: before this fix, the
         // tick's separately-reconstructed `RuntimeConfig::default()` carried
@@ -8735,7 +9649,7 @@ backend = "schedule-backend"
             "schedule",
         ]);
 
-        let result = build_server(&args);
+        let result = build_server(&args).await;
 
         match prev_strict {
             Some(v) => std::env::set_var("KHIVE_REQUIRE_ATTRIBUTED_ACTOR", v),
@@ -8802,7 +9716,9 @@ backend = "schedule-backend"
         use clap::Parser;
         let args = Args::parse_from(["mcp", "--config", config_path.to_str().expect("utf8 path")]);
 
-        let (_server, schedule_rt) = build_server(&args).expect("build_server must succeed");
+        let (_server, schedule_rt) = build_server(&args)
+            .await
+            .expect("build_server must succeed");
         let rt = schedule_rt.expect("schedule pack is loaded by default and declared here");
 
         let marker_content = "adr106-multi-backend-schedule-marker";
@@ -8926,7 +9842,9 @@ backend = "kg-backend"
             "--no-embed",
         ]);
 
-        let (server, schedule_rt) = build_server(&args).expect("build_server must succeed");
+        let (server, schedule_rt) = build_server(&args)
+            .await
+            .expect("build_server must succeed");
         // No `[packs.schedule]` entry above, so it defaults to "main".
         let rt = schedule_rt.expect("schedule pack is loaded by default");
         assert!(
@@ -9451,6 +10369,7 @@ backend = "kg-backend"
                 &khive_cfg,
                 None,
             )
+            .await
             .expect("mixed-topology registry must build");
             assert_eq!(
                 multi.per_pack_runtimes["kg"].backend_id().as_str(),
@@ -11180,7 +12099,7 @@ backend = "kg-backend"
             "--pack",
             "kg",
         ]);
-        let (server, _schedule_rt) = build_server(&args).expect("build server");
+        let (server, _schedule_rt) = build_server(&args).await.expect("build server");
 
         let registry = TransportRegistry::default();
         let err = tokio::time::timeout(
@@ -11237,7 +12156,7 @@ backend = "kg-backend"
             "--pack",
             "kg",
         ]);
-        let (server, _schedule_rt) = build_server(&args).expect("build server");
+        let (server, _schedule_rt) = build_server(&args).await.expect("build server");
 
         let completed = Arc::new(AtomicBool::new(false));
         let (shutdown_tx, mut shutdown_rx) = tokio::sync::watch::channel(());

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -968,6 +968,12 @@ fn stdio_serve_mode_for(resumed_generation: Option<u32>) -> StdioServeMode {
 
 impl KhiveMcpServer {
     /// Build a server from `runtime.config().packs`. Errors if any pack is unknown or missing deps.
+    ///
+    /// This constructor assumes the supplied runtime's database is already at a
+    /// complete V21 attachment cutover. It intentionally performs no migration
+    /// or blob-evidence verification. Production hosts opening a database should
+    /// use the async builders in [`crate::serve`] and reserve this constructor for
+    /// already-prepared runtimes and tests.
     // The error variant intentionally carries the runtime so callers can recover.
     #[allow(clippy::result_large_err)]
     pub fn new(runtime: KhiveRuntime) -> Result<Self, PackRegError> {
@@ -978,6 +984,8 @@ impl KhiveMcpServer {
     }
 
     /// Build a server with an explicit pack list (strict — fails on unknown names).
+    ///
+    /// The same already-prepared-runtime precondition as [`Self::new`] applies.
     // The error variant intentionally carries the runtime by value so callers
     // can recover and retry. Boxing would force every recovery path through a
     // deref for no real benefit.
@@ -2208,6 +2216,7 @@ fn storage_capability_wire_name(capability: StorageCapability) -> &'static str {
         StorageCapability::Sparse => "sparse",
         StorageCapability::Text => "text",
         StorageCapability::Blob => "blob",
+        StorageCapability::Attachments => "attachments",
     }
 }
 

--- a/crates/khive-pack-moodboard/src/handlers.rs
+++ b/crates/khive-pack-moodboard/src/handlers.rs
@@ -14,7 +14,7 @@ use khive_storage::blob::ContentRef;
 use khive_storage::types::{
     SqlStatement, SqlValue, VectorIndexKind, VectorSearchHit, VectorSearchRequest,
 };
-use khive_storage::{BlobStore, Entity, VectorStore};
+use khive_storage::{BlobStore, Entity, NewAttachment, VectorStore};
 use khive_types::SubstrateKind;
 
 use crate::model::{validate_embedding, DescriptorIdentity, LoadedVisionModel, VisionModelState};
@@ -400,9 +400,12 @@ async fn find_visual_asset(
     let mut reader = runtime.sql().reader().await?;
     let row = reader
         .query_row(SqlStatement {
-            sql: "SELECT id FROM entities WHERE namespace = ?1 AND kind = 'artifact' \
-                  AND entity_type = 'visual_asset' AND content_ref = ?2 \
-                  AND deleted_at IS NULL ORDER BY created_at, id LIMIT 1"
+            sql: "SELECT e.id FROM entities e \
+                  JOIN attachments a ON a.record_uuid = e.id \
+                    AND a.substrate = 'entity' AND a.role = 'content' \
+                  WHERE e.namespace = ?1 AND e.kind = 'artifact' \
+                  AND e.entity_type = 'visual_asset' AND a.content_ref = ?2 \
+                  AND e.deleted_at IS NULL ORDER BY e.created_at, e.id LIMIT 1"
                 .to_string(),
             params: vec![
                 SqlValue::Text(token.namespace().as_str().to_string()),
@@ -448,8 +451,11 @@ async fn find_or_create_visual_asset(
     }
 
     let default_name = format!("asset-{}", &content_ref.as_str()[..12]);
+    let size_bytes = u64::try_from(original_len).map_err(|_| {
+        RuntimeError::Internal("moodboard visual asset size exceeds u64".to_string())
+    })?;
     let asset = runtime
-        .create_entity_with_content_ref(
+        .create_entity_with_attachments(
             token,
             "artifact",
             Some("visual_asset"),
@@ -457,7 +463,12 @@ async fn find_or_create_visual_asset(
             caption,
             Some(asset_properties(prepared, original_len)),
             vec!["moodboard".to_string(), "visual_asset".to_string()],
-            content_ref,
+            vec![NewAttachment {
+                role: "content".to_string(),
+                content_ref: content_ref.clone(),
+                media_type: Some(prepared.media_type.to_string()),
+                size_bytes: Some(size_bytes),
+            }],
         )
         .await?;
     Ok((asset, true))
@@ -616,6 +627,7 @@ mod tests {
     use async_trait::async_trait;
     use khive_db::stores::blob::FsBlobStore;
     use khive_runtime::{BackendId, RuntimeConfig};
+    use khive_storage::{Attachment, AttachmentSubstrate};
     use khive_types::Namespace;
 
     #[derive(Debug)]
@@ -976,24 +988,52 @@ mod tests {
         let extra_ref = blob_store.put(b"extra".to_vec()).await.unwrap();
         let mut primary_entity =
             Entity::new(narrow.namespace().as_str(), "artifact", "primary candidate")
-                .with_entity_type(Some("visual_asset"))
-                .with_content_ref(primary_ref.to_string());
+                .with_entity_type(Some("visual_asset"));
         primary_entity.id = primary_id;
+        let primary_created_at = primary_entity.created_at;
         runtime
             .entities(&narrow)
             .unwrap()
             .upsert_entity(primary_entity)
             .await
             .unwrap();
+        runtime
+            .attachments()
+            .unwrap()
+            .upsert_attachment(Attachment {
+                record_uuid: primary_id,
+                substrate: AttachmentSubstrate::Entity,
+                role: "content".to_string(),
+                content_ref: primary_ref,
+                media_type: None,
+                size_bytes: Some(7),
+                created_at: primary_created_at,
+            })
+            .await
+            .unwrap();
         let mut extra_entity =
             Entity::new(extra.namespace().as_str(), "artifact", "extra candidate")
-                .with_entity_type(Some("visual_asset"))
-                .with_content_ref(extra_ref.to_string());
+                .with_entity_type(Some("visual_asset"));
         extra_entity.id = extra_id;
+        let extra_created_at = extra_entity.created_at;
         runtime
             .entities(&extra)
             .unwrap()
             .upsert_entity(extra_entity)
+            .await
+            .unwrap();
+        runtime
+            .attachments()
+            .unwrap()
+            .upsert_attachment(Attachment {
+                record_uuid: extra_id,
+                substrate: AttachmentSubstrate::Entity,
+                role: "content".to_string(),
+                content_ref: extra_ref,
+                media_type: None,
+                size_bytes: Some(5),
+                created_at: extra_created_at,
+            })
             .await
             .unwrap();
 
@@ -1151,11 +1191,9 @@ mod tests {
         let live_ref = blob_store.put(b"live original".to_vec()).await.unwrap();
         let stale = Uuid::new_v4();
         let live = Entity::new(token.namespace().as_str(), "artifact", "live candidate")
-            .with_entity_type(Some("visual_asset"))
-            .with_content_ref(live_ref.to_string());
+            .with_entity_type(Some("visual_asset"));
         let missing = Entity::new(token.namespace().as_str(), "artifact", "missing blob")
-            .with_entity_type(Some("visual_asset"))
-            .with_content_ref("b".repeat(64));
+            .with_entity_type(Some("visual_asset"));
         runtime
             .entities(&token)
             .unwrap()
@@ -1166,6 +1204,34 @@ mod tests {
             .entities(&token)
             .unwrap()
             .upsert_entity(missing.clone())
+            .await
+            .unwrap();
+        runtime
+            .attachments()
+            .unwrap()
+            .upsert_attachment(Attachment {
+                record_uuid: live.id,
+                substrate: AttachmentSubstrate::Entity,
+                role: "content".to_string(),
+                content_ref: live_ref,
+                media_type: None,
+                size_bytes: Some(13),
+                created_at: live.created_at,
+            })
+            .await
+            .unwrap();
+        runtime
+            .attachments()
+            .unwrap()
+            .upsert_attachment(Attachment {
+                record_uuid: missing.id,
+                substrate: AttachmentSubstrate::Entity,
+                role: "content".to_string(),
+                content_ref: ContentRef::from_hex("b".repeat(64)).unwrap(),
+                media_type: None,
+                size_bytes: None,
+                created_at: missing.created_at,
+            })
             .await
             .unwrap();
         index_embedding(&runtime, &token, &descriptor, stale, &[1.0, 0.0, 0.0, 0.0])

--- a/crates/khive-pack-moodboard/src/lib.rs
+++ b/crates/khive-pack-moodboard/src/lib.rs
@@ -12,6 +12,7 @@ pub mod handlers;
 mod model;
 mod pack;
 mod preference;
+mod preference_artifact;
 mod preference_handlers;
 mod preprocess;
 pub mod vocab;
@@ -20,6 +21,11 @@ use khive_runtime::KhiveRuntime;
 use khive_types::{EntityTypeDef, HandlerDef, Pack};
 
 use model::VisionModelState;
+
+pub use preference_artifact::{
+    legacy_preference_model_count, verify_legacy_preference_attachments,
+    VerifiedModelNetworkAttachment,
+};
 
 pub(crate) const PACK_NAME: &str = "moodboard";
 

--- a/crates/khive-pack-moodboard/src/preference_artifact.rs
+++ b/crates/khive-pack-moodboard/src/preference_artifact.rs
@@ -1,0 +1,969 @@
+//! Authenticated preference-model artifact verification shared by serving and boot cutover.
+
+use khive_runtime::{BlobHydrator, RuntimeError};
+use khive_storage::blob::ContentRef;
+use khive_storage::event::Event;
+use khive_storage::types::{PageRequest, SqlRow, SqlStatement, SqlValue};
+use khive_storage::SqlAccess;
+use khive_types::{EventKind, EventOutcome, SubstrateKind};
+use uuid::Uuid;
+
+use crate::preference::{
+    deserialize_fann, sha256_hex, validate_loaded_bundle, ModelBundle, PreferenceScope,
+    MODEL_BUNDLE_SCHEMA_VERSION,
+};
+
+/// Persistent ADR-149 namespace for immutable preference-model publication events.
+const MODEL_EVENT_UUID_NAMESPACE: Uuid = Uuid::from_u128(0x1dc2_337e_b200_5bd1_824f_2653_1164_5c16);
+const MAX_MODEL_BLOB_BYTES: u64 = 1024 * 1024;
+const LEGACY_MODEL_PAGE_SIZE: u32 = 128;
+
+pub(crate) fn model_event_id(model_id: Uuid, bundle_ref: &ContentRef) -> Uuid {
+    let mut name = Vec::with_capacity(16 + 1 + 64);
+    name.extend_from_slice(model_id.as_bytes());
+    name.push(0);
+    name.extend_from_slice(bundle_ref.as_str().as_bytes());
+    Uuid::new_v5(&MODEL_EVENT_UUID_NAMESPACE, &name)
+}
+
+#[derive(Debug)]
+pub(crate) struct VerifiedPreferenceBundle {
+    pub bundle: ModelBundle,
+    pub bundle_sha256: String,
+    pub network_ref: ContentRef,
+    pub network_sha256: String,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn validate_model_event_evidence(
+    event: &Event,
+    entity_namespace: &str,
+    model_id: Uuid,
+    scope: &PreferenceScope,
+    bundle_ref: &ContentRef,
+    bundle_sha256: &str,
+    network_ref: &ContentRef,
+    network_sha256: &str,
+) -> Result<(), RuntimeError> {
+    let expected = serde_json::json!({
+        "schema_version": MODEL_BUNDLE_SCHEMA_VERSION,
+        "preference_model_id": model_id,
+        "model_content_ref": bundle_ref,
+        "model_fingerprint": bundle_sha256,
+        "network_content_ref": network_ref,
+        "network_sha256": network_sha256,
+        "scope": scope,
+    });
+    let expected_actor = format!("{}:{}", scope.actor_kind, scope.actor_id);
+    if event.id != model_event_id(model_id, bundle_ref)
+        || event.namespace != entity_namespace
+        || event.substrate != SubstrateKind::Entity
+        || event.outcome != EventOutcome::Success
+        || event.verb != "moodboard.model_record"
+        || event.kind != EventKind::Audit
+        || event.actor != expected_actor
+        || event.target_id != Some(model_id)
+        || event.aggregate_kind.as_deref() != Some("moodboard_model")
+        || event.aggregate_id != Some(model_id)
+        || event.payload_schema_version != 1
+        || event.profile_state_version.is_some()
+        || event.duration_us != 0
+        || event.session_id.is_some()
+        || event.payload != expected
+    {
+        return Err(RuntimeError::InvalidInput(format!(
+            "moodboard preference model {model_id} lacks matching immutable pack provenance"
+        )));
+    }
+    Ok(())
+}
+
+pub(crate) fn verify_preference_bundle_evidence(
+    model_id: Uuid,
+    entity_namespace: &str,
+    bundle_ref: &ContentRef,
+    bundle_bytes: &[u8],
+    event: &Event,
+) -> Result<VerifiedPreferenceBundle, RuntimeError> {
+    let bundle_sha256 = sha256_hex(bundle_bytes);
+    let bundle: ModelBundle = serde_json::from_slice(bundle_bytes).map_err(|error| {
+        RuntimeError::InvalidInput(format!(
+            "moodboard preference model {model_id} bundle is corrupt: {error}"
+        ))
+    })?;
+    validate_loaded_bundle(&bundle)?;
+    if bundle.scope.namespace != entity_namespace {
+        return Err(RuntimeError::InvalidInput(format!(
+            "moodboard preference model {model_id} bundle namespace {:?} does not match entity namespace {entity_namespace:?}",
+            bundle.scope.namespace
+        )));
+    }
+    let network_ref =
+        ContentRef::from_hex(bundle.fann.network_content_ref.clone()).map_err(|error| {
+            RuntimeError::InvalidInput(format!(
+                "moodboard preference model {model_id} network_content_ref: {error}"
+            ))
+        })?;
+    validate_model_event_evidence(
+        event,
+        entity_namespace,
+        model_id,
+        &bundle.scope,
+        bundle_ref,
+        &bundle_sha256,
+        &network_ref,
+        &bundle.fann.network_sha256,
+    )?;
+    let network_sha256 = bundle.fann.network_sha256.clone();
+    Ok(VerifiedPreferenceBundle {
+        bundle,
+        bundle_sha256,
+        network_ref,
+        network_sha256,
+    })
+}
+
+pub(crate) fn verify_preference_network(
+    evidence: &VerifiedPreferenceBundle,
+    network_bytes: &[u8],
+) -> Result<lattice_fann::Network, RuntimeError> {
+    if sha256_hex(network_bytes) != evidence.network_sha256 {
+        return Err(RuntimeError::InvalidInput(
+            "moodboard preference model FANN SHA-256 does not match its authenticated bundle"
+                .to_string(),
+        ));
+    }
+    deserialize_fann(network_bytes)
+}
+
+/// One authenticated network role for the attachment cutover coordinator.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VerifiedModelNetworkAttachment {
+    pub model_id: Uuid,
+    pub network_content_ref: ContentRef,
+    pub size_bytes: u64,
+}
+
+/// Count every legacy preference-model candidate, including soft-deleted rows.
+pub async fn legacy_preference_model_count(sql: &dyn SqlAccess) -> Result<u64, RuntimeError> {
+    let mut reader = sql.reader().await?;
+    match reader
+        .query_scalar(SqlStatement {
+            sql: "SELECT COUNT(*) FROM entities \
+                  WHERE kind = 'artifact' AND entity_type = 'moodboard_model' \
+                    AND content_ref IS NOT NULL"
+                .to_string(),
+            params: vec![],
+            label: Some("moodboard_legacy_preference_model_count".to_string()),
+        })
+        .await?
+    {
+        Some(SqlValue::Integer(count)) if count >= 0 => Ok(count as u64),
+        other => Err(RuntimeError::Internal(format!(
+            "moodboard legacy preference model count returned invalid value {other:?}"
+        ))),
+    }
+}
+
+#[derive(Debug)]
+struct LegacyPreferenceModelRow {
+    model_id: Uuid,
+    namespace: String,
+    bundle_ref: ContentRef,
+    fann_attachment_ref: Option<ContentRef>,
+}
+
+fn required_text(row: &SqlRow, name: &str, context: &str) -> Result<String, RuntimeError> {
+    match row.get(name) {
+        Some(SqlValue::Text(value)) => Ok(value.clone()),
+        other => Err(RuntimeError::Internal(format!(
+            "{context} returned invalid {name}: {other:?}"
+        ))),
+    }
+}
+
+fn required_uuid(row: &SqlRow, name: &str, context: &str) -> Result<Uuid, RuntimeError> {
+    match row.get(name) {
+        Some(SqlValue::Uuid(value)) => Ok(*value),
+        Some(SqlValue::Text(value)) => Uuid::parse_str(value).map_err(|error| {
+            RuntimeError::Internal(format!(
+                "{context} returned invalid {name} {value:?}: {error}"
+            ))
+        }),
+        other => Err(RuntimeError::Internal(format!(
+            "{context} returned invalid {name}: {other:?}"
+        ))),
+    }
+}
+
+fn optional_text(row: &SqlRow, name: &str, context: &str) -> Result<Option<String>, RuntimeError> {
+    match row.get(name) {
+        Some(SqlValue::Null) | None => Ok(None),
+        Some(SqlValue::Text(value)) => Ok(Some(value.clone())),
+        other => Err(RuntimeError::Internal(format!(
+            "{context} returned invalid {name}: {other:?}"
+        ))),
+    }
+}
+
+fn optional_uuid(row: &SqlRow, name: &str, context: &str) -> Result<Option<Uuid>, RuntimeError> {
+    match row.get(name) {
+        Some(SqlValue::Null) | None => Ok(None),
+        Some(SqlValue::Uuid(value)) => Ok(Some(*value)),
+        Some(SqlValue::Text(value)) => Uuid::parse_str(value).map(Some).map_err(|error| {
+            RuntimeError::Internal(format!(
+                "{context} returned invalid {name} {value:?}: {error}"
+            ))
+        }),
+        other => Err(RuntimeError::Internal(format!(
+            "{context} returned invalid {name}: {other:?}"
+        ))),
+    }
+}
+
+fn required_i64(row: &SqlRow, name: &str, context: &str) -> Result<i64, RuntimeError> {
+    match row.get(name) {
+        Some(SqlValue::Integer(value)) => Ok(*value),
+        other => Err(RuntimeError::Internal(format!(
+            "{context} returned invalid {name}: {other:?}"
+        ))),
+    }
+}
+
+fn optional_nonnegative_u64(
+    row: &SqlRow,
+    name: &str,
+    context: &str,
+) -> Result<Option<u64>, RuntimeError> {
+    match row.get(name) {
+        Some(SqlValue::Null) | None => Ok(None),
+        Some(SqlValue::Integer(value)) if *value >= 0 => Ok(Some(*value as u64)),
+        other => Err(RuntimeError::Internal(format!(
+            "{context} returned invalid {name}: {other:?}"
+        ))),
+    }
+}
+
+fn parse_legacy_model_row(row: &SqlRow) -> Result<LegacyPreferenceModelRow, RuntimeError> {
+    let context = "moodboard legacy preference model scan";
+    let model_id = required_uuid(row, "id", context)?;
+    let namespace = required_text(row, "namespace", context)?;
+    let bundle_ref = ContentRef::from_hex(required_text(row, "legacy_content_ref", context)?)
+        .map_err(|error| {
+            RuntimeError::InvalidInput(format!(
+                "moodboard legacy preference model {model_id} has invalid bundle content_ref: {error}"
+            ))
+        })?;
+    let content_attachment_ref = optional_text(row, "content_attachment_ref", context)?
+        .ok_or_else(|| {
+            RuntimeError::InvalidInput(format!(
+                "moodboard legacy preference model {model_id} lacks its stage-1 content attachment"
+            ))
+        })?;
+    let content_attachment_ref = ContentRef::from_hex(content_attachment_ref).map_err(|error| {
+        RuntimeError::InvalidInput(format!(
+            "moodboard legacy preference model {model_id} has invalid content attachment: {error}"
+        ))
+    })?;
+    if content_attachment_ref != bundle_ref {
+        return Err(RuntimeError::InvalidInput(format!(
+            "moodboard legacy preference model {model_id} content attachment disagrees with its legacy bundle reference"
+        )));
+    }
+    let fann_attachment_ref = optional_text(row, "fann_attachment_ref", context)?
+        .map(ContentRef::from_hex)
+        .transpose()
+        .map_err(|error| {
+            RuntimeError::InvalidInput(format!(
+                "moodboard legacy preference model {model_id} has invalid fann-network attachment: {error}"
+            ))
+        })?;
+    Ok(LegacyPreferenceModelRow {
+        model_id,
+        namespace,
+        bundle_ref,
+        fann_attachment_ref,
+    })
+}
+
+fn parse_event_row(row: &SqlRow, model_id: Uuid) -> Result<Event, RuntimeError> {
+    let context = "moodboard legacy model event lookup";
+    let payload = match row.get("payload") {
+        Some(SqlValue::Json(value)) => value.clone(),
+        Some(SqlValue::Text(value)) => serde_json::from_str(value).map_err(|error| {
+            RuntimeError::InvalidInput(format!(
+                "moodboard preference model {model_id} event payload is corrupt: {error}"
+            ))
+        })?,
+        other => {
+            return Err(RuntimeError::Internal(format!(
+                "{context} returned invalid payload: {other:?}"
+            )))
+        }
+    };
+    let substrate_raw = required_text(row, "substrate", context)?;
+    let substrate = substrate_raw.parse::<SubstrateKind>().map_err(|error| {
+        RuntimeError::Internal(format!("{context} returned invalid substrate: {error}"))
+    })?;
+    let kind_raw = required_text(row, "kind", context)?;
+    let kind = kind_raw.parse::<EventKind>().map_err(|error| {
+        RuntimeError::Internal(format!("{context} returned invalid kind: {error}"))
+    })?;
+    let outcome = match required_text(row, "outcome", context)?.as_str() {
+        "success" => EventOutcome::Success,
+        "denied" => EventOutcome::Denied,
+        "error" => EventOutcome::Error,
+        other => {
+            return Err(RuntimeError::Internal(format!(
+                "{context} returned invalid outcome {other:?}"
+            )))
+        }
+    };
+    let payload_schema_version =
+        u32::try_from(required_i64(row, "payload_schema_version", context)?).map_err(|_| {
+            RuntimeError::Internal(format!("{context} returned invalid payload version"))
+        })?;
+    Ok(Event {
+        id: required_uuid(row, "id", context)?,
+        namespace: required_text(row, "namespace", context)?,
+        verb: required_text(row, "verb", context)?,
+        substrate,
+        actor: required_text(row, "actor", context)?,
+        kind,
+        outcome,
+        payload,
+        payload_schema_version,
+        profile_state_version: optional_nonnegative_u64(row, "profile_state_version", context)?,
+        duration_us: required_i64(row, "duration_us", context)?,
+        target_id: optional_uuid(row, "target_id", context)?,
+        session_id: optional_uuid(row, "session_id", context)?,
+        aggregate_kind: optional_text(row, "aggregate_kind", context)?,
+        aggregate_id: optional_uuid(row, "aggregate_id", context)?,
+        created_at: required_i64(row, "created_at", context)?,
+    })
+}
+
+async fn load_exact_model_event(
+    sql: &dyn SqlAccess,
+    model: &LegacyPreferenceModelRow,
+) -> Result<Event, RuntimeError> {
+    let event_id = model_event_id(model.model_id, &model.bundle_ref);
+    let mut reader = sql.reader().await?;
+    let row = reader
+        .query_row(SqlStatement {
+            sql: "SELECT id, namespace, verb, substrate, actor, kind, outcome, payload, \
+                         payload_schema_version, profile_state_version, duration_us, target_id, \
+                         session_id, aggregate_kind, aggregate_id, created_at \
+                  FROM events WHERE namespace = ?1 AND id = ?2"
+                .to_string(),
+            params: vec![
+                SqlValue::Text(model.namespace.clone()),
+                SqlValue::Text(event_id.to_string()),
+            ],
+            label: Some("moodboard_legacy_model_event".to_string()),
+        })
+        .await?
+        .ok_or_else(|| {
+            RuntimeError::InvalidInput(format!(
+                "moodboard preference model {} has no exact immutable pack provenance event",
+                model.model_id
+            ))
+        })?;
+    parse_event_row(&row, model.model_id)
+}
+
+/// Authenticate legacy model bundles and networks without loading or selecting the pack.
+///
+/// This boot-only path performs read-only SQL through [`SqlAccess`] and all object reads
+/// through the already shared [`BlobHydrator`]. It never constructs an `EventStore`, runtime
+/// store, or SQL writer task.
+pub async fn verify_legacy_preference_attachments(
+    sql: &dyn SqlAccess,
+    hydrator: &BlobHydrator,
+) -> Result<Vec<VerifiedModelNetworkAttachment>, RuntimeError> {
+    let mut verified_rows = Vec::new();
+    let mut offset = 0_u64;
+    loop {
+        let mut reader = sql.reader().await?;
+        let rows = reader
+            .query_page(
+                SqlStatement {
+                    sql: "SELECT e.id, e.namespace, e.content_ref AS legacy_content_ref, \
+                                 content.content_ref AS content_attachment_ref, \
+                                 fann.content_ref AS fann_attachment_ref \
+                          FROM entities e \
+                          LEFT JOIN attachments content ON content.record_uuid = e.id \
+                            AND content.substrate = 'entity' AND content.role = 'content' \
+                          LEFT JOIN attachments fann ON fann.record_uuid = e.id \
+                            AND fann.substrate = 'entity' AND fann.role = 'fann-network' \
+                          WHERE e.kind = 'artifact' AND e.entity_type = 'moodboard_model' \
+                            AND e.content_ref IS NOT NULL \
+                          ORDER BY e.namespace, e.id"
+                        .to_string(),
+                    params: vec![],
+                    label: Some("moodboard_legacy_preference_models".to_string()),
+                },
+                PageRequest {
+                    offset,
+                    limit: LEGACY_MODEL_PAGE_SIZE,
+                },
+            )
+            .await?;
+        drop(reader);
+        if rows.is_empty() {
+            break;
+        }
+        let row_count = rows.len();
+        for row in rows {
+            let model = parse_legacy_model_row(&row)?;
+            let event = load_exact_model_event(sql, &model).await?;
+            let bundle_blob = hydrator
+                .hydrate_verified(&model.bundle_ref, MAX_MODEL_BLOB_BYTES)
+                .await?;
+            let evidence = verify_preference_bundle_evidence(
+                model.model_id,
+                &model.namespace,
+                &model.bundle_ref,
+                bundle_blob.bytes(),
+                &event,
+            )?;
+            drop(bundle_blob);
+            if model
+                .fann_attachment_ref
+                .as_ref()
+                .is_some_and(|attached| attached != &evidence.network_ref)
+            {
+                return Err(RuntimeError::InvalidInput(format!(
+                    "moodboard preference model {} fann-network attachment disagrees with its authenticated bundle",
+                    model.model_id
+                )));
+            }
+            let network_blob = hydrator
+                .hydrate_verified(&evidence.network_ref, MAX_MODEL_BLOB_BYTES)
+                .await?;
+            let size_bytes = u64::try_from(network_blob.bytes().len()).map_err(|_| {
+                RuntimeError::Internal(format!(
+                    "moodboard preference model {} network size exceeds u64",
+                    model.model_id
+                ))
+            })?;
+            let _network = verify_preference_network(&evidence, network_blob.bytes())?;
+            drop(network_blob);
+            verified_rows.push(VerifiedModelNetworkAttachment {
+                model_id: model.model_id,
+                network_content_ref: evidence.network_ref,
+                size_bytes,
+            });
+        }
+        offset = offset.checked_add(row_count as u64).ok_or_else(|| {
+            RuntimeError::Internal("moodboard legacy model scan offset overflow".to_string())
+        })?;
+        if row_count < LEGACY_MODEL_PAGE_SIZE as usize {
+            break;
+        }
+    }
+    Ok(verified_rows)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::any::Any;
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use base64::Engine as _;
+    use khive_db::stores::blob::FsBlobStore;
+    use khive_runtime::BlobHydrator;
+    use khive_storage::blob::ContentRef;
+    use khive_storage::event::Event;
+    use khive_storage::types::{
+        PageRequest, SqlColumn, SqlRow, SqlStatement, SqlValue, StorageResult,
+    };
+    use khive_storage::{AtomicUnitOp, BlobStore, SqlAccess, SqlReader, SqlWriter};
+    use khive_types::{EventKind, SubstrateKind};
+    use uuid::Uuid;
+
+    use crate::preference::{
+        feature_schema_id, materialize_fann, sha256_hex, CalibrationProvenance, FannProvenance,
+        ModelBundle, OptimizerProvenance, PreferenceScope, SplitCounts, TestMetrics,
+        TrainingProvenance, FANN_CRATE_VERSION, FANN_FORMAT, FEATURE_COUNT,
+        FEATURE_SCHEMA_CANONICAL_JSON, FEATURE_SCHEMA_VERSION, MODEL_BUNDLE_SCHEMA_VERSION,
+        MODEL_FAMILY, OPTIMIZER_BACKTRACKING_IDENTITY, PAIR_SPLIT_REVISION, TIE_BAND_RULE_IDENTITY,
+        TRAINING_REVISION,
+    };
+
+    use super::{
+        legacy_preference_model_count, model_event_id, verify_legacy_preference_attachments,
+        verify_preference_bundle_evidence, verify_preference_network,
+    };
+
+    struct ArtifactFixture {
+        model_id: Uuid,
+        bundle_ref: ContentRef,
+        bundle_bytes: Vec<u8>,
+        network_bytes: Vec<u8>,
+        event: Event,
+    }
+
+    fn artifact_fixture() -> ArtifactFixture {
+        let model_id = Uuid::from_u128(42);
+        let scope = PreferenceScope {
+            namespace: "local".to_string(),
+            actor_kind: "actor".to_string(),
+            actor_id: "alice".to_string(),
+            board_entity_id: Uuid::from_u128(7),
+            board_id: "a".repeat(64),
+            model_key: "fixture_visual_model".to_string(),
+            descriptor_fingerprint: "b".repeat(64),
+            feature_schema_id: feature_schema_id().to_string(),
+        };
+        let (_, network_bytes) = materialize_fann(&[0.25; FEATURE_COUNT]).unwrap();
+        let network_ref = ContentRef::from_digest_bytes(blake3::hash(&network_bytes).as_bytes());
+        let split_counts = BTreeMap::from([
+            (
+                "train".to_string(),
+                SplitCounts {
+                    decisive_groups: 64,
+                    decisive_judgments: 64,
+                    left_labels: 32,
+                    right_labels: 32,
+                    ..Default::default()
+                },
+            ),
+            (
+                "calibration".to_string(),
+                SplitCounts {
+                    decisive_groups: 16,
+                    decisive_judgments: 16,
+                    left_labels: 8,
+                    right_labels: 8,
+                    tie_groups: 16,
+                    tie_judgments: 16,
+                    ..Default::default()
+                },
+            ),
+            (
+                "test".to_string(),
+                SplitCounts {
+                    decisive_groups: 16,
+                    decisive_judgments: 16,
+                    left_labels: 8,
+                    right_labels: 8,
+                    ..Default::default()
+                },
+            ),
+        ]);
+        let bundle = ModelBundle {
+            schema_version: MODEL_BUNDLE_SCHEMA_VERSION.to_string(),
+            model_family: MODEL_FAMILY.to_string(),
+            scope: scope.clone(),
+            feature_schema_version: FEATURE_SCHEMA_VERSION.to_string(),
+            feature_schema_canonical_json_base64: base64::engine::general_purpose::STANDARD
+                .encode(FEATURE_SCHEMA_CANONICAL_JSON),
+            training: TrainingProvenance {
+                snapshot_sha256: "c".repeat(64),
+                snapshot_event_count: 112,
+                excluded_probability_shown: 0,
+                split_revision: PAIR_SPLIT_REVISION.to_string(),
+                split_counts,
+                optimizer: OptimizerProvenance {
+                    revision: TRAINING_REVISION.to_string(),
+                    loss: "weighted_binary_cross_entropy".to_string(),
+                    precision: "float64".to_string(),
+                    intercept: "fixed_zero".to_string(),
+                    l2: 1.0e-2,
+                    max_iterations: 2_048,
+                    iterations: 12,
+                    converged: true,
+                    final_objective: 0.5,
+                    gradient_infinity_norm: 1.0e-9,
+                    seed: 0,
+                    backtracking: OPTIMIZER_BACKTRACKING_IDENTITY.to_string(),
+                },
+            },
+            calibration: CalibrationProvenance {
+                calibrated: true,
+                temperature: 1.25,
+                log_temperature_bounds: [-4.0, 4.0],
+                temperature_search_iterations: 128,
+                tie_band_half_width: 0.05,
+                tie_band_rule: TIE_BAND_RULE_IDENTITY.to_string(),
+                tie_balanced_error: 0.25,
+            },
+            test_metrics: TestMetrics {
+                decisive_groups: 16,
+                decisive_judgments: 16,
+                log_loss: 0.5,
+                brier: 0.2,
+                accuracy: 0.75,
+                tie_groups: 0,
+                tie_detection_rate: None,
+            },
+            fann: FannProvenance {
+                crate_name: "lattice-fann".to_string(),
+                crate_version: FANN_CRATE_VERSION.to_string(),
+                format: FANN_FORMAT.to_string(),
+                architecture: format!("{FEATURE_COUNT}->1 linear; zero intercept"),
+                network_content_ref: network_ref.to_string(),
+                network_sha256: sha256_hex(&network_bytes),
+            },
+        };
+        let bundle_bytes = serde_json::to_vec(&bundle).unwrap();
+        let bundle_ref = ContentRef::from_digest_bytes(blake3::hash(&bundle_bytes).as_bytes());
+        let bundle_sha256 = sha256_hex(&bundle_bytes);
+        let payload = serde_json::json!({
+            "schema_version": MODEL_BUNDLE_SCHEMA_VERSION,
+            "preference_model_id": model_id,
+            "model_content_ref": bundle_ref,
+            "model_fingerprint": bundle_sha256,
+            "network_content_ref": network_ref,
+            "network_sha256": bundle.fann.network_sha256,
+            "scope": scope,
+        });
+        let mut event = Event::new(
+            "local",
+            "moodboard.model_record",
+            EventKind::Audit,
+            SubstrateKind::Entity,
+            "actor:alice",
+        )
+        .with_target(model_id)
+        .with_aggregate("moodboard_model", model_id)
+        .with_payload(payload)
+        .with_payload_schema_version(1);
+        event.id = model_event_id(model_id, &bundle_ref);
+        ArtifactFixture {
+            model_id,
+            bundle_ref,
+            bundle_bytes,
+            network_bytes,
+            event,
+        }
+    }
+
+    #[derive(Clone)]
+    struct ReadOnlyLegacySql {
+        model_row: SqlRow,
+        event_row: SqlRow,
+    }
+
+    struct LegacyReader(ReadOnlyLegacySql);
+
+    fn column(name: &str, value: SqlValue) -> SqlColumn {
+        SqlColumn {
+            name: name.to_string(),
+            value,
+        }
+    }
+
+    fn legacy_model_row(
+        fixture: &ArtifactFixture,
+        fann_attachment_ref: Option<&ContentRef>,
+    ) -> SqlRow {
+        SqlRow {
+            columns: vec![
+                column("id", SqlValue::Text(fixture.model_id.to_string())),
+                column("namespace", SqlValue::Text("local".to_string())),
+                column(
+                    "legacy_content_ref",
+                    SqlValue::Text(fixture.bundle_ref.to_string()),
+                ),
+                column(
+                    "content_attachment_ref",
+                    SqlValue::Text(fixture.bundle_ref.to_string()),
+                ),
+                column(
+                    "fann_attachment_ref",
+                    fann_attachment_ref
+                        .map(|content_ref| SqlValue::Text(content_ref.to_string()))
+                        .unwrap_or(SqlValue::Null),
+                ),
+            ],
+        }
+    }
+
+    fn event_row(event: &Event) -> SqlRow {
+        SqlRow {
+            columns: vec![
+                column("id", SqlValue::Text(event.id.to_string())),
+                column("namespace", SqlValue::Text(event.namespace.clone())),
+                column("verb", SqlValue::Text(event.verb.clone())),
+                column("substrate", SqlValue::Text(event.substrate.to_string())),
+                column("actor", SqlValue::Text(event.actor.clone())),
+                column("kind", SqlValue::Text(event.kind.to_string())),
+                column("outcome", SqlValue::Text(event.outcome.to_string())),
+                column("payload", SqlValue::Json(event.payload.clone())),
+                column(
+                    "payload_schema_version",
+                    SqlValue::Integer(i64::from(event.payload_schema_version)),
+                ),
+                column("profile_state_version", SqlValue::Null),
+                column("duration_us", SqlValue::Integer(event.duration_us)),
+                column(
+                    "target_id",
+                    event
+                        .target_id
+                        .map(SqlValue::Uuid)
+                        .unwrap_or(SqlValue::Null),
+                ),
+                column("session_id", SqlValue::Null),
+                column(
+                    "aggregate_kind",
+                    event
+                        .aggregate_kind
+                        .clone()
+                        .map(SqlValue::Text)
+                        .unwrap_or(SqlValue::Null),
+                ),
+                column(
+                    "aggregate_id",
+                    event
+                        .aggregate_id
+                        .map(SqlValue::Uuid)
+                        .unwrap_or(SqlValue::Null),
+                ),
+                column("created_at", SqlValue::Integer(event.created_at)),
+            ],
+        }
+    }
+
+    #[async_trait]
+    impl SqlReader for LegacyReader {
+        async fn query_row(&mut self, statement: SqlStatement) -> StorageResult<Option<SqlRow>> {
+            assert_eq!(
+                statement.label.as_deref(),
+                Some("moodboard_legacy_model_event")
+            );
+            Ok(Some(self.0.event_row.clone()))
+        }
+
+        async fn query_all(&mut self, statement: SqlStatement) -> StorageResult<Vec<SqlRow>> {
+            assert_eq!(
+                statement.label.as_deref(),
+                Some("moodboard_legacy_preference_models")
+            );
+            assert!(
+                !statement.sql.contains("deleted_at IS NULL"),
+                "soft-deleted recoverable models must be scanned"
+            );
+            Ok(vec![self.0.model_row.clone()])
+        }
+
+        async fn query_page(
+            &mut self,
+            statement: SqlStatement,
+            page: PageRequest,
+        ) -> StorageResult<Vec<SqlRow>> {
+            let rows = self.query_all(statement).await?;
+            Ok(rows
+                .into_iter()
+                .skip(page.offset as usize)
+                .take(page.limit as usize)
+                .collect())
+        }
+
+        async fn query_scalar(
+            &mut self,
+            statement: SqlStatement,
+        ) -> StorageResult<Option<SqlValue>> {
+            assert_eq!(
+                statement.label.as_deref(),
+                Some("moodboard_legacy_preference_model_count")
+            );
+            assert!(!statement.sql.contains("deleted_at IS NULL"));
+            Ok(Some(SqlValue::Integer(1)))
+        }
+
+        async fn explain(&mut self, _statement: SqlStatement) -> StorageResult<Vec<SqlRow>> {
+            Ok(Vec::new())
+        }
+    }
+
+    #[async_trait]
+    impl SqlAccess for ReadOnlyLegacySql {
+        async fn reader(&self) -> StorageResult<Box<dyn SqlReader>> {
+            Ok(Box::new(LegacyReader(self.clone())))
+        }
+
+        async fn writer(&self) -> StorageResult<Box<dyn SqlWriter>> {
+            panic!("boot verifier must never acquire a SQL writer")
+        }
+
+        async fn atomic_unit(&self, _op: AtomicUnitOp) -> StorageResult<Box<dyn Any + Send>> {
+            panic!("boot verifier must never enter a SQL write transaction")
+        }
+    }
+
+    #[test]
+    fn model_event_identity_preserves_the_adr_149_golden() {
+        let model_id = Uuid::parse_str("11111111-2222-4333-8444-555555555555").unwrap();
+        let bundle_ref = ContentRef::from_hex("ab".repeat(32)).unwrap();
+
+        assert_eq!(
+            model_event_id(model_id, &bundle_ref),
+            Uuid::parse_str("b5b8f223-6cab-5738-9b81-6488c2e3722b").unwrap()
+        );
+    }
+
+    #[test]
+    fn bundle_verifier_authenticates_event_and_derives_actor_from_scope() {
+        let fixture = artifact_fixture();
+
+        let verified = verify_preference_bundle_evidence(
+            fixture.model_id,
+            "local",
+            &fixture.bundle_ref,
+            &fixture.bundle_bytes,
+            &fixture.event,
+        )
+        .expect("matching immutable evidence");
+
+        assert_eq!(verified.bundle.scope.actor_id, "alice");
+        assert_eq!(
+            verified.network_ref.as_str(),
+            verified.bundle.fann.network_content_ref
+        );
+    }
+
+    #[test]
+    fn bundle_verifier_rejects_a_current_actor_instead_of_the_recorded_scope_actor() {
+        let mut fixture = artifact_fixture();
+        fixture.event.actor = "actor:bob".to_string();
+
+        let error = verify_preference_bundle_evidence(
+            fixture.model_id,
+            "local",
+            &fixture.bundle_ref,
+            &fixture.bundle_bytes,
+            &fixture.event,
+        )
+        .expect_err("event actor must derive from immutable bundle scope");
+
+        assert!(error.to_string().contains("immutable pack provenance"));
+    }
+
+    #[test]
+    fn bundle_verifier_rejects_noncanonical_event_envelope_metadata() {
+        let mut fixture = artifact_fixture();
+        fixture.event.session_id = Some(Uuid::from_u128(99));
+
+        let error = verify_preference_bundle_evidence(
+            fixture.model_id,
+            "local",
+            &fixture.bundle_ref,
+            &fixture.bundle_bytes,
+            &fixture.event,
+        )
+        .expect_err("the immutable model event envelope must be exact");
+
+        assert!(error.to_string().contains("immutable pack provenance"));
+    }
+
+    #[test]
+    fn bundle_verifier_rejects_entity_namespace_mismatch() {
+        let fixture = artifact_fixture();
+
+        let error = verify_preference_bundle_evidence(
+            fixture.model_id,
+            "foreign",
+            &fixture.bundle_ref,
+            &fixture.bundle_bytes,
+            &fixture.event,
+        )
+        .expect_err("bundle scope cannot cross entity namespaces");
+
+        assert!(error.to_string().contains("namespace"));
+    }
+
+    #[test]
+    fn network_verifier_rejects_corrupt_governed_bytes() {
+        let fixture = artifact_fixture();
+        let verified = verify_preference_bundle_evidence(
+            fixture.model_id,
+            "local",
+            &fixture.bundle_ref,
+            &fixture.bundle_bytes,
+            &fixture.event,
+        )
+        .unwrap();
+        let mut corrupt = fixture.network_bytes;
+        corrupt[0] ^= 0xff;
+
+        let error = verify_preference_network(&verified, &corrupt)
+            .expect_err("governed network SHA must fail before FANN use");
+
+        assert!(error.to_string().contains("SHA-256"));
+    }
+
+    #[tokio::test]
+    async fn boot_verifier_is_pack_selection_independent_and_includes_soft_deleted_models() {
+        let fixture = artifact_fixture();
+        let temp = tempfile::tempdir().unwrap();
+        let store = Arc::new(FsBlobStore::new(temp.path().to_path_buf(), 0).unwrap());
+        assert_eq!(
+            store.put(fixture.bundle_bytes.clone()).await.unwrap(),
+            fixture.bundle_ref
+        );
+        let network_ref = store.put(fixture.network_bytes.clone()).await.unwrap();
+        let hydrator = BlobHydrator::new(store, 64 * 1024 * 1024).unwrap();
+        let sql = ReadOnlyLegacySql {
+            model_row: legacy_model_row(&fixture, None),
+            event_row: event_row(&fixture.event),
+        };
+
+        assert_eq!(legacy_preference_model_count(&sql).await.unwrap(), 1);
+        let verified = verify_legacy_preference_attachments(&sql, &hydrator)
+            .await
+            .unwrap();
+
+        assert_eq!(verified.len(), 1);
+        assert_eq!(verified[0].model_id, fixture.model_id);
+        assert_eq!(verified[0].network_content_ref, network_ref);
+        assert_eq!(verified[0].size_bytes, fixture.network_bytes.len() as u64);
+    }
+
+    #[tokio::test]
+    async fn boot_verifier_rejects_a_preexisting_fann_role_disagreement() {
+        let fixture = artifact_fixture();
+        let temp = tempfile::tempdir().unwrap();
+        let store = Arc::new(FsBlobStore::new(temp.path().to_path_buf(), 0).unwrap());
+        store.put(fixture.bundle_bytes.clone()).await.unwrap();
+        store.put(fixture.network_bytes.clone()).await.unwrap();
+        let hydrator = BlobHydrator::new(store, 64 * 1024 * 1024).unwrap();
+        let wrong_ref = ContentRef::from_hex("f".repeat(64)).unwrap();
+        let sql = ReadOnlyLegacySql {
+            model_row: legacy_model_row(&fixture, Some(&wrong_ref)),
+            event_row: event_row(&fixture.event),
+        };
+
+        let error = verify_legacy_preference_attachments(&sql, &hydrator)
+            .await
+            .expect_err("migration must never overwrite contradictory role evidence");
+
+        assert!(error
+            .to_string()
+            .contains("fann-network attachment disagrees"));
+    }
+
+    #[tokio::test]
+    async fn boot_verifier_rejects_corrupt_immutable_event_evidence() {
+        let mut fixture = artifact_fixture();
+        fixture.event.payload["network_sha256"] = serde_json::Value::String("0".repeat(64));
+        let temp = tempfile::tempdir().unwrap();
+        let store = Arc::new(FsBlobStore::new(temp.path().to_path_buf(), 0).unwrap());
+        store.put(fixture.bundle_bytes.clone()).await.unwrap();
+        store.put(fixture.network_bytes.clone()).await.unwrap();
+        let hydrator = BlobHydrator::new(store, 64 * 1024 * 1024).unwrap();
+        let sql = ReadOnlyLegacySql {
+            model_row: legacy_model_row(&fixture, None),
+            event_row: event_row(&fixture.event),
+        };
+
+        let error = verify_legacy_preference_attachments(&sql, &hydrator)
+            .await
+            .expect_err("migration must authenticate the raw immutable event");
+
+        assert!(error.to_string().contains("immutable pack provenance"));
+    }
+}

--- a/crates/khive-pack-moodboard/src/preference_handlers.rs
+++ b/crates/khive-pack-moodboard/src/preference_handlers.rs
@@ -14,17 +14,21 @@ use khive_runtime::{
 use khive_storage::blob::ContentRef;
 use khive_storage::event::{Event, EventFilter};
 use khive_storage::types::{PageRequest, SqlStatement, SqlValue};
-use khive_storage::{BlobStore, Entity};
+use khive_storage::{AttachmentSubstrate, BlobStore, Entity, NewAttachment};
 use khive_types::{EdgeRelation, EventKind, EventOutcome, SubstrateKind};
 
 use crate::preference::{
-    deserialize_fann, feature_schema_id, feature_schema_response, is_lower_hex_64, predict,
-    prepare_training_data, sha256_hex, train_model, validate_features, validate_loaded_bundle,
-    validate_reason_code, JudgmentChoice, JudgmentRecord, ModelBundle, PreferenceScope,
-    PresentationProvenance, RandomizationProvenance, ReasonCode, ResultOccurrence,
-    SelectionProvenance, ServeRecord, TrainedModel, FEATURE_COUNT, FEATURE_SCHEMA_VERSION,
-    JUDGMENT_SCHEMA_VERSION, MAX_TRAINING_EVENTS, MODEL_BUNDLE_SCHEMA_VERSION,
-    PREFERENCE_RESPONSE_SCHEMA_VERSION, RANDOMIZATION_REVISION, SERVE_SCHEMA_VERSION,
+    feature_schema_id, feature_schema_response, is_lower_hex_64, predict, prepare_training_data,
+    sha256_hex, train_model, validate_features, validate_loaded_bundle, validate_reason_code,
+    JudgmentChoice, JudgmentRecord, ModelBundle, PreferenceScope, PresentationProvenance,
+    RandomizationProvenance, ReasonCode, ResultOccurrence, SelectionProvenance, ServeRecord,
+    TrainedModel, FEATURE_COUNT, FEATURE_SCHEMA_VERSION, JUDGMENT_SCHEMA_VERSION,
+    MAX_TRAINING_EVENTS, MODEL_BUNDLE_SCHEMA_VERSION, PREFERENCE_RESPONSE_SCHEMA_VERSION,
+    RANDOMIZATION_REVISION, SERVE_SCHEMA_VERSION,
+};
+use crate::preference_artifact::{
+    model_event_id, validate_model_event_evidence, verify_preference_bundle_evidence,
+    verify_preference_network,
 };
 use crate::MoodboardPack;
 
@@ -36,7 +40,6 @@ const MAX_RESPONSE_MS: u64 = 3_600_000;
 // These UUIDv5 namespaces and their name framing are persistent wire identity.
 // ADR-149 freezes both values; golden tests below prevent accidental drift.
 const JUDGMENT_UUID_NAMESPACE: Uuid = Uuid::from_u128(0x8fc4_55de_533c_5d1d_9228_09b8_1ef1_8e33);
-const MODEL_EVENT_UUID_NAMESPACE: Uuid = Uuid::from_u128(0x1dc2_337e_b200_5bd1_824f_2653_1164_5c16);
 static JUDGMENT_LOCKS: [Mutex<()>; 256] = [const { Mutex::const_new(()) }; 256];
 static MODEL_LOCKS: [Mutex<()>; 256] = [const { Mutex::const_new(()) }; 256];
 const TRAIN_CONCURRENCY: usize = 1;
@@ -396,6 +399,12 @@ pub(crate) async fn handle_train_preference(
             "serialize moodboard preference model bundle: {error}"
         ))
     })?;
+    let bundle_size = u64::try_from(bundle_bytes.len()).map_err(|_| {
+        RuntimeError::Internal("moodboard preference bundle size exceeds u64".to_string())
+    })?;
+    let network_size = u64::try_from(trained.network_bytes.len()).map_err(|_| {
+        RuntimeError::Internal("moodboard preference network size exceeds u64".to_string())
+    })?;
     let bundle_sha256 = sha256_hex(&bundle_bytes);
     let bundle_content_ref = blob_store.put(bundle_bytes).await?;
 
@@ -408,6 +417,9 @@ pub(crate) async fn handle_train_preference(
         &trained.bundle,
         &bundle_content_ref,
         &bundle_sha256,
+        bundle_size,
+        &network_content_ref,
+        network_size,
     )
     .await?;
     core.link(
@@ -429,7 +441,7 @@ pub(crate) async fn handle_train_preference(
         &scope,
         &bundle_content_ref,
         &bundle_sha256,
-        &trained.bundle.fann.network_content_ref,
+        &network_content_ref,
         &trained.bundle.fann.network_sha256,
     )
     .await?;
@@ -1210,9 +1222,12 @@ async fn find_model_by_content_ref(
     let mut reader = runtime.sql().reader().await?;
     let row = reader
         .query_row(SqlStatement {
-            sql: "SELECT id FROM entities WHERE namespace = ?1 AND kind = 'artifact' \
-                  AND entity_type = 'moodboard_model' AND content_ref = ?2 \
-                  AND deleted_at IS NULL ORDER BY created_at, id LIMIT 1"
+            sql: "SELECT e.id FROM entities e \
+                  JOIN attachments a ON a.record_uuid = e.id \
+                    AND a.substrate = 'entity' AND a.role = 'content' \
+                  WHERE e.namespace = ?1 AND e.kind = 'artifact' \
+                  AND e.entity_type = 'moodboard_model' AND a.content_ref = ?2 \
+                  AND e.deleted_at IS NULL ORDER BY e.created_at, e.id LIMIT 1"
                 .to_string(),
             params: vec![
                 SqlValue::Text(token.namespace().as_str().to_string()),
@@ -1247,8 +1262,29 @@ async fn find_or_create_model(
     bundle: &ModelBundle,
     bundle_content_ref: &ContentRef,
     bundle_sha256: &str,
+    bundle_size: u64,
+    network_content_ref: &ContentRef,
+    network_size: u64,
 ) -> Result<(Entity, bool), RuntimeError> {
     if let Some(existing) = find_model_by_content_ref(runtime, token, bundle_content_ref).await? {
+        let attachment = runtime
+            .attachments()?
+            .get_attachment(existing.id, "fann-network")
+            .await?
+            .ok_or_else(|| {
+                RuntimeError::InvalidInput(format!(
+                    "moodboard preference model {} has no fann-network attachment",
+                    existing.id
+                ))
+            })?;
+        if attachment.substrate != AttachmentSubstrate::Entity
+            || attachment.content_ref != *network_content_ref
+        {
+            return Err(RuntimeError::InvalidInput(format!(
+                "moodboard preference model {} fann-network attachment disagrees with its authenticated bundle",
+                existing.id
+            )));
+        }
         return Ok((existing, false));
     }
     let properties = json!({
@@ -1267,7 +1303,7 @@ async fn find_or_create_model(
         "network_sha256": bundle.fann.network_sha256,
     });
     let model = runtime
-        .create_entity_with_content_ref(
+        .create_entity_with_attachments(
             token,
             "artifact",
             Some("moodboard_model"),
@@ -1279,18 +1315,23 @@ async fn find_or_create_model(
                 "preference_model".to_string(),
                 "experimental".to_string(),
             ],
-            bundle_content_ref,
+            vec![
+                NewAttachment {
+                    role: "content".to_string(),
+                    content_ref: bundle_content_ref.clone(),
+                    media_type: Some("application/json".to_string()),
+                    size_bytes: Some(bundle_size),
+                },
+                NewAttachment {
+                    role: "fann-network".to_string(),
+                    content_ref: network_content_ref.clone(),
+                    media_type: Some("application/octet-stream".to_string()),
+                    size_bytes: Some(network_size),
+                },
+            ],
         )
         .await?;
     Ok((model, true))
-}
-
-fn model_event_id(model_id: Uuid, bundle_content_ref: &ContentRef) -> Uuid {
-    let mut name = Vec::with_capacity(16 + 1 + 64);
-    name.extend_from_slice(model_id.as_bytes());
-    name.push(0);
-    name.extend_from_slice(bundle_content_ref.as_str().as_bytes());
-    Uuid::new_v5(&MODEL_EVENT_UUID_NAMESPACE, &name)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1301,7 +1342,7 @@ async fn ensure_model_event(
     scope: &PreferenceScope,
     bundle_content_ref: &ContentRef,
     bundle_sha256: &str,
-    network_content_ref: &str,
+    network_content_ref: &ContentRef,
     network_sha256: &str,
 ) -> Result<(), RuntimeError> {
     let event_id = model_event_id(model.id, bundle_content_ref);
@@ -1316,9 +1357,9 @@ async fn ensure_model_event(
     });
     let store = runtime.events(token)?;
     if let Some(existing) = store.get_event(event_id).await? {
-        return validate_model_event(
+        return validate_model_event_evidence(
             &existing,
-            token,
+            &model.namespace,
             model.id,
             scope,
             bundle_content_ref,
@@ -1342,9 +1383,9 @@ async fn ensure_model_event(
     match store.append_event(event).await {
         Ok(()) => Ok(()),
         Err(first_error) => match store.get_event(event_id).await? {
-            Some(existing) => validate_model_event(
+            Some(existing) => validate_model_event_evidence(
                 &existing,
-                token,
+                &model.namespace,
                 model.id,
                 scope,
                 bundle_content_ref,
@@ -1355,44 +1396,6 @@ async fn ensure_model_event(
             None => Err(first_error.into()),
         },
     }
-}
-
-#[allow(clippy::too_many_arguments)]
-fn validate_model_event(
-    event: &Event,
-    token: &NamespaceToken,
-    model_id: Uuid,
-    scope: &PreferenceScope,
-    bundle_content_ref: &ContentRef,
-    bundle_sha256: &str,
-    network_content_ref: &str,
-    network_sha256: &str,
-) -> Result<(), RuntimeError> {
-    let expected = json!({
-        "schema_version": MODEL_BUNDLE_SCHEMA_VERSION,
-        "preference_model_id": model_id,
-        "model_content_ref": bundle_content_ref,
-        "model_fingerprint": bundle_sha256,
-        "network_content_ref": network_content_ref,
-        "network_sha256": network_sha256,
-        "scope": scope,
-    });
-    if event.id != model_event_id(model_id, bundle_content_ref)
-        || !has_success_entity_envelope(event, token)
-        || event.verb != MODEL_RECORD_VERB
-        || event.kind != EventKind::Audit
-        || event.actor != actor_label(token)
-        || event.target_id != Some(model_id)
-        || event.aggregate_kind.as_deref() != Some("moodboard_model")
-        || event.aggregate_id != Some(model_id)
-        || event.payload_schema_version != 1
-        || event.payload != expected
-    {
-        return Err(RuntimeError::InvalidInput(format!(
-            "moodboard preference model {model_id} lacks matching immutable pack provenance"
-        )));
-    }
-    Ok(())
 }
 
 async fn load_preference_model(
@@ -1413,38 +1416,6 @@ async fn load_preference_model(
         ))
     })?;
     let bundle_content_ref = parse_content_ref(raw_ref, "moodboard model content_ref")?;
-    let hydrator = require_blob_hydrator(runtime)?;
-    let bundle_blob = hydrator
-        .hydrate_verified(&bundle_content_ref, MAX_MODEL_BLOB_BYTES)
-        .await?;
-    let bundle_sha256 = sha256_hex(bundle_blob.bytes());
-    let bundle: ModelBundle = serde_json::from_slice(bundle_blob.bytes()).map_err(|error| {
-        RuntimeError::InvalidInput(format!(
-            "moodboard preference model {model_id} bundle is corrupt: {error}"
-        ))
-    })?;
-    validate_loaded_bundle(&bundle)?;
-    if &bundle.scope != expected_scope {
-        return Err(RuntimeError::InvalidInput(format!(
-            "moodboard preference model {model_id} has the wrong board, actor, descriptor, or feature-schema scope"
-        )));
-    }
-    validate_entity_model_properties(&entity, &bundle, &bundle_sha256)?;
-    let network_content_ref = parse_content_ref(
-        &bundle.fann.network_content_ref,
-        "moodboard model network_content_ref",
-    )?;
-    drop(bundle_blob);
-    let network_blob = hydrator
-        .hydrate_verified(&network_content_ref, MAX_MODEL_BLOB_BYTES)
-        .await?;
-    if sha256_hex(network_blob.bytes()) != bundle.fann.network_sha256 {
-        return Err(RuntimeError::InvalidInput(format!(
-            "moodboard preference model {model_id} FANN SHA-256 does not match its bundle"
-        )));
-    }
-    let network = deserialize_fann(network_blob.bytes())?;
-    drop(network_blob);
     let event_id = model_event_id(model_id, &bundle_content_ref);
     let event = runtime
         .events(token)?
@@ -1455,21 +1426,52 @@ async fn load_preference_model(
                 "moodboard preference model {model_id} has no immutable pack provenance event"
             ))
         })?;
-    validate_model_event(
-        &event,
-        token,
+    let hydrator = require_blob_hydrator(runtime)?;
+    let bundle_blob = hydrator
+        .hydrate_verified(&bundle_content_ref, MAX_MODEL_BLOB_BYTES)
+        .await?;
+    let verified = verify_preference_bundle_evidence(
         model_id,
-        &bundle.scope,
+        &entity.namespace,
         &bundle_content_ref,
-        &bundle_sha256,
-        &bundle.fann.network_content_ref,
-        &bundle.fann.network_sha256,
+        bundle_blob.bytes(),
+        &event,
     )?;
+    drop(bundle_blob);
+    let network_attachment = runtime
+        .attachments()?
+        .get_attachment(model_id, "fann-network")
+        .await?
+        .ok_or_else(|| {
+            RuntimeError::InvalidInput(format!(
+                "moodboard preference model {model_id} has no fann-network attachment"
+            ))
+        })?;
+    if network_attachment.record_uuid != model_id
+        || network_attachment.substrate != AttachmentSubstrate::Entity
+        || network_attachment.role != "fann-network"
+        || network_attachment.content_ref != verified.network_ref
+    {
+        return Err(RuntimeError::InvalidInput(format!(
+            "moodboard preference model {model_id} fann-network attachment disagrees with its authenticated bundle"
+        )));
+    }
+    let network_blob = hydrator
+        .hydrate_verified(&verified.network_ref, MAX_MODEL_BLOB_BYTES)
+        .await?;
+    let network = verify_preference_network(&verified, network_blob.bytes())?;
+    drop(network_blob);
+    if &verified.bundle.scope != expected_scope {
+        return Err(RuntimeError::InvalidInput(format!(
+            "moodboard preference model {model_id} has the wrong board, actor, descriptor, or feature-schema scope"
+        )));
+    }
+    validate_entity_model_properties(&entity, &verified.bundle, &verified.bundle_sha256)?;
     Ok(LoadedPreferenceModel {
         entity,
         bundle_content_ref,
-        bundle_sha256,
-        bundle,
+        bundle_sha256: verified.bundle_sha256,
+        bundle: verified.bundle,
         network,
     })
 }
@@ -1535,11 +1537,16 @@ mod tests {
     use std::collections::BTreeMap;
     use std::path::Path;
     use std::sync::{Arc, Mutex};
+    use std::time::Duration;
 
     use base64::engine::general_purpose::STANDARD as BASE64;
     use base64::Engine as _;
+    use khive_db::migrations::{AttachmentCutoverStatus, ATTACHMENT_CUTOVER_VERSION, MIGRATIONS};
+    use khive_db::stores::blob::acquire_database_gc_owner;
     use khive_db::stores::blob::FsBlobStore;
+    use khive_db::StorageBackend;
     use khive_runtime::{BackendId, Namespace, RuntimeConfig};
+    use khive_storage::Attachment;
 
     use super::*;
     use crate::preference::{
@@ -1591,8 +1598,8 @@ mod tests {
         }
     }
 
-    fn persistent_runtime(db_path: &Path, actor_id: &str) -> KhiveRuntime {
-        KhiveRuntime::new(RuntimeConfig {
+    fn persistent_runtime_config(db_path: &Path, actor_id: &str) -> RuntimeConfig {
+        RuntimeConfig {
             git_write: Default::default(),
             db_path: Some(db_path.to_path_buf()),
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
@@ -1606,8 +1613,46 @@ mod tests {
             visible_namespaces: vec![],
             allowed_outbound_namespaces: vec![],
             actor_id: Some(actor_id.to_string()),
-        })
-        .expect("persistent runtime")
+        }
+    }
+
+    fn persistent_runtime(db_path: &Path, actor_id: &str) -> KhiveRuntime {
+        KhiveRuntime::new(persistent_runtime_config(db_path, actor_id)).expect("persistent runtime")
+    }
+
+    fn canonical_v20_backend(db_path: &Path) -> Arc<StorageBackend> {
+        let backend = Arc::new(StorageBackend::sqlite(db_path).expect("V20 fixture backend"));
+        let mut writer = backend.pool().try_writer().expect("V20 fixture writer");
+        let conn = writer.conn_mut();
+        conn.execute_batch(
+            "CREATE TABLE _schema_migrations (\
+                 version INTEGER PRIMARY KEY, \
+                 name TEXT NOT NULL, \
+                 applied_at INTEGER NOT NULL\
+             ) STRICT;",
+        )
+        .expect("create V20 fixture migration ledger");
+        for migration in MIGRATIONS
+            .iter()
+            .filter(|migration| migration.version < ATTACHMENT_CUTOVER_VERSION)
+        {
+            let tx = conn.transaction().expect("begin V20 fixture migration");
+            tx.execute_batch(migration.up)
+                .unwrap_or_else(|error| panic!("apply V{}: {error}", migration.version));
+            tx.execute(
+                "INSERT INTO _schema_migrations (version, name, applied_at) \
+                 VALUES (?1, ?2, ?3)",
+                (
+                    migration.version,
+                    migration.name,
+                    i64::from(migration.version),
+                ),
+            )
+            .unwrap_or_else(|error| panic!("record V{}: {error}", migration.version));
+            tx.commit().expect("commit V20 fixture migration");
+        }
+        drop(writer);
+        backend
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1662,7 +1707,7 @@ mod tests {
             .await
             .unwrap();
         let asset = runtime
-            .create_entity_with_content_ref(
+            .create_entity_with_attachments(
                 &token,
                 "artifact",
                 Some("visual_asset"),
@@ -1670,7 +1715,12 @@ mod tests {
                 None,
                 None,
                 vec![],
-                &content_ref,
+                vec![NewAttachment {
+                    role: "content".to_string(),
+                    content_ref: content_ref.clone(),
+                    media_type: Some("image/png".to_string()),
+                    size_bytes: Some(32),
+                }],
             )
             .await
             .unwrap();
@@ -1885,7 +1935,9 @@ mod tests {
             descriptor_fingerprint: "b".repeat(64),
             feature_schema_id: feature_schema_id().to_string(),
         };
-        let (_, network_bytes) = materialize_fann(&[0.25; FEATURE_COUNT]).unwrap();
+        let (network, network_bytes) = materialize_fann(&[0.25; FEATURE_COUNT]).unwrap();
+        let (_, expected_probability) =
+            predict(&network, 1.25, &[0.9; FEATURE_COUNT], &[0.1; FEATURE_COUNT]).unwrap();
         let network_content_ref = blob_store.put(network_bytes.clone()).await.unwrap();
         let split_counts = BTreeMap::from([
             (
@@ -1977,6 +2029,7 @@ mod tests {
         };
         validate_loaded_bundle(&bundle).unwrap();
         let bundle_bytes = serde_json::to_vec(&bundle).unwrap();
+        let bundle_size = u64::try_from(bundle_bytes.len()).unwrap();
         let bundle_sha256 = sha256_hex(&bundle_bytes);
         let bundle_content_ref = blob_store.put(bundle_bytes).await.unwrap();
         let (entity, created) = find_or_create_model(
@@ -1986,6 +2039,9 @@ mod tests {
             &bundle,
             &bundle_content_ref,
             &bundle_sha256,
+            bundle_size,
+            &network_content_ref,
+            u64::try_from(network_bytes.len()).unwrap(),
         )
         .await
         .unwrap();
@@ -1997,7 +2053,7 @@ mod tests {
             &scope,
             &bundle_content_ref,
             &bundle_sha256,
-            &bundle.fann.network_content_ref,
+            &network_content_ref,
             &bundle.fann.network_sha256,
         )
         .await
@@ -2009,7 +2065,7 @@ mod tests {
 
         let restarted = persistent_runtime(&db_path, "alice");
         let recording_store = Arc::new(RecordingBoundedStore {
-            inner: Arc::new(FsBlobStore::new(blob_root, 0).unwrap()),
+            inner: Arc::new(FsBlobStore::new(blob_root.clone(), 0).unwrap()),
             calls: Mutex::new(Vec::new()),
         });
         restarted
@@ -2026,7 +2082,10 @@ mod tests {
             &[0.1; FEATURE_COUNT],
         )
         .unwrap();
-        assert!(probability > 0.5);
+        assert_eq!(
+            probability, expected_probability,
+            "attachment-backed restart must reconstruct the exact prior FANN prediction"
+        );
         assert_eq!(
             *recording_store.calls.lock().unwrap(),
             vec![
@@ -2036,11 +2095,185 @@ mod tests {
             "bundle and network must each enter shared bounded hydration at the 1 MiB pack cap"
         );
 
-        let mut wrong_scope = scope;
+        let mut wrong_scope = scope.clone();
         wrong_scope.board_id = "f".repeat(64);
         let error = load_preference_model(&restarted, &restarted_token, model_id, &wrong_scope)
             .await
             .expect_err("wrong identity must fail closed");
         assert!(error.to_string().contains("wrong board"));
+
+        let published_event = restarted
+            .events(&restarted_token)
+            .unwrap()
+            .get_event(model_event_id(model_id, &bundle_content_ref))
+            .await
+            .unwrap()
+            .expect("published model event");
+        let legacy_db_path = temp.path().join("legacy-v20.db");
+        let legacy_backend = canonical_v20_backend(&legacy_db_path);
+        {
+            let writer = legacy_backend
+                .pool()
+                .try_writer()
+                .expect("legacy fixture writer");
+            writer
+                .conn()
+                .execute(
+                    "INSERT INTO entities (\
+                         id, namespace, kind, entity_type, name, description, properties, tags, \
+                         created_at, updated_at, deleted_at, merged_into, merge_event_id, \
+                         content_ref\
+                     ) VALUES (\
+                         ?1, 'local', 'artifact', 'moodboard_model', 'legacy preference model', \
+                         NULL, ?2, '[]', ?3, ?3, NULL, NULL, NULL, ?4\
+                     )",
+                    (
+                        model_id.to_string(),
+                        entity
+                            .properties
+                            .as_ref()
+                            .expect("model property mirror")
+                            .to_string(),
+                        entity.created_at,
+                        bundle_content_ref.to_string(),
+                    ),
+                )
+                .expect("insert pre-V21 legacy model");
+        }
+        legacy_backend
+            .events_for_namespace("local")
+            .unwrap()
+            .append_event(published_event)
+            .await
+            .expect("insert immutable legacy model event");
+
+        let legacy_sql = legacy_backend.sql();
+        let owner = acquire_database_gc_owner(legacy_sql.as_ref())
+            .await
+            .expect("acquire legacy database GC owner");
+        legacy_backend
+            .stage_attachment_cutover(&owner)
+            .expect("stage real V21 cutover");
+        assert_eq!(
+            legacy_backend.attachment_cutover_status().unwrap(),
+            AttachmentCutoverStatus::Incomplete
+        );
+        assert_eq!(
+            crate::legacy_preference_model_count(legacy_sql.as_ref())
+                .await
+                .unwrap(),
+            1
+        );
+        let shared_hydrator = restarted.blob_hydrator().expect("shared restart hydrator");
+        let verified = crate::verify_legacy_preference_attachments(
+            legacy_sql.as_ref(),
+            shared_hydrator.as_ref(),
+        )
+        .await
+        .expect("verify real pre-V21 model evidence");
+        assert_eq!(verified.len(), 1);
+        assert_eq!(verified[0].model_id, model_id);
+        assert_eq!(verified[0].network_content_ref, network_content_ref);
+        let verified_attachments = verified
+            .into_iter()
+            .map(|verified| Attachment {
+                record_uuid: verified.model_id,
+                substrate: AttachmentSubstrate::Entity,
+                role: "fann-network".to_string(),
+                content_ref: verified.network_content_ref,
+                media_type: Some("application/octet-stream".to_string()),
+                size_bytes: Some(verified.size_bytes),
+                created_at: entity.created_at,
+            })
+            .collect::<Vec<_>>();
+        legacy_backend
+            .apply_verified_attachments(&owner, &verified_attachments)
+            .expect("apply verified fann-network role");
+        legacy_backend
+            .finalize_attachment_cutover(&owner)
+            .expect("finalize real V21 cutover");
+        assert_eq!(
+            legacy_backend.attachment_cutover_status().unwrap(),
+            AttachmentCutoverStatus::Complete
+        );
+        drop(owner);
+
+        let sweep_store = Arc::new(
+            FsBlobStore::new(blob_root, 0)
+                .unwrap()
+                .with_orphan_sweep_grace(Duration::ZERO),
+        );
+        let migrated = KhiveRuntime::from_prepared_backend(
+            Arc::clone(&legacy_backend),
+            persistent_runtime_config(&legacy_db_path, "alice"),
+        )
+        .expect("runtime over finalized V21 database");
+        migrated
+            .install_blob_store(sweep_store.clone())
+            .expect("install migrated blob store");
+        let migrated_token = migrated.authorize(Namespace::local()).unwrap();
+        let migrated_model = load_preference_model(&migrated, &migrated_token, model_id, &scope)
+            .await
+            .expect("load migrated model");
+        let (_, migrated_probability) = predict(
+            &migrated_model.network,
+            migrated_model.bundle.calibration.temperature,
+            &[0.9; FEATURE_COUNT],
+            &[0.1; FEATURE_COUNT],
+        )
+        .unwrap();
+        assert_eq!(migrated_probability, expected_probability);
+
+        let orphan_ref = sweep_store
+            .put(b"unreferenced migration regression object".to_vec())
+            .await
+            .unwrap();
+        let sweep = sweep_store
+            .transactional_orphan_sweep(legacy_sql.as_ref(), false)
+            .await
+            .expect("attachment-only GC after V21 finalization");
+        assert_eq!(sweep.deleted, 1, "the control orphan proves GC executed");
+        assert!(!sweep_store.exists(&orphan_ref).await.unwrap());
+        assert!(sweep_store.exists(&bundle_content_ref).await.unwrap());
+        assert!(sweep_store.exists(&network_content_ref).await.unwrap());
+        let after_gc = load_preference_model(&migrated, &migrated_token, model_id, &scope)
+            .await
+            .expect("load migrated model after attachment-only GC");
+        let (_, after_gc_probability) = predict(
+            &after_gc.network,
+            after_gc.bundle.calibration.temperature,
+            &[0.9; FEATURE_COUNT],
+            &[0.1; FEATURE_COUNT],
+        )
+        .unwrap();
+        assert_eq!(after_gc_probability, expected_probability);
+
+        let wrong_network_ref = ContentRef::from_hex("f".repeat(64)).unwrap();
+        restarted
+            .attachments()
+            .unwrap()
+            .upsert_attachment(Attachment {
+                record_uuid: model_id,
+                substrate: AttachmentSubstrate::Entity,
+                role: "fann-network".to_string(),
+                content_ref: wrong_network_ref,
+                media_type: Some("application/octet-stream".to_string()),
+                size_bytes: Some(u64::try_from(network_bytes.len()).unwrap()),
+                created_at: entity.created_at,
+            })
+            .await
+            .unwrap();
+        recording_store.calls.lock().unwrap().clear();
+        let error = load_preference_model(&restarted, &restarted_token, model_id, &scope)
+            .await
+            .expect_err("attachment disagreement must fail before network hydration");
+        assert!(error
+            .to_string()
+            .contains("fann-network attachment disagrees"));
+        assert_eq!(
+            *recording_store.calls.lock().unwrap(),
+            vec![(bundle_content_ref, MAX_MODEL_BLOB_BYTES)],
+            "an unauthenticated attachment reference must never reach the hydrator"
+        );
     }
 }

--- a/crates/khive-pack-moodboard/src/preference_handlers.rs
+++ b/crates/khive-pack-moodboard/src/preference_handlers.rs
@@ -1255,6 +1255,7 @@ async fn find_model_by_content_ref(
     runtime.get_entity(token, id).await.map(Some)
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn find_or_create_model(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,

--- a/crates/khive-pack-moodboard/tests/integration.rs
+++ b/crates/khive-pack-moodboard/tests/integration.rs
@@ -8,7 +8,7 @@ use khive_runtime::{
     BackendId, KhiveRuntime, Namespace, PackRegistration, RuntimeConfig, VerbRegistry,
     VerbRegistryBuilder,
 };
-use khive_storage::{BlobStore, ContentRef};
+use khive_storage::{BlobStore, ContentRef, NewAttachment};
 use khive_types::{EntityKind, Pack};
 use sha2::{Digest, Sha256};
 
@@ -279,7 +279,7 @@ async fn attributed_serve_randomizes_occurrences_and_judgment_is_immutable() {
     {
         let content_ref = blob_store.put(bytes.to_vec()).await.expect("asset blob");
         let asset = runtime
-            .create_entity_with_content_ref(
+            .create_entity_with_attachments(
                 &setup_token,
                 "artifact",
                 Some("visual_asset"),
@@ -287,7 +287,12 @@ async fn attributed_serve_randomizes_occurrences_and_judgment_is_immutable() {
                 None,
                 Some(serde_json::json!({"schema_version": "fixture"})),
                 vec![],
-                &content_ref,
+                vec![NewAttachment {
+                    role: "content".to_string(),
+                    content_ref: content_ref.clone(),
+                    media_type: Some("application/octet-stream".to_string()),
+                    size_bytes: Some(u64::try_from(bytes.len()).unwrap()),
+                }],
             )
             .await
             .expect("asset");
@@ -530,7 +535,7 @@ async fn public_training_publishes_calibrated_fann_and_preference_stays_nonconfo
         .await
         .expect("anchor blob");
     let anchor = runtime
-        .create_entity_with_content_ref(
+        .create_entity_with_attachments(
             &setup_token,
             "artifact",
             Some("visual_asset"),
@@ -538,7 +543,12 @@ async fn public_training_publishes_calibrated_fann_and_preference_stays_nonconfo
             None,
             Some(serde_json::json!({"schema_version": "fixture"})),
             vec![],
-            &anchor_ref,
+            vec![NewAttachment {
+                role: "content".to_string(),
+                content_ref: anchor_ref.clone(),
+                media_type: Some("application/octet-stream".to_string()),
+                size_bytes: Some(6),
+            }],
         )
         .await
         .expect("anchor asset");
@@ -565,6 +575,7 @@ async fn public_training_publishes_calibrated_fann_and_preference_stays_nonconfo
             break;
         }
         let bytes = format!("candidate-{candidate_index}").into_bytes();
+        let candidate_size = u64::try_from(bytes.len()).unwrap();
         let candidate_ref = ContentRef::from_digest_bytes(blake3::hash(&bytes).as_bytes());
         let split = preference_pair_split(
             &board_fingerprint,
@@ -580,7 +591,7 @@ async fn public_training_publishes_calibrated_fann_and_preference_stays_nonconfo
         let stored_ref = blob_store.put(bytes).await.expect("candidate blob");
         assert_eq!(stored_ref, candidate_ref);
         let other = runtime
-            .create_entity_with_content_ref(
+            .create_entity_with_attachments(
                 &setup_token,
                 "artifact",
                 Some("visual_asset"),
@@ -588,7 +599,12 @@ async fn public_training_publishes_calibrated_fann_and_preference_stays_nonconfo
                 None,
                 Some(serde_json::json!({"schema_version": "fixture"})),
                 vec![],
-                &candidate_ref,
+                vec![NewAttachment {
+                    role: "content".to_string(),
+                    content_ref: candidate_ref.clone(),
+                    media_type: Some("application/octet-stream".to_string()),
+                    size_bytes: Some(candidate_size),
+                }],
             )
             .await
             .expect("candidate asset");

--- a/crates/khive-runtime/README.md
+++ b/crates/khive-runtime/README.md
@@ -13,6 +13,9 @@ verb-dispatch machinery that lets packs (`kg`, `gtd`, `memory`, …) extend the 
   bounded, digest-verified whole-blob reads. Its non-cloneable `VerifiedBlob`
   keeps admission until callers finish using the borrowed bytes, and tracked
   supervisors keep native work visible to daemon drain after request cancellation
+- **Role-keyed attachments** — main-backend-only record metadata over `ContentRef`,
+  atomic entity-plus-role publication, compatibility `content_ref` projection,
+  and transactional hard-delete cleanup
 - **`VerbRegistry` / `VerbRegistryBuilder`** — registers packs (`PackRuntime` impls),
   an authorization `Gate`, an actor identity, and dispatches verbs by name
 - **`PackRuntime` trait** — the object-safe runtime counterpart to `khive-types::Pack`;
@@ -37,8 +40,9 @@ verb-dispatch machinery that lets packs (`kg`, `gtd`, `memory`, …) extend the 
 use khive_runtime::{KhiveRuntime, RuntimeConfig};
 use khive_types::namespace::Namespace;
 
-// In-memory runtime (tests); production callers set RuntimeConfig::db_path or
-// use KhiveRuntime::from_backend with a pre-built StorageBackend.
+// In-memory runtime (tests and pure local embedding). Production callers use
+// khive-mcp/kkernel's async host builders so legacy V21 attachment cutover is
+// completed before any runtime is exposed.
 let runtime = KhiveRuntime::new(RuntimeConfig::default())?;
 
 // Every read/write is scoped by a NamespaceToken minted through the configured Gate.
@@ -46,6 +50,28 @@ let token = runtime.authorize(Namespace::local())?;
 let entities = runtime.entities(&token)?; // Arc<dyn khive_storage::EntityStore>
 let graph = runtime.graph(&token)?; // Arc<dyn khive_storage::GraphStore>
 ```
+
+`KhiveRuntime::new` is suitable for fresh, exact-current, and in-memory
+databases. It deliberately refuses a legacy V20 database that needs verified
+application-assisted migration. Official production boot uses the async
+`khive_mcp::serve::build_single_backend_runtime` or multi-backend builders and
+then `KhiveRuntime::from_prepared_backend`. The infallible `from_backend`
+constructor is a low-level assembly seam whose caller must already have
+completed V21; it is not a migration or serving entrypoint.
+
+Before any Phase-4b builder is deployed, the Phase-4a GC compatibility build
+must converge on every process sharing the database/blob root and all pre-Phase-4a
+processes must be drained. Phase 4a leaves V20 schema/data unchanged and only
+fail-closes transactional GC unless the database is exact completed V21.
+Every Phase-4a application-serving/read-write process must also be quiesced for
+cutover, or proven unable to access the database. Only a GC-only worker has
+narrow completed-V21 compatibility; start Phase-4b serving after exact-current
+topology validation.
+
+Artifact publication uses `create_entity_with_attachments`; the former
+single-column `create_entity_with_content_ref` seam is removed. Packs assigned
+to a secondary database must call `runtime.core().attachments()` because only
+the canonical main database participates in blob GC liveness.
 
 Packs are composed through the builder, not `KhiveRuntime` directly:
 

--- a/crates/khive-runtime/docs/design.md
+++ b/crates/khive-runtime/docs/design.md
@@ -33,10 +33,31 @@
 - A tracked supervisor owns admitted backend work. Request cancellation drops
   only the waiter, while capacity remains charged until native work ends; daemon
   drain observes the supervisor through ADR-119 background-task accounting
-- Raw store access remains temporarily available for mutation, stat, existence,
-  and compatibility with the still-unmigrated whole-buffer readers. ADR-160
-  Phase 3 routes those production reads through `BlobHydrator` and removes the
-  raw read surface
+- Raw store access is limited to mutation, stat, existence, delete, and
+  maintenance. Production whole-buffer reads route through `BlobHydrator`; the
+  unbounded raw read surface was removed in ADR-160 Phase 3
+
+### Role-Keyed Attachments and V21 Cutover (ADR-121, ADR-160 D4)
+
+- Phase 4a separately ships the transactional-GC compatibility gate without
+  changing V20 schema/data. Phase-4b runtime builders may cut over only after
+  that build converges fleet-wide and every pre-Phase-4a process sharing the
+  database/blob root is drained. Every Phase-4a application reader/writer must
+  also be quiesced or unable to access the database during cutover; only a
+  GC-only worker has narrow completed-V21 compatibility. Phase-4b serving
+  starts after exact-current topology validation
+- `Entity.content_ref` is a compatibility read projection of attachment role
+  `content`; entity writes do not persist a same-named column
+- `create_entity_with_attachments` verifies every referenced blob, then commits
+  the entity and all initial roles in one backend transaction
+- `KhiveRuntime::attachments()` is accepted only on backend `main`. A pack bound
+  to a secondary backend routes record-plus-attachment work through `core()`
+- Hard entity/note deletion removes attachment rows in the same transaction;
+  soft deletion retains them as recoverable liveness anchors
+- Direct `KhiveRuntime::new` may finish an empty V21 migration, but refuses a
+  legacy application-assisted cutover. Production hosts use
+  `from_prepared_backend` only after the async boot coordinator has authenticated
+  legacy pack evidence and completed V21
 
 ### Namespace Strategy (Rev 6) (ADR-007)
 
@@ -56,9 +77,17 @@
 ### Multi-Backend Deployment (ADR-009, ADR-028)
 
 - `BackendId` identifies a named backend in multi-backend deployments; single-backend uses `"main"`
-- `KhiveRuntime::from_backend` is the preferred boot path for multi-backend deployments
+- Official multi-backend host boot coordinates schema/V21 first, then uses the
+  low-level backend assembly seam; unchecked `from_backend` is not itself a
+  migration or serving entrypoint
+- The host prepares and inventories every secondary before enabling V21 on
+  main; any secondary attachment liveness blocks boot because main is the sole
+  SQL authority visible to transactional blob GC
 - Cross-backend `merge_entity` is unsupported in v1; both entities must reside on the same backend
-- `db_path` and `embedding_model` on `RuntimeConfig` are deprecated in favour of the external-backend path
+- `RuntimeConfig::db_path` remains the database input to the supported async
+  single-backend host builder. `embedding_model` remains the compatibility
+  primary-model shorthand beside `EmbedderRegistry`; neither field makes direct
+  `from_backend` assembly a supported production boot path
 
 ### KG Versioning / Portability (ADR-010)
 
@@ -218,5 +247,5 @@
 ## Consistency Notes
 
 - `validation.rs` line 112 references `ADR-020` (git-native write path) in relation to `GraphPatch`. The git-native write path is out of scope for the v0.2 validation cluster; this is accurate documentation of a deferred feature, not a discrepancy.
-- `RuntimeConfig::db_path` and `RuntimeConfig::embedding_model` are documented as deprecated (in favour of `from_backend` and `EmbedderRegistry`) but remain in place for backward compatibility with tests and single-binary deployments. They should be removed when all callers migrate to the external-backend boot path.
+- `RuntimeConfig::db_path` remains the database input to the supported async khive-mcp/kkernel host builders and to current-schema tests. Direct `from_backend` assembly is a low-level, already-prepared-backend seam; production boot coordinates V21 first and may use `from_prepared_backend`. `embedding_model` remains the primary-model shorthand beside `EmbedderRegistry`.
 - `PackRuntime::register_embedders` hook docs reference "ADR-031 extension" — this is the pack-extensible embedder hook added alongside ADR-031, not a separate ADR. The name is stable.

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -20,7 +20,7 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use khive_storage::types::SqlValue;
-use khive_storage::{EdgeRelation, SqlStatement};
+use khive_storage::{AttachmentSubstrate, EdgeRelation, SqlStatement};
 use khive_types::{EventKind, SubstrateKind};
 
 use crate::atomic_plan::{
@@ -37,6 +37,7 @@ use crate::operations::{
 };
 use crate::runtime::{KhiveRuntime, NamespaceToken};
 
+use khive_db::stores::attachment::delete_record_attachments_statement;
 use khive_db::stores::entity::{
     entity_hard_delete_statement, entity_soft_delete_statement, entity_upsert_statement,
 };
@@ -1114,10 +1115,19 @@ pub async fn prepare_delete(
             // khive-db's own `SqlEntityStore::delete_entity` calls — no DML
             // text is hand-duplicated here.
             let mut statements = if hard {
-                vec![PlanStatement {
-                    statement: entity_hard_delete_statement(id),
-                    guard: Some(AffectedRowGuard::exactly(1)),
-                }]
+                vec![
+                    PlanStatement {
+                        statement: delete_record_attachments_statement(
+                            id,
+                            AttachmentSubstrate::Entity,
+                        ),
+                        guard: None,
+                    },
+                    PlanStatement {
+                        statement: entity_hard_delete_statement(id),
+                        guard: Some(AffectedRowGuard::exactly(1)),
+                    },
+                ]
             } else {
                 let deleted_at = chrono::Utc::now().timestamp_micros();
                 vec![PlanStatement {
@@ -1199,10 +1209,19 @@ pub async fn prepare_delete(
             // `note_hard_delete_statement` are the SAME khive-db builders
             // khive-db's own `SqlNoteStore::delete_note` calls.
             let mut statements = if hard {
-                vec![PlanStatement {
-                    statement: note_hard_delete_statement(id),
-                    guard: Some(AffectedRowGuard::exactly(1)),
-                }]
+                vec![
+                    PlanStatement {
+                        statement: delete_record_attachments_statement(
+                            id,
+                            AttachmentSubstrate::Note,
+                        ),
+                        guard: None,
+                    },
+                    PlanStatement {
+                        statement: note_hard_delete_statement(id),
+                        guard: Some(AffectedRowGuard::exactly(1)),
+                    },
+                ]
             } else {
                 let deleted_at = chrono::Utc::now().timestamp_micros();
                 vec![PlanStatement {

--- a/crates/khive-runtime/src/config.rs
+++ b/crates/khive-runtime/src/config.rs
@@ -209,16 +209,19 @@ pub fn process_ref_from_env() -> Option<String> {
 
 /// Runtime configuration.
 ///
-/// The `db_path` and `embedding_model` fields are deprecated in favour of
-/// constructing the backend externally and calling [`crate::KhiveRuntime::from_backend`].
-/// They remain for backward compatibility with tests and single-binary deployments.
+/// The `db_path` field remains for backward compatibility and as input to the
+/// supported async khive-mcp/kkernel host builders. Direct backend assembly is
+/// reserved for an already-coordinated database; use
+/// [`crate::KhiveRuntime::from_prepared_backend`] when that precondition has
+/// been established. `embedding_model` remains as the primary-model config
+/// shorthand beside the provider registry.
 #[derive(Clone, Debug)]
 pub struct RuntimeConfig {
     /// Path to the SQLite database file. `None` = in-memory (tests).
     ///
-    /// Deprecated: use [`crate::KhiveRuntime::from_backend`] instead. The boot path
-    /// constructs backends from `khive.toml` (`AppConfig`) and passes them to
-    /// `from_backend`. Direct `db_path` usage persists only in tests.
+    /// Production boot passes this value to the async khive-mcp/kkernel host
+    /// builders, which coordinate V21 before constructing runtimes. Tests and
+    /// already-current single-backend callers may still use it directly.
     pub db_path: Option<std::path::PathBuf>,
     /// Namespace used when no explicit namespace is provided.
     pub default_namespace: Namespace,

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -2039,7 +2039,10 @@ fn read_merge_entity(
     let id_str = id.to_string();
     let mut stmt = conn.prepare(
         "SELECT id, namespace, kind, entity_type, name, description, properties, tags, \
-         created_at, updated_at, deleted_at, merged_into, merge_event_id, content_ref \
+         created_at, updated_at, deleted_at, merged_into, merge_event_id, \
+         (SELECT a.content_ref FROM attachments AS a \
+          WHERE a.record_uuid = entities.id AND a.substrate = 'entity' \
+            AND a.role = 'content') AS content_ref \
          FROM entities WHERE id = ?1 AND deleted_at IS NULL",
     )?;
     let mut rows = stmt.query(rusqlite::params![id_str])?;
@@ -2477,8 +2480,9 @@ fn merge_entity_sql(
 
     if !dry_run {
         // UPDATE only the merged fields — a full-row INSERT OR REPLACE silently
-        // nulls any column missing from its list (entity_type and content_ref
-        // were lost this way; khive#1214).
+        // nulls any column missing from its list (entity_type and the former
+        // entity-owned content_ref were lost this way; khive#1214). Attachments
+        // now live in their own table and this targeted UPDATE leaves them alone.
         conn.execute(
             "UPDATE entities SET \
                  name = ?1, description = ?2, properties = ?3, tags = ?4, \
@@ -4899,7 +4903,7 @@ mod tests {
     }
 
     // The survivor row write must not null columns it doesn't merge —
-    // entity_type (and content_ref) were lost by the old full-row
+    // entity_type (and the old entity-owned content_ref) were lost by the old full-row
     // INSERT OR REPLACE.
     #[tokio::test]
     async fn merge_entity_preserves_survivor_entity_type() {
@@ -4947,11 +4951,21 @@ mod tests {
             .await
             .unwrap();
 
-        let content_ref = "blake3:0000000000000000000000000000000000000000000000000000000000000000";
+        let content_ref = khive_storage::ContentRef::from_hex("0".repeat(64)).unwrap();
         let store = rt.entities(&tok).unwrap();
-        let stored = store.get_entity(into.id).await.unwrap().unwrap();
-        store
-            .upsert_entity(stored.with_content_ref(content_ref))
+        rt.attachments()
+            .unwrap()
+            .upsert_attachment(khive_storage::Attachment::from_new(
+                into.id,
+                khive_storage::AttachmentSubstrate::Entity,
+                khive_storage::NewAttachment {
+                    role: "content".to_string(),
+                    content_ref: content_ref.clone(),
+                    media_type: None,
+                    size_bytes: None,
+                },
+                into.created_at,
+            ))
             .await
             .unwrap();
 
@@ -4969,7 +4983,7 @@ mod tests {
         let got = store.get_entity(into.id).await.unwrap().unwrap();
         assert_eq!(
             got.content_ref.as_deref(),
-            Some(content_ref),
+            Some(content_ref.as_str()),
             "merge must not null the survivor's content_ref"
         );
     }

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -842,15 +842,15 @@ impl Drop for BackgroundTaskGuard {
     }
 }
 
-/// Spawn a fire-and-forget background task that daemon shutdown's `drain()`
-/// waits for, instead of a bare `tokio::spawn` that a SIGTERM can abort
-/// mid-flight with no trace. Only the enqueue (an atomic increment) is
-/// synchronous on the caller's path — the future itself still runs fully
-/// off-path, unawaited. The decrement happens via `BackgroundTaskGuard`'s
-/// `Drop`, so a panic inside `fut` still restores the count.
-pub fn track_background_task<F>(fut: F)
+/// Spawn a task that daemon shutdown's `drain()` waits for and return its join
+/// handle. Retaining the handle lets boot coordinators form an explicit barrier;
+/// dropping it deliberately detaches the task while the background counter still
+/// keeps daemon drain aware of its lifetime. The decrement happens via
+/// `BackgroundTaskGuard`'s `Drop`, including panic and cancellation paths.
+pub fn spawn_tracked_task<F, T>(fut: F) -> tokio::task::JoinHandle<T>
 where
-    F: std::future::Future<Output = ()> + Send + 'static,
+    F: std::future::Future<Output = T> + Send + 'static,
+    T: Send + 'static,
 {
     background_tasks().fetch_add(1, std::sync::atomic::Ordering::SeqCst);
     let guard = BackgroundTaskGuard {
@@ -858,8 +858,19 @@ where
     };
     tokio::spawn(async move {
         let _guard = guard;
-        fut.await;
-    });
+        fut.await
+    })
+}
+
+/// Spawn a fire-and-forget task through [`spawn_tracked_task`].
+///
+/// Callers that need a boot or shutdown barrier should retain and await the
+/// returned handle from [`spawn_tracked_task`] instead of detaching it here.
+pub fn track_background_task<F>(fut: F)
+where
+    F: std::future::Future<Output = ()> + Send + 'static,
+{
+    drop(spawn_tracked_task(fut));
 }
 
 /// Current count of in-flight tasks started via [`track_background_task`].

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -10,14 +10,16 @@ use serde::Serialize;
 use uuid::Uuid;
 
 use khive_score::DeterministicScore;
-use khive_storage::blob::ContentRef;
 use khive_storage::note::Note;
 use khive_storage::types::{
     DeleteMode, DirectedNeighborHit, Direction, EdgeSortField, GraphPath, LinkId, NeighborHit,
     NeighborQuery, Page, PageRequest, SeekCursor, SortOrder, SqlRow, SqlStatement, SqlValue,
     TextFilter, TextQueryMode, TextSearchRequest, TraversalRequest,
 };
-use khive_storage::{Edge, EdgeRelation, Entity, EntityFilter, Event, EventFilter};
+use khive_storage::{
+    Attachment, AttachmentSubstrate, Edge, EdgeRelation, Entity, EntityFilter, Event, EventFilter,
+    NewAttachment,
+};
 use khive_types::{EdgeEndpointRule, EndpointKind, EventKind, KhiveError, SubstrateKind};
 
 use khive_db::stores::entity::{entity_hard_delete_statement, entity_upsert_statement};
@@ -1214,22 +1216,23 @@ impl KhiveRuntime {
                 description,
                 properties,
                 tags,
-                None,
+                Vec::new(),
             )
             .await?
             .0)
     }
 
-    /// Create an entity that references bytes already published to `BlobStore`.
+    /// Create an entity with role-keyed bytes already published to `BlobStore`.
     ///
-    /// The typed [`ContentRef`] prevents malformed references from entering the
-    /// substrate through this consumer seam. The entity row, FTS document, and
-    /// configured text-vector rows use the same compensated create path as
-    /// [`Self::create_entity`]. The caller remains responsible for publishing the
-    /// blob before this call; a later failure deliberately leaves those bytes for
-    /// the blob store's grace-period orphan collection.
+    /// Every [`NewAttachment`] carries a typed content reference, so malformed
+    /// references cannot enter through this consumer seam. Blob existence is
+    /// checked before the database write. The entity row and all attachment rows
+    /// then commit in one storage transaction; the FTS/vector compensation path
+    /// hard-deletes the entity and its attachments together if a later indexing
+    /// step fails. Published bytes remain recoverable by the BlobStore grace-period
+    /// orphan policy when any post-publication step fails.
     #[allow(clippy::too_many_arguments)]
-    pub async fn create_entity_with_content_ref(
+    pub async fn create_entity_with_attachments(
         &self,
         token: &NamespaceToken,
         kind: &str,
@@ -1238,17 +1241,34 @@ impl KhiveRuntime {
         description: Option<&str>,
         properties: Option<serde_json::Value>,
         tags: Vec<String>,
-        content_ref: &ContentRef,
+        attachments: Vec<NewAttachment>,
     ) -> RuntimeResult<Entity> {
+        // Attachment rows are the process-wide BlobStore's liveness authority.
+        // Validate placement before existence probes or any record write: pack
+        // runtimes bound to a secondary backend must explicitly call `core()`.
+        drop(self.attachments()?);
         let blob_store = self.blob_store().ok_or_else(|| {
             RuntimeError::Unconfigured(
-                "create_entity_with_content_ref requires an installed BlobStore".to_string(),
+                "create_entity_with_attachments requires an installed BlobStore".to_string(),
             )
         })?;
-        if !blob_store.exists(content_ref).await? {
-            return Err(RuntimeError::InvalidInput(format!(
-                "create_entity_with_content_ref requires a published blob; no object exists for {content_ref}"
-            )));
+        let mut roles = std::collections::HashSet::with_capacity(attachments.len());
+        for attachment in &attachments {
+            attachment.validate()?;
+            if !roles.insert(attachment.role.as_str()) {
+                return Err(RuntimeError::InvalidInput(format!(
+                    "duplicate attachment role {:?}",
+                    attachment.role
+                )));
+            }
+        }
+        for attachment in &attachments {
+            if !blob_store.exists(&attachment.content_ref).await? {
+                return Err(RuntimeError::InvalidInput(format!(
+                    "create_entity_with_attachments requires a published blob; no object exists for {}",
+                    attachment.content_ref
+                )));
+            }
         }
         let validated_type = self.validate_entity_type_for_kind(kind, entity_type)?;
         Ok(self
@@ -1260,7 +1280,7 @@ impl KhiveRuntime {
                 description,
                 properties,
                 tags,
-                Some(content_ref),
+                attachments,
             )
             .await?
             .0)
@@ -1285,7 +1305,7 @@ impl KhiveRuntime {
             description,
             properties,
             tags,
-            None,
+            Vec::new(),
         )
         .await
     }
@@ -1300,7 +1320,7 @@ impl KhiveRuntime {
         description: Option<&str>,
         properties: Option<serde_json::Value>,
         tags: Vec<String>,
-        content_ref: Option<&ContentRef>,
+        attachments: Vec<NewAttachment>,
     ) -> RuntimeResult<(Entity, crate::retrieval::EmbeddingTruncationReport)> {
         self.validate_entity_kind(kind)?;
         // Secret gate: scan name, description, structured properties, and tags.
@@ -1323,10 +1343,25 @@ impl KhiveRuntime {
         if !tags.is_empty() {
             entity = entity.with_tags(tags);
         }
-        if let Some(content_ref) = content_ref {
-            entity = entity.with_content_ref(content_ref.to_string());
-        }
-        self.entities(token)?.upsert_entity(entity.clone()).await?;
+        let projected_content_ref = attachments
+            .iter()
+            .find(|attachment| attachment.role == "content")
+            .map(|attachment| attachment.content_ref.to_string());
+        let attachment_rows = attachments
+            .into_iter()
+            .map(|attachment| {
+                Attachment::from_new(
+                    entity.id,
+                    AttachmentSubstrate::Entity,
+                    attachment,
+                    entity.created_at,
+                )
+            })
+            .collect();
+        self.entities(token)?
+            .upsert_entity_with_attachments(entity.clone(), attachment_rows)
+            .await?;
+        entity.content_ref = projected_content_ref;
 
         let doc = entity_fts_document(&entity);
         let embed_body = doc.body.clone();
@@ -16146,5 +16181,73 @@ mod tests {
              In the ADR but not enforced by the runtime: {missing_from_runtime:#?}\n\
              Enforced by the runtime but not in the ADR: {extra_in_runtime:#?}"
         );
+    }
+
+    #[tokio::test]
+    async fn create_entity_with_attachments_commits_roles_and_projects_content() {
+        use khive_db::stores::blob::FsBlobStore;
+        use khive_storage::BlobStore as _;
+
+        let runtime = rt();
+        let token = NamespaceToken::local();
+        let blob_dir = tempfile::tempdir().expect("blob tempdir");
+        let blob_store =
+            Arc::new(FsBlobStore::new(blob_dir.path().to_path_buf(), 0).expect("blob store"));
+        let content_ref = blob_store
+            .put(b"bundle".to_vec())
+            .await
+            .expect("publish bundle");
+        let network_ref = blob_store
+            .put(b"network".to_vec())
+            .await
+            .expect("publish network");
+        runtime
+            .install_blob_store(blob_store)
+            .expect("install blob store");
+
+        let created = runtime
+            .create_entity_with_attachments(
+                &token,
+                "artifact",
+                None,
+                "role-keyed artifact",
+                None,
+                None,
+                vec![],
+                vec![
+                    NewAttachment {
+                        role: "content".to_string(),
+                        content_ref: content_ref.clone(),
+                        media_type: Some("application/json".to_string()),
+                        size_bytes: Some(6),
+                    },
+                    NewAttachment {
+                        role: "fann-network".to_string(),
+                        content_ref: network_ref.clone(),
+                        media_type: Some("application/octet-stream".to_string()),
+                        size_bytes: Some(7),
+                    },
+                ],
+            )
+            .await
+            .expect("atomic record + attachments publication");
+
+        assert_eq!(created.content_ref.as_deref(), Some(content_ref.as_str()));
+        let reloaded = runtime
+            .get_entity(&token, created.id)
+            .await
+            .expect("reload entity");
+        assert_eq!(reloaded.content_ref.as_deref(), Some(content_ref.as_str()));
+        let attachments = runtime
+            .attachments()
+            .expect("main attachment store")
+            .list_attachments(created.id)
+            .await
+            .expect("list attachments");
+        assert_eq!(attachments.len(), 2);
+        assert_eq!(attachments[0].role, "content");
+        assert_eq!(attachments[0].content_ref, content_ref);
+        assert_eq!(attachments[1].role, "fann-network");
+        assert_eq!(attachments[1].content_ref, network_ref);
     }
 }

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -12,7 +12,7 @@ use khive_gate::AllowAllGate;
 use khive_gate::GateRequest;
 use khive_storage::types::{SqlStatement, SqlValue};
 use khive_storage::{
-    EntityStore, Event, EventStore, GraphStore, NoteStore, SqlAccess, VectorStore,
+    AttachmentStore, EntityStore, Event, EventStore, GraphStore, NoteStore, SqlAccess, VectorStore,
 };
 use khive_types::{EdgeEndpointRule, EventKind, Namespace, SubstrateKind};
 use lattice_embed::{EmbeddingModel, EmbeddingService};
@@ -238,10 +238,13 @@ impl KhiveRuntime {
     /// Create a new runtime with the given config.
     ///
     /// The config's `db_path` is used to open or create the SQLite backend.
-    /// For the preferred boot path in multi-backend deployments, use
-    /// [`from_backend`](Self::from_backend) instead.
+    /// This direct constructor is intended for fresh/current single-backend
+    /// databases and tests. Production and multi-backend hosts must use the
+    /// async khive-mcp/kkernel builders so secondary inventory and any
+    /// application-assisted V21 cutover complete before serving. The
+    /// [`from_backend`](Self::from_backend) seam is likewise only for an
+    /// already-prepared backend.
     pub fn new(config: RuntimeConfig) -> RuntimeResult<Self> {
-        let ann_fresh_tail_enabled = crate::config::ann_fresh_tail_enabled_from_env();
         let backend = match &config.db_path {
             Some(path) => {
                 if let Some(parent) = path.parent() {
@@ -254,28 +257,20 @@ impl KhiveRuntime {
         // Writable backends migrate before handlers touch the DB. A detected
         // read-only snapshot is validated at the current schema version without
         // attempting migration DDL.
-        backend.prepare_core_schema()?;
+        let schema_version = backend.prepare_core_schema()?;
+        if schema_version < khive_db::migrations::ATTACHMENT_CUTOVER_VERSION {
+            return Err(khive_db::SqliteError::InvalidData(
+                "database requires the host application-assisted V21 attachment cutover; \
+                 start through khive-mcp/kkernel boot instead of constructing KhiveRuntime \
+                 directly"
+                    .into(),
+            )
+            .into());
+        }
         if !backend.is_read_only() {
             register_configured_embedding_models(&backend, &config)?;
         }
-        let (registry, default_embedder_name) = build_embedder_registry(&config);
-        Ok(Self {
-            backend: Arc::new(backend),
-            core_backend: None,
-            config,
-            ann_fresh_tail_enabled,
-            embedder_registry: Arc::new(std::sync::RwLock::new(registry)),
-            default_embedder_name,
-            edge_rules: Arc::new(RwLock::new(Vec::new())),
-            valid_entity_kinds: Arc::new(RwLock::new(Vec::new())),
-            valid_note_kinds: Arc::new(RwLock::new(Vec::new())),
-            entity_type_validator: Arc::new(RwLock::new(None)),
-            note_mutation_hook: Arc::new(RwLock::new(None)),
-            note_write_validator: Arc::new(RwLock::new(None)),
-            pack_owned_note_kinds: Arc::new(RwLock::new(Vec::new())),
-            blob_hydrator: Arc::new(OnceLock::new()),
-            fusion_executors: Arc::new(RwLock::new(HashMap::new())),
-        })
+        Ok(Self::assemble_from_backend(Arc::new(backend), config))
     }
 
     /// Open a runtime for read-only inspection (no model registration, no DB creation).
@@ -285,48 +280,61 @@ impl KhiveRuntime {
     /// or configured-model registration writes are attempted. A `None` path
     /// retains the historical ephemeral in-memory behavior for tests.
     pub fn new_readonly(config: RuntimeConfig) -> RuntimeResult<Self> {
-        let ann_fresh_tail_enabled = crate::config::ann_fresh_tail_enabled_from_env();
         let backend = match &config.db_path {
             Some(path) => StorageBackend::sqlite_read_only(path)?,
             None => StorageBackend::memory()?,
         };
         backend.prepare_core_schema()?;
-        let (registry, default_embedder_name) = build_embedder_registry(&config);
-        Ok(Self {
-            backend: Arc::new(backend),
-            core_backend: None,
-            config,
-            ann_fresh_tail_enabled,
-            embedder_registry: Arc::new(std::sync::RwLock::new(registry)),
-            default_embedder_name,
-            edge_rules: Arc::new(RwLock::new(Vec::new())),
-            valid_entity_kinds: Arc::new(RwLock::new(Vec::new())),
-            valid_note_kinds: Arc::new(RwLock::new(Vec::new())),
-            entity_type_validator: Arc::new(RwLock::new(None)),
-            note_mutation_hook: Arc::new(RwLock::new(None)),
-            note_write_validator: Arc::new(RwLock::new(None)),
-            pack_owned_note_kinds: Arc::new(RwLock::new(Vec::new())),
-            blob_hydrator: Arc::new(OnceLock::new()),
-            fusion_executors: Arc::new(RwLock::new(HashMap::new())),
-        })
+        Ok(Self::assemble_from_backend(Arc::new(backend), config))
     }
 
     /// Construct a runtime from an already-opened backend.
     ///
-    /// This is the preferred constructor for multi-backend deployments. The caller
-    /// (boot path in `kkernel` or `khive-mcp`) opens each backend from `khive.toml`,
-    /// then constructs a `KhiveRuntime` per pack using this method.
+    /// This is a low-level, infallible assembly seam for already-prepared
+    /// multi-backend deployments. It does not inspect or migrate the V21
+    /// attachment-cutover state. Production hosts must first run the async
+    /// kkernel/khive-mcp coordinator and must not expose a server over a
+    /// pending or incomplete backend. Prefer [`Self::from_prepared_backend`]
+    /// when constructing one fallible host runtime.
     ///
     /// The returned runtime has `db_path = None` and `embedding_model = None`; all
     /// storage access is through the provided `backend`. Set `backend_id` and
     /// `default_namespace` via the config builder pattern if non-defaults are needed.
     pub fn from_backend(backend: Arc<StorageBackend>, config: RuntimeConfig) -> Self {
-        let ann_fresh_tail_enabled = crate::config::ann_fresh_tail_enabled_from_env();
         if !backend.is_read_only() {
             if let Err(err) = register_configured_embedding_models(&backend, &config) {
                 tracing::warn!(error = %err, "failed to register configured embedding models");
             }
         }
+        Self::assemble_from_backend(backend, config)
+    }
+
+    /// Construct a single-backend runtime after a host boot coordinator has
+    /// completed schema preparation and any application-assisted cutover.
+    ///
+    /// Unlike [`Self::from_backend`], configured embedding-model registration
+    /// is fallible here, preserving [`Self::new`]'s single-backend startup
+    /// semantics. This method never runs migrations itself.
+    pub fn from_prepared_backend(
+        backend: Arc<StorageBackend>,
+        config: RuntimeConfig,
+    ) -> RuntimeResult<Self> {
+        if backend.attachment_cutover_status()?
+            != khive_db::migrations::AttachmentCutoverStatus::Complete
+        {
+            return Err(khive_db::SqliteError::InvalidData(
+                "from_prepared_backend requires a complete V21 attachment cutover".into(),
+            )
+            .into());
+        }
+        if !backend.is_read_only() {
+            register_configured_embedding_models(&backend, &config)?;
+        }
+        Ok(Self::assemble_from_backend(backend, config))
+    }
+
+    fn assemble_from_backend(backend: Arc<StorageBackend>, config: RuntimeConfig) -> Self {
+        let ann_fresh_tail_enabled = crate::config::ann_fresh_tail_enabled_from_env();
         let (registry, default_embedder_name) = build_embedder_registry(&config);
         Self {
             backend,
@@ -539,6 +547,22 @@ impl KhiveRuntime {
         Ok(self
             .backend
             .notes_for_namespace(token.namespace().as_str())?)
+    }
+
+    /// Return the role-keyed attachment substrate on the canonical main backend.
+    ///
+    /// Attachment rows are the process-shared BlobStore's sole SQL liveness
+    /// authority. A runtime bound directly to a secondary pack backend must call
+    /// [`Self::core`] first; accepting a secondary mutation here would create a
+    /// reference that the main-database GC sweep cannot see or fence.
+    pub fn attachments(&self) -> RuntimeResult<Arc<dyn AttachmentStore>> {
+        if self.config.backend_id.as_str() != BackendId::MAIN {
+            return Err(RuntimeError::InvalidInput(format!(
+                "attachments are owned by the canonical main backend; runtime backend {:?} must route through KhiveRuntime::core()",
+                self.config.backend_id.as_str()
+            )));
+        }
+        Ok(self.backend.attachments()?)
     }
 
     /// Get an EventStore scoped to the token's namespace.
@@ -2607,6 +2631,84 @@ mod tests {
             rt_secondary.core().backend_id().as_str(),
             BackendId::MAIN,
             "core() on a secondary runtime must return a main-bound handle"
+        );
+    }
+
+    #[test]
+    fn attachment_store_rejects_secondary_handle_and_accepts_its_core_projection() {
+        let main_arc = migrated_memory_backend();
+        let secondary_arc = migrated_memory_backend();
+        let rt_secondary = KhiveRuntime::from_backend(secondary_arc, secondary_config())
+            .with_core_backend(main_arc);
+
+        let error = match rt_secondary.attachments() {
+            Ok(_) => panic!("a secondary runtime must not expose attachment mutation"),
+            Err(error) => error,
+        };
+        assert!(matches!(error, RuntimeError::InvalidInput(_)));
+        assert!(
+            error.to_string().contains("canonical main backend"),
+            "secondary refusal must explain the liveness authority: {error}"
+        );
+        rt_secondary
+            .core()
+            .attachments()
+            .expect("core projection must expose the main attachment store");
+    }
+
+    #[tokio::test]
+    async fn record_plus_attachment_publication_rejects_a_secondary_runtime() {
+        use khive_storage::{BlobStore as _, NewAttachment};
+
+        let main_arc = migrated_memory_backend();
+        let secondary_arc = migrated_memory_backend();
+        let rt_secondary =
+            KhiveRuntime::from_backend(Arc::clone(&secondary_arc), secondary_config())
+                .with_core_backend(Arc::clone(&main_arc));
+        let blob_root = tempfile::tempdir().expect("blob root");
+        let blob_store = Arc::new(
+            khive_db::stores::blob::FsBlobStore::new(blob_root.path().to_path_buf(), 0)
+                .expect("blob store"),
+        );
+        let content_ref = blob_store.put(b"secondary-ref".to_vec()).await.unwrap();
+        rt_secondary
+            .install_blob_store(blob_store.clone())
+            .expect("shared blob store");
+        let token = rt_secondary.authorize(Namespace::local()).unwrap();
+
+        let error = rt_secondary
+            .create_entity_with_attachments(
+                &token,
+                "artifact",
+                Some("visual_asset"),
+                "must route through core",
+                None,
+                None,
+                vec![],
+                vec![NewAttachment {
+                    role: "content".to_string(),
+                    content_ref: content_ref.clone(),
+                    media_type: None,
+                    size_bytes: Some(13),
+                }],
+            )
+            .await
+            .expect_err("secondary attachment publication must fail closed");
+        assert!(error.to_string().contains("canonical main backend"));
+        assert!(rt_secondary
+            .list_entities(&token, None, None, 10, 0)
+            .await
+            .unwrap()
+            .is_empty());
+        assert!(rt_secondary
+            .core()
+            .list_entities(&token, None, None, 10, 0)
+            .await
+            .unwrap()
+            .is_empty());
+        assert!(
+            blob_store.exists(&content_ref).await.unwrap(),
+            "refusal must not mutate the already-published object"
         );
     }
 

--- a/crates/khive-runtime/tests/integration.rs
+++ b/crates/khive-runtime/tests/integration.rs
@@ -6,7 +6,7 @@
 use khive_runtime::{KhiveRuntime, Namespace, RuntimeConfig};
 use khive_storage::blob::ContentRef;
 use khive_storage::types::{Direction, PageRequest, TraversalOptions, TraversalRequest};
-use khive_storage::{BlobStore, EdgeRelation, Event, EventFilter};
+use khive_storage::{BlobStore, EdgeRelation, Event, EventFilter, NewAttachment};
 use khive_types::{EventKind, SubstrateKind};
 use uuid::Uuid;
 
@@ -68,7 +68,7 @@ async fn entity_create_with_properties_and_tags() {
 }
 
 #[tokio::test]
-async fn entity_create_with_content_ref_roundtrip() {
+async fn entity_create_with_content_attachment_roundtrip() {
     let rt = rt();
     let tok = rt.authorize(Namespace::local()).unwrap();
     let temp = tempfile::tempdir().unwrap();
@@ -80,7 +80,7 @@ async fn entity_create_with_content_ref_roundtrip() {
     let content_ref = blob_store.put(b"asset bytes".to_vec()).await.unwrap();
 
     let entity = rt
-        .create_entity_with_content_ref(
+        .create_entity_with_attachments(
             &tok,
             "artifact",
             Some("visual_asset"),
@@ -88,7 +88,12 @@ async fn entity_create_with_content_ref_roundtrip() {
             None,
             None,
             vec![],
-            &content_ref,
+            vec![NewAttachment {
+                role: "content".to_string(),
+                content_ref: content_ref.clone(),
+                media_type: None,
+                size_bytes: Some(11),
+            }],
         )
         .await
         .unwrap();
@@ -98,7 +103,7 @@ async fn entity_create_with_content_ref_roundtrip() {
 }
 
 #[tokio::test]
-async fn entity_create_with_content_ref_rejects_unpublished_blob() {
+async fn entity_create_with_content_attachment_rejects_unpublished_blob() {
     let rt = rt();
     let tok = rt.authorize(Namespace::local()).unwrap();
     let temp = tempfile::tempdir().unwrap();
@@ -109,7 +114,7 @@ async fn entity_create_with_content_ref_rejects_unpublished_blob() {
     let missing = ContentRef::from_digest_bytes(&[7; 32]);
 
     let error = rt
-        .create_entity_with_content_ref(
+        .create_entity_with_attachments(
             &tok,
             "artifact",
             Some("visual_asset"),
@@ -117,7 +122,12 @@ async fn entity_create_with_content_ref_rejects_unpublished_blob() {
             None,
             None,
             vec![],
-            &missing,
+            vec![NewAttachment {
+                role: "content".to_string(),
+                content_ref: missing,
+                media_type: None,
+                size_bytes: None,
+            }],
         )
         .await
         .expect_err("unpublished ref must fail");

--- a/crates/khive-storage/README.md
+++ b/crates/khive-storage/README.md
@@ -2,7 +2,7 @@
 
 Storage capability traits for khive's substrate: `SqlAccess`, `VectorStore`,
 `TextSearch`, `GraphStore`, `NoteStore`, `EntityStore`, `EventStore`,
-`SparseStore`. Zero implementations — only contracts
+`SparseStore`, `BlobStore`, and `AttachmentStore`. Zero implementations — only contracts
 ([ADR-005](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-005-storage-capability-traits.md)).
 A concrete backend (`khive-db`'s SQLite implementation, for example) implements
 these traits; the runtime and every pack depend only on this crate, never on a
@@ -17,13 +17,15 @@ specific backend.
 | `TextSearch`                               | FTS document upsert/search/stats, optional term-stats (IDF)                      |
 | `GraphStore`                               | edge CRUD, neighbor queries, multi-hop traversal, batched neighbor/edge fetch    |
 | `NoteStore` / `EntityStore` / `EventStore` | substrate-specific CRUD and filtered listing                                     |
+| `AttachmentStore`                          | role-keyed blob references owned by entity or note records                       |
+| `BlobStore`                                | content-addressed CRUD and bounded, digest-verified whole-object reads           |
 | `SparseStore`                              | sparse (BM25-style) vector storage                                               |
 
 Every method returns `StorageResult<T> = Result<T, StorageError>`.
 `StorageError` variants (`NotFound`, `AlreadyExists`, `Conflict`,
 `InvalidInput`, `Unsupported`, `Pool`, `Timeout`, `Transaction`, …) are tagged
 with the offending `StorageCapability`
-(`Sql | Notes | Entities | Graph | Events | Vectors | Sparse | Text`).
+(`Sql | Notes | Entities | Graph | Events | Vectors | Sparse | Text | Blob | Attachments`).
 
 ## Usage
 
@@ -58,6 +60,12 @@ compiles without overriding anything: `get_edges` loops `get_edge` per ID and
 `batch_neighbors` loops `neighbors` per source. Backends that support batched
 `IN (...)` queries or filter pushdown override the corresponding method and
 the trait's `capabilities()` accessor to advertise it.
+
+`EntityStore::upsert_entity_with_attachments` also has a conservative
+`Unsupported` default, so adding the atomic publication seam does not force an
+immediate implementation in third-party entity stores. `AttachmentStore`
+itself is a new required trait only for backends that advertise the
+`Attachments` capability.
 
 ## Where this sits
 

--- a/crates/khive-storage/docs/api/attachments.md
+++ b/crates/khive-storage/docs/api/attachments.md
@@ -1,0 +1,45 @@
+# Attachments — role-keyed record content
+
+`AttachmentStore` is the backend-neutral ADR-121 capability for blob references
+owned by an entity or note. It stores metadata only; bytes remain in `BlobStore`.
+The key is `(record_uuid, role)`, and one record may therefore carry parallel
+renditions such as `content`, `pdf`, or the moodboard-owned `fann-network`.
+
+## Types and validation
+
+- `AttachmentSubstrate` has the stable lowercase values `entity` and `note`.
+- `NewAttachment` is caller-supplied metadata. `Attachment::from_new` binds it
+  to a record UUID, substrate, and creation timestamp.
+- `ContentRef` is canonical by construction. A role must be non-empty and
+  contain no control characters. `size_bytes`, when present, must fit a SQLite
+  signed integer; it is descriptive metadata rather than read authority.
+
+`AttachmentStore` supports upsert, exact `(record_uuid, role)` lookup, stable
+role-ordered listing, and role deletion. Deleting an attachment never deletes
+the referenced blob; attachment-only GC later reclaims objects with zero live
+rows.
+
+## Atomic record publication and deletion
+
+`EntityStore::upsert_entity_with_attachments` is the storage contract for
+committing an entity plus all initial attachment roles in one transaction.
+Concrete hard-delete paths remove every row for the record in the same
+transaction as the entity or note deletion. Soft delete retains attachments so
+recoverable records continue to anchor their bytes.
+
+`Entity.content_ref` is retained only as a compatibility response field. Reads
+project attachment role `content`; ordinary entity upserts ignore that field and
+cannot recreate the removed database column.
+
+## Runtime ownership and GC
+
+The canonical main/core database is the sole attachment and blob-liveness
+authority. Pack runtimes assigned to a secondary backend must route through
+`KhiveRuntime::core()`; direct `KhiveRuntime::attachments()` on a secondary is
+rejected. The concrete V21 migration backfills legacy entity refs, authenticates
+pack-owned roles before finalization, switches GC anti-joins and claim fences to
+`attachments`, and then drops `entities.content_ref`.
+
+The low-level trait does not hydrate bytes or authorize callers. Production
+whole-object reads use the shared runtime `BlobHydrator`, while Gate and
+record/role eligibility remain runtime and pack policy.

--- a/crates/khive-storage/docs/api/blob-store.md
+++ b/crates/khive-storage/docs/api/blob-store.md
@@ -55,11 +55,11 @@ raw store access is for metadata, mutation, and maintenance paths only.
 ## `BlobStore::delete` — concurrency hazard
 
 `delete` performs an unconditional physical removal with **no coordination
-against any entity that might reference `content_ref`**. It is safe to call
+against any record attachment that might reference `content_ref`**. It is safe to call
 only when the caller has independently ensured — outside this trait,
-typically by quiescing whatever writer could attach a new `content_ref` to an
-entity — that nothing live references `content_ref` for the duration of the
-call. A caller that races an entity write against a `delete` can dangle a
+typically by quiescing whatever writer could attach a new `content_ref` to a
+record — that nothing live references `content_ref` for the duration of the
+call. A caller that races an attachment write against a `delete` can dangle a
 live reference; this trait does not detect or prevent that.
 
 ## `BlobStore::orphan_sweep` — concurrency hazard
@@ -69,7 +69,7 @@ operation, not an MCP verb, mirroring `VectorStore::orphan_sweep`'s CLI-only
 precedent (ADR-044). `BlobStore` has no visibility into SQL substrates
 (ADR-005 constraint 4: a trait instance talks to exactly one backend), so it
 cannot itself discover which content refs are still referenced by, e.g., the
-`entities.content_ref` column — the caller assembles `BlobOrphanSweepConfig.live_refs`
+`attachments.content_ref` column — the caller assembles `BlobOrphanSweepConfig.live_refs`
 and passes it in.
 
 `live_refs` is a **snapshot** the caller assembled before the call.
@@ -78,7 +78,7 @@ between when that snapshot was taken and when the sweep runs; such a
 reference is deleted anyway (see `khive-db`'s
 `orphan_sweep_race_demonstrates_the_documented_quiescence_requirement` test,
 which reproduces exactly this). This trait provides no transactional
-coordination with an entity writer. **Callers MUST quiesce entity writes**
+coordination with an attachment writer. **Callers MUST quiesce attachment writes**
 (nothing may create a new `content_ref` reference) for the duration of
 snapshot-plus-sweep — a maintenance window, a single-writer admin CLI
 invocation with no live traffic, or equivalent.
@@ -92,8 +92,8 @@ database owner makes all pre-existing claims abandoned, including claims copied
 by a backup or left under a relocated root; validated abandoned rows are removed
 in batches of at most 128. Candidates then pass through bounded claim, physical
 delete, and cleanup batches of the same maximum size. Each short
-`SqlAccess::atomic_unit` anti-joins live entity references and commits durable
-`blob_gc_claims`; entity INSERT/UPDATE triggers reject a new live reference to a
+`SqlAccess::atomic_unit` anti-joins every attachment row and commits durable
+`blob_gc_claims`; attachment INSERT/UPDATE triggers reject a new live reference to a
 claimed digest. Physical deletion runs outside SQLite while both owner/root locks
 remain held, followed by a bounded SQL-only cleanup. A crash after claim commit
 leaves the fence durable and fail-closed; the next exclusive database owner
@@ -103,6 +103,32 @@ after release, `put` rechecks the target and republishes bytes removed as an
 orphan before returning the `ContentRef`. Direct filesystem mutation does not
 participate in the advisory-lock protocol. Backends that cannot provide both
 coordination boundaries return `Unsupported`.
+
+### Schema epoch gate and the two-release V21 rollout
+
+The shipped filesystem implementation selects SQL liveness only after proving
+one exact completed V21 epoch: the V21 ledger row is uniquely present and latest,
+the cutover marker is complete, the attachment/claim tables and attachment claim
+triggers are present, and the legacy entity column/index/triggers are absent. It
+then validates stored evidence and exercises both attachment claim triggers
+before it can delete. V20, pending, incomplete, and malformed combinations fail
+closed in both dry-run and destructive modes before filesystem or claim
+mutation. Ordinary epoch mismatch is `StorageError::Unsupported`; malformed
+schema or evidence may retain its more specific validation/driver error.
+
+This gate ships first as **Phase 4a**. That compatibility release leaves V20
+schema and data untouched: no attachments, backfill, dual-read/write, or V21
+ledger entry. Every process and scheduled job sharing the database/blob root
+must converge on Phase 4a or newer, and every pre-Phase-4a process must be
+drained and prevented from restarting, before **Phase 4b** may perform the
+attachment backfill, fence swap, and legacy-column drop. Every Phase-4a
+application-serving/read-write process must also be quiesced, or proven unable
+to access the database, during cutover. A Phase-4a GC-only worker can safely
+recognize exact completed V21, but that narrow property is not general entity
+reader/writer compatibility. Start Phase-4b serving only after exact-current
+topology validation. Transactional GC is intentionally unavailable while Phase
+4a operates on V20; do not bypass the pause with caller-snapshot `orphan_sweep`
+or unconditional `delete`.
 
 The original `orphan_sweep` remains an offline-maintenance API for callers that
 already have a trusted `live_refs` snapshot. It intentionally retains its

--- a/crates/khive-storage/docs/api/error-taxonomy.md
+++ b/crates/khive-storage/docs/api/error-taxonomy.md
@@ -86,6 +86,20 @@ and `BlobDigestMismatch` is evaluated only for a metadata-consistent complete
 body. None of these variants carries bytes or changes the existing flattened
 runtime/MCP error envelope.
 
+## Attachment capability source compatibility
+
+ADR-121/ADR-160 adds `StorageCapability::Attachments`. Because
+`StorageCapability` is a public closed enum, downstream exhaustive matches must
+add an `Attachments` arm. The new `AttachmentStore` trait does not change
+existing store implementers; `EntityStore::upsert_entity_with_attachments` has
+a conservative `Unsupported` default.
+
+Removing `Entity::with_content_ref` and runtime
+`create_entity_with_content_ref` is intentionally caller-source-breaking.
+`Entity.content_ref` itself remains for wire/read compatibility, but it is a
+read-only projection of attachment role `content`; ordinary entity upserts
+ignore it.
+
 ## Typed writer-pool checkout timeout source
 
 `khive-db` retains `SqliteError::WriterPoolCheckoutTimeout` as the typed source

--- a/crates/khive-storage/docs/design.md
+++ b/crates/khive-storage/docs/design.md
@@ -1,6 +1,6 @@
 # khive-storage Design
 
-Function-specific technical reference docs (error taxonomy, blob store,
+Function-specific technical reference docs (error taxonomy, blob store, attachments,
 transaction registry) live in [`docs/api/`](api/). This document covers
 design rationale and ADR compliance.
 
@@ -23,10 +23,23 @@ verb, substrate, actor, session, aggregate, and observed/selected referents.
 
 The `StorageCapability` enum in `capability.rs` identifies which surface produced
 an error (`Sql`, `Notes`, `Entities`, `Graph`, `Events`, `Vectors`, `Sparse`,
-`Text`). Each trait file defines one capability surface as a separate module.
+`Text`, `Blob`, `Attachments`). Each trait file defines one capability surface as a separate module.
 `NoteStore::set_note_property` is the atomic, top-level JSON-key mutation
 contract: backend implementations must preserve unrelated keys without a
 caller-side read/replace cycle.
+
+### [ADR-121: Attachments](../../../docs/adr/ADR-121-attachments-first-class.md)
+
+`AttachmentStore` exposes a role-keyed map of `ContentRef` values for entity
+and note records. `EntityStore::upsert_entity_with_attachments` is the atomic
+publication seam for an entity row and its initial roles. `Entity.content_ref`
+remains a compatibility response projection of role `"content"`; it is not a
+writable entity field. Hard record deletion removes attachment rows in the same
+transaction, while soft deletion retains them.
+
+The trait layer does not choose a database or garbage collector. Runtime boot
+routes attachment mutation to the canonical main backend, and the concrete
+backend makes `attachments` the sole SQL liveness source for blob GC.
 
 ### [ADR-009: Backend Architecture](../../../docs/adr/ADR-009-backend-architecture.md)
 
@@ -66,6 +79,8 @@ Key design constraints:
 
 | Module                                      | Purpose                                                                     |
 | ------------------------------------------- | --------------------------------------------------------------------------- |
+| [`src/attachment.rs`](../src/attachment.rs) | role-keyed attachment types and `AttachmentStore`                           |
+| [`src/blob.rs`](../src/blob.rs)             | `ContentRef`, bounded read contract, and `BlobStore`                        |
 | [`src/capability.rs`](../src/capability.rs) | `StorageCapability` enum                                                    |
 | [`src/entity.rs`](../src/entity.rs)         | `Entity`, `EntityFilter`, `EntityStore`                                     |
 | [`src/error.rs`](../src/error.rs)           | `StorageError`                                                              |
@@ -80,10 +95,11 @@ Key design constraints:
 
 ## Tests
 
-| Path                                            | Coverage                                                                                                           |
-| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| [`tests/compliance.rs`](../tests/compliance.rs) | Validate() invariant tests for `VectorSearchRequest`, `SparseVector`, `EdgeFilter`; vector filter compliance suite |
-| [`tests/vectors.rs`](../tests/vectors.rs)       | `VectorStore` default-impl behavior: capabilities, batch, update, orphan sweep                                     |
+| Path                                                              | Coverage                                                                                                           |
+| ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| [`tests/attachment_contract.rs`](../tests/attachment_contract.rs) | attachment validation and stable substrate wire values                                                             |
+| [`tests/compliance.rs`](../tests/compliance.rs)                   | Validate() invariant tests for `VectorSearchRequest`, `SparseVector`, `EdgeFilter`; vector filter compliance suite |
+| [`tests/vectors.rs`](../tests/vectors.rs)                         | `VectorStore` default-impl behavior: capabilities, batch, update, orphan sweep                                     |
 
 ## Invariants
 
@@ -92,6 +108,8 @@ Key design constraints:
   increasing, all values finite.
 - `VectorSearchRequest`: query_vectors non-empty, top_k > 0, all values finite.
 - `EdgeFilter`: weight bounds must be finite and min <= max.
+- Attachment roles are non-empty and contain no control characters; optional
+  sizes fit SQLite's signed integer envelope.
 - Deserialization of `VectorSearchRequest`, `SparseVector`, and `EdgeFilter`
   enforces invariants via `serde(try_from)`.
 - Storage is ID-only. Namespace authorization is enforced at the runtime layer.
@@ -117,4 +135,4 @@ Key design constraints:
 - `TextTermStats.inverse_document_frequency` uses the Robertson-Walker IDF
   formula.
 
-Last reviewed: 2026-06-06
+Last reviewed: 2026-08-16

--- a/crates/khive-storage/src/attachment.rs
+++ b/crates/khive-storage/src/attachment.rs
@@ -1,0 +1,156 @@
+//! Role-keyed binary attachments for entity and note records.
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::blob::ContentRef;
+use crate::capability::StorageCapability;
+use crate::error::StorageError;
+use crate::types::StorageResult;
+
+/// The record substrate that owns an attachment.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AttachmentSubstrate {
+    Entity,
+    Note,
+}
+
+impl AttachmentSubstrate {
+    /// Stable lowercase value stored in SQLite and exposed on the wire.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Entity => "entity",
+            Self::Note => "note",
+        }
+    }
+}
+
+impl std::fmt::Display for AttachmentSubstrate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for AttachmentSubstrate {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "entity" => Ok(Self::Entity),
+            "note" => Ok(Self::Note),
+            other => Err(format!(
+                "attachment substrate must be \"entity\" or \"note\", got {other:?}"
+            )),
+        }
+    }
+}
+
+/// Caller-supplied metadata for one role-keyed attachment.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NewAttachment {
+    pub role: String,
+    pub content_ref: ContentRef,
+    pub media_type: Option<String>,
+    pub size_bytes: Option<u64>,
+}
+
+impl NewAttachment {
+    /// Validate values that must be represented in the SQLite attachment row.
+    pub fn validate(&self) -> StorageResult<()> {
+        validate_attachment_role(&self.role)?;
+        validate_attachment_size(self.size_bytes)
+    }
+}
+
+/// A persisted attachment row.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Attachment {
+    pub record_uuid: Uuid,
+    pub substrate: AttachmentSubstrate,
+    pub role: String,
+    pub content_ref: ContentRef,
+    pub media_type: Option<String>,
+    pub size_bytes: Option<u64>,
+    pub created_at: i64,
+}
+
+impl Attachment {
+    /// Bind caller-supplied metadata to one record and timestamp.
+    pub fn from_new(
+        record_uuid: Uuid,
+        substrate: AttachmentSubstrate,
+        new_attachment: NewAttachment,
+        created_at: i64,
+    ) -> Self {
+        Self {
+            record_uuid,
+            substrate,
+            role: new_attachment.role,
+            content_ref: new_attachment.content_ref,
+            media_type: new_attachment.media_type,
+            size_bytes: new_attachment.size_bytes,
+            created_at,
+        }
+    }
+
+    /// Validate values that must be represented in the SQLite attachment row.
+    pub fn validate(&self) -> StorageResult<()> {
+        validate_attachment_role(&self.role)?;
+        validate_attachment_size(self.size_bytes)
+    }
+}
+
+/// Validate a role at every lookup and mutation boundary.
+pub fn validate_attachment_role(role: &str) -> StorageResult<()> {
+    if role.is_empty() {
+        return Err(StorageError::InvalidInput {
+            capability: StorageCapability::Attachments,
+            operation: "validate_attachment_role".into(),
+            message: "attachment role must not be empty".to_string(),
+        });
+    }
+    if role.chars().any(char::is_control) {
+        return Err(StorageError::InvalidInput {
+            capability: StorageCapability::Attachments,
+            operation: "validate_attachment_role".into(),
+            message: "attachment role must not contain control characters".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_attachment_size(size_bytes: Option<u64>) -> StorageResult<()> {
+    if size_bytes.is_some_and(|size| size > i64::MAX as u64) {
+        return Err(StorageError::InvalidInput {
+            capability: StorageCapability::Attachments,
+            operation: "validate_attachment".into(),
+            message: format!(
+                "attachment size_bytes must fit SQLite INTEGER (maximum {} bytes)",
+                i64::MAX
+            ),
+        });
+    }
+    Ok(())
+}
+
+/// Role-keyed attachment metadata within one backend.
+///
+/// This trait is placement-blind; runtime/host wiring chooses the canonical
+/// main backend that participates in blob liveness.
+#[async_trait]
+pub trait AttachmentStore: Send + Sync + 'static {
+    /// Insert or replace one attachment role.
+    async fn upsert_attachment(&self, attachment: Attachment) -> StorageResult<()>;
+    /// Fetch one attachment role for a record.
+    async fn get_attachment(
+        &self,
+        record_uuid: Uuid,
+        role: &str,
+    ) -> StorageResult<Option<Attachment>>;
+    /// List all attachment roles for a record in stable role order.
+    async fn list_attachments(&self, record_uuid: Uuid) -> StorageResult<Vec<Attachment>>;
+    /// Remove one attachment role without touching the referenced blob.
+    async fn delete_attachment(&self, record_uuid: Uuid, role: &str) -> StorageResult<bool>;
+}

--- a/crates/khive-storage/src/blob.rs
+++ b/crates/khive-storage/src/blob.rs
@@ -120,8 +120,8 @@ fn hex_encode(bytes: &[u8]) -> String {
 /// rationale.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct BlobOrphanSweepConfig {
-    /// Content refs currently referenced by at least one live row somewhere
-    /// in the system, as of when the caller assembled this set. Anything
+    /// Content refs currently referenced by at least one committed record
+    /// attachment, as of when the caller assembled this set. Anything
     /// this backend stores that is NOT in this set is treated as orphaned
     /// and deleted (or reported, in `dry_run` mode) — including a
     /// `content_ref` that becomes live after this snapshot was taken.
@@ -143,8 +143,8 @@ pub struct BlobOrphanSweepResult {
     pub would_delete: u64,
     /// Objects with zero live references that were left alone because they
     /// are still inside their publish grace period — recently written and
-    /// not yet orphaned, just not yet referenced by an entity. Reported in
-    /// both modes; never counted in `would_delete` or `deleted`.
+    /// not yet orphaned, just not yet referenced by a record attachment.
+    /// Reported in both modes; never counted in `would_delete` or `deleted`.
     pub grace_period_skipped: u64,
 }
 
@@ -201,9 +201,9 @@ pub trait BlobStore: Send + Sync + std::fmt::Debug + 'static {
     /// # Safety / concurrency hazard (ADR-111 §8, amended)
     ///
     /// Unconditional physical removal with **no coordination against any
-    /// entity that might reference `content_ref`**. Safe to call only when
-    /// the caller has independently quiesced whatever writer could attach a
-    /// new `content_ref` to an entity for the duration of the call — this
+    /// record attachment that might reference `content_ref`**. Safe to call
+    /// only when the caller has independently quiesced whatever writer could
+    /// attach a new `content_ref` to a record for the duration of the call — this
     /// trait does not detect or prevent a race. Offline-maintenance-only.
     /// See `crates/khive-storage/docs/api/blob-store.md`.
     async fn delete(&self, content_ref: &ContentRef) -> StorageResult<bool>;
@@ -218,7 +218,7 @@ pub trait BlobStore: Send + Sync + std::fmt::Debug + 'static {
     ///
     /// `config.live_refs` is a **snapshot**; a `content_ref` that becomes
     /// newly live between the snapshot and the sweep is deleted anyway.
-    /// **Callers MUST quiesce entity writes** for the duration of
+    /// **Callers MUST quiesce attachment writes** for the duration of
     /// snapshot-plus-sweep. See `crates/khive-storage/docs/api/blob-store.md`
     /// for the race repro. Concurrent callers must use
     /// [`Self::transactional_orphan_sweep`] instead.
@@ -234,19 +234,19 @@ pub trait BlobStore: Send + Sync + std::fmt::Debug + 'static {
         })
     }
 
-    /// Select live entity references and sweep orphaned blobs behind a
+    /// Select live attachment references and sweep orphaned blobs behind a
     /// database-coordinated, bounded claim protocol.
     ///
     /// Unlike [`Self::orphan_sweep`], this operation obtains liveness itself
     /// from `sql`; callers do not assemble a stale snapshot. `sql` must be the
-    /// same database capability used for the entity writes that own these
-    /// references. Implementations must also ensure an object published after
+    /// canonical database capability used for the attachment writes that own
+    /// these references. Implementations must also ensure an object published after
     /// the sweep's candidate set is captured cannot be mistaken for an orphan,
     /// including when it is published between selecting live references and
     /// physical deletion. Implementations must not perform filesystem or
     /// other external I/O while holding the database writer transaction;
     /// durable claims/triggers or an equivalently fail-closed fence must keep
-    /// entity writes safe after each short transaction commits. Claim/result
+    /// attachment writes safe after each short transaction commits. Claim/result
     /// materialization and cleanup must have an explicit per-transaction
     /// cardinality bound rather than scale one writer hold with the complete
     /// object population. A file-backed `sql` implementation must expose its
@@ -258,8 +258,24 @@ pub trait BlobStore: Send + Sync + std::fmt::Debug + 'static {
     /// Backends that cannot provide both guarantees return
     /// `StorageError::Unsupported`.
     ///
-    /// Publishing a blob and committing the entity write that references it
-    /// are two separate client steps; nothing serializes them against this
+    /// The shipped filesystem implementation additionally fail-closes on the
+    /// database's liveness epoch. It accepts only an exact completed V21 state
+    /// (ledger and completed marker, attachment claim fences present, legacy
+    /// entity column/index/triggers absent). V20, pending, incomplete, and
+    /// malformed states fail closed in both dry-run and destructive modes before
+    /// filesystem or claim mutation. Ordinary epoch mismatch is `Unsupported`;
+    /// malformed schema/evidence may retain its specific validation/driver
+    /// error. This is the Phase-4a GC compatibility gate: Phase 4a changes no
+    /// schema or data. Every older process sharing the database/blob root must
+    /// be drained before Phase 4b
+    /// performs the attachment backfill and legacy-column drop. Phase-4a
+    /// application readers/writers must also be quiesced during cutover; only a
+    /// GC-only worker has narrow compatibility with exact completed V21. Callers
+    /// must not fall back to [`Self::orphan_sweep`] or [`Self::delete`] when this
+    /// gate refuses.
+    ///
+    /// Publishing a blob and committing the record attachment that references
+    /// it are two separate client steps; nothing serializes them against this
     /// sweep. Implementations must therefore also give a just-published,
     /// not-yet-referenced object a bounded grace period before treating it as
     /// an orphan (the filesystem backend does this via file age). A client

--- a/crates/khive-storage/src/capability.rs
+++ b/crates/khive-storage/src/capability.rs
@@ -13,4 +13,17 @@ pub enum StorageCapability {
     Text,
     /// Content-addressed binary object storage (`BlobStore`, khive#292).
     Blob,
+    /// Role-keyed blob references attached to entities or notes.
+    Attachments,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StorageCapability;
+
+    #[test]
+    fn additive_capabilities_preserve_the_public_discriminant_order() {
+        assert_eq!(StorageCapability::Blob as usize, 8);
+        assert_eq!(StorageCapability::Attachments as usize, 9);
+    }
 }

--- a/crates/khive-storage/src/entity.rs
+++ b/crates/khive-storage/src/entity.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
 
+use crate::attachment::Attachment;
 use crate::types::{
     BatchWriteSummary, DeleteMode, Page, PageRequest, SeekCursor, SeekPage, StorageResult,
 };
@@ -29,11 +30,11 @@ pub struct Entity {
     pub merged_into: Option<Uuid>,
     /// Opaque event ID for the merge that tombstoned this entity.
     pub merge_event_id: Option<Uuid>,
-    /// Content-addressed reference into a `BlobStore` (khive#292), stored as
-    /// the raw hex digest string. `None` when this entity has no attached
-    /// binary payload. Storage does not validate that the referenced blob
-    /// actually exists — callers publish the blob before setting this field
-    /// (see `docs/adr` BlobStore ADR "publish-then-reference" ordering).
+    /// Read-only compatibility projection of attachment role `"content"`.
+    ///
+    /// Entity writes ignore this field. Callers publish content through the
+    /// attachment substrate; reads populate it so existing response payloads
+    /// keep their `content_ref` field during the coordinated cutover.
     pub content_ref: Option<String>,
 }
 
@@ -61,12 +62,6 @@ impl Entity {
             merge_event_id: None,
             content_ref: None,
         }
-    }
-
-    /// Set the content-addressed blob reference (khive#292).
-    pub fn with_content_ref(mut self, content_ref: impl Into<String>) -> Self {
-        self.content_ref = Some(content_ref.into());
-        self
     }
 
     /// Set the pack-governed entity subtype token.
@@ -136,6 +131,18 @@ pub struct EntityFilter {
 pub trait EntityStore: Send + Sync + 'static {
     /// Insert or update a single entity.
     async fn upsert_entity(&self, entity: Entity) -> StorageResult<()>;
+    /// Atomically insert/update an entity and all supplied attachment roles.
+    async fn upsert_entity_with_attachments(
+        &self,
+        _entity: Entity,
+        _attachments: Vec<Attachment>,
+    ) -> StorageResult<()> {
+        Err(crate::StorageError::Unsupported {
+            capability: crate::StorageCapability::Attachments,
+            operation: "upsert_entity_with_attachments".into(),
+            message: "this backend does not implement atomic entity attachment publication".into(),
+        })
+    }
     /// Insert or update a batch of entities.
     async fn upsert_entities(&self, entities: Vec<Entity>) -> StorageResult<BatchWriteSummary>;
     /// Fetch an entity by UUID, returning `None` if absent.

--- a/crates/khive-storage/src/lib.rs
+++ b/crates/khive-storage/src/lib.rs
@@ -1,6 +1,9 @@
-//! Storage capability traits: `SqlAccess`, `VectorStore`, `TextSearch`, `GraphStore`, `NoteStore`, `EventStore`, `BlobStore`.
+//! Storage capability traits: `SqlAccess`, `VectorStore`, `TextSearch`,
+//! `GraphStore`, `NoteStore`, `EntityStore`, `EventStore`, `SparseStore`,
+//! `BlobStore`, and `AttachmentStore`.
 
 pub mod agent;
+pub mod attachment;
 pub mod blob;
 pub mod capability;
 pub mod entity;
@@ -19,6 +22,7 @@ pub mod usage;
 pub mod vectors;
 
 pub use agent::AgentStore;
+pub use attachment::{Attachment, AttachmentStore, AttachmentSubstrate, NewAttachment};
 pub use blob::{
     BlobOrphanSweepConfig, BlobOrphanSweepResult, BlobStore, ContentRef, MAX_BLOB_WHOLE_BYTES,
 };

--- a/crates/khive-storage/tests/attachment_contract.rs
+++ b/crates/khive-storage/tests/attachment_contract.rs
@@ -1,0 +1,87 @@
+use khive_storage::{
+    Attachment, AttachmentSubstrate, ContentRef, NewAttachment, StorageCapability, StorageError,
+};
+use uuid::Uuid;
+
+fn new_attachment(role: &str, size_bytes: Option<u64>) -> NewAttachment {
+    NewAttachment {
+        role: role.to_string(),
+        content_ref: ContentRef::from_hex("a".repeat(64)).expect("canonical ref"),
+        media_type: Some("application/octet-stream".to_string()),
+        size_bytes,
+    }
+}
+
+#[test]
+fn attachment_role_rejects_empty_and_control_characters() {
+    for role in ["", "content\nshadow", "fann\u{0000}network"] {
+        let error = new_attachment(role, Some(1))
+            .validate()
+            .expect_err("invalid role must be rejected");
+        assert!(matches!(
+            error,
+            StorageError::InvalidInput {
+                capability: StorageCapability::Attachments,
+                ..
+            }
+        ));
+    }
+}
+
+#[test]
+fn attachment_size_must_fit_sqlite_integer() {
+    new_attachment("content", Some(i64::MAX as u64))
+        .validate()
+        .expect("SQLite's maximum signed integer must be accepted");
+
+    let error = new_attachment("content", Some(i64::MAX as u64 + 1))
+        .validate()
+        .expect_err("size above SQLite INTEGER must be rejected");
+    assert!(matches!(
+        error,
+        StorageError::InvalidInput {
+            capability: StorageCapability::Attachments,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn from_new_preserves_attachment_metadata_and_identity() {
+    let record_uuid = Uuid::new_v4();
+    let new = new_attachment("fann-network", Some(42));
+    let expected_ref = new.content_ref.clone();
+
+    let attachment = Attachment::from_new(record_uuid, AttachmentSubstrate::Entity, new, 123_456);
+
+    assert_eq!(attachment.record_uuid, record_uuid);
+    assert_eq!(attachment.substrate, AttachmentSubstrate::Entity);
+    assert_eq!(attachment.role, "fann-network");
+    assert_eq!(attachment.content_ref, expected_ref);
+    assert_eq!(
+        attachment.media_type.as_deref(),
+        Some("application/octet-stream")
+    );
+    assert_eq!(attachment.size_bytes, Some(42));
+    assert_eq!(attachment.created_at, 123_456);
+}
+
+#[test]
+fn attachment_substrate_has_stable_lowercase_wire_values() {
+    assert_eq!(
+        serde_json::to_string(&AttachmentSubstrate::Entity).unwrap(),
+        "\"entity\""
+    );
+    assert_eq!(
+        serde_json::to_string(&AttachmentSubstrate::Note).unwrap(),
+        "\"note\""
+    );
+    assert_eq!(
+        serde_json::from_str::<AttachmentSubstrate>("\"entity\"").unwrap(),
+        AttachmentSubstrate::Entity
+    );
+    assert_eq!(
+        serde_json::from_str::<AttachmentSubstrate>("\"note\"").unwrap(),
+        AttachmentSubstrate::Note
+    );
+}

--- a/crates/kkernel/docs/design.md
+++ b/crates/kkernel/docs/design.md
@@ -15,10 +15,13 @@
 
 ### Multi-backend configuration (ADR-009, ADR-028)
 
-- `BackendRegistry` holds registered backends. Constructed at boot from `khive.toml`.
-- `kkernel backend list` and `kkernel backend info` expose the registry to operators.
-- Current v1 implementation exposes a single default backend. Full `khive.toml`-driven
-  multi-backend enumeration is deferred to a follow-up milestone.
+- MCP/exec host boot constructs `BackendRegistry` from `khive.toml`, deduplicates
+  physical databases, and routes each pack to its assigned runtime. Canonical
+  `main` remains the sole attachment and blob-GC liveness authority after every
+  secondary passes boot inventory.
+- `kkernel backend list` and `kkernel backend info` are a narrower legacy admin
+  surface: they currently expose only the synthetic default `main` backend, not
+  the full config-driven boot registry.
 
 ### VCS and sync (ADR-010, ADR-020)
 
@@ -29,10 +32,22 @@
 
 ### ADR-015: Schema migrations
 
-- `KhiveRuntime::new()` runs `run_migrations()` internally — constructing the runtime
-  is sufficient to apply all pending migrations.
-- `kkernel db migrate` wraps this; `kkernel db check` uses a read-only runtime to
-  report schema state without writing.
+- Ordinary schema preparation applies the canonical prefix automatically.
+  V21 is application-assisted when legacy blob references exist: the async
+  MCP/kkernel host installs bounded hydration, authenticates pack-owned
+  artifacts, and finalizes attachment-only GC before constructing a runtime.
+- `kkernel db migrate` loads the configured storage topology and reuses the
+  core-only host coordinator: physical aliases are deduplicated, distinct
+  secondaries are prepared before canonical `main`, and no pack runtime,
+  embedder, or pack-auxiliary DDL is constructed. `--backend` is an active
+  configured-backend selector; advancing `main` retains its secondary
+  prerequisites. `kkernel db check` loads the same target set and inspects each
+  migration ledger read-only without writing.
+- The V21 rollout requires Phase-4a fleet convergence and old-binary drain,
+  followed by quiescence of every Phase-4a application reader/writer during
+  cutover. A GC-only Phase-4a worker's completed-V21 compatibility is narrower
+  than serving compatibility. Phase-4b serving starts only after the same
+  planned topology validates exact-current.
 
 ### Pack standard (vocabulary + handlers) (ADR-017)
 
@@ -391,7 +406,8 @@ exactly the bug ADR-107 §4 was written to close.
 ## Consistency Notes
 
 - `kkernel db migrate --dry-run` delegates to `cmd_db_check` rather than implementing
-  a separate dry-run path. The `--check` flag makes the check exit nonzero if behind.
+  a separate dry-run path. Both reuse the migration target planner; the `--check`
+  flag exits nonzero for any behind, ahead, or invalid target.
 - The `cmd_vector_capabilities` function hard-codes baseline sqlite-vec values
   rather than instantiating a runtime — this is intentional for the v1 implementation
   but means the output does not reflect operator-configured backends.

--- a/crates/kkernel/docs/usage.md
+++ b/crates/kkernel/docs/usage.md
@@ -338,13 +338,53 @@ kkernel exec 'knowledge.index(ids=["my-slug", "<uuid>"])' --db ~/.khive/khive.db
 ## `kkernel db` — schema lifecycle
 
 ```bash
-kkernel db check --db ~/.khive/khive.db --human     # report current vs latest version
-kkernel db check --strict                            # exit nonzero if behind
-kkernel db migrate --db ~/.khive/khive.db            # apply pending migrations
-kkernel db migrate --dry-run                         # show pending without applying
+kkernel db check --config ~/.khive/khive.toml --human # report configured topology
+kkernel db check --backend archive --strict           # inspect one configured backend
+kkernel db migrate --config ~/.khive/khive.toml       # secondaries, then main
+kkernel db migrate --backend archive                  # migrate one named secondary
+kkernel db migrate --dry-run                          # read-only topology check
 ```
 
 The consolidated baseline is a single migration (V1, from `khive-db/sql/schema.sql`).
+Both commands load an explicit `--config`/`KHIVE_CONFIG` or use normal khive
+config discovery. With declared `[[backends]]`, omitting `--backend` targets the full
+configured set and `--backend <name>` is an active selector. Migration
+deduplicates physical aliases and prepares every distinct secondary before
+canonical `main`; selecting `main` keeps those prerequisites, while selecting a
+non-main secondary advances only that empty attachment-authority target. With no
+declared topology, the implicit target is `main` at `--db`/`KHIVE_DB` or the
+default `~/.khive/khive.db`. A concrete DB override may not conflict with a
+declared main path.
+
+The database admin path is core-only: it does not register packs, instantiate
+embedding models, or apply pack-auxiliary DDL. It still resolves the configured
+BlobStore and bounded hydrator when legacy V20 moodboard evidence must be
+authenticated. `db check` and migrate's `--dry-run`/`--check` modes never open a
+runtime or mutate the database; absent files report V0. They reuse migration's
+target planner, so selecting `main` or its SQLite alias includes every secondary
+prerequisite, while an independent secondary remains a single target.
+
+Before either command opens a database, the planner rejects physical SQLite
+aliases that disagree on `read_only`; a named target cannot bypass that topology
+check. `--db :memory:` changes every configured name into a distinct ephemeral
+backend, so only the literal `main` name carries main's prerequisite plan in that
+mode. Migration output marks `prerequisite` by physical backend identity: every
+alias of the selected main is a target, not a prerequisite.
+
+A legacy V20 database with blob-bearing entities uses the same boot-gated V21
+coordinator as MCP startup: it backfills role-keyed attachments, verifies any
+legacy moodboard bundle/event/FANN evidence through bounded hydration, switches
+GC liveness and claim fences, and only then drops `entities.content_ref`.
+`kkernel db migrate` waits for that cutover and fails without exposing an
+incomplete runtime when evidence or blob storage is unavailable.
+A Phase-4b binary must not be allowed to start this cutover until the Phase-4a
+GC compatibility build has converged across the fleet and every pre-Phase-4a
+process sharing the database/blob root has been drained. Every Phase-4a
+application-serving/read-write process must then be quiesced or proven unable
+to touch the database for cutover; only a GC-only worker has narrow
+compatibility with completed V21. Start the Phase-4b serving fleet only after
+`db check --strict` reports the planned topology exact-current. See
+`docs/operations.md` for the two-release runbook.
 A database whose `_schema_migrations` version is **ahead** of the latest known
 migration is rejected at open time — it predates the consolidation or was written by a
 newer build. Recreate it from the current schema; in-place downgrade is unsupported.

--- a/crates/kkernel/src/cli.rs
+++ b/crates/kkernel/src/cli.rs
@@ -19,7 +19,10 @@ use crate::{
     coordinator::{BackendRegistry, SubstrateCoordinator, SubstrateCoordinatorService},
     engine, exec, git_ingest, kg, pack_introspect, reindex, repo, sync, vector,
 };
-use khive_runtime::{BackendId, KhiveConfig, KhiveRuntime, RuntimeConfig};
+use khive_runtime::{
+    runtime_config_from_khive_config, BackendId, BackendKind, KhiveConfig, KhiveRuntime,
+    RuntimeConfig,
+};
 
 #[derive(Parser, Debug)]
 #[command(
@@ -120,8 +123,12 @@ enum DbCommand {
 #[derive(clap::Parser, Debug)]
 struct DbMigrateArgs {
     /// Database path (defaults to `~/.khive/khive.db`).
-    #[arg(long)]
-    db: Option<PathBuf>,
+    #[arg(long, env = "KHIVE_DB")]
+    db: Option<String>,
+
+    /// Explicit khive config path (otherwise use normal discovery).
+    #[arg(long, env = "KHIVE_CONFIG")]
+    config: Option<PathBuf>,
 
     /// Target a specific backend by name.
     #[arg(long)]
@@ -143,8 +150,16 @@ struct DbMigrateArgs {
 #[derive(clap::Parser, Debug)]
 struct DbCheckArgs {
     /// Database path (defaults to `~/.khive/khive.db`).
+    #[arg(long, env = "KHIVE_DB")]
+    db: Option<String>,
+
+    /// Explicit khive config path (otherwise use normal discovery).
+    #[arg(long, env = "KHIVE_CONFIG")]
+    config: Option<PathBuf>,
+
+    /// Target a specific backend by name.
     #[arg(long)]
-    db: Option<PathBuf>,
+    backend: Option<String>,
 
     /// Exit nonzero if any backend is behind the current schema version.
     #[arg(long)]
@@ -382,7 +397,8 @@ pub async fn cli_main() -> Result<()> {
                         &khive_cfg,
                         a.db.as_deref(),
                         db_anchor.as_deref(),
-                    )?;
+                    )
+                    .await?;
 
                 khive_mcp::serve::serve_server(
                     server,
@@ -458,7 +474,7 @@ fn resolve_command(exec: Option<String>, command: Option<Command>) -> Command {
 /// See `crates/kkernel/docs/coordinator.md#kkernel-mainrs--coordinator-attached-boot-path`
 /// for why this is the one place that assembles the coordinator inputs.
 #[cfg(test)]
-fn build_multi_backend_server_with_coordinator(
+async fn build_multi_backend_server_with_coordinator(
     base_cfg: RuntimeConfig,
     khive_cfg: &KhiveConfig,
     cli_db_override: Option<&str>,
@@ -474,9 +490,10 @@ fn build_multi_backend_server_with_coordinator(
         cli_db_override,
         db_anchor.as_deref(),
     )
+    .await
 }
 
-fn build_multi_backend_server_with_coordinator_and_db_anchor(
+async fn build_multi_backend_server_with_coordinator_and_db_anchor(
     base_cfg: RuntimeConfig,
     khive_cfg: &KhiveConfig,
     cli_db_override: Option<&str>,
@@ -487,7 +504,8 @@ fn build_multi_backend_server_with_coordinator_and_db_anchor(
         khive_cfg,
         cli_db_override,
         db_anchor,
-    )?;
+    )
+    .await?;
 
     let schedule_rt = multi
         .per_pack_runtimes
@@ -526,57 +544,113 @@ async fn cmd_db(cmd: DbCommand) -> Result<()> {
     }
 }
 
-async fn cmd_db_migrate(args: DbMigrateArgs) -> Result<()> {
-    // KhiveRuntime::new() runs run_migrations() internally.
-    // Constructing the runtime is therefore sufficient to apply all pending migrations.
-    let mut cfg = RuntimeConfig::default();
-    if let Some(ref db) = args.db {
-        cfg.db_path = Some(db.clone());
-    }
+struct DbCommandContext {
+    base_config: RuntimeConfig,
+    khive_config: KhiveConfig,
+    cli_db_override: Option<String>,
+}
 
+fn resolve_db_command_context(
+    db: Option<&str>,
+    config: Option<&std::path::Path>,
+) -> Result<DbCommandContext> {
+    let discovery_anchor = khive_mcp::serve::config_discovery_db_anchor(db);
+    let loaded =
+        KhiveConfig::load_with_home_fallback_and_source(config, discovery_anchor.as_deref())
+            .context("load database-command khive config")?;
+    let config_source = loaded.as_ref().map(|(_, source)| source.as_path());
+    let khive_config = loaded
+        .as_ref()
+        .map(|(config, _)| config.clone())
+        .unwrap_or_default();
+    khive_mcp::serve::reject_conflicting_db_override_with_source(
+        db,
+        &khive_config.backends,
+        config_source,
+    )?;
+
+    let mut base_config = RuntimeConfig::default();
+    base_config.db_path = khive_runtime::resolve_db_anchor(db);
+    base_config = runtime_config_from_khive_config(&khive_config, base_config);
+    // Schema administration never needs to instantiate an embedding model or
+    // register packs. Blob hydration remains configured because verified V20
+    // moodboard evidence may be part of the cutover.
+    base_config.embedding_model = None;
+    base_config.additional_embedding_models.clear();
+    base_config.packs.clear();
+
+    Ok(DbCommandContext {
+        base_config,
+        khive_config,
+        cli_db_override: db.map(str::to_owned),
+    })
+}
+
+async fn cmd_db_migrate(args: DbMigrateArgs) -> Result<()> {
     if args.dry_run || args.check {
         // For dry-run / --check, query the current schema version without writing.
         return cmd_db_check(DbCheckArgs {
             db: args.db,
+            config: args.config,
+            backend: args.backend,
             strict: args.check,
             human: args.human,
         })
         .await;
     }
 
-    let rt = KhiveRuntime::new(cfg).map_err(|e| anyhow::anyhow!("{e}"))?;
-    let latest = khive_db::MIGRATIONS.len() as u32;
+    let context = resolve_db_command_context(args.db.as_deref(), args.config.as_deref())?;
 
-    // Query the applied version to report what was done.
-    let sql = rt.sql();
-    let mut reader = sql
-        .reader()
-        .await
-        .context("open SQL reader after migration")?;
-    use khive_storage::types::{SqlStatement, SqlValue};
-    let rows = reader
-        .query_all(SqlStatement {
-            sql: "SELECT COALESCE(MAX(version), 0) FROM _schema_migrations".into(),
-            params: vec![],
-            label: Some("db_migrate_version".into()),
-        })
-        .await
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
-    let applied: u32 = rows
-        .first()
-        .and_then(|r| match r.get("COALESCE(MAX(version), 0)") {
-            Some(SqlValue::Integer(v)) => Some(*v as u32),
-            _ => None,
-        })
-        .unwrap_or(latest);
+    // V21 is application-assisted: after the ordinary V1-V20 schema prefix,
+    // the host must install bounded blob hydration, authenticate any legacy
+    // moodboard bundle/network evidence, and only then finalize attachment-only
+    // liveness. Reuse the same async choke point as MCP/exec boot so the admin
+    // command cannot strand an incomplete database or bypass the GC fence.
+    let statuses = khive_mcp::serve::migrate_configured_storage_topology(
+        context.base_config,
+        &context.khive_config,
+        context.cli_db_override.as_deref(),
+        args.backend.as_deref(),
+    )
+    .await
+    .context("migrate configured storage topology through the attachment cutover")?;
+    let latest = khive_db::MIGRATIONS
+        .last()
+        .map(|migration| migration.version)
+        .unwrap_or(0);
+    let current = statuses
+        .iter()
+        .all(|status| status.applied_version == latest);
 
     if args.human {
-        println!("schema migrated: version {applied} of {latest} (current)");
+        for status in &statuses {
+            let role = if status.prerequisite {
+                " prerequisite"
+            } else {
+                ""
+            };
+            println!(
+                "{}: V{} of V{} (current{role})",
+                status.backend, status.applied_version, latest
+            );
+        }
     } else {
+        let backends = statuses
+            .iter()
+            .map(|status| {
+                serde_json::json!({
+                    "backend": status.backend,
+                    "applied_version": status.applied_version,
+                    "latest_version": latest,
+                    "current": status.applied_version == latest,
+                    "prerequisite": status.prerequisite,
+                })
+            })
+            .collect::<Vec<_>>();
         let json = serde_json::json!({
-            "applied_version": applied,
             "latest_version": latest,
-            "current": applied == latest,
+            "current": current,
+            "backends": backends,
         });
         println!("{}", serde_json::to_string(&json).expect("serialize"));
     }
@@ -584,64 +658,134 @@ async fn cmd_db_migrate(args: DbMigrateArgs) -> Result<()> {
 }
 
 async fn cmd_db_check(args: DbCheckArgs) -> Result<()> {
-    let latest = khive_db::MIGRATIONS.len() as u32;
+    let context = resolve_db_command_context(args.db.as_deref(), args.config.as_deref())?;
+    let latest = khive_db::MIGRATIONS
+        .last()
+        .map(|migration| migration.version)
+        .unwrap_or(0);
+    let force_memory = context.cli_db_override.as_deref() == Some(":memory:");
 
-    // A schema check must never mutate the database. Resolve the effective path
-    // and read `_schema_migrations` read-only — opening through a runtime would
-    // run migrations and bring an out-of-date database current before reporting,
-    // masking the pending state this command exists to detect.
-    let resolved: Option<PathBuf> = match args.db {
-        Some(p) => Some(p),
-        None => std::env::var("HOME")
-            .ok()
-            .map(|h| PathBuf::from(h).join(".khive/khive.db")),
-    };
-
-    // An absent file is an un-migrated database (version 0); do not create it.
-    let current_version: u32 = match resolved {
-        Some(ref p) if p.exists() => {
-            khive_db::inspect_schema_version(p).map_err(|e| anyhow::anyhow!("{e}"))?
-        }
-        _ => 0,
-    };
-
-    let is_current = current_version == latest;
-    // A version beyond the latest known migration is a stale ledger: the database
-    // predates the consolidated V1 baseline (ADR-015) or was written by a newer
-    // build. Report it rather than treating it as current.
-    let ahead = current_version > latest;
-
-    if args.human {
-        let state = if ahead {
-            "ahead — predates the consolidated baseline (ADR-015) or written by a newer build; recreate it"
-        } else if is_current {
-            "current"
-        } else {
-            "behind — run: kkernel db migrate"
-        };
-        println!("main:    V{current_version} ({state})");
+    let mut targets = Vec::new();
+    if context.khive_config.backends.is_empty() {
+        khive_mcp::serve::configured_storage_check_targets(
+            &context.khive_config,
+            context.cli_db_override.as_deref(),
+            args.backend.as_deref(),
+        )?;
+        targets.push((BackendId::MAIN.to_string(), context.base_config.db_path));
     } else {
-        let json = serde_json::json!({
-            "current_version": current_version,
-            "latest_version": latest,
-            "current": is_current,
-            "ahead": ahead,
-            "pending": latest.saturating_sub(current_version),
-        });
-        println!("{}", serde_json::to_string(&json).expect("serialize"));
+        let planned_names = khive_mcp::serve::configured_storage_check_targets(
+            &context.khive_config,
+            context.cli_db_override.as_deref(),
+            args.backend.as_deref(),
+        )?;
+        for backend_name in planned_names {
+            let backend = context
+                .khive_config
+                .backends
+                .iter()
+                .find(|backend| backend.name == backend_name)
+                .expect("the shared topology planner returned a configured backend");
+            let path = if force_memory || backend.kind == BackendKind::Memory {
+                None
+            } else {
+                Some(khive_runtime::expand_tilde(
+                    backend.path.as_deref().ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "backend {:?}: sqlite backend requires a `path` field",
+                            backend.name
+                        )
+                    })?,
+                ))
+            };
+            targets.push((backend.name.clone(), path));
+        }
     }
 
-    if args.strict && !is_current {
-        if ahead {
-            anyhow::bail!(
-                "schema version {current_version} is ahead of the latest known migration {latest} — \
-                 this database predates the consolidated baseline (ADR-015) or was written by a newer \
-                 build; recreate it from the current schema"
-            );
+    let mut reports = Vec::with_capacity(targets.len());
+    for (backend, path) in targets {
+        let (current_version, validation_error) = match path.as_deref() {
+            Some(path) if path.exists() => {
+                let version = khive_db::inspect_schema_version(path)
+                    .map_err(|error| anyhow::anyhow!("backend {backend}: {error}"))?;
+                let validation_error = if version == latest {
+                    khive_db::inspect_schema_is_current(path)
+                        .err()
+                        .map(|error| error.to_string())
+                } else {
+                    None
+                };
+                (version, validation_error)
+            }
+            _ => (0, None),
+        };
+        let ahead = current_version > latest;
+        let is_current = current_version == latest && validation_error.is_none();
+        reports.push((
+            backend,
+            current_version,
+            is_current,
+            ahead,
+            validation_error,
+        ));
+    }
+
+    if args.human {
+        for (backend, current_version, is_current, ahead, validation_error) in &reports {
+            let state = if let Some(error) = validation_error {
+                format!("invalid current-schema state — {error}")
+            } else if *ahead {
+                "ahead — incompatible with this build".to_string()
+            } else if *is_current {
+                "current".to_string()
+            } else {
+                "behind — run: kkernel db migrate".to_string()
+            };
+            println!("{backend}: V{current_version} ({state})");
         }
+    } else {
+        let backends = reports
+            .iter()
+            .map(
+                |(backend, current_version, is_current, ahead, validation_error)| {
+                    serde_json::json!({
+                        "backend": backend,
+                        "current_version": current_version,
+                        "latest_version": latest,
+                        "current": is_current,
+                        "ahead": ahead,
+                        "pending": latest.saturating_sub(*current_version),
+                        "validation_error": validation_error,
+                    })
+                },
+            )
+            .collect::<Vec<_>>();
+        println!(
+            "{}",
+            serde_json::to_string(&serde_json::json!({
+                "current": reports.iter().all(|(_, _, current, _, _)| *current),
+                "latest_version": latest,
+                "backends": backends,
+            }))
+            .expect("serialize")
+        );
+    }
+
+    if args.strict && reports.iter().any(|(_, _, current, _, _)| !current) {
+        let summary = reports
+            .iter()
+            .filter(|(_, _, current, _, _)| !current)
+            .map(|(backend, version, _, _, validation_error)| {
+                validation_error
+                    .as_ref()
+                    .map(|error| format!("{backend}: V{version}, {error}"))
+                    .unwrap_or_else(|| format!("{backend}: V{version}"))
+            })
+            .collect::<Vec<_>>()
+            .join("; ");
         anyhow::bail!(
-            "schema is behind: V{current_version} applied, V{latest} is current — \
-             run `kkernel db migrate` to bring the schema up to date"
+            "schema topology is not current ({summary}); V{latest} with a complete canonical \
+             attachment cutover is required"
         );
     }
     Ok(())
@@ -835,6 +979,96 @@ mod tests {
     use serial_test::serial;
     use tempfile::TempDir;
 
+    fn write_empty_config(dir: &std::path::Path) -> PathBuf {
+        let path = dir.join("empty-khive.toml");
+        std::fs::write(&path, "").expect("write empty config");
+        path
+    }
+
+    fn create_v20_fixture(
+        path: &std::path::Path,
+        legacy: Option<(&str, Option<i64>)>,
+    ) -> Option<khive_storage::ContentRef> {
+        use khive_db::migrations::{ATTACHMENT_CUTOVER_VERSION, MIGRATIONS};
+
+        let backend = khive_db::StorageBackend::sqlite(path).expect("open V20 fixture backend");
+        let mut writer = backend
+            .pool()
+            .try_writer()
+            .expect("open V20 fixture writer");
+        let conn = writer.conn_mut();
+        conn.execute_batch(
+            "CREATE TABLE _schema_migrations (\
+                 version INTEGER PRIMARY KEY, \
+                 name TEXT NOT NULL, \
+                 applied_at INTEGER NOT NULL\
+             ) STRICT;",
+        )
+        .expect("create V20 ledger");
+        for migration in MIGRATIONS
+            .iter()
+            .filter(|migration| migration.version < ATTACHMENT_CUTOVER_VERSION)
+        {
+            let tx = conn.transaction().expect("begin V20 migration");
+            tx.execute_batch(migration.up)
+                .unwrap_or_else(|error| panic!("apply V{}: {error}", migration.version));
+            tx.execute(
+                "INSERT INTO _schema_migrations (version, name, applied_at) \
+                 VALUES (?1, ?2, ?3)",
+                (
+                    migration.version,
+                    migration.name,
+                    i64::from(migration.version),
+                ),
+            )
+            .unwrap_or_else(|error| panic!("record V{}: {error}", migration.version));
+            tx.commit().expect("commit V20 migration");
+        }
+
+        legacy.map(|(entity_type, deleted_at)| {
+            let content_ref =
+                khive_storage::ContentRef::from_hex("a".repeat(64)).expect("canonical legacy ref");
+            conn.execute(
+                "INSERT INTO entities (\
+                     id, namespace, kind, entity_type, name, tags, created_at, updated_at, \
+                     deleted_at, content_ref\
+                 ) VALUES (?1, 'local', 'artifact', ?2, 'legacy fixture', '[]', 1, 1, ?3, ?4)",
+                (
+                    uuid::Uuid::new_v4().to_string(),
+                    entity_type,
+                    deleted_at,
+                    content_ref.as_str(),
+                ),
+            )
+            .expect("insert legacy entity");
+            content_ref
+        })
+    }
+
+    fn write_topology_config(
+        dir: &std::path::Path,
+        main: &std::path::Path,
+        secondary: Option<(&str, &std::path::Path)>,
+    ) -> PathBuf {
+        let path = dir.join("topology.toml");
+        let mut config = format!(
+            "[[backends]]\nname = \"main\"\nkind = \"sqlite\"\npath = {:?}\n",
+            main.display().to_string()
+        );
+        if let Some((name, secondary)) = secondary {
+            config.push_str(&format!(
+                "\n[[backends]]\nname = {name:?}\nkind = \"sqlite\"\npath = {:?}\n",
+                secondary.display().to_string()
+            ));
+        }
+        config.push_str(&format!(
+            "\n[storage.blob]\nbackend = \"fs\"\nroot = {:?}\nfloor_bytes = 0\n",
+            dir.join("blobs").display().to_string()
+        ));
+        std::fs::write(&path, config).expect("write topology config");
+        path
+    }
+
     #[test]
     fn version_surfaces_share_the_compiled_provenance() {
         let command = Args::command();
@@ -859,9 +1093,12 @@ mod tests {
     async fn db_check_does_not_create_missing_file() {
         let tmp = TempDir::new().expect("temp dir");
         let path = tmp.path().join("missing.db");
+        let config = write_empty_config(tmp.path());
         assert!(!path.exists());
         cmd_db_check(DbCheckArgs {
-            db: Some(path.clone()),
+            db: Some(path.display().to_string()),
+            config: Some(config),
+            backend: None,
             strict: false,
             human: false,
         })
@@ -961,8 +1198,10 @@ mod tests {
     async fn db_check_does_not_mutate_existing_db() {
         let tmp = TempDir::new().expect("temp dir");
         let path = tmp.path().join("real.db");
+        let config = write_empty_config(tmp.path());
         cmd_db_migrate(DbMigrateArgs {
-            db: Some(path.clone()),
+            db: Some(path.display().to_string()),
+            config: Some(config.clone()),
             backend: None,
             dry_run: false,
             check: false,
@@ -992,7 +1231,9 @@ mod tests {
         let before = std::fs::read(&path).expect("read db before check");
         // strict passes only when the db is already current — proves the read sees V1.
         cmd_db_check(DbCheckArgs {
-            db: Some(path.clone()),
+            db: Some(path.display().to_string()),
+            config: Some(config),
+            backend: None,
             strict: true,
             human: false,
         })
@@ -1000,6 +1241,356 @@ mod tests {
         .expect("db check passes on a current db");
         let after = std::fs::read(&path).expect("read db after check");
         assert_eq!(before, after, "db check must not mutate the database");
+    }
+
+    #[tokio::test]
+    async fn db_check_strict_rejects_noncanonical_v21_without_mutating_it() {
+        let tmp = TempDir::new().expect("temp dir");
+        let path = tmp.path().join("corrupt-v21.db");
+        let config = write_empty_config(tmp.path());
+        let backend = khive_db::StorageBackend::sqlite(&path).expect("open fixture backend");
+        backend
+            .prepare_core_schema()
+            .expect("prepare canonical V21");
+        {
+            let mut writer = backend.pool().try_writer().expect("tamper V21 fixture");
+            writer
+                .conn_mut()
+                .execute("DELETE FROM attachment_cutover_state", [])
+                .expect("remove completion marker");
+            writer
+                .conn_mut()
+                .execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")
+                .expect("checkpoint tampered fixture");
+        }
+        drop(backend);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            for suffix in ["-wal", "-shm"] {
+                let mut name = path.file_name().unwrap().to_os_string();
+                name.push(suffix);
+                let sidecar = path.parent().unwrap().join(name);
+                if sidecar.exists() {
+                    let mut permissions = std::fs::metadata(&sidecar).unwrap().permissions();
+                    permissions.set_mode(0o444);
+                    std::fs::set_permissions(&sidecar, permissions).unwrap();
+                }
+            }
+        }
+        let before = std::fs::read(&path).expect("read corrupt fixture");
+
+        let error = cmd_db_check(DbCheckArgs {
+            db: Some(path.display().to_string()),
+            config: Some(config),
+            backend: None,
+            strict: true,
+            human: false,
+        })
+        .await
+        .expect_err("MAX(version)=21 cannot hide missing physical cutover state");
+        assert!(
+            error.to_string().contains("attachment cutover"),
+            "unexpected strict-check error: {error:#}"
+        );
+        assert_eq!(
+            before,
+            std::fs::read(&path).expect("read fixture after check"),
+            "strict validation must remain read-only"
+        );
+    }
+
+    #[tokio::test]
+    async fn db_check_main_includes_every_secondary_prerequisite() {
+        let tmp = TempDir::new().expect("temp dir");
+        let main = tmp.path().join("main.db");
+        let secondary = tmp.path().join("secondary.db");
+        let main_backend = khive_db::StorageBackend::sqlite(&main).expect("open main fixture");
+        main_backend
+            .prepare_core_schema()
+            .expect("prepare current main fixture");
+        drop(main_backend);
+        create_v20_fixture(&secondary, None);
+        let config =
+            write_topology_config(tmp.path(), &main, Some(("secondary", secondary.as_path())));
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            for path in [&main, &secondary] {
+                for suffix in ["-wal", "-shm"] {
+                    let mut name = path.file_name().unwrap().to_os_string();
+                    name.push(suffix);
+                    let sidecar = path.parent().unwrap().join(name);
+                    if sidecar.exists() {
+                        let mut permissions = std::fs::metadata(&sidecar).unwrap().permissions();
+                        permissions.set_mode(0o444);
+                        std::fs::set_permissions(&sidecar, permissions).unwrap();
+                    }
+                }
+            }
+        }
+
+        let error = cmd_db_check(DbCheckArgs {
+            db: None,
+            config: Some(config),
+            backend: Some(BackendId::MAIN.to_string()),
+            strict: true,
+            human: false,
+        })
+        .await
+        .expect_err("a current main cannot hide a behind secondary prerequisite");
+        let rendered = format!("{error:#}");
+        assert!(rendered.contains("secondary"), "{rendered}");
+        assert!(rendered.contains("V20"), "{rendered}");
+    }
+
+    #[tokio::test]
+    async fn db_migrate_runs_the_application_assisted_v21_cutover() {
+        use khive_db::migrations::{ATTACHMENT_CUTOVER_VERSION, MIGRATIONS};
+        use khive_db::StorageBackend;
+        use khive_storage::ContentRef;
+
+        let tmp = TempDir::new().expect("temp dir");
+        let path = tmp.path().join("legacy-v20.db");
+        let config = write_empty_config(tmp.path());
+        let entity_id = uuid::Uuid::new_v4();
+        let content_ref = ContentRef::from_hex("a".repeat(64)).expect("canonical fixture ref");
+
+        let backend = StorageBackend::sqlite(&path).expect("open V20 fixture backend");
+        {
+            let mut writer = backend.pool().try_writer().expect("V20 fixture writer");
+            let conn = writer.conn_mut();
+            conn.execute_batch(
+                "CREATE TABLE _schema_migrations (\
+                     version INTEGER PRIMARY KEY, \
+                     name TEXT NOT NULL, \
+                     applied_at INTEGER NOT NULL\
+                 ) STRICT;",
+            )
+            .expect("create V20 migration ledger");
+            for migration in MIGRATIONS
+                .iter()
+                .filter(|migration| migration.version < ATTACHMENT_CUTOVER_VERSION)
+            {
+                let tx = conn.transaction().expect("begin V20 fixture migration");
+                tx.execute_batch(migration.up)
+                    .unwrap_or_else(|error| panic!("apply V{}: {error}", migration.version));
+                tx.execute(
+                    "INSERT INTO _schema_migrations (version, name, applied_at) \
+                     VALUES (?1, ?2, ?3)",
+                    (
+                        migration.version,
+                        migration.name,
+                        i64::from(migration.version),
+                    ),
+                )
+                .unwrap_or_else(|error| panic!("record V{}: {error}", migration.version));
+                tx.commit().expect("commit V20 fixture migration");
+            }
+            conn.execute(
+                "INSERT INTO entities (\
+                     id, namespace, kind, entity_type, name, tags, created_at, updated_at, \
+                     content_ref\
+                 ) VALUES (?1, 'local', 'artifact', 'visual_asset', 'legacy visual', '[]', \
+                     1, 1, ?2)",
+                (entity_id.to_string(), content_ref.as_str()),
+            )
+            .expect("insert legacy attachment-bearing entity");
+        }
+        drop(backend);
+
+        cmd_db_migrate(DbMigrateArgs {
+            db: Some(path.display().to_string()),
+            config: Some(config),
+            backend: None,
+            dry_run: false,
+            check: false,
+            human: false,
+        })
+        .await
+        .expect("admin migrate must coordinate V21 rather than stop at V20");
+
+        let migrated = StorageBackend::sqlite(&path).expect("reopen migrated database");
+        assert_eq!(
+            migrated.prepare_core_schema().unwrap(),
+            ATTACHMENT_CUTOVER_VERSION
+        );
+        let attachment = migrated
+            .attachments()
+            .expect("V21 attachment store")
+            .get_attachment(entity_id, "content")
+            .await
+            .unwrap()
+            .expect("legacy content role must be backfilled");
+        assert_eq!(attachment.content_ref, content_ref);
+    }
+
+    #[tokio::test]
+    async fn db_migrate_preflights_soft_deleted_secondary_before_advancing_main() {
+        use khive_db::migrations::{
+            attachment_cutover_status, read_schema_version, AttachmentCutoverStatus,
+            ATTACHMENT_CUTOVER_VERSION,
+        };
+
+        let tmp = TempDir::new().expect("temp dir");
+        let main = tmp.path().join("main.db");
+        let secondary = tmp.path().join("secondary.db");
+        create_v20_fixture(&main, None);
+        create_v20_fixture(&secondary, Some(("visual_asset", Some(9))));
+        let config =
+            write_topology_config(tmp.path(), &main, Some(("secondary", secondary.as_path())));
+
+        let error = cmd_db_migrate(DbMigrateArgs {
+            db: None,
+            config: Some(config.clone()),
+            backend: None,
+            dry_run: false,
+            check: false,
+            human: false,
+        })
+        .await
+        .expect_err("secondary liveness must block main cutover");
+        let rendered = format!("{error:#}");
+        assert!(rendered.contains("secondary"), "{rendered}");
+
+        let main_backend =
+            khive_db::StorageBackend::sqlite(&main).expect("inspect blocked main backend");
+        let main_conn = main_backend.pool().reader().expect("inspect blocked main");
+        assert_eq!(
+            read_schema_version(main_conn.conn()).unwrap(),
+            ATTACHMENT_CUTOVER_VERSION - 1,
+            "main must remain V20 when secondary inventory fails"
+        );
+        assert_eq!(
+            attachment_cutover_status(main_conn.conn()).unwrap(),
+            AttachmentCutoverStatus::Pending
+        );
+        drop(main_conn);
+        drop(main_backend);
+
+        let secondary_backend =
+            khive_db::StorageBackend::sqlite(&secondary).expect("curate blocked secondary");
+        secondary_backend
+            .pool()
+            .try_writer()
+            .expect("secondary writer")
+            .conn_mut()
+            .execute("UPDATE entities SET content_ref = NULL", [])
+            .expect("relocate legacy secondary attachment authority");
+        drop(secondary_backend);
+
+        cmd_db_migrate(DbMigrateArgs {
+            db: None,
+            config: Some(config),
+            backend: None,
+            dry_run: false,
+            check: false,
+            human: false,
+        })
+        .await
+        .expect("curated topology must complete secondary then main");
+        for path in [&secondary, &main] {
+            let backend =
+                khive_db::StorageBackend::sqlite(path).expect("inspect completed topology backend");
+            let conn = backend.pool().reader().expect("inspect completed topology");
+            assert_eq!(
+                read_schema_version(conn.conn()).unwrap(),
+                ATTACHMENT_CUTOVER_VERSION
+            );
+            assert_eq!(
+                attachment_cutover_status(conn.conn()).unwrap(),
+                AttachmentCutoverStatus::Complete
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn db_migrate_named_secondary_does_not_advance_main() {
+        use khive_db::migrations::{read_schema_version, ATTACHMENT_CUTOVER_VERSION};
+
+        let tmp = TempDir::new().expect("temp dir");
+        let main = tmp.path().join("main.db");
+        let secondary = tmp.path().join("secondary.db");
+        create_v20_fixture(&main, None);
+        create_v20_fixture(&secondary, None);
+        let config =
+            write_topology_config(tmp.path(), &main, Some(("secondary", secondary.as_path())));
+
+        cmd_db_migrate(DbMigrateArgs {
+            db: None,
+            config: Some(config),
+            backend: Some("secondary".to_string()),
+            dry_run: false,
+            check: false,
+            human: false,
+        })
+        .await
+        .expect("named empty secondary migration");
+
+        let main_backend = khive_db::StorageBackend::sqlite(&main).unwrap();
+        let secondary_backend = khive_db::StorageBackend::sqlite(&secondary).unwrap();
+        let main_conn = main_backend.pool().reader().unwrap();
+        let secondary_conn = secondary_backend.pool().reader().unwrap();
+        assert_eq!(
+            read_schema_version(main_conn.conn()).unwrap(),
+            ATTACHMENT_CUTOVER_VERSION - 1
+        );
+        assert_eq!(
+            read_schema_version(secondary_conn.conn()).unwrap(),
+            ATTACHMENT_CUTOVER_VERSION
+        );
+    }
+
+    #[tokio::test]
+    async fn db_migrate_unknown_backend_creates_no_database() {
+        let tmp = TempDir::new().expect("temp dir");
+        let main = tmp.path().join("missing-main.db");
+        let secondary = tmp.path().join("missing-secondary.db");
+        let config =
+            write_topology_config(tmp.path(), &main, Some(("secondary", secondary.as_path())));
+
+        let error = cmd_db_migrate(DbMigrateArgs {
+            db: None,
+            config: Some(config),
+            backend: Some("missing".to_string()),
+            dry_run: false,
+            check: false,
+            human: false,
+        })
+        .await
+        .expect_err("unknown selector must fail before opening topology");
+        let rendered = format!("{error:#}");
+        assert!(rendered.contains("unknown backend"), "{rendered}");
+        assert!(!main.exists());
+        assert!(!secondary.exists());
+    }
+
+    #[tokio::test]
+    async fn db_migrate_one_declared_main_uses_its_configured_path() {
+        use khive_db::migrations::{read_schema_version, ATTACHMENT_CUTOVER_VERSION};
+
+        let tmp = TempDir::new().expect("temp dir");
+        let main = tmp.path().join("declared-main.db");
+        create_v20_fixture(&main, None);
+        let config = write_topology_config(tmp.path(), &main, None);
+
+        cmd_db_migrate(DbMigrateArgs {
+            db: None,
+            config: Some(config),
+            backend: None,
+            dry_run: false,
+            check: false,
+            human: false,
+        })
+        .await
+        .expect("one declared main must use topology path");
+        let backend = khive_db::StorageBackend::sqlite(&main).unwrap();
+        let conn = backend.pool().reader().unwrap();
+        assert_eq!(
+            read_schema_version(conn.conn()).unwrap(),
+            ATTACHMENT_CUTOVER_VERSION
+        );
     }
 
     // --- `-e` quick-shot shortcut for `exec` ---
@@ -1169,9 +1760,9 @@ mod tests {
 
     /// File-backed main: both boot paths must agree on every `WiringSurface`
     /// field — in particular, both must wire a checkpoint pool (#601/#604).
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn multi_backend_boot_paths_share_identical_wiring_surface_file_backed() {
+    async fn multi_backend_boot_paths_share_identical_wiring_surface_file_backed() {
         let dir = TempDir::new().expect("temp dir");
         let main_path = dir.path().join("main.db");
         let khive_cfg =
@@ -1182,6 +1773,7 @@ mod tests {
             &khive_cfg,
             None,
         )
+        .await
         .expect("plain multi-backend boot must succeed");
 
         let (coordinator_server, _schedule_rt) = build_multi_backend_server_with_coordinator(
@@ -1189,6 +1781,7 @@ mod tests {
             &khive_cfg,
             None,
         )
+        .await
         .expect("kkernel coordinator-attached multi-backend boot must succeed");
 
         let plain_surface = khive_mcp::serve::WiringSurface::capture(&plain_server);
@@ -1207,9 +1800,9 @@ mod tests {
 
     /// In-memory main: both paths must agree that no checkpoint pool is wired
     /// (checkpoint_once must never run on a non-WAL connection).
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn multi_backend_boot_paths_share_identical_wiring_surface_in_memory() {
+    async fn multi_backend_boot_paths_share_identical_wiring_surface_in_memory() {
         let khive_cfg = single_main_backend_config(khive_runtime::BackendKind::Memory, None);
 
         let plain_server = khive_mcp::serve::build_server_multi_backend(
@@ -1217,6 +1810,7 @@ mod tests {
             &khive_cfg,
             None,
         )
+        .await
         .expect("plain multi-backend boot must succeed");
 
         let (coordinator_server, _schedule_rt) = build_multi_backend_server_with_coordinator(
@@ -1224,6 +1818,7 @@ mod tests {
             &khive_cfg,
             None,
         )
+        .await
         .expect("kkernel coordinator-attached multi-backend boot must succeed");
 
         let plain_surface = khive_mcp::serve::WiringSurface::capture(&plain_server);
@@ -1242,9 +1837,9 @@ mod tests {
 
     /// #613 non-vacuous output-format parity check — see
     /// `crates/kkernel/docs/coordinator.md#kkernel-mainrs--coordinator-attached-boot-path`.
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn multi_backend_boot_paths_share_identical_non_default_output_format() {
+    async fn multi_backend_boot_paths_share_identical_non_default_output_format() {
         // RAII guard: snapshots KHIVE_OUTPUT_FORMAT, clears it, and restores the
         // original value (or leaves it removed) on drop — including on panic, so
         // a failing assertion or an unexpected constructor error never leaks the
@@ -1282,6 +1877,7 @@ mod tests {
             &khive_cfg,
             None,
         )
+        .await
         .expect("plain multi-backend boot must succeed");
 
         let (coordinator_server, _schedule_rt) = build_multi_backend_server_with_coordinator(
@@ -1289,6 +1885,7 @@ mod tests {
             &khive_cfg,
             None,
         )
+        .await
         .expect("kkernel coordinator-attached multi-backend boot must succeed");
 
         let plain_surface = khive_mcp::serve::WiringSurface::capture(&plain_server);
@@ -1313,8 +1910,8 @@ mod tests {
 
     /// db-anchor consistency guard applies at the coordinator choke point too —
     /// see `crates/kkernel/docs/coordinator.md#kkernel-mainrs--coordinator-attached-boot-path`.
-    #[test]
-    fn coordinator_boundary_rejects_diverging_db_path() {
+    #[tokio::test]
+    async fn coordinator_boundary_rejects_diverging_db_path() {
         let args_db = "/tmp/khive-coordinator-guard-real.db";
         let wrong_path = std::path::PathBuf::from("/tmp/khive-coordinator-guard-wrong.db");
 
@@ -1330,7 +1927,8 @@ mod tests {
             &khive_cfg,
             Some(args_db),
             db_anchor.as_deref(),
-        );
+        )
+        .await;
 
         let err = match result {
             Ok(_) => panic!(
@@ -1354,9 +1952,9 @@ mod tests {
 
     /// Regression for #720 — see
     /// `crates/kkernel/docs/coordinator.md#kkernel-mainrs--coordinator-attached-boot-path`.
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn coordinator_boot_uses_anchor_captured_by_runtime_config() {
+    async fn coordinator_boot_uses_anchor_captured_by_runtime_config() {
         struct HomeGuard(Option<std::ffi::OsString>);
 
         impl Drop for HomeGuard {
@@ -1406,7 +2004,8 @@ mod tests {
             &khive_cfg,
             None,
             db_anchor.as_deref(),
-        );
+        )
+        .await;
         if let Err(error) = result {
             panic!(
                 "coordinator-attached construction must retain the anchor captured by \
@@ -1464,6 +2063,7 @@ mod tests {
 
         let (server, _schedule_rt) =
             build_multi_backend_server_with_coordinator(base_cfg, &khive_cfg, None)
+                .await
                 .expect("coordinator-attached multi-backend boot must succeed");
 
         let dispatch = |ops: String| {

--- a/crates/kkernel/src/cli.rs
+++ b/crates/kkernel/src/cli.rs
@@ -569,9 +569,11 @@ fn resolve_db_command_context(
         config_source,
     )?;
 
-    let mut base_config = RuntimeConfig::default();
-    base_config.db_path = khive_runtime::resolve_db_anchor(db);
-    base_config = runtime_config_from_khive_config(&khive_config, base_config);
+    let base_config = RuntimeConfig {
+        db_path: khive_runtime::resolve_db_anchor(db),
+        ..RuntimeConfig::default()
+    };
+    let mut base_config = runtime_config_from_khive_config(&khive_config, base_config);
     // Schema administration never needs to instantiate an embedding model or
     // register packs. Blob hydration remains configured because verified V20
     // moodboard evidence may be part of the cutover.

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -46,8 +46,8 @@ use clap::Parser;
 #[cfg(test)]
 use khive_mcp::serve::resolve_runtime_config;
 use khive_mcp::serve::{
-    apply_env_output_format, build_server_multi_backend_with_db_anchor, config_discovery_db_anchor,
-    enforce_strict_actor_mode, install_resolved_blob_store,
+    apply_env_output_format, build_server_multi_backend_with_db_anchor,
+    build_single_backend_runtime, config_discovery_db_anchor, enforce_strict_actor_mode,
     normalize_redundant_db_override_with_source, reject_conflicting_db_override_with_source,
     validate_declared_backend_access_modes, RuntimeConfigInputs,
 };
@@ -55,9 +55,11 @@ use khive_mcp::server::KhiveMcpServer;
 #[cfg(unix)]
 use khive_mcp::server::{compute_config_id, compute_config_id_with_storage_mode};
 use khive_mcp::tools::request::RequestParams;
+#[cfg(test)]
+use khive_runtime::KhiveRuntime;
 #[cfg(unix)]
 use khive_runtime::{daemon::PROTOCOL_VERSION, DaemonRequestFrame};
-use khive_runtime::{KhiveConfig, KhiveRuntime, Namespace, RuntimeConfig};
+use khive_runtime::{KhiveConfig, Namespace, RuntimeConfig};
 use khive_types::RefusalReason;
 
 /// Stable stderr prefix for machine-classifiable exec refusals.
@@ -2333,7 +2335,8 @@ async fn run_exec_inline_with_forward(
         &khive_cfg,
         db_context.raw.as_deref(),
         db_context.anchor.as_deref(),
-    )?;
+    )
+    .await?;
 
     let params = RequestParams {
         ops,
@@ -2361,30 +2364,23 @@ async fn run_exec_inline_with_forward(
 /// bulk-apply paths). See
 /// `crates/kkernel/docs/design.md#exec-local-dispatch-fallback-server-adr-067-adr-028-8`
 /// for why this must agree with the daemon's own multi-backend boot logic.
-fn build_local_fallback_server(
+async fn build_local_fallback_server(
     cfg: RuntimeConfig,
     khive_cfg: &KhiveConfig,
     cli_db_override: Option<&str>,
     db_anchor: Option<&std::path::Path>,
 ) -> Result<KhiveMcpServer> {
-    // Held across construction below (`KhiveRuntime::new` / `KhiveMcpServer::new`
-    // / `build_server_multi_backend`, both of which run migrations and apply
-    // pack schema plans synchronously) and dropped when this function returns.
+    // Held across the real-host async schema/application coordinator and pack
+    // assembly; dropped only after the fully wired server is ready.
     let _boot_guard = acquire_local_construction_guard(&cfg)?;
     if khive_cfg.backends.is_empty() {
-        let rt = KhiveRuntime::new(cfg).map_err(|e| anyhow::anyhow!("{e}"))?;
-        // Mirror the `serve` boot path's single-backend branch (ADR-111
-        // Amendment 2): without this, `exec`'s in-process fallback server
-        // never installs a `BlobStore`, so `blob.put`/`blob.get`/`blob.stat`
-        // fail as "unconfigured" here even when `serve` resolves one from
-        // the same config and backend (khive#1209).
-        install_resolved_blob_store(&rt, khive_cfg, rt.backend())?;
+        let rt = build_single_backend_runtime(cfg, khive_cfg).await?;
         let env_fmt = apply_env_output_format(khive_cfg.runtime.default_output_format);
         Ok(KhiveMcpServer::new(rt)
             .map_err(|e| anyhow::anyhow!("{e}"))?
             .with_default_output_format(env_fmt))
     } else {
-        build_server_multi_backend_with_db_anchor(cfg, khive_cfg, cli_db_override, db_anchor)
+        build_server_multi_backend_with_db_anchor(cfg, khive_cfg, cli_db_override, db_anchor).await
     }
 }
 
@@ -2572,7 +2568,8 @@ async fn run_exec_ops_file(
         &khive_cfg,
         db_context.raw.as_deref(),
         db_context.anchor.as_deref(),
-    )?;
+    )
+    .await?;
 
     validated
         .snapshot
@@ -3136,7 +3133,9 @@ mod tests {
             ..RuntimeConfig::default()
         };
         apply_actor_pin_and_expectation(&mut cfg, Some("lambda:pinned"), None).unwrap();
-        let server = build_local_fallback_server(cfg, &KhiveConfig::default(), None, None).unwrap();
+        let server = build_local_fallback_server(cfg, &KhiveConfig::default(), None, None)
+            .await
+            .unwrap();
         let raw = server
             .dispatch_request_local(RequestParams {
                 ops: r#"comm.send(to="local", content="actor pin attribution")"#.to_string(),
@@ -3950,6 +3949,7 @@ id = "lambda:fallback"
         // (ADR-028 §8) since 2 backends are already declared.
         let db_anchor = cfg.db_path.clone();
         let server = build_local_fallback_server(cfg, &khive_cfg, None, db_anchor.as_deref())
+            .await
             .expect("multi-backend local fallback must build");
 
         let send = server
@@ -4022,9 +4022,9 @@ id = "lambda:fallback"
         );
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn build_local_fallback_server_uses_captured_anchor_after_home_changes() {
+    async fn build_local_fallback_server_uses_captured_anchor_after_home_changes() {
         let (previous_home, _first_home) = isolate_home_for_test();
         let cfg = RuntimeConfig {
             db_path: khive_runtime::resolve_db_anchor(None),
@@ -4048,7 +4048,7 @@ id = "lambda:fallback"
         let second_home = tempfile::tempdir().expect("second HOME");
         std::env::set_var("HOME", second_home.path());
 
-        let result = build_local_fallback_server(cfg, &khive_cfg, None, db_anchor.as_deref());
+        let result = build_local_fallback_server(cfg, &khive_cfg, None, db_anchor.as_deref()).await;
         restore_home(previous_home);
 
         assert!(
@@ -4072,8 +4072,8 @@ id = "lambda:fallback"
     // `[storage.blob]` config and no `KHIVE_BLOB_ROOT`, resolution falls
     // back to `<db_dir>/blobs` — that directory existing after construction
     // is proof the install call ran.
-    #[test]
-    fn build_local_fallback_server_installs_blob_store_single_backend() {
+    #[tokio::test]
+    async fn build_local_fallback_server_installs_blob_store_single_backend() {
         let dir = tempfile::tempdir().expect("tempdir");
         let db_path = dir.path().join("exec_blob.db");
         let cfg = RuntimeConfig {
@@ -4085,6 +4085,7 @@ id = "lambda:fallback"
         let khive_cfg = KhiveConfig::default();
 
         let _server = build_local_fallback_server(cfg, &khive_cfg, None, None)
+            .await
             .expect("single-backend local-exec construction must succeed");
 
         assert!(
@@ -4174,6 +4175,7 @@ id = "lambda:fallback"
             // guard, so it could run migrations/FTS DDL concurrently with
             // the guarded boot above against the same file.
             let server = build_local_fallback_server(cfg, &khive_cfg, None, None)
+                .await
                 .expect("guarded local-exec construction must succeed");
 
             for i in 0..count {
@@ -4254,7 +4256,7 @@ id = "lambda:fallback"
             // (daemon-unreachable fallback, --save-file, KHIVE_NO_DAEMON=1,
             // non-atomic --ops-file) funnels through this one function.
             let result = rt_handle
-                .block_on(async { build_local_fallback_server(cfg, &khive_cfg, None, None) });
+                .block_on(async { build_local_fallback_server(cfg, &khive_cfg, None, None).await });
             // Sent only AFTER construction returns — the test observes
             // whether this arrives before or after the lock is released.
             let _ = tx.send(());
@@ -6361,6 +6363,7 @@ path = "{}"
             .expect("explicit config must exist");
         let opened =
             khive_mcp::serve::build_registry_for_multi_backend(cfg, &khive_cfg, Some(":memory:"))
+                .await
                 .expect("force-memory runtime must build");
         restore_home(prev_home);
 

--- a/docs/adr/ADR-005-storage-capability-traits.md
+++ b/docs/adr/ADR-005-storage-capability-traits.md
@@ -5,7 +5,8 @@
 **Authors**: khive maintainers\
 **Amended by**: proposed [ADR-160](ADR-160-shared-pack-infrastructure.md), which adds the required
 backend-enforced bounded-and-verified BlobStore read while leaving admission and lifecycle policy
-in runtime, and binds vector operations to a complete embedding-space identity on acceptance.
+in runtime, binds vector operations to a complete embedding-space identity, and implements
+ADR-121's attachment capability/current ten-capability surface on acceptance.
 
 ## Context
 
@@ -35,7 +36,7 @@ The constraints on `khive-storage`:
 
 ## Decision
 
-### Eight capability traits
+### Original eight capability traits
 
 ```rust
 pub trait SqlAccess: Send + Sync + 'static {
@@ -132,6 +133,19 @@ pub trait TextSearch: Send + Sync + 'static {
 
 `SqlAccess` decomposes into `SqlReader`, `SqlWriter`, and `SqlTransaction` subtypes to
 enforce read/write/transactional boundaries at the type level.
+
+### Amendment: BlobStore and AttachmentStore extend the surface to ten
+
+ADR-111 added the ninth capability, `BlobStore`, for content-addressed bytes. ADR-121 and
+ADR-160 Phase 4 add the tenth, `AttachmentStore`, for role-keyed `ContentRef` metadata owned by
+entity or note records. `AttachmentStore` provides upsert, exact role lookup, stable listing, and
+role deletion. `EntityStore::upsert_entity_with_attachments` is the atomic entity-plus-initial-
+roles seam and has a conservative `Unsupported` default so existing third-party entity-store
+implementations remain valid.
+
+The trait remains placement-blind: it does not know which database is canonical. Runtime/host
+boot routes attachments to main/core and prevents a secondary backend from becoming invisible
+blob liveness.
 
 `EntityStore` is separate from `NoteStore` because Entity and Note are different substrates
 (ADR-004) with different field sets, lifecycle rules, and validation paths.
@@ -263,7 +277,7 @@ pub enum CoordinatorError {
 
 ### StorageCapability: one variant per trait
 
-`StorageCapability` maps exactly to the eight capability traits. Each variant corresponds
+`StorageCapability` maps exactly to the ten capability traits. Each variant corresponds
 to a real trait. No placeholders.
 
 ```rust
@@ -276,6 +290,8 @@ pub enum StorageCapability {
     Vectors,
     Sparse,
     Text,
+    Blob,
+    Attachments,
 }
 ```
 
@@ -340,11 +356,11 @@ is the backend's choice.
 
 | Belongs in `khive-storage`                                               | Does NOT belong in `khive-storage`               |
 | ------------------------------------------------------------------------ | ------------------------------------------------ |
-| Eight capability traits                                                  | `StorageProfile` / `PlacementRole`               |
+| Ten capability traits                                                    | `StorageProfile` / `PlacementRole`               |
 | Storage-facing record types (`Note`, `Entity`, `Edge`, `Event`)          | `BackendId` / `BackendHandle`                    |
 | Pagination / result types (`Page`, `PageRequest`, `BatchWriteSummary`)   | ATTACH schema aliases (`SqlScope`)               |
 | Single-backend `StorageError`                                            | `CoordinatorError` / federation errors           |
-| `StorageCapability` enum (8 variants)                                    | `CoordinatorStore` / `StorageCoordinator` trait  |
+| `StorageCapability` enum (10 variants)                                   | `CoordinatorStore` / `StorageCoordinator` trait  |
 | Mechanical default methods                                               | Policy default methods (quota, retention)        |
 | Filter types (`EntityFilter`, `EdgeFilter`, `EventFilter`, `TextFilter`) | `registered_kinds()` / kind discovery            |
 | Shared types (`SqlValue`, `SqlRow`, `VectorSearchHit`, `TextSearchHit`)  | Placement / routing logic                        |
@@ -382,20 +398,22 @@ depend on `rusqlite`, `sqlite-vec`, and FTS5 headers. The crate has zero heavy d
 dependencies: capability traits, shared values, and request execution context remain
 backend-neutral. Backend crates bring their own dependencies.
 
-### Why eight traits (not fewer)?
+### Why the original eight traits (and later additions) stay separate
 
 Each trait maps to a substrate or index capability with distinct operation shapes:
 
-| Trait         | Record type    | Key operations                    | Why separate                                           |
-| ------------- | -------------- | --------------------------------- | ------------------------------------------------------ |
-| `NoteStore`   | `Note`         | CRUD, kind filter, temporal query | Temporal/cognitive substrate                           |
-| `EntityStore` | `Entity`       | CRUD, kind+type filter            | Graph node substrate                                   |
-| `GraphStore`  | `Edge`         | Link CRUD, neighbors, traversal   | Graph link operations                                  |
-| `EventStore`  | `Event`        | Append-only, no update/delete     | Audit substrate                                        |
-| `VectorStore` | `VectorRecord` | Insert, search, rebuild           | Dense vector index (single or multi-vector per record) |
-| `SparseStore` | `SparseRecord` | Insert, search                    | Sparse vector index                                    |
-| `TextSearch`  | `TextDocument` | Upsert, search, stats             | Full-text index                                        |
-| `SqlAccess`   | `SqlRow`       | Raw SQL, transactions             | Escape hatch                                           |
+| Trait             | Record type    | Key operations                    | Why separate                                           |
+| ----------------- | -------------- | --------------------------------- | ------------------------------------------------------ |
+| `NoteStore`       | `Note`         | CRUD, kind filter, temporal query | Temporal/cognitive substrate                           |
+| `EntityStore`     | `Entity`       | CRUD, kind+type filter            | Graph node substrate                                   |
+| `GraphStore`      | `Edge`         | Link CRUD, neighbors, traversal   | Graph link operations                                  |
+| `EventStore`      | `Event`        | Append-only, no update/delete     | Audit substrate                                        |
+| `VectorStore`     | `VectorRecord` | Insert, search, rebuild           | Dense vector index (single or multi-vector per record) |
+| `SparseStore`     | `SparseRecord` | Insert, search                    | Sparse vector index                                    |
+| `TextSearch`      | `TextDocument` | Upsert, search, stats             | Full-text index                                        |
+| `SqlAccess`       | `SqlRow`       | Raw SQL, transactions             | Escape hatch                                           |
+| `BlobStore`       | opaque bytes   | CAS put/read/stat/delete/GC       | Backend object I/O and integrity                       |
+| `AttachmentStore` | metadata       | role-keyed CRUD                   | Record-owned blob liveness without graph edges         |
 
 Collapsing EntityStore into NoteStore would merge two substrates with different field sets
 (`entity_type` vs `salience`/`decay_factor`), different validation paths
@@ -439,8 +457,8 @@ is the natural representation.
 
 ### Negative
 
-- Eight traits is more implementation surface per backend. Each backend crate implements
-  eight traits plus `SqlReader`/`SqlWriter`/`SqlTransaction`.
+- Ten traits is more implementation surface per full backend. Each backend implements only the
+  capabilities it advertises; optional/default seams remain conservative.
 - `Arc<dyn Trait>` precludes compile-time specialization inside the runtime. Backends
   that could benefit from monomorphization (e.g., a hot-path HNSW search) must absorb
   the virtual dispatch cost.
@@ -452,10 +470,10 @@ is the natural representation.
 
 ## Implementation
 
-- `crates/khive-storage/src/lib.rs`: re-exports all eight traits plus shared types.
+- `crates/khive-storage/src/lib.rs`: re-exports all ten traits plus shared types.
 - One source file per trait: `sql.rs`, `note.rs`, `entity.rs`, `graph.rs`, `event.rs`,
-  `vectors.rs`, `sparse.rs`, `text.rs`.
-- `capability.rs`: `StorageCapability` enum (8 variants).
+  `vectors.rs`, `sparse.rs`, `text.rs`, `blob.rs`, `attachment.rs`.
+- `capability.rs`: `StorageCapability` enum (10 variants).
 - `error.rs`: `StorageError` with `StorageCapability` discriminant.
 - `types.rs`: shared types (`SqlRow`, `SqlValue`, `Page`, `BatchWriteSummary`, filter
   types, hit types).

--- a/docs/adr/ADR-009-backend-architecture.md
+++ b/docs/adr/ADR-009-backend-architecture.md
@@ -2,12 +2,16 @@
 
 **Status**: accepted\
 **Date**: 2026-05-23\
-**Authors**: khive maintainers
+**Authors**: khive maintainers\
+**Amended by**: [ADR-111](ADR-111-blob-store.md) adds `BlobStore`; [ADR-121](ADR-121-attachments-first-class.md)
+and ADR-160 Phase 4 add `AttachmentStore`. References below to eight traits describe the original
+surface; the current public capability enum has ten variants.
 
 ## Context
 
 khive persists its knowledge graph in SQLite. The storage layer is split: `khive-storage`
-defines eight capability traits (ADR-005); `khive-db` implements SQLite storage traits,
+defines capability traits (the original eight in ADR-005, later extended by ADR-111/121);
+`khive-db` implements SQLite storage traits,
 including FTS5 `TextSearch` and the current sqlite-vec `VectorStore`. Separate retrieval
 crates (`khive-retrieval`, `khive-bm25`, `khive-hnsw`, `khive-vamana`, `khive-fusion`)
 ship in-process retrieval engines and fusion.
@@ -20,7 +24,7 @@ The backend architecture must satisfy:
 2. **Multi-file federation.** Different packs may use different SQLite files (hot KG vs cold
    corpus vs archive). This is multiple SQLite files in one process, not a distributed
    database.
-3. **Trait portability.** The eight storage traits (ADR-005) are the contract boundary.
+3. **Trait portability.** The storage traits (ADR-005 and amendments) are the contract boundary.
    A future non-SQLite backend must be possible without changing runtime or pack code.
 4. **Vector search.** The current `khive-db` VectorStore is sqlite-vec compatibility.
    In-process retrieval engines also ship as separate crates, and pack-specific paths may
@@ -33,7 +37,8 @@ The backend architecture must satisfy:
 
 khive's v1 backend is SQLite. The concrete backend crate is `khive-db`.
 
-`khive-db` implements the eight `khive-storage` capability traits (ADR-005):
+`khive-db` implements the original eight `khive-storage` capability traits (ADR-005), plus the
+later blob and attachment capabilities:
 
 - `SqlAccess` — raw SQL reader/writer/transaction
 - `EntityStore` — entity/node CRUD
@@ -43,6 +48,8 @@ khive's v1 backend is SQLite. The concrete backend crate is `khive-db`.
 - `VectorStore` — current dense vector storage/search via sqlite-vec compatibility
 - `SparseStore` — sparse vector storage
 - `TextSearch` — full-text search via FTS5 trigram
+- `BlobStore` — content-addressed object storage and transactional filesystem GC
+- `AttachmentStore` — role-keyed entity/note blob-reference metadata
 - Retrieval engines — BM25, HNSW, Vamana, and fusion live outside `khive-db`
 
 `khive-db` supports both file-backed and in-memory storage. In-memory mode is used for
@@ -67,7 +74,8 @@ Current: khive-db (SQLite)
 Future:  khive-db-postgres, khive-db-rocksdb, etc. (if approved by ADR)
 ```
 
-Each backend crate implements the same eight `khive-storage` traits. The runtime and
+Each backend crate implements the capabilities it advertises under the same `khive-storage`
+contracts. The runtime and
 packs depend on traits, not on any specific backend crate.
 
 ### v1 multi-backend: multiple SQLite files
@@ -168,7 +176,7 @@ version commitment in this ADR.
 If a non-SQLite engine is proposed, it requires:
 
 1. A new ADR justifying the engine against the embedded deployment constraint.
-2. Its own backend crate implementing the eight storage traits.
+2. Its own backend crate implementing the required storage traits.
 3. Backend contract test coverage matching `khive-db`.
 
 ### `StorageError::Unsupported` contract
@@ -184,7 +192,7 @@ implementing traits only to fail at every call.
 
 ### Backend contract tests
 
-Backend contract tests exercise the eight storage traits against `khive-db` (both
+Backend contract tests exercise the advertised storage traits against `khive-db` (both
 SQLite memory and SQLite file-backed). They validate that the backend correctly
 implements the trait contracts.
 
@@ -292,10 +300,10 @@ read-only mode.
 
 ## Implementation
 
-- `crates/khive-db/`: SQLite backend implementing eight storage traits.
+- `crates/khive-db/`: SQLite backend implementing the current storage traits.
 - `crates/khive-db/src/stores/`: one module per trait implementation (entity, graph,
   note, event, vector, sparse, text, sql).
 - `crates/khive-db/src/migrations.rs`: SQLite schema migrations (applied by `kkernel db migrate`, ADR-003).
 - `crates/khive-db/src/backend.rs`: `StorageBackend` — the concrete SQLite connection
   wrapper providing `Arc<dyn Trait>` accessors.
-- Backend contract tests: `khive-db/tests/contract/` exercising all eight traits.
+- Backend contract tests: trait-specific suites exercising the advertised capabilities.

--- a/docs/adr/ADR-012-retrieval-composition.md
+++ b/docs/adr/ADR-012-retrieval-composition.md
@@ -64,8 +64,9 @@ NoteStore     ───┤        + expansion
 SqlAccess     ───┘        + reranking
 ```
 
-Of the eight capability traits in ADR-005, seven participate in retrieval. `EventStore`
-is the exception — it is audit/observability, not retrieval.
+Of ADR-005's original eight capability traits, seven participate in ranked retrieval.
+`EventStore` is audit/observability; the later `BlobStore` and `AttachmentStore` capabilities
+provide bytes/liveness and likewise do not become ranking signals.
 
 ### Five retrieval primitives
 
@@ -544,7 +545,8 @@ tree, benchmark suite, and dependency surface (`lattice-embed`). ADR-012 is now 
 ## References
 
 - ADR-003: System Architecture — SubstrateCoordinator owns cross-backend fan-out.
-- ADR-005: Storage Capability Traits — the eight traits retrieval composes from.
+- ADR-005: Storage Capability Traits — the seven ranked-retrieval capabilities and their
+  non-ranking Event/Blob/Attachment siblings.
 - ADR-006: Deterministic Scoring — `DeterministicScore`, RRF K=60.
 - ADR-008: Query Layer Separation — graph query language (`GQL`/`SPARQL`) is a separate
   surface; retrieval composes raw storage capabilities, not query strings.

--- a/docs/adr/ADR-015-schema-migrations.md
+++ b/docs/adr/ADR-015-schema-migrations.md
@@ -148,6 +148,7 @@ above remains the historical pre-consolidation record.
 |     V18 | #1479              | ann_consumer_pending               | shipped |
 |     V19 | #1649              | list_cursor_backfill_repair        | shipped |
 |     V20 | ADR-091 / #1850    | blob_gc_claims                     | shipped |
+|     V21 | ADR-121 / ADR-160  | attachments_first_class            | shipped |
 
 > **V9 record (2026-07-18)**: `entities_name_ci_index` (ADR-104) ships in the `MIGRATIONS`
 > array as `009-entities-name-ci-index.sql`; its status here was `claimed`, stale from ADR-104,
@@ -189,6 +190,58 @@ above remains the historical pre-consolidation record.
 > durable entity-write fence used by bounded transactional filesystem-blob GC.
 > The migration version is independent of ADR-091's amendment number.
 
+> **V21 record (2026-08-16, ADR-121 / ADR-160 Phase 4b)**:
+> `attachments_first_class` is boot-gated and resumable. `run_migrations` may
+> finish it atomically only for a zero-legacy-reference database. A legacy V20
+> database stops at V20; the async host coordinator holds the canonical blob-GC
+> owner across stage, verified application backfill, and finalization. The
+> durable marker is `Pending`/`Incomplete`/`Complete`, and the V21 ledger row is
+> inserted only in the final transaction that swaps claim fences and drops
+> `entities.content_ref`.
+
+> **Phase 4a compatibility record (2026-08-16, ADR-111 / ADR-160)**: the
+> separately deployed GC compatibility epoch gate does not add attachments,
+> backfill data, dual-read or dual-write, or record V21. It leaves every V20
+> database unchanged. Transactional filesystem-blob GC accepts only an exact,
+> completed V21 epoch; it refuses V20, pending, incomplete, and malformed epochs
+> in dry-run and destructive modes before filesystem or claim mutation. Every
+> pre-Phase-4a process must be drained after fleet convergence and before a
+> Phase-4b binary may start the destructive V21 cutover. Every Phase-4a
+> application-serving/read-write process must also be quiesced or proven unable
+> to access the database during cutover; only a GC-only worker has narrow
+> compatibility with exact completed V21. The Phase-4b serving fleet starts only
+> after exact-current topology validation.
+
+### 2026-08-16 implementation amendment — coordinated host boot
+
+This amendment supersedes the older boot-entrypoint and per-backend migration
+topology language later in this ADR, including the boot portion of Amendment A1.
+The current implementation has these boundaries:
+
+- Production MCP and kkernel serving paths are async host-boot coordinators.
+  They apply the ordinary migration prefix but expose no runtime, pack, request,
+  or blob-GC surface until V21 is complete.
+- `run_migrations` may finish V21 atomically only when no legacy content
+  references require application evidence. Otherwise it returns successfully at
+  V20; the host retains canonical database GC ownership across attachment stage,
+  bounded artifact verification, and exclusive finalization.
+- Multi-backend boot prepares and inventories every distinct secondary first.
+  Any legacy or current attachment authority there is an actionable error. Only
+  after those checks may canonical `main` complete V21, because its attachment
+  table is the sole SQL liveness source visible to process-shared blob GC.
+- `kkernel db migrate` and `kkernel db check` load the same discovered or
+  explicit khive config as host boot. With declared `[[backends]]`, omission of
+  `--backend` targets the configured topology; `--backend <name>` selects a
+  declared backend. Advancing canonical `main` or selecting one of its physical
+  aliases still requires every distinct secondary to be prepared and
+  inventoried first. With no declared topology, the implicit target is `main`
+  at `--db` or the default path.
+- The admin path is core-only: it does not register packs, instantiate embedding
+  models, or apply pack-auxiliary DDL. Migration still resolves bounded blob
+  hydration when legacy V20 application evidence requires it. `db check`
+  remains read-only and reports the targeted ledger state without constructing
+  a runtime or completing V21.
+
 > **Invariant**: ADR number order and migration version order are independent. Migration versions reflect schema ledger assignment order. A migration may only depend on schema created by earlier versions.
 
 > **Process**: When a new ADR introduces a schema migration, it MUST request the next ledger version here (claim by editing this table in the same PR). ADRs MUST NOT use placeholder text like "version: <next>" once merged.
@@ -200,10 +253,10 @@ above remains the historical pre-consolidation record.
 khive has two distinct schema-application mechanisms with non-overlapping
 responsibilities:
 
-| Mechanism                    | Owner      | Purpose                                         | Versioning                                  | Trigger                              |
-| ---------------------------- | ---------- | ----------------------------------------------- | ------------------------------------------- | ------------------------------------ |
-| **Versioned migrations**     | `khive-db` | Forward-only evolution of core substrate tables | Yes (`_schema_migrations`)                  | `kkernel db migrate`                 |
-| **Pack schema declarations** | Pack crate | Idempotent declaration of pack-auxiliary tables | No (boot-time `CREATE TABLE IF NOT EXISTS`) | Pack registration at runtime startup |
+| Mechanism                    | Owner      | Purpose                                         | Versioning                                  | Trigger                                 |
+| ---------------------------- | ---------- | ----------------------------------------------- | ------------------------------------------- | --------------------------------------- |
+| **Versioned migrations**     | `khive-db` | Forward-only evolution of core substrate tables | Yes (`_schema_migrations`)                  | Async host boot or `kkernel db migrate` |
+| **Pack schema declarations** | Pack crate | Idempotent declaration of pack-auxiliary tables | No (boot-time `CREATE TABLE IF NOT EXISTS`) | Pack registration at runtime startup    |
 
 Versioned migrations evolve the core schema — tables that ADR-004 substrates
 need. Pack schema declarations add pack-specific tables that depend on a backend
@@ -342,42 +395,58 @@ the DB stays at V4.
 ### Per-backend independence (multi-file federation)
 
 In a multi-backend deployment (ADR-009), each SQLite file has its own
-`_schema_migrations` table and its own current version. `kkernel db migrate`
-iterates over all configured backends and runs migrations independently on each:
+`_schema_migrations` table and its own current version. The async config-aware
+host opens and deduplicates those databases, then applies one ordered protocol:
 
 ```text
-for backend in config.backends:
-    run_migrations(backend.connection)
+for each distinct secondary:
+    prepare ordinary schema prefix
+    require zero legacy/current attachment authority
+    complete its empty V21 state
+prepare canonical main
+coordinate main attachment stage, verified backfill, and V21 finalization
 ```
 
-Backends advance independently. A freshly added backend starts at version 0 and
-catches up to the latest version on first migrate. An existing backend at V4
-advances to V7 when the codebase ships V5–V7. The migration array is the same
-for every backend; the application state may differ per backend until all are
-brought current.
+The migration array remains the same for every backend, and each file retains
+its own ledger. V21 nevertheless cannot be enabled independently in arbitrary
+order: secondary inventory must finish before `main` becomes the sole
+attachment/GC-liveness authority.
 
-### `kkernel db migrate` is the operator entry point
+### Host boot and `kkernel db migrate` entry points
 
-Migration execution is an operator-context operation (ADR-003), not an
-agent-context operation. `kkernel db migrate` is the canonical command:
+Migration execution remains host/operator context (ADR-003), never an agent
+verb. Production MCP/kkernel boot applies the required schema work before
+serving. The config-aware admin commands are:
 
 ```bash
-kkernel db migrate              # migrate all configured backends
-kkernel db migrate --backend main   # migrate one specific backend
-kkernel db migrate --dry-run        # show what would be applied
+kkernel db migrate                  # discovered topology, or implicit default main
+kkernel db migrate --config <path>  # explicit configured topology
+kkernel db migrate --backend <name> # named target (main/alias retains prerequisites)
+kkernel db migrate --db <path>      # implicit main, or a compatible main override
+kkernel db migrate --dry-run        # read-only report from the migration target plan
 kkernel db migrate --check          # exit 0 if current; nonzero otherwise
+kkernel db check --config <path> --strict
 ```
 
-The MCP binary (`khive-mcp`) does NOT apply migrations at startup. It assumes
-the operator has already run `kkernel db migrate`. If a backend's schema is
-behind the codebase's expectation, `khive-mcp` startup fails fast with a
-diagnostic pointing at `kkernel db migrate`. This prevents silent partial
-operation on a stale schema.
-
-**Exception**: in-memory `khive-db` backends (used for tests and ephemeral
-deployments) apply migrations automatically on creation. There's no operator
-to invoke `kkernel db migrate` for an ephemeral DB, and the migration cost is
-negligible against an empty store.
+`db migrate` uses the same async storage-topology coordinator as MCP boot, so a
+legacy V20 database cannot bypass secondary inventory, artifact authentication,
+or the incomplete-cutover fence. The coordinator deduplicates physical aliases,
+advances distinct secondaries before canonical `main`, and runs without pack
+registration, embedders, or pack DDL. Selecting a non-main secondary advances
+only that empty-authority target; selecting `main` (or its physical alias)
+retains the secondary prerequisites. `--dry-run` and `--check` delegate to the
+read-only topology inspection path. A concrete `--db`/`KHIVE_DB` override must
+agree with a declared main backend (or be the supported all-memory override),
+rather than silently replacing a configured topology.
+Read-only `db check` reuses the same pure target plan: selecting `main` or a
+SQLite alias includes every secondary prerequisite; an independent secondary
+remains a single target. Before either command opens anything, that planner
+validates `read_only` agreement across every physical SQLite alias, including
+aliases outside a named target. `--db :memory:` instead makes every configured
+name a distinct ephemeral backend, so only literal `main` retains the full
+prerequisite plan. Migration output derives `prerequisite` from physical backend
+identity: main's aliases are targets, while distinct secondary objects are
+prerequisites.
 
 ### Bootstrap path for pre-versioning databases
 
@@ -488,23 +557,27 @@ lock for the duration of its transaction; concurrent writers wait or fail with
 `SQLITE_BUSY`. Long-running queries during a migration are handled by SQLite's
 own concurrency model.
 
-Pool-level coordination (`ConnectionPool` in `khive-db`) ensures that migrations
-run before any other writer claims the lock. The `kkernel db migrate` command
-runs to completion before any service connections accept writes.
+Pool-level coordination (`ConnectionPool` in `khive-db`) ensures that each
+migration transaction owns the writer. The async host coordinator completes
+schema/V21 work before it exposes service connections; the explicit
+`kkernel db migrate` command likewise runs its planned target set to completion
+before returning.
 
 ### Schema diagnostics
 
-`kkernel db check` reports per-backend schema state without applying changes:
+`kkernel db check` reports every targeted backend's schema ledger and validates
+an exact current V21 state without applying changes:
 
 ```text
 $ kkernel db check
-main:    V7 (current)
-lore:    V5 (behind: V6, V7 pending)
-archive: V7 (current)
+main:    V21 (current)
+lore:    V20 (behind: V21 pending)
+archive: V21 (current)
 ```
 
-`kkernel db check --strict` exits nonzero if any backend is behind. CI uses
-this to verify migrations are current before deployment.
+`kkernel db check --strict` exits nonzero if any planned target is behind,
+ahead, or structurally invalid at the current version. CI uses this to verify
+migrations are exact-current before deployment.
 
 ## Rationale
 
@@ -558,23 +631,25 @@ are allowed only as documented, nullable, backward-compatible exceptions for
 already-shipped pack tables; the current v1 example is GTD audit namespace
 backfill. Structural/core schema changes still belong in versioned migrations.
 
-### Why migration application is operator-context, not agent-context?
+### Why migration application is host/operator-context, not agent-context?
 
-Migrations are operationally significant. A pack that auto-migrates on startup
-can corrupt data if the migration has a bug — and the bug isn't noticed until
-the agent makes a call that exercises the corrupted state. An operator running
-`kkernel db migrate` deliberately has the option to dry-run, check, and stage
-the change.
+Migrations are operationally significant and never run because an agent invoked
+a pack verb. The trusted host owns them before it exposes dispatch. V21 further
+requires an explicit coordinator that retains GC ownership, authenticates
+application evidence, and fails startup rather than serving a partial state.
 
-The operator can run migrations in a CI/CD pipeline, in a maintenance window,
-or after taking a backup. Auto-apply at startup forfeits all of these options.
+Operators who need preflight control can still run config-aware
+`kkernel db check --strict` and `kkernel db migrate` in CI/CD, a maintenance
+window, or after taking a backup. Startup application is therefore coordinated
+host work, not an ungoverned pack-side effect.
 
 ### Why per-backend independent state?
 
 Multi-backend deployments (ADR-009) have backends with different lifecycles. A
 backup-restored `archive.db` might be at V4 when the rest of the deployment is
-at V7. Running `kkernel db migrate` brings the restored backend current. If all
-backends shared one version, restoring `archive.db` would force a global
+at V7. Running `kkernel db migrate --config <path> --backend archive` brings
+that independent secondary current. If all backends shared one version,
+restoring `archive.db` would force a global
 rollback or break the system.
 
 Per-backend state isolates these cases. Each backend advances independently;
@@ -582,16 +657,16 @@ the codebase's migration set is global, but applied state is per-file.
 
 ## Alternatives Considered
 
-| Alternative                                      | Why rejected                                                                               |
-| ------------------------------------------------ | ------------------------------------------------------------------------------------------ |
-| `PRAGMA user_version` only                       | No audit trail, no names, no migration history.                                            |
-| `CREATE TABLE IF NOT EXISTS` only                | Cannot evolve schema (no ALTER), no ordering, no audit.                                    |
-| External migration tool (sqlx-migrate, refinery) | Heavy dependency; sqlx doesn't fit the trait-only model; we already wrote this.            |
-| Down migrations + reversal                       | Doubles maintenance; snapshots cover the use case.                                         |
-| Auto-apply migrations at startup                 | Operationally dangerous; no dry-run, no staging.                                           |
-| Single global version across all backends        | Breaks under multi-file federation with independent backend lifecycles.                    |
-| Pack-owned versioned migrations in v1            | Adds machinery for an unproven case; pack tables work via idempotent CREATE IF NOT EXISTS. |
-| All migrations in one transaction                | A single failure rolls back all prior migrations; wasted work and recovery confusion.      |
+| Alternative                                      | Why rejected                                                                                             |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| `PRAGMA user_version` only                       | No audit trail, no names, no migration history.                                                          |
+| `CREATE TABLE IF NOT EXISTS` only                | Cannot evolve schema (no ALTER), no ordering, no audit.                                                  |
+| External migration tool (sqlx-migrate, refinery) | Heavy dependency; sqlx doesn't fit the trait-only model; we already wrote this.                          |
+| Down migrations + reversal                       | Doubles maintenance; snapshots cover the use case.                                                       |
+| Uncoordinated eager migration at startup         | Operationally dangerous; current host boot uses an explicit ordered coordinator and durable V21 staging. |
+| Single global version across all backends        | Breaks under multi-file federation with independent backend lifecycles.                                  |
+| Pack-owned versioned migrations in v1            | Adds machinery for an unproven case; pack tables work via idempotent CREATE IF NOT EXISTS.               |
+| All migrations in one transaction                | A single failure rolls back all prior migrations; wasted work and recovery confusion.                    |
 
 ## Consequences
 
@@ -599,7 +674,8 @@ the codebase's migration set is global, but applied state is per-file.
 
 - Migration history is queryable: `SELECT * FROM _schema_migrations`.
 - Per-migration transactions: failure leaves the DB at the prior version.
-- Operator-context execution: deliberate, scriptable, dry-runnable.
+- Host/operator-context execution: coordinated before serving, with an explicit
+  config-aware topology admin path that remains scriptable and dry-runnable.
 - Multi-backend support: each SQLite file advances independently.
 - Pack tables stay separate from core schema: packs don't need to coordinate
   with `khive-db` releases for their own tables.
@@ -610,9 +686,9 @@ the codebase's migration set is global, but applied state is per-file.
 
 - No down migrations. Rollback requires snapshot restore.
   Mitigated: ADR-010 versioning is the rollback story; the dev path is drop+remigrate.
-- Operator must run `kkernel db migrate` before serving traffic.
-  Mitigated: `kkernel db check --strict` integrates with CI; documented in
-  deployment guide.
+- Starting a newer production host may perform schema writes before serving.
+  Mitigated: the async coordinator fails closed, V21 staging is durable and
+  resumable, and `kkernel db check --strict` remains available for CI preflight.
 - Pack tables can't evolve through `ALTER` in v1.
   Mitigated: deferred until a concrete pack use case justifies the machinery.
 - A buggy migration can lock progress until fixed and shipped as a new version.
@@ -626,8 +702,8 @@ the codebase's migration set is global, but applied state is per-file.
   databases bootstrapped via in-process schema before migrations existed.
 - `_schema_migrations` table is created lazily on first `run_migrations` call;
   it is not part of V1.
-- In-memory databases auto-migrate on creation (no operator to invoke
-  `kkernel db migrate`).
+- Writable file-backed and in-memory host boot both apply the ordinary prefix;
+  an empty database can take V21's atomic zero-reference fast path.
 
 ## Implementation
 
@@ -637,18 +713,24 @@ the codebase's migration set is global, but applied state is per-file.
 - `crates/khive-db/src/migrations.rs`:
   - `VersionedMigration` struct; `up` sourced from a `.sql` file via `include_str!`.
   - `MIGRATIONS: &[VersionedMigration]` — contiguous, append-only.
-  - `run_migrations(conn)` — applies all unapplied migrations in order.
+  - `run_migrations(conn)` — applies the ordinary prefix in order and completes
+    V21 only for the zero-reference fast path; legacy V20 returns at V20 for
+    host-assisted continuation.
   - `MIGRATION_TRACKING_TABLE` DDL for `_schema_migrations`.
 - `scripts/lint-sql.sh`:
   - Executes every `crates/**/*.sql` against an in-memory SQLite database and
     checks hygiene. Wired into `scripts/ci.sh` and `.pre-commit-config.yaml`.
-- `crates/kkernel/src/db.rs` (or similar subcommand module):
-  - `kkernel db migrate [--backend <name>] [--dry-run] [--check]`.
-  - `kkernel db check [--strict]`.
+- `crates/kkernel/src/cli.rs`:
+  - `kkernel db migrate [--config <path>] [--db <path>] [--backend <name>]
+    [--dry-run] [--check]`; config-aware and secondary-first before main.
+  - `kkernel db check [--config <path>] [--db <path>] [--backend <name>]
+    [--strict]`; read-only topology inspection.
 - `crates/khive-runtime/src/runtime.rs`:
   - In-memory `KhiveRuntime::memory()` calls `run_migrations` on creation.
-  - File-backed `KhiveRuntime::new(config)` verifies migration state at
-    startup; fails fast if behind.
+  - File-backed `KhiveRuntime::new(config)` accepts fresh/current state and
+    refuses legacy application-assisted V21. MCP/kkernel async host builders
+    coordinate it and construct through `from_prepared_backend` only after
+    durable completion.
 - `khive-storage::Pack` trait (ADR-017, Pack Standard): adds `fn schema_plan(&self) ->
   SchemaPlan` for pack-auxiliary tables. Applied during pack registration.
 
@@ -665,34 +747,38 @@ the codebase's migration set is global, but applied state is per-file.
   changes (rows in existing `notes` table).
 - ADR-017: Pack Standard — `SchemaPlan` trait for pack-auxiliary tables.
 - ADR-017: Pack Standard (§EDGE_RULES) — endpoint rules don't require migrations.
-- ADR-071: Backend-Pluggable Runtime — `BackendMigrator` trait (see Amendment A1 below).
+- ADR-071: Backend-Pluggable Runtime — historical `BackendMigrator` proposal
+  (see Amendment A1 and its implementation-status note below).
 
 ## Amendment A1: `BackendMigrator` trait (ADR-071, 2026-06-25)
 
-ADR-071 introduces a `BackendMigrator` trait in `khive-storage` that the runtime boot path
-calls instead of the current direct `run_migrations(conn: &mut rusqlite::Connection)` call.
+> **Implementation status (superseded boot shape, 2026-08-16):** the exact
+> `BackendMigrator`/`BackendHandle::boot()` shape described below is retained as
+> historical design context but is not the current production boot surface.
+> `StorageBackend::prepare_core_schema` supplies the ordinary prefix, and the
+> async khive-mcp/kkernel builders own secondary inventory and application-assisted
+> V21 coordination as specified in the implementation amendment above.
 
-The amendment to ADR-015 is narrow: the direct `run_migrations(conn)` call documented in
-§Implementation (`crates/khive-runtime/src/runtime.rs`) is replaced by the `BackendMigrator`
-trait, defined in `khive-storage`. The startup contract is unchanged from §Decision — the
-MCP binary does not apply migrations at startup. Per ADR-071 §2, boot dispatches by backend
-kind: a **file-backed** runtime calls `BackendMigrator::current_version()` and fails fast
-with a diagnostic pointing at `kkernel db migrate` when the persisted version is behind the
-codebase expectation; it does not call `migrate()`. `BackendMigrator::migrate()` is reserved
-for the `kkernel db migrate` operator command and for **in-memory/ephemeral** backends, whose
-`boot()` applies all migrations automatically (there is no operator to invoke `kkernel db
-migrate` for an ephemeral database).
+ADR-071 proposed a `BackendMigrator` trait in `khive-storage` that the runtime boot path
+would call instead of a direct `run_migrations(conn: &mut rusqlite::Connection)` call.
 
-`khive-db` provides `SqliteMigrator`, which implements `BackendMigrator` by wrapping the
-existing `run_migrations` function. The `VersionedMigration` struct, the migration array,
-the `_schema_migrations` table, the `.sql` file convention, and all other ADR-015 mechanics
-are unchanged. Only the call site in the runtime moves from a direct `rusqlite::Connection`
-call to the trait method.
+The planned amendment was narrow: replace the direct `run_migrations(conn)` call documented in
+§Implementation (`crates/khive-runtime/src/runtime.rs`) with the `BackendMigrator` trait while
+retaining the original operator-only startup contract. In that historical shape, a
+**file-backed** runtime would call `BackendMigrator::current_version()` and fail fast when behind;
+`BackendMigrator::migrate()` would be reserved for `kkernel db migrate` and
+**in-memory/ephemeral** boot. The 2026-08-16 implementation amendment above supersedes that
+startup policy and the proposed trait did not become the current host surface.
 
-This change removes `rusqlite` from `khive-runtime`'s production dependency tree, restoring
-the boundary specified in ADR-005 and ADR-009.
+The proposed `khive-db::SqliteMigrator` would have wrapped the existing `run_migrations`
+function. The implemented code instead keeps the `VersionedMigration` array,
+`_schema_migrations`, and `.sql` convention in `khive-db`, exposes
+`StorageBackend::prepare_core_schema`, and places application-assisted coordination in the async
+host.
 
-The `BackendMigrator` trait:
+The dependency-boundary goal remains: runtime and packs do not issue `rusqlite` calls directly.
+
+The historical proposed `BackendMigrator` trait was:
 
 ```rust
 // crates/khive-storage/src/migrations.rs
@@ -706,6 +792,5 @@ pub trait BackendMigrator: Send + Sync {
 }
 ```
 
-`SqliteMigrator` in `khive-db` implements this trait over a `ConnectionPool`. Alternate
-backends implement it over their own connection types. The runtime holds
-`Arc<dyn BackendMigrator>` in its `BackendHandle` (ADR-071 §1).
+This exact `SqliteMigrator` / `Arc<dyn BackendMigrator>` wiring is not part of the current
+implementation; the async host-builder contract above is authoritative.

--- a/docs/adr/ADR-028-pack-scoped-backends.md
+++ b/docs/adr/ADR-028-pack-scoped-backends.md
@@ -456,18 +456,57 @@ Rejected.
 ### Neutral
 
 - **`khive-db` largely unchanged** — adds `sqlite_read_only` + `apply_pragma` helpers.
-- **`khive-runtime` simpler** — `RuntimeConfig` shrinks; constructor becomes
-  `from_backend`; no embedder field (ADR-031).
+- **`khive-runtime` backend assembly is explicit** — `RuntimeConfig` remains a
+  host-builder input, while an already-opened backend can be assembled only
+  after schema and application-assisted cutover coordination. ADR-031 owns the
+  embedder-registry evolution.
 - **Verb dispatch unchanged** — verb→pack mapping resolved at pack construction.
 - **MCP wire protocol unchanged** — clients see the same verbs; backend assignment is
   invisible.
 
 ## Migration
 
-Single-backend users get auto-upgraded: the built-in default config produces one
-`[[backends.main]]` entry pointing at the existing `~/.khive/khive.db`. Existing data is
-unchanged. Existing `KhiveRuntime::new(RuntimeConfig)` deprecated but retained for tests;
-new code uses `from_backend`.
+When `[[backends]]` is empty, the supported async single-backend host builder
+opens the database selected by `RuntimeConfig::db_path` (defaulting to
+`~/.khive/khive.db`), applies the ordinary schema prefix, and completes the
+boot-gated V21 attachment cutover before exposing a runtime. With declared
+backends, the async multi-backend builder inventories every distinct secondary
+before coordinating V21 on canonical `main`.
+
+The explicit schema-admin surface uses the same resolved topology without
+constructing pack runtimes. `kkernel db migrate` and `kkernel db check` load an
+explicit/discovered config; omitting `--backend` targets the configured set,
+while `--backend <name>` selects a declared target. Migration deduplicates
+physical aliases and advances distinct secondaries before `main`; a selected
+`main` or physical alias retains those prerequisites. The admin configuration
+clears packs and embedders, so it applies no pack-auxiliary DDL, while retaining
+the blob configuration used only when authenticated legacy V20 moodboard
+evidence requires hydration. Exact-current admin paths and migrations without
+legacy moodboard model evidence do not resolve a BlobStore.
+`db check` is the read-only projection of the same target plan: `main` or its
+SQLite alias includes every secondary prerequisite; an independent secondary
+remains a single target.
+With no declared topology, the commands use implicit `main` at
+`--db`/`KHIVE_DB` or the default path.
+The pure planner rejects conflicting `read_only` declarations for any physical
+SQLite alias before a selected migration can open a database. `--db :memory:`
+instead makes every configured name a distinct ephemeral backend, so only the
+literal `main` name retains the full prerequisite plan. Reported prerequisite
+status follows physical backend identity; every alias of the selected main is a
+target, not a prerequisite.
+The Phase-4b V21 path remains subject to ADR-160's separately released Phase-4a
+GC gate and mandatory fleet convergence/drain. Before cutover, Phase-4a
+application-serving/read-write processes must also be quiesced or unable to
+access the database; GC-only compatibility with completed V21 is not general
+serving compatibility. The Phase-4b fleet starts only after the planned
+topology validates exact-current.
+
+`KhiveRuntime::new(RuntimeConfig)` remains a direct constructor for tests and
+fresh/already-current single-backend databases; it refuses a legacy database
+that needs application-assisted cutover. `from_backend` is a low-level assembly
+seam for an already-prepared backend, not production migration or boot guidance;
+fallible single-backend host assembly uses `from_prepared_backend` after
+coordination.
 
 ADR-029's `target_backend` column on `graph_edges` adds a nullable column with no data
 churn for single-backend deployments.

--- a/docs/adr/ADR-071-backend-pluggable-runtime.md
+++ b/docs/adr/ADR-071-backend-pluggable-runtime.md
@@ -22,6 +22,10 @@ ADR-005 specifies the polystore design: `khive-storage` defines eight capability
 `SparseStore`, `TextSearch`) and every crate above depends only on those traits, never
 on the concrete `khive-db` SQLite backend. ADR-005 §consequences states:
 
+Those eight are the surface at this ADR's ratification. ADR-111 later adds `BlobStore`, and
+ADR-121/ADR-160 Phase 4 add placement-blind `AttachmentStore`; runtime still owns placement and
+routes attachment liveness to canonical main.
+
 > "Runtime, packs, and coordinator compile without `rusqlite` on the dependency tree."
 
 ADR-009 §architecture states:
@@ -327,8 +331,8 @@ for the sqlite-vec backend; it just must not appear in the trait default.
 
 ### Why `BackendHandle` over a single `Arc<dyn Backend>` supertrait
 
-A supertrait that extends all eight capability traits forces every backend implementation
-to implement all eight. An alternate backend that provides the relational core but no
+A supertrait that extends every capability trait forces every backend implementation
+to implement all of them. An alternate backend that provides the relational core but no
 semantic or lexical search (e.g., a secondary session backend that delegates shared-graph
 reads to the main backend via `core()`) would be forced to provide stub implementations of
 `VectorStore`, `SparseStore`, and `TextSearch`. `BackendHandle` holds individual handles
@@ -421,7 +425,7 @@ says.
 Convert `khive_db::StorageBackend` from a concrete struct into a trait, with
 `SqliteStorageBackend` implementing it. Keep `KhiveRuntime { backend: Arc<dyn StorageBackend> }`.
 
-Rejected. A `StorageBackend` trait that returns all eight `Arc<dyn CapabilityTrait>` handles
+Rejected. A `StorageBackend` trait that returns every `Arc<dyn CapabilityTrait>` handle
 is functionally equivalent to `BackendHandle`. The difference is that a named trait imposes
 a single-implementor contract on backends while `BackendHandle::from_parts` allows the
 flexible per-slot construction described in §1 rationale. `BackendHandle` is simpler and

--- a/docs/adr/ADR-079-ann-persistence-warm-path-integration.md
+++ b/docs/adr/ADR-079-ann-persistence-warm-path-integration.md
@@ -140,15 +140,14 @@ per-tenant by construction, never shared across namespaces. ANN segments are der
 local-only state — they are git-ignored exactly as `working.db` vectors are (ADR-035 §6); they are
 never committed and never travel in NDJSON.
 
-**Backend data-dir accessor (new surface, a precondition of this section).** No filesystem-directory
-accessor exists on the storage/runtime surface today: `BackendConfig`/`Backend` take `path` as a
-_constructor input_, not a readable accessor, and `RuntimeConfig::db_path` is deprecated in favour of
-`from_backend` and is `None` for in-memory backends. Resolving `<backend_data_dir>` therefore
-requires adding a `backend_data_dir() -> Option<PathBuf>` accessor on the backend handle /
-`KhiveRuntime`, threaded to the knowledge pack. This is a real ADR-028 surface addition, not a free
-assumption. For a pathless/in-memory backend the accessor returns `None`: ANN persistence is disabled
-(segments are skipped) and every warm is a Cold rebuild (§2) — correct, since an in-memory backend
-has no durable home for derived state.
+**Backend data-dir accessor (implemented surface).** `StorageBackend::data_dir` and
+`KhiveRuntime::backend_data_dir() -> Option<PathBuf>` expose the directory of the pack-assigned
+backend, while `backend_ann_root()` exposes the database-scoped `<db-file>.ann/` root introduced by
+Amendment 1. `RuntimeConfig::db_path` remains an input to the supported async single-backend host
+builder; direct `from_backend` assembly neither replaces that input nor performs host coordination.
+For a pathless/in-memory backend the accessors return `None`: ANN persistence is disabled (segments
+are skipped) and every warm is a Cold rebuild (§2) — correct, since an in-memory backend has no
+durable home for derived state.
 
 **Relationship to `retrieval_snapshots` (no drop, no wholesale deprecation).** `retrieval_snapshots`
 is a **shared** table with consumers beyond the knowledge pack: the memory pack's own Vamana
@@ -306,9 +305,9 @@ path as production.
 
 ## Migration path
 
-0. **Backend data-dir accessor.** Add `backend_data_dir() -> Option<PathBuf>` to the backend handle /
-   `KhiveRuntime` (ADR-028 surface addition) and thread it to the knowledge pack; `None` ⇒ ANN
-   persistence disabled (Cold every warm). This is the precondition for steps 1–4.
+0. **Backend data-dir accessor (implemented).** `backend_data_dir() -> Option<PathBuf>` and the
+   database-scoped `backend_ann_root()` are exposed on `KhiveRuntime`; `None` ⇒ ANN persistence
+   disabled (Cold every warm). This is the precondition for steps 1–4.
 1. **Bridge persistence swap.** `AnnBridge` gains `save_atomic`/`load`/`load_or_build` delegations to
    its `VamanaIndex`; warm restores via the §2 raw-`load`-plus-content-hash decision against the
    per-(ns, model) segment dir. Keep the JSON path readable for one release for fallback; stop

--- a/docs/adr/ADR-091-wal-snapshot-lifetime.md
+++ b/docs/adr/ADR-091-wal-snapshot-lifetime.md
@@ -1369,17 +1369,17 @@ of course part of statement execution and is not “external work” in this rul
 **Complete production write-scope audit (current tree).** The owner row is the review unit; every
 production caller named in that row was inspected through its commit/rollback edge.
 
-| Transaction owner                               | Production scopes/callers                                                                                      | Work inside the transaction                                                   | Verdict                                 |
-| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | --------------------------------------- |
-| `run_migrations_locked` and `apply_schema_plan` | Core versioned migrations; pack service migrations                                                             | Migration DDL/DML and ledger insert                                           | SQL-only                                |
-| `WriterGuard::transaction`                      | Pack auxiliary DDL; runtime symmetric edge update; entity/note merge fallback                                  | Synchronous statement sequences over one borrowed connection                  | SQL-only                                |
-| `writer_task::drain_loop`                       | All `send`/`send_bounded` store mutations, queue-backed `SqlBridge` batches, and `atomic_unit` requests        | The request's prepared SQL statements and bounded row/result folding          | SQL-only after the blob-GC repair below |
-| `SqlBridge` manual owners                       | Standalone and pool-backed `execute_batch`; flag-off `run_manual_atomic_unit`                                  | Pre-prepared parameterized statements, commit/rollback, poisoning bookkeeping | SQL-only                                |
-| Store flag-off batch owners                     | `entity`, `note`, `event`, `graph`, `text`, `sparse`, `vectors`, and `agents` batch/upsert/delete methods      | Bounded per-item SQL loops and result counters                                | SQL-only                                |
-| Vector-store private IMMEDIATE transactions     | Vector batch upsert/delete/orphan reconciliation                                                               | sqlite-vec/ordinary table statements and bounded row binding                  | SQL-only                                |
-| Retrieval weight private IMMEDIATE transaction  | `engine_weights::apply_weight_delta_with_eta`                                                                  | One scalar read, bounded EMA arithmetic, weight upsert, and audit-row insert  | SQL-only                                |
-| Runtime/pack `AtomicUnitOp` callers             | Runtime atomic runner and ANN registry; brain fold/persist; session mirror ingest; blob recovery/claim/cleanup | DML/query statements and bounded validation/folding                           | SQL-only                                |
-| Blob physical GC (outside owner)                | `FsBlobStore::transactional_orphan_sweep`                                                                      | Root walk, metadata, advisory locking, and file deletion                      | Explicitly outside SQLite transactions  |
+| Transaction owner                               | Production scopes/callers                                                                                               | Work inside the transaction                                                   | Verdict                                 |
+| ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | --------------------------------------- |
+| `run_migrations_locked` and `apply_schema_plan` | Core versioned migrations; pack service migrations                                                                      | Migration DDL/DML and ledger insert                                           | SQL-only                                |
+| `WriterGuard::transaction`                      | Pack auxiliary DDL; runtime symmetric edge update; entity/note merge fallback                                           | Synchronous statement sequences over one borrowed connection                  | SQL-only                                |
+| `writer_task::drain_loop`                       | All `send`/`send_bounded` store mutations, queue-backed `SqlBridge` batches, and `atomic_unit` requests                 | The request's prepared SQL statements and bounded row/result folding          | SQL-only after the blob-GC repair below |
+| `SqlBridge` manual owners                       | Standalone and pool-backed `execute_batch`; flag-off `run_manual_atomic_unit`                                           | Pre-prepared parameterized statements, commit/rollback, poisoning bookkeeping | SQL-only                                |
+| Store flag-off batch owners                     | `entity`, `note`, `event`, `graph`, `text`, `sparse`, `vectors`, `agents`, and `attachment` batch/upsert/delete methods | Bounded per-item SQL loops and result counters                                | SQL-only                                |
+| Vector-store private IMMEDIATE transactions     | Vector batch upsert/delete/orphan reconciliation                                                                        | sqlite-vec/ordinary table statements and bounded row binding                  | SQL-only                                |
+| Retrieval weight private IMMEDIATE transaction  | `engine_weights::apply_weight_delta_with_eta`                                                                           | One scalar read, bounded EMA arithmetic, weight upsert, and audit-row insert  | SQL-only                                |
+| Runtime/pack `AtomicUnitOp` callers             | Runtime atomic runner and ANN registry; brain fold/persist; session mirror ingest; blob recovery/claim/cleanup          | DML/query statements and bounded validation/folding                           | SQL-only                                |
+| Blob physical GC (outside owner)                | `FsBlobStore::transactional_orphan_sweep`                                                                               | Root walk, metadata, advisory locking, and file deletion                      | Explicitly outside SQLite transactions  |
 
 **Blob cross-resource repair.** The sweep now prepares its file candidates before SQLite opens a
 writer transaction. The protocol first holds a process-local lock keyed by the canonical database
@@ -1390,9 +1390,15 @@ is removed in transactions of at most 128 rows. Recovery therefore does not depe
 path-derived `root_key` and also covers a relocated root or an online-backup snapshot restored at a
 different database path.
 
-Candidate processing is likewise split into units of at most 128. Each short atomic unit anti-joins
-live `entities.content_ref` values and commits only that bounded set of durable `blob_gc_claims`;
-V20 entity INSERT/UPDATE triggers reject a new live reference to any claimed digest. After commit,
+Candidate processing is likewise split into units of at most 128. The separately shipped Phase-4a
+gate first requires one exact completed V21 epoch: ledger/latest version, completed marker,
+attachment/claim tables and attachment claim triggers, and absence of the legacy entity
+column/index/triggers must agree. V20, pending, incomplete, and malformed states refuse dry-run and
+destructive sweep before filesystem or durable-claim mutation. After validating every
+`attachments.content_ref` and claim value, each short atomic unit anti-joins all attachment rows
+(including soft-deleted recoverable records) and commits only that bounded set of durable
+`blob_gc_claims`; attachment INSERT/UPDATE triggers reject a new live reference to any claimed
+digest. After commit,
 the sweep deletes only that batch's files outside SQLite and removes only that batch's claims in a
 second bounded atomic unit before advancing. JSON bindings, claim-table mutations, returned rows,
 and application result folding are therefore cardinality-bounded per writer hold. A crash between

--- a/docs/adr/ADR-111-blob-store.md
+++ b/docs/adr/ADR-111-blob-store.md
@@ -6,13 +6,16 @@
 accepted 2026-07-17; Amendment 4 accepted 2026-07-19)
 **Authors**: khive maintainers
 **Amended by**: proposed [ADR-160](ADR-160-shared-pack-infrastructure.md), which requires
-backend-enforced bounded and digest-verified reads and retires public unbounded `get` on acceptance.
+backend-enforced bounded and digest-verified reads, retires public unbounded `get`, and implements
+ADR-121's attachment-only liveness and claim fences through a Phase-4a GC compatibility release,
+mandatory fleet convergence/drain plus application-service quiescence, and boot-gated Phase-4b V21
+cutover on acceptance.
 **Depends on**:
 
 - [ADR-005](ADR-005-storage-capability-traits.md) — Storage Capability Traits (trait-only capability
   surface this ADR extends with a ninth capability)
 - [ADR-015](ADR-015-schema-migrations.md) — Schema Migrations (the versioned migration this ADR uses
-  to add `entities.content_ref`)
+  to add the historical V10 `entities.content_ref`, later superseded by V21 attachments)
 - [ADR-044](ADR-044-vector-store-extensions.md) — Vector Store Extensions (the `orphan_sweep`
   CLI-only precedent this ADR mirrors for `BlobStore`)
   **Related**: [ADR-086](ADR-086-doc-file-pack.md) — proposed Doc/File Pack that deferred
@@ -29,7 +32,7 @@ large blobs that a downstream consumer (the planned doc/file pack, ADR-086) want
 reference from the graph, without inflating `khive.db` itself or forcing every KG query to page
 through blob bytes it never asked for.
 
-ADR-005 defines eight storage capability traits (`Sql`, `Notes`, `Entities`, `Graph`, `Events`,
+At the time this ADR was accepted, ADR-005 defined eight storage capability traits (`Sql`, `Notes`, `Entities`, `Graph`, `Events`,
 `Vectors`, `Sparse`, `Text`) under a "zero implementation, trait-only" constraint for
 `khive-storage`. ADR-086 explicitly deferred adding a blob capability until a real consumer needed
 it, and named `StorageCapability::Blob` as the natural v2 amendment. This ADR is that amendment
@@ -210,6 +213,13 @@ beside, and `resolve_blob_root` returns an error rather than picking an arbitrar
 
 ### 7. `entities.content_ref` — the reference column
 
+**Superseded storage shape (ADR-121 / ADR-160 Phase 4b).** This section records the V10 design that
+preceded first-class attachments. After the separate Phase-4a GC compatibility release has
+converged and every older process is drained, V21 backfills the value under attachment role
+`"content"`, keeps `Entity.content_ref` only as a compatibility read projection, and drops the
+physical entity column, its index, and its claim triggers. `attachments.content_ref` is then the sole
+SQL liveness source.
+
 A new nullable, indexed column on `entities` (migration V10,
 `crates/khive-db/sql/010-entities-content-ref.sql`):
 
@@ -240,8 +250,8 @@ column: content_ref".
 `BlobStore::orphan_sweep` is the ninth capability's mirror of `VectorStore::orphan_sweep`
 (ADR-044): an admin-side operation, not an MCP verb (adding one would be a wire-surface change
 requiring its own ADR amendment, per ADR-023). The caller (an admin CLI, not a live consumer path)
-assembles the set of live `content_ref`s — e.g. `SELECT DISTINCT content_ref FROM entities WHERE
-content_ref IS NOT NULL AND deleted_at IS NULL` — and passes it in `BlobOrphanSweepConfig`;
+assembles the set of live `content_ref`s — e.g. `SELECT DISTINCT content_ref FROM attachments` —
+and passes it in `BlobOrphanSweepConfig`;
 `FsBlobStore` walks its shard tree and reports (`dry_run: true`) or deletes (`dry_run: false`)
 everything not in that set.
 
@@ -255,16 +265,16 @@ ever add references and let GC reconcile.
 paragraph above, as originally written, claimed this design "is never removed out from under a
 concurrent reader". That remains false for `delete` and the caller-snapshot
 `orphan_sweep(config)` API. Both are **offline-maintenance-only**, not safe to run against a live
-entity writer:
+attachment writer:
 
 - `orphan_sweep`'s `live_refs` set is a **snapshot** the caller assembles before the call. Nothing
-  in `BlobStore` detects a `content_ref` that becomes newly live — an entity write lands
+  in `BlobStore` detects a `content_ref` that becomes newly live — an attachment write lands
   referencing it — between when that snapshot was taken and when the sweep runs; such a blob is
   deleted anyway. `khive-db`'s
   `orphan_sweep_race_demonstrates_the_documented_quiescence_requirement` test reproduces this
   exactly, so the hazard is pinned in code, not just prose.
 - `delete` is an unconditional physical removal with the same class of hazard: any caller can
-  delete a `content_ref` an entity write races into existence a moment later, with no coordination
+  delete a `content_ref` an attachment write races into existence a moment later, with no coordination
   from this trait.
 
 Run those two methods only when writes that could create a new `content_ref` reference are
@@ -279,15 +289,35 @@ traffic alternative for backends that can coordinate both stores. The filesystem
    SQL-only transactions of at most 128 rows; ownership, not the mutable path-derived `root_key`,
    makes root relocation and restored-backup recovery safe;
 4. for each candidate batch of at most 128, enters a short, SQL-only `SqlAccess::atomic_unit`
-   (`BEGIN IMMEDIATE` on SQLite), selects distinct references from non-deleted entities, and
+   (`BEGIN IMMEDIATE` on SQLite), selects distinct references from attachments, and
    durably claims only absent candidates in `blob_gc_claims`;
 5. after that transaction commits, deletes only the claimed batch while retaining database/root
-   ownership; entity INSERT/UPDATE triggers reject a newly live reference to any active claim; and
+   ownership; attachment INSERT/UPDATE triggers reject a newly live reference to any active claim; and
 6. removes that bounded claim batch in a second short SQL-only atomic unit before advancing, then
    releases all locks after the final batch.
 
+**GC compatibility epoch gate (proposed ADR-160 Phase 4a).** Before the V21 schema implementation is
+released, the filesystem transactional sweep ships separately with an exact schema-epoch gate.
+Phase 4a makes no schema or data change: it does not create attachments, backfill, dual-read,
+dual-write, or record V21. The sweep accepts attachment liveness only when the V21 ledger row and
+latest version, completed cutover marker, attachment claim fences, and removal of the legacy entity
+column/index/triggers all agree. V20, pending, incomplete, and malformed combinations fail closed
+in both dry-run and destructive modes before filesystem or claim mutation. Ordinary epoch mismatch
+is `Unsupported`; malformed schema or evidence may retain its more specific validation/driver error.
+Callers must not fall back to caller-snapshot `orphan_sweep` or unconditional `delete`.
+
+Every process and scheduled job that can share the database/blob root must converge on the
+Phase-4a-or-newer gate, and every pre-Phase-4a process must be drained and restart-fenced, before a
+Phase-4b binary may migrate V21. Every Phase-4a application-serving/read-write process must also be
+quiesced for the cutover, or independently proven unable to touch the database: Phase 4a does not
+make its V20 entity readers and writers compatible with the V21 column drop. A Phase-4a GC-only
+worker is safe on exact completed V21, but that narrow property is not general serving
+compatibility. Start the Phase-4b service fleet only after exact-current topology validation. This
+intentionally pauses transactional GC on V20 during the compatibility epoch; operators must budget
+capacity rather than weaken the fence.
+
 This yields two concurrency guarantees pinned by tests. A blob published after candidate capture
-is not in the sweep set and survives. A committed entity reference cannot appear between the
+is not in the sweep set and survives. A committed attachment reference cannot appear between the
 liveness query and physical deletion: SQLite's writer lock covers the anti-join plus claim commit,
 then the durable trigger fence covers the external deletion phase without monopolizing SQLite's
 single writer. Invalid stored `content_ref` or claim values fail closed rather than making the
@@ -297,7 +327,7 @@ clears abandoned claims in bounded units, and freshly claims any still-eligible 
 does one writer transaction bind, mutate, or return more than 128 candidates, bounding claim-table
 and WAL work per writer hold.
 
-The guarantee still has a bounded publish gap. `put(bytes)` and the later entity write that stores
+The guarantee still has a bounded publish gap. `put(bytes)` and the later attachment write that stores
 its returned reference are separate client steps, outside one shared transaction. A candidate with
 no committed reference is therefore protected by file age: `FsBlobStore` defaults to a one-hour
 grace period, treats an unknown age as protected, and refreshes the mtime on a deduplicated `put`.
@@ -343,33 +373,38 @@ misses.
 
 ## Consequences
 
+The following bullets record the original V10 acceptance consequences. ADR-121 / ADR-160 Phase 4b
+supersedes their entity-column details with the V21 outcome described immediately afterward.
+
 - `khive-storage` grows one new module (`blob.rs`) and one new `StorageCapability` variant; no
   existing trait or type changes shape.
 - `khive-db` grows one new store module (`stores/blob.rs`, `FsBlobStore`), one new
   `StorageBackend::blob_store` factory method, and one new migration (V10). No existing migration
   is edited.
-- `Entity` (the `khive-storage` flat/SQL-facing struct, not `khive_types::entity::Entity`) grows a
-  `content_ref: Option<String>` field. Every call site constructing an `Entity` literal
-  (`khive-db`, `khive-runtime`, `khive-vcs`) needed updating; all currently set `content_ref: None`
-  except the SQL-backed CRUD paths in `khive-db::stores::entity`, which thread the real value
-  through.
+- `Entity` (the `khive-storage` flat/SQL-facing struct, not `khive_types::entity::Entity`) grew a
+  `content_ref: Option<String>` field. At V10 acceptance, SQL-backed entity CRUD threaded the
+  physical column through that field.
 - The pre-existing entity-merge SQL path in `khive-runtime::curation::merge_entity_sql`'s `INSERT
   OR REPLACE` already omits `entity_type` from its column list (a pre-existing gap, not introduced
   by this ADR) — merging an entity through that path resets `entity_type` to `NULL` in the stored
-  row today. `content_ref` was deliberately left out of that same `INSERT OR REPLACE` for
+  row at the time. `content_ref` was deliberately left out of that same `INSERT OR REPLACE` for
   consistency with the existing (undocumented) behavior rather than silently fixing one field and
   not the other; the in-memory `MergeResult`'s returned `Entity` does still carry the "into"
   entity's `content_ref` forward, matching how it already carries `entity_type` forward in memory
-  despite the DB row losing it. This existing gap should be fixed in its own change, not folded
-  into this ADR's scope.
+  despite the DB row losing it.
 - No MCP wire-surface change: `blob_store` is reached only through `StorageBackend`, not through
   any pack verb. A future doc/file pack ADR will define what (if anything) becomes MCP-visible.
+- **Current V21 outcome (ADR-121 / ADR-160 Phase 4b):** after the Phase-4a fleet gate, the physical
+  entity column and its index and
+  claim triggers are removed. `Entity.content_ref` remains only as a compatibility response
+  projection of attachment role `"content"`; entity writes and merges no longer read or write a
+  physical `entities.content_ref`. The role-keyed attachment row is authoritative for liveness.
 - **Amendments (2026-07-13, PR #922):** `ContentRef` no longer derives
   `Deserialize` — it is hand-implemented to route every input through `from_hex`, so a malformed
   serialized value is rejected at deserialization instead of later panicking in `shard_path`.
   `FsBlobStore::put`'s floor check now accounts for the pending write's own size. `delete` and
   `orphan_sweep` are now explicitly documented (trait doc comments, §8 above) as
-  offline-maintenance-only, requiring quiesced entity writes — a real concurrency hazard the
+  offline-maintenance-only, requiring quiesced attachment writes — a real concurrency hazard the
   original §8 text incorrectly described as absent. PR #1313 later added the distinct filesystem
   `transactional_orphan_sweep` path described in §8; it did not make these legacy methods safe.
 - **Further amendment (same date):** the first fix for serializing `put` scoped
@@ -490,10 +525,10 @@ Content-addressed keys plus conditional create replace the filesystem publish cr
 concurrent `put` calls.
 
 No object-store mutex replaces the §8 safety requirement because an in-process lock would not solve
-it. The hazardous race is between a database snapshot of live `content_ref`s and a later entity
+it. The hazardous race is between a database snapshot of live `content_ref`s and a later attachment
 write, potentially across processes and storage systems. `delete` and the caller-snapshot
 `orphan_sweep` therefore remain offline-maintenance-only for S3 and require deployment-wide
-quiescence of every writer that can create a new entity reference for the full snapshot-plus-sweep
+quiescence of every writer that can create a new attachment reference for the full snapshot-plus-sweep
 interval. PR #1313 implemented `transactional_orphan_sweep` only for `FsBlobStore`;
 `S3BlobStore` retains the trait default (`Unsupported`) and does not inherit the filesystem grace-
 period guarantee.
@@ -739,7 +774,9 @@ unauthenticated callers, or telemetry that leaves the deployment boundary.
   `BlobOrphanSweepResult`, `BlobStore`.
 - `crates/khive-storage/src/capability.rs` — `StorageCapability::Blob`.
 - `crates/khive-storage/src/error.rs` — `StorageError::CapacityFloor`.
-- `crates/khive-storage/src/entity.rs` — `Entity::content_ref`, `Entity::with_content_ref`.
+- `crates/khive-storage/src/entity.rs` — `Entity::content_ref` compatibility response projection;
+  the former writable helper is removed.
+- `crates/khive-storage/src/attachment.rs` — ADR-121 role-keyed attachment contract.
 - `crates/khive-db/src/stores/blob.rs` — `FsBlobStore`, `resolve_blob_root`,
   `write_lock_for_root`/`root_write_locks` (the canonical-root-keyed shared-lock registry),
   `crosses_floor` (the pure write-size-aware floor comparison).
@@ -749,12 +786,15 @@ unauthenticated callers, or telemetry that leaves the deployment boundary.
   `crates/khive-mcp/src/serve.rs` — config-aware blob-store selection and boot wiring from PR #1054;
   no provider type enters `khive-storage`.
 - `crates/khive-storage/src/blob.rs` and `crates/khive-db/src/stores/blob.rs` — provider-neutral
-  transactional sweep contract and filesystem implementation from PR #1313.
-- `crates/khive-db/sql/010-entities-content-ref.sql` — migration V10.
-- `crates/khive-db/sql/entities-ddl.sql` — mirrored `content_ref` column + index.
-- `crates/khive-db/src/stores/entity.rs` — `content_ref` threaded through
-  `entity_upsert_statement`, `batch_upsert_entities`, `read_entity`, and all three `SELECT` column
-  lists.
+  transactional sweep contract and filesystem implementation; the Phase-4a epoch gate refuses V20
+  and every incomplete/malformed V21 combination in both modes, while exact completed V21
+  anti-joins `attachments` and validates attachment/claim refs.
+- `crates/khive-db/sql/010-entities-content-ref.sql` — historical V10 column introduced by this
+  ADR; V21 removes it after backfill.
+- `crates/khive-db/sql/021-attachments-stage.sql` and
+  `021-attachments-claim-fences.sql` — resumable stage schema and final attachment fences.
+- `crates/khive-db/src/stores/entity.rs` — role `"content"` read projection, atomic
+  entity-plus-attachment publication, and transactional hard-delete cleanup.
 
 ## References
 

--- a/docs/adr/ADR-121-attachments-first-class.md
+++ b/docs/adr/ADR-121-attachments-first-class.md
@@ -5,8 +5,8 @@
 **Authors**: khive maintainers\
 **Amended by**: proposed [ADR-160](ADR-160-shared-pack-infrastructure.md), whose moodboard migration
 consumes this accepted role-keyed desired state, makes the canonical main backend the sole
-attachment/GC-liveness authority, and specifies a boot-gated two-stage cutover rather than
-extending legacy `entities.content_ref`.\
+attachment/GC-liveness authority, and specifies a two-release GC-compatibility/deployment gate plus
+a boot-gated two-stage cutover rather than extending legacy `entities.content_ref`.\
 **Depends on**:
 
 - [ADR-111](ADR-111-blob-store.md) — BlobStore (the content-addressed storage capability,
@@ -92,7 +92,10 @@ CREATE INDEX idx_attachments_content_ref ON attachments(content_ref);
 
 The migration backfills every non-null `entities.content_ref` into `attachments` with role
 `"content"` and drops the `entities.content_ref` column. After the migration there is exactly
-one reference source for blob garbage collection.
+one reference source for blob garbage collection. ADR-160 Phase 4 implements this as a
+boot-gated, resumable V21 state machine: the stage transaction retains the legacy column and
+claim fences while pack-owned roles are authenticated; one final transaction swaps the GC
+anti-join and claim triggers, drops the legacy column, and records completion before serving.
 
 ### 2. The rendition rule: what is an attachment, what is not
 
@@ -145,6 +148,11 @@ agent path for record content.
 
 ### 4. Atomic publication
 
+The generic `attach` and `create(..., attach=...)` wire behavior below belongs to rollout step 2
+and remains deferred after ADR-160 Phase 4. The shipped internal
+`create_entity_with_attachments` seam already enforces the same database atomicity for current
+consumers.
+
 `attach` (and `create` with `attach=`) performs blob write and reference commit as one
 operation behind the verb boundary: the blob is written to the store, then the attachment row
 is committed in the same database transaction as the record write. A failure on either side
@@ -187,7 +195,7 @@ exactly what it was; the record of what happened is not rewritten to serve the n
 
 ## Consumers
 
-The first live consumer, named at landing: **the channel message components**. Inbound media
+The first consumer named by this decision was **the channel message components**. Inbound media
 messages — a voice message, a shared photo — land as message notes whose text field carries
 the searchable rendition (transcript, caption) and whose raw payload attaches under a media
 role. This is the note-attachment case of §2 verbatim, and it is the consumer that makes the
@@ -197,6 +205,11 @@ with both renditions, and is retrievable through the record surface.
 Follow-on consumers, in expected order: document ingestion (paper entities holding PDF/HTML
 renditions) and multimodal retrieval (embedding fan-out over stored media renditions), each
 under its own design record.
+
+ADR-160 Phase 4 changes implementation order: moodboard visual assets and preference-model
+artifacts are the first live consumers of the internal attachment substrate. Channel ingestion and
+the agent-facing attachment verbs remain follow-on work; this ordering change does not alter the
+utterance-versus-thing rule above.
 
 ---
 
@@ -264,3 +277,21 @@ under its own design record.
    strings); atomicity, GC single-source, delete-cascade reclamation (hard delete removes
    attachment rows in-transaction and the freed blobs become sweep-eligible; soft delete
    retains them), promotion-by-ref, and hydration behavior are tested contracts.
+
+### Implementation state after ADR-160 Phase 4
+
+Rollout step 1 uses two releases. Phase 4a changes no schema or data and ships only the exact-V21
+transactional-GC epoch gate. After fleet convergence, old-binary drain, and quiescence of every
+Phase-4a application reader/writer, Phase 4b implements one coordinated schema/consumer cutover:
+typed storage and SQLite attachment stores, legacy `"content"` backfill, current entity/moodboard
+reader and writer migration, transactional hard-delete cleanup, attachment-only blob liveness and
+claim fences, authenticated `"fann-network"` reconstruction, and removal of
+`entities.content_ref`. A Phase-4a GC-only worker is narrowly safe on exact completed V21, but is
+not a schema-compatible entity server; the Phase-4b fleet starts only after exact-current topology
+validation. The canonical main/core database is the only attachment and GC-liveness authority;
+secondary runtime handles must route through `KhiveRuntime::core()` and direct attachment access on
+a secondary is rejected.
+
+The agent-facing `kg` verbs in rollout step 2 (`attach`, `detach`, `export`, create-with-attach,
+and selective hydration) remain deferred. Phase 4 adds internal runtime/storage publication seams
+for existing consumers; it does not claim the complete ADR-121 public verb rollout.

--- a/docs/adr/ADR-148-moodboard-visual-retrieval-pack.md
+++ b/docs/adr/ADR-148-moodboard-visual-retrieval-pack.md
@@ -139,10 +139,11 @@ and `rank` is one-based after self-exclusion.
 
 The runtime adds two consumer seams rather than exposing its backend:
 
-1. `create_entity_with_content_ref(..., &ContentRef)` is the typed publish-time attachment path.
-   It requires an installed `BlobStore` and verifies `exists(content_ref)` before any entity
-   mutation, then delegates to the same compensated entity-create implementation as `create_entity`, so an
-   FTS or text-vector failure cleans the entity row and every index touched by that call.
+1. `create_entity_with_attachments(..., Vec<NewAttachment>)` is the typed publish-time path.
+   Moodboard supplies the original under role `"content"`. The seam requires an installed
+   `BlobStore`, verifies every `ContentRef` before mutation, and commits the entity plus roles in
+   one transaction before the existing FTS/vector compensation path; compensation hard-deletes
+   the entity and attachment rows together.
 2. `vectors_for_named_identity(token, &NamedVectorIdentity)` returns a token-scoped vector store.
    `NamedVectorIdentity::new` rejects an empty/unsafe or over-128-byte model key, an empty or
    over-512-byte model name, zero dimension, and dimensions above 8192. The accessor validates the actual vec table's declared dimension
@@ -176,8 +177,8 @@ is shared by the two runtime handles.
    visual vector row.
 
 The normalized PNG is derived cache input, not a persisted attachment in the current
-implementation. Proposed ADR-160 migrates the original visual and the preference bundle/network
-blob anchors to ADR-121 roles on acceptance without promoting this normalized cache input. A
+implementation. ADR-160 Phase 4 migrates the original visual and the preference bundle/network
+blob anchors to ADR-121 roles without promoting this normalized cache input. A
 failure after blob publication may leave an orphan for ADR-111 grace-period GC. A
 failure after entity creation may leave an attached asset without the current descriptor row;
 retrying the same bytes reuses the entity and heals the vector. `created` reports whether this call
@@ -189,8 +190,9 @@ stored as mutable scalar asset properties; they belong to the immutable descript
 
 The lookup-before-create contract is retry-idempotent. A process-wide content-ref-striped critical
 section performs the lookup again before create, preventing duplicate first ingests within one
-Khive process without serializing unrelated content. Because `entities.content_ref` is indexed but
-not unique, separate Khive processes can still race and create duplicates. V1 discloses that
+Khive process without serializing unrelated content. Because attachment role `"content"` is indexed
+but not uniquely constrained across records, separate Khive processes can still race and create
+duplicates. V1 discloses that
 cross-process boundary rather than adding a uniqueness rule that would incorrectly apply to every
 entity kind or namespace.
 
@@ -372,4 +374,4 @@ before equivalent numerical claims may be made for 0.9.0.
 - [ADR-027](ADR-027-dynamic-pack-loading.md) — inventory registration and opt-in loading.
 - [ADR-095](ADR-095-verb-surface-consolidation.md) — CRUD consolidation.
 - [ADR-111](ADR-111-blob-store.md) — publish-then-reference CAS and orphan grace GC.
-- [ADR-121](ADR-121-attachments-first-class.md) — proposed multi-rendition attachment model.
+- [ADR-121](ADR-121-attachments-first-class.md) — accepted multi-rendition attachment model.

--- a/docs/adr/ADR-149-moodboard-preference-learning.md
+++ b/docs/adr/ADR-149-moodboard-preference-learning.md
@@ -225,7 +225,8 @@ containing:
 - exact `10 -> 1 Linear, bias=0` architecture; and
 - FANN blob reference and SHA-256.
 
-The bundle is a second BlobStore object attached to an `artifact/moodboard_model`; its SHA-256 is
+The bundle is a second BlobStore object attached to an `artifact/moodboard_model` under ADR-121
+role `"content"`; the FANN object is attached atomically under role `"fann-network"`. Its SHA-256 is
 the model fingerprint. The model is linked `derived_from` its board. A pack-only immutable
 `moodboard.model_record` `Audit` event binds actor, entity ID, bundle reference/fingerprint,
 network reference/digest, and full scope. Generic KG properties are display mirrors and cannot by
@@ -240,7 +241,15 @@ attributed bundle/event scope, both BlobStore BLAKE3 references, bundle and netw
 the model provenance event, support/calibration gates, FANN version, one-layer shape, Linear
 activation, finite parameters, and exactly zero bias. FANN's binary parser
 validates shape and exact length but accepts non-finite parameters, so the pack performs the
-additional finite-parameter walk. The bundle and FANN blobs are capped at 1 MiB each.
+additional finite-parameter walk. The authenticated bundle's network reference must equal the
+`"fann-network"` attachment before that object is hydrated. The bundle and FANN blobs are capped at
+1 MiB each.
+
+During V21 upgrade, the legacy bundle ref is backfilled as role `"content"`; role
+`"fann-network"` is reconstructed only after bounded hydration verifies that bundle, its exact
+immutable `moodboard.model_record` event, and the referenced FANN bytes. Mutable entity properties
+remain display mirrors and are never migration authority. Missing or conflicting evidence aborts
+the cutover rather than guessing, and both attachment rows participate in GC liveness.
 
 `Network::forward` reuses mutable activation buffers. Serving therefore keeps no shared mutable
 network instance: a validated network is cloned for each prediction. Concurrent calls use
@@ -313,3 +322,10 @@ identity, support failure, both labels, tie/abstain exclusion, deterministic tra
 FANN corrupt/wrong-shape/non-finite rejection, independent concurrent buffers, wrong scope/schema,
 uncalibrated rejection, BlobStore/entity/event round-trip across runtime restart, and the complete
 public `serve -> judge -> train_preference -> preference` path.
+
+ADR-160 Phase 4 additionally requires a real V20 database fixture to stage `content`, reconstruct
+`fann-network` only from the verified bundle plus exact immutable event, finalize V21, restart,
+and reproduce the prior exact prediction after attachment-only GC preserves both objects. The
+host migrator runs independently of active moodboard-pack selection. Corrupt, missing, or
+conflicting bundle/event/network evidence leaves the durable cutover incomplete and exposes no
+serving runtime.

--- a/docs/adr/ADR-160-shared-pack-infrastructure.md
+++ b/docs/adr/ADR-160-shared-pack-infrastructure.md
@@ -276,11 +276,27 @@ guarantee. The current critical section may remain pack-local until a durable un
 is separately justified. Content-hash stripe maps, model locks, judgment locks, and unrelated pack
 locks are not extracted by this program.
 
-Attachment migration is ADR-121's coordinated cutover, not a separately merged prerequisite. The
-same merged change adds and backfills attachments, migrates every legacy reader/writer plus hard
-delete and GC reference queries (including moodboard's `"content"` and `"fann-network"` roles), and
-then drops `entities.content_ref`. There is no merged dual-source interval, no recreated
-`create_entity_with_content_ref`, and no second legacy column.
+Attachment migration is ADR-121's coordinated cutover, but its destructive Phase 4b is preceded by
+one separately released compatibility epoch. **Phase 4a is only the GC compatibility epoch gate.**
+It leaves V20 schema and data byte-for-byte in their existing shape: it does not create
+attachments, backfill, dual-read, dual-write, or record V21. Instead, transactional filesystem-blob
+GC recognizes exactly two safe outcomes: an exact completed V21 ledger/marker/fence/schema epoch
+uses attachment liveness; every V20, pending, incomplete, or malformed epoch refuses both dry-run
+and destructive sweep before filesystem or claim mutation. There is no fallback to the
+caller-snapshot sweep or unconditional delete.
+
+Phase 4a must converge on every process that can share the database/blob root, and every
+pre-Phase-4a process must then be drained and prevented from restarting, before any Phase-4b binary
+is allowed to migrate the database. The cutover additionally requires service quiescence: every
+Phase-4a application-serving or read/write process must be drained, or independently proven unable
+to touch the database during migration. A Phase-4a **GC-only** worker is safe against an exact
+completed V21 because of the epoch gate, but that narrow mixed-fleet property is not general entity
+reader/writer or serving compatibility. Phase 4b itself adds and backfills attachments, migrates
+every legacy reader/writer plus hard delete and GC reference queries (including moodboard's
+`"content"` and `"fann-network"` roles), and then drops `entities.content_ref` in one reviewable
+change. The Phase-4b serving fleet starts only after exact-current topology validation. There is no
+released dual-source epoch, no recreated `create_entity_with_content_ref`, and no second legacy
+column.
 
 The canonical main/core backend is the sole database that owns attachment rows and the sole SQL
 liveness authority passed to ADR-111's transactional sweep. Record-plus-attachment APIs route
@@ -291,15 +307,16 @@ with an actionable inventory if it finds a live legacy `entities.content_ref`; t
 relocated to the main graph or explicitly curated. This program does not pretend that one
 single-database sweep can fence references spread across several databases.
 
-Before attachment-only GC or column drop is enabled, every existing `moodboard_model` with a legacy
+During Phase 4b, before attachment-only GC or column drop is enabled, every existing
+`moodboard_model` with a legacy
 bundle reference is backfilled under `"fann-network"` from a fully verified bundle plus its matching
 immutable `moodboard.model_record` event. The mutable display property is never migration authority.
 The backfill verifies bundle/network references and both governed digests; missing, mismatched, or
 corrupt evidence aborts the cutover for operator curation rather than guessing or silently
 invalidating a recoverable model.
 
-Because schema preparation currently precedes BlobStore installation, this cutover is a boot-gated,
-resumable two-stage migration within that one merged implementation:
+Because schema preparation currently precedes BlobStore installation, Phase 4b is a boot-gated,
+resumable two-stage migration within its one implementation release:
 
 1. Before recording any incomplete state, boot acquires ADR-111's same canonical-database GC
    ownership (in-process plus advisory lock), waiting for any incumbent transactional sweep, and
@@ -315,7 +332,7 @@ resumable two-stage migration within that one merged implementation:
    INSERT/UPDATE claim-fence triggers, removes the legacy entity claim triggers and
    `idx_entities_content_ref`, drops `entities.content_ref`, and marks the migration complete.
 
-This cutover migration is registered in the versioned schema ledger but invoked by the boot
+The Phase-4b cutover migration is registered in the versioned schema ledger but invoked by the boot
 coordinator after GC ownership is acquired; it is not executed eagerly by the unconditional backend
 constructor. Blob-independent schema work may still run at ordinary backend open.
 
@@ -852,12 +869,28 @@ The implementation sequence is normative:
    bundle/network reads; leave candidate checks metadata-only; delete unbounded `get`, the blob GET
    semaphore, and pack-local size/read/digest helpers without removing moodboard's decoded/raster
    preprocessing gate.
-4. **Attachment convergence.** Execute ADR-121's boot-gated coordinated cutover on the canonical
-   main backend: add/backfill the substrate while serving stays closed; after shared hydration is
-   installed, migrate every legacy reader, writer, hard-delete, GC query and claim fence plus
-   moodboard roles `"content"` and `"fann-network"`; reconstruct existing network roles only from
-   verified bundle/event evidence; cross-check the authenticated network reference; then finalize
-   and drop `entities.content_ref` in the same merged change. Reject secondary-backend anchors.
+4. **Attachment convergence (two releases plus a deployment gate).**
+
+   - **Phase 4a — GC compatibility epoch.** In an independently deployable release, make
+     transactional filesystem-blob GC select liveness only after it proves the exact completed V21
+     epoch. V20, pending, incomplete, and malformed epochs refuse dry-run and destructive sweep
+     before filesystem or claim mutation. Phase 4a performs no attachment DDL, backfill,
+     dual-read/write, or V21 ledger write.
+   - **Fleet convergence, drain, and service quiescence.** Deploy Phase 4a everywhere that can share
+     the database or blob root; record binary-fleet convergence, drain every pre-Phase-4a process
+     and scheduled job, and prevent old binaries from restarting. Before cutover, also drain every
+     Phase-4a application-serving/read-write process or prove that it cannot touch the database.
+     Only a GC-only Phase-4a worker has narrow post-cutover compatibility; Phase-4a entity serving
+     does not. Phase 4b must not merge into a deployable release or migrate against the fleet until
+     this operational gate is satisfied.
+   - **Phase 4b — attachment convergence.** Execute ADR-121's boot-gated coordinated cutover on the
+     canonical main backend: add/backfill the substrate while serving stays closed; after shared
+     hydration is installed, migrate every legacy reader, writer, hard-delete, GC query and claim
+     fence plus moodboard roles `"content"` and `"fann-network"`; reconstruct existing network roles
+     only from verified bundle/event evidence; cross-check the authenticated network reference;
+     then finalize and drop `entities.content_ref` in the same Phase-4b change. Reject
+     secondary-backend anchors. Require exact-current validation across the planned topology before
+     starting the Phase-4b serving fleet.
 5. **Pure retrieval.** Reuse `union_fusion`, add the ranked-prefix controller, and migrate moodboard
    with exact one-shot overfetch/underfill parity.
 6. **Identity fence.** Introduce `EmbeddingSpaceIdentity`, preserve moodboard descriptor goldens,
@@ -871,9 +904,9 @@ The implementation sequence is normative:
 10. **Query expansion.** Land the optional adapter and knowledge pilot last, default off, after
     benchmark evidence fixes its first recommended operating envelope.
 
-Each phase lands in a reviewable PR with its own rollback boundary. No later phase is required to
-make an earlier merged phase safe. Removal of the old path occurs in the same phase that closes its
-last consumer.
+Each phase, including each named Phase-4 subphase, lands in a reviewable PR/release with its own
+rollback boundary. No later phase is required to make an earlier merged phase safe. Removal of the
+old path occurs in the same subphase that closes its last consumer.
 
 ## Required verification
 
@@ -905,6 +938,20 @@ last consumer.
 
 ### Attachments and ranked materialization
 
+- Phase-4a tests prove exact V20, pending, incomplete, and malformed epoch fixtures refuse both
+  dry-run and destructive transactional sweep before filesystem or claim mutation; no caller-
+  snapshot sweep or unconditional delete is invoked as a fallback.
+- The same Phase-4a binary recognizes a self-consistent completed V21 only when the exact ledger
+  row/latest version, completed marker, attachment/claim tables and attachment claim triggers, and
+  absence of the legacy column/index/triggers all agree; it then anti-joins attachment liveness and
+  exercises the claim fence before deletion.
+- Release evidence proves every process and scheduled job sharing the database/blob root runs the
+  Phase-4a-or-newer gate, and all pre-Phase-4a processes are drained and restart-fenced before the
+  first Phase-4b migration. It separately proves that every Phase-4a application-serving/read-write
+  process is quiesced (or cannot access the database) throughout cutover and that the Phase-4b fleet
+  starts only after exact-current topology validation. A mixed-fleet test/runbook rehearsal proves
+  Phase 4b cannot be entered on elapsed time or partial rollout alone; any surviving Phase-4a
+  process is GC-only, not a schema-compatible entity server.
 - Original bytes publish and resolve through role `"content"`; existing wire content refs are
   unchanged.
 - Preference bundle and FANN network attachments both remain live under GC, and a disagreement

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -300,7 +300,7 @@ rows actually returned, and treat an incomplete empty page as non-resumable with
 filter or a larger effective limit.
 
 Row shape (each item in the offset or cursor envelope) depends on `kind`.
-For `kind="entity"`, `"note"`, `"edge"`, and `"event"`, the row is the **full stored record**
+For `kind="entity"`, `"note"`, `"edge"`, and `"event"`, the row is the **full public record shape**
 for that substrate, listed below in its **verbose** form (the shape returned with
 `presentation="verbose"`, which is also the default for `kkernel exec` and the `khive` CLI).
 This is the key difference from `search` and `neighbors` below, which both return narrow
@@ -318,6 +318,8 @@ compacted to a relative or minute-truncated form; and `salience`/`decay_factor` 
 
 - **`kind="entity"`**: `{id, namespace, kind, entity_type, name, description, properties, tags,
   created_at, updated_at, deleted_at, merged_into, merge_event_id, content_ref}`.
+  `content_ref`, when present, is the compatibility projection of attachment role `content`;
+  entities no longer store a writable same-named column.
   `created_at`/`updated_at`/`deleted_at` are ISO-8601 strings (the store keeps them as
   epoch-microseconds internally; the handler converts before returning).
 - **`kind="note"`**: `{id, namespace, kind, status, name, content, salience, decay_factor,

--- a/docs/guide/specialized-packs.md
+++ b/docs/guide/specialized-packs.md
@@ -110,15 +110,19 @@ It contributes the additive `artifact` subtypes `visual_asset`, `moodboard`, and
 `moodboard_model`. Its ADR-148 visual path publishes original raster bytes to BlobStore, derives
 an identity-bound Lattice descriptor, and performs exact descriptor-space retrieval through
 `moodboard.model`, `moodboard.ingest`, and `moodboard.search`.
+The original raster is anchored under attachment role `content`; existing `content_ref` response
+fields project that role and do not correspond to an entity database column.
 
 ADR-149 adds explicit interaction learning through `moodboard.serve`, `moodboard.judge`,
 `moodboard.train_preference`, and `moodboard.preference`. These four verbs require a canonically
 attributed non-`local` actor. Training uses immutable randomized pairwise judgments, deterministic
 unordered-pair train/calibration/test splits, a frozen ten-feature contract, and minimum support
 gates. It fits deterministic logistic binary cross-entropy in the pack, then persists and serves
-the exact zero-intercept `10 -> 1` head through `lattice-fann` 0.7.1. FANN bytes, the calibrated
+the exact zero-intercept `10 -> 1` head through `lattice-fann` 0.9.0. FANN bytes, the calibrated
 model bundle, and their provenance live in BlobStore, an `artifact/moodboard_model`, and immutable
-events.
+events. The bundle is attachment role `content`; the separately stored FANN object is role
+`fann-network`, and load fails before network hydration if that role disagrees with the
+authenticated bundle/event evidence.
 
 The learned result is a conditional pairwise-preference probability. It is deliberately returned
 separately from conformal evidence, retrieval similarity, and any later board-level coherence

--- a/docs/multi-backend.md
+++ b/docs/multi-backend.md
@@ -46,18 +46,18 @@ declared in the resolved config file. From `crates/khive-mcp/src/serve.rs`:
 
 ```rust
 if khive_cfg.backends.is_empty() {
-    // Single-backend path — identical to pre-ADR-028 behavior.
-    let runtime = KhiveRuntime::new(config)?;
+    // Single-backend host path: prepare schema, coordinate V21, then expose runtime.
+    let runtime = build_single_backend_runtime(config, &khive_cfg).await?;
     return KhiveMcpServer::new(runtime).map_err(|e| anyhow::anyhow!("{e}"));
 }
 
 // Multi-backend path (ADR-028).
-build_server_multi_backend(config, &khive_cfg)
+build_server_multi_backend(config, &khive_cfg, None).await
 ```
 
-With no `[[backends]]` section the server takes the byte-identical
-single-backend path: existing databases, MCP clients, and agent code are
-unaffected.
+With no `[[backends]]` section the server takes the single-backend async host
+path. Its external MCP behavior remains compatible, but boot now completes the
+V21 attachment/GC state machine before serving.
 
 ### The `main` backend is required
 
@@ -71,7 +71,7 @@ add a [[backends]] entry with name = "main"
 ```
 
 (Source: `build_server_multi_backend` and `build_registry_for_multi_backend` in
-`crates/khive-mcp/src/serve.rs`, lines 369-377 and 141-148.)
+`crates/khive-mcp/src/serve.rs`.)
 
 ### Pack default
 
@@ -177,11 +177,16 @@ path = "/var/lib/your-app/records.db"
 backend = "records"
 ```
 
-The guarantee: each pack's substrate writes are confined to its assigned
+The general guarantee: each pack's auxiliary substrate writes are confined to its assigned
 backend file. This is enforced structurally because `build_server_multi_backend`
 constructs one `KhiveRuntime` per pack, each wrapping its own
-`Arc<StorageBackend>`. The custom pack's runtime holds only its assigned
-backend; it has no handle to `agent.db`. The isolation test
+`Arc<StorageBackend>`. Record identity and attachment liveness are the deliberate
+exception: every pack runtime also has a `core()` handle to canonical `main`, and
+record-plus-attachment publication routes there. Direct attachment access on a
+secondary is rejected. Boot inventories every secondary before enabling V21 on
+main; any legacy ref or attachment row, including one retained by a soft-deleted
+record, blocks startup rather than creating liveness invisible to main-database
+GC. The isolation test
 (`multi_backend_isolates_pack_data_to_separate_files` in
 `crates/khive-mcp/src/serve.rs`) verifies this directly: it pins the `comm` pack
 to a second on-disk backend, writes through both packs, then opens each SQLite
@@ -308,12 +313,44 @@ protocol-version mismatch, never for config-id drift.
 
 ### Full schema on every backend
 
-Every writable declared backend receives the full khive schema via
-`run_migrations()` at startup. Packs do not write to tables outside their
-substrate; the schema is applied uniformly for simplicity. There is no
-per-backend schema trimming. A read-only backend is validated against the
-build's exact current core-schema version instead; boot never attempts a
-migration or pack-auxiliary DDL against it.
+Every writable declared backend reaches the full khive schema through the async
+host coordinator, but V21 makes the ordering load-bearing. Boot first prepares
+and inventories every distinct secondary, refuses any legacy or current
+attachment authority there, and completes its empty attachment state. Only then
+does it prepare canonical `main`, install bounded hydration, authenticate any
+pack-owned legacy roles, and finalize V21. `run_migrations()` supplies the
+ordinary prefix and zero-reference fast path; it intentionally stops at V20
+when application-assisted backfill is required. Packs do not write outside their
+substrate, and there is no per-backend schema trimming. A read-only backend is
+validated against the build's exact current core-schema version; boot never
+attempts migration or pack-auxiliary DDL against it.
+
+The admin surface uses the same configured target model without constructing
+pack runtimes: `kkernel db migrate --config <path>` deduplicates physical aliases
+and advances distinct secondaries before `main`; `--backend <name>` selects a
+declared target, while selecting `main` retains its secondary prerequisites.
+`kkernel db check` loads the same config and pure target plan: `main` or its
+SQLite alias includes every secondary prerequisite, while an independent
+secondary remains a single read-only target. Both commands suppress pack
+registration, embedders, and pack DDL;
+migration retains only core topology coordination plus blob configuration used
+when legacy V20 moodboard evidence actually requires hydration. Exact-current
+admin paths and migrations without legacy moodboard model evidence do not
+resolve a BlobStore. A concrete `--db` override must agree with the declared
+main backend instead of replacing the topology.
+The shared pure planner validates every physical SQLite alias's `read_only` mode
+before a selected migration opens anything. Under `--db :memory:` configured
+names become distinct ephemeral backends, so only the literal `main` name has
+the full prerequisite plan. Migration result flags use physical backend
+identity: aliases of the selected main are targets; distinct secondaries are
+prerequisites.
+
+The V21 cutover still uses ADR-160's two-release deployment gate. After the
+Phase-4a GC gate converges and pre-Phase-4a binaries are drained, quiesce every
+Phase-4a application-serving/read-write process (or prove it cannot touch any
+planned database) before migrating. Only a GC-only Phase-4a worker has narrow
+compatibility with completed V21. Start the Phase-4b serving fleet only after
+`db check --strict` reports the entire planned topology exact-current.
 
 ### Canonical-path deduplication
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -48,7 +48,9 @@ production database without a backup first: `kg status`, `kg validate` (no `--fi
 on their surface. The v1 implementation builds a synthetic single-backend registry from
 `RuntimeConfig::default()` and constructs a real `KhiveRuntime` over it (`main.rs:532-547`).
 `KhiveRuntime::new` creates the parent directory of the default DB path if missing, opens or
-creates the SQLite file, and runs all pending migrations (`khive-runtime/src/runtime.rs:80-106`).
+creates the SQLite file, and applies ordinary pending migrations. It may complete V21 only for an
+empty/fresh attachment state; a legacy V20 database requiring authenticated application backfill
+fails and must use the async MCP/kkernel host coordinator.
 So `kkernel backend list` (and `info`) can create/open/migrate the default runtime database
 (`~/.khive/khive.db`) today, on a machine where that file is absent or stale, purely as a side
 effect of listing backends.
@@ -551,19 +553,93 @@ none of its flags do anything yet.
 ### `db migrate` / `db check`
 
 ```bash
-kkernel db migrate [--db <path>] [--backend <name>] [--dry-run] [--check] [--human]
-kkernel db check   [--db <path>] [--strict] [--human]
+kkernel db migrate [--config <path>] [--db <path>] [--backend <name>] [--dry-run] [--check] [--human]
+kkernel db check   [--config <path>] [--db <path>] [--backend <name>] [--strict] [--human]
 ```
 
-`db migrate` opens the database via `KhiveRuntime::new`, which applies any pending migrations as a
-side effect of construction; there is no separate "apply" step. `--dry-run`/`--check` on
+Both commands load an explicit `--config`/`KHIVE_CONFIG` or use normal config
+discovery. With declared `[[backends]]`, omission of `--backend` targets the
+configured topology and `--backend <name>` selects a declared backend. Migration
+deduplicates physical aliases, inventories and advances every distinct secondary
+before canonical `main`, then conditionally resolves bounded hydration when
+legacy V20 moodboard evidence must be authenticated and finalizes the resumable
+V21 attachment/GC cutover. Exact-current paths and migrations without legacy
+moodboard model evidence do not resolve a BlobStore. Selecting a non-main
+secondary advances only that empty-authority target; selecting `main` (or a
+physical alias of it) retains all secondary prerequisites. With no declared
+topology, `--db <path>`/`KHIVE_DB` or the default `~/.khive/khive.db` supplies
+the implicit `main`. A concrete DB override must agree with configured `main`
+rather than silently replacing the topology.
+
+The admin coordinator is core-only: it does not register packs, instantiate
+embedding models, or apply pack-auxiliary DDL. Blob configuration remains active
+because bounded hydration may be required to authenticate legacy V20 pack-owned
+evidence.
+
+`--dry-run`/`--check` on
 `migrate` redirect to `db check` instead of touching anything. `db check` is deliberately
 read-only: it inspects `_schema_migrations`' `MAX(version)` directly rather than opening a runtime
-(which would migrate-on-open and mask the very state the command exists to report,
-`main.rs:385-397`). A missing database file is reported as version 0 without being created.
-`--strict` turns "behind" or "ahead of the latest known migration" (a schema newer than this
-binary knows, or corresponding to a pre-consolidated-baseline version) into a nonzero exit via
-`anyhow::bail!` (`main.rs:433-445`).
+(which would migrate-on-open and mask the very state the command exists to report). A missing
+database file is reported as version 0 without being created.
+It reuses the migration target planner: checking `main` or a SQLite alias of
+`main` includes every configured secondary prerequisite, while checking an
+independent secondary includes only that target.
+Before either command opens a database, the planner validates the complete
+configured alias set and rejects physical SQLite aliases whose `read_only` modes
+disagree; a named selector cannot bypass that check. With `--db :memory:`, each
+configured backend name becomes a distinct ephemeral database, so only the
+literal name `main` carries main's prerequisite plan. Migration result rows mark
+`prerequisite` by physical backend identity: aliases of the selected main are
+targets, while physically distinct secondaries are prerequisites.
+
+`--strict` turns behind, ahead-of-build, or an invalid exact-current schema
+(including an inconsistent V21 marker/fence state) into a nonzero exit via
+`anyhow::bail!`.
+
+#### V21 two-release rollout (mandatory)
+
+V21 is a destructive, forward-only schema cutover. It must use two releases;
+shipping the GC gate and column drop as one fleet rollout is unsafe.
+
+1. Deploy the **Phase 4a GC compatibility epoch gate** to every process that can
+   share the database/blob root or invoke transactional blob GC. Phase 4a leaves
+   V20 schema and data untouched: it does not create attachments, backfill,
+   dual-read or dual-write, or record V21. Its transactional filesystem sweep
+   accepts only an exact completed V21 epoch; V20, pending, incomplete, and
+   malformed epochs refuse both dry-run and destructive sweep before filesystem
+   or claim mutation.
+2. Prove fleet convergence on the Phase-4a-or-newer binary, then drain every
+   pre-Phase-4a daemon, worker, admin process, and scheduled job that can touch
+   the same database or blob root. Prevent the supervisor from restarting an old
+   build. Treat this as a deployment gate, not an elapsed-time wait.
+3. Quiesce every Phase-4a application-serving/read-write process, or prove that
+   it cannot touch the database during cutover. Phase 4a does not make V20 entity
+   readers or writers compatible with the V21 column drop. A Phase-4a GC-only
+   worker may safely recognize an exact completed V21, but that narrow property
+   is not permission to keep a Phase-4a serving process online.
+4. Take a matched database/blob-root backup and inventory the topology with
+   `kkernel db check --config <path> --human`. Do not substitute the
+   caller-snapshot `orphan_sweep` or unconditional `delete` while transactional
+   GC is refusing V20; plan blob capacity for this intentional GC pause.
+5. Only after the convergence, drain, and service-quiescence evidence is
+   recorded, run the Phase-4b migration with
+   `kkernel db migrate --config <path>`. The coordinator checks distinct
+   secondaries first; any recoverable attachment authority there blocks main.
+   Main then stages/backfills, verifies pack-owned evidence, swaps liveness and
+   claim fences, drops `entities.content_ref`, and records V21 atomically at
+   finalization. A normal Phase-4b host boot can start the same migration, so
+   keep the serving fleet stopped and use the controlled admin path for cutover.
+6. Run `kkernel db check --config <path> --strict --human` and require every
+   planned target to report the exact current schema before starting the
+   Phase-4b serving fleet. A pending, incomplete, or malformed marker remains
+   fail-closed for serving and GC; curate the reported evidence and rerun the
+   coordinator rather than bypassing it.
+
+There is no down migration. Rollback after Phase 4b means stopping the new fleet,
+restoring the matched V20 database/blob snapshot, and returning to the Phase-4a
+compatibility build. Do not resume its application-serving/read-write processes
+until the V20 restore is complete; never point a pre-Phase-4a process at the
+cut-over database.
 
 ### `exec --save-file` / `exec --ops-file`: daemon coexistence
 


### PR DESCRIPTION
> AI-assisted: Codex implemented and prepared this PR; independent agents performed storage, GC/boot, moodboard-evidence, contract, and documentation review.

## Summary

- Implement ADR-160 Phase 4b's coordinated V21 attachment cutover: durable Pending/Incomplete/Complete state, resumable verified backfill, and atomic final removal of `entities.content_ref`.
- Add the first-class attachment capability and storage/runtime seams, with entity/note hard-delete cleanup and main-backend-only attachment authority.
- Migrate moodboard visual/model publication and reuse to attachment role `content`, plus authenticated model role `fann-network`; legacy backfill verifies the bundle, immutable event, FANN digest/bytes, and includes soft-deleted models even when the moodboard pack is disabled.
- Add the async host coordinator and config-aware schema-admin topology planner: distinct secondaries are inventoried/finalized before main, serving remains closed while cutover is incomplete, and exact-current admin paths do not resolve an unused BlobStore.
- Switch transactional GC to completed-V21 attachment liveness while preserving Phase 4a's early epoch gate, evidence validation, functional fence probe, bounded claim batches, and DB-owner → root-lock ordering.
- Align ADRs, public API docs, runtime/MCP/kkernel guidance, multi-backend operations, and migration runbooks.

The database schema, legacy evidence hydration, attachment publication, GC fences, and final column drop form one crash-resumable cutover. Splitting those pieces into independently mergeable intermediate states would create a dual-source or unprotected-liveness window, so this PR is the smallest coherent Phase 4b unit.

## Deployment gate — required

**Do not deploy Phase 4b until #2013 (Phase 4a) has merged and reached fleet convergence.**

Before starting this cutover:

1. upgrade every process that can invoke transactional blob GC to Phase 4a or newer;
2. drain every pre-Phase4a process and confirm no old sweep remains in flight;
3. quiesce Phase4a application readers/writers for the cutover;
4. only then start a Phase4b fleet.

The shared GC owner makes new processes wait; it cannot restore a legacy FANN blob that an older V20 sweep already deleted.

## Test plan

Post-stack verification:

- [x] `RUSTC_WRAPPER= cargo test -p khive-db -j4 stores::blob::tests::` — 63 passed
- [x] `RUSTC_WRAPPER= cargo clippy -p khive-storage -p khive-db --all-targets -j4 -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `deno fmt --check` for stack-touched Markdown
- [x] `git diff --check`
- [x] Repository pre-commit hook

Phase 4b implementation verification before stacking Phase 4a:

- [x] khive-storage: 88 unit + 4 attachment contract + 33 compliance + 10 vector tests
- [x] khive-db: 788 library + 3 attachment integration tests
- [x] khive-runtime: 1,194 unit + 99 integration + doctests
- [x] khive-pack-moodboard: 59 unit (2 ignored) + 10 integration tests
- [x] khive-mcp: 420 unit + 142 integration tests
- [x] kkernel: 431 library tests
- [ ] Full workspace matrix — delegated to CI

## ADR

- [ADR-121](docs/adr/ADR-121-attachments-first-class.md)
- [ADR-160](docs/adr/ADR-160-shared-pack-infrastructure.md), Phase 4b coordinated attachment convergence
- Supporting amendments: ADR-005, ADR-015, ADR-028, ADR-079, ADR-091, ADR-111, ADR-148, and ADR-149

## Stack

- Base: `codex/adr-160-phase-4a-gc-compat` (#2013)
- Head includes Phase 4a commit `21badcee` as an ancestor.
- Phase 4a must merge and satisfy the deployment gate above before this PR can be deployed.

## Review map

- Attachment substrate / atomic record writes: `khive-storage`, `khive-db/src/stores/{attachment,entity,note}.rs`
- V21 state machine / GC fencing: `khive-db/src/{migrations,backend}.rs`, `khive-db/src/stores/blob.rs`
- Host topology / boot coordinator: `khive-mcp/src/{attachment_cutover,serve}.rs`, `kkernel/src/cli.rs`
- Authenticated moodboard migration: `khive-pack-moodboard/src/preference_artifact.rs` and preference handlers
- Operational contract: ADR-160 D4/D10, ADR-111, ADR-121, and `docs/operations.md`

## AI-assisted contribution checklist

- [x] Every claim in this PR description matches the actual diff
- [x] Any agent-authored comment / PR body starts with an attribution line
- [x] Behavior-changing code has targeted/full test evidence
- [x] Storage, migration, liveness, and main-backend ownership contracts are documented
- [x] Independent final reviews reported no remaining blocker/high finding

## Out of scope

- Public KG `attach` / `detach` verbs (a later ADR-121 rollout step).
- ADR-160 phases after attachment convergence (retrieval materialization, embedding identity, tuning extraction, checkpoint attestation, and query expansion).
- Treating mutable moodboard entity properties as migration authority.
- Making legacy offline `orphan_sweep` / `delete` safe during this rollout.
