### PR TITLE
fix(db): count writer-task BEGIN refusals

### DIFF
--- a/crates/khive-db/src/diagnostics.rs
+++ b/crates/khive-db/src/diagnostics.rs
@@ -439,7 +439,11 @@ pub fn wal_pin_attribution(_db_path: &Path, _sweep_interval: Duration) -> WalPin
 /// classes below. `writer_acquisition_timeouts` remains specific to the
 /// finite-wait pool-mutex stage; standalone SQLite failures and writer-task
 /// `BEGIN` failures have different ADR-135 F6 stages and are not mislabeled as
-/// pool checkout timeouts. `audit_append_failures` is supplied by the runtime
+/// pool checkout timeouts. Those stages now carry their OWN failure counters
+/// (`writer_task_begin_busy`, `writer_task_begin_errors`) rather than being
+/// absent: refusing to mislabel a failure is not a reason to omit it, and an
+/// omitted failure counter fails toward looking healthy, which is the reading
+/// an operator believes. `audit_append_failures` is supplied by the runtime
 /// because the audit store lives above `khive-db`; direct `khive-db` callers
 /// receive `None` plus an explicit reason instead of a fabricated zero.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -455,6 +459,14 @@ pub struct WriterContentionDiagnostics {
     pub writer_task_acquisitions: u64,
     /// Main-pool writer checkouts that exhausted their finite deadline.
     pub writer_acquisition_timeouts: u64,
+    /// Writer-task `BEGIN IMMEDIATE` attempts refused busy or locked. These
+    /// are the refusals a caller sees as the retryable `writer_task_begin_busy`
+    /// stage, so a nonzero value here has a matching failed request on the
+    /// caller's side rather than being visible only from inside the process.
+    pub writer_task_begin_busy: u64,
+    /// Writer-task `BEGIN IMMEDIATE` attempts that failed for a reason other
+    /// than busy or locked.
+    pub writer_task_begin_errors: u64,
     /// Process-wide audit appends whose errors were logged and swallowed.
     pub audit_append_failures: Option<u64>,
     /// Why `audit_append_failures` is unavailable to this caller.
@@ -470,6 +482,8 @@ impl WriterContentionDiagnostics {
             standalone_writer_acquisitions: writer.standalone_acquisitions,
             writer_task_acquisitions: writer.writer_task_acquisitions,
             writer_acquisition_timeouts: writer.timeouts,
+            writer_task_begin_busy: writer.writer_task_begin_busy,
+            writer_task_begin_errors: writer.writer_task_begin_errors,
             audit_append_failures,
             audit_append_failures_unavailable_reason: audit_append_failures.is_none().then(|| {
                 "runtime audit instrumentation was not supplied to khive-db diagnostics".to_string()

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -625,6 +625,13 @@ pub struct WriterAcquisitionSnapshot {
     pub writer_task_acquisitions: u64,
     /// Finite-wait pool writer checkouts that exhausted their deadline.
     pub timeouts: u64,
+    /// Writer-task `BEGIN IMMEDIATE` attempts refused busy or locked. Counted
+    /// separately from `timeouts` because that counter names the pool-mutex
+    /// checkout stage; folding the two would mislabel the stage.
+    pub writer_task_begin_busy: u64,
+    /// Writer-task `BEGIN IMMEDIATE` attempts that failed for a reason other
+    /// than busy or locked, and so surface as `StorageError::Pool`.
+    pub writer_task_begin_errors: u64,
 }
 
 /// Atomics backing [`WriterAcquisitionSnapshot`]. The writer task retains an
@@ -636,11 +643,31 @@ pub(crate) struct WriterAcquisitionCounters {
     standalone_acquisitions: AtomicU64,
     writer_task_acquisitions: AtomicU64,
     pooled_timeouts: AtomicU64,
+    writer_task_begin_busy: AtomicU64,
+    writer_task_begin_errors: AtomicU64,
 }
 
 impl WriterAcquisitionCounters {
     pub(crate) fn record_writer_task_acquisition(&self) {
         self.writer_task_acquisitions
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Records one writer-task `BEGIN IMMEDIATE` refused busy or locked.
+    ///
+    /// Callers classify by matching the value `writer_task_begin_error`
+    /// returned rather than re-testing the `rusqlite::Error`, so the busy
+    /// rule has exactly one home and the counter cannot drift from the
+    /// error the caller is actually told about.
+    pub(crate) fn record_writer_task_begin_busy(&self) {
+        self.writer_task_begin_busy.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Records one writer-task `BEGIN IMMEDIATE` that failed for any other
+    /// reason. Without this the non-busy arm reproduces, one level down, the
+    /// same silent-failure gap the busy counter closes.
+    pub(crate) fn record_writer_task_begin_error(&self) {
+        self.writer_task_begin_errors
             .fetch_add(1, Ordering::Relaxed);
     }
 
@@ -656,6 +683,8 @@ impl WriterAcquisitionCounters {
             standalone_acquisitions,
             writer_task_acquisitions,
             timeouts: self.pooled_timeouts.load(Ordering::Relaxed),
+            writer_task_begin_busy: self.writer_task_begin_busy.load(Ordering::Relaxed),
+            writer_task_begin_errors: self.writer_task_begin_errors.load(Ordering::Relaxed),
         }
     }
 }
@@ -3292,6 +3321,8 @@ mod tests {
                 standalone_acquisitions: 1,
                 writer_task_acquisitions: 0,
                 timeouts: 0,
+                writer_task_begin_busy: 0,
+                writer_task_begin_errors: 0,
             },
             "the public standalone boundary must contribute to the aggregate exactly once"
         );
@@ -3358,6 +3389,11 @@ mod tests {
                 standalone_acquisitions: 0,
                 writer_task_acquisitions: 0,
                 timeouts: 1,
+                // A pool-mutex checkout timeout must NOT bleed into the
+                // writer-task BEGIN counters: separate stages, separate
+                // counters. This is the mislabeling guard in assertion form.
+                writer_task_begin_busy: 0,
+                writer_task_begin_errors: 0,
             }
         );
 
@@ -3371,6 +3407,8 @@ mod tests {
                 standalone_acquisitions: 0,
                 writer_task_acquisitions: 0,
                 timeouts: 1,
+                writer_task_begin_busy: 0,
+                writer_task_begin_errors: 0,
             }
         );
     }

--- a/crates/khive-db/src/writer_task.rs
+++ b/crates/khive-db/src/writer_task.rs
@@ -976,9 +976,22 @@ async fn run_writer_task(
                         // it before waking the caller for the same reply-side
                         // lifecycle guarantee as successful requests (#1790).
                         drop(tx_span);
+                        // Count the refusal the caller is about to be told
+                        // about. Classify by matching the value the shared
+                        // classifier returned, never by re-testing `e`: a
+                        // second copy of the busy rule here could drift from
+                        // the error actually replied, and the counter would
+                        // then disagree with the caller's own experience.
+                        let begin_error = writer_task_begin_error(e, busy_timeout);
+                        match &begin_error {
+                            StorageError::WriterTaskBusy { .. } => {
+                                acquisition_counters.record_writer_task_begin_busy()
+                            }
+                            _ => acquisition_counters.record_writer_task_begin_error(),
+                        }
                         sealed::Sealed::reply_error_after_begin(
                             request,
-                            writer_task_begin_error(e, busy_timeout),
+                            begin_error,
                             queue_wait,
                             transaction_acquire,
                         );
@@ -1363,6 +1376,99 @@ mod tests {
         assert_eq!(
             count, 1,
             "the failed request must not land, while the next request commits on the same task"
+        );
+    }
+
+    // `#[serial(tx_registry)]`: same rationale as
+    // `begin_immediate_failure_replies_error_without_running_op`.
+    #[tokio::test]
+    #[serial(tx_registry)]
+    async fn contended_begin_increments_its_own_failure_counter() {
+        // Real contention, same construction as the test above: a refused
+        // write must be COUNTED, not merely reported to its caller. Before
+        // this counter, `db_diagnostics` showed a clean writer while requests
+        // were being refused after a full busy timeout, so an operator could
+        // not distinguish this daemon from one that had never refused a write.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("writer_task_begin_busy_counter.db");
+        let cfg = PoolConfig {
+            path: Some(path.clone()),
+            busy_timeout: Duration::from_millis(150),
+            ..PoolConfig::default()
+        };
+        let pool = ConnectionPool::new(cfg).unwrap();
+        {
+            let writer = pool.try_writer().unwrap();
+            writer
+                .conn()
+                .execute_batch("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+                .unwrap();
+        }
+
+        let handle = spawn(&pool, 8).expect("writer task should spawn on a file-backed pool");
+
+        let before = pool.writer_acquisition_snapshot();
+        assert_eq!(
+            before.writer_task_begin_busy, 0,
+            "baseline: nothing has been refused yet"
+        );
+
+        let lock_holder = pool.try_writer().unwrap();
+        lock_holder.conn().execute_batch("BEGIN IMMEDIATE").unwrap();
+
+        let result = handle
+            .send(|conn| {
+                conn.execute("INSERT INTO t (id) VALUES (1)", [])
+                    .map_err(|e| StorageError::Pool {
+                        operation: "test_insert".into(),
+                        message: e.to_string(),
+                    })
+            })
+            .await;
+        assert!(
+            matches!(&result, Err(StorageError::WriterTaskBusy { .. })),
+            "precondition: the request must actually be refused busy, got {result:?}"
+        );
+
+        let after = pool.writer_acquisition_snapshot();
+        assert_eq!(
+            after.writer_task_begin_busy, 1,
+            "the refusal the caller was told about must appear in the counters"
+        );
+        assert_eq!(
+            after.writer_task_begin_errors, 0,
+            "a busy refusal must not be counted as a non-busy BEGIN error"
+        );
+        assert_eq!(
+            after.timeouts, before.timeouts,
+            "a writer-task BEGIN refusal must not be mislabeled as a pool-mutex \
+             checkout timeout — separate ADR-135 F6 stages, separate counters"
+        );
+
+        // Discriminating arm: a SUCCEEDING request must not move the failure
+        // counter. Without this the assertion above would also pass against a
+        // counter that simply counted every request.
+        lock_holder.conn().execute_batch("ROLLBACK").unwrap();
+        drop(lock_holder);
+        handle
+            .send(|conn| {
+                conn.execute("INSERT INTO t (id) VALUES (2)", [])
+                    .map_err(|e| StorageError::Pool {
+                        operation: "test_insert_after_busy".into(),
+                        message: e.to_string(),
+                    })
+            })
+            .await
+            .expect("the writer task survives transient contention");
+
+        let settled = pool.writer_acquisition_snapshot();
+        assert_eq!(
+            settled.writer_task_begin_busy, 1,
+            "a successful request must leave the refusal counter untouched"
+        );
+        assert!(
+            settled.writer_task_acquisitions > after.writer_task_acquisitions,
+            "and it must still register as a success"
         );
     }
 


### PR DESCRIPTION
## Problem

`writer_task.rs` classifies a failed `BEGIN IMMEDIATE` into a retryable busy
refusal (`StorageError::WriterTaskBusy`) or a non-retryable error, and returns
that classification to the caller. Neither outcome is recorded anywhere.

The writer contention diagnostics surface (`db_diagnostics`) therefore carries
no writer-side BEGIN failure count. A run in which callers are receiving
retryable refusals is indistinguishable on that surface from a run in which
nothing failed, because the absent counter and a zero counter read the same.
The doc comment on `WriterContentionDiagnostics` previously described this gap
as deliberate on the grounds that a shared counter would mislabel the failure;
that reasoning argues against reusing an existing counter, not against having
one.

## Change

- `WriterAcquisitionCounters` / `WriterAcquisitionSnapshot` gain
  `writer_task_begin_busy` and `writer_task_begin_errors`.
- The single production call site increments from the classifier's **own
  output** rather than re-deriving the busy condition, so the counter and the
  error the caller receives cannot disagree about which of the two occurred.
- `WriterContentionDiagnostics` exposes both fields; the doc comment is
  rewritten to state what the counters mean.

`writer_task_acquisition_timeouts` is untouched and keeps its current meaning.
The new counters are additive: no existing field changes value or name.

## Test

`contended_begin_increments_its_own_failure_counter` creates real lock
contention by holding a `BEGIN IMMEDIATE` from a separate writer while the
writer task attempts its own, then asserts:

1. `writer_task_begin_busy` goes 0 → 1 and `writer_task_begin_errors` stays 0
   (the classifier's two branches are distinguished, not merged);
2. `writer_task_acquisition_timeouts` is unchanged across the same window, so
   a later change cannot quietly fold the two failure modes together;
3. a subsequent **succeeding** acquisition leaves the failure counter at 1
   while `writer_task_acquisitions` advances, so the counter is shown to count
   failures rather than attempts.

The assertions were verified load-bearing by reverting the increment: the test
fails, and restoring it returns to green with no residue.

## Gates

`cargo fmt --all --check`, `cargo clippy -p khive-db --all-targets -D warnings`,
and `cargo check --workspace --all-targets` (119 crates, 0 warnings) all pass.
