### PR TITLE
feat(kg-editor): share repository investigation locations

### DIFF
--- a/apps/kg-editor/DEMO.md
+++ b/apps/kg-editor/DEMO.md
@@ -33,7 +33,10 @@ Before presenting, verify that the source badge says **khive DB snapshot**, not
 
 This setup requires the DB snapshot API route from the companion backend PR (or
 its merged equivalent). Without that route, this UI branch intentionally uses
-the curated static fallback.
+the curated static fallback. The DB-backed snapshot is always an optional
+enhancement over the bundled static asset: any failure on that path — network
+error, non-2xx status, an oversized or malformed body, or a provenance
+mismatch — falls back to the static asset rather than failing the page.
 
 ## Five-to-seven-minute flow
 

--- a/apps/kg-editor/e2e/showcase.spec.ts
+++ b/apps/kg-editor/e2e/showcase.spec.ts
@@ -74,6 +74,43 @@ test("dogfoods every repository analysis from the curated static bundle", async 
   ]);
 });
 
+test("restores a shared investigation and follows browser back and forward", async ({ page }) => {
+  const snapshot = "c2979d2443738a075e55a170c772d1dc86cf0f91";
+  const pool = "crates/khive-db/src/pool.rs";
+  const writer = "crates/khive-db/src/writer_task.rs";
+  const query = new URLSearchParams({
+    repo: "https://github.com/ohdearquant/khive",
+    at: snapshot,
+    module: pool,
+    view: "dependency_topology",
+  });
+  await page.goto(`/?${query.toString()}`);
+
+  const inspector = page.locator("[data-module-inspector]");
+  await expect(inspector.getByRole("heading", { level: 3 })).toHaveText(pool);
+  await expect(page.locator('[data-view-id="dependency_topology"]')).toHaveAttribute(
+    "aria-current",
+    "page",
+  );
+
+  await page.getByRole("searchbox", { name: "Find a module or path" }).fill(writer);
+  await page.getByRole("button", { name: `Inspect ${writer}` }).click();
+  await expect(inspector.getByRole("heading", { level: 3 })).toHaveText(writer);
+  await expect(page).toHaveURL(new RegExp(`module=${encodeURIComponent(writer)}`));
+
+  await page.locator('[data-view-id="hidden_coupling"]').click();
+  await expect(page).toHaveURL(/view=hidden_coupling/);
+
+  await page.goBack();
+  await expect(page).toHaveURL(/view=dependency_topology/);
+  await expect(inspector.getByRole("heading", { level: 3 })).toHaveText(writer);
+
+  await page.goBack();
+  await expect(inspector.getByRole("heading", { level: 3 })).toHaveText(pool);
+  await page.goForward();
+  await expect(inspector.getByRole("heading", { level: 3 })).toHaveText(writer);
+});
+
 test("a valid repository miss stays local and renders an honest state", async ({ page }) => {
   const requestedAfterSubmit: string[] = [];
   let observing = false;

--- a/apps/kg-editor/src/app/showcase.css
+++ b/apps/kg-editor/src/app/showcase.css
@@ -291,6 +291,7 @@
 
 .repo-meta-row { flex-wrap: wrap; gap: 8px; justify-content: flex-end; }
 .repo-meta-row span,
+.repo-meta-row button,
 .repo-derived-badge {
   background: var(--khive-color-surface-raised);
   border: 1px solid var(--repo-border);
@@ -300,8 +301,56 @@
   gap: 5px;
   padding: 6px 9px;
 }
+.repo-meta-row button {
+  cursor: pointer;
+  font: inherit;
+}
+.repo-meta-row button:hover,
+.repo-meta-row button:focus-visible {
+  border-color: var(--repo-green);
+  color: var(--repo-green);
+}
 .repo-meta-row svg { height: 11px; width: 11px; }
 .repo-meta-row code { color: var(--repo-navy); font-size: var(--khive-type-md); }
+
+.repo-investigation-notice {
+  align-items: center;
+  background: var(--amber-pale);
+  border: 1px solid var(--repo-border);
+  border-radius: 11px;
+  color: var(--repo-muted);
+  display: flex;
+  font-size: 10px;
+  gap: 10px;
+  padding: 10px 13px;
+}
+.repo-investigation-notice > svg {
+  color: var(--amber);
+  flex: 0 0 auto;
+  height: 15px;
+  width: 15px;
+}
+.repo-investigation-notice span {
+  display: grid;
+  flex: 1;
+  gap: 2px;
+}
+.repo-investigation-notice strong { color: var(--repo-navy); }
+.repo-investigation-notice button {
+  background: var(--repo-paper);
+  border: 1px solid var(--repo-border);
+  border-radius: 999px;
+  color: var(--repo-navy);
+  cursor: pointer;
+  flex: 0 0 auto;
+  font: inherit;
+  padding: 6px 9px;
+}
+.repo-investigation-notice button:hover,
+.repo-investigation-notice button:focus-visible {
+  border-color: var(--repo-green);
+  color: var(--repo-green);
+}
 
 .repo-capability-strip {
   background: var(--khive-color-surface-raised);
@@ -712,6 +761,7 @@ button.repo-list-row:hover,
 }
 
 @media (max-width: 760px) {
+  .repo-investigation-notice { align-items: flex-start; flex-direction: column; }
   .repo-topbar { grid-template-columns: 1fr auto; padding: 0 15px; }
   .repo-product-nav { display: none; }
   .repo-brand > span:last-child { display: none; }

--- a/apps/kg-editor/src/components/showcase/repo-showcase.test.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase.test.tsx
@@ -2,10 +2,11 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RepoShowcase } from "@/components/showcase/repo-showcase";
 import { parseRepoBundle, type RepoBundle } from "@/lib/repo-bundle";
+import { repositoryLocationUrl } from "@/lib/repository-location";
 
 const goldenPath = resolve(process.cwd(), "../../docs/schemas/examples/khive-repo-v1-khive.json");
 const showcaseSourcePath = resolve(process.cwd(), "src/components/showcase/repo-showcase.tsx");
@@ -20,6 +21,257 @@ function exactish(value: string): RegExp {
 }
 
 describe("repository showcase", () => {
+  beforeEach(() => {
+    window.history.replaceState(null, "", "/");
+  });
+
+  it("restores and traverses a shareable module and analysis location", async () => {
+    const bundle = golden();
+    const pool = bundle.graph.modules.items.find((module) =>
+      module.source_path.endsWith("khive-db/src/pool.rs")
+    )!;
+    const writer = bundle.graph.modules.items.find((module) =>
+      module.source_path.endsWith("khive-db/src/writer_task.rs")
+    )!;
+    const direct = repositoryLocationUrl(new URL(window.location.href), {
+      repository: bundle.meta.repository.canonical_url,
+      snapshotSha: bundle.meta.snapshot.head_sha,
+      modulePath: pool.source_path,
+      view: "dependency_topology",
+    });
+    window.history.replaceState(null, "", direct);
+    const user = userEvent.setup();
+    const { container } = render(<RepoShowcase bundle={bundle} />);
+
+    const inspector = within(
+      container.querySelector<HTMLElement>("[data-repository-triage]")!,
+    ).getByRole("complementary", { name: "Module evidence" });
+    await waitFor(() =>
+      expect(within(inspector).getByRole("heading", { level: 3 })).toHaveTextContent(
+        pool.source_path,
+      )
+    );
+    expect(
+      screen.getByRole("button", {
+        name: bundle.capability.views.dependency_topology.label,
+      }),
+    ).toHaveAttribute("aria-current", "page");
+    const breadcrumb = within(inspector).getByRole("navigation", {
+      name: "Investigation location",
+    });
+    expect(breadcrumb).toHaveTextContent(`${bundle.meta.repository.owner}/${bundle.meta.repository.name}`);
+    expect(breadcrumb).toHaveTextContent(pool.source_path);
+
+    const pushState = vi.spyOn(window.history, "pushState");
+    const search = screen.getByRole("searchbox", { name: "Find a module or path" });
+    await user.type(search, writer.source_path);
+    await user.click(screen.getByRole("button", { name: `Inspect ${writer.source_path}` }));
+    await waitFor(() =>
+      expect(within(inspector).getByRole("heading", { level: 3 })).toHaveTextContent(
+        writer.source_path,
+      )
+    );
+    expect(new URL(window.location.href).searchParams.get("module")).toBe(
+      writer.source_path,
+    );
+    expect(pushState).toHaveBeenCalledTimes(1);
+
+    const hiddenCoupling = screen.getByRole("button", {
+      name: bundle.capability.views.hidden_coupling.label,
+    });
+    await user.click(hiddenCoupling);
+    expect(new URL(window.location.href).searchParams.get("view")).toBe(
+      "hidden_coupling",
+    );
+    expect(pushState).toHaveBeenCalledTimes(2);
+    await user.click(hiddenCoupling);
+    expect(pushState).toHaveBeenCalledTimes(2);
+
+    window.history.replaceState(null, "", direct);
+    window.dispatchEvent(new PopStateEvent("popstate"));
+    await waitFor(() =>
+      expect(within(inspector).getByRole("heading", { level: 3 })).toHaveTextContent(
+        pool.source_path,
+      )
+    );
+    expect(
+      screen.getByRole("button", {
+        name: bundle.capability.views.dependency_topology.label,
+      }),
+    ).toHaveAttribute("aria-current", "page");
+    expect(
+      screen.getByRole("status", { name: "Investigation navigation" }),
+    ).toHaveTextContent(
+      `Restored ${bundle.capability.views.dependency_topology.label} for ${pool.source_path}.`,
+    );
+    expect(pushState).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps stale and missing deep-link evidence explicit and recoverable", async () => {
+    const bundle = golden();
+    const missingPath = "crates/not-captured/src/missing.rs";
+    const direct = repositoryLocationUrl(new URL(window.location.href), {
+      repository: bundle.meta.repository.canonical_url,
+      snapshotSha: "0000000000000000000000000000000000000000",
+      modulePath: missingPath,
+      view: "scorecard",
+    });
+    window.history.replaceState(null, "", direct);
+    const user = userEvent.setup();
+    const { container } = render(<RepoShowcase bundle={bundle} />);
+
+    expect(await screen.findByRole("status", { name: /investigation link/i }))
+      .toHaveTextContent(/requested snapshot.*is not loaded/i);
+    const inspector = container.querySelector<HTMLElement>("[data-module-inspector]")!;
+    expect(within(inspector).getByText(new RegExp(missingPath))).toBeVisible();
+    const recovery = within(inspector).getByRole("button", {
+      name: /open recommended module/i,
+    });
+    await user.click(recovery);
+
+    await waitFor(() =>
+      expect(new URL(window.location.href).searchParams.get("at")).toBe(
+        bundle.meta.snapshot.head_sha,
+      )
+    );
+    await waitFor(() => expect(inspector).toHaveFocus());
+    expect(new URL(window.location.href).searchParams.get("module")).not.toBe(
+      missingPath,
+    );
+  });
+
+  it("copies the normalized investigation link with visible feedback", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.spyOn(navigator.clipboard, "writeText")
+      .mockResolvedValue(undefined);
+    render(<RepoShowcase bundle={golden()} />);
+
+    await waitFor(() =>
+      expect(new URL(window.location.href).searchParams.get("at")).not.toBeNull()
+    );
+    await user.click(
+      screen.getByRole("button", { name: "Copy investigation link" }),
+    );
+
+    expect(writeText).toHaveBeenCalledWith(window.location.href);
+    expect(screen.getByText("Investigation link copied.")).toHaveAttribute(
+      "role",
+      "status",
+    );
+  });
+
+  it("preserves stale-link evidence when clipboard access fails", async () => {
+    const bundle = golden();
+    const staleSha = "0000000000000000000000000000000000000000";
+    const direct = repositoryLocationUrl(new URL(window.location.href), {
+      repository: bundle.meta.repository.canonical_url,
+      snapshotSha: staleSha,
+      modulePath: bundle.graph.modules.items[0].source_path,
+      view: "scorecard",
+    });
+    window.history.replaceState(null, "", direct);
+    const writeText = vi.spyOn(navigator.clipboard, "writeText")
+      .mockRejectedValue(new Error("permission denied"));
+    writeText.mockClear();
+    const user = userEvent.setup();
+    render(<RepoShowcase bundle={bundle} />);
+
+    const notice = await screen.findByRole("status", {
+      name: "Investigation link status",
+    });
+    await user.click(
+      screen.getByRole("button", { name: "Copy investigation link" }),
+    );
+
+    expect(writeText).toHaveBeenCalledOnce();
+    expect(new URL(window.location.href).searchParams.get("at")).toBe(staleSha);
+    expect(notice).toBeVisible();
+    expect(screen.getByText("Investigation link could not be copied."))
+      .toHaveAttribute("role", "status");
+    await user.click(within(notice).getByRole("button", {
+      name: "Use current snapshot",
+    }));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Copy investigation link" }))
+        .toHaveFocus()
+    );
+  });
+
+  it("does not roll navigation back when clipboard completion is delayed", async () => {
+    const bundle = golden();
+    let finishCopy: (() => void) | undefined;
+    const writeText = vi.spyOn(navigator.clipboard, "writeText")
+      .mockImplementation(() => new Promise<void>((resolve) => {
+        finishCopy = resolve;
+      }));
+    writeText.mockClear();
+    const user = userEvent.setup();
+    render(<RepoShowcase bundle={bundle} />);
+    await waitFor(() =>
+      expect(new URL(window.location.href).searchParams.get("view"))
+        .toBe("structure_graph")
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Copy investigation link" }),
+    );
+    await waitFor(() => expect(writeText).toHaveBeenCalledOnce());
+    await user.click(screen.getByRole("button", {
+      name: bundle.capability.views.hidden_coupling.label,
+    }));
+    expect(new URL(window.location.href).searchParams.get("view"))
+      .toBe("hidden_coupling");
+
+    finishCopy?.();
+    expect(await screen.findByText("Investigation link copied."))
+      .toBeVisible();
+    expect(new URL(window.location.href).searchParams.get("view"))
+      .toBe("hidden_coupling");
+  });
+
+  it("labels generic repaired locations separately from stale snapshots", async () => {
+    const bundle = golden();
+    window.history.replaceState(
+      null,
+      "",
+      `/?repo=${encodeURIComponent(bundle.meta.repository.canonical_url)}&at=${bundle.meta.snapshot.head_sha}&view=not-a-view`,
+    );
+    const user = userEvent.setup();
+    render(<RepoShowcase bundle={bundle} />);
+
+    const notice = await screen.findByRole("status", {
+      name: "Investigation link status",
+    });
+    expect(notice).toHaveTextContent("Investigation link was repaired");
+    expect(within(notice).queryByRole("button", { name: "Use current snapshot" }))
+      .not.toBeInTheDocument();
+    await user.click(within(notice).getByRole("button", { name: "Dismiss" }));
+    expect(notice).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Copy investigation link" }))
+        .toHaveFocus()
+    );
+  });
+
+  it("does not offer a no-op module recovery for a snapshot with no modules", async () => {
+    const bundle = structuredClone(golden());
+    bundle.graph.modules.items = [];
+    window.history.replaceState(
+      null,
+      "",
+      `/?repo=${encodeURIComponent(bundle.meta.repository.canonical_url)}&at=${bundle.meta.snapshot.head_sha}&module=crates%2Fmissing.rs&view=scorecard`,
+    );
+    const { container } = render(<RepoShowcase bundle={bundle} />);
+
+    const inspector = container.querySelector<HTMLElement>(
+      "[data-module-inspector]",
+    )!;
+    const unavailable = await within(inspector).findByRole("status");
+    expect(unavailable).toHaveAttribute("data-state", "unavailable");
+    expect(unavailable).toHaveTextContent(/no captured modules/i);
+    expect(unavailable.querySelector("button")).toBeNull();
+  });
+
   it("answers repository triage questions before exposing the raw analysis views", async () => {
     const bundle = golden();
     const user = userEvent.setup();
@@ -360,7 +612,6 @@ describe("repository showcase", () => {
 
   it("keeps known-empty history distinct from unavailable and preserves available false", async () => {
     const bundle = structuredClone(golden());
-    const user = userEvent.setup();
     const first = bundle.graph.history_navigation.by_module.items[0];
     first.commits = {
       ...first.commits,
@@ -374,9 +625,25 @@ describe("repository showcase", () => {
       status: "available",
       value: false,
     };
+    const moduleNode = bundle.graph.modules.items.find((module) =>
+      module.id === first.module_id
+    )!;
+    window.history.replaceState(
+      null,
+      "",
+      repositoryLocationUrl(new URL(window.location.href), {
+        repository: bundle.meta.repository.canonical_url,
+        snapshotSha: bundle.meta.snapshot.head_sha,
+        modulePath: moduleNode.source_path,
+        view: "history_structure_navigation",
+      }),
+    );
 
     const { container } = render(<RepoShowcase bundle={bundle} />);
-    await user.click(container.querySelector('[data-view-id="history_structure_navigation"]')!);
+    await waitFor(() =>
+      expect(container.querySelector('[data-view-id="history_structure_navigation"]'))
+        .toHaveAttribute("aria-current", "page")
+    );
 
     const commits = container.querySelector<HTMLElement>("[data-history-commits]")!;
     expect(within(commits).getAllByText("0").length).toBeGreaterThan(0);

--- a/apps/kg-editor/src/components/showcase/repo-showcase.test.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase.test.tsx
@@ -164,6 +164,37 @@ describe("repository showcase", () => {
     );
   });
 
+  it("never copies foreign query parameters or the fragment into the share link", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.spyOn(navigator.clipboard, "writeText")
+      .mockResolvedValue(undefined);
+    render(<RepoShowcase bundle={golden()} />);
+
+    await waitFor(() =>
+      expect(new URL(window.location.href).searchParams.get("at")).not.toBeNull()
+    );
+    const polluted = new URL(window.location.href);
+    polluted.searchParams.set("access_token", "not-a-real-secret");
+    polluted.hash = "#fragment-value";
+    window.history.replaceState(
+      null,
+      "",
+      `${polluted.pathname}${polluted.search}${polluted.hash}`,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Copy investigation link" }),
+    );
+
+    const copied = writeText.mock.calls.at(-1)?.[0] as string;
+    expect(copied).not.toContain("not-a-real-secret");
+    expect(copied).not.toContain("fragment-value");
+    const copiedUrl = new URL(copied);
+    expect(copiedUrl.searchParams.get("repo")).not.toBeNull();
+    expect(copiedUrl.searchParams.get("at")).not.toBeNull();
+    expect(copiedUrl.searchParams.get("view")).not.toBeNull();
+  });
+
   it("preserves stale-link evidence when clipboard access fails", async () => {
     const bundle = golden();
     const staleSha = "0000000000000000000000000000000000000000";

--- a/apps/kg-editor/src/components/showcase/repo-showcase.test.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase.test.tsx
@@ -105,7 +105,9 @@ describe("repository showcase", () => {
       `Restored ${bundle.capability.views.dependency_topology.label} for ${pool.source_path}.`,
     );
     expect(pushState).toHaveBeenCalledTimes(2);
-  });
+    // Measured ~1.1-2.2s locally for this golden-fixture, multi-navigation flow; full-suite
+    // CPU contention pushed it past the default 5s timeout, so this needs headroom.
+  }, 20_000);
 
   it("keeps stale and missing deep-link evidence explicit and recoverable", async () => {
     const bundle = golden();
@@ -138,7 +140,9 @@ describe("repository showcase", () => {
     expect(new URL(window.location.href).searchParams.get("module")).not.toBe(
       missingPath,
     );
-  });
+    // Measured ~0.15-0.2s locally; full-suite CPU contention pushed it past the default
+    // 5s timeout, so this needs headroom.
+  }, 20_000);
 
   it("copies the normalized investigation link with visible feedback", async () => {
     const user = userEvent.setup();

--- a/apps/kg-editor/src/components/showcase/repo-showcase.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase.tsx
@@ -9,6 +9,7 @@ import {
   CircleDot,
   Clock3,
   Code2,
+  Copy,
   Database,
   GitBranch,
   GitCommitHorizontal,
@@ -23,7 +24,7 @@ import {
   TrendingUp,
   Users,
 } from "@/icons";
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { DataState } from "@/components/data-state";
 import { RepositoryTriage } from "@/components/showcase/repository-triage";
@@ -39,12 +40,18 @@ import {
 } from "@/components/ontology-mark";
 import { settleGraphLayout } from "@/lib/graph-layout";
 import { edgeLegendFor, entityLegendFor } from "@/lib/ontology-legend";
+import { buildRepositoryBrief } from "@/lib/repository-brief";
 import type {
   RepoBundle,
   RepoModule,
   RepoPage,
   ViewId,
 } from "@/lib/repo-bundle";
+import {
+  parseRepositoryLocation,
+  REPOSITORY_VIEW_IDS,
+  repositoryLocationUrl,
+} from "@/lib/repository-location";
 
 type Labels = RepoBundle["capability"]["labels"];
 type ViewCapability = RepoBundle["capability"]["views"][ViewId];
@@ -53,21 +60,12 @@ type ModuleMap = Map<string, RepoModule>;
 type ViewProps = Readonly<{
   bundle: RepoBundle;
   moduleById: ModuleMap;
+  selectedModuleId: string | null;
+  onSelectModule: (moduleId: string) => void;
   onExploreStructure: () => void;
 }>;
 
-const viewOrder: readonly ViewId[] = [
-  "structure_graph",
-  "history_structure_navigation",
-  "dependency_topology",
-  "hotspot_quadrant",
-  "hidden_coupling",
-  "structure_treemap",
-  "cadence_timeline",
-  "ownership",
-  "api_surface",
-  "scorecard",
-];
+const viewOrder: readonly ViewId[] = REPOSITORY_VIEW_IDS;
 
 const viewIcons: Record<ViewId, Icon> = {
   structure_graph: Network,
@@ -296,7 +294,7 @@ function ViewFrame({
   );
 }
 
-function StructureGraph({ bundle, moduleById }: { bundle: RepoBundle; moduleById: ModuleMap }) {
+function StructureGraph({ bundle }: { bundle: RepoBundle }) {
   const { graph, capability } = bundle;
   const labels = capability.labels;
   const [subtreeId, setSubtreeId] = useState(graph.repository.id);
@@ -588,14 +586,22 @@ function HistoryFacet({
   );
 }
 
-function HistoryStructure({ bundle, moduleById, onExploreStructure }: ViewProps) {
+function HistoryStructure({
+  bundle,
+  selectedModuleId,
+  onSelectModule,
+  onExploreStructure,
+}: ViewProps) {
   const { graph, capability } = bundle;
   const labels = capability.labels;
   const view = capability.views.history_structure_navigation;
-  const [selectedModuleId, setSelectedModuleId] = useState(
-    graph.history_navigation.by_module.items[0]?.module_id ?? graph.modules.items[0]?.id ?? "",
-  );
-  const [selectedCommitId, setSelectedCommitId] = useState("");
+  const [commitSelection, setCommitSelection] = useState<{
+    moduleId: string | null;
+    commitId: string;
+  }>({ moduleId: null, commitId: "" });
+  const selectedCommitId = commitSelection.moduleId === selectedModuleId
+    ? commitSelection.commitId
+    : "";
   const selectedModuleNavigation = graph.history_navigation.by_module.items.find((item) => item.module_id === selectedModuleId);
   const selectedCommitNavigation = graph.history_navigation.by_commit.items.find((item) => item.commit_id === selectedCommitId);
   const linkedCommitIds = new Set(selectedModuleNavigation?.commits.items ?? []);
@@ -618,7 +624,7 @@ function HistoryStructure({ bundle, moduleById, onExploreStructure }: ViewProps)
           <div className="repo-card-heading"><h3>{labels.node_types.module}</h3><p>{formatNumber(modules.length)}</p></div>
           <div className="repo-list">
             {modules.map((module) => (
-              <button type="button" data-module-id={module.id} aria-pressed={selectedModuleId === module.id} className={`repo-list-row ${selectedModuleId === module.id ? "selected" : ""}`} key={module.id} onClick={() => { setSelectedModuleId(module.id); setSelectedCommitId(""); }}>
+              <button type="button" data-module-id={module.id} aria-pressed={selectedModuleId === module.id} className={`repo-list-row ${selectedModuleId === module.id ? "selected" : ""}`} key={module.id} onClick={() => { onSelectModule(module.id); setCommitSelection({ moduleId: module.id, commitId: "" }); }}>
                 <Boxes aria-hidden="true" /><div><strong>{module.module_path}</strong><span>{module.source_path}</span></div>
               </button>
             ))}
@@ -629,7 +635,7 @@ function HistoryStructure({ bundle, moduleById, onExploreStructure }: ViewProps)
           <div className="repo-card-heading"><h3>{labels.node_types.commit}</h3><p>{formatNumber(commits.length)}</p></div>
           <div className="repo-list">
             {commits.map((commit) => (
-              <button type="button" data-commit-id={commit.id} aria-pressed={selectedCommitId === commit.id} className={`repo-list-row ${selectedCommitId === commit.id ? "selected" : ""}`} key={commit.id} onClick={() => setSelectedCommitId(commit.id)}>
+              <button type="button" data-commit-id={commit.id} aria-pressed={selectedCommitId === commit.id} className={`repo-list-row ${selectedCommitId === commit.id ? "selected" : ""}`} key={commit.id} onClick={() => setCommitSelection({ moduleId: selectedModuleId, commitId: commit.id })}>
                 <GitCommitHorizontal aria-hidden="true" /><div><strong>{commit.subject}</strong><span>{commit.author} · {formatDate(commit.committed_at)}</span></div><code>{commit.short_sha}</code>
               </button>
             ))}
@@ -838,7 +844,7 @@ function CadenceSeries({ id, page, label, labels, onExploreStructure }: { id: Ca
   );
 }
 
-function CadenceView({ bundle, moduleById, onExploreStructure }: ViewProps) {
+function CadenceView({ bundle, onExploreStructure }: ViewProps) {
   const analysis = bundle.aggregates.cadence_timeline;
   const labels = bundle.capability.labels;
   const commitRows = analysis.commits.items.slice(0, UI_ROW_LIMIT);
@@ -974,28 +980,255 @@ const viewComponents: Record<ViewId, React.ComponentType<ViewProps>> = {
   scorecard: ScorecardView,
 };
 
-function ActiveView({ id, bundle, moduleById, onExploreStructure }: ViewProps & { id: ViewId }) {
+function ActiveView({
+  id,
+  bundle,
+  moduleById,
+  selectedModuleId,
+  onSelectModule,
+  onExploreStructure,
+}: ViewProps & { id: ViewId }) {
   const capability = bundle.capability.views[id];
   const labels = bundle.capability.labels;
   const ViewComponent = viewComponents[id];
   return (
     <ViewFrame capability={capability} labels={labels} allowPartial={id === "ownership"}>
-      <ViewComponent bundle={bundle} moduleById={moduleById} onExploreStructure={onExploreStructure} />
+      <ViewComponent
+        bundle={bundle}
+        moduleById={moduleById}
+        selectedModuleId={selectedModuleId}
+        onSelectModule={onSelectModule}
+        onExploreStructure={onExploreStructure}
+      />
     </ViewFrame>
   );
 }
 
 export function RepoShowcase({ bundle, analysisSource = "curated-static-fallback" }: { bundle: RepoBundle; analysisSource?: ShowcaseBundleSource }) {
-  const [activeView, setActiveView] = useState<ViewId>("structure_graph");
-  const dashboardRef = useRef<HTMLDivElement>(null);
+  const { repository, snapshot, producer } = bundle.meta;
+  const { capability } = bundle;
   const moduleById = useMemo(
     () => new Map(bundle.graph.modules.items.map((module) => [module.id, module])),
     [bundle.graph.modules.items],
   );
-  const { repository, snapshot, producer } = bundle.meta;
-  const { capability } = bundle;
-  function openAnalysis(view: ViewId) {
+  const modulesBySourcePath = useMemo(() => {
+    const result = new Map<string, RepoModule[]>();
+    for (const moduleNode of bundle.graph.modules.items) {
+      const matches = result.get(moduleNode.source_path) ?? [];
+      matches.push(moduleNode);
+      result.set(moduleNode.source_path, matches);
+    }
+    return result;
+  }, [bundle.graph.modules.items]);
+  const brief = useMemo(() => buildRepositoryBrief(bundle), [bundle]);
+  const defaultModuleId: string | null = brief.startHere[0]?.moduleId ??
+    bundle.graph.modules.items[0]?.id ?? null;
+  const [selectedModuleId, setSelectedModuleId] = useState<string | null>(
+    defaultModuleId,
+  );
+  const [unresolvedModule, setUnresolvedModule] = useState<Readonly<{
+    path: string;
+    reason: string;
+  }> | null>(null);
+  const [activeView, setActiveView] = useState<ViewId>("structure_graph");
+  const [locationNotice, setLocationNotice] = useState<Readonly<{
+    title: string;
+    message: string;
+    action: "use-current-snapshot" | "dismiss";
+  }> | null>(null);
+  const [navigationStatus, setNavigationStatus] = useState("");
+  const [copyStatus, setCopyStatus] = useState("");
+  const dashboardRef = useRef<HTMLDivElement>(null);
+  const copyLinkRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    function restoreLocation(announce = false) {
+      const parsed = parseRepositoryLocation(new URL(window.location.href));
+      const requestedPath = parsed.location.modulePath;
+      let nextModuleId: string | null = defaultModuleId;
+      let nextUnresolved: typeof unresolvedModule = null;
+      if (requestedPath) {
+        const matches = modulesBySourcePath.get(requestedPath) ?? [];
+        if (matches.length === 1) {
+          nextModuleId = matches[0].id;
+        } else {
+          nextModuleId = null;
+          nextUnresolved = {
+            path: requestedPath,
+            reason: matches.length === 0
+              ? "The requested source path is not present in this bounded snapshot."
+              : "The requested source path is ambiguous in this snapshot.",
+          };
+        }
+      }
+      const nextView = parsed.location.view ?? "structure_graph";
+      const messages = parsed.issues.map((issue) => issue.message);
+      const staleSnapshot = Boolean(
+        parsed.location.snapshotSha &&
+          parsed.location.snapshotSha !== snapshot.head_sha,
+      );
+      if (staleSnapshot && parsed.location.snapshotSha) {
+        messages.unshift(
+          `The requested snapshot ${parsed.location.snapshotSha} is not loaded; this page is showing ${snapshot.head_sha}.`,
+        );
+      }
+
+      setSelectedModuleId(nextModuleId);
+      setUnresolvedModule(nextUnresolved);
+      setActiveView(nextView);
+      setCopyStatus("");
+      setLocationNotice(messages.length
+        ? {
+            title: staleSnapshot
+              ? "Investigation link needs attention"
+              : "Investigation link was repaired",
+            message: messages.join(" "),
+            action: staleSnapshot ? "use-current-snapshot" : "dismiss",
+          }
+        : null);
+      if (announce) {
+        const moduleLabel = nextModuleId
+          ? moduleById.get(nextModuleId)?.source_path ?? "repository overview"
+          : requestedPath
+          ? `unresolved module ${requestedPath}`
+          : "repository overview";
+        setNavigationStatus(
+          `Restored ${capability.views[nextView].label} for ${moduleLabel}.`,
+        );
+      }
+
+      const canonical = repositoryLocationUrl(
+        new URL(window.location.href),
+        {
+          repository: repository.canonical_url,
+          snapshotSha: parsed.location.snapshotSha ?? snapshot.head_sha,
+          modulePath: requestedPath ??
+            (nextModuleId ? moduleById.get(nextModuleId)?.source_path ?? null : null),
+          view: nextView,
+        },
+      );
+      if (canonical.href !== window.location.href) {
+        window.history.replaceState(
+          null,
+          "",
+          `${canonical.pathname}${canonical.search}${canonical.hash}`,
+        );
+      }
+    }
+
+    const handlePopState = () => restoreLocation(true);
+    restoreLocation();
+    window.addEventListener("popstate", handlePopState);
+    return () => window.removeEventListener("popstate", handlePopState);
+  }, [
+    capability.views,
+    defaultModuleId,
+    moduleById,
+    modulesBySourcePath,
+    repository.canonical_url,
+    snapshot.head_sha,
+  ]);
+
+  function locationFor(
+    moduleId: string | null,
+    view: ViewId,
+    missingPath: string | null = null,
+  ) {
+    return repositoryLocationUrl(new URL(window.location.href), {
+      repository: repository.canonical_url,
+      snapshotSha: snapshot.head_sha,
+      modulePath: moduleId
+        ? moduleById.get(moduleId)?.source_path ?? null
+        : missingPath,
+      view,
+    });
+  }
+
+  function pushLocation(
+    moduleId: string | null,
+    view: ViewId,
+    missingPath: string | null = null,
+  ) {
+    const next = locationFor(moduleId, view, missingPath);
+    if (next.href === window.location.href) return;
+    window.history.pushState(
+      null,
+      "",
+      `${next.pathname}${next.search}${next.hash}`,
+    );
+  }
+
+  function selectModule(moduleId: string) {
+    if (!moduleById.has(moduleId)) return;
+    pushLocation(moduleId, activeView);
+    setNavigationStatus("");
+    setSelectedModuleId(moduleId);
+    setUnresolvedModule(null);
+    setLocationNotice(null);
+    setCopyStatus("");
+  }
+
+  function selectView(view: ViewId) {
+    pushLocation(selectedModuleId, view, unresolvedModule?.path ?? null);
+    setNavigationStatus("");
     setActiveView(view);
+    setLocationNotice(null);
+    setCopyStatus("");
+  }
+
+  function dismissLocationNotice() {
+    setLocationNotice(null);
+    queueMicrotask(() => copyLinkRef.current?.focus());
+  }
+
+  function recoverModule() {
+    if (defaultModuleId) selectModule(defaultModuleId);
+  }
+
+  function normalizeCurrentLocation() {
+    const next = locationFor(
+      selectedModuleId,
+      activeView,
+      unresolvedModule?.path ?? null,
+    );
+    window.history.replaceState(
+      null,
+      "",
+      `${next.pathname}${next.search}${next.hash}`,
+    );
+    setLocationNotice(null);
+    setCopyStatus("");
+    queueMicrotask(() => copyLinkRef.current?.focus());
+  }
+
+  async function copyInvestigationLink() {
+    try {
+      if (!navigator.clipboard?.writeText) {
+        throw new Error("Clipboard access is unavailable");
+      }
+      const current = locationFor(
+        selectedModuleId,
+        activeView,
+        unresolvedModule?.path ?? null,
+      );
+      const sourceHref = window.location.href;
+      await navigator.clipboard.writeText(current.href);
+      if (window.location.href === sourceHref && current.href !== sourceHref) {
+        window.history.replaceState(
+          null,
+          "",
+          `${current.pathname}${current.search}${current.hash}`,
+        );
+        setLocationNotice(null);
+      }
+      setCopyStatus("Investigation link copied.");
+    } catch {
+      setCopyStatus("Investigation link could not be copied.");
+    }
+  }
+
+  function openAnalysis(view: ViewId) {
+    selectView(view);
     const dashboard = dashboardRef.current;
     if (!dashboard) return;
     dashboard.focus({ preventScroll: true });
@@ -1011,13 +1244,43 @@ export function RepoShowcase({ bundle, analysisSource = "curated-static-fallback
     <article className="repo-overview" data-head-sha={snapshot.head_sha} data-analysis-source={analysisSource}>
       <header className="repo-overview-heading">
         <div className="repo-identity"><span className="repo-avatar"><Package aria-hidden="true" /></span><div><span>{repository.host} · {availabilityText(repository.default_branch, capability.labels)}</span><strong>{repository.owner}/{repository.name}</strong></div></div>
-        <div className="repo-meta-row"><span><GitCommitHorizontal aria-hidden="true" /><code>{shortSha(snapshot.head_sha)}</code></span><span><Clock3 aria-hidden="true" />{formatDate(snapshot.ingested_at)}</span><span><Code2 aria-hidden="true" />{producer.exporter}</span><span><Database aria-hidden="true" />{analysisSource === "khive-db-snapshot" ? "khive DB snapshot" : "curated static fallback"}</span></div>
+        <div className="repo-meta-row"><span><GitCommitHorizontal aria-hidden="true" /><code>{shortSha(snapshot.head_sha)}</code></span><span><Clock3 aria-hidden="true" />{formatDate(snapshot.ingested_at)}</span><span><Code2 aria-hidden="true" />{producer.exporter}</span><span><Database aria-hidden="true" />{analysisSource === "khive-db-snapshot" ? "khive DB snapshot" : "curated static fallback"}</span><button ref={copyLinkRef} type="button" className="repo-copy-link" onClick={copyInvestigationLink}><Copy aria-hidden="true" /> Copy investigation link</button>{copyStatus && <span role="status" className="repo-copy-status">{copyStatus}</span>}</div>
       </header>
       <section className="repo-capability-strip" aria-label={capability.labels.product}>
         <div><ShieldCheck aria-hidden="true" /><div><strong>{capability.labels.product}</strong><span>{capability.mode}</span></div></div>
         <div className="repo-capability-flags">{Object.values(capability.languages).map((language) => <i key={language.label}>{language.label} · {language.module_join ? capability.views.history_structure_navigation.label : capability.labels.unavailable}</i>)}</div>
       </section>
-      <RepositoryTriage key={snapshot.head_sha} bundle={bundle} onOpenAnalysis={openAnalysis} />
+      <span
+        className="visually-hidden"
+        role="status"
+        aria-live="polite"
+        aria-label="Investigation navigation"
+      >
+        {navigationStatus}
+      </span>
+      {locationNotice && (
+        <aside
+          className="repo-investigation-notice"
+          role="status"
+          aria-label="Investigation link status"
+        >
+          <AlertTriangle aria-hidden="true" />
+          <span><strong>{locationNotice.title}</strong>{locationNotice.message}</span>
+          {locationNotice.action === "use-current-snapshot"
+            ? <button type="button" onClick={normalizeCurrentLocation}>Use current snapshot</button>
+            : <button type="button" onClick={dismissLocationNotice}>Dismiss</button>}
+        </aside>
+      )}
+      <RepositoryTriage
+        key={snapshot.head_sha}
+        bundle={bundle}
+        selectedModuleId={selectedModuleId}
+        unresolvedModule={unresolvedModule}
+        onSelectModule={selectModule}
+        onRecoverModule={recoverModule}
+        canRecoverModule={defaultModuleId !== null}
+        onOpenAnalysis={openAnalysis}
+      />
       <div
         className="repo-dashboard"
         data-repository-dashboard
@@ -1032,11 +1295,11 @@ export function RepoShowcase({ bundle, analysisSource = "curated-static-fallback
           {viewOrder.map((id) => {
             const view = capability.views[id];
             const Icon = viewIcons[id];
-            return <button type="button" data-view-id={id} className={activeView === id ? "active" : ""} aria-current={activeView === id ? "page" : undefined} key={id} onClick={() => setActiveView(id)}><Icon aria-hidden="true" /><span>{view.label}</span><i className={view.status} aria-hidden="true" />{view.status === "unavailable" && <span className="visually-hidden">{capability.labels.unavailable}</span>}</button>;
+            return <button type="button" data-view-id={id} className={activeView === id ? "active" : ""} aria-current={activeView === id ? "page" : undefined} key={id} onClick={() => selectView(id)}><Icon aria-hidden="true" /><span>{view.label}</span><i className={view.status} aria-hidden="true" />{view.status === "unavailable" && <span className="visually-hidden">{capability.labels.unavailable}</span>}</button>;
           })}
         </nav>
         <section className="repo-view-panel" aria-label={capability.views[activeView].label}>
-          <ActiveView key={`${snapshot.head_sha}-${activeView}`} id={activeView} bundle={bundle} moduleById={moduleById} onExploreStructure={() => setActiveView("structure_graph")} />
+          <ActiveView key={`${snapshot.head_sha}-${activeView}`} id={activeView} bundle={bundle} moduleById={moduleById} selectedModuleId={selectedModuleId} onSelectModule={selectModule} onExploreStructure={() => selectView("structure_graph")} />
         </section>
       </div>
     </article>

--- a/apps/kg-editor/src/components/showcase/repo-showcase.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase.tsx
@@ -50,6 +50,7 @@ import type {
 import {
   parseRepositoryLocation,
   REPOSITORY_VIEW_IDS,
+  investigationShareUrl,
   repositoryLocationUrl,
 } from "@/lib/repository-location";
 
@@ -1129,19 +1130,30 @@ export function RepoShowcase({ bundle, analysisSource = "curated-static-fallback
     snapshot.head_sha,
   ]);
 
-  function locationFor(
+  function investigationLocation(
     moduleId: string | null,
     view: ViewId,
     missingPath: string | null = null,
   ) {
-    return repositoryLocationUrl(new URL(window.location.href), {
+    return {
       repository: repository.canonical_url,
       snapshotSha: snapshot.head_sha,
       modulePath: moduleId
         ? moduleById.get(moduleId)?.source_path ?? null
         : missingPath,
       view,
-    });
+    };
+  }
+
+  function locationFor(
+    moduleId: string | null,
+    view: ViewId,
+    missingPath: string | null = null,
+  ) {
+    return repositoryLocationUrl(
+      new URL(window.location.href),
+      investigationLocation(moduleId, view, missingPath),
+    );
   }
 
   function pushLocation(
@@ -1206,13 +1218,23 @@ export function RepoShowcase({ bundle, analysisSource = "curated-static-fallback
       if (!navigator.clipboard?.writeText) {
         throw new Error("Clipboard access is unavailable");
       }
-      const current = locationFor(
+      const location = investigationLocation(
         selectedModuleId,
         activeView,
         unresolvedModule?.path ?? null,
       );
+      const current = repositoryLocationUrl(
+        new URL(window.location.href),
+        location,
+      );
+      // The copied link is the share form: investigation parameters only,
+      // no foreign query parameters and no fragment.
+      const share = investigationShareUrl(
+        new URL(window.location.href),
+        location,
+      );
       const sourceHref = window.location.href;
-      await navigator.clipboard.writeText(current.href);
+      await navigator.clipboard.writeText(share.href);
       if (window.location.href === sourceHref && current.href !== sourceHref) {
         window.history.replaceState(
           null,

--- a/apps/kg-editor/src/components/showcase/repository-triage.module.css
+++ b/apps/kg-editor/src/components/showcase/repository-triage.module.css
@@ -452,6 +452,25 @@
   height: 12px;
   width: 12px;
 }
+.breadcrumb {
+  align-items: center;
+  color: var(--repo-muted);
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 8px;
+  gap: 5px;
+  margin-top: 10px;
+}
+.breadcrumb svg {
+  flex: 0 0 auto;
+  height: 9px;
+  width: 9px;
+}
+.breadcrumb strong {
+  color: var(--repo-navy);
+  font-family: "SFMono-Regular", Consolas, monospace;
+  overflow-wrap: anywhere;
+}
 .inspectorHeader h3 {
   color: var(--repo-navy);
   font-family: "SFMono-Regular", Consolas, monospace;

--- a/apps/kg-editor/src/components/showcase/repository-triage.tsx
+++ b/apps/kg-editor/src/components/showcase/repository-triage.tsx
@@ -35,6 +35,11 @@ import styles from "./repository-triage.module.css";
 export type RepositoryTriageProps = Readonly<{
   bundle: RepoBundle;
   onOpenAnalysis: (view: ViewId) => void;
+  selectedModuleId: string | null;
+  onSelectModule: (moduleId: string) => void;
+  unresolvedModule: Readonly<{ path: string; reason: string }> | null;
+  onRecoverModule: () => void;
+  canRecoverModule: boolean;
 }>;
 
 function formatNumber(value: number): string {
@@ -163,6 +168,11 @@ function ModuleButton({
 export function RepositoryTriage({
   bundle,
   onOpenAnalysis,
+  selectedModuleId,
+  onSelectModule,
+  unresolvedModule,
+  onRecoverModule,
+  canRecoverModule,
 }: RepositoryTriageProps) {
   const brief = useMemo(() => buildRepositoryBrief(bundle), [bundle]);
   const labels = bundle.capability.labels;
@@ -173,10 +183,10 @@ export function RepositoryTriage({
       new Map(bundle.graph.modules.items.map((module) => [module.id, module])),
     [bundle.graph.modules.items],
   );
-  const initialModuleId = brief.startHere[0]?.moduleId ??
-    bundle.graph.modules.items[0]?.id ?? null;
-  const [selectedModuleId, setSelectedModuleId] = useState<string | null>(
-    initialModuleId,
+  const packageById = useMemo(
+    () =>
+      new Map(bundle.graph.packages.items.map((item) => [item.id, item])),
+    [bundle.graph.packages.items],
   );
   const inspectorRef = useRef<HTMLElement>(null);
   const [query, setQuery] = useState("");
@@ -195,8 +205,7 @@ export function RepositoryTriage({
   const searchResults = searchMatches.items;
   const searchTruncated = searchMatches.total > searchResults.length;
 
-  function selectModule(moduleId: string) {
-    setSelectedModuleId(moduleId);
+  function focusInspector() {
     const inspector = inspectorRef.current;
     if (!inspector) return;
     inspector.focus({ preventScroll: true });
@@ -207,6 +216,11 @@ export function RepositoryTriage({
       behavior: reduceMotion ? "auto" : "smooth",
       block: "start",
     });
+  }
+
+  function selectModule(moduleId: string) {
+    onSelectModule(moduleId);
+    focusInspector();
   }
 
   function selectSignal(signal: RepositorySignal) {
@@ -526,6 +540,24 @@ export function RepositoryTriage({
                   <span>
                     <FileText aria-hidden="true" /> {moduleLabel} evidence
                   </span>
+                  <nav
+                    className={styles.breadcrumb}
+                    aria-label="Investigation location"
+                  >
+                    <span>
+                      {bundle.meta.repository.owner}/{bundle.meta.repository.name}
+                    </span>
+                    {packageById.get(selectedInsight.module.package_id) && (
+                      <>
+                        <ArrowRight aria-hidden="true" />
+                        <span>
+                          {packageById.get(selectedInsight.module.package_id)?.name}
+                        </span>
+                      </>
+                    )}
+                    <ArrowRight aria-hidden="true" />
+                    <strong>{selectedInsight.module.source_path}</strong>
+                  </nav>
                   <h3>{selectedInsight.module.source_path}</h3>
                   <p>
                     {selectedInsight.module.language} ·{" "}
@@ -803,6 +835,31 @@ export function RepositoryTriage({
                   </dl>
                 </section>
               </>
+            )
+            : unresolvedModule && canRecoverModule
+            ? (
+              <DataState
+                className={styles.empty}
+                state="empty"
+                title={`${unresolvedModule.path} is not captured in this snapshot`}
+                message={unresolvedModule.reason}
+                action={{
+                  label: "Open recommended module",
+                  onClick: () => {
+                    onRecoverModule();
+                    focusInspector();
+                  },
+                }}
+              />
+            )
+            : unresolvedModule
+            ? (
+              <DataState
+                className={styles.empty}
+                state="unavailable"
+                title={`${unresolvedModule.path} is not captured in this snapshot`}
+                message={`${unresolvedModule.reason} This snapshot contains no captured modules to open.`}
+              />
             )
             : (
               <DataState

--- a/apps/kg-editor/src/components/showcase/showcase.test.tsx
+++ b/apps/kg-editor/src/components/showcase/showcase.test.tsx
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -21,7 +21,26 @@ const mockedLoad = vi.mocked(loadPreferredShowcaseBundle);
 describe("materialized repository lookup", () => {
   beforeEach(() => {
     window.history.replaceState(null, "", "/");
+    mockedLoad.mockClear();
     mockedLoad.mockResolvedValue({ bundle, source: "khive-db-snapshot" });
+  });
+
+  it("resolves the repository in a direct URL before loading the default", async () => {
+    window.history.replaceState(
+      null,
+      "",
+      `/?repo=${encodeURIComponent("https://github.com/example/not-curated")}&at=${bundle.meta.snapshot.head_sha}&module=crates%2Fexample%2Fsrc%2Flib.rs&view=scorecard`,
+    );
+
+    render(<Showcase />);
+
+    expect(
+      await screen.findByText("No curated showcase bundle matches this repository"),
+    ).toBeVisible();
+    expect(mockedLoad).not.toHaveBeenCalled();
+    expect(new URL(window.location.href).searchParams.get("repo")).toBe(
+      "https://github.com/example/not-curated",
+    );
   });
 
   it("normalizes a curated alias, reauthorizes each private snapshot load, and performs no bundle load for a later miss", async () => {
@@ -53,6 +72,11 @@ describe("materialized repository lookup", () => {
     // rather than being served from the module cache.
     expect(mockedLoad).toHaveBeenCalledTimes(2);
 
+    window.history.replaceState(
+      null,
+      "",
+      `${window.location.pathname}${window.location.search}&at=${bundle.meta.snapshot.head_sha}&module=crates%2Fkhive-db%2Fsrc%2Fpool.rs&view=dependency_topology`,
+    );
     await user.clear(input);
     await user.type(input, "https://github.com/example/not-curated");
     await user.click(screen.getByRole("button", { name: bundle.capability.labels.lookup_action }));
@@ -63,6 +87,11 @@ describe("materialized repository lookup", () => {
     expect(empty).toBeVisible();
     expect(empty?.querySelectorAll("button")).toHaveLength(1);
     expect(window.location.search).toBe("");
+    expect(new URL(window.location.href).searchParams.get("at")).toBeNull();
+    expect(new URL(window.location.href).searchParams.get("module")).toBeNull();
+    expect(new URL(window.location.href).searchParams.get("view")).toBeNull();
+    // Private snapshots are authorized per load, so the miss leaves the
+    // count at two loads rather than one served from a module cache.
     expect(mockedLoad).toHaveBeenCalledTimes(2);
 
     await user.click(screen.getByRole("button", { name: "Use the curated khive example" }));
@@ -92,4 +121,34 @@ describe("materialized repository lookup", () => {
     // Nothing private is retained here, so the cache may keep serving it.
     expect(mockedLoad).toHaveBeenCalledTimes(1);
   }, 15_000);
+
+  it("preserves a direct investigation while canonicalizing a curated alias", async () => {
+    const pool = bundle.graph.modules.items.find((module) =>
+      module.source_path.endsWith("khive-db/src/pool.rs")
+    )!;
+    window.history.replaceState(
+      null,
+      "",
+      `/?repo=${encodeURIComponent("http://github.com/ohdearquant/khive.git")}&at=${bundle.meta.snapshot.head_sha}&module=${encodeURIComponent(pool.source_path)}&view=dependency_topology`,
+    );
+
+    const { container } = render(<Showcase />);
+
+    const inspector = await screen.findByRole("complementary", {
+      name: "Module evidence",
+    });
+    await waitFor(() =>
+      expect(within(inspector).getByRole("heading", { level: 3 })).toHaveTextContent(
+        pool.source_path,
+      )
+    );
+    expect(container.querySelector('[data-view-id="dependency_topology"]'))
+      .toHaveAttribute("aria-current", "page");
+    expect(new URL(window.location.href).searchParams.get("repo")).toBe(
+      bundle.meta.repository.canonical_url,
+    );
+    expect(new URL(window.location.href).searchParams.get("module")).toBe(
+      pool.source_path,
+    );
+  });
 });

--- a/apps/kg-editor/src/components/showcase/showcase.test.tsx
+++ b/apps/kg-editor/src/components/showcase/showcase.test.tsx
@@ -120,7 +120,33 @@ describe("materialized repository lookup", () => {
     await waitFor(() => expect(container.querySelector(".repo-overview")).toBeVisible());
     // Nothing private is retained here, so the cache may keep serving it.
     expect(mockedLoad).toHaveBeenCalledTimes(1);
-  }, 15_000);
+    // Measured ~2.5-4.9s locally across several userEvent interactions and bundle loads;
+    // full-suite CPU contention pushed it past the default 5s timeout, so this needs headroom.
+  }, 30_000);
+
+  it.each([
+    ["query string", `${bundle.meta.repository.canonical_url}?tab=readme`],
+    ["fragment", `${bundle.meta.repository.canonical_url}#readme`],
+  ])(
+    "opens a direct link whose curated repository alias carries a %s",
+    async (_name, repositoryWithExtras) => {
+      window.history.replaceState(
+        null,
+        "",
+        `/?repo=${encodeURIComponent(repositoryWithExtras)}`,
+      );
+
+      const { container } = render(<Showcase />);
+
+      await waitFor(() => expect(container.querySelector(".repo-overview")).toBeVisible());
+      expect(
+        screen.queryByText("No curated showcase bundle matches this repository"),
+      ).not.toBeInTheDocument();
+      expect(new URL(window.location.href).searchParams.get("repo")).toBe(
+        bundle.meta.repository.canonical_url,
+      );
+    },
+  );
 
   it("preserves a direct investigation while canonicalizing a curated alias", async () => {
     const pool = bundle.graph.modules.items.find((module) =>

--- a/apps/kg-editor/src/components/showcase/showcase.tsx
+++ b/apps/kg-editor/src/components/showcase/showcase.tsx
@@ -18,6 +18,7 @@ import {
   SHOWCASE_REGISTRY,
   type ShowcaseRegistryEntry,
 } from "@/lib/showcase-registry";
+import { parseRepositoryLocation } from "@/lib/repository-location";
 
 type LoadState =
   | Readonly<{ status: "loading"; entry: ShowcaseRegistryEntry }>
@@ -61,10 +62,18 @@ function sourceLabel(source: ShowcaseBundleSource): string {
   return source === "khive-db-snapshot" ? "khive DB snapshot" : "curated static fallback";
 }
 
-function replaceRepositoryQuery(repository?: string) {
+function replaceRepositoryQuery(
+  repository?: string,
+  clearInvestigation = true,
+) {
   const query = new URL(window.location.href);
   if (repository) query.searchParams.set("repo", repository);
   else query.searchParams.delete("repo");
+  if (clearInvestigation) {
+    query.searchParams.delete("at");
+    query.searchParams.delete("module");
+    query.searchParams.delete("view");
+  }
   const search = query.searchParams.size ? `?${query.searchParams.toString()}` : "";
   window.history.replaceState(null, "", `${query.pathname}${search}${query.hash}`);
 }
@@ -77,22 +86,56 @@ export function Showcase() {
   const loadSequence = useRef(0);
 
   useEffect(() => {
-    const sequence = ++loadSequence.current;
-    void loadEntry(defaultEntry)
-      .then((loaded) => {
-        setLabels(loaded.bundle.capability.labels);
-        if (loadSequence.current === sequence) {
-          setState({ status: "ready", entry: defaultEntry, loaded });
-        }
-      })
-      .catch((error: unknown) => {
-        if (loadSequence.current === sequence) {
-          setState({
-            status: "error",
-            reason: error instanceof Error ? error.message : "The showcase bundle could not be loaded.",
-          });
-        }
-      });
+    let cancelled = false;
+    queueMicrotask(() => {
+      if (cancelled) return;
+      const parsed = parseRepositoryLocation(new URL(window.location.href));
+      const repositoryIssue = parsed.issues.find((issue) =>
+        issue.parameter === "repo"
+      );
+      if (repositoryIssue) {
+        setState({ status: "invalid", reason: repositoryIssue.message });
+        return;
+      }
+
+      const requestedRepository = parsed.location.repository ??
+        defaultEntry.canonicalUrl;
+      const lookup = resolveShowcaseRepository(requestedRepository);
+      setInput(requestedRepository);
+      if (lookup.status === "invalid") {
+        setState(lookup);
+        return;
+      }
+      if (lookup.status === "miss") {
+        setState(lookup);
+        return;
+      }
+
+      const sequence = ++loadSequence.current;
+      setInput(lookup.normalizedUrl);
+      setState({ status: "loading", entry: lookup.entry });
+      if (parsed.location.repository !== lookup.normalizedUrl) {
+        replaceRepositoryQuery(lookup.normalizedUrl, false);
+      }
+      void loadEntry(lookup.entry)
+        .then((loaded) => {
+          if (loadSequence.current === sequence) {
+            setLabels(loaded.bundle.capability.labels);
+            setState({ status: "ready", entry: lookup.entry, loaded });
+          }
+        })
+        .catch((error: unknown) => {
+          if (loadSequence.current === sequence) {
+            setState({
+              status: "error",
+              reason: error instanceof Error ? error.message : "The showcase bundle could not be loaded.",
+            });
+          }
+        });
+    });
+    return () => {
+      cancelled = true;
+    };
   }, [defaultEntry]);
 
   function submit(event: FormEvent<HTMLFormElement>) {

--- a/apps/kg-editor/src/lib/adapters/preferred-showcase-source.test.ts
+++ b/apps/kg-editor/src/lib/adapters/preferred-showcase-source.test.ts
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  DB_SNAPSHOT_TIMEOUT_MS,
   loadPreferredShowcaseBundle,
   readOperatorShowcaseAccessToken,
   SHOWCASE_ACCESS_TOKEN_STORAGE_KEY,
@@ -54,6 +55,7 @@ describe("preferred showcase source", () => {
       cache: "no-store",
       credentials: "same-origin",
       redirect: "error",
+      signal: expect.any(AbortSignal),
     });
   });
 
@@ -76,6 +78,7 @@ describe("preferred showcase source", () => {
       cache: "no-store",
       credentials: "same-origin",
       redirect: "error",
+      signal: expect.any(AbortSignal),
       headers: { authorization: "Bearer operator-secret" },
     });
   });
@@ -96,6 +99,7 @@ describe("preferred showcase source", () => {
       cache: "no-store",
       credentials: "same-origin",
       redirect: "error",
+      signal: expect.any(AbortSignal),
     });
   });
 
@@ -249,6 +253,62 @@ describe("preferred showcase source", () => {
     expect(result.source).toBe("curated-static-fallback");
     expect(result.bundle.schema_version).toBe("khive.repo.v1");
     expect(fetchBundle).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to the static asset when the DB snapshot request never settles", async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchBundle = vi.fn((input: string) => {
+        if (input.startsWith("/api/")) {
+          return new Promise<never>(() => {});
+        }
+        return Promise.resolve(response(golden, 200));
+      });
+
+      const resultPromise = loadPreferredShowcaseBundle(
+        SHOWCASE_REGISTRY[0],
+        fetchBundle,
+      );
+      await vi.advanceTimersByTimeAsync(DB_SNAPSHOT_TIMEOUT_MS);
+      const result = await resultPromise;
+
+      expect(result.source).toBe("curated-static-fallback");
+      expect(result.bundle.schema_version).toBe("khive.repo.v1");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("falls back to the static asset when the DB snapshot response body never completes", async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchBundle = vi.fn((input: string) => {
+        if (input.startsWith("/api/")) {
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            headers: new Headers({
+              "x-khive-analysis-id": "khive",
+              "x-khive-analysis-source": "khive-db-snapshot",
+            }),
+            arrayBuffer: () => new Promise<ArrayBuffer>(() => {}),
+          });
+        }
+        return Promise.resolve(response(golden, 200));
+      });
+
+      const resultPromise = loadPreferredShowcaseBundle(
+        SHOWCASE_REGISTRY[0],
+        fetchBundle,
+      );
+      await vi.advanceTimersByTimeAsync(DB_SNAPSHOT_TIMEOUT_MS);
+      const result = await resultPromise;
+
+      expect(result.source).toBe("curated-static-fallback");
+      expect(result.bundle.schema_version).toBe("khive.repo.v1");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("does not surface an unhandled rejection or thrown error when every DB snapshot failure mode falls back", async () => {

--- a/apps/kg-editor/src/lib/adapters/preferred-showcase-source.test.ts
+++ b/apps/kg-editor/src/lib/adapters/preferred-showcase-source.test.ts
@@ -131,42 +131,147 @@ describe("preferred showcase source", () => {
     );
   });
 
-  it("does not hide an invalid or unavailable DB snapshot behind stale static data", async () => {
-    const fetchBundle = vi.fn(async () => response(new Uint8Array(), 503));
-
-    await expect(
-      loadPreferredShowcaseBundle(SHOWCASE_REGISTRY[0], fetchBundle),
-    ).rejects.toThrow(/database snapshot.*503/i);
-    expect(fetchBundle).toHaveBeenCalledOnce();
-  });
-
-  it("rejects a successful response without the configured snapshot identity", async () => {
-    const fetchBundle = vi.fn(async () =>
-      response(golden, 200, {
-        "x-khive-analysis-id": "other",
-        "x-khive-analysis-source": "khive-db-snapshot",
-      })
+  it("falls back to the static asset when the DB snapshot service errors", async () => {
+    const fetchBundle = vi.fn(async (input: string) =>
+      input.startsWith("/api/")
+        ? response(new Uint8Array(), 503)
+        : response(golden, 200)
     );
 
-    await expect(
-      loadPreferredShowcaseBundle(SHOWCASE_REGISTRY[0], fetchBundle),
-    ).rejects.toThrow(/provenance/i);
+    const result = await loadPreferredShowcaseBundle(
+      SHOWCASE_REGISTRY[0],
+      fetchBundle,
+    );
+
+    expect(result.source).toBe("curated-static-fallback");
+    expect(result.bundle.schema_version).toBe("khive.repo.v1");
+    expect(fetchBundle).toHaveBeenCalledTimes(2);
   });
 
-  it("rejects a valid snapshot for a different repository", async () => {
+  it("falls back to the static asset when the fetch rejects at the network level", async () => {
+    const fetchBundle = vi.fn(async (input: string) => {
+      if (input.startsWith("/api/")) {
+        throw new TypeError("Failed to fetch");
+      }
+      return response(golden, 200);
+    });
+
+    const result = await loadPreferredShowcaseBundle(
+      SHOWCASE_REGISTRY[0],
+      fetchBundle,
+    );
+
+    expect(result.source).toBe("curated-static-fallback");
+    expect(result.bundle.schema_version).toBe("khive.repo.v1");
+    expect(fetchBundle).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to the static asset when the DB snapshot body is invalid", async () => {
+    const invalid = new TextEncoder().encode("not json");
+    const fetchBundle = vi.fn(async (input: string) =>
+      input.startsWith("/api/")
+        ? response(invalid, 200, {
+          "x-khive-analysis-id": "khive",
+          "x-khive-analysis-source": "khive-db-snapshot",
+        })
+        : response(golden, 200)
+    );
+
+    const result = await loadPreferredShowcaseBundle(
+      SHOWCASE_REGISTRY[0],
+      fetchBundle,
+    );
+
+    expect(result.source).toBe("curated-static-fallback");
+    expect(result.bundle.schema_version).toBe("khive.repo.v1");
+    expect(fetchBundle).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to the static asset when the DB snapshot body exceeds the browser limit", async () => {
+    const oversized = new Uint8Array(9 * 1024 * 1024);
+    const fetchBundle = vi.fn(async (input: string) =>
+      input.startsWith("/api/")
+        ? response(oversized, 200, {
+          "x-khive-analysis-id": "khive",
+          "x-khive-analysis-source": "khive-db-snapshot",
+        })
+        : response(golden, 200)
+    );
+
+    const result = await loadPreferredShowcaseBundle(
+      SHOWCASE_REGISTRY[0],
+      fetchBundle,
+    );
+
+    expect(result.source).toBe("curated-static-fallback");
+    expect(result.bundle.schema_version).toBe("khive.repo.v1");
+    expect(fetchBundle).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to the static asset when the DB snapshot response lacks the configured provenance identity", async () => {
+    const fetchBundle = vi.fn(async (input: string) =>
+      input.startsWith("/api/")
+        ? response(golden, 200, {
+          "x-khive-analysis-id": "other",
+          "x-khive-analysis-source": "khive-db-snapshot",
+        })
+        : response(golden, 200)
+    );
+
+    const result = await loadPreferredShowcaseBundle(
+      SHOWCASE_REGISTRY[0],
+      fetchBundle,
+    );
+
+    expect(result.source).toBe("curated-static-fallback");
+    expect(result.bundle.schema_version).toBe("khive.repo.v1");
+    expect(fetchBundle).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to the static asset when a valid snapshot is for a different repository", async () => {
     const wrongRepository = JSON.parse(golden.toString("utf8"));
     wrongRepository.meta.repository.canonical_url =
       "https://github.com/example/not-khive";
-    const fetchBundle = vi.fn(async () =>
-      response(Buffer.from(JSON.stringify(wrongRepository)), 200, {
-        "x-khive-analysis-id": "khive",
-        "x-khive-analysis-source": "khive-db-snapshot",
-      })
+    const fetchBundle = vi.fn(async (input: string) =>
+      input.startsWith("/api/")
+        ? response(Buffer.from(JSON.stringify(wrongRepository)), 200, {
+          "x-khive-analysis-id": "khive",
+          "x-khive-analysis-source": "khive-db-snapshot",
+        })
+        : response(golden, 200)
     );
 
-    await expect(
-      loadPreferredShowcaseBundle(SHOWCASE_REGISTRY[0], fetchBundle),
-    ).rejects.toThrow(/repository identity/i);
-    expect(fetchBundle).toHaveBeenCalledOnce();
+    const result = await loadPreferredShowcaseBundle(
+      SHOWCASE_REGISTRY[0],
+      fetchBundle,
+    );
+
+    expect(result.source).toBe("curated-static-fallback");
+    expect(result.bundle.schema_version).toBe("khive.repo.v1");
+    expect(fetchBundle).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not surface an unhandled rejection or thrown error when every DB snapshot failure mode falls back", async () => {
+    const failureModes: Array<() => Promise<ReturnType<typeof response>>> = [
+      () => Promise.reject(new TypeError("network down")),
+      () => Promise.resolve(response(new Uint8Array(), 500)),
+      () =>
+        Promise.resolve(
+          response(new TextEncoder().encode("{"), 200, {
+            "x-khive-analysis-id": "khive",
+            "x-khive-analysis-source": "khive-db-snapshot",
+          }),
+        ),
+    ];
+
+    for (const failureMode of failureModes) {
+      const fetchBundle = vi.fn(async (input: string) =>
+        input.startsWith("/api/") ? failureMode() : response(golden, 200)
+      );
+
+      await expect(
+        loadPreferredShowcaseBundle(SHOWCASE_REGISTRY[0], fetchBundle),
+      ).resolves.toMatchObject({ source: "curated-static-fallback" });
+    }
   });
 });

--- a/apps/kg-editor/src/lib/adapters/preferred-showcase-source.ts
+++ b/apps/kg-editor/src/lib/adapters/preferred-showcase-source.ts
@@ -2,6 +2,7 @@ import {
   loadStaticShowcaseBundle,
   parseBoundedShowcaseResponse,
   type ShowcaseFetch,
+  type ShowcaseResponse,
 } from "@/lib/adapters/static-showcase-source";
 import type { RepoBundle } from "@/lib/repo-bundle";
 import {
@@ -55,57 +56,105 @@ export async function loadPreferredShowcaseBundle(
     };
   }
 
-  const endpoint = `/api/showcase/analyses/${entry.analysisId}`;
-  const accessToken = options.accessToken?.trim();
-  const response = await fetchBundle(endpoint, {
-    cache: "no-store",
-    credentials: "same-origin",
-    redirect: "error",
-    ...(accessToken
-      ? { headers: { authorization: `Bearer ${accessToken}` } }
-      : {}),
+  const dbBundle = await tryLoadDbSnapshotBundle(entry, fetchBundle, options);
+  if (dbBundle) {
+    return { bundle: dbBundle, source: "khive-db-snapshot" };
+  }
+
+  return {
+    bundle: await loadStaticShowcaseBundle(entry, fetchBundle),
+    source: "curated-static-fallback",
+  };
+}
+
+// A connection that never resolves, or a response body that stops
+// delivering bytes without rejecting, would otherwise leave the snapshot
+// read pending forever and keep the page in its loading state instead of
+// reaching the static fallback below. This deadline bounds the connection,
+// header wait, and full body parse together, so any of those hangs falls
+// back to the curated static asset once it elapses.
+export const DB_SNAPSHOT_TIMEOUT_MS = 5_000;
+
+// The DB snapshot is a progressive enhancement over the static asset: any
+// failure on this path (network, status, provenance, schema, identity, or
+// timeout) must fall back to the static render rather than fail the page.
+async function tryLoadDbSnapshotBundle(
+  entry: ShowcaseRegistryEntry,
+  fetchBundle: ShowcaseFetch,
+  options: PreferredShowcaseOptions,
+): Promise<RepoBundle | null> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(
+    () => controller.abort(),
+    DB_SNAPSHOT_TIMEOUT_MS,
+  );
+  const deadline = new Promise<null>((resolve) => {
+    controller.signal.addEventListener("abort", () => resolve(null), {
+      once: true,
+    });
   });
 
-  if (response.status === 404) {
-    return {
-      bundle: await loadStaticShowcaseBundle(entry, fetchBundle),
-      source: "curated-static-fallback",
-    };
+  try {
+    return await Promise.race([
+      readDbSnapshotBundle(entry, fetchBundle, options, controller.signal),
+      deadline,
+    ]);
+  } finally {
+    clearTimeout(timeoutId);
   }
+}
+
+async function readDbSnapshotBundle(
+  entry: ShowcaseRegistryEntry,
+  fetchBundle: ShowcaseFetch,
+  options: PreferredShowcaseOptions,
+  signal: AbortSignal,
+): Promise<RepoBundle | null> {
+  const endpoint = `/api/showcase/analyses/${entry.analysisId}`;
+  const accessToken = options.accessToken?.trim();
+  let response: ShowcaseResponse;
+  try {
+    response = await fetchBundle(endpoint, {
+      cache: "no-store",
+      credentials: "same-origin",
+      redirect: "error",
+      signal,
+      ...(accessToken
+        ? { headers: { authorization: `Bearer ${accessToken}` } }
+        : {}),
+    });
+  } catch {
+    return null;
+  }
+
   if (!response.ok) {
-    throw new Error(
-      `Database snapshot could not be loaded (HTTP ${response.status}).`,
-    );
+    return null;
   }
   if (
     response.headers.get("x-khive-analysis-source") !== "khive-db-snapshot" ||
     response.headers.get("x-khive-analysis-id") !== entry.analysisId
   ) {
-    throw new Error(
-      "Database snapshot provenance did not match the curated registry.",
-    );
+    return null;
   }
 
-  const bundle = await parseBoundedShowcaseResponse(
-    response,
-    "Database snapshot",
-  );
-  const expectedRepository = normalizeRepositoryUrl(entry.canonicalUrl);
-  const actualRepository = normalizeRepositoryUrl(
-    bundle.meta.repository.canonical_url,
-  );
-  if (
-    !expectedRepository.ok ||
-    !actualRepository.ok ||
-    actualRepository.value !== expectedRepository.value
-  ) {
-    throw new Error(
-      "Database snapshot repository identity did not match the curated registry.",
+  try {
+    const bundle = await parseBoundedShowcaseResponse(
+      response,
+      "Database snapshot",
     );
+    const expectedRepository = normalizeRepositoryUrl(entry.canonicalUrl);
+    const actualRepository = normalizeRepositoryUrl(
+      bundle.meta.repository.canonical_url,
+    );
+    if (
+      !expectedRepository.ok ||
+      !actualRepository.ok ||
+      actualRepository.value !== expectedRepository.value
+    ) {
+      return null;
+    }
+    return bundle;
+  } catch {
+    return null;
   }
-
-  return {
-    bundle,
-    source: "khive-db-snapshot",
-  };
 }

--- a/apps/kg-editor/src/lib/repo-bundle.test.ts
+++ b/apps/kg-editor/src/lib/repo-bundle.test.ts
@@ -44,6 +44,42 @@ describe("khive.repo.v1 browser contract", () => {
     expect(repoBundleSchema.safeParse(value).success).toBe(false);
   });
 
+  it("rejects duplicate module source paths that cannot form a stable investigation link", () => {
+    const value = goldenValue() as {
+      graph: { modules: { items: Array<{ id: string; source_path: string }> } };
+    };
+    expect(value.graph.modules.items.length).toBeGreaterThan(1);
+    value.graph.modules.items[1].source_path =
+      value.graph.modules.items[0].source_path;
+
+    expect(repoBundleSchema.safeParse(value).success).toBe(false);
+  });
+
+  it.each([
+    "",
+    "/absolute.rs",
+    "crates/../outside.rs",
+    "crates\\windows.rs",
+    `crates/${"a".repeat(1_025)}`,
+    "crates/control\u0000.rs",
+  ])("rejects a non-addressable module source path %j", (sourcePath) => {
+    const value = goldenValue() as {
+      graph: { modules: { items: Array<{ source_path: string }> } };
+    };
+    value.graph.modules.items[0].source_path = sourcePath;
+
+    expect(repoBundleSchema.safeParse(value).success).toBe(false);
+  });
+
+  it("rejects a canonical repository URL that cannot be shared publicly", () => {
+    const value = goldenValue() as {
+      meta: { repository: { canonical_url: string } };
+    };
+    value.meta.repository.canonical_url = "file:///private/repository";
+
+    expect(repoBundleSchema.safeParse(value).success).toBe(false);
+  });
+
   it("accepts repository ownership when only the module join is unavailable", () => {
     const value = goldenValue() as {
       capability: { views: { ownership: { status: string; unavailable_reason?: string } } };

--- a/apps/kg-editor/src/lib/repo-bundle.ts
+++ b/apps/kg-editor/src/lib/repo-bundle.ts
@@ -1,5 +1,10 @@
 import { z } from "zod";
 
+import {
+  addressableModulePathIssue,
+  publicRepositoryUrlIssue,
+} from "@/lib/repository-location";
+
 // Generic strings intentionally have no local minLength: the normative JSON
 // Schema does not add one. Shape closure and field-specific formats stay strict.
 const wireString = z.string();
@@ -484,6 +489,16 @@ export const repoBundleSchema = z.strictObject({
   }),
   capability: capabilitySchema,
 }).superRefine((bundle, context) => {
+  const repositoryIssue = publicRepositoryUrlIssue(
+    bundle.meta.repository.canonical_url,
+  );
+  if (repositoryIssue) {
+    context.addIssue({
+      code: "custom",
+      path: ["meta", "repository", "canonical_url"],
+      message: repositoryIssue,
+    });
+  }
   if (bundle.meta.ingest.code_ingest.status === "available" &&
       bundle.meta.snapshot.head_sha !== bundle.meta.ingest.code_ingest.value.source_revision) {
     context.addIssue({ code: "custom", path: ["meta", "ingest", "code_ingest", "source_revision"], message: "code map revision must equal the bundle HEAD" });
@@ -492,6 +507,25 @@ export const repoBundleSchema = z.strictObject({
     if (bundle.graph[key].items.length !== 0) {
       context.addIssue({ code: "custom", path: ["graph", key, "items"], message: "symbol-tier collections are typed but empty in khive.repo.v1" });
     }
+  }
+  const sourcePaths = new Set<string>();
+  for (const [index, moduleNode] of bundle.graph.modules.items.entries()) {
+    const pathIssue = addressableModulePathIssue(moduleNode.source_path);
+    if (pathIssue) {
+      context.addIssue({
+        code: "custom",
+        path: ["graph", "modules", "items", index, "source_path"],
+        message: pathIssue,
+      });
+    }
+    if (sourcePaths.has(moduleNode.source_path)) {
+      context.addIssue({
+        code: "custom",
+        path: ["graph", "modules", "items", index, "source_path"],
+        message: "module source paths must be unique within a repository snapshot",
+      });
+    }
+    sourcePaths.add(moduleNode.source_path);
   }
   for (const key of [
     "dependency_topology",

--- a/apps/kg-editor/src/lib/repository-location.test.ts
+++ b/apps/kg-editor/src/lib/repository-location.test.ts
@@ -72,6 +72,23 @@ describe("repository investigation location", () => {
     },
   );
 
+  it.each([
+    ["query string", `${repository}?tab=readme`],
+    ["fragment", `${repository}#readme`],
+  ])(
+    "accepts a curated repository URL carrying a %s",
+    (_name, repositoryWithExtras) => {
+      const parsed = parseRepositoryLocation(
+        new URL(
+          `https://example.test/?repo=${encodeURIComponent(repositoryWithExtras)}`,
+        ),
+      );
+
+      expect(parsed.issues).toEqual([]);
+      expect(parsed.location.repository).toBe(repositoryWithExtras);
+    },
+  );
+
   it("canonicalizes only the closed location parameters in stable order", () => {
     const url = repositoryLocationUrl(
       new URL(

--- a/apps/kg-editor/src/lib/repository-location.test.ts
+++ b/apps/kg-editor/src/lib/repository-location.test.ts
@@ -133,4 +133,42 @@ describe("repository investigation location", () => {
       }&at=${snapshotSha}&module=crates%2Fkhive-db%2Fsrc%2Fpool.rs&view=dependency_topology`,
     );
   });
+
+  it("share form strips a repository value's own query and fragment", () => {
+    const url = investigationShareUrl(new URL("https://example.test/app"), {
+      repository:
+        "https://forge.example/group/repo?access_token=not-a-real-secret#token-fragment",
+      snapshotSha,
+      modulePath: "crates/khive-db/src/pool.rs",
+      view: "dependency_topology",
+    });
+
+    expect(url.searchParams.get("repo")).toBe(
+      "https://forge.example/group/repo",
+    );
+    expect(url.href).not.toContain("access_token");
+    expect(url.href).not.toContain("token-fragment");
+  });
+
+  it("share form omits a module path carrying a query or fragment delimiter", () => {
+    for (
+      const modulePath of [
+        "src/x?access_token=not-a-real-secret",
+        "src/x#token-fragment",
+      ]
+    ) {
+      const url = investigationShareUrl(new URL("https://example.test/app"), {
+        repository,
+        snapshotSha,
+        modulePath,
+        view: "dependency_topology",
+      });
+
+      expect(url.searchParams.get("module")).toBeNull();
+      expect(url.href).not.toContain("access_token");
+      expect(url.href).not.toContain("token-fragment");
+      expect(url.searchParams.get("repo")).toBe(repository);
+      expect(url.searchParams.get("at")).toBe(snapshotSha);
+    }
+  });
 });

--- a/apps/kg-editor/src/lib/repository-location.test.ts
+++ b/apps/kg-editor/src/lib/repository-location.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+
+import type { ViewId } from "@/lib/repo-bundle";
+import {
+  parseRepositoryLocation,
+  REPOSITORY_VIEW_IDS,
+  type RepositoryLocation,
+  repositoryLocationUrl,
+} from "@/lib/repository-location";
+
+const repository = "https://github.com/ohdearquant/khive";
+const snapshotSha = "0123456789abcdef0123456789abcdef01234567";
+
+describe("repository investigation location", () => {
+  it.each(REPOSITORY_VIEW_IDS)(
+    "round-trips a shareable %s investigation",
+    (view: ViewId) => {
+      const location: RepositoryLocation = {
+        repository,
+        snapshotSha,
+        modulePath: "crates/space & signals/src/lib.rs",
+        view,
+      };
+
+      const url = repositoryLocationUrl(
+        new URL("https://example.test/?utm_source=demo#analysis"),
+        location,
+      );
+      const parsed = parseRepositoryLocation(url);
+
+      expect(parsed.issues).toEqual([]);
+      expect(parsed.location).toEqual(location);
+      expect(url.searchParams.get("utm_source")).toBe("demo");
+      expect(url.hash).toBe("#analysis");
+    },
+  );
+
+  it.each([
+    [
+      "duplicate repository",
+      `repo=${encodeURIComponent(repository)}&repo=${
+        encodeURIComponent(repository)
+      }`,
+      "repo",
+    ],
+    ["duplicate module", "module=crates%2Fa.rs&module=crates%2Fb.rs", "module"],
+    ["malformed snapshot", "at=abc123", "at"],
+    ["unknown view", "view=everything", "view"],
+    ["absolute module path", "module=%2Fetc%2Fpasswd", "module"],
+    ["parent traversal", "module=crates%2F..%2Fsecret.rs", "module"],
+    ["empty path segment", "module=crates%2F%2Fsecret.rs", "module"],
+    ["empty module", "module=", "module"],
+    ["overlong module", `module=${"a".repeat(1025)}`, "module"],
+  ])(
+    "rejects %s without accepting the ambiguous value",
+    (_name, search, parameter) => {
+      const parsed = parseRepositoryLocation(
+        new URL(`https://example.test/?${search}`),
+      );
+
+      expect(parsed.issues).toContainEqual(
+        expect.objectContaining({ parameter }),
+      );
+      const property = parameter === "repo"
+        ? "repository"
+        : parameter === "at"
+        ? "snapshotSha"
+        : parameter === "module"
+        ? "modulePath"
+        : "view";
+      expect(parsed.location[property]).toBeNull();
+    },
+  );
+
+  it("canonicalizes only the closed location parameters in stable order", () => {
+    const url = repositoryLocationUrl(
+      new URL(
+        "https://example.test/?view=scorecard&module=old.rs&at=old&repo=old&keep=1",
+      ),
+      {
+        repository,
+        snapshotSha,
+        modulePath: "crates/khive-db/src/pool.rs",
+        view: "dependency_topology",
+      },
+    );
+
+    expect(url.search).toBe(
+      `?keep=1&repo=${
+        encodeURIComponent(repository)
+      }&at=${snapshotSha}&module=crates%2Fkhive-db%2Fsrc%2Fpool.rs&view=dependency_topology`,
+    );
+  });
+});

--- a/apps/kg-editor/src/lib/repository-location.test.ts
+++ b/apps/kg-editor/src/lib/repository-location.test.ts
@@ -5,6 +5,7 @@ import {
   parseRepositoryLocation,
   REPOSITORY_VIEW_IDS,
   type RepositoryLocation,
+  investigationShareUrl,
   repositoryLocationUrl,
 } from "@/lib/repository-location";
 
@@ -104,6 +105,30 @@ describe("repository investigation location", () => {
 
     expect(url.search).toBe(
       `?keep=1&repo=${
+        encodeURIComponent(repository)
+      }&at=${snapshotSha}&module=crates%2Fkhive-db%2Fsrc%2Fpool.rs&view=dependency_topology`,
+    );
+  });
+
+  it("share form carries only investigation parameters and drops the fragment", () => {
+    const url = investigationShareUrl(
+      new URL(
+        "https://example.test/app?repo=old&access_token=not-a-real-secret&utm_source=x#token-fragment",
+      ),
+      {
+        repository,
+        snapshotSha,
+        modulePath: "crates/khive-db/src/pool.rs",
+        view: "dependency_topology",
+      },
+    );
+
+    expect(url.pathname).toBe("/app");
+    expect(url.hash).toBe("");
+    expect(url.searchParams.get("access_token")).toBeNull();
+    expect(url.searchParams.get("utm_source")).toBeNull();
+    expect(url.search).toBe(
+      `?repo=${
         encodeURIComponent(repository)
       }&at=${snapshotSha}&module=crates%2Fkhive-db%2Fsrc%2Fpool.rs&view=dependency_topology`,
     );

--- a/apps/kg-editor/src/lib/repository-location.ts
+++ b/apps/kg-editor/src/lib/repository-location.ts
@@ -188,3 +188,26 @@ export function repositoryLocationUrl(
   if (location.view) url.searchParams.append("view", location.view);
   return url;
 }
+
+/**
+ * The shareable form of an investigation URL. A share link leaves the
+ * browser, so it carries ONLY the investigation parameters: every foreign
+ * query parameter and the URL fragment are dropped rather than copied,
+ * because the current address bar can hold values that must not be
+ * disclosed to a link recipient (tokens, authorization codes, tracker
+ * state). `repositoryLocationUrl` stays the in-browser history form, which
+ * preserves foreign parameters locally.
+ */
+export function investigationShareUrl(
+  base: URL,
+  location: RepositoryLocation,
+): URL {
+  const url = new URL(`${base.origin}${base.pathname}`);
+  if (location.repository) url.searchParams.append("repo", location.repository);
+  if (location.snapshotSha) url.searchParams.append("at", location.snapshotSha);
+  if (location.modulePath) {
+    url.searchParams.append("module", location.modulePath);
+  }
+  if (location.view) url.searchParams.append("view", location.view);
+  return url;
+}

--- a/apps/kg-editor/src/lib/repository-location.ts
+++ b/apps/kg-editor/src/lib/repository-location.ts
@@ -1,0 +1,192 @@
+import type { ViewId } from "@/lib/repo-bundle";
+
+export const REPOSITORY_VIEW_IDS = [
+  "structure_graph",
+  "history_structure_navigation",
+  "dependency_topology",
+  "hotspot_quadrant",
+  "hidden_coupling",
+  "structure_treemap",
+  "cadence_timeline",
+  "ownership",
+  "api_surface",
+  "scorecard",
+] as const satisfies readonly ViewId[];
+
+const LOCATION_PARAMETERS = ["repo", "at", "module", "view"] as const;
+const VIEW_IDS = new Set<string>(REPOSITORY_VIEW_IDS);
+const SNAPSHOT_SHA = /^[0-9a-f]{40}$/;
+const MODULE_PATH_LIMIT = 1_024;
+const REPOSITORY_URL_LIMIT = 2_048;
+
+type LocationParameter = (typeof LOCATION_PARAMETERS)[number];
+
+export type RepositoryLocation = Readonly<{
+  repository: string | null;
+  snapshotSha: string | null;
+  modulePath: string | null;
+  view: ViewId | null;
+}>;
+
+export type RepositoryLocationIssue = Readonly<{
+  parameter: LocationParameter;
+  message: string;
+}>;
+
+export type ParsedRepositoryLocation = Readonly<{
+  location: RepositoryLocation;
+  issues: readonly RepositoryLocationIssue[];
+}>;
+
+export function publicRepositoryUrlIssue(value: string): string | null {
+  if (value.length > REPOSITORY_URL_LIMIT) {
+    return "The repository URL is too long.";
+  }
+  try {
+    const repository = new URL(value);
+    if (
+      (repository.protocol !== "https:" && repository.protocol !== "http:") ||
+      repository.username ||
+      repository.password ||
+      repository.search ||
+      repository.hash
+    ) {
+      return "The repository must be a public HTTP or HTTPS URL.";
+    }
+  } catch {
+    return "The repository must be a public HTTP or HTTPS URL.";
+  }
+  return null;
+}
+
+export function addressableModulePathIssue(value: string): string | null {
+  const invalidSegment = value.split("/").some((segment) =>
+    !segment || segment === "." || segment === ".."
+  );
+  if (
+    value.length > MODULE_PATH_LIMIT ||
+    value.startsWith("/") ||
+    value.startsWith("\\") ||
+    value.includes("\\") ||
+    invalidSegment ||
+    /[\u0000-\u001f\u007f]/u.test(value)
+  ) {
+    return "The module must be a bounded repository-relative source path.";
+  }
+  return null;
+}
+
+function singleParameter(
+  url: URL,
+  parameter: LocationParameter,
+  issues: RepositoryLocationIssue[],
+): string | null {
+  const values = url.searchParams.getAll(parameter);
+  if (values.length === 0) return null;
+  if (values.length > 1) {
+    issues.push({
+      parameter,
+      message: `The ${parameter} parameter must appear at most once.`,
+    });
+    return null;
+  }
+  if (!values[0]) {
+    issues.push({
+      parameter,
+      message: `The ${parameter} parameter cannot be empty.`,
+    });
+    return null;
+  }
+  return values[0];
+}
+
+function parseRepository(
+  value: string | null,
+  issues: RepositoryLocationIssue[],
+): string | null {
+  if (value == null) return null;
+  const message = publicRepositoryUrlIssue(value);
+  if (message) {
+    issues.push({ parameter: "repo", message });
+    return null;
+  }
+  return value;
+}
+
+function parseSnapshotSha(
+  value: string | null,
+  issues: RepositoryLocationIssue[],
+): string | null {
+  if (value == null) return null;
+  if (!SNAPSHOT_SHA.test(value)) {
+    issues.push({
+      parameter: "at",
+      message: "The snapshot must be a lowercase 40-character Git SHA.",
+    });
+    return null;
+  }
+  return value;
+}
+
+function parseModulePath(
+  value: string | null,
+  issues: RepositoryLocationIssue[],
+): string | null {
+  if (value == null) return null;
+  const message = addressableModulePathIssue(value);
+  if (message) {
+    issues.push({ parameter: "module", message });
+    return null;
+  }
+  return value;
+}
+
+function parseView(
+  value: string | null,
+  issues: RepositoryLocationIssue[],
+): ViewId | null {
+  if (value == null) return null;
+  if (!VIEW_IDS.has(value)) {
+    issues.push({
+      parameter: "view",
+      message: "The requested analysis view is not supported.",
+    });
+    return null;
+  }
+  return value as ViewId;
+}
+
+export function parseRepositoryLocation(url: URL): ParsedRepositoryLocation {
+  const issues: RepositoryLocationIssue[] = [];
+  const repository = singleParameter(url, "repo", issues);
+  const snapshotSha = singleParameter(url, "at", issues);
+  const modulePath = singleParameter(url, "module", issues);
+  const view = singleParameter(url, "view", issues);
+
+  return {
+    location: {
+      repository: parseRepository(repository, issues),
+      snapshotSha: parseSnapshotSha(snapshotSha, issues),
+      modulePath: parseModulePath(modulePath, issues),
+      view: parseView(view, issues),
+    },
+    issues,
+  };
+}
+
+export function repositoryLocationUrl(
+  base: URL,
+  location: RepositoryLocation,
+): URL {
+  const url = new URL(base);
+  for (const parameter of LOCATION_PARAMETERS) {
+    url.searchParams.delete(parameter);
+  }
+  if (location.repository) url.searchParams.append("repo", location.repository);
+  if (location.snapshotSha) url.searchParams.append("at", location.snapshotSha);
+  if (location.modulePath) {
+    url.searchParams.append("module", location.modulePath);
+  }
+  if (location.view) url.searchParams.append("view", location.view);
+  return url;
+}

--- a/apps/kg-editor/src/lib/repository-location.ts
+++ b/apps/kg-editor/src/lib/repository-location.ts
@@ -197,17 +197,38 @@ export function repositoryLocationUrl(
  * disclosed to a link recipient (tokens, authorization codes, tracker
  * state). `repositoryLocationUrl` stays the in-browser history form, which
  * preserves foreign parameters locally.
+ *
+ * The boundary also applies to the parameter VALUES, not just the
+ * parameter names: a validated repository URL may legitimately carry a
+ * query string or fragment (deep-link support keeps them in-browser), so
+ * the shared copy is normalized to origin + pathname; a module path
+ * carrying a URL query or fragment delimiter is omitted entirely rather
+ * than encoded into the value, because encoding preserves — not redacts —
+ * whatever the delimiter introduced. `at` and `view` need no value
+ * boundary: their parse contracts are a 40-hex SHA and a closed id set.
  */
 export function investigationShareUrl(
   base: URL,
   location: RepositoryLocation,
 ): URL {
   const url = new URL(`${base.origin}${base.pathname}`);
-  if (location.repository) url.searchParams.append("repo", location.repository);
+  if (location.repository) {
+    const repository = shareSafeRepository(location.repository);
+    if (repository) url.searchParams.append("repo", repository);
+  }
   if (location.snapshotSha) url.searchParams.append("at", location.snapshotSha);
-  if (location.modulePath) {
+  if (location.modulePath && !/[?#]/u.test(location.modulePath)) {
     url.searchParams.append("module", location.modulePath);
   }
   if (location.view) url.searchParams.append("view", location.view);
   return url;
+}
+
+function shareSafeRepository(value: string): string | null {
+  try {
+    const repository = new URL(value);
+    return `${repository.origin}${repository.pathname}`;
+  } catch {
+    return null;
+  }
 }

--- a/apps/kg-editor/src/lib/repository-location.ts
+++ b/apps/kg-editor/src/lib/repository-location.ts
@@ -47,9 +47,7 @@ export function publicRepositoryUrlIssue(value: string): string | null {
     if (
       (repository.protocol !== "https:" && repository.protocol !== "http:") ||
       repository.username ||
-      repository.password ||
-      repository.search ||
-      repository.hash
+      repository.password
     ) {
       return "The repository must be a public HTTP or HTTPS URL.";
     }


### PR DESCRIPTION
feat(kg-editor): share repository investigation locations

Replaces #2092 (and the original #1951): the same five feature commits, replayed onto current main so the branch no longer carries the pre-#2071 lineage of the showcase files. Feature content: shareable repository investigation locations (URL deep links for repo, snapshot, module, and view), query- and fragment-tolerant deep-link parsing, static-asset fallback on any snapshot-service failure, and a deadline bound on the snapshot read. Conflicts with the newer showcase lineage were resolved by keeping the per-load snapshot authorization semantics main established; two exact-match fetch assertions gained the abort signal the deadline introduces.

Validation: tsc --noEmit clean; kg-editor vitest suite 210/210; design-token lint and eslint clean.

---

Refs #1881.

Stacked on #1938. This tranche makes a repository investigation shareable and browser-native without claiming the full ADR-152 interaction grammar:

- owns a closed repo/at/module/view URL contract while preserving unrelated query parameters and hashes
- restores direct links, module selection, active analysis, and browser Back/Forward
- keeps stale snapshots, malformed links, missing modules, and ambiguous paths explicit and recoverable
- adds bounded containment breadcrumbs, Copy investigation link feedback, and accessible history announcements/focus handoff
- controls history-view module selection from the same location state
- validates that DB-exported repository URLs and module paths can round-trip through the browser contract

Remaining #1881 work is intentionally out of scope: graph/package/commit selection, cross-surface selection unification, command palette, and keyboard traversal.

Validation:
- focused Vitest location/bundle/showcase suites: 71 passed; all focused source tests pass
- npm run lint
- npm run typecheck
- npm run check:showcase
- Next production build with webpack
- focused Playwright real Back/Forward regression: 1 passed
- independent correctness and product/a11y reviews: APPROVE

Known inherited baseline failures, reproduced unchanged at exact parent 48f993dd: full Vitest has ontology-mark ad-hoc SVG and duplicate Studio Clear filter failures; the broad Showcase Playwright spec also observes the expected 404 from the separately stacked DB-snapshot API route. The new navigation regression passes.
