### PR TITLE
fix(blob): gate GC on completed attachment epoch (ADR-160 Phase 4a)

### DIFF
--- a/crates/khive-db/src/stores/blob.rs
+++ b/crates/khive-db/src/stores/blob.rs
@@ -739,34 +739,6 @@ fn within_publish_grace(path: &Path, now: SystemTime, grace_period: Duration) ->
     }
 }
 
-fn sweep_blob_candidates(
-    root: &Path,
-    files: Vec<(ContentRef, PathBuf)>,
-    live_refs: &std::collections::HashSet<ContentRef>,
-    dry_run: bool,
-    grace_period: Duration,
-) -> StorageResult<BlobOrphanSweepResult> {
-    let mut result = BlobOrphanSweepResult::default();
-    let now = SystemTime::now();
-    for (content_ref, path) in files {
-        result.scanned += 1;
-        if live_refs.contains(&content_ref) {
-            continue;
-        }
-        if within_publish_grace(&path, now, grace_period) {
-            result.grace_period_skipped += 1;
-            continue;
-        }
-        result.would_delete += 1;
-        if !dry_run {
-            unlink_blob_shard_file_no_follow(root, &content_ref)
-                .map_err(|e| map_io_err(e, "orphan_sweep_delete"))?;
-            result.deleted += 1;
-        }
-    }
-    Ok(result)
-}
-
 #[derive(Debug)]
 struct PreparedTransactionalSweep {
     result: BlobOrphanSweepResult,
@@ -1366,16 +1338,6 @@ async fn release_blob_gc_batch(sql: &dyn SqlAccess, root_key: String) -> Storage
     Ok(())
 }
 
-fn sweep_blob_files(
-    root: &Path,
-    live_refs: &std::collections::HashSet<ContentRef>,
-    dry_run: bool,
-    grace_period: Duration,
-) -> StorageResult<BlobOrphanSweepResult> {
-    let files = walk_blob_files(root).map_err(|e| map_io_err(e, "orphan_sweep_walk"))?;
-    sweep_blob_candidates(root, files, live_refs, dry_run, grace_period)
-}
-
 /// Process-wide database owner fence for transactional blob sweeps.
 ///
 /// Claims live in the database and their attachment triggers are database-global,
@@ -1698,24 +1660,28 @@ impl BlobStore for FsBlobStore {
         .map_err(|e| StorageError::driver(StorageCapability::Blob, "delete", e))?
     }
 
-    // Offline-maintenance-only — see `BlobStore::orphan_sweep`'s doc comment
-    // for the concurrency hazard (`config.live_refs` is a snapshot; a
-    // `content_ref` that becomes live after the snapshot is deleted anyway).
-    // This method performs no DB coordination; it only compares against
-    // whatever set the caller handed it.
+    // Disabled for this compatibility release (Phase4a, ADR-111 §8 amended
+    // 2026-08-21): this API has no `SqlAccess` capability of its own, so it
+    // cannot prove the completed-V21 epoch `transactional_orphan_sweep`
+    // requires before any destructive path runs. A caller-assembled
+    // `live_refs` snapshot could otherwise delete an object a V20 SQL query
+    // cannot see as live (e.g. a moodboard FANN network), bypassing the
+    // epoch gate entirely. Report-only and destructive calls both refuse,
+    // matching the trait default, until a snapshot API can carry its own
+    // epoch proof.
     async fn orphan_sweep(
         &self,
         config: &BlobOrphanSweepConfig,
     ) -> StorageResult<BlobOrphanSweepResult> {
-        let root = self.root.clone();
-        let live_refs = config.live_refs.clone();
-        let dry_run = config.dry_run;
-        let grace_period = self.orphan_sweep_grace;
-        tokio::task::spawn_blocking(move || {
-            sweep_blob_files(&root, &live_refs, dry_run, grace_period)
+        let _ = config;
+        Err(StorageError::Unsupported {
+            capability: StorageCapability::Blob,
+            operation: "orphan_sweep".into(),
+            message: "caller-snapshot orphan_sweep is disabled in this compatibility release; \
+                      it cannot prove a completed V21 attachment epoch, use \
+                      transactional_orphan_sweep instead"
+                .into(),
         })
-        .await
-        .map_err(|e| StorageError::driver(StorageCapability::Blob, "orphan_sweep", e))?
     }
 
     // `put` and the attachment write that later commits a `content_ref` to its
@@ -1763,13 +1729,41 @@ impl BlobStore for FsBlobStore {
         let database_guard = sweep_lock_for_database(database_path.as_deref())
             .lock_owned()
             .await;
+        let lock_database_path = database_path.clone();
+        #[cfg(test)]
+        let hook_database_path = database_path.clone();
+        let database_file_guard = tokio::task::spawn_blocking(move || {
+            let guard = acquire_database_gc_lock(lock_database_path.as_deref())?;
+            #[cfg(test)]
+            if let Some(hook) = db_ownership_sync_hook::take(hook_database_path.as_deref()) {
+                let _ = hook.reached.send(());
+                let _ = hook.release.recv();
+            }
+            Ok::<_, StorageError>(guard)
+        })
+        .await
+        .map_err(|e| {
+            StorageError::driver(
+                StorageCapability::Blob,
+                "transactional_orphan_sweep_lock",
+                e,
+            )
+        })??;
+
+        // Recheck immediately once database ownership -- the process-local
+        // guard plus the cross-process advisory lock -- is held, and before
+        // ever waiting on the root guard/lock or walking the filesystem, so
+        // the documented pre-lock refusal contract holds even if the epoch
+        // regressed between the read-only preflight above and ownership.
+        if !blob_gc_fencing_complete(sql).await? {
+            return Err(unsupported_blob_gc_epoch());
+        }
+
         let root_guard = self.write_lock.clone().lock_owned().await;
         let root = self.root.clone();
         let scan_root = root.clone();
-        let lock_database_path = database_path.clone();
         let grace_period = self.orphan_sweep_grace;
         let (write_guards, canonical_root, prepared) = tokio::task::spawn_blocking(move || {
-            let database_file_guard = acquire_database_gc_lock(lock_database_path.as_deref())?;
             let canonical_root = scan_root
                 .canonicalize()
                 .map_err(|e| map_io_err(e, "transactional_orphan_sweep_root"))?;
@@ -1797,13 +1791,6 @@ impl BlobStore for FsBlobStore {
             )
         })??;
         let root_key = blob_root_key(&canonical_root);
-        // Recheck after acquiring the existing Phase-3 database/root owner
-        // sequence. Completed V21 is monotonic in supported writers, but this
-        // closes the safety gap if external maintenance replaced the schema
-        // between the read-only compatibility preflight and ownership.
-        if !blob_gc_fencing_complete(sql).await? {
-            return Err(unsupported_blob_gc_epoch());
-        }
         validate_blob_gc_evidence(sql).await?;
         blob_gc_fence_probe(sql).await?;
         if !dry_run {
@@ -2040,6 +2027,56 @@ mod bounded_read_sync_hook {
     }
 }
 
+/// Test-only pause on `transactional_orphan_sweep`'s database-ownership
+/// blocking task, right after the cross-process advisory lock is acquired
+/// and before the epoch recheck that immediately follows it. Lets a test
+/// mutate the database strictly between the read-only preflight and the
+/// recheck, making the recheck's ordering relative to the root guard/lock
+/// deterministic instead of racing on scheduling.
+#[cfg(test)]
+mod db_ownership_sync_hook {
+    use std::collections::{HashMap, VecDeque};
+    use std::path::{Path, PathBuf};
+    use std::sync::mpsc::{Receiver, Sender};
+    use std::sync::{Mutex as StdMutex, OnceLock};
+
+    pub(super) struct Hook {
+        pub(super) reached: Sender<()>,
+        pub(super) release: Receiver<()>,
+    }
+
+    fn registry() -> &'static StdMutex<HashMap<Option<PathBuf>, VecDeque<Hook>>> {
+        static REGISTRY: OnceLock<StdMutex<HashMap<Option<PathBuf>, VecDeque<Hook>>>> =
+            OnceLock::new();
+        REGISTRY.get_or_init(|| StdMutex::new(HashMap::new()))
+    }
+
+    pub(super) fn install(database_path: Option<&Path>) -> (Receiver<()>, Sender<()>) {
+        let key = database_path.map(Path::to_path_buf);
+        let (reached_tx, reached_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        registry()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .entry(key)
+            .or_default()
+            .push_back(Hook {
+                reached: reached_tx,
+                release: release_rx,
+            });
+        (reached_rx, release_tx)
+    }
+
+    pub(super) fn take(database_path: Option<&Path>) -> Option<Hook> {
+        let key = database_path.map(Path::to_path_buf);
+        registry()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get_mut(&key)
+            .and_then(VecDeque::pop_front)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2119,7 +2156,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn completed_v21_gc_gate_requires_new_indexes_and_absent_legacy_column() {
+    async fn completed_v21_gc_gate_requires_the_attachments_content_ref_index_and_absent_legacy_column(
+    ) {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("khive.db");
         let backend = crate::StorageBackend::sqlite(&db_path).unwrap();
@@ -2156,6 +2194,206 @@ mod tests {
         assert!(!blob_gc_fencing_complete(backend.sql().as_ref())
             .await
             .unwrap());
+    }
+
+    /// Table-driven acceptance matrix: starting from a fixture that passes
+    /// the gate, remove exactly one required table/index/trigger/marker/
+    /// ledger fact at a time and prove the gate rejects it, no probe or
+    /// abandoned-claim residue survives, and every candidate file and
+    /// pre-existing claim is untouched. A wrong implementation that stops
+    /// requiring any single one of these facts (e.g. the claims content_ref
+    /// index, the V21 ledger row/name/max, the marker row/`completed_at`, or
+    /// the INSERT fence alone) would still pass the narrower pre-existing
+    /// tests but fails here.
+    #[tokio::test]
+    async fn completed_v21_gate_acceptance_matrix_rejects_each_removed_fact_independently() {
+        let cases: &[(&str, &str)] = &[
+            (
+                "blob_gc_claims_content_ref_index_dropped",
+                "DROP INDEX idx_blob_gc_claims_content_ref",
+            ),
+            (
+                "v21_ledger_row_deleted",
+                "DELETE FROM _schema_migrations WHERE version = 21",
+            ),
+            (
+                "v21_ledger_row_renamed",
+                "UPDATE _schema_migrations SET name = 'not_attachments_first_class' \
+                 WHERE version = 21",
+            ),
+            (
+                "ledger_max_version_advances_past_v21",
+                "INSERT INTO _schema_migrations (version, name, applied_at) \
+                 VALUES (22, 'future_migration', 22)",
+            ),
+            (
+                "marker_row_deleted",
+                "DELETE FROM attachment_cutover_state WHERE singleton = 1",
+            ),
+            (
+                // The schema's own compound CHECK constraint already forbids
+                // `state = 'complete' AND completed_at IS NULL` via a plain
+                // UPDATE, so this rebuilds the table without that constraint
+                // to construct the row directly -- proving the gate's own
+                // `completed_at IS NOT NULL` predicate rejects it too,
+                // independent of the CHECK constraint's own enforcement.
+                "marker_completed_at_null_while_state_complete",
+                "DROP TABLE attachment_cutover_state; \
+                 CREATE TABLE attachment_cutover_state ( \
+                     singleton    INTEGER PRIMARY KEY CHECK (singleton = 1), \
+                     state        TEXT NOT NULL CHECK (state IN ('incomplete', 'complete')), \
+                     started_at   INTEGER NOT NULL, \
+                     completed_at INTEGER \
+                 ) STRICT; \
+                 INSERT INTO attachment_cutover_state \
+                     (singleton, state, started_at, completed_at) \
+                 VALUES (1, 'complete', 21, NULL)",
+            ),
+            (
+                "insert_fence_dropped_alone",
+                "DROP TRIGGER attachments_reject_claimed_blob_insert",
+            ),
+        ];
+
+        for (case, mutation_sql) in cases {
+            let dir = tempfile::tempdir().unwrap();
+            let db_path = dir.path().join("khive.db");
+            let backend = crate::StorageBackend::sqlite(&db_path).unwrap();
+            {
+                let mut writer = backend.pool().writer().unwrap();
+                prepare_completed_v21_gc_fixture(writer.conn_mut());
+                writer
+                    .conn_mut()
+                    .execute_batch(mutation_sql)
+                    .unwrap_or_else(|e| panic!("case {case}: failed to apply mutation: {e}"));
+            }
+
+            assert!(
+                !blob_gc_fencing_complete(backend.sql().as_ref())
+                    .await
+                    .unwrap(),
+                "case {case}: gate must reject with this fact removed"
+            );
+
+            let store = Arc::new(
+                FsBlobStore::new(dir.path().join("blobs"), 0)
+                    .unwrap()
+                    .with_orphan_sweep_grace(Duration::ZERO),
+            );
+            let orphan = store
+                .put(format!("gate matrix orphan for {case}").into_bytes())
+                .await
+                .unwrap();
+            let abandoned_ref = "c".repeat(64);
+            {
+                let writer = backend.pool().writer().unwrap();
+                writer
+                    .conn()
+                    .execute(
+                        "INSERT INTO blob_gc_claims (root_key, content_ref, claimed_at) \
+                         VALUES ('gate-matrix-abandoned', ?1, 1)",
+                        [abandoned_ref.as_str()],
+                    )
+                    .unwrap();
+            }
+
+            let _root_guard = store.write_lock.clone().lock_owned().await;
+            for dry_run in [true, false] {
+                let outcome = tokio::time::timeout(
+                    Duration::from_secs(1),
+                    store.transactional_orphan_sweep(backend.sql().as_ref(), dry_run),
+                )
+                .await
+                .unwrap_or_else(|_| panic!("case {case}: refusal must precede the root wait"));
+                assert!(
+                    matches!(outcome, Err(StorageError::Unsupported { .. })),
+                    "case {case} dry_run={dry_run}: expected Unsupported, got {outcome:?}"
+                );
+            }
+
+            assert!(
+                store.exists(&orphan).await.unwrap(),
+                "case {case}: a refused sweep must not delete anything"
+            );
+            let remaining: i64 = backend
+                .pool()
+                .reader()
+                .unwrap()
+                .conn()
+                .query_row(
+                    "SELECT COUNT(*) FROM blob_gc_claims WHERE root_key = 'gate-matrix-abandoned'",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(remaining, 1, "case {case}: refusal must not recover claims");
+        }
+    }
+
+    /// A read failure while evaluating the completed-marker/ledger predicate
+    /// (a malformed or partially-migrated `attachment_cutover_state`) must
+    /// propagate as an error, not be silently treated as "not complete" via
+    /// some default-to-false path that could theoretically be confused with
+    /// a permissive read elsewhere. The gate's three `query_scalar` calls all
+    /// use `?`, so this pins that direction rather than leaving it assumed.
+    #[tokio::test]
+    async fn completed_v21_gate_fails_closed_when_marker_read_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("khive.db");
+        let backend = crate::StorageBackend::sqlite(&db_path).unwrap();
+        {
+            let mut writer = backend.pool().writer().unwrap();
+            prepare_completed_v21_gc_fixture(writer.conn_mut());
+            // `ALTER TABLE ... DROP COLUMN` refuses outright here because the
+            // table's own compound CHECK constraint still references
+            // `completed_at`; rebuild the table without the column instead
+            // to get a genuine "no such column" read failure.
+            writer
+                .conn_mut()
+                .execute_batch(
+                    "DROP TABLE attachment_cutover_state; \
+                     CREATE TABLE attachment_cutover_state ( \
+                         singleton  INTEGER PRIMARY KEY CHECK (singleton = 1), \
+                         state      TEXT NOT NULL CHECK (state IN ('incomplete', 'complete')), \
+                         started_at INTEGER NOT NULL \
+                     ) STRICT; \
+                     INSERT INTO attachment_cutover_state (singleton, state, started_at) \
+                     VALUES (1, 'complete', 21)",
+                )
+                .unwrap();
+        }
+
+        let gate_error = blob_gc_fencing_complete(backend.sql().as_ref())
+            .await
+            .expect_err("a marker read error must propagate, not silently resolve to false");
+        assert!(
+            !matches!(gate_error, StorageError::Unsupported { .. }),
+            "a read error is a distinct failure from the typed epoch refusal: {gate_error:?}"
+        );
+
+        let store = Arc::new(
+            FsBlobStore::new(dir.path().join("blobs"), 0)
+                .unwrap()
+                .with_orphan_sweep_grace(Duration::ZERO),
+        );
+        let orphan = store
+            .put(b"marker read error orphan".to_vec())
+            .await
+            .unwrap();
+        let _root_guard = store.write_lock.clone().lock_owned().await;
+        for dry_run in [true, false] {
+            let outcome = tokio::time::timeout(
+                Duration::from_secs(1),
+                store.transactional_orphan_sweep(backend.sql().as_ref(), dry_run),
+            )
+            .await
+            .expect("a marker read error must fail before waiting on the root lock");
+            assert!(
+                outcome.is_err(),
+                "dry_run={dry_run}: expected the sweep to fail closed, got {outcome:?}"
+            );
+        }
+        assert!(store.exists(&orphan).await.unwrap());
     }
 
     #[test]
@@ -2254,18 +2492,11 @@ mod tests {
         );
 
         // The unrelated real shard, never touched by the attack, must still
-        // sweep normally after the fix.
-        let swept = store
-            .orphan_sweep(&BlobOrphanSweepConfig {
-                live_refs: std::collections::HashSet::new(),
-                dry_run: false,
-            })
-            .await
-            .unwrap();
-        assert_eq!(
-            swept.deleted, 1,
-            "the real, unsymlinked shard must still sweep"
-        );
+        // unlink normally after the fix. `orphan_sweep` is disabled in this
+        // compatibility release (it cannot prove a completed V21 epoch), so
+        // this exercises the same underlying primitive directly rather than
+        // going through that disabled API.
+        unlink_blob_shard_file_no_follow(&root, &real).unwrap();
         assert!(!store.exists(&real).await.unwrap());
     }
 
@@ -2878,50 +3109,37 @@ mod tests {
         );
     }
 
+    /// `orphan_sweep` is disabled in this compatibility release: it has no
+    /// `SqlAccess` capability with which to prove a completed V21 epoch, so
+    /// every call refuses regardless of `live_refs` contents or `dry_run`,
+    /// and nothing on disk is ever touched. This replaces the prior
+    /// `orphan_sweep_race_demonstrates_the_documented_quiescence_requirement`
+    /// regression, which pinned the now-eliminated caller-snapshot deletion
+    /// hazard this disablement closes.
     #[tokio::test]
-    async fn orphan_sweep_race_demonstrates_the_documented_quiescence_requirement() {
-        // `orphan_sweep` and `delete` are documented
-        // (`BlobStore::orphan_sweep`'s doc comment, ADR-111 §8) as
-        // offline-maintenance-only APIs that require the caller to quiesce
-        // entity writes for the duration of snapshot-plus-sweep, because
-        // `live_refs` is a snapshot with no database coordination. This test
-        // reproduces the exact hazard in code rather than leaving it as
-        // prose: a blob that becomes newly "live" AFTER the caller's
-        // `live_refs` snapshot was taken, but BEFORE the sweep runs, is
-        // deleted anyway. That is the documented boundary, not a bug in this
-        // test — it exists so a future change that silently narrows this
-        // hazard (without updating the docs) breaks a test instead of
-        // shipping a doc/behavior mismatch.
+    async fn orphan_sweep_is_disabled_in_both_modes_regardless_of_live_refs() {
         let (_dir, store) = store(0);
         let blob = store
-            .put(b"about to become live mid-sweep".to_vec())
+            .put(b"never swept by this API".to_vec())
             .await
             .unwrap();
+        let mut live_refs = std::collections::HashSet::new();
+        live_refs.insert(blob.clone());
 
-        // The caller's live_refs snapshot was taken before an entity write
-        // referencing `blob` landed (represented here by simply never adding
-        // it to the snapshot — orphan_sweep has no other way to learn about
-        // it).
-        let live_refs_snapshot = std::collections::HashSet::new();
-
-        let result = store
-            .orphan_sweep(&BlobOrphanSweepConfig {
-                live_refs: live_refs_snapshot,
-                dry_run: false,
-            })
-            .await
-            .unwrap();
-
-        assert_eq!(
-            result.deleted, 1,
-            "the now-live blob is deleted anyway: this is the documented hazard"
-        );
-        assert!(
-            !store.exists(&blob).await.unwrap(),
-            "orphan_sweep is unsafe against a content_ref that becomes live after the \
-             snapshot was taken — callers MUST quiesce entity writes before running it \
-             (ADR-111 §8)"
-        );
+        for dry_run in [true, false] {
+            let error = store
+                .orphan_sweep(&BlobOrphanSweepConfig {
+                    live_refs: live_refs.clone(),
+                    dry_run,
+                })
+                .await
+                .expect_err("caller-snapshot orphan_sweep must be disabled");
+            assert!(
+                matches!(error, StorageError::Unsupported { .. }),
+                "expected typed Unsupported, got {error:?}"
+            );
+        }
+        assert!(store.exists(&blob).await.unwrap());
     }
 
     /// Rollout compatibility fence: the Phase-3 binary's V20 schema cannot
@@ -3081,6 +3299,154 @@ mod tests {
             )
             .unwrap();
         assert_eq!(remaining, 1, "refusal must not recover abandoned claims");
+        assert!(store.exists(&orphan).await.unwrap());
+    }
+
+    /// Both public sweep APIs must refuse under the same non-completed
+    /// epochs, in both `dry_run` modes, without touching files or claims.
+    /// `orphan_sweep` ignores the fixture's `SqlAccess` entirely (it has no
+    /// epoch capability of its own -- that is exactly why it is disabled),
+    /// so this proves the disablement holds even when a caller has a real,
+    /// otherwise-plausible database sitting right next to it.
+    #[tokio::test]
+    async fn both_sweep_apis_refuse_v20_and_incomplete_v21_epochs_in_both_modes() {
+        for incomplete_v21 in [false, true] {
+            let dir = tempfile::tempdir().unwrap();
+            let db_path = dir.path().join("khive.db");
+            let backend = crate::StorageBackend::sqlite(&db_path).unwrap();
+            {
+                let mut writer = backend.pool().writer().unwrap();
+                if incomplete_v21 {
+                    prepare_completed_v21_gc_fixture(writer.conn_mut());
+                    writer
+                        .conn_mut()
+                        .execute(
+                            "UPDATE attachment_cutover_state \
+                             SET state = 'incomplete', completed_at = NULL \
+                             WHERE singleton = 1",
+                            [],
+                        )
+                        .unwrap();
+                } else {
+                    crate::run_migrations(writer.conn_mut()).unwrap();
+                }
+            }
+
+            let store = FsBlobStore::new(dir.path().join("blobs"), 0)
+                .unwrap()
+                .with_orphan_sweep_grace(Duration::ZERO);
+            let orphan = store
+                .put(format!("both-apis orphan (incomplete_v21={incomplete_v21})").into_bytes())
+                .await
+                .unwrap();
+
+            for dry_run in [true, false] {
+                let snapshot_error = store
+                    .orphan_sweep(&BlobOrphanSweepConfig {
+                        live_refs: std::collections::HashSet::new(),
+                        dry_run,
+                    })
+                    .await
+                    .expect_err("orphan_sweep must refuse regardless of epoch");
+                assert!(
+                    matches!(snapshot_error, StorageError::Unsupported { .. }),
+                    "incomplete_v21={incomplete_v21} dry_run={dry_run}: expected Unsupported \
+                     from orphan_sweep, got {snapshot_error:?}"
+                );
+
+                let transactional_error = store
+                    .transactional_orphan_sweep(backend.sql().as_ref(), dry_run)
+                    .await
+                    .expect_err("transactional_orphan_sweep must refuse this epoch");
+                assert!(
+                    matches!(transactional_error, StorageError::Unsupported { .. }),
+                    "incomplete_v21={incomplete_v21} dry_run={dry_run}: expected Unsupported \
+                     from transactional_orphan_sweep, got {transactional_error:?}"
+                );
+            }
+
+            assert!(
+                store.exists(&orphan).await.unwrap(),
+                "incomplete_v21={incomplete_v21}: a refused sweep must not delete anything"
+            );
+        }
+    }
+
+    /// The epoch recheck taken under database ownership must run before the
+    /// sweep ever waits on the root guard/lock, even when the epoch was
+    /// still valid at the read-only preflight and only regressed while the
+    /// call was waiting for database ownership. Without the fix this recheck
+    /// used to run after the root guard, filesystem root lock, and directory
+    /// walk -- this pins the corrected ordering with a real cross-task race
+    /// instead of trusting the comment above it.
+    #[tokio::test]
+    async fn transactional_orphan_sweep_recheck_refuses_before_root_lock_when_epoch_regresses_after_db_ownership(
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("khive.db");
+        let backend = Arc::new(crate::StorageBackend::sqlite(&db_path).unwrap());
+        {
+            let mut writer = backend.pool().writer().unwrap();
+            prepare_completed_v21_gc_fixture(writer.conn_mut());
+        }
+        assert!(blob_gc_fencing_complete(backend.sql().as_ref())
+            .await
+            .unwrap());
+
+        let store = Arc::new(
+            FsBlobStore::new(dir.path().join("blobs"), 0)
+                .unwrap()
+                .with_orphan_sweep_grace(Duration::ZERO),
+        );
+        let orphan = store
+            .put(b"epoch regressed after database ownership".to_vec())
+            .await
+            .unwrap();
+
+        // Hold the root guard externally. If the recheck still ran after
+        // root acquisition (the pre-fix order), the background call below
+        // would block waiting for this guard instead of refusing, and the
+        // timeout on its join would fire.
+        let _root_guard = store.write_lock.clone().lock_owned().await;
+
+        // Key the hook by the same canonicalized path `SqlAccess::database_path`
+        // returns -- not the raw `db_path` above -- since that's what the
+        // implementation looks the hook up by.
+        let canonical_db_path = backend.sql().database_path();
+        let (reached, release) = db_ownership_sync_hook::install(canonical_db_path.as_deref());
+        let sweep_store = store.clone();
+        let sweep_backend = backend.clone();
+        let handle = tokio::spawn(async move {
+            sweep_store
+                .transactional_orphan_sweep(sweep_backend.sql().as_ref(), false)
+                .await
+        });
+
+        // The hook fires only once database ownership (process-local guard
+        // plus the cross-process advisory lock) is held, strictly after the
+        // read-only preflight already observed a valid epoch.
+        assert!(
+            recv_blocking(reached).await,
+            "the sweep must reach database ownership before this test's timeout"
+        );
+        {
+            let writer = backend.pool().writer().unwrap();
+            writer
+                .conn()
+                .execute("DELETE FROM _schema_migrations WHERE version = 21", [])
+                .unwrap();
+        }
+        release.send(()).unwrap();
+
+        let outcome = tokio::time::timeout(Duration::from_secs(1), handle)
+            .await
+            .expect("the recheck must refuse before ever waiting on the externally held root lock")
+            .unwrap();
+        assert!(
+            matches!(outcome, Err(StorageError::Unsupported { .. })),
+            "expected the regressed epoch to be caught immediately after database ownership: \
+             {outcome:?}"
+        );
         assert!(store.exists(&orphan).await.unwrap());
     }
 
@@ -4333,23 +4699,29 @@ mod tests {
 
     #[tokio::test]
     async fn put_dedup_mtime_refresh_has_no_observable_effect_under_zero_grace_period() {
-        // The assumption the fix relies on for every `store(0)`-flavored
-        // test in this file: `within_publish_grace` with `Duration::ZERO`
-        // never protects a candidate regardless of its mtime (`age <
-        // Duration::ZERO` is always false), so refreshing the mtime on a
-        // deduplicated republish must not change zero-grace sweep behavior.
-        // Verified directly rather than assumed.
-        let (_dir, store) = store(0);
+        // The assumption the fix relies on for every zero-grace test in this
+        // file: `within_publish_grace` with `Duration::ZERO` never protects a
+        // candidate regardless of its mtime (`age < Duration::ZERO` is always
+        // false), so refreshing the mtime on a deduplicated republish must
+        // not change zero-grace sweep behavior. Verified directly rather
+        // than assumed.
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("khive.db");
+        let backend = crate::StorageBackend::sqlite(&db_path).unwrap();
+        {
+            let mut writer = backend.pool().writer().unwrap();
+            prepare_completed_v21_gc_fixture(writer.conn_mut());
+        }
+        let store = FsBlobStore::new(dir.path().join("blobs"), 0)
+            .unwrap()
+            .with_orphan_sweep_grace(Duration::ZERO);
         let bytes = b"zero grace dedup refresh".to_vec();
         let first = store.put(bytes.clone()).await.unwrap();
         let second = store.put(bytes.clone()).await.unwrap();
         assert_eq!(first, second);
 
         let result = store
-            .orphan_sweep(&BlobOrphanSweepConfig {
-                live_refs: std::collections::HashSet::new(),
-                dry_run: false,
-            })
+            .transactional_orphan_sweep(backend.sql().as_ref(), false)
             .await
             .unwrap();
         assert_eq!(
@@ -4403,58 +4775,6 @@ mod tests {
         );
         assert_eq!(result.grace_period_skipped, 0);
         assert!(!store.exists(&orphan).await.unwrap());
-    }
-
-    #[tokio::test]
-    async fn orphan_sweep_dry_run_reports_without_deleting() {
-        let (_dir, store) = store(0);
-        let live = store.put(b"keep me".to_vec()).await.unwrap();
-        let orphan = store.put(b"orphaned".to_vec()).await.unwrap();
-
-        let mut live_refs = std::collections::HashSet::new();
-        live_refs.insert(live.clone());
-        let result = store
-            .orphan_sweep(&BlobOrphanSweepConfig {
-                live_refs,
-                dry_run: true,
-            })
-            .await
-            .unwrap();
-
-        assert_eq!(result.scanned, 2);
-        assert_eq!(result.would_delete, 1);
-        assert_eq!(result.deleted, 0);
-        assert!(
-            store.exists(&orphan).await.unwrap(),
-            "dry run must not delete"
-        );
-        assert!(store.exists(&live).await.unwrap());
-    }
-
-    #[tokio::test]
-    async fn orphan_sweep_real_run_deletes_only_unreferenced_blobs() {
-        let (_dir, store) = store(0);
-        let live = store.put(b"keep me".to_vec()).await.unwrap();
-        let orphan = store.put(b"orphaned".to_vec()).await.unwrap();
-
-        let mut live_refs = std::collections::HashSet::new();
-        live_refs.insert(live.clone());
-        let result = store
-            .orphan_sweep(&BlobOrphanSweepConfig {
-                live_refs,
-                dry_run: false,
-            })
-            .await
-            .unwrap();
-
-        assert_eq!(result.scanned, 2);
-        assert_eq!(result.would_delete, 1);
-        assert_eq!(result.deleted, 1);
-        assert!(!store.exists(&orphan).await.unwrap());
-        assert!(
-            store.exists(&live).await.unwrap(),
-            "live blob must survive sweep"
-        );
     }
 
     #[test]

--- a/crates/khive-db/src/stores/blob.rs
+++ b/crates/khive-db/src/stores/blob.rs
@@ -2315,10 +2315,8 @@ mod tests {
                 store.exists(&orphan).await.unwrap(),
                 "case {case}: a refused sweep must not delete anything"
             );
-            let remaining: i64 = backend
-                .pool()
-                .reader()
-                .unwrap()
+            let reader = backend.pool().reader().unwrap();
+            let remaining: i64 = reader
                 .conn()
                 .query_row(
                     "SELECT COUNT(*) FROM blob_gc_claims WHERE root_key = 'gate-matrix-abandoned'",
@@ -2327,6 +2325,36 @@ mod tests {
                 )
                 .unwrap();
             assert_eq!(remaining, 1, "case {case}: refusal must not recover claims");
+
+            // The gate refuses before `blob_gc_fence_probe` ever runs in
+            // every one of these cases, so no probe-shaped row (the fence
+            // probe's own claim/attachment id patterns) should exist in
+            // either table for either dry_run mode.
+            let probe_claims: i64 = reader
+                .conn()
+                .query_row(
+                    "SELECT COUNT(*) FROM blob_gc_claims WHERE root_key GLOB '__fence_probe-*'",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(
+                probe_claims, 0,
+                "case {case}: refusal must leave no fence-probe claim residue"
+            );
+            let probe_attachments: i64 = reader
+                .conn()
+                .query_row(
+                    "SELECT COUNT(*) FROM attachments \
+                     WHERE record_uuid GLOB '__blob-gc-fence-probe-*'",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(
+                probe_attachments, 0,
+                "case {case}: refusal must leave no fence-probe attachment residue"
+            );
         }
     }
 
@@ -3340,6 +3368,41 @@ mod tests {
                 .await
                 .unwrap();
 
+            // A known claim, seeded once per epoch case, must survive every
+            // refused arm below untouched -- refusal must never recover or
+            // otherwise mutate an existing claim.
+            let known_claim_ref = "f".repeat(64);
+            {
+                let writer = backend.pool().writer().unwrap();
+                writer
+                    .conn()
+                    .execute(
+                        "INSERT INTO blob_gc_claims (root_key, content_ref, claimed_at) \
+                         VALUES ('both-api-known-claim', ?1, 1)",
+                        [known_claim_ref.as_str()],
+                    )
+                    .unwrap();
+            }
+            let assert_known_claim_unchanged = |arm: &str| {
+                let remaining: i64 = backend
+                    .pool()
+                    .reader()
+                    .unwrap()
+                    .conn()
+                    .query_row(
+                        "SELECT COUNT(*) FROM blob_gc_claims \
+                         WHERE root_key = 'both-api-known-claim' AND content_ref = ?1",
+                        [known_claim_ref.as_str()],
+                        |row| row.get(0),
+                    )
+                    .unwrap();
+                assert_eq!(
+                    remaining, 1,
+                    "incomplete_v21={incomplete_v21} arm={arm}: refusal must not mutate \
+                     an existing claim"
+                );
+            };
+
             for dry_run in [true, false] {
                 let snapshot_error = store
                     .orphan_sweep(&BlobOrphanSweepConfig {
@@ -3353,6 +3416,7 @@ mod tests {
                     "incomplete_v21={incomplete_v21} dry_run={dry_run}: expected Unsupported \
                      from orphan_sweep, got {snapshot_error:?}"
                 );
+                assert_known_claim_unchanged(&format!("orphan_sweep dry_run={dry_run}"));
 
                 let transactional_error = store
                     .transactional_orphan_sweep(backend.sql().as_ref(), dry_run)
@@ -3363,6 +3427,9 @@ mod tests {
                     "incomplete_v21={incomplete_v21} dry_run={dry_run}: expected Unsupported \
                      from transactional_orphan_sweep, got {transactional_error:?}"
                 );
+                assert_known_claim_unchanged(&format!(
+                    "transactional_orphan_sweep dry_run={dry_run}"
+                ));
             }
 
             assert!(
@@ -3379,6 +3446,18 @@ mod tests {
     /// used to run after the root guard, filesystem root lock, and directory
     /// walk -- this pins the corrected ordering with a real cross-task race
     /// instead of trusting the comment above it.
+    ///
+    /// The externally held blocking point is the OS-level root advisory lock
+    /// (`acquire_root_write_lock`), not the process-local `write_lock`
+    /// mutex. The old (pre-fix) ordering acquired the process-local mutex
+    /// before ever reaching database ownership -- holding that mutex here
+    /// would have starved the sweep task before it ever reached the hook
+    /// below, hanging this test instead of failing it. The OS-level root
+    /// lock is only ever acquired after database ownership under both the
+    /// old and the new ordering, so both orderings reach the hook; only the
+    /// old ordering then blocks trying to acquire the lock held here,
+    /// because its (mis-placed) recheck runs after that acquisition instead
+    /// of before it.
     #[tokio::test]
     async fn transactional_orphan_sweep_recheck_refuses_before_root_lock_when_epoch_regresses_after_db_ownership(
     ) {
@@ -3393,8 +3472,9 @@ mod tests {
             .await
             .unwrap());
 
+        let blob_root = dir.path().join("blobs");
         let store = Arc::new(
-            FsBlobStore::new(dir.path().join("blobs"), 0)
+            FsBlobStore::new(blob_root.clone(), 0)
                 .unwrap()
                 .with_orphan_sweep_grace(Duration::ZERO),
         );
@@ -3403,11 +3483,10 @@ mod tests {
             .await
             .unwrap();
 
-        // Hold the root guard externally. If the recheck still ran after
-        // root acquisition (the pre-fix order), the background call below
-        // would block waiting for this guard instead of refusing, and the
-        // timeout on its join would fire.
-        let _root_guard = store.write_lock.clone().lock_owned().await;
+        // Hold the same OS-level root lock the real sweep acquires, on the
+        // same canonicalized path it canonicalizes to.
+        let canonical_root = blob_root.canonicalize().unwrap();
+        let _root_write_guard = acquire_root_write_lock(&canonical_root).unwrap();
 
         // Key the hook by the same canonicalized path `SqlAccess::database_path`
         // returns -- not the raw `db_path` above -- since that's what the
@@ -3424,11 +3503,13 @@ mod tests {
 
         // The hook fires only once database ownership (process-local guard
         // plus the cross-process advisory lock) is held, strictly after the
-        // read-only preflight already observed a valid epoch.
-        assert!(
-            recv_blocking(reached).await,
-            "the sweep must reach database ownership before this test's timeout"
-        );
+        // read-only preflight already observed a valid epoch. Bounded so a
+        // regression that drops the hook call (or blocks ahead of it) fails
+        // this test instead of hanging it.
+        let reached_signal = tokio::time::timeout(Duration::from_secs(1), recv_blocking(reached))
+            .await
+            .expect("the sweep must reach database ownership before this test's timeout");
+        assert!(reached_signal, "hook sender was dropped before signaling");
         {
             let writer = backend.pool().writer().unwrap();
             writer
@@ -3440,7 +3521,11 @@ mod tests {
 
         let outcome = tokio::time::timeout(Duration::from_secs(1), handle)
             .await
-            .expect("the recheck must refuse before ever waiting on the externally held root lock")
+            .expect(
+                "the recheck must refuse before ever waiting on the externally held root lock -- \
+                 under the old (pre-fix) ordering this join times out instead, because the \
+                 sweep blocks acquiring the OS-level root lock held above",
+            )
             .unwrap();
         assert!(
             matches!(outcome, Err(StorageError::Unsupported { .. })),

--- a/crates/khive-db/src/stores/blob.rs
+++ b/crates/khive-db/src/stores/blob.rs
@@ -578,7 +578,7 @@ where
     // refreshed to now: a prior orphan re-published through this path
     // restarts its publish-grace clock exactly as a fresh write would,
     // rather than keeping a stale mtime that lets the orphan sweep delete it
-    // out from under the caller's follow-up entity write (khive#1313). The
+    // out from under the caller's follow-up attachment write (khive#1313). The
     // caller already holds both the async and file-based publish advisory
     // locks for the duration of this call, so the refresh is serialized
     // against a concurrent sweep the same way an ordinary write is.
@@ -720,7 +720,7 @@ fn walk_blob_files(root: &Path) -> std::io::Result<Vec<(ContentRef, PathBuf)>> {
 /// Whether a candidate file is still inside its publish grace period and must
 /// be left alone regardless of liveness.
 ///
-/// `put`'s two-step client protocol (bytes land first, a *later* entity write
+/// `put`'s two-step client protocol (bytes land first, a *later* attachment write
 /// commits the `content_ref`) means a blob can be physically on disk with
 /// zero live references for a window entirely outside this store's control —
 /// the referencing write simply hasn't happened yet. A file whose mtime is
@@ -817,15 +817,14 @@ fn invalid_content_ref(message: String) -> StorageError {
     }
 }
 
-/// Whether this database carries the complete V20 `blob_gc_claims` fencing
-/// set: the claims table plus both entity triggers
-/// (`sql/020-blob-gc-claims.sql`).
+/// Whether this database carries the complete V21 attachment-only GC fencing
+/// set and durable completed cutover marker.
 ///
 /// `transactional_orphan_sweep` is reachable from any `SqlAccess` a caller
 /// hands it, including a `StorageBackend` constructed directly (e.g.
 /// `StorageBackend::memory()`/`sqlite()` used without `prepare_core_schema`)
 /// that never ran core migrations. The triggers are the fence that keeps a
-/// concurrent entity write from resurrecting a claimed digest in the
+/// concurrent attachment write from resurrecting a claimed digest in the
 /// released-writer window, so a database missing any element of the set
 /// cannot satisfy the fail-closed guarantee the
 /// [`BlobStore::transactional_orphan_sweep`] contract requires; the sweep
@@ -837,10 +836,15 @@ async fn blob_gc_fencing_complete(sql: &dyn SqlAccess) -> StorageResult<bool> {
         reader
             .query_scalar(SqlStatement {
                 sql: "SELECT COUNT(*) FROM sqlite_master \
-                      WHERE (type = 'table' AND name = 'blob_gc_claims') \
+                      WHERE (type = 'table' AND name IN ( \
+                                 'blob_gc_claims', 'attachments', \
+                                 'attachment_cutover_state')) \
+                         OR (type = 'index' AND name IN ( \
+                             'idx_blob_gc_claims_content_ref', \
+                             'idx_attachments_content_ref')) \
                          OR (type = 'trigger' AND name IN ( \
-                             'entities_reject_claimed_blob_insert', \
-                             'entities_reject_claimed_blob_update'))"
+                             'attachments_reject_claimed_blob_insert', \
+                             'attachments_reject_claimed_blob_update'))"
                     .to_string(),
                 params: vec![],
                 label: Some("blob_gc_fencing_complete".to_string()),
@@ -848,7 +852,62 @@ async fn blob_gc_fencing_complete(sql: &dyn SqlAccess) -> StorageResult<bool> {
             .await?,
         "blob_gc_fencing_complete",
     )?;
-    Ok(present == 3)
+    if present != 7 {
+        return Ok(false);
+    }
+
+    let legacy_objects = required_nonnegative_count(
+        reader
+            .query_scalar(SqlStatement {
+                sql: "SELECT \
+                        (SELECT COUNT(*) FROM pragma_table_info('entities') \
+                         WHERE name = 'content_ref') \
+                      + (SELECT COUNT(*) FROM sqlite_master \
+                         WHERE (type = 'index' AND name = 'idx_entities_content_ref') \
+                            OR (type = 'trigger' AND name IN ( \
+                                'entities_reject_claimed_blob_insert', \
+                                'entities_reject_claimed_blob_update')))"
+                    .to_string(),
+                params: vec![],
+                label: Some("blob_gc_legacy_fencing_absent".to_string()),
+            })
+            .await?,
+        "blob_gc_legacy_fencing_absent",
+    )?;
+    if legacy_objects != 0 {
+        return Ok(false);
+    }
+
+    let complete = required_nonnegative_count(
+        reader
+            .query_scalar(SqlStatement {
+                sql: "SELECT COUNT(*) FROM attachment_cutover_state AS cutover \
+                      WHERE cutover.singleton = 1 \
+                        AND cutover.state = 'complete' \
+                        AND cutover.completed_at IS NOT NULL \
+                        AND (SELECT COUNT(*) FROM _schema_migrations \
+                             WHERE version = 21 \
+                               AND name = 'attachments_first_class') = 1 \
+                        AND (SELECT MAX(version) FROM _schema_migrations) = 21"
+                    .to_string(),
+                params: vec![],
+                label: Some("blob_gc_cutover_complete".to_string()),
+            })
+            .await?,
+        "blob_gc_cutover_complete",
+    )?;
+    Ok(complete == 1)
+}
+
+fn unsupported_blob_gc_epoch() -> StorageError {
+    StorageError::Unsupported {
+        capability: StorageCapability::Blob,
+        operation: "transactional_orphan_sweep".into(),
+        message: "transactional blob GC requires a complete V21 attachment cutover with \
+                  the attachment claim-fencing set; refusing both report-only and \
+                  destructive sweep in this database epoch"
+            .into(),
+    }
 }
 
 /// The sentinel digest the fence probe claims. All zeros is canonical-form
@@ -857,16 +916,16 @@ async fn blob_gc_fencing_complete(sql: &dyn SqlAccess) -> StorageResult<bool> {
 const BLOB_GC_FENCE_PROBE_REF: &str =
     "0000000000000000000000000000000000000000000000000000000000000000";
 
-/// The RAISE(ABORT) message both V20 fencing triggers carry. The probe
+/// The RAISE(ABORT) message shared by the V20 and V21 fencing triggers. The probe
 /// requires the rejection to be OUR fence, not an incidental failure.
 const BLOB_GC_FENCE_TRIGGER_MESSAGE: &str = "content_ref is reserved by an active blob sweep";
 
-/// Prove the V20 fence actually fences, not merely that objects with the
+/// Prove the V21 fence actually fences, not merely that objects with the
 /// right NAMES exist in `sqlite_master`. Same-named no-op triggers (or a
 /// rewritten trigger body) would pass the name census while letting a
 /// claimed `content_ref` become live in the released-writer window, so the
 /// gate exercises the fence: inside one writer transaction it claims a
-/// sentinel digest, attempts the entity INSERT and the entity UPDATE that
+/// sentinel digest, attempts the attachment INSERT and attachment UPDATE that
 /// the triggers must reject, requires both to fail with the triggers' own
 /// RAISE message, and deletes every probe row before the unit commits. Any
 /// other outcome — either write accepted, or rejected for a different
@@ -911,13 +970,10 @@ async fn blob_gc_fence_probe_with_ids(
             // Ownership guard: the cleanup below deletes these ids
             // unconditionally, so the probe may only proceed when it can
             // prove every id is unclaimed in EVERY table cleanup touches.
-            // entities_seq is checked separately from entities because the
-            // ledger intentionally retains rows after entity hard deletion —
-            // a retained-only collision has no entities row to trip on.
             let preexisting = writer
                 .query_row(SqlStatement {
-                    sql: "SELECT (SELECT COUNT(*) FROM entities WHERE id IN (?1, ?2)) \
-                              + (SELECT COUNT(*) FROM entities_seq WHERE entity_id IN (?1, ?2)) \
+                    sql: "SELECT (SELECT COUNT(*) FROM attachments \
+                                   WHERE record_uuid IN (?1, ?2)) \
                               + (SELECT COUNT(*) FROM blob_gc_claims WHERE root_key = ?3)"
                         .to_string(),
                     params: vec![
@@ -948,6 +1004,45 @@ async fn blob_gc_fence_probe_with_ids(
                 }
             }
 
+            // The UPDATE arm needs a valid, initially unclaimed reference.
+            // Select it under this same writer transaction instead of using a
+            // fixed sentinel that a recoverable abandoned claim could fence
+            // forever. Eight fresh candidates keep collision handling bounded;
+            // no candidate means a safe, retryable refusal.
+            let seed_ref = writer
+                .query_row(SqlStatement {
+                    sql: "WITH RECURSIVE candidates(attempt, content_ref) AS ( \
+                              SELECT 1, lower(hex(randomblob(32))) \
+                              UNION ALL \
+                              SELECT attempt + 1, lower(hex(randomblob(32))) \
+                              FROM candidates WHERE attempt < 8 \
+                          ) \
+                          SELECT candidate.content_ref FROM candidates AS candidate \
+                          WHERE candidate.content_ref <> ?1 \
+                            AND NOT EXISTS ( \
+                                SELECT 1 FROM blob_gc_claims \
+                                WHERE content_ref = candidate.content_ref \
+                            ) \
+                          LIMIT 1"
+                        .to_string(),
+                    params: vec![SqlValue::Text(BLOB_GC_FENCE_PROBE_REF.to_string())],
+                    label: Some("blob_gc_fence_probe_select_seed".to_string()),
+                })
+                .await?
+                .and_then(|row| row.columns.first().map(|column| column.value.clone()));
+            let seed_ref = match seed_ref {
+                Some(SqlValue::Text(seed_ref)) => seed_ref,
+                _ => {
+                    return Err(StorageError::Unsupported {
+                        capability: StorageCapability::Blob,
+                        operation: "transactional_orphan_sweep".into(),
+                        message: "the blob GC fence probe could not select an unclaimed \
+                                  canonical seed; refusing deletion so a later sweep can retry"
+                            .into(),
+                    });
+                }
+            };
+
             writer
                 .execute(SqlStatement {
                     sql: "INSERT INTO blob_gc_claims (root_key, content_ref, claimed_at) \
@@ -963,9 +1058,9 @@ async fn blob_gc_fence_probe_with_ids(
 
             let insert_attempt = writer
                 .execute(SqlStatement {
-                    sql: "INSERT INTO entities \
-                          (id, namespace, kind, name, tags, created_at, updated_at, content_ref) \
-                          VALUES (?1, 'local', 'document', 'fence probe', '[]', 0, 0, ?2)"
+                    sql: "INSERT INTO attachments \
+                          (record_uuid, substrate, role, content_ref, created_at) \
+                          VALUES (?1, 'entity', 'content', ?2, 0)"
                         .to_string(),
                     params: vec![
                         SqlValue::Text(insert_id.clone()),
@@ -978,17 +1073,19 @@ async fn blob_gc_fence_probe_with_ids(
 
             writer
                 .execute(SqlStatement {
-                    sql: "INSERT INTO entities \
-                          (id, namespace, kind, name, tags, created_at, updated_at) \
-                          VALUES (?1, 'local', 'document', 'fence probe', '[]', 0, 0)"
+                    sql: "INSERT INTO attachments \
+                          (record_uuid, substrate, role, content_ref, created_at) \
+                          VALUES (?1, 'entity', 'content', ?2, 0)"
                         .to_string(),
-                    params: vec![SqlValue::Text(update_id.clone())],
+                    params: vec![SqlValue::Text(update_id.clone()), SqlValue::Text(seed_ref)],
                     label: Some("blob_gc_fence_probe_update_arm_seed".to_string()),
                 })
                 .await?;
             let update_attempt = writer
                 .execute(SqlStatement {
-                    sql: "UPDATE entities SET content_ref = ?1 WHERE id = ?2".to_string(),
+                    sql: "UPDATE attachments SET content_ref = ?1 \
+                          WHERE record_uuid = ?2 AND role = 'content'"
+                        .to_string(),
                     params: vec![
                         SqlValue::Text(BLOB_GC_FENCE_PROBE_REF.to_string()),
                         SqlValue::Text(update_id.clone()),
@@ -999,25 +1096,15 @@ async fn blob_gc_fence_probe_with_ids(
             let update_fenced = fence_rejection(update_attempt);
 
             // Remove every probe row before this unit commits, including an
-            // entity row a dead fence let through and the list-sequence
-            // ledger rows the seed inserts created. The ledger rows were
-            // never visible outside this uncommitted transaction, so no
-            // cursor can have observed them.
+            // attachment row a dead fence let through.
             writer
                 .execute(SqlStatement {
-                    sql: "DELETE FROM entities WHERE id IN (?1, ?2)".to_string(),
+                    sql: "DELETE FROM attachments WHERE record_uuid IN (?1, ?2)".to_string(),
                     params: vec![
                         SqlValue::Text(insert_id.clone()),
                         SqlValue::Text(update_id.clone()),
                     ],
-                    label: Some("blob_gc_fence_probe_cleanup_entities".to_string()),
-                })
-                .await?;
-            writer
-                .execute(SqlStatement {
-                    sql: "DELETE FROM entities_seq WHERE entity_id IN (?1, ?2)".to_string(),
-                    params: vec![SqlValue::Text(insert_id), SqlValue::Text(update_id)],
-                    label: Some("blob_gc_fence_probe_cleanup_entities_seq".to_string()),
+                    label: Some("blob_gc_fence_probe_cleanup_attachments".to_string()),
                 })
                 .await?;
             writer
@@ -1044,15 +1131,15 @@ async fn blob_gc_fence_probe_with_ids(
                 capability: StorageCapability::Blob,
                 operation: "transactional_orphan_sweep".into(),
                 message: format!(
-                    "the V20 fencing triggers exist by name but did not reject a claimed \
-                     content_ref on the entity {arm} path; refusing unfenced deletion"
+                    "the V21 fencing triggers exist by name but did not reject a claimed \
+                     content_ref on the attachment {arm} path; refusing unfenced deletion"
                 ),
             }),
             Err(other) => Err(StorageError::Unsupported {
                 capability: StorageCapability::Blob,
                 operation: "transactional_orphan_sweep".into(),
                 message: format!(
-                    "the blob GC fence probe could not verify the entity {arm} fence \
+                    "the blob GC fence probe could not verify the attachment {arm} fence \
                      (unexpected rejection: {other}); refusing unfenced deletion"
                 ),
             }),
@@ -1088,11 +1175,10 @@ async fn validate_blob_gc_evidence(sql: &dyn SqlAccess) -> StorageResult<()> {
 
     let invalid_live = reader
         .query_row(SqlStatement {
-            sql: "SELECT content_ref FROM entities \
-                  WHERE deleted_at IS NULL AND content_ref IS NOT NULL \
-                    AND (typeof(content_ref) <> 'text' \
+            sql: "SELECT content_ref FROM attachments \
+                  WHERE typeof(content_ref) <> 'text' \
                       OR length(content_ref) <> 64 \
-                      OR content_ref GLOB '*[^0-9a-f]*') \
+                      OR content_ref GLOB '*[^0-9a-f]*' \
                   LIMIT 1"
                 .to_string(),
             params: vec![],
@@ -1101,7 +1187,7 @@ async fn validate_blob_gc_evidence(sql: &dyn SqlAccess) -> StorageResult<()> {
         .await?;
     if invalid_live.is_some() {
         return Err(invalid_content_ref(
-            "entities.content_ref contained a non-canonical value".into(),
+            "attachments.content_ref contained a non-canonical value".into(),
         ));
     }
     Ok(())
@@ -1168,9 +1254,8 @@ async fn claim_blob_gc_batch(
                     .query_scalar(SqlStatement {
                         sql: "SELECT COUNT(*) FROM json_each(?1) AS candidate \
                               WHERE NOT EXISTS ( \
-                                SELECT 1 FROM entities \
-                                WHERE deleted_at IS NULL \
-                                  AND content_ref = candidate.value \
+                                SELECT 1 FROM attachments \
+                                WHERE content_ref = candidate.value \
                               )"
                         .to_string(),
                         params: vec![SqlValue::Text(grace_json)],
@@ -1186,9 +1271,8 @@ async fn claim_blob_gc_batch(
                         .query_scalar(SqlStatement {
                             sql: "SELECT COUNT(*) FROM json_each(?1) AS candidate \
                                   WHERE NOT EXISTS ( \
-                                    SELECT 1 FROM entities \
-                                    WHERE deleted_at IS NULL \
-                                      AND content_ref = candidate.value \
+                                    SELECT 1 FROM attachments \
+                                    WHERE content_ref = candidate.value \
                                   )"
                             .to_string(),
                             params: vec![SqlValue::Text(eligible_json)],
@@ -1210,9 +1294,8 @@ async fn claim_blob_gc_batch(
                           SELECT ?1, candidate.value, ?3 \
                           FROM json_each(?2) AS candidate \
                           WHERE NOT EXISTS ( \
-                            SELECT 1 FROM entities \
-                            WHERE deleted_at IS NULL \
-                              AND content_ref = candidate.value \
+                            SELECT 1 FROM attachments \
+                            WHERE content_ref = candidate.value \
                           )"
                     .to_string(),
                     params: vec![
@@ -1295,7 +1378,7 @@ fn sweep_blob_files(
 
 /// Process-wide database owner fence for transactional blob sweeps.
 ///
-/// Claims live in the database and their entity triggers are database-global,
+/// Claims live in the database and their attachment triggers are database-global,
 /// so a root-only lock is insufficient: two differently configured roots for
 /// one database must not recover each other's live claims. File-backed pools
 /// additionally take [`acquire_database_gc_lock`] for cross-process exclusion.
@@ -1377,7 +1460,7 @@ pub struct FsBlobStore {
     /// How long a blob with zero live references is left alone before an
     /// orphan sweep will delete it — see `within_publish_grace`. Bounds the
     /// window between `put` (bytes land, lock released) and the later,
-    /// separate entity write that commits a `content_ref` to it; it does not
+    /// separate attachment write that commits a `content_ref` to it; it does not
     /// close that window entirely; see `within_publish_grace` and
     /// `transactional_orphan_sweep`'s doc comment for the residual exposure.
     orphan_sweep_grace: Duration,
@@ -1390,7 +1473,7 @@ impl FsBlobStore {
 
     /// Default orphan-sweep publish grace period: 1 hour. Generous on
     /// purpose — it only needs to outlast the gap between a client's `put`
-    /// call returning and its follow-up entity write landing, not any
+    /// call returning and its follow-up attachment write landing, not any
     /// steady-state condition.
     pub const DEFAULT_ORPHAN_SWEEP_GRACE: Duration = Duration::from_secs(3600);
 
@@ -1635,24 +1718,24 @@ impl BlobStore for FsBlobStore {
         .map_err(|e| StorageError::driver(StorageCapability::Blob, "orphan_sweep", e))?
     }
 
-    // `put` and the entity write that later commits a `content_ref` to its
+    // `put` and the attachment write that later commits a `content_ref` to its
     // result are two separate steps of the client protocol -- the write
     // lock this method takes only serializes it against a concurrent `put`,
     // it is not held across the caller's own gap between finishing `put` and
-    // issuing that follow-up entity write. A blob can therefore be fully on
+    // issuing that follow-up attachment write. A blob can therefore be fully on
     // disk with zero live references purely because its referencing write
     // hasn't landed yet, not because it is actually orphaned.
     // `within_publish_grace` (via `orphan_sweep_grace`) is what protects that
     // window: a file younger than the grace period is left alone regardless
     // of liveness. Residual assumption: a client that waits longer than the
-    // grace period between `put` returning and its entity write committing
+    // grace period between `put` returning and its attachment write committing
     // is still exposed to this method deleting the blob out from under it --
     // callers with an unusually slow publish path should widen the grace
     // period (`FsBlobStore::with_orphan_sweep_grace`) accordingly.
     //
     // Cross-resource ordering (#1850): database/root ownership and filesystem
     // walk/metadata happen before SQL. Bounded SQL-only units recover abandoned
-    // rows and commit at most 128 fresh claims whose entity triggers fence new
+    // rows and commit at most 128 fresh claims whose attachment triggers fence new
     // live references; physical deletion happens after each COMMIT; a second
     // bounded SQL-only unit releases that batch. Owner/root locks span all
     // phases, but SQLite's single writer never spans external I/O.
@@ -1661,7 +1744,15 @@ impl BlobStore for FsBlobStore {
         sql: &dyn SqlAccess,
         dry_run: bool,
     ) -> StorageResult<BlobOrphanSweepResult> {
-        // Claims and their entity triggers are database-global. Serialize the
+        // This compatibility gate deliberately precedes every database/root
+        // owner wait, filesystem walk, and abandoned-claim cleanup. V20 and
+        // staged V21 cannot represent the complete attachment liveness set,
+        // so even report-only sweeps must refuse without observable mutation.
+        if !blob_gc_fencing_complete(sql).await? {
+            return Err(unsupported_blob_gc_epoch());
+        }
+
+        // Claims and their attachment triggers are database-global. Serialize the
         // whole cross-resource protocol by database before taking the root
         // locks, so differently configured roots cannot recover one another's
         // active claim batches. The OS lock is the crash-detecting owner:
@@ -1706,19 +1797,15 @@ impl BlobStore for FsBlobStore {
             )
         })??;
         let root_key = blob_root_key(&canonical_root);
+        // Recheck after acquiring the existing Phase-3 database/root owner
+        // sequence. Completed V21 is monotonic in supported writers, but this
+        // closes the safety gap if external maintenance replaced the schema
+        // between the read-only compatibility preflight and ownership.
         if !blob_gc_fencing_complete(sql).await? {
-            return Err(StorageError::Unsupported {
-                capability: StorageCapability::Blob,
-                operation: "transactional_orphan_sweep".into(),
-                message: "this database lacks the complete V20 blob_gc_claims fencing set \
-                          (claims table plus both entity triggers); refusing unfenced \
-                          deletion — run core migrations (prepare_core_schema) to enable \
-                          the sweep"
-                    .into(),
-            });
+            return Err(unsupported_blob_gc_epoch());
         }
-        blob_gc_fence_probe(sql).await?;
         validate_blob_gc_evidence(sql).await?;
+        blob_gc_fence_probe(sql).await?;
         if !dry_run {
             loop {
                 let released = release_abandoned_blob_gc_claim_batch(sql).await?;
@@ -1967,6 +2054,108 @@ mod tests {
             .unwrap()
             .with_orphan_sweep_grace(Duration::ZERO);
         (dir, store)
+    }
+
+    /// Test-only representation of the schema a later attachment-cutover
+    /// release publishes atomically.  This compatibility branch deliberately
+    /// does not register or execute V21; the fixture lets its GC reader prove
+    /// that it is safe both before the rollout (V20 must refuse) and after a
+    /// newer binary has completed the cutover (attachment liveness may sweep).
+    fn prepare_completed_v21_gc_fixture(conn: &mut rusqlite::Connection) {
+        crate::run_migrations(conn).expect("prepare canonical V20 prefix");
+        conn.execute_batch(
+            "BEGIN IMMEDIATE; \
+             CREATE TABLE attachments ( \
+                 record_uuid TEXT NOT NULL, \
+                 substrate   TEXT NOT NULL CHECK (substrate IN ('entity', 'note')), \
+                 role        TEXT NOT NULL CHECK (length(role) > 0), \
+                 content_ref TEXT NOT NULL \
+                     CHECK (length(content_ref) = 64 \
+                            AND content_ref NOT GLOB '*[^0-9a-f]*'), \
+                 media_type  TEXT, \
+                 size_bytes  INTEGER CHECK (size_bytes IS NULL OR size_bytes >= 0), \
+                 created_at  INTEGER NOT NULL, \
+                 PRIMARY KEY (record_uuid, role) \
+             ) STRICT; \
+             CREATE INDEX idx_attachments_content_ref ON attachments(content_ref); \
+             CREATE TABLE attachment_cutover_state ( \
+                 singleton    INTEGER PRIMARY KEY CHECK (singleton = 1), \
+                 state        TEXT NOT NULL CHECK (state IN ('incomplete', 'complete')), \
+                 started_at   INTEGER NOT NULL, \
+                 completed_at INTEGER, \
+                 CHECK ((state = 'incomplete' AND completed_at IS NULL) \
+                        OR (state = 'complete' AND completed_at IS NOT NULL)) \
+             ) STRICT; \
+             INSERT INTO attachments \
+                 (record_uuid, substrate, role, content_ref, created_at) \
+             SELECT id, 'entity', 'content', content_ref, updated_at \
+             FROM entities WHERE content_ref IS NOT NULL; \
+             INSERT INTO attachment_cutover_state \
+                 (singleton, state, started_at, completed_at) \
+             VALUES (1, 'complete', 21, 21); \
+             CREATE TRIGGER attachments_reject_claimed_blob_insert \
+             BEFORE INSERT ON attachments \
+             WHEN EXISTS (SELECT 1 FROM blob_gc_claims \
+                          WHERE content_ref = NEW.content_ref) \
+             BEGIN \
+                 SELECT RAISE(ABORT, 'content_ref is reserved by an active blob sweep'); \
+             END; \
+             CREATE TRIGGER attachments_reject_claimed_blob_update \
+             BEFORE UPDATE OF content_ref ON attachments \
+             WHEN EXISTS (SELECT 1 FROM blob_gc_claims \
+                          WHERE content_ref = NEW.content_ref) \
+             BEGIN \
+                 SELECT RAISE(ABORT, 'content_ref is reserved by an active blob sweep'); \
+             END; \
+             DROP TRIGGER entities_reject_claimed_blob_insert; \
+             DROP TRIGGER entities_reject_claimed_blob_update; \
+             DROP INDEX idx_entities_content_ref; \
+             ALTER TABLE entities DROP COLUMN content_ref; \
+             INSERT INTO _schema_migrations (version, name, applied_at) \
+             VALUES (21, 'attachments_first_class', 21); \
+             COMMIT;",
+        )
+        .expect("materialize completed V21 attachment-GC fixture");
+    }
+
+    #[tokio::test]
+    async fn completed_v21_gc_gate_requires_new_indexes_and_absent_legacy_column() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("khive.db");
+        let backend = crate::StorageBackend::sqlite(&db_path).unwrap();
+        {
+            let mut writer = backend.pool().writer().unwrap();
+            prepare_completed_v21_gc_fixture(writer.conn_mut());
+        }
+        assert!(blob_gc_fencing_complete(backend.sql().as_ref())
+            .await
+            .unwrap());
+
+        {
+            let writer = backend.pool().writer().unwrap();
+            writer
+                .conn()
+                .execute_batch("DROP INDEX idx_attachments_content_ref")
+                .unwrap();
+        }
+        assert!(!blob_gc_fencing_complete(backend.sql().as_ref())
+            .await
+            .unwrap());
+
+        {
+            let writer = backend.pool().writer().unwrap();
+            writer
+                .conn()
+                .execute_batch(
+                    "CREATE INDEX idx_attachments_content_ref \
+                         ON attachments(content_ref); \
+                     ALTER TABLE entities ADD COLUMN content_ref TEXT",
+                )
+                .unwrap();
+        }
+        assert!(!blob_gc_fencing_complete(backend.sql().as_ref())
+            .await
+            .unwrap());
     }
 
     #[test]
@@ -2735,11 +2924,232 @@ mod tests {
         );
     }
 
+    /// Rollout compatibility fence: the Phase-3 binary's V20 schema cannot
+    /// represent a moodboard model's nested FANN network as SQL liveness.
+    /// Both report-only and destructive transactional sweeps must therefore
+    /// refuse before taking the root lock or mutating abandoned claims.
+    #[tokio::test]
+    async fn transactional_orphan_sweep_refuses_v20_before_root_or_claim_mutation() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("khive.db");
+        let backend = crate::StorageBackend::sqlite(&db_path).unwrap();
+        {
+            let mut writer = backend.pool().writer().unwrap();
+            crate::run_migrations(writer.conn_mut()).unwrap();
+        }
+
+        let root = dir.path().join("blobs");
+        let store = Arc::new(
+            FsBlobStore::new(root, 0)
+                .unwrap()
+                .with_orphan_sweep_grace(Duration::ZERO),
+        );
+        let bundle = store.put(b"legacy model bundle".to_vec()).await.unwrap();
+        let network = store.put(b"legacy FANN network".to_vec()).await.unwrap();
+        let orphan = store.put(b"ordinary old orphan".to_vec()).await.unwrap();
+        let abandoned_ref = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+        {
+            let writer = backend.pool().writer().unwrap();
+            writer
+                .conn()
+                .execute(
+                    "INSERT INTO entities \
+                     (id, namespace, kind, entity_type, name, tags, created_at, updated_at, \
+                      content_ref) \
+                     VALUES ('legacy-model', 'local', 'artifact', 'moodboard_model', \
+                             'legacy model', '[]', 1, 1, ?1)",
+                    [bundle.as_str()],
+                )
+                .unwrap();
+            writer
+                .conn()
+                .execute(
+                    "INSERT INTO blob_gc_claims (root_key, content_ref, claimed_at) \
+                     VALUES ('abandoned-before-compat', ?1, 1)",
+                    [abandoned_ref],
+                )
+                .unwrap();
+        }
+
+        // If the compatibility gate is below the root lock, the call parks
+        // here and the timeout fails. A correct V20 refusal never waits for it.
+        let _root_guard = store.write_lock.clone().lock_owned().await;
+        for dry_run in [true, false] {
+            let outcome = tokio::time::timeout(
+                Duration::from_secs(1),
+                store.transactional_orphan_sweep(backend.sql().as_ref(), dry_run),
+            )
+            .await
+            .expect("V20 refusal must happen before waiting for the held root lock");
+            let error = outcome.expect_err("V20 transactional sweep must be disabled");
+            match error {
+                StorageError::Unsupported {
+                    capability: StorageCapability::Blob,
+                    operation,
+                    message,
+                } => {
+                    assert_eq!(operation, "transactional_orphan_sweep");
+                    assert!(
+                        message.contains("complete V21 attachment cutover"),
+                        "unexpected compatibility diagnostic: {message}"
+                    );
+                }
+                other => panic!("expected typed Unsupported refusal, got {other:?}"),
+            }
+        }
+
+        let reader = backend.pool().reader().unwrap();
+        let abandoned: i64 = reader
+            .conn()
+            .query_row(
+                "SELECT COUNT(*) FROM blob_gc_claims \
+                 WHERE root_key = 'abandoned-before-compat' AND content_ref = ?1",
+                [abandoned_ref],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(abandoned, 1, "V20 refusal must not clean abandoned claims");
+        drop(reader);
+        assert!(store.exists(&bundle).await.unwrap());
+        assert!(store.exists(&network).await.unwrap());
+        assert!(store.exists(&orphan).await.unwrap());
+    }
+
+    /// The durable marker is authoritative, not the mere presence of V21
+    /// tables, triggers, or even a ledger row. An interrupted/inconsistent
+    /// cutover remains non-sweepable for both modes and is rejected before
+    /// the root wait or abandoned-claim recovery.
+    #[tokio::test]
+    async fn transactional_orphan_sweep_refuses_incomplete_v21_marker_without_mutation() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("khive.db");
+        let backend = crate::StorageBackend::sqlite(&db_path).unwrap();
+        let abandoned_ref = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+        {
+            let mut writer = backend.pool().writer().unwrap();
+            prepare_completed_v21_gc_fixture(writer.conn_mut());
+            writer
+                .conn_mut()
+                .execute(
+                    "UPDATE attachment_cutover_state \
+                     SET state = 'incomplete', completed_at = NULL \
+                     WHERE singleton = 1",
+                    [],
+                )
+                .unwrap();
+            writer
+                .conn_mut()
+                .execute(
+                    "INSERT INTO blob_gc_claims (root_key, content_ref, claimed_at) \
+                     VALUES ('abandoned-incomplete-v21', ?1, 1)",
+                    [abandoned_ref],
+                )
+                .unwrap();
+        }
+
+        let store = Arc::new(
+            FsBlobStore::new(dir.path().join("blobs"), 0)
+                .unwrap()
+                .with_orphan_sweep_grace(Duration::ZERO),
+        );
+        let orphan = store.put(b"incomplete V21 orphan".to_vec()).await.unwrap();
+        let _root_guard = store.write_lock.clone().lock_owned().await;
+
+        for dry_run in [true, false] {
+            let outcome = tokio::time::timeout(
+                Duration::from_secs(1),
+                store.transactional_orphan_sweep(backend.sql().as_ref(), dry_run),
+            )
+            .await
+            .expect("incomplete V21 must refuse before waiting for the root lock");
+            assert!(
+                matches!(outcome, Err(StorageError::Unsupported { .. })),
+                "incomplete V21 must return typed Unsupported: {outcome:?}"
+            );
+        }
+
+        let remaining: i64 = backend
+            .pool()
+            .reader()
+            .unwrap()
+            .conn()
+            .query_row(
+                "SELECT COUNT(*) FROM blob_gc_claims \
+                 WHERE root_key = 'abandoned-incomplete-v21' AND content_ref = ?1",
+                [abandoned_ref],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(remaining, 1, "refusal must not recover abandoned claims");
+        assert!(store.exists(&orphan).await.unwrap());
+    }
+
+    /// A Phase-4a binary can remain in a mixed fleet after a newer binary has
+    /// atomically completed V21. It must then use every attachment role as
+    /// liveness, including a moodboard FANN network, and delete only the true
+    /// orphan.
+    #[tokio::test]
+    async fn transactional_orphan_sweep_accepts_completed_v21_attachment_liveness() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("khive.db");
+        let backend = crate::StorageBackend::sqlite(&db_path).unwrap();
+        {
+            let mut writer = backend.pool().writer().unwrap();
+            prepare_completed_v21_gc_fixture(writer.conn_mut());
+        }
+
+        let store = FsBlobStore::new(dir.path().join("blobs"), 0)
+            .unwrap()
+            .with_orphan_sweep_grace(Duration::ZERO);
+        let bundle = store.put(b"V21 model bundle".to_vec()).await.unwrap();
+        let network = store.put(b"V21 FANN network".to_vec()).await.unwrap();
+        let orphan = store.put(b"V21 true orphan".to_vec()).await.unwrap();
+        {
+            let writer = backend.pool().writer().unwrap();
+            writer
+                .conn()
+                .execute(
+                    "INSERT INTO entities \
+                     (id, namespace, kind, entity_type, name, tags, created_at, updated_at) \
+                     VALUES ('model', 'local', 'artifact', 'moodboard_model', \
+                             'model', '[]', 1, 1)",
+                    [],
+                )
+                .unwrap();
+            writer
+                .conn()
+                .execute(
+                    "INSERT INTO attachments \
+                     (record_uuid, substrate, role, content_ref, created_at) \
+                     VALUES ('model', 'entity', 'content', ?1, 1), \
+                            ('model', 'entity', 'fann-network', ?2, 1)",
+                    rusqlite::params![bundle.as_str(), network.as_str()],
+                )
+                .unwrap();
+        }
+
+        let dry_run = store
+            .transactional_orphan_sweep(backend.sql().as_ref(), true)
+            .await
+            .expect("completed V21 dry run must be supported");
+        assert_eq!(dry_run.would_delete, 1);
+        assert_eq!(dry_run.deleted, 0);
+
+        let result = store
+            .transactional_orphan_sweep(backend.sql().as_ref(), false)
+            .await
+            .expect("completed V21 destructive sweep must be supported");
+        assert_eq!(result.deleted, 1);
+        assert!(store.exists(&bundle).await.unwrap());
+        assert!(store.exists(&network).await.unwrap());
+        assert!(!store.exists(&orphan).await.unwrap());
+    }
+
     /// A `StorageBackend` constructed directly and never run through the
     /// versioned migration ledger (`run_migrations`/`prepare_core_schema`) —
     /// only the ad hoc, idempotent `entities` DDL a plain `entities()` call
-    /// applies — has no `blob_gc_claims` table and no entity fencing
-    /// triggers. Without that fence a reference committed between liveness
+    /// applies — has no completed V21 marker, attachment liveness table, or
+    /// attachment fencing triggers. Without that set a reference committed between liveness
     /// selection and physical deletion would dangle, so the trait contract
     /// requires `StorageError::Unsupported` here rather than an unfenced
     /// sweep, and every candidate must survive.
@@ -2789,9 +3199,9 @@ mod tests {
         );
     }
 
-    /// The fencing gate must demand the complete V20 set, not just the
+    /// The fencing gate must demand the complete V21 set, not just the
     /// claims table: with a fencing trigger dropped, a claim no longer
-    /// blocks a concurrent entity write from resurrecting the digest, so
+    /// blocks a concurrent attachment write from resurrecting the digest, so
     /// the sweep must refuse exactly as it does with no migration at all.
     #[tokio::test]
     async fn transactional_orphan_sweep_refuses_with_incomplete_fencing_triggers() {
@@ -2800,10 +3210,20 @@ mod tests {
         let backend = std::sync::Arc::new(crate::StorageBackend::sqlite(&db_path).unwrap());
         {
             let mut writer = backend.pool().writer().unwrap();
-            crate::run_migrations(writer.conn_mut()).unwrap();
+            prepare_completed_v21_gc_fixture(writer.conn_mut());
             writer
                 .conn_mut()
-                .execute_batch("DROP TRIGGER entities_reject_claimed_blob_update")
+                .execute_batch("DROP TRIGGER attachments_reject_claimed_blob_update")
+                .unwrap();
+            writer
+                .conn_mut()
+                .execute(
+                    "INSERT INTO blob_gc_claims (root_key, content_ref, claimed_at) \
+                     VALUES ('abandoned-partial-fence', \
+                             'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd', \
+                             1)",
+                    [],
+                )
                 .unwrap();
         }
 
@@ -2816,10 +3236,14 @@ mod tests {
         let orphan = store.put(b"partial-fence orphan".to_vec()).await.unwrap();
 
         let sql = backend.sql();
-        let error = store
-            .transactional_orphan_sweep(sql.as_ref(), false)
-            .await
-            .expect_err("sweep must refuse when any V20 fencing trigger is missing");
+        let _root_guard = store.write_lock.clone().lock_owned().await;
+        let error = tokio::time::timeout(
+            Duration::from_secs(1),
+            store.transactional_orphan_sweep(sql.as_ref(), false),
+        )
+        .await
+        .expect("an incomplete V21 fence must refuse before the root wait")
+        .expect_err("sweep must refuse when any V21 fencing trigger is missing");
         assert!(
             matches!(error, StorageError::Unsupported { .. }),
             "expected StorageError::Unsupported, got {error:?}"
@@ -2828,6 +3252,19 @@ mod tests {
             store.exists(&orphan).await.unwrap(),
             "a refused sweep must not have deleted anything"
         );
+        let remaining: i64 = backend
+            .pool()
+            .reader()
+            .unwrap()
+            .conn()
+            .query_row(
+                "SELECT COUNT(*) FROM blob_gc_claims \
+                 WHERE root_key = 'abandoned-partial-fence'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(remaining, 1, "a refused sweep must not recover claims");
     }
 
     /// The gate must verify the fence FUNCTIONS, not that three names exist
@@ -2842,16 +3279,16 @@ mod tests {
         let backend = std::sync::Arc::new(crate::StorageBackend::sqlite(&db_path).unwrap());
         {
             let mut writer = backend.pool().writer().unwrap();
-            crate::run_migrations(writer.conn_mut()).unwrap();
+            prepare_completed_v21_gc_fixture(writer.conn_mut());
             writer
                 .conn_mut()
                 .execute_batch(
-                    "DROP TRIGGER entities_reject_claimed_blob_insert; \
-                     DROP TRIGGER entities_reject_claimed_blob_update; \
-                     CREATE TRIGGER entities_reject_claimed_blob_insert \
-                     BEFORE INSERT ON entities BEGIN SELECT 0; END; \
-                     CREATE TRIGGER entities_reject_claimed_blob_update \
-                     BEFORE UPDATE OF content_ref, deleted_at ON entities \
+                    "DROP TRIGGER attachments_reject_claimed_blob_insert; \
+                     DROP TRIGGER attachments_reject_claimed_blob_update; \
+                     CREATE TRIGGER attachments_reject_claimed_blob_insert \
+                     BEFORE INSERT ON attachments BEGIN SELECT 0; END; \
+                     CREATE TRIGGER attachments_reject_claimed_blob_update \
+                     BEFORE UPDATE OF content_ref ON attachments \
                      BEGIN SELECT 0; END;",
                 )
                 .unwrap();
@@ -2886,10 +3323,8 @@ mod tests {
             .query_row(
                 "SELECT (SELECT COUNT(*) FROM blob_gc_claims \
                          WHERE root_key GLOB '__fence_probe-*') \
-                      + (SELECT COUNT(*) FROM entities \
-                         WHERE id GLOB '__blob-gc-fence-probe-*') \
-                      + (SELECT COUNT(*) FROM entities_seq \
-                         WHERE entity_id GLOB '__blob-gc-fence-probe-*')",
+                      + (SELECT COUNT(*) FROM attachments \
+                         WHERE record_uuid GLOB '__blob-gc-fence-probe-*')",
                 [],
                 |row| row.get(0),
             )
@@ -2898,19 +3333,21 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn fence_probe_refuses_id_collision_and_preserves_the_colliding_entity() {
+    async fn fence_probe_refuses_id_collision_and_preserves_the_colliding_attachment() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("khive.db");
         let backend = std::sync::Arc::new(crate::StorageBackend::sqlite(&db_path).unwrap());
         {
             let mut writer = backend.pool().writer().unwrap();
-            crate::run_migrations(writer.conn_mut()).unwrap();
+            prepare_completed_v21_gc_fixture(writer.conn_mut());
             writer
                 .conn_mut()
                 .execute(
-                    "INSERT INTO entities \
-                     (id, namespace, kind, name, tags, created_at, updated_at) \
-                     VALUES ('victim-id', 'local', 'document', 'unrelated data', '[]', 7, 7)",
+                    "INSERT INTO attachments \
+                     (record_uuid, substrate, role, content_ref, media_type, created_at) \
+                     VALUES ('victim-id', 'entity', 'content', \
+                             '2222222222222222222222222222222222222222222222222222222222222222', \
+                             'application/test', 7)",
                     [],
                 )
                 .unwrap();
@@ -2931,26 +3368,27 @@ mod tests {
         );
 
         let reader = backend.pool().reader().unwrap();
-        let (name, created_at): (String, i64) = reader
+        let (media_type, created_at): (String, i64) = reader
             .conn()
             .query_row(
-                "SELECT name, created_at FROM entities WHERE id = 'victim-id'",
+                "SELECT media_type, created_at FROM attachments \
+                 WHERE record_uuid = 'victim-id' AND role = 'content'",
                 [],
                 |row| Ok((row.get(0)?, row.get(1)?)),
             )
-            .expect("the colliding entity must survive the refused probe untouched");
-        assert_eq!(name, "unrelated data");
+            .expect("the colliding attachment must survive the refused probe untouched");
+        assert_eq!(media_type, "application/test");
         assert_eq!(created_at, 7);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn fence_probe_refuses_retained_seq_collision_and_preserves_the_ledger_row() {
+    async fn fence_probe_does_not_touch_an_unrelated_retained_entity_sequence() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("khive.db");
         let backend = std::sync::Arc::new(crate::StorageBackend::sqlite(&db_path).unwrap());
         {
             let mut writer = backend.pool().writer().unwrap();
-            crate::run_migrations(writer.conn_mut()).unwrap();
+            prepare_completed_v21_gc_fixture(writer.conn_mut());
             // entities_seq rows intentionally survive entity hard deletion, so
             // an id can collide with the ledger alone — no entities row left
             // for the guard to trip on.
@@ -2979,18 +3417,14 @@ mod tests {
         }
 
         let sql = backend.sql();
-        let error = super::blob_gc_fence_probe_with_ids(
+        super::blob_gc_fence_probe_with_ids(
             sql.as_ref(),
             "retained-id".to_string(),
             "retained-update-id".to_string(),
             "retained-claim-key".to_string(),
         )
         .await
-        .expect_err("the probe must refuse when an id collides with a retained ledger row");
-        assert!(
-            matches!(error, StorageError::Unsupported { .. }),
-            "expected StorageError::Unsupported, got {error:?}"
-        );
+        .expect("attachment probe has no reason to mutate an entity sequence row");
 
         let reader = backend.pool().reader().unwrap();
         let survivors: i64 = reader
@@ -3003,7 +3437,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             survivors, 1,
-            "the retained ledger row must survive the refused probe"
+            "the retained entity ledger row must survive the attachment probe"
         );
     }
 
@@ -3014,7 +3448,7 @@ mod tests {
         let backend = std::sync::Arc::new(crate::StorageBackend::sqlite(&db_path).unwrap());
         {
             let mut writer = backend.pool().writer().unwrap();
-            crate::run_migrations(writer.conn_mut()).unwrap();
+            prepare_completed_v21_gc_fixture(writer.conn_mut());
         }
         let root = dir.path().join("blobs");
         let store = std::sync::Arc::new(
@@ -3069,7 +3503,7 @@ mod tests {
         let backend = std::sync::Arc::new(crate::StorageBackend::sqlite(&db_path).unwrap());
         {
             let mut writer = backend.pool().writer().unwrap();
-            crate::run_migrations(writer.conn_mut()).unwrap();
+            prepare_completed_v21_gc_fixture(writer.conn_mut());
         }
         let root = dir.path().join("blobs");
         let store = std::sync::Arc::new(
@@ -3126,13 +3560,13 @@ mod tests {
             .expect("external filesystem work must not retain SQLite's writer lock");
 
         // The claim trigger is the cross-resource fence: while the file is
-        // selected for deletion, a concurrent entity writer cannot make it
+        // selected for deletion, a concurrent attachment writer cannot make it
         // newly live in the released-writer window.
         let claimed_err = unrelated
             .execute(
-                "INSERT INTO entities \
-                 (id, namespace, kind, name, tags, created_at, updated_at, content_ref) \
-                 VALUES ('racing-reference', 'local', 'document', 'racing', '[]', 1, 1, ?1)",
+                "INSERT INTO attachments \
+                 (record_uuid, substrate, role, content_ref, created_at) \
+                 VALUES ('racing-reference', 'entity', 'content', ?1, 1)",
                 [orphan.as_str()],
             )
             .expect_err("a claimed content_ref must fail closed before deletion");
@@ -3166,7 +3600,7 @@ mod tests {
         let backend = std::sync::Arc::new(crate::StorageBackend::sqlite(&db_path).unwrap());
         {
             let mut writer = backend.pool().writer().unwrap();
-            crate::run_migrations(writer.conn_mut()).unwrap();
+            prepare_completed_v21_gc_fixture(writer.conn_mut());
         }
         let root = dir.path().join("blobs");
         let store = std::sync::Arc::new(
@@ -3247,7 +3681,7 @@ mod tests {
         let backend = crate::StorageBackend::sqlite(&db_path).unwrap();
         {
             let mut writer = backend.pool().writer().unwrap();
-            crate::run_migrations(writer.conn_mut()).unwrap();
+            prepare_completed_v21_gc_fixture(writer.conn_mut());
         }
         let root = dir.path().join("blobs");
         let store = FsBlobStore::new(root.clone(), 0)
@@ -3258,22 +3692,29 @@ mod tests {
         let canonical_root = root.canonicalize().unwrap();
         let root_key = blob_root_key(&canonical_root);
         let absent_ref = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+        let former_probe_seed = "1111111111111111111111111111111111111111111111111111111111111111";
         {
             let writer = backend.pool().writer().unwrap();
             writer
                 .conn()
                 .execute(
                     "INSERT INTO blob_gc_claims (root_key, content_ref, claimed_at) \
-                     VALUES (?1, ?2, 1), (?1, ?3, 1)",
-                    rusqlite::params![root_key, content_ref.as_str(), absent_ref],
+                     VALUES (?1, ?2, 1), (?1, ?3, 1), (?1, ?4, 1)",
+                    rusqlite::params![
+                        root_key,
+                        content_ref.as_str(),
+                        absent_ref,
+                        former_probe_seed
+                    ],
                 )
                 .unwrap();
         }
 
         // A publisher that recovered after the claiming process crashed
-        // refreshes the digest's grace witness before its entity write. The
-        // next sweep must clear both this protected claim and the claim whose
-        // file was already removed, never resume deletion blindly.
+        // refreshes the digest's grace witness before its attachment write. The
+        // next sweep must clear this protected claim, the claim whose file was
+        // already removed, and the former fixed probe seed without letting a
+        // healthy attachment fence block abandoned-claim recovery forever.
         assert_eq!(store.put(bytes).await.unwrap(), content_ref);
         let result = store
             .transactional_orphan_sweep(backend.sql().as_ref(), false)
@@ -3304,7 +3745,7 @@ mod tests {
         let backend = crate::StorageBackend::sqlite(&db_path).unwrap();
         {
             let mut writer = backend.pool().writer().unwrap();
-            crate::run_migrations(writer.conn_mut()).unwrap();
+            prepare_completed_v21_gc_fixture(writer.conn_mut());
         }
 
         let old_root = dir.path().join("old-blobs");
@@ -3368,7 +3809,7 @@ mod tests {
         {
             let source = crate::StorageBackend::sqlite(&source_path).unwrap();
             let mut writer = source.pool().writer().unwrap();
-            crate::run_migrations(writer.conn_mut()).unwrap();
+            prepare_completed_v21_gc_fixture(writer.conn_mut());
             writer
                 .conn()
                 .execute(
@@ -3414,7 +3855,7 @@ mod tests {
         let backend = std::sync::Arc::new(crate::StorageBackend::sqlite(&db_path).unwrap());
         {
             let mut writer = backend.pool().writer().unwrap();
-            crate::run_migrations(writer.conn_mut()).unwrap();
+            prepare_completed_v21_gc_fixture(writer.conn_mut());
         }
         let root = dir.path().join("blobs");
         let store = std::sync::Arc::new(
@@ -3503,7 +3944,7 @@ mod tests {
         let backend = crate::StorageBackend::sqlite(&db_path).unwrap();
         {
             let mut writer = backend.pool().writer().unwrap();
-            crate::run_migrations(writer.conn_mut()).unwrap();
+            prepare_completed_v21_gc_fixture(writer.conn_mut());
         }
         let root = dir.path().join("blobs");
         let store = FsBlobStore::new(root.clone(), 0)
@@ -3515,14 +3956,17 @@ mod tests {
             .unwrap();
 
         let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute_batch("PRAGMA ignore_check_constraints = ON")
+            .unwrap();
         conn.execute(
-            "INSERT INTO entities \
-             (id, namespace, kind, name, tags, created_at, updated_at, content_ref) \
-             VALUES ('corrupt-live', 'local', 'document', 'corrupt', '[]', 1, 1, \
-                     'not-a-content-ref')",
+            "INSERT INTO attachments \
+             (record_uuid, substrate, role, content_ref, created_at) \
+             VALUES ('corrupt-live', 'entity', 'content', 'not-a-content-ref', 1)",
             [],
         )
         .unwrap();
+        conn.execute_batch("PRAGMA ignore_check_constraints = OFF")
+            .unwrap();
         let live_error = store
             .transactional_orphan_sweep(backend.sql().as_ref(), false)
             .await
@@ -3533,8 +3977,11 @@ mod tests {
             "no file may be removed after corrupt live evidence"
         );
 
-        conn.execute("DELETE FROM entities WHERE id = 'corrupt-live'", [])
-            .unwrap();
+        conn.execute(
+            "DELETE FROM attachments WHERE record_uuid = 'corrupt-live'",
+            [],
+        )
+        .unwrap();
         let root_key = blob_root_key(&root.canonicalize().unwrap());
         conn.execute(
             "INSERT INTO blob_gc_claims (root_key, content_ref, claimed_at) \
@@ -3563,6 +4010,20 @@ mod tests {
             remaining, 1,
             "corrupt claim evidence is not silently erased"
         );
+        let probe_residue: i64 = conn
+            .query_row(
+                "SELECT (SELECT COUNT(*) FROM blob_gc_claims \
+                         WHERE root_key GLOB '__fence_probe-*') \
+                      + (SELECT COUNT(*) FROM attachments \
+                         WHERE record_uuid GLOB '__blob-gc-fence-probe-*')",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            probe_residue, 0,
+            "invalid evidence must abort before the functional fence probe"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -3572,7 +4033,7 @@ mod tests {
         let backend = std::sync::Arc::new(crate::StorageBackend::sqlite(&db_path).unwrap());
         {
             let mut writer = backend.pool().writer().unwrap();
-            crate::run_migrations(writer.conn_mut()).unwrap();
+            prepare_completed_v21_gc_fixture(writer.conn_mut());
         }
         let root = dir.path().join("blobs");
         let store = std::sync::Arc::new(
@@ -3631,13 +4092,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn transactional_orphan_sweep_uses_only_non_deleted_entity_refs_as_live() {
+    async fn transactional_orphan_sweep_uses_all_attachment_refs_as_live() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("khive.db");
         let backend = crate::StorageBackend::sqlite(&db_path).unwrap();
         {
             let mut writer = backend.pool().writer().unwrap();
-            crate::run_migrations(writer.conn_mut()).unwrap();
+            prepare_completed_v21_gc_fixture(writer.conn_mut());
         }
         let store = FsBlobStore::new(dir.path().join("blobs"), 0)
             .unwrap()
@@ -3649,11 +4110,20 @@ mod tests {
             let writer = backend.pool().writer().unwrap();
             writer
                 .conn()
-                .execute(
+                .execute_batch(
                     "INSERT INTO entities \
-                     (id, namespace, kind, name, tags, created_at, updated_at, deleted_at, content_ref) \
-                     VALUES ('live', 'local', 'document', 'live', '[]', 1, 1, NULL, ?1), \
-                            ('deleted', 'local', 'document', 'deleted', '[]', 1, 1, 2, ?2)",
+                     (id, namespace, kind, name, tags, created_at, updated_at, deleted_at) \
+                     VALUES ('live', 'local', 'document', 'live', '[]', 1, 1, NULL), \
+                            ('deleted', 'local', 'document', 'deleted', '[]', 1, 1, 2);",
+                )
+                .unwrap();
+            writer
+                .conn()
+                .execute(
+                    "INSERT INTO attachments \
+                     (record_uuid, substrate, role, content_ref, created_at) \
+                     VALUES ('live', 'entity', 'content', ?1, 1), \
+                            ('deleted', 'entity', 'content', ?2, 1)",
                     rusqlite::params![live.as_str(), soft_deleted.as_str()],
                 )
                 .unwrap();
@@ -3663,7 +4133,7 @@ mod tests {
             .transactional_orphan_sweep(backend.sql().as_ref(), true)
             .await
             .unwrap();
-        assert_eq!(dry_run.would_delete, 2);
+        assert_eq!(dry_run.would_delete, 1);
         assert_eq!(dry_run.deleted, 0);
         assert!(store.exists(&soft_deleted).await.unwrap());
         assert!(store.exists(&orphan).await.unwrap());
@@ -3674,9 +4144,12 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.scanned, 3);
-        assert_eq!(result.deleted, 2);
+        assert_eq!(result.deleted, 1);
         assert!(store.exists(&live).await.unwrap());
-        assert!(!store.exists(&soft_deleted).await.unwrap());
+        assert!(
+            store.exists(&soft_deleted).await.unwrap(),
+            "soft delete retains attachment rows and their blobs"
+        );
         assert!(!store.exists(&orphan).await.unwrap());
     }
 
@@ -3684,36 +4157,36 @@ mod tests {
     async fn transactional_orphan_sweep_protects_a_freshly_published_blob_before_its_reference_commits(
     ) {
         // The exact two-step client protocol hazard: `put` completes and
-        // releases its write lock (step 1) while the entity write that will
+        // releases its write lock (step 1) while the attachment write that will
         // *later* commit a `content_ref` to this blob (step 2) has not
         // happened yet -- nothing in this store's locking serializes the
         // two, because they are separate calls the client makes with an
         // arbitrary gap in between. A sweep that lands in that gap must not
-        // delete the blob: `entities.content_ref` has no row for it yet
+        // delete the blob: `attachments.content_ref` has no row for it yet
         // purely because the referencing write hasn't landed, not because
         // it is actually orphaned. Without the publish-grace window this
         // reproduces khive#1313's dangling-reference defect: the blob file
-        // is deleted here, and the still-pending entity write below would
+        // is deleted here, and the still-pending attachment write below would
         // commit a `content_ref` to nothing.
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("khive.db");
         let backend = crate::StorageBackend::sqlite(&db_path).unwrap();
         {
             let mut writer = backend.pool().writer().unwrap();
-            crate::run_migrations(writer.conn_mut()).unwrap();
+            prepare_completed_v21_gc_fixture(writer.conn_mut());
         }
         // Default (non-zero) grace period -- this test exercises exactly
         // what it exists to protect.
         let store = FsBlobStore::new(dir.path().join("blobs"), 0).unwrap();
 
-        // Step 1: put completes, lock released. No entity anywhere
+        // Step 1: put completes, lock released. No attachment anywhere
         // references this blob yet.
         let blob = store
             .put(b"published, reference not yet committed".to_vec())
             .await
             .unwrap();
 
-        // A sweep runs in the gap before step 2 (the entity write) happens.
+        // A sweep runs in the gap before step 2 (the attachment write) happens.
         let result = store
             .transactional_orphan_sweep(backend.sql().as_ref(), false)
             .await
@@ -3733,7 +4206,7 @@ mod tests {
             "a blob still inside its publish grace period must survive the sweep"
         );
 
-        // Step 2 now lands: the entity write commits content_ref to the
+        // Step 2 now lands: the record-plus-attachment write commits content_ref to the
         // still-present blob.
         {
             let writer = backend.pool().writer().unwrap();
@@ -3741,9 +4214,18 @@ mod tests {
                 .conn()
                 .execute(
                     "INSERT INTO entities \
-                     (id, namespace, kind, name, tags, created_at, updated_at, deleted_at, content_ref) \
-                     VALUES ('e1', 'local', 'document', 'e1', '[]', 1, 1, NULL, ?1)",
-                    rusqlite::params![blob.as_str()],
+                     (id, namespace, kind, name, tags, created_at, updated_at, deleted_at) \
+                     VALUES ('e1', 'local', 'document', 'e1', '[]', 1, 1, NULL)",
+                    [],
+                )
+                .unwrap();
+            writer
+                .conn()
+                .execute(
+                    "INSERT INTO attachments \
+                     (record_uuid, substrate, role, content_ref, created_at) \
+                     VALUES ('e1', 'entity', 'content', ?1, 1)",
+                    [blob.as_str()],
                 )
                 .unwrap();
         }
@@ -3765,7 +4247,7 @@ mod tests {
         // touching the file at all -- so a stale, already-orphaned blob
         // re-published by an identical `put` kept its OLD mtime, bypassed
         // the publish-grace check, and a transactional sweep landing in the
-        // gap before the caller's follow-up entity write could delete it
+        // gap before the caller's follow-up attachment write could delete it
         // out from under that write (khive#1313). This reproduces the
         // race end to end and proves the mtime refresh closes it.
         let dir = tempfile::tempdir().unwrap();
@@ -3773,7 +4255,7 @@ mod tests {
         let backend = crate::StorageBackend::sqlite(&db_path).unwrap();
         {
             let mut writer = backend.pool().writer().unwrap();
-            crate::run_migrations(writer.conn_mut()).unwrap();
+            prepare_completed_v21_gc_fixture(writer.conn_mut());
         }
         let store = FsBlobStore::new(dir.path().join("blobs"), 0)
             .unwrap()
@@ -3793,12 +4275,12 @@ mod tests {
             .set_modified(old_mtime)
             .unwrap();
 
-        // A deduplicating put republishes the identical bytes. No entity
+        // A deduplicating put republishes the identical bytes. No attachment
         // anywhere references this blob yet.
         let second = store.put(bytes).await.unwrap();
         assert_eq!(first, second);
 
-        // The sweep lands in the gap before the follow-up entity write --
+        // The sweep lands in the gap before the follow-up attachment write --
         // the refreshed mtime must keep it inside the grace window.
         let result = store
             .transactional_orphan_sweep(backend.sql().as_ref(), false)
@@ -3815,16 +4297,25 @@ mod tests {
         );
         assert!(store.exists(&first).await.unwrap());
 
-        // The caller's follow-up entity write now lands.
+        // The caller's follow-up record-plus-attachment write now lands.
         {
             let writer = backend.pool().writer().unwrap();
             writer
                 .conn()
                 .execute(
                     "INSERT INTO entities \
-                     (id, namespace, kind, name, tags, created_at, updated_at, deleted_at, content_ref) \
-                     VALUES ('e1', 'local', 'document', 'e1', '[]', 1, 1, NULL, ?1)",
-                    rusqlite::params![first.as_str()],
+                     (id, namespace, kind, name, tags, created_at, updated_at, deleted_at) \
+                     VALUES ('e1', 'local', 'document', 'e1', '[]', 1, 1, NULL)",
+                    [],
+                )
+                .unwrap();
+            writer
+                .conn()
+                .execute(
+                    "INSERT INTO attachments \
+                     (record_uuid, substrate, role, content_ref, created_at) \
+                     VALUES ('e1', 'entity', 'content', ?1, 1)",
+                    [first.as_str()],
                 )
                 .unwrap();
         }
@@ -3880,7 +4371,7 @@ mod tests {
         let backend = crate::StorageBackend::sqlite(&db_path).unwrap();
         {
             let mut writer = backend.pool().writer().unwrap();
-            crate::run_migrations(writer.conn_mut()).unwrap();
+            prepare_completed_v21_gc_fixture(writer.conn_mut());
         }
         let store = FsBlobStore::new(dir.path().join("blobs"), 0)
             .unwrap()

--- a/crates/khive-db/tests/blob_conformance.rs
+++ b/crates/khive-db/tests/blob_conformance.rs
@@ -232,15 +232,23 @@ async fn assert_conforms(store: Arc<dyn BlobStore>) {
     ));
 
     // orphan_sweep dry-run against an empty live set reports would_delete
-    // for the object we just wrote, without touching it.
-    let sweep = store
+    // for the object we just wrote, without touching it -- unless this
+    // backend disables the caller-snapshot API outright in favor of a
+    // database-coordinated sweep (`FsBlobStore` in this compatibility
+    // release: ADR-111 §8, it has no epoch capability of its own), in which
+    // case a typed `Unsupported` refusal is the conforming outcome instead.
+    // Either way nothing is touched.
+    match store
         .orphan_sweep(&BlobOrphanSweepConfig {
             live_refs: Default::default(),
             dry_run: true,
         })
         .await
-        .expect("orphan_sweep dry-run");
-    assert!(sweep.would_delete >= 1);
+    {
+        Ok(sweep) => assert!(sweep.would_delete >= 1),
+        Err(StorageError::Unsupported { .. }) => {}
+        Err(other) => panic!("unexpected orphan_sweep error: {other:?}"),
+    }
     assert!(store
         .exists(&ref_a)
         .await

--- a/crates/khive-db/tests/blob_conformance.rs
+++ b/crates/khive-db/tests/blob_conformance.rs
@@ -150,7 +150,19 @@ impl BlobStore for FixtureBlobStore {
     }
 }
 
-async fn assert_conforms(store: Arc<dyn BlobStore>) {
+/// What a conforming backend's `orphan_sweep` must return. Only
+/// `FsBlobStore` gets the `TypedUnsupported` exception (ADR-111 §8: it has
+/// no epoch capability of its own in this compatibility release). Every
+/// other backend still implements a real caller-snapshot sweep and must
+/// keep returning a real report -- a regression that widens the exception
+/// to a backend that still retains real sweep behavior must fail here.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum OrphanSweepExpectation {
+    RealReport,
+    TypedUnsupported,
+}
+
+async fn assert_conforms(store: Arc<dyn BlobStore>, orphan_sweep: OrphanSweepExpectation) {
     let bytes = b"khive blob conformance suite".to_vec();
 
     // put is dedup-idempotent: two puts of the same bytes return the same
@@ -237,17 +249,30 @@ async fn assert_conforms(store: Arc<dyn BlobStore>) {
     // database-coordinated sweep (`FsBlobStore` in this compatibility
     // release: ADR-111 §8, it has no epoch capability of its own), in which
     // case a typed `Unsupported` refusal is the conforming outcome instead.
-    // Either way nothing is touched.
-    match store
-        .orphan_sweep(&BlobOrphanSweepConfig {
-            live_refs: Default::default(),
-            dry_run: true,
-        })
-        .await
-    {
-        Ok(sweep) => assert!(sweep.would_delete >= 1),
-        Err(StorageError::Unsupported { .. }) => {}
-        Err(other) => panic!("unexpected orphan_sweep error: {other:?}"),
+    // Every other backend still implements a real sweep and must keep
+    // returning a real, validated report -- a regression to `Unsupported`
+    // there is not a conforming outcome. Either way nothing is touched.
+    match (
+        orphan_sweep,
+        store
+            .orphan_sweep(&BlobOrphanSweepConfig {
+                live_refs: Default::default(),
+                dry_run: true,
+            })
+            .await,
+    ) {
+        (OrphanSweepExpectation::RealReport, Ok(sweep)) => assert!(sweep.would_delete >= 1),
+        (OrphanSweepExpectation::RealReport, Err(other)) => {
+            panic!("this backend must retain a real orphan_sweep report, got: {other:?}")
+        }
+        (OrphanSweepExpectation::TypedUnsupported, Err(StorageError::Unsupported { .. })) => {}
+        (OrphanSweepExpectation::TypedUnsupported, Ok(sweep)) => panic!(
+            "this backend is expected to refuse orphan_sweep with typed Unsupported, \
+             got a real report instead: {sweep:?}"
+        ),
+        (OrphanSweepExpectation::TypedUnsupported, Err(other)) => {
+            panic!("unexpected orphan_sweep error: {other:?}")
+        }
     }
     assert!(store
         .exists(&ref_a)
@@ -267,7 +292,7 @@ async fn assert_conforms(store: Arc<dyn BlobStore>) {
 #[tokio::test]
 async fn scripted_fixture_blob_store_conforms() {
     let store: Arc<dyn BlobStore> = Arc::new(FixtureBlobStore::default());
-    assert_conforms(store).await;
+    assert_conforms(store, OrphanSweepExpectation::RealReport).await;
 }
 
 #[tokio::test]
@@ -356,7 +381,7 @@ async fn fs_blob_store_conforms() {
             .expect("FsBlobStore::new")
             .with_orphan_sweep_grace(std::time::Duration::ZERO),
     );
-    assert_conforms(store).await;
+    assert_conforms(store, OrphanSweepExpectation::TypedUnsupported).await;
 }
 
 #[tokio::test]
@@ -380,7 +405,7 @@ async fn s3_blob_store_conforms_against_a_live_endpoint() {
         .with_prefix(format!("conformance-{}", uuid::Uuid::new_v4()));
     let store: Arc<dyn BlobStore> =
         Arc::new(S3BlobStore::new(config).expect("S3BlobStore::new against MinIO"));
-    assert_conforms(store).await;
+    assert_conforms(store, OrphanSweepExpectation::RealReport).await;
 }
 
 /// ADR-111 Amendment 2: `orphan_sweep`'s `ListObjectsV2`

--- a/crates/khive-storage/docs/api/blob-store.md
+++ b/crates/khive-storage/docs/api/blob-store.md
@@ -62,7 +62,7 @@ reference — that nothing live references `content_ref` for the duration of the
 call. A caller that races a reference write against a `delete` can dangle a
 live reference; this trait does not detect or prevent that.
 
-## `BlobStore::orphan_sweep` — concurrency hazard
+## `BlobStore::orphan_sweep` — concurrency hazard, disabled in this compatibility release
 
 The operator-side GC path (khive#292 deliverable 5) — an admin-side
 operation, not an MCP verb, mirroring `VectorStore::orphan_sweep`'s CLI-only
@@ -75,13 +75,17 @@ and passes it in.
 `live_refs` is a **snapshot** the caller assembled before the call.
 `orphan_sweep` has no way to detect a `content_ref` that becomes newly live
 between when that snapshot was taken and when the sweep runs; such a
-reference is deleted anyway (see `khive-db`'s
-`orphan_sweep_race_demonstrates_the_documented_quiescence_requirement` test,
-which reproduces exactly this). This trait provides no transactional
-coordination with a reference writer. **Callers MUST quiesce reference writes**
-(nothing may create a new `content_ref` reference) for the duration of
-snapshot-plus-sweep — a maintenance window, a single-writer admin CLI
-invocation with no live traffic, or equivalent.
+reference would be deleted anyway. This trait provides no transactional
+coordination with a reference writer, and — unlike
+`transactional_orphan_sweep` — it has no `SqlAccess` capability with which to
+prove a completed V21 attachment epoch either. **The filesystem
+implementation therefore returns typed `StorageError::Unsupported` for every
+call in this compatibility release, in both `dry_run` modes, regardless of
+`live_refs`.** A caller-assembled snapshot could otherwise delete an object a
+V20 SQL query cannot see as live (e.g. a moodboard FANN network), silently
+bypassing the epoch gate `transactional_orphan_sweep` enforces. Use
+`transactional_orphan_sweep` for all sweeps against a live database; there is
+currently no supported destructive path through `orphan_sweep`.
 
 A DB-coordinated sweep is available separately as
 `BlobStore::transactional_orphan_sweep`. The Phase4a filesystem implementation
@@ -95,9 +99,13 @@ retained-legacy, and ahead-of-V21 epochs return typed
 `StorageError::Unsupported` before waiting for the blob-root lock, walking
 files, or recovering abandoned claims.
 
-After that gate, the filesystem implementation acquires database/root ownership,
-captures the complete candidate set, and classifies file age outside SQLite's
-writer transaction. It revalidates the epoch under ownership, validates every
+After that gate, the filesystem implementation acquires database ownership (the
+process-local guard plus the cross-process advisory lock) and revalidates the
+epoch immediately, before ever waiting on the root guard/lock or walking the
+filesystem — closing the gap if external maintenance changed the schema
+between the read-only preflight and ownership. Only once that recheck passes
+does it acquire root ownership, capture the complete candidate set, and
+classify file age outside SQLite's writer transaction, then validate every
 attachment and claim reference before the functional fence probe. Malformed
 stored evidence returns its validation error, and a malformed schema or
 nonfunctional named fence returns its storage or typed `Unsupported` error;
@@ -120,10 +128,11 @@ GC implementation can interpret an exact completed V21 attachment epoch. The
 Phase4b cutover still requires every Phase4a application reader and writer to be
 quiesced first.
 
-The original `orphan_sweep` remains an offline-maintenance API for callers that
-already have a trusted `live_refs` snapshot. It intentionally retains its
-quiescence requirement for compatibility; concurrent callers must use
-`transactional_orphan_sweep`.
+The original caller-snapshot `orphan_sweep` is disabled on the filesystem
+backend in this compatibility release (see above); it is not an alternative
+path for callers who want to avoid the epoch gate. All sweeps against a live
+database must go through `transactional_orphan_sweep`.
 
 Default `orphan_sweep` implementation returns `StorageError::Unsupported`; the
-filesystem backend overrides it with a real directory walk. No silent no-op.
+filesystem backend currently returns the same typed refusal rather than
+performing a real directory walk. No silent no-op.

--- a/crates/khive-storage/docs/api/blob-store.md
+++ b/crates/khive-storage/docs/api/blob-store.md
@@ -55,11 +55,11 @@ raw store access is for metadata, mutation, and maintenance paths only.
 ## `BlobStore::delete` — concurrency hazard
 
 `delete` performs an unconditional physical removal with **no coordination
-against any entity that might reference `content_ref`**. It is safe to call
+against any record or attachment that might reference `content_ref`**. It is safe to call
 only when the caller has independently ensured — outside this trait,
-typically by quiescing whatever writer could attach a new `content_ref` to an
-entity — that nothing live references `content_ref` for the duration of the
-call. A caller that races an entity write against a `delete` can dangle a
+typically by quiescing every writer that could commit a new SQL liveness
+reference — that nothing live references `content_ref` for the duration of the
+call. A caller that races a reference write against a `delete` can dangle a
 live reference; this trait does not detect or prevent that.
 
 ## `BlobStore::orphan_sweep` — concurrency hazard
@@ -68,8 +68,8 @@ The operator-side GC path (khive#292 deliverable 5) — an admin-side
 operation, not an MCP verb, mirroring `VectorStore::orphan_sweep`'s CLI-only
 precedent (ADR-044). `BlobStore` has no visibility into SQL substrates
 (ADR-005 constraint 4: a trait instance talks to exactly one backend), so it
-cannot itself discover which content refs are still referenced by, e.g., the
-`entities.content_ref` column — the caller assembles `BlobOrphanSweepConfig.live_refs`
+cannot itself discover which content refs are still referenced by the active
+SQL liveness authority — the caller assembles `BlobOrphanSweepConfig.live_refs`
 and passes it in.
 
 `live_refs` is a **snapshot** the caller assembled before the call.
@@ -78,31 +78,47 @@ between when that snapshot was taken and when the sweep runs; such a
 reference is deleted anyway (see `khive-db`'s
 `orphan_sweep_race_demonstrates_the_documented_quiescence_requirement` test,
 which reproduces exactly this). This trait provides no transactional
-coordination with an entity writer. **Callers MUST quiesce entity writes**
+coordination with a reference writer. **Callers MUST quiesce reference writes**
 (nothing may create a new `content_ref` reference) for the duration of
 snapshot-plus-sweep — a maintenance window, a single-writer admin CLI
 invocation with no live traffic, or equivalent.
 
 A DB-coordinated sweep is available separately as
-`BlobStore::transactional_orphan_sweep`. The filesystem implementation acquires
-a database-scoped process mutex and `<database>.khive-blob-gc.lock` before the
-same root-local locks as `put`, captures the complete candidate set, and
-classifies file age before opening SQLite's writer transaction. Acquiring the
-database owner makes all pre-existing claims abandoned, including claims copied
-by a backup or left under a relocated root; validated abandoned rows are removed
-in batches of at most 128. Candidates then pass through bounded claim, physical
-delete, and cleanup batches of the same maximum size. Each short
-`SqlAccess::atomic_unit` anti-joins live entity references and commits durable
-`blob_gc_claims`; entity INSERT/UPDATE triggers reject a new live reference to a
-claimed digest. Physical deletion runs outside SQLite while both owner/root locks
-remain held, followed by a bounded SQL-only cleanup. A crash after claim commit
-leaves the fence durable and fail-closed; the next exclusive database owner
-rescans rather than resuming deletion blindly. A filesystem publisher in
-another process that begins while the sweep holds the advisory root lock waits;
-after release, `put` rechecks the target and republishes bytes removed as an
-orphan before returning the `ContentRef`. Direct filesystem mutation does not
-participate in the advisory-lock protocol. Backends that cannot provide both
-coordination boundaries return `Unsupported`.
+`BlobStore::transactional_orphan_sweep`. The Phase4a filesystem implementation
+first performs a read-only schema-epoch gate. Both `dry_run` and destructive
+calls are supported only when the database proves the named objects and epoch
+markers of the exact completed V21 attachment cutover: the complete marker and
+V21 ledger row, the attachment and claim tables/indexes, attachment
+INSERT/UPDATE claim fences, and no legacy entity content-ref
+column/index/triggers. V20, pending, incomplete, missing-required-object,
+retained-legacy, and ahead-of-V21 epochs return typed
+`StorageError::Unsupported` before waiting for the blob-root lock, walking
+files, or recovering abandoned claims.
+
+After that gate, the filesystem implementation acquires database/root ownership,
+captures the complete candidate set, and classifies file age outside SQLite's
+writer transaction. It revalidates the epoch under ownership, validates every
+attachment and claim reference before the functional fence probe. Malformed
+stored evidence returns its validation error, and a malformed schema or
+nonfunctional named fence returns its storage or typed `Unsupported` error;
+every such path fails closed before claim recovery or deletion. The sweep then
+removes validated abandoned rows in batches of at most 128. Each short
+`SqlAccess::atomic_unit` anti-joins every `attachments.content_ref` role and
+commits durable `blob_gc_claims`; attachment INSERT/UPDATE triggers reject a new
+live reference to a claimed digest. Physical deletion runs outside SQLite while
+ownership remains held, followed by bounded SQL-only cleanup. A crash after
+claim commit leaves the fence durable and fail-closed; the next exclusive owner
+rescans rather than resuming deletion blindly. Direct filesystem mutation does
+not participate in the advisory-lock protocol. Backends that cannot provide the
+coordination and epoch guarantees return `Unsupported`.
+
+Phase4a changes only this GC reader/fence behavior. It does not create
+attachments, register or run V21, backfill data, drop `entities.content_ref`, or
+make Phase4a application serving compatible with a V21 database. The positive
+mixed-version guarantee is deliberately narrower: an already-running Phase4a
+GC implementation can interpret an exact completed V21 attachment epoch. The
+Phase4b cutover still requires every Phase4a application reader and writer to be
+quiesced first.
 
 The original `orphan_sweep` remains an offline-maintenance API for callers that
 already have a trusted `live_refs` snapshot. It intentionally retains its

--- a/crates/khive-storage/src/blob.rs
+++ b/crates/khive-storage/src/blob.rs
@@ -212,16 +212,22 @@ pub trait BlobStore: Send + Sync + std::fmt::Debug + 'static {
     /// `dry_run` mode, report) those absent from `config.live_refs`.
     /// Operator-side GC path (khive#292 deliverable 5) — admin-only, not an
     /// MCP verb. Default returns `StorageError::Unsupported`; the filesystem
-    /// backend overrides it with a real directory walk.
+    /// backend currently returns the same typed refusal for every call (see
+    /// below) rather than performing a real directory walk.
     ///
     /// # Safety / concurrency hazard (ADR-111 §8, amended)
     ///
     /// `config.live_refs` is a **snapshot**; a `content_ref` that becomes
-    /// newly live between the snapshot and the sweep is deleted anyway.
-    /// **Callers MUST quiesce reference writes** for the duration of
+    /// newly live between the snapshot and the sweep would be deleted
+    /// anyway. **Callers MUST quiesce reference writes** for the duration of
     /// snapshot-plus-sweep. See `crates/khive-storage/docs/api/blob-store.md`
-    /// for the race repro. Concurrent callers must use
-    /// [`Self::transactional_orphan_sweep`] instead.
+    /// for the hazard. This API also has no [`SqlAccess`] capability with
+    /// which to prove a completed V21 attachment epoch, so — unlike
+    /// [`Self::transactional_orphan_sweep`] — it cannot honor that gate. The
+    /// filesystem backend therefore disables this method entirely in this
+    /// compatibility release, in both `dry_run` modes: concurrent AND
+    /// offline callers alike must use [`Self::transactional_orphan_sweep`]
+    /// instead.
     async fn orphan_sweep(
         &self,
         config: &BlobOrphanSweepConfig,

--- a/crates/khive-storage/src/blob.rs
+++ b/crates/khive-storage/src/blob.rs
@@ -143,7 +143,7 @@ pub struct BlobOrphanSweepResult {
     pub would_delete: u64,
     /// Objects with zero live references that were left alone because they
     /// are still inside their publish grace period — recently written and
-    /// not yet orphaned, just not yet referenced by an entity. Reported in
+    /// not yet orphaned, just not yet committed to the SQL liveness authority. Reported in
     /// both modes; never counted in `would_delete` or `deleted`.
     pub grace_period_skipped: u64,
 }
@@ -201,9 +201,9 @@ pub trait BlobStore: Send + Sync + std::fmt::Debug + 'static {
     /// # Safety / concurrency hazard (ADR-111 §8, amended)
     ///
     /// Unconditional physical removal with **no coordination against any
-    /// entity that might reference `content_ref`**. Safe to call only when
-    /// the caller has independently quiesced whatever writer could attach a
-    /// new `content_ref` to an entity for the duration of the call — this
+    /// record or attachment that might reference `content_ref`**. Safe to call only when
+    /// the caller has independently quiesced every writer that could commit a
+    /// new SQL liveness reference for the duration of the call — this
     /// trait does not detect or prevent a race. Offline-maintenance-only.
     /// See `crates/khive-storage/docs/api/blob-store.md`.
     async fn delete(&self, content_ref: &ContentRef) -> StorageResult<bool>;
@@ -218,7 +218,7 @@ pub trait BlobStore: Send + Sync + std::fmt::Debug + 'static {
     ///
     /// `config.live_refs` is a **snapshot**; a `content_ref` that becomes
     /// newly live between the snapshot and the sweep is deleted anyway.
-    /// **Callers MUST quiesce entity writes** for the duration of
+    /// **Callers MUST quiesce reference writes** for the duration of
     /// snapshot-plus-sweep. See `crates/khive-storage/docs/api/blob-store.md`
     /// for the race repro. Concurrent callers must use
     /// [`Self::transactional_orphan_sweep`] instead.
@@ -234,19 +234,19 @@ pub trait BlobStore: Send + Sync + std::fmt::Debug + 'static {
         })
     }
 
-    /// Select live entity references and sweep orphaned blobs behind a
+    /// Select canonical SQL liveness references and sweep orphaned blobs behind a
     /// database-coordinated, bounded claim protocol.
     ///
     /// Unlike [`Self::orphan_sweep`], this operation obtains liveness itself
     /// from `sql`; callers do not assemble a stale snapshot. `sql` must be the
-    /// same database capability used for the entity writes that own these
+    /// canonical main database capability used for the writes that own these
     /// references. Implementations must also ensure an object published after
     /// the sweep's candidate set is captured cannot be mistaken for an orphan,
     /// including when it is published between selecting live references and
     /// physical deletion. Implementations must not perform filesystem or
     /// other external I/O while holding the database writer transaction;
     /// durable claims/triggers or an equivalently fail-closed fence must keep
-    /// entity writes safe after each short transaction commits. Claim/result
+    /// liveness writes safe after each short transaction commits. Claim/result
     /// materialization and cleanup must have an explicit per-transaction
     /// cardinality bound rather than scale one writer hold with the complete
     /// object population. A file-backed `sql` implementation must expose its
@@ -258,7 +258,21 @@ pub trait BlobStore: Send + Sync + std::fmt::Debug + 'static {
     /// Backends that cannot provide both guarantees return
     /// `StorageError::Unsupported`.
     ///
-    /// Publishing a blob and committing the entity write that references it
+    /// The filesystem implementation is schema-epoch gated and supports both
+    /// report-only and destructive modes only when `sql` proves the exact
+    /// completed V21 attachment cutover: durable complete marker and ledger
+    /// row, attachment table/indexes and INSERT/UPDATE claim fences, and
+    /// absence of every legacy entity reference column/index/fence. V20,
+    /// pending, incomplete, missing-required-object, retained-legacy, and
+    /// ahead-of-V21 epochs return typed `Unsupported` before root locking,
+    /// filesystem walking, or abandoned-claim cleanup. Malformed stored
+    /// evidence or a nonfunctional named fence fails closed with its validation,
+    /// storage, or typed `Unsupported` error before claim cleanup or deletion.
+    /// Once admitted, every attachment role is live; soft deletion alone does
+    /// not make its blob collectible. This GC compatibility does not imply that
+    /// a Phase4a application reader or writer can serve a V21 database.
+    ///
+    /// Publishing a blob and committing the attachment write that references it
     /// are two separate client steps; nothing serializes them against this
     /// sweep. Implementations must therefore also give a just-published,
     /// not-yet-referenced object a bounded grace period before treating it as

--- a/docs/adr/ADR-111-blob-store.md
+++ b/docs/adr/ADR-111-blob-store.md
@@ -3,10 +3,12 @@
 **Status**: accepted
 **Date**: 2026-07-12 (amended 2026-07-13, PR #922; Amendment 2 accepted and implemented
 2026-07-17, PR #1054; Amendment 3
-accepted 2026-07-17; Amendment 4 accepted 2026-07-19)
+accepted 2026-07-17; Amendment 4 accepted 2026-07-19; attachment-GC compatibility epoch proposed
+2026-08-16 by ADR-160)
 **Authors**: khive maintainers
 **Amended by**: proposed [ADR-160](ADR-160-shared-pack-infrastructure.md), which requires
-backend-enforced bounded and digest-verified reads and retires public unbounded `get` on acceptance.
+backend-enforced bounded and digest-verified reads, retires public unbounded `get`, and introduces
+the two-release attachment-GC compatibility gate on acceptance.
 **Depends on**:
 
 - [ADR-005](ADR-005-storage-capability-traits.md) — Storage Capability Traits (trait-only capability
@@ -255,55 +257,74 @@ ever add references and let GC reconcile.
 paragraph above, as originally written, claimed this design "is never removed out from under a
 concurrent reader". That remains false for `delete` and the caller-snapshot
 `orphan_sweep(config)` API. Both are **offline-maintenance-only**, not safe to run against a live
-entity writer:
+reference writer:
 
 - `orphan_sweep`'s `live_refs` set is a **snapshot** the caller assembles before the call. Nothing
-  in `BlobStore` detects a `content_ref` that becomes newly live — an entity write lands
+  in `BlobStore` detects a `content_ref` that becomes newly live — a reference write lands
   referencing it — between when that snapshot was taken and when the sweep runs; such a blob is
   deleted anyway. `khive-db`'s
   `orphan_sweep_race_demonstrates_the_documented_quiescence_requirement` test reproduces this
   exactly, so the hazard is pinned in code, not just prose.
 - `delete` is an unconditional physical removal with the same class of hazard: any caller can
-  delete a `content_ref` an entity write races into existence a moment later, with no coordination
+  delete a `content_ref` a reference write races into existence a moment later, with no coordination
   from this trait.
 
 Run those two methods only when writes that could create a new `content_ref` reference are
 quiesced. `BlobStore::transactional_orphan_sweep(sql, dry_run)`, added by PR #1313, is the live-
-traffic alternative for backends that can coordinate both stores. The filesystem implementation:
+traffic alternative for backends that can coordinate both stores.
 
-1. acquires a canonical-database in-process lock and `<database>.khive-blob-gc.lock`, then the
-   canonical-root in-process and advisory write locks, and captures the complete blob candidate
-   set while publishers are excluded;
-2. outside SQLite, evaluates file age and prepares the complete candidate set;
-3. after validating durable evidence, removes claims abandoned by the previous database owner in
-   SQL-only transactions of at most 128 rows; ownership, not the mutable path-derived `root_key`,
-   makes root relocation and restored-backup recovery safe;
+**Attachment-cutover compatibility epoch (amended 2026-08-16, Phase4a).** The filesystem
+implementation no longer sweeps against V20 entity liveness. Both report-only and destructive
+calls first require the named objects and markers of the exact completed V21 attachment epoch: the
+durable complete marker and V21 ledger row; attachment and claim tables/indexes; attachment
+INSERT/UPDATE claim fences; and no legacy `entities.content_ref` column, index, or triggers. V20,
+pending, incomplete, missing-required-object, retained-legacy, and ahead-of-V21 epochs return typed
+`StorageError::Unsupported` before root locking, filesystem walking, or abandoned-claim cleanup.
+Malformed table/evidence reads fail with their validation or storage error, and a nonfunctional
+named fence returns typed `Unsupported`; all fail closed before claim cleanup or deletion.
+`dry_run` does not weaken this contract.
+
+Once admitted, the filesystem implementation:
+
+1. acquires database/root ownership, captures the complete blob candidate set while publishers are
+   excluded, and evaluates file age outside SQLite's writer transaction;
+2. rechecks the completed epoch under ownership, validates every attachment and claim reference,
+   and then proves the attachment INSERT/UPDATE fences function before any abandoned-claim cleanup;
+3. removes validated claims abandoned by the previous database owner in SQL-only transactions of
+   at most 128 rows; ownership, not the mutable path-derived `root_key`, makes root relocation and
+   restored-backup recovery safe;
 4. for each candidate batch of at most 128, enters a short, SQL-only `SqlAccess::atomic_unit`
-   (`BEGIN IMMEDIATE` on SQLite), selects distinct references from non-deleted entities, and
-   durably claims only absent candidates in `blob_gc_claims`;
-5. after that transaction commits, deletes only the claimed batch while retaining database/root
-   ownership; entity INSERT/UPDATE triggers reject a newly live reference to any active claim; and
+   (`BEGIN IMMEDIATE` on SQLite), anti-joins every `attachments.content_ref` role, and durably
+   claims only absent candidates in `blob_gc_claims`;
+5. after that transaction commits, deletes only the claimed batch while retaining ownership;
+   attachment INSERT/UPDATE triggers reject a newly live reference to any active claim; and
 6. removes that bounded claim batch in a second short SQL-only atomic unit before advancing, then
    releases all locks after the final batch.
 
 This yields two concurrency guarantees pinned by tests. A blob published after candidate capture
-is not in the sweep set and survives. A committed entity reference cannot appear between the
+is not in the sweep set and survives. A committed attachment reference cannot appear between the
 liveness query and physical deletion: SQLite's writer lock covers the anti-join plus claim commit,
 then the durable trigger fence covers the external deletion phase without monopolizing SQLite's
-single writer. Invalid stored `content_ref` or claim values fail closed rather than making the
-sweep delete against an incomplete live set. A crash after claim commit leaves a durable
-fail-closed row; the next exclusive database owner rescans the current root and liveness state,
-clears abandoned claims in bounded units, and freshly claims any still-eligible work. At no point
-does one writer transaction bind, mutate, or return more than 128 candidates, bounding claim-table
-and WAL work per writer hold.
+single writer. Invalid stored attachment or claim refs fail closed before the functional probe,
+claim recovery, or deletion. A crash after claim commit leaves a durable fail-closed row; the next
+exclusive database owner rescans the current root and liveness state, clears abandoned claims in
+bounded units, and freshly claims any still-eligible work. At no point does one writer transaction
+bind, mutate, or return more than 128 candidates, bounding claim-table and WAL work per writer hold.
 
-The guarantee still has a bounded publish gap. `put(bytes)` and the later entity write that stores
-its returned reference are separate client steps, outside one shared transaction. A candidate with
-no committed reference is therefore protected by file age: `FsBlobStore` defaults to a one-hour
-grace period, treats an unknown age as protected, and refreshes the mtime on a deduplicated `put`.
-A client whose put-to-reference gap exceeds the configured grace remains exposed to deletion.
-Tests cover a fresh unreferenced publish, deduplicated republication, zero-grace behavior, and
-deletion after grace expiry; the warning is not weakened beyond that evidence.
+The guarantee still has a bounded publish gap. `put(bytes)` and the later attachment write that
+stores its returned reference are separate client steps, outside one shared transaction. A
+candidate with no committed reference is therefore protected by file age: `FsBlobStore` defaults
+to a one-hour grace period, treats an unknown age as protected, and refreshes the mtime on a
+deduplicated `put`. A client whose put-to-reference gap exceeds the configured grace remains
+exposed to deletion. Tests cover a fresh unreferenced publish, deduplicated republication,
+zero-grace behavior, and deletion after grace expiry; the warning is not weakened beyond that
+evidence.
+
+Phase4a is only the compatibility fence. It does not create `attachments`, register or execute
+V21, backfill records, drop the legacy column, or make application serving V21-compatible. Before
+a later Phase4b cutover, operators first drain and restart-fence every pre-Phase4a binary, deploy
+Phase4a everywhere, and then quiesce every Phase4a application reader/writer. Only the GC method is
+mixed-V21 compatible; the Phase4b migration and serving changes are a separate follow-up.
 
 `S3BlobStore` does not override `transactional_orphan_sweep` and returns `Unsupported`; its
 caller-snapshot `orphan_sweep` has no publish-grace accounting and remains offline-maintenance-

--- a/docs/adr/ADR-111-blob-store.md
+++ b/docs/adr/ADR-111-blob-store.md
@@ -261,17 +261,29 @@ reference writer:
 
 - `orphan_sweep`'s `live_refs` set is a **snapshot** the caller assembles before the call. Nothing
   in `BlobStore` detects a `content_ref` that becomes newly live — a reference write lands
-  referencing it — between when that snapshot was taken and when the sweep runs; such a blob is
-  deleted anyway. `khive-db`'s
-  `orphan_sweep_race_demonstrates_the_documented_quiescence_requirement` test reproduces this
-  exactly, so the hazard is pinned in code, not just prose.
+  referencing it — between when that snapshot was taken and when the sweep runs; such a blob would
+  be deleted anyway. As of the amendment below, the filesystem backend closes this specific
+  destructive path in this compatibility release by refusing every call outright, rather than
+  narrowing the hazard.
 - `delete` is an unconditional physical removal with the same class of hazard: any caller can
   delete a `content_ref` a reference write races into existence a moment later, with no coordination
   from this trait.
 
-Run those two methods only when writes that could create a new `content_ref` reference are
-quiesced. `BlobStore::transactional_orphan_sweep(sql, dry_run)`, added by PR #1313, is the live-
-traffic alternative for backends that can coordinate both stores.
+Run `delete` only when writes that could create a new `content_ref` reference are quiesced.
+`BlobStore::transactional_orphan_sweep(sql, dry_run)`, added by PR #1313, is the live-traffic
+alternative for backends that can coordinate both stores.
+
+**Caller-snapshot `orphan_sweep` disabled on the filesystem backend (amended 2026-08-21).** This
+API has no `SqlAccess` capability of its own, so — unlike `transactional_orphan_sweep` — it cannot
+prove a completed V21 attachment epoch before deleting anything. A caller-assembled `live_refs`
+snapshot could delete an object a V20 SQL query cannot see as live (e.g. a moodboard FANN network),
+bypassing the epoch gate below entirely. `FsBlobStore::orphan_sweep` therefore returns typed
+`StorageError::Unsupported` for every call in this release, in both `dry_run` modes, matching the
+trait default; there is no destructive path through this method until a snapshot API can carry its
+own epoch proof. This does not affect `S3BlobStore`, whose `orphan_sweep` remains the
+offline-maintenance-only quiescence-required path described near the end of this section — the
+disablement is filesystem-specific because only the filesystem backend has a competing,
+epoch-gated `transactional_orphan_sweep` implementation to defer to.
 
 **Attachment-cutover compatibility epoch (amended 2026-08-16, Phase4a).** The filesystem
 implementation no longer sweeps against V20 entity liveness. Both report-only and destructive
@@ -286,10 +298,15 @@ named fence returns typed `Unsupported`; all fail closed before claim cleanup or
 
 Once admitted, the filesystem implementation:
 
-1. acquires database/root ownership, captures the complete blob candidate set while publishers are
-   excluded, and evaluates file age outside SQLite's writer transaction;
-2. rechecks the completed epoch under ownership, validates every attachment and claim reference,
-   and then proves the attachment INSERT/UPDATE fences function before any abandoned-claim cleanup;
+1. acquires database ownership (the process-local guard plus the cross-process advisory lock) and
+   immediately rechecks the completed epoch, before ever waiting on the root guard/lock or walking
+   the filesystem — this closes the gap if external maintenance changed the schema between the
+   read-only preflight above and ownership, and keeps the pre-lock refusal contract true for every
+   listed epoch, not only the one the preflight observed;
+2. only once that recheck passes, acquires root ownership, captures the complete blob candidate set
+   while publishers are excluded, evaluates file age outside SQLite's writer transaction, validates
+   every attachment and claim reference, and then proves the attachment INSERT/UPDATE fences
+   function before any abandoned-claim cleanup;
 3. removes validated claims abandoned by the previous database owner in SQL-only transactions of
    at most 128 rows; ownership, not the mutable path-derived `root_key`, makes root relocation and
    restored-backup recovery safe;

--- a/docs/adr/ADR-160-shared-pack-infrastructure.md
+++ b/docs/adr/ADR-160-shared-pack-infrastructure.md
@@ -276,11 +276,21 @@ guarantee. The current critical section may remain pack-local until a durable un
 is separately justified. Content-hash stripe maps, model locks, judgment locks, and unrelated pack
 locks are not extracted by this program.
 
-Attachment migration is ADR-121's coordinated cutover, not a separately merged prerequisite. The
-same merged change adds and backfills attachments, migrates every legacy reader/writer plus hard
-delete and GC reference queries (including moodboard's `"content"` and `"fann-network"` roles), and
-then drops `entities.content_ref`. There is no merged dual-source interval, no recreated
-`create_entity_with_content_ref`, and no second legacy column.
+Attachment migration is ADR-121's coordinated cutover, but its safe rollout is split across two
+releases. Phase4a is a compatibility fence only: it leaves V20 schema and data untouched and adds
+no attachment table, migration, backfill, pack writer, runtime reader, or column drop. Its
+filesystem transactional GC refuses both report-only and destructive sweeps in V20, pending,
+incomplete, missing-required-object, retained-legacy, or ahead-of-V21 epochs before root locking,
+walking, or claim cleanup. Malformed schema/evidence and nonfunctional named fences also fail
+closed before claim cleanup or deletion, though their validation/probe can occur after ownership
+and the filesystem walk. It sweeps only an exact completed V21 epoch, using every attachment role
+as liveness and the attachment INSERT/UPDATE claim fences.
+
+Phase4b is the separate follow-up that will add and backfill attachments, migrate every legacy
+reader/writer plus hard delete and GC reference query (including moodboard's `"content"` and
+`"fann-network"` roles), and then drop `entities.content_ref`. Phase4a does not ship that
+implementation. Phase4b has no serving interval over a dual source, recreates no
+`create_entity_with_content_ref`, and adds no second legacy column.
 
 The canonical main/core backend is the sole database that owns attachment rows and the sole SQL
 liveness authority passed to ADR-111's transactional sweep. Record-plus-attachment APIs route
@@ -298,12 +308,22 @@ The backfill verifies bundle/network references and both governed digests; missi
 corrupt evidence aborts the cutover for operator curation rather than guessing or silently
 invalidating a recoverable model.
 
-Because schema preparation currently precedes BlobStore installation, this cutover is a boot-gated,
-resumable two-stage migration within that one merged implementation:
+Because schema preparation currently precedes BlobStore installation, the Phase4b follow-up is a
+boot-gated, resumable two-stage migration. It may begin only after this release sequence:
+
+1. Drain every pre-Phase4a process and install a restart fence so no older binary that can still run
+   V20 GC can return. Deploy Phase4a to the complete fleet while the database remains V20.
+2. Confirm Phase4a transactional GC returns typed `Unsupported` in both modes on V20. This is the
+   intended compatibility state, not a reason to bypass the gate with caller-snapshot GC.
+3. Before Phase4b changes the database, quiesce every Phase4a application reader and writer. Only
+   its GC implementation understands an exact completed V21 epoch; Phase4a serving code remains a
+   V20 consumer and is not permitted to coexist with the V21 column drop.
+
+Phase4b, which is not implemented by the Phase4a change, then performs the coordinated boot work:
 
 1. Before recording any incomplete state, boot acquires ADR-111's same canonical-database GC
    ownership (in-process plus advisory lock), waiting for any incumbent transactional sweep, and
-   retains it through finalization. A versioned main-database migration then creates `attachments`,
+   retains it through finalization. A versioned main-database migration creates `attachments`,
    backfills legacy `"content"` rows, and records an incomplete migration state while retaining the
    old column and old GC fence.
 2. Before packs, requests, or GC start, boot installs the one shared BlobStore and `BlobHydrator`,
@@ -315,21 +335,22 @@ resumable two-stage migration within that one merged implementation:
    INSERT/UPDATE claim-fence triggers, removes the legacy entity claim triggers and
    `idx_entities_content_ref`, drops `entities.content_ref`, and marks the migration complete.
 
-This cutover migration is registered in the versioned schema ledger but invoked by the boot
-coordinator after GC ownership is acquired; it is not executed eagerly by the unconditional backend
-constructor. Blob-independent schema work may still run at ordinary backend open.
+The Phase4b cutover migration will be registered in the versioned schema ledger but invoked by the
+boot coordinator after GC ownership is acquired; it is not executed eagerly by the unconditional
+backend constructor. Blob-independent schema work may still run at ordinary backend open.
 
-A crash in either stage resumes from durable state; it never opens a serving or sweep window over
-the intermediate dual representation. Every daemon and administrative sweep entrypoint refuses to
-run while the durable migration marker is incomplete; restart reacquires GC ownership before
-resuming. The final schema contains no trigger or query that names the dropped entity column.
-Attachment publication racing an active `blob_gc_claims` row is rejected by the same durable fence
-that ADR-111 currently applies to entity publication.
+A Phase4b crash in either stage must resume from durable state and never open a serving or sweep
+window over the intermediate dual representation. Phase4a GC already refuses an incomplete marker;
+Phase4b daemon and administrative entrypoints must also refuse serving or sweeping until restart
+reacquires GC ownership and completes the cutover. The final schema contains no trigger or query
+that names the dropped entity column. Attachment publication racing an active `blob_gc_claims` row
+is rejected by the attachment fence.
 
-The migrated sweep validates every distinct `attachments.content_ref` and
-`blob_gc_claims.content_ref` as canonical `ContentRef` values before it commits any new claim or
-physical deletion. Corrupt liveness or claim evidence aborts the sweep with every blob preserved;
-moving the anti-join must not drop ADR-111's fail-closed value validation.
+The attachment-only sweep validates every distinct `attachments.content_ref` and
+`blob_gc_claims.content_ref` as canonical `ContentRef` values before the functional fence probe,
+abandoned-claim cleanup, any new claim, or physical deletion. Corrupt liveness or claim evidence
+aborts the sweep with every blob preserved; moving the anti-join must not drop ADR-111's fail-closed
+value validation.
 
 ADR-155's two generic pack obligations remain in force after this record supersedes it: a verb that
 requires an absent BlobStore fails closed with a typed unconfigured-capability error and never falls
@@ -852,12 +873,16 @@ The implementation sequence is normative:
    bundle/network reads; leave candidate checks metadata-only; delete unbounded `get`, the blob GET
    semaphore, and pack-local size/read/digest helpers without removing moodboard's decoded/raster
    preprocessing gate.
-4. **Attachment convergence.** Execute ADR-121's boot-gated coordinated cutover on the canonical
-   main backend: add/backfill the substrate while serving stays closed; after shared hydration is
-   installed, migrate every legacy reader, writer, hard-delete, GC query and claim fence plus
-   moodboard roles `"content"` and `"fann-network"`; reconstruct existing network roles only from
-   verified bundle/event evidence; cross-check the authenticated network reference; then finalize
-   and drop `entities.content_ref` in the same merged change. Reject secondary-backend anchors.
+4. **Attachment convergence.** Phase4a changes no V20 schema/data: transactional filesystem GC
+   refuses every non-complete-V21 epoch in both modes and uses attachment liveness/fences only after
+   exact completion. Drain and restart-fence every older binary before fleet-wide deployment.
+   Phase4b is a separate follow-up: with Phase4a application traffic quiesced, execute ADR-121's
+   boot-gated coordinated cutover on the canonical main backend; add/backfill the substrate while
+   serving stays closed; after shared hydration is installed, migrate every legacy reader, writer,
+   hard-delete, GC query and claim fence plus moodboard roles `"content"` and `"fann-network"`;
+   reconstruct existing network roles only from verified bundle/event evidence; cross-check the
+   authenticated network reference; then finalize and drop `entities.content_ref`. Reject
+   secondary-backend anchors. Phase4b is not part of the Phase4a PR.
 5. **Pure retrieval.** Reuse `union_fusion`, add the ranked-prefix controller, and migrate moodboard
    with exact one-shot overfetch/underfill parity.
 6. **Identity fence.** Introduce `EmbeddingSpaceIdentity`, preserve moodboard descriptor goldens,
@@ -904,6 +929,23 @@ last consumer.
   decode/normalization remains bounded exactly as before.
 
 ### Attachments and ranked materialization
+
+#### Phase4a GC compatibility
+
+- On an exact V20 database, both report-only and destructive transactional sweeps return typed
+  `Unsupported` before waiting for the root lock; every blob and abandoned claim remains unchanged.
+- Missing/malformed V21 objects, a pending or incomplete marker, a wrong/ahead ledger, retained
+  legacy column/index/fences, and same-named no-op attachment fences all fail closed.
+- On a synthetic exact completed V21 epoch, a Phase4a sweep treats every attachment role as live:
+  the moodboard preference bundle and its `"fann-network"` object survive while a true orphan is
+  reported/deleted.
+- Non-canonical attachment or GC-claim evidence aborts before the functional probe, abandoned-claim
+  cleanup, new claims, or deletion; a former probe-seed claim remains recoverable.
+- Rollout evidence proves every pre-Phase4a binary is drained and restart-fenced before Phase4a is
+  fleet-wide. Before Phase4b, every Phase4a application reader/writer is quiesced; the completed-V21
+  GC test is not evidence that Phase4a serving is mixed-schema compatible.
+
+#### Phase4b attachment cutover (follow-up, not in the Phase4a PR)
 
 - Original bytes publish and resolve through role `"content"`; existing wire content refs are
   unchanged.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -564,11 +564,20 @@ readers or writers, or drop `entities.content_ref`. Its filesystem
 destructive calls on V20, pending/incomplete V21, missing required objects, retained legacy
 objects, or a schema newer than the exact V21 contract. Malformed schema/evidence or nonfunctional
 named fences also fail closed, using the applicable validation, storage, or typed `Unsupported`
-error before claim cleanup or deletion. Do not bypass a refusal with caller-snapshot
-`orphan_sweep`; that API requires deployment-wide reference-write quiescence and cannot account
-for the moodboard FANN object missing from V20 SQL liveness.
+error before claim cleanup or deletion. There is no bypass through caller-snapshot `orphan_sweep`:
+that API is disabled outright in this release (typed `Unsupported` for every call, both `dry_run`
+modes) because it has no way to prove a completed V21 epoch and cannot account for the moodboard
+FANN object missing from V20 SQL liveness.
 
-Use this two-release rollout order:
+**What you can do today, right now, in this release:** back up, drain old binaries, and deploy
+Phase4a (steps 1-3 below). If a database's `attachment_cutover_state` marker is anything other than
+the exact completed V21 epoch — including "incomplete", missing, or partially applied — GC simply
+stays refused on both APIs, in both modes; the database and blob root are otherwise untouched.
+There is no restore, rollback, or marker-repair command shipped in this release, and none is
+required for the compatibility fence itself: an incomplete marker is not an error state to recover
+from, it is V20's normal, permanently-supported epoch as far as Phase4a GC is concerned.
+
+Use this rollout order for what Phase4a actually ships:
 
 1. Back up the canonical main database and inventory every process that can open it or the shared
    blob root, including daemons, one-shot admin jobs, and independently supervised replicas.
@@ -577,6 +586,12 @@ Use this two-release rollout order:
 3. Deploy Phase4a everywhere while the database remains V20. A typed V20 GC refusal in either mode
    is the expected safe state. Phase4a `db migrate` still knows only the V20 prefix and does not
    perform the attachment cutover.
+
+The following is **future design, not a runnable procedure in this release.** No Phase4b
+migration/serving tooling, boot gate, or durable-marker completion path exists in the committed
+migration registry today (it ends at V20) — do not treat the steps below as operator instructions;
+they describe what a later Phase4b release must do, once it ships:
+
 4. Before introducing Phase4b, quiesce every Phase4a application reader and writer. Only the
    Phase4a GC implementation can interpret an exact completed V21 attachment epoch; its serving,
    pack, runtime, and ordinary migration paths remain V20 consumers. Do not perform a rolling

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -555,6 +555,39 @@ none of its flags do anything yet.
 
 ## 4. Maintenance
 
+### Blob-GC attachment rollout: Phase4a before Phase4b
+
+Phase4a is a compatibility release, not the attachment migration. It leaves the database at V20:
+it does not create `attachments`, register or run V21, backfill records, change pack/runtime
+readers or writers, or drop `entities.content_ref`. Its filesystem
+`transactional_orphan_sweep` intentionally returns typed `Unsupported` for both report-only and
+destructive calls on V20, pending/incomplete V21, missing required objects, retained legacy
+objects, or a schema newer than the exact V21 contract. Malformed schema/evidence or nonfunctional
+named fences also fail closed, using the applicable validation, storage, or typed `Unsupported`
+error before claim cleanup or deletion. Do not bypass a refusal with caller-snapshot
+`orphan_sweep`; that API requires deployment-wide reference-write quiescence and cannot account
+for the moodboard FANN object missing from V20 SQL liveness.
+
+Use this two-release rollout order:
+
+1. Back up the canonical main database and inventory every process that can open it or the shared
+   blob root, including daemons, one-shot admin jobs, and independently supervised replicas.
+2. Drain every pre-Phase4a process. Install a restart fence (deployment revision pin, disabled old
+   unit, or equivalent) so an older binary cannot return and run V20 transactional GC.
+3. Deploy Phase4a everywhere while the database remains V20. A typed V20 GC refusal in either mode
+   is the expected safe state. Phase4a `db migrate` still knows only the V20 prefix and does not
+   perform the attachment cutover.
+4. Before introducing Phase4b, quiesce every Phase4a application reader and writer. Only the
+   Phase4a GC implementation can interpret an exact completed V21 attachment epoch; its serving,
+   pack, runtime, and ordinary migration paths remain V20 consumers. Do not perform a rolling
+   Phase4a/Phase4b serving cutover against one database.
+5. Run the future Phase4b boot-gated migration only with Phase4b tooling, keep serving closed until
+   its durable marker is complete, and then admit only Phase4b-or-newer application processes.
+
+Phase4b migration/serving support is a follow-up and is not present in the Phase4a release. The
+positive completed-V21 Phase4a GC regression exists to prove the compatibility fence itself; it is
+not an operator command or authorization to keep Phase4a application traffic live during cutover.
+
 ### `db migrate` / `db check`
 
 ```bash


### PR DESCRIPTION
Transplants #2013 onto main now that the phase-3 consumer migration (#2103) has landed; supersedes #2013, which was stacked on the pre-merge phase-3 branch.

Blob garbage collection is gated on a completed attachment epoch: GC refuses to collect while the attachment-epoch marker shows the cutover incomplete, so a partially migrated store never loses blobs that the pending attachment convergence still references. The ADR-160 phase table records the gate, and the operations guide documents the epoch marker and its recovery path.