### PR TITLE
docs(comments): keep durable invariants, drop transient context in edge-listing comments

### DIFF
--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -555,7 +555,7 @@ async fn batched_namespace_edge_counts_exceed_sqlite_variable_limit() {
     );
 }
 
-/// #2089 round-1 HIGH finding: `query_edges_in_namespaces` used to bind one
+/// #2089: `query_edges_in_namespaces` used to bind one
 /// `?N` SQL variable per visible namespace, so a caller visible in ~998+
 /// namespaces would blow past `SQLITE_LIMIT_VARIABLE_NUMBER` (999 by
 /// default) before any filter parameter was even added — well within a

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -6935,8 +6935,8 @@ mod tests {
         assert_eq!(updated.relation, EdgeRelation::VariantOf);
     }
 
-    /// #2088 regression at the runtime seam, rebuilt deterministic under
-    /// #2089: the previous fixture created edges
+    /// #2088 regression at the runtime seam; this fixture was rebuilt
+    /// deterministically for #2089 because the previous fixture created edges
     /// through the normal `link()` path (random UUIDs, wall-clock
     /// timestamps), so whether it exposed the pre-image bug — sorting the
     /// per-namespace merge by UUID alone, a key unrelated to the

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -6935,8 +6935,8 @@ mod tests {
         assert_eq!(updated.relation, EdgeRelation::VariantOf);
     }
 
-    /// #2088 regression at the runtime seam, rebuilt deterministic per the
-    /// #2089 round-1 review (finding 3): the previous fixture created edges
+    /// #2088 regression at the runtime seam, rebuilt deterministic under
+    /// #2089: the previous fixture created edges
     /// through the normal `link()` path (random UUIDs, wall-clock
     /// timestamps), so whether it exposed the pre-image bug — sorting the
     /// per-namespace merge by UUID alone, a key unrelated to the
@@ -7072,7 +7072,7 @@ mod tests {
         );
     }
 
-    /// #2089 round-1 MEDIUM finding 2: `list_edges`'s trait-default fallback
+    /// #2089: `list_edges`'s trait-default fallback
     /// (taken when a `GraphStore` backend returns `Unsupported` from
     /// `query_edges_in_namespaces` — i.e. it does not override the batched
     /// namespace query, per [`khive_storage::GraphStore`]'s default) merges

--- a/crates/khive-storage/tests/graph_namespace_trait_default.rs
+++ b/crates/khive-storage/tests/graph_namespace_trait_default.rs
@@ -1,4 +1,4 @@
-//! #2089 round-1 MEDIUM finding 2: any `GraphStore` backend that does not
+//! #2089: any `GraphStore` backend that does not
 //! override `query_edges_in_namespaces` (the trait default) must still
 //! behave correctly for the 0/1-namespace cases, and must reject a
 //! multi-namespace request with `StorageError::Unsupported { operation:
@@ -27,7 +27,7 @@ use khive_types::EdgeRelation;
 /// default (plus `query_edges`, needed for `query_edges_in_namespaces`'s
 /// 1-namespace delegation). It deliberately does NOT override
 /// `query_edges_in_namespaces` or `count_edges_in_namespaces` — exactly the
-/// "backend exercising the trait default" the round-1 review asked for.
+/// "backend exercising the trait default" this suite exists to cover.
 struct TraitDefaultOnlyGraphStore {
     edges: Mutex<Vec<Edge>>,
 }


### PR DESCRIPTION
Comment-only diff. The edge-listing doc comments keep what the fixtures pin and why (the deterministic UUID/created_at interleave, the trait-default Unsupported fallback shape) and drop transient context lines that do not describe the durable invariant.