### PR TITLE
feat(storage): stage dormant embedding-space registry shadow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Core migration V22, `embedding_space_shadow_stage`, adds dormant
+  embedding-registry shadow, exact legacy-tuple provenance, and cutover-state
+  tables without changing the live registry or vector-serving paths (ADR-160
+  D6 Phase 7a).
 - `khive_storage::EmbeddingSpaceIdentity`, a validated immutable physical-vector
   fence derived from a protocol-owned fingerprint and dimensions (ADR-160 D6).
 - ADR-149 Moodboard pairwise preference learning: actor-attributed randomized
@@ -28,6 +32,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The V20 attachment coordinator now completes V21 and advances through dormant
+  V22 before returning; prepared runtime assembly requires exact-current V22.
+  V22 preflights bounded legacy-registry staging before DDL. Transactional
+  filesystem blob GC admits only V21 or canonical
+  `(22, "embedding_space_shadow_stage")` after revalidating V21, and refuses a
+  foreign V22 or unknown V23-or-later epoch before root work. Older exact-V21
+  Phase4a binaries safely refuse V22.
 - Pack-owned vector consumers replace `khive_runtime::NamedVectorIdentity` and
   `vectors_for_named_identity` with `khive_storage::EmbeddingSpaceIdentity` and
   `vectors_for_embedding_space`; the source-breaking replacement intentionally

--- a/crates/khive-db/README.md
+++ b/crates/khive-db/README.md
@@ -73,6 +73,16 @@ zero-reference database may complete it atomically inside `run_migrations`; a
 legacy V20 database stops at V20 and requires the async MCP/kkernel host
 coordinator to hold the blob-GC owner, stage attachments, authenticate pack-owned
 roles, and finalize. The V21 ledger row is written only in that final transaction.
+The coordinator then releases GC ownership and applies ordinary V22
+(`embedding_space_shadow_stage`) before returning. Low-level prepared-runtime
+construction requires exact current V22; a completed V21 database is physically
+valid attachment history but is behind this binary.
+
+V22 creates only `_embedding_models_v22_shadow`,
+`_embedding_model_legacy_provenance`, and `_embedding_space_cutover_state`. It
+records exact legacy tuple provenance and `legacy_staged` state while the old
+`_embedding_models` table remains authoritative. It does not switch providers,
+vector/ANN/cache/log identity, copy vectors, or complete ADR-160 Phase 7.
 
 Phase 4b may run only after the separately shipped Phase-4a transactional-GC
 epoch gate has converged across every process sharing the database/blob root and
@@ -82,6 +92,11 @@ dry-run and destructive modes; it does not create or backfill attachments.
 Before cutover, also quiesce every Phase-4a application reader/writer or prove
 it cannot access the database. Only a GC-only worker has narrow completed-V21
 compatibility; start Phase-4b serving after exact-current topology validation.
+The current filesystem GC gate admits only V21 or canonical
+`(22, "embedding_space_shadow_stage")` after revalidating the complete V21
+physical fence. Foreign V22 and unknown V23-or-later schemas fail closed before
+root/filesystem work; an older exact-V21 Phase-4a binary also
+safely refuses V22 as ahead of its contract.
 
 ## Vector storage
 

--- a/crates/khive-db/docs/design.md
+++ b/crates/khive-db/docs/design.md
@@ -17,8 +17,8 @@
 
 ### Schema Migration System (ADR-015)
 
-- `migrations.rs` contains all versioned DDL in a single file — splitting
-  across files would make migration sequencing harder to verify.
+- `migrations.rs` owns the contiguous version/name ledger and includes each
+  migration's DDL from a numbered file under `sql/`.
 - Migrations are forward-only, applied in version order, each in its own
   transaction. V1 is immutable.
 - Legacy `ServiceSchemaPlan`/`apply_schema_plan` API preserved for
@@ -37,6 +37,12 @@
   then atomically switches liveness/fences to attachments and drops
   `entities.content_ref`. Pending/incomplete state never enables GC, and the
   Phase-4b service fleet starts only after exact-current topology validation.
+- V22 (`embedding_space_shadow_stage`) is an additive, dormant registry stage.
+  It preserves exact legacy tuple provenance in dedicated tables and records
+  `legacy_staged`, but leaves `_embedding_models` and every provider/vector/ANN/
+  cache/log path live and unchanged. The V20 coordinator advances through V22
+  after completing V21 and before returning. Prepared-runtime assembly requires
+  exact current V22 rather than merely a completed V21 marker.
 
 ### Attachments and Blob Liveness (ADR-111, ADR-121, ADR-160)
 
@@ -46,10 +52,13 @@
   cleanup are transactional. Soft deletion retains attachment liveness.
 - Transactional filesystem blob GC validates every attachment/claim ref,
   anti-joins all attachment rows, and relies on attachment INSERT/UPDATE claim
-  fences. Its Phase-4a epoch gate accepts only an exact completed V21
-  ledger/marker/fence/schema combination; V20 and pending, incomplete, or
-  malformed states refuse dry-run and destructive sweep before filesystem or
-  claim mutation.
+  fences. The current epoch gate admits only V21 or canonical
+  `(22, "embedding_space_shadow_stage")`
+  after revalidating the exact completed-V21 ledger/marker/fence/schema
+  combination; V20, pending/incomplete/malformed V21, foreign V22, and unknown V23-or-later
+  states refuse dry-run and destructive sweep before root/filesystem or claim
+  mutation. The older Phase-4a binary safely refuses V22 as ahead of its exact
+  V21 contract.
 
 ### Pack Standard — Pack-Auxiliary Schema (ADR-017)
 
@@ -75,6 +84,11 @@
 - V16 adds `embedding_model` column to regular `vec_*` tables; V17 performs
   a preserving rebuild of vec0 virtual tables to add the same column without
   data loss.
+- Live V22 stages ADR-160 D6's target registry shape in
+  `_embedding_models_v22_shadow` and preserves the complete legacy source tuple
+  in `_embedding_model_legacy_provenance`. The shadow is intentionally not a
+  serving API: no vector or ANN object is relabeled, rebuilt, or selected from
+  it, and the later provider-bound atomic cutover remains unimplemented.
 
 ### Old-Schema Vec0 Detection (ADR-044)
 
@@ -164,4 +178,4 @@ released-writer interval.
   `embedding_coverage: 0.0` regardless of actual indexed vector count. This is
   a known lie in the stats implementation, not a data issue.
 
-Last reviewed: 2026-08-09
+Last reviewed: 2026-08-17

--- a/crates/khive-db/docs/migration.md
+++ b/crates/khive-db/docs/migration.md
@@ -27,6 +27,22 @@ the async host acquires the database GC owner, records durable `Incomplete`,
 authenticates pack-owned blob roles, and records V21 only in the exclusive
 final transaction. Restart resumes this state before serving or GC.
 
+After V21 completes, V22 (`embedding_space_shadow_stage`) is an ordinary
+single-transaction follow-through. It creates a dormant target-registry shadow,
+preserves every legacy `_embedding_models` tuple in explicit provenance, derives
+the frozen legacy identity, and records `legacy_staged` together with its V22
+ledger row. Any invalid row or collision rolls back the DDL, copied provenance,
+state, and ledger atomically. A legacy V20 coordinator releases the GC owner
+after V21 and reaches exact-current V22 before returning. Low-level
+prepared-runtime construction refuses a completed-but-behind V21 database.
+Before DDL, a metadata-only preflight caps the legacy source at 4,096 rows,
+4,096-byte engine/key-version fields, a 512-byte model label, a 65,536-byte
+opaque canonical key, and 16 MiB of weighted staging payload.
+
+V22 does not replace the canonical `_embedding_models` table or alter provider,
+vector, ANN, cache, pending-log, watermark, or reopen behavior. It is dormant
+staging for a later rebuild/cutover, not completion of ADR-160 Phase 7.
+
 Phase 4b has an operational prerequisite that is not encoded in the V20 ledger.
 Phase 4a first ships only the transactional-GC epoch gate: it leaves V20 schema
 and data untouched, and refuses V20 or any incomplete/malformed V21 state in
@@ -37,6 +53,12 @@ read/write processes must also be quiesced, or proven unable to access the
 database, during cutover; only a GC-only Phase-4a worker is compatible with
 exact completed V21. Phase-4b serving starts after exact-current topology
 validation.
+
+That paragraph records the original Phase-4a release. The current binary's GC
+gate also recognizes canonical `(22, "embedding_space_shadow_stage")` as a known-safe epoch because V21's attachment
+liveness contract is unchanged. It admits only V21..=V22 after physically
+revalidating V21; unknown V23-or-later epochs fail closed before root/filesystem
+work. An old Phase-4a binary sees V22 as ahead and safely refuses GC.
 
 ## Version numbering
 
@@ -85,6 +107,10 @@ V1 baseline at v0.2.8. The live post-consolidation sequence is:
 - **V21 (Phase 4b)**: Adds first-class attachments, backfills role `content`,
   switches blob GC claim fences to attachment writes, and drops
   `entities.content_ref` after verified application backfill.
+- **V22 (ADR-160 D6 Phase 7a)**: Adds dormant embedding-registry shadow,
+  exact legacy provenance, and cutover-state tables; maps valid legacy tuples
+  to frozen `legacy_...` identities and records `legacy_staged`. The live
+  registry and all vector-serving paths remain unchanged.
 
 The historical pre-consolidation allocation table remains in ADR-015 for
 provenance; its version numbers do not describe the live migration array.

--- a/crates/khive-db/sql/022-embedding-space-shadow-stage.sql
+++ b/crates/khive-db/sql/022-embedding-space-shadow-stage.sql
@@ -1,0 +1,70 @@
+-- V22 stage 1: dormant embedding-space registry shadow (ADR-160 D6).
+--
+-- The canonical _embedding_models registry remains authoritative until a
+-- later, coordinated rebuild verifies every replacement space and completes
+-- the atomic cutover.  These objects deliberately use fail-closed creation:
+-- replaying the stage DDL against a partial or pre-existing shadow is an error.
+
+CREATE TABLE _embedding_models_v22_shadow (
+    id                      BLOB PRIMARY KEY NOT NULL,
+    lineage_slot            TEXT NOT NULL,
+    space_key               TEXT NOT NULL UNIQUE,
+    identity_protocol       TEXT NOT NULL,
+    identity_fingerprint    BLOB NOT NULL
+        CHECK (
+            typeof(identity_fingerprint) = 'blob'
+            AND length(identity_fingerprint) = 32
+        ),
+    model_name              TEXT NOT NULL,
+    dimensions              INTEGER NOT NULL
+        CHECK (
+            typeof(dimensions) = 'integer'
+            AND dimensions BETWEEN 1 AND 8192
+        ),
+    status                  TEXT NOT NULL
+        CHECK (status IN ('pending', 'active', 'superseded', 'archived')),
+    activated_at            INTEGER,
+    superseded_at           INTEGER,
+    superseded_by           BLOB,
+    created_at              INTEGER NOT NULL
+) STRICT;
+
+CREATE UNIQUE INDEX idx_embedding_models_v22_shadow_one_active
+    ON _embedding_models_v22_shadow(lineage_slot)
+    WHERE status = 'active';
+
+CREATE INDEX idx_embedding_models_v22_shadow_lineage_status
+    ON _embedding_models_v22_shadow(lineage_slot, status);
+
+CREATE TABLE _embedding_model_legacy_provenance (
+    id                      BLOB PRIMARY KEY NOT NULL,
+    engine_name             TEXT NOT NULL,
+    model_id                TEXT NOT NULL,
+    key_version             TEXT NOT NULL,
+    dim                     INTEGER NOT NULL,
+    output_dim              INTEGER,
+    canonical_key           BLOB NOT NULL,
+    pre_migration_status    TEXT NOT NULL
+        CHECK (pre_migration_status IN ('pending', 'active', 'superseded', 'archived'))
+) STRICT;
+
+CREATE TABLE _embedding_space_cutover_state (
+    singleton       INTEGER PRIMARY KEY CHECK (singleton = 1),
+    state           TEXT NOT NULL
+        CHECK (state IN ('unstaged', 'legacy_staged', 'rebuild_ready', 'complete')),
+    staged_at       INTEGER,
+    completed_at    INTEGER,
+    CHECK (
+        (state = 'unstaged' AND staged_at IS NULL AND completed_at IS NULL)
+        OR (state = 'legacy_staged' AND staged_at IS NOT NULL AND completed_at IS NULL)
+        OR (state = 'rebuild_ready' AND staged_at IS NOT NULL AND completed_at IS NULL)
+        OR (state = 'complete' AND staged_at IS NOT NULL AND completed_at IS NOT NULL)
+    )
+) STRICT;
+
+INSERT INTO _embedding_space_cutover_state (
+    singleton,
+    state,
+    staged_at,
+    completed_at
+) VALUES (1, 'unstaged', NULL, NULL);

--- a/crates/khive-db/src/backend.rs
+++ b/crates/khive-db/src/backend.rs
@@ -212,8 +212,7 @@ impl StorageBackend {
     /// the snapshot to be at this build's exact latest schema version.
     pub fn prepare_core_schema(&self) -> Result<u32, SqliteError> {
         if self.is_read_only() {
-            let reader = self.pool.reader()?;
-            crate::migrations::validate_schema_is_current(reader.conn())
+            self.validate_core_schema_is_current()
         } else {
             let latest = crate::migrations::MIGRATIONS
                 .last()
@@ -237,6 +236,17 @@ impl StorageBackend {
             let mut writer = self.pool.try_writer()?;
             crate::migrations::run_migrations_with_database_gc_owner(writer.conn_mut(), &owner)
         }
+    }
+
+    /// Require the exact canonical current core schema without applying
+    /// migrations or creating migration-owner sidecars.
+    ///
+    /// Host coordinators use this query-only fence immediately before low-level
+    /// runtime assembly so a completed older application-assisted cutover is
+    /// not mistaken for this binary's fully prepared schema.
+    pub fn validate_core_schema_is_current(&self) -> Result<u32, SqliteError> {
+        let reader = self.pool.reader()?;
+        crate::migrations::validate_schema_is_current(reader.conn())
     }
 
     /// Inspect the coordinated V21 attachment cutover state.

--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -7,7 +7,9 @@
 //!   migration pipeline for the core tables.
 
 use khive_storage::blob::ContentRef;
+use khive_storage::EmbeddingSpaceIdentity;
 use rusqlite::{Connection, OptionalExtension};
+use sha2::Digest as _;
 use std::path::PathBuf;
 
 use crate::error::SqliteError;
@@ -148,8 +150,36 @@ const V21_STAGE_UP: &str = include_str!("../sql/021-attachments-stage.sql");
 
 const V21_ATTACHMENT_FENCES_UP: &str = include_str!("../sql/021-attachments-claim-fences.sql");
 
+const V22_UP: &str = include_str!("../sql/022-embedding-space-shadow-stage.sql");
+
 /// Core schema version reserved for ADR-121's attachments-first cutover.
 pub const ATTACHMENT_CUTOVER_VERSION: u32 = 21;
+
+/// Core schema version for ADR-160's dormant embedding-registry shadow stage.
+///
+/// V22 records only legacy identity provenance and an invisible candidate
+/// registry. The canonical registry and every serving/vector/ANN path remain
+/// authoritative until a later coordinated cutover.
+pub const EMBEDDING_SPACE_SHADOW_VERSION: u32 = 22;
+
+/// Canonical ledger name for the dormant embedding-registry shadow stage.
+pub const EMBEDDING_SPACE_SHADOW_MIGRATION_NAME: &str = "embedding_space_shadow_stage";
+
+/// Frozen protocol for exact, non-serving identities derived from legacy
+/// `_embedding_models` tuples.
+pub const LEGACY_EMBEDDING_IDENTITY_PROTOCOL: &str = "khive.legacy-embedding-space.v1";
+
+// V22 runs under one IMMEDIATE migration transaction and the database-GC
+// owner. Legacy registry rows predate structural size constraints, so bound
+// both individual values and aggregate staging work before allocating or
+// copying their payloads. The live registry normally contains only a handful
+// of rows; these ceilings are intentionally generous for valid installations.
+const MAX_LEGACY_EMBEDDING_REGISTRY_ROWS: usize = 4_096;
+const MAX_LEGACY_EMBEDDING_TEXT_BYTES: u64 = 4_096;
+const MAX_LEGACY_EMBEDDING_MODEL_BYTES: u64 = 512;
+const MAX_LEGACY_EMBEDDING_CANONICAL_KEY_BYTES: u64 = 65_536;
+const MAX_LEGACY_EMBEDDING_STAGE_BYTES: u64 = 16 * 1024 * 1024;
+const LEGACY_EMBEDDING_FIXED_STAGE_BYTES_PER_ROW: u64 = 512;
 
 /// DDL for the `ann_write_log` delta table.
 ///
@@ -296,6 +326,11 @@ pub const MIGRATIONS: &[VersionedMigration] = &[
         // the ledger entry self-describing for migration inspection tooling.
         up: V21_STAGE_UP,
     },
+    VersionedMigration {
+        version: EMBEDDING_SPACE_SHADOW_VERSION,
+        name: EMBEDDING_SPACE_SHADOW_MIGRATION_NAME,
+        up: V22_UP,
+    },
 ];
 
 /// Durable state of ADR-121's boot-gated, two-stage attachment cutover.
@@ -390,6 +425,42 @@ fn validate_complete_attachment_schema(conn: &Connection) -> Result<(), SqliteEr
     Ok(())
 }
 
+fn validate_embedding_space_shadow_stage(conn: &Connection) -> Result<(), SqliteError> {
+    for (object_type, name) in [
+        ("table", "_embedding_models_v22_shadow"),
+        ("table", "_embedding_model_legacy_provenance"),
+        ("table", "_embedding_space_cutover_state"),
+        ("index", "idx_embedding_models_v22_shadow_one_active"),
+        ("index", "idx_embedding_models_v22_shadow_lineage_status"),
+    ] {
+        if !schema_object_exists(conn, object_type, name)? {
+            return Err(SqliteError::InvalidData(format!(
+                "V22 embedding-space shadow stage is missing {object_type} {name:?}"
+            )));
+        }
+    }
+
+    let state: Option<(String, Option<i64>, Option<i64>)> = conn
+        .query_row(
+            "SELECT state, staged_at, completed_at \
+             FROM _embedding_space_cutover_state WHERE singleton = 1",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .optional()?;
+    match state {
+        Some((state, Some(_), None)) if state == "legacy_staged" => Ok(()),
+        Some((state, staged_at, completed_at)) => Err(SqliteError::InvalidData(format!(
+            "V22 embedding-space shadow must be legacy_staged with staged_at and no \
+             completed_at, got state={state:?}, staged_at={staged_at:?}, \
+             completed_at={completed_at:?}"
+        ))),
+        None => Err(SqliteError::InvalidData(
+            "V22 embedding-space shadow state is missing its singleton row".into(),
+        )),
+    }
+}
+
 /// Inspect the coordinated V21 state without mutating the connection.
 ///
 /// The marker and migration ledger form one state machine. Impossible pairs
@@ -432,12 +503,12 @@ pub fn attachment_cutover_status(
             }
         }
         Some((state, Some(_))) if state == "complete" => {
-            if version == ATTACHMENT_CUTOVER_VERSION {
+            if version >= ATTACHMENT_CUTOVER_VERSION {
                 validate_complete_attachment_schema(conn)?;
                 Ok(AttachmentCutoverStatus::Complete)
             } else {
                 Err(SqliteError::InvalidData(format!(
-                    "attachment cutover is complete but schema ledger is at V{version}, expected V{ATTACHMENT_CUTOVER_VERSION}"
+                    "attachment cutover is complete but schema ledger is at V{version}, expected at least V{ATTACHMENT_CUTOVER_VERSION}"
                 )))
             }
         }
@@ -821,6 +892,387 @@ pub fn finalize_attachment_cutover(conn: &mut Connection) -> Result<(), SqliteEr
     Ok(())
 }
 
+fn legacy_u32(field: &str, value: i64) -> Result<u32, SqliteError> {
+    u32::try_from(value).map_err(|_| {
+        SqliteError::InvalidData(format!(
+            "legacy _embedding_models.{field} value {value} is outside the u32 range"
+        ))
+    })
+}
+
+fn invalid_legacy_registry(rowid: i64, message: impl std::fmt::Display) -> SqliteError {
+    SqliteError::InvalidData(format!("legacy _embedding_models rowid {rowid} {message}"))
+}
+
+fn require_legacy_sqlite_type(
+    rowid: i64,
+    field: &str,
+    actual: &str,
+    allowed: &[&str],
+) -> Result<(), SqliteError> {
+    if allowed.contains(&actual) {
+        Ok(())
+    } else {
+        Err(invalid_legacy_registry(
+            rowid,
+            format_args!(
+                "field {field:?} has SQLite type {actual:?}; expected {}",
+                allowed.join(" or ")
+            ),
+        ))
+    }
+}
+
+fn bounded_legacy_length(
+    rowid: i64,
+    field: &str,
+    raw_length: i64,
+    maximum: u64,
+) -> Result<u64, SqliteError> {
+    let length = u64::try_from(raw_length).map_err(|_| {
+        invalid_legacy_registry(
+            rowid,
+            format_args!("field {field:?} reported invalid byte length {raw_length}"),
+        )
+    })?;
+    if length > maximum {
+        return Err(invalid_legacy_registry(
+            rowid,
+            format_args!("field {field:?} is {length} bytes; the V22 staging limit is {maximum}"),
+        ));
+    }
+    Ok(length)
+}
+
+fn add_legacy_stage_bytes(
+    rowid: i64,
+    total: &mut u64,
+    field: &str,
+    bytes: u64,
+    copies: u64,
+) -> Result<(), SqliteError> {
+    let staged = bytes
+        .checked_mul(copies)
+        .and_then(|value| total.checked_add(value))
+        .ok_or_else(|| {
+            invalid_legacy_registry(rowid, "overflows the V22 staging-byte accounting")
+        })?;
+    if staged > MAX_LEGACY_EMBEDDING_STAGE_BYTES {
+        return Err(invalid_legacy_registry(
+            rowid,
+            format_args!(
+                "would raise bounded V22 staging payload above \
+                 {MAX_LEGACY_EMBEDDING_STAGE_BYTES} bytes while accounting field {field:?}"
+            ),
+        ));
+    }
+    *total = staged;
+    Ok(())
+}
+
+/// Validate legacy row types and byte budgets without materializing any
+/// attacker-sized TEXT or BLOB value in Rust.
+fn preflight_legacy_embedding_registry(conn: &Connection) -> Result<(), SqliteError> {
+    let mut statement = conn.prepare(
+        "SELECT rowid, \
+                typeof(id), octet_length(id), \
+                typeof(engine_name), octet_length(engine_name), \
+                typeof(model_id), octet_length(model_id), \
+                typeof(key_version), octet_length(key_version), \
+                typeof(dim), typeof(output_dim), \
+                typeof(status), octet_length(status), \
+                typeof(activated_at), typeof(superseded_at), \
+                typeof(superseded_by), COALESCE(octet_length(superseded_by), 0), \
+                typeof(canonical_key), octet_length(canonical_key), \
+                typeof(created_at) \
+         FROM _embedding_models ORDER BY rowid LIMIT ?1",
+    )?;
+    let inspection_limit = i64::try_from(MAX_LEGACY_EMBEDDING_REGISTRY_ROWS + 1)
+        .expect("legacy registry row ceiling fits i64");
+    let mut rows = statement.query([inspection_limit])?;
+    let mut rows_seen = 0_usize;
+    let mut staged_bytes = 0_u64;
+
+    while let Some(row) = rows.next()? {
+        rows_seen += 1;
+        if rows_seen > MAX_LEGACY_EMBEDDING_REGISTRY_ROWS {
+            return Err(SqliteError::InvalidData(format!(
+                "legacy _embedding_models contains more than the V22 staging limit of \
+                 {MAX_LEGACY_EMBEDDING_REGISTRY_ROWS} rows"
+            )));
+        }
+
+        let rowid: i64 = row.get(0)?;
+        let id_type: String = row.get(1)?;
+        let id_length = bounded_legacy_length(rowid, "id", row.get(2)?, 16)?;
+        require_legacy_sqlite_type(rowid, "id", &id_type, &["blob"])?;
+        if id_length != 16 {
+            return Err(invalid_legacy_registry(
+                rowid,
+                format_args!("field \"id\" must contain exactly 16 bytes, got {id_length}"),
+            ));
+        }
+
+        let engine_type: String = row.get(3)?;
+        require_legacy_sqlite_type(rowid, "engine_name", &engine_type, &["text"])?;
+        let engine_length = bounded_legacy_length(
+            rowid,
+            "engine_name",
+            row.get(4)?,
+            MAX_LEGACY_EMBEDDING_TEXT_BYTES,
+        )?;
+
+        let model_type: String = row.get(5)?;
+        require_legacy_sqlite_type(rowid, "model_id", &model_type, &["text"])?;
+        let model_length = bounded_legacy_length(
+            rowid,
+            "model_id",
+            row.get(6)?,
+            MAX_LEGACY_EMBEDDING_MODEL_BYTES,
+        )?;
+
+        let key_version_type: String = row.get(7)?;
+        require_legacy_sqlite_type(rowid, "key_version", &key_version_type, &["text"])?;
+        let key_version_length = bounded_legacy_length(
+            rowid,
+            "key_version",
+            row.get(8)?,
+            MAX_LEGACY_EMBEDDING_TEXT_BYTES,
+        )?;
+
+        let dim_type: String = row.get(9)?;
+        require_legacy_sqlite_type(rowid, "dim", &dim_type, &["integer"])?;
+        let output_dim_type: String = row.get(10)?;
+        require_legacy_sqlite_type(rowid, "output_dim", &output_dim_type, &["null", "integer"])?;
+
+        let status_type: String = row.get(11)?;
+        require_legacy_sqlite_type(rowid, "status", &status_type, &["text"])?;
+        let status_length = bounded_legacy_length(rowid, "status", row.get(12)?, 16)?;
+
+        let activated_type: String = row.get(13)?;
+        require_legacy_sqlite_type(rowid, "activated_at", &activated_type, &["null", "integer"])?;
+        let superseded_type: String = row.get(14)?;
+        require_legacy_sqlite_type(
+            rowid,
+            "superseded_at",
+            &superseded_type,
+            &["null", "integer"],
+        )?;
+        let superseded_by_type: String = row.get(15)?;
+        require_legacy_sqlite_type(
+            rowid,
+            "superseded_by",
+            &superseded_by_type,
+            &["null", "blob"],
+        )?;
+        let superseded_by_length = bounded_legacy_length(rowid, "superseded_by", row.get(16)?, 16)?;
+        if superseded_by_type == "blob" && superseded_by_length != 16 {
+            return Err(invalid_legacy_registry(
+                rowid,
+                format_args!(
+                    "field \"superseded_by\" must contain exactly 16 bytes when present, \
+                     got {superseded_by_length}"
+                ),
+            ));
+        }
+
+        let canonical_key_type: String = row.get(17)?;
+        require_legacy_sqlite_type(rowid, "canonical_key", &canonical_key_type, &["blob"])?;
+        let canonical_key_length = bounded_legacy_length(
+            rowid,
+            "canonical_key",
+            row.get(18)?,
+            MAX_LEGACY_EMBEDDING_CANONICAL_KEY_BYTES,
+        )?;
+        let created_at_type: String = row.get(19)?;
+        require_legacy_sqlite_type(rowid, "created_at", &created_at_type, &["integer"])?;
+
+        add_legacy_stage_bytes(
+            rowid,
+            &mut staged_bytes,
+            "fixed generated fields",
+            LEGACY_EMBEDDING_FIXED_STAGE_BYTES_PER_ROW,
+            1,
+        )?;
+        add_legacy_stage_bytes(rowid, &mut staged_bytes, "id", id_length, 2)?;
+        add_legacy_stage_bytes(rowid, &mut staged_bytes, "engine_name", engine_length, 2)?;
+        add_legacy_stage_bytes(rowid, &mut staged_bytes, "model_id", model_length, 2)?;
+        add_legacy_stage_bytes(
+            rowid,
+            &mut staged_bytes,
+            "key_version",
+            key_version_length,
+            1,
+        )?;
+        add_legacy_stage_bytes(rowid, &mut staged_bytes, "status", status_length, 2)?;
+        add_legacy_stage_bytes(
+            rowid,
+            &mut staged_bytes,
+            "superseded_by",
+            superseded_by_length,
+            1,
+        )?;
+        add_legacy_stage_bytes(
+            rowid,
+            &mut staged_bytes,
+            "canonical_key",
+            canonical_key_length,
+            1,
+        )?;
+    }
+    Ok(())
+}
+
+fn hash_legacy_text(
+    hasher: &mut sha2::Sha256,
+    field: &str,
+    value: &str,
+) -> Result<(), SqliteError> {
+    let length = u32::try_from(value.len()).map_err(|_| {
+        SqliteError::InvalidData(format!(
+            "legacy _embedding_models.{field} exceeds the u32 length-framing limit"
+        ))
+    })?;
+    hasher.update(length.to_be_bytes());
+    hasher.update(value.as_bytes());
+    Ok(())
+}
+
+/// Derive ADR-160's exact, non-serving identity for one legacy registry tuple.
+///
+/// This identity is provenance only: it explicitly does not certify that any
+/// current provider emits equivalent vectors, and V22 never opens a physical
+/// vector table from the resulting key.
+fn legacy_embedding_space_identity(
+    engine_name: &str,
+    model_id: &str,
+    key_version: &str,
+    dim: u32,
+    output_dim: Option<u32>,
+) -> Result<EmbeddingSpaceIdentity, SqliteError> {
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(LEGACY_EMBEDDING_IDENTITY_PROTOCOL.as_bytes());
+    hasher.update([0]);
+    hash_legacy_text(&mut hasher, "engine_name", engine_name)?;
+    hash_legacy_text(&mut hasher, "model_id", model_id)?;
+    hash_legacy_text(&mut hasher, "key_version", key_version)?;
+    hasher.update(dim.to_be_bytes());
+    match output_dim {
+        None => hasher.update([0]),
+        Some(value) => {
+            hasher.update([1]);
+            hasher.update(value.to_be_bytes());
+        }
+    }
+    let fingerprint: [u8; 32] = hasher.finalize().into();
+    let dimensions = output_dim.unwrap_or(dim);
+    EmbeddingSpaceIdentity::new(
+        "legacy",
+        LEGACY_EMBEDDING_IDENTITY_PROTOCOL,
+        fingerprint,
+        model_id,
+        dimensions,
+    )
+    .map_err(|error| {
+        SqliteError::InvalidData(format!(
+            "invalid legacy embedding identity for engine {engine_name:?}: {error}"
+        ))
+    })
+}
+
+fn stage_embedding_space_shadow(conn: &Connection, now: i64) -> Result<(), SqliteError> {
+    if attachment_cutover_status(conn)? != AttachmentCutoverStatus::Complete {
+        return Err(SqliteError::InvalidData(
+            "V22 embedding-space shadow requires a physically complete V21 attachment cutover"
+                .into(),
+        ));
+    }
+    preflight_legacy_embedding_registry(conn)?;
+    conn.execute_batch(V22_UP)?;
+
+    // Stream one legacy row at a time. Registry cardinality is normally tiny,
+    // but the migration must not materialize an attacker-sized table in RAM.
+    let mut statement = conn.prepare(
+        "SELECT rowid, engine_name, model_id, key_version, dim, output_dim, status \
+         FROM _embedding_models ORDER BY rowid",
+    )?;
+    let mut provenance_insert = conn.prepare(
+        "INSERT INTO _embedding_model_legacy_provenance \
+         (id, engine_name, model_id, key_version, dim, output_dim, canonical_key, \
+          pre_migration_status) \
+         SELECT id, engine_name, model_id, key_version, dim, output_dim, canonical_key, status \
+         FROM _embedding_models WHERE rowid = ?1",
+    )?;
+    let mut shadow_insert = conn.prepare(
+        "INSERT INTO _embedding_models_v22_shadow \
+         (id, lineage_slot, space_key, identity_protocol, identity_fingerprint, \
+          model_name, dimensions, status, activated_at, superseded_at, superseded_by, \
+          created_at) \
+         SELECT id, ?2, ?3, ?4, ?5, ?6, ?7, status, activated_at, superseded_at, \
+                superseded_by, created_at \
+         FROM _embedding_models WHERE rowid = ?1",
+    )?;
+    let mut rows = statement.query([])?;
+    while let Some(row) = rows.next()? {
+        let rowid: i64 = row.get(0)?;
+        let engine_name: String = row.get(1)?;
+        let model_id: String = row.get(2)?;
+        let key_version: String = row.get(3)?;
+        let dim_raw: i64 = row.get(4)?;
+        let output_dim_raw: Option<i64> = row.get(5)?;
+        let status: String = row.get(6)?;
+        if !matches!(
+            status.as_str(),
+            "pending" | "active" | "superseded" | "archived"
+        ) {
+            return Err(invalid_legacy_registry(
+                rowid,
+                "field \"status\" is not a recognized lifecycle value",
+            ));
+        }
+        let dim = legacy_u32("dim", dim_raw)?;
+        let output_dim = output_dim_raw
+            .map(|value| legacy_u32("output_dim", value))
+            .transpose()?;
+        let identity = legacy_embedding_space_identity(
+            &engine_name,
+            &model_id,
+            &key_version,
+            dim,
+            output_dim,
+        )?;
+
+        provenance_insert.execute([rowid])?;
+        shadow_insert.execute(rusqlite::params![
+            rowid,
+            engine_name,
+            identity.space_key().as_str(),
+            identity.protocol().as_str(),
+            identity.fingerprint().as_slice(),
+            model_id,
+            i64::from(identity.dimensions().get()),
+        ])?;
+    }
+    drop(rows);
+    drop(statement);
+    drop(provenance_insert);
+    drop(shadow_insert);
+
+    let updated = conn.execute(
+        "UPDATE _embedding_space_cutover_state \
+         SET state = 'legacy_staged', staged_at = ?1 \
+         WHERE singleton = 1 AND state = 'unstaged' AND staged_at IS NULL \
+           AND completed_at IS NULL",
+        [now],
+    )?;
+    if updated != 1 {
+        return Err(SqliteError::InvalidData(
+            "V22 embedding-space shadow stage did not own one unstaged singleton".into(),
+        ));
+    }
+    Ok(())
+}
+
 /// Read the ordered migration ledger prefix without interpreting its rows.
 fn read_applied_migration_ledger(
     conn: &Connection,
@@ -1000,12 +1452,15 @@ pub fn validate_schema_is_current(conn: &Connection) -> Result<u32, SqliteError>
     // must not accept a history that ordinary boot would reject merely because
     // it cannot repair it in place.
     validate_applied_migration_ledger(conn, current_version)?;
-    if current_version == ATTACHMENT_CUTOVER_VERSION
+    if current_version >= ATTACHMENT_CUTOVER_VERSION
         && attachment_cutover_status(conn)? != AttachmentCutoverStatus::Complete
     {
         return Err(SqliteError::InvalidData(
             "read-only database has not completed the V21 attachment cutover".into(),
         ));
+    }
+    if current_version >= EMBEDDING_SPACE_SHADOW_VERSION {
+        validate_embedding_space_shadow_stage(conn)?;
     }
 
     Ok(current_version)
@@ -1318,6 +1773,12 @@ fn run_migrations_locked(conn: &mut Connection) -> Result<u32, SqliteError> {
                     version: migration.version,
                     error: e.to_string(),
                 }
+            })?;
+        } else if migration.version == EMBEDDING_SPACE_SHADOW_VERSION {
+            let now = chrono::Utc::now().timestamp_micros();
+            stage_embedding_space_shadow(&tx, now).map_err(|error| SqliteError::Migration {
+                version: migration.version,
+                error: error.to_string(),
             })?;
         } else {
             tx.execute_batch(migration.up)

--- a/crates/khive-db/src/migrations_tests.rs
+++ b/crates/khive-db/src/migrations_tests.rs
@@ -867,10 +867,11 @@ fn v4_creates_consolidated_fts_tables() {
 #[test]
 fn rejects_pre_consolidation_ledger() {
     let mut conn = open_memory();
-    // Simulate a database carrying the old, pre-consolidation V1..V22 ledger.
+    // Simulate a database carrying a ledger newer than this build. V22 is now
+    // canonical, so the synthetic foreign row must sit beyond it.
     conn.execute_batch(MIGRATION_TRACKING_TABLE).unwrap();
     conn.execute(
-        "INSERT INTO _schema_migrations (version, name, applied_at) VALUES (22, 'legacy', 0)",
+        "INSERT INTO _schema_migrations (version, name, applied_at) VALUES (23, 'legacy', 0)",
         [],
     )
     .unwrap();
@@ -2442,7 +2443,10 @@ fn v21_legacy_refs_remain_pending_until_explicit_stage_and_finalize() {
 #[test]
 fn v21_empty_database_fast_path_is_atomic_and_complete() {
     let mut conn = open_memory();
-    assert_eq!(run_migrations(&mut conn).unwrap(), 21);
+    assert_eq!(
+        run_migrations(&mut conn).unwrap(),
+        EMBEDDING_SPACE_SHADOW_VERSION
+    );
     assert_eq!(
         attachment_cutover_status(&conn).unwrap(),
         AttachmentCutoverStatus::Complete
@@ -2584,4 +2588,761 @@ fn v21_finalize_revalidates_model_coverage_and_attachment_claim_fences() {
         )
         .expect_err("an attachment cannot acquire a claimed digest");
     assert!(insert_error.to_string().contains("active blob sweep"));
+}
+
+// ── V22: dormant embedding-space registry shadow (ADR-160 D6) ─────────────────
+
+const V22_MIGRATION_NAME: &str = "embedding_space_shadow_stage";
+const V22_SHADOW_TABLE: &str = "_embedding_models_v22_shadow";
+const V22_PROVENANCE_TABLE: &str = "_embedding_model_legacy_provenance";
+const V22_STATE_TABLE: &str = "_embedding_space_cutover_state";
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct LegacyEmbeddingModelFixture {
+    id: Vec<u8>,
+    engine_name: String,
+    model_id: String,
+    key_version: String,
+    dim: i64,
+    output_dim: Option<i64>,
+    status: String,
+    activated_at: Option<i64>,
+    superseded_at: Option<i64>,
+    superseded_by: Option<Vec<u8>>,
+    canonical_key: Vec<u8>,
+    created_at: i64,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct StagedEmbeddingModelRow {
+    id: Vec<u8>,
+    lineage_slot: String,
+    space_key: String,
+    identity_protocol: String,
+    identity_fingerprint: Vec<u8>,
+    model_name: String,
+    dimensions: i64,
+    status: String,
+    activated_at: Option<i64>,
+    superseded_at: Option<i64>,
+    superseded_by: Option<Vec<u8>>,
+    created_at: i64,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct LegacyEmbeddingProvenanceRow {
+    id: Vec<u8>,
+    engine_name: String,
+    model_id: String,
+    key_version: String,
+    dim: i64,
+    output_dim: Option<i64>,
+    canonical_key: Vec<u8>,
+    pre_migration_status: String,
+}
+
+fn completed_v21_database() -> Connection {
+    let mut conn = open_memory();
+    migrate_through(&mut conn, ATTACHMENT_CUTOVER_VERSION - 1);
+    stage_attachment_cutover(&mut conn).expect("stage empty V21 fixture");
+    finalize_attachment_cutover(&mut conn).expect("complete empty V21 fixture");
+    assert_eq!(
+        read_schema_version(&conn).unwrap(),
+        ATTACHMENT_CUTOVER_VERSION
+    );
+    conn
+}
+
+fn record_synthetic_v22_ledger(conn: &Connection) {
+    conn.execute(
+        "INSERT INTO _schema_migrations (version, name, applied_at) VALUES (?1, ?2, 0)",
+        rusqlite::params![EMBEDDING_SPACE_SHADOW_VERSION, V22_MIGRATION_NAME],
+    )
+    .expect("record synthetic V22 ledger row");
+}
+
+fn minilm_legacy_fixture() -> LegacyEmbeddingModelFixture {
+    LegacyEmbeddingModelFixture {
+        id: vec![0x11; 16],
+        engine_name: "default".to_string(),
+        model_id: "all-minilm-l6-v2".to_string(),
+        key_version: "v2".to_string(),
+        dim: 384,
+        output_dim: None,
+        status: "active".to_string(),
+        activated_at: Some(100),
+        superseded_at: None,
+        superseded_by: None,
+        canonical_key: vec![0xa1; 32],
+        created_at: 90,
+    }
+}
+
+fn qwen_legacy_fixture() -> LegacyEmbeddingModelFixture {
+    LegacyEmbeddingModelFixture {
+        id: vec![0x22; 16],
+        engine_name: "primary".to_string(),
+        model_id: "qwen3-embedding-4b".to_string(),
+        key_version: "v3".to_string(),
+        dim: 2_560,
+        output_dim: Some(1_024),
+        status: "superseded".to_string(),
+        activated_at: Some(200),
+        superseded_at: Some(300),
+        superseded_by: Some(vec![0x33; 16]),
+        canonical_key: vec![0xb2; 32],
+        created_at: 190,
+    }
+}
+
+fn insert_legacy_embedding_model(conn: &Connection, fixture: &LegacyEmbeddingModelFixture) {
+    conn.execute(
+        "INSERT INTO _embedding_models \
+         (id, engine_name, model_id, key_version, dim, output_dim, status, activated_at, \
+          superseded_at, superseded_by, canonical_key, created_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+        rusqlite::params![
+            fixture.id,
+            fixture.engine_name,
+            fixture.model_id,
+            fixture.key_version,
+            fixture.dim,
+            fixture.output_dim,
+            fixture.status,
+            fixture.activated_at,
+            fixture.superseded_at,
+            fixture.superseded_by,
+            fixture.canonical_key,
+            fixture.created_at,
+        ],
+    )
+    .expect("insert legacy embedding-model fixture");
+}
+
+fn insert_archived_legacy_embedding_models(
+    conn: &mut Connection,
+    count: usize,
+    canonical_key_bytes: usize,
+) {
+    let transaction = conn.transaction().expect("begin bulk legacy fixture");
+    {
+        let mut insert = transaction
+            .prepare(
+                "INSERT INTO _embedding_models \
+                 (id, engine_name, model_id, key_version, dim, output_dim, status, \
+                  canonical_key, created_at) \
+                 VALUES (?1, 'bulk', 'bulk-model', 'v1', 384, NULL, 'archived', ?2, 0)",
+            )
+            .expect("prepare bulk legacy insert");
+        for index in 0..count {
+            let index_bytes = u64::try_from(index).unwrap().to_be_bytes();
+            let mut id = [0_u8; 16];
+            id[8..].copy_from_slice(&index_bytes);
+            let mut canonical_key = vec![0_u8; canonical_key_bytes.max(index_bytes.len())];
+            canonical_key[..index_bytes.len()].copy_from_slice(&index_bytes);
+            insert
+                .execute(rusqlite::params![id.as_slice(), canonical_key])
+                .expect("insert bulk legacy row");
+        }
+    }
+    transaction.commit().expect("commit bulk legacy fixture");
+}
+
+fn table_column_names(conn: &Connection, table: &str) -> Vec<String> {
+    let mut statement = conn
+        .prepare("SELECT name FROM pragma_table_info(?1) ORDER BY cid")
+        .expect("prepare table-column query");
+    statement
+        .query_map([table], |row| row.get(0))
+        .expect("query table columns")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect table columns")
+}
+
+fn hex_bytes(hex: &str) -> Vec<u8> {
+    assert_eq!(hex.len() % 2, 0, "hex fixture must contain full bytes");
+    hex.as_bytes()
+        .chunks_exact(2)
+        .map(|pair| {
+            let pair = std::str::from_utf8(pair).expect("ASCII hex fixture");
+            u8::from_str_radix(pair, 16).expect("valid hex fixture")
+        })
+        .collect()
+}
+
+fn sha256(bytes: &[u8]) -> Vec<u8> {
+    use sha2::Digest as _;
+    sha2::Sha256::digest(bytes).to_vec()
+}
+
+fn read_staged_embedding_model(conn: &Connection, id: &[u8]) -> StagedEmbeddingModelRow {
+    conn.query_row(
+        "SELECT id, lineage_slot, space_key, identity_protocol, identity_fingerprint, \
+                model_name, dimensions, status, activated_at, superseded_at, superseded_by, \
+                created_at \
+         FROM _embedding_models_v22_shadow WHERE id = ?1",
+        [id],
+        |row| {
+            Ok(StagedEmbeddingModelRow {
+                id: row.get(0)?,
+                lineage_slot: row.get(1)?,
+                space_key: row.get(2)?,
+                identity_protocol: row.get(3)?,
+                identity_fingerprint: row.get(4)?,
+                model_name: row.get(5)?,
+                dimensions: row.get(6)?,
+                status: row.get(7)?,
+                activated_at: row.get(8)?,
+                superseded_at: row.get(9)?,
+                superseded_by: row.get(10)?,
+                created_at: row.get(11)?,
+            })
+        },
+    )
+    .expect("read staged embedding-model row")
+}
+
+fn read_legacy_embedding_provenance(conn: &Connection, id: &[u8]) -> LegacyEmbeddingProvenanceRow {
+    conn.query_row(
+        "SELECT id, engine_name, model_id, key_version, dim, output_dim, canonical_key, \
+                pre_migration_status \
+         FROM _embedding_model_legacy_provenance WHERE id = ?1",
+        [id],
+        |row| {
+            Ok(LegacyEmbeddingProvenanceRow {
+                id: row.get(0)?,
+                engine_name: row.get(1)?,
+                model_id: row.get(2)?,
+                key_version: row.get(3)?,
+                dim: row.get(4)?,
+                output_dim: row.get(5)?,
+                canonical_key: row.get(6)?,
+                pre_migration_status: row.get(7)?,
+            })
+        },
+    )
+    .expect("read legacy embedding-model provenance")
+}
+
+fn assert_v22_stage_rolled_back(conn: &mut Connection, expected_diagnostic: &str) {
+    let error = run_migrations(conn).expect_err("invalid legacy identity must abort V22");
+    let message = error.to_string();
+    assert!(
+        message.contains(expected_diagnostic),
+        "V22 diagnostic must contain {expected_diagnostic:?}, got: {message}"
+    );
+    assert_eq!(
+        read_schema_version(conn).unwrap(),
+        ATTACHMENT_CUTOVER_VERSION,
+        "failed V22 must leave V21 authoritative"
+    );
+    assert_eq!(
+        conn.query_row(
+            "SELECT COUNT(*) FROM _schema_migrations WHERE version = ?1",
+            [EMBEDDING_SPACE_SHADOW_VERSION],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap(),
+        0,
+        "failed V22 must not publish its ledger row"
+    );
+    for table in [V22_SHADOW_TABLE, V22_PROVENANCE_TABLE, V22_STATE_TABLE] {
+        assert!(
+            !table_exists(conn, table),
+            "failed V22 must roll back newly-created table {table}"
+        );
+    }
+}
+
+#[test]
+fn completed_v21_remains_valid_at_synthetic_v22() {
+    let conn = completed_v21_database();
+    record_synthetic_v22_ledger(&conn);
+
+    assert_eq!(
+        attachment_cutover_status(&conn).expect("V21 completion remains valid after V22"),
+        AttachmentCutoverStatus::Complete
+    );
+}
+
+#[test]
+fn v22_current_validation_rejects_a_missing_v21_completion_marker() {
+    let mut conn = open_memory();
+    assert_eq!(
+        run_migrations(&mut conn).expect("migrate valid V22 fixture"),
+        EMBEDDING_SPACE_SHADOW_VERSION
+    );
+    conn.execute("DROP TABLE attachment_cutover_state", [])
+        .unwrap();
+
+    let error = validate_schema_is_current(&conn)
+        .expect_err("current-schema validation must not hide a missing V21 marker at V22");
+    assert!(
+        error.to_string().contains("marker is absent"),
+        "unexpected diagnostic: {error}"
+    );
+}
+
+#[test]
+fn v22_current_validation_revalidates_completed_v21_physical_schema() {
+    let mut conn = open_memory();
+    assert_eq!(
+        run_migrations(&mut conn).expect("migrate valid V22 fixture"),
+        EMBEDDING_SPACE_SHADOW_VERSION
+    );
+    conn.execute("DROP TRIGGER attachments_reject_claimed_blob_insert", [])
+        .unwrap();
+
+    let error = validate_schema_is_current(&conn)
+        .expect_err("current-schema validation must revalidate V21 physical state at V22");
+    assert!(
+        error
+            .to_string()
+            .contains("attachments_reject_claimed_blob_insert"),
+        "diagnostic must identify the missing V21 object: {error}"
+    );
+}
+
+#[test]
+fn v22_upgrade_revalidates_v21_physical_schema_before_staging() {
+    let mut conn = completed_v21_database();
+    conn.execute("DROP TRIGGER attachments_reject_claimed_blob_insert", [])
+        .unwrap();
+
+    assert_v22_stage_rolled_back(&mut conn, "attachments_reject_claimed_blob_insert");
+}
+
+#[test]
+fn v22_current_validation_requires_the_dormant_shadow_stage() {
+    let mut missing_index = open_memory();
+    run_migrations(&mut missing_index).expect("migrate missing-index fixture");
+    missing_index
+        .execute(
+            "DROP INDEX idx_embedding_models_v22_shadow_lineage_status",
+            [],
+        )
+        .unwrap();
+    let missing_error = validate_schema_is_current(&missing_index)
+        .expect_err("a V22 ledger must not hide a missing shadow index");
+    assert!(
+        missing_error
+            .to_string()
+            .contains("idx_embedding_models_v22_shadow_lineage_status"),
+        "diagnostic must identify the missing V22 object: {missing_error}"
+    );
+
+    let mut wrong_state = open_memory();
+    run_migrations(&mut wrong_state).expect("migrate wrong-state fixture");
+    wrong_state
+        .execute(
+            "UPDATE _embedding_space_cutover_state \
+             SET state = 'unstaged', staged_at = NULL",
+            [],
+        )
+        .unwrap();
+    let state_error = validate_schema_is_current(&wrong_state)
+        .expect_err("V22 current validation must require a completed dormant stage");
+    assert!(
+        state_error.to_string().contains("legacy_staged"),
+        "diagnostic must name the required dormant state: {state_error}"
+    );
+}
+
+#[test]
+fn v22_fresh_migration_creates_only_dormant_shadow_state() {
+    let mut conn = open_memory();
+    assert_eq!(
+        run_migrations(&mut conn).expect("fresh migration through V22"),
+        EMBEDDING_SPACE_SHADOW_VERSION
+    );
+    assert_eq!(
+        validate_schema_is_current(&conn).expect("complete V22 validates read-only"),
+        EMBEDDING_SPACE_SHADOW_VERSION
+    );
+    assert_eq!(
+        conn.query_row(
+            "SELECT name FROM _schema_migrations WHERE version = ?1",
+            [EMBEDDING_SPACE_SHADOW_VERSION],
+            |row| row.get::<_, String>(0),
+        )
+        .unwrap(),
+        V22_MIGRATION_NAME
+    );
+
+    assert_eq!(
+        table_column_names(&conn, V22_SHADOW_TABLE),
+        [
+            "id",
+            "lineage_slot",
+            "space_key",
+            "identity_protocol",
+            "identity_fingerprint",
+            "model_name",
+            "dimensions",
+            "status",
+            "activated_at",
+            "superseded_at",
+            "superseded_by",
+            "created_at",
+        ]
+    );
+    assert_eq!(
+        table_column_names(&conn, V22_PROVENANCE_TABLE),
+        [
+            "id",
+            "engine_name",
+            "model_id",
+            "key_version",
+            "dim",
+            "output_dim",
+            "canonical_key",
+            "pre_migration_status",
+        ]
+    );
+    assert_eq!(
+        table_column_names(&conn, V22_STATE_TABLE),
+        ["singleton", "state", "staged_at", "completed_at"]
+    );
+    assert!(index_exists(
+        &conn,
+        "idx_embedding_models_v22_shadow_one_active"
+    ));
+    assert!(index_exists(
+        &conn,
+        "idx_embedding_models_v22_shadow_lineage_status"
+    ));
+
+    let (state, staged_at, completed_at): (String, Option<i64>, Option<i64>) = conn
+        .query_row(
+            "SELECT state, staged_at, completed_at \
+             FROM _embedding_space_cutover_state WHERE singleton = 1",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(state, "legacy_staged");
+    assert!(staged_at.is_some(), "successful V22 records its stage time");
+    assert_eq!(completed_at, None, "V22 must not publish a cutover");
+    assert_eq!(
+        conn.query_row(
+            "SELECT COUNT(*) FROM _embedding_models_v22_shadow",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap(),
+        0
+    );
+    assert_eq!(
+        conn.query_row(
+            "SELECT COUNT(*) FROM _embedding_model_legacy_provenance",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap(),
+        0
+    );
+}
+
+#[test]
+fn v22_legacy_mapping_pins_two_complete_goldens() {
+    let mut conn = completed_v21_database();
+    let minilm = minilm_legacy_fixture();
+    let qwen = qwen_legacy_fixture();
+    insert_legacy_embedding_model(&conn, &minilm);
+    insert_legacy_embedding_model(&conn, &qwen);
+    assert_eq!(
+        LEGACY_EMBEDDING_IDENTITY_PROTOCOL,
+        "khive.legacy-embedding-space.v1"
+    );
+
+    assert_eq!(
+        run_migrations(&mut conn).expect("stage valid legacy rows"),
+        EMBEDDING_SPACE_SHADOW_VERSION
+    );
+
+    let minilm_preimage = hex_bytes(
+        "6b686976652e6c65676163792d656d62656464696e672d73706163652e763100\
+         0000000764656661756c7400000010616c6c2d6d696e696c6d2d6c362d7632\
+         0000000276320000018000",
+    );
+    let minilm_digest =
+        hex_bytes("d2914e3806c1df27d7f64935dc8adceb0d9a3124531075637f677a862a3bd9cf");
+    assert_eq!(sha256(&minilm_preimage), minilm_digest);
+    let minilm_identity = legacy_embedding_space_identity(
+        &minilm.engine_name,
+        &minilm.model_id,
+        &minilm.key_version,
+        u32::try_from(minilm.dim).unwrap(),
+        minilm.output_dim.map(|value| u32::try_from(value).unwrap()),
+    )
+    .expect("valid MiniLM legacy identity");
+    assert_eq!(
+        minilm_identity.space_key().as_str(),
+        "legacy_d2914e3806c1df27d7f64935dc8adceb0d9a3124531075637f677a862a3bd9cf_384"
+    );
+    assert_eq!(
+        minilm_identity.protocol().as_str(),
+        LEGACY_EMBEDDING_IDENTITY_PROTOCOL
+    );
+    assert_eq!(minilm_identity.fingerprint().as_slice(), minilm_digest);
+    assert_eq!(minilm_identity.model_name(), "all-minilm-l6-v2");
+    assert_eq!(minilm_identity.dimensions().get(), 384);
+    assert_eq!(
+        read_staged_embedding_model(&conn, &minilm.id),
+        StagedEmbeddingModelRow {
+            id: minilm.id.clone(),
+            lineage_slot: "default".to_string(),
+            space_key: minilm_identity.space_key().to_string(),
+            identity_protocol: LEGACY_EMBEDDING_IDENTITY_PROTOCOL.to_string(),
+            identity_fingerprint: minilm_digest,
+            model_name: "all-minilm-l6-v2".to_string(),
+            dimensions: 384,
+            status: "active".to_string(),
+            activated_at: Some(100),
+            superseded_at: None,
+            superseded_by: None,
+            created_at: 90,
+        }
+    );
+    assert_eq!(
+        read_legacy_embedding_provenance(&conn, &minilm.id),
+        LegacyEmbeddingProvenanceRow {
+            id: minilm.id.clone(),
+            engine_name: "default".to_string(),
+            model_id: "all-minilm-l6-v2".to_string(),
+            key_version: "v2".to_string(),
+            dim: 384,
+            output_dim: None,
+            canonical_key: vec![0xa1; 32],
+            pre_migration_status: "active".to_string(),
+        }
+    );
+
+    let qwen_preimage = hex_bytes(
+        "6b686976652e6c65676163792d656d62656464696e672d73706163652e763100\
+         000000077072696d617279000000127177656e332d656d62656464696e672d3462\
+         00000002763300000a000100000400",
+    );
+    let qwen_digest = hex_bytes("a25e53e4485d1fae571cb5f1a15bf763c281a77097e2a273b36998b69d5e3a55");
+    assert_eq!(sha256(&qwen_preimage), qwen_digest);
+    let qwen_identity = legacy_embedding_space_identity(
+        &qwen.engine_name,
+        &qwen.model_id,
+        &qwen.key_version,
+        u32::try_from(qwen.dim).unwrap(),
+        qwen.output_dim.map(|value| u32::try_from(value).unwrap()),
+    )
+    .expect("valid Qwen legacy identity");
+    assert_eq!(
+        qwen_identity.space_key().as_str(),
+        "legacy_a25e53e4485d1fae571cb5f1a15bf763c281a77097e2a273b36998b69d5e3a55_1024"
+    );
+    assert_eq!(
+        qwen_identity.protocol().as_str(),
+        LEGACY_EMBEDDING_IDENTITY_PROTOCOL
+    );
+    assert_eq!(qwen_identity.fingerprint().as_slice(), qwen_digest);
+    assert_eq!(qwen_identity.model_name(), "qwen3-embedding-4b");
+    assert_eq!(qwen_identity.dimensions().get(), 1_024);
+    assert_eq!(
+        read_staged_embedding_model(&conn, &qwen.id),
+        StagedEmbeddingModelRow {
+            id: qwen.id.clone(),
+            lineage_slot: "primary".to_string(),
+            space_key: qwen_identity.space_key().to_string(),
+            identity_protocol: LEGACY_EMBEDDING_IDENTITY_PROTOCOL.to_string(),
+            identity_fingerprint: qwen_digest,
+            model_name: "qwen3-embedding-4b".to_string(),
+            dimensions: 1_024,
+            status: "superseded".to_string(),
+            activated_at: Some(200),
+            superseded_at: Some(300),
+            superseded_by: Some(vec![0x33; 16]),
+            created_at: 190,
+        }
+    );
+    assert_eq!(
+        read_legacy_embedding_provenance(&conn, &qwen.id),
+        LegacyEmbeddingProvenanceRow {
+            id: qwen.id.clone(),
+            engine_name: "primary".to_string(),
+            model_id: "qwen3-embedding-4b".to_string(),
+            key_version: "v3".to_string(),
+            dim: 2_560,
+            output_dim: Some(1_024),
+            canonical_key: vec![0xb2; 32],
+            pre_migration_status: "superseded".to_string(),
+        }
+    );
+}
+
+#[test]
+fn v22_invalid_effective_dimensions_roll_back_atomically() {
+    for (dim, output_dim) in [(0, None), (384, Some(8_193))] {
+        let mut conn = completed_v21_database();
+        let mut fixture = minilm_legacy_fixture();
+        fixture.dim = dim;
+        fixture.output_dim = output_dim;
+        insert_legacy_embedding_model(&conn, &fixture);
+        assert_v22_stage_rolled_back(&mut conn, "dimensions");
+    }
+}
+
+#[test]
+fn v22_invalid_legacy_model_label_rolls_back_atomically() {
+    let mut conn = completed_v21_database();
+    let mut fixture = minilm_legacy_fixture();
+    fixture.model_id = " model-with-surrounding-space ".to_string();
+    insert_legacy_embedding_model(&conn, &fixture);
+
+    assert_v22_stage_rolled_back(&mut conn, "model name");
+}
+
+#[test]
+fn v22_oversized_legacy_text_refuses_before_materialization() {
+    let mut conn = completed_v21_database();
+    let mut fixture = minilm_legacy_fixture();
+    fixture.engine_name = "e".repeat(usize::try_from(MAX_LEGACY_EMBEDDING_TEXT_BYTES).unwrap() + 1);
+    insert_legacy_embedding_model(&conn, &fixture);
+
+    assert_v22_stage_rolled_back(&mut conn, "engine_name");
+}
+
+#[test]
+fn v22_over_cardinality_legacy_registry_rolls_back_atomically() {
+    let mut conn = completed_v21_database();
+    insert_archived_legacy_embedding_models(&mut conn, MAX_LEGACY_EMBEDDING_REGISTRY_ROWS + 1, 8);
+
+    assert_v22_stage_rolled_back(&mut conn, "more than the V22 staging limit");
+}
+
+#[test]
+fn v22_aggregate_stage_budget_is_checked_before_writes() {
+    let mut total = MAX_LEGACY_EMBEDDING_STAGE_BYTES - 1;
+    let error = add_legacy_stage_bytes(1, &mut total, "fixture", 2, 1)
+        .expect_err("aggregate staging bytes must be bounded before V22 writes");
+    assert!(
+        error.to_string().contains("staging payload above"),
+        "unexpected aggregate-budget diagnostic: {error}"
+    );
+    assert_eq!(
+        total,
+        MAX_LEGACY_EMBEDDING_STAGE_BYTES - 1,
+        "a rejected charge must not mutate the accumulated budget"
+    );
+}
+
+#[test]
+fn v22_wrong_legacy_sqlite_type_rolls_back_atomically() {
+    let mut conn = completed_v21_database();
+    conn.execute(
+        "INSERT INTO _embedding_models \
+         (id, engine_name, model_id, key_version, dim, output_dim, status, canonical_key, \
+          created_at) \
+         VALUES (?1, 'default', 'all-minilm-l6-v2', 'v2', ?2, NULL, 'active', ?3, 90)",
+        rusqlite::params![vec![0x44_u8; 16], vec![0x01_u8, 0x80], vec![0xc4_u8; 32]],
+    )
+    .unwrap();
+    assert_eq!(
+        conn.query_row(
+            "SELECT typeof(dim) FROM _embedding_models WHERE id = ?1",
+            [vec![0x44; 16]],
+            |row| row.get::<_, String>(0),
+        )
+        .unwrap(),
+        "blob",
+        "fixture must bypass INTEGER affinity rather than becoming a valid integer"
+    );
+
+    assert_v22_stage_rolled_back(&mut conn, "dim");
+}
+
+#[test]
+fn v22_duplicate_derived_space_key_rolls_back_atomically() {
+    let mut conn = completed_v21_database();
+    let active = minilm_legacy_fixture();
+    let mut historical_duplicate = active.clone();
+    historical_duplicate.id = vec![0x55; 16];
+    historical_duplicate.status = "archived".to_string();
+    historical_duplicate.activated_at = None;
+    historical_duplicate.canonical_key = vec![0xd5; 32];
+    insert_legacy_embedding_model(&conn, &active);
+    insert_legacy_embedding_model(&conn, &historical_duplicate);
+
+    assert_v22_stage_rolled_back(&mut conn, "space_key");
+}
+
+#[test]
+fn v22_shadow_does_not_change_canonical_registry_serving() {
+    let mut conn = completed_v21_database();
+    let fixture = minilm_legacy_fixture();
+    insert_legacy_embedding_model(&conn, &fixture);
+    let canonical_columns_before = table_column_names(&conn, "_embedding_models");
+
+    assert_eq!(
+        run_migrations(&mut conn).expect("stage legacy identity"),
+        EMBEDDING_SPACE_SHADOW_VERSION
+    );
+    assert_eq!(
+        table_column_names(&conn, "_embedding_models"),
+        canonical_columns_before,
+        "V22 must not replace or reshape the serving registry"
+    );
+    assert_eq!(
+        canonical_columns_before,
+        [
+            "id",
+            "engine_name",
+            "model_id",
+            "key_version",
+            "dim",
+            "output_dim",
+            "status",
+            "activated_at",
+            "superseded_at",
+            "superseded_by",
+            "canonical_key",
+            "created_at",
+        ]
+    );
+
+    conn.execute(
+        "UPDATE _embedding_models_v22_shadow \
+         SET lineage_slot = 'shadow-only-slot', model_name = 'shadow-only-model', \
+             dimensions = 1, status = 'archived' \
+         WHERE id = ?1",
+        [fixture.id.as_slice()],
+    )
+    .unwrap();
+
+    let served = query_embedding_models_conn(&conn, Some("default")).unwrap();
+    assert_eq!(served.len(), 1);
+    assert_eq!(served[0].engine_name, "default");
+    assert_eq!(served[0].model_id, "all-minilm-l6-v2");
+    assert_eq!(served[0].key_version, "v2");
+    assert_eq!(served[0].dimensions, 384);
+    assert_eq!(served[0].status, "active");
+    assert_eq!(served[0].activated_at, Some(100));
+    assert_eq!(served[0].superseded_at, None);
+    assert!(
+        query_embedding_models_conn(&conn, Some("shadow-only-slot"))
+            .unwrap()
+            .is_empty(),
+        "the dormant shadow must not participate in serving lookups"
+    );
+
+    assert_eq!(
+        conn.query_row(
+            "SELECT COUNT(*) FROM _embedding_models \
+             WHERE id = ?1 AND engine_name = 'default' AND model_id = 'all-minilm-l6-v2' \
+               AND key_version = 'v2' AND dim = 384 AND output_dim IS NULL \
+               AND status = 'active' AND activated_at = 100 AND superseded_at IS NULL \
+               AND superseded_by IS NULL AND canonical_key = ?2 AND created_at = 90",
+            rusqlite::params![fixture.id, vec![0xa1_u8; 32]],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap(),
+        1,
+        "dormant shadow mutation must not alter any canonical serving column"
+    );
 }

--- a/crates/khive-db/src/stores/blob.rs
+++ b/crates/khive-db/src/stores/blob.rs
@@ -818,7 +818,8 @@ fn invalid_content_ref(message: String) -> StorageError {
 }
 
 /// Whether this database carries the complete V21 attachment-only GC fencing
-/// set and durable completed cutover marker.
+/// set and durable completed cutover marker in a schema epoch this binary
+/// knows preserves that liveness contract.
 ///
 /// `transactional_orphan_sweep` is reachable from any `SqlAccess` a caller
 /// hands it, including a `StorageBackend` constructed directly (e.g.
@@ -886,11 +887,24 @@ async fn blob_gc_fencing_complete(sql: &dyn SqlAccess) -> StorageResult<bool> {
                         AND cutover.state = 'complete' \
                         AND cutover.completed_at IS NOT NULL \
                         AND (SELECT COUNT(*) FROM _schema_migrations \
-                             WHERE version = 21 \
+                             WHERE version = ?1 \
                                AND name = 'attachments_first_class') = 1 \
-                        AND (SELECT MAX(version) FROM _schema_migrations) = 21"
-                    .to_string(),
-                params: vec![],
+                        AND ( \
+                            (SELECT MAX(version) FROM _schema_migrations) = ?1 \
+                            OR ( \
+                                (SELECT MAX(version) FROM _schema_migrations) = ?2 \
+                                AND (SELECT COUNT(*) FROM _schema_migrations \
+                                     WHERE version = ?2 AND name = ?3) = 1 \
+                            ) \
+                        )"
+                .to_string(),
+                params: vec![
+                    SqlValue::Integer(i64::from(crate::migrations::ATTACHMENT_CUTOVER_VERSION)),
+                    SqlValue::Integer(i64::from(crate::migrations::EMBEDDING_SPACE_SHADOW_VERSION)),
+                    SqlValue::Text(
+                        crate::migrations::EMBEDDING_SPACE_SHADOW_MIGRATION_NAME.to_string(),
+                    ),
+                ],
                 label: Some("blob_gc_cutover_complete".to_string()),
             })
             .await?,
@@ -2237,7 +2251,11 @@ mod tests {
     /// instead of retaining Phase 4a's synthetic future-schema fixture.
     fn prepare_completed_v21_gc_fixture(conn: &mut rusqlite::Connection) {
         let version = crate::run_migrations(conn).expect("prepare canonical completed V21");
-        assert_eq!(version, 21, "empty fixture must take the V21 fast path");
+        assert_eq!(
+            version,
+            crate::migrations::EMBEDDING_SPACE_SHADOW_VERSION,
+            "empty fixture must complete V21 and every later dormant migration"
+        );
     }
 
     #[tokio::test]
@@ -2278,6 +2296,60 @@ mod tests {
         assert!(!blob_gc_fencing_complete(backend.sql().as_ref())
             .await
             .unwrap());
+    }
+
+    #[tokio::test]
+    async fn completed_v22_gc_gate_refuses_an_unknown_future_schema_epoch() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("khive.db");
+        let backend = crate::StorageBackend::sqlite(&db_path).unwrap();
+        {
+            let mut writer = backend.pool().writer().unwrap();
+            prepare_completed_v21_gc_fixture(writer.conn_mut());
+            writer
+                .conn()
+                .execute(
+                    "INSERT INTO _schema_migrations (version, name, applied_at) \
+                     VALUES (?1, 'future_unknown', 0)",
+                    [i64::from(
+                        crate::migrations::EMBEDDING_SPACE_SHADOW_VERSION + 1,
+                    )],
+                )
+                .unwrap();
+        }
+
+        assert!(
+            !blob_gc_fencing_complete(backend.sql().as_ref())
+                .await
+                .unwrap(),
+            "known additive V22 is safe, but this binary must refuse an unknown V23+ epoch"
+        );
+    }
+
+    #[tokio::test]
+    async fn completed_v22_gc_gate_refuses_a_foreign_v22_ledger_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("khive.db");
+        let backend = crate::StorageBackend::sqlite(&db_path).unwrap();
+        {
+            let mut writer = backend.pool().writer().unwrap();
+            prepare_completed_v21_gc_fixture(writer.conn_mut());
+            writer
+                .conn()
+                .execute(
+                    "UPDATE _schema_migrations SET name = 'foreign_shadow_stage' \
+                     WHERE version = ?1",
+                    [i64::from(crate::migrations::EMBEDDING_SPACE_SHADOW_VERSION)],
+                )
+                .unwrap();
+        }
+
+        assert!(
+            !blob_gc_fencing_complete(backend.sql().as_ref())
+                .await
+                .unwrap(),
+            "a numeric V22 is not known-safe unless its canonical ledger name also matches"
+        );
     }
 
     #[test]

--- a/crates/khive-mcp/src/attachment_cutover.rs
+++ b/crates/khive-mcp/src/attachment_cutover.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use anyhow::Context as _;
-use khive_db::migrations::AttachmentCutoverStatus;
+use khive_db::migrations::{AttachmentCutoverStatus, EMBEDDING_SPACE_SHADOW_VERSION};
 use khive_runtime::{BlobHydrator, StorageBackend};
 use khive_storage::types::{SqlStatement, SqlValue};
 use khive_storage::{Attachment, AttachmentSubstrate};
@@ -95,6 +95,29 @@ async fn cutover_status(backend: Arc<StorageBackend>) -> anyhow::Result<Attachme
         .await
         .context("attachment cutover status task panicked")?
         .context("inspect attachment cutover status")
+}
+
+/// Advance ordinary migrations after V21 releases the database GC owner.
+///
+/// The caller must explicitly drop its `DatabaseGcOwnerGuard` before
+/// awaiting this helper: `StorageBackend::prepare_core_schema` acquires that
+/// same per-database owner before V22 and the guard is deliberately
+/// non-reentrant. This helper remains inside the outer ADR-119 tracked task so
+/// cancellation cannot detach the post-V21 schema advance from boot.
+async fn advance_to_embedding_space_shadow(backend: Arc<StorageBackend>) -> anyhow::Result<()> {
+    let version = tokio::task::spawn_blocking(move || backend.prepare_core_schema())
+        .await
+        .context("post-V21 V22 schema-advance task panicked")?
+        .context("advance ordinary schema to the dormant V22 embedding-space shadow")?;
+    if version != EMBEDDING_SPACE_SHADOW_VERSION {
+        anyhow::bail!(
+            "post-V21 ordinary schema advance returned V{version}, expected exact V{}; \
+             inspect the core migration ledger and V22 embedding-space shadow tables before \
+             retrying boot",
+            EMBEDDING_SPACE_SHADOW_VERSION
+        );
+    }
+    Ok(())
 }
 
 /// Reject attachment evidence on a non-main database before the main database
@@ -213,8 +236,13 @@ async fn coordinate_attachment_cutover_inner(
         .context("V21 stage-1 blocking task panicked")??;
         if already_complete {
             if let Some(backend_name) = mode.secondary_name() {
-                require_secondary_attachment_empty(backend, backend_name).await?;
+                require_secondary_attachment_empty(Arc::clone(&backend), backend_name).await?;
             }
+            // A sibling completed V21 while this task waited for ownership.
+            // Release the non-reentrant guard before ordinary migration tries
+            // to acquire the same owner for V22.
+            drop(owner);
+            advance_to_embedding_space_shadow(backend).await?;
             return Ok(());
         }
 
@@ -271,24 +299,30 @@ async fn coordinate_attachment_cutover_inner(
             })
             .collect::<Vec<_>>();
 
-        tokio::task::spawn_blocking(move || {
+        let (backend, owner) = tokio::task::spawn_blocking(move || {
             backend
                 .apply_verified_attachments(&owner, &attachments)
                 .context("atomically apply verified pack-owned attachments")?;
             backend
                 .finalize_attachment_cutover(&owner)
                 .context("finalize V21 attachment/GC cutover")?;
-            Ok::<_, anyhow::Error>(())
+            Ok::<_, anyhow::Error>((backend, owner))
         })
         .await
         .context("V21 finalization blocking task panicked")??;
+
+        // `prepare_core_schema` acquires this same guard before applying V22.
+        // Make the ownership boundary explicit rather than relying on a
+        // temporary's drop order and deadlocking on a reentrant acquisition.
+        drop(owner);
+        advance_to_embedding_space_shadow(backend).await?;
 
         Ok::<_, anyhow::Error>(())
     });
 
     handle
         .await
-        .context("tracked V21 attachment migrator panicked")??;
+        .context("tracked V21/V22 schema coordinator panicked")??;
     Ok(())
 }
 
@@ -354,7 +388,9 @@ pub(crate) fn create_v20_database_fixture(
 
 #[cfg(test)]
 mod tests {
-    use khive_db::migrations::ATTACHMENT_CUTOVER_VERSION;
+    use khive_db::migrations::{
+        validate_schema_is_current, ATTACHMENT_CUTOVER_VERSION, EMBEDDING_SPACE_SHADOW_VERSION,
+    };
     use khive_db::stores::blob::FsBlobStore;
     use khive_storage::BlobStore as _;
 
@@ -398,6 +434,162 @@ mod tests {
             )
             .unwrap();
         assert_eq!(legacy_columns, 0, "final V21 must drop the legacy column");
+    }
+
+    #[tokio::test]
+    async fn v20_legacy_ref_coordinator_reaches_v22_shadow_before_return() {
+        let temp = tempfile::tempdir().unwrap();
+        let db_path = temp.path().join("legacy-through-shadow.db");
+        create_v20_database_fixture(&db_path, "visual_asset", None);
+        let backend = Arc::new(StorageBackend::sqlite(&db_path).unwrap());
+
+        assert_eq!(
+            backend.prepare_core_schema().unwrap(),
+            ATTACHMENT_CUTOVER_VERSION - 1,
+            "canonical legacy evidence must stop ordinary migration at V20"
+        );
+        coordinate_attachment_cutover(Arc::clone(&backend), None)
+            .await
+            .expect("the coordinator must finish V21 and continue through dormant V22");
+
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        assert_eq!(
+            validate_schema_is_current(&conn).unwrap(),
+            EMBEDDING_SPACE_SHADOW_VERSION,
+            "the coordinator must not return with a writable database stranded at V21"
+        );
+        for table in [
+            "_embedding_models_v22_shadow",
+            "_embedding_model_legacy_provenance",
+            "_embedding_space_cutover_state",
+        ] {
+            let present: bool = conn
+                .query_row(
+                    "SELECT COUNT(*) = 1 FROM sqlite_master \
+                     WHERE type = 'table' AND name = ?1",
+                    [table],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert!(present, "V22 must materialize dormant shadow table {table}");
+        }
+        let shadow_state = conn
+            .query_row(
+                "SELECT state, staged_at IS NOT NULL, completed_at IS NULL \
+                 FROM _embedding_space_cutover_state",
+                [],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, bool>(1)?,
+                        row.get::<_, bool>(2)?,
+                    ))
+                },
+            )
+            .unwrap();
+        assert_eq!(shadow_state, ("legacy_staged".to_string(), true, true));
+    }
+
+    #[tokio::test]
+    async fn exact_current_v22_coordinator_does_not_repeat_shadow_writes() {
+        let temp = tempfile::tempdir().unwrap();
+        let db_path = temp.path().join("exact-current-shadow.db");
+        let backend = Arc::new(StorageBackend::sqlite(&db_path).unwrap());
+        assert_eq!(
+            backend.prepare_core_schema().unwrap(),
+            EMBEDDING_SPACE_SHADOW_VERSION
+        );
+
+        let observer = rusqlite::Connection::open(&db_path).unwrap();
+        let data_version_before: i64 = observer
+            .query_row("PRAGMA data_version", [], |row| row.get(0))
+            .unwrap();
+        let stage_before = observer
+            .query_row(
+                "SELECT state, staged_at, completed_at \
+                 FROM _embedding_space_cutover_state",
+                [],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, Option<i64>>(2)?,
+                    ))
+                },
+            )
+            .unwrap();
+        let ledger_rows_before: i64 = observer
+            .query_row(
+                "SELECT COUNT(*) FROM _schema_migrations WHERE version = ?1",
+                [i64::from(EMBEDDING_SPACE_SHADOW_VERSION)],
+                |row| row.get(0),
+            )
+            .unwrap();
+
+        coordinate_attachment_cutover(backend, None)
+            .await
+            .expect("an exact-current database must take the query-only fast path");
+
+        let data_version_after: i64 = observer
+            .query_row("PRAGMA data_version", [], |row| row.get(0))
+            .unwrap();
+        let stage_after = observer
+            .query_row(
+                "SELECT state, staged_at, completed_at \
+                 FROM _embedding_space_cutover_state",
+                [],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, Option<i64>>(2)?,
+                    ))
+                },
+            )
+            .unwrap();
+        let ledger_rows_after: i64 = observer
+            .query_row(
+                "SELECT COUNT(*) FROM _schema_migrations WHERE version = ?1",
+                [i64::from(EMBEDDING_SPACE_SHADOW_VERSION)],
+                |row| row.get(0),
+            )
+            .unwrap();
+
+        assert_eq!(data_version_after, data_version_before);
+        assert_eq!(stage_after, stage_before);
+        assert_eq!(ledger_rows_before, 1);
+        assert_eq!(ledger_rows_after, ledger_rows_before);
+    }
+
+    #[tokio::test]
+    async fn incomplete_v21_resumes_through_v22_before_coordinator_returns() {
+        let temp = tempfile::tempdir().unwrap();
+        let db_path = temp.path().join("incomplete-through-shadow.db");
+        create_v20_database_fixture(&db_path, "visual_asset", None);
+        let backend = Arc::new(StorageBackend::sqlite(&db_path).unwrap());
+        assert_eq!(
+            backend.prepare_core_schema().unwrap(),
+            ATTACHMENT_CUTOVER_VERSION - 1
+        );
+
+        let owner = khive_db::stores::blob::acquire_database_gc_owner(backend.sql().as_ref())
+            .await
+            .unwrap();
+        backend.stage_attachment_cutover(&owner).unwrap();
+        drop(owner);
+        assert_eq!(
+            backend.attachment_cutover_status().unwrap(),
+            AttachmentCutoverStatus::Incomplete
+        );
+
+        coordinate_attachment_cutover(backend, None)
+            .await
+            .expect("an interrupted V21 must finalize and advance ordinary V22 before return");
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        assert_eq!(
+            validate_schema_is_current(&conn).unwrap(),
+            EMBEDDING_SPACE_SHADOW_VERSION
+        );
     }
 
     #[tokio::test]
@@ -475,11 +667,21 @@ mod tests {
         test_sync::clear();
         drop(owner);
 
-        first.await.unwrap().unwrap();
-        second.await.unwrap().unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(10), async move {
+            first.await.unwrap().unwrap();
+            second.await.unwrap().unwrap();
+        })
+        .await
+        .expect("both coordinators must release the V21 owner before re-entering for V22");
         assert_eq!(
             backend.attachment_cutover_status().unwrap(),
             AttachmentCutoverStatus::Complete
+        );
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        assert_eq!(
+            validate_schema_is_current(&conn).unwrap(),
+            EMBEDDING_SPACE_SHADOW_VERSION,
+            "the under-owner sibling-complete path must also await ordinary V22"
         );
     }
 

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -250,14 +250,7 @@ impl KhiveRuntime {
         backend: Arc<StorageBackend>,
         config: RuntimeConfig,
     ) -> RuntimeResult<Self> {
-        if backend.attachment_cutover_status()?
-            != khive_db::migrations::AttachmentCutoverStatus::Complete
-        {
-            return Err(khive_db::SqliteError::InvalidData(
-                "from_prepared_backend requires a complete V21 attachment cutover".into(),
-            )
-            .into());
-        }
+        backend.validate_core_schema_is_current()?;
         if !backend.is_read_only() {
             register_configured_embedding_models(&backend, &config)?;
         }
@@ -1509,6 +1502,43 @@ mod tests {
     fn memory_runtime_creates_successfully() {
         let rt = KhiveRuntime::memory().expect("memory runtime should create");
         assert!(rt.config().db_path.is_none());
+    }
+
+    #[test]
+    fn from_prepared_backend_rejects_a_complete_but_behind_core_schema() {
+        let directory = tempfile::tempdir().expect("database directory");
+        let path = directory.path().join("complete-v21-behind-v22.db");
+        let mut connection = rusqlite::Connection::open(&path).expect("open fixture database");
+        assert_eq!(
+            khive_db::migrations::run_migrations(&mut connection).expect("migrate through V22"),
+            khive_db::migrations::EMBEDDING_SPACE_SHADOW_VERSION
+        );
+        connection
+            .execute_batch(
+                "DROP TABLE _embedding_models_v22_shadow; \
+                 DROP TABLE _embedding_model_legacy_provenance; \
+                 DROP TABLE _embedding_space_cutover_state; \
+                 DELETE FROM _schema_migrations WHERE version = 22;",
+            )
+            .expect("restore a physically valid completed V21 fixture");
+        drop(connection);
+
+        let backend = Arc::new(StorageBackend::sqlite(&path).expect("open behind backend"));
+        assert_eq!(
+            backend.attachment_cutover_status().unwrap(),
+            khive_db::migrations::AttachmentCutoverStatus::Complete
+        );
+        let error =
+            match KhiveRuntime::from_prepared_backend(backend, RuntimeConfig::no_embeddings()) {
+                Ok(_) => panic!("the low-level assembly seam must require exact current schema"),
+                Err(error) => error,
+            };
+        assert!(
+            error
+                .to_string()
+                .contains("behind the latest known migration"),
+            "unexpected behind-schema diagnostic: {error}"
+        );
     }
 
     #[tokio::test]

--- a/crates/khive-storage/docs/api/blob-store.md
+++ b/crates/khive-storage/docs/api/blob-store.md
@@ -84,14 +84,14 @@ snapshot-plus-sweep — a maintenance window, a single-writer admin CLI
 invocation with no live traffic, or equivalent.
 
 A DB-coordinated sweep is available separately as
-`BlobStore::transactional_orphan_sweep`. The Phase4a filesystem implementation
-first performs a read-only schema-epoch gate. Both `dry_run` and destructive
-calls are supported only when the database proves the named objects and epoch
-markers of the exact completed V21 attachment cutover: the complete marker and
-V21 ledger row, the attachment and claim tables/indexes, attachment
-INSERT/UPDATE claim fences, and no legacy entity content-ref
-column/index/triggers. V20, pending, incomplete, missing-required-object,
-retained-legacy, and ahead-of-V21 epochs return typed
+`BlobStore::transactional_orphan_sweep`. The filesystem implementation first
+performs a read-only schema-epoch gate. Both `dry_run` and destructive calls are
+supported only for exact V21 or canonical `(22, "embedding_space_shadow_stage")`, and only when the
+database proves the named objects and markers of the completed V21 attachment
+cutover: the complete marker and V21 ledger row, the attachment and claim
+tables/indexes, attachment INSERT/UPDATE claim fences, and no legacy entity
+content-ref column/index/triggers. V20, pending, incomplete,
+missing-required-object, retained-legacy, and unknown V23-or-later epochs return typed
 `StorageError::Unsupported` before waiting for the blob-root lock, walking
 files, or recovering abandoned claims.
 
@@ -120,12 +120,12 @@ coordination and epoch guarantees return `Unsupported`.
 
 ### Schema epoch gate and the two-release V21 rollout
 
-The shipped filesystem implementation selects SQL liveness only after proving
-one exact completed V21 epoch: the V21 ledger row is uniquely present and latest,
-the cutover marker is complete, the required attachment/claim objects and
-attachment claim triggers are present, and the legacy entity
-column/index/triggers are absent. Known non-admitted epochs—V20, pending,
-incomplete, missing-required-object, retained-legacy, or ahead-of-V21—return
+The original Phase4a filesystem implementation selects SQL liveness only after
+proving one exact completed V21 epoch: the V21 ledger row is uniquely present
+and latest, the cutover marker is complete, the required attachment/claim
+objects and attachment claim triggers are present, and the legacy entity
+column/index/triggers are absent. Its known non-admitted epochs—V20, pending,
+incomplete, missing-required-object, retained-legacy, or ahead of V21—return
 `StorageError::Unsupported` in both modes before root locking, filesystem
 walking, or abandoned-claim cleanup. Malformed stored evidence or a
 nonfunctional named fence may retain a more specific validation, storage, or
@@ -146,6 +146,16 @@ reader/writer compatibility. Start Phase-4b serving only after exact-current
 topology validation. Transactional GC is intentionally unavailable while Phase
 4a operates on V20; do not bypass the pause with caller-snapshot `orphan_sweep`
 or unconditional `delete`.
+
+The current binary adds one narrow epoch qualification without changing that
+V21 physical contract. V22, `embedding_space_shadow_stage`, contains only
+dormant embedding-registry shadow/provenance/state and leaves attachment
+liveness unchanged, so the current GC gate accepts V21 through canonical V22 after
+revalidating all completed-V21 evidence and functional fences. It refuses an
+unknown V23 or later before root locking or filesystem work. An older Phase4a
+binary sees V22 as ahead and refuses it, which remains safe. V22 does not make
+that older binary suitable for serving, and it does not complete ADR-160 Phase
+7's provider/vector cutover.
 
 The original `orphan_sweep` remains an offline-maintenance API for callers that
 already have a trusted `live_refs` snapshot. It intentionally retains its

--- a/crates/khive-storage/src/blob.rs
+++ b/crates/khive-storage/src/blob.rs
@@ -259,23 +259,30 @@ pub trait BlobStore: Send + Sync + std::fmt::Debug + 'static {
     /// `StorageError::Unsupported`.
     ///
     /// The filesystem implementation is schema-epoch gated and supports both
-    /// report-only and destructive modes only when `sql` proves the exact
-    /// completed V21 attachment cutover: durable complete marker and ledger
-    /// row, attachment table/indexes and INSERT/UPDATE claim fences, and
-    /// absence of every legacy entity reference column/index/fence. V20,
-    /// pending, incomplete, missing-required-object, retained-legacy, and
-    /// ahead-of-V21 epochs return typed `Unsupported` before root locking,
-    /// filesystem walking, or abandoned-claim cleanup. Malformed stored
+    /// report-only and destructive modes only for a closed set of schema
+    /// epochs this binary knows preserve the completed V21 attachment cutover.
+    /// It always proves the durable V21 complete marker and ledger row,
+    /// attachment table/indexes and INSERT/UPDATE claim fences, and absence of
+    /// every legacy entity reference column/index/fence. This binary admits V21
+    /// through dormant V22; V20, pending, incomplete, missing-required-object,
+    /// retained-legacy, and unknown V23-or-later epochs return typed
+    /// `Unsupported` before root locking, filesystem walking, or
+    /// abandoned-claim cleanup. Malformed stored
     /// evidence or a nonfunctional named fence fails closed with its validation,
     /// storage, or typed `Unsupported` error before claim cleanup or deletion.
     /// Once admitted, every attachment role is live; soft deletion alone does
     /// not make its blob collectible.
     ///
-    /// This is the Phase-4a GC compatibility gate. Phase 4a changes no schema or
-    /// data. Every older process sharing the database/blob root must be drained
-    /// before Phase 4b performs the attachment backfill and legacy-column drop.
-    /// Phase-4a application readers/writers must also be quiesced during cutover;
-    /// only a GC-only worker has narrow compatibility with exact completed V21.
+    /// The original Phase-4a GC compatibility gate changes no schema or data
+    /// and accepts exact completed V21 only. Every older process sharing the
+    /// database/blob root must be drained before Phase 4b performs the
+    /// attachment backfill and legacy-column drop. Phase-4a application
+    /// readers/writers must also be quiesced during cutover; only a GC-only
+    /// worker has narrow compatibility with exact completed V21. An older
+    /// Phase-4a worker presented with V22 safely refuses it as ahead. Current
+    /// Canonical `(22, "embedding_space_shadow_stage")` only adds dormant
+    /// embedding-registry staging and does not relax the
+    /// V21 physical liveness fence.
     /// Callers must not fall back to [`Self::orphan_sweep`] or [`Self::delete`]
     /// when this gate refuses.
     ///

--- a/docs/adr/ADR-015-schema-migrations.md
+++ b/docs/adr/ADR-015-schema-migrations.md
@@ -3,7 +3,8 @@
 **Status**: accepted\
 **Date**: 2026-05-23\
 **Authors**: khive maintainers
-**Amended by**: [ADR-062](ADR-062-fts-ann-consolidation.md), which adds schema version 4.
+**Amended by**: [ADR-062](ADR-062-fts-ann-consolidation.md), which adds schema version 4;
+[ADR-160](ADR-160-shared-pack-infrastructure.md), which governs coordinated V21 and dormant V22.
 
 ## Context
 
@@ -149,6 +150,7 @@ above remains the historical pre-consolidation record.
 |     V19 | #1649              | list_cursor_backfill_repair        | shipped |
 |     V20 | ADR-091 / #1850    | blob_gc_claims                     | shipped |
 |     V21 | ADR-121 / ADR-160  | attachments_first_class            | shipped |
+|     V22 | ADR-160 D6         | embedding_space_shadow_stage       | shipped |
 
 > **V9 record (2026-07-18)**: `entities_name_ci_index` (ADR-104) ships in the `MIGRATIONS`
 > array as `009-entities-name-ci-index.sql`; its status here was `claimed`, stale from ADR-104,
@@ -199,6 +201,20 @@ above remains the historical pre-consolidation record.
 > inserted only in the final transaction that swaps claim fences and drops
 > `entities.content_ref`.
 
+> **V22 record (2026-08-17, ADR-160 D6 Phase 7a)**:
+> `embedding_space_shadow_stage` is an additive, dormant migration. It creates
+> `_embedding_models_v22_shadow`, `_embedding_model_legacy_provenance`, and
+> `_embedding_space_cutover_state`; maps every valid legacy registry tuple to
+> exact `khive.legacy-embedding-space.v1` provenance; and records
+> `legacy_staged`. The existing `_embedding_models` table remains the live
+> serving registry. V22 does not change provider registration, vector rows or
+> tables, ANN state, caches, pending logs, replay watermarks, or reopen lookup.
+> It is staging for a later coordinated rebuild/cutover, not completion of
+> ADR-160 Phase 7.
+> A metadata-only preflight bounds the legacy registry at 4,096 rows, individual
+> identity/provenance values, and a 16 MiB weighted staging payload before V22
+> materializes legacy values or creates any shadow object.
+
 > **Phase 4a compatibility record (2026-08-16, ADR-111 / ADR-160)**: the
 > separately deployed GC compatibility epoch gate does not add attachments,
 > backfill data, dual-read or dual-write, or record V21. It leaves every V20
@@ -241,6 +257,30 @@ The current implementation has these boundaries:
   hydration when legacy V20 application evidence requires it. `db check`
   remains read-only and reports the targeted ledger state without constructing
   a runtime or completing V21.
+
+### 2026-08-17 implementation qualification — dormant V22 follow-through
+
+This qualification preserves V21's attachment cutover and the original Phase-4a rollout record;
+it describes the next live schema epoch rather than redefining that history.
+
+- Completed V21 attachment schema, marker, ledger row, and claim fences remain
+  the physical blob-liveness prerequisite at V22. Exact-current validation
+  rechecks that V21 state for every recognized version at or above V21, then
+  validates V22's dormant shadow objects and `legacy_staged` singleton.
+- A legacy V20 host coordinator does not return immediately after recording
+  V21. It releases the non-reentrant database-GC owner, applies ordinary V22,
+  and returns only after exact-current V22 validation. An interrupted V21
+  resumes through the same boundary.
+- This binary's filesystem transactional GC admits only the closed, known-safe
+  epoch range V21 through canonical `(22, "embedding_space_shadow_stage")`, while still requiring the complete V21 physical
+  fence. V22 is safe because it does not change attachment liveness. An unknown
+  V23 or later epoch is refused before root locking, filesystem walking, or
+  abandoned-claim recovery. Conversely, the older Phase-4a binary sees V22 as
+  ahead of its exact-V21 contract and refuses GC, which is safe fail-closed
+  behavior rather than mixed-version support.
+- Low-level prepared-runtime construction requires this binary's exact current
+  schema. A physically complete V21 database is valid attachment history but is
+  behind V22 and cannot be served through that seam.
 
 > **Invariant**: ADR number order and migration version order are independent. Migration versions reflect schema ledger assignment order. A migration may only depend on schema created by earlier versions.
 
@@ -559,20 +599,21 @@ own concurrency model.
 
 Pool-level coordination (`ConnectionPool` in `khive-db`) ensures that each
 migration transaction owns the writer. The async host coordinator completes
-schema/V21 work before it exposes service connections; the explicit
+schema/V21/V22 work before it exposes service connections; the explicit
 `kkernel db migrate` command likewise runs its planned target set to completion
 before returning.
 
 ### Schema diagnostics
 
 `kkernel db check` reports every targeted backend's schema ledger and validates
-an exact current V21 state without applying changes:
+the exact current V22 state, including its completed V21 physical prerequisite,
+without applying changes:
 
 ```text
 $ kkernel db check
-main:    V21 (current)
-lore:    V20 (behind: V21 pending)
-archive: V21 (current)
+main:    V22 (current)
+lore:    V20 (behind: V21 pending; V22 follows)
+archive: V21 (behind: V22 pending)
 ```
 
 `kkernel db check --strict` exits nonzero if any planned target is behind,
@@ -637,6 +678,8 @@ Migrations are operationally significant and never run because an agent invoked
 a pack verb. The trusted host owns them before it exposes dispatch. V21 further
 requires an explicit coordinator that retains GC ownership, authenticates
 application evidence, and fails startup rather than serving a partial state.
+After V21 releases that ownership, the same tracked coordinator advances the
+ordinary dormant V22 stage before returning.
 
 Operators who need preflight control can still run config-aware
 `kkernel db check --strict` and `kkernel db migrate` in CI/CD, a maintenance
@@ -657,16 +700,16 @@ the codebase's migration set is global, but applied state is per-file.
 
 ## Alternatives Considered
 
-| Alternative                                      | Why rejected                                                                                             |
-| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
-| `PRAGMA user_version` only                       | No audit trail, no names, no migration history.                                                          |
-| `CREATE TABLE IF NOT EXISTS` only                | Cannot evolve schema (no ALTER), no ordering, no audit.                                                  |
-| External migration tool (sqlx-migrate, refinery) | Heavy dependency; sqlx doesn't fit the trait-only model; we already wrote this.                          |
-| Down migrations + reversal                       | Doubles maintenance; snapshots cover the use case.                                                       |
-| Uncoordinated eager migration at startup         | Operationally dangerous; current host boot uses an explicit ordered coordinator and durable V21 staging. |
-| Single global version across all backends        | Breaks under multi-file federation with independent backend lifecycles.                                  |
-| Pack-owned versioned migrations in v1            | Adds machinery for an unproven case; pack tables work via idempotent CREATE IF NOT EXISTS.               |
-| All migrations in one transaction                | A single failure rolls back all prior migrations; wasted work and recovery confusion.                    |
+| Alternative                                      | Why rejected                                                                                                 |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| `PRAGMA user_version` only                       | No audit trail, no names, no migration history.                                                              |
+| `CREATE TABLE IF NOT EXISTS` only                | Cannot evolve schema (no ALTER), no ordering, no audit.                                                      |
+| External migration tool (sqlx-migrate, refinery) | Heavy dependency; sqlx doesn't fit the trait-only model; we already wrote this.                              |
+| Down migrations + reversal                       | Doubles maintenance; snapshots cover the use case.                                                           |
+| Uncoordinated eager migration at startup         | Operationally dangerous; current host boot uses an explicit ordered coordinator and durable V21/V22 staging. |
+| Single global version across all backends        | Breaks under multi-file federation with independent backend lifecycles.                                      |
+| Pack-owned versioned migrations in v1            | Adds machinery for an unproven case; pack tables work via idempotent CREATE IF NOT EXISTS.                   |
+| All migrations in one transaction                | A single failure rolls back all prior migrations; wasted work and recovery confusion.                        |
 
 ## Consequences
 
@@ -688,7 +731,8 @@ the codebase's migration set is global, but applied state is per-file.
   Mitigated: ADR-010 versioning is the rollback story; the dev path is drop+remigrate.
 - Starting a newer production host may perform schema writes before serving.
   Mitigated: the async coordinator fails closed, V21 staging is durable and
-  resumable, and `kkernel db check --strict` remains available for CI preflight.
+  resumable, dormant V22 is atomic, and `kkernel db check --strict` remains
+  available for CI preflight.
 - Pack tables can't evolve through `ALTER` in v1.
   Mitigated: deferred until a concrete pack use case justifies the machinery.
 - A buggy migration can lock progress until fixed and shipped as a new version.
@@ -703,7 +747,8 @@ the codebase's migration set is global, but applied state is per-file.
 - `_schema_migrations` table is created lazily on first `run_migrations` call;
   it is not part of V1.
 - Writable file-backed and in-memory host boot both apply the ordinary prefix;
-  an empty database can take V21's atomic zero-reference fast path.
+  an empty database can take V21's atomic zero-reference fast path and continue
+  directly to dormant V22.
 
 ## Implementation
 
@@ -715,7 +760,8 @@ the codebase's migration set is global, but applied state is per-file.
   - `MIGRATIONS: &[VersionedMigration]` — contiguous, append-only.
   - `run_migrations(conn)` — applies the ordinary prefix in order and completes
     V21 only for the zero-reference fast path; legacy V20 returns at V20 for
-    host-assisted continuation.
+    host-assisted continuation. Once V21 is complete, ordinary migration applies
+    dormant V22 atomically.
   - `MIGRATION_TRACKING_TABLE` DDL for `_schema_migrations`.
 - `scripts/lint-sql.sh`:
   - Executes every `crates/**/*.sql` against an in-memory SQLite database and
@@ -730,7 +776,8 @@ the codebase's migration set is global, but applied state is per-file.
   - File-backed `KhiveRuntime::new(config)` accepts fresh/current state and
     refuses legacy application-assisted V21. MCP/kkernel async host builders
     coordinate it and construct through `from_prepared_backend` only after
-    durable completion.
+    durable V21 completion and exact-current V22 validation. The low-level
+    prepared seam never treats completed-but-behind V21 as current.
 - `khive-storage::Pack` trait (ADR-017, Pack Standard): adds `fn schema_plan(&self) ->
   SchemaPlan` for pack-auxiliary tables. Applied during pack registration.
 

--- a/docs/adr/ADR-111-blob-store.md
+++ b/docs/adr/ADR-111-blob-store.md
@@ -3,14 +3,14 @@
 **Status**: accepted
 **Date**: 2026-07-12 (amended 2026-07-13, PR #922; Amendment 2 accepted and implemented
 2026-07-17, PR #1054; Amendment 3
-accepted 2026-07-17; Amendment 4 accepted 2026-07-19; attachment-GC compatibility epoch proposed
-2026-08-16 by ADR-160)
+accepted 2026-07-17; Amendment 4 accepted 2026-07-19; attachment-GC compatibility epoch accepted
+2026-08-16 by ADR-160; known-safe V22 epoch qualification implemented 2026-08-17)
 **Authors**: khive maintainers
-**Amended by**: proposed [ADR-160](ADR-160-shared-pack-infrastructure.md), which requires
+**Amended by**: accepted [ADR-160](ADR-160-shared-pack-infrastructure.md), which requires
 backend-enforced bounded and digest-verified reads, retires public unbounded `get`, and implements
 ADR-121's attachment-only liveness and claim fences through a Phase-4a GC compatibility release,
 mandatory fleet convergence/drain plus application-service quiescence, and boot-gated Phase-4b V21
-cutover on acceptance.
+cutover.
 **Depends on**:
 
 - [ADR-005](ADR-005-storage-capability-traits.md) — Storage Capability Traits (trait-only capability
@@ -325,6 +325,18 @@ worker is safe on exact completed V21, but that narrow property is not general s
 compatibility. Start the Phase-4b service fleet only after exact-current topology validation. This
 intentionally pauses transactional GC on V20 during the compatibility epoch; operators must budget
 capacity rather than weaken the fence.
+
+**Known-safe V22 qualification (implemented 2026-08-17, ADR-160 Phase 7a).** The Phase-4a
+paragraphs above remain the historical contract of that independently released binary: it accepts
+only exact completed V21. The current binary retains completed V21 as the physical liveness fence
+but admits transactional GC when the latest ledger is exact V21 or canonical
+`(22, "embedding_space_shadow_stage")`.
+V22 (`embedding_space_shadow_stage`) only records dormant embedding-registry shadow/provenance
+state; it does not change attachments, claims, liveness, or any live registry/provider/vector/ANN/
+cache/log path. Every sweep still revalidates the complete V21 marker, schema, and functional claim
+fences. A foreign same-number V22 or unknown V23-or-later epoch is refused before root locking, filesystem walking, or
+abandoned-claim recovery. An older Phase-4a binary presented with V22 likewise treats it as ahead
+of its exact-V21 contract and refuses GC, so the downgrade direction remains fail closed.
 
 This yields two concurrency guarantees pinned by tests. A blob published after candidate capture
 is not in the sweep set and survives. A committed attachment reference cannot appear between the
@@ -796,9 +808,10 @@ unauthenticated callers, or telemetry that leaves the deployment boundary.
   `crates/khive-mcp/src/serve.rs` — config-aware blob-store selection and boot wiring from PR #1054;
   no provider type enters `khive-storage`.
 - `crates/khive-storage/src/blob.rs` and `crates/khive-db/src/stores/blob.rs` — provider-neutral
-  transactional sweep contract and filesystem implementation; the Phase-4a epoch gate refuses V20
-  and every incomplete/malformed V21 combination in both modes, while exact completed V21
-  anti-joins `attachments` and validates attachment/claim refs.
+  transactional sweep contract and filesystem implementation; the current epoch gate refuses V20,
+  every incomplete/malformed V21 combination, and unknown V23-or-later schemas in both modes. It
+  admits only the known-safe V21..=V22 range after revalidating completed V21, then anti-joins
+  `attachments` and validates attachment/claim refs.
 - `crates/khive-db/sql/010-entities-content-ref.sql` — historical V10 column introduced by this
   ADR; V21 removes it after backfill.
 - `crates/khive-db/sql/021-attachments-stage.sql` and

--- a/docs/adr/ADR-160-shared-pack-infrastructure.md
+++ b/docs/adr/ADR-160-shared-pack-infrastructure.md
@@ -1,6 +1,6 @@
 # ADR-160: Shared Pack Infrastructure Program
 
-**Status**: proposed\
+**Status**: accepted\
 **Date**: 2026-08-16\
 **Authors**: khive maintainers\
 **Depends on**:
@@ -41,7 +41,7 @@
   Lattice while preserving byte/event identities, and anchor the existing FANN object under
   ADR-121 role `"fann-network"` with authenticated cross-checks
 
-**Supersedes**: [ADR-155](ADR-155-pack-artifact-ingest-blobstore.md) in full on acceptance.\
+**Supersedes**: [ADR-155](ADR-155-pack-artifact-ingest-blobstore.md) in full.\
 **Related**: proposed [ADR-156](ADR-156-named-vector-restart-durability.md), whose restart and
 honest-underfill concerns remain useful but whose identity and materialization assumptions must be
 rebased on this record before ratification.
@@ -595,6 +595,37 @@ does not dual-read or fuse cosine scores across different identities.
 `NamedVectorIdentity` and sanitized-name-derived physical keys are deleted in the same program.
 There is no alias or compatibility constructor.
 
+#### 2026-08-17 implementation qualification — V22 dormant shadow stage
+
+The first independently safe slice of Phase 7 has shipped as core migration V22,
+`embedding_space_shadow_stage`. V22 creates `_embedding_models_v22_shadow`,
+`_embedding_model_legacy_provenance`, and `_embedding_space_cutover_state`; validates and maps each
+legacy tuple through the exact `khive.legacy-embedding-space.v1` digest; preserves every legacy
+registry lifecycle field and the opaque source tuple; and commits the singleton as
+`legacy_staged`. Invalid dimensions, model labels, SQLite types, or duplicate derived keys roll the
+whole migration back with no V22 ledger row or partial shadow schema.
+
+Before creating the shadow schema, V22 performs a metadata-only resource preflight. It accepts at
+most 4,096 legacy rows, bounds `engine_name` and `key_version` at 4,096 bytes, `model_id` at 512
+bytes, and opaque `canonical_key` at 65,536 bytes, requires UUID-shaped 16-byte identifiers, and
+caps the weighted copied/generated staging payload at 16 MiB. Over-limit evidence fails atomically
+before any legacy TEXT/BLOB is materialized in Rust or any V22 DDL is written.
+
+This is deliberately dormant. `_embedding_models` remains the sole live registry, and no provider,
+vector table or row, ANN segment/snapshot, cache, pending log, replay watermark, or reopen lookup
+reads the V22 shadow or a staged `legacy_...` key. V22 neither relabels old vectors nor performs the
+provider-bound rebuild, parity validation, lifecycle transition, or atomic publication required by
+the rest of Phase 7. The desired cutover contract above remains normative and unimplemented.
+
+V21's completed attachment marker, schema, and claim fences remain the physical blob-liveness
+foundation. A legacy V20 coordinator now completes V21, releases the database-GC owner, advances
+ordinary migration through V22, and verifies exact current state before it returns or constructs a
+prepared runtime. The current filesystem GC implementation admits only the recognized safe schema
+range V21 through the canonical `(22, "embedding_space_shadow_stage")` ledger row after
+revalidating the complete V21 fence; a foreign same-number row and every V23-or-later epoch fail
+closed before root locking or filesystem work. The older Phase-4a binary still accepts exact V21
+only, so it sees V22 as ahead and safely refuses GC.
+
 ### D7 — Pairwise numerical fitting moves literally to lattice-tune
 
 The deterministic numerical portion of ADR-149 moves to the existing `lattice-tune` crate under a
@@ -923,6 +954,10 @@ Each phase, including each named Phase-4 subphase, lands in a reviewable PR/rele
 rollback boundary. No later phase is required to make an earlier merged phase safe. Removal of the
 old path occurs in the same subphase that closes its last consumer.
 
+As of 2026-08-17, V22 is only the additive dormant-staging slice described in the D6 implementation
+qualification. It is a rollback boundary within item 7, not evidence that the text-vector cutover
+or Phase 7 as a whole is complete.
+
 ## Required verification
 
 ### Blob and runtime resource safety
@@ -1019,6 +1054,12 @@ old path occurs in the same subphase that closes its last consumer.
 
 ### Embedding identity and migration
 
+- V22 is present in the canonical ledger as `embedding_space_shadow_stage`; fresh and completed-V21
+  upgrades produce only dormant shadow/provenance/state objects while `_embedding_models` remains
+  serving-authoritative.
+- Completed V21 remains physically valid at V22 and is revalidated by exact-current checks. The
+  legacy V20 coordinator reaches V22 before return; low-level prepared runtime assembly refuses a
+  completed-but-behind V21 database.
 - Moodboard canonical descriptor bytes, fingerprint, model key, response, and table selection are
   exact goldens.
 - Every registered identity protocol ships a field-mutation matrix proving that changing each of

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -51,6 +51,9 @@ on their surface. The v1 implementation builds a synthetic single-backend regist
 creates the SQLite file, and applies ordinary pending migrations. It may complete V21 only for an
 empty/fresh attachment state; a legacy V20 database requiring authenticated application backfill
 fails and must use the async MCP/kkernel host coordinator.
+After V21 is complete, ordinary migration advances to dormant V22 before runtime assembly. The
+low-level prepared-runtime seam requires this binary's exact current schema; completed V21 alone is
+now behind and is not serveable through that seam.
 So `kkernel backend list` (and `info`) can create/open/migrate the default runtime database
 (`~/.khive/khive.db`) today, on a machine where that file is absent or stale, purely as a side
 effect of listing backends.
@@ -583,6 +586,22 @@ Phase4b migration/serving support is a follow-up and is not present in the Phase
 positive completed-V21 Phase4a GC regression exists to prove the compatibility fence itself; it is
 not an operator command or authorization to keep Phase4a application traffic live during cutover.
 
+#### Current binary: dormant V22 after the V21 cutover
+
+The historical Phase4a release above still accepts only exact completed V21. The current binary's
+latest core migration is V22, `embedding_space_shadow_stage`. It adds only dormant embedding-model
+shadow, legacy-provenance, and cutover-state tables; `_embedding_models` remains authoritative and
+provider/vector/ANN/cache/log serving behavior does not change. This is a staging slice, not a
+completed ADR-160 Phase 7 text-vector cutover.
+
+Because V22 leaves attachment liveness unchanged, current transactional filesystem GC accepts only
+V21 or canonical `(22, "embedding_space_shadow_stage")`, always after revalidating the completed
+V21 marker, physical schema, and functional claim fences. It refuses V20 and incomplete/malformed
+V21 as before, and refuses a foreign V22 or unknown V23-or-later epoch before root locking,
+filesystem walking, or abandoned-claim recovery. An
+old Phase4a binary pointed at V22 also refuses because V22 is ahead of its exact-V21 contract; that
+fail-closed refusal is safe, but it does not make the old binary application-serving compatible.
+
 ### `db migrate` / `db check`
 
 ```bash
@@ -596,7 +615,8 @@ configured topology and `--backend <name>` selects a declared backend. Migration
 deduplicates physical aliases, inventories and advances every distinct secondary
 before canonical `main`, then conditionally resolves bounded hydration when
 legacy V20 moodboard evidence must be authenticated and finalizes the resumable
-V21 attachment/GC cutover. Exact-current paths and migrations without legacy
+V21 attachment/GC cutover. After releasing the database-GC owner, it advances
+ordinary migration through dormant V22 before returning. Exact-current paths and migrations without legacy
 moodboard model evidence do not resolve a BlobStore. Selecting a non-main
 secondary advances only that empty-authority target; selecting `main` (or a
 physical alias of it) retains all secondary prerequisites. With no declared
@@ -626,7 +646,7 @@ literal name `main` carries main's prerequisite plan. Migration result rows mark
 targets, while physically distinct secondaries are prerequisites.
 
 `--strict` turns behind, ahead-of-build, or an invalid exact-current schema
-(including an inconsistent V21 marker/fence state) into a nonzero exit via
+(including an inconsistent V21 marker/fence state or invalid V22 shadow state) into a nonzero exit via
 `anyhow::bail!`.
 
 #### V21 two-release rollout (mandatory)
@@ -660,10 +680,12 @@ shipping the GC gate and column drop as one fleet rollout is unsafe.
    secondaries first; any recoverable attachment authority there blocks main.
    Main then stages/backfills, verifies pack-owned evidence, swaps liveness and
    claim fences, drops `entities.content_ref`, and records V21 atomically at
-   finalization. A normal Phase-4b host boot can start the same migration, so
+   finalization. It then releases GC ownership and advances dormant V22 before
+   returning. A normal Phase-4b host boot can start the same migration, so
    keep the serving fleet stopped and use the controlled admin path for cutover.
 6. Run `kkernel db check --config <path> --strict --human` and require every
-   planned target to report the exact current schema before starting the
+   planned target to report exact current V22, including valid completed-V21
+   physical fences and `legacy_staged` V22 state, before starting the
    Phase-4b serving fleet. A pending, incomplete, or malformed marker remains
    fail-closed for serving and GC; curate the reported evidence and rerun the
    coordinator rather than bypassing it.


### PR DESCRIPTION
## Stack

- Depends on #2017.
- Implements the independently safe dormant preparation slice of accepted ADR-160 Phase 7.

## Scope

- Adds canonical V22 migration `embedding_space_shadow_stage` with private shadow, legacy-provenance, and cutover-state tables.
- Stages deterministic legacy embedding-space identities while preserving the canonical `_embedding_models` registry as the only serving authority.
- Bounds row count, per-field bytes, and aggregate staging payload before materialization; reuses prepared inserts inside one atomic migration transaction.
- Revalidates the complete V21 attachment/GC fence before V22 staging and on exact-current startup.
- Advances V20/V21 attachment coordination to V22 without holding the DB-GC owner across blocking migration work.
- Lets destructive GC admit only canonical known-safe V21 or V22 ledgers; foreign V22 names and V23+ fail closed.

## Explicit non-goals

- No live provider registry replacement.
- No vector-table, ANN, cache, segment, watermark, pending-log, or daemon identity cutover.
- No activation of shadow rows. Existing provider and retrieval paths remain byte-for-byte authoritative.

## Verification

- `RUSTC_WRAPPER= cargo test -p khive-db -j4 v22_`: 16 passed.
- `RUSTC_WRAPPER= cargo clippy -p khive-storage -p khive-db -p khive-runtime -p khive-mcp --all-targets --all-features -j4 -- -D warnings`: passed.
- `RUSTC_WRAPPER= cargo check --workspace --all-targets -j4`: passed, including kkernel.
- `cargo fmt --all -- --check`, Deno formatting, staged diff, and conflict-marker checks: passed.
- Independent schema and resource-safety reviews: PASS, no Blocker/High/Medium findings.

## Follow-up gates before Phase 7 activation

1. Lattice must expose a prepared service sealed to a complete attestation of effective artifacts, transforms, execution backend, and cache behavior.
2. ADR lineage mapping must resolve legacy `_embedding_models.engine_name` versus the operator `[[engines]].name` slot.
3. Phase 7b must rebuild fresh vector/ANN/cache state and publish it atomically; it must not adopt legacy operational state by label.

This stays draft and stacked until #2017 and the prerequisite gates are resolved.