### PR TITLE
ci: cache Playwright browsers and bound the KG Studio install step with one retry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,8 +298,17 @@ jobs:
         run: npm run check:showcase
       - name: Production build
         run: npm run build
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('apps/kg-editor/package-lock.json') }}
+      # The browser download intermittently stalls until the job-level timeout
+      # cancels the whole run (#2066). Bound each attempt well under the job
+      # budget and retry once so a stalled download fails fast instead of
+      # consuming the run; the cache above makes a warm install a near no-op.
       - name: Install browser for repository dogfood
-        run: npx playwright install --with-deps chromium
+        run: timeout 240 npx playwright install --with-deps chromium || timeout 240 npx playwright install --with-deps chromium
       - name: Repository showcase dogfood
         run: npx playwright test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,17 +298,26 @@ jobs:
         run: npm run check:showcase
       - name: Production build
         run: npm run build
+      # The install intermittently stalls in a hung mirror download until the
+      # job-level timeout cancels the whole run (#2066). Bounding the npx
+      # process with timeout(1) is unsound for the apt half: killing the
+      # wrapper orphans apt-get with the dpkg lock held and the retry then
+      # fails on the lock. Instead, bound stalls where they happen: apt gets
+      # transport-level read timeouts and native retries, and only the
+      # lock-free browser download is wrapped in timeout-with-retry.
+      - name: Bound apt downloads against mirror stalls
+        run: |
+          printf 'Acquire::http::Timeout "30";\nAcquire::https::Timeout "30";\nAcquire::Retries "3";\n' \
+            | sudo tee /etc/apt/apt.conf.d/99-download-timeouts
       - name: Cache Playwright browsers
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('apps/kg-editor/package-lock.json') }}
-      # The browser download intermittently stalls until the job-level timeout
-      # cancels the whole run (#2066). Bound each attempt well under the job
-      # budget and retry once so a stalled download fails fast instead of
-      # consuming the run; the cache above makes a warm install a near no-op.
       - name: Install browser for repository dogfood
-        run: timeout 240 npx playwright install --with-deps chromium || timeout 240 npx playwright install --with-deps chromium
+        run: timeout 240 npx playwright install chromium || timeout 240 npx playwright install chromium
+      - name: Install browser OS dependencies
+        run: npx playwright install-deps chromium
       - name: Repository showcase dogfood
         run: npx playwright test
 


### PR DESCRIPTION
Fixes #2066.

The KG Studio job intermittently stalls during `npx playwright install --with-deps chromium` until the job-level 10-minute timeout cancels the run; healthy runs complete the entire job in 1.5-3 minutes (four stalls interleaved with normal runs on 2026-08-19 alone). This PR's own first CI run localized the stall: the apt half of the install sat minutes in a hung mirror download of a font package.

Three changes, all scoped to the `kg-editor` job:

1. **Bound apt downloads at the transport layer**: an `apt.conf.d` drop-in sets 30-second read timeouts and `Acquire::Retries 3`, so a hung mirror connection times out and retries instead of stalling indefinitely. (Wrapping the whole installer in `timeout(1)` with a retry is unsound here: killing the npx wrapper orphans `apt-get` with the dpkg frontend lock held, and the retry then fails immediately on that lock — measured on this PR's first run.)
2. **Cache `~/.cache/ms-playwright`** keyed on the app lockfile, so warm runs skip the browser download entirely.
3. **Split the install**: the lock-free browser download runs under `timeout 240` with one retry; OS dependencies install as a separate unwrapped step protected by the apt-level bounds.

Worst case remains well inside the job budget, and a stalled mirror now degrades to a bounded retry instead of a cancelled run.