### PR TITLE
feat(merge): carry edge properties and provenance through the semantic three-way merge

### DIFF
--- a/crates/khive-merge/README.md
+++ b/crates/khive-merge/README.md
@@ -44,9 +44,9 @@ going through the `MergeEngine` trait object.
 `MergeConflict` enumerates what `Auto` can detect: `NameConflict`, `KindConflict`,
 `PropertyMismatch`, `ModifyDelete` (one branch edited, the other deleted),
 `DuplicateAddition` (both branches added the same UUID with different content),
-`EdgeModifyDelete`, and `DanglingEdge` (a merged edge references an entity not in the
-merged set). `BranchSide::{Ours, Theirs}` identifies which branch a `ModifyDelete` /
-`EdgeModifyDelete` change came from.
+`EdgeModifyDelete`, `EdgeIdentityMismatch`, `EdgeIdentityCollision`, `EdgePropertyMismatch`, and `DanglingEdge`
+(a merged edge references an entity not in the merged set). `BranchSide::{Ours, Theirs}`
+identifies which branch a `ModifyDelete` / `EdgeModifyDelete` change came from.
 
 ## Invariants
 
@@ -56,8 +56,9 @@ merged set). `BranchSide::{Ours, Theirs}` identifies which branch a `ModifyDelet
   aborts with `MergeError::InvalidEdgeWeight`, never silently coerced.
 - **Deterministic output** — entities sort by UUID, edges by `(source, target, relation)`;
   repeated calls over equal inputs produce byte-identical `KgArchive` output.
-- **Edge identity preserved** — a merged edge keeps the `edge_id` of the originating
-  branch's edge rather than minting a fresh UUID.
+- **Complete edge changes preserved** — edge UUID, weight, properties, and the selected
+  branch's independent timestamps survive merge; timestamp-only rebuild drift does not
+  manufacture a semantic change.
 
 ## Where this sits
 

--- a/crates/khive-merge/docs/api/conflict-and-error-taxonomy.md
+++ b/crates/khive-merge/docs/api/conflict-and-error-taxonomy.md
@@ -12,15 +12,18 @@ The merge API separates valid semantic conflicts from invalid inputs and interna
 
 ## `MergeConflict`
 
-| Variant             | Meaning                                                                 |
-| ------------------- | ----------------------------------------------------------------------- |
-| `NameConflict`      | both branches supply different entity names                             |
-| `KindConflict`      | both branches supply different entity kinds                             |
-| `PropertyMismatch`  | both branches supply different values for one property or `entity_type` |
-| `ModifyDelete`      | one branch modifies an entity while the other deletes it                |
-| `DuplicateAddition` | both branches add the same UUID with different content                  |
-| `EdgeModifyDelete`  | one branch changes an edge weight while the other deletes it            |
-| `DanglingEdge`      | a selected edge references an entity absent from the merged entity set  |
+| Variant                 | Meaning                                                                        |
+| ----------------------- | ------------------------------------------------------------------------------ |
+| `NameConflict`          | both branches supply different entity names                                    |
+| `KindConflict`          | both branches supply different entity kinds                                    |
+| `PropertyMismatch`      | both branches supply different values for one entity property or `entity_type` |
+| `ModifyDelete`          | one branch modifies an entity while the other deletes it                       |
+| `DuplicateAddition`     | both branches add the same UUID with different content                         |
+| `EdgeModifyDelete`      | one branch changes edge identity, weight, or properties while the other deletes it |
+| `EdgeIdentityMismatch`  | both branches replace one semantic edge's durable UUID differently             |
+| `EdgeIdentityCollision` | a branch-chosen edge UUID already belongs to a different semantic edge in the merged set; the edge falls back to its own unclaimed base UUID, or is dropped from the merged set if none is available |
+| `EdgePropertyMismatch`  | both branches change the same property key on one semantic edge differently    |
+| `DanglingEdge`          | a selected edge references an entity absent from the merged entity set         |
 
 `BranchSide::Ours` denotes the local branch being merged into the common base; `Theirs` denotes the remote branch being incorporated.
 
@@ -32,7 +35,7 @@ The merge API separates valid semantic conflicts from invalid inputs and interna
 | `InvalidEdgeWeight` | an input edge weight is NaN or infinite                                            |
 | `DuplicateEntityId` | one archive repeats an entity UUID                                                 |
 | `DuplicateEdgeKey`  | one archive repeats a semantic `(source, target, relation)` key                    |
-| `Internal`          | duplicate edge UUID, relation reconstruction failure, or another invariant failure |
+| `Internal`          | duplicate edge UUID or another invariant failure                                   |
 
 A conflict is not an error: it represents well-formed inputs whose changes need a policy or human decision. Invalid archives fail before diff computation.
 

--- a/crates/khive-merge/docs/api/edge-merge.md
+++ b/crates/khive-merge/docs/api/edge-merge.md
@@ -8,7 +8,9 @@ Edge merging treats `(source, target, relation)` as semantic identity while pres
 
 ## `diff_edges`
 
-Each semantic key is classified as `Added`, `Deleted`, `Unchanged`, or `WeightModified`. Weight equality uses an absolute difference below `f64::EPSILON`. Added changes retain the complete `ExportedEdge`, rather than only its weight, specifically so `edge_id` is not regenerated later. Weight modifications retain both weights for future diff display even though the current merge consumes the branch weight.
+Each semantic key is classified as `Added`, `Deleted`, `Unchanged`, or `Modified`. Added and modified changes retain the complete `ExportedEdge`, so one-sided changes pass through without regenerating identity or dropping properties and provenance.
+
+The semantic key already governs source, target, and relation. Within one key, durable `edge_id`, weight, and properties participate in change classification; weight equality uses an absolute difference below `f64::EPSILON`. `created_at` and `updated_at` do not create a change by themselves. This matches entity merge's timestamp policy and prevents deterministic archive rebuild times from creating false conflicts. When a branch wins a merge-relevant change, its complete independent timestamp pair is carried with the record.
 
 Keys are processed in source/target/relation order. Input archives are validated for duplicate keys by the top-level merge before this diff is used.
 
@@ -16,23 +18,32 @@ Keys are processed in source/target/relation order. Input archives are validated
 
 The edge pass applies the following policies:
 
-| Ours             | Theirs            | Result                             |
-| ---------------- | ----------------- | ---------------------------------- |
-| unchanged        | unchanged         | base edge                          |
-| added            | absent/unchanged  | added edge with branch ID          |
-| absent/unchanged | added             | added edge with branch ID          |
-| added            | added             | one edge, maximum weight, ours ID  |
-| deleted          | deleted/unchanged | omit                               |
-| unchanged        | deleted           | omit                               |
-| weight changed   | unchanged         | changed edge with ours ID          |
-| unchanged        | weight changed    | changed edge with theirs ID        |
-| weight changed   | weight changed    | maximum weight, preferring ours ID |
-| deleted          | weight changed    | `EdgeModifyDelete`                 |
-| weight changed   | deleted           | `EdgeModifyDelete`                 |
+| Ours             | Theirs            | Result                                                                 |
+| ---------------- | ----------------- | ---------------------------------------------------------------------- |
+| unchanged        | unchanged         | base edge                                                              |
+| added            | absent/unchanged  | complete added branch edge                                             |
+| absent/unchanged | added             | complete added branch edge                                             |
+| added            | added             | maximum weight and ours identity/timestamps; properties merge per key      |
+| deleted          | deleted/unchanged | omit                                                                   |
+| unchanged        | deleted           | omit                                                                   |
+| modified         | unchanged         | complete modified ours edge                                            |
+| unchanged        | modified          | complete modified theirs edge                                          |
+| modified         | modified          | field-level three-way reconciliation                                   |
+| deleted          | modified          | `EdgeModifyDelete`                                                     |
+| modified         | deleted           | `EdgeModifyDelete`                                                     |
 
-Maximum weight is the automatic last-write-wins policy for simultaneous weight changes. When rebuilding a modified edge, the implementation preserves an ID from the responsible branch; simultaneous changes prefer ours for deterministic identity. A fresh UUID is only a defensive fallback when no originating edge can be found.
+Double-modified records use these field policies:
 
-Relation reconstruction can return `MergeError::Internal` if the semantic key's relation string no longer parses as a governed relation.
+- A weight changed by only one branch is retained exactly, including a decrease. Simultaneous weight changes retain the established maximum-weight policy.
+- Object properties use base-aware three-way reconciliation per key, matching the existing entity-property policy: independent key changes are combined, a one-sided change or identical double change is retained, and divergent changes to the same key yield one payload-level `EdgePropertyMismatch` with ours as the provisional value for that key. `None` acts as an empty map; malformed legacy non-object payloads are reconciled atomically and conflict on divergent double changes.
+- `edge_id` uses the same three-way rule. Divergent replacements yield `EdgeIdentityMismatch`; independently added records have no common durable identity and continue to prefer ours.
+- Timestamps never trigger a modification or conflict. One-sided changes carry that branch's exact pair. A double-modified or double-added result deterministically carries ours' pair while reconciling the governed fields above.
+
+`SnapshotMergeStrategy::Ours` and `Theirs` are the explicit resolutions for property or identity conflicts and retain the selected branch's complete record.
+
+### Cross-key identity collisions
+
+Per-key reconciliation above decides each semantic edge's UUID independently, so a branch-chosen identity (an added edge, or a one-sided/double modification that changes `edge_id`) can coincide with a durable UUID already used by a *different* semantic edge in the merged set. `merge_edges` reserves every UUID inherited unchanged from base first, then resolves branch-chosen UUIDs against that reserved set in deterministic key order: an edge whose own identity did not change always keeps it; a colliding branch-chosen identity falls back to that key's own base UUID and reports `EdgeIdentityCollision`. That fallback UUID must itself still be unclaimed — a chained collision (the fallback target was already taken by an earlier-sorted edge) is checked the same way as the initial attempt. When there is no unclaimed identity to fall back to, whether because the key has no base UUID or because its base UUID was already claimed, the edge is dropped from the merged set rather than duplicating another edge's UUID; the `EdgeIdentityCollision` conflict is the record of the drop.
 
 ## `validate_dangling_edges`
 

--- a/crates/khive-merge/docs/api/three-way-merge.md
+++ b/crates/khive-merge/docs/api/three-way-merge.md
@@ -13,7 +13,7 @@ Every strategy first validates four input invariants:
 3. entity IDs and edge IDs are unique within each archive; and
 4. semantic edge keys `(source, target, relation)` are unique within each archive.
 
-Namespace, weight, duplicate-entity, and duplicate-edge-key failures have dedicated `MergeError` variants. A duplicate edge ID or an edge relation that cannot be reconstructed is reported as `MergeError::Internal`.
+Namespace, weight, duplicate-entity, and duplicate-edge-key failures have dedicated `MergeError` variants. A duplicate edge ID or another invariant failure is reported as `MergeError::Internal`.
 
 ## Automatic strategy
 

--- a/crates/khive-merge/src/diff_local.rs
+++ b/crates/khive-merge/src/diff_local.rs
@@ -38,12 +38,12 @@ pub enum EdgeChange {
     Added(ExportedEdge),
     /// Deleted in branch.
     Deleted,
-    /// Weight modified.
-    WeightModified {
-        // Retained for future “was → now” diff displays.
-        #[allow(dead_code)]
-        base_weight: f64,
-        branch_weight: f64,
+    /// Merge-relevant edge content or durable identity modified.
+    Modified {
+        // Complete records are retained so a one-sided change can pass through
+        // without losing edge identity, properties, or provenance timestamps.
+        base: ExportedEdge,
+        branch: ExportedEdge,
     },
 }
 
@@ -119,8 +119,11 @@ pub fn diff_entities(base: &KgArchive, branch: &KgArchive) -> HashMap<Uuid, Enti
 
 /// Classifies every semantic edge key in the union of `base` and `branch`.
 ///
-/// Added values retain their original `edge_id`; weights differing by less
-/// than `f64::EPSILON` are unchanged. See `crates/khive-merge/docs/api/edge-merge.md`.
+/// Added and modified values retain complete edge records. Durable `edge_id`,
+/// weight, and properties participate in classification; timestamps do not,
+/// so deterministic archive rebuilds cannot manufacture semantic changes.
+/// Weights differing by less than `f64::EPSILON` are unchanged. See
+/// `crates/khive-merge/docs/api/edge-merge.md`.
 ///
 /// # Errors
 ///
@@ -157,12 +160,12 @@ pub fn diff_edges(
             (None, Some(branch_e)) => EdgeChange::Added((*branch_e).clone()),
             (Some(_), None) => EdgeChange::Deleted,
             (Some(base_e), Some(branch_e)) => {
-                if (base_e.weight - branch_e.weight).abs() < f64::EPSILON {
+                if edges_equal(base_e, branch_e) {
                     EdgeChange::Unchanged
                 } else {
-                    EdgeChange::WeightModified {
-                        base_weight: base_e.weight,
-                        branch_weight: branch_e.weight,
+                    EdgeChange::Modified {
+                        base: (*base_e).clone(),
+                        branch: (*branch_e).clone(),
                     }
                 }
             }
@@ -172,6 +175,18 @@ pub fn diff_edges(
     }
 
     Ok(result)
+}
+
+/// Compares merge-relevant fields for one semantic edge key.
+///
+/// Source, target, and relation form [`EdgeKey`] and are therefore classified
+/// structurally as add/delete when they change. Timestamps are provenance, not
+/// semantic content: a branch that wins a real change carries its complete
+/// timestamps, while timestamp-only rebuild drift remains unchanged.
+fn edges_equal(a: &ExportedEdge, b: &ExportedEdge) -> bool {
+    a.edge_id == b.edge_id
+        && (a.weight - b.weight).abs() < f64::EPSILON
+        && properties_equal(&a.properties, &b.properties)
 }
 
 /// Compares merge-relevant entity fields, excluding timestamps.
@@ -326,12 +341,74 @@ mod tests {
             target: b,
             relation: "extends".into(),
         };
-        assert!(matches!(
-            diff[&key],
-            EdgeChange::WeightModified {
-                base_weight: _,
-                branch_weight: _
+        assert!(matches!(diff[&key], EdgeChange::Modified { .. }));
+    }
+
+    #[test]
+    fn property_only_edge_change_is_modified_with_full_branch_record() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let base_edge = edge(a, b, 0.7);
+        let mut branch_edge = base_edge.clone();
+        branch_edge.properties = Some(serde_json::json!({"confidence": 0.95}));
+        branch_edge.created_at = chrono::DateTime::parse_from_rfc3339("2026-03-03T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        branch_edge.updated_at = chrono::DateTime::parse_from_rfc3339("2026-04-04T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        let base = make_archive(vec![], vec![base_edge.clone()]);
+        let branch = make_archive(vec![], vec![branch_edge.clone()]);
+        let diff = diff_edges(&base, &branch).unwrap();
+        let key = EdgeKey::from_edge(&base_edge);
+
+        match &diff[&key] {
+            EdgeChange::Modified { base, branch } => {
+                assert_eq!(base.properties, None);
+                assert_eq!(branch.edge_id, branch_edge.edge_id);
+                assert_eq!(branch.properties, branch_edge.properties);
+                assert_eq!(branch.created_at, branch_edge.created_at);
+                assert_eq!(branch.updated_at, branch_edge.updated_at);
             }
+            other => panic!("property-only change must be Modified, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn edge_identity_change_is_modified() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let base_edge = edge(a, b, 0.7);
+        let mut branch_edge = base_edge.clone();
+        branch_edge.edge_id = Uuid::new_v4();
+
+        let base = make_archive(vec![], vec![base_edge.clone()]);
+        let branch = make_archive(vec![], vec![branch_edge]);
+        let diff = diff_edges(&base, &branch).unwrap();
+
+        assert!(matches!(
+            diff[&EdgeKey::from_edge(&base_edge)],
+            EdgeChange::Modified { .. }
+        ));
+    }
+
+    #[test]
+    fn timestamp_only_edge_drift_is_unchanged() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let base_edge = edge(a, b, 0.7);
+        let mut rebuilt_edge = base_edge.clone();
+        rebuilt_edge.created_at += chrono::TimeDelta::seconds(1);
+        rebuilt_edge.updated_at += chrono::TimeDelta::seconds(2);
+
+        let base = make_archive(vec![], vec![base_edge.clone()]);
+        let branch = make_archive(vec![], vec![rebuilt_edge]);
+        let diff = diff_edges(&base, &branch).unwrap();
+
+        assert!(matches!(
+            diff[&EdgeKey::from_edge(&base_edge)],
+            EdgeChange::Unchanged
         ));
     }
 }

--- a/crates/khive-merge/src/edge.rs
+++ b/crates/khive-merge/src/edge.rs
@@ -6,23 +6,23 @@
 
 use std::collections::{HashMap, HashSet};
 
-use chrono::Utc;
 use khive_runtime::portability::{ExportedEdge, KgArchive};
 use uuid::Uuid;
 
-use crate::diff_local::{diff_edges, EdgeChange, EdgeKey};
+use crate::diff_local::{diff_edges, properties_equal, EdgeChange, EdgeKey};
 use crate::types::{BranchSide, MergeConflict, MergeError};
 
 /// Merges edges from `base`, `ours`, and `theirs` by semantic edge key.
 ///
-/// Returns the provisional edge set and any modify/delete conflicts. Call
+/// Returns the provisional edge set and any typed edge conflicts. Call
 /// [`validate_dangling_edges`] after entity merge before accepting the set.
 ///
 /// # Errors
 ///
-/// Returns [`MergeError::Internal`] if a relation cannot be reconstructed.
-/// Use the top-level merge to validate namespaces, weights, and duplicates.
-/// See `crates/khive-merge/docs/api/edge-merge.md` for all merge rules.
+/// The current edge pass is infallible after top-level input validation; the
+/// `Result` shape remains part of the merge-layer contract. Use the top-level
+/// merge to validate namespaces, weights, and duplicates. See
+/// `crates/khive-merge/docs/api/edge-merge.md` for all merge rules.
 pub fn merge_edges(
     base: &KgArchive,
     ours: &KgArchive,
@@ -45,103 +45,108 @@ pub fn merge_edges(
             .then(a.relation.cmp(&b.relation))
     });
 
-    let mut merged: Vec<ExportedEdge> = Vec::new();
     let mut conflicts: Vec<MergeConflict> = Vec::new();
 
-    // Preserve originating edge IDs across merge/diff cycles.
+    // Preserve the common-base record for unchanged output.
     let base_edge_map: HashMap<EdgeKey, &ExportedEdge> = base
         .edges
         .iter()
         .map(|e| (EdgeKey::from_edge(e), e))
         .collect();
-    let ours_edge_map: HashMap<EdgeKey, &ExportedEdge> = ours
-        .edges
-        .iter()
-        .map(|e| (EdgeKey::from_edge(e), e))
-        .collect();
-    let theirs_edge_map: HashMap<EdgeKey, &ExportedEdge> = theirs
-        .edges
-        .iter()
-        .map(|e| (EdgeKey::from_edge(e), e))
-        .collect();
 
-    for key in &all_keys_sorted {
-        let ours_change = ours_diff.get(key);
-        let theirs_change = theirs_diff.get(key);
+    // First pass: decide each key's provisional edge per-key, same as before,
+    // and note whether its durable identity is exactly base's (untouched) or
+    // was chosen by branch content (added, or a modification that changed
+    // `edge_id`). This classification drives collision resolution below,
+    // independent of key iteration order.
+    let mut candidates: Vec<(EdgeKey, Option<(ExportedEdge, bool)>)> =
+        Vec::with_capacity(all_keys_sorted.len());
 
-        match (ours_change, theirs_change) {
+    for key in all_keys_sorted {
+        let ours_change = ours_diff.get(&key);
+        let theirs_change = theirs_diff.get(&key);
+
+        let candidate = match (ours_change, theirs_change) {
             (Some(EdgeChange::Unchanged), Some(EdgeChange::Unchanged)) => {
-                if let Some(&e) = base_edge_map.get(key) {
-                    merged.push(e.clone());
-                }
+                base_edge_map.get(&key).map(|&e| (e.clone(), true))
             }
 
             (Some(EdgeChange::Added(e)), None)
-            | (Some(EdgeChange::Added(e)), Some(EdgeChange::Unchanged)) => {
-                merged.push(e.clone());
-            }
+            | (Some(EdgeChange::Added(e)), Some(EdgeChange::Unchanged)) => Some((e.clone(), false)),
 
             (None, Some(EdgeChange::Added(e)))
-            | (Some(EdgeChange::Unchanged), Some(EdgeChange::Added(e))) => {
-                merged.push(e.clone());
-            }
+            | (Some(EdgeChange::Unchanged), Some(EdgeChange::Added(e))) => Some((e.clone(), false)),
 
             (Some(EdgeChange::Added(e_ours)), Some(EdgeChange::Added(e_theirs))) => {
-                // Simultaneous weight changes auto-resolve to the maximum.
-                let weight = f64::max(e_ours.weight, e_theirs.weight);
-                let mut edge = e_ours.clone();
-                edge.weight = weight;
-                merged.push(edge);
+                let (edge, edge_conflicts) = merge_added_edges(&key, e_ours, e_theirs);
+                conflicts.extend(edge_conflicts);
+                Some((edge, false))
             }
 
-            (Some(EdgeChange::Deleted), Some(EdgeChange::Deleted)) => {}
+            (Some(EdgeChange::Deleted), Some(EdgeChange::Deleted)) => None,
 
             (Some(EdgeChange::Deleted), Some(EdgeChange::Unchanged))
-            | (Some(EdgeChange::Deleted), None) => {}
+            | (Some(EdgeChange::Deleted), None) => None,
 
             (Some(EdgeChange::Unchanged), Some(EdgeChange::Deleted))
-            | (None, Some(EdgeChange::Deleted)) => {}
+            | (None, Some(EdgeChange::Deleted)) => None,
 
             (
-                Some(EdgeChange::WeightModified { branch_weight, .. }),
+                Some(EdgeChange::Modified {
+                    branch: edge_ours, ..
+                }),
                 Some(EdgeChange::Unchanged),
             )
-            | (Some(EdgeChange::WeightModified { branch_weight, .. }), None) => {
-                let id = ours_edge_map.get(key).map(|e| e.edge_id);
-                let edge = build_edge(key, *branch_weight, id)?;
-                merged.push(edge);
+            | (
+                Some(EdgeChange::Modified {
+                    branch: edge_ours, ..
+                }),
+                None,
+            ) => {
+                let identity_is_base = base_edge_map
+                    .get(&key)
+                    .is_some_and(|&b| b.edge_id == edge_ours.edge_id);
+                Some((edge_ours.clone(), identity_is_base))
             }
 
             (
                 Some(EdgeChange::Unchanged),
-                Some(EdgeChange::WeightModified { branch_weight, .. }),
-            )
-            | (None, Some(EdgeChange::WeightModified { branch_weight, .. })) => {
-                let id = theirs_edge_map.get(key).map(|e| e.edge_id);
-                let edge = build_edge(key, *branch_weight, id)?;
-                merged.push(edge);
-            }
-
-            // Prefer ours' ID when both weights changed for deterministic identity.
-            (
-                Some(EdgeChange::WeightModified {
-                    branch_weight: ours_w,
+                Some(EdgeChange::Modified {
+                    branch: edge_theirs,
                     ..
                 }),
-                Some(EdgeChange::WeightModified {
-                    branch_weight: theirs_w,
+            )
+            | (
+                None,
+                Some(EdgeChange::Modified {
+                    branch: edge_theirs,
                     ..
                 }),
             ) => {
-                let id = ours_edge_map
-                    .get(key)
-                    .or_else(|| theirs_edge_map.get(key))
-                    .map(|e| e.edge_id);
-                let edge = build_edge(key, f64::max(*ours_w, *theirs_w), id)?;
-                merged.push(edge);
+                let identity_is_base = base_edge_map
+                    .get(&key)
+                    .is_some_and(|&b| b.edge_id == edge_theirs.edge_id);
+                Some((edge_theirs.clone(), identity_is_base))
             }
 
-            (Some(EdgeChange::Deleted), Some(EdgeChange::WeightModified { .. })) => {
+            (
+                Some(EdgeChange::Modified {
+                    base,
+                    branch: edge_ours,
+                }),
+                Some(EdgeChange::Modified {
+                    branch: edge_theirs,
+                    ..
+                }),
+            ) => {
+                let (edge, edge_conflicts) =
+                    merge_modified_edges(&key, base, edge_ours, edge_theirs);
+                conflicts.extend(edge_conflicts);
+                let identity_is_base = edge.edge_id == base.edge_id;
+                Some((edge, identity_is_base))
+            }
+
+            (Some(EdgeChange::Deleted), Some(EdgeChange::Modified { .. })) => {
                 conflicts.push(MergeConflict::EdgeModifyDelete {
                     source_id: key.source,
                     target_id: key.target,
@@ -149,9 +154,10 @@ pub fn merge_edges(
                     modified_in: BranchSide::Theirs,
                     deleted_in: BranchSide::Ours,
                 });
+                None
             }
 
-            (Some(EdgeChange::WeightModified { .. }), Some(EdgeChange::Deleted)) => {
+            (Some(EdgeChange::Modified { .. }), Some(EdgeChange::Deleted)) => {
                 conflicts.push(MergeConflict::EdgeModifyDelete {
                     source_id: key.source,
                     target_id: key.target,
@@ -159,13 +165,243 @@ pub fn merge_edges(
                     modified_in: BranchSide::Ours,
                     deleted_in: BranchSide::Theirs,
                 });
+                None
             }
 
-            _ => {}
+            _ => None,
+        };
+
+        candidates.push((key, candidate));
+    }
+
+    // Second pass: reserve every durable identity inherited unchanged from
+    // base before resolving branch-chosen identities, so a one-sided or
+    // double edge modification can never displace an edge that kept its
+    // pre-existing UUID — regardless of which key sorts first. Base edges are
+    // validated duplicate-free on ingest, so these reservations never collide
+    // with each other.
+    let mut used_edge_ids: HashSet<Uuid> = HashSet::new();
+    for (_, candidate) in &candidates {
+        if let Some((edge, true)) = candidate {
+            used_edge_ids.insert(edge.edge_id);
         }
     }
 
+    // Third pass: resolve branch-chosen identities against the reserved set,
+    // in the original sorted order, and emit the final deterministic output.
+    let mut merged: Vec<ExportedEdge> = Vec::with_capacity(candidates.len());
+    for (key, candidate) in candidates {
+        let Some((mut edge, identity_is_base)) = candidate else {
+            continue;
+        };
+
+        if !identity_is_base && !used_edge_ids.insert(edge.edge_id) {
+            let attempted_edge_id = edge.edge_id;
+            // The key's own base id is only a safe fallback if nothing else
+            // has claimed it yet -- e.g. an earlier-sorted edge that
+            // branch-chose this exact id. `insert`'s return value must be
+            // checked, or a chained collision silently duplicates that
+            // earlier edge's id instead of being caught here.
+            let resolved_edge_id = base_edge_map
+                .get(&key)
+                .map(|&base_edge| base_edge.edge_id)
+                .filter(|&id| used_edge_ids.insert(id));
+
+            conflicts.push(MergeConflict::EdgeIdentityCollision {
+                source_id: key.source,
+                target_id: key.target,
+                relation: key.relation.clone(),
+                attempted_edge_id,
+                retained_edge_id: resolved_edge_id.unwrap_or(attempted_edge_id),
+            });
+
+            match resolved_edge_id {
+                Some(id) => edge.edge_id = id,
+                // No unclaimed identity to restore -- dropping the edge is
+                // the only way to keep the merged set duplicate-free; the
+                // conflict entry above is the record of what was dropped.
+                None => continue,
+            }
+        }
+
+        merged.push(edge);
+    }
+
     Ok((merged, conflicts))
+}
+
+/// Reconciles two independently added records for one semantic edge key.
+///
+/// Independent additions have no common durable UUID, so the established
+/// policy keeps ours' identity and timestamps and takes the maximum weight.
+/// Object properties reconcile per key; same-key divergence remains a typed
+/// conflict rather than being silently discarded.
+fn merge_added_edges(
+    key: &EdgeKey,
+    ours: &ExportedEdge,
+    theirs: &ExportedEdge,
+) -> (ExportedEdge, Vec<MergeConflict>) {
+    let mut result = ours.clone();
+    result.weight = f64::max(ours.weight, theirs.weight);
+    let no_base = None;
+    let (properties, conflicts) =
+        merge_edge_properties(key, &no_base, &ours.properties, &theirs.properties);
+    result.properties = properties;
+
+    (result, conflicts)
+}
+
+/// Three-way reconciliation for two modified records of one semantic edge.
+///
+/// Weight follows the existing maximum policy only when both branches changed
+/// it; a one-sided increase or decrease is retained exactly. Property objects
+/// reconcile per key, while durable UUIDs use ordinary three-way selection;
+/// each reports a typed conflict only when both branches changed the same
+/// governed value differently. Ours' complete timestamp pair is the
+/// deterministic provenance carrier for a double-modified result; timestamps
+/// never create a change or conflict alone.
+fn merge_modified_edges(
+    key: &EdgeKey,
+    base: &ExportedEdge,
+    ours: &ExportedEdge,
+    theirs: &ExportedEdge,
+) -> (ExportedEdge, Vec<MergeConflict>) {
+    let mut result = ours.clone();
+    let mut conflicts = Vec::new();
+
+    let ours_weight_changed = !weights_equal(base.weight, ours.weight);
+    let theirs_weight_changed = !weights_equal(base.weight, theirs.weight);
+    result.weight = match (ours_weight_changed, theirs_weight_changed) {
+        (false, false) => base.weight,
+        (true, false) => ours.weight,
+        (false, true) => theirs.weight,
+        (true, true) => f64::max(ours.weight, theirs.weight),
+    };
+
+    let (properties, property_conflicts) =
+        merge_edge_properties(key, &base.properties, &ours.properties, &theirs.properties);
+    result.properties = properties;
+    conflicts.extend(property_conflicts);
+
+    let ours_identity_changed = base.edge_id != ours.edge_id;
+    let theirs_identity_changed = base.edge_id != theirs.edge_id;
+    result.edge_id = match (ours_identity_changed, theirs_identity_changed) {
+        (false, false) => base.edge_id,
+        (true, false) => ours.edge_id,
+        (false, true) => theirs.edge_id,
+        (true, true) if ours.edge_id == theirs.edge_id => ours.edge_id,
+        (true, true) => {
+            conflicts.push(MergeConflict::EdgeIdentityMismatch {
+                source_id: key.source,
+                target_id: key.target,
+                relation: key.relation.clone(),
+                ours: ours.edge_id,
+                theirs: theirs.edge_id,
+            });
+            ours.edge_id
+        }
+    };
+
+    (result, conflicts)
+}
+
+/// Three-way merges governed edge metadata without discarding independent keys.
+///
+/// The accepted wire/storage contract makes properties an object. `None` is
+/// treated as an empty map for key-level reconciliation; non-object legacy
+/// payloads retain conservative atomic selection. A divergent same-key edit
+/// produces one payload-level conflict and keeps ours for that key in the
+/// provisional record.
+fn merge_edge_properties(
+    key: &EdgeKey,
+    base: &Option<serde_json::Value>,
+    ours: &Option<serde_json::Value>,
+    theirs: &Option<serde_json::Value>,
+) -> (Option<serde_json::Value>, Vec<MergeConflict>) {
+    if properties_equal(ours, theirs) {
+        return (ours.clone(), Vec::new());
+    }
+    if properties_equal(ours, base) {
+        return (theirs.clone(), Vec::new());
+    }
+    if properties_equal(theirs, base) {
+        return (ours.clone(), Vec::new());
+    }
+
+    let all_object_like = [base, ours, theirs]
+        .into_iter()
+        .all(|value| matches!(value, None | Some(serde_json::Value::Object(_))));
+    if !all_object_like {
+        return (
+            ours.clone(),
+            vec![edge_property_conflict(key, ours, theirs)],
+        );
+    }
+
+    let base_object = base.as_ref().and_then(serde_json::Value::as_object);
+    let ours_object = ours.as_ref().and_then(serde_json::Value::as_object);
+    let theirs_object = theirs.as_ref().and_then(serde_json::Value::as_object);
+    let mut property_keys: HashSet<String> = HashSet::new();
+    for object in [base_object, ours_object, theirs_object]
+        .into_iter()
+        .flatten()
+    {
+        property_keys.extend(object.keys().cloned());
+    }
+    let mut property_keys: Vec<String> = property_keys.into_iter().collect();
+    property_keys.sort();
+
+    let mut merged = serde_json::Map::new();
+    let mut has_conflict = false;
+    for property_key in property_keys {
+        let base_value = base_object.and_then(|object| object.get(&property_key));
+        let ours_value = ours_object.and_then(|object| object.get(&property_key));
+        let theirs_value = theirs_object.and_then(|object| object.get(&property_key));
+        let selected = if ours_value == theirs_value {
+            ours_value
+        } else if ours_value == base_value {
+            theirs_value
+        } else if theirs_value == base_value {
+            ours_value
+        } else {
+            has_conflict = true;
+            ours_value
+        };
+
+        if let Some(value) = selected {
+            merged.insert(property_key, value.clone());
+        }
+    }
+
+    let merged = if merged.is_empty() && (ours.is_none() || theirs.is_none()) {
+        None
+    } else {
+        Some(serde_json::Value::Object(merged))
+    };
+    let conflicts = if has_conflict {
+        vec![edge_property_conflict(key, ours, theirs)]
+    } else {
+        Vec::new()
+    };
+    (merged, conflicts)
+}
+
+fn edge_property_conflict(
+    key: &EdgeKey,
+    ours: &Option<serde_json::Value>,
+    theirs: &Option<serde_json::Value>,
+) -> MergeConflict {
+    MergeConflict::EdgePropertyMismatch {
+        source_id: key.source,
+        target_id: key.target,
+        relation: key.relation.clone(),
+        ours: ours.clone(),
+        theirs: theirs.clone(),
+    }
+}
+
+fn weights_equal(a: f64, b: f64) -> bool {
+    (a - b).abs() < f64::EPSILON
 }
 
 /// Reports edges whose source or target is absent from `entity_ids`.
@@ -197,30 +433,9 @@ pub fn validate_dangling_edges(
     conflicts
 }
 
-/// Reconstructs an edge, preserving `existing_id` or minting a fallback UUID.
-fn build_edge(
-    key: &EdgeKey,
-    weight: f64,
-    existing_id: Option<Uuid>,
-) -> Result<ExportedEdge, MergeError> {
-    let relation = key
-        .relation
-        .parse::<khive_storage::EdgeRelation>()
-        .map_err(|e| MergeError::Internal(e.to_string()))?;
-    Ok(ExportedEdge {
-        edge_id: existing_id.unwrap_or_else(Uuid::new_v4),
-        source: key.source,
-        target: key.target,
-        relation,
-        weight,
-        properties: None,
-        created_at: Utc::now(),
-        updated_at: Utc::now(),
-    })
-}
-
 #[cfg(test)]
 mod tests {
+    use chrono::Utc;
     use khive_runtime::portability::{ExportedEdge, KgArchive};
     use khive_storage::EdgeRelation;
     use uuid::Uuid;
@@ -375,5 +590,299 @@ mod tests {
             merged[0].edge_id, expected_id,
             "merged edge_id must equal ours' edge_id after weight modification"
         );
+    }
+
+    #[test]
+    fn one_sided_property_change_preserves_complete_branch_edge() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let base_edge = edge(a, b, 0.7);
+        let mut ours_edge = base_edge.clone();
+        ours_edge.properties = Some(serde_json::json!({"confidence": 0.95}));
+        ours_edge.created_at = chrono::DateTime::parse_from_rfc3339("2026-03-03T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        ours_edge.updated_at = chrono::DateTime::parse_from_rfc3339("2026-04-04T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        let base = archive(vec![base_edge.clone()]);
+        let ours = archive(vec![ours_edge.clone()]);
+        let theirs = archive(vec![base_edge]);
+        let (merged, conflicts) = merge_edges(&base, &ours, &theirs).unwrap();
+
+        assert!(conflicts.is_empty(), "unexpected conflicts: {conflicts:?}");
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].edge_id, ours_edge.edge_id);
+        assert_eq!(merged[0].properties, ours_edge.properties);
+        assert_eq!(merged[0].created_at, ours_edge.created_at);
+        assert_eq!(merged[0].updated_at, ours_edge.updated_at);
+    }
+
+    #[test]
+    fn divergent_property_only_changes_report_typed_conflict() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let mut base_edge = edge(a, b, 0.7);
+        base_edge.properties = Some(serde_json::json!({"confidence": 0.5}));
+        let mut ours_edge = base_edge.clone();
+        ours_edge.properties = Some(serde_json::json!({"confidence": 0.8}));
+        let mut theirs_edge = base_edge.clone();
+        theirs_edge.properties = Some(serde_json::json!({"confidence": 0.9}));
+
+        let base = archive(vec![base_edge]);
+        let ours = archive(vec![ours_edge]);
+        let theirs = archive(vec![theirs_edge]);
+        let (_, conflicts) = merge_edges(&base, &ours, &theirs).unwrap();
+
+        assert!(matches!(
+            conflicts.as_slice(),
+            [MergeConflict::EdgePropertyMismatch {
+                source_id,
+                target_id,
+                relation,
+                ours: Some(ours),
+                theirs: Some(theirs),
+            }] if *source_id == a
+                && *target_id == b
+                && relation == "extends"
+                && ours == &serde_json::json!({"confidence": 0.8})
+                && theirs == &serde_json::json!({"confidence": 0.9})
+        ));
+    }
+
+    #[test]
+    fn independent_property_key_changes_merge_without_loss() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let mut base_edge = edge(a, b, 0.7);
+        base_edge.properties = Some(serde_json::json!({"shared": "base"}));
+        let mut ours_edge = base_edge.clone();
+        ours_edge.properties = Some(serde_json::json!({
+            "ours": 1,
+            "shared": "base",
+        }));
+        let mut theirs_edge = base_edge.clone();
+        theirs_edge.properties = Some(serde_json::json!({
+            "shared": "base",
+            "theirs": 2,
+        }));
+
+        let base = archive(vec![base_edge]);
+        let ours = archive(vec![ours_edge]);
+        let theirs = archive(vec![theirs_edge]);
+        let (merged, conflicts) = merge_edges(&base, &ours, &theirs).unwrap();
+
+        assert!(conflicts.is_empty(), "unexpected conflicts: {conflicts:?}");
+        assert_eq!(
+            merged[0].properties,
+            Some(serde_json::json!({
+                "ours": 1,
+                "shared": "base",
+                "theirs": 2,
+            }))
+        );
+    }
+
+    #[test]
+    fn independent_weight_and_property_changes_merge_without_loss() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let mut base_edge = edge(a, b, 0.5);
+        base_edge.properties = Some(serde_json::json!({"origin": "base"}));
+        let mut ours_edge = base_edge.clone();
+        ours_edge.properties = Some(serde_json::json!({"origin": "ours"}));
+        let mut theirs_edge = base_edge.clone();
+        theirs_edge.weight = 0.2;
+
+        let base = archive(vec![base_edge]);
+        let ours = archive(vec![ours_edge.clone()]);
+        let theirs = archive(vec![theirs_edge]);
+        let (merged, conflicts) = merge_edges(&base, &ours, &theirs).unwrap();
+
+        assert!(conflicts.is_empty(), "unexpected conflicts: {conflicts:?}");
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].weight, 0.2);
+        assert_eq!(merged[0].properties, ours_edge.properties);
+        assert_eq!(merged[0].created_at, ours_edge.created_at);
+        assert_eq!(merged[0].updated_at, ours_edge.updated_at);
+    }
+
+    #[test]
+    fn divergent_edge_identity_changes_report_typed_conflict() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let base_edge = edge(a, b, 0.7);
+        let mut ours_edge = base_edge.clone();
+        ours_edge.edge_id = Uuid::new_v4();
+        let mut theirs_edge = base_edge.clone();
+        theirs_edge.edge_id = Uuid::new_v4();
+
+        let base = archive(vec![base_edge]);
+        let ours = archive(vec![ours_edge.clone()]);
+        let theirs = archive(vec![theirs_edge.clone()]);
+        let (_, conflicts) = merge_edges(&base, &ours, &theirs).unwrap();
+
+        assert!(matches!(
+            conflicts.as_slice(),
+            [MergeConflict::EdgeIdentityMismatch {
+                source_id,
+                target_id,
+                relation,
+                ours,
+                theirs,
+            }] if *source_id == a
+                && *target_id == b
+                && relation == "extends"
+                && *ours == ours_edge.edge_id
+                && *theirs == theirs_edge.edge_id
+        ));
+    }
+
+    #[test]
+    fn one_sided_identity_change_colliding_with_other_edge_is_rejected() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let c = Uuid::new_v4();
+        let d = Uuid::new_v4();
+
+        let edge1_base = edge(a, b, 1.0);
+        let edge2 = edge(c, d, 1.0);
+
+        let mut edge1_ours = edge1_base.clone();
+        edge1_ours.edge_id = edge2.edge_id;
+
+        let base = archive(vec![edge1_base.clone(), edge2.clone()]);
+        let ours = archive(vec![edge1_ours, edge2.clone()]);
+        let theirs = archive(vec![edge1_base, edge2.clone()]);
+
+        let (merged, conflicts) = merge_edges(&base, &ours, &theirs).unwrap();
+
+        let mut seen_ids = HashSet::new();
+        for merged_edge in &merged {
+            assert!(
+                seen_ids.insert(merged_edge.edge_id),
+                "merge output must not contain duplicate durable edge_id {:?}: {merged:?}",
+                merged_edge.edge_id
+            );
+        }
+        assert!(
+            conflicts
+                .iter()
+                .any(|c| matches!(c, MergeConflict::EdgeIdentityCollision { .. })),
+            "expected an EdgeIdentityCollision conflict, got: {conflicts:?}"
+        );
+    }
+
+    #[test]
+    fn chained_identity_collision_through_base_fallback_is_rejected() {
+        // Three semantic edges, sorted by (source, target, relation) as
+        // key1 < key_early < key_chained:
+        //
+        //   key1:        base-identity edge, reserves ID_B in the second pass.
+        //   key_early:   a freshly added edge that branch-chooses ID_X, which
+        //                happens to equal key_chained's *own* base edge_id.
+        //                It claims ID_X first because it sorts before
+        //                key_chained.
+        //   key_chained: a modified edge whose branch-chosen id collides with
+        //                ID_B (already reserved), so it falls back to its own
+        //                base id -- ID_X -- but ID_X was just claimed by
+        //                key_early. The fallback insert must be checked, or
+        //                key_chained silently duplicates key_early's ID_X.
+        let s1 = Uuid::from_u128(1);
+        let t1 = Uuid::from_u128(2);
+        let s2 = Uuid::from_u128(3);
+        let t2 = Uuid::from_u128(4);
+        let s3 = Uuid::from_u128(5);
+        let t3 = Uuid::from_u128(6);
+
+        let id_b = Uuid::from_u128(100);
+        let id_x = Uuid::from_u128(200);
+
+        let key1_base = edge(s1, t1, 1.0);
+        let mut key1_ours = key1_base.clone();
+        key1_ours.edge_id = id_b;
+        let mut key1_base_fixed = key1_base.clone();
+        key1_base_fixed.edge_id = id_b;
+        let key1_base = key1_base_fixed;
+        key1_ours.weight = 2.0;
+
+        let key_chained_base = {
+            let mut e = edge(s3, t3, 1.0);
+            e.edge_id = id_x;
+            e
+        };
+        let mut key_chained_ours = key_chained_base.clone();
+        key_chained_ours.edge_id = id_b; // collides with key1's reserved id_b
+        key_chained_ours.weight = 2.0;
+
+        let key_early_ours = {
+            let mut e = edge(s2, t2, 1.0);
+            e.edge_id = id_x; // collides with key_chained's fallback target
+            e
+        };
+
+        let base = archive(vec![key1_base.clone(), key_chained_base.clone()]);
+        let ours = archive(vec![key1_ours, key_early_ours, key_chained_ours]);
+        let theirs = archive(vec![key1_base, key_chained_base]);
+
+        let (merged, conflicts) = merge_edges(&base, &ours, &theirs).unwrap();
+
+        let merged_rows: Vec<(Uuid, Uuid, Uuid, f64)> = merged
+            .iter()
+            .map(|e| (e.source, e.target, e.edge_id, e.weight))
+            .collect();
+        assert_eq!(
+            merged_rows,
+            vec![(s1, t1, id_b, 2.0), (s2, t2, id_x, 1.0)],
+            "exactly key1 (reserved ID_B) and key_early (branch-chosen ID_X) \
+             survive; key_chained is dropped rather than duplicating ID_X: \
+             {merged:?}"
+        );
+
+        match conflicts.as_slice() {
+            [MergeConflict::EdgeIdentityCollision {
+                source_id,
+                target_id,
+                relation,
+                attempted_edge_id,
+                retained_edge_id,
+            }] => {
+                assert_eq!((*source_id, *target_id), (s3, t3));
+                assert_eq!(relation, &EdgeRelation::Extends.to_string());
+                assert_eq!(*attempted_edge_id, id_b);
+                assert_eq!(
+                    *retained_edge_id, id_b,
+                    "a dropped edge records the attempted id as retained"
+                );
+            }
+            other => panic!(
+                "expected exactly one EdgeIdentityCollision for key_chained, \
+                 got: {other:?}"
+            ),
+        }
+    }
+
+    #[test]
+    fn property_modify_delete_is_an_edge_modify_delete_conflict() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let base_edge = edge(a, b, 0.7);
+        let mut theirs_edge = base_edge.clone();
+        theirs_edge.properties = Some(serde_json::json!({"confidence": 0.95}));
+
+        let base = archive(vec![base_edge]);
+        let ours = archive(vec![]);
+        let theirs = archive(vec![theirs_edge]);
+        let (_, conflicts) = merge_edges(&base, &ours, &theirs).unwrap();
+
+        assert!(matches!(
+            conflicts.as_slice(),
+            [MergeConflict::EdgeModifyDelete {
+                modified_in: BranchSide::Theirs,
+                deleted_in: BranchSide::Ours,
+                ..
+            }]
+        ));
     }
 }

--- a/crates/khive-merge/src/edge.rs
+++ b/crates/khive-merge/src/edge.rs
@@ -171,7 +171,13 @@ pub fn merge_edges(
             _ => None,
         };
 
-        candidates.push((key, candidate));
+        // Enforce the symmetric-endpoint invariant on every emitted record:
+        // EdgeKey canonicalizes only the lookup key, so a branch record that
+        // won a merge may still carry reversed endpoints.
+        candidates.push((
+            key,
+            candidate.map(|(e, id_base)| (canonicalize_endpoints(e), id_base)),
+        ));
     }
 
     // Second pass: reserve every durable identity inherited unchanged from
@@ -228,6 +234,16 @@ pub fn merge_edges(
     }
 
     Ok((merged, conflicts))
+}
+
+/// Returns the record with symmetric-relation endpoints in canonical
+/// `(min, max)` order, the same normalization [`EdgeKey`] applies to lookup
+/// keys, so merged output always satisfies the storage endpoint invariant.
+fn canonicalize_endpoints(mut e: ExportedEdge) -> ExportedEdge {
+    if e.relation.is_symmetric() && e.target < e.source {
+        std::mem::swap(&mut e.source, &mut e.target);
+    }
+    e
 }
 
 /// Reconciles two independently added records for one semantic edge key.

--- a/crates/khive-merge/src/merge.rs
+++ b/crates/khive-merge/src/merge.rs
@@ -110,7 +110,7 @@ fn deterministic_timestamp(ours: &KgArchive, theirs: &KgArchive) -> chrono::Date
 /// # Errors
 ///
 /// Returns [`MergeError`] for namespace mismatch, non-finite edge weights,
-/// duplicate entity IDs, duplicate edge IDs or keys, or relation reconstruction.
+/// duplicate entity IDs, or duplicate edge IDs or keys.
 /// See `crates/khive-merge/docs/api/three-way-merge.md` for the full pipeline.
 pub fn three_way_merge(
     base: &KgArchive,

--- a/crates/khive-merge/src/types.rs
+++ b/crates/khive-merge/src/types.rs
@@ -71,6 +71,36 @@ pub enum MergeConflict {
         modified_in: BranchSide,
         deleted_in: BranchSide,
     },
+    /// Both branches changed an edge's durable UUID to different values.
+    EdgeIdentityMismatch {
+        source_id: Uuid,
+        target_id: Uuid,
+        relation: String,
+        ours: Uuid,
+        theirs: Uuid,
+    },
+    /// An edge's identity change collided with another edge's durable UUID
+    /// already claimed in the merged set. If the key's own unmodified base
+    /// UUID is still unclaimed, the edge falls back to it and
+    /// `retained_edge_id` differs from `attempted_edge_id`. Otherwise there
+    /// is no identity left to restore without creating a second duplicate,
+    /// so the edge is dropped from the merged set and `retained_edge_id`
+    /// equals `attempted_edge_id`.
+    EdgeIdentityCollision {
+        source_id: Uuid,
+        target_id: Uuid,
+        relation: String,
+        attempted_edge_id: Uuid,
+        retained_edge_id: Uuid,
+    },
+    /// Both branches changed the same edge-property key differently.
+    EdgePropertyMismatch {
+        source_id: Uuid,
+        target_id: Uuid,
+        relation: String,
+        ours: Option<serde_json::Value>,
+        theirs: Option<serde_json::Value>,
+    },
     /// An edge references a missing entity (dangling reference).
     DanglingEdge {
         source_id: Uuid,

--- a/crates/khive-merge/tests/three_way_merge.rs
+++ b/crates/khive-merge/tests/three_way_merge.rs
@@ -790,6 +790,143 @@ fn merge_preserves_weight_modified_edge_id() {
     }
 }
 
+#[test]
+fn auto_preserves_one_sided_property_only_edge_with_provenance() {
+    let a = Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap();
+    let b = Uuid::parse_str("22222222-2222-2222-2222-222222222222").unwrap();
+    let entities = vec![entity(a, "A"), entity(b, "B")];
+    let mut base_edge = edge_weighted(a, b, 0.7);
+    base_edge.created_at = chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    base_edge.updated_at = chrono::DateTime::parse_from_rfc3339("2026-01-02T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    let mut ours_edge = base_edge.clone();
+    ours_edge.properties = Some(serde_json::json!({"confidence": 0.95}));
+    ours_edge.created_at = chrono::DateTime::parse_from_rfc3339("2026-03-03T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    ours_edge.updated_at = chrono::DateTime::parse_from_rfc3339("2026-04-04T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+
+    let base = archive_full(entities.clone(), vec![base_edge.clone()]);
+    let ours = archive_full(entities.clone(), vec![ours_edge.clone()]);
+    let theirs = archive_full(entities, vec![base_edge]);
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap();
+
+    match result {
+        MergeResult::Clean { merged } => {
+            assert_eq!(merged.edges.len(), 1);
+            assert_eq!(merged.edges[0].edge_id, ours_edge.edge_id);
+            assert_eq!(merged.edges[0].properties, ours_edge.properties);
+            assert_eq!(merged.edges[0].created_at, ours_edge.created_at);
+            assert_eq!(merged.edges[0].updated_at, ours_edge.updated_at);
+        }
+        MergeResult::Conflicts { conflicts } => {
+            panic!("one-sided property change must merge cleanly: {conflicts:?}")
+        }
+    }
+}
+
+fn divergent_property_archives() -> (KgArchive, KgArchive, KgArchive) {
+    let a = Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap();
+    let b = Uuid::parse_str("22222222-2222-2222-2222-222222222222").unwrap();
+    let entities = vec![entity(a, "A"), entity(b, "B")];
+    let mut base_edge = edge_weighted(a, b, 0.7);
+    base_edge.properties = Some(serde_json::json!({"confidence": 0.5}));
+    let mut ours_edge = base_edge.clone();
+    ours_edge.properties = Some(serde_json::json!({"confidence": 0.8}));
+    ours_edge.created_at = chrono::DateTime::parse_from_rfc3339("2026-05-05T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    ours_edge.updated_at = chrono::DateTime::parse_from_rfc3339("2026-06-06T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    let mut theirs_edge = base_edge.clone();
+    theirs_edge.properties = Some(serde_json::json!({"confidence": 0.9}));
+    theirs_edge.created_at = chrono::DateTime::parse_from_rfc3339("2026-07-07T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    theirs_edge.updated_at = chrono::DateTime::parse_from_rfc3339("2026-08-08T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+
+    (
+        archive_full(entities.clone(), vec![base_edge]),
+        archive_full(entities.clone(), vec![ours_edge]),
+        archive_full(entities, vec![theirs_edge]),
+    )
+}
+
+#[test]
+fn auto_reports_divergent_edge_property_changes() {
+    let (base, ours, theirs) = divergent_property_archives();
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap();
+
+    assert!(matches!(
+        result,
+        MergeResult::Conflicts { ref conflicts }
+            if conflicts.iter().any(|conflict| matches!(
+                conflict,
+                MergeConflict::EdgePropertyMismatch { .. }
+            ))
+    ));
+}
+
+#[test]
+fn ours_strategy_resolves_divergent_edge_properties_to_ours() {
+    let (base, ours, theirs) = divergent_property_archives();
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Ours).unwrap();
+
+    match result {
+        MergeResult::Clean { merged } => {
+            assert_eq!(
+                merged.edges[0].properties,
+                Some(serde_json::json!({"confidence": 0.8}))
+            );
+            assert_eq!(
+                merged.edges[0].created_at.to_rfc3339(),
+                "2026-05-05T00:00:00+00:00"
+            );
+            assert_eq!(
+                merged.edges[0].updated_at.to_rfc3339(),
+                "2026-06-06T00:00:00+00:00"
+            );
+        }
+        MergeResult::Conflicts { conflicts } => {
+            panic!("ours strategy must resolve the property conflict: {conflicts:?}")
+        }
+    }
+}
+
+#[test]
+fn theirs_strategy_resolves_divergent_edge_properties_to_theirs() {
+    let (base, ours, theirs) = divergent_property_archives();
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Theirs).unwrap();
+
+    match result {
+        MergeResult::Clean { merged } => {
+            assert_eq!(
+                merged.edges[0].properties,
+                Some(serde_json::json!({"confidence": 0.9}))
+            );
+            assert_eq!(
+                merged.edges[0].created_at.to_rfc3339(),
+                "2026-07-07T00:00:00+00:00"
+            );
+            assert_eq!(
+                merged.edges[0].updated_at.to_rfc3339(),
+                "2026-08-08T00:00:00+00:00"
+            );
+        }
+        MergeResult::Conflicts { conflicts } => {
+            panic!("theirs strategy must resolve the property conflict: {conflicts:?}")
+        }
+    }
+}
+
 // ── Strategy tests ──────────────────────────────────────────────────────────
 
 #[test]
@@ -927,7 +1064,7 @@ fn diff_added_edge() {
 }
 
 #[test]
-fn diff_weight_modified_edge() {
+fn diff_weight_change_is_modified_edge() {
     use khive_merge::diff_local::{diff_edges, EdgeChange, EdgeKey};
     let a = Uuid::new_v4();
     let b = Uuid::new_v4();
@@ -939,7 +1076,7 @@ fn diff_weight_modified_edge() {
         target: b,
         relation: "extends".into(),
     };
-    assert!(matches!(diff[&key], EdgeChange::WeightModified { .. }));
+    assert!(matches!(diff[&key], EdgeChange::Modified { .. }));
 }
 
 // ── #454: entity_type must participate in diff and merge ───────────────────

--- a/crates/khive-merge/tests/three_way_merge.rs
+++ b/crates/khive-merge/tests/three_way_merge.rs
@@ -1274,6 +1274,57 @@ fn rejects_swapped_symmetric_duplicate_edges_in_archive() {
     }
 }
 
+#[test]
+fn modified_symmetric_edge_is_emitted_with_canonical_endpoints() {
+    let (lo, hi) = {
+        let x = Uuid::new_v4();
+        let y = Uuid::new_v4();
+        if x < y {
+            (x, y)
+        } else {
+            (y, x)
+        }
+    };
+
+    let base_edge = ExportedEdge {
+        edge_id: Uuid::new_v4(),
+        source: lo,
+        target: hi,
+        relation: EdgeRelation::CompetesWith,
+        weight: 0.5,
+        properties: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    };
+    // Theirs modifies the weight and carries the endpoints reversed; the
+    // semantic key matches base, so this is a modification, not an add.
+    let mut theirs_edge = base_edge.clone();
+    theirs_edge.source = hi;
+    theirs_edge.target = lo;
+    theirs_edge.weight = 0.9;
+
+    let entities = vec![entity(lo, "A"), entity(hi, "B")];
+    let base = archive_full(entities.clone(), vec![base_edge.clone()]);
+    let ours = archive_full(entities.clone(), vec![base_edge]);
+    let theirs = archive_full(entities, vec![theirs_edge]);
+
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap();
+    if let MergeResult::Clean { merged } = result {
+        assert_eq!(merged.edges.len(), 1);
+        assert_eq!(merged.edges[0].weight, 0.9);
+        assert_eq!(
+            merged.edges[0].source, lo,
+            "canonical source must be min(source, target)"
+        );
+        assert_eq!(
+            merged.edges[0].target, hi,
+            "canonical target must be max(source, target)"
+        );
+    } else {
+        panic!("expected Clean, got: {result:?}");
+    }
+}
+
 // ── #456: shortcut strategies must not report dangling edges as Clean ──────
 
 #[test]


### PR DESCRIPTION
Second half of #2070, stacked on the portability-core change that extends the `ExportedEdge` wire shape. Retarget to `main` after the base merges.

- The semantic edge merge carries `properties` and provenance timestamps across added, modified, and reconciled edges instead of minting defaults at reconstruction time.
- Chained identity collisions are recorded and dropped rather than silently duplicating an earlier edge's durable id, with the regression test pinning exact surviving edges and conflict fields.
- Conflict and error taxonomy docs cover the new merge outcomes.

## Testing

- khive-merge (workspace-excluded): `cargo check`/`clippy --all-targets --locked -- -D warnings` clean, `cargo fmt --check` clean, 98 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)