### PR TITLE
fix(kg-editor): neutral self-contained demo fixtures

### DIFF
--- a/apps/kg-editor/src/components/studio.test.tsx
+++ b/apps/kg-editor/src/components/studio.test.tsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 
 import { Studio } from "@/components/studio";
-import { atlasReviewFixture } from "@/lib/fixtures/atlas-review";
+import { demoReviewFixture } from "@/lib/fixtures/demo-review";
 import { REVIEW_IMPORT_MAX_BYTES, type ReviewBundle, type ReviewReport } from "@/lib/review-bundle";
 
 const zeroPageCases = [
@@ -39,7 +39,7 @@ const zeroPageCases = [
 
 describe("KG Studio", () => {
   it("makes the no-write and unavailable capability boundary visible", () => {
-    render(<Studio initialBundle={atlasReviewFixture} />);
+    render(<Studio initialBundle={demoReviewFixture} />);
 
     expect(screen.getByText("Demo data · no writes")).toBeVisible();
     expect(screen.getByText("WASM unavailable")).toBeVisible();
@@ -48,7 +48,7 @@ describe("KG Studio", () => {
 
   it("renders an actionable shared empty state for filtered graph changes", async () => {
     const user = userEvent.setup();
-    const { container } = render(<Studio initialBundle={atlasReviewFixture} />);
+    const { container } = render(<Studio initialBundle={demoReviewFixture} />);
 
     await user.type(screen.getByPlaceholderText("Filter entities, edges, tiers…"), "nothing-matches-this");
 
@@ -60,7 +60,7 @@ describe("KG Studio", () => {
   });
 
   it.each(zeroPageCases)("renders $name zero pages through one actionable empty state", async ({ view, empty }) => {
-    const bundle = structuredClone(atlasReviewFixture);
+    const bundle = structuredClone(demoReviewFixture);
     empty(bundle);
     const user = userEvent.setup();
     const { container } = render(<Studio initialBundle={bundle} />);
@@ -74,7 +74,7 @@ describe("KG Studio", () => {
   });
 
   it("renders Studio page bounds as the shared truncated state", () => {
-    const bundle = structuredClone(atlasReviewFixture);
+    const bundle = structuredClone(demoReviewFixture);
     bundle.changes.truncated = true;
     bundle.changes.next_cursor = "next-page";
     const { container } = render(<Studio initialBundle={bundle} />);
@@ -89,7 +89,7 @@ describe("KG Studio", () => {
     ["truncated", { truncated: true, next_cursor: null }],
     ["next cursor", { truncated: false, next_cursor: "next-page" }],
   ] as const)("does not mislabel a zero-item %s page as known-empty", (_name, incomplete) => {
-    const bundle = structuredClone(atlasReviewFixture);
+    const bundle = structuredClone(demoReviewFixture);
     bundle.changes.items = [];
     bundle.changes.truncated = incomplete.truncated;
     bundle.changes.next_cursor = incomplete.next_cursor;
@@ -107,7 +107,7 @@ describe("KG Studio", () => {
     ["truncated", { truncated: true, next_cursor: null }],
     ["next cursor", { truncated: false, next_cursor: "next-page" }],
   ] as const)("does not render the checks success hero for a zero-item %s page", async (_name, incomplete) => {
-    const bundle = structuredClone(atlasReviewFixture);
+    const bundle = structuredClone(demoReviewFixture);
     bundle.checks.items = [];
     bundle.checks.truncated = incomplete.truncated;
     bundle.checks.next_cursor = incomplete.next_cursor;
@@ -124,7 +124,7 @@ describe("KG Studio", () => {
 
   it("navigates from semantic diff to the affected graph", async () => {
     const user = userEvent.setup();
-    const { container } = render(<Studio initialBundle={atlasReviewFixture} />);
+    const { container } = render(<Studio initialBundle={demoReviewFixture} />);
 
     await user.click(screen.getAllByRole("button", { name: /affected graph/i })[0]);
     expect(screen.getByRole("heading", { name: "Affected subgraph" })).toBeVisible();
@@ -143,7 +143,7 @@ describe("KG Studio", () => {
 
   it("makes graph edges addressable with a shared selection and contextual inspector", async () => {
     const user = userEvent.setup();
-    render(<Studio initialBundle={atlasReviewFixture} />);
+    render(<Studio initialBundle={demoReviewFixture} />);
 
     await user.click(screen.getAllByRole("button", { name: /affected graph/i })[0]);
     const edgeSummaryRegion = screen.getByRole("region", { name: "Affected graph relationships" });
@@ -159,7 +159,7 @@ describe("KG Studio", () => {
 
   it("dispatches retrieval note kinds through the note legend", async () => {
     const user = userEvent.setup();
-    const { container } = render(<Studio initialBundle={atlasReviewFixture} />);
+    const { container } = render(<Studio initialBundle={demoReviewFixture} />);
 
     await user.click(screen.getAllByRole("button", { name: /Khive context/i })[0]);
     expect(container.querySelector('[data-kind="observation"]')).toHaveTextContent("Observation");
@@ -169,7 +169,7 @@ describe("KG Studio", () => {
   it("uses explicit entity_kind in core review operation lists", async () => {
     const user = userEvent.setup();
     const operation = {
-      ...atlasReviewFixture.change_set.operations[0],
+      ...demoReviewFixture.change_set.operations[0],
       after: { kind: "entity", entity_kind: "concept", name: "Canonical concept" },
     };
     const report: ReviewReport = {
@@ -186,23 +186,23 @@ describe("KG Studio", () => {
         persistence: false,
         unavailable_actions: ["apply", "commit", "push", "publish", "persist_review"],
       },
-      change_set: { envelope: atlasReviewFixture.change_set.envelope, operations: [operation] },
+      change_set: { envelope: demoReviewFixture.change_set.envelope, operations: [operation] },
       tier_summary: {
-        ...atlasReviewFixture.tier_summary,
+        ...demoReviewFixture.tier_summary,
         operations: 1,
         tier_1: 1,
         tier_2: 0,
         highest_tier: "tier_1",
         requires_independent_review: false,
       },
-      validation: atlasReviewFixture.validation,
+      validation: demoReviewFixture.validation,
       findings: [],
-      review_gate: atlasReviewFixture.review_gate,
+      review_gate: demoReviewFixture.review_gate,
     };
     const serialized = JSON.stringify(report);
     const imported = new File([serialized], "core-review.json", { type: "application/json" });
     Object.defineProperty(imported, "text", { value: () => Promise.resolve(serialized) });
-    const { container } = render(<Studio initialBundle={atlasReviewFixture} />);
+    const { container } = render(<Studio initialBundle={demoReviewFixture} />);
 
     await user.upload(container.querySelector<HTMLInputElement>('input[type="file"]')!, imported);
 
@@ -212,7 +212,7 @@ describe("KG Studio", () => {
 
   it("refuses same-family approval and records no approval state", async () => {
     const user = userEvent.setup();
-    render(<Studio initialBundle={atlasReviewFixture} />);
+    render(<Studio initialBundle={demoReviewFixture} />);
 
     await user.click(screen.getByRole("button", { name: /Approve locally/i }));
 
@@ -224,7 +224,7 @@ describe("KG Studio", () => {
 
   it("clears a local approval when reviewer-family eligibility changes", async () => {
     const user = userEvent.setup();
-    render(<Studio initialBundle={atlasReviewFixture} />);
+    render(<Studio initialBundle={demoReviewFixture} />);
 
     const reviewer = screen.getByRole("combobox", { name: "Reviewer model family" });
     await user.selectOptions(reviewer, "family:independent-reasoner");
@@ -237,7 +237,7 @@ describe("KG Studio", () => {
 
   it("rejects an oversized review bundle before reading it", async () => {
     const user = userEvent.setup();
-    const { container } = render(<Studio initialBundle={atlasReviewFixture} />);
+    const { container } = render(<Studio initialBundle={demoReviewFixture} />);
     const input = container.querySelector<HTMLInputElement>('input[type="file"]');
     expect(input).not.toBeNull();
 
@@ -257,7 +257,7 @@ describe("KG Studio", () => {
 
   it("resets local conversation notes when the imported review identity changes", async () => {
     const user = userEvent.setup();
-    const { container } = render(<Studio initialBundle={atlasReviewFixture} />);
+    const { container } = render(<Studio initialBundle={demoReviewFixture} />);
 
     await user.click(screen.getAllByRole("button", { name: /^Activity/i })[0]);
     await user.type(screen.getByRole("textbox", { name: "Review comment" }), "Only for review 184");
@@ -265,10 +265,10 @@ describe("KG Studio", () => {
     expect(screen.getByText("Only for review 184")).toBeVisible();
 
     const nextBundle = {
-      ...atlasReviewFixture,
-      repository: { ...atlasReviewFixture.repository, head_sha: "1".repeat(40) },
+      ...demoReviewFixture,
+      repository: { ...demoReviewFixture.repository, head_sha: "1".repeat(40) },
       pull_request: {
-        ...atlasReviewFixture.pull_request,
+        ...demoReviewFixture.pull_request,
         number: 185,
         head_sha: "1".repeat(40),
       },

--- a/apps/kg-editor/src/components/studio.test.tsx
+++ b/apps/kg-editor/src/components/studio.test.tsx
@@ -217,7 +217,7 @@ describe("KG Studio", () => {
     await user.click(screen.getByRole("button", { name: /Approve locally/i }));
 
     expect(
-      screen.getAllByText(/ADR-102 requires a reviewer outside family:atlas-frontier/i),
+      screen.getAllByText(/ADR-102 requires a reviewer outside family:demo-frontier/i),
     ).toHaveLength(2);
     expect(screen.queryByText(/Local decision: approved/i)).not.toBeInTheDocument();
   });
@@ -231,7 +231,7 @@ describe("KG Studio", () => {
     await user.click(screen.getByRole("button", { name: /Approve locally/i }));
     expect(screen.getByText(/Local decision: approved/i)).toBeVisible();
 
-    await user.selectOptions(reviewer, "family:atlas-frontier");
+    await user.selectOptions(reviewer, "family:demo-frontier");
     expect(screen.queryByText(/Local decision: approved/i)).not.toBeInTheDocument();
   });
 

--- a/apps/kg-editor/src/components/studio.tsx
+++ b/apps/kg-editor/src/components/studio.tsx
@@ -79,7 +79,7 @@ const viewLabels: Record<View, string> = {
 };
 
 const reviewerFamilies = [
-  "family:atlas-frontier",
+  "family:demo-frontier",
   "family:independent-reasoner",
   "family:human-curator",
 ];

--- a/apps/kg-editor/src/lib/adapters/fixture-review-source.ts
+++ b/apps/kg-editor/src/lib/adapters/fixture-review-source.ts
@@ -1,9 +1,9 @@
-import { atlasReviewFixture } from "@/lib/fixtures/atlas-review";
+import { demoReviewFixture } from "@/lib/fixtures/demo-review";
 import { parseReviewBundle } from "@/lib/review-bundle";
 import type { ReviewSource } from "@/lib/adapters/review-source";
 
 export const fixtureReviewSource: ReviewSource = {
-  id: "atlas-review-fixture",
+  id: "demo-review-fixture",
   capabilities: {
     gitReads: false,
     khiveReads: false,
@@ -11,6 +11,6 @@ export const fixtureReviewSource: ReviewSource = {
     wasm: false,
   },
   async load() {
-    return parseReviewBundle(atlasReviewFixture);
+    return parseReviewBundle(demoReviewFixture);
   },
 };

--- a/apps/kg-editor/src/lib/fixtures/atlas-review.ts
+++ b/apps/kg-editor/src/lib/fixtures/atlas-review.ts
@@ -17,11 +17,11 @@ export const atlasReviewFixture: ReviewBundle = {
     unavailable_actions: ["apply", "commit", "push", "publish", "persist_review"],
   },
   repository: {
-    owner: "ohdearquant",
-    name: "atlas-kg",
+    owner: "acme-demo",
+    name: "demo-kg",
     visibility: "private",
     default_branch: "main",
-    head_branch: "atlas/enrich/provenance-batch-184",
+    head_branch: "demo/enrich/provenance-batch-184",
     base_sha: "4c82e846d657ade7f2f2567618b9e63e80f42ea6",
     head_sha: "7ea9c6b25e23a64c9b8b602b8a61c5da41f36e1a",
   },
@@ -35,9 +35,9 @@ export const atlasReviewFixture: ReviewBundle = {
   pull_request: {
     number: 184,
     title: "Curate assertion-level provenance and retire the batch-only model",
-    body: "Atlas found that corrections are reviewed per assertion while provenance is currently attached only at batch level. This change preserves batch lineage and adds assertion-level evidence anchors.",
+    body: "Casey found that corrections are reviewed per assertion while provenance is currently attached only at batch level. This change preserves batch lineage and adds assertion-level evidence anchors.",
     state: "open",
-    author: "lambda:atlas",
+    author: "actor:casey",
     created_at: "2026-08-07T17:20:00Z",
     head_sha: "7ea9c6b25e23a64c9b8b602b8a61c5da41f36e1a",
   },
@@ -53,10 +53,10 @@ export const atlasReviewFixture: ReviewBundle = {
   change_set: {
     envelope: {
       schema_version: 1,
-      producer: "lambda:atlas",
-      producer_model_family: "family:atlas-frontier",
+      producer: "actor:casey",
+      producer_model_family: "family:demo-frontier",
       staged_at: 1786123200000000,
-      batch_id: "atlas-enrich-2026-08-07-184",
+      batch_id: "demo-enrich-2026-08-07-184",
     },
     operations: [
       {
@@ -203,12 +203,12 @@ export const atlasReviewFixture: ReviewBundle = {
   ],
   review_gate: {
     required: true,
-    producer_model_family: "family:atlas-frontier",
+    producer_model_family: "family:demo-frontier",
     reviewer_model_family: null,
     eligible: false,
     approval_ready: false,
     status: "awaiting_independent_reviewer",
-    reason: "Select a reviewer outside family:atlas-frontier before approval.",
+    reason: "Select a reviewer outside family:demo-frontier before approval.",
     persisted: false,
   },
   summary: {
@@ -255,7 +255,7 @@ export const atlasReviewFixture: ReviewBundle = {
       id: "review-family",
       label: "Independent reviewer",
       status: "pending",
-      detail: "Select a reviewer outside family:atlas-frontier before approval.",
+      detail: "Select a reviewer outside family:demo-frontier before approval.",
       duration_ms: 0,
     },
     ],
@@ -480,21 +480,21 @@ export const atlasReviewFixture: ReviewBundle = {
     {
       sha: "7ea9c6b25e23a64c9b8b602b8a61c5da41f36e1a",
       subject: "kg: stage assertion-level provenance",
-      author: "lambda:atlas",
+      author: "actor:casey",
       created_at: "2026-08-07T17:20:00Z",
       state: "head",
     },
     {
       sha: "4c82e846d657ade7f2f2567618b9e63e80f42ea6",
       subject: "kg: snapshot after source refresh",
-      author: "lambda:atlas",
+      author: "actor:casey",
       created_at: "2026-08-07T15:08:00Z",
       state: "base",
     },
     {
       sha: "d124b53e0ff383b4aa2d872f0c1e7bd1065f2001",
       subject: "kg: resume the snapshot lane",
-      author: "lambda:khive",
+      author: "khive-bot",
       created_at: "2026-07-28T02:19:00Z",
       state: "ancestor",
     },
@@ -506,9 +506,9 @@ export const atlasReviewFixture: ReviewBundle = {
     items: [
     {
       id: "activity-1",
-      actor: "lambda:atlas",
+      actor: "actor:casey",
       action: "opened this review",
-      body: "Seven staged operations from atlas-enrich-2026-08-07-184. Four route to tier 2.",
+      body: "Seven staged operations from demo-enrich-2026-08-07-184. Four route to tier 2.",
       created_at: "2026-08-07T17:20:00Z",
       tone: "neutral",
     },
@@ -522,7 +522,7 @@ export const atlasReviewFixture: ReviewBundle = {
     },
     {
       id: "activity-3",
-      actor: "lambda:reviewer",
+      actor: "actor:robin",
       action: "left a review note",
       body: "Keep the historical batch model visible; supersession should affect the current view, not erase lineage.",
       created_at: "2026-08-07T17:24:00Z",

--- a/apps/kg-editor/src/lib/fixtures/demo-review.ts
+++ b/apps/kg-editor/src/lib/fixtures/demo-review.ts
@@ -1,6 +1,6 @@
 import type { ReviewBundle } from "@/lib/review-bundle";
 
-export const atlasReviewFixture: ReviewBundle = {
+export const demoReviewFixture: ReviewBundle = {
   schema_version: "khive.review.v1",
   review_kind: "pull_request",
   generated_at: "2026-08-07T17:26:00Z",
@@ -566,7 +566,7 @@ export const atlasReviewFixture: ReviewBundle = {
         id: "436254d4",
         score: 0.853,
         memory_type: "semantic",
-        content: "Build the KG editor local-first with Atlas as the driving committer and make growth reviewable, diffable, and revertible.",
+        content: "Build the KG editor local-first with the curator persona as the driving committer and make growth reviewable, diffable, and revertible.",
       },
       {
         id: "b07f238e",

--- a/apps/kg-editor/src/lib/graph-layout.test.ts
+++ b/apps/kg-editor/src/lib/graph-layout.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "vitest";
 
 import { settleGraphLayout } from "@/lib/graph-layout";
-import { atlasReviewFixture } from "@/lib/fixtures/atlas-review";
+import { demoReviewFixture } from "@/lib/fixtures/demo-review";
 
 describe("settleGraphLayout", () => {
   it("settles the golden review graph independently of input order", () => {
-    const nodes = atlasReviewFixture.graph.nodes.items;
-    const edges = atlasReviewFixture.graph.edges.items;
+    const nodes = demoReviewFixture.graph.nodes.items;
+    const edges = demoReviewFixture.graph.edges.items;
     const settled = settleGraphLayout(nodes, edges).map(({ id, x, y }) => ({
       id,
       x,

--- a/apps/kg-editor/src/lib/review-bundle.test.ts
+++ b/apps/kg-editor/src/lib/review-bundle.test.ts
@@ -24,8 +24,8 @@ describe("khive.review.v1", () => {
     expect(bundle.snapshot_identity.hash_status).toBe("fixture");
     expect(bundle.snapshot_identity.head_hash).toMatch(/^sha256:/);
     expect(bundle.pull_request.number).toBe(184);
-    expect(bundle.change_set.envelope.batch_id).toBe("atlas-enrich-2026-08-07-184");
-    expect(bundle.change_set.envelope.producer).toBe("lambda:atlas");
+    expect(bundle.change_set.envelope.batch_id).toBe("demo-enrich-2026-08-07-184");
+    expect(bundle.change_set.envelope.producer).toBe("actor:casey");
     expect(bundle.live_proposal).toBeNull();
   });
 
@@ -115,10 +115,10 @@ describe("khive.review.v1", () => {
       change_set: {
         envelope: {
           schema_version: 1,
-          producer: "lambda:atlas",
-          producer_model_family: "family:atlas",
+          producer: "actor:casey",
+          producer_model_family: "family:demo",
           staged_at: 2_000_000,
-          batch_id: "atlas-batch-7",
+          batch_id: "demo-batch-7",
         },
         operations: [
           {
@@ -155,7 +155,7 @@ describe("khive.review.v1", () => {
       findings: [],
       review_gate: {
         required: false,
-        producer_model_family: "family:atlas",
+        producer_model_family: "family:demo",
         reviewer_model_family: null,
         eligible: true,
         approval_ready: true,
@@ -182,7 +182,7 @@ describe("review gate", () => {
       ),
     ).toEqual({
       allowed: false,
-      reason: "ADR-102 requires a reviewer outside family:atlas-frontier.",
+      reason: "ADR-102 requires a reviewer outside family:demo-frontier.",
     });
   });
 

--- a/apps/kg-editor/src/lib/review-bundle.test.ts
+++ b/apps/kg-editor/src/lib/review-bundle.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { atlasReviewFixture } from "@/lib/fixtures/atlas-review";
+import { demoReviewFixture } from "@/lib/fixtures/demo-review";
 import {
   isReviewReport,
   parseReviewBundle,
@@ -17,7 +17,7 @@ import {
 
 describe("khive.review.v1", () => {
   it("keeps present identities distinct and marks an absent live proposal explicitly", () => {
-    const bundle = parseReviewBundle(atlasReviewFixture);
+    const bundle = parseReviewBundle(demoReviewFixture);
 
     expect(bundle.repository.head_sha).toHaveLength(40);
     expect(bundle.pull_request.head_sha).toBe(bundle.repository.head_sha);
@@ -31,20 +31,20 @@ describe("khive.review.v1", () => {
 
   it("fails closed when the version or a full identifier is missing", () => {
     expect(() =>
-      parseReviewBundle({ ...atlasReviewFixture, schema_version: "khive.review.v2" }),
+      parseReviewBundle({ ...demoReviewFixture, schema_version: "khive.review.v2" }),
     ).toThrow();
     expect(() =>
       parseReviewBundle({
-        ...atlasReviewFixture,
-        repository: { ...atlasReviewFixture.repository, head_sha: undefined },
+        ...demoReviewFixture,
+        repository: { ...demoReviewFixture.repository, head_sha: undefined },
       }),
     ).toThrow();
   });
 
   it("represents a stale pull-request head without rejecting the review bundle", () => {
     const stale = parseReviewBundle({
-      ...atlasReviewFixture,
-      pull_request: { ...atlasReviewFixture.pull_request, head_sha: "0".repeat(40) },
+      ...demoReviewFixture,
+      pull_request: { ...demoReviewFixture.pull_request, head_sha: "0".repeat(40) },
     });
 
     expect(stale.pull_request.head_sha).not.toBe(stale.repository.head_sha);
@@ -57,9 +57,9 @@ describe("khive.review.v1", () => {
   it("does not accept verified canonical hashes before an algorithm is ratified", () => {
     expect(() =>
       parseReviewBundle({
-        ...atlasReviewFixture,
+        ...demoReviewFixture,
         snapshot_identity: {
-          ...atlasReviewFixture.snapshot_identity,
+          ...demoReviewFixture.snapshot_identity,
           hash_status: "verified",
         },
       }),
@@ -67,12 +67,12 @@ describe("khive.review.v1", () => {
   });
 
   it("bounds adapter pages and in-memory operation lists", () => {
-    const firstCheck = atlasReviewFixture.checks.items[0];
+    const firstCheck = demoReviewFixture.checks.items[0];
     expect(() =>
       parseReviewBundle({
-        ...atlasReviewFixture,
+        ...demoReviewFixture,
         checks: {
-          ...atlasReviewFixture.checks,
+          ...demoReviewFixture.checks,
           items: Array.from({ length: REVIEW_PAGE_MAX_ITEMS + 1 }, (_, index) => ({
             ...firstCheck,
             id: `bounded-check-${index}`,
@@ -81,12 +81,12 @@ describe("khive.review.v1", () => {
       }),
     ).toThrow();
 
-    const firstOperation = atlasReviewFixture.change_set.operations[0];
+    const firstOperation = demoReviewFixture.change_set.operations[0];
     expect(() =>
       parseReviewBundle({
-        ...atlasReviewFixture,
+        ...demoReviewFixture,
         change_set: {
-          ...atlasReviewFixture.change_set,
+          ...demoReviewFixture.change_set,
           operations: Array.from({ length: REVIEW_CORE_MAX_ITEMS + 1 }, (_, index) => ({
             ...firstOperation,
             index,
@@ -177,8 +177,8 @@ describe("review gate", () => {
   it("refuses a same-family reviewer", () => {
     expect(
       canApproveReview(
-        atlasReviewFixture,
-        atlasReviewFixture.change_set.envelope.producer_model_family,
+        demoReviewFixture,
+        demoReviewFixture.change_set.envelope.producer_model_family,
       ),
     ).toEqual({
       allowed: false,
@@ -187,17 +187,17 @@ describe("review gate", () => {
   });
 
   it("allows an independent reviewer when no required check failed", () => {
-    expect(canApproveReview(atlasReviewFixture, "family:independent-reasoner").allowed).toBe(
+    expect(canApproveReview(demoReviewFixture, "family:independent-reasoner").allowed).toBe(
       true,
     );
   });
 
   it("refuses approval when any required check fails", () => {
     const bundle = {
-      ...atlasReviewFixture,
+      ...demoReviewFixture,
       checks: {
-        ...atlasReviewFixture.checks,
-        items: atlasReviewFixture.checks.items.map((check, index) =>
+        ...demoReviewFixture.checks,
+        items: demoReviewFixture.checks.items.map((check, index) =>
           index === 0 ? { ...check, status: "fail" as const } : check,
         ),
       },
@@ -210,16 +210,16 @@ describe("review gate", () => {
   });
 
   it("blocks non-reviewer pending checks but resolves the fixture's reviewer check locally", () => {
-    expect(canApproveReview(atlasReviewFixture, "family:independent-reasoner").allowed).toBe(
+    expect(canApproveReview(demoReviewFixture, "family:independent-reasoner").allowed).toBe(
       true,
     );
 
     const pending = {
-      ...atlasReviewFixture,
+      ...demoReviewFixture,
       checks: {
-        ...atlasReviewFixture.checks,
+        ...demoReviewFixture.checks,
         items: [
-          ...atlasReviewFixture.checks.items,
+          ...demoReviewFixture.checks.items,
           {
             id: "github-required-check",
             label: "Repository policy",
@@ -239,9 +239,9 @@ describe("review gate", () => {
 
   it("respects semantic gate blockers that a local reviewer selection cannot resolve", () => {
     const blocked = {
-      ...atlasReviewFixture,
+      ...demoReviewFixture,
       review_gate: {
-        ...atlasReviewFixture.review_gate,
+        ...demoReviewFixture.review_gate,
         eligible: true,
         approval_ready: false,
         status: "blocked_by_repository_policy",
@@ -257,18 +257,18 @@ describe("review gate", () => {
 
   it("refuses stale PR heads and error-level semantic findings", () => {
     const stale = parseReviewBundle({
-      ...atlasReviewFixture,
-      pull_request: { ...atlasReviewFixture.pull_request, head_sha: "0".repeat(40) },
+      ...demoReviewFixture,
+      pull_request: { ...demoReviewFixture.pull_request, head_sha: "0".repeat(40) },
     });
     expect(canApproveReview(stale, "family:independent-reasoner").reason).toMatch(
       /head changed/i,
     );
 
     const invalid = {
-      ...atlasReviewFixture,
-      validation: { ...atlasReviewFixture.validation, passed: false, errors: 1 },
+      ...demoReviewFixture,
+      validation: { ...demoReviewFixture.validation, passed: false, errors: 1 },
       findings: [
-        ...atlasReviewFixture.findings,
+        ...demoReviewFixture.findings,
         {
           rule_id: "review-rule-coverage",
           severity: "error",
@@ -288,17 +288,17 @@ describe("review gate", () => {
 
 describe("review presentation helpers", () => {
   it("groups semantic changes without mutating source order", () => {
-    const original = atlasReviewFixture.changes.items.map((change) => change.id);
-    const grouped = groupChanges(atlasReviewFixture.changes.items);
+    const original = demoReviewFixture.changes.items.map((change) => change.id);
+    const grouped = groupChanges(demoReviewFixture.changes.items);
 
     expect(grouped.added).toHaveLength(5);
     expect(grouped.modified).toHaveLength(1);
     expect(grouped.removed).toHaveLength(1);
-    expect(atlasReviewFixture.changes.items.map((change) => change.id)).toEqual(original);
+    expect(demoReviewFixture.changes.items.map((change) => change.id)).toEqual(original);
   });
 
   it("searches semantic labels and tier metadata", () => {
-    const changedWeight = atlasReviewFixture.changes.items.find(
+    const changedWeight = demoReviewFixture.changes.items.find(
       (change) => change.change === "modified",
     );
     expect(changedWeight).toBeDefined();
@@ -308,7 +308,7 @@ describe("review presentation helpers", () => {
   });
 
   it("shortens both Git SHAs and labeled KG hashes for display only", () => {
-    expect(shortHash(atlasReviewFixture.repository.head_sha)).toBe("7ea9c6b2");
-    expect(shortHash(atlasReviewFixture.snapshot_identity.head_hash!, 10)).toBe("3f1e93775c");
+    expect(shortHash(demoReviewFixture.repository.head_sha)).toBe("7ea9c6b2");
+    expect(shortHash(demoReviewFixture.snapshot_identity.head_hash!, 10)).toBe("3f1e93775c");
   });
 });

--- a/apps/kg-editor/src/lib/review-json-schema.test.ts
+++ b/apps/kg-editor/src/lib/review-json-schema.test.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 import { buildReviewJsonSchema } from "../../scripts/review-json-schema.mjs";
 import reviewSchema from "../../../../docs/schemas/khive-review-v1.schema.json";
 import changesetGolden from "../../../../docs/schemas/examples/khive-review-v1-changeset.json";
-import { atlasReviewFixture } from "@/lib/fixtures/atlas-review";
+import { demoReviewFixture } from "@/lib/fixtures/demo-review";
 import { parseReviewInput, reviewInputSchema } from "@/lib/review-bundle";
 
 describe("normative khive.review.v1 JSON Schema", () => {
@@ -19,7 +19,7 @@ describe("normative khive.review.v1 JSON Schema", () => {
   });
 
   it("accepts the bounded pull-request fixture", () => {
-    expect(validate(atlasReviewFixture), JSON.stringify(validate.errors)).toBe(true);
+    expect(validate(demoReviewFixture), JSON.stringify(validate.errors)).toBe(true);
   });
 
   it("accepts the exact Rust-produced shared changeset golden", () => {
@@ -40,16 +40,16 @@ describe("normative khive.review.v1 JSON Schema", () => {
     expect(() => parseReviewInput(inventedNested)).toThrow();
 
     const missingLabel = {
-      ...atlasReviewFixture,
-      capability: { ...atlasReviewFixture.capability, label: undefined },
+      ...demoReviewFixture,
+      capability: { ...demoReviewFixture.capability, label: undefined },
     };
     expect(validate(missingLabel)).toBe(false);
     expect(() => parseReviewInput(missingLabel)).toThrow();
 
     const unratifiedVerifiedHash = {
-      ...atlasReviewFixture,
+      ...demoReviewFixture,
       snapshot_identity: {
-        ...atlasReviewFixture.snapshot_identity,
+        ...demoReviewFixture.snapshot_identity,
         hash_status: "verified",
       },
     };
@@ -57,9 +57,9 @@ describe("normative khive.review.v1 JSON Schema", () => {
     expect(() => parseReviewInput(unratifiedVerifiedHash)).toThrow();
 
     const unavailableWithHashes = {
-      ...atlasReviewFixture,
+      ...demoReviewFixture,
       snapshot_identity: {
-        ...atlasReviewFixture.snapshot_identity,
+        ...demoReviewFixture.snapshot_identity,
         hash_status: "unavailable",
       },
     };
@@ -69,10 +69,10 @@ describe("normative khive.review.v1 JSON Schema", () => {
 
   it("maps current-algorithm output to an unavailable identity with null hashes (ADR-145 D4)", () => {
     const unratifiedProducerIdentity = {
-      ...atlasReviewFixture,
-      capability: { ...atlasReviewFixture.capability, source: "import" },
+      ...demoReviewFixture,
+      capability: { ...demoReviewFixture.capability, source: "import" },
       snapshot_identity: {
-        ...atlasReviewFixture.snapshot_identity,
+        ...demoReviewFixture.snapshot_identity,
         hash_status: "unavailable",
         algorithm: null,
         base_hash: null,
@@ -83,9 +83,9 @@ describe("normative khive.review.v1 JSON Schema", () => {
     expect(() => parseReviewInput(unratifiedProducerIdentity)).not.toThrow();
 
     for (const carried of [
-      { algorithm: atlasReviewFixture.snapshot_identity.algorithm },
-      { base_hash: atlasReviewFixture.snapshot_identity.base_hash },
-      { head_hash: atlasReviewFixture.snapshot_identity.head_hash },
+      { algorithm: demoReviewFixture.snapshot_identity.algorithm },
+      { base_hash: demoReviewFixture.snapshot_identity.base_hash },
+      { head_hash: demoReviewFixture.snapshot_identity.head_hash },
     ]) {
       const unavailableCarryingValue = {
         ...unratifiedProducerIdentity,


### PR DESCRIPTION
## Summary

- The kg-editor review/studio demo fixtures hardcoded actor-style identifiers and an
  organization-flavored repository slug. Replaced them with clearly fictional, neutral
  values (a demo org/repo slug and generic personas) so the demo data is self-contained
  and doesn't resemble any real account or organization.
- Kept the `family:` prefix on the reviewer-model-family value since it's read verbatim
  by the Studio component's reviewer-family dropdown (its default selection has to match
  the fixture's producer family for the demo's "select an independent reviewer" flow to
  make sense).

## Why

Demo/fixture data shouldn't reference names that look like real accounts or orgs.

## Test plan

- [x] `git grep -nE 'lambda:' -- apps/kg-editor/src apps/kg-editor/e2e` — empty
- [x] `git grep -niE 'atlas-frontier|family:atlas' -- apps/kg-editor/src apps/kg-editor/e2e` — empty
- [x] `npm run test` — 96/96 tests pass
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (3 pre-existing, unrelated warnings)
- [x] `npm run check:showcase` — passes, showcase bundle untouched/byte-identical

Refs #2037