### PR TITLE
feat(kg-editor): consume a repository analysis catalog in the showcase

### DIFF
--- a/apps/kg-editor/DEMO.md
+++ b/apps/kg-editor/DEMO.md
@@ -33,10 +33,11 @@ Before presenting, verify that the source badge says **khive DB snapshot**, not
 
 This setup requires the DB snapshot API route from the companion backend PR (or
 its merged equivalent). Without that route, this UI branch intentionally uses
-the curated static fallback. The DB-backed snapshot is always an optional
-enhancement over the bundled static asset: any failure on that path — network
-error, non-2xx status, an oversized or malformed body, or a provenance
-mismatch — falls back to the static asset rather than failing the page.
+the curated static fallback. Per ADR-147 Amendment 3, only a 404 on the
+snapshot route may fall back to the approved static asset; server errors,
+timeouts, oversized or malformed bodies, and provenance or repository
+mismatches are surfaced as hard failures so a stale static bundle never
+conceals a configured report's integrity or availability failure.
 
 ## Five-to-seven-minute flow
 

--- a/apps/kg-editor/README.md
+++ b/apps/kg-editor/README.md
@@ -1,10 +1,12 @@
 # khive repository atlas + KG Studio
 
-The default route is ADR-147's static-first repository showcase. Entering a public
-repository URL performs a local lookup against the curated set; a hit renders the exact
-checked-in `khive.repo.v1` golden bytes, and a miss performs no clone, forge request, or
-server-side execution. The original ADR-145 semantic review workbench remains available
-at `/review`.
+The default route is ADR-147's catalog-driven repository showcase. The browser first
+discovers configured DB-backed analyses, merges them with its curated static set by
+normalized repository URL, and offers the result in a native repository selector.
+Entering a public repository URL still performs a local lookup only: a miss performs no
+clone, forge request, or server-side execution. If the catalog is absent or unhealthy,
+the curated checked-in `khive.repo.v1` golden remains usable and the degraded state is
+visible. The original ADR-145 semantic review workbench remains available at `/review`.
 
 The repository showcase renders all ten ADR-147 views at their declared granularity:
 structure, history navigation, dependency topology, hotspots, hidden coupling, treemap,
@@ -112,6 +114,15 @@ both be unique; one invalid entry makes the entire catalog unavailable. The cata
 sorted by analysis ID and exposes only those two public fields. It does not scan the
 analysis root or read a report.
 
+The default page consumes this catalog before resolving its initial `repo=` location.
+Configured entries appear in **Repository analysis** and resolve to their opaque report
+route. The browser accepts only the exact bounded v1 envelope. A catalog 404 means
+static-only operation; transport, server, or validation failures produce a disclosed
+degraded state while keeping curated static entries usable. Configured and static
+entries with the same normalized URL are one selection: the DB snapshot is preferred,
+and only its 404 may use the approved static asset. A 5xx, invalid bundle, provenance or
+repository mismatch never falls back. A configured-only 404 is shown as an honest miss.
+
 Both API routes require `Authorization: Bearer $KHIVE_SHOWCASE_ACCESS_TOKEN` on every
 request, checked in constant time. To use the DB-backed setup through the showcase UI,
 supply the same token to your own browser session before loading a repository:
@@ -148,7 +159,7 @@ containment and file identity after opening and reads at most 8 MiB plus one sen
 byte.
 
 This is a pinned DB-backed snapshot, not a live mutable query and not arbitrary URL
-ingest. See ADR-147 Amendments 1–2 and the repository-showcase CLI guide.
+ingest. See ADR-147 Amendments 1–4 and the repository-showcase CLI guide.
 
 ## Adapter boundary
 

--- a/apps/kg-editor/e2e/showcase.spec.ts
+++ b/apps/kg-editor/e2e/showcase.spec.ts
@@ -1,4 +1,66 @@
+import { readFileSync } from "node:fs";
+
 import { expect, test } from "@playwright/test";
+
+const goldenShowcase = JSON.parse(readFileSync(
+  new URL("../../../docs/schemas/examples/khive-repo-v1-khive.json", import.meta.url),
+  "utf8",
+)) as { meta: { repository: { canonical_url: string } } };
+
+test("discovers and switches to a configured DB-backed repository analysis", async ({ page }) => {
+  const analysisId = "dynamic-e2e";
+  const canonicalUrl = "https://github.com/example/dynamic-e2e";
+  const dynamicBundle = structuredClone(goldenShowcase);
+  dynamicBundle.meta.repository.canonical_url = canonicalUrl;
+  let releaseReport = () => {};
+  const reportGate = new Promise<void>((resolveReport) => {
+    releaseReport = resolveReport;
+  });
+
+  await page.route(/\/api\/showcase\/analyses\/?$/, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        schema_version: "khive.showcase.catalog.v1",
+        entries: [{ analysis_id: analysisId, canonical_url: canonicalUrl }],
+      }),
+    });
+  });
+  await page.route(`**/api/showcase/analyses/${analysisId}`, async (route) => {
+    await reportGate;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      headers: {
+        "x-khive-analysis-id": analysisId,
+        "x-khive-analysis-source": "khive-db-snapshot",
+      },
+      body: JSON.stringify(dynamicBundle),
+    });
+  });
+
+  await page.goto("/");
+  const selector = page.getByRole("combobox", { name: "Repository analysis" });
+  await expect(selector).toBeVisible();
+  await expect(page.getByRole("status", { name: "Repository catalog status" }))
+    .toHaveText("1 configured repository analysis discovered.");
+  await expect(page.getByLabel("Analysis source"))
+    .toHaveText("curated static fallback");
+
+  await selector.selectOption(`analysis:${analysisId}`);
+  await expect(selector).toHaveAttribute("aria-busy", "true");
+  await expect(page.locator(".repo-result")).toHaveAttribute("aria-busy", "true");
+  await expect(page.getByRole("status", { name: "Repository analysis status" }))
+    .toContainText(`Opening ${canonicalUrl}`);
+  releaseReport();
+
+  await expect(page.locator(".repo-overview")).toBeVisible();
+  await expect(selector).toHaveAttribute("aria-busy", "false");
+  await expect(page.getByLabel("Public repository URL")).toHaveValue(canonicalUrl);
+  await expect(page.getByLabel("Analysis source")).toHaveText("khive DB snapshot");
+  await expect(page).toHaveURL(new RegExp(`repo=${encodeURIComponent(canonicalUrl)}`));
+});
 
 test("dogfoods every repository analysis from the curated static bundle", async ({ page }) => {
   const consoleErrors: string[] = [];

--- a/apps/kg-editor/src/app/showcase.css
+++ b/apps/kg-editor/src/app/showcase.css
@@ -179,6 +179,39 @@
   text-transform: uppercase;
 }
 
+.repo-url-form > .repo-analysis-picker {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.repo-analysis-picker select {
+  background: var(--khive-color-surface-overlay);
+  border: 1px solid var(--khive-color-border);
+  border-radius: var(--khive-radius-lg);
+  color: var(--repo-navy);
+  cursor: pointer;
+  font-family: var(--khive-font-mono);
+  font-size: var(--khive-type-base);
+  font-weight: 600;
+  min-width: 0;
+  padding: 12px;
+  text-transform: none;
+  width: 100%;
+}
+
+.repo-analysis-picker select:focus-visible {
+  border-color: var(--repo-green);
+  box-shadow: 0 0 0 4px var(--khive-color-accent-soft);
+  outline: none;
+}
+
+.repo-analysis-picker select:disabled,
+.repo-url-form button:disabled {
+  cursor: wait;
+  opacity: 0.62;
+}
+
 .repo-url-form > div {
   background: var(--khive-color-surface-overlay);
   border: 1px solid var(--khive-color-border);
@@ -222,8 +255,40 @@
 }
 
 .repo-url-form button:hover { background: var(--khive-color-accent-hover); }
+.repo-url-form button:disabled:hover { background: var(--repo-navy); }
 .repo-url-form button svg { height: 13px; width: 13px; }
 .repo-url-form small { color: var(--repo-muted); display: block; font-size: var(--khive-type-md); line-height: 1.5; margin: 10px 3px 0; }
+
+.repo-analysis-statuses {
+  border-left: 2px solid var(--khive-color-accent-soft);
+  display: grid;
+  gap: 4px;
+  margin: 13px 3px 0;
+  padding-left: 10px;
+}
+
+.repo-analysis-statuses > span,
+.repo-analysis-statuses p {
+  color: var(--repo-muted);
+  font-size: var(--khive-type-sm);
+  line-height: 1.45;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.repo-analysis-statuses > span {
+  align-items: baseline;
+  display: flex;
+  gap: 6px;
+  text-transform: uppercase;
+}
+
+.repo-analysis-statuses output {
+  color: var(--repo-navy);
+  font-family: var(--khive-font-mono);
+  font-weight: 700;
+  text-transform: none;
+}
 
 .repo-result {
   margin: 0 auto;

--- a/apps/kg-editor/src/components/showcase/showcase.test.tsx
+++ b/apps/kg-editor/src/components/showcase/showcase.test.tsx
@@ -419,6 +419,42 @@ describe("materialized repository lookup", () => {
     expect([...url.searchParams.keys()]).toEqual(["repo"]);
   });
 
+  it("treats an empty repo parameter as invalid instead of falling back to the default entry", async () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/?repo=&access_token=secret#fragment",
+    );
+
+    render(<Showcase />);
+
+    expect(await screen.findByText("Repository lookup could not start")).toBeVisible();
+    const url = new URL(window.location.href);
+    expect(url.searchParams.has("access_token")).toBe(false);
+    expect(url.hash).toBe("");
+    expect([...url.searchParams.keys()]).toEqual([]);
+  });
+
+  it("treats duplicate repo parameters as invalid instead of resolving the first value", async () => {
+    const repo = bundle.meta.repository.canonical_url;
+    window.history.replaceState(
+      null,
+      "",
+      `/?repo=${encodeURIComponent(repo)}&repo=${
+        encodeURIComponent(repo)
+      }&access_token=secret#fragment`,
+    );
+
+    render(<Showcase />);
+
+    expect(await screen.findByText("Repository lookup could not start")).toBeVisible();
+    const url = new URL(window.location.href);
+    expect(url.searchParams.get("repo")).toBe(repo);
+    expect(url.searchParams.has("access_token")).toBe(false);
+    expect(url.hash).toBe("");
+    expect([...url.searchParams.keys()]).toEqual(["repo"]);
+  });
+
   it("drops foreign query parameters and the fragment from history for a registry miss", async () => {
     const repo = "https://github.com/example/not-catalog-registered";
     window.history.replaceState(

--- a/apps/kg-editor/src/components/showcase/showcase.test.tsx
+++ b/apps/kg-editor/src/components/showcase/showcase.test.tsx
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   loadPreferredShowcaseBundle,
+  readOperatorShowcaseAccessToken,
   ShowcaseAnalysisNotFoundError,
 } from "@/lib/adapters/preferred-showcase-source";
 import { loadShowcaseAnalysisCatalog } from "@/lib/adapters/showcase-analysis-catalog";
@@ -35,6 +36,7 @@ const goldenPath = resolve(process.cwd(), "../../docs/schemas/examples/khive-rep
 const bundle = parseRepoBundle(JSON.parse(readFileSync(goldenPath, "utf8")));
 const mockedLoad = vi.mocked(loadPreferredShowcaseBundle);
 const mockedCatalog = vi.mocked(loadShowcaseAnalysisCatalog);
+const mockedAccessToken = vi.mocked(readOperatorShowcaseAccessToken);
 const defaultCatalogEntry = {
   analysis_id: "khive",
   canonical_url: "https://github.com/ohdearquant/khive",
@@ -51,6 +53,8 @@ describe("materialized repository lookup", () => {
       entries: [defaultCatalogEntry],
       message: "1 configured repository analysis discovered.",
     });
+    mockedAccessToken.mockReset();
+    mockedAccessToken.mockReturnValue(null);
   });
 
   it("resolves the repository in a direct URL before loading the default", async () => {
@@ -206,6 +210,40 @@ describe("materialized repository lookup", () => {
     );
   });
 
+  it("sends the operator bearer token on catalog discovery and still merges dynamic entries", async () => {
+    mockedAccessToken.mockReturnValue("operator-secret");
+    const actualCatalog = await vi.importActual<
+      typeof import("@/lib/adapters/showcase-analysis-catalog")
+    >("@/lib/adapters/showcase-analysis-catalog");
+    const dynamicUrl = "https://github.com/example/header-check-only";
+    const dynamicAnalysisId = "header-check-only";
+    const body = new TextEncoder().encode(JSON.stringify({
+      schema_version: "khive.showcase.catalog.v1",
+      entries: [{ analysis_id: dynamicAnalysisId, canonical_url: dynamicUrl }],
+    }));
+    const fetchCatalog = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-length": String(body.byteLength) }),
+      arrayBuffer: async () => body.buffer as ArrayBuffer,
+    }));
+    mockedCatalog.mockImplementation(() =>
+      actualCatalog.loadShowcaseAnalysisCatalog(fetchCatalog)
+    );
+
+    render(<Showcase />);
+
+    await waitFor(() =>
+      expect(screen.getByRole("option", { name: dynamicUrl })).toBeInTheDocument()
+    );
+    expect(fetchCatalog).toHaveBeenCalledWith(
+      "/api/showcase/analyses",
+      expect.objectContaining({
+        headers: { authorization: "Bearer operator-secret" },
+      }),
+    );
+  });
+
   it("waits for catalog discovery before resolving a dynamic deep link", async () => {
     const dynamicAnalysisId = "deep-link-only";
     let releaseCatalog: ((value: Awaited<ReturnType<typeof loadShowcaseAnalysisCatalog>>) => void) | undefined;
@@ -338,6 +376,67 @@ describe("materialized repository lookup", () => {
     expect(screen.getByLabelText("Analysis source")).toHaveTextContent(
       "khive DB snapshot",
     );
+  });
+
+  it("drops foreign query parameters and the fragment from history on a successful initial resolution", async () => {
+    const repo = bundle.meta.repository.canonical_url;
+    window.history.replaceState(
+      null,
+      "",
+      `/?repo=${encodeURIComponent(repo)}&access_token=secret#fragment`,
+    );
+
+    const { container } = render(<Showcase />);
+
+    await waitFor(() => expect(container.querySelector(".repo-overview")).toBeVisible());
+    const url = new URL(window.location.href);
+    expect(url.searchParams.get("repo")).toBe(repo);
+    expect(url.searchParams.has("access_token")).toBe(false);
+    expect(url.hash).toBe("");
+    expect([...url.searchParams.keys()]).toEqual(
+      expect.arrayContaining(["repo"]),
+    );
+    for (const key of url.searchParams.keys()) {
+      expect(["repo", "at", "module", "view"]).toContain(key);
+    }
+  });
+
+  it("drops foreign query parameters and the fragment from history for an invalid repository", async () => {
+    window.history.replaceState(
+      null,
+      "",
+      `/?repo=${
+        encodeURIComponent("ftp://example.com/owner/repo")
+      }&access_token=secret#fragment`,
+    );
+
+    render(<Showcase />);
+
+    expect(await screen.findByText("Repository lookup could not start")).toBeVisible();
+    const url = new URL(window.location.href);
+    expect(url.searchParams.has("access_token")).toBe(false);
+    expect(url.hash).toBe("");
+    expect([...url.searchParams.keys()]).toEqual(["repo"]);
+  });
+
+  it("drops foreign query parameters and the fragment from history for a registry miss", async () => {
+    const repo = "https://github.com/example/not-catalog-registered";
+    window.history.replaceState(
+      null,
+      "",
+      `/?repo=${encodeURIComponent(repo)}&access_token=secret#fragment`,
+    );
+
+    render(<Showcase />);
+
+    expect(
+      await screen.findByText("No curated showcase bundle matches this repository"),
+    ).toBeVisible();
+    const url = new URL(window.location.href);
+    expect(url.searchParams.get("repo")).toBe(repo);
+    expect(url.searchParams.has("access_token")).toBe(false);
+    expect(url.hash).toBe("");
+    expect([...url.searchParams.keys()]).toEqual(["repo"]);
   });
 
   it("renders an honest miss when a dynamic-only analysis disappears", async () => {

--- a/apps/kg-editor/src/components/showcase/showcase.test.tsx
+++ b/apps/kg-editor/src/components/showcase/showcase.test.tsx
@@ -4,12 +4,29 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { loadPreferredShowcaseBundle } from "@/lib/adapters/preferred-showcase-source";
+import {
+  loadPreferredShowcaseBundle,
+  ShowcaseAnalysisNotFoundError,
+} from "@/lib/adapters/preferred-showcase-source";
+import { loadShowcaseAnalysisCatalog } from "@/lib/adapters/showcase-analysis-catalog";
 import { parseRepoBundle } from "@/lib/repo-bundle";
 
 vi.mock("@/lib/adapters/preferred-showcase-source", () => ({
   loadPreferredShowcaseBundle: vi.fn(),
   readOperatorShowcaseAccessToken: vi.fn(() => null),
+  ShowcaseAnalysisNotFoundError: class ShowcaseAnalysisNotFoundError extends Error {
+    canonicalUrl: string;
+
+    constructor(canonicalUrl: string) {
+      super("The configured repository analysis is not available.");
+      this.canonicalUrl = canonicalUrl;
+    }
+  },
+}));
+
+vi.mock("@/lib/adapters/showcase-analysis-catalog", async (importOriginal) => ({
+  ...await importOriginal<typeof import("@/lib/adapters/showcase-analysis-catalog")>(),
+  loadShowcaseAnalysisCatalog: vi.fn(),
 }));
 
 import { Showcase } from "@/components/showcase/showcase";
@@ -17,12 +34,23 @@ import { Showcase } from "@/components/showcase/showcase";
 const goldenPath = resolve(process.cwd(), "../../docs/schemas/examples/khive-repo-v1-khive.json");
 const bundle = parseRepoBundle(JSON.parse(readFileSync(goldenPath, "utf8")));
 const mockedLoad = vi.mocked(loadPreferredShowcaseBundle);
+const mockedCatalog = vi.mocked(loadShowcaseAnalysisCatalog);
+const defaultCatalogEntry = {
+  analysis_id: "khive",
+  canonical_url: "https://github.com/ohdearquant/khive",
+} as const;
 
 describe("materialized repository lookup", () => {
   beforeEach(() => {
     window.history.replaceState(null, "", "/");
-    mockedLoad.mockClear();
+    mockedLoad.mockReset();
     mockedLoad.mockResolvedValue({ bundle, source: "khive-db-snapshot" });
+    mockedCatalog.mockReset();
+    mockedCatalog.mockResolvedValue({
+      status: "ready",
+      entries: [defaultCatalogEntry],
+      message: "1 configured repository analysis discovered.",
+    });
   });
 
   it("resolves the repository in a direct URL before loading the default", async () => {
@@ -97,10 +125,10 @@ describe("materialized repository lookup", () => {
     await user.click(screen.getByRole("button", { name: "Use the curated khive example" }));
     await waitFor(() => expect(container.querySelector(".repo-overview")).toBeVisible());
     expect(mockedLoad).toHaveBeenCalledTimes(3);
-  }, 15_000);
+  }, 30_000);
 
   it("serves the public static fallback from cache instead of reloading it", async () => {
-    mockedLoad.mockClear();
+    mockedLoad.mockReset();
     mockedLoad.mockResolvedValue({ bundle, source: "curated-static-fallback" });
     const user = userEvent.setup();
     const { container } = render(<Showcase />);
@@ -176,5 +204,166 @@ describe("materialized repository lookup", () => {
     expect(new URL(window.location.href).searchParams.get("module")).toBe(
       pool.source_path,
     );
+  });
+
+  it("waits for catalog discovery before resolving a dynamic deep link", async () => {
+    const dynamicAnalysisId = "deep-link-only";
+    let releaseCatalog: ((value: Awaited<ReturnType<typeof loadShowcaseAnalysisCatalog>>) => void) | undefined;
+    mockedCatalog.mockReturnValue(new Promise((resolveCatalog) => {
+      releaseCatalog = resolveCatalog;
+    }));
+    window.history.replaceState(
+      null,
+      "",
+      `/?repo=${encodeURIComponent("https://github.com/example/dynamic-only")}`,
+    );
+
+    render(<Showcase />);
+
+    const selector = screen.getByRole("combobox", { name: "Repository analysis" });
+    expect(selector).toHaveAttribute("aria-busy", "true");
+    expect(mockedLoad).not.toHaveBeenCalled();
+
+    releaseCatalog?.({
+      status: "ready",
+      entries: [{
+        analysis_id: dynamicAnalysisId,
+        canonical_url: "https://github.com/example/dynamic-only",
+      }],
+      message: "1 configured repository analysis discovered.",
+    });
+
+    await waitFor(() => expect(mockedLoad).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: `analysis:${dynamicAnalysisId}`,
+        analysisId: dynamicAnalysisId,
+        assetPath: undefined,
+      }),
+      expect.any(Function),
+      { accessToken: null },
+    ));
+  });
+
+  it("keeps the curated static repository usable when the catalog degrades", async () => {
+    mockedCatalog.mockResolvedValue({
+      status: "degraded",
+      entries: [],
+      message: "The server analysis catalog is unavailable; curated static repositories remain available.",
+    });
+    mockedLoad.mockResolvedValue({
+      bundle,
+      source: "curated-static-fallback",
+    });
+
+    const { container } = render(<Showcase />);
+
+    await waitFor(() => expect(container.querySelector(".repo-overview")).toBeVisible());
+    expect(screen.getByRole("status", { name: "Repository catalog status" }))
+      .toHaveTextContent(/catalog is unavailable.*static repositories remain available/i);
+    expect(screen.getByRole("combobox", { name: "Repository analysis" }))
+      .toHaveValue("github.com/ohdearquant/khive");
+    expect(screen.getByLabelText("Analysis source")).toHaveTextContent(
+      "curated static fallback",
+    );
+    expect(mockedLoad).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assetPath: "/showcase/khive-repo-v1-khive.json",
+        analysisId: undefined,
+      }),
+      expect.any(Function),
+      { accessToken: null },
+    );
+  });
+
+  it("switches a native repository selector and exposes URL, source, busy, and status", async () => {
+    const user = userEvent.setup();
+    const dynamicAnalysisId = "selector-only";
+    const dynamicUrl = "https://github.com/example/dynamic-only";
+    const dynamicBundle = {
+      ...bundle,
+      meta: {
+        ...bundle.meta,
+        repository: {
+          ...bundle.meta.repository,
+          canonical_url: dynamicUrl,
+        },
+      },
+    };
+    let releaseDynamic: (() => void) | undefined;
+    mockedCatalog.mockResolvedValue({
+      status: "ready",
+      entries: [
+        {
+          analysis_id: dynamicAnalysisId,
+          canonical_url: dynamicUrl,
+        },
+        defaultCatalogEntry,
+      ],
+      message: "2 configured repository analyses discovered.",
+    });
+    mockedLoad.mockImplementation((entry) => {
+      if (entry.analysisId !== dynamicAnalysisId) {
+        return Promise.resolve({ bundle, source: "khive-db-snapshot" });
+      }
+      return new Promise((resolveLoad) => {
+        releaseDynamic = () => resolveLoad({
+          bundle: dynamicBundle,
+          source: "khive-db-snapshot",
+        });
+      });
+    });
+    const { container } = render(<Showcase />);
+    await waitFor(() => expect(container.querySelector(".repo-overview")).toBeVisible());
+
+    const selector = screen.getByRole("combobox", { name: "Repository analysis" });
+    expect(screen.getByLabelText("Public repository URL")).toBeVisible();
+    expect(screen.getByRole("status", { name: "Repository catalog status" }))
+      .toHaveTextContent("2 configured repository analyses discovered.");
+
+    await user.selectOptions(selector, `analysis:${dynamicAnalysisId}`);
+
+    expect(selector).toHaveAttribute("aria-busy", "true");
+    expect(container.querySelector(".repo-result")).toHaveAttribute("aria-busy", "true");
+    expect(screen.getByRole("status", { name: "Repository analysis status" }))
+      .toHaveTextContent(/opening.*dynamic-only/i);
+    releaseDynamic?.();
+
+    await waitFor(() => expect(selector).toHaveAttribute("aria-busy", "false"));
+    expect(screen.getByLabelText("Public repository URL")).toHaveValue(
+      dynamicUrl,
+    );
+    expect(new URL(window.location.href).searchParams.get("repo")).toBe(
+      dynamicUrl,
+    );
+    expect(screen.getByLabelText("Analysis source")).toHaveTextContent(
+      "khive DB snapshot",
+    );
+  });
+
+  it("renders an honest miss when a dynamic-only analysis disappears", async () => {
+    const dynamicUrl = "https://github.com/example/dynamic-only";
+    const dynamicAnalysisId = "missing-only";
+    mockedCatalog.mockResolvedValue({
+      status: "ready",
+      entries: [{
+        analysis_id: dynamicAnalysisId,
+        canonical_url: dynamicUrl,
+      }],
+      message: "1 configured repository analysis discovered.",
+    });
+    mockedLoad.mockRejectedValue(new ShowcaseAnalysisNotFoundError(dynamicUrl));
+    window.history.replaceState(
+      null,
+      "",
+      `/?repo=${encodeURIComponent(dynamicUrl)}`,
+    );
+
+    const { container } = render(<Showcase />);
+
+    await waitFor(() => expect(container.querySelector('[data-state="empty"]')).toBeVisible());
+    expect(screen.getByText("Configured repository analysis is unavailable"))
+      .toBeVisible();
+    expect(container.querySelector('[data-state="empty"]')).toHaveTextContent(dynamicUrl);
+    expect(mockedLoad).toHaveBeenCalledOnce();
   });
 });

--- a/apps/kg-editor/src/components/showcase/showcase.tsx
+++ b/apps/kg-editor/src/components/showcase/showcase.tsx
@@ -167,8 +167,9 @@ export function Showcase() {
   useEffect(() => {
     let cancelled = false;
     const sequence = ++loadSequence.current;
+    const originalLocation = new URL(window.location.href);
     replaceRepositoryQuery(
-      new URL(window.location.href).searchParams.get("repo") ?? undefined,
+      originalLocation.searchParams.get("repo") ?? undefined,
       false,
     );
     void loadShowcaseAnalysisCatalog().then((catalogResult) => {
@@ -180,7 +181,7 @@ export function Showcase() {
         message: catalogResult.message,
       });
 
-      const parsed = parseRepositoryLocation(new URL(window.location.href));
+      const parsed = parseRepositoryLocation(originalLocation);
       const repositoryIssue = parsed.issues.find((issue) =>
         issue.parameter === "repo"
       );

--- a/apps/kg-editor/src/components/showcase/showcase.tsx
+++ b/apps/kg-editor/src/components/showcase/showcase.tsx
@@ -2,20 +2,31 @@
 
 import { ArrowRight, GitBranch, Search, ShieldCheck } from "@/icons";
 import Link from "next/link";
-import { useEffect, useRef, useState, type FormEvent } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type FormEvent,
+} from "react";
 
 import { RepoShowcase } from "@/components/showcase/repo-showcase";
 import { DataState } from "@/components/data-state";
 import {
   loadPreferredShowcaseBundle,
   readOperatorShowcaseAccessToken,
+  ShowcaseAnalysisNotFoundError,
   type LoadedShowcaseBundle,
   type ShowcaseBundleSource,
 } from "@/lib/adapters/preferred-showcase-source";
+import {
+  loadShowcaseAnalysisCatalog,
+  mergeShowcaseRegistry,
+  type ShowcaseAnalysisCatalogResult,
+} from "@/lib/adapters/showcase-analysis-catalog";
 import type { RepoBundle } from "@/lib/repo-bundle";
 import {
   resolveShowcaseRepository,
-  SHOWCASE_REGISTRY,
   type ShowcaseRegistryEntry,
 } from "@/lib/showcase-registry";
 import { parseRepositoryLocation } from "@/lib/repository-location";
@@ -23,11 +34,27 @@ import { parseRepositoryLocation } from "@/lib/repository-location";
 type LoadState =
   | Readonly<{ status: "loading"; entry: ShowcaseRegistryEntry }>
   | Readonly<{ status: "ready"; entry: ShowcaseRegistryEntry; loaded: LoadedShowcaseBundle }>
-  | Readonly<{ status: "miss"; normalizedUrl: string }>
+  | Readonly<{
+      status: "miss";
+      normalizedUrl: string;
+      cause: "registry" | "analysis-not-found";
+    }>
   | Readonly<{ status: "invalid"; reason: string }>
   | Readonly<{ status: "error"; reason: string }>;
 
+type CatalogState = Readonly<{
+  status: "loading" | ShowcaseAnalysisCatalogResult["status"];
+  registry: readonly ShowcaseRegistryEntry[];
+  message: string;
+}>;
+
 const bundleCache = new Map<string, Promise<LoadedShowcaseBundle>>();
+const STATIC_SHOWCASE_REGISTRY = mergeShowcaseRegistry([]);
+const staticShowcaseEntry = STATIC_SHOWCASE_REGISTRY[0];
+if (!staticShowcaseEntry) {
+  throw new Error("The repository showcase requires one curated static entry.");
+}
+const DEFAULT_SHOWCASE_ENTRY = staticShowcaseEntry;
 
 function loadEntry(entry: ShowcaseRegistryEntry): Promise<LoadedShowcaseBundle> {
   // The cache must never outlive the authorization that filled it: the key
@@ -37,7 +64,12 @@ function loadEntry(entry: ShowcaseRegistryEntry): Promise<LoadedShowcaseBundle> 
   // token adds no exposure here: sessionStorage already holds it and both
   // are readable by the same origin's scripts.
   const accessToken = readOperatorShowcaseAccessToken();
-  const cacheKey = `${entry.id}\u0000${accessToken ?? ""}`;
+  const cacheKey = [
+    entry.id,
+    entry.analysisId ?? "static",
+    entry.assetPath ?? "no-asset",
+    accessToken ?? "",
+  ].join("|");
   const existing = bundleCache.get(cacheKey);
   if (existing) return existing;
   const pending = loadPreferredShowcaseBundle(entry, fetch, {
@@ -79,16 +111,64 @@ function replaceRepositoryQuery(
 }
 
 export function Showcase() {
-  const defaultEntry = SHOWCASE_REGISTRY[0];
-  const [input, setInput] = useState(defaultEntry.canonicalUrl);
-  const [state, setState] = useState<LoadState>({ status: "loading", entry: defaultEntry });
+  const [input, setInput] = useState(DEFAULT_SHOWCASE_ENTRY.canonicalUrl);
+  const [state, setState] = useState<LoadState>({
+    status: "loading",
+    entry: DEFAULT_SHOWCASE_ENTRY,
+  });
+  const [catalog, setCatalog] = useState<CatalogState>({
+    status: "loading",
+    registry: STATIC_SHOWCASE_REGISTRY,
+    message: "Discovering configured repository analyses.",
+  });
   const [labels, setLabels] = useState<RepoBundle["capability"]["labels"] | null>(null);
   const loadSequence = useRef(0);
 
+  const beginLoad = useCallback((
+    entry: ShowcaseRegistryEntry,
+    clearInvestigation = true,
+  ) => {
+    const sequence = ++loadSequence.current;
+    setInput(entry.canonicalUrl);
+    setState({ status: "loading", entry });
+    replaceRepositoryQuery(entry.canonicalUrl, clearInvestigation);
+    void loadEntry(entry)
+      .then((loaded) => {
+        if (loadSequence.current !== sequence) return;
+        setLabels(loaded.bundle.capability.labels);
+        setState({ status: "ready", entry, loaded });
+      })
+      .catch((error: unknown) => {
+        if (loadSequence.current !== sequence) return;
+        if (error instanceof ShowcaseAnalysisNotFoundError) {
+          setState({
+            status: "miss",
+            normalizedUrl: error.canonicalUrl,
+            cause: "analysis-not-found",
+          });
+          return;
+        }
+        setState({
+          status: "error",
+          reason: error instanceof Error
+            ? error.message
+            : "The showcase bundle could not be loaded.",
+        });
+      });
+  }, []);
+
   useEffect(() => {
     let cancelled = false;
-    queueMicrotask(() => {
-      if (cancelled) return;
+    const sequence = ++loadSequence.current;
+    void loadShowcaseAnalysisCatalog().then((catalogResult) => {
+      if (cancelled || loadSequence.current !== sequence) return;
+      const registry = mergeShowcaseRegistry(catalogResult.entries);
+      setCatalog({
+        status: catalogResult.status,
+        registry,
+        message: catalogResult.message,
+      });
+
       const parsed = parseRepositoryLocation(new URL(window.location.href));
       const repositoryIssue = parsed.issues.find((issue) =>
         issue.parameter === "repo"
@@ -99,101 +179,73 @@ export function Showcase() {
       }
 
       const requestedRepository = parsed.location.repository ??
-        defaultEntry.canonicalUrl;
-      const lookup = resolveShowcaseRepository(requestedRepository);
+        DEFAULT_SHOWCASE_ENTRY.canonicalUrl;
+      const lookup = resolveShowcaseRepository(requestedRepository, registry);
       setInput(requestedRepository);
       if (lookup.status === "invalid") {
         setState(lookup);
         return;
       }
       if (lookup.status === "miss") {
-        setState(lookup);
+        setState({ ...lookup, cause: "registry" });
         return;
       }
 
-      const sequence = ++loadSequence.current;
-      setInput(lookup.normalizedUrl);
-      setState({ status: "loading", entry: lookup.entry });
-      if (parsed.location.repository !== lookup.normalizedUrl) {
-        replaceRepositoryQuery(lookup.normalizedUrl, false);
-      }
-      void loadEntry(lookup.entry)
-        .then((loaded) => {
-          if (loadSequence.current === sequence) {
-            setLabels(loaded.bundle.capability.labels);
-            setState({ status: "ready", entry: lookup.entry, loaded });
-          }
-        })
-        .catch((error: unknown) => {
-          if (loadSequence.current === sequence) {
-            setState({
-              status: "error",
-              reason: error instanceof Error ? error.message : "The showcase bundle could not be loaded.",
-            });
-          }
-        });
+      beginLoad(lookup.entry, false);
     });
     return () => {
       cancelled = true;
+      loadSequence.current += 1;
     };
-  }, [defaultEntry]);
+  }, [beginLoad]);
 
   function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    const lookup = resolveShowcaseRepository(input);
-    const sequence = ++loadSequence.current;
+    if (catalog.status === "loading") return;
+    const lookup = resolveShowcaseRepository(input, catalog.registry);
 
     if (lookup.status === "invalid") {
+      loadSequence.current += 1;
       replaceRepositoryQuery();
       setState(lookup);
       return;
     }
     if (lookup.status === "miss") {
+      loadSequence.current += 1;
       replaceRepositoryQuery();
-      setState(lookup);
+      setState({ ...lookup, cause: "registry" });
       return;
     }
 
-    setState({ status: "loading", entry: lookup.entry });
-    replaceRepositoryQuery(lookup.normalizedUrl);
-    void loadEntry(lookup.entry)
-      .then((loaded) => {
-        if (loadSequence.current === sequence) {
-          setLabels(loaded.bundle.capability.labels);
-          setState({ status: "ready", entry: lookup.entry, loaded });
-        }
-      })
-      .catch((error: unknown) => {
-        if (loadSequence.current === sequence) {
-          setState({
-            status: "error",
-            reason: error instanceof Error ? error.message : "The showcase bundle could not be loaded.",
-          });
-        }
-      });
+    beginLoad(lookup.entry);
   }
 
   function openCuratedExample() {
-    const sequence = ++loadSequence.current;
-    setInput(defaultEntry.canonicalUrl);
-    setState({ status: "loading", entry: defaultEntry });
-    replaceRepositoryQuery(defaultEntry.canonicalUrl);
-    void loadEntry(defaultEntry)
-      .then((loaded) => {
-        if (loadSequence.current === sequence) {
-          setLabels(loaded.bundle.capability.labels);
-          setState({ status: "ready", entry: defaultEntry, loaded });
-        }
-      })
-      .catch((error: unknown) => {
-        if (loadSequence.current === sequence) {
-          setState({
-            status: "error",
-            reason: error instanceof Error ? error.message : "The showcase bundle could not be loaded.",
-          });
-        }
-      });
+    const curated = catalog.registry.find((entry) => entry.assetPath) ??
+      DEFAULT_SHOWCASE_ENTRY;
+    beginLoad(curated);
   }
+
+  const busy = catalog.status === "loading" || state.status === "loading";
+  const selectedEntryId = state.status === "loading" || state.status === "ready"
+    ? state.entry.id
+    : "";
+  const analysisSource = state.status === "ready"
+    ? sourceLabel(state.loaded.source)
+    : state.status === "loading"
+    ? "Pending"
+    : "Not loaded";
+  const analysisStatus = catalog.status === "loading"
+    ? "Discovering configured repository analyses."
+    : state.status === "loading"
+    ? `Opening ${state.entry.canonicalUrl}.`
+    : state.status === "ready"
+    ? `Loaded ${state.entry.canonicalUrl} from ${sourceLabel(state.loaded.source)}.`
+    : state.status === "miss"
+    ? `No repository analysis is available for ${state.normalizedUrl}.`
+    : state.status === "invalid"
+    ? `Repository URL is invalid: ${state.reason}`
+    : `Repository analysis failed: ${state.reason}`;
 
   return (
     <div className="repo-shell">
@@ -220,7 +272,29 @@ export function Showcase() {
               one precomputed, reproducible graph bundle.
             </p>
           </div>
-          <form className="repo-url-form" onSubmit={submit} noValidate>
+          <form className="repo-url-form" onSubmit={submit} noValidate aria-busy={busy}>
+            <label className="repo-analysis-picker" htmlFor="repository-analysis">
+              <span>Repository analysis</span>
+              <select
+                id="repository-analysis"
+                value={selectedEntryId}
+                disabled={catalog.status === "loading"}
+                aria-busy={busy}
+                onChange={(event) => {
+                  const entry = catalog.registry.find((candidate) =>
+                    candidate.id === event.target.value
+                  );
+                  if (entry) beginLoad(entry);
+                }}
+              >
+                {!selectedEntryId && <option value="">Select a repository analysis</option>}
+                {catalog.registry.map((entry) => (
+                  <option key={entry.id} value={entry.id}>
+                    {entry.canonicalUrl}
+                  </option>
+                ))}
+              </select>
+            </label>
             <label htmlFor="repository-url">Public repository URL</label>
             <div>
               <Search aria-hidden="true" />
@@ -232,8 +306,15 @@ export function Showcase() {
                 onChange={(event) => setInput(event.target.value)}
                 placeholder={labels?.input_placeholder ?? "https://github.com/owner/repository"}
               />
-              <button type="submit">{labels?.lookup_action ?? "…"} <ArrowRight aria-hidden="true" /></button>
+              <button type="submit" disabled={catalog.status === "loading"}>
+                {labels?.lookup_action ?? "Open analysis"} <ArrowRight aria-hidden="true" />
+              </button>
             </div>
+            <section className="repo-analysis-statuses" aria-label="Repository analysis state">
+              <span>Source <output aria-label="Analysis source">{analysisSource}</output></span>
+              <p role="status" aria-label="Repository catalog status">{catalog.message}</p>
+              <p role="status" aria-label="Repository analysis status">{analysisStatus}</p>
+            </section>
             <small>A configured server snapshot is built from khive history and code-map databases. The browser never clones, ingests, or opens SQLite.</small>
           </form>
         </section>
@@ -259,8 +340,12 @@ export function Showcase() {
             <DataState
               className="repo-state-card"
               state="empty"
-              title={labels?.miss_title ?? "No curated showcase bundle matches this repository"}
-              message={`${labels?.miss_body ?? "Curated repository showcase bundles belong here."} · ${state.normalizedUrl}`}
+              title={state.cause === "analysis-not-found"
+                ? "Configured repository analysis is unavailable"
+                : labels?.miss_title ?? "No curated showcase bundle matches this repository"}
+              message={state.cause === "analysis-not-found"
+                ? `The configured snapshot is no longer available and has no approved static fallback. · ${state.normalizedUrl}`
+                : `${labels?.miss_body ?? "Curated repository showcase bundles belong here."} · ${state.normalizedUrl}`}
               action={{ label: "Use the curated khive example", onClick: openCuratedExample }}
             />
           )}
@@ -272,7 +357,13 @@ export function Showcase() {
               message={state.reason}
             />
           )}
-          {state.status === "ready" && <RepoShowcase bundle={state.loaded.bundle} analysisSource={state.loaded.source} />}
+          {state.status === "ready" && (
+            <RepoShowcase
+              key={state.entry.id}
+              bundle={state.loaded.bundle}
+              analysisSource={state.loaded.source}
+            />
+          )}
         </div>
       </main>
     </div>

--- a/apps/kg-editor/src/components/showcase/showcase.tsx
+++ b/apps/kg-editor/src/components/showcase/showcase.tsx
@@ -29,7 +29,11 @@ import {
   resolveShowcaseRepository,
   type ShowcaseRegistryEntry,
 } from "@/lib/showcase-registry";
-import { parseRepositoryLocation } from "@/lib/repository-location";
+import {
+  parseRepositoryLocation,
+  repositoryLocationUrl,
+  type RepositoryLocation,
+} from "@/lib/repository-location";
 
 type LoadState =
   | Readonly<{ status: "loading"; entry: ShowcaseRegistryEntry }>
@@ -98,16 +102,19 @@ function replaceRepositoryQuery(
   repository?: string,
   clearInvestigation = true,
 ) {
-  const query = new URL(window.location.href);
-  if (repository) query.searchParams.set("repo", repository);
-  else query.searchParams.delete("repo");
-  if (clearInvestigation) {
-    query.searchParams.delete("at");
-    query.searchParams.delete("module");
-    query.searchParams.delete("view");
-  }
-  const search = query.searchParams.size ? `?${query.searchParams.toString()}` : "";
-  window.history.replaceState(null, "", `${query.pathname}${search}${query.hash}`);
+  const current = new URL(window.location.href);
+  const location: RepositoryLocation = {
+    repository: repository ?? null,
+    snapshotSha: clearInvestigation ? null : current.searchParams.get("at"),
+    modulePath: clearInvestigation
+      ? null
+      : current.searchParams.get("module"),
+    view: clearInvestigation
+      ? null
+      : (current.searchParams.get("view") as RepositoryLocation["view"]),
+  };
+  const url = repositoryLocationUrl(current, location);
+  window.history.replaceState(null, "", `${url.pathname}${url.search}`);
 }
 
 export function Showcase() {
@@ -160,6 +167,10 @@ export function Showcase() {
   useEffect(() => {
     let cancelled = false;
     const sequence = ++loadSequence.current;
+    replaceRepositoryQuery(
+      new URL(window.location.href).searchParams.get("repo") ?? undefined,
+      false,
+    );
     void loadShowcaseAnalysisCatalog().then((catalogResult) => {
       if (cancelled || loadSequence.current !== sequence) return;
       const registry = mergeShowcaseRegistry(catalogResult.entries);

--- a/apps/kg-editor/src/lib/adapters/preferred-showcase-source.test.ts
+++ b/apps/kg-editor/src/lib/adapters/preferred-showcase-source.test.ts
@@ -7,6 +7,7 @@ import {
   loadPreferredShowcaseBundle,
   readOperatorShowcaseAccessToken,
   SHOWCASE_ACCESS_TOKEN_STORAGE_KEY,
+  ShowcaseAnalysisNotFoundError,
 } from "@/lib/adapters/preferred-showcase-source";
 import { SHOWCASE_REGISTRY } from "@/lib/showcase-registry";
 
@@ -35,6 +36,11 @@ function response(
 }
 
 describe("preferred showcase source", () => {
+  const configuredStaticEntry = {
+    ...SHOWCASE_REGISTRY[0],
+    analysisId: "khive",
+  };
+
   it("prefers the configured khive DB snapshot and verifies its provenance", async () => {
     const fetchBundle = vi.fn(async () =>
       response(golden, 200, {
@@ -44,7 +50,7 @@ describe("preferred showcase source", () => {
     );
 
     const result = await loadPreferredShowcaseBundle(
-      SHOWCASE_REGISTRY[0],
+      configuredStaticEntry,
       fetchBundle,
     );
 
@@ -68,7 +74,7 @@ describe("preferred showcase source", () => {
     );
 
     const result = await loadPreferredShowcaseBundle(
-      SHOWCASE_REGISTRY[0],
+      configuredStaticEntry,
       fetchBundle,
       { accessToken: "  operator-secret  " },
     );
@@ -91,7 +97,7 @@ describe("preferred showcase source", () => {
       })
     );
 
-    await loadPreferredShowcaseBundle(SHOWCASE_REGISTRY[0], fetchBundle, {
+    await loadPreferredShowcaseBundle(configuredStaticEntry, fetchBundle, {
       accessToken: "   ",
     });
 
@@ -124,7 +130,7 @@ describe("preferred showcase source", () => {
     );
 
     const result = await loadPreferredShowcaseBundle(
-      SHOWCASE_REGISTRY[0],
+      configuredStaticEntry,
       fetchBundle,
     );
 
@@ -135,183 +141,131 @@ describe("preferred showcase source", () => {
     );
   });
 
-  it("falls back to the static asset when the DB snapshot service errors", async () => {
-    const fetchBundle = vi.fn(async (input: string) =>
-      input.startsWith("/api/")
-        ? response(new Uint8Array(), 503)
-        : response(golden, 200)
-    );
+  it("does not hide an invalid or unavailable DB snapshot behind stale static data", async () => {
+    const fetchBundle = vi.fn(async () => response(new Uint8Array(), 503));
 
-    const result = await loadPreferredShowcaseBundle(
-      SHOWCASE_REGISTRY[0],
-      fetchBundle,
-    );
-
-    expect(result.source).toBe("curated-static-fallback");
-    expect(result.bundle.schema_version).toBe("khive.repo.v1");
-    expect(fetchBundle).toHaveBeenCalledTimes(2);
+    await expect(
+      loadPreferredShowcaseBundle(configuredStaticEntry, fetchBundle),
+    ).rejects.toThrow(/database snapshot.*503/i);
+    expect(fetchBundle).toHaveBeenCalledOnce();
   });
 
-  it("falls back to the static asset when the fetch rejects at the network level", async () => {
-    const fetchBundle = vi.fn(async (input: string) => {
-      if (input.startsWith("/api/")) {
-        throw new TypeError("Failed to fetch");
-      }
-      return response(golden, 200);
-    });
-
-    const result = await loadPreferredShowcaseBundle(
-      SHOWCASE_REGISTRY[0],
-      fetchBundle,
+  it("rejects a successful response without the configured snapshot identity", async () => {
+    const fetchBundle = vi.fn(async () =>
+      response(golden, 200, {
+        "x-khive-analysis-id": "other",
+        "x-khive-analysis-source": "khive-db-snapshot",
+      })
     );
 
-    expect(result.source).toBe("curated-static-fallback");
-    expect(result.bundle.schema_version).toBe("khive.repo.v1");
-    expect(fetchBundle).toHaveBeenCalledTimes(2);
+    await expect(
+      loadPreferredShowcaseBundle(configuredStaticEntry, fetchBundle),
+    ).rejects.toThrow(/provenance/i);
   });
 
-  it("falls back to the static asset when the DB snapshot body is invalid", async () => {
-    const invalid = new TextEncoder().encode("not json");
-    const fetchBundle = vi.fn(async (input: string) =>
-      input.startsWith("/api/")
-        ? response(invalid, 200, {
-          "x-khive-analysis-id": "khive",
-          "x-khive-analysis-source": "khive-db-snapshot",
-        })
-        : response(golden, 200)
-    );
-
-    const result = await loadPreferredShowcaseBundle(
-      SHOWCASE_REGISTRY[0],
-      fetchBundle,
-    );
-
-    expect(result.source).toBe("curated-static-fallback");
-    expect(result.bundle.schema_version).toBe("khive.repo.v1");
-    expect(fetchBundle).toHaveBeenCalledTimes(2);
-  });
-
-  it("falls back to the static asset when the DB snapshot body exceeds the browser limit", async () => {
-    const oversized = new Uint8Array(9 * 1024 * 1024);
-    const fetchBundle = vi.fn(async (input: string) =>
-      input.startsWith("/api/")
-        ? response(oversized, 200, {
-          "x-khive-analysis-id": "khive",
-          "x-khive-analysis-source": "khive-db-snapshot",
-        })
-        : response(golden, 200)
-    );
-
-    const result = await loadPreferredShowcaseBundle(
-      SHOWCASE_REGISTRY[0],
-      fetchBundle,
-    );
-
-    expect(result.source).toBe("curated-static-fallback");
-    expect(result.bundle.schema_version).toBe("khive.repo.v1");
-    expect(fetchBundle).toHaveBeenCalledTimes(2);
-  });
-
-  it("falls back to the static asset when the DB snapshot response lacks the configured provenance identity", async () => {
-    const fetchBundle = vi.fn(async (input: string) =>
-      input.startsWith("/api/")
-        ? response(golden, 200, {
-          "x-khive-analysis-id": "other",
-          "x-khive-analysis-source": "khive-db-snapshot",
-        })
-        : response(golden, 200)
-    );
-
-    const result = await loadPreferredShowcaseBundle(
-      SHOWCASE_REGISTRY[0],
-      fetchBundle,
-    );
-
-    expect(result.source).toBe("curated-static-fallback");
-    expect(result.bundle.schema_version).toBe("khive.repo.v1");
-    expect(fetchBundle).toHaveBeenCalledTimes(2);
-  });
-
-  it("falls back to the static asset when a valid snapshot is for a different repository", async () => {
+  it("rejects a valid snapshot for a different repository", async () => {
     const wrongRepository = JSON.parse(golden.toString("utf8"));
     wrongRepository.meta.repository.canonical_url =
       "https://github.com/example/not-khive";
-    const fetchBundle = vi.fn(async (input: string) =>
-      input.startsWith("/api/")
-        ? response(Buffer.from(JSON.stringify(wrongRepository)), 200, {
-          "x-khive-analysis-id": "khive",
-          "x-khive-analysis-source": "khive-db-snapshot",
-        })
-        : response(golden, 200)
+    const fetchBundle = vi.fn(async () =>
+      response(Buffer.from(JSON.stringify(wrongRepository)), 200, {
+        "x-khive-analysis-id": "khive",
+        "x-khive-analysis-source": "khive-db-snapshot",
+      })
     );
 
+    await expect(
+      loadPreferredShowcaseBundle(configuredStaticEntry, fetchBundle),
+    ).rejects.toThrow(/repository identity/i);
+    expect(fetchBundle).toHaveBeenCalledOnce();
+  });
+
+  it("loads a static-only entry without probing the analysis API", async () => {
+    const fetchBundle = vi.fn(async () => response(golden, 200));
+
     const result = await loadPreferredShowcaseBundle(
-      SHOWCASE_REGISTRY[0],
+      {
+        ...SHOWCASE_REGISTRY[0],
+        analysisId: undefined,
+      },
       fetchBundle,
     );
 
     expect(result.source).toBe("curated-static-fallback");
-    expect(result.bundle.schema_version).toBe("khive.repo.v1");
-    expect(fetchBundle).toHaveBeenCalledTimes(2);
+    expect(fetchBundle).toHaveBeenCalledOnce();
+    expect(fetchBundle).toHaveBeenCalledWith(
+      "/showcase/khive-repo-v1-khive.json",
+      expect.any(Object),
+    );
   });
 
-  it("falls back to the static asset when the DB snapshot request never settles", async () => {
+  it("returns a miss for a dynamic-only analysis 404", async () => {
+    const entry = {
+      id: "analysis:dynamic-only",
+      canonicalUrl: "https://github.com/example/dynamic-only",
+      aliases: ["https://github.com/example/dynamic-only"],
+      analysisId: "dynamic-only",
+    };
+    const fetchBundle = vi.fn(async () => response(new Uint8Array(), 404));
+
+    await expect(loadPreferredShowcaseBundle(entry, fetchBundle)).rejects
+      .toBeInstanceOf(ShowcaseAnalysisNotFoundError);
+    expect(fetchBundle).toHaveBeenCalledOnce();
+    expect(fetchBundle).toHaveBeenCalledWith(
+      "/api/showcase/analyses/dynamic-only",
+      expect.any(Object),
+    );
+  });
+
+  it("reports a hard failure when the DB snapshot request never settles", async () => {
     vi.useFakeTimers();
     try {
-      const fetchBundle = vi.fn((input: string) => {
-        if (input.startsWith("/api/")) {
-          return new Promise<never>(() => {});
-        }
-        return Promise.resolve(response(golden, 200));
-      });
+      const fetchBundle = vi.fn(() => new Promise<never>(() => {}));
 
       const resultPromise = loadPreferredShowcaseBundle(
-        SHOWCASE_REGISTRY[0],
+        configuredStaticEntry,
         fetchBundle,
       );
+      const assertion = expect(resultPromise).rejects.toThrow(
+        /did not settle/i,
+      );
       await vi.advanceTimersByTimeAsync(DB_SNAPSHOT_TIMEOUT_MS);
-      const result = await resultPromise;
-
-      expect(result.source).toBe("curated-static-fallback");
-      expect(result.bundle.schema_version).toBe("khive.repo.v1");
+      await assertion;
     } finally {
       vi.useRealTimers();
     }
   });
 
-  it("falls back to the static asset when the DB snapshot response body never completes", async () => {
+  it("reports a hard failure when the DB snapshot response body never completes", async () => {
     vi.useFakeTimers();
     try {
-      const fetchBundle = vi.fn((input: string) => {
-        if (input.startsWith("/api/")) {
-          return Promise.resolve({
-            ok: true,
-            status: 200,
-            headers: new Headers({
-              "x-khive-analysis-id": "khive",
-              "x-khive-analysis-source": "khive-db-snapshot",
-            }),
-            arrayBuffer: () => new Promise<ArrayBuffer>(() => {}),
-          });
-        }
-        return Promise.resolve(response(golden, 200));
-      });
+      const fetchBundle = vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          headers: new Headers({
+            "x-khive-analysis-id": "khive",
+            "x-khive-analysis-source": "khive-db-snapshot",
+          }),
+          arrayBuffer: () => new Promise<ArrayBuffer>(() => {}),
+        })
+      );
 
       const resultPromise = loadPreferredShowcaseBundle(
-        SHOWCASE_REGISTRY[0],
+        configuredStaticEntry,
         fetchBundle,
       );
+      const assertion = expect(resultPromise).rejects.toThrow(
+        /did not settle/i,
+      );
       await vi.advanceTimersByTimeAsync(DB_SNAPSHOT_TIMEOUT_MS);
-      const result = await resultPromise;
-
-      expect(result.source).toBe("curated-static-fallback");
-      expect(result.bundle.schema_version).toBe("khive.repo.v1");
+      await assertion;
     } finally {
       vi.useRealTimers();
     }
   });
 
-  it("does not surface an unhandled rejection or thrown error when every DB snapshot failure mode falls back", async () => {
+  it("never substitutes stale static data for a failing DB snapshot", async () => {
     const failureModes: Array<() => Promise<ReturnType<typeof response>>> = [
       () => Promise.reject(new TypeError("network down")),
       () => Promise.resolve(response(new Uint8Array(), 500)),
@@ -330,8 +284,9 @@ describe("preferred showcase source", () => {
       );
 
       await expect(
-        loadPreferredShowcaseBundle(SHOWCASE_REGISTRY[0], fetchBundle),
-      ).resolves.toMatchObject({ source: "curated-static-fallback" });
+        loadPreferredShowcaseBundle(configuredStaticEntry, fetchBundle),
+      ).rejects.toThrow();
+      expect(fetchBundle).toHaveBeenCalledOnce();
     }
   });
 });

--- a/apps/kg-editor/src/lib/adapters/preferred-showcase-source.ts
+++ b/apps/kg-editor/src/lib/adapters/preferred-showcase-source.ts
@@ -2,7 +2,6 @@ import {
   loadStaticShowcaseBundle,
   parseBoundedShowcaseResponse,
   type ShowcaseFetch,
-  type ShowcaseResponse,
 } from "@/lib/adapters/static-showcase-source";
 import type { RepoBundle } from "@/lib/repo-bundle";
 import {
@@ -44,61 +43,62 @@ export function readOperatorShowcaseAccessToken(): string | null {
   }
 }
 
+export class ShowcaseAnalysisNotFoundError extends Error {
+  readonly canonicalUrl: string;
+
+  constructor(canonicalUrl: string) {
+    super("The configured repository analysis is not available.");
+    this.name = "ShowcaseAnalysisNotFoundError";
+    this.canonicalUrl = canonicalUrl;
+  }
+}
+
+// A connection that never resolves, or a response body that stops
+// delivering bytes without rejecting, would otherwise leave the snapshot
+// read pending forever and keep the page in its loading state. This
+// deadline bounds the connection, header wait, and full body parse
+// together. Per ADR-147 Amendment 3 only a 404 may fall back to the
+// curated static asset, so an elapsed deadline is reported as a hard
+// failure rather than silently serving stale static data.
+export const DB_SNAPSHOT_TIMEOUT_MS = 5_000;
+
 export async function loadPreferredShowcaseBundle(
   entry: ShowcaseRegistryEntry,
   fetchBundle: ShowcaseFetch = fetch,
   options: PreferredShowcaseOptions = {},
 ): Promise<LoadedShowcaseBundle> {
   if (!isAllowedShowcaseAnalysis(entry)) {
+    if (!entry.assetPath) {
+      throw new ShowcaseAnalysisNotFoundError(entry.canonicalUrl);
+    }
     return {
       bundle: await loadStaticShowcaseBundle(entry, fetchBundle),
       source: "curated-static-fallback",
     };
   }
 
-  const dbBundle = await tryLoadDbSnapshotBundle(entry, fetchBundle, options);
-  if (dbBundle) {
-    return { bundle: dbBundle, source: "khive-db-snapshot" };
-  }
-
-  return {
-    bundle: await loadStaticShowcaseBundle(entry, fetchBundle),
-    source: "curated-static-fallback",
-  };
-}
-
-// A connection that never resolves, or a response body that stops
-// delivering bytes without rejecting, would otherwise leave the snapshot
-// read pending forever and keep the page in its loading state instead of
-// reaching the static fallback below. This deadline bounds the connection,
-// header wait, and full body parse together, so any of those hangs falls
-// back to the curated static asset once it elapses.
-export const DB_SNAPSHOT_TIMEOUT_MS = 5_000;
-
-// The DB snapshot is a progressive enhancement over the static asset: any
-// failure on this path (network, status, provenance, schema, identity, or
-// timeout) must fall back to the static render rather than fail the page.
-async function tryLoadDbSnapshotBundle(
-  entry: ShowcaseRegistryEntry,
-  fetchBundle: ShowcaseFetch,
-  options: PreferredShowcaseOptions,
-): Promise<RepoBundle | null> {
   const controller = new AbortController();
   const timeoutId = setTimeout(
     () => controller.abort(),
     DB_SNAPSHOT_TIMEOUT_MS,
   );
-  const deadline = new Promise<null>((resolve) => {
-    controller.signal.addEventListener("abort", () => resolve(null), {
-      once: true,
-    });
+  const deadline = new Promise<never>((_, reject) => {
+    controller.signal.addEventListener("abort", () => {
+      reject(
+        new Error(
+          `Database snapshot request did not settle within ${DB_SNAPSHOT_TIMEOUT_MS}ms.`,
+        ),
+      );
+    }, { once: true });
   });
 
+  const read = readDbSnapshotBundle(entry, fetchBundle, options, controller.signal);
+  // When the deadline wins the race the abandoned read may still reject
+  // later (e.g. an AbortError from the fetch); mark it handled so it never
+  // surfaces as an unhandled rejection.
+  read.catch(() => {});
   try {
-    return await Promise.race([
-      readDbSnapshotBundle(entry, fetchBundle, options, controller.signal),
-      deadline,
-    ]);
+    return await Promise.race([read, deadline]);
   } finally {
     clearTimeout(timeoutId);
   }
@@ -109,52 +109,62 @@ async function readDbSnapshotBundle(
   fetchBundle: ShowcaseFetch,
   options: PreferredShowcaseOptions,
   signal: AbortSignal,
-): Promise<RepoBundle | null> {
+): Promise<LoadedShowcaseBundle> {
   const endpoint = `/api/showcase/analyses/${entry.analysisId}`;
   const accessToken = options.accessToken?.trim();
-  let response: ShowcaseResponse;
-  try {
-    response = await fetchBundle(endpoint, {
-      cache: "no-store",
-      credentials: "same-origin",
-      redirect: "error",
-      signal,
-      ...(accessToken
-        ? { headers: { authorization: `Bearer ${accessToken}` } }
-        : {}),
-    });
-  } catch {
-    return null;
-  }
+  const response = await fetchBundle(endpoint, {
+    cache: "no-store",
+    credentials: "same-origin",
+    redirect: "error",
+    signal,
+    ...(accessToken
+      ? { headers: { authorization: `Bearer ${accessToken}` } }
+      : {}),
+  });
 
+  if (response.status === 404) {
+    if (!entry.assetPath) {
+      throw new ShowcaseAnalysisNotFoundError(entry.canonicalUrl);
+    }
+    return {
+      bundle: await loadStaticShowcaseBundle(entry, fetchBundle),
+      source: "curated-static-fallback",
+    };
+  }
   if (!response.ok) {
-    return null;
+    throw new Error(
+      `Database snapshot could not be loaded (HTTP ${response.status}).`,
+    );
   }
   if (
     response.headers.get("x-khive-analysis-source") !== "khive-db-snapshot" ||
     response.headers.get("x-khive-analysis-id") !== entry.analysisId
   ) {
-    return null;
+    throw new Error(
+      "Database snapshot provenance did not match the curated registry.",
+    );
   }
 
-  try {
-    const bundle = await parseBoundedShowcaseResponse(
-      response,
-      "Database snapshot",
+  const bundle = await parseBoundedShowcaseResponse(
+    response,
+    "Database snapshot",
+  );
+  const expectedRepository = normalizeRepositoryUrl(entry.canonicalUrl);
+  const actualRepository = normalizeRepositoryUrl(
+    bundle.meta.repository.canonical_url,
+  );
+  if (
+    !expectedRepository.ok ||
+    !actualRepository.ok ||
+    actualRepository.value !== expectedRepository.value
+  ) {
+    throw new Error(
+      "Database snapshot repository identity did not match the curated registry.",
     );
-    const expectedRepository = normalizeRepositoryUrl(entry.canonicalUrl);
-    const actualRepository = normalizeRepositoryUrl(
-      bundle.meta.repository.canonical_url,
-    );
-    if (
-      !expectedRepository.ok ||
-      !actualRepository.ok ||
-      actualRepository.value !== expectedRepository.value
-    ) {
-      return null;
-    }
-    return bundle;
-  } catch {
-    return null;
   }
+
+  return {
+    bundle,
+    source: "khive-db-snapshot",
+  };
 }

--- a/apps/kg-editor/src/lib/adapters/showcase-analysis-catalog.test.ts
+++ b/apps/kg-editor/src/lib/adapters/showcase-analysis-catalog.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  loadShowcaseAnalysisCatalog,
+  mergeShowcaseRegistry,
+  parseShowcaseAnalysisCatalog,
+  SHOWCASE_CATALOG_MAX_BYTES,
+  SHOWCASE_CATALOG_MAX_ENTRIES,
+} from "@/lib/adapters/showcase-analysis-catalog";
+import type { ShowcaseRegistryEntry } from "@/lib/showcase-registry";
+
+const staticEntry: ShowcaseRegistryEntry = {
+  id: "github.com/example/repository",
+  canonicalUrl: "https://github.com/example/repository",
+  aliases: ["http://github.com/example/repository.git"],
+  assetPath: "/showcase/example.json",
+  analysisId: "legacy-static-id",
+};
+
+function catalogResponse(
+  value: unknown,
+  status = 200,
+  headers: Record<string, string> = {},
+) {
+  const bytes = new TextEncoder().encode(JSON.stringify(value));
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: new Headers({
+      "content-length": String(bytes.byteLength),
+      ...headers,
+    }),
+    arrayBuffer: () => Promise.resolve(bytes.buffer as ArrayBuffer),
+  };
+}
+
+describe("showcase analysis catalog", () => {
+  it("parses the exact deterministic v1 envelope", () => {
+    expect(parseShowcaseAnalysisCatalog({
+      schema_version: "khive.showcase.catalog.v1",
+      entries: [
+        {
+          analysis_id: "alpha",
+          canonical_url: "https://github.com/example/alpha",
+        },
+        {
+          analysis_id: "zeta",
+          canonical_url: "https://github.com/example/zeta",
+        },
+      ],
+    })).toEqual([
+      {
+        analysis_id: "alpha",
+        canonical_url: "https://github.com/example/alpha",
+      },
+      {
+        analysis_id: "zeta",
+        canonical_url: "https://github.com/example/zeta",
+      },
+    ]);
+  });
+
+  it.each([
+    ["an unknown envelope field", {
+      schema_version: "khive.showcase.catalog.v1",
+      entries: [],
+      root: "/private/analyses",
+    }],
+    ["an unknown entry field", {
+      schema_version: "khive.showcase.catalog.v1",
+      entries: [{
+        analysis_id: "alpha",
+        canonical_url: "https://github.com/example/alpha",
+        report_path: "/private/report.json",
+      }],
+    }],
+    ["a non-canonical repository URL", {
+      schema_version: "khive.showcase.catalog.v1",
+      entries: [{
+        analysis_id: "alpha",
+        canonical_url: "http://www.github.com/example/alpha.git",
+      }],
+    }],
+    ["entries outside deterministic ID order", {
+      schema_version: "khive.showcase.catalog.v1",
+      entries: [
+        {
+          analysis_id: "zeta",
+          canonical_url: "https://github.com/example/zeta",
+        },
+        {
+          analysis_id: "alpha",
+          canonical_url: "https://github.com/example/alpha",
+        },
+      ],
+    }],
+  ])("rejects %s", (_name, value) => {
+    expect(() => parseShowcaseAnalysisCatalog(value)).toThrow(/catalog/i);
+  });
+
+  it("rejects an oversized catalog before accepting any entry", () => {
+    const entries = Array.from(
+      { length: SHOWCASE_CATALOG_MAX_ENTRIES + 1 },
+      (_, index) => ({
+        analysis_id: `analysis-${index}`,
+        canonical_url: `https://github.com/example/repository-${index}`,
+      }),
+    );
+
+    expect(() => parseShowcaseAnalysisCatalog({
+      schema_version: "khive.showcase.catalog.v1",
+      entries,
+    })).toThrow(/catalog/i);
+  });
+
+  it("rejects an empty successful catalog instead of treating it as unconfigured", () => {
+    expect(() => parseShowcaseAnalysisCatalog({
+      schema_version: "khive.showcase.catalog.v1",
+      entries: [],
+    })).toThrow(/catalog/i);
+  });
+
+  it.each([
+    [
+      "analysis ID",
+      [
+        {
+          analysis_id: "same",
+          canonical_url: "https://github.com/example/one",
+        },
+        {
+          analysis_id: "same",
+          canonical_url: "https://github.com/example/two",
+        },
+      ],
+    ],
+    [
+      "normalized repository URL",
+      [
+        {
+          analysis_id: "one",
+          canonical_url: "https://github.com/example/same",
+        },
+        {
+          analysis_id: "two",
+          canonical_url: "https://github.com/example/same",
+        },
+      ],
+    ],
+  ])("rejects a duplicate %s", (_name, entries) => {
+    expect(() => parseShowcaseAnalysisCatalog({
+      schema_version: "khive.showcase.catalog.v1",
+      entries,
+    })).toThrow(/catalog/i);
+  });
+
+  it("treats an unconfigured 404 as static-only", async () => {
+    const fetchCatalog = vi.fn(async () => catalogResponse({}, 404));
+
+    await expect(loadShowcaseAnalysisCatalog(fetchCatalog)).resolves.toEqual({
+      status: "static-only",
+      entries: [],
+      message: expect.stringMatching(/not configured/i),
+    });
+  });
+
+  it.each([
+    ["an unavailable response", async () => catalogResponse({}, 503)],
+    ["a malformed successful response", async () => catalogResponse({ entries: [] })],
+    ["a transport failure", async () => { throw new Error("offline"); }],
+  ])("degrades safely for %s", async (_name, fetchCatalog) => {
+    await expect(loadShowcaseAnalysisCatalog(fetchCatalog)).resolves.toEqual({
+      status: "degraded",
+      entries: [],
+      message: expect.stringMatching(/catalog.*unavailable/i),
+    });
+  });
+
+  it("rejects a declared catalog body above its browser limit", async () => {
+    const fetchCatalog = vi.fn(async () => catalogResponse(
+      {
+        schema_version: "khive.showcase.catalog.v1",
+        entries: [],
+      },
+      200,
+      { "content-length": String(SHOWCASE_CATALOG_MAX_BYTES + 1) },
+    ));
+
+    await expect(loadShowcaseAnalysisCatalog(fetchCatalog)).resolves.toMatchObject({
+      status: "degraded",
+    });
+  });
+
+  it("merges dynamic and static entries by normalized URL", () => {
+    const registry = mergeShowcaseRegistry([
+      {
+        analysis_id: "configured-analysis",
+        canonical_url: "https://github.com/example/repository",
+      },
+      {
+        analysis_id: "dynamic-only",
+        canonical_url: "https://github.com/example/dynamic",
+      },
+    ], [staticEntry]);
+
+    expect(registry).toStrictEqual([
+      {
+        ...staticEntry,
+        analysisId: "configured-analysis",
+      },
+      {
+        id: "analysis:dynamic-only",
+        canonicalUrl: "https://github.com/example/dynamic",
+        aliases: ["https://github.com/example/dynamic"],
+        assetPath: undefined,
+        analysisId: "dynamic-only",
+      },
+    ]);
+  });
+
+  it("removes legacy analysis IDs when the catalog does not configure them", () => {
+    expect(mergeShowcaseRegistry([], [staticEntry])).toEqual([
+      {
+        ...staticEntry,
+        analysisId: undefined,
+      },
+    ]);
+  });
+});

--- a/apps/kg-editor/src/lib/adapters/showcase-analysis-catalog.test.ts
+++ b/apps/kg-editor/src/lib/adapters/showcase-analysis-catalog.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { SHOWCASE_ACCESS_TOKEN_STORAGE_KEY } from "@/lib/adapters/preferred-showcase-source";
 import {
   loadShowcaseAnalysisCatalog,
   mergeShowcaseRegistry,
@@ -173,6 +174,35 @@ describe("showcase analysis catalog", () => {
       status: "degraded",
       entries: [],
       message: expect.stringMatching(/catalog.*unavailable/i),
+    });
+  });
+
+  it("sends the operator bearer token on the catalog fetch when a session token is present", async () => {
+    window.sessionStorage.setItem(
+      SHOWCASE_ACCESS_TOKEN_STORAGE_KEY,
+      "  operator-secret  ",
+    );
+    try {
+      const fetchCatalog = vi.fn(async () => catalogResponse({}, 404));
+      await loadShowcaseAnalysisCatalog(fetchCatalog);
+      expect(fetchCatalog).toHaveBeenCalledWith("/api/showcase/analyses", {
+        cache: "no-store",
+        credentials: "same-origin",
+        redirect: "error",
+        headers: { authorization: "Bearer operator-secret" },
+      });
+    } finally {
+      window.sessionStorage.removeItem(SHOWCASE_ACCESS_TOKEN_STORAGE_KEY);
+    }
+  });
+
+  it("sends no Authorization header on the catalog fetch when no session token is present", async () => {
+    const fetchCatalog = vi.fn(async () => catalogResponse({}, 404));
+    await loadShowcaseAnalysisCatalog(fetchCatalog);
+    expect(fetchCatalog).toHaveBeenCalledWith("/api/showcase/analyses", {
+      cache: "no-store",
+      credentials: "same-origin",
+      redirect: "error",
     });
   });
 

--- a/apps/kg-editor/src/lib/adapters/showcase-analysis-catalog.ts
+++ b/apps/kg-editor/src/lib/adapters/showcase-analysis-catalog.ts
@@ -1,0 +1,182 @@
+import {
+  normalizeRepositoryUrl,
+  SHOWCASE_REGISTRY,
+  type ShowcaseRegistryEntry,
+} from "@/lib/showcase-registry";
+
+export const SHOWCASE_CATALOG_MAX_ENTRIES = 64;
+export const SHOWCASE_CATALOG_MAX_BYTES = 256 * 1024;
+
+const ANALYSIS_ID = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/;
+const CATALOG_SCHEMA = "khive.showcase.catalog.v1";
+
+export type ShowcaseAnalysisCatalogEntry = Readonly<{
+  analysis_id: string;
+  canonical_url: string;
+}>;
+
+export type ShowcaseAnalysisCatalogResult =
+  | Readonly<{
+      status: "ready";
+      entries: readonly ShowcaseAnalysisCatalogEntry[];
+      message: string;
+    }>
+  | Readonly<{
+      status: "static-only" | "degraded";
+      entries: readonly [];
+      message: string;
+    }>;
+
+export type ShowcaseCatalogFetch = (
+  input: string,
+  init?: RequestInit,
+) => Promise<Pick<Response, "ok" | "status" | "headers" | "arrayBuffer">>;
+
+function exactKeys(value: object, expected: readonly string[]): boolean {
+  return Object.keys(value).sort().join(",") === [...expected].sort().join(",");
+}
+
+function invalidCatalog(): never {
+  throw new Error("The repository analysis catalog is invalid.");
+}
+
+export function parseShowcaseAnalysisCatalog(
+  value: unknown,
+): readonly ShowcaseAnalysisCatalogEntry[] {
+  if (
+    !value || typeof value !== "object" || Array.isArray(value) ||
+    !exactKeys(value, ["schema_version", "entries"]) ||
+    Reflect.get(value, "schema_version") !== CATALOG_SCHEMA
+  ) {
+    return invalidCatalog();
+  }
+
+  const candidates = Reflect.get(value, "entries");
+  if (
+    !Array.isArray(candidates) ||
+    candidates.length === 0 ||
+    candidates.length > SHOWCASE_CATALOG_MAX_ENTRIES
+  ) {
+    return invalidCatalog();
+  }
+
+  const entries: ShowcaseAnalysisCatalogEntry[] = [];
+  const ids = new Set<string>();
+  const urls = new Set<string>();
+  let previousId: string | undefined;
+  for (const candidate of candidates) {
+    if (
+      !candidate || typeof candidate !== "object" || Array.isArray(candidate) ||
+      !exactKeys(candidate, ["analysis_id", "canonical_url"])
+    ) {
+      return invalidCatalog();
+    }
+    const analysisId = Reflect.get(candidate, "analysis_id");
+    const canonicalUrl = Reflect.get(candidate, "canonical_url");
+    if (
+      typeof analysisId !== "string" || !ANALYSIS_ID.test(analysisId) ||
+      typeof canonicalUrl !== "string"
+    ) {
+      return invalidCatalog();
+    }
+    const normalized = normalizeRepositoryUrl(canonicalUrl);
+    if (
+      !normalized.ok || normalized.value !== canonicalUrl ||
+      ids.has(analysisId) || urls.has(normalized.value) ||
+      (previousId !== undefined && analysisId < previousId)
+    ) {
+      return invalidCatalog();
+    }
+    ids.add(analysisId);
+    urls.add(normalized.value);
+    previousId = analysisId;
+    entries.push({
+      analysis_id: analysisId,
+      canonical_url: normalized.value,
+    });
+  }
+  return entries;
+}
+
+export async function loadShowcaseAnalysisCatalog(
+  fetchCatalog: ShowcaseCatalogFetch = fetch,
+): Promise<ShowcaseAnalysisCatalogResult> {
+  try {
+    const response = await fetchCatalog("/api/showcase/analyses", {
+      cache: "no-store",
+      credentials: "same-origin",
+      redirect: "error",
+    });
+    if (response.status === 404) {
+      return {
+        status: "static-only",
+        entries: [],
+        message: "The server analysis catalog is not configured; curated static repositories remain available.",
+      };
+    }
+    if (!response.ok) {
+      throw new Error(`catalog HTTP ${response.status}`);
+    }
+
+    const declaredLength = Number(response.headers.get("content-length"));
+    if (
+      Number.isFinite(declaredLength) &&
+      declaredLength > SHOWCASE_CATALOG_MAX_BYTES
+    ) {
+      return invalidCatalog();
+    }
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    if (bytes.byteLength > SHOWCASE_CATALOG_MAX_BYTES) {
+      return invalidCatalog();
+    }
+    const json = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+    const entries = parseShowcaseAnalysisCatalog(JSON.parse(json));
+    return {
+      status: "ready",
+      entries,
+      message: `${entries.length} configured repository ${entries.length === 1 ? "analysis" : "analyses"} discovered.`,
+    };
+  } catch {
+    return {
+      status: "degraded",
+      entries: [],
+      message: "The server analysis catalog is unavailable; curated static repositories remain available.",
+    };
+  }
+}
+
+export function mergeShowcaseRegistry(
+  catalog: readonly ShowcaseAnalysisCatalogEntry[],
+  staticRegistry: readonly ShowcaseRegistryEntry[] = SHOWCASE_REGISTRY,
+): readonly ShowcaseRegistryEntry[] {
+  const merged: ShowcaseRegistryEntry[] = staticRegistry.map((entry) => ({
+    ...entry,
+    analysisId: undefined,
+  }));
+  const staticByUrl = new Map<string, number>();
+  for (const [index, entry] of merged.entries()) {
+    const normalized = normalizeRepositoryUrl(entry.canonicalUrl);
+    if (normalized.ok && !staticByUrl.has(normalized.value)) {
+      staticByUrl.set(normalized.value, index);
+    }
+  }
+
+  for (const entry of catalog) {
+    const staticIndex = staticByUrl.get(entry.canonical_url);
+    if (staticIndex !== undefined) {
+      merged[staticIndex] = {
+        ...merged[staticIndex],
+        analysisId: entry.analysis_id,
+      };
+      continue;
+    }
+    merged.push({
+      id: `analysis:${entry.analysis_id}`,
+      canonicalUrl: entry.canonical_url,
+      aliases: [entry.canonical_url],
+      assetPath: undefined,
+      analysisId: entry.analysis_id,
+    });
+  }
+  return merged;
+}

--- a/apps/kg-editor/src/lib/adapters/showcase-analysis-catalog.ts
+++ b/apps/kg-editor/src/lib/adapters/showcase-analysis-catalog.ts
@@ -1,3 +1,4 @@
+import { readOperatorShowcaseAccessToken } from "@/lib/adapters/preferred-showcase-source";
 import {
   normalizeRepositoryUrl,
   SHOWCASE_REGISTRY,
@@ -102,10 +103,14 @@ export async function loadShowcaseAnalysisCatalog(
   fetchCatalog: ShowcaseCatalogFetch = fetch,
 ): Promise<ShowcaseAnalysisCatalogResult> {
   try {
+    const accessToken = readOperatorShowcaseAccessToken()?.trim();
     const response = await fetchCatalog("/api/showcase/analyses", {
       cache: "no-store",
       credentials: "same-origin",
       redirect: "error",
+      ...(accessToken
+        ? { headers: { authorization: `Bearer ${accessToken}` } }
+        : {}),
     });
     if (response.status === 404) {
       return {

--- a/apps/kg-editor/src/lib/adapters/static-showcase-source.ts
+++ b/apps/kg-editor/src/lib/adapters/static-showcase-source.ts
@@ -41,11 +41,12 @@ export async function loadStaticShowcaseBundle(
   entry: ShowcaseRegistryEntry,
   fetchBundle: ShowcaseFetch = fetch,
 ): Promise<RepoBundle> {
-  if (!isAllowedShowcaseAsset(entry.assetPath)) {
+  const assetPath = entry.assetPath;
+  if (!isAllowedShowcaseAsset(assetPath)) {
     throw new Error("The curated registry referenced an unapproved showcase asset.");
   }
 
-  const response = await fetchBundle(entry.assetPath, {
+  const response = await fetchBundle(assetPath, {
     cache: "force-cache",
     credentials: "same-origin",
     redirect: "error",

--- a/apps/kg-editor/src/lib/repository-location.test.ts
+++ b/apps/kg-editor/src/lib/repository-location.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import type { ViewId } from "@/lib/repo-bundle";
 import {
+  investigationShareUrl,
   parseRepositoryLocation,
   REPOSITORY_VIEW_IDS,
   type RepositoryLocation,
-  investigationShareUrl,
   repositoryLocationUrl,
 } from "@/lib/repository-location";
 
@@ -31,8 +31,8 @@ describe("repository investigation location", () => {
 
       expect(parsed.issues).toEqual([]);
       expect(parsed.location).toEqual(location);
-      expect(url.searchParams.get("utm_source")).toBe("demo");
-      expect(url.hash).toBe("#analysis");
+      expect(url.searchParams.has("utm_source")).toBe(false);
+      expect(url.hash).toBe("");
     },
   );
 
@@ -90,7 +90,7 @@ describe("repository investigation location", () => {
     },
   );
 
-  it("canonicalizes only the closed location parameters in stable order", () => {
+  it("canonicalizes to only the closed location parameters in stable order, dropping every other query parameter", () => {
     const url = repositoryLocationUrl(
       new URL(
         "https://example.test/?view=scorecard&module=old.rs&at=old&repo=old&keep=1",
@@ -104,10 +104,47 @@ describe("repository investigation location", () => {
     );
 
     expect(url.search).toBe(
-      `?keep=1&repo=${
+      `?repo=${
         encodeURIComponent(repository)
       }&at=${snapshotSha}&module=crates%2Fkhive-db%2Fsrc%2Fpool.rs&view=dependency_topology`,
     );
+    expect(url.searchParams.has("keep")).toBe(false);
+  });
+
+  it("drops credential-bearing query parameters instead of preserving them", () => {
+    const url = repositoryLocationUrl(
+      new URL(
+        "https://example.test/?access_token=super-secret&id_token=another-secret",
+      ),
+      {
+        repository,
+        snapshotSha,
+        modulePath: null,
+        view: "scorecard",
+      },
+    );
+
+    expect(url.searchParams.has("access_token")).toBe(false);
+    expect(url.searchParams.has("id_token")).toBe(false);
+    expect(url.href).not.toContain("super-secret");
+    expect(url.href).not.toContain("another-secret");
+  });
+
+  it("drops a fragment-borne credential instead of preserving it", () => {
+    const url = repositoryLocationUrl(
+      new URL(
+        "https://example.test/#access_token=super-secret",
+      ),
+      {
+        repository,
+        snapshotSha,
+        modulePath: null,
+        view: "scorecard",
+      },
+    );
+
+    expect(url.hash).toBe("");
+    expect(url.href).not.toContain("super-secret");
   });
 
   it("share form carries only investigation parameters and drops the fragment", () => {

--- a/apps/kg-editor/src/lib/repository-location.ts
+++ b/apps/kg-editor/src/lib/repository-location.ts
@@ -1,4 +1,5 @@
 import type { ViewId } from "@/lib/repo-bundle";
+import { normalizeRepositoryUrl } from "@/lib/showcase-registry";
 
 export const REPOSITORY_VIEW_IDS = [
   "structure_graph",
@@ -103,9 +104,13 @@ function parseRepository(
   issues: RepositoryLocationIssue[],
 ): string | null {
   if (value == null) return null;
-  const message = publicRepositoryUrlIssue(value);
-  if (message) {
-    issues.push({ parameter: "repo", message });
+  if (value.length > REPOSITORY_URL_LIMIT) {
+    issues.push({ parameter: "repo", message: "The repository URL is too long." });
+    return null;
+  }
+  const normalized = normalizeRepositoryUrl(value);
+  if (!normalized.ok) {
+    issues.push({ parameter: "repo", message: normalized.reason });
     return null;
   }
   return value;
@@ -172,40 +177,42 @@ export function parseRepositoryLocation(url: URL): ParsedRepositoryLocation {
   };
 }
 
+// Investigation URLs are copied to the clipboard and written to browser
+// history, so they carry ONLY the four parameters this app defines. A page
+// URL that arrived with an unrelated query parameter or fragment — a
+// credential such as ?access_token=..., a fragment-borne secret, a tracker
+// value — is never copied forward: the URL is rebuilt from the origin and
+// path only, and every other parameter and the hash are discarded.
 export function repositoryLocationUrl(
   base: URL,
   location: RepositoryLocation,
 ): URL {
-  const url = new URL(base);
+  const url = new URL(base.origin + base.pathname);
+  const values: Record<LocationParameter, string | null> = {
+    repo: location.repository,
+    at: location.snapshotSha,
+    module: location.modulePath,
+    view: location.view,
+  };
   for (const parameter of LOCATION_PARAMETERS) {
-    url.searchParams.delete(parameter);
+    const value = values[parameter];
+    if (value) url.searchParams.append(parameter, value);
   }
-  if (location.repository) url.searchParams.append("repo", location.repository);
-  if (location.snapshotSha) url.searchParams.append("at", location.snapshotSha);
-  if (location.modulePath) {
-    url.searchParams.append("module", location.modulePath);
-  }
-  if (location.view) url.searchParams.append("view", location.view);
   return url;
 }
 
 /**
- * The shareable form of an investigation URL. A share link leaves the
- * browser, so it carries ONLY the investigation parameters: every foreign
- * query parameter and the URL fragment are dropped rather than copied,
- * because the current address bar can hold values that must not be
- * disclosed to a link recipient (tokens, authorization codes, tracker
- * state). `repositoryLocationUrl` stays the in-browser history form, which
- * preserves foreign parameters locally.
- *
- * The boundary also applies to the parameter VALUES, not just the
- * parameter names: a validated repository URL may legitimately carry a
- * query string or fragment (deep-link support keeps them in-browser), so
- * the shared copy is normalized to origin + pathname; a module path
- * carrying a URL query or fragment delimiter is omitted entirely rather
- * than encoded into the value, because encoding preserves — not redacts —
- * whatever the delimiter introduced. `at` and `view` need no value
- * boundary: their parse contracts are a 40-hex SHA and a closed id set.
+ * The shareable form of an investigation URL. `repositoryLocationUrl`
+ * already discards every foreign query parameter and the fragment, but a
+ * validated repository URL may legitimately carry a query string or
+ * fragment of its OWN (deep-link support keeps those in-browser), so this
+ * boundary also applies to the parameter VALUES, not just the parameter
+ * names: the shared repository value is normalized to origin + pathname,
+ * and a module path carrying a URL query or fragment delimiter is omitted
+ * entirely rather than encoded into the value, because encoding preserves
+ * — not redacts — whatever the delimiter introduced. `at` and `view` need
+ * no value boundary: their parse contracts are a 40-hex SHA and a closed
+ * id set.
  */
 export function investigationShareUrl(
   base: URL,

--- a/apps/kg-editor/src/lib/showcase-registry.ts
+++ b/apps/kg-editor/src/lib/showcase-registry.ts
@@ -4,7 +4,7 @@ export type ShowcaseRegistryEntry = Readonly<{
   id: string;
   canonicalUrl: string;
   aliases: readonly string[];
-  assetPath: string;
+  assetPath?: string;
   analysisId?: string;
 }>;
 
@@ -94,20 +94,17 @@ export function resolveShowcaseRepository(
 }
 
 export function isAllowedShowcaseAsset(
-  assetPath: string,
+  assetPath: string | undefined,
   registry: readonly ShowcaseRegistryEntry[] = SHOWCASE_REGISTRY,
-): boolean {
-  return assetPath.startsWith(SHOWCASE_ASSET_PREFIX) &&
+): assetPath is string {
+  return typeof assetPath === "string" &&
+    assetPath.startsWith(SHOWCASE_ASSET_PREFIX) &&
     registry.some((entry) => entry.assetPath === assetPath);
 }
 
 export function isAllowedShowcaseAnalysis(
   entry: ShowcaseRegistryEntry,
-  registry: readonly ShowcaseRegistryEntry[] = SHOWCASE_REGISTRY,
 ): entry is ShowcaseRegistryEntry & Readonly<{ analysisId: string }> {
   return typeof entry.analysisId === "string" &&
-    /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/.test(entry.analysisId) &&
-    registry.some((candidate) =>
-      candidate.id === entry.id && candidate.analysisId === entry.analysisId
-    );
+    /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/.test(entry.analysisId);
 }

--- a/docs/adr/ADR-147-repo-showcase-bundle.md
+++ b/docs/adr/ADR-147-repo-showcase-bundle.md
@@ -368,7 +368,47 @@ A mismatch is `ANALYSIS_INVALID`; neither URL nor a private path is reflected in
 error. Request-time clone, export, SQLite access, process execution, directory scanning,
 and arbitrary URL ingest remain forbidden.
 
-## Amendment 3 — Bearer-token authorization on the snapshot routes (2026-08-17)
+## Amendment 3 — Browser catalog consumer and fallback boundary (2026-08-14)
+
+The showcase browser discovers the operator catalog before it resolves either the
+default repository or a `repo=` deep link. Until discovery completes, repository
+selection and URL submission remain busy and cannot start a report request. The
+consumer accepts only the exact `khive.showcase.catalog.v1` envelope from Amendment 2,
+with at most 64 entries, exact entry fields, canonical URLs, unique IDs and normalized
+URLs, and deterministic ascending ID order. It also enforces a 256 KiB transport bound.
+An unknown envelope field, malformed or non-canonical entry, duplicate, out-of-order
+entry, invalid UTF-8/JSON, or exceeded bound invalidates the complete dynamic catalog.
+
+Catalog discovery has three explicit outcomes:
+
+- `200` with a valid envelope enables the configured entries;
+- the sanitized `404 NOT_CONFIGURED` outcome selects the curated static registry only;
+- transport failure, a non-404 error, or an invalid response degrades to that same
+  static registry while disclosing the degraded catalog state.
+
+The browser merges configured and curated entries by normalized repository URL. A
+configured entry for an existing curated URL supplies its analysis ID while retaining
+the curated asset as a narrowly scoped fallback. A configured URL absent from the
+curated registry is selectable and deep-linkable but has no static asset. URL input is
+resolved locally against this merged registry; it never becomes a server path, report
+path, process argument, clone target, or analysis endpoint parameter.
+
+For a configured entry, the browser requests the opaque ID route first. Only a `404`
+may fall back, and only when that same merged entry owns an approved curated asset.
+Server errors, malformed or oversized reports, missing or mismatched provenance
+headers, and repository-identity mismatches are hard failures and never fall back. A
+configured-only entry whose report returns `404` becomes an honest repository miss.
+Static-only entries load their approved same-origin asset directly.
+
+The selection surface is a labeled native repository selector paired with the public
+repository URL. It exposes catalog status, report-loading status, busy state, and the
+actual source (`khive DB snapshot` or `curated static fallback`) as visible and
+assistive-technology-readable state. Selecting another repository clears stale module,
+snapshot, and view investigation parameters; canonicalizing the initial deep link
+preserves them. These rules keep fallback useful without allowing a stale static bundle
+to conceal a configured report's integrity or availability failure.
+
+## Amendment 4 — Bearer-token authorization on the snapshot routes (2026-08-17)
 
 Amendments 1 and 2 kept the report and catalog server-private by never accepting
 browser-supplied paths, but neither route authenticated the caller: any network


### PR DESCRIPTION
Ports the analysis-catalog feature onto current main, superseding #1960 (stale fork point; its content is squash-ported here on top of the module-inspector and bearer-token work that landed since).

## What

- The showcase discovers repository analyses dynamically from a served catalog (`loadShowcaseAnalysisCatalog`, `mergeShowcaseRegistry`) instead of only the static registry; catalog-only entries need no static asset (`assetPath` becomes optional).
- Repository-analysis picker and analysis-status section in the showcase UI, with honest-miss reporting (`ShowcaseAnalysisNotFoundError`; only a 404 with a static asset present falls back — timeouts, 5xx, malformed bodies, and provenance mismatches are hard failures per ADR-147 Amendment 3).
- `repositoryLocationUrl` now strips foreign query parameters and the fragment, so tokens or tracking parameters in a pasted repository URL cannot survive into history/clipboard links.
- `isAllowedShowcaseAnalysis` validates `analysisId` by format (lowercase DNS-label shape); the previous static-registry membership requirement would reject every catalog-discovered entry and is structurally redundant for internally constructed entries.
- Bearer-token support (access-token cache keys, re-authorization on snapshot loads) and the strict-fallback contract are merged, both preserved from main.

## Gates

`npm run test` 260/260 across 25 files, `npm run typecheck` clean, `npm run lint` clean (all re-run by the submitting lane).

Closes #1960.