### PR TITLE
perf(kg-editor): reuse showcase graph layout

### DIFF
--- a/apps/kg-editor/src/components/showcase/repo-showcase-layout.test.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase-layout.test.tsx
@@ -61,6 +61,25 @@ describe("repository showcase graph layout", () => {
     rerender(<RepoShowcase bundle={bundle} />);
     expect(settleGraphLayoutSpy).toHaveBeenCalledTimes(2);
 
+    // An unrelated bundle-field change (a capability label) with every graph
+    // layout input reference preserved must not recompute the layout. The
+    // graph container is deliberately a fresh object: a whole-`graph`
+    // dependency would recompute here, while the fine-grained inputs
+    // (repository id and the three item arrays) keep their identity.
+    const relabeledBundle = {
+      ...bundle,
+      capability: {
+        ...bundle.capability,
+        labels: {
+          ...bundle.capability.labels,
+          truncated: `${bundle.capability.labels.truncated} (relabeled)`,
+        },
+      },
+      graph: { ...bundle.graph },
+    };
+    rerender(<RepoShowcase bundle={relabeledBundle} />);
+    expect(settleGraphLayoutSpy).toHaveBeenCalledTimes(2);
+
     const replacedModulePage = {
       ...bundle,
       graph: {

--- a/apps/kg-editor/src/components/showcase/repo-showcase-layout.test.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase-layout.test.tsx
@@ -1,0 +1,77 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RepoShowcase } from "@/components/showcase/repo-showcase";
+import { parseRepoBundle, type RepoBundle } from "@/lib/repo-bundle";
+
+const settleGraphLayoutSpy = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/graph-layout", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/graph-layout")>();
+  settleGraphLayoutSpy.mockImplementation(actual.settleGraphLayout);
+  return { ...actual, settleGraphLayout: settleGraphLayoutSpy };
+});
+
+const goldenPath = resolve(
+  process.cwd(),
+  "../../docs/schemas/examples/khive-repo-v1-khive.json",
+);
+
+function golden(): RepoBundle {
+  return parseRepoBundle(JSON.parse(readFileSync(goldenPath, "utf8")));
+}
+
+describe("repository showcase graph layout", () => {
+  beforeEach(() => {
+    settleGraphLayoutSpy.mockClear();
+    window.history.replaceState(null, "", "/");
+  });
+
+  it("reuses settled positions for local interaction and invalidates on layout input changes", async () => {
+    const bundle = golden();
+    const user = userEvent.setup();
+    const { container, rerender } = render(<RepoShowcase bundle={bundle} />);
+
+    await waitFor(() => expect(settleGraphLayoutSpy).toHaveBeenCalledTimes(1));
+
+    await user.click(screen.getByRole("button", {
+      name: `${bundle.capability.views.structure_graph.label} +`,
+    }));
+    const graphNodes = container.querySelectorAll<HTMLButtonElement>(
+      ".repo-graph-node",
+    );
+    expect(graphNodes.length).toBeGreaterThan(1);
+    await user.click(graphNodes[1]);
+    expect(settleGraphLayoutSpy).toHaveBeenCalledTimes(1);
+
+    const packageChoice = bundle.graph.packages.items[0];
+    expect(packageChoice).toBeDefined();
+    await user.selectOptions(
+      screen.getByRole("combobox", {
+        name:
+          `${bundle.capability.labels.node_types.package} · ${bundle.capability.views.structure_graph.label}`,
+      }),
+      packageChoice.id,
+    );
+    expect(settleGraphLayoutSpy).toHaveBeenCalledTimes(2);
+
+    rerender(<RepoShowcase bundle={bundle} />);
+    expect(settleGraphLayoutSpy).toHaveBeenCalledTimes(2);
+
+    const replacedModulePage = {
+      ...bundle,
+      graph: {
+        ...bundle.graph,
+        modules: {
+          ...bundle.graph.modules,
+          items: [...bundle.graph.modules.items],
+        },
+      },
+    };
+    rerender(<RepoShowcase bundle={replacedModulePage} />);
+    expect(settleGraphLayoutSpy).toHaveBeenCalledTimes(3);
+  });
+});

--- a/apps/kg-editor/src/components/showcase/repo-showcase.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase.tsx
@@ -303,67 +303,87 @@ function StructureGraph({ bundle }: { bundle: RepoBundle }) {
   const [zoom, setZoom] = useState(1);
   const [selectedId, setSelectedId] = useState(graph.repository.id);
   const {
-    subtreePackageCount,
-    displayedPackages,
-    selectablePackages,
-    subtreeModuleCount,
-    displayedModules,
     displayedEdges,
-    visibleIds,
+    displayedModules,
+    displayedPackages,
     positions,
+    selectablePackages,
+    subtreeModules,
+    subtreePackages,
+    visibleIds,
   } = useMemo(() => {
-    const subtreePackages = subtreeId === graph.repository.id
+    const nextSubtreePackages = subtreeId === graph.repository.id
       ? graph.packages.items
       : graph.packages.items.filter((item) => item.id === subtreeId);
     // Sort by id before truncating so the displayed slice — and therefore the
     // shared seeded layout fed by it — is independent of input array order
     // (ADR-153 D4).
-    const displayedPackages = [...subtreePackages].sort((left, right) => left.id.localeCompare(right.id)).slice(0, 8);
-    const selectablePackages = graph.packages.items.slice(0, UI_ROW_LIMIT);
-    const displayedPackageIds = new Set(displayedPackages.map((item) => item.id));
-    const subtreeModules = graph.modules.items.filter((item) => subtreeId === graph.repository.id || item.package_id === subtreeId);
-    const displayedModules = subtreeModules.filter((item) => displayedPackageIds.has(item.package_id))
+    const nextDisplayedPackages = [...nextSubtreePackages]
+      .sort((left, right) => left.id.localeCompare(right.id))
+      .slice(0, 8);
+    const nextSelectablePackages = graph.packages.items.slice(0, UI_ROW_LIMIT);
+    const displayedPackageIds = new Set(nextDisplayedPackages.map((item) => item.id));
+    const nextSubtreeModules = graph.modules.items.filter((item) =>
+      subtreeId === graph.repository.id || item.package_id === subtreeId
+    );
+    const nextDisplayedModules = nextSubtreeModules
+      .filter((item) => displayedPackageIds.has(item.package_id))
       .sort((left, right) => left.id.localeCompare(right.id))
       .slice(0, 42);
-    const visibleIds = new Set([
+    const nextVisibleIds = new Set([
       graph.repository.id,
-      ...displayedPackages.map((item) => item.id),
-      ...displayedModules.map((item) => item.id),
+      ...nextDisplayedPackages.map((item) => item.id),
+      ...nextDisplayedModules.map((item) => item.id),
     ]);
-    const visibleEdges = graph.structure_edges.items.filter((edge) => visibleIds.has(edge.source) && visibleIds.has(edge.target));
-    const displayedEdges = visibleEdges.slice(0, UI_GRAPH_EDGE_LIMIT);
+    const visibleEdges = graph.structure_edges.items.filter((edge) =>
+      nextVisibleIds.has(edge.source) && nextVisibleIds.has(edge.target)
+    );
+    const nextDisplayedEdges = visibleEdges.slice(0, UI_GRAPH_EDGE_LIMIT);
     const layoutNodes = [
       { id: graph.repository.id },
-      ...displayedPackages.map((item) => ({ id: item.id })),
-      ...displayedModules.map((item) => ({ id: item.id })),
+      ...nextDisplayedPackages.map((item) => ({ id: item.id })),
+      ...nextDisplayedModules.map((item) => ({ id: item.id })),
     ];
     const layoutEdges = [
-      ...displayedPackages.map((item) => ({
+      ...nextDisplayedPackages.map((item) => ({
         id: `contains-${graph.repository.id}-${item.id}`,
         source: graph.repository.id,
         target: item.id,
       })),
-      ...displayedModules.map((item) => ({
+      ...nextDisplayedModules.map((item) => ({
         id: `contains-${item.package_id}-${item.id}`,
         source: item.package_id,
         target: item.id,
       })),
-      ...displayedEdges.map((edge) => ({ id: edge.id, source: edge.source, target: edge.target })),
+      ...nextDisplayedEdges.map((edge) => ({
+        id: edge.id,
+        source: edge.source,
+        target: edge.target,
+      })),
     ];
-    const positions = new Map(
-      settleGraphLayout(layoutNodes, layoutEdges).map((node) => [node.id, { x: node.x, y: node.y }]),
+    const nextPositions = new Map(
+      settleGraphLayout(layoutNodes, layoutEdges).map((node) => [
+        node.id,
+        { x: node.x, y: node.y },
+      ]),
     );
     return {
-      subtreePackageCount: subtreePackages.length,
-      displayedPackages,
-      selectablePackages,
-      subtreeModuleCount: subtreeModules.length,
-      displayedModules,
-      displayedEdges,
-      visibleIds,
-      positions,
+      displayedEdges: nextDisplayedEdges,
+      displayedModules: nextDisplayedModules,
+      displayedPackages: nextDisplayedPackages,
+      positions: nextPositions,
+      selectablePackages: nextSelectablePackages,
+      subtreeModules: nextSubtreeModules,
+      subtreePackages: nextSubtreePackages,
+      visibleIds: nextVisibleIds,
     };
-  }, [graph, subtreeId]);
+  }, [
+    graph.repository.id,
+    graph.packages.items,
+    graph.modules.items,
+    graph.structure_edges.items,
+    subtreeId,
+  ]);
   const degrees = new Map<string, number>();
   const fanIn = new Map<string, number>();
   const fanOut = new Map<string, number>();
@@ -532,8 +552,8 @@ function StructureGraph({ bundle }: { bundle: RepoBundle }) {
           ))}
         </ul>
         <LocalSliceDisclosure shown={displayedEdges.length} total={graph.structure_edges.items.length} label={capability.views.structure_graph.label} labels={labels} />
-        <LocalSliceDisclosure shown={displayedPackages.length} total={subtreePackageCount} label={labels.node_types.package} labels={labels} />
-        <LocalSliceDisclosure shown={displayedModules.length} total={subtreeModuleCount} label={labels.node_types.module} labels={labels} />
+        <LocalSliceDisclosure shown={displayedPackages.length} total={subtreePackages.length} label={labels.node_types.package} labels={labels} />
+        <LocalSliceDisclosure shown={displayedModules.length} total={subtreeModules.length} label={labels.node_types.module} labels={labels} />
       </div>
       <BoundDisclosure page={graph.packages} labels={labels} />
       <BoundDisclosure page={graph.modules} labels={labels} />

--- a/apps/kg-editor/src/lib/repository-brief.test.ts
+++ b/apps/kg-editor/src/lib/repository-brief.test.ts
@@ -353,6 +353,39 @@ describe("repository triage model", () => {
     });
   });
 
+  it("reports truncated attention coverage when an input analysis is capped", () => {
+    const brief = buildRepositoryBrief(bundle);
+
+    expect(bundle.aggregates.hidden_coupling.data.truncated).toBe(true);
+    expect(brief.attentionState.status).toBe("truncated");
+    expect(brief.attentionState.reason).toContain(
+      "section limited to 1000 items",
+    );
+  });
+
+  it("treats a page carrying a pagination cursor as incomplete even when its disclosure reports complete", () => {
+    const cursorPage = structuredClone(bundle);
+    cursorPage.aggregates.hidden_coupling.data.truncated = false;
+    cursorPage.aggregates.hidden_coupling.data.disclosure = {
+      status: "complete",
+      reason: null,
+    };
+    cursorPage.aggregates.hidden_coupling.data.next_cursor = "offset:1000";
+
+    const brief = buildRepositoryBrief(cursorPage);
+    const coupling = brief.attentionSignals.find(
+      (signal) => signal.kind === "hidden_coupling",
+    );
+    const coverage = coupling?.evidence.find((item) =>
+      item.label === "Coverage"
+    );
+
+    expect(coverage?.value).toContain("Truncated");
+    expect(coverage?.value).toContain(
+      "Additional items are available beyond this page.",
+    );
+  });
+
   it("finds a module by the path a user already knows", () => {
     const matches = findRepositoryModules(bundle, "pool.rs", 8);
     expect(matches.items.length).toBeGreaterThan(0);

--- a/apps/kg-editor/src/lib/repository-brief.test.ts
+++ b/apps/kg-editor/src/lib/repository-brief.test.ts
@@ -384,6 +384,20 @@ describe("repository triage model", () => {
     expect(coverage?.value).toContain(
       "Additional items are available beyond this page.",
     );
+
+    // The metric path must carry the same cursor-aware default reason as the
+    // evidence path, and the attention rollup must surface it rather than
+    // falling back to the generic aggregate text.
+    expect(brief.attentionState.status).toBe("truncated");
+    expect(brief.attentionState.reason).toContain(
+      "Additional items are available beyond this page.",
+    );
+    const target = buildRepositoryBrief(bundle).startHere[0];
+    const insight = buildModuleInsight(cursorPage, target.moduleId);
+    expect(insight?.couplingState).toMatchObject({
+      status: "truncated",
+      reason: "Additional items are available beyond this page.",
+    });
   });
 
   it("finds a module by the path a user already knows", () => {

--- a/apps/kg-editor/src/lib/repository-brief.test.ts
+++ b/apps/kg-editor/src/lib/repository-brief.test.ts
@@ -400,6 +400,28 @@ describe("repository triage model", () => {
     });
   });
 
+  it("keeps the unknown-total reason on a cursor-bearing page instead of the generic continuation text", () => {
+    const cursorUnknownTotal = structuredClone(bundle);
+    cursorUnknownTotal.aggregates.hidden_coupling.data.truncated = false;
+    cursorUnknownTotal.aggregates.hidden_coupling.data.disclosure = {
+      status: "complete",
+      reason: null,
+    };
+    cursorUnknownTotal.aggregates.hidden_coupling.data.next_cursor =
+      "offset:1000";
+    cursorUnknownTotal.aggregates.hidden_coupling.data.total_count = {
+      status: "unavailable",
+      reason: "total not computed for this export",
+    };
+
+    const target = buildRepositoryBrief(bundle).startHere[0];
+    const insight = buildModuleInsight(cursorUnknownTotal, target.moduleId);
+    expect(insight?.couplingState).toMatchObject({
+      status: "truncated",
+      reason: "total not computed for this export",
+    });
+  });
+
   it("finds a module by the path a user already knows", () => {
     const matches = findRepositoryModules(bundle, "pool.rs", 8);
     expect(matches.items.length).toBeGreaterThan(0);

--- a/apps/kg-editor/src/lib/repository-brief.ts
+++ b/apps/kg-editor/src/lib/repository-brief.ts
@@ -132,6 +132,8 @@ export interface ModuleInsight {
 
 const RECENT_COMMIT_LIMIT = 12;
 const OWNERSHIP_MINIMUM_COMMITS = 5;
+const PAGE_CONTINUATION_REASON =
+  "Additional items are available beyond this page.";
 
 function compareText(left: string, right: string): number {
   if (left < right) return -1;
@@ -199,9 +201,7 @@ function pageEvidence(
     page.disclosure.status === "complete";
   const disclosureStatus = hasUnseenPage ? "truncated" : page.disclosure.status;
   const reason = page.disclosure.reason ??
-    (hasUnseenPage
-      ? "Additional items are available beyond this page."
-      : null);
+    (hasUnseenPage ? PAGE_CONTINUATION_REASON : null);
   const status = disclosureStatus === "complete"
     ? "complete"
     : `${
@@ -254,7 +254,9 @@ function pageMetric(
       ? "truncated"
       : "complete";
   const reason = page.disclosure.reason ??
-    (status !== "complete" && page.total_count.status === "unavailable"
+    (status === "truncated" && page.next_cursor != null
+      ? PAGE_CONTINUATION_REASON
+      : status !== "complete" && page.total_count.status === "unavailable"
       ? page.total_count.reason
       : null);
   const reasonSuffix = reason ? `; ${reason}` : "";

--- a/apps/kg-editor/src/lib/repository-brief.ts
+++ b/apps/kg-editor/src/lib/repository-brief.ts
@@ -183,8 +183,8 @@ function pageEvidence(
       | { status: "available"; value: number }
       | { status: "unavailable"; reason: string };
     bound: { kind: "all" | "top_n"; max_items: number; order: string };
-    truncated: boolean;
     next_cursor?: string | null;
+    truncated: boolean;
     disclosure: {
       status: "complete" | "truncated" | "unavailable";
       reason?: string | null;
@@ -195,14 +195,18 @@ function pageEvidence(
   const total = page.total_count.status === "available"
     ? `${page.total_count.value} declared`
     : `total ${labels.unavailable}`;
-  const reasonSuffix = page.disclosure.reason
-    ? `: ${page.disclosure.reason}`
-    : "";
-  const status = page.disclosure.status === "unavailable"
-    ? `${labels.unavailable}${reasonSuffix}`
-    : page.disclosure.status === "truncated" || page.next_cursor != null
-    ? `${labels.truncated}${reasonSuffix}`
-    : "complete";
+  const hasUnseenPage = page.next_cursor != null &&
+    page.disclosure.status === "complete";
+  const disclosureStatus = hasUnseenPage ? "truncated" : page.disclosure.status;
+  const reason = page.disclosure.reason ??
+    (hasUnseenPage
+      ? "Additional items are available beyond this page."
+      : null);
+  const status = disclosureStatus === "complete"
+    ? "complete"
+    : `${
+      disclosureStatus === "truncated" ? labels.truncated : labels.unavailable
+    }${reason ? `: ${reason}` : ""}`;
   return {
     label,
     value: `${page.items.length} present, ${total}; ${status}`,

--- a/apps/kg-editor/src/lib/repository-brief.ts
+++ b/apps/kg-editor/src/lib/repository-brief.ts
@@ -254,10 +254,10 @@ function pageMetric(
       ? "truncated"
       : "complete";
   const reason = page.disclosure.reason ??
-    (status === "truncated" && page.next_cursor != null
-      ? PAGE_CONTINUATION_REASON
-      : status !== "complete" && page.total_count.status === "unavailable"
+    (status !== "complete" && page.total_count.status === "unavailable"
       ? page.total_count.reason
+      : status === "truncated" && page.next_cursor != null
+      ? PAGE_CONTINUATION_REASON
       : null);
   const reasonSuffix = reason ? `; ${reason}` : "";
   const summary = status === "complete"


### PR DESCRIPTION
Reuse the showcase structure-graph layout across unrelated bundle changes: the
layout memo now keys on the graph's own inputs (repository id, package, module,
and structure-edge lists plus the selected subtree) instead of the whole bundle,
and returns the subtree slices it computes so disclosure totals read from the
same memoized data. Truncated evidence now propagates through attention and
page disclosures: a complete page with a next cursor reports as truncated with
an explanatory reason.

Replaces #1956, rebuilding on the current mainline.
