### PR TITLE
feat(kg-editor): add repository command palette

### DIFF
--- a/apps/kg-editor/e2e/showcase.spec.ts
+++ b/apps/kg-editor/e2e/showcase.spec.ts
@@ -111,6 +111,55 @@ test("restores a shared investigation and follows browser back and forward", asy
   await expect(inspector.getByRole("heading", { level: 3 })).toHaveText(writer);
 });
 
+test("navigates from module to analysis using only the command palette", async ({ page }) => {
+  const writer = "crates/khive-db/src/writer_task.rs";
+  await page.goto("/");
+  await expect(page.getByRole("button", { name: "Open command palette" }))
+    .toBeVisible();
+
+  await page.keyboard.press("Control+K");
+  const palette = page.getByRole("dialog", { name: "Repository commands" });
+  await expect(palette).toBeVisible();
+  const query = palette.getByRole("combobox", {
+    name: "Search repository commands",
+  });
+  await query.fill(writer);
+  await page.keyboard.press("Enter");
+
+  const inspector = page.locator("[data-module-inspector]");
+  await expect(inspector.getByRole("heading", { level: 3 })).toHaveText(writer);
+  await expect(page).toHaveURL(new RegExp(`module=${encodeURIComponent(writer)}`));
+
+  await page.keyboard.press("Control+K");
+  const apiSurface = palette.getByRole("option", {
+    name: /De-facto API surface/i,
+  });
+  for (let step = 0; step < 8; step += 1) {
+    await page.keyboard.press("ArrowDown");
+  }
+  await expect(apiSurface).toHaveAttribute("aria-selected", "true");
+  const [optionBox, resultsBox] = await Promise.all([
+    apiSurface.boundingBox(),
+    palette.getByRole("listbox", {
+      name: "Repository command results",
+    }).boundingBox(),
+  ]);
+  expect(optionBox).not.toBeNull();
+  expect(resultsBox).not.toBeNull();
+  expect(optionBox!.y).toBeGreaterThanOrEqual(resultsBox!.y);
+  expect(optionBox!.y + optionBox!.height)
+    .toBeLessThanOrEqual(resultsBox!.y + resultsBox!.height);
+  await page.keyboard.press("Enter");
+
+  await expect(page.locator('[data-view-id="api_surface"]')).toHaveAttribute(
+    "aria-current",
+    "page",
+  );
+  await expect(page).toHaveURL(/view=api_surface/);
+  await expect(page).toHaveURL(new RegExp(`module=${encodeURIComponent(writer)}`));
+  await expect(page.locator("[data-repository-dashboard]")).toBeFocused();
+});
+
 test("a valid repository miss stays local and renders an honest state", async ({ page }) => {
   const requestedAfterSubmit: string[] = [];
   let observing = false;

--- a/apps/kg-editor/src/components/showcase/repo-showcase.test.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase.test.tsx
@@ -148,6 +148,7 @@ describe("repository showcase", () => {
     const user = userEvent.setup();
     const writeText = vi.spyOn(navigator.clipboard, "writeText")
       .mockResolvedValue(undefined);
+    writeText.mockClear();
     render(<RepoShowcase bundle={golden()} />);
 
     await waitFor(() =>
@@ -874,6 +875,67 @@ describe("repository showcase", () => {
     const localSlice = container.querySelector<HTMLElement>(`.repo-view-panel [data-state="truncated"][data-shown="200"][data-known-total="${bundle.aggregates.hotspot_quadrant.data.items.length}"]`);
     expect(localSlice).toBeVisible();
     expect(localSlice).toHaveTextContent(/truncated/i);
+  });
+
+  it("routes palette module, view, and copy commands through the shared location controller", async () => {
+    const bundle = golden();
+    const writer = bundle.graph.modules.items.find((module) =>
+      module.source_path.endsWith("khive-db/src/writer_task.rs")
+    )!;
+    const user = userEvent.setup();
+    const writeText = vi.spyOn(navigator.clipboard, "writeText")
+      .mockResolvedValue(undefined);
+    writeText.mockClear();
+    const { container } = render(<RepoShowcase bundle={bundle} />);
+    await waitFor(() =>
+      expect(new URL(window.location.href).searchParams.get("view"))
+        .toBe("structure_graph")
+    );
+    const pushState = vi.spyOn(window.history, "pushState");
+    pushState.mockClear();
+
+    await user.keyboard("{Meta>}k{/Meta}");
+    await user.type(
+      screen.getByRole("combobox", { name: "Search repository commands" }),
+      writer.source_path,
+    );
+    await user.keyboard("{Enter}");
+    const inspector = container.querySelector<HTMLElement>(
+      "[data-module-inspector]",
+    )!;
+    await waitFor(() =>
+      expect(within(inspector).getByRole("heading", { level: 3 }))
+        .toHaveTextContent(writer.source_path)
+    );
+    expect(inspector).toHaveFocus();
+    expect(new URL(window.location.href).searchParams.get("module"))
+      .toBe(writer.source_path);
+    expect(pushState).toHaveBeenCalledTimes(1);
+
+    await user.keyboard("{Meta>}k{/Meta}");
+    await user.type(
+      screen.getByRole("combobox", { name: "Search repository commands" }),
+      bundle.capability.views.hidden_coupling.label,
+    );
+    await user.keyboard("{Enter}");
+    const dashboard = container.querySelector<HTMLElement>(
+      "[data-repository-dashboard]",
+    )!;
+    await waitFor(() => expect(dashboard).toHaveFocus());
+    expect(new URL(window.location.href).searchParams.get("module"))
+      .toBe(writer.source_path);
+    expect(new URL(window.location.href).searchParams.get("view"))
+      .toBe("hidden_coupling");
+    expect(pushState).toHaveBeenCalledTimes(2);
+
+    await user.keyboard("{Meta>}k{/Meta}");
+    await user.type(
+      screen.getByRole("combobox", { name: "Search repository commands" }),
+      "copy link",
+    );
+    await user.keyboard("{Enter}");
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(window.location.href));
+    expect(pushState).toHaveBeenCalledTimes(2);
   });
 
   it("settles the structure graph without collapsing nodes onto a handful of shared coordinates", () => {

--- a/apps/kg-editor/src/components/showcase/repo-showcase.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase.tsx
@@ -27,6 +27,7 @@ import {
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { DataState } from "@/components/data-state";
+import { RepositoryCommandPalette } from "@/components/showcase/repository-command-palette";
 import { RepositoryTriage } from "@/components/showcase/repository-triage";
 import type { ShowcaseBundleSource } from "@/lib/adapters/preferred-showcase-source";
 import {
@@ -1039,6 +1040,7 @@ export function RepoShowcase({ bundle, analysisSource = "curated-static-fallback
   }> | null>(null);
   const [navigationStatus, setNavigationStatus] = useState("");
   const [copyStatus, setCopyStatus] = useState("");
+  const overviewRef = useRef<HTMLElement>(null);
   const dashboardRef = useRef<HTMLDivElement>(null);
   const copyLinkRef = useRef<HTMLButtonElement>(null);
 
@@ -1262,11 +1264,27 @@ export function RepoShowcase({ bundle, analysisSource = "curated-static-fallback
       block: "start",
     });
   }
+
+  function openModuleFromPalette(moduleId: string) {
+    selectModule(moduleId);
+    const inspector = overviewRef.current?.querySelector<HTMLElement>(
+      "[data-module-inspector]",
+    );
+    if (!inspector) return;
+    inspector.focus({ preventScroll: true });
+    const reduceMotion = window.matchMedia?.(
+      "(prefers-reduced-motion: reduce)",
+    ).matches ?? false;
+    inspector.scrollIntoView?.({
+      behavior: reduceMotion ? "auto" : "smooth",
+      block: "start",
+    });
+  }
   return (
-    <article className="repo-overview" data-head-sha={snapshot.head_sha} data-analysis-source={analysisSource}>
+    <article ref={overviewRef} className="repo-overview" data-head-sha={snapshot.head_sha} data-analysis-source={analysisSource}>
       <header className="repo-overview-heading">
         <div className="repo-identity"><span className="repo-avatar"><Package aria-hidden="true" /></span><div><span>{repository.host} · {availabilityText(repository.default_branch, capability.labels)}</span><strong>{repository.owner}/{repository.name}</strong></div></div>
-        <div className="repo-meta-row"><span><GitCommitHorizontal aria-hidden="true" /><code>{shortSha(snapshot.head_sha)}</code></span><span><Clock3 aria-hidden="true" />{formatDate(snapshot.ingested_at)}</span><span><Code2 aria-hidden="true" />{producer.exporter}</span><span><Database aria-hidden="true" />{analysisSource === "khive-db-snapshot" ? "khive DB snapshot" : "curated static fallback"}</span><button ref={copyLinkRef} type="button" className="repo-copy-link" onClick={copyInvestigationLink}><Copy aria-hidden="true" /> Copy investigation link</button>{copyStatus && <span role="status" className="repo-copy-status">{copyStatus}</span>}</div>
+        <div className="repo-meta-row"><span><GitCommitHorizontal aria-hidden="true" /><code>{shortSha(snapshot.head_sha)}</code></span><span><Clock3 aria-hidden="true" />{formatDate(snapshot.ingested_at)}</span><span><Code2 aria-hidden="true" />{producer.exporter}</span><span><Database aria-hidden="true" />{analysisSource === "khive-db-snapshot" ? "khive DB snapshot" : "curated static fallback"}</span><RepositoryCommandPalette bundle={bundle} activeView={activeView} selectedModuleId={selectedModuleId} onSelectModule={openModuleFromPalette} onSelectView={openAnalysis} onCopyLink={copyInvestigationLink} /><button ref={copyLinkRef} type="button" className="repo-copy-link" onClick={copyInvestigationLink}><Copy aria-hidden="true" /> Copy investigation link</button>{copyStatus && <span role="status" className="repo-copy-status">{copyStatus}</span>}</div>
       </header>
       <section className="repo-capability-strip" aria-label={capability.labels.product}>
         <div><ShieldCheck aria-hidden="true" /><div><strong>{capability.labels.product}</strong><span>{capability.mode}</span></div></div>

--- a/apps/kg-editor/src/components/showcase/repo-showcase.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase.tsx
@@ -302,47 +302,68 @@ function StructureGraph({ bundle }: { bundle: RepoBundle }) {
   const [subtreeId, setSubtreeId] = useState(graph.repository.id);
   const [zoom, setZoom] = useState(1);
   const [selectedId, setSelectedId] = useState(graph.repository.id);
-  const subtreePackages = subtreeId === graph.repository.id
-    ? graph.packages.items
-    : graph.packages.items.filter((item) => item.id === subtreeId);
-  // Sort by id before truncating so the displayed slice — and therefore the
-  // shared seeded layout fed by it — is independent of input array order
-  // (ADR-153 D4).
-  const displayedPackages = [...subtreePackages].sort((left, right) => left.id.localeCompare(right.id)).slice(0, 8);
-  const selectablePackages = graph.packages.items.slice(0, UI_ROW_LIMIT);
-  const displayedPackageIds = new Set(displayedPackages.map((item) => item.id));
-  const subtreeModules = graph.modules.items.filter((item) => subtreeId === graph.repository.id || item.package_id === subtreeId);
-  const displayedModules = subtreeModules.filter((item) => displayedPackageIds.has(item.package_id))
-    .sort((left, right) => left.id.localeCompare(right.id))
-    .slice(0, 42);
-  const visibleIds = new Set([
-    graph.repository.id,
-    ...displayedPackages.map((item) => item.id),
-    ...displayedModules.map((item) => item.id),
-  ]);
-  const visibleEdges = graph.structure_edges.items.filter((edge) => visibleIds.has(edge.source) && visibleIds.has(edge.target));
-  const displayedEdges = visibleEdges.slice(0, UI_GRAPH_EDGE_LIMIT);
-  const layoutNodes = [
-    { id: graph.repository.id },
-    ...displayedPackages.map((item) => ({ id: item.id })),
-    ...displayedModules.map((item) => ({ id: item.id })),
-  ];
-  const layoutEdges = [
-    ...displayedPackages.map((item) => ({
-      id: `contains-${graph.repository.id}-${item.id}`,
-      source: graph.repository.id,
-      target: item.id,
-    })),
-    ...displayedModules.map((item) => ({
-      id: `contains-${item.package_id}-${item.id}`,
-      source: item.package_id,
-      target: item.id,
-    })),
-    ...displayedEdges.map((edge) => ({ id: edge.id, source: edge.source, target: edge.target })),
-  ];
-  const positions = new Map(
-    settleGraphLayout(layoutNodes, layoutEdges).map((node) => [node.id, { x: node.x, y: node.y }]),
-  );
+  const {
+    subtreePackageCount,
+    displayedPackages,
+    selectablePackages,
+    subtreeModuleCount,
+    displayedModules,
+    displayedEdges,
+    visibleIds,
+    positions,
+  } = useMemo(() => {
+    const subtreePackages = subtreeId === graph.repository.id
+      ? graph.packages.items
+      : graph.packages.items.filter((item) => item.id === subtreeId);
+    // Sort by id before truncating so the displayed slice — and therefore the
+    // shared seeded layout fed by it — is independent of input array order
+    // (ADR-153 D4).
+    const displayedPackages = [...subtreePackages].sort((left, right) => left.id.localeCompare(right.id)).slice(0, 8);
+    const selectablePackages = graph.packages.items.slice(0, UI_ROW_LIMIT);
+    const displayedPackageIds = new Set(displayedPackages.map((item) => item.id));
+    const subtreeModules = graph.modules.items.filter((item) => subtreeId === graph.repository.id || item.package_id === subtreeId);
+    const displayedModules = subtreeModules.filter((item) => displayedPackageIds.has(item.package_id))
+      .sort((left, right) => left.id.localeCompare(right.id))
+      .slice(0, 42);
+    const visibleIds = new Set([
+      graph.repository.id,
+      ...displayedPackages.map((item) => item.id),
+      ...displayedModules.map((item) => item.id),
+    ]);
+    const visibleEdges = graph.structure_edges.items.filter((edge) => visibleIds.has(edge.source) && visibleIds.has(edge.target));
+    const displayedEdges = visibleEdges.slice(0, UI_GRAPH_EDGE_LIMIT);
+    const layoutNodes = [
+      { id: graph.repository.id },
+      ...displayedPackages.map((item) => ({ id: item.id })),
+      ...displayedModules.map((item) => ({ id: item.id })),
+    ];
+    const layoutEdges = [
+      ...displayedPackages.map((item) => ({
+        id: `contains-${graph.repository.id}-${item.id}`,
+        source: graph.repository.id,
+        target: item.id,
+      })),
+      ...displayedModules.map((item) => ({
+        id: `contains-${item.package_id}-${item.id}`,
+        source: item.package_id,
+        target: item.id,
+      })),
+      ...displayedEdges.map((edge) => ({ id: edge.id, source: edge.source, target: edge.target })),
+    ];
+    const positions = new Map(
+      settleGraphLayout(layoutNodes, layoutEdges).map((node) => [node.id, { x: node.x, y: node.y }]),
+    );
+    return {
+      subtreePackageCount: subtreePackages.length,
+      displayedPackages,
+      selectablePackages,
+      subtreeModuleCount: subtreeModules.length,
+      displayedModules,
+      displayedEdges,
+      visibleIds,
+      positions,
+    };
+  }, [graph, subtreeId]);
   const degrees = new Map<string, number>();
   const fanIn = new Map<string, number>();
   const fanOut = new Map<string, number>();
@@ -511,8 +532,8 @@ function StructureGraph({ bundle }: { bundle: RepoBundle }) {
           ))}
         </ul>
         <LocalSliceDisclosure shown={displayedEdges.length} total={graph.structure_edges.items.length} label={capability.views.structure_graph.label} labels={labels} />
-        <LocalSliceDisclosure shown={displayedPackages.length} total={subtreePackages.length} label={labels.node_types.package} labels={labels} />
-        <LocalSliceDisclosure shown={displayedModules.length} total={subtreeModules.length} label={labels.node_types.module} labels={labels} />
+        <LocalSliceDisclosure shown={displayedPackages.length} total={subtreePackageCount} label={labels.node_types.package} labels={labels} />
+        <LocalSliceDisclosure shown={displayedModules.length} total={subtreeModuleCount} label={labels.node_types.module} labels={labels} />
       </div>
       <BoundDisclosure page={graph.packages} labels={labels} />
       <BoundDisclosure page={graph.modules} labels={labels} />

--- a/apps/kg-editor/src/components/showcase/repository-command-palette.module.css
+++ b/apps/kg-editor/src/components/showcase/repository-command-palette.module.css
@@ -45,7 +45,7 @@
 
 .backdrop {
   align-items: flex-start;
-  background: color-mix(in srgb, var(--repo-navy) 42%, transparent);
+  background: color-mix(in srgb, var(--repo-navy) 42%, var(--khive-color-transparent));
   display: flex;
   inset: 0;
   justify-content: center;
@@ -94,7 +94,7 @@
 
 .close {
   align-items: center;
-  background: transparent;
+  background: var(--khive-color-transparent);
   border: 0;
   border-radius: 7px;
   color: var(--repo-muted);
@@ -133,7 +133,7 @@
 }
 
 .search input {
-  background: transparent;
+  background: var(--khive-color-transparent);
   border: 0;
   color: var(--repo-navy);
   flex: 1 1 auto;
@@ -167,8 +167,8 @@
 
 .result {
   align-items: center;
-  background: transparent;
-  border: 1px solid transparent;
+  background: var(--khive-color-transparent);
+  border: 1px solid var(--khive-color-transparent);
   border-radius: 9px;
   color: inherit;
   cursor: pointer;

--- a/apps/kg-editor/src/components/showcase/repository-command-palette.module.css
+++ b/apps/kg-editor/src/components/showcase/repository-command-palette.module.css
@@ -1,0 +1,298 @@
+.trigger {
+  align-items: center;
+  background: var(--repo-paper);
+  border: 1px solid var(--repo-border);
+  border-radius: 8px;
+  color: var(--repo-navy);
+  cursor: pointer;
+  display: inline-flex;
+  font: inherit;
+  font-size: 10px;
+  font-weight: 750;
+  gap: 6px;
+  min-height: 30px;
+  padding: 4px 7px;
+}
+
+.trigger:hover {
+  background: var(--repo-paper);
+}
+
+.trigger:focus-visible,
+.close:focus-visible,
+.result:focus-visible {
+  box-shadow: 0 0 0 3px var(--selection-ring-accent);
+  outline: 0;
+}
+
+.trigger svg {
+  height: 13px;
+  width: 13px;
+}
+
+.trigger kbd,
+.search kbd,
+.footer kbd {
+  background: var(--repo-paper);
+  border: 1px solid var(--repo-border);
+  border-radius: 5px;
+  box-shadow: 0 1px 0 var(--repo-border);
+  color: var(--repo-muted);
+  font: inherit;
+  font-size: 9px;
+  padding: 2px 5px;
+}
+
+.backdrop {
+  align-items: flex-start;
+  background: color-mix(in srgb, var(--repo-navy) 42%, transparent);
+  display: flex;
+  inset: 0;
+  justify-content: center;
+  padding: min(13vh, 110px) 18px 24px;
+  position: fixed;
+  z-index: 1000;
+}
+
+.dialog {
+  background: var(--repo-paper);
+  border: 1px solid var(--repo-border);
+  border-radius: 16px;
+  box-shadow: var(--shadow);
+  color: var(--repo-navy);
+  display: flex;
+  flex-direction: column;
+  max-height: min(74vh, 680px);
+  max-width: 720px;
+  overflow: hidden;
+  width: 100%;
+}
+
+.header {
+  align-items: flex-start;
+  border-bottom: 1px solid var(--repo-border);
+  display: flex;
+  gap: 18px;
+  justify-content: space-between;
+  padding: 18px 20px 14px;
+}
+
+.header h2 {
+  font-size: 21px;
+  letter-spacing: -0.025em;
+  line-height: 1.1;
+  margin: 4px 0 0;
+}
+
+.eyebrow {
+  color: var(--repo-green);
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.close {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 7px;
+  color: var(--repo-muted);
+  cursor: pointer;
+  display: inline-flex;
+  justify-content: center;
+  min-height: 34px;
+  min-width: 34px;
+  padding: 7px;
+}
+
+.close:hover {
+  background: var(--repo-border);
+  color: var(--repo-navy);
+}
+
+.close svg {
+  height: 18px;
+  width: 18px;
+}
+
+.search {
+  align-items: center;
+  border-bottom: 1px solid var(--repo-border);
+  display: flex;
+  gap: 10px;
+  min-height: 55px;
+  padding: 0 20px;
+}
+
+.search > svg {
+  color: var(--repo-green);
+  flex: 0 0 auto;
+  height: 18px;
+  width: 18px;
+}
+
+.search input {
+  background: transparent;
+  border: 0;
+  color: var(--repo-navy);
+  flex: 1 1 auto;
+  font: inherit;
+  font-size: 15px;
+  min-width: 0;
+  outline: 0;
+}
+
+.search input::placeholder {
+  color: var(--repo-muted);
+}
+
+.summary {
+  color: var(--repo-muted);
+  font-size: 9px;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  padding: 10px 20px 7px;
+  text-transform: uppercase;
+}
+
+.results {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: 3px;
+  overflow-y: auto;
+  padding: 0 10px 12px;
+}
+
+.result {
+  align-items: center;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 9px;
+  color: inherit;
+  cursor: pointer;
+  display: grid;
+  font: inherit;
+  gap: 10px;
+  grid-template-columns: 28px minmax(0, 1fr) auto;
+  min-height: 48px;
+  padding: 7px 10px;
+  text-align: left;
+  width: 100%;
+}
+
+.result[data-highlighted] {
+  background: var(--repo-navy);
+  border-color: var(--repo-green);
+  color: var(--repo-paper);
+}
+
+.result[data-highlighted] .resultCopy strong,
+.result[data-highlighted] .resultCopy small,
+.result[data-highlighted] .resultMeta {
+  color: var(--repo-paper);
+}
+
+.resultIcon {
+  align-items: center;
+  background: var(--repo-paper);
+  border: 1px solid var(--repo-border);
+  border-radius: 7px;
+  color: var(--repo-green);
+  display: inline-flex;
+  font-size: 9px;
+  font-weight: 850;
+  height: 28px;
+  justify-content: center;
+  width: 28px;
+}
+
+.resultIcon svg {
+  height: 14px;
+  width: 14px;
+}
+
+.resultCopy {
+  min-width: 0;
+}
+
+.resultCopy strong,
+.resultCopy small {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.resultCopy strong {
+  font-size: 12px;
+}
+
+.resultCopy small {
+  color: var(--repo-muted);
+  font-size: 10px;
+  margin-top: 3px;
+}
+
+.resultMeta {
+  color: var(--repo-muted);
+  font-size: 8px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.empty {
+  color: var(--repo-muted);
+  font-size: 12px;
+  margin: 22px;
+  text-align: center;
+}
+
+.footer {
+  align-items: center;
+  background: var(--repo-paper);
+  border-top: 1px solid var(--repo-border);
+  color: var(--repo-muted);
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 9px;
+  gap: 15px;
+  padding: 9px 20px;
+}
+
+.footer span {
+  align-items: center;
+  display: inline-flex;
+  gap: 4px;
+}
+
+.footer .scope {
+  border-top: 1px solid var(--repo-border);
+  flex-basis: 100%;
+  line-height: 1.4;
+  padding-top: 7px;
+}
+
+@media (max-width: 640px) {
+  .trigger > span:not(:last-child) {
+    display: none;
+  }
+
+  .backdrop {
+    padding: 12px;
+  }
+
+  .dialog {
+    max-height: calc(100vh - 24px);
+  }
+
+  .resultMeta {
+    display: none;
+  }
+
+  .result {
+    grid-template-columns: 28px minmax(0, 1fr);
+  }
+}

--- a/apps/kg-editor/src/components/showcase/repository-command-palette.test.tsx
+++ b/apps/kg-editor/src/components/showcase/repository-command-palette.test.tsx
@@ -1,0 +1,227 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { RepositoryCommandPalette } from "@/components/showcase/repository-command-palette";
+import { parseRepoBundle, type RepoBundle } from "@/lib/repo-bundle";
+import { REPOSITORY_VIEW_IDS } from "@/lib/repository-location";
+
+const goldenPath = resolve(
+  process.cwd(),
+  "../../docs/schemas/examples/khive-repo-v1-khive.json",
+);
+
+function golden(): RepoBundle {
+  return parseRepoBundle(JSON.parse(readFileSync(goldenPath, "utf8")));
+}
+
+function renderPalette(
+  overrides: Partial<React.ComponentProps<typeof RepositoryCommandPalette>> =
+    {},
+) {
+  const bundle = golden();
+  const props: React.ComponentProps<typeof RepositoryCommandPalette> = {
+    bundle,
+    activeView: "structure_graph",
+    selectedModuleId: bundle.graph.modules.items[0]?.id ?? null,
+    onSelectModule: vi.fn(),
+    onSelectView: vi.fn(),
+    onCopyLink: vi.fn(),
+    ...overrides,
+  };
+  return {
+    bundle,
+    props,
+    ...render(
+      <div className="repo-shell">
+        <div className="repo-meta-row">
+          <RepositoryCommandPalette {...props} />
+        </div>
+      </div>,
+    ),
+  };
+}
+
+describe("repository command palette", () => {
+  it("opens from either platform shortcut, exposes every view, and restores focus", async () => {
+    const user = userEvent.setup();
+    const { bundle } = renderPalette();
+    const trigger = screen.getByRole("button", {
+      name: "Open command palette",
+    });
+    trigger.focus();
+
+    await user.keyboard("{Meta>}k{/Meta}");
+    const dialog = screen.getByRole("dialog", { name: "Repository commands" });
+    expect(dialog).toBeVisible();
+    expect(dialog.closest(".repo-shell")).not.toBeNull();
+    expect(dialog.closest(".repo-meta-row")).toBeNull();
+    const query = screen.getByRole("combobox", {
+      name: "Search repository commands",
+    });
+    expect(query).toHaveFocus();
+    expect(within(dialog).getAllByRole("option")[0])
+      .toHaveAttribute("aria-selected", "true");
+    for (const viewId of REPOSITORY_VIEW_IDS) {
+      expect(
+        within(dialog).getByRole("option", {
+          name: new RegExp(bundle.capability.views[viewId].label, "i"),
+        }),
+      ).toBeVisible();
+    }
+    await user.tab();
+    expect(
+      within(dialog).getByRole("button", {
+        name: "Close command palette",
+      }),
+    ).toHaveFocus();
+    await user.tab({ shift: true });
+    expect(query).toHaveFocus();
+
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("dialog", { name: "Repository commands" }))
+      .not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+
+    await user.keyboard("{Control>}k{/Control}");
+    expect(screen.getByRole("dialog", { name: "Repository commands" }))
+      .toBeVisible();
+    const repeatedShortcut = new KeyboardEvent("keydown", {
+      key: "k",
+      ctrlKey: true,
+      repeat: true,
+      cancelable: true,
+    });
+    window.dispatchEvent(repeatedShortcut);
+    expect(repeatedShortcut.defaultPrevented).toBe(true);
+    expect(screen.getByRole("dialog", { name: "Repository commands" }))
+      .toBeVisible();
+  });
+
+  it("uses arrow traversal and Enter for bounded module, view, and copy commands", async () => {
+    const bundle = golden();
+    const writer = bundle.graph.modules.items.find((module) =>
+      module.source_path.endsWith("khive-db/src/writer_task.rs")
+    )!;
+    const onSelectModule = vi.fn();
+    const onSelectView = vi.fn();
+    const onCopyLink = vi.fn();
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoView,
+    });
+    const user = userEvent.setup();
+    renderPalette({ bundle, onSelectModule, onSelectView, onCopyLink });
+
+    await user.keyboard("{Meta>}k{/Meta}");
+    let query = screen.getByRole("combobox", {
+      name: "Search repository commands",
+    });
+    const defaultOptions = screen.getAllByRole("option");
+    expect(defaultOptions[0]).toHaveAttribute("aria-selected", "true");
+    scrollIntoView.mockClear();
+    await user.keyboard("{ArrowDown}");
+    expect(defaultOptions[1]).toHaveAttribute("aria-selected", "true");
+    expect(scrollIntoView).toHaveBeenLastCalledWith({ block: "nearest" });
+    await user.keyboard("{Enter}");
+    expect(onSelectView).toHaveBeenCalledWith(
+      "history_structure_navigation",
+    );
+
+    await user.keyboard("{Meta>}k{/Meta}");
+    query = screen.getByRole("combobox", {
+      name: "Search repository commands",
+    });
+    await user.type(query, writer.source_path);
+    expect(screen.getAllByRole("option")).toHaveLength(1);
+    await user.keyboard("{Enter}");
+    expect(onSelectModule).toHaveBeenCalledOnce();
+    expect(onSelectModule).toHaveBeenCalledWith(writer.id);
+
+    await user.keyboard("{Meta>}k{/Meta}");
+    const copyOption = screen.getAllByRole("option").at(-1)!;
+    await user.keyboard("{ArrowUp}");
+    expect(copyOption).toHaveAttribute("aria-selected", "true");
+    await user.keyboard("{Enter}");
+    expect(onCopyLink).toHaveBeenCalledOnce();
+  });
+
+  it("keeps unavailable views addressable and explains their status", async () => {
+    const original = golden();
+    const bundle = {
+      ...original,
+      capability: {
+        ...original.capability,
+        views: {
+          ...original.capability.views,
+          scorecard: {
+            ...original.capability.views.scorecard,
+            status: "unavailable" as const,
+            unavailable_reason: "Score inputs were not captured.",
+          },
+        },
+      },
+    };
+    const onSelectView = vi.fn();
+    const user = userEvent.setup();
+    renderPalette({ bundle, onSelectView });
+
+    await user.click(
+      screen.getByRole("button", { name: "Open command palette" }),
+    );
+    const scorecard = screen.getByRole("option", { name: /scorecard/i });
+    expect(scorecard).toHaveTextContent("Unavailable");
+    expect(scorecard).toHaveTextContent("Score inputs were not captured.");
+    await user.click(scorecard);
+    expect(onSelectView).toHaveBeenCalledWith("scorecard");
+  });
+
+  it("discloses when module search only covers a bounded captured page", async () => {
+    const bundle = structuredClone(golden());
+    bundle.graph.modules.truncated = true;
+    bundle.graph.modules.next_cursor = "next-module-page";
+    bundle.graph.modules.total_count = {
+      status: "available",
+      value: bundle.graph.modules.items.length + 42,
+    };
+    bundle.graph.modules.disclosure = {
+      status: "truncated",
+      reason: "module page reached its export bound",
+    };
+    const user = userEvent.setup();
+    renderPalette({ bundle });
+
+    await user.click(
+      screen.getByRole("button", { name: "Open command palette" }),
+    );
+    expect(screen.getByText(
+      new RegExp(
+        `${bundle.graph.modules.items.length} of ${
+          bundle.graph.modules.items.length + 42
+        } captured module records`,
+        "i",
+      ),
+    )).toHaveTextContent(/Truncated.*module page reached its export bound/i);
+    expect(screen.getByText(/Up to 8 module matches/i)).toBeVisible();
+  });
+
+  it("does not claim complete module search coverage when a next page exists", async () => {
+    const bundle = structuredClone(golden());
+    bundle.graph.modules.truncated = false;
+    bundle.graph.modules.next_cursor = "next-module-page";
+    bundle.graph.modules.disclosure = { status: "complete" };
+    const user = userEvent.setup();
+    renderPalette({ bundle });
+
+    await user.click(
+      screen.getByRole("button", { name: "Open command palette" }),
+    );
+    expect(screen.getByText(/captured module records/i))
+      .toHaveTextContent(/Truncated/i);
+    expect(screen.getByText(/captured module records/i))
+      .not.toHaveTextContent(/complete/i);
+  });
+});

--- a/apps/kg-editor/src/components/showcase/repository-command-palette.tsx
+++ b/apps/kg-editor/src/components/showcase/repository-command-palette.tsx
@@ -87,15 +87,16 @@ export function RepositoryCommandPalette({
       !normalizedQuery || includesQuery(command, normalizedQuery)
     );
     const moduleCommands: PaletteCommand[] = normalizedQuery
-      ? findRepositoryModules(bundle, normalizedQuery, MODULE_RESULT_LIMIT).map(
-        (module) => ({
-          id: `module:${module.id}`,
-          kind: "module" as const,
-          label: module.source_path,
-          detail: module.module_path,
-          module,
-        }),
-      )
+      ? findRepositoryModules(bundle, normalizedQuery, MODULE_RESULT_LIMIT).items
+        .map(
+          (module) => ({
+            id: `module:${module.id}`,
+            kind: "module" as const,
+            label: module.source_path,
+            detail: module.module_path,
+            module,
+          }),
+        )
       : [];
     const copyCommand: PaletteCommand = {
       id: "action:copy-link",

--- a/apps/kg-editor/src/components/showcase/repository-command-palette.tsx
+++ b/apps/kg-editor/src/components/showcase/repository-command-palette.tsx
@@ -1,0 +1,386 @@
+"use client";
+
+import { Copy, Search, X } from "@/icons";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+import styles from "@/components/showcase/repository-command-palette.module.css";
+import { findRepositoryModules } from "@/lib/repository-brief";
+import type { RepoBundle, RepoModule, ViewId } from "@/lib/repo-bundle";
+import { REPOSITORY_VIEW_IDS } from "@/lib/repository-location";
+
+const MODULE_RESULT_LIMIT = 8;
+
+type PaletteCommand =
+  | Readonly<{
+    id: string;
+    kind: "view";
+    label: string;
+    detail: string;
+    view: ViewId;
+  }>
+  | Readonly<{
+    id: string;
+    kind: "module";
+    label: string;
+    detail: string;
+    module: RepoModule;
+  }>
+  | Readonly<{
+    id: "action:copy-link";
+    kind: "action";
+    label: "Copy investigation link";
+    detail: "Copy the current repository, snapshot, module, and view.";
+  }>;
+
+export type RepositoryCommandPaletteProps = Readonly<{
+  bundle: RepoBundle;
+  activeView: ViewId;
+  selectedModuleId: string | null;
+  onSelectModule: (moduleId: string) => void;
+  onSelectView: (view: ViewId) => void;
+  onCopyLink: () => void | Promise<void>;
+}>;
+
+function includesQuery(command: PaletteCommand, query: string): boolean {
+  const haystack = `${command.label} ${command.detail}`.toLowerCase();
+  return query.split(/\s+/u).every((token) => haystack.includes(token));
+}
+
+export function RepositoryCommandPalette({
+  bundle,
+  activeView,
+  selectedModuleId,
+  onSelectModule,
+  onSelectView,
+  onCopyLink,
+}: RepositoryCommandPaletteProps) {
+  const [open, setOpen] = useState(false);
+  const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
+  const [query, setQuery] = useState("");
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const closeRef = useRef<HTMLButtonElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const returnFocusRef = useRef<HTMLElement | null>(null);
+  const listboxId = useId();
+  const dialogTitleId = useId();
+
+  const commands = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    const viewCommands: PaletteCommand[] = REPOSITORY_VIEW_IDS.map((view) => {
+      const capability = bundle.capability.views[view];
+      const availability = capability.status === "unavailable"
+        ? `${bundle.capability.labels.unavailable}. ${
+          capability.unavailable_reason ?? "No reason was supplied."
+        }`
+        : "Analysis view";
+      return {
+        id: `view:${view}`,
+        kind: "view" as const,
+        label: capability.label,
+        detail: availability,
+        view,
+      };
+    }).filter((command) =>
+      !normalizedQuery || includesQuery(command, normalizedQuery)
+    );
+    const moduleCommands: PaletteCommand[] = normalizedQuery
+      ? findRepositoryModules(bundle, normalizedQuery, MODULE_RESULT_LIMIT).map(
+        (module) => ({
+          id: `module:${module.id}`,
+          kind: "module" as const,
+          label: module.source_path,
+          detail: module.module_path,
+          module,
+        }),
+      )
+      : [];
+    const copyCommand: PaletteCommand = {
+      id: "action:copy-link",
+      kind: "action",
+      label: "Copy investigation link",
+      detail: "Copy the current repository, snapshot, module, and view.",
+    };
+    const actionCommands = !normalizedQuery ||
+        includesQuery(copyCommand, normalizedQuery)
+      ? [copyCommand]
+      : [];
+    return [...viewCommands, ...moduleCommands, ...actionCommands];
+  }, [bundle, query]);
+  const modulePage = bundle.graph.modules;
+  const moduleLabel = bundle.capability.labels.node_types.module.toLowerCase();
+  const moduleTotal = modulePage.total_count.status === "available"
+    ? modulePage.total_count.value
+    : null;
+  const moduleSearchScope = `${modulePage.items.length}${
+    moduleTotal != null && moduleTotal !== modulePage.items.length
+      ? ` of ${moduleTotal}`
+      : ""
+  } captured ${moduleLabel} records · ${
+    modulePage.disclosure.status === "complete" &&
+      !modulePage.truncated &&
+      modulePage.next_cursor == null
+      ? "complete"
+      : modulePage.disclosure.status === "unavailable"
+      ? bundle.capability.labels.unavailable
+      : bundle.capability.labels.truncated
+  }${modulePage.disclosure.reason ? `: ${modulePage.disclosure.reason}` : ""}`;
+
+  function openPalette(source?: HTMLElement | null) {
+    returnFocusRef.current = source ??
+      (document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null);
+    setQuery("");
+    setHighlightedIndex(0);
+    setPortalTarget(
+      source?.closest<HTMLElement>(".repo-shell") ??
+        triggerRef.current?.closest<HTMLElement>(".repo-shell") ??
+        document.body,
+    );
+    setOpen(true);
+  }
+
+  function closePalette(restoreFocus = true) {
+    setOpen(false);
+    setQuery("");
+    setHighlightedIndex(0);
+    if (restoreFocus) {
+      queueMicrotask(() => {
+        if (returnFocusRef.current?.isConnected) returnFocusRef.current.focus();
+      });
+    }
+  }
+
+  function execute(command: PaletteCommand | undefined) {
+    if (!command) return;
+    if (command.kind === "view") {
+      closePalette(false);
+      onSelectView(command.view);
+    } else if (command.kind === "module") {
+      closePalette(false);
+      onSelectModule(command.module.id);
+    } else {
+      closePalette();
+      void onCopyLink();
+    }
+  }
+
+  useEffect(() => {
+    function handleShortcut(event: KeyboardEvent) {
+      if (
+        event.key.toLowerCase() === "k" &&
+        (event.metaKey || event.ctrlKey) &&
+        !event.altKey
+      ) {
+        event.preventDefault();
+        if (event.repeat) return;
+        if (open) closePalette();
+        else openPalette();
+      } else if (open && event.key === "Escape") {
+        event.preventDefault();
+        closePalette();
+      }
+    }
+    window.addEventListener("keydown", handleShortcut);
+    return () => window.removeEventListener("keydown", handleShortcut);
+  });
+
+  useEffect(() => {
+    if (open) inputRef.current?.focus();
+  }, [open]);
+
+  const safeHighlightedIndex = commands.length
+    ? Math.min(highlightedIndex, commands.length - 1)
+    : 0;
+
+  useEffect(() => {
+    if (!open || commands.length === 0) return;
+    optionRefs.current[safeHighlightedIndex]?.scrollIntoView?.({
+      block: "nearest",
+    });
+  }, [commands.length, open, query, safeHighlightedIndex]);
+
+  function handleInputKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setHighlightedIndex((index) =>
+        commands.length ? (index + 1) % commands.length : 0
+      );
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setHighlightedIndex((index) =>
+        commands.length ? (index - 1 + commands.length) % commands.length : 0
+      );
+    } else if (event.key === "Home") {
+      event.preventDefault();
+      setHighlightedIndex(0);
+    } else if (event.key === "End") {
+      event.preventDefault();
+      setHighlightedIndex(Math.max(0, commands.length - 1));
+    } else if (event.key === "Enter") {
+      event.preventDefault();
+      execute(commands[safeHighlightedIndex]);
+    }
+  }
+
+  function trapDialogFocus(event: React.KeyboardEvent<HTMLDivElement>) {
+    if (event.key !== "Tab") return;
+    if (!event.shiftKey && document.activeElement === inputRef.current) {
+      event.preventDefault();
+      closeRef.current?.focus();
+    } else if (event.shiftKey && document.activeElement === closeRef.current) {
+      event.preventDefault();
+      inputRef.current?.focus();
+    }
+  }
+
+  const highlightedCommand = commands[safeHighlightedIndex];
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        className={styles.trigger}
+        aria-label="Open command palette"
+        aria-keyshortcuts="Meta+K Control+K"
+        onClick={(event) => openPalette(event.currentTarget)}
+      >
+        <Search aria-hidden="true" />
+        <span>Commands</span>
+        <kbd>⌘/Ctrl K</kbd>
+        <span className="visually-hidden">Open command palette</span>
+      </button>
+      {open && portalTarget && createPortal(
+        (
+          <div
+            className={styles.backdrop}
+            onMouseDown={(event) => {
+              if (event.target === event.currentTarget) closePalette();
+            }}
+          >
+            <div
+              className={styles.dialog}
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby={dialogTitleId}
+              onKeyDown={trapDialogFocus}
+            >
+              <header className={styles.header}>
+                <div>
+                  <span className={styles.eyebrow}>Repository navigation</span>
+                  <h2 id={dialogTitleId}>Repository commands</h2>
+                </div>
+                <button
+                  ref={closeRef}
+                  type="button"
+                  className={styles.close}
+                  onClick={() => closePalette()}
+                >
+                  <X aria-hidden="true" />
+                  <span className="visually-hidden">Close command palette</span>
+                </button>
+              </header>
+              <label className={styles.search}>
+                <Search aria-hidden="true" />
+                <span className="visually-hidden">
+                  Search repository commands
+                </span>
+                <input
+                  ref={inputRef}
+                  role="combobox"
+                  aria-label="Search repository commands"
+                  aria-expanded="true"
+                  aria-controls={listboxId}
+                  aria-activedescendant={highlightedCommand
+                    ? `${listboxId}-${safeHighlightedIndex}`
+                    : undefined}
+                  autoComplete="off"
+                  value={query}
+                  placeholder="Jump to a module, view, or action"
+                  onChange={(event) => {
+                    setQuery(event.target.value);
+                    setHighlightedIndex(0);
+                  }}
+                  onKeyDown={handleInputKeyDown}
+                />
+                <kbd>Esc</kbd>
+              </label>
+              <div className={styles.summary} aria-live="polite">
+                {commands.length}{" "}
+                {commands.length === 1 ? "command" : "commands"}
+                {query.trim() ? " matched" : " available"}
+              </div>
+              <div
+                id={listboxId}
+                className={styles.results}
+                role="listbox"
+                aria-label="Repository command results"
+              >
+                {commands.map((command, index) => {
+                  const current = command.kind === "view"
+                    ? command.view === activeView
+                    : command.kind === "module"
+                    ? command.module.id === selectedModuleId
+                    : false;
+                  return (
+                    <button
+                      key={command.id}
+                      ref={(node) => {
+                        optionRefs.current[index] = node;
+                      }}
+                      id={`${listboxId}-${index}`}
+                      type="button"
+                      role="option"
+                      tabIndex={-1}
+                      aria-selected={index === safeHighlightedIndex}
+                      className={styles.result}
+                      data-highlighted={index === safeHighlightedIndex ||
+                        undefined}
+                      onMouseMove={() => setHighlightedIndex(index)}
+                      onClick={() => execute(command)}
+                    >
+                      <span className={styles.resultIcon} aria-hidden="true">
+                        {command.kind === "action"
+                          ? <Copy />
+                          : command.kind === "module"
+                          ? "M"
+                          : "V"}
+                      </span>
+                      <span className={styles.resultCopy}>
+                        <strong>{command.label}</strong>
+                        <small>{command.detail}</small>
+                      </span>
+                      <span className={styles.resultMeta}>
+                        {current ? "Current" : command.kind}
+                      </span>
+                    </button>
+                  );
+                })}
+                {commands.length === 0 && (
+                  <p className={styles.empty}>
+                    No repository command matches this query.
+                  </p>
+                )}
+              </div>
+              <footer className={styles.footer}>
+                <span>
+                  <kbd>↑</kbd>
+                  <kbd>↓</kbd> Navigate
+                </span>
+                <span>
+                  <kbd>↵</kbd> Open
+                </span>
+                <span>Up to {MODULE_RESULT_LIMIT} module matches</span>
+                <span className={styles.scope}>{moduleSearchScope}</span>
+              </footer>
+            </div>
+          </div>
+        ),
+        portalTarget,
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
Add a repository command palette to the kg-editor showcase: keyboard-driven
navigation over analysis views and module matches, with tokenized styling and
memoized structure-graph layout so palette interaction does not recompute the
graph. Includes component tests covering open/close, filtering, match
consumption, and keyboard flow.

Replaces #1955, rebuilding on the current mainline.
