### PR TITLE
docs(adr): read-path performance recovery (ADR-165) + hot-path latency regression guard (ADR-166)

### DIFF
--- a/docs/adr/ADR-165-read-path-performance-recovery.md
+++ b/docs/adr/ADR-165-read-path-performance-recovery.md
@@ -135,6 +135,12 @@ new standalone-read call site is a reviewable event, not a default.
 
 Contract:
 
+- This slice deliberately changes the failure mode under saturation: a read that
+  previously succeeded slowly through standalone-connection churn now fails fast at
+  the pool-checkout timeout. That is the intended trade — bounded, observable
+  failure instead of unbounded degradation that also starves the writer — and a
+  checkout timeout under load is this contract working, not a regression to fix by
+  reintroducing a standalone fallback.
 - Pool capacity and checkout timeout keep their existing envs. Pool exhaustion returns
   the existing timeout error and MUST NOT fall back to a standalone open — a fallback
   would reintroduce the connection churn under exactly the load that makes it harmful,

--- a/docs/adr/ADR-165-read-path-performance-recovery.md
+++ b/docs/adr/ADR-165-read-path-performance-recovery.md
@@ -263,10 +263,14 @@ Contract:
 
 - The four slices remove, respectively: writer-queue inheritance on reads (Slice 1),
   per-read connection setup plus WAL-pinning churn — which also shrinks the writer's
-  own starvation, compounding Slice 1 (Slice 2), the ~580 MB-per-query scan (Slice 3),
-  and cross-backend waste plus the structural obstacle to store splitting (Slice 4).
-- Slice 3 makes `search` results boundedly stale in the same way recall already is.
-  The staleness bound is the ADR-118 fresh-tail contract, not a new one.
+  own starvation, compounding Slice 1 (Slice 2), the ~580 MB-per-query scan for the
+  note-substrate `search` vector leg (Slice 3), and cross-backend waste plus the
+  structural obstacle to store splitting (Slice 4). Entity search is outside Slice 3:
+  it continues to pay the shared-table scan and keeps its current same-snapshot
+  freshness contract; recovering it is future work under a separate decision.
+- Slice 3 makes note-substrate `search` results boundedly stale in the same way
+  recall already is. The staleness bound is the ADR-118 fresh-tail contract, not a
+  new one. Entity search freshness is unchanged.
 - Risk concentrates in Slice 2 (connection lifecycle) and Slice 3 (ranking parity).
   Both carry route/counter observability so a production anomaly is attributable to
   the slice that caused it, and both are revertible by routing flags at their seam.

--- a/docs/adr/ADR-165-read-path-performance-recovery.md
+++ b/docs/adr/ADR-165-read-path-performance-recovery.md
@@ -25,8 +25,9 @@
 
 **Amends**:
 
-- [ADR-079](ADR-079-ann-persistence-warm-path-integration.md) — the warm ANN bridge
-  additionally serves the `search` vector leg, not only `memory.recall`
+- [ADR-079](ADR-079-ann-persistence-warm-path-integration.md) — the note-vector
+  graphs gain a second, distinctly named consumer (the note-substrate `search`
+  vector leg); the memory consumer's contract and the graphs' corpus are unchanged
 - [ADR-091](ADR-091-wal-snapshot-lifetime.md) — its reader-pin inventory's
   "standalone connection per file-backed read" population shrinks to the pooled
   reader set plus the enumerated structural exceptions
@@ -49,32 +50,56 @@ feedback loop that converts concurrency into timeouts.
 The `search` vector leg queries sqlite-vec `vec0` virtual tables directly
 (`crates/khive-db/src/stores/vectors.rs`, KNN `MATCH` query; DDL in
 `crates/khive-db/src/backend.rs`). The DDL declares no partition keys, so a KNN query
-linearly scans every chunk: at the current corpus (~189k vectors x 384 dims per model,
-two engines) that is ~290 MB read and decoded per engine, ~580 MB per query. Repetition
-appears fast only because the OS page cache absorbs the file reads; under memory
-pressure the scan cost returns and scales with system load.
+linearly scans every chunk of the whole per-model table regardless of the `kind`
+filter: at the current corpus (~189k note vectors plus ~8.5k entity vectors x 384 dims
+per model, two engines) that is ~290 MB read and decoded per engine, ~580 MB per
+query — for a note search and an entity search alike, since both substrates share the
+table. Repetition appears fast only because the OS page cache absorbs the file reads;
+under memory pressure the scan cost returns and scales with system load.
 
-The memory pack already maintains warm Vamana ANN graphs over the same vector corpus
-(ADR-079): both engine graphs persist beside the database, stay current under the
-ADR-118 fresh-tail contract, and serve `memory.recall`'s vector leg in microseconds.
-The `search` path never consults them.
+The memory pack already maintains warm Vamana ANN graphs (ADR-079) whose corpus is the
+global live-note content vectors — every namespace, `kind = 'note'`,
+`field = 'note.content'`, deletion-filtered at build (the corpus join in
+`crates/khive-pack-memory/src/ann.rs`). That is exactly the population a
+note-substrate search's vector leg needs, for both engines, current under the ADR-118
+fresh-tail contract, serving `memory.recall` in microseconds. The `search` path never
+consults these graphs. They do NOT cover entity vectors, which bounds what Slice 3
+may claim.
 
-### Mechanism 2 — read verbs write synchronously through a contended writer
+### Mechanism 2 — read verbs put writer acquisitions on, and behind, the request path
 
-Every `search` and `memory.recall` performs synchronous SQLite INSERTs before returning:
-a per-dispatch audit row, a serve-tracking event, and (recall) per-target serve-ledger
-rows. ADR-133 inventoried this population fully — in a deployed daemon **every** verb
-dispatch acquires the writer at least once — and decided the fix (batched appends
-sharing one transaction; per-call serve-ledger batching; classifier-driven
-commit-failure handling). ADR-133 has not been implemented.
+Two distinct write populations attach to a read verb, and they sit in different
+places:
 
-The new measurements convert ADR-133's contention argument from structural to observed:
-the serving daemon's log records its own writer-begin attempts failing at the full 30 s
-timeout repeatedly under ordinary concurrent load ("writer task could not begin within
-30000ms because SQLite remained busy"), and a live counter-delta experiment shows one
-`memory.recall` adding 1-4 writer-task acquisitions above the ambient baseline. A
-nominally read-only verb therefore inherits the writer queue's worst case — this is the
-dominant term in recall's latency and the mechanism behind the 150 s outlier.
+**On the request path**: the per-dispatch audit row
+(`append_audit_event_best_effort` at the dispatch layer). ADR-133's census
+established that in a deployed daemon **every** verb dispatch acquires the writer at
+least once for this row before the dispatch completes. Under writer starvation the
+append waits up to the writer-begin timeout before its failure is swallowed, so a
+nominally read-only verb carries up to that full timeout on its wall clock.
+
+**Behind the request path**: `memory.recall` schedules a detached background task
+(`track_background_task`, `crates/khive-pack-memory/src/handlers/recall.rs`)
+carrying the `brain.record_serve` serve-ledger dispatch — which, being itself a
+dispatch, appends a second audit row — and the recall-executed event. These do not
+sit on the caller's wall clock; they add writer-queue load that the _next_
+request's audit append then queues behind.
+
+ADR-133 inventoried both populations and decided the fix (batched appends sharing
+one transaction; per-call serve-ledger batching; classifier-driven commit-failure
+handling). ADR-133 has not been implemented.
+
+The new measurements convert ADR-133's contention argument from structural to
+observed: the serving daemon's log records its own writer-begin attempts failing at
+the full 30 s timeout repeatedly under ordinary concurrent load ("writer task could
+not begin within 30000ms because SQLite remained busy"), and a live counter-delta
+experiment shows one `memory.recall` adding 1-4 writer-task acquisitions to the
+process within a five-second window spanning the call and its background
+completion — consistent with one request-path audit append plus the background
+ledger/event work. The request-path exposure (audit append inheriting the writer
+queue, bounded by the writer-begin timeout) is a first-order term in recall's
+latency under load; the background population amplifies the very queue it waits
+in.
 
 ### Mechanism 3 — every file-backed store read opens a fresh standalone connection
 
@@ -97,8 +122,11 @@ The cross-backend coordinator (`crates/kkernel/src/coordinator/dispatch.rs`) fan
 `search` out to all registered backends regardless of the requested `kind`. A
 `kind=note` search also queries the session backend — a database two orders of
 magnitude larger than any result it could contribute — paying its FTS and vector cost
-on every note search. Registration knows which kinds each backend serves; the dispatch
-loop discards that information.
+on every note search. The coordinator registry stores only a backend identifier and
+runtime; no kind information exists anywhere in registration today, so the dispatch
+loop has nothing to filter on. Which kinds a backend serves is knowable from the
+pack-scoped backend configuration that wires it (ADR-028), but nothing carries that
+knowledge to the coordinator.
 
 ### Non-findings (measured and excluded)
 
@@ -118,11 +146,19 @@ the regression cannot silently return.
 
 ### Slice 1 — implement ADR-133 (batched incidental writes)
 
-Implementation order within ADR-133's decisions, chosen by measured impact: D8
-(acquisition-site instrumentation — partially landed via the writer-task begin
-counters), D1/D1a-d (batched audit appends), D7 (per-call serve-ledger batching), D2/D3
-(classifier and accounting-bearing wait), D6 (bulk read-flag form). No contract stated
-here; ADR-133 is the contract.
+Implementation order within ADR-133's decisions, chosen by measured impact, with each
+decision mapped to the write population (Mechanism 2) it addresses:
+
+- D8 (acquisition-site instrumentation — partially landed via the writer-task begin
+  counters): prerequisite for both populations.
+- D1/D1a-d (batched audit appends): the request-path population — the per-dispatch
+  audit row every verb carries, including the second audit row the background
+  `brain.record_serve` dispatch generates by being a dispatch.
+- D7 (per-call serve-ledger batching): the background population — collapses recall's
+  per-target serve-ledger acquisitions to one per call.
+- D2/D3 (classifier and accounting-bearing wait), then D6 (bulk read-flag form).
+
+No contract stated here; ADR-133 is the contract.
 
 ### Slice 2 — file-backed store reads route through pooled readers
 
@@ -148,44 +184,75 @@ Contract:
 - A pooled reader returns to the pool with no open read transaction (no WAL pin across
   checkouts). This composes with ADR-091's registry: pooled reads hold their snapshot
   for the duration of one operation, bounded by the existing read-deadline context.
-- Pooled vs standalone acquisition counters (already separated in `db_diagnostics`)
-  make the routing observable in production; the ADR-166 invariant asserts the
-  standalone counter stays flat across a read-verb suite.
+- Reader-side acquisition counters are a NEW instrumentation prerequisite of this
+  slice: `db_diagnostics` today separates pooled/standalone/writer-task acquisitions
+  on the WRITER side only and exposes no reader-open or reader-checkout counters.
+  This slice adds pooled-reader checkouts and standalone-reader opens as counters
+  (with defined reset semantics, and infrastructure opens from the closed exception
+  list attributed separately), landing before or with the routing change so the
+  route is observable in production; the ADR-166 invariant asserts the
+  standalone-reader counter stays flat across a read-verb suite.
 
-### Slice 3 — `search` vector leg served by the warm ANN bridge
+### Slice 3 — note-substrate `search` vector leg served by the warm ANN graphs
 
-`search`'s vector retrieval consults the warm Vamana graphs (ADR-079) over the shared
-vector corpus. The exact sqlite-vec scan remains solely as the explicit fallback for a
-model with no installed graph.
+Scope: the **note-substrate** vector leg of `search` only. The existing graphs'
+corpus (global live-note `note.content` vectors, every namespace, both engines) is
+the note-search population; the graphs contain no entity vectors, so entity search
+is explicitly out of this slice's scope. The entity vector corpus (~8.5k vectors)
+still pays the shared-table scan after this slice; whether it gets its own graph, a
+partitioned table, or stays on the scan is a separate follow-up decision with its
+own consumer definition — this record deliberately does not decide it.
 
-Contract:
+The note-search vector leg consults the warm Vamana graphs as a **new, named
+ADR-118 consumer** — not silent reuse of the memory consumer:
 
-- Freshness follows the existing bridge semantics (ADR-118 fresh-tail plus
-  staleness-triggered background rebuild): `search` accepts the same bounded staleness
-  `memory.recall` already accepts. This is an explicit relaxation for `search` and is
-  the trade this slice makes; a caller that requires scan-exact results has no flag —
-  exactness at 580 MB per query is the defect this record removes, not a mode to
-  preserve.
-- Namespace, kind, and visibility post-filtering are identical between routes; the ANN
-  route overfetches and post-filters exactly as recall does today.
-- Ranking stays deterministic under the ADR-006 contract: distances convert through the
-  same canonical conversion on both routes, and result ordering for equal scores keeps
-  the existing tie-break.
-- The serving route (ANN vs fallback) is recorded per query in `db_diagnostics`
-  counters so a silent permanent fallback is detectable; the ADR-166 invariant asserts
-  the fallback rate is zero on a warm store.
+- The consumer registers under its own identity with its scope predicate (global,
+  `kind = 'note'`, `field = 'note.content'`) per ADR-118's
+  registration-before-tail-dependent-read rule, and defines its watermark and
+  compaction handling with the same same-snapshot discipline as the memory
+  consumer.
+- Result visibility: search performs the ADR-118 fresh-tail merge (stale graph
+  candidates plus exact fresh-tail leg read in the same snapshot), giving
+  note-search the same read-your-writes visibility recall has. If implementation
+  instead chooses graph-only candidates without the tail merge, that weaker
+  visibility contract must be stated here and land as an ADR-118 amendment before
+  the code does — it is not an implementation detail.
+- The exact sqlite-vec scan remains solely as the explicit fallback for a model
+  with no installed graph.
+
+Contract (both routes):
+
+- Namespace, kind, and visibility post-filtering are identical between routes; the
+  ANN route overfetches and post-filters exactly as recall does today (the graphs
+  are global-scope; namespace filtering happens after candidate generation).
+- Ranking stays deterministic under the ADR-006 contract: distances convert through
+  the same canonical conversion on both routes, and result ordering for equal
+  scores keeps the existing tie-break.
+- The serving route (ANN vs fallback) is recorded per query in a NEW
+  `db_diagnostics` counter pair delivered by this slice, so a silent permanent
+  fallback is detectable; the ADR-166 invariant asserts the fallback count is zero
+  on a warm store.
+- The **Amends ADR-079** line of this record means: ADR-079 gains this second,
+  distinctly named consumer of the note-vector graphs. It does not mean the memory
+  consumer's contract changes, and it does not extend the graphs' corpus.
 
 ### Slice 4 — coordinator fan-out filtered by declared backend kinds
 
-Backend registration declares which substrate kinds each backend serves; the
-coordinator dispatch loop skips backends whose declaration cannot match the request. A
+The coordinator registry today stores only a backend identifier and runtime — no
+kind information exists at registration. This slice ADDS a served-kinds declaration
+to backend registration as new registry metadata, supplied by the same
+configuration that registers the backend (the pack-scoped backend wiring,
+ADR-028), with values drawn from the closed substrate-kind set. The dispatch loop
+then skips backends whose declaration affirmatively excludes the requested kind. A
 `kind=note` search no longer dispatches to the session backend.
 
 Contract:
 
-- The filter is a registration-time declaration, not a per-call heuristic. A backend
-  that declares nothing is conservatively included (fail-open on inclusion: the filter
-  can only skip a backend that affirmatively declared non-service of the kind).
+- The filter is a registration-time declaration, not a per-call heuristic. An ABSENT
+  declaration (backend registered without the new metadata) is conservatively
+  included; an EMPTY declaration is a configuration error rejected at registration,
+  so "declares nothing" and "declares no kinds" cannot be conflated. The filter can
+  only skip a backend whose declaration is present and excludes the kind.
 - Merged-result semantics (RRF, visibility) are unchanged for the backends that remain.
 - This slice is a prerequisite for any physical store split (for example a dedicated
   knowledge database): without it, each split adds one backend to every search's

--- a/docs/adr/ADR-165-read-path-performance-recovery.md
+++ b/docs/adr/ADR-165-read-path-performance-recovery.md
@@ -1,0 +1,215 @@
+# ADR-165: Read-Path Performance Recovery
+
+**Status**: proposed\
+**Date**: 2026-08-17\
+**Authors**: khive maintainers\
+**Depends on**:
+
+- [ADR-005](ADR-005-storage-capability-traits.md) — backend-neutral storage capabilities
+- [ADR-006](ADR-006-deterministic-scoring.md) — deterministic ranking and score conversion
+- [ADR-012](ADR-012-retrieval-composition.md) — retrieval composition ownership
+- [ADR-021](ADR-021-memory-pack.md) — memory recall contract
+- [ADR-028](ADR-028-pack-scoped-backends.md) — pack-scoped backends
+- [ADR-079](ADR-079-ann-persistence-warm-path-integration.md) — memory ANN warm path
+  (Vamana bridge, persisted segments)
+- [ADR-091](ADR-091-wal-snapshot-lifetime.md) — WAL snapshot lifetime, reader-pin
+  inventory and enforcement
+- [ADR-118](ADR-118-fresh-tail-recall-visibility.md) — ANN fresh-tail consistency
+- [ADR-133](ADR-133-incidental-writes-off-the-request-hot-path.md) — writer-acquisition
+  reduction for incidental writes (batched audit/serve appends)
+
+**Related**:
+
+- [ADR-166](ADR-166-hot-path-latency-regression-guard.md) — the regression guard that
+  pins each slice's recovered mechanism (depends on this record, not the reverse)
+
+**Amends**:
+
+- [ADR-079](ADR-079-ann-persistence-warm-path-integration.md) — the warm ANN bridge
+  additionally serves the `search` vector leg, not only `memory.recall`
+- [ADR-091](ADR-091-wal-snapshot-lifetime.md) — its reader-pin inventory's
+  "standalone connection per file-backed read" population shrinks to the pooled
+  reader set plus the enumerated structural exceptions
+
+---
+
+## Context
+
+Warm-path read latency has regressed by two to three orders of magnitude against the
+published budget (10-15 ms per unified verb): `search` measures 0.6-5 s warm and hard-fails
+at the 5 s coordinator deadline under load; `memory.recall` measures 4.9-8.6 s with a 150 s
+outlier under sustained write load. A thirteen-hypothesis investigation — live-process CPU
+accounting, connection-level source reads, on-disk index inspection, daemon log analysis,
+and a counter-delta experiment against the serving process — established four independent
+mechanisms. Each is a separate defect with its own fix; two of them close a positive
+feedback loop that converts concurrency into timeouts.
+
+### Mechanism 1 — the `search` vector leg is a full-table scan
+
+The `search` vector leg queries sqlite-vec `vec0` virtual tables directly
+(`crates/khive-db/src/stores/vectors.rs`, KNN `MATCH` query; DDL in
+`crates/khive-db/src/backend.rs`). The DDL declares no partition keys, so a KNN query
+linearly scans every chunk: at the current corpus (~189k vectors x 384 dims per model,
+two engines) that is ~290 MB read and decoded per engine, ~580 MB per query. Repetition
+appears fast only because the OS page cache absorbs the file reads; under memory
+pressure the scan cost returns and scales with system load.
+
+The memory pack already maintains warm Vamana ANN graphs over the same vector corpus
+(ADR-079): both engine graphs persist beside the database, stay current under the
+ADR-118 fresh-tail contract, and serve `memory.recall`'s vector leg in microseconds.
+The `search` path never consults them.
+
+### Mechanism 2 — read verbs write synchronously through a contended writer
+
+Every `search` and `memory.recall` performs synchronous SQLite INSERTs before returning:
+a per-dispatch audit row, a serve-tracking event, and (recall) per-target serve-ledger
+rows. ADR-133 inventoried this population fully — in a deployed daemon **every** verb
+dispatch acquires the writer at least once — and decided the fix (batched appends
+sharing one transaction; per-call serve-ledger batching; classifier-driven
+commit-failure handling). ADR-133 has not been implemented.
+
+The new measurements convert ADR-133's contention argument from structural to observed:
+the serving daemon's log records its own writer-begin attempts failing at the full 30 s
+timeout repeatedly under ordinary concurrent load ("writer task could not begin within
+30000ms because SQLite remained busy"), and a live counter-delta experiment shows one
+`memory.recall` adding 1-4 writer-task acquisitions above the ambient baseline. A
+nominally read-only verb therefore inherits the writer queue's worst case — this is the
+dominant term in recall's latency and the mechanism behind the 150 s outlier.
+
+### Mechanism 3 — every file-backed store read opens a fresh standalone connection
+
+The file-backed read arm of every store (text, vectors, note, entity, graph, event)
+calls `open_standalone_reader` per read. The pooled readers
+(`ConnectionPool::reader`, pre-opened at init) are reached only by the non-file-backed
+arm. ADR-091 documented this posture while deliberately leaving connection-acquisition
+strategy untouched (its subject was transaction lifetime, not routing).
+
+Costs, per read: connection setup and a cold SQLite page cache; across the process: a
+churning population of standalone read connections whose WAL snapshots pin checkpoint
+progress. The daemon log shows the consequence: sustained WAL pressure past the
+high-water mark with PASSIVE checkpoints unable to reclaim. Pinned WAL grows writer
+work, which lengthens the writer queue, which — via Mechanism 2 — lengthens reads. This
+is the feedback loop.
+
+### Mechanism 4 — coordinator search fans out to every backend unconditionally
+
+The cross-backend coordinator (`crates/kkernel/src/coordinator/dispatch.rs`) fans
+`search` out to all registered backends regardless of the requested `kind`. A
+`kind=note` search also queries the session backend — a database two orders of
+magnitude larger than any result it could contribute — paying its FTS and vector cost
+on every note search. Registration knows which kinds each backend serves; the dispatch
+loop discards that information.
+
+### Non-findings (measured and excluded)
+
+Query embedding (cached; embedding threads parked under load), dispatch-layer overhead
+(sub-millisecond), per-request engine re-initialization (none), and recall's ANN leg
+itself (warm, current, zero degradation warnings all day) contribute nothing
+measurable. Fix effort spent on those layers is spent where the measurements show no
+cost.
+
+## Decision
+
+A four-slice recovery program. Slice 1 is ADR-133, unchanged, elevated to first
+implementation slot by the measurements above — this record adds no new decision to it.
+Slices 2-4 are the decisions of this record. Each slice is independently shippable,
+independently revertible, and lands together with its ADR-166 mechanism invariant so
+the regression cannot silently return.
+
+### Slice 1 — implement ADR-133 (batched incidental writes)
+
+Implementation order within ADR-133's decisions, chosen by measured impact: D8
+(acquisition-site instrumentation — partially landed via the writer-task begin
+counters), D1/D1a-d (batched audit appends), D7 (per-call serve-ledger batching), D2/D3
+(classifier and accounting-bearing wait), D6 (bulk read-flag form). No contract stated
+here; ADR-133 is the contract.
+
+### Slice 2 — file-backed store reads route through pooled readers
+
+The file-backed read arm of every store routes through `ConnectionPool::reader`.
+`open_standalone_reader` remains only for enumerated structural exceptions: boot-time
+schema probing, diagnostics that must observe an independent snapshot
+(`db_diagnostics`), and any path ADR-091 already binds to a standalone connection by
+documented constraint. The exception list is closed and lives at the pool surface; a
+new standalone-read call site is a reviewable event, not a default.
+
+Contract:
+
+- Pool capacity and checkout timeout keep their existing envs. Pool exhaustion returns
+  the existing timeout error and MUST NOT fall back to a standalone open — a fallback
+  would reintroduce the connection churn under exactly the load that makes it harmful,
+  invisibly.
+- A pooled reader returns to the pool with no open read transaction (no WAL pin across
+  checkouts). This composes with ADR-091's registry: pooled reads hold their snapshot
+  for the duration of one operation, bounded by the existing read-deadline context.
+- Pooled vs standalone acquisition counters (already separated in `db_diagnostics`)
+  make the routing observable in production; the ADR-166 invariant asserts the
+  standalone counter stays flat across a read-verb suite.
+
+### Slice 3 — `search` vector leg served by the warm ANN bridge
+
+`search`'s vector retrieval consults the warm Vamana graphs (ADR-079) over the shared
+vector corpus. The exact sqlite-vec scan remains solely as the explicit fallback for a
+model with no installed graph.
+
+Contract:
+
+- Freshness follows the existing bridge semantics (ADR-118 fresh-tail plus
+  staleness-triggered background rebuild): `search` accepts the same bounded staleness
+  `memory.recall` already accepts. This is an explicit relaxation for `search` and is
+  the trade this slice makes; a caller that requires scan-exact results has no flag —
+  exactness at 580 MB per query is the defect this record removes, not a mode to
+  preserve.
+- Namespace, kind, and visibility post-filtering are identical between routes; the ANN
+  route overfetches and post-filters exactly as recall does today.
+- Ranking stays deterministic under the ADR-006 contract: distances convert through the
+  same canonical conversion on both routes, and result ordering for equal scores keeps
+  the existing tie-break.
+- The serving route (ANN vs fallback) is recorded per query in `db_diagnostics`
+  counters so a silent permanent fallback is detectable; the ADR-166 invariant asserts
+  the fallback rate is zero on a warm store.
+
+### Slice 4 — coordinator fan-out filtered by declared backend kinds
+
+Backend registration declares which substrate kinds each backend serves; the
+coordinator dispatch loop skips backends whose declaration cannot match the request. A
+`kind=note` search no longer dispatches to the session backend.
+
+Contract:
+
+- The filter is a registration-time declaration, not a per-call heuristic. A backend
+  that declares nothing is conservatively included (fail-open on inclusion: the filter
+  can only skip a backend that affirmatively declared non-service of the kind).
+- Merged-result semantics (RRF, visibility) are unchanged for the backends that remain.
+- This slice is a prerequisite for any physical store split (for example a dedicated
+  knowledge database): without it, each split adds one backend to every search's
+  fan-out and makes latency strictly worse. With it, a split changes which backends
+  serve which kinds, and fan-out cost follows the declaration.
+
+## Consequences
+
+- The four slices remove, respectively: writer-queue inheritance on reads (Slice 1),
+  per-read connection setup plus WAL-pinning churn — which also shrinks the writer's
+  own starvation, compounding Slice 1 (Slice 2), the ~580 MB-per-query scan (Slice 3),
+  and cross-backend waste plus the structural obstacle to store splitting (Slice 4).
+- Slice 3 makes `search` results boundedly stale in the same way recall already is.
+  The staleness bound is the ADR-118 fresh-tail contract, not a new one.
+- Risk concentrates in Slice 2 (connection lifecycle) and Slice 3 (ranking parity).
+  Both carry route/counter observability so a production anomaly is attributable to
+  the slice that caused it, and both are revertible by routing flags at their seam.
+- ADR-166's guard suite is the enforcement that this recovery, unlike previous
+  point fixes in this area, stays recovered: each slice's mechanism is pinned by a
+  deterministic counter invariant that fails CI if the mechanism regresses.
+
+## Verification
+
+Each slice lands with:
+
+1. Before/after latency for `search kind=note limit=3` and `memory.recall limit=3` on
+   the same corpus and machine class, quiet and loaded, recorded in the PR.
+2. Counter evidence the intended mechanism moved: Slice 1 — writer-task acquisitions
+   per recall at ambient; Slice 2 — standalone acquisition counter flat under a
+   read-verb suite while the pooled counter carries the traffic, WAL steady-state under
+   the high-water mark; Slice 3 — ANN route counter carries the traffic, fallback near
+   zero warm; Slice 4 — zero note-search dispatches to the session backend.
+3. The corresponding ADR-166 mechanism invariant merged and green in the same PR.

--- a/docs/adr/ADR-166-hot-path-latency-regression-guard.md
+++ b/docs/adr/ADR-166-hot-path-latency-regression-guard.md
@@ -76,7 +76,16 @@ documents the known-bad state instead of hiding it):
 | G2        | One `search` / `memory.recall` performs 0 standalone-reader opens (pooled-reader checkout counter carries the traffic)                                                                                                                                                                                   | ADR-165 Slice 2 |
 | G3        | On a store with installed ANN graphs, a note-substrate `search`'s vector leg is ANN-served; full-scan fallback count is 0                                                                                                                                                                                | ADR-165 Slice 3 |
 | G4        | A `kind=note` search dispatches 0 operations to a registered backend whose declaration excludes notes                                                                                                                                                                                                    | ADR-165 Slice 4 |
-| G5        | Candidate hydration row count per read verb ≤ the per-arm overfetch constant documented at the retrieval seam times the number of arms (today: `limit x 4` per arm, two arms), measured at the hydration seam                                                                                            | ADR-165 Slice 3 |
+| G5        | A note-substrate `search` hydrates no more candidate rows than the documented per-arm overfetch times the number of arms (today: `limit x 4` per arm, two arms) plus the registered ANN consumer's fresh-tail contribution, measured at the hydration seam after fusion and fresh-tail merge             | ADR-165 Slice 3 |
+
+G5 is scoped to the note-substrate `search` union deliberately. `memory.recall`'s
+hydration is governed by different, configured terms — a per-model ANN candidate
+floor of `max(k x 4, k + 32)`, multi-round candidate widening up to a further
+factor of four, and fresh-tail merge additions — so the search constant is not its
+bound, and a green G5 says nothing about recall. Recall's hydration invariant lands
+as a separate entry once Slice 3's hydration counter exists, expressed against
+those configured terms rather than the search constant, so the asserted bound and
+the configuration that produces it cannot drift apart silently.
 
 Suite contract:
 
@@ -123,19 +132,29 @@ noise floor for that execution.
 
 ### D3 — The budget and thresholds are versioned with the code
 
-A checked-in trend-configuration file, read by the D2 lane, defines every normative
-value D2 references — none may live only in prose or in an implementer's judgment:
+A checked-in trend-configuration file — `bench/trend-config.toml`, read by the D2
+lane — defines every normative value D2 references; none may live only in prose or
+in an implementer's judgment:
 
 - per-metric latency budget (initially: unified verb 10-15 ms; `search` and
   `memory.recall` server-side p50 at the seeded reference scale);
-- `noise_ceiling`: the maximum A/A spread (as a ratio) under which a run may report
-  a measurement; above it the run reports UNMEASURED;
-- `breach_multiplier`: the factor over baseline that, sustained across 3
-  consecutive measured runs, files the D2 issue;
-- baseline provenance and update policy: the baseline is the median of the last N
-  accepted measured runs on the same runner class, recorded in the tracked
-  history; it updates automatically as measured runs accept, while the BUDGET
-  changes only by reviewed diff carrying the measurement that justifies it.
+- `noise_ceiling` (initial value `1.15`): the maximum A/A spread ratio under which
+  a run may report a measurement; above it the run reports UNMEASURED;
+- `breach_multiplier` (initial value `1.5`): the factor over baseline that,
+  sustained across 3 consecutive measured runs, files the D2 issue;
+- `baseline_window` (initial value `7`): the baseline is the median of the last
+  `baseline_window` accepted measured runs on the same runner class, recorded in
+  the tracked history; it updates automatically as measured runs accept, while the
+  BUDGET changes only by reviewed diff carrying the measurement that justifies it;
+- bootstrap and runner-class matching: each history entry records its runner class
+  (os, arch, runner label), and the baseline is computed only over entries of the
+  same class. With fewer than `baseline_window` but at least 3 accepted same-class
+  runs, the median of what exists serves as an interim baseline; below 3 the lane
+  reports BASELINE-PENDING and files no breach. A runner-class change starts a
+  fresh window rather than comparing across classes.
+
+The initial values above seed the file; after that, the file is the single source
+and this ADR's numbers are historical.
 
 A budget that only exists in documentation regresses by being forgotten, which is
 how the 10-15 ms budget and a 5-second reality coexisted without any instrument

--- a/docs/adr/ADR-166-hot-path-latency-regression-guard.md
+++ b/docs/adr/ADR-166-hot-path-latency-regression-guard.md
@@ -52,33 +52,48 @@ every PR; timed trend measurement informs but never gates.
 ### D1 — Mechanism invariants: per-PR, deterministic, gating
 
 A dedicated integration-test suite (`hot_path_guard`) runs the canonical read verbs
-against a seeded file-backed store and asserts counter deltas from `db_diagnostics`
-before/after each operation. The suite is ordinary `cargo test` — no timing, no
-statistics, no machine dependence — and a violated invariant fails CI like any other
-test.
+against a seeded file-backed store and asserts counter deltas before/after each
+operation. The suite is ordinary `cargo test` — no timing, no statistics, no machine
+dependence — and a violated invariant fails CI like any other test.
+
+**Counter prerequisites.** `db_diagnostics` today exposes writer-side counters only
+(pooled/standalone/writer-task acquisitions, begin-refusal counters, checkpoint/WAL
+state). Every counter an invariant reads that does not exist yet is a named
+deliverable of the ADR-165 slice that owns the invariant, landing before or with
+that slice: standalone-reader opens and pooled-reader checkouts (Slice 2), ANN-route
+vs fallback serve counts for the note-search consumer (Slice 3), per-backend
+dispatch counts by requested kind at the coordinator (Slice 4), and candidate
+hydration row count per operation (Slice 3, hydration seam). An invariant whose
+counter has not landed is expected-fail, never silently green.
 
 Initial invariant set (each lands with the ADR-165 slice that makes it true; until
 that slice merges, the invariant is present but marked expected-fail so the suite
 documents the known-bad state instead of hiding it):
 
-| Invariant | Property asserted                                                                                                                                                                                                                                                     | Guards          |
-| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
-| G1        | One `memory.recall` performs 0 synchronous writer-task acquisitions on its request path (post ADR-133 D1/D7: the dispatch may wait on a shared batch commit, but acquisition-counter delta attributable to the recall itself is bounded by the batch, not per-target) | ADR-165 Slice 1 |
-| G2        | One `search` / `memory.recall` performs 0 standalone reader opens (pooled counter carries the traffic)                                                                                                                                                                | ADR-165 Slice 2 |
-| G3        | On a store with installed ANN graphs, `search`'s vector leg is ANN-served; full-scan fallback count is 0                                                                                                                                                              | ADR-165 Slice 3 |
-| G4        | A `kind=note` search dispatches 0 operations to a registered backend that declares it does not serve notes                                                                                                                                                            | ADR-165 Slice 4 |
-| G5        | A read verb on the seeded corpus touches a bounded row population: candidate hydration row count ≤ the documented overfetch bound for the requested limit                                                                                                             | overfetch creep |
+| Invariant | Property asserted                                                                                                                                                                                                                                                                                        | Guards          |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
+| G1        | One `memory.recall` performs no per-target writer-task acquisition and at most ONE writer-task acquisition for the shared batch carrying its rows (ADR-133 D1/D7 semantics: the batch may also carry other dispatches' rows; attribution is to the batch, asserted after the harness quiescence barrier) | ADR-165 Slice 1 |
+| G2        | One `search` / `memory.recall` performs 0 standalone-reader opens (pooled-reader checkout counter carries the traffic)                                                                                                                                                                                   | ADR-165 Slice 2 |
+| G3        | On a store with installed ANN graphs, a note-substrate `search`'s vector leg is ANN-served; full-scan fallback count is 0                                                                                                                                                                                | ADR-165 Slice 3 |
+| G4        | A `kind=note` search dispatches 0 operations to a registered backend whose declaration excludes notes                                                                                                                                                                                                    | ADR-165 Slice 4 |
+| G5        | Candidate hydration row count per read verb ≤ the per-arm overfetch constant documented at the retrieval seam times the number of arms (today: `limit x 4` per arm, two arms), measured at the hydration seam                                                                                            | ADR-165 Slice 3 |
 
 Suite contract:
 
 - **Counters, not clocks.** An invariant may count acquisitions, opens, dispatches,
   routes, rows, and bytes. It may not assert a duration.
-- **The counter must be attributable.** Each assertion isolates its operation (single
-  in-process runtime, no concurrent traffic) so a delta belongs to the asserted
-  operation alone. Where a background task contributes (ANN maintenance, batch
-  flushes), the invariant either drains it first or asserts on a counter the
-  background path does not touch — the guard must not intermittently fail from its
-  own harness concurrency.
+- **The counter must be attributable, and "no concurrent traffic" is not enough.**
+  Read verbs launch detached background work (`memory.recall`'s serve-ledger and
+  event task via `track_background_task`; ANN maintenance; batch flushes), so a
+  before/after snapshot around the verb call alone can race that work in either
+  direction. Each assertion therefore runs on a single in-process runtime with no
+  concurrent traffic AND takes its after-snapshot only past a **quiescence
+  barrier**: the harness drains host-tracked background tasks (the same
+  tracked-task seam the daemon's shutdown drain uses) before reading counters. An
+  invariant over work the barrier cannot drain is redesigned onto a counter the
+  background path does not touch, or split into a separate deterministic assertion
+  — the guard must not intermittently pass or fail from its own harness
+  concurrency.
 - **New hot-path mechanisms add an invariant in the same PR.** A change that
   introduces a new class of work on `search`/`recall`/`get` (a new per-dispatch write,
   a new fan-out target, a new retrieval pass) must extend the suite with the counter
@@ -106,14 +121,25 @@ noise floor for that execution.
   invariants green means a mechanism class is missing from D1, and the issue's job is
   to name it and add the invariant.
 
-### D3 — The budget is versioned with the code
+### D3 — The budget and thresholds are versioned with the code
 
-The per-verb latency budgets (currently: unified verb 10-15 ms; `search` and
-`memory.recall` server-side p50 at the seeded reference scale) live in a checked-in
-budget file read by the trend lane, not in prose. Changing a budget is a reviewed
-diff with the measurement that justifies it — a budget that only exists in
-documentation regresses by being forgotten, which is how the 10-15 ms budget and a
-5-second reality coexisted without any instrument noticing.
+A checked-in trend-configuration file, read by the D2 lane, defines every normative
+value D2 references — none may live only in prose or in an implementer's judgment:
+
+- per-metric latency budget (initially: unified verb 10-15 ms; `search` and
+  `memory.recall` server-side p50 at the seeded reference scale);
+- `noise_ceiling`: the maximum A/A spread (as a ratio) under which a run may report
+  a measurement; above it the run reports UNMEASURED;
+- `breach_multiplier`: the factor over baseline that, sustained across 3
+  consecutive measured runs, files the D2 issue;
+- baseline provenance and update policy: the baseline is the median of the last N
+  accepted measured runs on the same runner class, recorded in the tracked
+  history; it updates automatically as measured runs accept, while the BUDGET
+  changes only by reviewed diff carrying the measurement that justifies it.
+
+A budget that only exists in documentation regresses by being forgotten, which is
+how the 10-15 ms budget and a 5-second reality coexisted without any instrument
+noticing.
 
 ## Consequences
 

--- a/docs/adr/ADR-166-hot-path-latency-regression-guard.md
+++ b/docs/adr/ADR-166-hot-path-latency-regression-guard.md
@@ -1,0 +1,137 @@
+# ADR-166: Hot-Path Latency Regression Guard
+
+**Status**: proposed\
+**Date**: 2026-08-17\
+**Authors**: khive maintainers\
+**Depends on**:
+
+- [ADR-103](ADR-103-resource-attribution-model.md) — per-dispatch resource accounting
+- [ADR-133](ADR-133-incidental-writes-off-the-request-hot-path.md) — writer-acquisition
+  reduction and acquisition-site instrumentation (D8)
+- [ADR-165](ADR-165-read-path-performance-recovery.md) — the recovery program whose
+  mechanisms this guard pins
+
+---
+
+## Context
+
+The read-path regression that ADR-165 recovers was not a single event. This area has
+been fixed repeatedly and has regressed repeatedly, because nothing in CI observes the
+properties the fixes restore. A 300-800x latency regression accumulated across months
+of merges, each individually green: the test suite asserts correctness, and correctness
+was never violated — a search that takes 5 seconds returns the same rows as one that
+takes 5 milliseconds.
+
+Wall-clock benchmarks in CI are the obvious answer and the wrong first one. Shared CI
+runners have noisy neighbours, variable page cache state, and no admission control;
+a timing gate tight enough to catch a 2x regression false-fails weekly, gets a retry
+button, and is dead within a month. A gate loose enough to never false-fail admits the
+regression this repository actually experienced — three orders of magnitude, arriving
+a factor at a time.
+
+The investigation behind ADR-165 exposes the alternative. Every mechanism of the
+regression is visible in **deterministic counters**, independent of machine speed:
+
+- recall's latency inheritance is _writer-task acquisitions per read dispatch_ (measured
+  live: +1-4 per recall against an idle-path expectation of 0);
+- connection churn is _standalone reader opens per read operation_ (measured: one per
+  file-backed store read against a pooled expectation of 0);
+- the vector-scan cost is _which route served the query_ (ANN vs full scan);
+- fan-out waste is _dispatch count per backend per kind_ (session backend receiving
+  note searches).
+
+A counter is exact on the slowest runner. The defect classes that produced the
+regression are all countable. Timing remains useful as a trend instrument; it is not
+fit to be the gate.
+
+## Decision
+
+Two tiers with different gating authority: deterministic mechanism invariants gate
+every PR; timed trend measurement informs but never gates.
+
+### D1 — Mechanism invariants: per-PR, deterministic, gating
+
+A dedicated integration-test suite (`hot_path_guard`) runs the canonical read verbs
+against a seeded file-backed store and asserts counter deltas from `db_diagnostics`
+before/after each operation. The suite is ordinary `cargo test` — no timing, no
+statistics, no machine dependence — and a violated invariant fails CI like any other
+test.
+
+Initial invariant set (each lands with the ADR-165 slice that makes it true; until
+that slice merges, the invariant is present but marked expected-fail so the suite
+documents the known-bad state instead of hiding it):
+
+| Invariant | Property asserted                                                                                                                                                                                                                                                     | Guards          |
+| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
+| G1        | One `memory.recall` performs 0 synchronous writer-task acquisitions on its request path (post ADR-133 D1/D7: the dispatch may wait on a shared batch commit, but acquisition-counter delta attributable to the recall itself is bounded by the batch, not per-target) | ADR-165 Slice 1 |
+| G2        | One `search` / `memory.recall` performs 0 standalone reader opens (pooled counter carries the traffic)                                                                                                                                                                | ADR-165 Slice 2 |
+| G3        | On a store with installed ANN graphs, `search`'s vector leg is ANN-served; full-scan fallback count is 0                                                                                                                                                              | ADR-165 Slice 3 |
+| G4        | A `kind=note` search dispatches 0 operations to a registered backend that declares it does not serve notes                                                                                                                                                            | ADR-165 Slice 4 |
+| G5        | A read verb on the seeded corpus touches a bounded row population: candidate hydration row count ≤ the documented overfetch bound for the requested limit                                                                                                             | overfetch creep |
+
+Suite contract:
+
+- **Counters, not clocks.** An invariant may count acquisitions, opens, dispatches,
+  routes, rows, and bytes. It may not assert a duration.
+- **The counter must be attributable.** Each assertion isolates its operation (single
+  in-process runtime, no concurrent traffic) so a delta belongs to the asserted
+  operation alone. Where a background task contributes (ANN maintenance, batch
+  flushes), the invariant either drains it first or asserts on a counter the
+  background path does not touch — the guard must not intermittently fail from its
+  own harness concurrency.
+- **New hot-path mechanisms add an invariant in the same PR.** A change that
+  introduces a new class of work on `search`/`recall`/`get` (a new per-dispatch write,
+  a new fan-out target, a new retrieval pass) must extend the suite with the counter
+  that makes the new work visible, or state in the PR why the existing set already
+  bounds it. Reviewers hold this line; the suite's own docs list the classes.
+- **Expected-fail is temporary and dated.** An invariant in expected-fail state names
+  the slice that will flip it. Expected-fail entries older than one release cycle are
+  a release-blocking finding.
+
+### D2 — Timed trend lane: informative, never gating
+
+A benchmark suite (criterion) over the same seeded corpus runs on a schedule (not per
+PR): `search` and `memory.recall` p50/p95 at fixed corpus sizes, plus an A/A
+calibration pair (the same benchmark run twice) whose spread measures the runner's
+noise floor for that execution.
+
+- Results append to a tracked history (per commit: metric, value, A/A spread).
+- A run whose A/A spread exceeds the declared noise ceiling reports UNMEASURED for
+  that execution — visibly, not as a pass. UNMEASURED twice consecutively is a
+  finding about the bench environment, filed, not ignored.
+- A sustained trend breach (p50 above the recorded baseline by the declared multiplier
+  across 3 consecutive measured runs) files an issue automatically with the counter
+  snapshot attached. It does not block merges: by construction, any real mechanism
+  regression should have tripped a D1 invariant first — a trend breach with all
+  invariants green means a mechanism class is missing from D1, and the issue's job is
+  to name it and add the invariant.
+
+### D3 — The budget is versioned with the code
+
+The per-verb latency budgets (currently: unified verb 10-15 ms; `search` and
+`memory.recall` server-side p50 at the seeded reference scale) live in a checked-in
+budget file read by the trend lane, not in prose. Changing a budget is a reviewed
+diff with the measurement that justifies it — a budget that only exists in
+documentation regresses by being forgotten, which is how the 10-15 ms budget and a
+5-second reality coexisted without any instrument noticing.
+
+## Consequences
+
+- The gate that protects the hot path is exact, fast, and runs on every PR at zero
+  flake cost; the expensive noisy instrument is demoted to trend duty where its noise
+  cannot burn trust.
+- The guard is only as complete as its invariant list. D1's same-PR extension rule
+  and D2's invariants-green-but-trend-breached escalation are the two mechanisms that
+  grow the list; both produce named findings rather than silence.
+- Expected-fail entries make the current known-bad state executable documentation:
+  the suite tells the truth about today while gating tomorrow.
+- Marginal CI cost is one integration-test binary per PR and a scheduled bench job.
+
+## Verification
+
+- The suite exists, runs in `make ci`, and G1-G5 are present (expected-fail where the
+  corresponding slice has not merged).
+- Reverting any merged ADR-165 slice's core change locally flips its invariant to
+  red (mutation check recorded in the introducing PR).
+- The trend lane produces history entries with A/A spread on its first scheduled run,
+  and an artificially throttled run reports UNMEASURED rather than passing.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -181,6 +181,8 @@ The same head-binding governs review: a verdict authorizes only the exact commit
 | [ADR-162](ADR-162-unified-event-plane-ownership.md)                     | Unified Event-Plane Ownership                                                                              |
 | [ADR-163](ADR-163-restart-boundary-event-legibility.md)                 | Restart-Boundary Event Legibility                                                                          |
 | [ADR-164](ADR-164-event-sink-boundary.md)                               | Event Sink Boundary                                                                                        |
+| [ADR-165](ADR-165-read-path-performance-recovery.md)                    | Read-Path Performance Recovery                                                                             |
+| [ADR-166](ADR-166-hot-path-latency-regression-guard.md)                 | Hot-Path Latency Regression Guard                                                                          |
 
 <!-- END GENERATED ADR CATALOG -->
 


### PR DESCRIPTION
## Summary

Two proposed ADRs responding to the measured warm-path read latency regression (search 0.6-5s and coordinator-deadline failures under load; recall 4.9-8.6s against a 10-15ms budget).

**ADR-165 — Read-Path Performance Recovery.** Records the four measured mechanisms:

1. `search`'s vector leg is a full-table sqlite-vec scan (~580 MB/query across two engines); the warm Vamana ANN bridge (ADR-079) already covers the same corpus but only serves `memory.recall`.
2. Read verbs perform synchronous incidental writes behind a contended writer (ADR-133's subject, measured live: +1-4 writer-task acquisitions per recall; writer-begin failures at the full 30s timeout in the serving daemon's log).
3. Every file-backed store read opens a fresh standalone connection, pinning WAL snapshots and starving PASSIVE checkpoints (observed past the high-water mark).
4. Coordinator search fans out to every registered backend regardless of requested kind, including a backend two orders of magnitude larger than any result it could contribute.

Decision: a four-slice recovery — implement ADR-133 (by reference, no new decision), route file-backed reads through the existing pooled readers, serve `search`'s vector leg from the warm ANN bridge, filter coordinator fan-out by declared backend kinds.

**ADR-166 — Hot-Path Latency Regression Guard.** This area has regressed repeatedly because CI observes correctness, not cost. The guard gates PRs on deterministic mechanism counters (writer acquisitions, standalone opens, serving route, per-backend dispatch counts — exact on any runner), and demotes wall-clock benchmarking to a scheduled non-gating trend lane with A/A noise calibration and versioned budgets.

## Notes for review

- ADR numbering: 161-164 are allocated in the catalog with files landing on their own branches; this PR takes 165/166. Branch name predates the collision discovery.
- Docs-only: two new ADRs + catalog rows. `scripts/lint-adr-refs.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)