### PR TITLE
fix(runtime): preserve imported edge metadata through the portability core

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2570,6 +2570,7 @@ dependencies = [
 name = "khive-vcs-adapters"
 version = "0.7.0"
 dependencies = [
+ "chrono",
  "khive-types",
  "serde",
  "serde_json",

--- a/crates/khive-merge/README.md
+++ b/crates/khive-merge/README.md
@@ -44,9 +44,9 @@ going through the `MergeEngine` trait object.
 `MergeConflict` enumerates what `Auto` can detect: `NameConflict`, `KindConflict`,
 `PropertyMismatch`, `ModifyDelete` (one branch edited, the other deleted),
 `DuplicateAddition` (both branches added the same UUID with different content),
-`EdgeModifyDelete`, and `DanglingEdge` (a merged edge references an entity not in the
-merged set). `BranchSide::{Ours, Theirs}` identifies which branch a `ModifyDelete` /
-`EdgeModifyDelete` change came from.
+`EdgeModifyDelete`, `EdgeIdentityMismatch`, `EdgeIdentityCollision`, `EdgePropertyMismatch`, and `DanglingEdge`
+(a merged edge references an entity not in the merged set). `BranchSide::{Ours, Theirs}`
+identifies which branch a `ModifyDelete` / `EdgeModifyDelete` change came from.
 
 ## Invariants
 
@@ -56,8 +56,9 @@ merged set). `BranchSide::{Ours, Theirs}` identifies which branch a `ModifyDelet
   aborts with `MergeError::InvalidEdgeWeight`, never silently coerced.
 - **Deterministic output** — entities sort by UUID, edges by `(source, target, relation)`;
   repeated calls over equal inputs produce byte-identical `KgArchive` output.
-- **Edge identity preserved** — a merged edge keeps the `edge_id` of the originating
-  branch's edge rather than minting a fresh UUID.
+- **Complete edge changes preserved** — edge UUID, weight, properties, and the selected
+  branch's independent timestamps survive merge; timestamp-only rebuild drift does not
+  manufacture a semantic change.
 
 ## Where this sits
 

--- a/crates/khive-merge/docs/api/conflict-and-error-taxonomy.md
+++ b/crates/khive-merge/docs/api/conflict-and-error-taxonomy.md
@@ -12,15 +12,18 @@ The merge API separates valid semantic conflicts from invalid inputs and interna
 
 ## `MergeConflict`
 
-| Variant             | Meaning                                                                 |
-| ------------------- | ----------------------------------------------------------------------- |
-| `NameConflict`      | both branches supply different entity names                             |
-| `KindConflict`      | both branches supply different entity kinds                             |
-| `PropertyMismatch`  | both branches supply different values for one property or `entity_type` |
-| `ModifyDelete`      | one branch modifies an entity while the other deletes it                |
-| `DuplicateAddition` | both branches add the same UUID with different content                  |
-| `EdgeModifyDelete`  | one branch changes an edge weight while the other deletes it            |
-| `DanglingEdge`      | a selected edge references an entity absent from the merged entity set  |
+| Variant                 | Meaning                                                                        |
+| ----------------------- | ------------------------------------------------------------------------------ |
+| `NameConflict`          | both branches supply different entity names                                    |
+| `KindConflict`          | both branches supply different entity kinds                                    |
+| `PropertyMismatch`      | both branches supply different values for one entity property or `entity_type` |
+| `ModifyDelete`          | one branch modifies an entity while the other deletes it                       |
+| `DuplicateAddition`     | both branches add the same UUID with different content                         |
+| `EdgeModifyDelete`      | one branch changes edge identity, weight, or properties while the other deletes it |
+| `EdgeIdentityMismatch`  | both branches replace one semantic edge's durable UUID differently             |
+| `EdgeIdentityCollision` | a branch-chosen edge UUID already belongs to a different semantic edge in the merged set; the edge falls back to its own unclaimed base UUID, or is dropped from the merged set if none is available |
+| `EdgePropertyMismatch`  | both branches change the same property key on one semantic edge differently    |
+| `DanglingEdge`          | a selected edge references an entity absent from the merged entity set         |
 
 `BranchSide::Ours` denotes the local branch being merged into the common base; `Theirs` denotes the remote branch being incorporated.
 
@@ -32,7 +35,7 @@ The merge API separates valid semantic conflicts from invalid inputs and interna
 | `InvalidEdgeWeight` | an input edge weight is NaN or infinite                                            |
 | `DuplicateEntityId` | one archive repeats an entity UUID                                                 |
 | `DuplicateEdgeKey`  | one archive repeats a semantic `(source, target, relation)` key                    |
-| `Internal`          | duplicate edge UUID, relation reconstruction failure, or another invariant failure |
+| `Internal`          | duplicate edge UUID or another invariant failure                                   |
 
 A conflict is not an error: it represents well-formed inputs whose changes need a policy or human decision. Invalid archives fail before diff computation.
 

--- a/crates/khive-merge/docs/api/edge-merge.md
+++ b/crates/khive-merge/docs/api/edge-merge.md
@@ -8,7 +8,9 @@ Edge merging treats `(source, target, relation)` as semantic identity while pres
 
 ## `diff_edges`
 
-Each semantic key is classified as `Added`, `Deleted`, `Unchanged`, or `WeightModified`. Weight equality uses an absolute difference below `f64::EPSILON`. Added changes retain the complete `ExportedEdge`, rather than only its weight, specifically so `edge_id` is not regenerated later. Weight modifications retain both weights for future diff display even though the current merge consumes the branch weight.
+Each semantic key is classified as `Added`, `Deleted`, `Unchanged`, or `Modified`. Added and modified changes retain the complete `ExportedEdge`, so one-sided changes pass through without regenerating identity or dropping properties and provenance.
+
+The semantic key already governs source, target, and relation. Within one key, durable `edge_id`, weight, and properties participate in change classification; weight equality uses an absolute difference below `f64::EPSILON`. `created_at` and `updated_at` do not create a change by themselves. This matches entity merge's timestamp policy and prevents deterministic archive rebuild times from creating false conflicts. When a branch wins a merge-relevant change, its complete independent timestamp pair is carried with the record.
 
 Keys are processed in source/target/relation order. Input archives are validated for duplicate keys by the top-level merge before this diff is used.
 
@@ -16,23 +18,32 @@ Keys are processed in source/target/relation order. Input archives are validated
 
 The edge pass applies the following policies:
 
-| Ours             | Theirs            | Result                             |
-| ---------------- | ----------------- | ---------------------------------- |
-| unchanged        | unchanged         | base edge                          |
-| added            | absent/unchanged  | added edge with branch ID          |
-| absent/unchanged | added             | added edge with branch ID          |
-| added            | added             | one edge, maximum weight, ours ID  |
-| deleted          | deleted/unchanged | omit                               |
-| unchanged        | deleted           | omit                               |
-| weight changed   | unchanged         | changed edge with ours ID          |
-| unchanged        | weight changed    | changed edge with theirs ID        |
-| weight changed   | weight changed    | maximum weight, preferring ours ID |
-| deleted          | weight changed    | `EdgeModifyDelete`                 |
-| weight changed   | deleted           | `EdgeModifyDelete`                 |
+| Ours             | Theirs            | Result                                                                 |
+| ---------------- | ----------------- | ---------------------------------------------------------------------- |
+| unchanged        | unchanged         | base edge                                                              |
+| added            | absent/unchanged  | complete added branch edge                                             |
+| absent/unchanged | added             | complete added branch edge                                             |
+| added            | added             | maximum weight and ours identity/timestamps; properties merge per key      |
+| deleted          | deleted/unchanged | omit                                                                   |
+| unchanged        | deleted           | omit                                                                   |
+| modified         | unchanged         | complete modified ours edge                                            |
+| unchanged        | modified          | complete modified theirs edge                                          |
+| modified         | modified          | field-level three-way reconciliation                                   |
+| deleted          | modified          | `EdgeModifyDelete`                                                     |
+| modified         | deleted           | `EdgeModifyDelete`                                                     |
 
-Maximum weight is the automatic last-write-wins policy for simultaneous weight changes. When rebuilding a modified edge, the implementation preserves an ID from the responsible branch; simultaneous changes prefer ours for deterministic identity. A fresh UUID is only a defensive fallback when no originating edge can be found.
+Double-modified records use these field policies:
 
-Relation reconstruction can return `MergeError::Internal` if the semantic key's relation string no longer parses as a governed relation.
+- A weight changed by only one branch is retained exactly, including a decrease. Simultaneous weight changes retain the established maximum-weight policy.
+- Object properties use base-aware three-way reconciliation per key, matching the existing entity-property policy: independent key changes are combined, a one-sided change or identical double change is retained, and divergent changes to the same key yield one payload-level `EdgePropertyMismatch` with ours as the provisional value for that key. `None` acts as an empty map; malformed legacy non-object payloads are reconciled atomically and conflict on divergent double changes.
+- `edge_id` uses the same three-way rule. Divergent replacements yield `EdgeIdentityMismatch`; independently added records have no common durable identity and continue to prefer ours.
+- Timestamps never trigger a modification or conflict. One-sided changes carry that branch's exact pair. A double-modified or double-added result deterministically carries ours' pair while reconciling the governed fields above.
+
+`SnapshotMergeStrategy::Ours` and `Theirs` are the explicit resolutions for property or identity conflicts and retain the selected branch's complete record.
+
+### Cross-key identity collisions
+
+Per-key reconciliation above decides each semantic edge's UUID independently, so a branch-chosen identity (an added edge, or a one-sided/double modification that changes `edge_id`) can coincide with a durable UUID already used by a *different* semantic edge in the merged set. `merge_edges` reserves every UUID inherited unchanged from base first, then resolves branch-chosen UUIDs against that reserved set in deterministic key order: an edge whose own identity did not change always keeps it; a colliding branch-chosen identity falls back to that key's own base UUID and reports `EdgeIdentityCollision`. That fallback UUID must itself still be unclaimed — a chained collision (the fallback target was already taken by an earlier-sorted edge) is checked the same way as the initial attempt. When there is no unclaimed identity to fall back to, whether because the key has no base UUID or because its base UUID was already claimed, the edge is dropped from the merged set rather than duplicating another edge's UUID; the `EdgeIdentityCollision` conflict is the record of the drop.
 
 ## `validate_dangling_edges`
 

--- a/crates/khive-merge/docs/api/three-way-merge.md
+++ b/crates/khive-merge/docs/api/three-way-merge.md
@@ -13,7 +13,7 @@ Every strategy first validates four input invariants:
 3. entity IDs and edge IDs are unique within each archive; and
 4. semantic edge keys `(source, target, relation)` are unique within each archive.
 
-Namespace, weight, duplicate-entity, and duplicate-edge-key failures have dedicated `MergeError` variants. A duplicate edge ID or an edge relation that cannot be reconstructed is reported as `MergeError::Internal`.
+Namespace, weight, duplicate-entity, and duplicate-edge-key failures have dedicated `MergeError` variants. A duplicate edge ID or another invariant failure is reported as `MergeError::Internal`.
 
 ## Automatic strategy
 

--- a/crates/khive-merge/src/diff_local.rs
+++ b/crates/khive-merge/src/diff_local.rs
@@ -38,12 +38,12 @@ pub enum EdgeChange {
     Added(ExportedEdge),
     /// Deleted in branch.
     Deleted,
-    /// Weight modified.
-    WeightModified {
-        // Retained for future “was → now” diff displays.
-        #[allow(dead_code)]
-        base_weight: f64,
-        branch_weight: f64,
+    /// Merge-relevant edge content or durable identity modified.
+    Modified {
+        // Complete records are retained so a one-sided change can pass through
+        // without losing edge identity, properties, or provenance timestamps.
+        base: ExportedEdge,
+        branch: ExportedEdge,
     },
 }
 
@@ -119,8 +119,11 @@ pub fn diff_entities(base: &KgArchive, branch: &KgArchive) -> HashMap<Uuid, Enti
 
 /// Classifies every semantic edge key in the union of `base` and `branch`.
 ///
-/// Added values retain their original `edge_id`; weights differing by less
-/// than `f64::EPSILON` are unchanged. See `crates/khive-merge/docs/api/edge-merge.md`.
+/// Added and modified values retain complete edge records. Durable `edge_id`,
+/// weight, and properties participate in classification; timestamps do not,
+/// so deterministic archive rebuilds cannot manufacture semantic changes.
+/// Weights differing by less than `f64::EPSILON` are unchanged. See
+/// `crates/khive-merge/docs/api/edge-merge.md`.
 ///
 /// # Errors
 ///
@@ -157,12 +160,12 @@ pub fn diff_edges(
             (None, Some(branch_e)) => EdgeChange::Added((*branch_e).clone()),
             (Some(_), None) => EdgeChange::Deleted,
             (Some(base_e), Some(branch_e)) => {
-                if (base_e.weight - branch_e.weight).abs() < f64::EPSILON {
+                if edges_equal(base_e, branch_e) {
                     EdgeChange::Unchanged
                 } else {
-                    EdgeChange::WeightModified {
-                        base_weight: base_e.weight,
-                        branch_weight: branch_e.weight,
+                    EdgeChange::Modified {
+                        base: (*base_e).clone(),
+                        branch: (*branch_e).clone(),
                     }
                 }
             }
@@ -172,6 +175,18 @@ pub fn diff_edges(
     }
 
     Ok(result)
+}
+
+/// Compares merge-relevant fields for one semantic edge key.
+///
+/// Source, target, and relation form [`EdgeKey`] and are therefore classified
+/// structurally as add/delete when they change. Timestamps are provenance, not
+/// semantic content: a branch that wins a real change carries its complete
+/// timestamps, while timestamp-only rebuild drift remains unchanged.
+fn edges_equal(a: &ExportedEdge, b: &ExportedEdge) -> bool {
+    a.edge_id == b.edge_id
+        && (a.weight - b.weight).abs() < f64::EPSILON
+        && properties_equal(&a.properties, &b.properties)
 }
 
 /// Compares merge-relevant entity fields, excluding timestamps.
@@ -238,6 +253,9 @@ mod tests {
             target: tgt,
             relation: EdgeRelation::Extends,
             weight,
+            properties: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
         }
     }
 
@@ -323,12 +341,74 @@ mod tests {
             target: b,
             relation: "extends".into(),
         };
-        assert!(matches!(
-            diff[&key],
-            EdgeChange::WeightModified {
-                base_weight: _,
-                branch_weight: _
+        assert!(matches!(diff[&key], EdgeChange::Modified { .. }));
+    }
+
+    #[test]
+    fn property_only_edge_change_is_modified_with_full_branch_record() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let base_edge = edge(a, b, 0.7);
+        let mut branch_edge = base_edge.clone();
+        branch_edge.properties = Some(serde_json::json!({"confidence": 0.95}));
+        branch_edge.created_at = chrono::DateTime::parse_from_rfc3339("2026-03-03T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        branch_edge.updated_at = chrono::DateTime::parse_from_rfc3339("2026-04-04T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        let base = make_archive(vec![], vec![base_edge.clone()]);
+        let branch = make_archive(vec![], vec![branch_edge.clone()]);
+        let diff = diff_edges(&base, &branch).unwrap();
+        let key = EdgeKey::from_edge(&base_edge);
+
+        match &diff[&key] {
+            EdgeChange::Modified { base, branch } => {
+                assert_eq!(base.properties, None);
+                assert_eq!(branch.edge_id, branch_edge.edge_id);
+                assert_eq!(branch.properties, branch_edge.properties);
+                assert_eq!(branch.created_at, branch_edge.created_at);
+                assert_eq!(branch.updated_at, branch_edge.updated_at);
             }
+            other => panic!("property-only change must be Modified, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn edge_identity_change_is_modified() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let base_edge = edge(a, b, 0.7);
+        let mut branch_edge = base_edge.clone();
+        branch_edge.edge_id = Uuid::new_v4();
+
+        let base = make_archive(vec![], vec![base_edge.clone()]);
+        let branch = make_archive(vec![], vec![branch_edge]);
+        let diff = diff_edges(&base, &branch).unwrap();
+
+        assert!(matches!(
+            diff[&EdgeKey::from_edge(&base_edge)],
+            EdgeChange::Modified { .. }
+        ));
+    }
+
+    #[test]
+    fn timestamp_only_edge_drift_is_unchanged() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let base_edge = edge(a, b, 0.7);
+        let mut rebuilt_edge = base_edge.clone();
+        rebuilt_edge.created_at += chrono::TimeDelta::seconds(1);
+        rebuilt_edge.updated_at += chrono::TimeDelta::seconds(2);
+
+        let base = make_archive(vec![], vec![base_edge.clone()]);
+        let branch = make_archive(vec![], vec![rebuilt_edge]);
+        let diff = diff_edges(&base, &branch).unwrap();
+
+        assert!(matches!(
+            diff[&EdgeKey::from_edge(&base_edge)],
+            EdgeChange::Unchanged
         ));
     }
 }

--- a/crates/khive-merge/src/edge.rs
+++ b/crates/khive-merge/src/edge.rs
@@ -9,19 +9,20 @@ use std::collections::{HashMap, HashSet};
 use khive_runtime::portability::{ExportedEdge, KgArchive};
 use uuid::Uuid;
 
-use crate::diff_local::{diff_edges, EdgeChange, EdgeKey};
+use crate::diff_local::{diff_edges, properties_equal, EdgeChange, EdgeKey};
 use crate::types::{BranchSide, MergeConflict, MergeError};
 
 /// Merges edges from `base`, `ours`, and `theirs` by semantic edge key.
 ///
-/// Returns the provisional edge set and any modify/delete conflicts. Call
+/// Returns the provisional edge set and any typed edge conflicts. Call
 /// [`validate_dangling_edges`] after entity merge before accepting the set.
 ///
 /// # Errors
 ///
-/// Returns [`MergeError::Internal`] if a relation cannot be reconstructed.
-/// Use the top-level merge to validate namespaces, weights, and duplicates.
-/// See `crates/khive-merge/docs/api/edge-merge.md` for all merge rules.
+/// The current edge pass is infallible after top-level input validation; the
+/// `Result` shape remains part of the merge-layer contract. Use the top-level
+/// merge to validate namespaces, weights, and duplicates. See
+/// `crates/khive-merge/docs/api/edge-merge.md` for all merge rules.
 pub fn merge_edges(
     base: &KgArchive,
     ours: &KgArchive,
@@ -44,103 +45,108 @@ pub fn merge_edges(
             .then(a.relation.cmp(&b.relation))
     });
 
-    let mut merged: Vec<ExportedEdge> = Vec::new();
     let mut conflicts: Vec<MergeConflict> = Vec::new();
 
-    // Preserve originating edge IDs across merge/diff cycles.
+    // Preserve the common-base record for unchanged output.
     let base_edge_map: HashMap<EdgeKey, &ExportedEdge> = base
         .edges
         .iter()
         .map(|e| (EdgeKey::from_edge(e), e))
         .collect();
-    let ours_edge_map: HashMap<EdgeKey, &ExportedEdge> = ours
-        .edges
-        .iter()
-        .map(|e| (EdgeKey::from_edge(e), e))
-        .collect();
-    let theirs_edge_map: HashMap<EdgeKey, &ExportedEdge> = theirs
-        .edges
-        .iter()
-        .map(|e| (EdgeKey::from_edge(e), e))
-        .collect();
 
-    for key in &all_keys_sorted {
-        let ours_change = ours_diff.get(key);
-        let theirs_change = theirs_diff.get(key);
+    // First pass: decide each key's provisional edge per-key, same as before,
+    // and note whether its durable identity is exactly base's (untouched) or
+    // was chosen by branch content (added, or a modification that changed
+    // `edge_id`). This classification drives collision resolution below,
+    // independent of key iteration order.
+    let mut candidates: Vec<(EdgeKey, Option<(ExportedEdge, bool)>)> =
+        Vec::with_capacity(all_keys_sorted.len());
 
-        match (ours_change, theirs_change) {
+    for key in all_keys_sorted {
+        let ours_change = ours_diff.get(&key);
+        let theirs_change = theirs_diff.get(&key);
+
+        let candidate = match (ours_change, theirs_change) {
             (Some(EdgeChange::Unchanged), Some(EdgeChange::Unchanged)) => {
-                if let Some(&e) = base_edge_map.get(key) {
-                    merged.push(e.clone());
-                }
+                base_edge_map.get(&key).map(|&e| (e.clone(), true))
             }
 
             (Some(EdgeChange::Added(e)), None)
-            | (Some(EdgeChange::Added(e)), Some(EdgeChange::Unchanged)) => {
-                merged.push(e.clone());
-            }
+            | (Some(EdgeChange::Added(e)), Some(EdgeChange::Unchanged)) => Some((e.clone(), false)),
 
             (None, Some(EdgeChange::Added(e)))
-            | (Some(EdgeChange::Unchanged), Some(EdgeChange::Added(e))) => {
-                merged.push(e.clone());
-            }
+            | (Some(EdgeChange::Unchanged), Some(EdgeChange::Added(e))) => Some((e.clone(), false)),
 
             (Some(EdgeChange::Added(e_ours)), Some(EdgeChange::Added(e_theirs))) => {
-                // Simultaneous weight changes auto-resolve to the maximum.
-                let weight = f64::max(e_ours.weight, e_theirs.weight);
-                let mut edge = e_ours.clone();
-                edge.weight = weight;
-                merged.push(edge);
+                let (edge, edge_conflicts) = merge_added_edges(&key, e_ours, e_theirs);
+                conflicts.extend(edge_conflicts);
+                Some((edge, false))
             }
 
-            (Some(EdgeChange::Deleted), Some(EdgeChange::Deleted)) => {}
+            (Some(EdgeChange::Deleted), Some(EdgeChange::Deleted)) => None,
 
             (Some(EdgeChange::Deleted), Some(EdgeChange::Unchanged))
-            | (Some(EdgeChange::Deleted), None) => {}
+            | (Some(EdgeChange::Deleted), None) => None,
 
             (Some(EdgeChange::Unchanged), Some(EdgeChange::Deleted))
-            | (None, Some(EdgeChange::Deleted)) => {}
+            | (None, Some(EdgeChange::Deleted)) => None,
 
             (
-                Some(EdgeChange::WeightModified { branch_weight, .. }),
+                Some(EdgeChange::Modified {
+                    branch: edge_ours, ..
+                }),
                 Some(EdgeChange::Unchanged),
             )
-            | (Some(EdgeChange::WeightModified { branch_weight, .. }), None) => {
-                let id = ours_edge_map.get(key).map(|e| e.edge_id);
-                let edge = build_edge(key, *branch_weight, id)?;
-                merged.push(edge);
+            | (
+                Some(EdgeChange::Modified {
+                    branch: edge_ours, ..
+                }),
+                None,
+            ) => {
+                let identity_is_base = base_edge_map
+                    .get(&key)
+                    .is_some_and(|&b| b.edge_id == edge_ours.edge_id);
+                Some((edge_ours.clone(), identity_is_base))
             }
 
             (
                 Some(EdgeChange::Unchanged),
-                Some(EdgeChange::WeightModified { branch_weight, .. }),
-            )
-            | (None, Some(EdgeChange::WeightModified { branch_weight, .. })) => {
-                let id = theirs_edge_map.get(key).map(|e| e.edge_id);
-                let edge = build_edge(key, *branch_weight, id)?;
-                merged.push(edge);
-            }
-
-            // Prefer ours' ID when both weights changed for deterministic identity.
-            (
-                Some(EdgeChange::WeightModified {
-                    branch_weight: ours_w,
+                Some(EdgeChange::Modified {
+                    branch: edge_theirs,
                     ..
                 }),
-                Some(EdgeChange::WeightModified {
-                    branch_weight: theirs_w,
+            )
+            | (
+                None,
+                Some(EdgeChange::Modified {
+                    branch: edge_theirs,
                     ..
                 }),
             ) => {
-                let id = ours_edge_map
-                    .get(key)
-                    .or_else(|| theirs_edge_map.get(key))
-                    .map(|e| e.edge_id);
-                let edge = build_edge(key, f64::max(*ours_w, *theirs_w), id)?;
-                merged.push(edge);
+                let identity_is_base = base_edge_map
+                    .get(&key)
+                    .is_some_and(|&b| b.edge_id == edge_theirs.edge_id);
+                Some((edge_theirs.clone(), identity_is_base))
             }
 
-            (Some(EdgeChange::Deleted), Some(EdgeChange::WeightModified { .. })) => {
+            (
+                Some(EdgeChange::Modified {
+                    base,
+                    branch: edge_ours,
+                }),
+                Some(EdgeChange::Modified {
+                    branch: edge_theirs,
+                    ..
+                }),
+            ) => {
+                let (edge, edge_conflicts) =
+                    merge_modified_edges(&key, base, edge_ours, edge_theirs);
+                conflicts.extend(edge_conflicts);
+                let identity_is_base = edge.edge_id == base.edge_id;
+                Some((edge, identity_is_base))
+            }
+
+            (Some(EdgeChange::Deleted), Some(EdgeChange::Modified { .. })) => {
                 conflicts.push(MergeConflict::EdgeModifyDelete {
                     source_id: key.source,
                     target_id: key.target,
@@ -148,9 +154,10 @@ pub fn merge_edges(
                     modified_in: BranchSide::Theirs,
                     deleted_in: BranchSide::Ours,
                 });
+                None
             }
 
-            (Some(EdgeChange::WeightModified { .. }), Some(EdgeChange::Deleted)) => {
+            (Some(EdgeChange::Modified { .. }), Some(EdgeChange::Deleted)) => {
                 conflicts.push(MergeConflict::EdgeModifyDelete {
                     source_id: key.source,
                     target_id: key.target,
@@ -158,13 +165,243 @@ pub fn merge_edges(
                     modified_in: BranchSide::Ours,
                     deleted_in: BranchSide::Theirs,
                 });
+                None
             }
 
-            _ => {}
+            _ => None,
+        };
+
+        candidates.push((key, candidate));
+    }
+
+    // Second pass: reserve every durable identity inherited unchanged from
+    // base before resolving branch-chosen identities, so a one-sided or
+    // double edge modification can never displace an edge that kept its
+    // pre-existing UUID — regardless of which key sorts first. Base edges are
+    // validated duplicate-free on ingest, so these reservations never collide
+    // with each other.
+    let mut used_edge_ids: HashSet<Uuid> = HashSet::new();
+    for (_, candidate) in &candidates {
+        if let Some((edge, true)) = candidate {
+            used_edge_ids.insert(edge.edge_id);
         }
     }
 
+    // Third pass: resolve branch-chosen identities against the reserved set,
+    // in the original sorted order, and emit the final deterministic output.
+    let mut merged: Vec<ExportedEdge> = Vec::with_capacity(candidates.len());
+    for (key, candidate) in candidates {
+        let Some((mut edge, identity_is_base)) = candidate else {
+            continue;
+        };
+
+        if !identity_is_base && !used_edge_ids.insert(edge.edge_id) {
+            let attempted_edge_id = edge.edge_id;
+            // The key's own base id is only a safe fallback if nothing else
+            // has claimed it yet -- e.g. an earlier-sorted edge that
+            // branch-chose this exact id. `insert`'s return value must be
+            // checked, or a chained collision silently duplicates that
+            // earlier edge's id instead of being caught here.
+            let resolved_edge_id = base_edge_map
+                .get(&key)
+                .map(|&base_edge| base_edge.edge_id)
+                .filter(|&id| used_edge_ids.insert(id));
+
+            conflicts.push(MergeConflict::EdgeIdentityCollision {
+                source_id: key.source,
+                target_id: key.target,
+                relation: key.relation.clone(),
+                attempted_edge_id,
+                retained_edge_id: resolved_edge_id.unwrap_or(attempted_edge_id),
+            });
+
+            match resolved_edge_id {
+                Some(id) => edge.edge_id = id,
+                // No unclaimed identity to restore -- dropping the edge is
+                // the only way to keep the merged set duplicate-free; the
+                // conflict entry above is the record of what was dropped.
+                None => continue,
+            }
+        }
+
+        merged.push(edge);
+    }
+
     Ok((merged, conflicts))
+}
+
+/// Reconciles two independently added records for one semantic edge key.
+///
+/// Independent additions have no common durable UUID, so the established
+/// policy keeps ours' identity and timestamps and takes the maximum weight.
+/// Object properties reconcile per key; same-key divergence remains a typed
+/// conflict rather than being silently discarded.
+fn merge_added_edges(
+    key: &EdgeKey,
+    ours: &ExportedEdge,
+    theirs: &ExportedEdge,
+) -> (ExportedEdge, Vec<MergeConflict>) {
+    let mut result = ours.clone();
+    result.weight = f64::max(ours.weight, theirs.weight);
+    let no_base = None;
+    let (properties, conflicts) =
+        merge_edge_properties(key, &no_base, &ours.properties, &theirs.properties);
+    result.properties = properties;
+
+    (result, conflicts)
+}
+
+/// Three-way reconciliation for two modified records of one semantic edge.
+///
+/// Weight follows the existing maximum policy only when both branches changed
+/// it; a one-sided increase or decrease is retained exactly. Property objects
+/// reconcile per key, while durable UUIDs use ordinary three-way selection;
+/// each reports a typed conflict only when both branches changed the same
+/// governed value differently. Ours' complete timestamp pair is the
+/// deterministic provenance carrier for a double-modified result; timestamps
+/// never create a change or conflict alone.
+fn merge_modified_edges(
+    key: &EdgeKey,
+    base: &ExportedEdge,
+    ours: &ExportedEdge,
+    theirs: &ExportedEdge,
+) -> (ExportedEdge, Vec<MergeConflict>) {
+    let mut result = ours.clone();
+    let mut conflicts = Vec::new();
+
+    let ours_weight_changed = !weights_equal(base.weight, ours.weight);
+    let theirs_weight_changed = !weights_equal(base.weight, theirs.weight);
+    result.weight = match (ours_weight_changed, theirs_weight_changed) {
+        (false, false) => base.weight,
+        (true, false) => ours.weight,
+        (false, true) => theirs.weight,
+        (true, true) => f64::max(ours.weight, theirs.weight),
+    };
+
+    let (properties, property_conflicts) =
+        merge_edge_properties(key, &base.properties, &ours.properties, &theirs.properties);
+    result.properties = properties;
+    conflicts.extend(property_conflicts);
+
+    let ours_identity_changed = base.edge_id != ours.edge_id;
+    let theirs_identity_changed = base.edge_id != theirs.edge_id;
+    result.edge_id = match (ours_identity_changed, theirs_identity_changed) {
+        (false, false) => base.edge_id,
+        (true, false) => ours.edge_id,
+        (false, true) => theirs.edge_id,
+        (true, true) if ours.edge_id == theirs.edge_id => ours.edge_id,
+        (true, true) => {
+            conflicts.push(MergeConflict::EdgeIdentityMismatch {
+                source_id: key.source,
+                target_id: key.target,
+                relation: key.relation.clone(),
+                ours: ours.edge_id,
+                theirs: theirs.edge_id,
+            });
+            ours.edge_id
+        }
+    };
+
+    (result, conflicts)
+}
+
+/// Three-way merges governed edge metadata without discarding independent keys.
+///
+/// The accepted wire/storage contract makes properties an object. `None` is
+/// treated as an empty map for key-level reconciliation; non-object legacy
+/// payloads retain conservative atomic selection. A divergent same-key edit
+/// produces one payload-level conflict and keeps ours for that key in the
+/// provisional record.
+fn merge_edge_properties(
+    key: &EdgeKey,
+    base: &Option<serde_json::Value>,
+    ours: &Option<serde_json::Value>,
+    theirs: &Option<serde_json::Value>,
+) -> (Option<serde_json::Value>, Vec<MergeConflict>) {
+    if properties_equal(ours, theirs) {
+        return (ours.clone(), Vec::new());
+    }
+    if properties_equal(ours, base) {
+        return (theirs.clone(), Vec::new());
+    }
+    if properties_equal(theirs, base) {
+        return (ours.clone(), Vec::new());
+    }
+
+    let all_object_like = [base, ours, theirs]
+        .into_iter()
+        .all(|value| matches!(value, None | Some(serde_json::Value::Object(_))));
+    if !all_object_like {
+        return (
+            ours.clone(),
+            vec![edge_property_conflict(key, ours, theirs)],
+        );
+    }
+
+    let base_object = base.as_ref().and_then(serde_json::Value::as_object);
+    let ours_object = ours.as_ref().and_then(serde_json::Value::as_object);
+    let theirs_object = theirs.as_ref().and_then(serde_json::Value::as_object);
+    let mut property_keys: HashSet<String> = HashSet::new();
+    for object in [base_object, ours_object, theirs_object]
+        .into_iter()
+        .flatten()
+    {
+        property_keys.extend(object.keys().cloned());
+    }
+    let mut property_keys: Vec<String> = property_keys.into_iter().collect();
+    property_keys.sort();
+
+    let mut merged = serde_json::Map::new();
+    let mut has_conflict = false;
+    for property_key in property_keys {
+        let base_value = base_object.and_then(|object| object.get(&property_key));
+        let ours_value = ours_object.and_then(|object| object.get(&property_key));
+        let theirs_value = theirs_object.and_then(|object| object.get(&property_key));
+        let selected = if ours_value == theirs_value {
+            ours_value
+        } else if ours_value == base_value {
+            theirs_value
+        } else if theirs_value == base_value {
+            ours_value
+        } else {
+            has_conflict = true;
+            ours_value
+        };
+
+        if let Some(value) = selected {
+            merged.insert(property_key, value.clone());
+        }
+    }
+
+    let merged = if merged.is_empty() && (ours.is_none() || theirs.is_none()) {
+        None
+    } else {
+        Some(serde_json::Value::Object(merged))
+    };
+    let conflicts = if has_conflict {
+        vec![edge_property_conflict(key, ours, theirs)]
+    } else {
+        Vec::new()
+    };
+    (merged, conflicts)
+}
+
+fn edge_property_conflict(
+    key: &EdgeKey,
+    ours: &Option<serde_json::Value>,
+    theirs: &Option<serde_json::Value>,
+) -> MergeConflict {
+    MergeConflict::EdgePropertyMismatch {
+        source_id: key.source,
+        target_id: key.target,
+        relation: key.relation.clone(),
+        ours: ours.clone(),
+        theirs: theirs.clone(),
+    }
+}
+
+fn weights_equal(a: f64, b: f64) -> bool {
+    (a - b).abs() < f64::EPSILON
 }
 
 /// Reports edges whose source or target is absent from `entity_ids`.
@@ -196,25 +433,6 @@ pub fn validate_dangling_edges(
     conflicts
 }
 
-/// Reconstructs an edge, preserving `existing_id` or minting a fallback UUID.
-fn build_edge(
-    key: &EdgeKey,
-    weight: f64,
-    existing_id: Option<Uuid>,
-) -> Result<ExportedEdge, MergeError> {
-    let relation = key
-        .relation
-        .parse::<khive_storage::EdgeRelation>()
-        .map_err(|e| MergeError::Internal(e.to_string()))?;
-    Ok(ExportedEdge {
-        edge_id: existing_id.unwrap_or_else(Uuid::new_v4),
-        source: key.source,
-        target: key.target,
-        relation,
-        weight,
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use chrono::Utc;
@@ -242,6 +460,9 @@ mod tests {
             target: tgt,
             relation: EdgeRelation::Extends,
             weight,
+            properties: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
         }
     }
 
@@ -341,6 +562,9 @@ mod tests {
             target: b,
             relation: EdgeRelation::Extends,
             weight: 0.5,
+            properties: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
         };
         let ours_edge = ExportedEdge {
             edge_id: Uuid::new_v4(),
@@ -348,6 +572,9 @@ mod tests {
             target: b,
             relation: EdgeRelation::Extends,
             weight: 0.9,
+            properties: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
         };
         let expected_id = ours_edge.edge_id;
 
@@ -363,5 +590,299 @@ mod tests {
             merged[0].edge_id, expected_id,
             "merged edge_id must equal ours' edge_id after weight modification"
         );
+    }
+
+    #[test]
+    fn one_sided_property_change_preserves_complete_branch_edge() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let base_edge = edge(a, b, 0.7);
+        let mut ours_edge = base_edge.clone();
+        ours_edge.properties = Some(serde_json::json!({"confidence": 0.95}));
+        ours_edge.created_at = chrono::DateTime::parse_from_rfc3339("2026-03-03T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        ours_edge.updated_at = chrono::DateTime::parse_from_rfc3339("2026-04-04T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        let base = archive(vec![base_edge.clone()]);
+        let ours = archive(vec![ours_edge.clone()]);
+        let theirs = archive(vec![base_edge]);
+        let (merged, conflicts) = merge_edges(&base, &ours, &theirs).unwrap();
+
+        assert!(conflicts.is_empty(), "unexpected conflicts: {conflicts:?}");
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].edge_id, ours_edge.edge_id);
+        assert_eq!(merged[0].properties, ours_edge.properties);
+        assert_eq!(merged[0].created_at, ours_edge.created_at);
+        assert_eq!(merged[0].updated_at, ours_edge.updated_at);
+    }
+
+    #[test]
+    fn divergent_property_only_changes_report_typed_conflict() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let mut base_edge = edge(a, b, 0.7);
+        base_edge.properties = Some(serde_json::json!({"confidence": 0.5}));
+        let mut ours_edge = base_edge.clone();
+        ours_edge.properties = Some(serde_json::json!({"confidence": 0.8}));
+        let mut theirs_edge = base_edge.clone();
+        theirs_edge.properties = Some(serde_json::json!({"confidence": 0.9}));
+
+        let base = archive(vec![base_edge]);
+        let ours = archive(vec![ours_edge]);
+        let theirs = archive(vec![theirs_edge]);
+        let (_, conflicts) = merge_edges(&base, &ours, &theirs).unwrap();
+
+        assert!(matches!(
+            conflicts.as_slice(),
+            [MergeConflict::EdgePropertyMismatch {
+                source_id,
+                target_id,
+                relation,
+                ours: Some(ours),
+                theirs: Some(theirs),
+            }] if *source_id == a
+                && *target_id == b
+                && relation == "extends"
+                && ours == &serde_json::json!({"confidence": 0.8})
+                && theirs == &serde_json::json!({"confidence": 0.9})
+        ));
+    }
+
+    #[test]
+    fn independent_property_key_changes_merge_without_loss() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let mut base_edge = edge(a, b, 0.7);
+        base_edge.properties = Some(serde_json::json!({"shared": "base"}));
+        let mut ours_edge = base_edge.clone();
+        ours_edge.properties = Some(serde_json::json!({
+            "ours": 1,
+            "shared": "base",
+        }));
+        let mut theirs_edge = base_edge.clone();
+        theirs_edge.properties = Some(serde_json::json!({
+            "shared": "base",
+            "theirs": 2,
+        }));
+
+        let base = archive(vec![base_edge]);
+        let ours = archive(vec![ours_edge]);
+        let theirs = archive(vec![theirs_edge]);
+        let (merged, conflicts) = merge_edges(&base, &ours, &theirs).unwrap();
+
+        assert!(conflicts.is_empty(), "unexpected conflicts: {conflicts:?}");
+        assert_eq!(
+            merged[0].properties,
+            Some(serde_json::json!({
+                "ours": 1,
+                "shared": "base",
+                "theirs": 2,
+            }))
+        );
+    }
+
+    #[test]
+    fn independent_weight_and_property_changes_merge_without_loss() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let mut base_edge = edge(a, b, 0.5);
+        base_edge.properties = Some(serde_json::json!({"origin": "base"}));
+        let mut ours_edge = base_edge.clone();
+        ours_edge.properties = Some(serde_json::json!({"origin": "ours"}));
+        let mut theirs_edge = base_edge.clone();
+        theirs_edge.weight = 0.2;
+
+        let base = archive(vec![base_edge]);
+        let ours = archive(vec![ours_edge.clone()]);
+        let theirs = archive(vec![theirs_edge]);
+        let (merged, conflicts) = merge_edges(&base, &ours, &theirs).unwrap();
+
+        assert!(conflicts.is_empty(), "unexpected conflicts: {conflicts:?}");
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].weight, 0.2);
+        assert_eq!(merged[0].properties, ours_edge.properties);
+        assert_eq!(merged[0].created_at, ours_edge.created_at);
+        assert_eq!(merged[0].updated_at, ours_edge.updated_at);
+    }
+
+    #[test]
+    fn divergent_edge_identity_changes_report_typed_conflict() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let base_edge = edge(a, b, 0.7);
+        let mut ours_edge = base_edge.clone();
+        ours_edge.edge_id = Uuid::new_v4();
+        let mut theirs_edge = base_edge.clone();
+        theirs_edge.edge_id = Uuid::new_v4();
+
+        let base = archive(vec![base_edge]);
+        let ours = archive(vec![ours_edge.clone()]);
+        let theirs = archive(vec![theirs_edge.clone()]);
+        let (_, conflicts) = merge_edges(&base, &ours, &theirs).unwrap();
+
+        assert!(matches!(
+            conflicts.as_slice(),
+            [MergeConflict::EdgeIdentityMismatch {
+                source_id,
+                target_id,
+                relation,
+                ours,
+                theirs,
+            }] if *source_id == a
+                && *target_id == b
+                && relation == "extends"
+                && *ours == ours_edge.edge_id
+                && *theirs == theirs_edge.edge_id
+        ));
+    }
+
+    #[test]
+    fn one_sided_identity_change_colliding_with_other_edge_is_rejected() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let c = Uuid::new_v4();
+        let d = Uuid::new_v4();
+
+        let edge1_base = edge(a, b, 1.0);
+        let edge2 = edge(c, d, 1.0);
+
+        let mut edge1_ours = edge1_base.clone();
+        edge1_ours.edge_id = edge2.edge_id;
+
+        let base = archive(vec![edge1_base.clone(), edge2.clone()]);
+        let ours = archive(vec![edge1_ours, edge2.clone()]);
+        let theirs = archive(vec![edge1_base, edge2.clone()]);
+
+        let (merged, conflicts) = merge_edges(&base, &ours, &theirs).unwrap();
+
+        let mut seen_ids = HashSet::new();
+        for merged_edge in &merged {
+            assert!(
+                seen_ids.insert(merged_edge.edge_id),
+                "merge output must not contain duplicate durable edge_id {:?}: {merged:?}",
+                merged_edge.edge_id
+            );
+        }
+        assert!(
+            conflicts
+                .iter()
+                .any(|c| matches!(c, MergeConflict::EdgeIdentityCollision { .. })),
+            "expected an EdgeIdentityCollision conflict, got: {conflicts:?}"
+        );
+    }
+
+    #[test]
+    fn chained_identity_collision_through_base_fallback_is_rejected() {
+        // Three semantic edges, sorted by (source, target, relation) as
+        // key1 < key_early < key_chained:
+        //
+        //   key1:        base-identity edge, reserves ID_B in the second pass.
+        //   key_early:   a freshly added edge that branch-chooses ID_X, which
+        //                happens to equal key_chained's *own* base edge_id.
+        //                It claims ID_X first because it sorts before
+        //                key_chained.
+        //   key_chained: a modified edge whose branch-chosen id collides with
+        //                ID_B (already reserved), so it falls back to its own
+        //                base id -- ID_X -- but ID_X was just claimed by
+        //                key_early. The fallback insert must be checked, or
+        //                key_chained silently duplicates key_early's ID_X.
+        let s1 = Uuid::from_u128(1);
+        let t1 = Uuid::from_u128(2);
+        let s2 = Uuid::from_u128(3);
+        let t2 = Uuid::from_u128(4);
+        let s3 = Uuid::from_u128(5);
+        let t3 = Uuid::from_u128(6);
+
+        let id_b = Uuid::from_u128(100);
+        let id_x = Uuid::from_u128(200);
+
+        let key1_base = edge(s1, t1, 1.0);
+        let mut key1_ours = key1_base.clone();
+        key1_ours.edge_id = id_b;
+        let mut key1_base_fixed = key1_base.clone();
+        key1_base_fixed.edge_id = id_b;
+        let key1_base = key1_base_fixed;
+        key1_ours.weight = 2.0;
+
+        let key_chained_base = {
+            let mut e = edge(s3, t3, 1.0);
+            e.edge_id = id_x;
+            e
+        };
+        let mut key_chained_ours = key_chained_base.clone();
+        key_chained_ours.edge_id = id_b; // collides with key1's reserved id_b
+        key_chained_ours.weight = 2.0;
+
+        let key_early_ours = {
+            let mut e = edge(s2, t2, 1.0);
+            e.edge_id = id_x; // collides with key_chained's fallback target
+            e
+        };
+
+        let base = archive(vec![key1_base.clone(), key_chained_base.clone()]);
+        let ours = archive(vec![key1_ours, key_early_ours, key_chained_ours]);
+        let theirs = archive(vec![key1_base, key_chained_base]);
+
+        let (merged, conflicts) = merge_edges(&base, &ours, &theirs).unwrap();
+
+        let merged_rows: Vec<(Uuid, Uuid, Uuid, f64)> = merged
+            .iter()
+            .map(|e| (e.source, e.target, e.edge_id, e.weight))
+            .collect();
+        assert_eq!(
+            merged_rows,
+            vec![(s1, t1, id_b, 2.0), (s2, t2, id_x, 1.0)],
+            "exactly key1 (reserved ID_B) and key_early (branch-chosen ID_X) \
+             survive; key_chained is dropped rather than duplicating ID_X: \
+             {merged:?}"
+        );
+
+        match conflicts.as_slice() {
+            [MergeConflict::EdgeIdentityCollision {
+                source_id,
+                target_id,
+                relation,
+                attempted_edge_id,
+                retained_edge_id,
+            }] => {
+                assert_eq!((*source_id, *target_id), (s3, t3));
+                assert_eq!(relation, &EdgeRelation::Extends.to_string());
+                assert_eq!(*attempted_edge_id, id_b);
+                assert_eq!(
+                    *retained_edge_id, id_b,
+                    "a dropped edge records the attempted id as retained"
+                );
+            }
+            other => panic!(
+                "expected exactly one EdgeIdentityCollision for key_chained, \
+                 got: {other:?}"
+            ),
+        }
+    }
+
+    #[test]
+    fn property_modify_delete_is_an_edge_modify_delete_conflict() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let base_edge = edge(a, b, 0.7);
+        let mut theirs_edge = base_edge.clone();
+        theirs_edge.properties = Some(serde_json::json!({"confidence": 0.95}));
+
+        let base = archive(vec![base_edge]);
+        let ours = archive(vec![]);
+        let theirs = archive(vec![theirs_edge]);
+        let (_, conflicts) = merge_edges(&base, &ours, &theirs).unwrap();
+
+        assert!(matches!(
+            conflicts.as_slice(),
+            [MergeConflict::EdgeModifyDelete {
+                modified_in: BranchSide::Theirs,
+                deleted_in: BranchSide::Ours,
+                ..
+            }]
+        ));
     }
 }

--- a/crates/khive-merge/src/merge.rs
+++ b/crates/khive-merge/src/merge.rs
@@ -110,7 +110,7 @@ fn deterministic_timestamp(ours: &KgArchive, theirs: &KgArchive) -> chrono::Date
 /// # Errors
 ///
 /// Returns [`MergeError`] for namespace mismatch, non-finite edge weights,
-/// duplicate entity IDs, duplicate edge IDs or keys, or relation reconstruction.
+/// duplicate entity IDs, or duplicate edge IDs or keys.
 /// See `crates/khive-merge/docs/api/three-way-merge.md` for the full pipeline.
 pub fn three_way_merge(
     base: &KgArchive,

--- a/crates/khive-merge/src/types.rs
+++ b/crates/khive-merge/src/types.rs
@@ -71,6 +71,36 @@ pub enum MergeConflict {
         modified_in: BranchSide,
         deleted_in: BranchSide,
     },
+    /// Both branches changed an edge's durable UUID to different values.
+    EdgeIdentityMismatch {
+        source_id: Uuid,
+        target_id: Uuid,
+        relation: String,
+        ours: Uuid,
+        theirs: Uuid,
+    },
+    /// An edge's identity change collided with another edge's durable UUID
+    /// already claimed in the merged set. If the key's own unmodified base
+    /// UUID is still unclaimed, the edge falls back to it and
+    /// `retained_edge_id` differs from `attempted_edge_id`. Otherwise there
+    /// is no identity left to restore without creating a second duplicate,
+    /// so the edge is dropped from the merged set and `retained_edge_id`
+    /// equals `attempted_edge_id`.
+    EdgeIdentityCollision {
+        source_id: Uuid,
+        target_id: Uuid,
+        relation: String,
+        attempted_edge_id: Uuid,
+        retained_edge_id: Uuid,
+    },
+    /// Both branches changed the same edge-property key differently.
+    EdgePropertyMismatch {
+        source_id: Uuid,
+        target_id: Uuid,
+        relation: String,
+        ours: Option<serde_json::Value>,
+        theirs: Option<serde_json::Value>,
+    },
     /// An edge references a missing entity (dangling reference).
     DanglingEdge {
         source_id: Uuid,

--- a/crates/khive-merge/tests/three_way_merge.rs
+++ b/crates/khive-merge/tests/three_way_merge.rs
@@ -50,6 +50,9 @@ fn edge(src: Uuid, tgt: Uuid) -> ExportedEdge {
         target: tgt,
         relation: EdgeRelation::Extends,
         weight: 1.0,
+        properties: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
     }
 }
 
@@ -60,6 +63,9 @@ fn edge_weighted(src: Uuid, tgt: Uuid, weight: f64) -> ExportedEdge {
         target: tgt,
         relation: EdgeRelation::Extends,
         weight,
+        properties: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
     }
 }
 
@@ -750,6 +756,9 @@ fn merge_preserves_weight_modified_edge_id() {
         target: b,
         relation: EdgeRelation::Extends,
         weight: 0.5,
+        properties: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
     };
     let ours_edge = ExportedEdge {
         edge_id: Uuid::new_v4(),
@@ -757,6 +766,9 @@ fn merge_preserves_weight_modified_edge_id() {
         target: b,
         relation: EdgeRelation::Extends,
         weight: 0.9,
+        properties: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
     };
     let expected_id = ours_edge.edge_id;
     let entities = vec![entity(a, "A"), entity(b, "B")];
@@ -775,6 +787,143 @@ fn merge_preserves_weight_modified_edge_id() {
         );
     } else {
         panic!("expected Clean");
+    }
+}
+
+#[test]
+fn auto_preserves_one_sided_property_only_edge_with_provenance() {
+    let a = Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap();
+    let b = Uuid::parse_str("22222222-2222-2222-2222-222222222222").unwrap();
+    let entities = vec![entity(a, "A"), entity(b, "B")];
+    let mut base_edge = edge_weighted(a, b, 0.7);
+    base_edge.created_at = chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    base_edge.updated_at = chrono::DateTime::parse_from_rfc3339("2026-01-02T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    let mut ours_edge = base_edge.clone();
+    ours_edge.properties = Some(serde_json::json!({"confidence": 0.95}));
+    ours_edge.created_at = chrono::DateTime::parse_from_rfc3339("2026-03-03T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    ours_edge.updated_at = chrono::DateTime::parse_from_rfc3339("2026-04-04T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+
+    let base = archive_full(entities.clone(), vec![base_edge.clone()]);
+    let ours = archive_full(entities.clone(), vec![ours_edge.clone()]);
+    let theirs = archive_full(entities, vec![base_edge]);
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap();
+
+    match result {
+        MergeResult::Clean { merged } => {
+            assert_eq!(merged.edges.len(), 1);
+            assert_eq!(merged.edges[0].edge_id, ours_edge.edge_id);
+            assert_eq!(merged.edges[0].properties, ours_edge.properties);
+            assert_eq!(merged.edges[0].created_at, ours_edge.created_at);
+            assert_eq!(merged.edges[0].updated_at, ours_edge.updated_at);
+        }
+        MergeResult::Conflicts { conflicts } => {
+            panic!("one-sided property change must merge cleanly: {conflicts:?}")
+        }
+    }
+}
+
+fn divergent_property_archives() -> (KgArchive, KgArchive, KgArchive) {
+    let a = Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap();
+    let b = Uuid::parse_str("22222222-2222-2222-2222-222222222222").unwrap();
+    let entities = vec![entity(a, "A"), entity(b, "B")];
+    let mut base_edge = edge_weighted(a, b, 0.7);
+    base_edge.properties = Some(serde_json::json!({"confidence": 0.5}));
+    let mut ours_edge = base_edge.clone();
+    ours_edge.properties = Some(serde_json::json!({"confidence": 0.8}));
+    ours_edge.created_at = chrono::DateTime::parse_from_rfc3339("2026-05-05T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    ours_edge.updated_at = chrono::DateTime::parse_from_rfc3339("2026-06-06T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    let mut theirs_edge = base_edge.clone();
+    theirs_edge.properties = Some(serde_json::json!({"confidence": 0.9}));
+    theirs_edge.created_at = chrono::DateTime::parse_from_rfc3339("2026-07-07T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    theirs_edge.updated_at = chrono::DateTime::parse_from_rfc3339("2026-08-08T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+
+    (
+        archive_full(entities.clone(), vec![base_edge]),
+        archive_full(entities.clone(), vec![ours_edge]),
+        archive_full(entities, vec![theirs_edge]),
+    )
+}
+
+#[test]
+fn auto_reports_divergent_edge_property_changes() {
+    let (base, ours, theirs) = divergent_property_archives();
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap();
+
+    assert!(matches!(
+        result,
+        MergeResult::Conflicts { ref conflicts }
+            if conflicts.iter().any(|conflict| matches!(
+                conflict,
+                MergeConflict::EdgePropertyMismatch { .. }
+            ))
+    ));
+}
+
+#[test]
+fn ours_strategy_resolves_divergent_edge_properties_to_ours() {
+    let (base, ours, theirs) = divergent_property_archives();
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Ours).unwrap();
+
+    match result {
+        MergeResult::Clean { merged } => {
+            assert_eq!(
+                merged.edges[0].properties,
+                Some(serde_json::json!({"confidence": 0.8}))
+            );
+            assert_eq!(
+                merged.edges[0].created_at.to_rfc3339(),
+                "2026-05-05T00:00:00+00:00"
+            );
+            assert_eq!(
+                merged.edges[0].updated_at.to_rfc3339(),
+                "2026-06-06T00:00:00+00:00"
+            );
+        }
+        MergeResult::Conflicts { conflicts } => {
+            panic!("ours strategy must resolve the property conflict: {conflicts:?}")
+        }
+    }
+}
+
+#[test]
+fn theirs_strategy_resolves_divergent_edge_properties_to_theirs() {
+    let (base, ours, theirs) = divergent_property_archives();
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Theirs).unwrap();
+
+    match result {
+        MergeResult::Clean { merged } => {
+            assert_eq!(
+                merged.edges[0].properties,
+                Some(serde_json::json!({"confidence": 0.9}))
+            );
+            assert_eq!(
+                merged.edges[0].created_at.to_rfc3339(),
+                "2026-07-07T00:00:00+00:00"
+            );
+            assert_eq!(
+                merged.edges[0].updated_at.to_rfc3339(),
+                "2026-08-08T00:00:00+00:00"
+            );
+        }
+        MergeResult::Conflicts { conflicts } => {
+            panic!("theirs strategy must resolve the property conflict: {conflicts:?}")
+        }
     }
 }
 
@@ -915,7 +1064,7 @@ fn diff_added_edge() {
 }
 
 #[test]
-fn diff_weight_modified_edge() {
+fn diff_weight_change_is_modified_edge() {
     use khive_merge::diff_local::{diff_edges, EdgeChange, EdgeKey};
     let a = Uuid::new_v4();
     let b = Uuid::new_v4();
@@ -927,7 +1076,7 @@ fn diff_weight_modified_edge() {
         target: b,
         relation: "extends".into(),
     };
-    assert!(matches!(diff[&key], EdgeChange::WeightModified { .. }));
+    assert!(matches!(diff[&key], EdgeChange::Modified { .. }));
 }
 
 // ── #454: entity_type must participate in diff and merge ───────────────────
@@ -1034,6 +1183,9 @@ fn rejects_duplicate_edge_ids_in_archive() {
             target: b,
             relation: EdgeRelation::Extends,
             weight: 1.0,
+            properties: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
         },
         ExportedEdge {
             edge_id: dup_id,
@@ -1041,6 +1193,9 @@ fn rejects_duplicate_edge_ids_in_archive() {
             target: d,
             relation: EdgeRelation::DependsOn,
             weight: 1.0,
+            properties: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
         },
     ];
     let theirs = archive_full(vec![], vec![]);
@@ -1080,6 +1235,9 @@ fn rejects_swapped_symmetric_duplicate_edges_in_archive() {
                 target: hi,
                 relation: EdgeRelation::CompetesWith,
                 weight: 1.0,
+                properties: None,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
             },
             ExportedEdge {
                 edge_id: Uuid::new_v4(),
@@ -1087,6 +1245,9 @@ fn rejects_swapped_symmetric_duplicate_edges_in_archive() {
                 target: lo,
                 relation: EdgeRelation::CompetesWith,
                 weight: 1.0,
+                properties: None,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
             },
         ],
     );

--- a/crates/khive-runtime/docs/design.md
+++ b/crates/khive-runtime/docs/design.md
@@ -48,6 +48,8 @@
 - Embeddings are excluded from archives (regenerable from text + model)
 - Edges are collected by source entity, not by namespace scan, to capture cross-entity relationships
 - `edge_id` field on `ExportedEdge` is stable across export/import cycles; old archives without it receive a fresh UUID on import
+- `ExportedEdge::properties` round-trips storage `metadata`, and its independent creation/update
+  timestamps are preserved; legacy archives missing timestamps receive import-time defaults
 
 ### Note Kinds and Annotation (ADR-013, ADR-024)
 
@@ -181,6 +183,8 @@
 
 - `ExportedEdge::edge_id` carries the stable `LinkId` UUID across export/import cycles,
   as specified in ADR-020 (Git-Native KG Implementation) §edge_id.
+- `ExportedEdge::properties` maps to `Edge::metadata`; `created_at` and `updated_at` are
+  exported and imported independently rather than being regenerated.
 - Old archives (pre-0.2) omit `edge_id`; `serde(default)` assigns a fresh UUID on import.
 
 ### Persistent Daemon (ADR-049)

--- a/crates/khive-runtime/src/portability.rs
+++ b/crates/khive-runtime/src/portability.rs
@@ -65,6 +65,37 @@ pub struct ExportedEdge {
     /// One of the canonical edge relations (closed enum).
     pub relation: EdgeRelation,
     pub weight: f64,
+    /// Portable edge metadata, named `properties` in the ADR-020 wire shape.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub properties: Option<serde_json::Value>,
+    /// Edge creation time. Older archives may omit it; those imports use the
+    /// time at which the archive is decoded.
+    #[serde(
+        default = "default_import_timestamp",
+        deserialize_with = "deserialize_import_timestamp"
+    )]
+    pub created_at: DateTime<Utc>,
+    /// Edge last-update time. Kept independent from `created_at` so imported
+    /// provenance is not collapsed during a round trip.
+    #[serde(
+        default = "default_import_timestamp",
+        deserialize_with = "deserialize_import_timestamp"
+    )]
+    pub updated_at: DateTime<Utc>,
+}
+
+fn default_import_timestamp() -> DateTime<Utc> {
+    Utc::now()
+}
+
+fn deserialize_import_timestamp<'de, D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw = String::deserialize(deserializer)?;
+    DateTime::parse_from_rfc3339(&raw)
+        .map(|timestamp| timestamp.with_timezone(&Utc))
+        .map_err(|error| serde::de::Error::custom(format!("timestamp must be RFC3339: {error}")))
 }
 
 /// Outcome of a successful import operation.
@@ -160,6 +191,9 @@ impl KhiveRuntime {
                     target: e.target_id,
                     relation: e.relation,
                     weight: e.weight,
+                    properties: e.metadata,
+                    created_at: e.created_at,
+                    updated_at: e.updated_at,
                 })
                 .collect()
         };
@@ -208,16 +242,31 @@ impl KhiveRuntime {
 
         let ns = token.namespace().as_str().to_owned();
 
-        let store = self.entities(token)?;
-        let mut entities_imported = 0usize;
-        let mut embedding_truncation = crate::retrieval::EmbeddingTruncationReport::default();
-        for ee in &archive.entities {
-            self.validate_entity_kind(&ee.kind)?;
+        // Complete deterministic validation before opening a store or issuing
+        // the first write. Endpoint existence and namespace checks remain at
+        // write time because they depend on mutable target state.
+        for (index, entity) in archive.entities.iter().enumerate() {
+            self.validate_entity_kind(&entity.kind)?;
             // Archive content is caller-controlled input: the runtime-owned
             // `khive:secret_gate` property key is reservation-only on import,
             // exactly as on every other properties-bearing write path
             // (ADR-115 Amendment 1 §3). Import never consumes exemptions.
-            crate::secret_gate::reject_reserved_secret_gate_property(ee.properties.as_ref())?;
+            crate::secret_gate::reject_reserved_secret_gate_property(entity.properties.as_ref())?;
+            if entity.name.trim().is_empty() {
+                return Err(RuntimeError::InvalidInput(format!(
+                    "archive entity {index} ({}) name must be non-blank",
+                    entity.id
+                )));
+            }
+        }
+        for edge in &archive.edges {
+            crate::operations::validate_edge_weight(edge.weight)?;
+        }
+
+        let store = self.entities(token)?;
+        let mut entities_imported = 0usize;
+        let mut embedding_truncation = crate::retrieval::EmbeddingTruncationReport::default();
+        for ee in &archive.entities {
             let created_micros = ee.created_at.timestamp_micros();
             let updated_micros = ee.updated_at.timestamp_micros();
             let entity = khive_storage::entity::Entity {
@@ -249,7 +298,6 @@ impl KhiveRuntime {
         let mut edges_imported = 0usize;
         let mut edges_skipped = 0usize;
         for ee in &archive.edges {
-            crate::operations::validate_edge_weight(ee.weight)?;
             let source_ok = match self.get_entity(token, ee.source).await {
                 Ok(_) => true,
                 Err(RuntimeError::NotFound(_)) => false,
@@ -302,7 +350,6 @@ impl KhiveRuntime {
                 }
                 Err(e) => return Err(e),
             }
-            let now = Utc::now();
             let edge = khive_storage::types::Edge {
                 id: LinkId::from(ee.edge_id),
                 namespace: ns.clone(),
@@ -310,10 +357,10 @@ impl KhiveRuntime {
                 target_id: ee.target,
                 relation: ee.relation,
                 weight: ee.weight,
-                created_at: now,
-                updated_at: now,
+                created_at: ee.created_at,
+                updated_at: ee.updated_at,
                 deleted_at: None,
-                metadata: None,
+                metadata: ee.properties.clone(),
                 target_backend: None,
             };
             graph.upsert_edge(edge).await?;
@@ -439,6 +486,57 @@ mod tests {
         assert!(summary.embedding_truncation.discarded_bytes > 0);
         let wire = serde_json::to_value(&summary).expect("serialize import summary");
         assert_eq!(wire["embedding_truncation"]["truncated"], 1);
+    }
+
+    #[tokio::test]
+    async fn import_rejects_whitespace_name_before_any_entity_write() {
+        let runtime = make_rt().await;
+        let token = NamespaceToken::local();
+        let valid_id = Uuid::new_v4();
+        let archive = KgArchive {
+            format: "khive-kg".to_string(),
+            version: "0.1".to_string(),
+            namespace: "local".to_string(),
+            exported_at: Utc::now(),
+            entities: vec![
+                ExportedEntity {
+                    id: valid_id,
+                    kind: "concept".to_string(),
+                    entity_type: None,
+                    name: "Must not be written".to_string(),
+                    description: None,
+                    properties: None,
+                    tags: vec![],
+                    created_at: Utc::now(),
+                    updated_at: Utc::now(),
+                },
+                ExportedEntity {
+                    id: Uuid::new_v4(),
+                    kind: "concept".to_string(),
+                    entity_type: None,
+                    name: " \t\n ".to_string(),
+                    description: None,
+                    properties: None,
+                    tags: vec![],
+                    created_at: Utc::now(),
+                    updated_at: Utc::now(),
+                },
+            ],
+            edges: vec![],
+        };
+
+        let err = runtime
+            .import_kg(&archive, &token)
+            .await
+            .expect_err("whitespace-only entity names must fail the whole import");
+        assert!(
+            err.to_string().contains("non-blank"),
+            "error must explain the name invariant: {err}"
+        );
+        assert!(
+            runtime.get_entity(&token, valid_id).await.is_err(),
+            "deterministic validation must finish before the first entity write"
+        );
     }
 
     /// 1. Roundtrip: 3 entities + 2 edges survive export → import on a fresh runtime.
@@ -717,6 +815,9 @@ mod tests {
                 target: real.id,
                 relation: EdgeRelation::Extends,
                 weight: 1.0,
+                properties: None,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
             }],
         };
 
@@ -770,6 +871,9 @@ mod tests {
                 target: phantom_target,
                 relation: EdgeRelation::DependsOn,
                 weight: 0.8,
+                properties: None,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
             }],
         };
 
@@ -856,6 +960,9 @@ mod tests {
                     target: b.id,
                     relation: EdgeRelation::Extends,
                     weight: 1.0,
+                    properties: None,
+                    created_at: Utc::now(),
+                    updated_at: Utc::now(),
                 },
                 ExportedEdge {
                     edge_id: Uuid::new_v4(),
@@ -867,6 +974,9 @@ mod tests {
                     // not an endpoint-contract violation this test isn't about.
                     relation: EdgeRelation::VariantOf,
                     weight: 0.9,
+                    properties: None,
+                    created_at: Utc::now(),
+                    updated_at: Utc::now(),
                 },
                 ExportedEdge {
                     edge_id: Uuid::new_v4(),
@@ -874,6 +984,9 @@ mod tests {
                     target: phantom,
                     relation: EdgeRelation::Enables,
                     weight: 0.5,
+                    properties: None,
+                    created_at: Utc::now(),
+                    updated_at: Utc::now(),
                 },
             ],
         };
@@ -971,6 +1084,9 @@ mod tests {
                 target: e2.id,
                 relation: EdgeRelation::Precedes,
                 weight: 1.0,
+                properties: None,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
             }],
         };
 
@@ -1029,9 +1145,9 @@ mod tests {
         );
     }
 
-    /// 11. import_kg writes the archive edge_id as the stored LinkId.
+    /// 11. import_kg writes the archive edge identity and timestamps exactly.
     #[tokio::test]
-    async fn import_kg_persists_edge_id() {
+    async fn import_kg_persists_edge_id_and_timestamps() {
         let src = make_rt().await;
         let tok = NamespaceToken::local();
         let a = src
@@ -1048,7 +1164,16 @@ mod tests {
             .unwrap();
         let original_id: Uuid = stored_edge.id.into();
 
-        let archive = src.export_kg(&tok).await.unwrap();
+        let expected_created = chrono::DateTime::parse_from_rfc3339("2026-03-03T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let expected_updated = chrono::DateTime::parse_from_rfc3339("2026-04-04T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let mut archive = src.export_kg(&tok).await.unwrap();
+        archive.edges[0].created_at = expected_created;
+        archive.edges[0].updated_at = expected_updated;
+        archive.edges[0].properties = Some(serde_json::json!({"confidence": 0.95}));
         let dst = make_rt().await;
         dst.import_kg(&archive, &tok).await.unwrap();
 
@@ -1062,6 +1187,26 @@ mod tests {
             Uuid::from(imported_edge.id),
             original_id,
             "stored edge id must equal the archive edge_id"
+        );
+        assert_eq!(
+            imported_edge.created_at, expected_created,
+            "present edge created_at must not be replaced with import time"
+        );
+        assert_eq!(
+            imported_edge.updated_at, expected_updated,
+            "present edge updated_at must not be replaced with created_at or import time"
+        );
+        assert_eq!(
+            imported_edge.metadata,
+            Some(serde_json::json!({"confidence": 0.95})),
+            "edge properties must persist as storage metadata"
+        );
+
+        let reexported = dst.export_kg(&tok).await.unwrap();
+        assert_eq!(
+            reexported.edges[0].properties,
+            Some(serde_json::json!({"confidence": 0.95})),
+            "edge metadata must re-export as portable properties"
         );
     }
 

--- a/crates/khive-vcs-adapters/Cargo.toml
+++ b/crates/khive-vcs-adapters/Cargo.toml
@@ -10,6 +10,7 @@ homepage.workspace = true
 description = "KG import/export format adapters — CSV, JSON, and future format support (ADR-036)"
 
 [dependencies]
+chrono = { workspace = true }
 khive-types = { version = "0.7.0", path = "../khive-types" }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/khive-vcs-adapters/README.md
+++ b/crates/khive-vcs-adapters/README.md
@@ -5,8 +5,8 @@ records `khive kg import` validates and loads.
 
 An adapter is a pure, stateless transform: it reads a source and yields `EntityRecord`
 / `EdgeRecord` values. It writes no database state and generates no IDs beyond filling
-in a missing UUID. Fatal errors (missing required fields, unknown entity kind or edge
-relation, out-of-range weight) abort the corresponding iterator item; non-fatal issues
+in a missing UUID. Fatal errors (missing/blank required fields, ambiguous record shapes,
+malformed timestamps, unknown entity kind or edge relation, out-of-range weight) abort the corresponding iterator item; non-fatal issues
 accumulate as strings retrievable via `FormatAdapter::warnings`.
 
 ## Usage
@@ -32,9 +32,11 @@ assert!(adapter.warnings().is_empty());
 ```
 
 `JsonFormatAdapter::new` parses eagerly and dispatches each array element: an object
-carrying a `source`/`from` **and** `target`/`to` key (case-insensitive) becomes an
-`EdgeRecord`; every other object becomes an `EntityRecord`. Unknown keys fold into the
-record's `properties`.
+carrying canonical `source` **and** `target` keys (case-insensitive) becomes an
+`EdgeRecord`; every other object becomes an `EntityRecord`. `from`/`to` are ordinary
+entity metadata. A complete `kind`+`name` entity signature combined with a complete
+`source`+`target` edge signature is rejected as ambiguous. Unknown entity keys fold into
+the record's `properties`.
 
 ## Taxonomy validation
 
@@ -46,6 +48,8 @@ record's `properties`.
 - `EdgeRecord.weight` must be finite and in `[0.0, 1.0]`; deserialization enforces this
   at the JSON boundary as well as via the `JsonFormatAdapter`'s own `extract_weight`
   path. Absent, it defaults to `0.7`.
+- Present `created_at`/`updated_at` values must be RFC 3339 strings. Missing timestamps
+  remain optional; malformed values are never replaced with import time.
 
 ## Format support
 
@@ -58,8 +62,7 @@ Turtle/N-Triples, JSON-LD, GraphML, GEXF, Markdown) are tracked as deferred work
 
 ## Where this sits
 
-`khive-vcs-adapters` depends only on `khive-types` (for kind/relation validation) —
-it has no dependency on `khive-storage` or `khive-runtime`. Its output feeds the
+`khive-vcs-adapters` has no dependency on `khive-storage` or `khive-runtime`. Its output feeds the
 standard `khive kg import` pipeline, which is what performs validation and loading
 into `working.db`; the adapter itself never touches a database.
 

--- a/crates/khive-vcs-adapters/docs/api/adapter-protocol.md
+++ b/crates/khive-vcs-adapters/docs/api/adapter-protocol.md
@@ -40,8 +40,9 @@ The current modules divide responsibilities as follows: `adapter` defines the tr
 
 The `JsonFormatAdapter` accepts a JSON array of objects. Dispatch:
 
-- Object with `source`/`from` **and** `target`/`to` keys → edge record
-- All other objects → entity record
+- Object with canonical `source` **and** `target` keys → edge record
+- All other objects → entity record (`from`/`to` remain ordinary metadata)
+- Complete `kind`+`name` and `source`+`target` signatures in one object → fatal ambiguity error
 
 Field lookup is case-insensitive (ADR-036 §2). Unknown entity keys fold into `properties`.
 
@@ -51,10 +52,10 @@ requires `impl Read` pipeline wiring.
 
 ## Error boundary
 
-Missing fields, invalid values, structural parse failures, unknown entity kinds, and unknown edge
-relations are fatal. Deferred formats return `AdapterError::NotYetImplemented`. Malformed optional
-reserved fields (e.g. a non-string `created_at`) produce warnings; absent optional fields are
-accepted silently, and unknown non-reserved keys are folded into `properties` without a warning.
+Missing or blank required fields, invalid values, structural parse failures, malformed present
+RFC 3339 timestamps, unknown entity kinds, and unknown edge relations are fatal. Deferred formats
+return `AdapterError::NotYetImplemented`. Absent optional fields are accepted silently, and unknown
+non-reserved keys are folded into `properties` without a warning.
 Callers inspect `warnings()` after draining the streams.
 
 ## Deferred formats

--- a/crates/khive-vcs-adapters/docs/api/json-array-adapter.md
+++ b/crates/khive-vcs-adapters/docs/api/json-array-adapter.md
@@ -17,22 +17,28 @@ runtime validation.
 
 ## Entity/edge dispatch
 
-Key matching is ASCII case-insensitive. An object with both `source`/`from` and `target`/`to` is an
-edge; every other object is parsed as an entity. Entity and edge iteration drain their stored
-results, so a second call produces no records.
+Key matching is ASCII case-insensitive. An object with canonical `source` and `target` is an edge;
+every other object is parsed as an entity. `from` and `to` are ordinary entity metadata keys. A
+record carrying both the complete entity signature (`kind` and `name`) and complete edge signature
+(`source` and `target`) is a fatal ambiguous-record error. Entity and edge iteration drain their
+stored results, so a second call produces no records.
 
 ## Entity parsing
 
-Required non-empty fields are `kind` and `name`; an absent ID receives a new UUID. Reserved fields
+Required non-blank fields are `kind` and `name`; an absent ID receives a new UUID. Reserved fields
 include `entity_type`, description, tags, timestamps, and properties. Remaining unknown keys fold
 into the properties object rather than being discarded. Unknown kinds fail unless accepted by the
 base taxonomy, an alias, or the supplied extra-kind set.
 
 ## Edge parsing
 
-Source, target, and relation are required. Relations always use the closed `EdgeRelation` taxonomy.
-Weight defaults to `0.7` and must be finite in `[0, 1]`; IDs default to new UUIDs. Unknown edge
-relations are fatal regardless of entity schema mode.
+Source, target, and relation are required non-blank strings. Validation inspects a trimmed view but
+preserves the original accepted source and target bytes. Relations always use the closed
+`EdgeRelation` taxonomy. Weight defaults to `0.7` and must be finite in `[0, 1]`; IDs default to new
+UUIDs. Unknown edge relations are fatal regardless of entity schema mode.
+
+For both substrates, a present `created_at` or `updated_at` must be an RFC 3339 string. Absence is
+accepted; a malformed or wrongly typed present value is fatal rather than warned away or defaulted.
 
 ## Warnings and streaming
 

--- a/crates/khive-vcs-adapters/docs/api/wire-records.md
+++ b/crates/khive-vcs-adapters/docs/api/wire-records.md
@@ -5,19 +5,20 @@ pipeline; adapters do not write them directly to the database.
 
 ## `EntityRecord`
 
-The record carries UUID `id`, string `kind`, optional `entity_type`, non-empty `name`, optional
-description, JSON properties, tags, and optional creation/update timestamp strings. Timestamp
-strings are preserved as supplied without format validation — RFC 3339 conformance is the import
-pipeline's responsibility — and a non-string timestamp value is dropped with a warning. The adapter
+The record carries UUID `id`, string `kind`, optional `entity_type`, non-blank `name`, optional
+description, JSON properties, tags, and optional creation/update timestamp strings. Present
+timestamp values must be RFC 3339 strings and are preserved exactly after validation; malformed or
+non-string timestamp values are fatal. The adapter
 reserves `entity_type`, `created_at`, and `updated_at` before folding unknown input keys into
 properties, so those compatibility fields never appear twice.
 
 ## `EdgeRecord`
 
-The record carries UUID `edge_id`, source and target IDs, relation, weight, JSON properties, and
-optional timestamps. Weight defaults to `0.7`. Custom deserialization rejects NaN and infinities,
-then rejects finite values outside `[0, 1]`; direct Rust construction remains the caller's
-responsibility.
+The record carries UUID `edge_id`, non-blank source and target IDs, relation, weight, JSON
+properties, and optional timestamps. The JSON adapter validates endpoint strings after trimming
+but preserves their original accepted bytes. Weight defaults to `0.7`. Custom deserialization
+rejects NaN and infinities, then rejects finite values outside `[0, 1]`; direct Rust construction
+remains the caller's responsibility.
 
 ## Error taxonomy
 

--- a/crates/khive-vcs-adapters/docs/design.md
+++ b/crates/khive-vcs-adapters/docs/design.md
@@ -7,11 +7,14 @@
 - This crate implements the format adapter layer of the two-stage KG import pipeline.
 - Adapters are pure transforms: they parse a source format and produce `EntityRecord`/`EdgeRecord`
   streams with no database access; records missing an ID receive a freshly generated UUID at parse time.
-- Fatal errors (missing required fields, unknown kinds/relations, out-of-range weights) abort the
-  iterator immediately. Non-fatal warnings accumulate in `FormatAdapter::warnings()` and are
-  available after the iterator is exhausted.
+- Eager structural/classification errors fail adapter construction. Per-record validation failures
+  are retained as `Result::Err` items in the corresponding entity/edge iterator; callers that need
+  all-or-nothing import must drain and collect both iterators before writing. Non-fatal warnings
+  accumulate in `FormatAdapter::warnings()`.
 - Field lookup is case-insensitive: keys are matched by ASCII-lowercase comparison, allowing
   `"Name"`, `"name"`, and `"NAME"` to all resolve to the `name` field.
+- Required entity labels and edge endpoint strings are non-blank after trimming, while their
+  original accepted bytes are preserved in the adapter record.
 - Unknown entity keys fold into the `properties` map rather than being rejected.
 - Schema mode strictness applies only to entity kinds; edge relations are always validated
   against the closed set regardless of schema mode.
@@ -21,8 +24,10 @@
 ### Git-Native KG Implementation (field shapes) (ADR-020)
 
 - `EntityRecord` and `EdgeRecord` follow the wire shapes specified for the import pipeline.
-- `EntityRecord` carries `id`, `kind`, `name`, `description?`, `properties`, `tags`.
-- `EdgeRecord` carries `edge_id`, `source`, `target`, `relation`, `weight`, `properties`.
+- `EntityRecord` carries `id`, `kind`, `entity_type?`, `name`, `description?`, `properties`,
+  `tags`, `created_at?`, and `updated_at?`.
+- `EdgeRecord` carries `edge_id`, `source`, `target`, `relation`, `weight`, `properties`,
+  `created_at?`, and `updated_at?`.
 - The adapter layer produces these shapes; the standard `khive kg import` pipeline validates
   and loads them into `working.db`.
 

--- a/crates/khive-vcs-adapters/src/json_adapter.rs
+++ b/crates/khive-vcs-adapters/src/json_adapter.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 
 /// A [`FormatAdapter`] that parses a JSON array of objects.
 ///
-/// Parsing is eager; objects with source and target keys become edges. See
+/// Parsing is eager; objects with canonical source and target keys become edges. See
 /// `crates/khive-vcs-adapters/docs/api/json-array-adapter.md`.
 pub struct JsonFormatAdapter {
     entities: Vec<Result<EntityRecord, AdapterError>>,
@@ -66,18 +66,22 @@ impl JsonFormatAdapter {
                 }
             };
 
-            // Normalise keys to lowercase once for dispatch detection.
-            // Keys are matched case-insensitively.
-            let has_source = obj.keys().any(|k| {
-                let l = k.to_ascii_lowercase();
-                l == "source" || l == "from"
-            });
-            let has_target = obj.keys().any(|k| {
-                let l = k.to_ascii_lowercase();
-                l == "target" || l == "to"
-            });
+            // Dispatch only on complete canonical signatures. `from`/`to`
+            // are common entity metadata keys and therefore remain ordinary
+            // properties. A record that supplies both complete signatures is
+            // ambiguous and must fail the whole eager parse before callers can
+            // persist either interpretation.
+            let entity_signature = has_key_ci(&obj, "kind") && has_key_ci(&obj, "name");
+            let edge_signature = has_key_ci(&obj, "source") && has_key_ci(&obj, "target");
+            if entity_signature && edge_signature {
+                return Err(AdapterError::InvalidField {
+                    index,
+                    field: "$record".into(),
+                    reason: "ambiguous record: complete entity (kind + name) and edge (source + target) signatures are both present".into(),
+                });
+            }
 
-            if has_source && has_target {
+            if edge_signature {
                 edges.push(parse_edge(index, obj, &mut warnings));
             } else {
                 entities.push(parse_entity(index, obj, &mut warnings, extra_valid_kinds));
@@ -90,6 +94,10 @@ impl JsonFormatAdapter {
             warnings,
         })
     }
+}
+
+fn has_key_ci(obj: &serde_json::Map<String, Value>, field: &str) -> bool {
+    obj.keys().any(|key| key.eq_ignore_ascii_case(field))
 }
 
 impl FormatAdapter for JsonFormatAdapter {
@@ -126,23 +134,48 @@ fn remove_ci(
     Some((key, val))
 }
 
-/// Extract a required non-empty string field, case-insensitive.
+/// Extract a required non-blank string field, case-insensitive.
 fn extract_required_string(
     obj: &mut serde_json::Map<String, Value>,
     index: usize,
     field: &str,
 ) -> Result<String, AdapterError> {
     match remove_ci(obj, field) {
-        Some((_, Value::String(s))) if !s.is_empty() => Ok(s),
+        Some((_, Value::String(s))) if !s.trim().is_empty() => Ok(s),
         Some(_) => Err(AdapterError::InvalidField {
             index,
             field: field.into(),
-            reason: "must be a non-empty string".into(),
+            reason: "must be a non-blank string".into(),
         }),
         None => Err(AdapterError::MissingField {
             index,
             field: field.into(),
         }),
+    }
+}
+
+fn extract_optional_timestamp(
+    obj: &mut serde_json::Map<String, Value>,
+    index: usize,
+    field: &str,
+) -> Result<Option<String>, AdapterError> {
+    match remove_ci(obj, field) {
+        Some((_, Value::String(raw))) => {
+            chrono::DateTime::parse_from_rfc3339(&raw).map_err(|error| {
+                AdapterError::InvalidField {
+                    index,
+                    field: field.into(),
+                    reason: format!("must be RFC3339: {error}"),
+                }
+            })?;
+            Ok(Some(raw))
+        }
+        Some(_) => Err(AdapterError::InvalidField {
+            index,
+            field: field.into(),
+            reason: "must be an RFC3339 string".into(),
+        }),
+        None => Ok(None),
     }
 }
 
@@ -243,26 +276,8 @@ fn parse_entity(
         None => None,
     };
 
-    let created_at = match remove_ci(&mut obj, "created_at") {
-        Some((_, Value::String(s))) => Some(s),
-        Some(_) => {
-            warnings.push(format!(
-                "record {index}: 'created_at' is not a string; ignored"
-            ));
-            None
-        }
-        None => None,
-    };
-    let updated_at = match remove_ci(&mut obj, "updated_at") {
-        Some((_, Value::String(s))) => Some(s),
-        Some(_) => {
-            warnings.push(format!(
-                "record {index}: 'updated_at' is not a string; ignored"
-            ));
-            None
-        }
-        None => None,
-    };
+    let created_at = extract_optional_timestamp(&mut obj, index, "created_at")?;
+    let updated_at = extract_optional_timestamp(&mut obj, index, "updated_at")?;
 
     let id = extract_uuid_field(&mut obj, index, "id")?;
 
@@ -328,21 +343,10 @@ fn parse_edge(
     mut obj: serde_json::Map<String, Value>,
     warnings: &mut Vec<String>,
 ) -> Result<EdgeRecord, AdapterError> {
-    let source = remove_ci(&mut obj, "source")
-        .or_else(|| remove_ci(&mut obj, "from"))
-        .and_then(|(_, v)| v.as_str().map(|s| s.to_owned()))
-        .ok_or_else(|| AdapterError::MissingField {
-            index,
-            field: "source".into(),
-        })?;
-
-    let target = remove_ci(&mut obj, "target")
-        .or_else(|| remove_ci(&mut obj, "to"))
-        .and_then(|(_, v)| v.as_str().map(|s| s.to_owned()))
-        .ok_or_else(|| AdapterError::MissingField {
-            index,
-            field: "target".into(),
-        })?;
+    // Validate on a trimmed view but retain the caller's exact nonblank bytes,
+    // matching entity-name behavior and the ADR-036 adapter boundary.
+    let source = extract_required_string(&mut obj, index, "source")?;
+    let target = extract_required_string(&mut obj, index, "target")?;
 
     let relation = {
         let raw = extract_required_string(&mut obj, index, "relation")?;
@@ -375,26 +379,8 @@ fn parse_edge(
 
     let weight = extract_weight(&mut obj, index)?;
 
-    let created_at = match remove_ci(&mut obj, "created_at") {
-        Some((_, Value::String(s))) => Some(s),
-        Some(_) => {
-            warnings.push(format!(
-                "record {index}: edge 'created_at' is not a string; ignored"
-            ));
-            None
-        }
-        None => None,
-    };
-    let updated_at = match remove_ci(&mut obj, "updated_at") {
-        Some((_, Value::String(s))) => Some(s),
-        Some(_) => {
-            warnings.push(format!(
-                "record {index}: edge 'updated_at' is not a string; ignored"
-            ));
-            None
-        }
-        None => None,
-    };
+    let created_at = extract_optional_timestamp(&mut obj, index, "created_at")?;
+    let updated_at = extract_optional_timestamp(&mut obj, index, "updated_at")?;
 
     let mut properties = match remove_ci(&mut obj, "properties") {
         Some((_, Value::Object(m))) => m,

--- a/crates/khive-vcs-adapters/tests/json_adapter_tests.rs
+++ b/crates/khive-vcs-adapters/tests/json_adapter_tests.rs
@@ -713,3 +713,156 @@ fn test_json_adapter_new_with_valid_kinds_still_rejects_unregistered_kind() {
         "unregistered kind must still be rejected with a non-empty valid-kinds registry"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #1758 — fail-closed identity, discriminator, and timestamp validation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_json_adapter_rejects_whitespace_only_entity_name() {
+    let mut adapter = JsonFormatAdapter::new(r#"[{"kind":"concept","name":" \t\n "}]"#)
+        .expect("structurally valid JSON must construct");
+    let first = adapter.entities().next().expect("one entity record");
+    assert!(
+        matches!(first, Err(AdapterError::InvalidField { field, reason, .. })
+            if field == "name" && reason.contains("non-blank")),
+        "whitespace-only names must fail closed at the adapter boundary"
+    );
+}
+
+#[test]
+fn test_json_adapter_entity_signature_wins_over_from_to_metadata() {
+    let mut adapter = JsonFormatAdapter::new(
+        r#"[{"kind":"concept","name":"Lineage","from":"source-system","to":"target-system"}]"#,
+    )
+    .expect("entity metadata must not be misclassified as an edge");
+
+    let entities: Vec<_> = adapter
+        .entities()
+        .map(|record| record.expect("entity must parse"))
+        .collect();
+    let edges: Vec<_> = adapter.edges().collect();
+
+    assert_eq!(entities.len(), 1);
+    assert!(edges.is_empty());
+    assert_eq!(entities[0].properties["from"], "source-system");
+    assert_eq!(entities[0].properties["to"], "target-system");
+}
+
+#[test]
+fn test_json_adapter_rejects_ambiguous_entity_and_edge_signatures() {
+    let err = match JsonFormatAdapter::new(
+        r#"[{"kind":"concept","name":"Ambiguous","source":"aa","target":"bb","relation":"extends"}]"#,
+    ) {
+        Err(err) => err,
+        Ok(_) => panic!("a record with complete entity and edge signatures must be rejected"),
+    };
+
+    assert!(
+        matches!(err, AdapterError::InvalidField { index: 0, field, reason }
+            if field == "$record" && reason.contains("ambiguous")),
+        "the fatal error must identify the ambiguous record shape"
+    );
+}
+
+#[test]
+fn test_json_adapter_canonical_source_target_still_dispatches_edge() {
+    let mut adapter =
+        JsonFormatAdapter::new(r#"[{"source":"aa","target":"bb","relation":"extends"}]"#)
+            .expect("canonical edge signature must remain accepted");
+
+    assert!(adapter.entities().next().is_none());
+    let edge = adapter
+        .edges()
+        .next()
+        .expect("one edge")
+        .expect("edge must parse");
+    assert_eq!(edge.source, "aa");
+    assert_eq!(edge.target, "bb");
+}
+
+#[test]
+fn test_json_adapter_rejects_whitespace_only_edge_source() {
+    let mut adapter =
+        JsonFormatAdapter::new(r#"[{"source":" \t\n ","target":"bb","relation":"extends"}]"#)
+            .expect("structurally valid JSON must construct");
+    let error = adapter
+        .edges()
+        .next()
+        .expect("one edge")
+        .expect_err("whitespace-only source must fail closed");
+
+    assert!(matches!(
+        error,
+        AdapterError::InvalidField { field, reason, .. }
+            if field == "source" && reason.contains("non-blank")
+    ));
+}
+
+#[test]
+fn test_json_adapter_rejects_whitespace_only_edge_target() {
+    let mut adapter =
+        JsonFormatAdapter::new(r#"[{"source":"aa","target":" \t\n ","relation":"extends"}]"#)
+            .expect("structurally valid JSON must construct");
+    let error = adapter
+        .edges()
+        .next()
+        .expect("one edge")
+        .expect_err("whitespace-only target must fail closed");
+
+    assert!(matches!(
+        error,
+        AdapterError::InvalidField { field, reason, .. }
+            if field == "target" && reason.contains("non-blank")
+    ));
+}
+
+#[test]
+fn test_json_adapter_preserves_accepted_edge_endpoint_bytes() {
+    let mut adapter = JsonFormatAdapter::new(
+        r#"[{"source":"  source-id\t","target":"\ttarget-id  ","relation":"extends"}]"#,
+    )
+    .expect("structurally valid JSON must construct");
+    let edge = adapter
+        .edges()
+        .next()
+        .expect("one edge")
+        .expect("non-blank endpoints must parse");
+
+    assert_eq!(edge.source, "  source-id\t");
+    assert_eq!(edge.target, "\ttarget-id  ");
+}
+
+#[test]
+fn test_json_adapter_rejects_malformed_or_non_string_timestamps() {
+    for (json, expected_field) in [
+        (
+            r#"[{"kind":"concept","name":"Bad time","created_at":"not-rfc3339"}]"#,
+            "created_at",
+        ),
+        (
+            r#"[{"source":"aa","target":"bb","relation":"extends","updated_at":42}]"#,
+            "updated_at",
+        ),
+    ] {
+        let mut adapter = JsonFormatAdapter::new(json).expect("structurally valid JSON");
+        let error = if expected_field == "created_at" {
+            adapter
+                .entities()
+                .next()
+                .expect("one entity")
+                .expect_err("malformed entity timestamp must fail")
+        } else {
+            adapter
+                .edges()
+                .next()
+                .expect("one edge")
+                .expect_err("malformed edge timestamp must fail")
+        };
+        assert!(
+            matches!(error, AdapterError::InvalidField { field, reason, .. }
+                if field == expected_field && reason.contains("RFC3339")),
+            "present malformed timestamps must be rejected, not defaulted or warned away"
+        );
+    }
+}

--- a/crates/khive-vcs/docs/api/snapshot-hash.md
+++ b/crates/khive-vcs/docs/api/snapshot-hash.md
@@ -27,7 +27,7 @@ Sort order (ADR-020 §canonical NDJSON record shape and snapshot hash):
 
 1. Entities sorted by UUID string, case-insensitive ascending.
 2. Edges sorted by `(source, target, relation)` ascending.
-3. Property keys sorted alphabetically within each entity.
+3. Property keys sorted recursively within each entity and edge.
 4. Tags sorted lexicographically within each entity.
 
 Root object key order is alphabetical (`edges` before `entities`).
@@ -35,7 +35,8 @@ Root object key order is alphabetical (`edges` before `entities`).
 `VCS-AUD-003` tests confirm two entities differing only in `entity_type`
 produce different `SnapshotId` values. `exported_at`, `namespace`, `format`,
 and `version` are excluded from the hash; only entity and edge content
-contributes.
+contributes. Edge `properties` are included, so a metadata-only edge change
+produces a different `SnapshotId` while object key insertion order does not.
 
 Non-finite edge weights (`NaN`, `Infinity`) are rejected by
 `edge_to_canonical_value` with `VcsError::Internal` — a correctness gate on

--- a/crates/khive-vcs/docs/api/sync.md
+++ b/crates/khive-vcs/docs/api/sync.md
@@ -9,7 +9,7 @@ visible as the "current" state.
 
 1. Read `<repo_root>/.khive/kg/entities.ndjson` and `edges.ndjson`.
 2. **Validate-first gate** (`validate_ndjson_records`, issue #476): full
-   ADR-020 structural validation — entity kind validity, entity/edge
+   ADR-020 structural validation — entity kind validity, non-blank entity names, entity/edge
    timestamp validity, entity/edge sort order, duplicate entity ids,
    duplicate edge ids, duplicate semantic edge triples
    `(source, target, relation)`, dangling edge endpoints, edge
@@ -19,8 +19,10 @@ visible as the "current" state.
 4. Upsert entities and populate the FTS5 index. Vector embeddings are
    skipped — they're local-only derived state repaired explicitly via
    `kkernel reindex` (ADR-035 §5).
-5. Checkpoint the WAL (`PRAGMA wal_checkpoint(TRUNCATE)`).
-6. Atomic rename: `<db_path>.tmp` → `<db_path>`. A crash before this step
+5. Upsert edges without normalizing their wire provenance: `properties` map to
+   storage `metadata`, and `created_at`/`updated_at` remain independent.
+6. Checkpoint the WAL (`PRAGMA wal_checkpoint(TRUNCATE)`).
+7. Atomic rename: `<db_path>.tmp` → `<db_path>`. A crash before this step
    leaves the previous DB intact (all-or-nothing guarantee).
 
 Records are converted and written in chunks of `SYNC_CHUNK_SIZE` (10,000 in
@@ -36,8 +38,10 @@ batching path intact.
 1. `git clone --depth=1 --filter=blob:none` into a temporary staging
    directory.
 2. Sparse-checkout `.khive/kg/entities.ndjson` and `.khive/kg/edges.ndjson`.
-3. **Validate-first**: `build_kg_archive` parses all edge relations and
-   returns an error if any relation is invalid — before any cache write.
+3. **Validate-first**: the same full `validate_ndjson_records` gate used by
+   local sync rejects blank names, malformed timestamps, invalid kinds,
+   relations/weights, duplicates, sort violations, and dangling endpoints
+   before any cache write.
 4. Compute the `SnapshotId` over the validated archive (see
    `snapshot-hash.md`).
 5. **Pin verification, fail-closed**: if `pin` is set and `repin=false`, a
@@ -55,6 +59,10 @@ batching path intact.
    directory, briefly absent, or the complete new directory.
 7. `meta.json` records `fetched_at`, `git_ref`, `commit_sha`, `content_hash`
    — written even when no pin is present, for auditability.
+
+The remote archive conversion retains edge properties and both timestamps. Edge
+properties are recursively canonicalized into `SnapshotId`, so metadata-only
+changes cannot pass an existing pin unnoticed.
 
 ### `RemoteName` — construction-time path-traversal safety
 

--- a/crates/khive-vcs/docs/design.md
+++ b/crates/khive-vcs/docs/design.md
@@ -31,6 +31,8 @@ and `api/snapshot-hash.md` (content-addressed `SnapshotId` hashing).
   on every invocation."
 - `entity_type` is included in the canonical hash representation so that two snapshots
   differing only in `entity_type` produce different `SnapshotId` values.
+- Edge `properties` round-trip to storage `metadata`; both edge timestamps are preserved
+  independently, and recursively canonicalized edge properties participate in snapshot identity.
 - Custom merge engine variants (`MergeNotImplemented`) were removed; the merge engine is
   superseded for v1.
 - Custom push/pull error variants (`RemoteUnreachable`, `AuthFailed`, `NonFastForward`,
@@ -69,7 +71,7 @@ and `api/snapshot-hash.md` (content-addressed `SnapshotId` hashing).
   §canonical NDJSON record shape and snapshot hash):
   1. Entities sorted by UUID string (case-insensitive ascending).
   2. Edges sorted by (source, target, relation) ascending.
-  3. Property keys sorted alphabetically within each entity.
+  3. Property keys sorted recursively within each entity and edge.
   4. Tags sorted lexicographically within each entity.
 - Root object key order: `{"edges": [...], "entities": [...]}` (alphabetical).
 - `exported_at`, `namespace`, `format`, `version` are excluded from the hash;
@@ -92,8 +94,8 @@ and `api/snapshot-hash.md` (content-addressed `SnapshotId` hashing).
   different `SnapshotId` values, enforcing the canonical entity record shape.
 - `VCS-AUD-004`: tests in `src/types.rs` verify that the custom `Deserialize` impl
   rejects non-canonical inputs (missing prefix, uppercase hex, whitespace, wrong length).
-- The `build_kg_archive` function in `src/sync.rs` validates edge relations before
-  computing the hash, ensuring that invalid relations are caught before any cache or
-  database write (fail-closed behaviour consistent with ADR-037).
+- Local and remote sync call the same complete `validate_ndjson_records` gate before
+  creating a temporary database or publishing a cache. `build_kg_archive` then preserves
+  edge metadata and both timestamps for canonical hashing.
 - Non-finite edge weights (`NaN`, `Infinity`) are rejected by `edge_to_canonical_value`
   with `VcsError::Internal` — this is a correctness gate, not just a serialization concern.

--- a/crates/khive-vcs/src/hash.rs
+++ b/crates/khive-vcs/src/hash.rs
@@ -121,6 +121,10 @@ fn edge_to_canonical_value(e: &ExportedEdge) -> Result<Value, VcsError> {
         ))
     })?;
     obj.insert("weight".to_string(), Value::Number(weight_num));
+    obj.insert(
+        "properties".to_string(),
+        sort_properties_value(e.properties.clone()).unwrap_or(Value::Null),
+    );
     Ok(Value::Object(obj))
 }
 
@@ -251,11 +255,74 @@ mod tests {
             target: uid2,
             relation: EdgeRelation::Extends,
             weight: 1.0,
+            properties: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
         }];
 
         assert_ne!(
             snapshot_id_for_archive(&without_edge).unwrap(),
             snapshot_id_for_archive(&with_edge).unwrap()
+        );
+    }
+
+    #[test]
+    fn edge_properties_change_snapshot_hash() {
+        let source = Uuid::parse_str("00000000-0000-0000-0000-000000000001").unwrap();
+        let target = Uuid::parse_str("00000000-0000-0000-0000-000000000002").unwrap();
+        let edge_id = Uuid::parse_str("00000000-0000-0000-0000-000000000003").unwrap();
+        let timestamp = Utc::now();
+        let edge = ExportedEdge {
+            edge_id,
+            source,
+            target,
+            relation: EdgeRelation::Extends,
+            weight: 1.0,
+            properties: Some(serde_json::json!({"confidence": 0.4})),
+            created_at: timestamp,
+            updated_at: timestamp,
+        };
+        let mut changed = edge.clone();
+        changed.properties = Some(serde_json::json!({"confidence": 0.9}));
+
+        let mut before = empty_archive();
+        before.edges = vec![edge];
+        let mut after = empty_archive();
+        after.edges = vec![changed];
+
+        assert_ne!(
+            snapshot_id_for_archive(&before).unwrap(),
+            snapshot_id_for_archive(&after).unwrap(),
+            "metadata-only edge changes must alter snapshot identity"
+        );
+    }
+
+    #[test]
+    fn edge_property_key_order_is_hash_independent() {
+        let source = Uuid::parse_str("00000000-0000-0000-0000-000000000001").unwrap();
+        let target = Uuid::parse_str("00000000-0000-0000-0000-000000000002").unwrap();
+        let timestamp = Utc::now();
+        let edge = ExportedEdge {
+            edge_id: Uuid::parse_str("00000000-0000-0000-0000-000000000003").unwrap(),
+            source,
+            target,
+            relation: EdgeRelation::Extends,
+            weight: 1.0,
+            properties: Some(serde_json::json!({"a": 1, "z": {"a": 2, "z": 3}})),
+            created_at: timestamp,
+            updated_at: timestamp,
+        };
+        let mut reordered = edge.clone();
+        reordered.properties = Some(serde_json::json!({"z": {"z": 3, "a": 2}, "a": 1}));
+        let mut left = empty_archive();
+        left.edges = vec![edge];
+        let mut right = empty_archive();
+        right.edges = vec![reordered];
+
+        assert_eq!(
+            snapshot_id_for_archive(&left).unwrap(),
+            snapshot_id_for_archive(&right).unwrap(),
+            "edge property object ordering must not affect snapshot identity"
         );
     }
 
@@ -320,6 +387,9 @@ mod tests {
             target: uid2,
             relation: EdgeRelation::Extends,
             weight: 1.0,
+            properties: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
         };
         let edge2 = ExportedEdge {
             edge_id: edge_id2,
@@ -327,6 +397,9 @@ mod tests {
             target: uid3,
             relation: EdgeRelation::Extends,
             weight: 0.5,
+            properties: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
         };
 
         let mut a1 = empty_archive();
@@ -351,6 +424,9 @@ mod tests {
             target: uid2,
             relation: EdgeRelation::Extends,
             weight: f64::NAN,
+            properties: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
         }];
         let err = snapshot_id_for_archive(&archive).unwrap_err();
         assert!(matches!(err, VcsError::Internal(ref msg) if msg.contains("not finite")));

--- a/crates/khive-vcs/src/sync.rs
+++ b/crates/khive-vcs/src/sync.rs
@@ -52,17 +52,11 @@ struct NdjsonEdge {
     relation: String,
     #[serde(default = "default_weight")]
     weight: f64,
-    // properties: accepted but not yet persisted to the storage-layer Edge
-    // struct. Parsed here so existing NDJSON files round-trip without warning.
     #[serde(default)]
-    // REASON: Accepted for NDJSON round-trip compatibility; not yet persisted to the Edge struct.
-    #[allow(dead_code)]
     properties: Option<serde_json::Value>,
     #[serde(default)]
     created_at: Option<String>,
     #[serde(default)]
-    // REASON: Accepted for NDJSON round-trip compatibility; edge updated_at is derived from created_at.
-    #[allow(dead_code)]
     updated_at: Option<String>,
 }
 
@@ -70,12 +64,21 @@ fn default_weight() -> f64 {
     1.0
 }
 
-/// Parse an ISO-8601 timestamp string into microseconds since epoch.
-/// Returns `now` if the string is `None` or unparseable.
-fn parse_ts_micros(s: Option<&str>) -> i64 {
-    s.and_then(|t| chrono::DateTime::parse_from_rfc3339(t).ok())
-        .map(|dt| dt.timestamp_micros())
-        .unwrap_or_else(|| chrono::Utc::now().timestamp_micros())
+/// Parse a present RFC3339 timestamp exactly; only absence uses `fallback`.
+fn parse_timestamp(
+    s: Option<&str>,
+    fallback: chrono::DateTime<Utc>,
+) -> Result<chrono::DateTime<Utc>> {
+    let Some(raw) = s else {
+        return Ok(fallback);
+    };
+    chrono::DateTime::parse_from_rfc3339(raw)
+        .map(|dt| dt.with_timezone(&Utc))
+        .with_context(|| format!("timestamp {raw:?} must be RFC3339"))
+}
+
+fn parse_ts_micros(s: Option<&str>, fallback: chrono::DateTime<Utc>) -> Result<i64> {
+    Ok(parse_timestamp(s, fallback)?.timestamp_micros())
 }
 
 /// Summary of a completed sync run.
@@ -270,8 +273,10 @@ pub async fn run_sync_remote(
     // `staging` tempdir is still alive here — we drop it after moving files.
 
     // ── 3. Build KgArchive and compute canonical hash ─────────────────────────
-    // build_kg_archive is fallible: an invalid relation causes it to return an
-    // error here, before any cache file is written (fail-closed).
+    // Apply the same deterministic gate used by local DB rebuilds before hash
+    // computation or reader-visible cache publication.
+    validate_ndjson_records(&entities_ndjson, &edges_ndjson)
+        .with_context(|| format!("validating remote {:?} NDJSON", remote.name))?;
     let archive = build_kg_archive(&remote.namespace, &entities_ndjson, &edges_ndjson)
         .with_context(|| format!("validating archive for remote {:?}", remote.name))?;
     let actual_hash = snapshot_id_for_archive(&archive)
@@ -588,28 +593,22 @@ fn build_kg_archive(
     let now = Utc::now();
     let exported_entities: Vec<ExportedEntity> = entities
         .iter()
-        .map(|e| ExportedEntity {
-            id: e.id,
-            kind: e.kind.clone(),
-            entity_type: e.entity_type.clone(),
-            name: e.name.clone(),
-            description: e.description.clone(),
-            properties: e.properties.clone(),
-            tags: e.tags.clone(),
-            created_at: e
-                .created_at
-                .as_deref()
-                .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
-                .map(|dt| dt.with_timezone(&Utc))
-                .unwrap_or(now),
-            updated_at: e
-                .updated_at
-                .as_deref()
-                .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
-                .map(|dt| dt.with_timezone(&Utc))
-                .unwrap_or(now),
+        .map(|e| {
+            Ok(ExportedEntity {
+                id: e.id,
+                kind: e.kind.clone(),
+                entity_type: e.entity_type.clone(),
+                name: e.name.clone(),
+                description: e.description.clone(),
+                properties: e.properties.clone(),
+                tags: e.tags.clone(),
+                created_at: parse_timestamp(e.created_at.as_deref(), now)
+                    .with_context(|| format!("entity {} invalid created_at", e.id))?,
+                updated_at: parse_timestamp(e.updated_at.as_deref(), now)
+                    .with_context(|| format!("entity {} invalid updated_at", e.id))?,
+            })
         })
-        .collect();
+        .collect::<Result<Vec<_>>>()?;
 
     let mut exported_edges: Vec<ExportedEdge> = Vec::with_capacity(edges.len());
     for e in edges {
@@ -623,6 +622,11 @@ fn build_kg_archive(
             target: e.target,
             relation,
             weight: e.weight,
+            properties: e.properties.clone(),
+            created_at: parse_timestamp(e.created_at.as_deref(), now)
+                .with_context(|| format!("edge {} invalid created_at", e.edge_id))?,
+            updated_at: parse_timestamp(e.updated_at.as_deref(), now)
+                .with_context(|| format!("edge {} invalid updated_at", e.edge_id))?,
         });
     }
 
@@ -698,6 +702,9 @@ fn validate_ndjson_records(entities: &[NdjsonEntity], edges: &[NdjsonEdge]) -> R
     for (i, e) in entities.iter().enumerate() {
         EntityKind::from_str(&e.kind)
             .map_err(|_| anyhow!("entity {i} ({}): unknown kind {:?}", e.id, e.kind))?;
+        if e.name.trim().is_empty() {
+            bail!("entity {i} ({}): name must be a non-blank name", e.id);
+        }
 
         if !entity_ids.insert(e.id) {
             bail!("entity {i}: duplicate entity id {}", e.id);
@@ -954,8 +961,11 @@ async fn upsert_entities(
         let mut entities_chunk = Vec::with_capacity(chunk.len());
         let mut docs_chunk = Vec::with_capacity(chunk.len());
         for r in chunk {
-            let created_at = parse_ts_micros(r.created_at.as_deref());
-            let updated_at = parse_ts_micros(r.updated_at.as_deref());
+            let fallback = Utc::now();
+            let created_at = parse_ts_micros(r.created_at.as_deref(), fallback)
+                .with_context(|| format!("entity {} invalid created_at", r.id))?;
+            let updated_at = parse_ts_micros(r.updated_at.as_deref(), fallback)
+                .with_context(|| format!("entity {} invalid updated_at", r.id))?;
             let entity = khive_storage::entity::Entity {
                 id: r.id,
                 namespace: namespace.to_string(),
@@ -1036,9 +1046,11 @@ async fn upsert_edges(
                 .relation
                 .parse()
                 .map_err(|e| anyhow!("invalid relation {:?}: {}", r.relation, e))?;
-            let created_at =
-                chrono::DateTime::from_timestamp_micros(parse_ts_micros(r.created_at.as_deref()))
-                    .unwrap_or_else(chrono::Utc::now);
+            let fallback = Utc::now();
+            let created_at = parse_timestamp(r.created_at.as_deref(), fallback)
+                .with_context(|| format!("edge {} invalid created_at", r.edge_id))?;
+            let updated_at = parse_timestamp(r.updated_at.as_deref(), fallback)
+                .with_context(|| format!("edge {} invalid updated_at", r.edge_id))?;
             let edge = Edge {
                 id: LinkId::from(r.edge_id),
                 namespace: namespace.to_string(),
@@ -1047,9 +1059,9 @@ async fn upsert_edges(
                 relation,
                 weight: r.weight,
                 created_at,
-                updated_at: created_at,
+                updated_at,
                 deleted_at: None,
-                metadata: None,
+                metadata: r.properties.clone(),
                 target_backend: None,
             };
             edge_chunk.push(edge);
@@ -1124,6 +1136,30 @@ mod tests {
         let edges = read_edges(&kg.join("edges.ndjson")).unwrap();
         let archive = build_kg_archive(namespace, &entities, &edges).unwrap();
         snapshot_id_for_archive(&archive).unwrap()
+    }
+
+    #[test]
+    fn remote_snapshot_pin_detects_edge_metadata_only_change() {
+        let source = "11111111-1111-1111-1111-111111111111";
+        let target = "22222222-2222-2222-2222-222222222222";
+        let edge_id = "33333333-3333-3333-3333-333333333333";
+        let entities = [
+            format!(r#"{{"id":"{source}","kind":"concept","name":"A"}}"#),
+            format!(r#"{{"id":"{target}","kind":"concept","name":"B"}}"#),
+        ]
+        .join("\n");
+        let before = format!(
+            r#"{{"edge_id":"{edge_id}","source":"{source}","target":"{target}","relation":"extends","weight":0.8,"properties":{{"confidence":0.4}}}}"#
+        );
+        let after = format!(
+            r#"{{"edge_id":"{edge_id}","source":"{source}","target":"{target}","relation":"extends","weight":0.8,"properties":{{"confidence":0.9}}}}"#
+        );
+
+        assert_ne!(
+            compute_pin(&entities, &before, "remote-ns"),
+            compute_pin(&entities, &after, "remote-ns"),
+            "remote snapshot identity must cover edge properties"
+        );
     }
 
     // ── test_run_sync_local_path_unchanged_behavior ───────────────────────────
@@ -1414,6 +1450,18 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn sync_rejects_whitespace_only_entity_name_before_db_write() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path();
+        let db_path = repo.join(".khive/state/working.db");
+        let id = "11111111-1111-1111-1111-111111111111";
+        let entities =
+            format!(r#"{{"id":"{id}","kind":"concept","name":"   ","properties":{{}},"tags":[]}}"#);
+
+        assert_sync_rejected_before_db_write(repo, &db_path, &entities, "", "non-blank name").await;
+    }
+
+    #[tokio::test]
     async fn sync_rejects_out_of_range_edge_weight_before_db_write() {
         let tmp = TempDir::new().unwrap();
         let repo = tmp.path();
@@ -1586,6 +1634,49 @@ mod tests {
             "invalid updated_at",
         )
         .await;
+    }
+
+    #[tokio::test]
+    async fn sync_preserves_distinct_edge_timestamps() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path();
+        let db_path = repo.join(".khive/state/working.db");
+        let id_a = "11111111-1111-1111-1111-111111111111";
+        let id_b = "22222222-2222-2222-2222-222222222222";
+        let edge_id = "33333333-3333-3333-3333-333333333333";
+        let entities = [
+            format!(r#"{{"id":"{id_a}","kind":"concept","name":"A","properties":{{}},"tags":[]}}"#),
+            format!(r#"{{"id":"{id_b}","kind":"concept","name":"B","properties":{{}},"tags":[]}}"#),
+        ]
+        .join("\n");
+        let edges = format!(
+            r#"{{"edge_id":"{edge_id}","source":"{id_a}","target":"{id_b}","relation":"extends","weight":0.5,"properties":{{"confidence":0.95}},"created_at":"2026-03-03T00:00:00Z","updated_at":"2026-04-04T00:00:00Z"}}"#
+        );
+        write_repo(repo, &entities, &edges);
+
+        run_sync(repo, &db_path, "test-ns").await.unwrap();
+
+        let ns = khive_types::Namespace::parse("test-ns").unwrap();
+        let runtime = KhiveRuntime::new(RuntimeConfig {
+            db_path: Some(db_path),
+            default_namespace: ns.clone(),
+            embedding_model: None,
+            ..RuntimeConfig::default()
+        })
+        .unwrap();
+        let token = runtime.authorize(ns).unwrap();
+        let edge = runtime
+            .get_edge(&token, edge_id.parse().unwrap())
+            .await
+            .unwrap()
+            .expect("synced edge must exist");
+        assert_eq!(edge.created_at.to_rfc3339(), "2026-03-03T00:00:00+00:00");
+        assert_eq!(edge.updated_at.to_rfc3339(), "2026-04-04T00:00:00+00:00");
+        assert_eq!(
+            edge.metadata,
+            Some(serde_json::json!({"confidence": 0.95})),
+            "parsed edge properties must persist as storage metadata"
+        );
     }
 
     #[tokio::test]
@@ -2094,6 +2185,74 @@ mod tests {
         assert!(
             meta["commit_sha"].as_str().is_some(),
             "meta.json must have commit_sha"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_sync_remote_rejects_blank_name_before_cache_publish() {
+        let remote_dir = TempDir::new().unwrap();
+        let repo_dir = TempDir::new().unwrap();
+        let entity_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+        let entities = format!(
+            r#"{{"id":"{entity_id}","kind":"concept","name":"   ","properties":{{}},"tags":[]}}"#
+        );
+        let remote_url = make_git_remote(remote_dir.path(), &entities, "");
+        let remote = RemoteConfig {
+            name: RemoteName::parse("blank-name").unwrap(),
+            url: remote_url,
+            git_ref: "main".to_string(),
+            namespace: "remote-ns".to_string(),
+            pin: None,
+        };
+
+        let err = run_sync_remote(repo_dir.path(), &remote, false)
+            .await
+            .expect_err("remote fetch must reject a whitespace-only entity name");
+        assert!(
+            err.chain()
+                .any(|cause| cause.to_string().contains("non-blank name")),
+            "error must explain the name invariant: {err:#}"
+        );
+        assert!(
+            !repo_dir
+                .path()
+                .join(".khive/kg/remotes/blank-name")
+                .exists(),
+            "invalid remote records must not publish a cache generation"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_sync_remote_rejects_malformed_timestamp_before_cache_publish() {
+        let remote_dir = TempDir::new().unwrap();
+        let repo_dir = TempDir::new().unwrap();
+        let entity_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+        let entities = format!(
+            r#"{{"id":"{entity_id}","kind":"concept","name":"Valid","properties":{{}},"tags":[],"updated_at":"not-rfc3339"}}"#
+        );
+        let remote_url = make_git_remote(remote_dir.path(), &entities, "");
+        let remote = RemoteConfig {
+            name: RemoteName::parse("bad-timestamp").unwrap(),
+            url: remote_url,
+            git_ref: "main".to_string(),
+            namespace: "remote-ns".to_string(),
+            pin: None,
+        };
+
+        let err = run_sync_remote(repo_dir.path(), &remote, false)
+            .await
+            .expect_err("remote fetch must reject a present malformed timestamp");
+        assert!(
+            err.chain()
+                .any(|cause| cause.to_string().contains("invalid updated_at")),
+            "error must identify the malformed timestamp: {err:#}"
+        );
+        assert!(
+            !repo_dir
+                .path()
+                .join(".khive/kg/remotes/bad-timestamp")
+                .exists(),
+            "invalid remote records must not publish a cache generation"
         );
     }
 

--- a/crates/khive-vcs/tests/integration.rs
+++ b/crates/khive-vcs/tests/integration.rs
@@ -126,6 +126,9 @@ fn snapshot_id_changes_when_edge_added() {
         target: e2.id,
         relation: EdgeRelation::Extends,
         weight: 1.0,
+        properties: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
     });
 
     let h_after = snapshot_id_for_archive(&archive).unwrap();

--- a/crates/kkernel/src/kg/archive.rs
+++ b/crates/kkernel/src/kg/archive.rs
@@ -82,30 +82,17 @@ pub(super) async fn cmd_export(args: ExportArgs) -> Result<()> {
 
 pub(super) async fn cmd_import(args: ImportArgs) -> Result<()> {
     let ns = Namespace::parse(&args.namespace)?;
-    let config = RuntimeConfig {
-        db_path: Some(args.db.clone()),
-        default_namespace: ns.clone(),
-        embedding_model: None,
-        additional_embedding_models: vec![],
-        ..Default::default()
-    };
-    let runtime = KhiveRuntime::new(config)?;
-    let valid_entity_kinds = install_import_kind_registry(&runtime)?;
-    let token = runtime.authorize(ns)?;
-
     let source = std::fs::read_to_string(&args.source)
         .with_context(|| format!("read {}", args.source.display()))?;
 
-    let summary = match args.format {
-        ImportFormat::Archive => {
-            let archive: KgArchive = serde_json::from_str(&source)
-                .with_context(|| format!("parse archive {}", args.source.display()))?;
-            validate_archive_edge_weights(&archive)?;
-            runtime
-                .import_kg(&archive, &token)
-                .await
-                .with_context(|| format!("import archive {}", args.source.display()))?
-        }
+    // Discover the merged pack vocabulary against an in-memory runtime. This
+    // deliberately happens before the target runtime exists: deterministic
+    // source failures must not create or migrate `--db` as a side effect.
+    let validation_runtime = KhiveRuntime::memory().context("create import validation runtime")?;
+    let valid_entity_kinds = install_import_kind_registry(&validation_runtime)?;
+    let archive = match args.format {
+        ImportFormat::Archive => serde_json::from_str(&source)
+            .with_context(|| format!("parse archive {}", args.source.display()))?,
         ImportFormat::Json | ImportFormat::Ndjson => {
             let input = match args.format {
                 ImportFormat::Json => source,
@@ -125,13 +112,26 @@ pub(super) async fn cmd_import(args: ImportArgs) -> Result<()> {
             let edges: Vec<EdgeRecord> = adapter
                 .edges()
                 .collect::<std::result::Result<Vec<_>, _>>()?;
-            let archive = adapter_records_to_archive(&args.namespace, entities, edges)?;
-            runtime
-                .import_kg(&archive, &token)
-                .await
-                .with_context(|| format!("import adapter records {}", args.source.display()))?
+            adapter_records_to_archive(&args.namespace, entities, edges)?
         }
     };
+    validate_archive_deterministic(&archive, &valid_entity_kinds)?;
+    drop(validation_runtime);
+
+    let config = RuntimeConfig {
+        db_path: Some(args.db.clone()),
+        default_namespace: ns.clone(),
+        embedding_model: None,
+        additional_embedding_models: vec![],
+        ..Default::default()
+    };
+    let runtime = KhiveRuntime::new(config)?;
+    install_import_kind_registry(&runtime)?;
+    let token = runtime.authorize(ns)?;
+    let summary = runtime
+        .import_kg(&archive, &token)
+        .await
+        .with_context(|| format!("import {}", args.source.display()))?;
 
     let json = serde_json::to_string(&summary).expect("serialize ImportSummary");
     println!("{json}");
@@ -166,6 +166,10 @@ fn adapter_records_to_archive(
             // Entity kind is validated against the merged pack/runtime kind
             // registry inside `runtime.import_kg`, not here — a bare base-enum
             // parse would reject valid pack-registered kinds like `resource`.
+            let created_at = parse_dt(e.created_at.as_deref(), now)
+                .with_context(|| format!("entity {} invalid created_at", e.id))?;
+            let updated_at = parse_dt(e.updated_at.as_deref(), now)
+                .with_context(|| format!("entity {} invalid updated_at", e.id))?;
             Ok(ExportedEntity {
                 id: e.id,
                 kind: e.kind,
@@ -178,8 +182,8 @@ fn adapter_records_to_archive(
                     Some(e.properties)
                 },
                 tags: e.tags,
-                created_at: parse_dt(e.created_at.as_deref(), now),
-                updated_at: parse_dt(e.updated_at.as_deref(), now),
+                created_at,
+                updated_at,
             })
         })
         .collect::<Result<Vec<_>>>()?;
@@ -224,6 +228,40 @@ pub(super) fn validate_archive_edge_weights(archive: &KgArchive) -> Result<()> {
         validate_edge_weight(edge.weight, edge.edge_id)?;
     }
     Ok(())
+}
+
+fn validate_archive_deterministic(
+    archive: &KgArchive,
+    valid_entity_kinds: &[String],
+) -> Result<()> {
+    if archive.format != "khive-kg" {
+        bail!(
+            "unsupported archive format {:?}; expected \"khive-kg\"",
+            archive.format
+        );
+    }
+    if archive.version != "0.1" {
+        bail!(
+            "unsupported archive version {:?}; supported: \"0.1\"",
+            archive.version
+        );
+    }
+    for (index, entity) in archive.entities.iter().enumerate() {
+        if !valid_entity_kinds.iter().any(|kind| kind == &entity.kind) {
+            bail!(
+                "archive entity {index} ({}) has unknown entity kind {:?}",
+                entity.id,
+                entity.kind
+            );
+        }
+        if entity.name.trim().is_empty() {
+            bail!(
+                "archive entity {index} ({}) name must be non-blank",
+                entity.id
+            );
+        }
+    }
+    validate_archive_edge_weights(archive)
 }
 
 /// Install the merged pack/runtime entity- and note-kind registry on `runtime`
@@ -286,12 +324,24 @@ fn adapter_edge_to_exported(edge: EdgeRecord, entity_ids: &HashSet<Uuid>) -> Res
         .with_context(|| format!("edge {} invalid relation {:?}", edge.edge_id, edge.relation))?;
 
     validate_edge_weight(edge.weight, edge.edge_id)?;
+    let now = Utc::now();
+    let created_at = parse_dt(edge.created_at.as_deref(), now)
+        .with_context(|| format!("edge {} invalid created_at", edge.edge_id))?;
+    let updated_at = parse_dt(edge.updated_at.as_deref(), now)
+        .with_context(|| format!("edge {} invalid updated_at", edge.edge_id))?;
     Ok(ExportedEdge {
         edge_id: edge.edge_id,
         source,
         target,
         relation,
         weight: edge.weight,
+        properties: if edge.properties.is_null() {
+            None
+        } else {
+            Some(edge.properties)
+        },
+        created_at,
+        updated_at,
     })
 }
 
@@ -326,6 +376,12 @@ pub(super) fn archive_from_ndjson_repo(repo: &Path, namespace: &str) -> Result<K
         relation: String,
         #[serde(default = "default_weight")]
         weight: f64,
+        #[serde(default)]
+        properties: Option<serde_json::Value>,
+        #[serde(default)]
+        created_at: Option<String>,
+        #[serde(default)]
+        updated_at: Option<String>,
     }
 
     fn default_weight() -> f64 {
@@ -339,18 +395,24 @@ pub(super) fn archive_from_ndjson_repo(repo: &Path, namespace: &str) -> Result<K
 
     let exported_entities = entities
         .into_iter()
-        .map(|e| ExportedEntity {
-            id: e.id,
-            kind: e.kind,
-            entity_type: e.entity_type,
-            name: e.name,
-            description: e.description,
-            properties: e.properties,
-            tags: e.tags,
-            created_at: parse_dt(e.created_at.as_deref(), now),
-            updated_at: parse_dt(e.updated_at.as_deref(), now),
+        .map(|e| {
+            let created_at = parse_dt(e.created_at.as_deref(), now)
+                .with_context(|| format!("entity {} invalid created_at", e.id))?;
+            let updated_at = parse_dt(e.updated_at.as_deref(), now)
+                .with_context(|| format!("entity {} invalid updated_at", e.id))?;
+            Ok(ExportedEntity {
+                id: e.id,
+                kind: e.kind,
+                entity_type: e.entity_type,
+                name: e.name,
+                description: e.description,
+                properties: e.properties,
+                tags: e.tags,
+                created_at,
+                updated_at,
+            })
         })
-        .collect();
+        .collect::<Result<Vec<_>>>()?;
 
     let exported_edges = edges
         .into_iter()
@@ -360,12 +422,19 @@ pub(super) fn archive_from_ndjson_repo(repo: &Path, namespace: &str) -> Result<K
                 .parse()
                 .with_context(|| format!("invalid relation {:?}", edge.relation))?;
             validate_edge_weight(edge.weight, edge.edge_id)?;
+            let created_at = parse_dt(edge.created_at.as_deref(), now)
+                .with_context(|| format!("edge {} invalid created_at", edge.edge_id))?;
+            let updated_at = parse_dt(edge.updated_at.as_deref(), now)
+                .with_context(|| format!("edge {} invalid updated_at", edge.edge_id))?;
             Ok(ExportedEdge {
                 edge_id: edge.edge_id,
                 source: edge.source,
                 target: edge.target,
                 relation,
                 weight: edge.weight,
+                properties: edge.properties,
+                created_at,
+                updated_at,
             })
         })
         .collect::<Result<Vec<_>>>()?;
@@ -401,11 +470,13 @@ where
     Ok(records)
 }
 
-fn parse_dt(value: Option<&str>, fallback: chrono::DateTime<Utc>) -> chrono::DateTime<Utc> {
-    value
-        .and_then(|raw| chrono::DateTime::parse_from_rfc3339(raw).ok())
+fn parse_dt(value: Option<&str>, fallback: chrono::DateTime<Utc>) -> Result<chrono::DateTime<Utc>> {
+    let Some(raw) = value else {
+        return Ok(fallback);
+    };
+    chrono::DateTime::parse_from_rfc3339(raw)
         .map(|dt| dt.with_timezone(&Utc))
-        .unwrap_or(fallback)
+        .with_context(|| format!("timestamp {raw:?} must be RFC3339"))
 }
 
 #[cfg(test)]
@@ -843,6 +914,61 @@ mod tests {
         assert_eq!(e.updated_at.to_rfc3339(), "2026-02-02T00:00:00+00:00");
     }
 
+    #[test]
+    fn adapter_records_to_archive_preserves_edge_adr020_timestamps() {
+        let source = Uuid::new_v4();
+        let target = Uuid::new_v4();
+        let entities = [source, target]
+            .into_iter()
+            .map(|id| EntityRecord {
+                id,
+                kind: "concept".to_string(),
+                entity_type: None,
+                name: format!("Entity-{id}"),
+                description: None,
+                properties: serde_json::Value::Null,
+                tags: vec![],
+                created_at: None,
+                updated_at: None,
+            })
+            .collect();
+        let edge = EdgeRecord {
+            edge_id: Uuid::new_v4(),
+            source: source.to_string(),
+            target: target.to_string(),
+            relation: "extends".to_string(),
+            weight: 0.8,
+            properties: serde_json::json!({"confidence": 0.95}),
+            created_at: Some("2026-03-03T00:00:00Z".to_string()),
+            updated_at: Some("2026-04-04T00:00:00Z".to_string()),
+        };
+
+        let archive = adapter_records_to_archive("test-ns", entities, vec![edge]).unwrap();
+        assert_eq!(archive.edges.len(), 1);
+        assert_eq!(
+            archive.edges[0].properties,
+            Some(serde_json::json!({"confidence": 0.95}))
+        );
+        assert_eq!(
+            archive.edges[0].created_at.to_rfc3339(),
+            "2026-03-03T00:00:00+00:00"
+        );
+        assert_eq!(
+            archive.edges[0].updated_at.to_rfc3339(),
+            "2026-04-04T00:00:00+00:00"
+        );
+    }
+
+    #[test]
+    fn parse_dt_defaults_only_when_timestamp_is_absent() {
+        let fallback = Utc::now();
+        assert_eq!(parse_dt(None, fallback).unwrap(), fallback);
+
+        let err = parse_dt(Some("not-rfc3339"), fallback)
+            .expect_err("a present malformed timestamp must not become import time");
+        assert!(err.to_string().contains("RFC3339"));
+    }
+
     /// #472: importing adapter JSON with `entity_type`/timestamps end-to-end
     /// through `cmd_import` must land those fields in the runtime, not `None`
     /// + import-time `Utc::now()`.
@@ -961,6 +1087,96 @@ mod tests {
         assert!(
             rt2.get_entity(&tok2, never_imported_uuid).await.is_err(),
             "entity preceding the malformed element in the array must not have been imported"
+        );
+    }
+
+    #[tokio::test]
+    async fn import_json_adapter_rejects_malformed_timestamp_without_db_write() {
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().join("adapter-malformed-time.db");
+        let valid_id = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+        let bad_id = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+        let source_path = tmp.path().join("bad-time.json");
+        std::fs::write(
+            &source_path,
+            format!(
+                r#"[{{"id":"{valid_id}","kind":"concept","name":"MustNotLand"}},{{"id":"{bad_id}","kind":"concept","name":"BadTime","created_at":"not-rfc3339"}}]"#
+            ),
+        )
+        .unwrap();
+
+        let err = cmd_import(ImportArgs {
+            source: source_path,
+            db: db_path.clone(),
+            namespace: "test-ns".to_string(),
+            format: ImportFormat::Json,
+            verbose: false,
+        })
+        .await
+        .expect_err("present malformed timestamps must reject the complete import");
+        assert!(
+            err.chain()
+                .any(|cause| cause.to_string().contains("created_at")
+                    && cause.to_string().contains("RFC3339")),
+            "error must identify the malformed timestamp: {err:#}"
+        );
+        assert!(
+            !db_path.exists(),
+            "deterministically malformed adapter input must be rejected before the target DB is created"
+        );
+
+        let ns = Namespace::parse("test-ns").unwrap();
+        let runtime = KhiveRuntime::new(RuntimeConfig {
+            db_path: Some(db_path),
+            default_namespace: ns.clone(),
+            embedding_model: None,
+            ..Default::default()
+        })
+        .unwrap();
+        let token = runtime.authorize(ns).unwrap();
+        assert!(
+            runtime
+                .get_entity(&token, valid_id.parse().unwrap())
+                .await
+                .is_err(),
+            "the valid record before the malformed record must not be written"
+        );
+    }
+
+    #[tokio::test]
+    async fn import_archive_rejects_malformed_edge_timestamp_without_creating_target() {
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().join("archive-malformed-edge-time.db");
+        let source = Uuid::new_v4();
+        let target = Uuid::new_v4();
+        let edge_id = Uuid::new_v4();
+        let source_path = tmp.path().join("bad-edge-time-archive.json");
+        std::fs::write(
+            &source_path,
+            format!(
+                r#"{{"format":"khive-kg","version":"0.1","namespace":"test-ns","exported_at":"2026-01-01T00:00:00Z","entities":[{{"id":"{source}","kind":"concept","name":"Source","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}},{{"id":"{target}","kind":"concept","name":"Target","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}}],"edges":[{{"edge_id":"{edge_id}","source":"{source}","target":"{target}","relation":"extends","weight":0.8,"created_at":"not-rfc3339","updated_at":"2026-04-04T00:00:00Z"}}]}}"#
+            ),
+        )
+        .unwrap();
+
+        let err = cmd_import(ImportArgs {
+            source: source_path,
+            db: db_path.clone(),
+            namespace: "test-ns".to_string(),
+            format: ImportFormat::Archive,
+            verbose: false,
+        })
+        .await
+        .expect_err("a present malformed archive edge timestamp must reject the import");
+        assert!(
+            err.chain()
+                .any(|cause| cause.to_string().contains("created_at")
+                    || cause.to_string().contains("RFC3339")),
+            "error must identify the malformed edge timestamp: {err:#}"
+        );
+        assert!(
+            !db_path.exists(),
+            "malformed archive input must not create or migrate the target DB"
         );
     }
 

--- a/docs/adr/ADR-020-git-native-kg-implementation.md
+++ b/docs/adr/ADR-020-git-native-kg-implementation.md
@@ -167,6 +167,11 @@ opaque stable handle for `update`/`delete`. `target` may be a local UUID or a
 `kg://<remote>/<namespace>/<id>` cross-repo reference (§8, per
 [ADR-037](ADR-037-remote-resolution-and-hash-verification.md)).
 
+Edge `properties` map losslessly to the storage edge's `metadata` object and participate in
+snapshot identity after recursive key canonicalization. `created_at` and `updated_at` remain
+independent provenance fields through adapter, archive, runtime, local-sync, and remote-hash paths;
+a missing legacy timestamp may use import time, while a present value is never replaced.
+
 Field ordering within both record types is fixed at the serializer level. Re-exporting
 the same logical state always produces the same bytes — a property the SHA-256 snapshot
 hash from [ADR-010](ADR-010-kg-versioning.md) depends on.

--- a/docs/adr/ADR-036-kg-import-export-adapters.md
+++ b/docs/adr/ADR-036-kg-import-export-adapters.md
@@ -118,8 +118,10 @@ adapter reads the file twice, filtering rows by the presence of required columns
 
 Expects a JSON array of objects at the top level. Without a mapping file, the adapter maps
 keys directly to entity fields (case-insensitive): `id`, `name`, `kind`, `description`. All
-other keys collect into `properties`. Edge objects are detected by the presence of `source` and
-`target` fields. Mixed arrays (entities and edges in the same file) are supported.
+other keys collect into `properties`. Edge objects are detected only by the complete canonical
+`source` and `target` signature. `from` and `to` are ordinary entity metadata. A record with both
+complete `kind`+`name` and `source`+`target` signatures is rejected as ambiguous. Mixed arrays
+(entities and edges in the same file) are supported.
 
 With a mapping file, the `entities` section applies (same shape as CSV mapping, with JSON key
 paths instead of column names).
@@ -217,8 +219,9 @@ Mapping files are deferred. The shipped CLI rejects `--mapping` with a clear
 
 - CSV/TSV: auto-detect entity rows vs edge rows from header names; `--default-kind`
   supplies a kind when entity rows omit one.
-- JSON: parse a top-level array of objects; objects with `source` and `target` become
-  edges, other objects become entities; unrecognized keys fold into `properties`.
+- JSON: parse a top-level array of objects; objects with canonical `source` and `target` become
+  edges, other objects become entities; ambiguous complete dual signatures are rejected and
+  unrecognized entity keys fold into `properties`.
 
 Interactive mapping generation and `.khive/kg/import-mapping.yaml` are not shipped.
 
@@ -502,6 +505,30 @@ taxonomy values are rejected through validation.
 | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Shipped  | Deno CSV/TSV/JSON import; Rust `FormatAdapter`/record/error types; Rust `JsonFormatAdapter`; `kkernel kg import` archive/json/ndjson                    |
 | Deferred | mapping files, schema modes, Rust CSV/TSV modules, BibTeX/RDF/JSON-LD/GraphML/GEXF/Markdown, non-NDJSON export formats other than archive compatibility |
+
+## Amendment 1 (2026-08-09): fail-closed generic JSON identity and timestamps
+
+The shipped generic JSON/NDJSON and canonical NDJSON import boundaries validate deterministic
+record invariants before the first target write:
+
+1. Entity `name` and other required strings are non-blank after trimming. The original non-blank
+   bytes are preserved; validation does not normalize the stored label.
+2. A present `created_at` or `updated_at` is a string that parses as RFC 3339. Missing timestamps
+   may use the documented import-time fallback. A present malformed value is never treated as
+   missing and never replaced by the current time.
+3. JSON record classification uses only the complete canonical `source`+`target` edge signature.
+   `from`/`to` alone are entity properties. A complete entity signature (`kind`+`name`) combined
+   with a complete edge signature is rejected as ambiguous rather than silently choosing one.
+4. `khive-vcs` runs non-blank-name validation with its existing kind/timestamp/sort/referential
+   validate-first gate before creating a temporary database. `khive-runtime::import_kg` likewise
+   completes deterministic entity-kind/name and edge-weight validation before opening the target
+   entity store; mutable endpoint existence and namespace checks remain at write time.
+5. Edge `properties`, `created_at`, and `updated_at` remain reserved portable fields through adapter,
+   archive, runtime, and VCS conversion. Properties persist as storage edge metadata and contribute
+   to the canonical snapshot hash; the two timestamps persist independently.
+
+These rules supersede any earlier implementation text that allowed alias-based edge detection or
+warning/default behavior for a present malformed timestamp, or discarded edge metadata/provenance.
 
 ## Format-v2 migration UX (deferred to ADR-048)
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -116,22 +116,23 @@ kkernel kg import /tmp/my-namespace.khive-kg.json --db /path/to/target.db --name
   follow a pre-existing symlink), `fsync`s it, then renames it into place (`archive.rs:54-80`).
 - `kg import <source> --db <path> [--namespace local] [--format archive|json|ndjson] [--verbose]`:
   `source` and `--db` are required, `--format` defaults to `archive`.
-  - `--format archive` (default): parses `source` directly as a `KgArchive` JSON envelope, checks
-    edge weights are finite and in `[0.0, 1.0]`, then calls `runtime.import_kg`. Entity/note kind
-    validation runs against the **full merged pack kind registry** (every loaded pack's kinds,
-    including pack-registered ones like `resource`), because `cmd_import` installs that registry
-    before importing (`archive.rs:93, 233-255`).
+  - `--format archive` (default): parses `source` directly as a `KgArchive` JSON envelope and
+    completes format/version, entity kind/name, timestamp, and edge-weight validation before the
+    target runtime is constructed. Kind validation uses the **full merged pack kind registry**
+    (including pack-registered kinds such as `resource`) discovered against an in-memory validation
+    runtime, so malformed input cannot create or migrate `--db`.
   - `--format json` / `--format ndjson`: parsed through `khive_vcs_adapters::JsonFormatAdapter`,
     a flat array of entity/edge records in the adapter's own wire shape (a `json` file is one JSON
-    array; an `ndjson` file is one record per line, joined into an array before parsing). **These
-    two formats are not the same code path as `--format archive`** and validate entity kind
-    earlier, against only the base 8 `khive_types::EntityKind` variants, not the merged pack
-    registry. A pack-registered kind such as `resource` imports successfully with `--format
-    archive` but is rejected by `--format json`/`--format ndjson`; this asymmetry is a known,
-    explicitly-commented gap (`archive.rs:609-620`), not a bug to work around locally.
-  - A malformed record anywhere in a `json`/`ndjson` array aborts the entire import before any DB
-    write; earlier well-formed records in the same file are not partially applied
-    (`archive.rs:823-891`).
+    array; an `ndjson` file is one record per line, joined into an array before parsing). These
+    formats pass the merged pack kind registry into the adapter, so pack-registered kinds such as
+    `resource` use the same installed taxonomy as archive import. Canonical `source`+`target`
+    identifies an edge; `from`/`to` remain entity metadata; a complete dual entity/edge signature
+    is rejected as ambiguous. Required names must be non-blank and present timestamps must be valid
+    RFC 3339 strings. Entity labels retain their original nonblank bytes. Edge properties and the
+    two timestamps remain top-level portable fields and persist as storage metadata/provenance.
+  - A malformed record anywhere in an archive, `json`, or `ndjson` input aborts before the target
+    runtime is constructed; `--db` is neither created nor migrated and earlier valid records are
+    not partially applied.
   - The positional `source` argument points at an arbitrary file the operator names. It is **not** the same as reading
     the repo's tracked `.khive/kg/{entities,edges}.ndjson`; that directory-reading path
     (`archive_from_ndjson_repo`) is used only by `kg status`, and separately by `kkernel sync` /
@@ -168,6 +169,9 @@ kkernel kg fetch upstream --url https://github.com/org/kg-data.git --ref main \
   `git_ref`, `commit_sha`, and `content_hash`.
 - Git remote URLs and any embedded credentials are redacted from error messages before they reach
   stdout/stderr (`khive-vcs/src/sync.rs:462-523`).
+- Remote validation uses the same full deterministic gate as local sync. Edge properties are part
+  of `content_hash`, so a metadata-only remote change fails an old pin; independent edge creation
+  and update timestamps are preserved through archive conversion.
 
 **Do not confuse `kg fetch`/`kg sync` with the top-level `kkernel sync`.** They share a name
 fragment but are different commands: `kkernel sync --repo . --db <path> [--namespace local]`
@@ -175,9 +179,10 @@ rebuilds a **local** SQLite DB from the repo's own tracked `.khive/kg/*.ndjson` 
 pin), atomically, via a `.tmp` file and rename, checkpointing the WAL first so no committed rows
 are left behind by the rename (`khive-vcs/src/sync.rs:822-882`). `kg fetch`/`kg sync` instead
 populate a **remote cache directory** with pin verification; it does not touch any SQLite file by
-itself. Both validate NDJSON before writing anything (fail-closed): duplicate ids, dangling edge
-endpoints, out-of-range edge weights, unsorted files, and unknown entity kinds/edge relations all
-abort before any DB write (`khive-vcs/src/sync.rs:707-810`).
+itself. Both validate NDJSON before writing anything (fail-closed): blank names, malformed entity
+or edge timestamps, duplicate ids, dangling endpoints, out-of-range edge weights, unsorted files,
+and unknown entity kinds/edge relations all abort before publication. Local sync maps edge
+`properties` to storage `metadata` and preserves `created_at` and `updated_at` independently.
 
 ### `kg status`: drift between DB and tracked NDJSON
 
@@ -194,6 +199,8 @@ hashes the repo's tracked `.khive/kg/{entities,edges}.ndjson`, and reports:
 
 `clean` is a pure content-hash equality check: not a field-by-field diff, so it tells you _that_
 the DB and tracked files disagree, not _what_ disagrees (use `kg export` + a diff tool for that).
+Edge properties contribute to this hash after recursive key canonicalization; a metadata-only edge
+change therefore makes `clean` false.
 **`kg status` never calls `std::process::exit`**: a "dirty" result is reported only via
 `clean: false` in the JSON, not a nonzero exit code (`kg/status.rs`). This is the opposite of `kg
 validate` (below), which does hard-exit on failure. A cron/CI check against drift must parse


### PR DESCRIPTION
## Summary

Rust-core successor to #1837 (the TypeScript CLI importer slice follows separately). Carries the portability core and the semantic edge merge together because CI compiles the workspace-excluded merge crate against the extended `ExportedEdge` shape.

- `ExportedEdge` gains portable `properties` and independent `created_at`/`updated_at` provenance fields in the ADR-020 wire shape. Legacy archives without timestamps deserialize with import-time defaults; a present value is never replaced.
- Export, import, archive encode/decode, local sync, remote hash, and the JSON array adapter carry the metadata losslessly; edge properties participate in snapshot identity after recursive key canonicalization.
- Deterministic import validation (entity kind, blank name, reserved secret-gate property key, edge weight) completes before the first write, so a rejected archive can no longer partially import.
- JSON adapter edge detection now requires the complete canonical `source`+`target` signature; records ambiguous between entity and edge shapes are rejected (ADR-036).

## Testing

- `cargo check --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all --check`
- `cargo test`: khive-runtime portability (18), khive-vcs (81), khive-vcs-adapters (48), kkernel archive (21) — all passing
- Semantic edge merge carries `properties` and provenance timestamps across added, modified, and reconciled edges; chained identity collisions are recorded and dropped rather than silently duplicating an earlier edge's durable id, with the regression test pinning exact surviving edges and conflict fields (khive-merge: 98 tests, clippy and doc build clean).
