### PR TITLE
ci: run CI on pull requests regardless of base branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,10 @@ on:
     branches: [main, "integration/**"]
   # Keep pull_request (not pull_request_target): GitHub's first-time-contributor
   # approval gate must remain in front of workflows from external forks.
+  # No branches filter: stacked PRs (base = another feature branch) must run CI
+  # too — a filtered trigger leaves them mergeStateStatus=CLEAN with zero checks,
+  # and a base retarget after the parent merges does not re-fire the workflow.
   pull_request:
-    branches: [main, "integration/**"]
   workflow_dispatch:
   schedule:
     - cron: "17 6 * * *"


### PR DESCRIPTION
The `pull_request` trigger was filtered to `branches: [main, integration/**]`, so a stacked PR whose base is another feature branch never runs CI: it reads `mergeStateStatus=CLEAN` with zero CI checks in its rollup. Retargeting the base after a parent merges emits no `synchronize` event, so the gap survives until merge time. Measured on this repository: 13 of 28 open PRs currently read CLEAN with no CI gate check.

Fix: drop the branches filter on `pull_request` (the `push` trigger keeps its filter). Stacked chains now spend CI minutes per PR, which is the point — no PR can present as mergeable without its checks having run.