### PR TITLE
feat(kg-editor): connect analysis results to the module inspector

### DIFF
--- a/apps/kg-editor/e2e/showcase.spec.ts
+++ b/apps/kg-editor/e2e/showcase.spec.ts
@@ -94,7 +94,8 @@ test("restores a shared investigation and follows browser back and forward", asy
   );
 
   await page.getByRole("searchbox", { name: "Find a module or path" }).fill(writer);
-  await page.getByRole("button", { name: `Inspect ${writer}` }).click();
+  await page.getByLabel("Module search results")
+    .getByRole("button", { name: `Inspect ${writer}` }).click();
   await expect(inspector.getByRole("heading", { level: 3 })).toHaveText(writer);
   await expect(page).toHaveURL(new RegExp(`module=${encodeURIComponent(writer)}`));
 
@@ -158,6 +159,52 @@ test("navigates from module to analysis using only the command palette", async (
   await expect(page).toHaveURL(/view=api_surface/);
   await expect(page).toHaveURL(new RegExp(`module=${encodeURIComponent(writer)}`));
   await expect(page.locator("[data-repository-dashboard]")).toBeFocused();
+});
+
+test("drills from analysis results into the shared inspector and browser history", async ({ page }) => {
+  await page.goto("/");
+  const panel = page.locator(".repo-view-panel");
+  const inspector = page.locator("[data-module-inspector]");
+
+  await page.locator('[data-view-id="api_surface"]').click();
+  const apiResult = panel.locator(
+    'button[aria-label^="Inspect "][aria-pressed="false"]',
+  ).first();
+  const apiLabel = await apiResult.getAttribute("aria-label");
+  const apiPath = apiLabel?.replace(/^Inspect /, "");
+  expect(apiPath).toBeTruthy();
+  await apiResult.press("Enter");
+  await expect(inspector).toBeFocused();
+  await expect(inspector.getByRole("heading", { level: 3 })).toHaveText(apiPath!);
+  await expect(page).toHaveURL(/view=api_surface/);
+  await expect(page).toHaveURL(new RegExp(`module=${encodeURIComponent(apiPath!)}`));
+
+  await page.locator('[data-view-id="structure_treemap"]').click();
+  const treemapResult = panel.locator(
+    'button[aria-label^="Inspect "][aria-pressed="false"]',
+  ).first();
+  const treemapLabel = await treemapResult.getAttribute("aria-label");
+  const treemapPath = treemapLabel?.replace(/^Inspect /, "");
+  expect(treemapPath).toBeTruthy();
+  await treemapResult.press("Enter");
+  await expect(inspector).toBeFocused();
+  await expect(inspector.getByRole("heading", { level: 3 })).toHaveText(
+    treemapPath!,
+  );
+  await expect(page).toHaveURL(/view=structure_treemap/);
+
+  await page.goBack();
+  await expect(page.locator('[data-view-id="structure_treemap"]')).toHaveAttribute(
+    "aria-current",
+    "page",
+  );
+  await expect(inspector.getByRole("heading", { level: 3 })).toHaveText(apiPath!);
+  await page.goBack();
+  await expect(page.locator('[data-view-id="api_surface"]')).toHaveAttribute(
+    "aria-current",
+    "page",
+  );
+  await expect(inspector.getByRole("heading", { level: 3 })).toHaveText(apiPath!);
 });
 
 test("a valid repository miss stays local and renders an honest state", async ({ page }) => {

--- a/apps/kg-editor/src/app/showcase.css
+++ b/apps/kg-editor/src/app/showcase.css
@@ -630,6 +630,33 @@ button.repo-list-row:hover,
 .repo-table td { border-top: 1px solid var(--repo-border); padding: 10px 11px; vertical-align: middle; }
 .repo-table td code { color: var(--repo-muted); font-size: var(--khive-type-sm); }
 .repo-table td strong { font-size: var(--khive-type-md); }
+.repo-module-action {
+  background: var(--khive-color-transparent);
+  border: 0;
+  border-radius: var(--khive-radius-sm);
+  color: inherit;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  font: inherit;
+  gap: 2px;
+  max-width: 100%;
+  padding: 3px 4px;
+  text-align: left;
+}
+.repo-module-action > strong,
+.repo-module-action > span { overflow: hidden; text-overflow: ellipsis; }
+.repo-module-action > span { color: var(--repo-muted); font-size: var(--khive-type-xs); }
+.repo-module-action:hover,
+.repo-module-action[aria-pressed="true"] { background: var(--khive-color-accent-soft); }
+.repo-module-action:focus-visible,
+.repo-treemap-module:focus-visible { outline: 2px solid var(--khive-color-accent); outline-offset: 2px; }
+.repo-module-action.compact { display: inline-flex; margin: 1px 2px; padding: 2px 4px; vertical-align: baseline; width: auto; }
+.repo-module-action.compact > strong { display: none; }
+.repo-module-action.compact > span { color: inherit; display: inline; font-size: inherit; }
+.repo-cycle-members { overflow: visible !important; text-overflow: clip !important; white-space: normal !important; }
+.repo-cycle-members > span { display: inline !important; overflow: visible !important; white-space: normal !important; }
+.repo-module-reference-missing { color: var(--khive-color-warning); display: inline; font-size: var(--khive-type-xs); overflow-wrap: anywhere; }
 .repo-inline-state { align-items: flex-start; color: var(--amber); display: inline-flex; font-size: var(--khive-type-xs); gap: 4px; margin-top: 4px; }
 .repo-inline-state > svg { flex: 0 0 auto; height: 10px; margin-top: 1px; width: 10px; }
 .repo-inline-state .data-state-copy { gap: 1px; }
@@ -677,11 +704,12 @@ button.repo-list-row:hover,
   grid-template-columns: repeat(12, 1fr);
   min-height: 420px;
 }
-.repo-treemap article {
+.repo-treemap-module {
   background: var(--khive-color-accent-soft);
   border: 1px solid var(--khive-color-border-strong);
   border-radius: var(--khive-radius-md);
   color: var(--khive-color-success);
+  font: inherit;
   min-height: 64px;
   overflow: hidden;
   padding: 9px;
@@ -689,11 +717,14 @@ button.repo-list-row:hover,
   width: 100%;
 }
 .repo-treemap > div { min-width: 0; }
-.repo-treemap article.hot { background: var(--khive-color-warning-soft); border-color: var(--khive-color-warning-soft); color: var(--khive-color-warning); }
-.repo-treemap article strong,
-.repo-treemap article span { display: block; overflow: hidden; text-overflow: ellipsis; }
-.repo-treemap article strong { font-size: var(--khive-type-md); white-space: nowrap; }
-.repo-treemap article span { font-size: var(--khive-type-xs); margin-top: 3px; }
+.repo-treemap-module { cursor: pointer; }
+.repo-treemap-module:hover,
+.repo-treemap-module[aria-pressed="true"] { box-shadow: inset 0 0 0 2px var(--khive-color-accent); }
+.repo-treemap-module.hot { background: var(--khive-color-warning-soft); border-color: var(--khive-color-warning-soft); color: var(--khive-color-warning); }
+.repo-treemap-module strong,
+.repo-treemap-module span { display: block; overflow: hidden; text-overflow: ellipsis; }
+.repo-treemap-module strong { font-size: var(--khive-type-md); white-space: nowrap; }
+.repo-treemap-module span { font-size: var(--khive-type-xs); margin-top: 3px; }
 
 .repo-score-grid { display: grid; gap: 10px; grid-template-columns: repeat(3, minmax(0, 1fr)); }
 .repo-score-card { background: var(--khive-color-surface-overlay); border: 1px solid var(--repo-border); border-radius: var(--khive-radius-lg); min-height: 126px; padding: 13px; }
@@ -702,6 +733,7 @@ button.repo-list-row:hover,
 .repo-score-value strong { color: var(--repo-navy); font-size: var(--khive-type-3xl); letter-spacing: -0.04em; overflow-wrap: anywhere; }
 .repo-score-value svg { color: var(--repo-green); height: 16px; width: 16px; }
 .repo-score-card p { color: var(--repo-muted); font-size: var(--khive-type-sm); line-height: 1.45; margin: 9px 0 0; }
+.repo-score-modules { display: flex; flex-wrap: wrap; gap: 3px; margin-top: 8px; }
 .repo-score-tags { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 8px; }
 .repo-score-tags i { background: var(--khive-color-surface-raised); border-radius: var(--khive-radius-pill); color: var(--repo-muted); font-size: var(--khive-type-xs); font-style: normal; padding: 3px 5px; }
 

--- a/apps/kg-editor/src/components/showcase/repo-showcase-drilldown.test.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase-drilldown.test.tsx
@@ -1,0 +1,344 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RepoShowcase } from "@/components/showcase/repo-showcase";
+import { buildModuleInsight, buildRepositoryBrief } from "@/lib/repository-brief";
+import {
+  parseRepoBundle,
+  type RepoBundle,
+  type ViewId,
+} from "@/lib/repo-bundle";
+
+const goldenPath = resolve(
+  process.cwd(),
+  "../../docs/schemas/examples/khive-repo-v1-khive.json",
+);
+
+const drilldownViews = [
+  "history_structure_navigation",
+  "dependency_topology",
+  "hotspot_quadrant",
+  "hidden_coupling",
+  "structure_treemap",
+  "ownership",
+  "api_surface",
+  "scorecard",
+] as const satisfies readonly ViewId[];
+
+function golden(): RepoBundle {
+  return parseRepoBundle(JSON.parse(readFileSync(goldenPath, "utf8")));
+}
+
+function chooseCapturedModule(
+  bundle: RepoBundle,
+  candidates: readonly string[],
+): string {
+  const captured = new Set(bundle.graph.modules.items.map((module) => module.id));
+  const defaultId = buildRepositoryBrief(bundle).startHere[0]?.moduleId ??
+    bundle.graph.modules.items[0]?.id;
+  const candidate = candidates.find((id) => id !== defaultId && captured.has(id)) ??
+    candidates.find((id) => captured.has(id));
+  if (!candidate) throw new Error("fixture has no captured module candidate");
+  return candidate;
+}
+
+function targetForView(bundle: RepoBundle, view: typeof drilldownViews[number]): string {
+  if (view === "history_structure_navigation") {
+    return chooseCapturedModule(
+      bundle,
+      bundle.graph.modules.items.map((module) => module.id),
+    );
+  }
+  if (view === "dependency_topology") {
+    return chooseCapturedModule(
+      bundle,
+      bundle.aggregates.dependency_topology.modules.items.map((row) =>
+        row.module_id
+      ),
+    );
+  }
+  if (view === "hotspot_quadrant") {
+    return chooseCapturedModule(
+      bundle,
+      bundle.aggregates.hotspot_quadrant.data.items.map((row) => row.module_id),
+    );
+  }
+  if (view === "hidden_coupling") {
+    return chooseCapturedModule(
+      bundle,
+      bundle.aggregates.hidden_coupling.data.items.flatMap((row) => [
+        row.right_module_id,
+        row.left_module_id,
+      ]),
+    );
+  }
+  if (view === "structure_treemap") {
+    return chooseCapturedModule(
+      bundle,
+      bundle.aggregates.structure_treemap.data.items.map((row) => row.module_id),
+    );
+  }
+  if (view === "ownership") {
+    return chooseCapturedModule(
+      bundle,
+      bundle.aggregates.ownership.modules.items.map((row) => row.module_id),
+    );
+  }
+  if (view === "api_surface") {
+    return chooseCapturedModule(
+      bundle,
+      bundle.aggregates.api_surface.data.items.map((row) => row.module_id),
+    );
+  }
+  const ids = bundle.aggregates.scorecard.fields.flatMap((field) =>
+    field.value.status === "available" &&
+      field.value.value.value_kind === "module_ids"
+      ? field.value.value.value.items
+      : []
+  );
+  return chooseCapturedModule(bundle, ids);
+}
+
+describe("repository showcase analysis drilldown", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    window.history.replaceState(null, "", "/");
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: vi.fn(),
+    });
+  });
+
+  it.each(drilldownViews)(
+    "opens a %s module result in the shared inspector without changing views",
+    async (view) => {
+      const bundle = golden();
+      const targetId = targetForView(bundle, view);
+      const target = bundle.graph.modules.items.find((module) =>
+        module.id === targetId
+      )!;
+      const user = userEvent.setup();
+      const { container } = render(<RepoShowcase bundle={bundle} />);
+
+      await user.click(screen.getByRole("button", {
+        name: bundle.capability.views[view].label,
+      }));
+      const pushState = vi.spyOn(window.history, "pushState");
+      pushState.mockClear();
+      const panel = container.querySelector<HTMLElement>(".repo-view-panel")!;
+      const control = within(panel).getAllByRole("button", {
+        name: `Inspect ${target.source_path}`,
+      })[0];
+      await user.click(control);
+
+      const inspector = container.querySelector<HTMLElement>(
+        "[data-module-inspector]",
+      )!;
+      await waitFor(() => expect(inspector).toHaveFocus());
+      expect(within(inspector).getByRole("heading", { level: 3 }))
+        .toHaveTextContent(target.source_path);
+      expect(control).toHaveAttribute("aria-pressed", "true");
+      expect(new URL(window.location.href).searchParams.get("view")).toBe(view);
+      expect(new URL(window.location.href).searchParams.get("module"))
+        .toBe(target.source_path);
+      expect(pushState).toHaveBeenCalledOnce();
+
+      await user.click(control);
+      expect(inspector).toHaveFocus();
+      expect(pushState).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("lets each coupling side and SCC member select its own module", async () => {
+    const bundle = golden();
+    const coupling = bundle.aggregates.hidden_coupling.data.items.find((row) =>
+      row.left_module_id !== row.right_module_id
+    )!;
+    const right = bundle.graph.modules.items.find((module) =>
+      module.id === coupling.right_module_id
+    )!;
+    const cycle = bundle.aggregates.dependency_topology.cycles.items.find(
+      (row) => row.module_ids.length > 1,
+    )!;
+    const cycleMember = bundle.graph.modules.items.find((module) =>
+      module.id === cycle.module_ids[1]
+    )!;
+    const user = userEvent.setup();
+    const { container } = render(<RepoShowcase bundle={bundle} />);
+
+    await user.click(screen.getByRole("button", {
+      name: bundle.capability.views.hidden_coupling.label,
+    }));
+    let panel = container.querySelector<HTMLElement>(".repo-view-panel")!;
+    await user.click(within(panel).getAllByRole("button", {
+      name: `Inspect ${right.source_path}`,
+    })[0]);
+    expect(new URL(window.location.href).searchParams.get("module"))
+      .toBe(right.source_path);
+
+    await user.click(screen.getByRole("button", {
+      name: bundle.capability.views.dependency_topology.label,
+    }));
+    panel = container.querySelector<HTMLElement>(".repo-view-panel")!;
+    const cycleRow = within(panel).getByText(cycle.id).closest(".repo-list-row")!;
+    await user.click(within(cycleRow as HTMLElement).getByRole("button", {
+      name: `Inspect ${cycleMember.source_path}`,
+    }));
+    expect(new URL(window.location.href).searchParams.get("module"))
+      .toBe(cycleMember.source_path);
+  });
+
+  it.each([
+    ["truncated", "truncated", "outside the captured module page"],
+    ["unavailable", "unavailable", "module page is unavailable"],
+    ["complete", "complete", "bundle integrity mismatch"],
+  ] as const)(
+    "renders a non-interactive %s state for an unresolved aggregate module",
+    async (_label, status, expectedReason) => {
+      const draft = structuredClone(golden());
+      const missingId = "module:not-captured";
+      draft.aggregates.api_surface.data.items[0].module_id = missingId;
+      draft.graph.modules.truncated = status === "truncated";
+      draft.graph.modules.next_cursor = status === "truncated"
+        ? "next-module-page"
+        : null;
+      draft.graph.modules.disclosure = status === "truncated"
+        ? { status, reason: "module page reached its bound" }
+        : status === "unavailable"
+        ? { status, reason: "module export was disabled" }
+        : { status };
+      if (status === "unavailable") {
+        draft.graph.modules.items = [];
+        draft.graph.modules.total_count = {
+          status: "unavailable",
+          reason: "module export was disabled",
+        };
+      }
+      const bundle = parseRepoBundle(draft);
+      const user = userEvent.setup();
+      const { container } = render(<RepoShowcase bundle={bundle} />);
+
+      await user.click(screen.getByRole("button", {
+        name: bundle.capability.views.api_surface.label,
+      }));
+      const panel = container.querySelector<HTMLElement>(".repo-view-panel")!;
+      const missing = panel.querySelector<HTMLElement>(
+        `[data-missing-module-id="${missingId}"]`,
+      );
+      expect(missing).toHaveTextContent(expectedReason);
+      expect(within(panel).queryByRole("button", {
+        name: `Inspect ${missingId}`,
+      })).not.toBeInTheDocument();
+    },
+  );
+
+  it("does not invent module drilldown for cadence-only results", async () => {
+    const bundle = golden();
+    const user = userEvent.setup();
+    const { container } = render(<RepoShowcase bundle={bundle} />);
+    await user.click(screen.getByRole("button", {
+      name: bundle.capability.views.cadence_timeline.label,
+    }));
+    const panel = container.querySelector<HTMLElement>(".repo-view-panel")!;
+    expect(within(panel).queryByRole("button", { name: /^Inspect / }))
+      .not.toBeInTheDocument();
+  });
+
+  it("follows the inspector's own fan-in, fan-out, and hidden-coupling links to their modules", async () => {
+    const bundle = golden();
+    const labels = bundle.capability.labels;
+    const target = bundle.graph.modules.items.find((module) => {
+      const insight = buildModuleInsight(bundle, module.id);
+      return insight != null &&
+        insight.dependents.length > 0 &&
+        insight.dependencies.length > 0 &&
+        insight.couplings.length > 0;
+    });
+    if (!target) {
+      throw new Error(
+        "fixture has no module with fan-in, fan-out, and hidden-coupling evidence",
+      );
+    }
+    const insight = buildModuleInsight(bundle, target.id)!;
+    const dependent = insight.dependents[0];
+    const dependency = insight.dependencies[0];
+    const coupling = insight.couplings[0];
+
+    const user = userEvent.setup();
+    const { container } = render(<RepoShowcase bundle={bundle} />);
+    const inspector = container.querySelector<HTMLElement>(
+      "[data-module-inspector]",
+    )!;
+
+    const search = screen.getByRole("searchbox", { name: "Find a module or path" });
+    await user.clear(search);
+    await user.type(search, target.source_path);
+    await user.click(within(screen.getByLabelText("Module search results"))
+      .getByRole("button", { name: `Inspect ${target.source_path}` }));
+    await waitFor(() =>
+      expect(within(inspector).getByRole("heading", { level: 3 }))
+        .toHaveTextContent(target.source_path)
+    );
+
+    const fanInSection = within(inspector)
+      .getByRole("heading", { level: 4, name: labels.metrics.fan_in })
+      .closest("section")!;
+    await user.click(within(fanInSection).getByRole("button", {
+      name: dependent.source_path,
+    }));
+    await waitFor(() =>
+      expect(within(inspector).getByRole("heading", { level: 3 }))
+        .toHaveTextContent(dependent.source_path)
+    );
+    expect(new URL(window.location.href).searchParams.get("module"))
+      .toBe(dependent.source_path);
+
+    await user.clear(search);
+    await user.type(search, target.source_path);
+    await user.click(within(screen.getByLabelText("Module search results"))
+      .getByRole("button", { name: `Inspect ${target.source_path}` }));
+    await waitFor(() =>
+      expect(within(inspector).getByRole("heading", { level: 3 }))
+        .toHaveTextContent(target.source_path)
+    );
+    const fanOutSection = within(inspector)
+      .getByRole("heading", { level: 4, name: labels.metrics.fan_out })
+      .closest("section")!;
+    await user.click(within(fanOutSection).getByRole("button", {
+      name: dependency.source_path,
+    }));
+    await waitFor(() =>
+      expect(within(inspector).getByRole("heading", { level: 3 }))
+        .toHaveTextContent(dependency.source_path)
+    );
+    expect(new URL(window.location.href).searchParams.get("module"))
+      .toBe(dependency.source_path);
+
+    await user.clear(search);
+    await user.type(search, target.source_path);
+    await user.click(within(screen.getByLabelText("Module search results"))
+      .getByRole("button", { name: `Inspect ${target.source_path}` }));
+    await waitFor(() =>
+      expect(within(inspector).getByRole("heading", { level: 3 }))
+        .toHaveTextContent(target.source_path)
+    );
+    const couplingSection = within(inspector)
+      .getByRole("heading", {
+        level: 4,
+        name: bundle.capability.views.hidden_coupling.label,
+      })
+      .closest("section")!;
+    await user.click(within(couplingSection).getByRole("button", {
+      name: coupling.module.source_path,
+    }));
+    await waitFor(() =>
+      expect(within(inspector).getByRole("heading", { level: 3 }))
+        .toHaveTextContent(coupling.module.source_path)
+    );
+    expect(new URL(window.location.href).searchParams.get("module"))
+      .toBe(coupling.module.source_path);
+  });
+});

--- a/apps/kg-editor/src/components/showcase/repo-showcase-drilldown.test.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase-drilldown.test.tsx
@@ -157,6 +157,9 @@ describe("repository showcase analysis drilldown", () => {
     const coupling = bundle.aggregates.hidden_coupling.data.items.find((row) =>
       row.left_module_id !== row.right_module_id
     )!;
+    const left = bundle.graph.modules.items.find((module) =>
+      module.id === coupling.left_module_id
+    )!;
     const right = bundle.graph.modules.items.find((module) =>
       module.id === coupling.right_module_id
     )!;
@@ -168,16 +171,43 @@ describe("repository showcase analysis drilldown", () => {
     )!;
     const user = userEvent.setup();
     const { container } = render(<RepoShowcase bundle={bundle} />);
+    const inspector = container.querySelector<HTMLElement>(
+      "[data-module-inspector]",
+    )!;
 
     await user.click(screen.getByRole("button", {
       name: bundle.capability.views.hidden_coupling.label,
     }));
     let panel = container.querySelector<HTMLElement>(".repo-view-panel")!;
-    await user.click(within(panel).getAllByRole("button", {
+    const couplingRow = within(panel).getAllByRole("button", {
       name: `Inspect ${right.source_path}`,
-    })[0]);
+    })
+      .map((button) => button.closest("tr")!)
+      .find((row) =>
+        within(row).queryByRole("button", {
+          name: `Inspect ${left.source_path}`,
+        })
+      )!;
+
+    await user.click(within(couplingRow).getByRole("button", {
+      name: `Inspect ${right.source_path}`,
+    }));
     expect(new URL(window.location.href).searchParams.get("module"))
       .toBe(right.source_path);
+    await waitFor(() =>
+      expect(within(inspector).getByRole("heading", { level: 3 }))
+        .toHaveTextContent(right.source_path)
+    );
+
+    await user.click(within(couplingRow).getByRole("button", {
+      name: `Inspect ${left.source_path}`,
+    }));
+    expect(new URL(window.location.href).searchParams.get("module"))
+      .toBe(left.source_path);
+    await waitFor(() =>
+      expect(within(inspector).getByRole("heading", { level: 3 }))
+        .toHaveTextContent(left.source_path)
+    );
 
     await user.click(screen.getByRole("button", {
       name: bundle.capability.views.dependency_topology.label,
@@ -229,7 +259,13 @@ describe("repository showcase analysis drilldown", () => {
         `[data-missing-module-id="${missingId}"]`,
       );
       expect(missing).toHaveTextContent(expectedReason);
+      expect(
+        panel.querySelector(`[data-module-id="${missingId}"]`),
+      ).not.toBeInTheDocument();
       expect(within(panel).queryByRole("button", {
+        name: `Inspect ${missingId}`,
+      })).not.toBeInTheDocument();
+      expect(within(panel).queryByRole("link", {
         name: `Inspect ${missingId}`,
       })).not.toBeInTheDocument();
     },

--- a/apps/kg-editor/src/components/showcase/repo-showcase-drilldown.test.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase-drilldown.test.tsx
@@ -257,17 +257,15 @@ describe("repository showcase analysis drilldown", () => {
       const panel = container.querySelector<HTMLElement>(".repo-view-panel")!;
       const missing = panel.querySelector<HTMLElement>(
         `[data-missing-module-id="${missingId}"]`,
-      );
+      )!;
       expect(missing).toHaveTextContent(expectedReason);
       expect(
         panel.querySelector(`[data-module-id="${missingId}"]`),
       ).not.toBeInTheDocument();
-      expect(within(panel).queryByRole("button", {
-        name: `Inspect ${missingId}`,
-      })).not.toBeInTheDocument();
-      expect(within(panel).queryByRole("link", {
-        name: `Inspect ${missingId}`,
-      })).not.toBeInTheDocument();
+      const missingRow = missing.closest("tr")!;
+      expect(missingRow).toBeInTheDocument();
+      expect(within(missingRow).queryAllByRole("button")).toHaveLength(0);
+      expect(within(missingRow).queryAllByRole("link")).toHaveLength(0);
     },
   );
 

--- a/apps/kg-editor/src/components/showcase/repo-showcase-layout.test.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase-layout.test.tsx
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -92,5 +92,72 @@ describe("repository showcase graph layout", () => {
     };
     rerender(<RepoShowcase bundle={replacedModulePage} />);
     expect(settleGraphLayoutSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it("reports the selected subtree's true totals, not the displayed slice, in the disclosure counts", async () => {
+    const draft = structuredClone(golden());
+    const moduleCountByPackage = new Map<string, number>();
+    for (const moduleItem of draft.graph.modules.items) {
+      moduleCountByPackage.set(
+        moduleItem.package_id,
+        (moduleCountByPackage.get(moduleItem.package_id) ?? 0) + 1,
+      );
+    }
+    const [targetPackageId, baselineCount] = [...moduleCountByPackage.entries()]
+      .sort((left, right) => right[1] - left[1])[0];
+    const template = draft.graph.modules.items.find((module) =>
+      module.package_id === targetPackageId
+    )!;
+    const extraModules = Array.from(
+      { length: Math.max(0, 50 - baselineCount) },
+      (_, index) => ({
+        ...template,
+        id: `${template.id}-subtree-cap-${index}`,
+        source_path: `${template.source_path}.subtree-cap-${index}`,
+      }),
+    );
+    draft.graph.modules.items.push(...extraModules);
+    if (draft.graph.modules.total_count.status === "available") {
+      draft.graph.modules.total_count.value = draft.graph.modules.items.length;
+    }
+    const bundle = parseRepoBundle(draft);
+    const labels = bundle.capability.labels;
+    const totalPackages = bundle.graph.packages.items.length;
+    const totalModulesInPackage = bundle.graph.modules.items.filter((module) =>
+      module.package_id === targetPackageId
+    ).length;
+    expect(totalPackages).toBeGreaterThan(8);
+    expect(totalModulesInPackage).toBeGreaterThan(42);
+
+    const user = userEvent.setup();
+    const { container } = render(<RepoShowcase bundle={bundle} />);
+    await waitFor(() => expect(settleGraphLayoutSpy).toHaveBeenCalledTimes(1));
+
+    const card = container.querySelector<HTMLElement>(".repo-card")!;
+    const packageDisclosure = within(card)
+      .getByText(`${labels.node_types.package} ${labels.truncated.toLocaleLowerCase()}`)
+      .closest('[data-state="truncated"]') as HTMLElement;
+    expect(packageDisclosure).toHaveAttribute("data-shown", "8");
+    expect(packageDisclosure).toHaveAttribute(
+      "data-known-total",
+      String(totalPackages),
+    );
+
+    await user.selectOptions(
+      screen.getByRole("combobox", {
+        name:
+          `${labels.node_types.package} · ${bundle.capability.views.structure_graph.label}`,
+      }),
+      targetPackageId,
+    );
+
+    const moduleDisclosure = within(card)
+      .getByText(`${labels.node_types.module} ${labels.truncated.toLocaleLowerCase()}`)
+      .closest('[data-state="truncated"]') as HTMLElement;
+    expect(moduleDisclosure).toHaveAttribute("data-shown", "42");
+    expect(moduleDisclosure).toHaveAttribute(
+      "data-known-total",
+      String(totalModulesInPackage),
+    );
   });
 });

--- a/apps/kg-editor/src/components/showcase/repo-showcase.test.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase.test.tsx
@@ -65,7 +65,8 @@ describe("repository showcase", () => {
     const pushState = vi.spyOn(window.history, "pushState");
     const search = screen.getByRole("searchbox", { name: "Find a module or path" });
     await user.type(search, writer.source_path);
-    await user.click(screen.getByRole("button", { name: `Inspect ${writer.source_path}` }));
+    await user.click(within(screen.getByLabelText("Module search results"))
+      .getByRole("button", { name: `Inspect ${writer.source_path}` }));
     await waitFor(() =>
       expect(within(inspector).getByRole("heading", { level: 3 })).toHaveTextContent(
         writer.source_path,

--- a/apps/kg-editor/src/components/showcase/repo-showcase.test.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase.test.tsx
@@ -116,6 +116,29 @@ describe("repository showcase", () => {
     expect(pushState).toHaveBeenCalledTimes(2);
     await waitFor(() => expect(inspector).toHaveFocus());
     expect(scrollIntoView).toHaveBeenCalled();
+
+    // An unresolved history restore must not move focus or scroll: the inspector
+    // has no restored module to show, so yanking focus there would strand the user.
+    scrollIntoView.mockClear();
+    inspector.blur();
+    expect(inspector).not.toHaveFocus();
+    const unresolvedRestore = repositoryLocationUrl(new URL(window.location.href), {
+      repository: bundle.meta.repository.canonical_url,
+      snapshotSha: bundle.meta.snapshot.head_sha,
+      modulePath: "crates/not-captured/src/missing.rs",
+      view: "dependency_topology",
+    });
+    window.history.replaceState(null, "", unresolvedRestore);
+    window.dispatchEvent(new PopStateEvent("popstate"));
+    await waitFor(() =>
+      expect(
+        screen.getByRole("status", { name: "Investigation navigation" }),
+      ).toHaveTextContent(
+        `Restored ${bundle.capability.views.dependency_topology.label} for unresolved module crates/not-captured/src/missing.rs.`,
+      )
+    );
+    expect(inspector).not.toHaveFocus();
+    expect(scrollIntoView).not.toHaveBeenCalled();
     // Measured ~1.1-2.2s locally for this golden-fixture, multi-navigation flow; full-suite
     // CPU contention pushed it past the default 5s timeout, so this needs headroom.
   }, 20_000);

--- a/apps/kg-editor/src/components/showcase/repo-showcase.test.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase.test.tsx
@@ -88,6 +88,14 @@ describe("repository showcase", () => {
     await user.click(hiddenCoupling);
     expect(pushState).toHaveBeenCalledTimes(2);
 
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(inspector, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoView,
+    });
+    inspector.blur();
+    expect(inspector).not.toHaveFocus();
+
     window.history.replaceState(null, "", direct);
     window.dispatchEvent(new PopStateEvent("popstate"));
     await waitFor(() =>
@@ -106,6 +114,8 @@ describe("repository showcase", () => {
       `Restored ${bundle.capability.views.dependency_topology.label} for ${pool.source_path}.`,
     );
     expect(pushState).toHaveBeenCalledTimes(2);
+    await waitFor(() => expect(inspector).toHaveFocus());
+    expect(scrollIntoView).toHaveBeenCalled();
     // Measured ~1.1-2.2s locally for this golden-fixture, multi-navigation flow; full-suite
     // CPU contention pushed it past the default 5s timeout, so this needs headroom.
   }, 20_000);

--- a/apps/kg-editor/src/components/showcase/repo-showcase.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase.tsx
@@ -1137,10 +1137,12 @@ export function RepoShowcase({ bundle, analysisSource = "curated-static-fallback
       const requestedPath = parsed.location.modulePath;
       let nextModuleId: string | null = defaultModuleId;
       let nextUnresolved: typeof unresolvedModule = null;
+      let resolvedModuleRestore = false;
       if (requestedPath) {
         const matches = modulesBySourcePath.get(requestedPath) ?? [];
         if (matches.length === 1) {
           nextModuleId = matches[0].id;
+          resolvedModuleRestore = true;
         } else {
           nextModuleId = null;
           nextUnresolved = {
@@ -1185,6 +1187,7 @@ export function RepoShowcase({ bundle, analysisSource = "curated-static-fallback
         setNavigationStatus(
           `Restored ${capability.views[nextView].label} for ${moduleLabel}.`,
         );
+        if (resolvedModuleRestore) focusAndScrollInspector();
       }
 
       const canonical = repositoryLocationUrl(
@@ -1352,9 +1355,7 @@ export function RepoShowcase({ bundle, analysisSource = "curated-static-fallback
     });
   }
 
-  function inspectModule(moduleId: string) {
-    if (!moduleById.has(moduleId)) return;
-    selectModule(moduleId);
+  function focusAndScrollInspector() {
     const inspector = moduleInspectorRef.current;
     if (!inspector) return;
     inspector.focus({ preventScroll: true });
@@ -1365,6 +1366,12 @@ export function RepoShowcase({ bundle, analysisSource = "curated-static-fallback
       behavior: reduceMotion ? "auto" : "smooth",
       block: "start",
     });
+  }
+
+  function inspectModule(moduleId: string) {
+    if (!moduleById.has(moduleId)) return;
+    selectModule(moduleId);
+    focusAndScrollInspector();
   }
   return (
     <article className="repo-overview" data-head-sha={snapshot.head_sha} data-analysis-source={analysisSource}>

--- a/apps/kg-editor/src/components/showcase/repo-showcase.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase.tsx
@@ -63,7 +63,7 @@ type ViewProps = Readonly<{
   bundle: RepoBundle;
   moduleById: ModuleMap;
   selectedModuleId: string | null;
-  onSelectModule: (moduleId: string) => void;
+  onInspectModule: (moduleId: string) => void;
   onExploreStructure: () => void;
 }>;
 
@@ -132,6 +132,53 @@ function isKnownEmptyRepoPage<T>(page: RepoPage<T>): boolean {
     && page.disclosure.status === "complete"
     && !page.truncated
     && page.next_cursor == null;
+}
+
+function ModuleInspectionControl({
+  moduleId,
+  moduleById,
+  modulePage,
+  selectedModuleId,
+  onInspectModule,
+  className = "",
+}: {
+  moduleId: string;
+  moduleById: ModuleMap;
+  modulePage: RepoBundle["graph"]["modules"];
+  selectedModuleId: string | null;
+  onInspectModule: (moduleId: string) => void;
+  className?: string;
+}) {
+  const moduleNode = moduleById.get(moduleId);
+  if (!moduleNode) {
+    const reason = modulePage.disclosure.status === "unavailable"
+      ? `module page is unavailable${modulePage.disclosure.reason ? ` · ${modulePage.disclosure.reason}` : ""}`
+      : isIncompleteRepoPage(modulePage)
+      ? "outside the captured module page"
+      : "bundle integrity mismatch";
+    return (
+      <span
+        className="repo-module-reference-missing"
+        data-missing-module-id={moduleId}
+      >
+        <code>{moduleId}</code> · {reason}
+      </span>
+    );
+  }
+  return (
+    <button
+      type="button"
+      className={`repo-module-action ${className}`.trim()}
+      data-module-id={moduleId}
+      aria-label={`Inspect ${moduleNode.source_path}`}
+      aria-controls="repository-module-inspector"
+      aria-pressed={selectedModuleId === moduleId}
+      onClick={() => onInspectModule(moduleId)}
+    >
+      <strong>{moduleNode.module_path}</strong>
+      <span>{moduleNode.source_path}</span>
+    </button>
+  );
 }
 
 function BoundDisclosure<T>({ page, labels }: { page: RepoPage<T>; labels: Labels }) {
@@ -308,8 +355,8 @@ function StructureGraph({ bundle }: { bundle: RepoBundle }) {
     displayedPackages,
     positions,
     selectablePackages,
-    subtreeModules,
-    subtreePackages,
+    subtreeModuleCount,
+    subtreePackageCount,
     visibleIds,
   } = useMemo(() => {
     const nextSubtreePackages = subtreeId === graph.repository.id
@@ -373,8 +420,8 @@ function StructureGraph({ bundle }: { bundle: RepoBundle }) {
       displayedPackages: nextDisplayedPackages,
       positions: nextPositions,
       selectablePackages: nextSelectablePackages,
-      subtreeModules: nextSubtreeModules,
-      subtreePackages: nextSubtreePackages,
+      subtreeModuleCount: nextSubtreeModules.length,
+      subtreePackageCount: nextSubtreePackages.length,
       visibleIds: nextVisibleIds,
     };
   }, [
@@ -552,8 +599,8 @@ function StructureGraph({ bundle }: { bundle: RepoBundle }) {
           ))}
         </ul>
         <LocalSliceDisclosure shown={displayedEdges.length} total={graph.structure_edges.items.length} label={capability.views.structure_graph.label} labels={labels} />
-        <LocalSliceDisclosure shown={displayedPackages.length} total={subtreePackages.length} label={labels.node_types.package} labels={labels} />
-        <LocalSliceDisclosure shown={displayedModules.length} total={subtreeModules.length} label={labels.node_types.module} labels={labels} />
+        <LocalSliceDisclosure shown={displayedPackages.length} total={subtreePackageCount} label={labels.node_types.package} labels={labels} />
+        <LocalSliceDisclosure shown={displayedModules.length} total={subtreeModuleCount} label={labels.node_types.module} labels={labels} />
       </div>
       <BoundDisclosure page={graph.packages} labels={labels} />
       <BoundDisclosure page={graph.modules} labels={labels} />
@@ -632,7 +679,7 @@ function HistoryFacet({
 function HistoryStructure({
   bundle,
   selectedModuleId,
-  onSelectModule,
+  onInspectModule,
   onExploreStructure,
 }: ViewProps) {
   const { graph, capability } = bundle;
@@ -667,7 +714,7 @@ function HistoryStructure({
           <div className="repo-card-heading"><h3>{labels.node_types.module}</h3><p>{formatNumber(modules.length)}</p></div>
           <div className="repo-list">
             {modules.map((module) => (
-              <button type="button" data-module-id={module.id} aria-pressed={selectedModuleId === module.id} className={`repo-list-row ${selectedModuleId === module.id ? "selected" : ""}`} key={module.id} onClick={() => { onSelectModule(module.id); setCommitSelection({ moduleId: module.id, commitId: "" }); }}>
+              <button type="button" data-module-id={module.id} aria-label={`Inspect ${module.source_path}`} aria-controls="repository-module-inspector" aria-pressed={selectedModuleId === module.id} className={`repo-list-row ${selectedModuleId === module.id ? "selected" : ""}`} key={module.id} onClick={() => { onInspectModule(module.id); setCommitSelection({ moduleId: module.id, commitId: "" }); }}>
                 <Boxes aria-hidden="true" /><div><strong>{module.module_path}</strong><span>{module.source_path}</span></div>
               </button>
             ))}
@@ -769,7 +816,7 @@ function HistoryStructure({
   );
 }
 
-function DependencyTopology({ bundle, moduleById, onExploreStructure }: ViewProps) {
+function DependencyTopology({ bundle, moduleById, selectedModuleId, onInspectModule, onExploreStructure }: ViewProps) {
   const analysis = bundle.aggregates.dependency_topology;
   const labels = bundle.capability.labels;
   const moduleRows = analysis.modules.items.slice(0, UI_ROW_LIMIT);
@@ -779,14 +826,14 @@ function DependencyTopology({ bundle, moduleById, onExploreStructure }: ViewProp
       <section className="repo-card repo-table-wrap">
         <table className="repo-table">
           <thead><tr><th>{labels.node_types.module}</th><th>{labels.metrics.fan_in}</th><th>{labels.metrics.fan_out}</th><th>{labels.metrics.cycle_count}</th></tr></thead>
-          <tbody>{moduleRows.map((row) => <tr key={row.module_id}><td><strong>{moduleName(moduleById, row.module_id)}</strong></td><td>{formatNumber(row.fan_in)}</td><td>{formatNumber(row.fan_out)}</td><td>{formatNumber(row.cycle_ids.length)}</td></tr>)}</tbody>
+          <tbody>{moduleRows.map((row) => <tr key={row.module_id}><td><ModuleInspectionControl moduleId={row.module_id} moduleById={moduleById} modulePage={bundle.graph.modules} selectedModuleId={selectedModuleId} onInspectModule={onInspectModule} /></td><td>{formatNumber(row.fan_in)}</td><td>{formatNumber(row.fan_out)}</td><td>{formatNumber(row.cycle_ids.length)}</td></tr>)}</tbody>
         </table>
         <LocalSliceDisclosure shown={moduleRows.length} total={analysis.modules.items.length} label={labels.node_types.module} labels={labels} />
         <BoundDisclosure page={analysis.modules} labels={labels} />
       </section>
       <section className="repo-card">
         <div className="repo-card-heading"><h3>{labels.metrics.cycle_count}</h3><p>{formatNumber(analysis.cycles.items.length)}</p></div>
-        <div className="repo-list">{cycleRows.map((cycle) => <div className="repo-list-row" key={cycle.id}><GitFork aria-hidden="true" /><div><strong>{cycle.id}</strong><span>SCC members: {cycle.module_ids.map((id) => moduleName(moduleById, id)).join(" · ")}</span></div></div>)}</div>
+        <div className="repo-list">{cycleRows.map((cycle) => <div className="repo-list-row" key={cycle.id}><GitFork aria-hidden="true" /><div><strong>{cycle.id}</strong><span className="repo-cycle-members">SCC members: {cycle.module_ids.map((id, index) => <span key={id}><ModuleInspectionControl moduleId={id} moduleById={moduleById} modulePage={bundle.graph.modules} selectedModuleId={selectedModuleId} onInspectModule={onInspectModule} className="compact" />{index < cycle.module_ids.length - 1 ? " · " : ""}</span>)}</span></div></div>)}</div>
         {isKnownEmptyRepoPage(analysis.cycles) && <DataState className="repo-empty" state="empty" title="No dependency cycles in this bundle" message="Dependency cycles found by the captured topology analysis belong here." action={{ label: "Explore repository structure", onClick: onExploreStructure }} />}
         <LocalSliceDisclosure shown={cycleRows.length} total={analysis.cycles.items.length} label={labels.metrics.cycle_count} labels={labels} />
         <BoundDisclosure page={analysis.cycles} labels={labels} />
@@ -795,7 +842,7 @@ function DependencyTopology({ bundle, moduleById, onExploreStructure }: ViewProp
   );
 }
 
-function HotspotQuadrantView({ bundle, moduleById }: { bundle: RepoBundle; moduleById: ModuleMap }) {
+function HotspotQuadrantView({ bundle, moduleById, selectedModuleId, onInspectModule }: ViewProps) {
   const analysis = bundle.aggregates.hotspot_quadrant;
   const labels = bundle.capability.labels;
   const rows = analysis.data.items.slice(0, UI_ROW_LIMIT);
@@ -818,7 +865,7 @@ function HotspotQuadrantView({ bundle, moduleById }: { bundle: RepoBundle; modul
         </svg>
       </div>
       <section className="repo-card repo-table-wrap">
-        <table className="repo-table"><thead><tr><th>{labels.node_types.module}</th><th>{labels.metrics.change_frequency}</th><th>{labels.metrics.fan_in}</th><th>{bundle.capability.views.hotspot_quadrant.label}</th></tr></thead><tbody>{rows.map((row) => <tr key={row.module_id}><td><strong>{moduleName(moduleById, row.module_id)}</strong></td><td>{row.commit_count}</td><td>{row.fan_in}</td><td>{labels.hotspot_quadrants[row.quadrant]}</td></tr>)}</tbody></table>
+        <table className="repo-table"><thead><tr><th>{labels.node_types.module}</th><th>{labels.metrics.change_frequency}</th><th>{labels.metrics.fan_in}</th><th>{bundle.capability.views.hotspot_quadrant.label}</th></tr></thead><tbody>{rows.map((row) => <tr key={row.module_id}><td><ModuleInspectionControl moduleId={row.module_id} moduleById={moduleById} modulePage={bundle.graph.modules} selectedModuleId={selectedModuleId} onInspectModule={onInspectModule} /></td><td>{row.commit_count}</td><td>{row.fan_in}</td><td>{labels.hotspot_quadrants[row.quadrant]}</td></tr>)}</tbody></table>
         <LocalSliceDisclosure shown={rows.length} total={analysis.data.items.length} label={bundle.capability.views.hotspot_quadrant.label} labels={labels} />
         <BoundDisclosure page={analysis.data} labels={labels} />
       </section>
@@ -826,14 +873,14 @@ function HotspotQuadrantView({ bundle, moduleById }: { bundle: RepoBundle; modul
   );
 }
 
-function HiddenCouplingView({ bundle, moduleById, onExploreStructure }: ViewProps) {
+function HiddenCouplingView({ bundle, moduleById, selectedModuleId, onInspectModule, onExploreStructure }: ViewProps) {
   const analysis = bundle.aggregates.hidden_coupling;
   const labels = bundle.capability.labels;
   const rows = analysis.data.items.slice(0, UI_ROW_LIMIT);
   return (
     <div className="repo-view-body">
       <section className="repo-card repo-table-wrap">
-        <table className="repo-table"><thead><tr><th>{labels.node_types.module}</th><th>{labels.node_types.module}</th><th>{labels.metrics.cochange_count}</th><th>{labels.metrics.support}</th></tr></thead><tbody>{rows.map((row) => <tr key={`${row.left_module_id}-${row.right_module_id}`}><td><strong>{moduleName(moduleById, row.left_module_id)}</strong></td><td><strong>{moduleName(moduleById, row.right_module_id)}</strong></td><td>{formatNumber(row.cochange_count)}</td><td><div className="repo-bar violet" aria-label={`${labels.metrics.support} ${formatPercent(row.support)}`}><span style={{ width: `${Math.min(100, row.support * 100)}%` }} /></div></td></tr>)}</tbody></table>
+        <table className="repo-table"><thead><tr><th>{labels.node_types.module}</th><th>{labels.node_types.module}</th><th>{labels.metrics.cochange_count}</th><th>{labels.metrics.support}</th></tr></thead><tbody>{rows.map((row) => <tr key={`${row.left_module_id}-${row.right_module_id}`}><td><ModuleInspectionControl moduleId={row.left_module_id} moduleById={moduleById} modulePage={bundle.graph.modules} selectedModuleId={selectedModuleId} onInspectModule={onInspectModule} /></td><td><ModuleInspectionControl moduleId={row.right_module_id} moduleById={moduleById} modulePage={bundle.graph.modules} selectedModuleId={selectedModuleId} onInspectModule={onInspectModule} /></td><td>{formatNumber(row.cochange_count)}</td><td><div className="repo-bar violet" aria-label={`${labels.metrics.support} ${formatPercent(row.support)}`}><span style={{ width: `${Math.min(100, row.support * 100)}%` }} /></div></td></tr>)}</tbody></table>
         {isKnownEmptyRepoPage(analysis.data) && <DataState className="repo-empty" state="empty" title={`No ${bundle.capability.views.hidden_coupling.label.toLocaleLowerCase()} in this bundle`} message="Module pairs with captured co-change signals belong here." action={{ label: "Explore repository structure", onClick: onExploreStructure }} />}
         <LocalSliceDisclosure shown={rows.length} total={analysis.data.items.length} label={bundle.capability.views.hidden_coupling.label} labels={labels} />
         <BoundDisclosure page={analysis.data} labels={labels} />
@@ -842,7 +889,7 @@ function HiddenCouplingView({ bundle, moduleById, onExploreStructure }: ViewProp
   );
 }
 
-function TreemapView({ bundle, moduleById }: { bundle: RepoBundle; moduleById: ModuleMap }) {
+function TreemapView({ bundle, moduleById, selectedModuleId, onInspectModule }: ViewProps) {
   const analysis = bundle.aggregates.structure_treemap;
   const labels = bundle.capability.labels;
   const rows = analysis.data.items.slice(0, UI_TREEMAP_LIMIT);
@@ -854,7 +901,8 @@ function TreemapView({ bundle, moduleById }: { bundle: RepoBundle; moduleById: M
         {rows.map((row) => {
           const activity = row.recent_commit_count.status === "available" ? row.recent_commit_count.value : 0;
           const span = Math.min(6, Math.max(2, row.source_file_count));
-          return <div role="listitem" style={{ gridColumn: `span ${span}` }} key={row.module_id}><article className={activity > maxActivity * 0.55 ? "hot" : ""}><strong>{moduleName(moduleById, row.module_id)}</strong><span>{labels.metrics.source_files}: {row.source_file_count}</span><span>{labels.metrics.recent_activity}: {availabilityText(row.recent_commit_count, labels, formatNumber)}</span></article></div>;
+          const moduleNode = moduleById.get(row.module_id);
+          return <div role="listitem" style={{ gridColumn: `span ${span}` }} key={row.module_id}>{moduleNode ? <button type="button" className={`repo-treemap-module ${activity > maxActivity * 0.55 ? "hot" : ""}`} data-module-id={row.module_id} aria-label={`Inspect ${moduleNode.source_path}`} aria-controls="repository-module-inspector" aria-pressed={selectedModuleId === row.module_id} onClick={() => onInspectModule(row.module_id)}><strong>{moduleNode.module_path}</strong><span>{labels.metrics.source_files}: {row.source_file_count}</span><span>{labels.metrics.recent_activity}: {availabilityText(row.recent_commit_count, labels, formatNumber)}</span></button> : <ModuleInspectionControl moduleId={row.module_id} moduleById={moduleById} modulePage={bundle.graph.modules} selectedModuleId={selectedModuleId} onInspectModule={onInspectModule} />}</div>;
         })}
       </div>
       <LocalSliceDisclosure shown={rows.length} total={analysis.data.items.length} label={bundle.capability.views.structure_treemap.label} labels={labels} />
@@ -924,7 +972,7 @@ function CadenceView({ bundle, onExploreStructure }: ViewProps) {
   );
 }
 
-function OwnershipView({ bundle, moduleById }: { bundle: RepoBundle; moduleById: ModuleMap }) {
+function OwnershipView({ bundle, moduleById, selectedModuleId, onInspectModule }: ViewProps) {
   const analysis = bundle.aggregates.ownership;
   const labels = bundle.capability.labels;
   const moduleRows = analysis.modules.items.slice(0, UI_ROW_LIMIT);
@@ -949,7 +997,7 @@ function OwnershipView({ bundle, moduleById }: { bundle: RepoBundle; moduleById:
         </section>
       </div>
       <section className="repo-card repo-table-wrap">
-        {analysis.modules.disclosure.status === "unavailable" ? <DataState className="repo-empty" state="unavailable" title={`${labels.node_types.module} ${labels.unavailable.toLocaleLowerCase()}`} message={analysis.modules.disclosure.reason ?? "This bundle does not claim ownership modules."} /> : <table className="repo-table"><thead><tr><th>{labels.node_types.module}</th><th>{labels.metrics.commits}</th><th>{labels.metrics.author_concentration}</th><th>{labels.metrics.bus_factor}</th></tr></thead><tbody>{moduleRows.map((row) => <tr key={row.module_id}><td><strong>{moduleName(moduleById, row.module_id)}</strong><div>{row.authors.items.slice(0, 8).map((author) => `${author.author} ${formatPercent(author.share)}`).join(" · ")}</div><InlineLocalSlice shown={Math.min(8, row.authors.items.length)} total={row.authors.items.length} labels={labels} /><InlinePageState page={row.authors} labels={labels} /></td><td>{row.commit_count}</td><td>{row.author_concentration.status === "available" ? <div className="repo-bar" aria-label={`${labels.metrics.author_concentration} ${formatPercent(row.author_concentration.value)}`}><span style={{ width: `${Math.min(100, row.author_concentration.value * 100)}%` }} /></div> : availabilityText(row.author_concentration, labels)}</td><td>{availabilityText(row.bus_factor, labels, formatNumber)}</td></tr>)}</tbody></table>}
+        {analysis.modules.disclosure.status === "unavailable" ? <DataState className="repo-empty" state="unavailable" title={`${labels.node_types.module} ${labels.unavailable.toLocaleLowerCase()}`} message={analysis.modules.disclosure.reason ?? "This bundle does not claim ownership modules."} /> : <table className="repo-table"><thead><tr><th>{labels.node_types.module}</th><th>{labels.metrics.commits}</th><th>{labels.metrics.author_concentration}</th><th>{labels.metrics.bus_factor}</th></tr></thead><tbody>{moduleRows.map((row) => <tr key={row.module_id}><td><ModuleInspectionControl moduleId={row.module_id} moduleById={moduleById} modulePage={bundle.graph.modules} selectedModuleId={selectedModuleId} onInspectModule={onInspectModule} /><div>{row.authors.items.slice(0, 8).map((author) => `${author.author} ${formatPercent(author.share)}`).join(" · ")}</div><InlineLocalSlice shown={Math.min(8, row.authors.items.length)} total={row.authors.items.length} labels={labels} /><InlinePageState page={row.authors} labels={labels} /></td><td>{row.commit_count}</td><td>{row.author_concentration.status === "available" ? <div className="repo-bar" aria-label={`${labels.metrics.author_concentration} ${formatPercent(row.author_concentration.value)}`}><span style={{ width: `${Math.min(100, row.author_concentration.value * 100)}%` }} /></div> : availabilityText(row.author_concentration, labels)}</td><td>{availabilityText(row.bus_factor, labels, formatNumber)}</td></tr>)}</tbody></table>}
         <LocalSliceDisclosure shown={moduleRows.length} total={analysis.modules.items.length} label={labels.node_types.module} labels={labels} />
         <BoundDisclosure page={analysis.modules} labels={labels} />
       </section>
@@ -957,13 +1005,13 @@ function OwnershipView({ bundle, moduleById }: { bundle: RepoBundle; moduleById:
   );
 }
 
-function ApiSurfaceView({ bundle, moduleById }: { bundle: RepoBundle; moduleById: ModuleMap }) {
+function ApiSurfaceView({ bundle, moduleById, selectedModuleId, onInspectModule }: ViewProps) {
   const analysis = bundle.aggregates.api_surface;
   const labels = bundle.capability.labels;
   const rows = analysis.data.items.slice(0, UI_ROW_LIMIT);
   const max = Math.max(1, ...rows.map((row) => row.dependent_count));
   return (
-    <div className="repo-view-body"><section className="repo-card repo-table-wrap"><table className="repo-table"><thead><tr><th>{labels.node_types.module}</th><th>{labels.metrics.dependent_count}</th><th>{labels.metrics.dependent_count}</th></tr></thead><tbody>{rows.map((row) => <tr key={row.module_id}><td><strong>{moduleName(moduleById, row.module_id)}</strong></td><td>{formatNumber(row.dependent_count)}</td><td><div className="repo-bar"><span style={{ width: `${(row.dependent_count / max) * 100}%` }} /></div></td></tr>)}</tbody></table><LocalSliceDisclosure shown={rows.length} total={analysis.data.items.length} label={bundle.capability.views.api_surface.label} labels={labels} /><BoundDisclosure page={analysis.data} labels={labels} /></section></div>
+    <div className="repo-view-body"><section className="repo-card repo-table-wrap"><table className="repo-table"><thead><tr><th>{labels.node_types.module}</th><th>{labels.metrics.dependent_count}</th><th>{labels.metrics.dependent_count}</th></tr></thead><tbody>{rows.map((row) => <tr key={row.module_id}><td><ModuleInspectionControl moduleId={row.module_id} moduleById={moduleById} modulePage={bundle.graph.modules} selectedModuleId={selectedModuleId} onInspectModule={onInspectModule} /></td><td>{formatNumber(row.dependent_count)}</td><td><div className="repo-bar"><span style={{ width: `${(row.dependent_count / max) * 100}%` }} /></div></td></tr>)}</tbody></table><LocalSliceDisclosure shown={rows.length} total={analysis.data.items.length} label={bundle.capability.views.api_surface.label} labels={labels} /><BoundDisclosure page={analysis.data} labels={labels} /></section></div>
   );
 }
 
@@ -981,29 +1029,27 @@ function scoreLabel(labels: Labels, key: RepoBundle["aggregates"]["scorecard"]["
   return keys[key];
 }
 
-function scoreValue(field: RepoBundle["aggregates"]["scorecard"]["fields"][number], labels: Labels, moduleById: ModuleMap): string {
+function scoreValue(field: RepoBundle["aggregates"]["scorecard"]["fields"][number], labels: Labels): string {
   if (field.value.status === "unavailable") return labels.unavailable;
   const value = field.value.value;
   if (value.value_kind === "count") return formatNumber(value.value);
   if (value.value_kind === "ratio") return formatPercent(value.value);
   if (value.value_kind === "module_ids") {
-    return value.value.items.length === 0
-      ? "0"
-      : value.value.items.slice(0, 8).map((id) => moduleName(moduleById, id)).join(", ");
+    return formatNumber(value.value.items.length);
   }
   return value.value;
 }
 
-function ScorecardView({ bundle, moduleById }: { bundle: RepoBundle; moduleById: ModuleMap }) {
+function ScorecardView({ bundle, moduleById, selectedModuleId, onInspectModule }: ViewProps) {
   const analysis = bundle.aggregates.scorecard;
   const labels = bundle.capability.labels;
   const fields = analysis.fields.slice(0, UI_ROW_LIMIT);
   return (
     <div className="repo-view-body">
       <div className="repo-score-grid">{fields.map((field) => {
-        const value = scoreValue(field, labels, moduleById);
+        const value = scoreValue(field, labels);
         const moduleIds = field.value.status === "available" && field.value.value.value_kind === "module_ids" ? field.value.value.value : null;
-        return <article className="repo-score-card" key={field.key}><span>{scoreLabel(labels, field.key)}</span><div className="repo-score-value">{field.value.status === "unavailable" ? <AlertTriangle aria-hidden="true" /> : <TrendingUp aria-hidden="true" />}<strong>{value}</strong></div>{field.value.status === "unavailable" && <p>{field.value.reason}</p>}{moduleIds && <><InlineLocalSlice shown={Math.min(8, moduleIds.items.length)} total={moduleIds.items.length} labels={labels} /><InlinePageState page={moduleIds} labels={labels} /></>}<div className="repo-score-tags"><i>{field.granularity}</i><i>{field.join}</i></div></article>;
+        return <article className="repo-score-card" key={field.key}><span>{scoreLabel(labels, field.key)}</span><div className="repo-score-value">{field.value.status === "unavailable" ? <AlertTriangle aria-hidden="true" /> : <TrendingUp aria-hidden="true" />}<strong>{value}</strong></div>{field.value.status === "unavailable" && <p>{field.value.reason}</p>}{moduleIds && <><div className="repo-score-modules">{moduleIds.items.slice(0, 8).map((moduleId) => <ModuleInspectionControl key={moduleId} moduleId={moduleId} moduleById={moduleById} modulePage={bundle.graph.modules} selectedModuleId={selectedModuleId} onInspectModule={onInspectModule} className="compact" />)}</div><InlineLocalSlice shown={Math.min(8, moduleIds.items.length)} total={moduleIds.items.length} labels={labels} /><InlinePageState page={moduleIds} labels={labels} /></>}<div className="repo-score-tags"><i>{field.granularity}</i><i>{field.join}</i></div></article>;
       })}</div>
       <LocalSliceDisclosure shown={fields.length} total={analysis.fields.length} label={bundle.capability.views.scorecard.label} labels={labels} />
     </div>
@@ -1028,7 +1074,7 @@ function ActiveView({
   bundle,
   moduleById,
   selectedModuleId,
-  onSelectModule,
+  onInspectModule,
   onExploreStructure,
 }: ViewProps & { id: ViewId }) {
   const capability = bundle.capability.views[id];
@@ -1040,7 +1086,7 @@ function ActiveView({
         bundle={bundle}
         moduleById={moduleById}
         selectedModuleId={selectedModuleId}
-        onSelectModule={onSelectModule}
+        onInspectModule={onInspectModule}
         onExploreStructure={onExploreStructure}
       />
     </ViewFrame>
@@ -1081,7 +1127,7 @@ export function RepoShowcase({ bundle, analysisSource = "curated-static-fallback
   }> | null>(null);
   const [navigationStatus, setNavigationStatus] = useState("");
   const [copyStatus, setCopyStatus] = useState("");
-  const overviewRef = useRef<HTMLElement>(null);
+  const moduleInspectorRef = useRef<HTMLElement>(null);
   const dashboardRef = useRef<HTMLDivElement>(null);
   const copyLinkRef = useRef<HTMLButtonElement>(null);
 
@@ -1237,7 +1283,7 @@ export function RepoShowcase({ bundle, analysisSource = "curated-static-fallback
   }
 
   function recoverModule() {
-    if (defaultModuleId) selectModule(defaultModuleId);
+    if (defaultModuleId) inspectModule(defaultModuleId);
   }
 
   function normalizeCurrentLocation() {
@@ -1306,11 +1352,10 @@ export function RepoShowcase({ bundle, analysisSource = "curated-static-fallback
     });
   }
 
-  function openModuleFromPalette(moduleId: string) {
+  function inspectModule(moduleId: string) {
+    if (!moduleById.has(moduleId)) return;
     selectModule(moduleId);
-    const inspector = overviewRef.current?.querySelector<HTMLElement>(
-      "[data-module-inspector]",
-    );
+    const inspector = moduleInspectorRef.current;
     if (!inspector) return;
     inspector.focus({ preventScroll: true });
     const reduceMotion = window.matchMedia?.(
@@ -1322,10 +1367,10 @@ export function RepoShowcase({ bundle, analysisSource = "curated-static-fallback
     });
   }
   return (
-    <article ref={overviewRef} className="repo-overview" data-head-sha={snapshot.head_sha} data-analysis-source={analysisSource}>
+    <article className="repo-overview" data-head-sha={snapshot.head_sha} data-analysis-source={analysisSource}>
       <header className="repo-overview-heading">
         <div className="repo-identity"><span className="repo-avatar"><Package aria-hidden="true" /></span><div><span>{repository.host} · {availabilityText(repository.default_branch, capability.labels)}</span><strong>{repository.owner}/{repository.name}</strong></div></div>
-        <div className="repo-meta-row"><span><GitCommitHorizontal aria-hidden="true" /><code>{shortSha(snapshot.head_sha)}</code></span><span><Clock3 aria-hidden="true" />{formatDate(snapshot.ingested_at)}</span><span><Code2 aria-hidden="true" />{producer.exporter}</span><span><Database aria-hidden="true" />{analysisSource === "khive-db-snapshot" ? "khive DB snapshot" : "curated static fallback"}</span><RepositoryCommandPalette bundle={bundle} activeView={activeView} selectedModuleId={selectedModuleId} onSelectModule={openModuleFromPalette} onSelectView={openAnalysis} onCopyLink={copyInvestigationLink} /><button ref={copyLinkRef} type="button" className="repo-copy-link" onClick={copyInvestigationLink}><Copy aria-hidden="true" /> Copy investigation link</button>{copyStatus && <span role="status" className="repo-copy-status">{copyStatus}</span>}</div>
+        <div className="repo-meta-row"><span><GitCommitHorizontal aria-hidden="true" /><code>{shortSha(snapshot.head_sha)}</code></span><span><Clock3 aria-hidden="true" />{formatDate(snapshot.ingested_at)}</span><span><Code2 aria-hidden="true" />{producer.exporter}</span><span><Database aria-hidden="true" />{analysisSource === "khive-db-snapshot" ? "khive DB snapshot" : "curated static fallback"}</span><RepositoryCommandPalette bundle={bundle} activeView={activeView} selectedModuleId={selectedModuleId} onSelectModule={inspectModule} onSelectView={openAnalysis} onCopyLink={copyInvestigationLink} /><button ref={copyLinkRef} type="button" className="repo-copy-link" onClick={copyInvestigationLink}><Copy aria-hidden="true" /> Copy investigation link</button>{copyStatus && <span role="status" className="repo-copy-status">{copyStatus}</span>}</div>
       </header>
       <section className="repo-capability-strip" aria-label={capability.labels.product}>
         <div><ShieldCheck aria-hidden="true" /><div><strong>{capability.labels.product}</strong><span>{capability.mode}</span></div></div>
@@ -1356,8 +1401,9 @@ export function RepoShowcase({ bundle, analysisSource = "curated-static-fallback
         key={snapshot.head_sha}
         bundle={bundle}
         selectedModuleId={selectedModuleId}
+        moduleInspectorRef={moduleInspectorRef}
         unresolvedModule={unresolvedModule}
-        onSelectModule={selectModule}
+        onInspectModule={inspectModule}
         onRecoverModule={recoverModule}
         canRecoverModule={defaultModuleId !== null}
         onOpenAnalysis={openAnalysis}
@@ -1380,7 +1426,7 @@ export function RepoShowcase({ bundle, analysisSource = "curated-static-fallback
           })}
         </nav>
         <section className="repo-view-panel" aria-label={capability.views[activeView].label}>
-          <ActiveView key={`${snapshot.head_sha}-${activeView}`} id={activeView} bundle={bundle} moduleById={moduleById} selectedModuleId={selectedModuleId} onSelectModule={selectModule} onExploreStructure={() => selectView("structure_graph")} />
+          <ActiveView key={`${snapshot.head_sha}-${activeView}`} id={activeView} bundle={bundle} moduleById={moduleById} selectedModuleId={selectedModuleId} onInspectModule={inspectModule} onExploreStructure={() => selectView("structure_graph")} />
         </section>
       </div>
     </article>

--- a/apps/kg-editor/src/components/showcase/repository-triage.tsx
+++ b/apps/kg-editor/src/components/showcase/repository-triage.tsx
@@ -18,7 +18,7 @@ import {
   Signpost,
   Users,
 } from "@/icons";
-import { useMemo, useRef, useState } from "react";
+import { useMemo, useState, type RefObject } from "react";
 
 import { DataState } from "@/components/data-state";
 import {
@@ -36,7 +36,8 @@ export type RepositoryTriageProps = Readonly<{
   bundle: RepoBundle;
   onOpenAnalysis: (view: ViewId) => void;
   selectedModuleId: string | null;
-  onSelectModule: (moduleId: string) => void;
+  onInspectModule: (moduleId: string) => void;
+  moduleInspectorRef: RefObject<HTMLElement | null>;
   unresolvedModule: Readonly<{ path: string; reason: string }> | null;
   onRecoverModule: () => void;
   canRecoverModule: boolean;
@@ -169,7 +170,8 @@ export function RepositoryTriage({
   bundle,
   onOpenAnalysis,
   selectedModuleId,
-  onSelectModule,
+  onInspectModule,
+  moduleInspectorRef,
   unresolvedModule,
   onRecoverModule,
   canRecoverModule,
@@ -188,7 +190,6 @@ export function RepositoryTriage({
       new Map(bundle.graph.packages.items.map((item) => [item.id, item])),
     [bundle.graph.packages.items],
   );
-  const inspectorRef = useRef<HTMLElement>(null);
   const [query, setQuery] = useState("");
   const selectedInsight = useMemo(
     () =>
@@ -205,29 +206,11 @@ export function RepositoryTriage({
   const searchResults = searchMatches.items;
   const searchTruncated = searchMatches.total > searchResults.length;
 
-  function focusInspector() {
-    const inspector = inspectorRef.current;
-    if (!inspector) return;
-    inspector.focus({ preventScroll: true });
-    const reduceMotion = window.matchMedia?.(
-      "(prefers-reduced-motion: reduce)",
-    ).matches ?? false;
-    inspector.scrollIntoView?.({
-      behavior: reduceMotion ? "auto" : "smooth",
-      block: "start",
-    });
-  }
-
-  function selectModule(moduleId: string) {
-    onSelectModule(moduleId);
-    focusInspector();
-  }
-
   function selectSignal(signal: RepositorySignal) {
     const moduleId = signal.moduleIds.find((candidate) =>
       moduleById.has(candidate)
     );
-    if (moduleId) selectModule(moduleId);
+    if (moduleId) onInspectModule(moduleId);
   }
 
   return (
@@ -345,7 +328,7 @@ export function RepositoryTriage({
                           module={module}
                           selected={module.id === selectedModuleId}
                           detail={`${module.language} · ${module.module_path}`}
-                          onSelect={() => selectModule(module.id)}
+                          onSelect={() => onInspectModule(module.id)}
                         />
                       ))
                     )
@@ -385,7 +368,7 @@ export function RepositoryTriage({
                                 detail={`${bundle.capability.views.api_surface.label} · ${
                                   formatNumber(entry.dependentCount)
                                 } ${labels.metrics.dependent_count} · ${entry.modulePath}`}
-                                onSelect={() => selectModule(moduleNode.id)}
+                                onSelect={() => onInspectModule(moduleNode.id)}
                               />
                             </div>
                           );
@@ -527,7 +510,7 @@ export function RepositoryTriage({
         <aside
           className={styles.inspector}
           id="repository-module-inspector"
-          ref={inspectorRef}
+          ref={moduleInspectorRef}
           aria-label={`${moduleLabel} evidence`}
           data-module-inspector
           aria-live="polite"
@@ -637,7 +620,7 @@ export function RepositoryTriage({
                               <li key={module.id}>
                                 <button
                                   type="button"
-                                  onClick={() => selectModule(module.id)}
+                                  onClick={() => onInspectModule(module.id)}
                                 >
                                   {module.source_path}
                                 </button>
@@ -667,7 +650,7 @@ export function RepositoryTriage({
                                 <li key={module.id}>
                                   <button
                                     type="button"
-                                    onClick={() => selectModule(module.id)}
+                                    onClick={() => onInspectModule(module.id)}
                                   >
                                     {module.source_path}
                                   </button>
@@ -699,7 +682,7 @@ export function RepositoryTriage({
                               <span key={module.id}>
                                 <button
                                   type="button"
-                                  onClick={() => selectModule(module.id)}
+                                  onClick={() => onInspectModule(module.id)}
                                 >
                                   {module.source_path}
                                 </button>
@@ -731,7 +714,7 @@ export function RepositoryTriage({
                           <li key={coupling.module.id}>
                             <button
                               type="button"
-                              onClick={() => selectModule(coupling.module.id)}
+                              onClick={() => onInspectModule(coupling.module.id)}
                             >
                               {coupling.module.source_path}
                             </button>
@@ -845,10 +828,7 @@ export function RepositoryTriage({
                 message={unresolvedModule.reason}
                 action={{
                   label: "Open recommended module",
-                  onClick: () => {
-                    onRecoverModule();
-                    focusInspector();
-                  },
+                  onClick: onRecoverModule,
                 }}
               />
             )


### PR DESCRIPTION
Supersedes #1958, transplanting the analysis-inspector feature directly onto main: the stacked branch had absorbed older trees whose conflict resolutions dropped behaviors main has since gained, so this branch starts from main and carries only the feature.

Aggregate analysis results connect to the module inspector: fan-in, fan-out, and hidden-coupling entries render as inspection links that focus the inspector and update the module URL state; the command palette, treemap, and cycle views share the same inspection control; structure-graph subtree counts replace joined name strings. Preserved main-side behavior is pinned by tests, including bearer-token snapshot authorization with a non-retaining private cache, sanitized share links that never carry repository-supplied query or fragment data, page-metric reason precedence, cursor-aware history and series accounting, and layout reuse across metric-only changes.

Test suite: 24 files, 238 tests passing, with typecheck and lint clean.