### PR TITLE
docs(adr): ADR-167 service provenance, classification criteria, kind migration

### DIFF
--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -747,6 +747,9 @@ pub const BASE_ENTITY_ENDPOINT_RULES: &[(&str, EdgeRelation, &str)] = &[
     ("concept", EdgeRelation::IntroducedBy, "document"),
     ("concept", EdgeRelation::IntroducedBy, "person"),
     ("artifact", EdgeRelation::IntroducedBy, "document"),
+    // ADR-002 amendment (ADR-167): service provenance — the document that
+    // introduced a service (its ADR or design record).
+    ("service", EdgeRelation::IntroducedBy, "document"),
     ("document", EdgeRelation::IntroducedBy, "person"),
     ("document", EdgeRelation::IntroducedBy, "org"),
     ("concept", EdgeRelation::IntroducedBy, "org"),

--- a/docs/adr/ADR-001-entity-kind-taxonomy.md
+++ b/docs/adr/ADR-001-entity-kind-taxonomy.md
@@ -3,6 +3,11 @@
 **Status**: accepted\
 **Date**: 2026-05-22\
 **Authors**: khive maintainers
+**Amended 2026-08-21 ([ADR-167](ADR-167-service-provenance-and-kind-classification.md))**:
+step 5 of the classification decision tree gains a record-observable service/concept
+sub-procedure with a mandatory split for records naming both a technique and a deployment
+of it, and step 9 gains a question-note requirement for records carrying deployment
+vocabulary without an instance identifier. See "Service/concept tie-break" below.
 
 ## Context
 
@@ -204,8 +209,10 @@ that accept a `kind` parameter.
 4. Is it a curated collection of examples/records for training, evaluation, or benchmarking?
    → Dataset
 
-5. Is it a running operational instance with endpoint, health, deployment state, or latency?
-   → Service
+5. Does the record identify a specific deployed or deployable instance (see the
+   service/concept tie-break below)?
+   → Service — or a mandatory two-record split when the record also names the
+     technique the instance embodies
 
 6. Is it a codebase, library, framework, tool, application, or repository?
    → Project
@@ -218,8 +225,44 @@ that accept a `kind` parameter.
    → Concept
 
 9. If still uncertain:
-   → Concept (with entity_type if known)
+   → Concept (with entity_type if known); if the record mentions deployment
+     vocabulary without an instance identifier, also record the open
+     classification question as a note annotating the record
 ```
+
+### Service/concept tie-break (2026-08-21 amendment, [ADR-167](ADR-167-service-provenance-and-kind-classification.md))
+
+Step 5 is evaluated as a sub-procedure over two predicates, each decidable from the record
+being written — its name, description, `entity_type`, and properties — with no reference to
+the writer's state of mind or to the world at write time:
+
+- **Instance evidence (D)**: the record identifies a specific deployed or deployable
+  instance — its fields name at least one instance identifier: an endpoint or address, a
+  deployment surface (host, region, cluster), an operator, or an operational state or state
+  history. Whether the instance is up at write time is not consulted: a deployable system
+  between deployments still satisfies D when the record names the deployment. Fields that
+  identify only a codebase (repository, package, crate, source language) are step 6
+  evidence, not instance identifiers — a record carrying only codebase identity does not
+  satisfy D and continues to step 6, where it classifies `Project`.
+- **Technique identity (T)** — evaluated only when D holds: the record's name or
+  description also denotes the technique, method, pattern, or named result the instance
+  embodies, as distinct from the instance itself.
+
+The sub-procedure:
+
+1. If D does not hold, step 5 does not fire; continue to step 6. A pure technique reaches
+   step 8 and classifies `Concept` exactly as before this amendment.
+2. If D holds and T does not, classify `Service`.
+3. If D and T both hold, **the split is mandatory**: create two records, a `Concept`
+   naming the technique and a `Service` naming the deployment, joined by
+   `Service instance_of Concept`. Classifying the single record as either kind alone is
+   out of contract; the record naming two things is the evidence that there are two things.
+
+The three arms are mutually exclusive by construction (they partition on D, then on T), so
+first-match ordering cannot mask an arm. Step 9's uncertainty default is unchanged; the
+amendment adds only the question-note requirement stated in the tree, whose trigger — the
+record mentions deployment vocabulary but carries no instance identifier — is likewise read
+off the record itself, so the classification stays revisitable instead of silently settled.
 
 ### Signal table
 

--- a/docs/adr/ADR-001-entity-kind-taxonomy.md
+++ b/docs/adr/ADR-001-entity-kind-taxonomy.md
@@ -244,9 +244,13 @@ the writer's state of mind or to the world at write time:
   identify only a codebase (repository, package, crate, source language) are step 6
   evidence, not instance identifiers — a record carrying only codebase identity does not
   satisfy D and continues to step 6, where it classifies `Project`.
-- **Technique identity (T)** — evaluated only when D holds: the record's name or
-  description also denotes the technique, method, pattern, or named result the instance
-  embodies, as distinct from the instance itself.
+- **Technique identity (T)** — evaluated only when D holds: the record's own text names a
+  technique as its referent. T holds exactly when the record's `entity_type` is a
+  technique-designating `Concept` subtype (`algorithm`, `technique`, `method`, `pattern`,
+  `architecture`, `model`), or its name or description names the referent with one of those
+  designators (the designating word is present in the record's text). T is a
+  vocabulary-presence test on the record's own fields — the same instrument as step 9's
+  question-note trigger — never an inference about what the prose "really" means.
 
 The sub-procedure:
 
@@ -304,6 +308,9 @@ artifact is generated state — its identity is the process that produced it.
 ## Edge endpoint rules for new kinds
 
 The following `(source, relation, target)` triples are allowed for `Artifact` and `Service`.
+These tables are a summary for classification writers;
+[ADR-002](ADR-002-edge-ontology.md)'s base endpoint contract is the endpoint authority, and on
+any disagreement ADR-002 governs.
 
 ### Artifact
 
@@ -328,19 +335,21 @@ is for "this checkpoint is an instance of this architecture."
 
 ### Service
 
-| Source    | Relation      | Target     | Meaning                                    |
-| --------- | ------------- | ---------- | ------------------------------------------ |
-| `Service` | `instance_of` | `Project`  | deployed/running instance of this codebase |
-| `Service` | `depends_on`  | `Project`  | runtime dependency on code/library         |
-| `Service` | `depends_on`  | `Service`  | service-to-service dependency              |
-| `Service` | `depends_on`  | `Artifact` | uses checkpoint, index, config, state      |
-| `Service` | `depends_on`  | `Dataset`  | uses raw data at runtime                   |
-| `Service` | `implements`  | `Concept`  | realizes an algorithm/protocol             |
-| `Service` | `enables`     | `Concept`  | makes a technique/workflow possible        |
-| `Service` | `precedes`    | `Service`  | earlier deployment/version                 |
-| `Service` | `supersedes`  | `Service`  | replacement service                        |
-| `Org`     | `contains`    | `Service`  | organization operates this service         |
-| `Note`    | `annotates`   | `Service`  | notes can annotate services                |
+| Source    | Relation        | Target     | Meaning                                                      |
+| --------- | --------------- | ---------- | ------------------------------------------------------------ |
+| `Service` | `instance_of`   | `Project`  | deployed/running instance of this codebase                   |
+| `Service` | `instance_of`   | `Concept`  | deployment of a technique (the amended step 5 split outcome) |
+| `Service` | `introduced_by` | `Document` | first described in a paper/spec (2026-08-21 amendment)       |
+| `Service` | `depends_on`    | `Project`  | runtime dependency on code/library                           |
+| `Service` | `depends_on`    | `Service`  | service-to-service dependency                                |
+| `Service` | `depends_on`    | `Artifact` | uses checkpoint, index, config, state                        |
+| `Service` | `depends_on`    | `Dataset`  | uses raw data at runtime                                     |
+| `Service` | `implements`    | `Concept`  | realizes an algorithm/protocol                               |
+| `Service` | `enables`       | `Concept`  | makes a technique/workflow possible                          |
+| `Service` | `precedes`      | `Service`  | earlier deployment/version                                   |
+| `Service` | `supersedes`    | `Service`  | replacement service                                          |
+| `Org`     | `contains`      | `Service`  | organization operates this service                           |
+| `Note`    | `annotates`     | `Service`  | notes can annotate services                                  |
 
 `Service -[instance_of]-> Project` is for "deployed from" semantics.
 `Service -[depends_on]-> Project` is for "requires at runtime."

--- a/docs/adr/ADR-001-entity-kind-taxonomy.md
+++ b/docs/adr/ADR-001-entity-kind-taxonomy.md
@@ -245,12 +245,14 @@ the writer's state of mind or to the world at write time:
   evidence, not instance identifiers — a record carrying only codebase identity does not
   satisfy D and continues to step 6, where it classifies `Project`.
 - **Technique identity (T)** — evaluated only when D holds: the record's own text names a
-  technique as its referent. T holds exactly when the record's `entity_type` is a
-  technique-designating `Concept` subtype (`algorithm`, `technique`, `method`, `pattern`,
-  `architecture`, `model`), or its name or description names the referent with one of those
-  designators (the designating word is present in the record's text). T is a
-  vocabulary-presence test on the record's own fields — the same instrument as step 9's
-  question-note trigger — never an inference about what the prose "really" means.
+  technique as its referent. T holds exactly when the record's `entity_type` is one of
+  `Concept`'s canonical subtypes (the "Initial canonical subtypes" table above), or its name or
+  description names the referent with one of step 8's own designators (`idea`, `method`,
+  `algorithm`, `theory`, `architecture`, `research gap`, `metric`) or with a `Concept`
+  canonical-subtype name — the designating word present in the record's text. Both arms
+  reuse vocabulary this ADR already owns; no new designator list is minted. T is a vocabulary-presence test on the record's own
+  fields — the same instrument as step 9's question-note trigger — never an inference about
+  what the prose "really" means.
 
 The sub-procedure:
 

--- a/docs/adr/ADR-001-entity-kind-taxonomy.md
+++ b/docs/adr/ADR-001-entity-kind-taxonomy.md
@@ -237,13 +237,19 @@ being written — its name, description, `entity_type`, and properties — with 
 the writer's state of mind or to the world at write time:
 
 - **Instance evidence (D)**: the record identifies a specific deployed or deployable
-  instance — its fields name at least one instance identifier: an endpoint or address, a
-  deployment surface (host, region, cluster), an operator, or an operational state or state
-  history. Whether the instance is up at write time is not consulted: a deployable system
-  between deployments still satisfies D when the record names the deployment. Fields that
-  identify only a codebase (repository, package, crate, source language) are step 6
-  evidence, not instance identifiers — a record carrying only codebase identity does not
-  satisfy D and continues to step 6, where it classifies `Project`.
+  instance — its fields name at least one instance identifier, each a concrete referent
+  stated in the record: an endpoint or address; a named deployment surface (a specific
+  host, region, or cluster); a named operator; or an operational state or state history
+  carried in the record's property fields (a status property, an incident record, a dated
+  transition). Bare deployment or liveness vocabulary in name or description prose —
+  `deployed`, `running`, `live`, `in production`, `down` and the like, with no concrete
+  referent beside it — is not an instance identifier and does not satisfy D; that is
+  exactly the question-note trigger's case below. Whether the instance is up at write
+  time is not consulted: a deployable system between deployments still satisfies D when
+  the record names such an identifier. Fields that identify only a codebase (repository,
+  package, crate, source language) are step 6 evidence, not instance identifiers — a
+  record carrying only codebase identity does not satisfy D and continues to step 6,
+  where it classifies `Project`.
 - **Technique identity (T)** — evaluated only when D holds: the record's own text names a
   technique as its referent. T holds exactly when the record's `entity_type` is one of
   `Concept`'s canonical subtypes (the "Initial canonical subtypes" table above), or its name or

--- a/docs/adr/ADR-001-entity-kind-taxonomy.md
+++ b/docs/adr/ADR-001-entity-kind-taxonomy.md
@@ -278,16 +278,16 @@ off the record itself, so the classification stays revisitable instead of silent
 
 ### Signal table
 
-| Kind         | Strong positive signals                                               | Do NOT use when                                              |
-| ------------ | --------------------------------------------------------------------- | ------------------------------------------------------------ |
-| **Concept**  | abstract idea, method, theory, algorithm, architecture, gap, metric   | concrete document, dataset, codebase, service, or gen. state |
-| **Document** | title, authors, DOI, arXiv, publication venue, spec, report           | generated state or raw dataset                               |
-| **Dataset**  | examples, records, benchmark, corpus, train/eval/test split           | vectorized/generated index or checkpoint                     |
-| **Project**  | repo, package, crate, library, framework, source code, language       | running endpoint or deployed instance                        |
-| **Artifact** | generated, checkpointed, exported, content-addressed, version lineage | curated example collection or authored document              |
-| **Service**  | endpoint, health, latency, deployment, live process, backend          | source code project or static artifact                       |
-| **Person**   | individual human                                                      | author role without standalone entity                        |
-| **Org**      | lab, company, university, institution, consortium                     | project team used only as metadata                           |
+| Kind         | Strong positive signals                                                                 | Do NOT use when                                                        |
+| ------------ | --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| **Concept**  | abstract idea, method, theory, algorithm, architecture, gap, metric                     | concrete document, dataset, codebase, service, or gen. state           |
+| **Document** | title, authors, DOI, arXiv, publication venue, spec, report                             | generated state or raw dataset                                         |
+| **Dataset**  | examples, records, benchmark, corpus, train/eval/test split                             | vectorized/generated index or checkpoint                               |
+| **Project**  | repo, package, crate, library, framework, source code, language                         | running endpoint or deployed instance                                  |
+| **Artifact** | generated, checkpointed, exported, content-addressed, version lineage                   | curated example collection or authored document                        |
+| **Service**  | named endpoint/address; named host/region/cluster/operator; health/status in properties | source code project or static artifact; bare deployment/liveness words |
+| **Person**   | individual human                                                                        | author role without standalone entity                                  |
+| **Org**      | lab, company, university, institution, consortium                                       | project team used only as metadata                                     |
 
 ### Key distinctions
 

--- a/docs/adr/ADR-002-edge-ontology.md
+++ b/docs/adr/ADR-002-edge-ontology.md
@@ -63,12 +63,12 @@ classification ambiguity.
 
 ### Category 2: Derivation (intellectual lineage)
 
-| Relation        | Direction                                               | When                                                                                       |
-| --------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| `extends`       | child → parent                                          | Builds on, generalizes (FlashAttention-2 → FlashAttention)                                 |
-| `variant_of`    | variant → original                                      | Modified version (QLoRA → LoRA)                                                            |
-| `introduced_by` | concept/document/artifact/service → document/person/org | First described in (LoRA → Hu et al. 2021); document authorship (paper → author/publisher) |
-| `supersedes`    | new → old                                               | Replaces entirely; old stops being authoritative                                           |
+| Relation        | Direction                                                                           | When                                                                                       |
+| --------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `extends`       | child → parent                                                                      | Builds on, generalizes (FlashAttention-2 → FlashAttention)                                 |
+| `variant_of`    | variant → original                                                                  | Modified version (QLoRA → LoRA)                                                            |
+| `introduced_by` | concept → document/person/org · document → person/org · artifact/service → document | First described in (LoRA → Hu et al. 2021); document authorship (paper → author/publisher) |
+| `supersedes`    | new → old                                                                           | Replaces entirely; old stops being authoritative                                           |
 
 ### Category 3: Provenance (material/generative source lineage)
 

--- a/docs/adr/ADR-002-edge-ontology.md
+++ b/docs/adr/ADR-002-edge-ontology.md
@@ -23,6 +23,10 @@ carry a relation-specific payload atomically with the delete, as specified in "C
 with a per-relation coherence classification for curation), records the existing self-loop
 rejection, and states the delete-then-relink direction rule. See "Reciprocal pairs,
 self-loops, and repricing" below. Motivated by issue #1667.
+**Amended 2026-08-21 ([ADR-167](ADR-167-service-provenance-and-kind-classification.md))**:
+base endpoint contract gains one derivation pair — `Service introduced_by Document` — so a
+service can record the specification, ADR, or paper that introduced it. See "Base endpoint
+contract" below.
 
 ## Context
 
@@ -59,12 +63,12 @@ classification ambiguity.
 
 ### Category 2: Derivation (intellectual lineage)
 
-| Relation        | Direction                              | When                                                                                       |
-| --------------- | -------------------------------------- | ------------------------------------------------------------------------------------------ |
-| `extends`       | child → parent                         | Builds on, generalizes (FlashAttention-2 → FlashAttention)                                 |
-| `variant_of`    | variant → original                     | Modified version (QLoRA → LoRA)                                                            |
-| `introduced_by` | concept/document → document/person/org | First described in (LoRA → Hu et al. 2021); document authorship (paper → author/publisher) |
-| `supersedes`    | new → old                              | Replaces entirely; old stops being authoritative                                           |
+| Relation        | Direction                                               | When                                                                                       |
+| --------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `extends`       | child → parent                                          | Builds on, generalizes (FlashAttention-2 → FlashAttention)                                 |
+| `variant_of`    | variant → original                                      | Modified version (QLoRA → LoRA)                                                            |
+| `introduced_by` | concept/document/artifact/service → document/person/org | First described in (LoRA → Hu et al. 2021); document authorship (paper → author/publisher) |
+| `supersedes`    | new → old                                               | Replaces entirely; old stops being authoritative                                           |
 
 ### Category 3: Provenance (material/generative source lineage)
 
@@ -399,6 +403,7 @@ allowlist but cannot remove base rules.
 | `Document` | `introduced_by` | `Person`   |
 | `Document` | `introduced_by` | `Org`      |
 | `Concept`  | `introduced_by` | `Org`      |
+| `Service`  | `introduced_by` | `Document` |
 | `Concept`  | `supersedes`    | `Concept`  |
 | `Document` | `supersedes`    | `Document` |
 | `Artifact` | `supersedes`    | `Artifact` |
@@ -411,6 +416,15 @@ allowlist but cannot remove base rules.
 > or published it) or for a _concept originating from an org_ rather than a paper or person
 > (e.g. an architecture originated by a company). Direction is unchanged: source is the thing
 > whose origin is being recorded, target is the origin.
+
+> **Amended 2026-08-21 ([ADR-167](ADR-167-service-provenance-and-kind-classification.md))**:
+> added `Service introduced_by Document`. A service could supersede another service and be
+> contained by an org, but could not point at the specification or paper that introduced it;
+> its origin was being recorded as prose in notes, invisible to lineage traversal. This is
+> deliberately one pair: the measured refusals concern a service recording its own origin,
+> and the wider forms (`Service introduced_by Person`/`Org`, any `derived_from` pair
+> involving a service) were considered and rejected for lack of evidence. Direction is
+> unchanged: source is the thing whose origin is being recorded, target is the origin.
 
 #### Provenance relation
 

--- a/docs/adr/ADR-167-service-provenance-and-kind-classification.md
+++ b/docs/adr/ADR-167-service-provenance-and-kind-classification.md
@@ -127,8 +127,11 @@ reference to the writer's state of mind or to the world at write time:
   Liveness at write time is not consulted, so a deployable system between deployments still
   satisfies D. Codebase identifiers (repository, package, crate, source language) are
   explicitly step 6 evidence, not instance identifiers.
-- **Technique identity (T)**, evaluated only when D holds: the record's name or description
-  also denotes the technique the instance embodies, as distinct from the instance itself.
+- **Technique identity (T)**, evaluated only when D holds: the record's own text names a
+  technique as its referent — its `entity_type` is a technique-designating `Concept` subtype
+  (`algorithm`, `technique`, `method`, `pattern`, `architecture`, `model`), or its name or
+  description names the referent with one of those designators. A vocabulary-presence test
+  on the record's fields, not an inference about the prose.
 
 The arms partition on D, then on T, so they are mutually exclusive by construction: D absent →
 step 5 does not fire and the walk continues to step 6 (a codebase classifies `Project`, a pure
@@ -144,8 +147,9 @@ split arm required two earlier arms to hold simultaneously — unreachable under
 and whose predicates ("meaningful to say", "when deployed would have", "the writer cannot state
 which") were not decidable from the record; its broad liveness arm could also claim a static
 codebase that ADR-001 step 6 assigns to `Project`. The partition form above closes all three
-defects: no arm can be masked by ordering, every predicate is a field-presence test on the
-record, and codebase identity is routed to step 6 before `Service` can be reached.
+defects: no arm can be masked by ordering, every predicate is a presence test on the record's
+own fields and vocabulary, and codebase identity is routed to step 6 before `Service` can be
+reached.
 
 ### 3. Kind migration: keep delete-and-recreate, and require a re-anchor plan
 
@@ -260,19 +264,33 @@ this ADR is complete when all of the following hold:
 - ADR-001 itself carries the amendment in this PR's diff: its decision tree's step 5 names the
   instance-evidence test and its §"Service/concept tie-break" states the D/T partition. A test
   reading ADR-001 finds the operative text; ADR-167 records the decision and rationale.
-- Each arm has a worked fixture stated as record fields and an expected stored outcome:
-  - D without T → `Service`: a record whose properties name an endpoint and an operator, whose
-    description names no technique, and whose deployment is currently down (no liveness field
-    consulted) classifies `Service`.
-  - D absent, codebase identity → `Project` via step 6: a record naming only a repository and
-    source language classifies `Project`, never `Service`.
-  - D absent, technique identity → `Concept` via step 8: a record describing a method with no
-    instance identifier classifies `Concept`.
-  - D with T → split: a record whose name denotes a technique and whose properties name an
-    endpoint yields two records joined by `Service instance_of Concept`; classifying it as a
-    single record of either kind is rejected by the written rule.
-  - Step 9 note: a record whose description mentions deployment vocabulary but carries no
-    instance identifier lands `Concept` with a question note annotating the record.
+- Each arm has a worked fixture stated as exact record fields, with the tree preconditions
+  explicit (every fixture is not a person, org, document, or dataset, so steps 1-4 are false
+  by construction), and an expected stored outcome decidable from the written rule alone:
+  - D without T → `Service`: name `retrieval-gateway-prod`, description `the deployment
+    serving vector retrieval; currently down between deployments`, properties
+    `{endpoint: "https://retrieval.example/api", operator: "platform"}`, no `entity_type`.
+    D holds (endpoint, operator); T does not (no technique designator in any field).
+    Classifies `Service`; liveness is not consulted.
+  - D absent, codebase identity → `Project` via step 6: name `retrieval-gateway`,
+    description `Rust codebase for the retrieval gateway`, properties
+    `{repository: "https://example.com/r/gateway", language: "rust"}`. No instance
+    identifier, so step 5 does not fire; step 6 matches the repository field. Classifies
+    `Project`, never `Service`.
+  - D absent, technique identity → `Concept` via step 8: name `HNSW`, description
+    `graph-based approximate nearest neighbour search algorithm`, no instance identifier.
+    Step 5 does not fire; step 8 classifies `Concept`.
+  - D with T → split: name `Vamana index service`, description `deployment of the Vamana
+    graph-index algorithm`, properties `{endpoint: "https://ann.example/v1"}`. D holds
+    (endpoint); T holds (`algorithm` designator). The split is mandatory: two records
+    joined by `Service instance_of Concept`; classifying it as a single record of either
+    kind is rejected by the written rule.
+  - Step 9 note: name `experimental serving stack`, description `deployed somewhere in the
+    lab, details unrecorded` — deployment vocabulary (`deployed`) present, no instance
+    identifier, no codebase field (step 6 false), no technique designator (step 8's
+    abstract-idea test unresolved), steps 1-8 thereby exhausted without resolving. Lands
+    `Concept` per step 9, with the open classification question recorded as a note
+    annotating the record.
 
 **Migration procedure (Decision 3).**
 
@@ -280,16 +298,30 @@ this ADR is complete when all of the following hold:
   pages, stable page order) is owned by the tests of the change that closed #2088 and is not
   re-owned here; this ADR's enumeration criteria assume it and test what the listing surface
   cannot answer.
-- Enumeration, destructive-scope completeness: the fixture holds six incident edges on the
-  migrating record spread across two namespaces, of which one is in a namespace NOT visible
-  to the migrating caller and one is already soft-deleted. A visible/live enumeration (the
-  cursor walk or the listing surface) returns four; the in-transaction purge-predicate
-  enumeration returns all six edge ids exactly once (deduplicated, so a self-loop edge
-  matching on both source and target counts once), and reconciles with `COUNT(*)` = 6 under
-  the same predicate in the same transaction. All six receive dispositions before any plan
-  is prepared — because the purge would delete all six. A migration prepared from the
-  four-row visible/live enumeration must be refused, and the refusal is the asserted
-  outcome, not a warning.
+- Enumeration, destructive-scope completeness: the fixture is this exact matrix of six
+  incident edges on the migrating record R. The caller's visible namespaces are `ns_a` and
+  `ns_b`; `ns_hidden` is not visible to it. The invisible row (e5) and the tombstoned row
+  (e6) are distinct edges, both directions appear in both the included and excluded sets,
+  and e3 is a self-loop matching the purge predicate on both source and target:
+
+  | id | source → target   | namespace   | deleted_at | in visible/live walk | in purge set |
+  | -- | ----------------- | ----------- | ---------- | -------------------- | ------------ |
+  | e1 | R → X1            | `ns_a`      | live       | yes                  | yes          |
+  | e2 | X2 → R            | `ns_a`      | live       | yes                  | yes          |
+  | e3 | R → R (self-loop) | `ns_a`      | live       | yes                  | yes, once    |
+  | e4 | X3 → R            | `ns_b`      | live       | yes                  | yes          |
+  | e5 | R → X4            | `ns_hidden` | live       | no (namespace)       | yes          |
+  | e6 | X5 → R            | `ns_a`      | tombstoned | no (live filter)     | yes          |
+
+  The visible/live enumeration (cursor walk or listing surface) returns exactly
+  {e1, e2, e3, e4}. The in-transaction purge-predicate enumeration returns exactly
+  {e1, e2, e3, e4, e5, e6}, each id once — e3 appears once despite matching both the
+  source and target arms of the predicate (the predicate is evaluated per row, so the one
+  self-loop row matches once) — and reconciles with `COUNT(*)` = 6 under the same predicate
+  in the same transaction, the same count Decision 3 step 1 names. All six rows receive dispositions
+  before any plan is prepared, because the purge would delete all six. A migration
+  prepared from the four-row visible/live enumeration must be refused, and the refusal is
+  the asserted outcome, not a warning.
 - Edge-as-endpoint coverage: the fixture includes an `annotates` edge whose TARGET is itself an
   edge incident to the migrating record; the enumeration finds it, and after migration the
   annotation is re-anchored to the recreated edge's new id (or deleted with a recorded

--- a/docs/adr/ADR-167-service-provenance-and-kind-classification.md
+++ b/docs/adr/ADR-167-service-provenance-and-kind-classification.md
@@ -10,8 +10,9 @@
 
 **Amends**:
 
-- [ADR-002](ADR-002-edge-ontology.md) — add one derivation pair, `Service introduced_by Document`,
-  and record written classification criteria for `service` versus `concept`
+- [ADR-002](ADR-002-edge-ontology.md) — add one derivation pair, `Service introduced_by Document`
+- [ADR-001](ADR-001-entity-kind-taxonomy.md) — add a deterministic tie-break to the
+  classification decision tree for the `service` / `concept` boundary
 
 ## Context
 
@@ -30,11 +31,16 @@ outside that set. The gap does not look deliberate — the 2026-07-08 amendment 
 The practical consequence is that a service's origin gets recorded as an annotation on a note
 instead of as an edge, where it is invisible to lineage traversal.
 
-**2. The service-versus-concept split is undocumented, and as a result it is not reproducible.**
-ADR-002 fixes the relation set and the endpoint contract, but no ADR states what makes something
-a `service` rather than a `concept`. The two kinds have materially different endpoint contracts,
-so the choice at creation time silently decides what edges the record will ever be allowed to
-carry. Made without written criteria, that choice is made on the name.
+**2. The service-versus-concept split is under-determined at exactly the boundary that matters.**
+[ADR-001](ADR-001-entity-kind-taxonomy.md) §"Agent Classification Heuristics" already provides an
+ordered decision tree (a running operational instance resolves to `Service` at step 5 before an
+abstract idea resolves to `Concept` at step 8) and a signal table for each kind. What it does not
+resolve is the case the store actually mishandled: a deployable system that is not currently
+running, where "running operational instance" reads false and the record falls through to
+`Concept` even though its endpoint needs are `Service`-shaped. The two kinds have materially
+different endpoint contracts, so that fall-through silently decides what edges the record will
+ever be allowed to carry. The gap is a missing tie-break rule inside ADR-001's existing
+procedure, not a missing procedure.
 
 **3. Kind is immutable, so a misclassification is only correctable by delete-and-recreate, and
 that path destroys edges under the only deletion mode that can actually free the record.**
@@ -56,11 +62,17 @@ What remains open is exhaustive ENUMERATION, which is a different question from 
 matches. Issue #2088 records that the multi-namespace visibility path fetches each namespace's rows
 ordered by `created_at`, re-sorts the union by UUID, and then slices `[offset, offset+limit)`: the
 window floats as the prefix grows, so successive pages both duplicate and skip rows, and a paged
-walk terminates having seen a fraction of the population while reporting nothing wrong. A procedure
-that can lose edges must not rest its completeness on offset paging while that holds. The
-enumeration below is therefore specified from the source side, which is unaffected either way, and
-stays that way after the paging fix lands — a deletion procedure earns nothing by depending on the
-more fragile of two available reads.
+walk terminates having seen a fraction of the population while reporting nothing wrong. That defect
+is not confined to inbound reads: `source_id` and `target_id` are filter predicates on the same
+listing path (`build_edge_filter_sql` in `crates/khive-db/src/stores/graph.rs`), so a source-filtered
+walk pages through the same floating window. No direction of offset-paged enumeration is safe while
+the defect stands, and a procedure that can lose edges must not rest its completeness on offset
+paging in either direction. The runtime already carries the sound primitive: `list_edges_after`
+(`crates/khive-runtime/src/operations.rs`) walks the durable insertion-sequence ledger with an
+explicit cursor, merges every visible namespace at one sequence boundary, and fails loudly on a
+hard-deleted or out-of-scope cursor instead of hiding an incomplete traversal. The enumeration
+contract in Decision 3 is therefore stated against that cursor walk (or a transaction-scoped direct
+query executed inside the migration's own transaction), never against offset paging.
 
 ## Decision
 
@@ -85,28 +97,38 @@ rationale exists to keep narrow.
 The relation set stays at 17. The closed-set property is unaffected; this is one row in the
 endpoint table.
 
-### 2. Write down the classification criteria
+### 2. Amend ADR-001's decision tree with a deterministic service/concept tie-break
 
-Add to ADR-002 a subsection stating the test, so that the decision is made against a written rule
-rather than against a name:
+ADR-001 §"Agent Classification Heuristics" stays the single classification source. This ADR does
+not introduce a parallel set of criteria; it amends step 5 of ADR-001's decision tree so that the
+one under-determined boundary resolves the same way for every writer. The amendment replaces
+step 5's condition with an ordered sub-procedure:
 
-> A record is a `service` when it names **a running or deployable system that has an operator, a
-> deployment surface, and a lifecycle independent of any document describing it** — something
-> that can be up or down. A record is a `concept` when it names **an idea, technique, pattern, or
-> named result** whose existence does not depend on anything running.
+> **5. Evaluate, in order, stopping at the first rule whose condition holds:**
 >
-> Two tests that discriminate where the name does not. **The liveness test**: ask whether it is
-> meaningful to say the thing is currently down. If yes, `service`. **The independence test**:
-> ask whether the thing would still exist if every deployment of it were removed. If yes,
-> `concept`.
+> 5a. It is meaningful to say the thing is currently up or down (it has, or when deployed would
+> have, an endpoint, health state, deployment surface, and an operator) → `Service`. Current
+> downtime does not disqualify: a deployable system between deployments is still a `Service`.
 >
-> Where both tests point the same way, that is the kind. Where they disagree, there are usually
-> two records and not one — a concept naming the technique and a service naming the deployment —
-> and they are joined by `Service instance_of Concept`, which the contract already admits.
+> 5b. The name refers to an idea, technique, pattern, or named result that would still exist if
+> every deployment of it were removed, AND no record-specific deployment is being named →
+> `Concept` (continue to step 8's signals to confirm).
+>
+> 5c. Both 5a and 5b hold — the name is being used for a technique AND for a deployment of it —
+> → **the split is mandatory**: create two records, a `Concept` naming the technique and a
+> `Service` naming the deployment, joined by `Service instance_of Concept`. Classifying the
+> single record either way is out of contract; the disagreement is the evidence that there are
+> two things.
+>
+> 5d. Neither holds cleanly and the writer cannot state which — record it as `Concept` per
+> ADR-001 step 9's uncertainty default, and record the open question as a note annotating the
+> record, so the classification is revisitable instead of silently settled.
 
-The criteria are stated as tests rather than as a category list because the failure mode observed
-is a borderline record being classified on its name, and a list of examples does not help a
-borderline record.
+The rules are ordered, each condition is decidable from the record being written (no "usually",
+no evidence threshold left to taste), and the disagreement case has exactly one outcome. The
+earlier draft of this section stated the liveness and independence tests without an order or a
+mandatory outcome for the disagreement case; two writers could reach different kinds for a
+currently-down deployable system, which is the drift this decision exists to stop.
 
 ### 3. Kind migration: keep delete-and-recreate, and require a re-anchor plan
 
@@ -132,7 +154,13 @@ has two variants and they differ in exactly the way that matters here. `Soft` ma
 leaves the row queryable under an explicit soft-delete filter. `Hard` physically removes the row **and
 cascades incident edges** — `purge_incident_edges_statement` issues
 `DELETE FROM graph_edges WHERE source_id = ?1 OR target_id = ?1`, unconditionally and with no soft
-counterpart, and it runs BEFORE the record's own row is removed.
+counterpart. The statement order inside the atomic plan is: the record's own row delete first (under
+an exactly-one-row guard), lineage-warning statements second, and the incident-edge purge LAST
+(`crates/khive-runtime/src/operations.rs`, `crates/khive-runtime/src/atomic_prepare.rs` — both build
+this order). Nothing in a migration plan may therefore rely on the old record row still existing when
+the purge runs; it is already gone. The order is invisible to callers only because the whole plan
+commits in a single synchronous pass — which is one more reason the atomicity requirement below is
+load-bearing rather than advisory.
 
 Two consequences, and the first is a correction to this ADR's own framing. **The 62-edge figure is a
 HARD-delete figure.** A soft delete destroys no edges at all; it leaves every one of them as a live row
@@ -167,8 +195,13 @@ ADR exists to prevent, so an unclassifiable edge stops the migration rather than
 
 With those settled, a kind correction:
 
-1. Enumerates the record's edges in **both directions** before deleting anything, from the source side,
-   and does not rest completeness on a single inbound filter (see the enumeration note in Context).
+1. Enumerates the record's edges in **both directions and across every namespace visible to the
+   migrating caller** before deleting anything, using the insertion-sequence cursor walk
+   (`list_edges_after`) or a direct query inside the migration's own transaction — never offset
+   paging, in either direction (see the enumeration note in Context). The walk runs to cursor
+   exhaustion, and the collected edge IDs are reconciled against an independently computed count
+   of the record's incident edges; a mismatch stops the migration before any destructive plan is
+   prepared.
 2. Enumerates the notes annotating the record's **edges**, not only those annotating the record itself.
    A recreated edge is a new edge id, so an edge-targeting annotation is orphaned by recreation even
    when the record's own annotations were handled correctly, and a hard delete's cascade removes those
@@ -186,6 +219,49 @@ If kind changes later become common enough that this procedure is being run rout
 evidence that would justify the mechanism, and the count of times it has been run is what should
 open that decision. This ADR does not pre-commit to it.
 
+## Acceptance criteria
+
+Each decision above is accepted by a test that fails against the pre-image. An implementation of
+this ADR is complete when all of the following hold:
+
+**Endpoint pair (Decision 1).**
+
+- `link(source=<service>, relation="introduced_by", target=<document>)` succeeds and the edge
+  reads back.
+- The neighboring pairs this ADR deliberately did not add are still rejected, each with an error
+  naming the valid values: `Service introduced_by Person`, `Service introduced_by Org`,
+  `Document introduced_by Service` (the reverse direction), and `Service derived_from Document`.
+
+**Classification tie-break (Decision 2).**
+
+- The ADR-001 amendment text contains the ordered 5a–5d sub-procedure, and each branch has a
+  worked fixture: a currently-down deployable system classifies `Service` (5a); a technique with
+  no named deployment classifies `Concept` (5b); a name used for both yields two records joined
+  by `Service instance_of Concept`, and classifying it as a single record of either kind is
+  rejected by the written rule (5c); an undecidable record lands `Concept` with an annotating
+  question note (5d).
+
+**Migration procedure (Decision 3).**
+
+- Enumeration: against a fixture population large enough to exercise the paging defect in issue
+  #2088 (rows spread across at least two namespaces, with interleaved creation timestamps and
+  UUID order that disagrees with `created_at` order), the cursor walk returns every incident edge
+  in both directions exactly once, and its result reconciles against the independent count. An
+  offset-paged walk over the same fixture demonstrably misses or duplicates rows — that fixture
+  is what makes this criterion a real discriminator rather than a restatement.
+- Edge-as-endpoint coverage: the fixture includes an `annotates` edge whose TARGET is itself an
+  edge incident to the migrating record; the enumeration finds it, and after migration the
+  annotation is re-anchored to the recreated edge's new id (or deleted with a recorded
+  disposition) — never left pointing at a purged edge id.
+- Disposition gate: a fixture edge with no legal expression under the new kind (for example
+  `Org contains <record>` migrating to `concept`) causes the migration to stop with a REFUSE
+  before any plan is prepared; no row in the store changes.
+- Atomicity and rollback: with the full plan prepared, a forced failure on a late statement (a
+  violated `AffectedRowGuard` on one of the recreations) rolls the whole plan back — the old
+  record row, every incident edge, and every annotating note read back unchanged afterward.
+- Traceability: after a successful migration, the new record's properties carry the old record's
+  id.
+
 ## Consequences
 
 **Positive.** Service origins become traversable lineage rather than prose in a note. The
@@ -195,9 +271,10 @@ number, so the next person deciding whether to build a mechanism has the evidenc
 
 **Negative, stated plainly.** One more endpoint pair is one more row that has to stay consistent
 with the validation code, and the endpoint contract is already the part of ADR-002 that has been
-amended most often. The classification criteria are a test and not a decision procedure: two
-readers can still disagree on a genuinely borderline record, and the ADR's answer in that case is
-that there are probably two records.
+amended most often. The tie-break procedure resolves the disagreement case by mandating a split
+into two records, which costs a second record and an `instance_of` edge in cases where a single
+looser record would have been tolerable; the procedure prefers that cost to unreproducible
+classification.
 
 **Not addressed.** This ADR does not make services reachable as targets of provenance edges in
 general. An earlier framing of this proposal asked for that, and it was withdrawn: the measured
@@ -219,7 +296,7 @@ explicitly about not doing that.
 That is the alternative worth taking seriously, since a `Concept introduced_by Document` pair
 already exists. It was rejected because it inverts the problem: it asks records to be given the
 kind whose endpoint contract is convenient rather than the kind that describes them, which is the
-same failure the classification criteria in this ADR exist to prevent. It would also cost the 62
+same failure the tie-break procedure in this ADR exists to prevent. It would also cost the 62
 edges, since kind is immutable.
 
 ### Why is the classification gap worth an ADR at all?

--- a/docs/adr/ADR-167-service-provenance-and-kind-classification.md
+++ b/docs/adr/ADR-167-service-provenance-and-kind-classification.md
@@ -1,0 +1,173 @@
+# ADR-167: Service Provenance, Service/Concept Classification, and Kind Migration
+
+**Status**: proposed\
+**Date**: 2026-08-20\
+**Authors**: khive maintainers\
+**Depends on**:
+
+- [ADR-002](ADR-002-edge-ontology.md) — the closed 17-relation set and the base endpoint contract
+- [ADR-055](ADR-055-epistemic-edge-relations.md) — same-substrate restriction on `supports` / `refutes`
+
+**Amends**:
+
+- [ADR-002](ADR-002-edge-ontology.md) — add one derivation pair, `Service introduced_by Document`,
+  and record written classification criteria for `service` versus `concept`
+
+## Context
+
+Three findings from operating a production store, stated with what was measured rather than
+inferred. The store holds 19 entities of kind `service`.
+
+**1. A service cannot record where it came from.** The base endpoint contract admits no pair in
+which a `Service` participates in a derivation or provenance relation with a `Document`. A
+service may be contained by an org, be an instance of a project, supersede another service, and
+relate to concepts through `enables` / `implements` / `instance_of`. It cannot point at the
+specification, ADR, or paper that introduced it. Every sibling kind can: `Concept introduced_by
+Document`, `Artifact introduced_by Document`, `Document introduced_by Person`. `Service` is the
+gap in that row, and the gap is not deliberate — the 2026-07-08 amendment that added three
+`introduced_by` pairs was reasoning about documents and orgs and did not consider services.
+
+The practical consequence is that a service's origin gets recorded as an annotation on a note
+instead of as an edge, where it is invisible to lineage traversal.
+
+**2. The service-versus-concept split is undocumented, and as a result it is not reproducible.**
+ADR-002 fixes the relation set and the endpoint contract, but no ADR states what makes something
+a `service` rather than a `concept`. The two kinds have materially different endpoint contracts,
+so the choice at creation time silently decides what edges the record will ever be allowed to
+carry. Made without written criteria, that choice is made on the name.
+
+**3. Kind is immutable, so a misclassification is only correctable by delete-and-recreate, and
+that path destroys edges.** Measured against the 19-service population: 16 carry at least one
+edge and 3 carry none. Delete-and-recreate across the population would destroy **62 edges**, of
+which **42 are `annotates`**. Because `annotates` runs note → entity, each destroyed annotates
+edge leaves a note whose subject no longer exists — the note survives, saying something about
+nothing, which is worse than either deleting it or keeping it attached.
+
+There is a further complication in enumerating that blast radius, filed separately as issue
+#2085: `list(kind="edge", target_id=…)` cannot match an edge whose target is itself an edge, and
+returns an empty result rather than an error. So the affected-edge count for a migration cannot
+be obtained from that filter alone, and an empty result there must not be read as "nothing points
+at this."
+
+## Decision
+
+### 1. Add one derivation pair
+
+Add to the base endpoint contract, Derivation relations:
+
+| Source    | Relation        | Target     |
+| --------- | --------------- | ---------- |
+| `Service` | `introduced_by` | `Document` |
+
+Direction is unchanged from every other `introduced_by` row: the source is the thing whose origin
+is being recorded, the target is the origin.
+
+This is deliberately one pair and not a class of them. The wider forms considered and **rejected
+for lack of evidence** are `Service introduced_by Person`, `Service introduced_by Org`, and any
+`derived_from` pair involving a service. `Org contains Service` already carries organizational
+attribution, and no measured refusal in the store's rejection record asked for the `derived_from`
+forms. Adding pairs that nothing has asked for widens the contract that ADR-002's "why closed"
+rationale exists to keep narrow.
+
+The relation set stays at 17. The closed-set property is unaffected; this is one row in the
+endpoint table.
+
+### 2. Write down the classification criteria
+
+Add to ADR-002 a subsection stating the test, so that the decision is made against a written rule
+rather than against a name:
+
+> A record is a `service` when it names **a running or deployable system that has an operator, a
+> deployment surface, and a lifecycle independent of any document describing it** — something
+> that can be up or down. A record is a `concept` when it names **an idea, technique, pattern, or
+> named result** whose existence does not depend on anything running.
+>
+> Two tests that discriminate where the name does not. **The liveness test**: ask whether it is
+> meaningful to say the thing is currently down. If yes, `service`. **The independence test**:
+> ask whether the thing would still exist if every deployment of it were removed. If yes,
+> `concept`.
+>
+> Where both tests point the same way, that is the kind. Where they disagree, there are usually
+> two records and not one — a concept naming the technique and a service naming the deployment —
+> and they are joined by `Service instance_of Concept`, which the contract already admits.
+
+The criteria are stated as tests rather than as a category list because the failure mode observed
+is a borderline record being classified on its name, and a list of examples does not help a
+borderline record.
+
+### 3. Kind migration: keep delete-and-recreate, and require a re-anchor plan
+
+We propose **not** adding a kind-migration mechanism, and instead requiring that any
+delete-and-recreate carries a written re-anchor plan. The reasoning is priced against the
+measured number rather than asserted.
+
+A migration mechanism would have to re-point every inbound and outbound edge, preserve edge ids
+so that anything referencing an edge stays valid, and preserve `annotates` targets across the
+substrate boundary. That is a substantial amount of runtime surface, and the population it would
+serve is small: kind changes are rare, and the store measured 19 services in total.
+
+Against that, the cost of the status quo is bounded and known — 62 edges across a whole-population
+migration, 42 of them annotations. For a single-record correction the cost is that record's own
+edge count, which is typically small.
+
+So the proposal is a **procedure**, not a mechanism. Any kind correction:
+
+1. Enumerates the record's edges in **both directions** before deleting anything, and does not
+   rely on `list(kind="edge", target_id=…)` alone for the inbound side (issue #2085).
+2. Names, for each `annotates` edge, whether the annotating note is re-anchored to the new record
+   or deleted with it. A note left pointing at a deleted subject is not an acceptable outcome.
+3. Enumerates the notes annotating the record's **edges**, not only those annotating the record
+   itself, and gives each the same re-anchor-or-delete disposition. This population is easy to
+   miss twice over: a re-created edge is a new edge id, so an edge-targeting annotation is
+   orphaned by the recreation in step 4 even though the record itself was handled correctly; and
+   it is exactly the population issue #2085 makes invisible, since the target-side filter returns
+   an empty result rather than an error. Enumerate it from the source side.
+4. Re-creates the edges against the new record and reads them back, since a re-created edge is a
+   new edge id and anything that referenced the old id does not follow.
+5. Records the old record's id in the new record's properties, so the discontinuity is traceable.
+
+If kind changes later become common enough that this procedure is being run routinely, that is the
+evidence that would justify the mechanism, and the count of times it has been run is what should
+open that decision. This ADR does not pre-commit to it.
+
+## Consequences
+
+**Positive.** Service origins become traversable lineage rather than prose in a note. The
+classification decision becomes checkable against a written rule, so a disagreement about a
+record's kind can be resolved rather than argued. The migration cost is written down with its
+number, so the next person deciding whether to build a mechanism has the evidence.
+
+**Negative, stated plainly.** One more endpoint pair is one more row that has to stay consistent
+with the validation code, and the endpoint contract is already the part of ADR-002 that has been
+amended most often. The classification criteria are a test and not a decision procedure: two
+readers can still disagree on a genuinely borderline record, and the ADR's answer in that case is
+that there are probably two records.
+
+**Not addressed.** This ADR does not make services reachable as targets of provenance edges in
+general. An earlier framing of this proposal asked for that, and it was withdrawn: the measured
+refusals concern a service recording its own origin, and the evidence licenses one pair, not a
+class. If a case for the general form appears, it is a separate amendment with its own evidence.
+
+## Rationale
+
+### Why one pair rather than a symmetric provenance class?
+
+Because the refusals that motivated this are asymmetric. What was blocked in practice was a
+service pointing at the document that introduced it. Nothing measured asked for a document to
+point at a service. Adding the reverse direction on the grounds that it looks symmetric would put
+a pair in the contract that no observed use needs, and ADR-002's closed-set rationale is
+explicitly about not doing that.
+
+### Why not fix this by classifying the affected records as concepts instead?
+
+That is the alternative worth taking seriously, since a `Concept introduced_by Document` pair
+already exists. It was rejected because it inverts the problem: it asks records to be given the
+kind whose endpoint contract is convenient rather than the kind that describes them, which is the
+same failure the classification criteria in this ADR exist to prevent. It would also cost the 62
+edges, since kind is immutable.
+
+### Why is the classification gap worth an ADR at all?
+
+Because the endpoint contract makes kind consequential and irreversible in the same stroke. A
+record's kind decides what edges it may ever carry, and it cannot be changed without destroying
+edges. A decision with that shape should be made against a written rule.

--- a/docs/adr/ADR-167-service-provenance-and-kind-classification.md
+++ b/docs/adr/ADR-167-service-provenance-and-kind-classification.md
@@ -22,9 +22,9 @@ inferred. The store holds 19 entities of kind `service`.
 which a `Service` participates in a derivation or provenance relation with a `Document`. A
 service may be contained by an org, be an instance of a project, supersede another service, and
 relate to concepts through `enables` / `implements` / `instance_of`. It cannot point at the
-specification, ADR, or paper that introduced it. Every sibling kind can: `Concept introduced_by
-Document`, `Artifact introduced_by Document`, `Document introduced_by Person`. `Service` is the
-gap in that row, and the gap is not deliberate — the 2026-07-08 amendment that added three
+specification, ADR, or paper that introduced it. The kinds that can are `Concept`, `Artifact` and
+`Document` — those are the only `introduced_by` sources the contract admits, and `Service` sits
+outside that set. The gap does not look deliberate — the 2026-07-08 amendment that added three
 `introduced_by` pairs was reasoning about documents and orgs and did not consider services.
 
 The practical consequence is that a service's origin gets recorded as an annotation on a note
@@ -37,17 +37,23 @@ so the choice at creation time silently decides what edges the record will ever 
 carry. Made without written criteria, that choice is made on the name.
 
 **3. Kind is immutable, so a misclassification is only correctable by delete-and-recreate, and
-that path destroys edges.** Measured against the 19-service population: 16 carry at least one
-edge and 3 carry none. Delete-and-recreate across the population would destroy **62 edges**, of
-which **42 are `annotates`**. Because `annotates` runs note → entity, each destroyed annotates
+that path destroys edges under the only deletion mode that can actually free the record.**
+Measured against the 19-service population: 16 carry at least one edge and 3 carry none. A
+HARD delete-and-recreate across the population would destroy **62 edges**, of which **42 are
+`annotates`** — the figure is stated for `DeleteMode::Hard` specifically, because soft deletion
+destroys none of them and instead strands all 62 on a deleted endpoint (Decision 3). Because `annotates` runs note → entity, each destroyed annotates
 edge leaves a note whose subject no longer exists — the note survives, saying something about
 nothing, which is worse than either deleting it or keeping it attached.
 
-There is a further complication in enumerating that blast radius, filed separately as issue
-#2085: `list(kind="edge", target_id=…)` cannot match an edge whose target is itself an edge, and
-returns an empty result rather than an error. So the affected-edge count for a migration cannot
-be obtained from that filter alone, and an empty result there must not be read as "nothing points
-at this."
+Enumerating that blast radius has a complication of its own, because an edge may itself be an
+endpoint. `endpoint_exists_clause` in `crates/khive-db/src/stores/graph.rs` admits an undeleted
+`graph_edges` row as a valid endpoint alongside entities, notes and events, so an `annotates` edge
+may point AT another edge, and those rows are part of any migration's affected set. Whether the
+inbound filter `list(kind="edge", target_id=…)` reaches them is disputed and under verification at
+issue #2085 — one measurement says it returns empty, a later integration test says it matches. This
+ADR takes no position on that, and deliberately does not depend on it: a procedure that can lose
+edges must not have its completeness rest on a filter whose behaviour is in question, so the
+enumeration below is specified from the source side, which is unaffected either way.
 
 ## Decision
 
@@ -107,23 +113,66 @@ substrate boundary. That is a substantial amount of runtime surface, and the pop
 serve is small: kind changes are rare, and the store measured 19 services in total.
 
 Against that, the cost of the status quo is bounded and known — 62 edges across a whole-population
-migration, 42 of them annotations. For a single-record correction the cost is that record's own
+hard migration, 42 of them annotations. For a single-record correction the cost is that record's own
 edge count, which is typically small.
 
-So the proposal is a **procedure**, not a mechanism. Any kind correction:
+So the proposal is a **procedure**, not a mechanism. Two things have to be pinned down before the
+steps make sense, because the earlier draft of this section left both implicit and the procedure was
+unsound without them.
 
-1. Enumerates the record's edges in **both directions** before deleting anything, and does not
-   rely on `list(kind="edge", target_id=…)` alone for the inbound side (issue #2085).
-2. Names, for each `annotates` edge, whether the annotating note is re-anchored to the new record
-   or deleted with it. A note left pointing at a deleted subject is not an acceptable outcome.
-3. Enumerates the notes annotating the record's **edges**, not only those annotating the record
-   itself, and gives each the same re-anchor-or-delete disposition. This population is easy to
-   miss twice over: a re-created edge is a new edge id, so an edge-targeting annotation is
-   orphaned by the recreation in step 4 even though the record itself was handled correctly; and
-   it is exactly the population issue #2085 makes invisible, since the target-side filter returns
-   an empty result rather than an error. Enumerate it from the source side.
-4. Re-creates the edges against the new record and reads them back, since a re-created edge is a
-   new edge id and anything that referenced the old id does not follow.
+**Deletion mode, and what each mode actually does.** `DeleteMode` (`crates/khive-storage/src/types/mod.rs`)
+has two variants and they differ in exactly the way that matters here. `Soft` marks `deleted_at` and
+leaves the row queryable under an explicit soft-delete filter. `Hard` physically removes the row **and
+cascades incident edges** — `purge_incident_edges_statement` issues
+`DELETE FROM graph_edges WHERE source_id = ?1 OR target_id = ?1`, unconditionally and with no soft
+counterpart, and it runs BEFORE the record's own row is removed.
+
+Two consequences, and the first is a correction to this ADR's own framing. **The 62-edge figure is a
+HARD-delete figure.** A soft delete destroys no edges at all; it leaves every one of them as a live row
+pointing at a record that now reads as deleted. So soft deletion is not the cheap option it appears to
+be — it converts edge destruction into a set of edges whose endpoint no longer satisfies
+`endpoint_exists_clause`, which is a worse state than either outcome, because nothing reports it. And
+hard deletion is genuinely irreversible: the cascade is a `DELETE`, there is no `deleted_at` to
+restore from, and edges are not FTS or vector indexed so no secondary copy exists.
+
+**Therefore the whole correction is one atomic unit, or it is not attempted.** The runtime already has
+the seam: `atomic_prepare` builds a plain-data `AtomicOpPlan` that `run_atomic_unit` commits in a
+single synchronous pass, with a per-statement `AffectedRowGuard`. A kind correction is prepared as one
+such plan covering deletion and every recreation, so a failure after the delete rolls the delete back
+with it. **A correction executed as a sequence of independent calls is out of contract**, because the
+window between the cascade and the last recreation is exactly where the edges are unrecoverable.
+
+**Edges whose triples become ILLEGAL under the new kind.** Recreation is not always available, and this
+is not an edge case: `Org contains Service` has no `Org contains Concept` counterpart in the endpoint
+matrix, so an org-contained service cannot simply be recreated as a concept. Every incident edge must
+therefore be classified against ADR-002's matrix BEFORE anything is deleted, into exactly three
+dispositions, each of which must be written down per edge:
+
+- **RECREATE** — the triple is legal under the new kind. Recreate and read back.
+- **RE-EXPRESS** — the triple is illegal but the fact survives under a different relation or a
+  different endpoint. Name the replacement triple and why it carries the same claim.
+- **REFUSE** — the fact has no legal expression under the new kind. This does not mean drop the edge;
+  it means **the migration does not proceed** on that record until someone decides, on the record,
+  either to accept the loss with a named carrier for the fact or to leave the kind as it is.
+
+The default is REFUSE. A procedure whose failure mode is a silently dropped edge is the thing this
+ADR exists to prevent, so an unclassifiable edge stops the migration rather than being absorbed by it.
+
+With those settled, a kind correction:
+
+1. Enumerates the record's edges in **both directions** before deleting anything, from the source side,
+   and does not rest completeness on a single inbound filter (see the enumeration note in Context).
+2. Enumerates the notes annotating the record's **edges**, not only those annotating the record itself.
+   A recreated edge is a new edge id, so an edge-targeting annotation is orphaned by recreation even
+   when the record's own annotations were handled correctly, and a hard delete's cascade removes those
+   rows outright. Each gets the same re-anchor-or-delete disposition as step 3.
+3. Classifies every enumerated edge as RECREATE, RE-EXPRESS or REFUSE against the endpoint matrix, and
+   names for each `annotates` edge whether the annotating note is re-anchored to the new record or
+   deleted with it. A note left pointing at a deleted subject is not an acceptable outcome. **Any
+   REFUSE stops here.**
+4. Prepares deletion and all recreations as ONE atomic plan, commits it, and reads back every recreated
+   edge. A recreated edge is a new edge id, so anything that referenced the old id does not follow and
+   must be re-pointed in the same plan.
 5. Records the old record's id in the new record's properties, so the discontinuity is traceable.
 
 If kind changes later become common enough that this procedure is being run routinely, that is the
@@ -169,5 +218,5 @@ edges, since kind is immutable.
 ### Why is the classification gap worth an ADR at all?
 
 Because the endpoint contract makes kind consequential and irreversible in the same stroke. A
-record's kind decides what edges it may ever carry, and it cannot be changed without destroying
-edges. A decision with that shape should be made against a written rule.
+record's kind decides what edges it may ever carry, and it cannot be changed without hard-deleting
+the record and cascading its edges. A decision with that shape should be made against a written rule.

--- a/docs/adr/ADR-167-service-provenance-and-kind-classification.md
+++ b/docs/adr/ADR-167-service-provenance-and-kind-classification.md
@@ -59,20 +59,33 @@ filter `list(kind="edge", target_id=…)` does reach them: the earlier report th
 (issue #2085) has been retracted, and an integration test covering the edge-as-target case matches.
 
 What remains open is exhaustive ENUMERATION, which is a different question from whether the filter
-matches. Issue #2088 records that the multi-namespace visibility path fetches each namespace's rows
-ordered by `created_at`, re-sorts the union by UUID, and then slices `[offset, offset+limit)`: the
-window floats as the prefix grows, so successive pages both duplicate and skip rows, and a paged
-walk terminates having seen a fraction of the population while reporting nothing wrong. That defect
-is not confined to inbound reads: `source_id` and `target_id` are filter predicates on the same
-listing path (`build_edge_filter_sql` in `crates/khive-db/src/stores/graph.rs`), so a source-filtered
-walk pages through the same floating window. No direction of offset-paged enumeration is safe while
-the defect stands, and a procedure that can lose edges must not rest its completeness on offset
-paging in either direction. The runtime already carries the sound primitive: `list_edges_after`
-(`crates/khive-runtime/src/operations.rs`) walks the durable insertion-sequence ledger with an
-explicit cursor, merges every visible namespace at one sequence boundary, and fails loudly on a
-hard-deleted or out-of-scope cursor instead of hiding an incomplete traversal. The enumeration
-contract in Decision 3 is therefore stated against that cursor walk (or a transaction-scoped direct
-query executed inside the migration's own transaction), never against offset paging.
+matches. Two independent gaps stand between the listing surface and the set the purge will delete.
+
+First, offset paging is unsound. Issue #2088 records that the multi-namespace visibility path
+fetches each namespace's rows ordered by `created_at`, re-sorts the union by UUID, and then slices
+`[offset, offset+limit)`: the window floats as the prefix grows, so successive pages both duplicate
+and skip rows, and a paged walk terminates having seen a fraction of the population while reporting
+nothing wrong. The defect is not confined to inbound reads: `source_id` and `target_id` are filter
+predicates on the same listing path (`build_edge_filter_sql` in
+`crates/khive-db/src/stores/graph.rs`), so a source-filtered walk pages through the same floating
+window. No direction of offset-paged enumeration is safe while the defect stands.
+
+Second — and this holds even for a sound cursor walk — the listing surface answers a narrower
+question than the purge asks. `list_edges_after` (`crates/khive-runtime/src/operations.rs`) walks
+the durable insertion-sequence ledger correctly, but it is visibility-scoped to the caller's
+namespaces and, like every listing path, filters to live rows (`deleted_at IS NULL`). The purge is
+`DELETE FROM graph_edges WHERE source_id = ?1 OR target_id = ?1` — no namespace predicate, no
+tombstone predicate. An incident edge in a namespace the migrating caller cannot see, or one
+already soft-deleted, passes a visible/live enumeration and its matching count while the purge
+deletes it anyway. A completeness check scoped narrower than the destructive statement it guards
+is not a completeness check.
+
+The enumeration contract in Decision 3 is therefore stated against the purge's own predicate: the
+authoritative enumeration is a direct query executed inside the migration's own transaction using
+the same `source_id = ?1 OR target_id = ?1` predicate as the purge, with no visibility scoping and
+no live-row filter, so the enumerated set equals the destructive set by construction. The cursor
+walk remains the sound primitive for caller-facing pre-checks and planning reads; it is not the
+completeness instrument.
 
 ## Decision
 
@@ -100,35 +113,36 @@ endpoint table.
 ### 2. Amend ADR-001's decision tree with a deterministic service/concept tie-break
 
 ADR-001 §"Agent Classification Heuristics" stays the single classification source. This ADR does
-not introduce a parallel set of criteria; it amends step 5 of ADR-001's decision tree so that the
-one under-determined boundary resolves the same way for every writer. The amendment replaces
-step 5's condition with an ordered sub-procedure:
+not introduce a parallel set of criteria; it amends ADR-001 in place — this PR carries the
+ADR-001 edit, and the operative text is ADR-001's new §"Service/concept tie-break". The
+amendment replaces step 5's condition with a sub-procedure over two predicates, each decidable
+from the record being written (its name, description, `entity_type`, and properties), with no
+reference to the writer's state of mind or to the world at write time:
 
-> **5. Evaluate, in order, stopping at the first rule whose condition holds:**
->
-> 5a. It is meaningful to say the thing is currently up or down (it has, or when deployed would
-> have, an endpoint, health state, deployment surface, and an operator) → `Service`. Current
-> downtime does not disqualify: a deployable system between deployments is still a `Service`.
->
-> 5b. The name refers to an idea, technique, pattern, or named result that would still exist if
-> every deployment of it were removed, AND no record-specific deployment is being named →
-> `Concept` (continue to step 8's signals to confirm).
->
-> 5c. Both 5a and 5b hold — the name is being used for a technique AND for a deployment of it —
-> → **the split is mandatory**: create two records, a `Concept` naming the technique and a
-> `Service` naming the deployment, joined by `Service instance_of Concept`. Classifying the
-> single record either way is out of contract; the disagreement is the evidence that there are
-> two things.
->
-> 5d. Neither holds cleanly and the writer cannot state which — record it as `Concept` per
-> ADR-001 step 9's uncertainty default, and record the open question as a note annotating the
-> record, so the classification is revisitable instead of silently settled.
+- **Instance evidence (D)**: the record names at least one instance identifier — an endpoint or
+  address, a deployment surface, an operator, or an operational state or state history.
+  Liveness at write time is not consulted, so a deployable system between deployments still
+  satisfies D. Codebase identifiers (repository, package, crate, source language) are
+  explicitly step 6 evidence, not instance identifiers.
+- **Technique identity (T)**, evaluated only when D holds: the record's name or description
+  also denotes the technique the instance embodies, as distinct from the instance itself.
 
-The rules are ordered, each condition is decidable from the record being written (no "usually",
-no evidence threshold left to taste), and the disagreement case has exactly one outcome. The
-earlier draft of this section stated the liveness and independence tests without an order or a
-mandatory outcome for the disagreement case; two writers could reach different kinds for a
-currently-down deployable system, which is the drift this decision exists to stop.
+The arms partition on D, then on T, so they are mutually exclusive by construction: D absent →
+step 5 does not fire and the walk continues to step 6 (a codebase classifies `Project`, a pure
+technique reaches step 8 and classifies `Concept`); D without T → `Service`; D with T → the
+split is **mandatory** — two records, `Concept` for the technique and `Service` for the
+deployment, joined by `Service instance_of Concept`, and single-record classification either
+way is out of contract. Step 9's uncertainty default is unchanged; the amendment adds a
+question-note requirement whose trigger (deployment vocabulary present, instance identifier
+absent) is likewise read off the record.
+
+The earlier draft of this section stated the procedure as four ordered first-match rules whose
+split arm required two earlier arms to hold simultaneously — unreachable under first-match —
+and whose predicates ("meaningful to say", "when deployed would have", "the writer cannot state
+which") were not decidable from the record; its broad liveness arm could also claim a static
+codebase that ADR-001 step 6 assigns to `Project`. The partition form above closes all three
+defects: no arm can be masked by ordering, every predicate is a field-presence test on the
+record, and codebase identity is routed to step 6 before `Service` can be reached.
 
 ### 3. Kind migration: keep delete-and-recreate, and require a re-anchor plan
 
@@ -195,17 +209,23 @@ ADR exists to prevent, so an unclassifiable edge stops the migration rather than
 
 With those settled, a kind correction:
 
-1. Enumerates the record's edges in **both directions and across every namespace visible to the
-   migrating caller** before deleting anything, using the insertion-sequence cursor walk
-   (`list_edges_after`) or a direct query inside the migration's own transaction — never offset
-   paging, in either direction (see the enumeration note in Context). The walk runs to cursor
-   exhaustion, and the collected edge IDs are reconciled against an independently computed count
-   of the record's incident edges; a mismatch stops the migration before any destructive plan is
-   prepared.
-2. Enumerates the notes annotating the record's **edges**, not only those annotating the record itself.
-   A recreated edge is a new edge id, so an edge-targeting annotation is orphaned by recreation even
-   when the record's own annotations were handled correctly, and a hard delete's cascade removes those
-   rows outright. Each gets the same re-anchor-or-delete disposition as step 3.
+1. Enumerates the **complete purge set** before deleting anything: a direct query inside the
+   migration's own transaction using the purge's own predicate
+   (`source_id = ?1 OR target_id = ?1`), with **no visibility scoping and no live-row filter** —
+   every namespace, tombstoned rows included, because the purge deletes across both (see the
+   enumeration note in Context). The collected edge IDs are deduplicated (an edge matching on
+   both source and target — a self-loop — is one row and is counted once) and reconciled
+   against an independently computed `COUNT(*)` under the same predicate in the same
+   transaction; a mismatch stops the migration before any destructive plan is prepared. The
+   caller-facing cursor walk (`list_edges_after`) may be used for planning reads, but the
+   destructive plan is prepared only from the in-transaction enumeration. Offset paging is
+   out of contract in any role, in either direction.
+2. Enumerates the second-order rows under the same completeness contract: the `annotates`
+   edges whose TARGET is one of the enumerated incident edges, and the notes those edges
+   anchor — again by direct in-transaction query over the enumerated edge IDs, with no
+   visibility or live-row filter. A recreated edge is a new edge id, so an edge-targeting
+   annotation is orphaned by recreation even when the record's own annotations were handled
+   correctly. Each gets the same re-anchor-or-delete disposition as step 3.
 3. Classifies every enumerated edge as RECREATE, RE-EXPRESS or REFUSE against the endpoint matrix, and
    names for each `annotates` edge whether the annotating note is re-anchored to the new record or
    deleted with it. A note left pointing at a deleted subject is not an acceptable outcome. **Any
@@ -234,21 +254,43 @@ this ADR is complete when all of the following hold:
 
 **Classification tie-break (Decision 2).**
 
-- The ADR-001 amendment text contains the ordered 5a–5d sub-procedure, and each branch has a
-  worked fixture: a currently-down deployable system classifies `Service` (5a); a technique with
-  no named deployment classifies `Concept` (5b); a name used for both yields two records joined
-  by `Service instance_of Concept`, and classifying it as a single record of either kind is
-  rejected by the written rule (5c); an undecidable record lands `Concept` with an annotating
-  question note (5d).
+- ADR-001 itself carries the amendment in this PR's diff: its decision tree's step 5 names the
+  instance-evidence test and its §"Service/concept tie-break" states the D/T partition. A test
+  reading ADR-001 finds the operative text; ADR-167 records the decision and rationale.
+- Each arm has a worked fixture stated as record fields and an expected stored outcome:
+  - D without T → `Service`: a record whose properties name an endpoint and an operator, whose
+    description names no technique, and whose deployment is currently down (no liveness field
+    consulted) classifies `Service`.
+  - D absent, codebase identity → `Project` via step 6: a record naming only a repository and
+    source language classifies `Project`, never `Service`.
+  - D absent, technique identity → `Concept` via step 8: a record describing a method with no
+    instance identifier classifies `Concept`.
+  - D with T → split: a record whose name denotes a technique and whose properties name an
+    endpoint yields two records joined by `Service instance_of Concept`; classifying it as a
+    single record of either kind is rejected by the written rule.
+  - Step 9 note: a record whose description mentions deployment vocabulary but carries no
+    instance identifier lands `Concept` with a question note annotating the record.
 
 **Migration procedure (Decision 3).**
 
-- Enumeration: against a fixture population large enough to exercise the paging defect in issue
-  #2088 (rows spread across at least two namespaces, with interleaved creation timestamps and
-  UUID order that disagrees with `created_at` order), the cursor walk returns every incident edge
-  in both directions exactly once, and its result reconciles against the independent count. An
-  offset-paged walk over the same fixture demonstrably misses or duplicates rows — that fixture
-  is what makes this criterion a real discriminator rather than a restatement.
+- Enumeration, offset-paging discriminator: the fixture is exact, so the pre-image failure is
+  decidable rather than probabilistic. Six incident edges on the migrating record, three per
+  namespace across two namespaces (`A`: a1, a2, a3; `B`: b1, b2, b3), creation timestamps
+  strictly interleaved (a1 < b1 < a2 < b2 < a3 < b3), and edge UUIDs assigned in strictly
+  descending order of creation, so every later-created edge id sorts before every
+  earlier-created one. Page size 2. The defective offset walk (per-namespace `created_at`
+  prefix of size `offset + limit`, union re-sorted by UUID, sliced) then returns page 1 =
+  {b2, a2}, page 2 = {b2, a2} again (b3 and a3, newly exposed in the page-2 prefix, sort
+  before b2 and displace the window), page 3 = {b1, a1}: b2 and a2 are duplicated and b3 and
+  a3 are never returned. The test asserts the offset walk produces exactly that duplicate-
+  and-omission pattern while the in-transaction purge-predicate enumeration returns all six
+  edge ids exactly once and reconciles with `COUNT(*)` = 6.
+- Enumeration, destructive-scope completeness: the fixture additionally holds one incident
+  edge in a namespace NOT visible to the migrating caller and one incident edge already
+  soft-deleted. A visible/live enumeration (the cursor walk) returns neither; the
+  in-transaction purge-predicate enumeration returns both, the count reconciles, and both
+  rows receive dispositions before any plan is prepared — because the purge would delete
+  both. A migration prepared from the visible/live enumeration alone must be refused.
 - Edge-as-endpoint coverage: the fixture includes an `annotates` edge whose TARGET is itself an
   edge incident to the migrating record; the enumeration finds it, and after migration the
   annotation is re-anchored to the recreated edge's new id (or deleted with a recorded

--- a/docs/adr/ADR-167-service-provenance-and-kind-classification.md
+++ b/docs/adr/ADR-167-service-provenance-and-kind-classification.md
@@ -128,10 +128,11 @@ reference to the writer's state of mind or to the world at write time:
   satisfies D. Codebase identifiers (repository, package, crate, source language) are
   explicitly step 6 evidence, not instance identifiers.
 - **Technique identity (T)**, evaluated only when D holds: the record's own text names a
-  technique as its referent — its `entity_type` is a technique-designating `Concept` subtype
-  (`algorithm`, `technique`, `method`, `pattern`, `architecture`, `model`), or its name or
-  description names the referent with one of those designators. A vocabulary-presence test
-  on the record's fields, not an inference about the prose.
+  technique as its referent — its `entity_type` is one of `Concept`'s canonical subtypes, or
+  its name or description names the referent with one of ADR-001 step 8's own designators
+  (`idea`, `method`, `algorithm`, `theory`, `architecture`, `research gap`, `metric`) or
+  with a `Concept` canonical-subtype name. A vocabulary-presence test on the record's
+  fields reusing vocabulary ADR-001 already owns, not an inference about the prose.
 
 The arms partition on D, then on T, so they are mutually exclusive by construction: D absent →
 step 5 does not fire and the walk continues to step 6 (a codebase classifies `Project`, a pure

--- a/docs/adr/ADR-167-service-provenance-and-kind-classification.md
+++ b/docs/adr/ADR-167-service-provenance-and-kind-classification.md
@@ -61,17 +61,20 @@ filter `list(kind="edge", target_id=…)` does reach them: the earlier report th
 What remains open is exhaustive ENUMERATION, which is a different question from whether the filter
 matches. Two independent gaps stand between the listing surface and the set the purge will delete.
 
-First, offset paging is unsound. Issue #2088 records that the multi-namespace visibility path
-fetches each namespace's rows ordered by `created_at`, re-sorts the union by UUID, and then slices
-`[offset, offset+limit)`: the window floats as the prefix grows, so successive pages both duplicate
-and skip rows, and a paged walk terminates having seen a fraction of the population while reporting
-nothing wrong. The defect is not confined to inbound reads: `source_id` and `target_id` are filter
-predicates on the same listing path (`build_edge_filter_sql` in
-`crates/khive-db/src/stores/graph.rs`), so a source-filtered walk pages through the same floating
-window. No direction of offset-paged enumeration is safe while the defect stands.
+First, offset paging over multiple namespaces was unsound when this ADR was drafted. Issue #2088
+recorded that the multi-namespace visibility path fetched each namespace's rows ordered by
+`created_at`, re-sorted the union by UUID, and then sliced `[offset, offset+limit)`: the window
+floats as the prefix grows, so successive pages both duplicate and skip rows while reporting
+nothing wrong, in both filter directions (`source_id` and `target_id` share the listing path).
+That defect has since been fixed: the multi-namespace branch now issues a single statement over
+the whole namespace set with a real `LIMIT`/`OFFSET` (the change that closed #2088), and the
+exact-enumeration and page-stability regressions are owned by that change's own tests. This ADR
+does not re-own them; the defect remains in this record because it is measured evidence of how
+quietly an enumeration can be incomplete, which is the failure class the contract below exists
+to exclude.
 
-Second — and this holds even for a sound cursor walk — the listing surface answers a narrower
-question than the purge asks. `list_edges_after` (`crates/khive-runtime/src/operations.rs`) walks
+Second — and this holds even now that the listing paths are sound — the listing surface answers
+a narrower question than the purge asks. `list_edges_after` (`crates/khive-runtime/src/operations.rs`) walks
 the durable insertion-sequence ledger correctly, but it is visibility-scoped to the caller's
 namespaces and, like every listing path, filters to live rows (`deleted_at IS NULL`). The purge is
 `DELETE FROM graph_edges WHERE source_id = ?1 OR target_id = ?1` — no namespace predicate, no
@@ -273,24 +276,20 @@ this ADR is complete when all of the following hold:
 
 **Migration procedure (Decision 3).**
 
-- Enumeration, offset-paging discriminator: the fixture is exact, so the pre-image failure is
-  decidable rather than probabilistic. Six incident edges on the migrating record, three per
-  namespace across two namespaces (`A`: a1, a2, a3; `B`: b1, b2, b3), creation timestamps
-  strictly interleaved (a1 < b1 < a2 < b2 < a3 < b3), and edge UUIDs assigned in strictly
-  descending order of creation, so every later-created edge id sorts before every
-  earlier-created one. Page size 2. The defective offset walk (per-namespace `created_at`
-  prefix of size `offset + limit`, union re-sorted by UUID, sliced) then returns page 1 =
-  {b2, a2}, page 2 = {b2, a2} again (b3 and a3, newly exposed in the page-2 prefix, sort
-  before b2 and displace the window), page 3 = {b1, a1}: b2 and a2 are duplicated and b3 and
-  a3 are never returned. The test asserts the offset walk produces exactly that duplicate-
-  and-omission pattern while the in-transaction purge-predicate enumeration returns all six
-  edge ids exactly once and reconciles with `COUNT(*)` = 6.
-- Enumeration, destructive-scope completeness: the fixture additionally holds one incident
-  edge in a namespace NOT visible to the migrating caller and one incident edge already
-  soft-deleted. A visible/live enumeration (the cursor walk) returns neither; the
-  in-transaction purge-predicate enumeration returns both, the count reconciles, and both
-  rows receive dispositions before any plan is prepared — because the purge would delete
-  both. A migration prepared from the visible/live enumeration alone must be refused.
+- Enumeration, exactness: multi-namespace listing exactness (every row exactly once across
+  pages, stable page order) is owned by the tests of the change that closed #2088 and is not
+  re-owned here; this ADR's enumeration criteria assume it and test what the listing surface
+  cannot answer.
+- Enumeration, destructive-scope completeness: the fixture holds six incident edges on the
+  migrating record spread across two namespaces, of which one is in a namespace NOT visible
+  to the migrating caller and one is already soft-deleted. A visible/live enumeration (the
+  cursor walk or the listing surface) returns four; the in-transaction purge-predicate
+  enumeration returns all six edge ids exactly once (deduplicated, so a self-loop edge
+  matching on both source and target counts once), and reconciles with `COUNT(*)` = 6 under
+  the same predicate in the same transaction. All six receive dispositions before any plan
+  is prepared — because the purge would delete all six. A migration prepared from the
+  four-row visible/live enumeration must be refused, and the refusal is the asserted
+  outcome, not a warning.
 - Edge-as-endpoint coverage: the fixture includes an `annotates` edge whose TARGET is itself an
   edge incident to the migrating record; the enumeration finds it, and after migration the
   annotation is re-anchored to the recreated edge's new id (or deleted with a recorded

--- a/docs/adr/ADR-167-service-provenance-and-kind-classification.md
+++ b/docs/adr/ADR-167-service-provenance-and-kind-classification.md
@@ -122,14 +122,12 @@ amendment replaces step 5's condition with a sub-procedure over two predicates, 
 from the record being written (its name, description, `entity_type`, and properties), with no
 reference to the writer's state of mind or to the world at write time:
 
-- **Instance evidence (D)**: the record names at least one instance identifier — an endpoint or
-  address, a named deployment surface, a named operator, or an operational state or state
-  history carried in the record's property fields. Bare deployment or liveness vocabulary in
-  name or description prose (`deployed`, `running`, `in production`) with no concrete referent
-  beside it is not an instance identifier and does not satisfy D. Liveness at write time is
-  not consulted, so a deployable system between deployments still satisfies D. Codebase
-  identifiers (repository, package, crate, source language) are explicitly step 6 evidence,
-  not instance identifiers.
+- **Instance evidence (D)**: defined normatively in ADR-001 §"Service/concept tie-break" — the
+  record names at least one concrete instance identifier stated in the record. ADR-001's
+  statement (including its specific host/region/cluster qualification of deployment surfaces,
+  the property-field requirement for operational state, and the exclusion of bare
+  deployment/liveness vocabulary) is the single normative text; this ADR deliberately does not
+  restate it, so the two documents cannot diverge.
 - **Technique identity (T)**, evaluated only when D holds: the record's own text names a
   technique as its referent — its `entity_type` is one of `Concept`'s canonical subtypes, or
   its name or description names the referent with one of ADR-001 step 8's own designators

--- a/docs/adr/ADR-167-service-provenance-and-kind-classification.md
+++ b/docs/adr/ADR-167-service-provenance-and-kind-classification.md
@@ -48,12 +48,19 @@ nothing, which is worse than either deleting it or keeping it attached.
 Enumerating that blast radius has a complication of its own, because an edge may itself be an
 endpoint. `endpoint_exists_clause` in `crates/khive-db/src/stores/graph.rs` admits an undeleted
 `graph_edges` row as a valid endpoint alongside entities, notes and events, so an `annotates` edge
-may point AT another edge, and those rows are part of any migration's affected set. Whether the
-inbound filter `list(kind="edge", target_id=…)` reaches them is disputed and under verification at
-issue #2085 — one measurement says it returns empty, a later integration test says it matches. This
-ADR takes no position on that, and deliberately does not depend on it: a procedure that can lose
-edges must not have its completeness rest on a filter whose behaviour is in question, so the
-enumeration below is specified from the source side, which is unaffected either way.
+may point AT another edge, and those rows are part of any migration's affected set. The inbound
+filter `list(kind="edge", target_id=…)` does reach them: the earlier report that it returns empty
+(issue #2085) has been retracted, and an integration test covering the edge-as-target case matches.
+
+What remains open is exhaustive ENUMERATION, which is a different question from whether the filter
+matches. Issue #2088 records that the multi-namespace visibility path fetches each namespace's rows
+ordered by `created_at`, re-sorts the union by UUID, and then slices `[offset, offset+limit)`: the
+window floats as the prefix grows, so successive pages both duplicate and skip rows, and a paged
+walk terminates having seen a fraction of the population while reporting nothing wrong. A procedure
+that can lose edges must not rest its completeness on offset paging while that holds. The
+enumeration below is therefore specified from the source side, which is unaffected either way, and
+stays that way after the paging fix lands — a deletion procedure earns nothing by depending on the
+more fragile of two available reads.
 
 ## Decision
 

--- a/docs/adr/ADR-167-service-provenance-and-kind-classification.md
+++ b/docs/adr/ADR-167-service-provenance-and-kind-classification.md
@@ -123,10 +123,13 @@ from the record being written (its name, description, `entity_type`, and propert
 reference to the writer's state of mind or to the world at write time:
 
 - **Instance evidence (D)**: the record names at least one instance identifier — an endpoint or
-  address, a deployment surface, an operator, or an operational state or state history.
-  Liveness at write time is not consulted, so a deployable system between deployments still
-  satisfies D. Codebase identifiers (repository, package, crate, source language) are
-  explicitly step 6 evidence, not instance identifiers.
+  address, a named deployment surface, a named operator, or an operational state or state
+  history carried in the record's property fields. Bare deployment or liveness vocabulary in
+  name or description prose (`deployed`, `running`, `in production`) with no concrete referent
+  beside it is not an instance identifier and does not satisfy D. Liveness at write time is
+  not consulted, so a deployable system between deployments still satisfies D. Codebase
+  identifiers (repository, package, crate, source language) are explicitly step 6 evidence,
+  not instance identifiers.
 - **Technique identity (T)**, evaluated only when D holds: the record's own text names a
   technique as its referent — its `entity_type` is one of `Concept`'s canonical subtypes, or
   its name or description names the referent with one of ADR-001 step 8's own designators
@@ -287,11 +290,14 @@ this ADR is complete when all of the following hold:
     joined by `Service instance_of Concept`; classifying it as a single record of either
     kind is rejected by the written rule.
   - Step 9 note: name `experimental serving stack`, description `deployed somewhere in the
-    lab, details unrecorded` — deployment vocabulary (`deployed`) present, no instance
-    identifier, no codebase field (step 6 false), no technique designator (step 8's
+    lab, details unrecorded`, no properties — deployment vocabulary (`deployed`) appears
+    only as bare prose: no endpoint or address, no named host, region, cluster, or
+    operator, and no state record in any property field, so D does not hold and step 5
+    does not fire; no codebase field (step 6 false), no technique designator (step 8's
     abstract-idea test unresolved), steps 1-8 thereby exhausted without resolving. Lands
     `Concept` per step 9, with the open classification question recorded as a note
-    annotating the record.
+    annotating the record — the question-note trigger (deployment vocabulary present, no
+    instance identifier) is exactly this case.
 
 **Migration procedure (Decision 3).**
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -183,6 +183,7 @@ The same head-binding governs review: a verdict authorizes only the exact commit
 | [ADR-164](ADR-164-event-sink-boundary.md)                               | Event Sink Boundary                                                                                        |
 | [ADR-165](ADR-165-read-path-performance-recovery.md)                    | Read-Path Performance Recovery                                                                             |
 | [ADR-166](ADR-166-hot-path-latency-regression-guard.md)                 | Hot-Path Latency Regression Guard                                                                          |
+| [ADR-167](ADR-167-service-provenance-and-kind-classification.md)        | Service Provenance, Service/Concept Classification, and Kind Migration                                     |
 
 <!-- END GENERATED ADR CATALOG -->
 


### PR DESCRIPTION
Proposes three related changes to the entity/edge ontology, each motivated by something measured against a production store rather than inferred.

**1. One derivation endpoint pair: `Service introduced_by Document`.**
No pair currently admits a `Service` into a derivation or provenance relation with a `Document`, so a service cannot record the specification or ADR that introduced it. Every sibling kind can. The gap looks incidental rather than deliberate: the 2026-07-08 `introduced_by` amendment was reasoning about documents and orgs and did not consider services. The ADR explicitly rejects the wider forms (`Service introduced_by Person`/`Org`, any `derived_from` involving a service) because no observed refusal asked for them. The relation set stays at 17.

**2. Written service-vs-concept classification criteria.**
The two kinds have materially different endpoint contracts, so the choice at creation time silently decides what edges a record may ever carry, and there is no ADR stating what makes something one rather than the other. Proposed as two tests rather than a category list, because the observed failure is a borderline record being classified on its name: a liveness test (is it meaningful to say the thing is currently down) and an independence test (would it exist if every deployment were removed). Where they disagree there are usually two records, joined by `Service instance_of Concept`, which the contract already admits.

**3. Kind migration: a written procedure, not a mechanism.**
Kind is immutable, so a misclassification is correctable only by delete-and-recreate, which destroys edges. Measured over the 19-service population: 16 carry at least one edge, and a whole-population migration would destroy 62 edges, 42 of them `annotates`. Because `annotates` runs note to entity, each destroyed one leaves a note whose subject no longer exists.

The ADR proposes **not** building a kind-migration mechanism. Such a mechanism would have to re-point both directions, preserve edge ids, and carry annotations across the substrate boundary, which is substantial runtime surface for a rare operation on a small population. It proposes a five-step re-anchor procedure instead, and states the trigger that would reopen the mechanism decision as a countable thing: the number of times the procedure gets run.

Step 3 of that procedure is worth flagging for review. Re-creating an edge yields a new edge id, so notes annotating the record's *edges* are orphaned even when the record's own annotations were handled correctly, and that population is exactly what #2085 makes invisible: the target-side filter returns an empty result rather than an error. The procedure enumerates it from the source side.

Related: #2085.