### PR TITLE
docs(adr): ADR-115 Amendment 1 — executable initial scope and activation gates

### DIFF
--- a/docs/adr/ADR-115-secret-gate-content-manifest-exemption.md
+++ b/docs/adr/ADR-115-secret-gate-content-manifest-exemption.md
@@ -747,8 +747,15 @@ atomic success event keyed to the target's identity:
 - entity create, update, and bulk mutations, including direct code-ingest entity candidates;
 - note create, update, and atomic-message mutations, including direct code-ingest note candidates.
 
-Merge and restore operations participate only by routing a final entity or note candidate through
-that same finalizer; an operation that cannot do so is excluded and follows its legacy path.
+The admission-capable set is defined by code path, not by verb: a mutation is admission-capable if
+and only if it reaches storage through the shared finalizer's entity or note constructor entry
+points named above. Merge and restore participate exactly when their implementations construct a
+final entity or note candidate through those entry points; a merge or restore implementation that
+writes rows by any other path is reservation-only and owned by #2057. Curation, atomic-prepare, and
+proposal-materialization paths are reservation-only in this slice and owned by #2057. The first
+acceptance rung's matrix enumerates the finalizer's constructor entry points, and #2057's inventory
+is every write path that does not pass through them; both lists are derivable from the code without
+further judgment.
 Everything else is reservation-only in this slice: knowledge atoms and domains, proposal-only
 metadata, edge metadata, merge reasons, embedding-content overrides, and any field not present in
 the final stored entity or note use the unchanged blocking scanner and can never receive a stamp.

--- a/docs/adr/ADR-115-secret-gate-content-manifest-exemption.md
+++ b/docs/adr/ADR-115-secret-gate-content-manifest-exemption.md
@@ -751,19 +751,19 @@ tracked issue before this amendment merges:
 - **Complete full write-inventory finalization.** Route every remaining property-bearing runtime,
   pack, proposal-materialization, curation, merge, restore, and direct-write path named in Decision
   §4 through the shared finalization and reservation contract. **Owner reference:**
-  `(follow-on issue: TBD)`.
+  `(follow-on issue: #2057)`.
 - **Extend knowledge admission beyond the legacy path.** Define the durable stamp, target identity,
   atomic event representation, and readback contract before a knowledge record can consume an
-  exemption. **Owner reference:** `(follow-on issue: TBD)`.
+  exemption. **Owner reference:** `(follow-on issue: #2058)`.
 - **Integrate the git redaction surface.** Define whether it remains permanently mask-only or gains
   a final stored target with the same stamp and atomic success-event guarantees; no exemption is
-  allowed until then. **Owner reference:** `(follow-on issue: TBD)`.
+  allowed until then. **Owner reference:** `(follow-on issue: #2059)`.
 - **Integrate the session redaction surface.** Define whether it remains permanently mask-only or
   gains a final stored target with the same stamp and atomic success-event guarantees; no exemption
-  is allowed until then. **Owner reference:** `(follow-on issue: TBD)`.
+  is allowed until then. **Owner reference:** `(follow-on issue: #2060)`.
 - **Integrate the MCP redaction surface.** Preserve current masking until a final stored target,
   stamp location, and atomic success-event boundary are specified and implemented; no exemption is
-  allowed until then. **Owner reference:** `(follow-on issue: TBD)`.
+  allowed until then. **Owner reference:** `(follow-on issue: #2061)`.
 
 An excluded surface follows its unchanged blocking or masking behavior. It cannot consume a
 manifest match, synthesize the reserved stamp, or claim coverage under either acceptance rung.

--- a/docs/adr/ADR-115-secret-gate-content-manifest-exemption.md
+++ b/docs/adr/ADR-115-secret-gate-content-manifest-exemption.md
@@ -188,6 +188,11 @@ properties["khive:secret_gate"] = "exempted:content-sha256-manifest-v1"
 as part of the same write that persists the record. The caller cannot request, set, or supply this
 value; it originates only from the typed internal exemption outcome the gate returns.
 
+> **Amendment 1 supersession:** The full-inventory requirements in the remainder of this subsection
+> remain the target architecture, but they are superseded as acceptance conditions for the initial
+> slice by [Amendment 1 §3](#3-initial-implementation-scope-and-follow-on-obligations). The original
+> requirements remain visible here as the specification for the named follow-on work.
+
 Every write path that accepts or carries `properties` **must reject** a caller attempt to create,
 set, replace, merge, or remove `khive:secret_gate`, whether or not the record is actually exempted.
 The sole tolerated caller-side appearance of the key is the byte-exact echo of the currently
@@ -278,6 +283,13 @@ a queryable audit event; if the
 implementation cannot make this atomic in one transaction, it must use a transactional outbox or
 equivalent, and audit-persistence failure on this path blocks the write rather than proceeding.
 
+> **Amendment 1 supersession:** The paragraph above remains normative for successful admissions,
+> including atomic record, stamp, and success-event durability. Its requirement that all failure
+> distinctions be durable through the event store is superseded by
+> [Amendment 1 §4](#4-failure-observability-and-load-bearing-atomicity), which makes those
+> distinctions typed runtime outcomes and requires a store-independent signal when best-effort
+> failure-audit emission fails.
+
 ### 5. View behavior: annotate by default
 
 The posture property is durable record data, not a filtering directive. Recall, search, `context`,
@@ -289,6 +301,10 @@ follows (`docs/adr/../CLAUDE.md` — data records history and marks state, the q
 what is shown).
 
 ### 6. Fail-closed, unconditionally
+
+> **Amendment 1 clarification:** `stale` no longer denotes manifest age. The concrete,
+> fail-closed version and corpus-identity faults, and the acceptance construction for each, are
+> defined by [Amendment 1 §5](#5-concrete-manifest-version-and-freshness-semantics).
 
 The exemption is a scoped carve-out from the existing heuristic path, not a replacement for it. Any
 error condition on the exemption path — missing, unreadable, malformed, stale, duplicate-conflicting,
@@ -395,6 +411,10 @@ the claim to the boundaries above.
 
 ## Acceptance: the frozen 548-file corpus
 
+> **Amendment 1 sequencing:** This section is the second rung of the acceptance ladder and is a
+> mandatory precondition for shipping any non-empty operator manifest. The first, behavior-neutral
+> implementation slice is accepted under [Amendment 1 §1](#1-acceptance-ladder).
+
 ### Frozen inputs and adjudication
 
 1. Check in, or otherwise immutably identify, the existing 548-entry blocked list and a corpus
@@ -437,6 +457,10 @@ the claim to the boundaries above.
    field.
 
 ### Failure and laundering path
+
+> **Amendment 1 clarification:** In item 1, `stale-version` is constructed through the four
+> concrete cases in [Amendment 1 §5](#5-concrete-manifest-version-and-freshness-semantics), not by
+> elapsed age.
 
 1. Exercise absent, unreadable, malformed, duplicate-conflicting, stale-version, unsupported-
    algorithm, truncated-digest, and refresh-failure manifests. Each case must preserve the current
@@ -586,6 +610,10 @@ patching individual manifest entries.
 
 ### Verify by
 
+> **Amendment 1 sequencing:** These checks remain the non-empty-manifest acceptance rung. They do
+> not prevent the behavior-neutral initial slice described in Amendment 1 §1 from landing with an
+> absent or empty deployed manifest.
+
 - 548 of 548 exact records persist through the end-to-end acceptance path.
 - 548 of 548 credential-mutated records are rejected, with zero persisted records among them.
 - Zero caller-originated reserved-property mutations succeed across the full write inventory in
@@ -639,3 +667,187 @@ patching individual manifest entries.
    may be best-effort rather than transactionally coupled to the write. This ADR's position is no;
    weakening it changes the accepted threat and explainability posture and should not be a local
    implementation trade.
+
+> **Amendment 1 resolution:** Open question 3 is superseded. Successful admission remains
+> transactionally coupled to its stamp and success event; failure-audit emission follows Amendment
+> 1 §4.
+
+---
+
+## Amendment 1 (2026-08-19): Executable initial scope and activation gates
+
+**Status**: Accepted
+
+This amendment resolves implementation sequencing and failure semantics that were not executable
+as written. It is normative and last-in-time where it conflicts with the base text. The
+exact-content eligibility rule, host-trust boundary, unchanged scanner fallback, reserved posture
+value, and prohibition on automatic enrollment remain unchanged.
+
+### 1. Acceptance ladder
+
+Acceptance has two explicit rungs.
+
+1. **Initial behavior-neutral implementation slice.** The deployed operator manifest is absent or
+   empty, so no ordinary runtime write can become newly eligible and externally observable behavior
+   remains unchanged. An in-process, crate-private harness is sufficient for this rung. It must
+   exercise the manifest types and digest parity, one-snapshot lookup, runtime-owned finalization,
+   reserved-key enforcement, typed outcomes, atomic successful admission, rollback faults, and the
+   legacy knowledge-admission behavior. It may use only the test-only fixture defined in §2 to
+   exercise a non-empty lookup. Passing this rung accepts the implementation mechanism; it does not
+   authorize a non-empty operator manifest.
+2. **Non-empty operator-manifest activation.** Before any release, configuration, or artifact may
+   ship a non-empty operator manifest, the existing frozen-corpus acceptance section must pass
+   through the real workspace script, daemon transport, normal `create` operation, shared handler,
+   secret gate, storage, and readback path. The bar remains 548 of 548 persisted with byte-exact
+   readback, the reserved stamp, exactly one successful exemption event per fresh admission, an
+   empty blocked-record list, and all existing negative and laundering checks. A crate-private
+   harness, a synthetic fixture, or a statement that the path will be tested later cannot satisfy
+   this rung.
+
+The second rung is a mandatory activation precondition, not optional release evidence. A failure at
+either rung fails closed and does not permit a partial manifest.
+
+### 2. Builder input and test-only fixture separation
+
+The operator-manifest builder **must consume an explicit, versioned adjudication artifact** whose
+entries are the operator-approved list. It must bind that artifact to the frozen corpus identity and
+must reject a missing artifact, an unapproved entry, an identity mismatch, or an incomplete mapping
+between approved entries and emitted manifest entries. Automated capture or freeze output may
+supply candidate bytes and reproducibility evidence, but it is never valid builder input on its own
+and never proves adjudication.
+
+A separate fixture named **`TestOnlyManifestFixture`** is permitted solely for the crate-private
+acceptance harness. Both of the following properties are normative:
+
+1. It is non-deployable by construction wherever the build system can enforce that boundary. It
+   must carry a distinct test schema marker or use a test-only load path that the production loader
+   refuses outside test builds; a production operator-manifest builder must not accept it.
+2. Its definition site must state: **“This fixture is not evidence of operator adjudication.”** A
+   passing fixture test cannot be cited as satisfying the adjudication prerequisite or the second
+   acceptance rung.
+
+```mermaid
+flowchart LR
+    C[Automated capture and freeze] --> O[Operator adjudication]
+    O --> A[Operator-approved adjudication artifact]
+    A --> B[Operator-manifest builder]
+    B --> M[Non-empty operator manifest]
+    T[TestOnlyManifestFixture] --> H[Crate-private harness]
+    M --> R[Runtime finalizer]
+    R --> X[Atomic record, stamp, and success event]
+```
+
+### 3. Initial implementation scope and follow-on obligations
+
+The initial slice covers only the runtime finalization boundary for final entity and note mutations,
+including direct code-ingest entity and note candidates, plus the legacy knowledge-admission path.
+The knowledge path retains its existing scanner behavior, rejects the reserved property wherever it
+accepts or carries properties, and cannot consume an exemption in this slice. This is a scope
+reduction for sequencing, not a deletion of the base ADR's target architecture.
+
+The following exclusions are named obligations. Each issue reference must be replaced with a real
+tracked issue before this amendment merges:
+
+- **Complete full write-inventory finalization.** Route every remaining property-bearing runtime,
+  pack, proposal-materialization, curation, merge, restore, and direct-write path named in Decision
+  §4 through the shared finalization and reservation contract. **Owner reference:**
+  `(follow-on issue: TBD)`.
+- **Extend knowledge admission beyond the legacy path.** Define the durable stamp, target identity,
+  atomic event representation, and readback contract before a knowledge record can consume an
+  exemption. **Owner reference:** `(follow-on issue: TBD)`.
+- **Integrate the git redaction surface.** Define whether it remains permanently mask-only or gains
+  a final stored target with the same stamp and atomic success-event guarantees; no exemption is
+  allowed until then. **Owner reference:** `(follow-on issue: TBD)`.
+- **Integrate the session redaction surface.** Define whether it remains permanently mask-only or
+  gains a final stored target with the same stamp and atomic success-event guarantees; no exemption
+  is allowed until then. **Owner reference:** `(follow-on issue: TBD)`.
+- **Integrate the MCP redaction surface.** Preserve current masking until a final stored target,
+  stamp location, and atomic success-event boundary are specified and implemented; no exemption is
+  allowed until then. **Owner reference:** `(follow-on issue: TBD)`.
+
+An excluded surface follows its unchanged blocking or masking behavior. It cannot consume a
+manifest match, synthesize the reserved stamp, or claim coverage under either acceptance rung.
+Narrowing the implementation without its named obligation is non-conforming.
+
+### 4. Failure observability and load-bearing atomicity
+
+The five required distinctions are typed runtime outcomes:
+
+- `Exempted`
+- `ManifestInvalid`
+- `AuditFailed`
+- `StampFailed`
+- `RecordWriteFailed`
+
+`Exempted` is the only successful admission outcome. A successful fresh admission must durably
+commit the record, reserved stamp, and one queryable success event in one atomic unit. If that
+atomic unit cannot commit all three, it commits none.
+
+Failure-audit emission is best-effort because a diagnostic cannot be required to persist through
+the event-store channel whose failure it reports. A failed stamp, audit, or record write returns its
+typed failure outcome after rollback and may attempt a failure audit. If that best-effort emission
+fails, the same code path **must emit a structured log line through a store-independent channel**.
+That log line must name the typed failure class and must not include submitted content or a detector
+excerpt. The independent log is evidence of an audit gap, not a substitute for a durable success
+event and not evidence that a record was admitted.
+
+The following invariant is load-bearing and unchanged: **no admitted record may survive a stamp,
+audit, or record-write failure.** Implementations must not weaken rollback in order to make failure
+diagnostics durable.
+
+```mermaid
+sequenceDiagram
+    participant F as Runtime finalizer
+    participant S as Atomic record and event store
+    participant L as Store-independent structured log
+    F->>S: commit record + stamp + success event
+    alt atomic commit succeeds
+        S-->>F: Exempted
+    else stamp, audit, or record write fails
+        S-->>F: rollback + typed failure
+        F->>S: best-effort failure audit
+        alt failure audit also fails
+            F->>L: structured failure class
+        end
+    end
+```
+
+### 5. Concrete manifest version and freshness semantics
+
+“Stale manifest” no longer means elapsed age. This ADR defines no time-to-live, age threshold, or
+wall-clock expiry for a manifest. The former `stale-version` acceptance label maps to four concrete,
+testable faults, each of which publishes or retains an empty effective manifest and follows the
+unchanged scanner path:
+
+1. **Unknown schema version.** Construct an otherwise well-formed document whose schema version is
+   not supported. Loading must return the typed version fault, leave no active entries, and reject a
+   corpus input that would have matched under a supported version.
+2. **Missing expected corpus identity.** Load a non-empty, otherwise valid document while the
+   runtime's own configuration has no expected corpus identity. Loading must return the typed
+   missing-identity fault, leave no active entries, and preserve the legacy rejection.
+3. **Corpus-identity mismatch.** Pin identity A in the runtime's own configuration and load an
+   otherwise valid document declaring identity B. Loading must return the typed mismatch fault,
+   leave no active entries, and preserve the legacy rejection. Caller-supplied request fields can
+   neither provide nor override the expected identity.
+4. **Refresh failure.** Begin with a valid snapshot, then refresh from an unreadable, malformed,
+   unknown-version, missing-identity, or identity-mismatched document. The refresh must make the
+   effective snapshot empty before returning its typed fault; a subsequent would-have-matched input
+   must follow the legacy scanner and receive no stamp or successful exemption event.
+
+For v1, the expected corpus identity is the corpus-level digest required by the frozen-inputs
+acceptance section and is pinned by runtime-owned configuration. Every construction above is
+fail-closed. Adding age, revision ordering, revocation, or manifest-id freshness requires a later
+amendment with an explicit source of truth and acceptance fixture.
+
+### Alternatives retained as rejected
+
+- Treating the crate-private harness as evidence for non-empty deployment is rejected because it
+  does not exercise the required transport and operator workflow.
+- Treating automated capture or freeze output as approval is rejected because generation and
+  adjudication are separate trust steps.
+- Expanding every persistence and redaction surface in the initial slice is deferred through the
+  named obligations above; inventing missing target and atomicity contracts locally is rejected.
+- Requiring a failure event to persist only through the failing event store is rejected as
+  non-executable; silently dropping a failed best-effort audit is also rejected.
+- Interpreting staleness as age is rejected because no clock, threshold, or revocation authority is
+  defined.

--- a/docs/adr/ADR-115-secret-gate-content-manifest-exemption.md
+++ b/docs/adr/ADR-115-secret-gate-content-manifest-exemption.md
@@ -751,11 +751,19 @@ The admission-capable set is defined by code path, not by verb: a mutation is ad
 and only if it reaches storage through the shared finalizer's entity or note constructor entry
 points named above. Merge and restore participate exactly when their implementations construct a
 final entity or note candidate through those entry points; a merge or restore implementation that
-writes rows by any other path is reservation-only and owned by #2057. Curation, atomic-prepare, and
-proposal-materialization paths are reservation-only in this slice and owned by #2057. The first
-acceptance rung's matrix enumerates the finalizer's constructor entry points, and #2057's inventory
-is every write path that does not pass through them; both lists are derivable from the code without
-further judgment.
+writes rows by any other path is reservation-only and owned by #2057. In the initial slice,
+curation, atomic-prepare, and proposal-materialization implementations must not route through the
+finalizer's entry points: they remain reservation-only on their legacy write paths, and #2057 owns
+their migration. That is an implementation obligation, not a competing classification — the
+code-path criterion stays the sole test of admission capability.
+
+The finalizer and its constructor entry points are introduced by this slice's implementation, and
+one runtime-owned module must declare the complete entry-point list. The first acceptance rung's
+matrix is generated from that declaration, and #2057's inventory is every property-bearing write
+path that does not pass through a declared entry point. A write path added later either routes
+through a declared entry point or extends #2057's inventory; the declaration is the auditable
+anchor for both.
+
 Everything else is reservation-only in this slice: knowledge atoms and domains, proposal-only
 metadata, edge metadata, merge reasons, embedding-content overrides, and any field not present in
 the final stored entity or note use the unchanged blocking scanner and can never receive a stamp.
@@ -785,6 +793,10 @@ tracked issue before this amendment merges:
 - **Integrate the MCP redaction surface.** Preserve current masking until a final stored target,
   stamp location, and atomic success-event boundary are specified and implemented; no exemption is
   allowed until then. **Owner reference:** `(follow-on issue: #2061)`.
+
+The five obligations are disjoint: #2058 through #2061 own exactly their named surfaces, and #2057
+owns every other excluded property-bearing path. Closing #2057 neither closes nor is blocked by the
+four named-surface obligations.
 
 An excluded surface follows its unchanged blocking or masking behavior. It cannot consume a
 manifest match, synthesize the reserved stamp, or claim coverage under either acceptance rung.
@@ -869,6 +881,10 @@ unchanged scanner path:
    unknown-version, missing-identity, or identity-mismatched document. The refresh must make the
    effective snapshot empty before returning its typed fault; a subsequent would-have-matched input
    must follow the legacy scanner and receive no stamp or successful exemption event.
+
+Each fault above is a distinguishable cause of the `ManifestInvalid` outcome defined in §4: loading
+and refresh return `ManifestInvalid` carrying the specific fault, and each acceptance construction
+asserts the specific fault rather than the bare outcome.
 
 For v1, the expected corpus identity is the corpus-level digest required by the frozen-inputs
 acceptance section and is pinned by runtime-owned configuration. Every construction above is

--- a/docs/adr/ADR-115-secret-gate-content-manifest-exemption.md
+++ b/docs/adr/ADR-115-secret-gate-content-manifest-exemption.md
@@ -691,8 +691,9 @@ Acceptance has two explicit rungs.
    empty, so no ordinary runtime write can become newly eligible and externally observable behavior
    remains unchanged. An in-process, crate-private harness is sufficient for this rung. It must
    exercise the manifest types and digest parity, one-snapshot lookup, runtime-owned finalization,
-   reserved-key enforcement, typed outcomes, atomic successful admission, rollback faults, and the
-   legacy knowledge-admission behavior. It may use only the test-only fixture defined in §2 to
+   reserved-key enforcement, typed outcomes, atomic successful admission, rollback faults, the
+   deterministic failure constructions of §4 including the second-order failure of the best-effort
+   failure audit, and the legacy knowledge-admission behavior. It may use only the test-only fixture defined in §2 to
    exercise a non-empty lookup. Passing this rung accepts the implementation mechanism; it does not
    authorize a non-empty operator manifest.
 2. **Non-empty operator-manifest activation.** Before any release, configuration, or artifact may
@@ -739,19 +740,32 @@ flowchart LR
 
 ### 3. Initial implementation scope and follow-on obligations
 
-The initial slice covers only the runtime finalization boundary for final entity and note mutations,
-including direct code-ingest entity and note candidates, plus the legacy knowledge-admission path.
-The knowledge path retains its existing scanner behavior, rejects the reserved property wherever it
-accepts or carries properties, and cannot consume an exemption in this slice. This is a scope
-reduction for sequencing, not a deletion of the base ADR's target architecture.
+The initial slice's admission-capable set is exactly the following, each routed through the shared
+runtime finalizer, with the durable stamp written into the final stored `properties` object and the
+atomic success event keyed to the target's identity:
+
+- entity create, update, and bulk mutations, including direct code-ingest entity candidates;
+- note create, update, and atomic-message mutations, including direct code-ingest note candidates.
+
+Merge and restore operations participate only by routing a final entity or note candidate through
+that same finalizer; an operation that cannot do so is excluded and follows its legacy path.
+Everything else is reservation-only in this slice: knowledge atoms and domains, proposal-only
+metadata, edge metadata, merge reasons, embedding-content overrides, and any field not present in
+the final stored entity or note use the unchanged blocking scanner and can never receive a stamp.
+Deletes preserve or remove existing rows without fresh exemption. The legacy knowledge-admission
+path retains its existing scanner behavior, rejects the reserved property wherever it accepts or
+carries properties, and cannot consume an exemption in this slice. This is a scope reduction for
+sequencing, not a deletion of the base ADR's target architecture. This enumeration and the first
+obligation below are the same list read in two directions: #2057 owns every property-bearing path
+not named admission-capable here.
 
 The following exclusions are named obligations. Each issue reference must be replaced with a real
 tracked issue before this amendment merges:
 
-- **Complete full write-inventory finalization.** Route every remaining property-bearing runtime,
-  pack, proposal-materialization, curation, merge, restore, and direct-write path named in Decision
-  §4 through the shared finalization and reservation contract. **Owner reference:**
-  `(follow-on issue: #2057)`.
+- **Complete full write-inventory finalization.** Route every property-bearing runtime, pack,
+  proposal-materialization, curation, merge, restore, and direct-write path named in Decision §4
+  that is not in this section's admission-capable enumeration through the shared finalization and
+  reservation contract. **Owner reference:** `(follow-on issue: #2057)`.
 - **Extend knowledge admission beyond the legacy path.** Define the durable stamp, target identity,
   atomic event representation, and readback contract before a knowledge record can consume an
   exemption. **Owner reference:** `(follow-on issue: #2058)`.
@@ -768,6 +782,12 @@ tracked issue before this amendment merges:
 An excluded surface follows its unchanged blocking or masking behavior. It cannot consume a
 manifest match, synthesize the reserved stamp, or claim coverage under either acceptance rung.
 Narrowing the implementation without its named obligation is non-conforming.
+
+The reserved-key reservation is not deferred. During the initial slice, every properties-bearing
+write path — admission-capable or excluded — must reject caller creation, replacement, merge, or
+removal of the reserved property, exactly as Decision §4 of the base text requires. The named
+obligations defer finalization routing, durable stamps, and exemption consumption for the excluded
+paths; they do not defer, narrow, or supersede the reservation rule on any path.
 
 ### 4. Failure observability and load-bearing atomicity
 
@@ -790,6 +810,15 @@ fails, the same code path **must emit a structured log line through a store-inde
 That log line must name the typed failure class and must not include submitted content or a detector
 excerpt. The independent log is evidence of an audit gap, not a substitute for a durable success
 event and not evidence that a record was admitted.
+
+These requirements are testable by construction. The implementation must expose an injectable
+failure seam for each of `ManifestInvalid`, `AuditFailed`, `StampFailed`, and `RecordWriteFailed`,
+and an injectable store-independent log sink. The first acceptance rung must include a deterministic
+construction for each typed failure, plus the second-order case in which the best-effort failure
+audit itself fails: the harness captures the structured log record through the injected sink and
+asserts that it names the typed failure class, that it contains no submitted content and no detector
+excerpt, and that no record, stamp, or success event survives the rollback, before the typed failure
+outcome is returned to the caller.
 
 The following invariant is load-bearing and unchanged: **no admitted record may survive a stamp,
 audit, or record-write failure.** Implementations must not weaken rollback in order to make failure


### PR DESCRIPTION
Amends ADR-115 (secret-gate content manifest exemption) to resolve five contract-level gaps found during implementation planning, without changing the exact-content eligibility rule, host-trust boundary, scanner fallback, reserved posture value, or the prohibition on automatic enrollment.

1. **Acceptance ladder**: an in-process crate-private harness accepts the behavior-neutral initial slice (absent/empty manifest); the full workspace-script → daemon → create → handler → gate → storage → readback path is a mandatory activation precondition before any non-empty operator manifest ships.
2. **Builder input separation**: the manifest builder consumes an explicit, versioned operator-approved adjudication artifact; automated capture/freeze output is never valid builder input alone. A `TestOnlyManifestFixture` is permitted for the harness, non-deployable by construction, and stated at its definition site as not evidence of adjudication.
3. **Initial scope with named obligations**: the slice covers the runtime finalization boundary plus legacy knowledge admission; every excluded surface is a named follow-on obligation — #2057 (full write-inventory finalization), #2058 (knowledge admission), #2059 (git redaction), #2060 (session redaction), #2061 (MCP redaction). Narrowing without a named obligation is non-conforming.
4. **Failure observability**: the five outcome distinctions become typed runtime outcomes; successful admission stays atomically durable (record + stamp + success event, all or none); failure audits are best-effort, and a failed emission must itself emit a structured log line on a store-independent channel naming the failure class. The rollback invariant is retained as load-bearing.
5. **Freshness semantics**: elapsed-age staleness is dropped; stale-version maps to four constructible fail-closed faults (unknown schema version, missing expected corpus identity, corpus-identity mismatch with config-pinned identity, refresh failure).

Docs-only diff: one file, +212 lines plus issue-reference pinning. `make docs-check` passes (198 files).