### PR TITLE
ci: raise matrix job timeout to 70 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,9 @@ jobs:
   ci:
     name: CI (${{ matrix.os }}, shard ${{ matrix.shard }}/2)
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    # 45 left a 4% margin over the macOS shard-1 healthy duration (~43 min),
+    # so any slow runner day converted a green run into a timeout cancellation.
+    timeout-minutes: 70
     strategy:
       # A fast failure cancels the sibling OS to control runner cost. The tradeoff
       # is that a macOS-only failure may need a second run after Linux is fixed.


### PR DESCRIPTION
The CI matrix job's `timeout-minutes: 45` leaves almost no headroom: a healthy
macOS shard-1 run takes about 43 minutes (run 32012384297: 08:52:04Z to
09:35:11Z), a 4% margin. On a slow runner day the job crosses 45 minutes and
GitHub cancels it, which reads as a red `CI gate` even though every completed
job was green. Three consecutive rerun attempts on main head 9b53aaff2 died
exactly this way today (attempt 4: started 18:02:52Z, cancelled 18:48:14Z at
45m22s, all other jobs green).

70 minutes keeps a bound on stuck execution (the stated purpose of the
timeout) while giving the longest healthy job ~60% headroom.
