### PR TITLE
fix(runtime): enumerate multi-namespace edge listing exactly

### DIFF
--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -777,6 +777,34 @@ fn micros_to_datetime(micros: i64) -> DateTime<Utc> {
         .unwrap_or_else(Utc::now)
 }
 
+/// Deterministic ORDER BY for edge queries. #1671: an `id` tiebreak is
+/// always appended (following the last sort field's direction, DESC for the
+/// empty default) so pages over equal sort values keep a total order. That
+/// removes tie-order instability only — offset paging can still duplicate or
+/// skip rows under concurrent inserts/deletes or sort-key updates (that
+/// would need snapshot isolation or keyset pagination).
+fn edge_order_clause(sort: &[SortOrder<EdgeSortField>]) -> String {
+    if sort.is_empty() {
+        return " ORDER BY created_at DESC, id DESC".to_string();
+    }
+    let mut parts: Vec<String> = sort
+        .iter()
+        .map(|s| {
+            let dir = match s.direction {
+                SortDirection::Asc => "ASC",
+                SortDirection::Desc => "DESC",
+            };
+            format!("{} {}", edge_sort_col(&s.field), dir)
+        })
+        .collect();
+    let dir = match sort.last().map(|s| &s.direction) {
+        Some(SortDirection::Asc) => "ASC",
+        _ => "DESC",
+    };
+    parts.push(format!("id {dir}"));
+    format!(" ORDER BY {}", parts.join(", "))
+}
+
 fn build_edge_filter_sql(
     namespace: &str,
     filter: &EdgeFilter,
@@ -1891,37 +1919,7 @@ impl GraphStore for SqlGraphStore {
                 stmt.query_row(param_refs.as_slice(), |row| row.get(0))?
             };
 
-            let order_clause = if sort.is_empty() {
-                // #1671: append `id` as the final tiebreak in the same DESC
-                // direction as the `created_at` primary sort key, giving a
-                // deterministic total order. That removes tie-order
-                // instability only — offset paging can still duplicate or
-                // skip rows under concurrent inserts/deletes or sort-key
-                // updates (that would need snapshot isolation or keyset
-                // pagination).
-                " ORDER BY created_at DESC, id DESC".to_string()
-            } else {
-                let mut parts: Vec<String> = sort
-                    .iter()
-                    .map(|s| {
-                        let dir = match s.direction {
-                            SortDirection::Asc => "ASC",
-                            SortDirection::Desc => "DESC",
-                        };
-                        format!("{} {}", edge_sort_col(&s.field), dir)
-                    })
-                    .collect();
-                // #1671: the appended `id` tiebreak follows the LAST sort
-                // field's direction (the behavior the multi-field sweep tests
-                // codify), so pages over equal sort values stay a
-                // deterministic total order.
-                let dir = match sort.last().map(|s| &s.direction) {
-                    Some(SortDirection::Asc) => "ASC",
-                    _ => "DESC",
-                };
-                parts.push(format!("id {dir}"));
-                format!(" ORDER BY {}", parts.join(", "))
-            };
+            let order_clause = edge_order_clause(&sort);
 
             let (_, data_filter_params) = build_edge_filter_sql(&namespace, &filter);
             let mut all_params: Vec<Box<dyn rusqlite::types::ToSql>> = data_filter_params;
@@ -1993,6 +1991,82 @@ impl GraphStore for SqlGraphStore {
                 total += count as u64;
             }
             Ok(total)
+        })
+        .await
+    }
+
+    async fn query_edges_in_namespaces(
+        &self,
+        namespaces: &[String],
+        filter: EdgeFilter,
+        sort: Vec<SortOrder<EdgeSortField>>,
+        page: PageRequest,
+    ) -> Result<Page<Edge>, StorageError> {
+        // One statement with `namespace IN (...)` and real SQL paging: a
+        // per-namespace prefix fetch merged and re-sliced client-side floats
+        // the offset window between calls, silently duplicating and skipping
+        // rows during enumeration (#2088).
+        let namespaces: Vec<String> = {
+            let mut seen = HashSet::new();
+            namespaces
+                .iter()
+                .filter(|ns| seen.insert((*ns).clone()))
+                .cloned()
+                .collect()
+        };
+        let limit_i64 = i64::from(page.limit);
+        let offset_i64 = i64::try_from(page.offset).map_err(|_| StorageError::InvalidInput {
+            capability: StorageCapability::Graph,
+            operation: "query_edges_in_namespaces".into(),
+            message: format!(
+                "PageRequest: offset must be <= i64::MAX, got {}",
+                page.offset
+            ),
+        })?;
+        self.with_reader("query_edges_in_namespaces", move |conn| {
+            let (where_clause, filter_params) =
+                build_edge_filter_sql_for_namespaces(&namespaces, &filter);
+
+            let count_sql = format!("SELECT COUNT(*) FROM graph_edges{}", where_clause);
+            let total: i64 = {
+                let mut stmt = conn.prepare(&count_sql)?;
+                let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+                    filter_params.iter().map(|p| p.as_ref()).collect();
+                stmt.query_row(param_refs.as_slice(), |row| row.get(0))?
+            };
+
+            let order_clause = edge_order_clause(&sort);
+
+            let (_, data_filter_params) =
+                build_edge_filter_sql_for_namespaces(&namespaces, &filter);
+            let mut all_params: Vec<Box<dyn rusqlite::types::ToSql>> = data_filter_params;
+            all_params.push(Box::new(limit_i64));
+            all_params.push(Box::new(offset_i64));
+
+            let limit_idx = all_params.len() - 1;
+            let offset_idx = all_params.len();
+
+            let data_sql = format!(
+                "SELECT namespace, id, source_id, target_id, relation, weight, \
+                        created_at, updated_at, deleted_at, metadata, target_backend \
+                 FROM graph_edges{}{} LIMIT ?{} OFFSET ?{}",
+                where_clause, order_clause, limit_idx, offset_idx,
+            );
+
+            let mut stmt = conn.prepare(&data_sql)?;
+            let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+                all_params.iter().map(|p| p.as_ref()).collect();
+            let rows = stmt.query_map(param_refs.as_slice(), read_edge)?;
+
+            let mut items = Vec::new();
+            for row in rows {
+                items.push(row?);
+            }
+
+            Ok(Page {
+                items,
+                total: Some(total as u64),
+            })
         })
         .await
     }

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -816,7 +816,7 @@ fn build_edge_filter_sql_for_namespaces(
     namespaces: &[String],
     filter: &EdgeFilter,
 ) -> (String, Vec<Box<dyn rusqlite::types::ToSql>>) {
-    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = namespaces
+    let params: Vec<Box<dyn rusqlite::types::ToSql>> = namespaces
         .iter()
         .map(|namespace| -> Box<dyn rusqlite::types::ToSql> { Box::new(namespace.clone()) })
         .collect();
@@ -829,6 +829,37 @@ fn build_edge_filter_sql_for_namespaces(
             format!("namespace IN ({})", placeholders.join(", "))
         }
     };
+    build_edge_filter_conditions(namespace_condition, params, filter)
+}
+
+/// Same filter conditions as [`build_edge_filter_sql_for_namespaces`], but
+/// the namespace set is bound as a single pre-serialized JSON array
+/// parameter (`?1`) matched via `json_each` rather than one `?N` per
+/// namespace.
+///
+/// `namespace IN (?1, ?2, ..., ?N)` costs one bound SQLite variable per
+/// namespace; a caller with a large visible-namespace set (hundreds to
+/// thousands, e.g. a broad `[actor]` visibility grant) can exceed
+/// `SQLITE_LIMIT_VARIABLE_NUMBER` (999 by default) before any of the
+/// filter's own parameters are even added. Binding one JSON string instead
+/// keeps this at O(1) parameters regardless of namespace count, so paged
+/// enumeration (which needs one exact-order SQL statement per page — see
+/// [`SqlGraphStore::query_edges_in_namespaces`]) never has to chunk the
+/// namespace set and cannot silently corrupt paging by doing so (#2088).
+fn build_edge_filter_sql_for_namespaces_json(
+    namespaces_json: &str,
+    filter: &EdgeFilter,
+) -> (String, Vec<Box<dyn rusqlite::types::ToSql>>) {
+    let params: Vec<Box<dyn rusqlite::types::ToSql>> = vec![Box::new(namespaces_json.to_string())];
+    let namespace_condition = "namespace IN (SELECT value FROM json_each(?1))".to_string();
+    build_edge_filter_conditions(namespace_condition, params, filter)
+}
+
+fn build_edge_filter_conditions(
+    namespace_condition: String,
+    mut params: Vec<Box<dyn rusqlite::types::ToSql>>,
+    filter: &EdgeFilter,
+) -> (String, Vec<Box<dyn rusqlite::types::ToSql>>) {
     let mut conditions = vec![namespace_condition, "deleted_at IS NULL".to_string()];
 
     if !filter.ids.is_empty() {
@@ -2006,6 +2037,16 @@ impl GraphStore for SqlGraphStore {
         // per-namespace prefix fetch merged and re-sliced client-side floats
         // the offset window between calls, silently duplicating and skipping
         // rows during enumeration (#2088).
+        //
+        // The namespace set is bound as a single JSON-array parameter (see
+        // `build_edge_filter_sql_for_namespaces_json`), not one `?N` per
+        // namespace: a caller visible in hundreds-to-thousands of namespaces
+        // would otherwise blow past `SQLITE_LIMIT_VARIABLE_NUMBER` before any
+        // filter parameter is even added, and chunking the namespace set (as
+        // the count-only aggregate methods below do) is not an option here —
+        // it would reintroduce exactly the floating-offset bug this method
+        // exists to close, since a per-chunk LIMIT/OFFSET cannot be
+        // re-sliced into one globally exact page.
         let namespaces: Vec<String> = {
             let mut seen = HashSet::new();
             namespaces
@@ -2024,8 +2065,11 @@ impl GraphStore for SqlGraphStore {
             ),
         })?;
         self.with_reader("query_edges_in_namespaces", move |conn| {
+            let namespaces_json = serde_json::to_string(&namespaces)
+                .map_err(|error| rusqlite::Error::ToSqlConversionFailure(Box::new(error)))?;
+
             let (where_clause, filter_params) =
-                build_edge_filter_sql_for_namespaces(&namespaces, &filter);
+                build_edge_filter_sql_for_namespaces_json(&namespaces_json, &filter);
 
             let count_sql = format!("SELECT COUNT(*) FROM graph_edges{}", where_clause);
             let total: i64 = {
@@ -2038,7 +2082,7 @@ impl GraphStore for SqlGraphStore {
             let order_clause = edge_order_clause(&sort);
 
             let (_, data_filter_params) =
-                build_edge_filter_sql_for_namespaces(&namespaces, &filter);
+                build_edge_filter_sql_for_namespaces_json(&namespaces_json, &filter);
             let mut all_params: Vec<Box<dyn rusqlite::types::ToSql>> = data_filter_params;
             all_params.push(Box::new(limit_i64));
             all_params.push(Box::new(offset_i64));

--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -287,6 +287,95 @@ fn make_edge(source: Uuid, target: Uuid, relation: EdgeRelation, weight: f64) ->
 }
 
 #[tokio::test]
+async fn query_edges_in_namespaces_offset_paging_enumerates_exactly() {
+    // #2088 regression: two namespaces, every edge sharing one created_at
+    // (the worst tie population), paged by offset to exhaustion. The single
+    // `namespace IN (...)` statement with the #1671 id tiebreak must
+    // enumerate every row exactly once, in a deterministic order.
+    let store = setup_memory_store();
+    let tied = Utc::now();
+    let mut expected: Vec<Uuid> = Vec::new();
+    for ns in ["ns-a", "ns-b"] {
+        for _ in 0..20 {
+            let mut edge = make_edge(Uuid::new_v4(), Uuid::new_v4(), EdgeRelation::Extends, 0.5);
+            edge.namespace = ns.to_string();
+            edge.created_at = tied;
+            edge.updated_at = tied;
+            expected.push(edge.id.into());
+            store.upsert_edge(edge).await.unwrap();
+        }
+    }
+
+    let namespaces = vec!["ns-a".to_string(), "ns-b".to_string()];
+    let sort = || {
+        vec![SortOrder {
+            field: EdgeSortField::CreatedAt,
+            direction: SortDirection::Asc,
+        }]
+    };
+
+    let mut seen: Vec<Uuid> = Vec::new();
+    let mut offset: u64 = 0;
+    loop {
+        let page = store
+            .query_edges_in_namespaces(
+                &namespaces,
+                EdgeFilter::default(),
+                sort(),
+                PageRequest { offset, limit: 7 },
+            )
+            .await
+            .unwrap();
+        assert_eq!(page.total, Some(40));
+        if page.items.is_empty() {
+            break;
+        }
+        for e in &page.items {
+            seen.push(e.id.into());
+        }
+        offset += 7;
+    }
+
+    assert_eq!(seen.len(), 40, "offset paging must enumerate every row");
+    let distinct: std::collections::HashSet<Uuid> = seen.iter().copied().collect();
+    assert_eq!(distinct.len(), 40, "no row may appear on two pages");
+    let mut want: Vec<Uuid> = expected.clone();
+    want.sort();
+    let mut got: Vec<Uuid> = seen.clone();
+    got.sort();
+    assert_eq!(got, want, "enumerated set must equal the seeded set");
+
+    // Determinism: the same page re-read returns the same rows in order.
+    let page1 = store
+        .query_edges_in_namespaces(
+            &namespaces,
+            EdgeFilter::default(),
+            sort(),
+            PageRequest {
+                offset: 14,
+                limit: 7,
+            },
+        )
+        .await
+        .unwrap();
+    let page2 = store
+        .query_edges_in_namespaces(
+            &namespaces,
+            EdgeFilter::default(),
+            sort(),
+            PageRequest {
+                offset: 14,
+                limit: 7,
+            },
+        )
+        .await
+        .unwrap();
+    let ids1: Vec<Uuid> = page1.items.iter().map(|e| e.id.into()).collect();
+    let ids2: Vec<Uuid> = page2.items.iter().map(|e| e.id.into()).collect();
+    assert_eq!(ids1, ids2, "a page must be stable across identical reads");
+}
+
+#[tokio::test]
 async fn test_upsert_and_get_edge() {
     let store = setup_memory_store();
 

--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -555,6 +555,91 @@ async fn batched_namespace_edge_counts_exceed_sqlite_variable_limit() {
     );
 }
 
+/// #2089 round-1 HIGH finding: `query_edges_in_namespaces` used to bind one
+/// `?N` SQL variable per visible namespace, so a caller visible in ~998+
+/// namespaces would blow past `SQLITE_LIMIT_VARIABLE_NUMBER` (999 by
+/// default) before any filter parameter was even added — well within a
+/// realistic broad `[actor]` visibility grant. The fix binds the namespace
+/// set as a single JSON-array parameter matched via `json_each`, so this
+/// must still enumerate correctly (paged, exactly, in order) even with the
+/// SQLite variable limit pinned to 999 and 1,001 distinct namespaces in the
+/// visibility set — mirroring
+/// `batched_namespace_edge_counts_exceed_sqlite_variable_limit` above, but
+/// through the paginated listing path rather than the count-only aggregate.
+#[tokio::test]
+async fn query_edges_in_namespaces_offset_paging_exceeds_sqlite_variable_limit() {
+    let config = PoolConfig {
+        path: None,
+        ..PoolConfig::default()
+    };
+    let pool = Arc::new(ConnectionPool::new(config).unwrap());
+    pool.writer()
+        .unwrap()
+        .conn()
+        .execute_batch(GRAPH_DDL)
+        .unwrap();
+    let store_a = SqlGraphStore::new_scoped(Arc::clone(&pool), false, "list-a");
+    let store_b = SqlGraphStore::new_scoped(Arc::clone(&pool), false, "list-b");
+
+    let tied = Utc::now();
+    let mut expected: HashSet<Uuid> = HashSet::new();
+    for (store, ns) in [(&store_a, "list-a"), (&store_b, "list-b")] {
+        for _ in 0..6 {
+            let mut edge = make_edge(Uuid::new_v4(), Uuid::new_v4(), EdgeRelation::Extends, 0.5);
+            edge.namespace = ns.to_string();
+            edge.created_at = tied;
+            edge.updated_at = tied;
+            expected.insert(edge.id.into());
+            store.upsert_edge(edge).await.unwrap();
+        }
+    }
+    assert_eq!(expected.len(), 12);
+
+    pool.writer()
+        .unwrap()
+        .conn()
+        .set_limit(rusqlite::limits::Limit::SQLITE_LIMIT_VARIABLE_NUMBER, 999)
+        .unwrap();
+
+    let mut namespaces = vec!["list-a".to_string(), "list-b".to_string()];
+    namespaces.extend((0..999).map(|i| format!("empty-{i}")));
+    assert_eq!(namespaces.len(), 1_001);
+
+    let sort = vec![SortOrder {
+        field: EdgeSortField::CreatedAt,
+        direction: SortDirection::Asc,
+    }];
+    let mut seen: Vec<Uuid> = Vec::new();
+    let mut offset: u64 = 0;
+    loop {
+        let page = store_a
+            .query_edges_in_namespaces(
+                &namespaces,
+                EdgeFilter::default(),
+                sort.clone(),
+                PageRequest { offset, limit: 5 },
+            )
+            .await
+            .unwrap();
+        assert_eq!(page.total, Some(12));
+        if page.items.is_empty() {
+            break;
+        }
+        for e in &page.items {
+            seen.push(e.id.into());
+        }
+        offset += 5;
+    }
+
+    assert_eq!(seen.len(), 12, "offset paging must enumerate every row");
+    let distinct: HashSet<Uuid> = seen.iter().copied().collect();
+    assert_eq!(distinct.len(), 12, "no row may appear on two pages");
+    assert_eq!(
+        distinct, expected,
+        "enumerated set must equal the seeded set"
+    );
+}
+
 #[tokio::test]
 async fn duplicate_namespace_across_chunk_boundary_is_not_double_counted() {
     let config = PoolConfig {

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -5021,22 +5021,90 @@ impl KhiveRuntime {
         // between calls — pages silently duplicate and skip rows, so
         // enumeration never covers the set (#2088).
         let ns_strs: Vec<String> = visible.iter().map(|ns| ns.as_str().to_owned()).collect();
-        let page = self
-            .graph(token)?
+        let sort = vec![SortOrder {
+            field: EdgeSortField::CreatedAt,
+            direction: khive_storage::types::SortDirection::Asc,
+        }];
+        let graph = self.graph(token)?;
+        match graph
             .query_edges_in_namespaces(
                 &ns_strs,
-                filter.into(),
-                vec![SortOrder {
-                    field: EdgeSortField::CreatedAt,
-                    direction: khive_storage::types::SortDirection::Asc,
-                }],
+                filter.clone().into(),
+                sort.clone(),
                 PageRequest {
                     offset: offset.into(),
                     limit,
                 },
             )
-            .await?;
-        Ok(page.items)
+            .await
+        {
+            Ok(page) => Ok(page.items),
+            Err(khive_storage::StorageError::Unsupported { operation, .. })
+                if operation == "query_edges_in_namespaces" =>
+            {
+                // Backend exercises the trait default (no batched
+                // namespace query support): fall back to one `query_edges`
+                // call per namespace. Unlike the pre-image fix for #2088,
+                // this fetches an `offset + limit` prefix from every
+                // namespace and merges by the *same* `(created_at, id)` key
+                // each per-namespace fetch already orders by — the
+                // pre-image bug sorted the merged set by UUID alone, a key
+                // unrelated to the order each per-namespace prefix was cut
+                // at, which floated the offset window and silently
+                // duplicated/skipped rows across pages. Sorting by the
+                // fetch's own order key keeps the top `offset + limit` of
+                // the merge exactly equal to the true global prefix.
+                let fetch_limit = offset.saturating_add(limit);
+                let mut namespace_prefixes = Vec::new();
+                for ns in visible {
+                    let temp = NamespaceToken::for_namespace(ns.clone());
+                    let page = self
+                        .graph(&temp)?
+                        .query_edges(
+                            filter.clone().into(),
+                            sort.clone(),
+                            PageRequest {
+                                offset: 0,
+                                limit: fetch_limit,
+                            },
+                        )
+                        .await?;
+                    namespace_prefixes.push(page.items);
+                }
+                Ok(Self::merge_paged_namespace_edges(
+                    namespace_prefixes,
+                    offset,
+                    limit,
+                ))
+            }
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    /// Merge per-namespace `(created_at, id)`-ordered edge prefixes (each
+    /// already fetched up to `offset + limit` from its own namespace, as
+    /// [`Self::list_edges`]'s trait-default fallback does) into one global
+    /// `[offset, offset + limit)` page.
+    ///
+    /// Sorting by the *same key each prefix was already cut at* is what
+    /// keeps this exact: the top `offset + limit` of the merged set is then
+    /// provably equal to the true global prefix (a standard k-way merge
+    /// argument — no element beyond position `offset + limit` in any single
+    /// namespace can appear before that position in the global order). The
+    /// pre-image #2088 bug instead re-sorted the merged set by UUID alone —
+    /// a key unrelated to the order each namespace's prefix was fetched in —
+    /// which floated the offset window and silently duplicated/skipped rows
+    /// across pages.
+    fn merge_paged_namespace_edges(
+        namespace_prefixes: Vec<Vec<Edge>>,
+        offset: u32,
+        limit: u32,
+    ) -> Vec<Edge> {
+        let mut results: Vec<Edge> = namespace_prefixes.into_iter().flatten().collect();
+        results.sort_by_key(|e| (e.created_at, Uuid::from(e.id)));
+        let start = (offset as usize).min(results.len());
+        let end = (start + limit as usize).min(results.len());
+        results[start..end].to_vec()
     }
 
     /// Keyset (seek) page of edges matching `filter`, ordered by immutable
@@ -6867,9 +6935,23 @@ mod tests {
         assert_eq!(updated.relation, EdgeRelation::VariantOf);
     }
 
-    /// #2088 regression at the runtime seam: a token whose visibility spans
-    /// two namespaces must offset-enumerate the combined edge set exactly —
-    /// no duplicates across pages, nothing skipped.
+    /// #2088 regression at the runtime seam, rebuilt deterministic per the
+    /// #2089 round-1 review (finding 3): the previous fixture created edges
+    /// through the normal `link()` path (random UUIDs, wall-clock
+    /// timestamps), so whether it exposed the pre-image bug — sorting the
+    /// per-namespace merge by UUID alone, a key unrelated to the
+    /// `created_at` order each per-namespace fetch was actually cut at —
+    /// depended on the RNG; it could pass against pre-image code by pure
+    /// luck.
+    ///
+    /// This fixture pins both: every `ns-a` edge gets a UUID numerically
+    /// greater than every `ns-b` edge, while `created_at` strictly
+    /// interleaves the two namespaces (a, b, a, b, a, b). A UUID-only sort
+    /// therefore reliably produces "every ns-b edge, then every ns-a edge"
+    /// — provably different from the true `created_at` interleaving — so
+    /// asserting this exact expected sequence (not just the resulting set)
+    /// is what a reverted pre-image implementation would fail to
+    /// reproduce.
     #[tokio::test]
     async fn list_edges_multi_namespace_offset_paging_enumerates_exactly() {
         let rt = rt();
@@ -6878,23 +6960,87 @@ mod tests {
         let tok_a = NamespaceToken::for_namespace(ns_a.clone());
         let tok_b = NamespaceToken::for_namespace(ns_b.clone());
 
-        let mut expected = std::collections::HashSet::new();
-        for (tok, n) in [(&tok_a, 15u32), (&tok_b, 15u32)] {
-            for i in 0..n {
-                let a = rt
-                    .create_entity(tok, "concept", None, &format!("S{i}"), None, None, vec![])
-                    .await
-                    .unwrap();
-                let b = rt
-                    .create_entity(tok, "concept", None, &format!("T{i}"), None, None, vec![])
-                    .await
-                    .unwrap();
-                let e = rt
-                    .link(tok, a.id, b.id, EdgeRelation::Extends, 0.5, None)
-                    .await
-                    .unwrap();
-                expected.insert(Uuid::from(e.id));
-            }
+        let source = rt
+            .create_entity(&tok_a, "concept", None, "Source", None, None, vec![])
+            .await
+            .unwrap();
+        let mut targets = Vec::new();
+        for index in 0..6 {
+            targets.push(
+                rt.create_entity(
+                    &tok_a,
+                    "concept",
+                    None,
+                    &format!("Target{index}"),
+                    None,
+                    None,
+                    vec![],
+                )
+                .await
+                .unwrap(),
+            );
+        }
+
+        // Every `a_uuids` entry is numerically greater than every
+        // `b_uuids` entry (leading nibble `f` vs `0`).
+        let a_uuids = [
+            Uuid::parse_str("ffffffff-ffff-4fff-8fff-ffffffffff01").unwrap(),
+            Uuid::parse_str("ffffffff-ffff-4fff-8fff-ffffffffff02").unwrap(),
+            Uuid::parse_str("ffffffff-ffff-4fff-8fff-ffffffffff03").unwrap(),
+        ];
+        let b_uuids = [
+            Uuid::parse_str("00000000-0000-4000-8000-000000000001").unwrap(),
+            Uuid::parse_str("00000000-0000-4000-8000-000000000002").unwrap(),
+            Uuid::parse_str("00000000-0000-4000-8000-000000000003").unwrap(),
+        ];
+
+        let graph_a = rt.graph(&tok_a).unwrap();
+        let graph_b = rt.graph(&tok_b).unwrap();
+        let mut expected_order: Vec<Uuid> = Vec::new();
+        for i in 0..3usize {
+            let a_created_at = chrono::DateTime::<chrono::Utc>::from_timestamp_micros(
+                1_000_000 + (2 * i as i64) * 1_000_000,
+            )
+            .unwrap();
+            graph_a
+                .upsert_edge(Edge {
+                    id: a_uuids[i].into(),
+                    namespace: "ns-a".into(),
+                    source_id: source.id,
+                    target_id: targets[2 * i].id,
+                    relation: EdgeRelation::Extends,
+                    weight: 0.5,
+                    created_at: a_created_at,
+                    updated_at: a_created_at,
+                    deleted_at: None,
+                    metadata: None,
+                    target_backend: None,
+                })
+                .await
+                .unwrap();
+            expected_order.push(a_uuids[i]);
+
+            let b_created_at = chrono::DateTime::<chrono::Utc>::from_timestamp_micros(
+                2_000_000 + (2 * i as i64) * 1_000_000,
+            )
+            .unwrap();
+            graph_b
+                .upsert_edge(Edge {
+                    id: b_uuids[i].into(),
+                    namespace: "ns-b".into(),
+                    source_id: source.id,
+                    target_id: targets[2 * i + 1].id,
+                    relation: EdgeRelation::Extends,
+                    weight: 0.5,
+                    created_at: b_created_at,
+                    updated_at: b_created_at,
+                    deleted_at: None,
+                    metadata: None,
+                    target_backend: None,
+                })
+                .await
+                .unwrap();
+            expected_order.push(b_uuids[i]);
         }
 
         let multi = NamespaceToken::mint_with_visibility(ns_a, vec![ns_b], ActorRef::anonymous());
@@ -6902,23 +7048,93 @@ mod tests {
         let mut offset = 0u32;
         loop {
             let page = rt
-                .list_edges(&multi, EdgeListFilter::default(), 4, offset)
+                .list_edges(&multi, EdgeListFilter::default(), 2, offset)
                 .await
                 .unwrap();
             if page.is_empty() {
                 break;
             }
             seen.extend(page.iter().map(|e| Uuid::from(e.id)));
-            offset += 4;
+            offset += 2;
         }
 
-        assert_eq!(seen.len(), 30, "must enumerate all edges across namespaces");
-        let distinct: std::collections::HashSet<Uuid> = seen.iter().copied().collect();
-        assert_eq!(distinct.len(), 30, "no duplicates across pages");
         assert_eq!(
-            distinct, expected,
-            "enumerated set must equal the created set"
+            seen, expected_order,
+            "must enumerate in exact created_at order, not UUID order"
         );
+        let distinct: std::collections::HashSet<Uuid> = seen.iter().copied().collect();
+        assert_eq!(distinct.len(), 6, "no duplicates across pages");
+        let expected_set: std::collections::HashSet<Uuid> =
+            expected_order.iter().copied().collect();
+        assert_eq!(
+            distinct, expected_set,
+            "enumerated set must equal the seeded set"
+        );
+    }
+
+    /// #2089 round-1 MEDIUM finding 2: `list_edges`'s trait-default fallback
+    /// (taken when a `GraphStore` backend returns `Unsupported` from
+    /// `query_edges_in_namespaces` — i.e. it does not override the batched
+    /// namespace query, per [`khive_storage::GraphStore`]'s default) merges
+    /// independently-fetched per-namespace prefixes through
+    /// [`KhiveRuntime::merge_paged_namespace_edges`]. This exercises that
+    /// merge directly: `ns_a`'s edges all carry numerically-greater UUIDs
+    /// than every `ns_b` edge, while `created_at` interleaves the two
+    /// namespaces. Sorting the merge by UUID alone (the pre-image #2088 bug)
+    /// would put every `ns_b` edge before every `ns_a` edge regardless of
+    /// `created_at` — provably different from this fixture's expected
+    /// order — so an exact-sequence assertion here is sufficient to catch a
+    /// regression back to that bug.
+    #[test]
+    fn merge_paged_namespace_edges_orders_by_created_at_not_uuid() {
+        fn edge(id_hex_suffix: &str, created_at_micros: i64) -> Edge {
+            let created_at =
+                chrono::DateTime::<chrono::Utc>::from_timestamp_micros(created_at_micros).unwrap();
+            Edge {
+                id: Uuid::parse_str(&format!("00000000-0000-4000-8000-{id_hex_suffix}"))
+                    .unwrap()
+                    .into(),
+                namespace: "irrelevant".into(),
+                source_id: Uuid::nil(),
+                target_id: Uuid::nil(),
+                relation: EdgeRelation::Extends,
+                weight: 0.5,
+                created_at,
+                updated_at: created_at,
+                deleted_at: None,
+                metadata: None,
+                target_backend: None,
+            }
+        }
+
+        // Every `a*` UUID (leading nibble `f`) is numerically greater than
+        // every `b*` UUID (leading nibble `0`), but `created_at` interleaves
+        // them: a0 < b0 < a1 < b1.
+        let a0 = edge("ffffffffffff", 1_000_000);
+        let b0 = edge("000000000001", 2_000_000);
+        let a1 = edge("fffffffffffe", 3_000_000);
+        let b1 = edge("000000000002", 4_000_000);
+
+        let namespace_prefixes = vec![vec![a0.clone(), a1.clone()], vec![b0.clone(), b1.clone()]];
+
+        let full_page = KhiveRuntime::merge_paged_namespace_edges(namespace_prefixes.clone(), 0, 4);
+        let ids: Vec<Uuid> = full_page.iter().map(|e| Uuid::from(e.id)).collect();
+        assert_eq!(
+            ids,
+            vec![
+                Uuid::from(a0.id),
+                Uuid::from(b0.id),
+                Uuid::from(a1.id),
+                Uuid::from(b1.id)
+            ],
+            "must order the merge by created_at, not by UUID magnitude"
+        );
+
+        // Mid-window offset must slice the same globally-ordered sequence,
+        // not re-derive order per page.
+        let middle_page = KhiveRuntime::merge_paged_namespace_edges(namespace_prefixes, 1, 2);
+        let middle_ids: Vec<Uuid> = middle_page.iter().map(|e| Uuid::from(e.id)).collect();
+        assert_eq!(middle_ids, vec![Uuid::from(b0.id), Uuid::from(a1.id)]);
     }
 
     #[tokio::test]

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -5014,34 +5014,29 @@ impl KhiveRuntime {
             return Ok(page.items);
         }
 
-        // Multi-namespace visibility: `offset` must apply to the combined,
-        // deduplicated set rather than per-namespace pages, so fetch enough
-        // of each namespace's page to cover it, merge, then slice.
-        let fetch_limit = offset.saturating_add(limit);
-        let mut results = Vec::new();
-        for ns in visible {
-            let temp = NamespaceToken::for_namespace(ns.clone());
-            let page = self
-                .graph(&temp)?
-                .query_edges(
-                    filter.clone().into(),
-                    vec![SortOrder {
-                        field: EdgeSortField::CreatedAt,
-                        direction: khive_storage::types::SortDirection::Asc,
-                    }],
-                    PageRequest {
-                        offset: 0,
-                        limit: fetch_limit,
-                    },
-                )
-                .await?;
-            results.extend(page.items);
-        }
-        results.sort_by_key(|e| Uuid::from(e.id));
-        results.dedup_by_key(|e| Uuid::from(e.id));
-        let start = (offset as usize).min(results.len());
-        let end = (start + limit as usize).min(results.len());
-        Ok(results[start..end].to_vec())
+        // Multi-namespace visibility: one deterministic query with
+        // `namespace IN (...)` and real SQL paging, mirroring
+        // `list_entities`. Fetching per-namespace prefixes and slicing a
+        // client-side merge re-sorted by UUID floats the offset window
+        // between calls — pages silently duplicate and skip rows, so
+        // enumeration never covers the set (#2088).
+        let ns_strs: Vec<String> = visible.iter().map(|ns| ns.as_str().to_owned()).collect();
+        let page = self
+            .graph(token)?
+            .query_edges_in_namespaces(
+                &ns_strs,
+                filter.into(),
+                vec![SortOrder {
+                    field: EdgeSortField::CreatedAt,
+                    direction: khive_storage::types::SortDirection::Asc,
+                }],
+                PageRequest {
+                    offset: offset.into(),
+                    limit,
+                },
+            )
+            .await?;
+        Ok(page.items)
     }
 
     /// Keyset (seek) page of edges matching `filter`, ordered by immutable
@@ -6870,6 +6865,60 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(updated.relation, EdgeRelation::VariantOf);
+    }
+
+    /// #2088 regression at the runtime seam: a token whose visibility spans
+    /// two namespaces must offset-enumerate the combined edge set exactly —
+    /// no duplicates across pages, nothing skipped.
+    #[tokio::test]
+    async fn list_edges_multi_namespace_offset_paging_enumerates_exactly() {
+        let rt = rt();
+        let ns_a = Namespace::parse("ns-a").unwrap();
+        let ns_b = Namespace::parse("ns-b").unwrap();
+        let tok_a = NamespaceToken::for_namespace(ns_a.clone());
+        let tok_b = NamespaceToken::for_namespace(ns_b.clone());
+
+        let mut expected = std::collections::HashSet::new();
+        for (tok, n) in [(&tok_a, 15u32), (&tok_b, 15u32)] {
+            for i in 0..n {
+                let a = rt
+                    .create_entity(tok, "concept", None, &format!("S{i}"), None, None, vec![])
+                    .await
+                    .unwrap();
+                let b = rt
+                    .create_entity(tok, "concept", None, &format!("T{i}"), None, None, vec![])
+                    .await
+                    .unwrap();
+                let e = rt
+                    .link(tok, a.id, b.id, EdgeRelation::Extends, 0.5, None)
+                    .await
+                    .unwrap();
+                expected.insert(Uuid::from(e.id));
+            }
+        }
+
+        let multi = NamespaceToken::mint_with_visibility(ns_a, vec![ns_b], ActorRef::anonymous());
+        let mut seen: Vec<Uuid> = Vec::new();
+        let mut offset = 0u32;
+        loop {
+            let page = rt
+                .list_edges(&multi, EdgeListFilter::default(), 4, offset)
+                .await
+                .unwrap();
+            if page.is_empty() {
+                break;
+            }
+            seen.extend(page.iter().map(|e| Uuid::from(e.id)));
+            offset += 4;
+        }
+
+        assert_eq!(seen.len(), 30, "must enumerate all edges across namespaces");
+        let distinct: std::collections::HashSet<Uuid> = seen.iter().copied().collect();
+        assert_eq!(distinct.len(), 30, "no duplicates across pages");
+        assert_eq!(
+            distinct, expected,
+            "enumerated set must equal the created set"
+        );
     }
 
     #[tokio::test]

--- a/crates/khive-storage/src/graph.rs
+++ b/crates/khive-storage/src/graph.rs
@@ -95,6 +95,34 @@ pub trait GraphStore: Send + Sync + 'static {
         sort: Vec<SortOrder<EdgeSortField>>,
         page: PageRequest,
     ) -> StorageResult<Page<Edge>>;
+    /// Query edges across the given namespaces in one deterministic query
+    /// with real SQL paging. The multi-namespace analogue of
+    /// [`Self::query_edges`]: a single statement with `namespace IN (...)`
+    /// keeps `offset` continuation coherent, where fetching per-namespace
+    /// prefixes and slicing a client-side merge floats the window between
+    /// calls (silent duplicate/skip enumeration). Backends without batched
+    /// namespace support retain the single-namespace path and reject
+    /// multi-namespace requests explicitly.
+    async fn query_edges_in_namespaces(
+        &self,
+        namespaces: &[String],
+        filter: EdgeFilter,
+        sort: Vec<SortOrder<EdgeSortField>>,
+        page: PageRequest,
+    ) -> StorageResult<Page<Edge>> {
+        match namespaces.len() {
+            0 => Ok(Page {
+                items: Vec::new(),
+                total: Some(0),
+            }),
+            1 => self.query_edges(filter, sort, page).await,
+            _ => Err(StorageError::Unsupported {
+                capability: StorageCapability::Graph,
+                operation: "query_edges_in_namespaces".into(),
+                message: "this backend does not implement batched namespace edge queries".into(),
+            }),
+        }
+    }
     /// Count edges matching the given filter.
     async fn count_edges(&self, filter: EdgeFilter) -> StorageResult<u64>;
     /// Count edges across the given namespaces in one aggregate query.

--- a/crates/khive-storage/tests/graph_namespace_trait_default.rs
+++ b/crates/khive-storage/tests/graph_namespace_trait_default.rs
@@ -1,0 +1,228 @@
+//! #2089 round-1 MEDIUM finding 2: any `GraphStore` backend that does not
+//! override `query_edges_in_namespaces` (the trait default) must still
+//! behave correctly for the 0/1-namespace cases, and must reject a
+//! multi-namespace request with `StorageError::Unsupported { operation:
+//! "query_edges_in_namespaces", .. }` — the exact shape
+//! `khive-runtime::operations::KhiveRuntime::list_edges` matches on to
+//! decide whether to fall back to a per-namespace merge. A backend that
+//! doesn't implement the batched query is a real, if uncompiled-in-this-
+//! workspace, case: `khive-merge` is forward-deployed outside the workspace
+//! members (see `crates/khive-merge`), so the runtime cannot assume every
+//! `GraphStore` it is handed overrides this method.
+
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use khive_storage::types::{
+    BatchWriteSummary, DeleteMode, Edge, EdgeFilter, EdgeSeekPage, EdgeSortField, GraphPath,
+    LinkId, NeighborHit, NeighborQuery, Page, PageRequest, SortDirection, SortOrder,
+    TraversalRequest,
+};
+use khive_storage::{GraphStore, StorageCapability, StorageError, StorageResult};
+use khive_types::EdgeRelation;
+
+/// A minimal `GraphStore` that only implements the methods with no trait
+/// default (plus `query_edges`, needed for `query_edges_in_namespaces`'s
+/// 1-namespace delegation). It deliberately does NOT override
+/// `query_edges_in_namespaces` or `count_edges_in_namespaces` — exactly the
+/// "backend exercising the trait default" the round-1 review asked for.
+struct TraitDefaultOnlyGraphStore {
+    edges: Mutex<Vec<Edge>>,
+}
+
+impl TraitDefaultOnlyGraphStore {
+    fn new(edges: Vec<Edge>) -> Self {
+        Self {
+            edges: Mutex::new(edges),
+        }
+    }
+}
+
+#[async_trait]
+impl GraphStore for TraitDefaultOnlyGraphStore {
+    async fn upsert_edge(&self, edge: Edge) -> StorageResult<()> {
+        self.edges.lock().unwrap().push(edge);
+        Ok(())
+    }
+
+    async fn upsert_edges(&self, edges: Vec<Edge>) -> StorageResult<BatchWriteSummary> {
+        let count = edges.len() as u64;
+        self.edges.lock().unwrap().extend(edges);
+        Ok(BatchWriteSummary {
+            affected: count,
+            ..Default::default()
+        })
+    }
+
+    async fn get_edge(&self, id: LinkId) -> StorageResult<Option<Edge>> {
+        Ok(self
+            .edges
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|e| e.id == id)
+            .cloned())
+    }
+
+    async fn get_edge_including_deleted(&self, id: LinkId) -> StorageResult<Option<Edge>> {
+        self.get_edge(id).await
+    }
+
+    async fn get_edge_by_natural_key_including_deleted(
+        &self,
+        _namespace: &str,
+        _source_id: Uuid,
+        _target_id: Uuid,
+        _relation: EdgeRelation,
+    ) -> StorageResult<Option<Edge>> {
+        Ok(None)
+    }
+
+    async fn delete_edge(&self, _id: LinkId, _mode: DeleteMode) -> StorageResult<bool> {
+        Ok(false)
+    }
+
+    async fn query_edges(
+        &self,
+        filter: EdgeFilter,
+        _sort: Vec<SortOrder<EdgeSortField>>,
+        page: PageRequest,
+    ) -> StorageResult<Page<Edge>> {
+        let mut matching: Vec<Edge> = self
+            .edges
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|e| filter.relations.is_empty() || filter.relations.contains(&e.relation))
+            .cloned()
+            .collect();
+        matching.sort_by_key(|e| (e.created_at, Uuid::from(e.id)));
+        let total = matching.len() as u64;
+        let start = (page.offset as usize).min(matching.len());
+        let end = (start + page.limit as usize).min(matching.len());
+        Ok(Page {
+            items: matching[start..end].to_vec(),
+            total: Some(total),
+        })
+    }
+
+    async fn count_edges(&self, filter: EdgeFilter) -> StorageResult<u64> {
+        Ok(self
+            .edges
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|e| filter.relations.is_empty() || filter.relations.contains(&e.relation))
+            .count() as u64)
+    }
+
+    async fn count_edges_by_relation(&self) -> StorageResult<Vec<(EdgeRelation, u64)>> {
+        Ok(Vec::new())
+    }
+
+    async fn query_edges_after(
+        &self,
+        _filter: EdgeFilter,
+        _after: Option<Uuid>,
+        _limit: u32,
+    ) -> StorageResult<EdgeSeekPage> {
+        Ok(EdgeSeekPage::default())
+    }
+
+    async fn neighbors(
+        &self,
+        _node_id: Uuid,
+        _query: NeighborQuery,
+    ) -> StorageResult<Vec<NeighborHit>> {
+        Ok(Vec::new())
+    }
+
+    async fn traverse(&self, _request: TraversalRequest) -> StorageResult<Vec<GraphPath>> {
+        Ok(Vec::new())
+    }
+
+    async fn purge_incident_edges(&self, _node_id: Uuid) -> StorageResult<u64> {
+        Ok(0)
+    }
+}
+
+fn make_edge(namespace: &str, id: Uuid, created_at_micros: i64) -> Edge {
+    let created_at =
+        chrono::DateTime::<chrono::Utc>::from_timestamp_micros(created_at_micros).unwrap();
+    Edge {
+        id: id.into(),
+        namespace: namespace.to_string(),
+        source_id: Uuid::nil(),
+        target_id: Uuid::nil(),
+        relation: EdgeRelation::Extends,
+        weight: 0.5,
+        created_at,
+        updated_at: created_at,
+        deleted_at: None,
+        metadata: None,
+        target_backend: None,
+    }
+}
+
+#[tokio::test]
+async fn query_edges_in_namespaces_default_rejects_multi_namespace_by_name() {
+    let store = TraitDefaultOnlyGraphStore::new(vec![make_edge("ns-a", Uuid::new_v4(), 1_000_000)]);
+
+    let sort = vec![SortOrder {
+        field: EdgeSortField::CreatedAt,
+        direction: SortDirection::Asc,
+    }];
+
+    // Empty visibility set: the default yields an empty page, not an error.
+    let empty = store
+        .query_edges_in_namespaces(
+            &[],
+            EdgeFilter::default(),
+            sort.clone(),
+            PageRequest::default(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(empty.items.len(), 0);
+    assert_eq!(empty.total, Some(0));
+
+    // Single namespace: the default delegates to `query_edges` and succeeds.
+    let single = store
+        .query_edges_in_namespaces(
+            &["ns-a".to_string()],
+            EdgeFilter::default(),
+            sort.clone(),
+            PageRequest::default(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(single.items.len(), 1);
+
+    // Multi-namespace: the default must reject explicitly, using the exact
+    // operation name `khive-runtime::operations::KhiveRuntime::list_edges`
+    // matches on to trigger its per-namespace merge fallback. A rename here
+    // that isn't mirrored in the runtime's `if operation == "..."` guard
+    // would silently stop the fallback from firing.
+    let err = store
+        .query_edges_in_namespaces(
+            &["ns-a".to_string(), "ns-b".to_string()],
+            EdgeFilter::default(),
+            sort,
+            PageRequest::default(),
+        )
+        .await
+        .unwrap_err();
+    match err {
+        StorageError::Unsupported {
+            capability,
+            operation,
+            ..
+        } => {
+            assert_eq!(capability, StorageCapability::Graph);
+            assert_eq!(operation, "query_edges_in_namespaces");
+        }
+        other => panic!("expected StorageError::Unsupported, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Problem

`list(kind="edge")` over multiple visible namespaces silently mis-enumerates under offset paging (#2088). The multi-namespace branch fetched a per-namespace `(created_at, id)` prefix of size `offset+limit` from each namespace, re-sorted the union by UUID, deduplicated, and sliced `[offset, offset+limit)`. Because the slice window is computed over a prefix union that grows with the offset, page boundaries float: consecutive pages return duplicate rows and skip others, with no error surfaced. Measured live: 4 pages of 500 over ~2000 edges returned 2000 rows of which only 1024 were distinct.

Entity listing does not have this defect because `list_entities` pushes the whole visible-namespace set into one SQL query with a real OFFSET.

## Fix

Mirror the entity path for edges:

- **khive-storage**: new `query_edges_in_namespaces` trait method. An empty namespace set yields an empty page, a single namespace delegates to the existing `query_edges`, and the multi-namespace form is a backend capability (default `Unsupported`).
- **khive-db**: implement it as a single statement with `namespace IN (...)` and real `LIMIT`/`OFFSET`. The deterministic id tiebreak (per #1671) is shared with `query_edges` through an extracted order-clause helper, so both paths order identically.
- **khive-runtime**: the multi-namespace `list_edges` branch now calls the new method instead of the prefix-union merge.

## Tests

- Store level: offset paging over two namespaces whose 40 edges all share one `created_at` (the worst tie population). Asserts exact enumeration (every edge exactly once across pages), `total`, and page stability (re-reading the same offset returns the identical id order).
- Runtime level: two namespaces, 30 edges, paged through a multi-visibility token to exhaustion; asserts 30 distinct rows seen and set equality with what was created.

Closes #2088.

🤖 Generated with [Claude Code](https://claude.com/claude-code)