### PR TITLE
feat(kg-editor): turn repository showcase into a triage cockpit

### DIFF
--- a/apps/kg-editor/DEMO.md
+++ b/apps/kg-editor/DEMO.md
@@ -14,11 +14,20 @@ the allowlisted server route:
 
 ```bash
 KHIVE_SHOWCASE_ANALYSIS_ROOT=/absolute/path/to/analyses \
-KHIVE_SHOWCASE_ANALYSIS_IDS=khive \
+KHIVE_SHOWCASE_ANALYSES='[{"analysis_id":"khive","canonical_url":"https://github.com/ohdearquant/khive"}]' \
+KHIVE_SHOWCASE_ACCESS_TOKEN=a-long-random-operator-secret \
 npm run dev
 ```
 
 Place the report at `$KHIVE_SHOWCASE_ANALYSIS_ROOT/khive/khive.repo.v1.json`.
+The protected route requires the bearer token on every request and fails closed
+to 404 without it, which silently selects the static fallback. Unlock the UI in
+the browser console before opening the repository:
+
+```js
+sessionStorage.setItem("khive.showcase.accessToken", "a-long-random-operator-secret");
+```
+
 Before presenting, verify that the source badge says **khive DB snapshot**, not
 **curated static fallback**.
 

--- a/apps/kg-editor/DEMO.md
+++ b/apps/kg-editor/DEMO.md
@@ -1,0 +1,162 @@
+# DB-backed repository analysis demo
+
+This walkthrough demonstrates the repository showcase as an investigation tool,
+not a generic dashboard. The example values below come from the khive snapshot
+at `288b9eee1f471d505e7f5de33e121c58773a10af`. When using a newer snapshot,
+narrate the values and coverage displayed by the UI.
+
+## Prepare the materialized snapshot
+
+The browser does not open SQLite or trigger repository ingestion. An operator
+first runs the `khive repo build` pipeline, which joins the history and code-map
+databases into one immutable, schema-validated `khive.repo.v1` report. Configure
+the allowlisted server route:
+
+```bash
+KHIVE_SHOWCASE_ANALYSIS_ROOT=/absolute/path/to/analyses \
+KHIVE_SHOWCASE_ANALYSIS_IDS=khive \
+npm run dev
+```
+
+Place the report at `$KHIVE_SHOWCASE_ANALYSIS_ROOT/khive/khive.repo.v1.json`.
+Before presenting, verify that the source badge says **khive DB snapshot**, not
+**curated static fallback**.
+
+This setup requires the DB snapshot API route from the companion backend PR (or
+its merged equivalent). Without that route, this UI branch intentionally uses
+the curated static fallback.
+
+## Five-to-seven-minute flow
+
+### 1. Establish provenance and limits
+
+1. Open `/`, leave `https://github.com/ohdearquant/khive` in the repository
+   field, and select **Open repository**.
+2. Point to the DB-snapshot badge, pinned SHA, ingestion time, and exporter
+   identity.
+3. Point to the overview: this snapshot contains 45 packages, 683 modules, 990
+   commits, and seven captured dependency SCCs.
+
+Say:
+
+> This is a reproducible analysis of one pinned revision, built from khive's
+> history and code-map databases. The browser cannot clone a repository or ask
+> the server to ingest an arbitrary URL. Every list carries its own completeness
+> and bound.
+
+Explain **Observed** versus **Candidate**. An SCC is an observed graph fact;
+hotspot, ownership, and co-change ranks are candidates for human verification.
+Also point out the source-role disclosure: the current import scan does not
+distinguish production, test, example, and generated modules.
+
+### 2. Start at the writer/storage seam
+
+1. Search for `crates/khive-db/src/pool.rs` and inspect it.
+2. Show fan-in 20, fan-out 2, 26 captured commits, and bus factor 1.
+3. In **Dependency topology**, follow the SCC member link to
+   `crates/khive-db/src/writer_task.rs`.
+4. Show its fan-in 9, fan-out 2, 21 captured commits, and the same two-member
+   SCC.
+
+Say:
+
+> The tool did more than rank a large file. It found a bidirectional ownership
+> boundary: the pool creates and stores the writer task, while the writer task
+> asks the pool for a connection and shared counters. That is a concrete
+> consolidation candidate—either co-locate the owner or extract a lower-level
+> writer-admission contract—without claiming there is a runtime deadlock.
+
+Keep the scope caveat visible: six of `pool.rs`'s 20 captured dependents are
+test modules, so 20 is not a production-only fan-in.
+
+### 3. Show an architectural insight that argues against consolidation
+
+Search for `crates/khive-db/src/checkpoint.rs`. It has 38 captured commits and
+co-change evidence across DB, runtime, and MCP. Source and ADR inspection
+explains why this control plane must remain physically independent of the writer
+queue: a dedicated checkpoint connection prevents checkpoint I/O from consuming
+writer admission. The useful consolidation target is the runtime-facing
+control/metrics facade, not SQLite connection ownership.
+
+### 4. Move to the runtime coordination knot
+
+1. Search for `crates/khive-runtime/src/operations.rs`.
+2. Show 90 captured commits, fan-in 4, fan-out 7, and its SCC with `pack.rs` and
+   `curation.rs`.
+3. Point to the history disclosure: the total is 90 while the inspector shows a
+   recent sample from the captured page.
+4. Open **Dependency topology** and show SCC membership without implying an edge
+   order.
+
+Say:
+
+> Change history and dependency topology converge on the same boundary. The safe
+> first extraction is the shared endpoint and resolution policy into a
+> dependency-lower contract, followed by the split plans already documented in
+> these source files.
+
+### 5. Use a false positive to demonstrate trustworthiness
+
+Open the top **Hidden coupling** candidate. In this snapshot it is
+`khive-pack-comm/tests/integration.rs` with `src/handlers.rs`, at 40 co-changes.
+The global analysis contains only the top 1,000 of 104,798 candidate pairs.
+
+Say:
+
+> Co-change is not a call edge or an instruction to merge files. This top pair
+> is healthy test-to-implementation coordination. The visible path and
+> source-role caveat let us falsify the scary interpretation instead of turning
+> a rank into a defect.
+
+If time permits, repeat the exercise with the MCP `coordinator.rs`/`server.rs`
+SCC. Its reverse edge comes from a `cfg(test)` import, while the production
+coordinator seam is one-way.
+
+### 6. Close with one confirmed contract drift
+
+Use repository search to inspect `operations.rs`, `runtime.rs`, and `daemon.rs`
+as separate modules, then follow the displayed source paths into the runtime
+manifest and imports. These are not direct `pool.rs` dependents in the captured
+import graph. The source follow-up is the proof: accepted ADR-005 says
+runtime-facing code depends on `khive-storage` traits, but the current runtime
+manifest and modules directly expose `khive-db`, `ConnectionPool`, SQLite
+planning, checkpoint, and diagnostics types.
+
+Say:
+
+> This is not a claimed runtime failure; it is a confirmed accepted-architecture
+> drift. The owner must either amend ADR-005 with a bootstrap/admin/atomic
+> SQLite exception or promote these capabilities into the storage contract.
+
+## Two falsifiable consolidation hypotheses
+
+1. **Writer ownership contract:** remove the `pool.rs`/`writer_task.rs` SCC by
+   extracting neutral admission/connection state or co-locating lifecycle
+   ownership. Preserve queue, strict-routing, WAL, checkpoint, and contention
+   tests; re-ingest and require the SCC to disappear without changing
+   single-writer semantics.
+2. **Runtime endpoint contract:** extract shared endpoint, relation, and
+   resolution policy below `operations.rs`, `curation.rs`, and `pack.rs`.
+   Preserve pack registration, endpoint-conformance, curation, and public API
+   tests; re-ingest and require a one-way dependency graph rather than merely
+   fewer lines in one file.
+
+## Closing line
+
+> The UI does not tell me that code is bad. It turns 683 modules into a
+> reproducible investigation: provenance, rank, topology, history, bounds, and
+> the exact paths needed to test an architecture hypothesis. Dogfooding also
+> exposed where the analysis itself must improve—especially production/test
+> source-role classification—so the tool is falsifiable rather than decorative.
+
+## Q&A caveats
+
+- The demo snapshot is pinned; it is not the current working tree.
+- Code ingestion in this report covers Rust.
+- Bus factor describes captured commit-author identities, not present-day
+  staffing.
+- Hidden-coupling support is co-change frequency in the declared window, not
+  causality.
+- The browser receives validated JSON transport bytes. “DB-backed” describes how
+  the immutable analysis is produced and selected, not live browser-side SQLite
+  access.

--- a/apps/kg-editor/README.md
+++ b/apps/kg-editor/README.md
@@ -29,6 +29,9 @@ scripts/generate-repo-showcase.sh
 The underlying one-shot pipeline is `khive repo build`: pinned clone → cursor-exhausted
 `git.digest` → separate `code.ingest` map → cross-store export.
 
+For the DB-backed interview walkthrough, investigation path, and evidence boundaries, see
+[DEMO.md](DEMO.md).
+
 ## KG review workbench
 
 KG Studio is the first read-only vertical slice of khive's local-first semantic review
@@ -110,7 +113,16 @@ sorted by analysis ID and exposes only those two public fields. It does not scan
 analysis root or read a report.
 
 Both API routes require `Authorization: Bearer $KHIVE_SHOWCASE_ACCESS_TOKEN` on every
-request, checked in constant time. An absent or mismatched token is indistinguishable
+request, checked in constant time. To use the DB-backed setup through the showcase UI,
+supply the same token to your own browser session before loading a repository:
+
+```js
+sessionStorage.setItem("khive.showcase.accessToken", "a-long-random-operator-secret");
+```
+
+The UI sends it as the bearer credential on snapshot requests. Without it the protected
+route answers 404 and the UI falls back to the curated static bundle, so the token never
+ships in the client build. An absent or mismatched token is indistinguishable
 from an unconfigured catalog: both routes fail closed to the same sanitized 404. Without
 `KHIVE_SHOWCASE_ACCESS_TOKEN` set, no request can be authorized, regardless of what
 credentials it presents.

--- a/apps/kg-editor/e2e/showcase.spec.ts
+++ b/apps/kg-editor/e2e/showcase.spec.ts
@@ -5,6 +5,9 @@ test("dogfoods every repository analysis from the curated static bundle", async 
   page.on("console", (message) => {
     if (message.type() === "error") consoleErrors.push(message.text());
   });
+  await page.route("**/api/showcase/analyses/khive", async (route) => {
+    await route.fulfill({ status: 404 });
+  });
 
   await page.goto("/");
   const overview = page.locator(".repo-overview");
@@ -66,7 +69,9 @@ test("dogfoods every repository analysis from the curated static bundle", async 
     await expect(page.locator(".repo-view-panel h2")).not.toBeEmpty();
   }
 
-  expect(consoleErrors).toEqual([]);
+  expect(consoleErrors).toEqual([
+    expect.stringMatching(/failed to load resource.*404/i),
+  ]);
 });
 
 test("a valid repository miss stays local and renders an honest state", async ({ page }) => {

--- a/apps/kg-editor/src/components/showcase/repo-showcase.test.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase.test.tsx
@@ -1,8 +1,8 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { RepoShowcase } from "@/components/showcase/repo-showcase";
 import { parseRepoBundle, type RepoBundle } from "@/lib/repo-bundle";
@@ -20,6 +20,246 @@ function exactish(value: string): RegExp {
 }
 
 describe("repository showcase", () => {
+  it("answers repository triage questions before exposing the raw analysis views", async () => {
+    const bundle = golden();
+    const user = userEvent.setup();
+
+    const { container } = render(<RepoShowcase bundle={bundle} />);
+
+    const triage = screen.getByRole("region", { name: "Repository triage" });
+    expect(within(triage).getByRole("heading", { name: "What deserves attention?" })).toBeVisible();
+    expect(container.querySelector('[data-repository-metric="modules"]')).toHaveTextContent(`${bundle.graph.modules.items.length}`);
+    expect(container.querySelector('[data-repository-metric="modules"]')).toHaveTextContent(/complete/i);
+    expect(container.querySelector('[data-repository-metric="commits"]')).toHaveTextContent(`${bundle.graph.commits.items.length}`);
+    expect(within(triage).getByText("Observed", { selector: "span" })).toBeVisible();
+    expect(within(triage).getAllByText("Candidate", { selector: "span" }).length).toBeGreaterThan(0);
+    expect(container.querySelector('[data-signal-kind="hidden_coupling"]')).toHaveTextContent(/truncated/i);
+
+    const firstStart = within(triage).getAllByRole("button", { name: /inspect .*\.rs/i })[0];
+    await user.click(firstStart);
+    const inspector = within(triage).getByRole("complementary", { name: "Module evidence" });
+    expect(within(inspector).getByText("Analysis window")).toBeVisible();
+    expect(within(inspector).getByRole("heading", { name: bundle.capability.labels.metrics.commits })).toBeVisible();
+
+    await user.type(within(triage).getByRole("searchbox", { name: "Find a module or path" }), "pool.rs");
+    const poolResult = within(triage).getByRole("button", { name: /inspect .*pool\.rs/i });
+    await user.click(poolResult);
+    expect(within(inspector).getByRole("heading", { level: 3 }).textContent).toContain("pool.rs");
+
+    await user.click(within(triage).getAllByRole("button", { name: /open full analysis/i })[0]);
+    expect(screen.getByRole("button", { name: bundle.capability.views.hotspot_quadrant.label })).toHaveAttribute("aria-current", "page");
+    expect(screen.getByRole("navigation", { name: bundle.capability.labels.product })).toBeVisible();
+  });
+
+  it("keeps module search bounded and gives an empty result one recovery action", async () => {
+    const user = userEvent.setup();
+    const { container } = render(<RepoShowcase bundle={golden()} />);
+    const triage = container.querySelector<HTMLElement>("[data-repository-triage]")!;
+
+    await user.type(within(triage).getByRole("searchbox", { name: "Find a module or path" }), "definitely-not-a-module");
+
+    const empty = triage.querySelector<HTMLElement>('[data-state="empty"]')!;
+    expect(empty).toBeVisible();
+    expect(empty.querySelectorAll("button")).toHaveLength(1);
+    expect(within(triage).getAllByRole("button", { name: "Clear search" })).toHaveLength(1);
+    await user.click(within(empty).getByRole("button", { name: "Clear search" }));
+    expect(within(triage).getByRole("searchbox", { name: "Find a module or path" })).toHaveValue("");
+  });
+
+  it("moves focus and scroll position to the analysis selected from triage", async () => {
+    const user = userEvent.setup();
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoView,
+    });
+    const { container } = render(<RepoShowcase bundle={golden()} />);
+    const triage = container.querySelector<HTMLElement>("[data-repository-triage]")!;
+
+    await user.click(within(triage).getAllByRole("button", { name: /open full analysis/i })[0]);
+
+    const dashboard = container.querySelector<HTMLElement>("[data-repository-dashboard]")!;
+    await waitFor(() => expect(dashboard).toHaveFocus());
+    expect(scrollIntoView).toHaveBeenCalledOnce();
+  });
+
+  it("renders an unavailable top-level metric as unavailable text, not a fabricated zero", () => {
+    const bundle = structuredClone(golden());
+    bundle.aggregates.dependency_topology.meta.status = "unavailable";
+    bundle.aggregates.dependency_topology.meta.unavailable_reason = "topology analysis was not produced";
+
+    const { container } = render(<RepoShowcase bundle={bundle} />);
+    const cyclesMetric = container.querySelector<HTMLElement>('[data-repository-metric="cycles"]')!;
+
+    expect(cyclesMetric).toHaveTextContent(bundle.capability.labels.unavailable);
+    expect(cyclesMetric.querySelector("strong")).not.toHaveTextContent(/^0$/);
+  });
+
+  it("marks the combined attention metric truncated (not complete) when one attention analysis is truncated", () => {
+    const bundle = structuredClone(golden());
+    bundle.aggregates.hotspot_quadrant.data.items = bundle.aggregates.hotspot_quadrant.data.items.slice(0, 1);
+    bundle.aggregates.hotspot_quadrant.data.total_count = { status: "available", value: 99 };
+    bundle.aggregates.hotspot_quadrant.data.truncated = true;
+    bundle.aggregates.hotspot_quadrant.data.disclosure = {
+      status: "truncated",
+      reason: "hotspot export was capped",
+    };
+
+    const { container } = render(<RepoShowcase bundle={bundle} />);
+    const triage = container.querySelector<HTMLElement>("[data-repository-triage]")!;
+
+    expect(within(triage).getAllByText(/hotspot export was capped/i).length).toBeGreaterThan(0);
+    expect(triage.querySelector('[data-state="unavailable"]')).not.toBeInTheDocument();
+  });
+
+  it("discloses when a bounded module search hides matches beyond its cap", async () => {
+    const user = userEvent.setup();
+    const { container } = render(<RepoShowcase bundle={golden()} />);
+    const triage = container.querySelector<HTMLElement>("[data-repository-triage]")!;
+
+    await user.type(within(triage).getByRole("searchbox", { name: "Find a module or path" }), "e");
+
+    const state = triage.querySelector<HTMLElement>('[data-state="truncated"][data-bound="8"]');
+    expect(state).toBeVisible();
+    expect(within(triage).getByText(/8 of \d+ captured matches/)).toBeVisible();
+  });
+
+  it("distinguishes unavailable recommendation analyses from measured empty", () => {
+    const bundle = structuredClone(golden());
+    bundle.aggregates.api_surface.meta.status = "unavailable";
+    bundle.aggregates.api_surface.meta.unavailable_reason = "API ranking was not produced";
+    for (const analysis of [bundle.aggregates.hotspot_quadrant, bundle.aggregates.dependency_topology, bundle.aggregates.hidden_coupling, bundle.aggregates.ownership]) {
+      analysis.meta.status = "unavailable";
+      analysis.meta.unavailable_reason = "attention analysis was not produced";
+    }
+
+    const { container } = render(<RepoShowcase bundle={bundle} />);
+    const triage = container.querySelector<HTMLElement>("[data-repository-triage]")!;
+
+    expect(within(triage).getByText("API ranking was not produced")).toBeVisible();
+    expect(within(triage).getAllByText(/attention analysis was not produced/i).length).toBeGreaterThan(0);
+    expect(triage.querySelectorAll('[data-state="unavailable"]').length).toBeGreaterThanOrEqual(2);
+    expect(triage).not.toHaveTextContent(/No captured module has a non-zero/i);
+  });
+
+  it("navigates inspector relationships and discloses cycles and history bounds", async () => {
+    const bundle = golden();
+    const cycle = bundle.aggregates.dependency_topology.cycles.items.find((candidate) => candidate.module_ids.length > 1)!;
+    const selected = bundle.graph.modules.items.find((module) => module.id === cycle.module_ids[0])!;
+    const peer = bundle.graph.modules.items.find((module) => module.id === cycle.module_ids[1])!;
+    const history = bundle.graph.history_navigation.by_module.items.find((row) => row.module_id === selected.id)!.commits;
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", { configurable: true, value: scrollIntoView });
+    const user = userEvent.setup();
+    const { container } = render(<RepoShowcase bundle={bundle} />);
+    const triage = container.querySelector<HTMLElement>("[data-repository-triage]")!;
+
+    await user.type(within(triage).getByRole("searchbox", { name: "Find a module or path" }), selected.source_path);
+    await user.click(within(triage).getByRole("button", { name: `Inspect ${selected.source_path}` }));
+
+    const inspector = within(triage).getByRole("complementary", { name: "Module evidence" });
+    await waitFor(() => expect(inspector).toHaveFocus());
+    expect(scrollIntoView).toHaveBeenCalled();
+    expect(within(inspector).getByText(cycle.id)).toBeVisible();
+    expect(within(inspector).getByText("Not classified in this snapshot")).toBeVisible();
+    const historyMetric = inspector.querySelector<HTMLElement>('[data-inspector-metric="commits"]')!;
+    expect(historyMetric).toHaveTextContent(String(history.total_count.status === "available" ? history.total_count.value : history.items.length));
+    expect(inspector).toHaveTextContent(/inspector sampled/i);
+
+    const cycleSection = within(inspector).getByText(cycle.id).closest("section")!;
+    await user.click(within(cycleSection).getByRole("button", { name: peer.source_path }));
+    expect(within(inspector).getByRole("heading", { level: 3 })).toHaveTextContent(peer.source_path);
+  });
+
+  it("renders strongly connected components as membership, not a directed path", async () => {
+    const bundle = golden();
+    const cycle = bundle.aggregates.dependency_topology.cycles.items[0];
+    const user = userEvent.setup();
+    const { container } = render(<RepoShowcase bundle={bundle} />);
+
+    await user.click(screen.getByRole("button", { name: bundle.capability.views.dependency_topology.label }));
+
+    const cycleRow = screen.getByText(cycle.id).closest(".repo-list-row")!;
+    expect(cycleRow).toHaveTextContent("SCC members:");
+    expect(cycleRow).not.toHaveTextContent("→");
+    expect(container.querySelector("[data-repository-dashboard]")).toBeVisible();
+  });
+
+  it("renders missing module history as unavailable rather than zero", () => {
+    const bundle = structuredClone(golden());
+    const target = [...bundle.aggregates.api_surface.data.items].sort((left, right) => right.dependent_count - left.dependent_count)[0];
+    bundle.graph.history_navigation.by_module.items = bundle.graph.history_navigation.by_module.items.filter((row) => row.module_id !== target.module_id);
+
+    const { container } = render(<RepoShowcase bundle={bundle} />);
+    const inspector = container.querySelector<HTMLElement>("[data-module-inspector]")!;
+    const commitMetric = inspector.querySelector<HTMLElement>('[data-inspector-metric="commits"]')!;
+
+    expect(commitMetric).toHaveTextContent(bundle.capability.labels.unavailable);
+    expect(commitMetric).not.toHaveTextContent(/^0$/);
+    expect(inspector).toHaveTextContent("No module history-navigation row was captured.");
+  });
+
+  it("reports truncated (not unavailable) history when a module's row is missing from a truncated by-module page", () => {
+    const bundle = structuredClone(golden());
+    const target = [...bundle.aggregates.api_surface.data.items].sort((left, right) => right.dependent_count - left.dependent_count)[0];
+    bundle.graph.history_navigation.by_module.items = bundle.graph.history_navigation.by_module.items.filter((row) => row.module_id !== target.module_id);
+    bundle.graph.history_navigation.by_module.truncated = true;
+    bundle.graph.history_navigation.by_module.disclosure = {
+      status: "truncated",
+      reason: "by-module history export was capped",
+    };
+
+    const { container } = render(<RepoShowcase bundle={bundle} />);
+    const inspector = container.querySelector<HTMLElement>("[data-module-inspector]")!;
+    const commitMetric = inspector.querySelector<HTMLElement>('[data-inspector-metric="commits"]')!;
+    const coverage = within(inspector)
+      .getByText(`${bundle.capability.labels.metrics.commits} coverage`)
+      .closest('[data-state="truncated"]') as HTMLElement;
+
+    expect(commitMetric).not.toHaveTextContent(/^0$/);
+    expect(commitMetric).not.toHaveTextContent(bundle.capability.labels.unavailable);
+    expect(commitMetric).toHaveTextContent(/0 shown/i);
+    expect(coverage).toBeVisible();
+    expect(coverage).toHaveTextContent(/by-module history export was capped/i);
+    expect(inspector).not.toHaveTextContent("No module history-navigation row was captured.");
+  });
+
+  it("renders unavailable topology metrics as unavailable rather than zero", () => {
+    const bundle = structuredClone(golden());
+    bundle.aggregates.dependency_topology.meta.status = "unavailable";
+    bundle.aggregates.dependency_topology.meta.unavailable_reason =
+      "topology analysis was not produced";
+    bundle.graph.structure_edges.disclosure.status = "unavailable";
+    bundle.graph.structure_edges.disclosure.reason =
+      "structure edges were not produced";
+
+    const { container } = render(<RepoShowcase bundle={bundle} />);
+    const inspector = container.querySelector<HTMLElement>(
+      "[data-module-inspector]",
+    )!;
+
+    for (const metric of ["fan-in", "fan-out"]) {
+      const row = inspector.querySelector<HTMLElement>(
+        `[data-inspector-metric="${metric}"]`,
+      )!;
+      expect(row).toHaveTextContent(bundle.capability.labels.unavailable);
+      expect(row).not.toHaveTextContent(/^0$/);
+    }
+    expect(inspector).toHaveTextContent("topology analysis was not produced");
+  });
+
+  it("shows unavailable coupling evidence instead of a measured-empty claim", () => {
+    const bundle = structuredClone(golden());
+    bundle.aggregates.hidden_coupling.meta.status = "unavailable";
+    bundle.aggregates.hidden_coupling.meta.unavailable_reason = "coupling analysis was not produced";
+
+    const { container } = render(<RepoShowcase bundle={bundle} />);
+    const inspector = container.querySelector<HTMLElement>("[data-module-inspector]")!;
+
+    expect(inspector).toHaveTextContent("coupling analysis was not produced");
+    expect(inspector).not.toHaveTextContent(/No pair for this module appears/i);
+  });
+
   it("renders all ten capability-owned view labels", () => {
     const bundle = golden();
     render(<RepoShowcase bundle={bundle} />);
@@ -151,10 +391,24 @@ describe("repository showcase", () => {
     const bundle = structuredClone(golden());
     const user = userEvent.setup();
     bundle.capability.views.hotspot_quadrant.label = "Contract-owned risk field";
+    bundle.capability.views.dependency_topology.label = "Contract-owned topology";
+    bundle.capability.views.hidden_coupling.label = "Contract-owned coupling";
+    bundle.capability.views.api_surface.label = "Contract-owned API surface";
+    bundle.capability.labels.node_types.module = "Contract-owned component";
+    bundle.capability.labels.metrics.package_count = "Contract-owned package count";
+    bundle.capability.labels.metrics.module_count = "Contract-owned module count";
+    bundle.capability.labels.metrics.commits = "Contract-owned commits";
+    bundle.capability.labels.metrics.cycle_count = "Contract-owned cycles";
     bundle.capability.labels.metrics.fan_in = "Contract-owned inbound degree";
+    bundle.capability.labels.metrics.fan_out = "Contract-owned outbound degree";
+    bundle.capability.labels.metrics.bus_factor = "Contract-owned bus factor";
+    bundle.capability.labels.metrics.dependent_count = "Contract-owned dependent count";
+    bundle.capability.labels.metrics.cochange_count = "Contract-owned co-change count";
+    bundle.capability.labels.metrics.support = "Contract-owned support";
     bundle.capability.labels.metrics.change_frequency = "Contract-owned revisions";
-    const quadrant = bundle.aggregates.hotspot_quadrant.data.items[0].quadrant;
-    bundle.capability.labels.hotspot_quadrants[quadrant] = "Contract-owned quadrant";
+    for (const quadrant of Object.keys(bundle.capability.labels.hotspot_quadrants) as Array<keyof typeof bundle.capability.labels.hotspot_quadrants>) {
+      bundle.capability.labels.hotspot_quadrants[quadrant] = "Contract-owned quadrant";
+    }
     bundle.capability.labels.metrics.p50 = "Contract-owned median";
     bundle.aggregates.cadence_timeline.pull_request_lead_time_hours = {
       status: "available",
@@ -162,6 +416,24 @@ describe("repository showcase", () => {
     };
 
     const { container } = render(<RepoShowcase bundle={bundle} />);
+    const triage = container.querySelector<HTMLElement>("[data-repository-triage]")!;
+    for (const label of [
+      "Contract-owned package count",
+      "Contract-owned module count",
+      "Contract-owned commits",
+      "Contract-owned cycles",
+      "Contract-owned inbound degree",
+      "Contract-owned outbound degree",
+      "Contract-owned bus factor",
+      "Contract-owned topology",
+      "Contract-owned coupling",
+      "Contract-owned component evidence",
+    ]) {
+      expect(within(triage).getAllByText(label).length).toBeGreaterThan(0);
+    }
+    expect(triage).toHaveTextContent("Contract-owned API surface");
+    expect(triage).toHaveTextContent("Contract-owned dependent count");
+    expect(triage).toHaveTextContent("Contract-owned quadrant");
     await user.click(screen.getByRole("button", { name: "Contract-owned risk field" }));
 
     expect(screen.getByRole("heading", { name: "Contract-owned risk field" })).toBeVisible();
@@ -181,12 +453,7 @@ describe("repository showcase", () => {
 
     const { container } = render(<RepoShowcase bundle={bundle} />);
 
-    // Multiple `[data-state="truncated"]` disclosures can coexist: the browser-side
-    // local display slice (bound = shown, always ambient once a list exceeds the UI
-    // row cap) is a separate concern from the bundle's own page-bound disclosure.
-    // Target the modules page's own disclosure by its distinguishing reason text.
-    const state = Array.from(container.querySelectorAll<HTMLElement>('[data-state="truncated"]'))
-      .find((node) => node.textContent?.includes("fixture node budget"));
+    const state = container.querySelector<HTMLElement>(`.repo-view-panel [data-state="truncated"][data-bound="${bundle.graph.modules.bound.max_items}"]`);
     expect(state).toBeVisible();
     expect(state).toHaveAttribute("data-bound", String(bundle.graph.modules.bound.max_items));
     if (bundle.graph.modules.total_count.status === "available") {
@@ -278,6 +545,23 @@ describe("repository showcase", () => {
     }
   });
 
+  it("reports a cursor-bearing cadence series as truncated even when its disclosure says complete", async () => {
+    const bundle = structuredClone(golden());
+    bundle.aggregates.cadence_timeline.commits.next_cursor = "cursor-after-first-page";
+    bundle.aggregates.cadence_timeline.commits.disclosure = {
+      status: "complete",
+      reason: null,
+    };
+    const user = userEvent.setup();
+    const { container } = render(<RepoShowcase bundle={bundle} />);
+    await user.click(container.querySelector('[data-view-id="cadence_timeline"]')!);
+
+    expect(container.querySelector('[data-cadence-series="commits"]')).toHaveAttribute(
+      "data-series-status",
+      "truncated",
+    );
+  });
+
   it("caps large browser tables and discloses the local slice", async () => {
     const bundle = golden();
     const user = userEvent.setup();
@@ -285,7 +569,9 @@ describe("repository showcase", () => {
     await user.click(container.querySelector('[data-view-id="hotspot_quadrant"]')!);
 
     expect(container.querySelectorAll(".repo-view-panel tbody tr")).toHaveLength(200);
-    expect(Array.from(container.querySelectorAll(".repo-view-panel .repo-bounded.truncated")).some((node) => node.textContent?.toLocaleLowerCase().includes(bundle.capability.labels.truncated.toLocaleLowerCase()))).toBe(true);
+    const localSlice = container.querySelector<HTMLElement>(`.repo-view-panel [data-state="truncated"][data-shown="200"][data-known-total="${bundle.aggregates.hotspot_quadrant.data.items.length}"]`);
+    expect(localSlice).toBeVisible();
+    expect(localSlice).toHaveTextContent(/truncated/i);
   });
 
   it("settles the structure graph without collapsing nodes onto a handful of shared coordinates", () => {

--- a/apps/kg-editor/src/components/showcase/repo-showcase.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase.tsx
@@ -9,6 +9,7 @@ import {
   CircleDot,
   Clock3,
   Code2,
+  Database,
   GitBranch,
   GitCommitHorizontal,
   GitFork,
@@ -22,9 +23,11 @@ import {
   TrendingUp,
   Users,
 } from "@/icons";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 
 import { DataState } from "@/components/data-state";
+import { RepositoryTriage } from "@/components/showcase/repository-triage";
+import type { ShowcaseBundleSource } from "@/lib/adapters/preferred-showcase-source";
 import {
   DerivedEdgeMark,
   edgeDirectionMark,
@@ -734,7 +737,7 @@ function DependencyTopology({ bundle, moduleById, onExploreStructure }: ViewProp
       </section>
       <section className="repo-card">
         <div className="repo-card-heading"><h3>{labels.metrics.cycle_count}</h3><p>{formatNumber(analysis.cycles.items.length)}</p></div>
-        <div className="repo-list">{cycleRows.map((cycle) => <div className="repo-list-row" key={cycle.id}><GitFork aria-hidden="true" /><div><strong>{cycle.id}</strong><span>{cycle.module_ids.map((id) => moduleName(moduleById, id)).join(" → ")}</span></div></div>)}</div>
+        <div className="repo-list">{cycleRows.map((cycle) => <div className="repo-list-row" key={cycle.id}><GitFork aria-hidden="true" /><div><strong>{cycle.id}</strong><span>SCC members: {cycle.module_ids.map((id) => moduleName(moduleById, id)).join(" · ")}</span></div></div>)}</div>
         {isKnownEmptyRepoPage(analysis.cycles) && <DataState className="repo-empty" state="empty" title="No dependency cycles in this bundle" message="Dependency cycles found by the captured topology analysis belong here." action={{ label: "Explore repository structure", onClick: onExploreStructure }} />}
         <LocalSliceDisclosure shown={cycleRows.length} total={analysis.cycles.items.length} label={labels.metrics.cycle_count} labels={labels} />
         <BoundDisclosure page={analysis.cycles} labels={labels} />
@@ -816,8 +819,11 @@ type CadenceSeriesId = "commits" | "issues_opened" | "issues_closed" | "pull_req
 
 function CadenceSeries({ id, page, label, labels, onExploreStructure }: { id: CadenceSeriesId; page: CadencePage; label: string; labels: Labels; onExploreStructure: () => void }) {
   const rows = page.items.slice(0, UI_ROW_LIMIT);
+  const seriesStatus = page.disclosure.status === "complete" && isIncompleteRepoPage(page)
+    ? "truncated"
+    : page.disclosure.status;
   return (
-    <section className="repo-card repo-table-wrap" data-cadence-series={id} data-series-status={page.disclosure.status}>
+    <section className="repo-card repo-table-wrap" data-cadence-series={id} data-series-status={seriesStatus}>
       <div className="repo-card-heading"><h3>{label}</h3><p>{page.total_count.status === "available" ? formatNumber(page.total_count.value) : labels.unavailable}</p></div>
       {page.disclosure.status === "unavailable" ? (
         <DataState className="repo-empty compact" state="unavailable" title={`${label} ${labels.unavailable.toLocaleLowerCase()}`} message={page.disclosure.reason ?? "This bundle does not claim cadence data."} />
@@ -979,25 +985,48 @@ function ActiveView({ id, bundle, moduleById, onExploreStructure }: ViewProps & 
   );
 }
 
-export function RepoShowcase({ bundle }: { bundle: RepoBundle }) {
+export function RepoShowcase({ bundle, analysisSource = "curated-static-fallback" }: { bundle: RepoBundle; analysisSource?: ShowcaseBundleSource }) {
   const [activeView, setActiveView] = useState<ViewId>("structure_graph");
+  const dashboardRef = useRef<HTMLDivElement>(null);
   const moduleById = useMemo(
     () => new Map(bundle.graph.modules.items.map((module) => [module.id, module])),
     [bundle.graph.modules.items],
   );
   const { repository, snapshot, producer } = bundle.meta;
   const { capability } = bundle;
+  function openAnalysis(view: ViewId) {
+    setActiveView(view);
+    const dashboard = dashboardRef.current;
+    if (!dashboard) return;
+    dashboard.focus({ preventScroll: true });
+    const reduceMotion = window.matchMedia?.(
+      "(prefers-reduced-motion: reduce)",
+    ).matches ?? false;
+    dashboard.scrollIntoView?.({
+      behavior: reduceMotion ? "auto" : "smooth",
+      block: "start",
+    });
+  }
   return (
-    <article className="repo-overview" data-head-sha={snapshot.head_sha}>
+    <article className="repo-overview" data-head-sha={snapshot.head_sha} data-analysis-source={analysisSource}>
       <header className="repo-overview-heading">
         <div className="repo-identity"><span className="repo-avatar"><Package aria-hidden="true" /></span><div><span>{repository.host} · {availabilityText(repository.default_branch, capability.labels)}</span><strong>{repository.owner}/{repository.name}</strong></div></div>
-        <div className="repo-meta-row"><span><GitCommitHorizontal aria-hidden="true" /><code>{shortSha(snapshot.head_sha)}</code></span><span><Clock3 aria-hidden="true" />{formatDate(snapshot.ingested_at)}</span><span><Code2 aria-hidden="true" />{producer.exporter}</span></div>
+        <div className="repo-meta-row"><span><GitCommitHorizontal aria-hidden="true" /><code>{shortSha(snapshot.head_sha)}</code></span><span><Clock3 aria-hidden="true" />{formatDate(snapshot.ingested_at)}</span><span><Code2 aria-hidden="true" />{producer.exporter}</span><span><Database aria-hidden="true" />{analysisSource === "khive-db-snapshot" ? "khive DB snapshot" : "curated static fallback"}</span></div>
       </header>
       <section className="repo-capability-strip" aria-label={capability.labels.product}>
         <div><ShieldCheck aria-hidden="true" /><div><strong>{capability.labels.product}</strong><span>{capability.mode}</span></div></div>
         <div className="repo-capability-flags">{Object.values(capability.languages).map((language) => <i key={language.label}>{language.label} · {language.module_join ? capability.views.history_structure_navigation.label : capability.labels.unavailable}</i>)}</div>
       </section>
-      <div className="repo-dashboard">
+      <RepositoryTriage key={snapshot.head_sha} bundle={bundle} onOpenAnalysis={openAnalysis} />
+      <div
+        className="repo-dashboard"
+        data-repository-dashboard
+        id="repository-analysis-dashboard"
+        ref={dashboardRef}
+        role="region"
+        aria-label={`${capability.labels.product} analysis`}
+        tabIndex={-1}
+      >
         <nav className="repo-view-nav" aria-label={capability.labels.product}>
           <span>{capability.labels.product}</span>
           {viewOrder.map((id) => {

--- a/apps/kg-editor/src/components/showcase/repository-triage.module.css
+++ b/apps/kg-editor/src/components/showcase/repository-triage.module.css
@@ -1,0 +1,701 @@
+.root {
+  background: var(--repo-paper);
+  border: 1px solid var(--repo-border);
+  border-radius: 14px;
+  box-shadow: var(--shadow-small);
+  overflow: hidden;
+}
+
+.header {
+  align-items: end;
+  border-bottom: 1px solid var(--repo-border);
+  display: grid;
+  gap: 28px;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 0.55fr);
+  padding: 25px 27px 22px;
+}
+
+.heading h2 {
+  color: var(--repo-navy);
+  font-size: clamp(24px, 2.7vw, 38px);
+  letter-spacing: -0.045em;
+  line-height: 1;
+  margin: 6px 0 10px;
+}
+
+.heading p,
+.panelHeading p,
+.inspectorHeader p,
+.signal p,
+.inspectorSection p,
+.relationships p {
+  color: var(--repo-muted);
+  line-height: 1.55;
+}
+
+.heading p {
+  font-size: 12px;
+  margin: 0;
+  max-width: 720px;
+}
+
+.eyebrow {
+  align-items: center;
+  color: var(--repo-green);
+  display: inline-flex;
+  font-size: 10px;
+  font-weight: 800;
+  gap: 7px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.eyebrow svg {
+  height: 14px;
+  width: 14px;
+}
+
+.search > span:first-child {
+  color: var(--repo-muted);
+  display: block;
+  font-size: 10px;
+  font-weight: 750;
+  margin: 0 0 7px 2px;
+}
+
+.searchControl {
+  align-items: center;
+  background: var(--surface-strong);
+  border: 1px solid var(--repo-border);
+  border-radius: 10px;
+  display: flex;
+  gap: 9px;
+  min-height: 42px;
+  padding: 0 12px;
+}
+
+.searchControl:focus-within {
+  border-color: var(--repo-green);
+  box-shadow: 0 0 0 4px var(--selection-ring-accent);
+}
+
+.searchControl svg {
+  color: var(--repo-green);
+  flex: 0 0 auto;
+  height: 16px;
+  width: 16px;
+}
+.searchControl input {
+  background: var(--khive-color-transparent);
+  border: 0;
+  min-width: 0;
+  outline: 0;
+  width: 100%;
+}
+
+.metrics {
+  border-bottom: 1px solid var(--repo-border);
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin: 0;
+}
+
+.metrics > div {
+  border-right: 1px solid var(--repo-border);
+  padding: 15px 20px;
+}
+.metrics > div:last-child {
+  border-right: 0;
+}
+.metrics dt {
+  align-items: center;
+  color: var(--repo-muted);
+  display: flex;
+  font-size: 9px;
+  gap: 6px;
+  text-transform: uppercase;
+}
+.metrics dt svg {
+  height: 12px;
+  width: 12px;
+}
+.metrics dd {
+  color: var(--repo-navy);
+  font-size: 22px;
+  font-weight: 800;
+  letter-spacing: -0.04em;
+  margin: 5px 0 0;
+}
+.metrics dd strong {
+  font: inherit;
+}
+.metricCoverage {
+  color: var(--repo-muted);
+  display: block;
+  font-size: 8px;
+  font-weight: 600;
+  letter-spacing: 0;
+  line-height: 1.35;
+  margin-top: 3px;
+}
+.metrics dd span {
+  color: var(--repo-muted);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0;
+}
+
+.layout {
+  align-items: start;
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(0, 1fr) minmax(330px, 0.42fr);
+  padding: 16px;
+}
+
+.content {
+  display: grid;
+  gap: 16px;
+  min-width: 0;
+}
+.panel {
+  border: 1px solid var(--repo-border);
+  border-radius: 11px;
+  overflow: hidden;
+}
+
+.panelHeading {
+  align-items: center;
+  background: color-mix(in srgb, var(--repo-paper) 75%, var(--canvas));
+  border-bottom: 1px solid var(--repo-border);
+  display: flex;
+  gap: 14px;
+  justify-content: space-between;
+  padding: 14px 16px;
+}
+
+.panelHeading > svg {
+  color: var(--repo-green);
+  height: 19px;
+  width: 19px;
+}
+.panelHeading span {
+  color: var(--repo-green);
+  font-size: 8px;
+  font-weight: 800;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+.panelHeading h3 {
+  color: var(--repo-navy);
+  font-size: 14px;
+  margin: 2px 0 0;
+}
+.panelHeading p {
+  font-size: 10px;
+  margin: 4px 0 0;
+}
+
+.startList {
+  display: grid;
+}
+.startRow {
+  align-items: center;
+  border-bottom: 1px solid var(--repo-border);
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr);
+}
+.startRow:last-child {
+  border-bottom: 0;
+}
+.rank {
+  color: var(--repo-muted);
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 10px;
+  text-align: center;
+}
+
+.moduleButton {
+  align-items: center;
+  background: var(--khive-color-transparent);
+  border: 0;
+  cursor: pointer;
+  display: flex;
+  gap: 10px;
+  min-width: 0;
+  padding: 12px 14px;
+  text-align: left;
+  width: 100%;
+}
+
+.moduleButton:hover,
+.moduleButton[aria-pressed="true"] {
+  background: color-mix(in srgb, var(--repo-green) 8%, var(--khive-color-transparent));
+}
+.moduleButton > svg {
+  color: var(--repo-muted);
+  flex: 0 0 auto;
+  height: 13px;
+  width: 13px;
+}
+.moduleIcon {
+  align-items: center;
+  background: var(--green-pale);
+  border-radius: 7px;
+  color: var(--repo-green);
+  display: flex;
+  flex: 0 0 auto;
+  height: 29px;
+  justify-content: center;
+  width: 29px;
+}
+.moduleIcon svg {
+  height: 14px;
+  width: 14px;
+}
+.moduleCopy {
+  display: block;
+  flex: 1;
+  min-width: 0;
+}
+.moduleCopy strong,
+.moduleCopy span {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.moduleCopy strong {
+  color: var(--repo-navy);
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 10px;
+}
+.moduleCopy span {
+  color: var(--repo-muted);
+  font-size: 9px;
+  margin-top: 4px;
+}
+
+.searchResults {
+  display: grid;
+}
+.resultHeading {
+  align-items: center;
+  background: color-mix(in srgb, var(--repo-green) 5%, var(--khive-color-transparent));
+  border-bottom: 1px solid var(--repo-border);
+  display: flex;
+  font-size: 10px;
+  justify-content: space-between;
+  padding: 8px 14px;
+}
+.resultHeading button {
+  background: var(--khive-color-transparent);
+  border: 0;
+  color: var(--repo-green);
+  cursor: pointer;
+  font-size: 9px;
+  font-weight: 750;
+}
+.searchResults .moduleButton {
+  border-bottom: 1px solid var(--repo-border);
+}
+.searchResults .moduleButton:last-child {
+  border-bottom: 0;
+}
+
+.signalGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+}
+.signal {
+  border-right: 1px solid var(--repo-border);
+  min-width: 0;
+  padding: 15px;
+}
+.signal:last-child {
+  border-right: 0;
+}
+.signalTop {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}
+.signalIcon {
+  align-items: center;
+  background: var(--purple-pale);
+  border-radius: 8px;
+  color: var(--repo-violet);
+  display: flex;
+  height: 30px;
+  justify-content: center;
+  width: 30px;
+}
+.signalIcon svg {
+  height: 15px;
+  width: 15px;
+}
+.classification {
+  align-items: center;
+  border: 1px solid var(--repo-border);
+  border-radius: 999px;
+  display: inline-flex;
+  font-size: 8px;
+  font-weight: 750;
+  gap: 4px;
+  padding: 4px 6px;
+  text-transform: uppercase;
+}
+.classification svg {
+  height: 10px;
+  width: 10px;
+}
+.classification.observed {
+  background: var(--green-pale);
+  color: var(--repo-green);
+}
+.classification.candidate {
+  background: var(--amber-pale);
+  color: var(--amber);
+}
+.signal h4 {
+  color: var(--repo-navy);
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 11px 0 5px;
+}
+.signal p {
+  font-size: 10px;
+  margin: 0;
+  min-height: 47px;
+}
+.why {
+  color: var(--repo-navy);
+  display: block;
+  font-size: 9px;
+  line-height: 1.45;
+  margin: 10px 0;
+}
+
+.evidenceCompact {
+  border-bottom: 1px solid var(--repo-border);
+  border-top: 1px solid var(--repo-border);
+  margin: 0 0 10px;
+  padding: 7px 0;
+}
+.evidenceCompact > div {
+  display: flex;
+  font-size: 8px;
+  gap: 8px;
+  justify-content: space-between;
+  margin: 3px 0;
+}
+.evidenceCompact dt {
+  color: var(--repo-muted);
+}
+.evidenceCompact dd {
+  color: var(--repo-navy);
+  font-weight: 700;
+  margin: 0;
+  text-align: right;
+}
+
+.signalActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+.signalActions button {
+  align-items: center;
+  background: var(--khive-color-transparent);
+  border: 1px solid var(--repo-border);
+  border-radius: 6px;
+  color: var(--repo-muted);
+  cursor: pointer;
+  display: inline-flex;
+  font-size: 8px;
+  font-weight: 700;
+  gap: 4px;
+  padding: 6px 7px;
+}
+.signalActions button:last-child {
+  color: var(--repo-green);
+}
+.signalActions svg {
+  height: 10px;
+  width: 10px;
+}
+
+.inspector {
+  background: color-mix(in srgb, var(--repo-paper) 86%, var(--canvas));
+  border: 1px solid var(--repo-border);
+  border-radius: 11px;
+  max-height: 920px;
+  overflow: auto;
+  position: sticky;
+  top: 82px;
+}
+.inspectorHeader {
+  border-bottom: 1px solid var(--repo-border);
+  padding: 16px;
+}
+.inspectorHeader > span {
+  align-items: center;
+  color: var(--repo-green);
+  display: flex;
+  font-size: 8px;
+  font-weight: 800;
+  gap: 6px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.inspectorHeader > span svg {
+  height: 12px;
+  width: 12px;
+}
+.inspectorHeader h3 {
+  color: var(--repo-navy);
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.45;
+  margin: 8px 0 4px;
+  overflow-wrap: anywhere;
+}
+.inspectorHeader p {
+  font-size: 9px;
+  margin: 0;
+}
+
+.inspectorMetrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin: 0;
+}
+.inspectorMetrics > div {
+  border-bottom: 1px solid var(--repo-border);
+  border-right: 1px solid var(--repo-border);
+  padding: 10px;
+}
+.inspectorMetrics > div:last-child {
+  border-right: 0;
+}
+.inspectorMetrics dt {
+  color: var(--repo-muted);
+  font-size: 8px;
+}
+.inspectorMetrics dd {
+  color: var(--repo-navy);
+  font-size: 15px;
+  font-weight: 800;
+  margin: 3px 0 0;
+}
+
+.inspectorSignal {
+  align-items: flex-start;
+  border-bottom: 1px solid var(--repo-border);
+  display: grid;
+  gap: 5px;
+  padding: 12px 14px;
+}
+.inspectorSignal .classification {
+  justify-self: start;
+}
+.inspectorSignal strong {
+  font-size: 10px;
+}
+.inspectorSignal > span:last-child {
+  color: var(--repo-muted);
+  font-size: 9px;
+  line-height: 1.45;
+}
+
+.relationships {
+  border-bottom: 1px solid var(--repo-border);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+}
+.relationships section {
+  min-width: 0;
+  padding: 12px 14px;
+}
+.relationships section + section {
+  border-left: 1px solid var(--repo-border);
+}
+.relationships h4,
+.inspectorSection h4 {
+  color: var(--repo-navy);
+  font-size: 9px;
+  margin: 0 0 8px;
+  text-transform: uppercase;
+}
+.relationships ul,
+.inspectorSection ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.relationships li {
+  color: var(--repo-muted);
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 8px;
+  margin: 5px 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.relationships p {
+  font-size: 8px;
+  margin: 0;
+}
+.relationships button,
+.inspectorSection li > button,
+.memberLinks button {
+  background: var(--khive-color-transparent);
+  border: 0;
+  color: var(--repo-muted);
+  cursor: pointer;
+  font: inherit;
+  padding: 0;
+  text-align: left;
+}
+.relationships button:hover,
+.relationships button:focus-visible,
+.inspectorSection li > button:hover,
+.inspectorSection li > button:focus-visible,
+.memberLinks button:hover,
+.memberLinks button:focus-visible {
+  color: var(--repo-green);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.inspectorSection {
+  border-bottom: 1px solid var(--repo-border);
+  padding: 12px 14px;
+}
+.inspectorSection:last-child {
+  border-bottom: 0;
+}
+.inspectorSection li {
+  align-items: baseline;
+  display: grid;
+  font-size: 8px;
+  gap: 7px;
+  grid-template-columns: auto minmax(0, 1fr);
+  margin: 7px 0;
+}
+.inspectorSection li code {
+  color: var(--repo-green);
+}
+.inspectorSection li span {
+  color: var(--repo-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.inspectorSection li strong {
+  color: var(--repo-navy);
+  font-size: 8px;
+}
+.memberLinks {
+  white-space: normal !important;
+}
+.sliceDisclosure {
+  color: var(--repo-muted);
+  font-size: 8px;
+  line-height: 1.45;
+  margin: 8px 0 0;
+}
+
+.evidence {
+  margin: 0;
+}
+.evidence > div {
+  display: grid;
+  gap: 2px;
+  grid-template-columns: minmax(90px, 0.7fr) minmax(0, 1fr);
+  margin: 6px 0;
+}
+.evidence dt {
+  color: var(--repo-muted);
+  font-size: 8px;
+}
+.evidence dd {
+  color: var(--repo-navy);
+  font-size: 8px;
+  margin: 0;
+  text-align: right;
+}
+.evidence .evidenceDetail {
+  color: var(--repo-muted);
+  grid-column: 1 / -1;
+  line-height: 1.4;
+  text-align: left;
+}
+
+.empty {
+  min-height: 150px;
+  padding: 20px;
+}
+.provenance {
+  align-items: center;
+  border-top: 1px solid var(--repo-border);
+  color: var(--repo-muted);
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 8px;
+  gap: 14px;
+  padding: 10px 16px;
+}
+.provenance code {
+  color: var(--repo-navy);
+}
+
+@media (max-width: 1050px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+  .inspector {
+    max-height: none;
+    position: static;
+  }
+}
+
+@media (max-width: 760px) {
+  .header {
+    align-items: stretch;
+    grid-template-columns: 1fr;
+    padding: 20px;
+  }
+  .metrics {
+    grid-template-columns: 1fr 1fr;
+  }
+  .metrics > div:nth-child(2) {
+    border-right: 0;
+  }
+  .metrics > div:nth-child(-n + 2) {
+    border-bottom: 1px solid var(--repo-border);
+  }
+  .signalGrid {
+    grid-template-columns: 1fr;
+  }
+  .signal {
+    border-bottom: 1px solid var(--repo-border);
+    border-right: 0;
+  }
+  .signal:last-child {
+    border-bottom: 0;
+  }
+  .relationships {
+    grid-template-columns: 1fr;
+  }
+  .relationships section + section {
+    border-left: 0;
+    border-top: 1px solid var(--repo-border);
+  }
+  .inspectorMetrics {
+    grid-template-columns: 1fr 1fr;
+  }
+  .inspectorMetrics > div:nth-child(2) {
+    border-right: 0;
+  }
+}

--- a/apps/kg-editor/src/components/showcase/repository-triage.tsx
+++ b/apps/kg-editor/src/components/showcase/repository-triage.tsx
@@ -1,0 +1,837 @@
+"use client";
+
+import {
+  ArrowRight,
+  Boxes,
+  Braces,
+  CheckCircle2,
+  CircleHelp,
+  Code2,
+  Eye,
+  FileText,
+  GitCommitHorizontal,
+  GitFork,
+  Network,
+  Package,
+  Radar,
+  Search,
+  Signpost,
+  Users,
+} from "@/icons";
+import { useMemo, useRef, useState } from "react";
+
+import { DataState } from "@/components/data-state";
+import {
+  buildModuleInsight,
+  buildRepositoryBrief,
+  findRepositoryModules,
+  type RepositoryMetric,
+  type RepositorySignal,
+} from "@/lib/repository-brief";
+import type { RepoBundle, RepoModule, ViewId } from "@/lib/repo-bundle";
+
+import styles from "./repository-triage.module.css";
+
+export type RepositoryTriageProps = Readonly<{
+  bundle: RepoBundle;
+  onOpenAnalysis: (view: ViewId) => void;
+}>;
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat("en").format(value);
+}
+
+function formatPercent(value: number): string {
+  return new Intl.NumberFormat("en", {
+    style: "percent",
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+function shortSha(value: string): string {
+  return value.slice(0, 8);
+}
+
+function MetricValue({
+  metric,
+  labels,
+}: {
+  metric: RepositoryMetric;
+  labels: RepoBundle["capability"]["labels"];
+}) {
+  return (
+    <dd>
+      <strong>
+        {metric.status === "unavailable"
+          ? labels.unavailable
+          : formatNumber(metric.shown)}
+      </strong>
+      <small className={styles.metricCoverage}>{metric.summary}</small>
+    </dd>
+  );
+}
+
+function CoverageState({
+  metric,
+  title,
+}: {
+  metric: RepositoryMetric;
+  title: string;
+}) {
+  if (metric.status === "complete") return null;
+  if (metric.status === "unavailable") {
+    return (
+      <DataState
+        presentation="inline"
+        state="unavailable"
+        title={title}
+        message={metric.reason ?? metric.summary}
+      />
+    );
+  }
+  return (
+    <DataState
+      presentation="inline"
+      state="truncated"
+      title={title}
+      shown={metric.shown}
+      bound={metric.bound ?? undefined}
+      knownTotal={metric.total ?? undefined}
+      reason={metric.reason ?? metric.summary}
+    />
+  );
+}
+
+function signalIcon(kind: RepositorySignal["kind"]) {
+  if (kind === "hotspot") return <Radar aria-hidden="true" />;
+  if (kind === "dependency_cycle") return <GitFork aria-hidden="true" />;
+  if (kind === "hidden_coupling") return <Braces aria-hidden="true" />;
+  return <Users aria-hidden="true" />;
+}
+
+function Classification({
+  value,
+}: {
+  value: RepositorySignal["classification"];
+}) {
+  return (
+    <span
+      className={`${styles.classification} ${styles[value]}`}
+      data-classification={value}
+    >
+      {value === "observed"
+        ? <CheckCircle2 aria-hidden="true" />
+        : <CircleHelp aria-hidden="true" />}
+      {value === "observed" ? "Observed" : "Candidate"}
+    </span>
+  );
+}
+
+function ModuleButton({
+  module,
+  selected,
+  detail,
+  onSelect,
+}: {
+  module: RepoModule;
+  selected: boolean;
+  detail: string;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={styles.moduleButton}
+      data-module-id={module.id}
+      aria-label={`Inspect ${module.source_path}`}
+      aria-controls="repository-module-inspector"
+      aria-pressed={selected}
+      onClick={onSelect}
+    >
+      <span className={styles.moduleIcon}>
+        <Code2 aria-hidden="true" />
+      </span>
+      <span className={styles.moduleCopy}>
+        <strong>{module.source_path}</strong>
+        <span>{detail}</span>
+      </span>
+      <ArrowRight aria-hidden="true" />
+    </button>
+  );
+}
+
+export function RepositoryTriage({
+  bundle,
+  onOpenAnalysis,
+}: RepositoryTriageProps) {
+  const brief = useMemo(() => buildRepositoryBrief(bundle), [bundle]);
+  const labels = bundle.capability.labels;
+  const moduleLabel = labels.node_types.module;
+  const moduleLabelLower = moduleLabel.toLocaleLowerCase();
+  const moduleById = useMemo(
+    () =>
+      new Map(bundle.graph.modules.items.map((module) => [module.id, module])),
+    [bundle.graph.modules.items],
+  );
+  const initialModuleId = brief.startHere[0]?.moduleId ??
+    bundle.graph.modules.items[0]?.id ?? null;
+  const [selectedModuleId, setSelectedModuleId] = useState<string | null>(
+    initialModuleId,
+  );
+  const inspectorRef = useRef<HTMLElement>(null);
+  const [query, setQuery] = useState("");
+  const selectedInsight = useMemo(
+    () =>
+      selectedModuleId ? buildModuleInsight(bundle, selectedModuleId) : null,
+    [bundle, selectedModuleId],
+  );
+  const searchMatches = useMemo(
+    () =>
+      query.trim()
+        ? findRepositoryModules(bundle, query, 8)
+        : { items: [], total: 0, bound: 8 },
+    [bundle, query],
+  );
+  const searchResults = searchMatches.items;
+  const searchTruncated = searchMatches.total > searchResults.length;
+
+  function selectModule(moduleId: string) {
+    setSelectedModuleId(moduleId);
+    const inspector = inspectorRef.current;
+    if (!inspector) return;
+    inspector.focus({ preventScroll: true });
+    const reduceMotion = window.matchMedia?.(
+      "(prefers-reduced-motion: reduce)",
+    ).matches ?? false;
+    inspector.scrollIntoView?.({
+      behavior: reduceMotion ? "auto" : "smooth",
+      block: "start",
+    });
+  }
+
+  function selectSignal(signal: RepositorySignal) {
+    const moduleId = signal.moduleIds.find((candidate) =>
+      moduleById.has(candidate)
+    );
+    if (moduleId) selectModule(moduleId);
+  }
+
+  return (
+    <section
+      className={styles.root}
+      aria-label="Repository triage"
+      data-repository-triage
+    >
+      <header className={styles.header}>
+        <div className={styles.heading}>
+          <span className={styles.eyebrow}>
+            <Signpost aria-hidden="true" /> Repository triage
+          </span>
+          <h2>What deserves attention?</h2>
+          <p>
+            Start with architectural leverage, inspect evidence, then open the
+            underlying analysis. Signals describe this captured snapshot; they
+            are not automatic defect claims.
+          </p>
+        </div>
+        <label className={styles.search}>
+          <span>Find a {moduleLabelLower} or path</span>
+          <span className={styles.searchControl}>
+            <Search aria-hidden="true" />
+            <input
+              type="search"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="pool.rs, writer_task, server…"
+              aria-label={`Find a ${moduleLabelLower} or path`}
+            />
+          </span>
+        </label>
+      </header>
+
+      <dl className={styles.metrics} aria-label="Captured repository metrics">
+        <div data-repository-metric="packages">
+          <dt>
+            <Package aria-hidden="true" /> {labels.metrics.package_count}
+          </dt>
+          <MetricValue metric={brief.metrics.packages} labels={labels} />
+        </div>
+        <div data-repository-metric="modules">
+          <dt>
+            <Boxes aria-hidden="true" /> {labels.metrics.module_count}
+          </dt>
+          <MetricValue metric={brief.metrics.modules} labels={labels} />
+        </div>
+        <div data-repository-metric="commits">
+          <dt>
+            <GitCommitHorizontal aria-hidden="true" /> {labels.metrics.commits}
+          </dt>
+          <MetricValue metric={brief.metrics.commits} labels={labels} />
+        </div>
+        <div data-repository-metric="cycles">
+          <dt>
+            <GitFork aria-hidden="true" /> {labels.metrics.cycle_count}
+          </dt>
+          <MetricValue metric={brief.metrics.cycles} labels={labels} />
+        </div>
+      </dl>
+
+      <div className={styles.layout}>
+        <div className={styles.content}>
+          <section className={styles.panel} aria-labelledby="repo-start-here">
+            <div className={styles.panelHeading}>
+              <div>
+                <span>Question 1</span>
+                <h3 id="repo-start-here">Where should I start?</h3>
+                <p>
+                  These captured {moduleLabelLower}{" "}
+                  records have the widest dependent surface in this snapshot.
+                </p>
+              </div>
+              <Network aria-hidden="true" />
+            </div>
+
+            {query.trim()
+              ? (
+                <div
+                  className={styles.searchResults}
+                  aria-label={`${moduleLabel} search results`}
+                >
+                  <div className={styles.resultHeading}>
+                    <strong>
+                      {searchTruncated
+                        ? `${searchResults.length} of ${searchMatches.total} captured matches`
+                        : `${searchResults.length} captured matches`}
+                    </strong>
+                    {searchResults.length > 0 && (
+                      <button
+                        type="button"
+                        onClick={() => setQuery("")}
+                      >
+                        Clear search
+                      </button>
+                    )}
+                  </div>
+                  {searchTruncated && (
+                    <DataState
+                      presentation="inline"
+                      state="truncated"
+                      title={`${moduleLabel} search matches`}
+                      shown={searchResults.length}
+                      bound={searchMatches.bound}
+                      knownTotal={searchMatches.total}
+                      reason="Narrow the search to see matches beyond this bound."
+                    />
+                  )}
+                  {searchResults.length
+                    ? (
+                      searchResults.map((module) => (
+                        <ModuleButton
+                          key={module.id}
+                          module={module}
+                          selected={module.id === selectedModuleId}
+                          detail={`${module.language} · ${module.module_path}`}
+                          onSelect={() => selectModule(module.id)}
+                        />
+                      ))
+                    )
+                    : (
+                      <DataState
+                        className={styles.empty}
+                        state="empty"
+                        title={`No captured ${moduleLabelLower} matches that path`}
+                        message={`Try a filename, crate, or ${moduleLabelLower} segment from this snapshot.`}
+                        action={{
+                          label: "Clear search",
+                          onClick: () => setQuery(""),
+                        }}
+                      />
+                    )}
+                </div>
+              )
+              : (
+                <div className={styles.startList}>
+                  {brief.startHere.length
+                    ? (
+                      <>
+                        {brief.startHere.map((entry, index) => {
+                          const moduleNode = moduleById.get(entry.moduleId);
+                          if (!moduleNode) return null;
+                          return (
+                            <div
+                              className={styles.startRow}
+                              key={entry.moduleId}
+                            >
+                              <span className={styles.rank}>
+                                {String(index + 1).padStart(2, "0")}
+                              </span>
+                              <ModuleButton
+                                module={moduleNode}
+                                selected={moduleNode.id === selectedModuleId}
+                                detail={`${bundle.capability.views.api_surface.label} · ${
+                                  formatNumber(entry.dependentCount)
+                                } ${labels.metrics.dependent_count} · ${entry.modulePath}`}
+                                onSelect={() => selectModule(moduleNode.id)}
+                              />
+                            </div>
+                          );
+                        })}
+                        <CoverageState
+                          metric={brief.startHereState}
+                          title={`${bundle.capability.views.api_surface.label} coverage`}
+                        />
+                      </>
+                    )
+                    : brief.startHereState.status !== "complete"
+                    ? (
+                      <CoverageState
+                        metric={brief.startHereState}
+                        title={`${bundle.capability.views.api_surface.label} coverage`}
+                      />
+                    )
+                    : (
+                      <DataState
+                        className={styles.empty}
+                        state="empty"
+                        title={`No ${bundle.capability.views.api_surface.label} recommendation is supported`}
+                        message={`No captured ${moduleLabelLower} has a non-zero ${labels.metrics.dependent_count.toLocaleLowerCase()} in this snapshot.`}
+                        action={{
+                          label:
+                            `Open ${bundle.capability.views.api_surface.label}`,
+                          onClick: () => onOpenAnalysis("api_surface"),
+                        }}
+                      />
+                    )}
+                </div>
+              )}
+          </section>
+
+          <section
+            className={styles.panel}
+            aria-labelledby="repo-attention-signals"
+          >
+            <div className={styles.panelHeading}>
+              <div>
+                <span>Question 2</span>
+                <h3 id="repo-attention-signals">
+                  What should I verify before changing code?
+                </h3>
+                <p>
+                  History and topology surface evidence-backed signals for human
+                  review.
+                </p>
+              </div>
+              <Eye aria-hidden="true" />
+            </div>
+            <div className={styles.signalGrid}>
+              {brief.attentionSignals.length
+                ? (
+                  <>
+                    {brief.attentionSignals.map((signal) => {
+                      const inspectionTarget = signal.moduleIds
+                        .map((moduleId) => moduleById.get(moduleId))
+                        .find((module): module is RepoModule => module != null);
+                      return (
+                        <article
+                          className={styles.signal}
+                          data-signal-kind={signal.kind}
+                          key={signal.id}
+                        >
+                    <div className={styles.signalTop}>
+                      <span className={styles.signalIcon}>
+                        {signalIcon(signal.kind)}
+                      </span>
+                      <Classification value={signal.classification} />
+                    </div>
+                    <h4>{signal.title}</h4>
+                    <p>{signal.summary}</p>
+                    <strong className={styles.why}>
+                      {signal.whyItMatters}
+                    </strong>
+                    <dl className={styles.evidenceCompact}>
+                      {signal.evidence.map((item) => (
+                        <div key={`${signal.id}-${item.label}`}>
+                          <dt>{item.label}</dt>
+                          <dd>{item.value}</dd>
+                        </div>
+                      ))}
+                    </dl>
+                    <div className={styles.signalActions}>
+                      {inspectionTarget && (
+                        <button
+                          type="button"
+                          onClick={() => selectSignal(signal)}
+                        >
+                          Inspect {inspectionTarget.source_path}
+                        </button>
+                      )}
+                      <button
+                        type="button"
+                        aria-controls="repository-analysis-dashboard"
+                        aria-label={`Open full analysis: ${
+                          bundle.capability.views[signal.targetView].label
+                        }`}
+                        onClick={() => onOpenAnalysis(signal.targetView)}
+                      >
+                        Open {bundle.capability.views[signal.targetView].label}
+                        {" "}
+                        <ArrowRight aria-hidden="true" />
+                      </button>
+                    </div>
+                        </article>
+                      );
+                    })}
+                    <CoverageState
+                      metric={brief.attentionState}
+                      title="Attention-analysis availability"
+                    />
+                  </>
+                )
+                : brief.attentionState.status !== "complete"
+                ? (
+                  <CoverageState
+                    metric={brief.attentionState}
+                    title="Attention-analysis availability"
+                  />
+                )
+                : (
+                  <DataState
+                    className={styles.empty}
+                    state="empty"
+                    title="No attention signal is supported"
+                    message="This snapshot does not contain enough measured evidence for a triage recommendation."
+                    action={{
+                      label: `Open ${bundle.capability.views.scorecard.label}`,
+                      onClick: () => onOpenAnalysis("scorecard"),
+                    }}
+                  />
+                )}
+            </div>
+          </section>
+        </div>
+
+        <aside
+          className={styles.inspector}
+          id="repository-module-inspector"
+          ref={inspectorRef}
+          aria-label={`${moduleLabel} evidence`}
+          data-module-inspector
+          aria-live="polite"
+          tabIndex={-1}
+        >
+          {selectedInsight
+            ? (
+              <>
+                <header className={styles.inspectorHeader}>
+                  <span>
+                    <FileText aria-hidden="true" /> {moduleLabel} evidence
+                  </span>
+                  <h3>{selectedInsight.module.source_path}</h3>
+                  <p>
+                    {selectedInsight.module.language} ·{" "}
+                    {selectedInsight.module.module_path}
+                  </p>
+                </header>
+
+                <dl className={styles.inspectorMetrics}>
+                  <div data-inspector-metric="fan-in">
+                    <dt>{labels.metrics.fan_in}</dt>
+                    <dd>
+                      {selectedInsight.topology.coverage.status ===
+                          "unavailable"
+                        ? labels.unavailable
+                        : formatNumber(selectedInsight.topology.fanIn)}
+                    </dd>
+                  </div>
+                  <div data-inspector-metric="fan-out">
+                    <dt>{labels.metrics.fan_out}</dt>
+                    <dd>
+                      {selectedInsight.topology.coverage.status ===
+                          "unavailable"
+                        ? labels.unavailable
+                        : formatNumber(selectedInsight.topology.fanOut)}
+                    </dd>
+                  </div>
+                  <div data-inspector-metric="commits">
+                    <dt>{labels.metrics.commits}</dt>
+                    <dd>
+                      {selectedInsight.history.status === "unavailable"
+                        ? labels.unavailable
+                        : selectedInsight.history.status === "truncated" &&
+                            selectedInsight.history.total == null
+                        ? `${formatNumber(selectedInsight.history.shown)} shown`
+                        : formatNumber(
+                          selectedInsight.history.total ??
+                            selectedInsight.history.shown,
+                        )}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt>{labels.metrics.bus_factor}</dt>
+                    <dd>{selectedInsight.ownership?.busFactor ?? "—"}</dd>
+                  </div>
+                </dl>
+
+                <CoverageState
+                  metric={selectedInsight.topology.coverage}
+                  title={`${bundle.capability.views.dependency_topology.label} coverage`}
+                />
+
+                {selectedInsight.hotspot && (
+                  <div className={styles.inspectorSignal}>
+                    <Classification value="candidate" />
+                    <strong>
+                      {bundle.capability.views.hotspot_quadrant.label} candidate
+                    </strong>
+                    <span>
+                      {selectedInsight.hotspot.commitCount} captured{" "}
+                      {labels.metrics.commits} · {labels.metrics.fan_in}{" "}
+                      {selectedInsight.hotspot.fanIn} · {labels
+                        .hotspot_quadrants[selectedInsight.hotspot.quadrant]}
+                    </span>
+                  </div>
+                )}
+
+                <div className={styles.relationships}>
+                  <section>
+                    <h4>{labels.metrics.fan_in}</h4>
+                    {selectedInsight.dependents.length
+                      ? (
+                        <>
+                          <ul>
+                            {selectedInsight.dependents.slice(0, 6).map((
+                              module,
+                            ) => (
+                              <li key={module.id}>
+                                <button
+                                  type="button"
+                                  onClick={() => selectModule(module.id)}
+                                >
+                                  {module.source_path}
+                                </button>
+                              </li>
+                            ))}
+                          </ul>
+                          {selectedInsight.dependents.length > 6 && (
+                            <p className={styles.sliceDisclosure}>
+                              Showing 6 of {selectedInsight.dependents.length}
+                              {" "}captured {labels.metrics.fan_in.toLocaleLowerCase()}
+                              {" "}records.
+                            </p>
+                          )}
+                        </>
+                      )
+                      : <p>No captured {labels.metrics.fan_in} evidence.</p>}
+                  </section>
+                  <section>
+                    <h4>{labels.metrics.fan_out}</h4>
+                    {selectedInsight.dependencies.length
+                      ? (
+                        <>
+                          <ul>
+                            {selectedInsight.dependencies
+                              .slice(0, 6)
+                              .map((module) => (
+                                <li key={module.id}>
+                                  <button
+                                    type="button"
+                                    onClick={() => selectModule(module.id)}
+                                  >
+                                    {module.source_path}
+                                  </button>
+                                </li>
+                              ))}
+                          </ul>
+                          {selectedInsight.dependencies.length > 6 && (
+                            <p className={styles.sliceDisclosure}>
+                              Showing 6 of {selectedInsight.dependencies.length}
+                              {" "}captured {labels.metrics.fan_out.toLocaleLowerCase()}
+                              {" "}records.
+                            </p>
+                          )}
+                        </>
+                      )
+                      : <p>No captured {labels.metrics.fan_out} evidence.</p>}
+                  </section>
+                </div>
+
+                {selectedInsight.topology.cycles.length > 0 && (
+                  <section className={styles.inspectorSection}>
+                    <h4>{bundle.capability.views.dependency_topology.label}</h4>
+                    <ul>
+                      {selectedInsight.topology.cycles.map((cycle) => (
+                        <li key={cycle.id}>
+                          <code>{cycle.id}</code>
+                          <span className={styles.memberLinks}>
+                            SCC members: {cycle.modules.map((module, index) => (
+                              <span key={module.id}>
+                                <button
+                                  type="button"
+                                  onClick={() => selectModule(module.id)}
+                                >
+                                  {module.source_path}
+                                </button>
+                                {index < cycle.modules.length - 1 ? " · " : ""}
+                              </span>
+                            ))}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  </section>
+                )}
+
+                {selectedInsight.couplingState.status === "unavailable"
+                  ? (
+                    <CoverageState
+                      metric={selectedInsight.couplingState}
+                      title={`${bundle.capability.views.hidden_coupling.label} coverage`}
+                    />
+                  )
+                  : selectedInsight.couplings.length > 0
+                  ? (
+                    <section className={styles.inspectorSection}>
+                      <h4>{bundle.capability.views.hidden_coupling.label}</h4>
+                      <ul>
+                        {selectedInsight.couplings.slice(0, 4).map((
+                          coupling,
+                        ) => (
+                          <li key={coupling.module.id}>
+                            <button
+                              type="button"
+                              onClick={() => selectModule(coupling.module.id)}
+                            >
+                              {coupling.module.source_path}
+                            </button>
+                            <strong>
+                              {coupling.cochangeCount}{" "}
+                              {labels.metrics.cochange_count} ·{" "}
+                              {formatPercent(coupling.support)}{" "}
+                              {labels.metrics.support}
+                            </strong>
+                          </li>
+                        ))}
+                      </ul>
+                      {selectedInsight.couplings.length > 4 && (
+                        <p className={styles.sliceDisclosure}>
+                          Showing 4 of {selectedInsight.couplings.length}
+                          {" "}captured pairs for this {moduleLabelLower}; the
+                          global analysis is independently bounded.
+                        </p>
+                      )}
+                      <CoverageState
+                        metric={selectedInsight.couplingState}
+                        title={`${bundle.capability.views.hidden_coupling.label} coverage`}
+                      />
+                    </section>
+                  )
+                  : (
+                    <section className={styles.inspectorSection}>
+                      <h4>{bundle.capability.views.hidden_coupling.label}</h4>
+                      <p>
+                        No pair for this {moduleLabelLower}{" "}
+                        appears in the captured top-N. Inspect the coverage
+                        evidence below before treating this as absence.
+                      </p>
+                      <CoverageState
+                        metric={selectedInsight.couplingState}
+                        title={`${bundle.capability.views.hidden_coupling.label} coverage`}
+                      />
+                    </section>
+                  )}
+
+                <section className={styles.inspectorSection}>
+                  <h4>{labels.metrics.commits}</h4>
+                  {selectedInsight.recentCommits.length
+                    ? (
+                      <>
+                        <ul>
+                          {selectedInsight.recentCommits.slice(0, 5).map((
+                            commit,
+                          ) => (
+                            <li key={commit.id}>
+                              <code>{shortSha(commit.sha)}</code>
+                              <span>{commit.subject}</span>
+                            </li>
+                          ))}
+                        </ul>
+                        <p className={styles.sliceDisclosure}>
+                          Showing {Math.min(
+                            5,
+                            selectedInsight.recentCommits.length,
+                          )}
+                          {" "}recent records; the inspector sampled {selectedInsight.recentCommits.length}
+                          {" "}from {selectedInsight.history.shown} captured history
+                          IDs. {selectedInsight.history.summary}.
+                        </p>
+                        <CoverageState
+                          metric={selectedInsight.history}
+                          title={`${labels.metrics.commits} coverage`}
+                        />
+                      </>
+                    )
+                    : selectedInsight.history.status !== "complete"
+                    ? (
+                      <CoverageState
+                        metric={selectedInsight.history}
+                        title={`${labels.metrics.commits} coverage`}
+                      />
+                    )
+                    : (
+                      <p>
+                        No captured {labels.metrics.commits.toLocaleLowerCase()}
+                        {" "}
+                        for this {moduleLabelLower}.
+                      </p>
+                    )}
+                </section>
+
+                <section className={styles.inspectorSection}>
+                  <h4>Evidence</h4>
+                  <dl className={styles.evidence}>
+                    {selectedInsight.evidence.map((item) => (
+                      <div key={item.label}>
+                        <dt>{item.label}</dt>
+                        <dd>{item.value}</dd>
+                        {item.detail && (
+                          <dd className={styles.evidenceDetail}>
+                            {item.detail}
+                          </dd>
+                        )}
+                      </div>
+                    ))}
+                  </dl>
+                </section>
+              </>
+            )
+            : (
+              <DataState
+                className={styles.empty}
+                state="unavailable"
+                title={`${moduleLabel} evidence is unavailable`}
+                message={`This snapshot does not contain a captured ${moduleLabelLower} to inspect.`}
+              />
+            )}
+        </aside>
+      </div>
+
+      <footer className={styles.provenance}>
+        <span>
+          Snapshot <code>{shortSha(bundle.meta.snapshot.head_sha)}</code>
+        </span>
+        <span>
+          Generated{" "}
+          {new Date(bundle.meta.snapshot.ingested_at).toLocaleString("en")}
+        </span>
+        <span>
+          Evidence is bounded by each analysis&apos;s declared window and export
+          limits.
+        </span>
+        <span data-source-role-disclosure>
+          Source roles are not classified: captured ranks can include
+          production, test, example, and generated modules.
+        </span>
+      </footer>
+    </section>
+  );
+}

--- a/apps/kg-editor/src/components/showcase/showcase.test.tsx
+++ b/apps/kg-editor/src/components/showcase/showcase.test.tsx
@@ -4,23 +4,24 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { loadStaticShowcaseBundle } from "@/lib/adapters/static-showcase-source";
+import { loadPreferredShowcaseBundle } from "@/lib/adapters/preferred-showcase-source";
 import { parseRepoBundle } from "@/lib/repo-bundle";
 
-vi.mock("@/lib/adapters/static-showcase-source", () => ({
-  loadStaticShowcaseBundle: vi.fn(),
+vi.mock("@/lib/adapters/preferred-showcase-source", () => ({
+  loadPreferredShowcaseBundle: vi.fn(),
+  readOperatorShowcaseAccessToken: vi.fn(() => null),
 }));
 
 import { Showcase } from "@/components/showcase/showcase";
 
 const goldenPath = resolve(process.cwd(), "../../docs/schemas/examples/khive-repo-v1-khive.json");
 const bundle = parseRepoBundle(JSON.parse(readFileSync(goldenPath, "utf8")));
-const mockedLoad = vi.mocked(loadStaticShowcaseBundle);
+const mockedLoad = vi.mocked(loadPreferredShowcaseBundle);
 
-describe("static repository lookup", () => {
+describe("materialized repository lookup", () => {
   beforeEach(() => {
     window.history.replaceState(null, "", "/");
-    mockedLoad.mockResolvedValue(bundle);
+    mockedLoad.mockResolvedValue({ bundle, source: "khive-db-snapshot" });
   });
 
   it("normalizes a curated alias and performs no bundle load for a later miss", async () => {
@@ -33,6 +34,11 @@ describe("static repository lookup", () => {
       "data-head-sha",
       "c2979d2443738a075e55a170c772d1dc86cf0f91",
     );
+    expect(container.querySelector(".repo-overview")).toHaveAttribute(
+      "data-analysis-source",
+      "khive-db-snapshot",
+    );
+    expect(screen.getAllByText(/khive DB snapshot/i).length).toBeGreaterThan(0);
 
     const input = screen.getByLabelText("Public repository URL");
     await user.clear(input);

--- a/apps/kg-editor/src/components/showcase/showcase.test.tsx
+++ b/apps/kg-editor/src/components/showcase/showcase.test.tsx
@@ -24,7 +24,7 @@ describe("materialized repository lookup", () => {
     mockedLoad.mockResolvedValue({ bundle, source: "khive-db-snapshot" });
   });
 
-  it("normalizes a curated alias and performs no bundle load for a later miss", async () => {
+  it("normalizes a curated alias, reauthorizes each private snapshot load, and performs no bundle load for a later miss", async () => {
     const user = userEvent.setup();
     const { container } = render(<Showcase />);
 
@@ -49,7 +49,9 @@ describe("materialized repository lookup", () => {
     expect(window.location.search).toContain(
       "repo=https%3A%2F%2Fgithub.com%2Fohdearquant%2Fkhive",
     );
-    expect(mockedLoad).toHaveBeenCalledTimes(1);
+    // Private snapshots are authorized per load: the same entry loads again
+    // rather than being served from the module cache.
+    expect(mockedLoad).toHaveBeenCalledTimes(2);
 
     await user.clear(input);
     await user.type(input, "https://github.com/example/not-curated");
@@ -61,10 +63,33 @@ describe("materialized repository lookup", () => {
     expect(empty).toBeVisible();
     expect(empty?.querySelectorAll("button")).toHaveLength(1);
     expect(window.location.search).toBe("");
-    expect(mockedLoad).toHaveBeenCalledTimes(1);
+    expect(mockedLoad).toHaveBeenCalledTimes(2);
 
     await user.click(screen.getByRole("button", { name: "Use the curated khive example" }));
     await waitFor(() => expect(container.querySelector(".repo-overview")).toBeVisible());
+    expect(mockedLoad).toHaveBeenCalledTimes(3);
+  }, 15_000);
+
+  it("serves the public static fallback from cache instead of reloading it", async () => {
+    mockedLoad.mockClear();
+    mockedLoad.mockResolvedValue({ bundle, source: "curated-static-fallback" });
+    const user = userEvent.setup();
+    const { container } = render(<Showcase />);
+
+    await waitFor(() => expect(container.querySelector(".repo-overview")).toBeVisible());
+    expect(mockedLoad).toHaveBeenCalledTimes(1);
+    expect(container.querySelector(".repo-overview")).toHaveAttribute(
+      "data-analysis-source",
+      "curated-static-fallback",
+    );
+
+    const input = screen.getByLabelText("Public repository URL");
+    await user.clear(input);
+    await user.type(input, "http://github.com/ohdearquant/khive.git");
+    await user.click(screen.getByRole("button", { name: bundle.capability.labels.lookup_action }));
+
+    await waitFor(() => expect(container.querySelector(".repo-overview")).toBeVisible());
+    // Nothing private is retained here, so the cache may keep serving it.
     expect(mockedLoad).toHaveBeenCalledTimes(1);
   }, 15_000);
 });

--- a/apps/kg-editor/src/components/showcase/showcase.tsx
+++ b/apps/kg-editor/src/components/showcase/showcase.tsx
@@ -41,6 +41,14 @@ function loadEntry(entry: ShowcaseRegistryEntry): Promise<LoadedShowcaseBundle> 
   if (existing) return existing;
   const pending = loadPreferredShowcaseBundle(entry, fetch, {
     accessToken,
+  }).then((loaded) => {
+    // A private snapshot is authorized per load. Caching it would keep
+    // serving it after server-side revocation, which no client-side check
+    // can observe, so only the public static fallback may stay cached; the
+    // entry below exists during the request solely to deduplicate
+    // concurrent loads.
+    if (loaded.source === "khive-db-snapshot") bundleCache.delete(cacheKey);
+    return loaded;
   }).catch((error: unknown) => {
     bundleCache.delete(cacheKey);
     throw error;

--- a/apps/kg-editor/src/components/showcase/showcase.tsx
+++ b/apps/kg-editor/src/components/showcase/showcase.tsx
@@ -29,15 +29,23 @@ type LoadState =
 const bundleCache = new Map<string, Promise<LoadedShowcaseBundle>>();
 
 function loadEntry(entry: ShowcaseRegistryEntry): Promise<LoadedShowcaseBundle> {
-  const existing = bundleCache.get(entry.id);
+  // The cache must never outlive the authorization that filled it: the key
+  // carries the current session token, so removal or rotation misses the
+  // cache and the protected route re-authorizes, instead of a previously
+  // authorized private snapshot being served from module memory. The raw
+  // token adds no exposure here: sessionStorage already holds it and both
+  // are readable by the same origin's scripts.
+  const accessToken = readOperatorShowcaseAccessToken();
+  const cacheKey = `${entry.id}\u0000${accessToken ?? ""}`;
+  const existing = bundleCache.get(cacheKey);
   if (existing) return existing;
   const pending = loadPreferredShowcaseBundle(entry, fetch, {
-    accessToken: readOperatorShowcaseAccessToken(),
+    accessToken,
   }).catch((error: unknown) => {
-    bundleCache.delete(entry.id);
+    bundleCache.delete(cacheKey);
     throw error;
   });
-  bundleCache.set(entry.id, pending);
+  bundleCache.set(cacheKey, pending);
   return pending;
 }
 

--- a/apps/kg-editor/src/components/showcase/showcase.tsx
+++ b/apps/kg-editor/src/components/showcase/showcase.tsx
@@ -6,7 +6,12 @@ import { useEffect, useRef, useState, type FormEvent } from "react";
 
 import { RepoShowcase } from "@/components/showcase/repo-showcase";
 import { DataState } from "@/components/data-state";
-import { loadStaticShowcaseBundle } from "@/lib/adapters/static-showcase-source";
+import {
+  loadPreferredShowcaseBundle,
+  readOperatorShowcaseAccessToken,
+  type LoadedShowcaseBundle,
+  type ShowcaseBundleSource,
+} from "@/lib/adapters/preferred-showcase-source";
 import type { RepoBundle } from "@/lib/repo-bundle";
 import {
   resolveShowcaseRepository,
@@ -16,22 +21,28 @@ import {
 
 type LoadState =
   | Readonly<{ status: "loading"; entry: ShowcaseRegistryEntry }>
-  | Readonly<{ status: "ready"; entry: ShowcaseRegistryEntry; bundle: RepoBundle }>
+  | Readonly<{ status: "ready"; entry: ShowcaseRegistryEntry; loaded: LoadedShowcaseBundle }>
   | Readonly<{ status: "miss"; normalizedUrl: string }>
   | Readonly<{ status: "invalid"; reason: string }>
   | Readonly<{ status: "error"; reason: string }>;
 
-const bundleCache = new Map<string, Promise<RepoBundle>>();
+const bundleCache = new Map<string, Promise<LoadedShowcaseBundle>>();
 
-function loadEntry(entry: ShowcaseRegistryEntry): Promise<RepoBundle> {
-  const existing = bundleCache.get(entry.assetPath);
+function loadEntry(entry: ShowcaseRegistryEntry): Promise<LoadedShowcaseBundle> {
+  const existing = bundleCache.get(entry.id);
   if (existing) return existing;
-  const pending = loadStaticShowcaseBundle(entry).catch((error: unknown) => {
-    bundleCache.delete(entry.assetPath);
+  const pending = loadPreferredShowcaseBundle(entry, fetch, {
+    accessToken: readOperatorShowcaseAccessToken(),
+  }).catch((error: unknown) => {
+    bundleCache.delete(entry.id);
     throw error;
   });
-  bundleCache.set(entry.assetPath, pending);
+  bundleCache.set(entry.id, pending);
   return pending;
+}
+
+function sourceLabel(source: ShowcaseBundleSource): string {
+  return source === "khive-db-snapshot" ? "khive DB snapshot" : "curated static fallback";
 }
 
 function replaceRepositoryQuery(repository?: string) {
@@ -52,10 +63,10 @@ export function Showcase() {
   useEffect(() => {
     const sequence = ++loadSequence.current;
     void loadEntry(defaultEntry)
-      .then((bundle) => {
-        setLabels(bundle.capability.labels);
+      .then((loaded) => {
+        setLabels(loaded.bundle.capability.labels);
         if (loadSequence.current === sequence) {
-          setState({ status: "ready", entry: defaultEntry, bundle });
+          setState({ status: "ready", entry: defaultEntry, loaded });
         }
       })
       .catch((error: unknown) => {
@@ -87,10 +98,10 @@ export function Showcase() {
     setState({ status: "loading", entry: lookup.entry });
     replaceRepositoryQuery(lookup.normalizedUrl);
     void loadEntry(lookup.entry)
-      .then((bundle) => {
+      .then((loaded) => {
         if (loadSequence.current === sequence) {
-          setLabels(bundle.capability.labels);
-          setState({ status: "ready", entry: lookup.entry, bundle });
+          setLabels(loaded.bundle.capability.labels);
+          setState({ status: "ready", entry: lookup.entry, loaded });
         }
       })
       .catch((error: unknown) => {
@@ -109,10 +120,10 @@ export function Showcase() {
     setState({ status: "loading", entry: defaultEntry });
     replaceRepositoryQuery(defaultEntry.canonicalUrl);
     void loadEntry(defaultEntry)
-      .then((bundle) => {
+      .then((loaded) => {
         if (loadSequence.current === sequence) {
-          setLabels(bundle.capability.labels);
-          setState({ status: "ready", entry: defaultEntry, bundle });
+          setLabels(loaded.bundle.capability.labels);
+          setState({ status: "ready", entry: defaultEntry, loaded });
         }
       })
       .catch((error: unknown) => {
@@ -137,7 +148,7 @@ export function Showcase() {
           <Link className="active" href="/"><Search aria-hidden="true" /> {labels?.product ?? "Showcase"}</Link>
           <Link href="/review"><ShieldCheck aria-hidden="true" /> KG review</Link>
         </nav>
-        <span className="repo-readonly"><GitBranch aria-hidden="true" /> {state.status === "ready" ? state.bundle.capability.mode : "…"}</span>
+        <span className="repo-readonly"><GitBranch aria-hidden="true" /> {state.status === "ready" ? sourceLabel(state.loaded.source) : "…"}</span>
       </header>
 
       <main>
@@ -164,7 +175,7 @@ export function Showcase() {
               />
               <button type="submit">{labels?.lookup_action ?? "…"} <ArrowRight aria-hidden="true" /></button>
             </div>
-            <small>Slice 1 looks up curated static bundles only. It never clones or queries the URL you enter.</small>
+            <small>A configured server snapshot is built from khive history and code-map databases. The browser never clones, ingests, or opens SQLite.</small>
           </form>
         </section>
 
@@ -173,8 +184,8 @@ export function Showcase() {
             <DataState
               className="repo-state-card"
               state="loading"
-              title="Opening the static showcase bundle"
-              message="Repository showcase data belongs here; no repository process is running."
+              title="Opening the repository analysis"
+              message="A validated materialized snapshot belongs here; no repository process is running in this request."
             />
           )}
           {state.status === "invalid" && (
@@ -198,11 +209,11 @@ export function Showcase() {
             <DataState
               className="repo-state-card"
               state="error"
-              title="Showcase bundle could not be opened"
+              title="Repository analysis could not be opened"
               message={state.reason}
             />
           )}
-          {state.status === "ready" && <RepoShowcase bundle={state.bundle} />}
+          {state.status === "ready" && <RepoShowcase bundle={state.loaded.bundle} analysisSource={state.loaded.source} />}
         </div>
       </main>
     </div>

--- a/apps/kg-editor/src/lib/adapters/preferred-showcase-source.test.ts
+++ b/apps/kg-editor/src/lib/adapters/preferred-showcase-source.test.ts
@@ -1,0 +1,172 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  loadPreferredShowcaseBundle,
+  readOperatorShowcaseAccessToken,
+  SHOWCASE_ACCESS_TOKEN_STORAGE_KEY,
+} from "@/lib/adapters/preferred-showcase-source";
+import { SHOWCASE_REGISTRY } from "@/lib/showcase-registry";
+
+const golden = readFileSync(
+  resolve(
+    process.cwd(),
+    "../../docs/schemas/examples/khive-repo-v1-khive.json",
+  ),
+);
+
+function response(
+  bytes: Uint8Array,
+  status: number,
+  headers: Record<string, string> = {},
+) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: new Headers({
+      "content-length": String(bytes.byteLength),
+      ...headers,
+    }),
+    arrayBuffer: () =>
+      Promise.resolve(Uint8Array.from(bytes).buffer as ArrayBuffer),
+  };
+}
+
+describe("preferred showcase source", () => {
+  it("prefers the configured khive DB snapshot and verifies its provenance", async () => {
+    const fetchBundle = vi.fn(async () =>
+      response(golden, 200, {
+        "x-khive-analysis-id": "khive",
+        "x-khive-analysis-source": "khive-db-snapshot",
+      })
+    );
+
+    const result = await loadPreferredShowcaseBundle(
+      SHOWCASE_REGISTRY[0],
+      fetchBundle,
+    );
+
+    expect(result.source).toBe("khive-db-snapshot");
+    expect(result.bundle.schema_version).toBe("khive.repo.v1");
+    expect(fetchBundle).toHaveBeenCalledOnce();
+    expect(fetchBundle).toHaveBeenCalledWith("/api/showcase/analyses/khive", {
+      cache: "no-store",
+      credentials: "same-origin",
+      redirect: "error",
+    });
+  });
+
+  it("sends the operator bearer token to the protected snapshot route when supplied", async () => {
+    const fetchBundle = vi.fn(async () =>
+      response(golden, 200, {
+        "x-khive-analysis-id": "khive",
+        "x-khive-analysis-source": "khive-db-snapshot",
+      })
+    );
+
+    const result = await loadPreferredShowcaseBundle(
+      SHOWCASE_REGISTRY[0],
+      fetchBundle,
+      { accessToken: "  operator-secret  " },
+    );
+
+    expect(result.source).toBe("khive-db-snapshot");
+    expect(fetchBundle).toHaveBeenCalledWith("/api/showcase/analyses/khive", {
+      cache: "no-store",
+      credentials: "same-origin",
+      redirect: "error",
+      headers: { authorization: "Bearer operator-secret" },
+    });
+  });
+
+  it("sends no Authorization header when the operator token is blank", async () => {
+    const fetchBundle = vi.fn(async () =>
+      response(golden, 200, {
+        "x-khive-analysis-id": "khive",
+        "x-khive-analysis-source": "khive-db-snapshot",
+      })
+    );
+
+    await loadPreferredShowcaseBundle(SHOWCASE_REGISTRY[0], fetchBundle, {
+      accessToken: "   ",
+    });
+
+    expect(fetchBundle).toHaveBeenCalledWith("/api/showcase/analyses/khive", {
+      cache: "no-store",
+      credentials: "same-origin",
+      redirect: "error",
+    });
+  });
+
+  it("reads the operator token from browser session storage", () => {
+    window.sessionStorage.setItem(
+      SHOWCASE_ACCESS_TOKEN_STORAGE_KEY,
+      "session-secret",
+    );
+    try {
+      expect(readOperatorShowcaseAccessToken()).toBe("session-secret");
+    } finally {
+      window.sessionStorage.removeItem(SHOWCASE_ACCESS_TOKEN_STORAGE_KEY);
+    }
+    expect(readOperatorShowcaseAccessToken()).toBeNull();
+  });
+
+  it("uses the curated asset only when the DB snapshot route is not configured", async () => {
+    const fetchBundle = vi.fn(async (input: string) =>
+      input.startsWith("/api/")
+        ? response(new Uint8Array(), 404)
+        : response(golden, 200)
+    );
+
+    const result = await loadPreferredShowcaseBundle(
+      SHOWCASE_REGISTRY[0],
+      fetchBundle,
+    );
+
+    expect(result.source).toBe("curated-static-fallback");
+    expect(fetchBundle).toHaveBeenCalledTimes(2);
+    expect(fetchBundle.mock.calls[1]?.[0]).toBe(
+      "/showcase/khive-repo-v1-khive.json",
+    );
+  });
+
+  it("does not hide an invalid or unavailable DB snapshot behind stale static data", async () => {
+    const fetchBundle = vi.fn(async () => response(new Uint8Array(), 503));
+
+    await expect(
+      loadPreferredShowcaseBundle(SHOWCASE_REGISTRY[0], fetchBundle),
+    ).rejects.toThrow(/database snapshot.*503/i);
+    expect(fetchBundle).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a successful response without the configured snapshot identity", async () => {
+    const fetchBundle = vi.fn(async () =>
+      response(golden, 200, {
+        "x-khive-analysis-id": "other",
+        "x-khive-analysis-source": "khive-db-snapshot",
+      })
+    );
+
+    await expect(
+      loadPreferredShowcaseBundle(SHOWCASE_REGISTRY[0], fetchBundle),
+    ).rejects.toThrow(/provenance/i);
+  });
+
+  it("rejects a valid snapshot for a different repository", async () => {
+    const wrongRepository = JSON.parse(golden.toString("utf8"));
+    wrongRepository.meta.repository.canonical_url =
+      "https://github.com/example/not-khive";
+    const fetchBundle = vi.fn(async () =>
+      response(Buffer.from(JSON.stringify(wrongRepository)), 200, {
+        "x-khive-analysis-id": "khive",
+        "x-khive-analysis-source": "khive-db-snapshot",
+      })
+    );
+
+    await expect(
+      loadPreferredShowcaseBundle(SHOWCASE_REGISTRY[0], fetchBundle),
+    ).rejects.toThrow(/repository identity/i);
+    expect(fetchBundle).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/kg-editor/src/lib/adapters/preferred-showcase-source.ts
+++ b/apps/kg-editor/src/lib/adapters/preferred-showcase-source.ts
@@ -1,0 +1,111 @@
+import {
+  loadStaticShowcaseBundle,
+  parseBoundedShowcaseResponse,
+  type ShowcaseFetch,
+} from "@/lib/adapters/static-showcase-source";
+import type { RepoBundle } from "@/lib/repo-bundle";
+import {
+  isAllowedShowcaseAnalysis,
+  normalizeRepositoryUrl,
+  type ShowcaseRegistryEntry,
+} from "@/lib/showcase-registry";
+
+export type ShowcaseBundleSource =
+  | "khive-db-snapshot"
+  | "curated-static-fallback";
+
+export type LoadedShowcaseBundle = Readonly<{
+  bundle: RepoBundle;
+  source: ShowcaseBundleSource;
+}>;
+
+export type PreferredShowcaseOptions = Readonly<{
+  /**
+   * Operator-supplied bearer token for the protected DB-snapshot routes.
+   * When absent, the request is sent without credentials and the protected
+   * route fails closed to 404, which selects the curated static fallback.
+   */
+  accessToken?: string | null;
+}>;
+
+/**
+ * Browser storage key an operator uses to unlock DB-backed snapshots in the
+ * UI: `sessionStorage.setItem(SHOWCASE_ACCESS_TOKEN_STORAGE_KEY, token)`.
+ */
+export const SHOWCASE_ACCESS_TOKEN_STORAGE_KEY = "khive.showcase.accessToken";
+
+export function readOperatorShowcaseAccessToken(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.sessionStorage.getItem(SHOWCASE_ACCESS_TOKEN_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export async function loadPreferredShowcaseBundle(
+  entry: ShowcaseRegistryEntry,
+  fetchBundle: ShowcaseFetch = fetch,
+  options: PreferredShowcaseOptions = {},
+): Promise<LoadedShowcaseBundle> {
+  if (!isAllowedShowcaseAnalysis(entry)) {
+    return {
+      bundle: await loadStaticShowcaseBundle(entry, fetchBundle),
+      source: "curated-static-fallback",
+    };
+  }
+
+  const endpoint = `/api/showcase/analyses/${entry.analysisId}`;
+  const accessToken = options.accessToken?.trim();
+  const response = await fetchBundle(endpoint, {
+    cache: "no-store",
+    credentials: "same-origin",
+    redirect: "error",
+    ...(accessToken
+      ? { headers: { authorization: `Bearer ${accessToken}` } }
+      : {}),
+  });
+
+  if (response.status === 404) {
+    return {
+      bundle: await loadStaticShowcaseBundle(entry, fetchBundle),
+      source: "curated-static-fallback",
+    };
+  }
+  if (!response.ok) {
+    throw new Error(
+      `Database snapshot could not be loaded (HTTP ${response.status}).`,
+    );
+  }
+  if (
+    response.headers.get("x-khive-analysis-source") !== "khive-db-snapshot" ||
+    response.headers.get("x-khive-analysis-id") !== entry.analysisId
+  ) {
+    throw new Error(
+      "Database snapshot provenance did not match the curated registry.",
+    );
+  }
+
+  const bundle = await parseBoundedShowcaseResponse(
+    response,
+    "Database snapshot",
+  );
+  const expectedRepository = normalizeRepositoryUrl(entry.canonicalUrl);
+  const actualRepository = normalizeRepositoryUrl(
+    bundle.meta.repository.canonical_url,
+  );
+  if (
+    !expectedRepository.ok ||
+    !actualRepository.ok ||
+    actualRepository.value !== expectedRepository.value
+  ) {
+    throw new Error(
+      "Database snapshot repository identity did not match the curated registry.",
+    );
+  }
+
+  return {
+    bundle,
+    source: "khive-db-snapshot",
+  };
+}

--- a/apps/kg-editor/src/lib/adapters/static-showcase-source.ts
+++ b/apps/kg-editor/src/lib/adapters/static-showcase-source.ts
@@ -12,6 +12,31 @@ export type ShowcaseFetch = (
   init?: RequestInit,
 ) => Promise<Pick<Response, "ok" | "status" | "headers" | "arrayBuffer">>;
 
+export type ShowcaseResponse = Awaited<ReturnType<ShowcaseFetch>>;
+
+export async function parseBoundedShowcaseResponse(
+  response: ShowcaseResponse,
+  sourceLabel = "Showcase bundle",
+): Promise<RepoBundle> {
+  const declaredLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declaredLength) && declaredLength > REPO_BUNDLE_MAX_BYTES) {
+    throw new Error(`${sourceLabel} exceeds the ${REPO_BUNDLE_MAX_MIB} MiB browser limit.`);
+  }
+
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  if (bytes.byteLength > REPO_BUNDLE_MAX_BYTES) {
+    throw new Error(`${sourceLabel} exceeds the ${REPO_BUNDLE_MAX_MIB} MiB browser limit.`);
+  }
+
+  let value: unknown;
+  try {
+    value = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes));
+  } catch {
+    throw new Error(`${sourceLabel} is not valid JSON.`);
+  }
+  return parseRepoBundle(value);
+}
+
 export async function loadStaticShowcaseBundle(
   entry: ShowcaseRegistryEntry,
   fetchBundle: ShowcaseFetch = fetch,
@@ -29,21 +54,5 @@ export async function loadStaticShowcaseBundle(
     throw new Error(`Showcase asset could not be loaded (HTTP ${response.status}).`);
   }
 
-  const declaredLength = Number(response.headers.get("content-length"));
-  if (Number.isFinite(declaredLength) && declaredLength > REPO_BUNDLE_MAX_BYTES) {
-    throw new Error(`Showcase bundle exceeds the ${REPO_BUNDLE_MAX_MIB} MiB browser limit.`);
-  }
-
-  const bytes = new Uint8Array(await response.arrayBuffer());
-  if (bytes.byteLength > REPO_BUNDLE_MAX_BYTES) {
-    throw new Error(`Showcase bundle exceeds the ${REPO_BUNDLE_MAX_MIB} MiB browser limit.`);
-  }
-
-  let value: unknown;
-  try {
-    value = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes));
-  } catch {
-    throw new Error("Showcase asset is not valid JSON.");
-  }
-  return parseRepoBundle(value);
+  return parseBoundedShowcaseResponse(response);
 }

--- a/apps/kg-editor/src/lib/repo-bundle.test.ts
+++ b/apps/kg-editor/src/lib/repo-bundle.test.ts
@@ -33,6 +33,39 @@ describe("khive.repo.v1 browser contract", () => {
     expect(repoBundleSchema.safeParse(value).success).toBe(false);
   });
 
+  it("rejects disagreement between view and aggregate availability", () => {
+    const value = goldenValue() as {
+      capability: { views: { hidden_coupling: { status: string; unavailable_reason?: string } } };
+    };
+    value.capability.views.hidden_coupling.status = "unavailable";
+    value.capability.views.hidden_coupling.unavailable_reason =
+      "analysis was not produced";
+
+    expect(repoBundleSchema.safeParse(value).success).toBe(false);
+  });
+
+  it("accepts repository ownership when only the module join is unavailable", () => {
+    const value = goldenValue() as {
+      capability: { views: { ownership: { status: string; unavailable_reason?: string } } };
+      aggregates: { ownership: { modules: { items: unknown[]; total_count: unknown; next_cursor?: string | null; truncated: boolean; disclosure: { status: string; reason?: string | null } } } };
+    };
+    value.capability.views.ownership.status = "unavailable";
+    value.capability.views.ownership.unavailable_reason = "module join was not complete";
+    value.aggregates.ownership.modules.items = [];
+    value.aggregates.ownership.modules.total_count = {
+      status: "unavailable",
+      reason: "module join was not complete",
+    };
+    value.aggregates.ownership.modules.next_cursor = null;
+    value.aggregates.ownership.modules.truncated = false;
+    value.aggregates.ownership.modules.disclosure = {
+      status: "unavailable",
+      reason: "module join was not complete",
+    };
+
+    expect(repoBundleSchema.safeParse(value).success).toBe(true);
+  });
+
   it("also validates the golden against the normative JSON Schema", () => {
     const ajv = new Ajv2020({ allErrors: true, strict: false });
     addFormats(ajv);

--- a/apps/kg-editor/src/lib/repo-bundle.ts
+++ b/apps/kg-editor/src/lib/repo-bundle.ts
@@ -493,6 +493,25 @@ export const repoBundleSchema = z.strictObject({
       context.addIssue({ code: "custom", path: ["graph", key, "items"], message: "symbol-tier collections are typed but empty in khive.repo.v1" });
     }
   }
+  for (const key of [
+    "dependency_topology",
+    "hotspot_quadrant",
+    "hidden_coupling",
+    "structure_treemap",
+    "cadence_timeline",
+    "ownership",
+    "api_surface",
+    "scorecard",
+  ] as const) {
+    const allowedPartialOwnership = key === "ownership" &&
+      bundle.capability.views.ownership.status === "unavailable" &&
+      bundle.aggregates.ownership.meta.status === "available" &&
+      bundle.aggregates.ownership.modules.disclosure.status === "unavailable";
+    if (allowedPartialOwnership) continue;
+    if (bundle.capability.views[key].status !== bundle.aggregates[key].meta.status) {
+      context.addIssue({ code: "custom", path: ["capability", "views", key, "status"], message: "view capability status must match aggregate analysis status" });
+    }
+  }
 });
 
 export type RepoBundle = z.infer<typeof repoBundleSchema>;

--- a/apps/kg-editor/src/lib/repository-brief.test.ts
+++ b/apps/kg-editor/src/lib/repository-brief.test.ts
@@ -238,6 +238,32 @@ describe("repository triage model", () => {
     expect(insight?.history.reason).toMatch(/truncated/i);
   });
 
+  it("reports a resolution gap when captured history IDs are missing from the commit page", () => {
+    const target = buildRepositoryBrief(bundle).startHere[0];
+    const truncated = structuredClone(bundle);
+    const navigation = truncated.graph.history_navigation.by_module.items.find(
+      (row) => row.module_id === target.moduleId,
+    );
+    expect(navigation).toBeDefined();
+    expect(navigation!.commits.items.length).toBeGreaterThan(0);
+    // The commit page is truncated independently of history navigation: every
+    // commit this module's history references sits on a page that was never
+    // served, while the navigation page itself remains complete.
+    const referenced = new Set(navigation!.commits.items);
+    truncated.graph.commits.items = truncated.graph.commits.items.filter(
+      (commit) => !referenced.has(commit.id),
+    );
+    truncated.graph.commits.next_cursor = "cursor-after-first-page";
+
+    const insight = buildModuleInsight(truncated, target.moduleId);
+
+    expect(insight?.recentCommits).toEqual([]);
+    expect(insight?.history.status).toBe("truncated");
+    expect(insight?.history.reason).toMatch(
+      /not present in the captured commit page/i,
+    );
+  });
+
   it("marks history-navigation evidence truncated when a cursor remains despite a complete disclosure", () => {
     const target = buildRepositoryBrief(bundle).startHere[0];
     const paged = structuredClone(bundle);

--- a/apps/kg-editor/src/lib/repository-brief.test.ts
+++ b/apps/kg-editor/src/lib/repository-brief.test.ts
@@ -264,6 +264,27 @@ describe("repository triage model", () => {
     );
   });
 
+  it("reports unresolved history IDs as unavailable when the commit page itself is unavailable", () => {
+    const target = buildRepositoryBrief(bundle).startHere[0];
+    const broken = structuredClone(bundle);
+    const navigation = broken.graph.history_navigation.by_module.items.find(
+      (row) => row.module_id === target.moduleId,
+    );
+    expect(navigation).toBeDefined();
+    expect(navigation!.commits.items.length).toBeGreaterThan(0);
+    broken.graph.commits.items = [];
+    broken.graph.commits.disclosure = {
+      status: "unavailable",
+      reason: "commit analysis not produced",
+    };
+
+    const insight = buildModuleInsight(broken, target.moduleId);
+
+    expect(insight?.recentCommits).toEqual([]);
+    expect(insight?.history.status).toBe("unavailable");
+    expect(insight?.history.reason).toMatch(/commit page is unavailable/i);
+  });
+
   it("marks history-navigation evidence truncated when a cursor remains despite a complete disclosure", () => {
     const target = buildRepositoryBrief(bundle).startHere[0];
     const paged = structuredClone(bundle);

--- a/apps/kg-editor/src/lib/repository-brief.test.ts
+++ b/apps/kg-editor/src/lib/repository-brief.test.ts
@@ -1,0 +1,323 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { parseRepoBundle } from "@/lib/repo-bundle";
+import {
+  buildModuleInsight,
+  buildRepositoryBrief,
+  findRepositoryModules,
+} from "@/lib/repository-brief";
+
+const bundle = parseRepoBundle(
+  JSON.parse(
+    readFileSync(
+      resolve(
+        process.cwd(),
+        "../../docs/schemas/examples/khive-repo-v1-khive.json",
+      ),
+      "utf8",
+    ),
+  ),
+);
+
+describe("repository triage model", () => {
+  it("turns the flat analyses into a deterministic evidence-backed brief", () => {
+    const apiSurfaceBefore = structuredClone(
+      bundle.aggregates.api_surface.data.items,
+    );
+    const brief = buildRepositoryBrief(bundle);
+
+    expect(brief.metrics.modules.shown).toBe(bundle.graph.modules.items.length);
+    expect(brief.metrics.modules.status).toBe("complete");
+    expect(brief.metrics.commits.shown).toBe(bundle.graph.commits.items.length);
+    expect(brief.metrics.cycles.shown).toBe(
+      bundle.aggregates.dependency_topology.cycles.items.length,
+    );
+    expect(
+      brief.attentionSignals.slice(0, 3).map((signal) => signal.kind),
+    ).toEqual(["hotspot", "dependency_cycle", "hidden_coupling"]);
+    expect(
+      brief.attentionSignals.find(
+        (signal) => signal.kind === "dependency_cycle",
+      ),
+    ).toMatchObject({ classification: "observed" });
+    expect(
+      brief.attentionSignals
+        .filter((signal) => signal.kind !== "dependency_cycle")
+        .every((signal) => signal.classification === "candidate"),
+    ).toBe(true);
+    expect(brief.startHere).toHaveLength(3);
+    expect(brief.startHere.map((entry) => entry.dependentCount)).toEqual(
+      [...brief.startHere.map((entry) => entry.dependentCount)].sort(
+        (left, right) => right - left,
+      ),
+    );
+    expect(
+      brief.attentionSignals.every((signal) => signal.evidence.length > 0),
+    ).toBe(true);
+    expect(bundle.aggregates.api_surface.data.items).toEqual(apiSurfaceBefore);
+  });
+
+  it("preserves unavailable and truncated page semantics in summary metrics", () => {
+    const partial = structuredClone(bundle);
+    partial.capability.labels.truncated = "Contract partial";
+    partial.capability.labels.unavailable = "Contract unavailable";
+    partial.graph.modules.items = partial.graph.modules.items.slice(0, 2);
+    partial.graph.modules.total_count = { status: "available", value: 37 };
+    partial.graph.modules.truncated = true;
+    partial.graph.modules.disclosure = {
+      status: "truncated",
+      reason: "module export was capped",
+    };
+    partial.graph.commits.items = [];
+    partial.graph.commits.total_count = {
+      status: "unavailable",
+      reason: "history count was not measured",
+    };
+    partial.graph.commits.disclosure = {
+      status: "unavailable",
+      reason: "history was not measured",
+    };
+
+    const brief = buildRepositoryBrief(partial);
+
+    expect(brief.metrics.modules).toMatchObject({
+      shown: 2,
+      total: 37,
+      status: "truncated",
+    });
+    expect(brief.metrics.modules.summary).toMatch(/2 captured of 37; Contract partial/i);
+    expect(brief.metrics.commits).toMatchObject({
+      shown: 0,
+      total: null,
+      status: "unavailable",
+    });
+    expect(brief.metrics.commits.summary).toMatch(/total Contract unavailable/i);
+  });
+
+  it("keeps a complete captured page complete when only its total is unknown", () => {
+    const unknownTotal = structuredClone(bundle);
+    unknownTotal.graph.commits.total_count = {
+      status: "unavailable",
+      reason: "the producer did not count all commits",
+    };
+    unknownTotal.graph.commits.truncated = false;
+    unknownTotal.graph.commits.next_cursor = null;
+    unknownTotal.graph.commits.disclosure = { status: "complete", reason: null };
+
+    const metric = buildRepositoryBrief(unknownTotal).metrics.commits;
+
+    expect(metric).toMatchObject({
+      shown: unknownTotal.graph.commits.items.length,
+      total: null,
+      status: "complete",
+    });
+    expect(metric.summary).toMatch(/total unavailable/i);
+  });
+
+  it("keeps unavailable recommendation analyses distinct from measured empty", () => {
+    const unavailable = structuredClone(bundle);
+    unavailable.aggregates.api_surface.meta.status = "unavailable";
+    unavailable.aggregates.api_surface.meta.unavailable_reason = "API ranking was not produced";
+    for (const analysis of [
+      unavailable.aggregates.hotspot_quadrant,
+      unavailable.aggregates.dependency_topology,
+      unavailable.aggregates.hidden_coupling,
+      unavailable.aggregates.ownership,
+    ]) {
+      analysis.meta.status = "unavailable";
+      analysis.meta.unavailable_reason = "attention analysis was not produced";
+    }
+
+    const brief = buildRepositoryBrief(unavailable);
+
+    expect(brief.startHere).toEqual([]);
+    expect(brief.startHereState).toMatchObject({
+      status: "unavailable",
+      reason: "API ranking was not produced",
+    });
+    expect(brief.attentionSignals).toEqual([]);
+    expect(brief.attentionState).toMatchObject({ status: "unavailable" });
+    expect(brief.attentionState.reason).toContain("attention analysis was not produced");
+    expect(brief.metrics.cycles).toMatchObject({
+      status: "unavailable",
+      reason: "attention analysis was not produced",
+    });
+  });
+
+  it("discloses one unavailable attention analysis without hiding other signals", () => {
+    const partial = structuredClone(bundle);
+    partial.aggregates.hidden_coupling.meta.status = "unavailable";
+    partial.aggregates.hidden_coupling.meta.unavailable_reason =
+      "coupling analysis was not produced";
+
+    const brief = buildRepositoryBrief(partial);
+
+    expect(brief.attentionSignals.length).toBeGreaterThan(0);
+    expect(
+      brief.attentionSignals.some((signal) => signal.kind === "hidden_coupling"),
+    ).toBe(false);
+    expect(brief.attentionState).toMatchObject({
+      status: "unavailable",
+      reason: "coupling analysis was not produced",
+    });
+  });
+
+  it("does not fabricate recommendations from zero-evidence rows or cycle order", () => {
+    const quiet = structuredClone(bundle);
+    quiet.aggregates.hotspot_quadrant.data.items = quiet.aggregates
+      .hotspot_quadrant.data.items.map((row) => ({
+        ...row,
+        commit_count: 0,
+        fan_in: 0,
+        quadrant: "low_churn_low_fan_in" as const,
+      }));
+    quiet.aggregates.api_surface.data.items = quiet.aggregates.api_surface.data
+      .items.map((row) => ({
+        ...row,
+        dependent_count: 0,
+      }));
+
+    const brief = buildRepositoryBrief(quiet);
+    const cycle = brief.attentionSignals.find(
+      (signal) => signal.kind === "dependency_cycle",
+    );
+
+    expect(brief.startHere).toEqual([]);
+    expect(
+      brief.attentionSignals.some((signal) => signal.kind === "hotspot"),
+    ).toBe(false);
+    expect(cycle?.summary).toMatch(/SCC members:/i);
+    expect(cycle?.summary).not.toContain("→");
+  });
+
+  it("builds one module inspector from topology, history, ownership, and coupling evidence", () => {
+    const target = buildRepositoryBrief(bundle).startHere[0];
+    const insight = buildModuleInsight(bundle, target.moduleId);
+
+    expect(insight).not.toBeNull();
+    expect(insight?.module.source_path).toBe(target.sourcePath);
+    expect(insight?.topology.fanIn).toBe(target.dependentCount);
+    expect(insight?.recentCommits.length).toBeGreaterThan(0);
+    expect(insight?.history.shown).toBeGreaterThanOrEqual(insight?.recentCommits.length ?? 0);
+    expect(insight?.history.total).not.toBeNull();
+    expect(insight?.recentCommits[0]).toMatchObject({
+      sha: expect.stringMatching(/^[0-9a-f]{40}$/),
+    });
+    expect(
+      insight?.evidence.some((item) => item.label === "Analysis window"),
+    ).toBe(true);
+    expect(
+      insight?.evidence.some(
+        (item) =>
+          item.label ===
+            `${bundle.capability.views.hidden_coupling.label} coverage`,
+      ),
+    ).toBe(true);
+    expect(
+      insight?.evidence.some((item) => item.value === "Not classified in this snapshot"),
+    ).toBe(true);
+  });
+
+  it("reports a module omitted from a cursor-paginated history page as truncated, not unavailable", () => {
+    const target = buildRepositoryBrief(bundle).startHere[0];
+    const paged = structuredClone(bundle);
+    const byModule = paged.graph.history_navigation.by_module;
+    byModule.items = byModule.items.filter(
+      (row) => row.module_id !== target.moduleId,
+    );
+    // A later page may hold the row: cursor set, page-level disclosure complete.
+    byModule.next_cursor = "cursor-after-first-page";
+
+    const insight = buildModuleInsight(paged, target.moduleId);
+
+    expect(insight?.history.status).toBe("truncated");
+    expect(insight?.history.shown).toBe(0);
+    expect(insight?.history.reason).toMatch(/truncated/i);
+  });
+
+  it("marks history-navigation evidence truncated when a cursor remains despite a complete disclosure", () => {
+    const target = buildRepositoryBrief(bundle).startHere[0];
+    const paged = structuredClone(bundle);
+    const navigation = paged.graph.history_navigation.by_module.items.find(
+      (row) => row.module_id === target.moduleId,
+    );
+    expect(navigation).toBeDefined();
+    navigation!.commits.next_cursor = "cursor-after-first-page";
+    navigation!.commits.disclosure = { status: "complete", reason: null };
+
+    const insight = buildModuleInsight(paged, target.moduleId);
+    const evidence = insight?.evidence.find(
+      (entry) => entry.label === "History navigation",
+    );
+
+    expect(evidence?.value).toMatch(/truncated/i);
+    expect(evidence?.value).not.toMatch(/complete/i);
+  });
+
+  it("attributes a missing history-navigation row to pagination when the page carries a cursor", () => {
+    const target = buildRepositoryBrief(bundle).startHere[0];
+    const paged = structuredClone(bundle);
+    const byModule = paged.graph.history_navigation.by_module;
+    byModule.items = byModule.items.filter(
+      (row) => row.module_id !== target.moduleId,
+    );
+    byModule.next_cursor = "cursor-after-first-page";
+    byModule.disclosure = { status: "complete", reason: null };
+
+    const insight = buildModuleInsight(paged, target.moduleId);
+    const evidence = insight?.evidence.find(
+      (entry) => entry.label === "History navigation",
+    );
+
+    expect(evidence?.value).toMatch(/truncated before reaching/i);
+    expect(evidence?.value).not.toMatch(/no module history-navigation row/i);
+  });
+
+  it("does not consume aggregate rows whose analysis is unavailable", () => {
+    const unavailable = structuredClone(bundle);
+    const target = buildRepositoryBrief(bundle).startHere[0];
+    for (const analysis of [
+      unavailable.aggregates.hotspot_quadrant,
+      unavailable.aggregates.dependency_topology,
+      unavailable.aggregates.hidden_coupling,
+      unavailable.aggregates.ownership,
+      unavailable.aggregates.api_surface,
+    ]) {
+      analysis.meta.status = "unavailable";
+      analysis.meta.unavailable_reason = "not produced";
+    }
+    unavailable.graph.structure_edges.disclosure.status = "unavailable";
+    unavailable.graph.structure_edges.disclosure.reason = "not produced";
+
+    expect(buildModuleInsight(unavailable, target.moduleId)).toMatchObject({
+      hotspot: null,
+      ownership: null,
+      apiSurface: null,
+      couplings: [],
+      couplingState: { status: "unavailable", reason: "not produced" },
+      topology: {
+        coverage: { status: "unavailable", reason: "not produced" },
+        cycles: [],
+        cycleIds: [],
+      },
+    });
+  });
+
+  it("finds a module by the path a user already knows", () => {
+    const matches = findRepositoryModules(bundle, "pool.rs", 8);
+    expect(matches.items.length).toBeGreaterThan(0);
+    expect(matches.items[0].source_path).toContain("pool.rs");
+    expect(matches.total).toBe(matches.items.length);
+    expect(matches.bound).toBe(8);
+  });
+
+  it("reports the total match count when a search is capped by the limit", () => {
+    const matches = findRepositoryModules(bundle, "e", 1);
+    expect(matches.items.length).toBe(1);
+    expect(matches.total).toBeGreaterThan(1);
+    expect(matches.bound).toBe(1);
+  });
+});

--- a/apps/kg-editor/src/lib/repository-brief.ts
+++ b/apps/kg-editor/src/lib/repository-brief.ts
@@ -389,8 +389,11 @@ function combinedAttentionMetric(
       .join("; ") || "One or more attention analyses were truncated.";
     return {
       shown,
-      total: shown,
-      bound: shown,
+      // The derived-signal count is not the population: a truncated analysis
+      // has undisclosed rows, so total and bound are unknown here rather than
+      // the count of what happened to be derived.
+      total: null,
+      bound: null,
       status: "truncated",
       reason,
       summary: `${shown} signals from available analyses; ${labels.truncated}: ${reason}`,

--- a/apps/kg-editor/src/lib/repository-brief.ts
+++ b/apps/kg-editor/src/lib/repository-brief.ts
@@ -290,6 +290,21 @@ function unavailableMetric(
   };
 }
 
+function commitResolutionGapMetric(
+  base: RepositoryMetric,
+  unresolved: number,
+  captured: number,
+): RepositoryMetric {
+  const gap =
+    `${unresolved} of ${captured} captured history IDs are not present in the captured commit page`;
+  return {
+    ...base,
+    status: "truncated",
+    reason: base.reason ? `${base.reason}; ${gap}` : gap,
+    summary: `${base.summary}; ${gap}`,
+  };
+}
+
 function missingHistoryNavigationMetric(
   coverage: {
     bound: { kind: "all" | "top_n"; max_items: number; order: string };
@@ -913,10 +928,26 @@ export function buildModuleInsight(
   const navigation = historyNavigationCoverage.items.find(
     (row) => row.module_id === moduleId,
   );
-  const history = navigation
+  const navigationHistory = navigation
     ? pageMetric(navigation.commits, labels)
     : missingHistoryNavigationMetric(historyNavigationCoverage, labels);
-  const recentCommits = (navigation?.commits.items ?? [])
+  const navigationCommitIds = navigation?.commits.items ?? [];
+  // History IDs resolve against the independently paged graph.commits
+  // section, so a truncated commit page can drop captured history without
+  // either page's own disclosure reporting it. The metric must carry that
+  // resolution gap, or the inspector renders a false "no captured commits"
+  // empty state for a module whose history was captured.
+  const unresolvedCommitCount = navigationCommitIds.filter(
+    (commitId) => !commitById.has(commitId),
+  ).length;
+  const history = unresolvedCommitCount === 0
+    ? navigationHistory
+    : commitResolutionGapMetric(
+      navigationHistory,
+      unresolvedCommitCount,
+      navigationCommitIds.length,
+    );
+  const recentCommits = navigationCommitIds
     .flatMap((commitId) => {
       const commit = commitById.get(commitId);
       return commit ? [commit] : [];

--- a/apps/kg-editor/src/lib/repository-brief.ts
+++ b/apps/kg-editor/src/lib/repository-brief.ts
@@ -1,0 +1,1140 @@
+import type {
+  RepoBundle,
+  RepoCommit,
+  RepoModule,
+  ViewId,
+} from "@/lib/repo-bundle";
+
+type HotspotRow =
+  RepoBundle["aggregates"]["hotspot_quadrant"]["data"]["items"][number];
+type OwnershipRow =
+  RepoBundle["aggregates"]["ownership"]["modules"]["items"][number];
+type AnalysisWindow =
+  RepoBundle["aggregates"]["hotspot_quadrant"]["meta"]["window"];
+
+export type RepositorySignalKind =
+  | "hotspot"
+  | "dependency_cycle"
+  | "hidden_coupling"
+  | "ownership";
+
+export type RepositorySignalClassification = "observed" | "candidate";
+
+export interface RepositoryEvidence {
+  label: string;
+  value: string;
+  detail?: string;
+}
+
+export interface RepositoryAttentionSignal {
+  id: string;
+  kind: RepositorySignalKind;
+  classification: RepositorySignalClassification;
+  title: string;
+  summary: string;
+  whyItMatters: string;
+  moduleIds: string[];
+  evidence: RepositoryEvidence[];
+  targetView: ViewId;
+}
+
+export interface RepositoryStartHereEntry {
+  moduleId: string;
+  moduleName: string;
+  modulePath: string;
+  sourcePath: string;
+  dependentCount: number;
+  commitCount: number | null;
+  reason: string;
+  evidence: RepositoryEvidence[];
+}
+
+export interface RepositoryMetric {
+  shown: number;
+  total: number | null;
+  bound: number | null;
+  status: "complete" | "truncated" | "unavailable";
+  reason: string | null;
+  summary: string;
+  detail: string;
+}
+
+export interface RepositoryBrief {
+  repository: {
+    name: string;
+    owner: string;
+    canonicalUrl: string;
+    headSha: string;
+    ingestedAt: string;
+  };
+  metrics: {
+    packages: RepositoryMetric;
+    modules: RepositoryMetric;
+    commits: RepositoryMetric;
+    cycles: RepositoryMetric;
+  };
+  startHere: RepositoryStartHereEntry[];
+  startHereState: RepositoryMetric;
+  attentionSignals: RepositoryAttentionSignal[];
+  attentionState: RepositoryMetric;
+  evidence: RepositoryEvidence[];
+}
+
+export type EvidenceItem = RepositoryEvidence;
+export type SignalClassification = RepositorySignalClassification;
+export type RepositorySignal = RepositoryAttentionSignal;
+export type StartHereEntry = RepositoryStartHereEntry;
+
+export interface ModuleCycle {
+  id: string;
+  moduleIds: string[];
+  modules: RepoModule[];
+}
+
+export interface ModuleCoupling {
+  module: RepoModule;
+  cochangeCount: number;
+  support: number;
+}
+
+export interface ModuleInsight {
+  module: RepoModule;
+  topology: {
+    fanIn: number;
+    fanOut: number;
+    coverage: RepositoryMetric;
+    cycleIds: string[];
+    cycles: ModuleCycle[];
+  };
+  hotspot: {
+    commitCount: number;
+    fanIn: number;
+    quadrant: HotspotRow["quadrant"];
+  } | null;
+  ownership: {
+    commitCount: number;
+    authorConcentration: number | null;
+    busFactor: number | null;
+    authors: OwnershipRow["authors"]["items"];
+  } | null;
+  apiSurface: {
+    dependentCount: number;
+    rank: number;
+  } | null;
+  dependencies: RepoModule[];
+  dependents: RepoModule[];
+  history: RepositoryMetric;
+  recentCommits: RepoCommit[];
+  couplings: ModuleCoupling[];
+  couplingState: RepositoryMetric;
+  evidence: RepositoryEvidence[];
+}
+
+const RECENT_COMMIT_LIMIT = 12;
+const OWNERSHIP_MINIMUM_COMMITS = 5;
+
+function compareText(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+function modulePath(
+  moduleById: ReadonlyMap<string, RepoModule>,
+  moduleId: string,
+): string {
+  return moduleById.get(moduleId)?.source_path ?? moduleId;
+}
+
+function compareModules(left: RepoModule, right: RepoModule): number {
+  return (
+    compareText(left.source_path, right.source_path) ||
+    compareText(left.id, right.id)
+  );
+}
+
+function uniqueSortedModules(modules: RepoModule[]): RepoModule[] {
+  return [
+    ...new Map(modules.map((module) => [module.id, module])).values(),
+  ].sort(compareModules);
+}
+
+function formatWindow(window: AnalysisWindow, snapshotTime: string): string {
+  if (window.kind === "rolling_days") {
+    const duration = window.days == null ? "Rolling" : `${window.days}-day`;
+    const range = window.start && window.end
+      ? ` (${window.start} to ${window.end})`
+      : "";
+    return `${duration} analysis window${range}`;
+  }
+  if (window.kind === "range") {
+    return `Bounded range ${window.start ?? "unspecified start"} to ${
+      window.end ?? "unspecified end"
+    }`;
+  }
+  return `Declared all-history window; snapshot ingested at ${snapshotTime}`;
+}
+
+function pageEvidence(
+  label: string,
+  page: {
+    items: unknown[];
+    total_count:
+      | { status: "available"; value: number }
+      | { status: "unavailable"; reason: string };
+    bound: { kind: "all" | "top_n"; max_items: number; order: string };
+    truncated: boolean;
+    next_cursor?: string | null;
+    disclosure: {
+      status: "complete" | "truncated" | "unavailable";
+      reason?: string | null;
+    };
+  },
+  labels: RepoBundle["capability"]["labels"],
+): RepositoryEvidence {
+  const total = page.total_count.status === "available"
+    ? `${page.total_count.value} declared`
+    : `total ${labels.unavailable}`;
+  const reasonSuffix = page.disclosure.reason
+    ? `: ${page.disclosure.reason}`
+    : "";
+  const status = page.disclosure.status === "unavailable"
+    ? `${labels.unavailable}${reasonSuffix}`
+    : page.disclosure.status === "truncated" || page.next_cursor != null
+    ? `${labels.truncated}${reasonSuffix}`
+    : "complete";
+  return {
+    label,
+    value: `${page.items.length} present, ${total}; ${status}`,
+    detail:
+      `Bound ${page.bound.kind} to ${page.bound.max_items}, ordered by ${page.bound.order}.`,
+  };
+}
+
+function sourceRoleEvidence(): RepositoryEvidence {
+  return {
+    label: "Source-role scope",
+    value: "Not classified in this snapshot",
+    detail:
+      "Captured module rows can include production, test, example, and generated sources; verify the path before treating a rank as production architecture.",
+  };
+}
+
+function pageMetric(
+  page: {
+  items: unknown[];
+  total_count:
+    | { status: "available"; value: number }
+    | { status: "unavailable"; reason: string };
+  bound: { kind: "all" | "top_n"; max_items: number; order: string };
+  next_cursor?: string | null;
+  truncated: boolean;
+  disclosure: {
+    status: "complete" | "truncated" | "unavailable";
+    reason?: string | null;
+  };
+  },
+  labels: RepoBundle["capability"]["labels"],
+): RepositoryMetric {
+  const shown = page.items.length;
+  const total = page.total_count.status === "available"
+    ? page.total_count.value
+    : null;
+  const status: RepositoryMetric["status"] =
+    page.disclosure.status === "unavailable"
+      ? "unavailable"
+      : page.truncated ||
+          page.next_cursor != null ||
+          page.disclosure.status === "truncated" ||
+          (total != null && total > shown)
+      ? "truncated"
+      : "complete";
+  const reason = page.disclosure.reason ??
+    (status !== "complete" && page.total_count.status === "unavailable"
+      ? page.total_count.reason
+      : null);
+  const reasonSuffix = reason ? `; ${reason}` : "";
+  const summary = status === "complete"
+    ? total == null
+      ? `${shown} captured; total ${labels.unavailable}`
+      : `${shown} captured; complete`
+    : status === "truncated"
+    ? total == null
+      ? `${shown} captured; total ${labels.unavailable}; ${labels.truncated}${reasonSuffix}`
+      : `${shown} captured of ${total}; ${labels.truncated}${reasonSuffix}`
+    : `${shown} captured; total ${labels.unavailable}; ${labels.unavailable}${reasonSuffix}`;
+  return {
+    shown,
+    total,
+    bound: page.bound.max_items,
+    status,
+    reason,
+    summary,
+    detail:
+      `Bound ${page.bound.kind} to ${page.bound.max_items}, ordered by ${page.bound.order}.`,
+  };
+}
+
+function unavailableMetric(
+  labels: RepoBundle["capability"]["labels"],
+  reason: string,
+): RepositoryMetric {
+  return {
+    shown: 0,
+    total: null,
+    bound: null,
+    status: "unavailable",
+    reason,
+    summary: `${labels.unavailable}: ${reason}`,
+    detail: reason,
+  };
+}
+
+function missingHistoryNavigationMetric(
+  coverage: {
+    bound: { kind: "all" | "top_n"; max_items: number; order: string };
+    next_cursor?: string | null;
+    disclosure: {
+      status: "complete" | "truncated" | "unavailable";
+      reason?: string | null;
+    };
+  },
+  labels: RepoBundle["capability"]["labels"],
+): RepositoryMetric {
+  if (coverage.disclosure.status === "unavailable") {
+    return unavailableMetric(
+      labels,
+      coverage.disclosure.reason ?? "History navigation was not produced.",
+    );
+  }
+  if (
+    coverage.disclosure.status === "truncated" ||
+    coverage.next_cursor != null
+  ) {
+    const reason = coverage.disclosure.reason ??
+      "The by-module history-navigation page was truncated before reaching this module.";
+    return {
+      shown: 0,
+      total: null,
+      bound: coverage.bound.max_items,
+      status: "truncated",
+      reason,
+      summary: `0 captured; ${labels.truncated}: ${reason}`,
+      detail:
+        `Bound ${coverage.bound.kind} to ${coverage.bound.max_items}, ordered by ${coverage.bound.order}; this module's row may exist beyond that bound.`,
+    };
+  }
+  return unavailableMetric(
+    labels,
+    "No module history-navigation row was captured.",
+  );
+}
+
+function analysisMetric(
+  analysis: {
+    meta: {
+      status: "available" | "unavailable";
+      unavailable_reason?: string | null;
+    };
+    data: Parameters<typeof pageMetric>[0];
+  },
+  labels: RepoBundle["capability"]["labels"],
+): RepositoryMetric {
+  if (analysis.meta.status === "unavailable") {
+    return unavailableMetric(
+      labels,
+      analysis.meta.unavailable_reason ?? "The analysis was not produced.",
+    );
+  }
+  return pageMetric(analysis.data, labels);
+}
+
+function combinedAttentionMetric(
+  metrics: readonly RepositoryMetric[],
+  shown: number,
+  labels: RepoBundle["capability"]["labels"],
+): RepositoryMetric {
+  const unavailable = metrics.filter((metric) =>
+    metric.status === "unavailable"
+  );
+  if (unavailable.length > 0) {
+    const reason = unavailable
+      .map((metric) => metric.reason)
+      .filter(Boolean)
+      .join("; ") || "One or more attention analyses were not produced.";
+    return unavailableMetric(labels, reason);
+  }
+  const truncated = metrics.filter((metric) => metric.status === "truncated");
+  if (truncated.length > 0) {
+    const reason = truncated
+      .map((metric) => metric.reason)
+      .filter(Boolean)
+      .join("; ") || "One or more attention analyses were truncated.";
+    return {
+      shown,
+      total: shown,
+      bound: shown,
+      status: "truncated",
+      reason,
+      summary: `${shown} signals from available analyses; ${labels.truncated}: ${reason}`,
+      detail:
+        "Each signal carries its own capability-owned row coverage and export bound.",
+    };
+  }
+  return {
+    shown,
+    total: shown,
+    bound: shown,
+    status: "complete",
+    reason: null,
+    summary: `${shown} signals from available analyses`,
+    detail:
+      "Each signal carries its own capability-owned row coverage and export bound.",
+  };
+}
+
+function hotspotComparator(
+  moduleById: ReadonlyMap<string, RepoModule>,
+): (left: HotspotRow, right: HotspotRow) => number {
+  return (left, right) => {
+    const leftPriority = left.quadrant === "high_churn_high_fan_in" ? 0 : 1;
+    const rightPriority = right.quadrant === "high_churn_high_fan_in" ? 0 : 1;
+    return (
+      leftPriority - rightPriority ||
+      right.commit_count - left.commit_count ||
+      right.fan_in - left.fan_in ||
+      compareText(
+        modulePath(moduleById, left.module_id),
+        modulePath(moduleById, right.module_id),
+      ) ||
+      compareText(left.module_id, right.module_id)
+    );
+  };
+}
+
+function buildHotspotSignal(
+  bundle: RepoBundle,
+  moduleById: ReadonlyMap<string, RepoModule>,
+): RepositoryAttentionSignal | null {
+  const analysis = bundle.aggregates.hotspot_quadrant;
+  if (analysis.meta.status !== "available") return null;
+  const hotspot = analysis.data.items
+    .filter(
+      (row) =>
+        moduleById.has(row.module_id) &&
+        row.quadrant !== "low_churn_low_fan_in",
+    )
+    .sort(hotspotComparator(moduleById))[0];
+  if (!hotspot) return null;
+
+  const moduleNode = moduleById.get(hotspot.module_id)!;
+  return {
+    id: `hotspot:${moduleNode.id}`,
+    kind: "hotspot",
+    classification: "candidate",
+    title:
+      `${moduleNode.source_path} is a ${bundle.capability.views.hotspot_quadrant.label} candidate`,
+    summary:
+      `${hotspot.commit_count} captured ${bundle.capability.labels.metrics.commits} and ${bundle.capability.labels.metrics.fan_in} ${hotspot.fan_in} place this module in ${
+        bundle.capability.labels.hotspot_quadrants[hotspot.quadrant]
+      }.`,
+    whyItMatters:
+      "Frequent change combined with incoming dependencies can increase review scope. These measurements identify where to inspect; they do not establish a defect.",
+    moduleIds: [moduleNode.id],
+    evidence: [
+      {
+        label: "Analysis window",
+        value: formatWindow(
+          analysis.meta.window,
+          bundle.meta.snapshot.ingested_at,
+        ),
+      },
+      {
+        label: bundle.capability.views.hotspot_quadrant.label,
+        value:
+          `${hotspot.commit_count} ${bundle.capability.labels.metrics.commits}; ${bundle.capability.labels.metrics.fan_in} ${hotspot.fan_in}`,
+      },
+      sourceRoleEvidence(),
+      pageEvidence("Coverage", analysis.data, bundle.capability.labels),
+    ],
+    targetView: "hotspot_quadrant",
+  };
+}
+
+function buildCycleSignal(
+  bundle: RepoBundle,
+  moduleById: ReadonlyMap<string, RepoModule>,
+): RepositoryAttentionSignal | null {
+  const analysis = bundle.aggregates.dependency_topology;
+  if (analysis.meta.status !== "available") return null;
+
+  const hotspotByModule = new Map(
+    bundle.aggregates.hotspot_quadrant.meta.status === "available"
+      ? bundle.aggregates.hotspot_quadrant.data.items.map((row) => [
+        row.module_id,
+        row,
+      ] as const)
+      : [],
+  );
+  const topologyByModule = new Map(
+    analysis.modules.items.map((row) => [row.module_id, row]),
+  );
+  const cycle = [...analysis.cycles.items].sort((left, right) => {
+    const churn = (item: typeof left) =>
+      item.module_ids.reduce(
+        (total, moduleId) =>
+          total + (hotspotByModule.get(moduleId)?.commit_count ?? 0),
+        0,
+      );
+    const fanIn = (item: typeof left) =>
+      item.module_ids.reduce(
+        (total, moduleId) =>
+          total + (topologyByModule.get(moduleId)?.fan_in ?? 0),
+        0,
+      );
+    return (
+      churn(right) - churn(left) ||
+      fanIn(right) - fanIn(left) ||
+      right.module_ids.length - left.module_ids.length ||
+      compareText(left.id, right.id)
+    );
+  })[0];
+  if (!cycle) return null;
+
+  const paths = cycle.module_ids.map((moduleId) =>
+    modulePath(moduleById, moduleId)
+  );
+  return {
+    id: `dependency-cycle:${cycle.id}`,
+    kind: "dependency_cycle",
+    classification: "observed",
+    title:
+      `Observed ${bundle.capability.views.dependency_topology.label} across ${cycle.module_ids.length} ${bundle.capability.labels.node_types.module.toLocaleLowerCase()} records`,
+    summary: `SCC members: ${paths.join(" · ")}`,
+    whyItMatters:
+      "The captured import graph contains a cycle, which can complicate change sequencing and boundary review. It does not by itself imply a runtime failure.",
+    moduleIds: [...cycle.module_ids],
+    evidence: [
+      {
+        label: "Analysis window",
+        value: formatWindow(
+          analysis.meta.window,
+          bundle.meta.snapshot.ingested_at,
+        ),
+      },
+      {
+        label: bundle.capability.views.dependency_topology.label,
+        value:
+          `${cycle.id}; ${cycle.module_ids.length} ${bundle.capability.labels.node_types.module.toLocaleLowerCase()} records`,
+      },
+      sourceRoleEvidence(),
+      pageEvidence("Coverage", analysis.cycles, bundle.capability.labels),
+    ],
+    targetView: "dependency_topology",
+  };
+}
+
+function buildCouplingSignal(
+  bundle: RepoBundle,
+  moduleById: ReadonlyMap<string, RepoModule>,
+): RepositoryAttentionSignal | null {
+  const analysis = bundle.aggregates.hidden_coupling;
+  if (analysis.meta.status !== "available") return null;
+  const coupling = analysis.data.items
+    .filter(
+      (row) =>
+        moduleById.has(row.left_module_id) &&
+        moduleById.has(row.right_module_id),
+    )
+    .sort(
+      (left, right) =>
+        right.cochange_count - left.cochange_count ||
+        right.support - left.support ||
+        compareText(
+          modulePath(moduleById, left.left_module_id),
+          modulePath(moduleById, right.left_module_id),
+        ) ||
+        compareText(
+          modulePath(moduleById, left.right_module_id),
+          modulePath(moduleById, right.right_module_id),
+        ) ||
+        compareText(left.left_module_id, right.left_module_id) ||
+        compareText(left.right_module_id, right.right_module_id),
+    )[0];
+  if (!coupling) return null;
+
+  const left = moduleById.get(coupling.left_module_id)!;
+  const right = moduleById.get(coupling.right_module_id)!;
+  return {
+    id: `hidden-coupling:${left.id}:${right.id}`,
+    kind: "hidden_coupling",
+    classification: "candidate",
+    title:
+      `${left.name} and ${right.name} are a ${bundle.capability.views.hidden_coupling.label} candidate`,
+    summary:
+      `${left.source_path} and ${right.source_path} changed together ${coupling.cochange_count} times in the captured window.`,
+    whyItMatters:
+      "Repeated co-change can reveal coordination cost or an implicit boundary worth inspecting. Co-change alone does not prove a dependency or defect.",
+    moduleIds: [left.id, right.id],
+    evidence: [
+      {
+        label: "Analysis window",
+        value: formatWindow(
+          analysis.meta.window,
+          bundle.meta.snapshot.ingested_at,
+        ),
+      },
+      {
+        label: bundle.capability.views.hidden_coupling.label,
+        value:
+          `${coupling.cochange_count} ${bundle.capability.labels.metrics.cochange_count}; ${bundle.capability.labels.metrics.support} ${
+            (coupling.support * 100).toFixed(1)
+          }%`,
+      },
+      sourceRoleEvidence(),
+      pageEvidence("Coverage", analysis.data, bundle.capability.labels),
+    ],
+    targetView: "hidden_coupling",
+  };
+}
+
+function buildOwnershipSignal(
+  bundle: RepoBundle,
+  moduleById: ReadonlyMap<string, RepoModule>,
+): RepositoryAttentionSignal | null {
+  const analysis = bundle.aggregates.ownership;
+  if (
+    analysis.meta.status !== "available" ||
+    bundle.capability.views.ownership.status !== "available"
+  ) return null;
+  const ownership = analysis.modules.items
+    .filter(
+      (row) =>
+        row.commit_count >= OWNERSHIP_MINIMUM_COMMITS &&
+        moduleById.has(row.module_id) &&
+        row.bus_factor.status === "available" &&
+        row.bus_factor.value <= 1,
+    )
+    .sort((left, right) => {
+      const leftConcentration = left.author_concentration.status === "available"
+        ? left.author_concentration.value
+        : -1;
+      const rightConcentration =
+        right.author_concentration.status === "available"
+          ? right.author_concentration.value
+          : -1;
+      return (
+        rightConcentration - leftConcentration ||
+        right.commit_count - left.commit_count ||
+        compareText(
+          modulePath(moduleById, left.module_id),
+          modulePath(moduleById, right.module_id),
+        ) ||
+        compareText(left.module_id, right.module_id)
+      );
+    })[0];
+  if (!ownership) return null;
+
+  if (ownership.bus_factor.status !== "available") return null;
+  const moduleNode = moduleById.get(ownership.module_id)!;
+  const concentration = ownership.author_concentration.status === "available"
+    ? `${
+      (ownership.author_concentration.value * 100).toFixed(1)
+    }% ${bundle.capability.labels.metrics.author_concentration}`
+    : `${bundle.capability.labels.metrics.author_concentration} ${bundle.capability.labels.unavailable}`;
+  return {
+    id: `ownership:${moduleNode.id}`,
+    kind: "ownership",
+    classification: "candidate",
+    title:
+      `${moduleNode.source_path} has concentrated captured ${bundle.capability.views.ownership.label}`,
+    summary:
+      `${ownership.commit_count} captured ${bundle.capability.labels.metrics.commits}, ${bundle.capability.labels.metrics.bus_factor} ${ownership.bus_factor.value}, and ${concentration}.`,
+    whyItMatters:
+      "Concentrated contribution history can indicate a review or knowledge-transfer candidate. It does not establish current team ownership or availability.",
+    moduleIds: [moduleNode.id],
+    evidence: [
+      {
+        label: "Analysis window",
+        value: formatWindow(
+          analysis.meta.window,
+          bundle.meta.snapshot.ingested_at,
+        ),
+      },
+      {
+        label: "Sample threshold",
+        value:
+          `${ownership.commit_count} ${bundle.capability.labels.metrics.commits} (minimum ${OWNERSHIP_MINIMUM_COMMITS})`,
+      },
+      sourceRoleEvidence(),
+      pageEvidence("Coverage", analysis.modules, bundle.capability.labels),
+    ],
+    targetView: "ownership",
+  };
+}
+
+export function buildRepositoryBrief(bundle: RepoBundle): RepositoryBrief {
+  const labels = bundle.capability.labels;
+  const moduleById = new Map(
+    bundle.graph.modules.items.map((module) => [module.id, module]),
+  );
+  const hotspotByModule = new Map(
+    bundle.aggregates.hotspot_quadrant.meta.status === "available"
+      ? bundle.aggregates.hotspot_quadrant.data.items.map((row) => [
+        row.module_id,
+        row,
+      ] as const)
+      : [],
+  );
+  const startHere = bundle.aggregates.api_surface.meta.status === "available"
+    ? [...bundle.aggregates.api_surface.data.items]
+      .filter(
+        (row) => row.dependent_count > 0 && moduleById.has(row.module_id),
+      )
+      .sort(
+        (left, right) =>
+          right.dependent_count - left.dependent_count ||
+          compareText(
+            modulePath(moduleById, left.module_id),
+            modulePath(moduleById, right.module_id),
+          ) ||
+          compareText(left.module_id, right.module_id),
+      )
+      .slice(0, 3)
+      .map((row): RepositoryStartHereEntry => {
+        const moduleNode = moduleById.get(row.module_id)!;
+        const hotspot = hotspotByModule.get(row.module_id);
+        return {
+          moduleId: moduleNode.id,
+          moduleName: moduleNode.name,
+          modulePath: moduleNode.module_path,
+          sourcePath: moduleNode.source_path,
+          dependentCount: row.dependent_count,
+          commitCount: hotspot?.commit_count ?? null,
+          reason:
+            "Many captured modules depend on this module; inspect its contract before broad changes.",
+          evidence: [
+            {
+              label: bundle.capability.views.api_surface.label,
+              value:
+                `${row.dependent_count} ${bundle.capability.labels.metrics.dependent_count}`,
+            },
+            {
+              label: "Analysis window",
+              value: formatWindow(
+                bundle.aggregates.api_surface.meta.window,
+                bundle.meta.snapshot.ingested_at,
+              ),
+            },
+            sourceRoleEvidence(),
+          ],
+        };
+      })
+    : [];
+
+  const attentionSignals = [
+    buildHotspotSignal(bundle, moduleById),
+    buildCycleSignal(bundle, moduleById),
+    buildCouplingSignal(bundle, moduleById),
+    buildOwnershipSignal(bundle, moduleById),
+  ].filter((signal): signal is RepositoryAttentionSignal => signal !== null);
+  const startHereState = analysisMetric(
+    bundle.aggregates.api_surface,
+    labels,
+  );
+  const attentionState = combinedAttentionMetric(
+    [
+      analysisMetric(bundle.aggregates.hotspot_quadrant, labels),
+      analysisMetric(
+        {
+          meta: bundle.aggregates.dependency_topology.meta,
+          data: bundle.aggregates.dependency_topology.cycles,
+        },
+        labels,
+      ),
+      analysisMetric(bundle.aggregates.hidden_coupling, labels),
+      analysisMetric(
+        {
+          meta: bundle.aggregates.ownership.meta,
+          data: bundle.aggregates.ownership.modules,
+        },
+        labels,
+      ),
+    ],
+    attentionSignals.length,
+    labels,
+  );
+
+  return {
+    repository: {
+      name: bundle.meta.repository.name,
+      owner: bundle.meta.repository.owner,
+      canonicalUrl: bundle.meta.repository.canonical_url,
+      headSha: bundle.meta.snapshot.head_sha,
+      ingestedAt: bundle.meta.snapshot.ingested_at,
+    },
+    metrics: {
+      packages: pageMetric(bundle.graph.packages, labels),
+      modules: pageMetric(bundle.graph.modules, labels),
+      commits: pageMetric(bundle.graph.commits, labels),
+      cycles: analysisMetric(
+        {
+          meta: bundle.aggregates.dependency_topology.meta,
+          data: bundle.aggregates.dependency_topology.cycles,
+        },
+        labels,
+      ),
+    },
+    startHere,
+    startHereState,
+    attentionSignals,
+    attentionState,
+    evidence: [
+      {
+        label: "Snapshot",
+        value:
+          `${bundle.meta.snapshot.head_sha} ingested at ${bundle.meta.snapshot.ingested_at}`,
+      },
+      pageEvidence("Module coverage", bundle.graph.modules, labels),
+      pageEvidence("Commit coverage", bundle.graph.commits, labels),
+      sourceRoleEvidence(),
+    ],
+  };
+}
+
+export function buildModuleInsight(
+  bundle: RepoBundle,
+  moduleId: string,
+): ModuleInsight | null {
+  const labels = bundle.capability.labels;
+  const moduleById = new Map(
+    bundle.graph.modules.items.map((module) => [module.id, module]),
+  );
+  const moduleNode = moduleById.get(moduleId);
+  if (!moduleNode) return null;
+
+  const topology = bundle.aggregates.dependency_topology.meta.status ===
+      "available"
+    ? bundle.aggregates.dependency_topology.modules.items.find(
+      (row) => row.module_id === moduleId,
+    )
+    : undefined;
+  const topologyAnalysisCoverage = analysisMetric(
+    {
+      meta: bundle.aggregates.dependency_topology.meta,
+      data: bundle.aggregates.dependency_topology.modules,
+    },
+    labels,
+  );
+  const structureEdgeCoverage = pageMetric(
+    bundle.graph.structure_edges,
+    labels,
+  );
+  const topologyCoverage = topologyAnalysisCoverage.status !== "unavailable"
+    ? topologyAnalysisCoverage
+    : structureEdgeCoverage.status !== "unavailable"
+    ? structureEdgeCoverage
+    : topologyAnalysisCoverage;
+  const cycleRows = bundle.aggregates.dependency_topology.meta.status ===
+      "available"
+    ? bundle.aggregates.dependency_topology.cycles.items
+    : [];
+  const cycles = cycleRows
+    .filter((cycle) => cycle.module_ids.includes(moduleId))
+    .map(
+      (cycle): ModuleCycle => ({
+        id: cycle.id,
+        moduleIds: [...cycle.module_ids],
+        modules: cycle.module_ids.flatMap((id) => {
+          const cycleModule = moduleById.get(id);
+          return cycleModule ? [cycleModule] : [];
+        }),
+      }),
+    )
+    .sort((left, right) => compareText(left.id, right.id));
+
+  const dependencyEdges = structureEdgeCoverage.status === "unavailable"
+    ? []
+    : bundle.graph.structure_edges.items.filter(
+      (edge) => edge.relation === "depends_on",
+    );
+  const dependencies = uniqueSortedModules(
+    dependencyEdges
+      .filter((edge) => edge.source === moduleId)
+      .flatMap((edge) => {
+        const dependency = moduleById.get(edge.target);
+        return dependency ? [dependency] : [];
+      }),
+  );
+  const dependents = uniqueSortedModules(
+    dependencyEdges
+      .filter((edge) => edge.target === moduleId)
+      .flatMap((edge) => {
+        const dependent = moduleById.get(edge.source);
+        return dependent ? [dependent] : [];
+      }),
+  );
+
+  const hotspotRow = bundle.aggregates.hotspot_quadrant.meta.status ===
+      "available"
+    ? bundle.aggregates.hotspot_quadrant.data.items.find(
+      (row) => row.module_id === moduleId,
+    )
+    : undefined;
+  const ownershipRow = bundle.aggregates.ownership.meta.status === "available" &&
+      bundle.capability.views.ownership.status === "available"
+    ? bundle.aggregates.ownership.modules.items.find(
+      (row) => row.module_id === moduleId,
+    )
+    : undefined;
+  const apiSurfaceRows = bundle.aggregates.api_surface.meta.status === "available"
+    ? bundle.aggregates.api_surface.data.items
+    : [];
+  const rankedApiSurface = [...apiSurfaceRows].sort(
+    (left, right) =>
+      right.dependent_count - left.dependent_count ||
+      compareText(
+        modulePath(moduleById, left.module_id),
+        modulePath(moduleById, right.module_id),
+      ) ||
+      compareText(left.module_id, right.module_id),
+  );
+  const apiSurfaceIndex = rankedApiSurface.findIndex(
+    (row) => row.module_id === moduleId,
+  );
+  const apiSurfaceRow = apiSurfaceIndex === -1
+    ? undefined
+    : rankedApiSurface[apiSurfaceIndex];
+
+  const commitById = new Map(
+    bundle.graph.commits.items.map((commit) => [commit.id, commit]),
+  );
+  const historyNavigationCoverage = bundle.graph.history_navigation.by_module;
+  const navigation = historyNavigationCoverage.items.find(
+    (row) => row.module_id === moduleId,
+  );
+  const history = navigation
+    ? pageMetric(navigation.commits, labels)
+    : missingHistoryNavigationMetric(historyNavigationCoverage, labels);
+  const recentCommits = (navigation?.commits.items ?? [])
+    .flatMap((commitId) => {
+      const commit = commitById.get(commitId);
+      return commit ? [commit] : [];
+    })
+    .sort(
+      (left, right) =>
+        compareText(right.committed_at, left.committed_at) ||
+        compareText(left.sha, right.sha),
+    )
+    .slice(0, RECENT_COMMIT_LIMIT);
+
+  const couplingRows = bundle.aggregates.hidden_coupling.meta.status ===
+      "available"
+    ? bundle.aggregates.hidden_coupling.data.items
+    : [];
+  const couplingState = analysisMetric(
+    bundle.aggregates.hidden_coupling,
+    labels,
+  );
+  const couplings = couplingRows
+    .flatMap((row): ModuleCoupling[] => {
+      const otherId = row.left_module_id === moduleId
+        ? row.right_module_id
+        : row.right_module_id === moduleId
+        ? row.left_module_id
+        : null;
+      if (!otherId) return [];
+      const otherModule = moduleById.get(otherId);
+      return otherModule
+        ? [
+          {
+            module: otherModule,
+            cochangeCount: row.cochange_count,
+            support: row.support,
+          },
+        ]
+        : [];
+    })
+    .sort(
+      (left, right) =>
+        right.cochangeCount - left.cochangeCount ||
+        right.support - left.support ||
+        compareModules(left.module, right.module),
+    );
+
+  const historyCoverage = navigation
+    ? pageEvidence("History navigation", navigation.commits, labels)
+    : {
+      label: "History navigation",
+      value: historyNavigationCoverage.disclosure.status === "truncated" ||
+          historyNavigationCoverage.next_cursor != null
+        ? historyNavigationCoverage.disclosure.reason ??
+          "The by-module history-navigation page was truncated before reaching this module."
+        : "No module history-navigation row was captured.",
+    };
+  const analysisWindows = [
+    bundle.aggregates.hotspot_quadrant.meta.status === "available"
+      ? `${bundle.capability.views.hotspot_quadrant.label}: ${
+        formatWindow(
+          bundle.aggregates.hotspot_quadrant.meta.window,
+          bundle.meta.snapshot.ingested_at,
+        )
+      }`
+      : null,
+    bundle.aggregates.hidden_coupling.meta.status === "available"
+      ? `${bundle.capability.views.hidden_coupling.label}: ${
+        formatWindow(
+          bundle.aggregates.hidden_coupling.meta.window,
+          bundle.meta.snapshot.ingested_at,
+        )
+      }`
+      : null,
+  ].filter((value): value is string => value !== null);
+  const couplingCoverage = bundle.aggregates.hidden_coupling.meta.status ===
+      "available"
+    ? pageEvidence(
+      `${bundle.capability.views.hidden_coupling.label} coverage`,
+      bundle.aggregates.hidden_coupling.data,
+      labels,
+    )
+    : {
+      label: `${bundle.capability.views.hidden_coupling.label} coverage`,
+      value: labels.unavailable,
+      detail:
+        bundle.aggregates.hidden_coupling.meta.unavailable_reason ??
+          "The analysis was not produced.",
+    };
+
+  return {
+    module: moduleNode,
+    topology: {
+      fanIn: topology?.fan_in ?? dependents.length,
+      fanOut: topology?.fan_out ?? dependencies.length,
+      coverage: topologyCoverage,
+      cycleIds: cycles.map((cycle) => cycle.id),
+      cycles,
+    },
+    hotspot: hotspotRow
+      ? {
+        commitCount: hotspotRow.commit_count,
+        fanIn: hotspotRow.fan_in,
+        quadrant: hotspotRow.quadrant,
+      }
+      : null,
+    ownership: ownershipRow
+      ? {
+        commitCount: ownershipRow.commit_count,
+        authorConcentration:
+          ownershipRow.author_concentration.status === "available"
+            ? ownershipRow.author_concentration.value
+            : null,
+        busFactor: ownershipRow.bus_factor.status === "available"
+          ? ownershipRow.bus_factor.value
+          : null,
+        authors: [...ownershipRow.authors.items],
+      }
+      : null,
+    apiSurface: apiSurfaceRow
+      ? {
+        dependentCount: apiSurfaceRow.dependent_count,
+        rank: apiSurfaceIndex + 1,
+      }
+      : null,
+    dependencies,
+    dependents,
+    history,
+    recentCommits,
+    couplings,
+    couplingState,
+    evidence: [
+      {
+        label: "Analysis window",
+        value: analysisWindows.length > 0
+          ? `${analysisWindows.join("; ")}.`
+          : labels.unavailable,
+        detail:
+          "Topology and ownership use their separately declared bundle windows.",
+      },
+      {
+        label: "Snapshot",
+        value:
+          `${bundle.meta.snapshot.head_sha} at ${bundle.meta.snapshot.ingested_at}`,
+      },
+      pageEvidence(
+        "Structure-edge coverage",
+        bundle.graph.structure_edges,
+        labels,
+      ),
+      historyCoverage,
+      sourceRoleEvidence(),
+      couplingCoverage,
+    ],
+  };
+}
+
+export interface RepositoryModuleMatches {
+  items: RepoModule[];
+  total: number;
+  bound: number;
+}
+
+export function findRepositoryModules(
+  bundle: RepoBundle,
+  query: string,
+  limit = 8,
+): RepositoryModuleMatches {
+  const normalizedQuery = query.trim().toLowerCase();
+  const normalizedLimit = Math.max(0, Math.floor(limit));
+  if (!normalizedQuery || normalizedLimit === 0) {
+    return { items: [], total: 0, bound: normalizedLimit };
+  }
+
+  const score = (module: RepoModule): number | null => {
+    const sourcePath = module.source_path.toLowerCase();
+    const modulePath = module.module_path.toLowerCase();
+    const name = module.name.toLowerCase();
+    const pathParts = sourcePath.split("/");
+    const basename = pathParts[pathParts.length - 1] ?? sourcePath;
+    if ([sourcePath, modulePath, name, basename].includes(normalizedQuery)) {
+      return 0;
+    }
+    if (
+      [sourcePath, modulePath, name, basename].some((value) =>
+        value.startsWith(normalizedQuery)
+      )
+    ) {
+      return 1;
+    }
+    if (
+      sourcePath.includes(`/${normalizedQuery}`) ||
+      modulePath.includes(`::${normalizedQuery}`)
+    ) {
+      return 2;
+    }
+    if (
+      [sourcePath, modulePath, name].some((value) =>
+        value.includes(normalizedQuery)
+      )
+    ) {
+      return 3;
+    }
+    return null;
+  };
+
+  const matches = bundle.graph.modules.items
+    .flatMap((module) => {
+      const relevance = score(module);
+      return relevance == null ? [] : [{ module, relevance }];
+    })
+    .sort(
+      (left, right) =>
+        left.relevance - right.relevance ||
+        left.module.source_path.length - right.module.source_path.length ||
+        compareModules(left.module, right.module),
+    );
+  return {
+    items: matches.slice(0, normalizedLimit).map(({ module }) => module),
+    total: matches.length,
+    bound: normalizedLimit,
+  };
+}

--- a/apps/kg-editor/src/lib/repository-brief.ts
+++ b/apps/kg-editor/src/lib/repository-brief.ts
@@ -294,12 +294,14 @@ function commitResolutionGapMetric(
   base: RepositoryMetric,
   unresolved: number,
   captured: number,
+  commitsUnavailable: boolean,
 ): RepositoryMetric {
-  const gap =
-    `${unresolved} of ${captured} captured history IDs are not present in the captured commit page`;
+  const gap = commitsUnavailable
+    ? `${unresolved} of ${captured} captured history IDs cannot be resolved because the commit page is unavailable`
+    : `${unresolved} of ${captured} captured history IDs are not present in the captured commit page`;
   return {
     ...base,
-    status: "truncated",
+    status: commitsUnavailable ? "unavailable" : "truncated",
     reason: base.reason ? `${base.reason}; ${gap}` : gap,
     summary: `${base.summary}; ${gap}`,
   };
@@ -946,6 +948,7 @@ export function buildModuleInsight(
       navigationHistory,
       unresolvedCommitCount,
       navigationCommitIds.length,
+      bundle.graph.commits.disclosure.status === "unavailable",
     );
   const recentCommits = navigationCommitIds
     .flatMap((commitId) => {

--- a/apps/kg-editor/src/lib/showcase-registry.ts
+++ b/apps/kg-editor/src/lib/showcase-registry.ts
@@ -5,6 +5,7 @@ export type ShowcaseRegistryEntry = Readonly<{
   canonicalUrl: string;
   aliases: readonly string[];
   assetPath: string;
+  analysisId?: string;
 }>;
 
 export type ShowcaseLookup =
@@ -22,6 +23,7 @@ export const SHOWCASE_REGISTRY: readonly ShowcaseRegistryEntry[] = [
       "https://www.github.com/ohdearquant/khive",
     ],
     assetPath: "/showcase/khive-repo-v1-khive.json",
+    analysisId: "khive",
   },
 ] as const;
 
@@ -97,4 +99,15 @@ export function isAllowedShowcaseAsset(
 ): boolean {
   return assetPath.startsWith(SHOWCASE_ASSET_PREFIX) &&
     registry.some((entry) => entry.assetPath === assetPath);
+}
+
+export function isAllowedShowcaseAnalysis(
+  entry: ShowcaseRegistryEntry,
+  registry: readonly ShowcaseRegistryEntry[] = SHOWCASE_REGISTRY,
+): entry is ShowcaseRegistryEntry & Readonly<{ analysisId: string }> {
+  return typeof entry.analysisId === "string" &&
+    /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/.test(entry.analysisId) &&
+    registry.some((candidate) =>
+      candidate.id === entry.id && candidate.analysisId === entry.analysisId
+    );
 }


### PR DESCRIPTION
## Summary

Supersedes #1938 with the same triage-cockpit feature plus a complete cursor-aware truncation contract.

- Deterministic evidence-backed repository brief: start-here ranking, summary metrics that preserve unavailable/truncated semantics, and a module inspector combining topology, history, ownership, and coupling evidence.
- Cadence series render per-series availability and bounds; operator access-token support for the preferred showcase source (`sessionStorage` key documented in the README).
- Every derived history-evidence path now treats a page carrying a continuation cursor as truncated, including pages whose disclosure status says `complete`: page evidence summaries, missing-history attribution, and the cadence series status attribute all incorporate `next_cursor`, so derived history status can never contradict pagination state.

## Testing

- `tsc --noEmit`, `eslint` (0 errors; 3 pre-existing warnings identical on the predecessor branch)
- `vitest`: 20 files, 160 tests passing, including focused regressions for `next_cursor` + `disclosure.status = "complete"` across all three derived-evidence paths
