### PR TITLE
feat(kg-editor): expose hidden coupling lens

### DIFF
--- a/apps/kg-editor/DEMO.md
+++ b/apps/kg-editor/DEMO.md
@@ -2,7 +2,7 @@
 
 This walkthrough demonstrates the repository showcase as an investigation tool,
 not a generic dashboard. The example values below come from the khive snapshot
-at `288b9eee1f471d505e7f5de33e121c58773a10af`. When using a newer snapshot,
+at `c2979d2443738a075e55a170c772d1dc86cf0f91`. When using a newer snapshot,
 narrate the values and coverage displayed by the UI.
 
 ## Prepare the materialized snapshot
@@ -47,8 +47,8 @@ conceals a configured report's integrity or availability failure.
    field, and select **Open repository**.
 2. Point to the DB-snapshot badge, pinned SHA, ingestion time, and exporter
    identity.
-3. Point to the overview: this snapshot contains 45 packages, 683 modules, 990
-   commits, and seven captured dependency SCCs.
+3. Point to the overview: this snapshot contains 43 packages, 658 modules, 938
+   commits, and five captured dependency SCCs.
 
 Say:
 
@@ -65,10 +65,10 @@ distinguish production, test, example, and generated modules.
 ### 2. Start at the writer/storage seam
 
 1. Search for `crates/khive-db/src/pool.rs` and inspect it.
-2. Show fan-in 20, fan-out 2, 26 captured commits, and bus factor 1.
+2. Show fan-in 20, fan-out 2, 19 captured commits, and bus factor 1.
 3. In **Dependency topology**, follow the SCC member link to
    `crates/khive-db/src/writer_task.rs`.
-4. Show its fan-in 9, fan-out 2, 21 captured commits, and the same two-member
+4. Show its fan-in 8, fan-out 2, 14 captured commits, and the same two-member
    SCC.
 
 Say:
@@ -84,7 +84,7 @@ test modules, so 20 is not a production-only fan-in.
 
 ### 3. Show an architectural insight that argues against consolidation
 
-Search for `crates/khive-db/src/checkpoint.rs`. It has 38 captured commits and
+Search for `crates/khive-db/src/checkpoint.rs`. It has 31 captured commits and
 co-change evidence across DB, runtime, and MCP. Source and ADR inspection
 explains why this control plane must remain physically independent of the writer
 queue: a dedicated checkpoint connection prevents checkpoint I/O from consuming
@@ -94,9 +94,9 @@ control/metrics facade, not SQLite connection ownership.
 ### 4. Move to the runtime coordination knot
 
 1. Search for `crates/khive-runtime/src/operations.rs`.
-2. Show 90 captured commits, fan-in 4, fan-out 7, and its SCC with `pack.rs` and
+2. Show 89 captured commits, fan-in 4, fan-out 7, and its SCC with `pack.rs` and
    `curation.rs`.
-3. Point to the history disclosure: the total is 90 while the inspector shows a
+3. Point to the history disclosure: the total is 89 while the inspector shows a
    recent sample from the captured page.
 4. Open **Dependency topology** and show SCC membership without implying an edge
    order.
@@ -108,11 +108,21 @@ Say:
 > dependency-lower contract, followed by the split plans already documented in
 > these source files.
 
-### 5. Use a false positive to demonstrate trustworthiness
+### 5. Verify a hidden boundary instead of trusting a rank
 
-Open the top **Hidden coupling** candidate. In this snapshot it is
-`khive-pack-comm/tests/integration.rs` with `src/handlers.rs`, at 40 co-changes.
-The global analysis contains only the top 1,000 of 104,798 candidate pairs.
+1. Return to **Structure graph**, select the `khive-db` package, and switch the
+   graph lens from **Structure graph** to **Hidden coupling**.
+2. Point out that the graph can verify only 70 captured visible pairs in this
+   package, renders the top 20, and discloses that the global aggregate contains
+   1,000 of 104,263 declared candidates.
+3. Focus `stores/graph_tests.rs` paired with `stores/graph.rs`: they changed
+   together 24 times in the 365-day window, but the complete captured structure
+   edge page has no direct dependency edge between them.
+4. Open either endpoint. The shared inspector, endpoint module, URL, and active
+   Structure view stay synchronized in the current session. A shared URL restores
+   the repository, snapshot, endpoint module, and Structure view; package
+   selection, lens choice, and pair focus are not yet URL-addressed, so reselect
+   them after opening the link. Track full lens replay as follow-up work in #1887.
 
 Say:
 
@@ -121,9 +131,11 @@ Say:
 > source-role caveat let us falsify the scary interpretation instead of turning
 > a rank into a defect.
 
-If time permits, repeat the exercise with the MCP `coordinator.rs`/`server.rs`
-SCC. Its reverse edge comes from a `cfg(test)` import, while the production
-coordinator seam is one-way.
+If time permits, open the full **Hidden coupling** ranking: its top captured
+pair is `khive-pack-comm/tests/integration.rs` with `src/handlers.rs`, at 39
+co-changes. Then repeat with the MCP `coordinator.rs`/`server.rs` SCC. Its
+reverse edge comes from a `cfg(test)` import, while the production coordinator
+seam is one-way.
 
 ### 6. Close with one confirmed contract drift
 
@@ -156,7 +168,7 @@ Say:
 
 ## Closing line
 
-> The UI does not tell me that code is bad. It turns 683 modules into a
+> The UI does not tell me that code is bad. It turns 658 modules into a
 > reproducible investigation: provenance, rank, topology, history, bounds, and
 > the exact paths needed to test an architecture hypothesis. Dogfooding also
 > exposed where the analysis itself must improve—especially production/test

--- a/apps/kg-editor/e2e/showcase.spec.ts
+++ b/apps/kg-editor/e2e/showcase.spec.ts
@@ -269,6 +269,87 @@ test("drills from analysis results into the shared inspector and browser history
   await expect(inspector.getByRole("heading", { level: 3 })).toHaveText(apiPath!);
 });
 
+test("uses the structure lens to verify a hidden khive-db boundary", async ({ page }) => {
+  const graphImplementation = "crates/khive-db/src/stores/graph.rs";
+  await page.goto("/");
+
+  const toolbar = page.locator(".repo-graph-toolbar");
+  await toolbar.getByRole("combobox", { name: /Package · Structure graph/ })
+    .selectOption({ label: "khive-db" });
+  await toolbar.getByRole("radio", { name: "Hidden coupling" }).check();
+
+  const lens = page.getByRole("region", { name: "Hidden coupling lens" });
+  await expect(lens).toContainText("20 of 70 captured visible pairs shown");
+  await expect(lens).toContainText("365-day analysis window");
+  await expect(lens).toContainText("1,000 captured of 104,263 declared");
+  await expect(page.locator("[data-coupling-overlay]")).toHaveCount(20);
+
+  const graphPair = lens.getByRole("button", {
+    name:
+      "Focus coupling candidate between crates/khive-db/src/stores/graph_tests.rs and crates/khive-db/src/stores/graph.rs",
+  });
+  await graphPair.press("Enter");
+  await expect(lens).toContainText("No captured direct dependency edge");
+  await expect(page.locator("[data-coupling-overlay].selected")).toHaveCount(1);
+  expect(await page.locator(".repo-graph-node.context-dimmed").count())
+    .toBeGreaterThan(0);
+
+  await graphPair.locator("..").getByRole("button", {
+    name: `Inspect ${graphImplementation}`,
+  })
+    .press("Enter");
+  await expect(page.locator("[data-module-inspector]")).toBeFocused();
+  await expect(page.locator("[data-module-inspector]").getByRole("heading", {
+    level: 3,
+  })).toHaveText(graphImplementation);
+  await expect(page).toHaveURL(/view=structure_graph/);
+  await expect(page).toHaveURL(
+    new RegExp(`module=${encodeURIComponent(graphImplementation)}`),
+  );
+});
+
+test("keeps the structure inspector legible across desktop and mobile", async ({ page }) => {
+  await page.goto("/");
+
+  await page.getByRole("combobox", { name: /Package · Structure graph/ })
+    .selectOption({ label: "khive-db" });
+  await page.getByRole("button", {
+    name: "Concept Module stores::graph",
+    exact: true,
+  }).click();
+
+  const heading = page.locator(".repo-inspector-heading");
+  await expect(heading.getByText("stores::graph", { exact: true })).toBeVisible();
+  await expect(heading.getByText("crates/khive-db/src/stores/graph.rs", { exact: true }))
+    .toBeVisible();
+
+  const measure = () => heading.evaluate((element) => {
+    const moduleName = element.querySelector("strong");
+    const sourcePath = element.querySelector("code");
+    if (!moduleName || !sourcePath) throw new Error("graph inspector heading is incomplete");
+    return {
+      moduleNameFits: moduleName.scrollWidth <= moduleName.clientWidth,
+      sourcePathFits: sourcePath.scrollWidth <= sourcePath.clientWidth,
+      sourcePathOverflowWrap: getComputedStyle(sourcePath).overflowWrap,
+      documentFits: document.documentElement.scrollWidth === document.documentElement.clientWidth,
+    };
+  });
+
+  expect(await measure()).toMatchObject({
+    moduleNameFits: true,
+    sourcePathFits: true,
+    documentFits: true,
+  });
+
+  await page.setViewportSize({ width: 375, height: 812 });
+  expect(await measure()).toEqual({
+    moduleNameFits: true,
+    sourcePathFits: true,
+    sourcePathOverflowWrap: "anywhere",
+    documentFits: true,
+  });
+});
+
 test("a valid repository miss stays local and renders an honest state", async ({ page }) => {
   const requestedAfterSubmit: string[] = [];
   let observing = false;

--- a/apps/kg-editor/src/app/showcase.css
+++ b/apps/kg-editor/src/app/showcase.css
@@ -568,6 +568,42 @@
 .repo-graph-toolbar button { cursor: pointer; font-size: var(--khive-type-lg); width: 30px; }
 .repo-graph-toolbar output { align-items: center; display: inline-flex; justify-content: center; min-width: 46px; padding: 0 5px; }
 
+.repo-graph-lens-picker {
+  align-items: center;
+  border: 0;
+  display: flex;
+  gap: 3px;
+  margin: 0;
+  padding: 0;
+}
+.repo-graph-lens-picker legend {
+  color: var(--repo-muted);
+  float: left;
+  font-size: var(--khive-type-sm);
+  margin-right: 3px;
+}
+.repo-graph-lens-picker label {
+  border: 1px solid var(--repo-border);
+  border-radius: var(--khive-radius-pill);
+  cursor: pointer;
+  min-height: 28px;
+  padding: 4px 8px;
+}
+.repo-graph-lens-picker label:has(input:checked) {
+  background: var(--khive-color-accent-soft);
+  border-color: var(--khive-color-accent);
+  color: var(--repo-navy);
+}
+.repo-graph-lens-picker input {
+  accent-color: var(--khive-color-accent);
+  height: 13px;
+  width: 13px;
+}
+.repo-graph-lens-picker label:focus-within {
+  outline: 2px solid var(--khive-color-accent);
+  outline-offset: 2px;
+}
+
 .repo-ontology-legend {
   border-bottom: 1px solid var(--repo-border);
   color: var(--repo-muted);
@@ -585,6 +621,24 @@
   position: relative;
 }
 
+.repo-graph-active-overlay {
+  align-items: center;
+  background: var(--khive-color-surface-overlay);
+  border: 1px solid var(--khive-color-warning);
+  border-radius: var(--khive-radius-md);
+  box-shadow: var(--shadow-small);
+  display: flex;
+  gap: 6px;
+  left: 10px;
+  padding: 6px 8px;
+  position: absolute;
+  top: 10px;
+  z-index: 4;
+}
+.repo-graph-active-overlay svg { color: var(--khive-color-warning); height: 13px; width: 13px; }
+.repo-graph-active-overlay span { color: var(--repo-muted); font-size: var(--khive-type-xs); }
+.repo-graph-active-overlay strong { font-size: var(--khive-type-sm); }
+
 .repo-graph-viewport {
   height: 100%;
   inset: 0;
@@ -597,6 +651,27 @@
 .repo-graph-stage svg.repo-edges { height: 100%; inset: 0; position: absolute; width: 100%; }
 .repo-edges line { stroke: var(--khive-color-border-strong); stroke-width: 1.2; }
 .repo-edges .ontology-edge-glyph { stroke: var(--repo-paper); }
+.repo-edges > g.context-dimmed .ontology-edge,
+.repo-edges > g.context-dimmed .ontology-derived-glyph { opacity: 0.28; }
+.repo-edges > g.context-dimmed .ontology-edge-glyph,
+.repo-edges > g.context-dimmed .ontology-direction-glyph {
+  fill: var(--khive-color-text-secondary) !important;
+  stroke: var(--khive-color-surface-base) !important;
+}
+.repo-edges [data-coupling-overlay] { transition: opacity 120ms ease; }
+.repo-edges [data-coupling-overlay].context-dimmed { opacity: 0.18; }
+.repo-edges [data-coupling-overlay].selected .repo-coupling-edge { stroke-width: 2.8; }
+.repo-coupling-edge {
+  stroke: var(--khive-color-warning) !important;
+  stroke-dasharray: 2 2;
+  stroke-linecap: round;
+  stroke-width: 2;
+}
+.repo-coupling-mark {
+  fill: var(--khive-color-surface-overlay);
+  stroke: var(--khive-color-warning);
+  stroke-width: 1.2;
+}
 .repo-graph-node {
   background: var(--khive-color-surface-overlay);
   border: 1px solid var(--khive-color-border);
@@ -610,6 +685,19 @@
   text-align: left;
   transform: translate(-50%, -50%);
   z-index: 2;
+}
+.repo-graph-node.context-dimmed {
+  background: var(--khive-color-surface-base);
+  border-color: var(--repo-border);
+  box-shadow: var(--khive-shadow-none);
+}
+.repo-graph-node.context-dimmed.selected {
+  border-color: var(--repo-border);
+  box-shadow: var(--khive-shadow-none);
+}
+.repo-graph-node.coupling-focused {
+  border-color: var(--khive-color-warning);
+  box-shadow: 0 0 0 3px var(--khive-color-warning-soft);
 }
 .repo-graph-node:hover,
 .repo-graph-node.selected { border-color: var(--ontology-kind-hue); box-shadow: 0 0 0 3px var(--khive-color-accent-soft); }
@@ -625,6 +713,76 @@
   font-size: var(--khive-type-lg);
   margin-right: var(--khive-space-3);
 }
+.repo-graph-node .repo-graph-overlay-badge {
+  align-items: center;
+  background: var(--khive-color-warning-soft);
+  border: 1px solid var(--khive-color-warning);
+  border-radius: var(--khive-radius-pill);
+  color: var(--khive-color-warning);
+  display: inline-flex;
+  font-size: var(--khive-type-xs);
+  gap: 2px;
+  line-height: 1;
+  padding: 2px 4px;
+  position: absolute;
+  right: -7px;
+  top: -8px;
+}
+.repo-graph-overlay-badge svg { height: 9px; width: 9px; }
+.repo-graph-overlay-badge b { font-size: inherit; }
+
+.repo-coupling-lens { border-top: 1px solid var(--repo-border); padding: 12px 14px; }
+.repo-coupling-lens > header {
+  align-items: flex-start;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+}
+.repo-coupling-lens > header div span,
+.repo-coupling-lens > header div strong { display: block; }
+.repo-coupling-lens > header div span { color: var(--repo-muted); font-size: var(--khive-type-xs); text-transform: uppercase; }
+.repo-coupling-lens > header div strong { font-size: var(--khive-type-md); margin-top: 3px; }
+.repo-coupling-lens > header p { color: var(--repo-muted); font-size: var(--khive-type-sm); margin: 0; text-align: right; }
+.repo-coupling-lens > header p span { display: block; }
+.repo-coupling-caveat { color: var(--repo-muted); font-size: var(--khive-type-sm); line-height: 1.45; margin: 9px 0; }
+.repo-coupling-evidence {
+  display: grid;
+  gap: 6px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  list-style: none;
+  margin: 0;
+  max-height: 260px;
+  overflow: auto;
+  padding: 0;
+}
+.repo-coupling-evidence li {
+  border: 1px solid var(--repo-border);
+  border-radius: var(--khive-radius-md);
+  min-width: 0;
+  padding: 7px;
+}
+.repo-coupling-evidence li.selected { border-color: var(--khive-color-warning); box-shadow: inset 0 0 0 1px var(--khive-color-warning); }
+.repo-coupling-focus {
+  align-items: flex-start;
+  background: var(--khive-color-transparent);
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  display: flex;
+  font: inherit;
+  gap: 6px;
+  padding: 2px;
+  text-align: left;
+  width: 100%;
+}
+.repo-coupling-focus:focus-visible { outline: 2px solid var(--khive-color-accent); outline-offset: 2px; }
+.repo-coupling-focus > svg { color: var(--khive-color-warning); flex: 0 0 auto; height: 13px; margin-top: 2px; width: 13px; }
+.repo-coupling-focus span,
+.repo-coupling-focus strong { display: block; }
+.repo-coupling-focus strong { font-size: var(--khive-type-sm); }
+.repo-coupling-focus span { color: var(--repo-muted); font-size: var(--khive-type-xs); line-height: 1.35; }
+.repo-coupling-endpoints { align-items: center; display: flex; flex-wrap: wrap; gap: 2px; margin-top: 5px; }
+.repo-coupling-endpoints > span { color: var(--repo-muted); font-size: var(--khive-type-xs); }
 
 .repo-inspector { border-top: 1px solid var(--repo-border); padding: 13px 15px; }
 .repo-inspector-heading { gap: 8px; }
@@ -880,6 +1038,24 @@ button.repo-list-row:hover,
   .repo-view-tags { justify-content: flex-start; }
   .repo-view-panel { min-height: 500px; }
   .repo-graph-stage { min-height: 360px; }
+  .repo-graph-toolbar { align-items: flex-start; flex-direction: column; }
+  .repo-graph-lens-picker { flex-wrap: wrap; }
+  .repo-graph-active-overlay { max-width: calc(100% - 20px); }
+  .repo-coupling-lens > header { flex-direction: column; }
+  .repo-coupling-lens > header p { text-align: left; }
+  .repo-coupling-evidence { grid-template-columns: 1fr; }
+  .repo-inspector-heading {
+    align-items: start;
+    display: grid;
+    grid-template-columns: 15px minmax(0, 1fr);
+  }
+  .repo-inspector-heading > svg { grid-column: 1; grid-row: 1; }
+  .repo-inspector-heading > div { grid-column: 2; grid-row: 1; }
+  .repo-inspector-heading > code {
+    grid-column: 2;
+    overflow-wrap: anywhere;
+    white-space: normal;
+  }
   .repo-treemap { grid-template-columns: repeat(6, 1fr); }
 }
 

--- a/apps/kg-editor/src/components/showcase/repo-showcase-coupling-lens.test.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase-coupling-lens.test.tsx
@@ -69,6 +69,20 @@ describe("repository showcase hidden-coupling lens", () => {
     );
     expect(settleGraphLayoutSpy).toHaveBeenCalledTimes(2);
 
+    const structureEdgeIds = new Set(
+      bundle.graph.structure_edges.items.map((edge) => edge.id),
+    );
+    for (const call of settleGraphLayoutSpy.mock.calls) {
+      const layoutEdges = call[1] as readonly { id: string }[];
+      expect(layoutEdges.length).toBeGreaterThan(0);
+      for (const edge of layoutEdges) {
+        expect(
+          edge.id.startsWith("contains-") || structureEdgeIds.has(edge.id),
+          `layout edge ${edge.id} is not a structure edge`,
+        ).toBe(true);
+      }
+    }
+
     const sampleNode = container.querySelector<HTMLElement>(
       ".repo-graph-node[data-node-id]",
     )!;

--- a/apps/kg-editor/src/components/showcase/repo-showcase-coupling-lens.test.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase-coupling-lens.test.tsx
@@ -24,6 +24,23 @@ function golden(): RepoBundle {
   return parseRepoBundle(JSON.parse(readFileSync(goldenPath, "utf8")));
 }
 
+function captureNodePositions(
+  container: HTMLElement,
+): Map<string, { left: string; top: string }> {
+  const positions = new Map<string, { left: string; top: string }>();
+  for (
+    const node of container.querySelectorAll<HTMLElement>(
+      ".repo-graph-node[data-node-id]",
+    )
+  ) {
+    positions.set(node.dataset.nodeId!, {
+      left: node.style.left,
+      top: node.style.top,
+    });
+  }
+  return positions;
+}
+
 describe("repository showcase hidden-coupling lens", () => {
   beforeEach(() => {
     settleGraphLayoutSpy.mockClear();
@@ -56,6 +73,7 @@ describe("repository showcase hidden-coupling lens", () => {
       ".repo-graph-node[data-node-id]",
     )!;
     const kindHue = sampleNode.style.getPropertyValue("--ontology-kind-hue");
+    const positionsBeforeLens = captureNodePositions(container);
     await user.click(screen.getByRole("radio", {
       name: bundle.capability.views.hidden_coupling.label,
     }));
@@ -76,6 +94,7 @@ describe("repository showcase hidden-coupling lens", () => {
       kindHue,
     );
     expect(settleGraphLayoutSpy).toHaveBeenCalledTimes(2);
+    expect(captureNodePositions(container)).toEqual(positionsBeforeLens);
 
     const focusButtons = screen.getAllByRole("button", {
       name: /Focus coupling candidate between/,
@@ -88,6 +107,7 @@ describe("repository showcase hidden-coupling lens", () => {
     expect(container.querySelectorAll("[data-coupling-overlay].selected"))
       .toHaveLength(1);
     expect(settleGraphLayoutSpy).toHaveBeenCalledTimes(2);
+    expect(captureNodePositions(container)).toEqual(positionsBeforeLens);
 
     const unrelatedNode = container.querySelector<HTMLButtonElement>(
       ".repo-graph-node.context-dimmed",

--- a/apps/kg-editor/src/components/showcase/repo-showcase-coupling-lens.test.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase-coupling-lens.test.tsx
@@ -1,0 +1,180 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RepoShowcase } from "@/components/showcase/repo-showcase";
+import { parseRepoBundle, type RepoBundle } from "@/lib/repo-bundle";
+
+const settleGraphLayoutSpy = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/graph-layout", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/graph-layout")>();
+  settleGraphLayoutSpy.mockImplementation(actual.settleGraphLayout);
+  return { ...actual, settleGraphLayout: settleGraphLayoutSpy };
+});
+
+const goldenPath = resolve(
+  process.cwd(),
+  "../../docs/schemas/examples/khive-repo-v1-khive.json",
+);
+
+function golden(): RepoBundle {
+  return parseRepoBundle(JSON.parse(readFileSync(goldenPath, "utf8")));
+}
+
+describe("repository showcase hidden-coupling lens", () => {
+  beforeEach(() => {
+    settleGraphLayoutSpy.mockClear();
+    window.history.replaceState(null, "", "/");
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: vi.fn(),
+    });
+  });
+
+  it("shows bounded candidate evidence without changing the ontology hue or layout", async () => {
+    const bundle = golden();
+    const databasePackage = bundle.graph.packages.items.find((item) =>
+      item.name === "khive-db"
+    )!;
+    const user = userEvent.setup();
+    const { container } = render(<RepoShowcase bundle={bundle} />);
+
+    await waitFor(() => expect(settleGraphLayoutSpy).toHaveBeenCalledOnce());
+    await user.selectOptions(
+      screen.getByRole("combobox", {
+        name:
+          `${bundle.capability.labels.node_types.package} · ${bundle.capability.views.structure_graph.label}`,
+      }),
+      databasePackage.id,
+    );
+    expect(settleGraphLayoutSpy).toHaveBeenCalledTimes(2);
+
+    const sampleNode = container.querySelector<HTMLElement>(
+      ".repo-graph-node[data-node-id]",
+    )!;
+    const kindHue = sampleNode.style.getPropertyValue("--ontology-kind-hue");
+    await user.click(screen.getByRole("radio", {
+      name: bundle.capability.views.hidden_coupling.label,
+    }));
+
+    expect(screen.getByRole("region", {
+      name: `${bundle.capability.views.hidden_coupling.label} lens`,
+    })).toHaveTextContent("20 of 70 captured visible pairs shown");
+    expect(screen.getByRole("region", {
+      name: `${bundle.capability.views.hidden_coupling.label} lens`,
+    })).toHaveTextContent("365-day analysis window");
+    expect(screen.getByRole("region", {
+      name: `${bundle.capability.views.hidden_coupling.label} lens`,
+    })).toHaveTextContent("1,000 captured of 104,263 declared");
+    expect(container.querySelectorAll("[data-coupling-overlay]")).toHaveLength(
+      20,
+    );
+    expect(sampleNode.style.getPropertyValue("--ontology-kind-hue")).toBe(
+      kindHue,
+    );
+    expect(settleGraphLayoutSpy).toHaveBeenCalledTimes(2);
+
+    const focusButtons = screen.getAllByRole("button", {
+      name: /Focus coupling candidate between/,
+    });
+    await user.click(focusButtons[0]);
+    expect(container.querySelectorAll(".repo-graph-node.context-dimmed").length)
+      .toBeGreaterThan(0);
+    expect(container.querySelectorAll(".repo-graph-node.coupling-focused"))
+      .toHaveLength(2);
+    expect(container.querySelectorAll("[data-coupling-overlay].selected"))
+      .toHaveLength(1);
+    expect(settleGraphLayoutSpy).toHaveBeenCalledTimes(2);
+
+    const unrelatedNode = container.querySelector<HTMLButtonElement>(
+      ".repo-graph-node.context-dimmed",
+    )!;
+    await user.click(unrelatedNode);
+    expect(container.querySelectorAll(".repo-graph-node.context-dimmed"))
+      .toHaveLength(0);
+    expect(container.querySelectorAll(".repo-graph-node.coupling-focused"))
+      .toHaveLength(0);
+    expect(focusButtons[0]).toHaveAttribute("aria-pressed", "false");
+    expect(settleGraphLayoutSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("opens either candidate endpoint in the shared inspector and preserves the graph view", async () => {
+    const bundle = golden();
+    const databasePackage = bundle.graph.packages.items.find((item) =>
+      item.name === "khive-db"
+    )!;
+    const user = userEvent.setup();
+    const { container } = render(<RepoShowcase bundle={bundle} />);
+
+    await user.selectOptions(
+      screen.getByRole("combobox", {
+        name:
+          `${bundle.capability.labels.node_types.package} · ${bundle.capability.views.structure_graph.label}`,
+      }),
+      databasePackage.id,
+    );
+    await user.click(screen.getByRole("radio", {
+      name: bundle.capability.views.hidden_coupling.label,
+    }));
+    const lens = screen.getByRole("region", {
+      name: `${bundle.capability.views.hidden_coupling.label} lens`,
+    });
+    const endpoint = within(lens).getAllByRole("button", {
+      name: /Inspect crates\/khive-db\/src\/stores\/graph(_tests)?\.rs/,
+    })[0];
+    const sourcePath = endpoint.getAttribute("aria-label")!.replace(
+      "Inspect ",
+      "",
+    );
+    await user.click(endpoint);
+
+    const inspector = container.querySelector<HTMLElement>(
+      "[data-module-inspector]",
+    )!;
+    await waitFor(() => expect(inspector).toHaveFocus());
+    expect(new URL(window.location.href).searchParams.get("view"))
+      .toBe("structure_graph");
+    expect(new URL(window.location.href).searchParams.get("module"))
+      .toBe(sourcePath);
+    expect(settleGraphLayoutSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("surfaces an unavailable aggregate instead of drawing empty evidence", async () => {
+    const draft = structuredClone(golden());
+    draft.capability.views.hidden_coupling.status = "unavailable";
+    draft.capability.views.hidden_coupling.unavailable_reason =
+      "co-change export was disabled";
+    draft.aggregates.hidden_coupling.meta.status = "unavailable";
+    draft.aggregates.hidden_coupling.data = {
+      ...draft.aggregates.hidden_coupling.data,
+      items: [],
+      total_count: {
+        status: "unavailable",
+        reason: "co-change export was disabled",
+      },
+      next_cursor: null,
+      truncated: false,
+      disclosure: {
+        status: "unavailable",
+        reason: "co-change export was disabled",
+      },
+    };
+    const bundle = parseRepoBundle(draft);
+    const user = userEvent.setup();
+    const { container } = render(<RepoShowcase bundle={bundle} />);
+
+    await user.click(screen.getByRole("radio", {
+      name: bundle.capability.views.hidden_coupling.label,
+    }));
+    const lens = screen.getByRole("region", {
+      name: `${bundle.capability.views.hidden_coupling.label} lens`,
+    });
+    expect(lens).toHaveTextContent("co-change export was disabled");
+    expect(container.querySelectorAll("[data-coupling-overlay]")).toHaveLength(
+      0,
+    );
+  });
+});

--- a/apps/kg-editor/src/components/showcase/repo-showcase.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase.tsx
@@ -24,7 +24,7 @@ import {
   TrendingUp,
   Users,
 } from "@/icons";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 
 import { DataState } from "@/components/data-state";
 import { RepositoryCommandPalette } from "@/components/showcase/repository-command-palette";
@@ -42,6 +42,7 @@ import {
 import { settleGraphLayout } from "@/lib/graph-layout";
 import { edgeLegendFor, entityLegendFor } from "@/lib/ontology-legend";
 import { buildRepositoryBrief } from "@/lib/repository-brief";
+import { buildStructureCouplingLens } from "@/lib/structure-coupling-lens";
 import type {
   RepoBundle,
   RepoModule,
@@ -59,6 +60,8 @@ type Labels = RepoBundle["capability"]["labels"];
 type ViewCapability = RepoBundle["capability"]["views"][ViewId];
 type Icon = typeof Network;
 type ModuleMap = Map<string, RepoModule>;
+type AnalysisWindow =
+  RepoBundle["aggregates"]["hidden_coupling"]["meta"]["window"];
 type ViewProps = Readonly<{
   bundle: RepoBundle;
   moduleById: ModuleMap;
@@ -86,6 +89,7 @@ const UI_ROW_LIMIT = 200;
 const UI_TREEMAP_LIMIT = 180;
 const UI_RESIDUAL_LIMIT = 80;
 const UI_GRAPH_EDGE_LIMIT = 50;
+const UI_COUPLING_EDGE_LIMIT = 20;
 
 function derivedDiamondPoints(x: number, y: number): string {
   const r = 1.1;
@@ -96,8 +100,31 @@ function formatNumber(value: number): string {
   return new Intl.NumberFormat("en", { notation: value >= 10_000 ? "compact" : "standard" }).format(value);
 }
 
+function formatExactNumber(value: number): string {
+  return new Intl.NumberFormat("en").format(value);
+}
+
 function formatDate(value: string): string {
   return new Intl.DateTimeFormat("en", { month: "short", day: "numeric", year: "numeric" }).format(new Date(value));
+}
+
+function formatAnalysisWindow(
+  window: AnalysisWindow,
+  snapshotTime: string,
+): string {
+  if (window.kind === "rolling_days") {
+    const duration = window.days == null ? "Rolling" : `${window.days}-day`;
+    const range = window.start && window.end
+      ? ` · ${formatDate(window.start)} to ${formatDate(window.end)}`
+      : "";
+    return `${duration} analysis window${range}`;
+  }
+  if (window.kind === "range") {
+    return `Bounded analysis window · ${
+      window.start ? formatDate(window.start) : "unspecified start"
+    } to ${window.end ? formatDate(window.end) : "unspecified end"}`;
+  }
+  return `All-history analysis window · snapshot ${formatDate(snapshotTime)}`;
 }
 
 function formatPercent(value: number): string {
@@ -343,12 +370,22 @@ function ViewFrame({
   );
 }
 
-function StructureGraph({ bundle }: { bundle: RepoBundle }) {
+function StructureGraph({
+  bundle,
+  moduleById,
+  selectedModuleId,
+  onInspectModule,
+}: ViewProps) {
   const { graph, capability } = bundle;
   const labels = capability.labels;
   const [subtreeId, setSubtreeId] = useState(graph.repository.id);
   const [zoom, setZoom] = useState(1);
   const [selectedId, setSelectedId] = useState(graph.repository.id);
+  const [lens, setLens] = useState<"structure" | "hidden_coupling">(
+    "structure",
+  );
+  const [focusedPairKey, setFocusedPairKey] = useState<string | null>(null);
+  const lensGroupName = useId();
   const {
     displayedEdges,
     displayedModules,
@@ -431,16 +468,27 @@ function StructureGraph({ bundle }: { bundle: RepoBundle }) {
     graph.structure_edges.items,
     subtreeId,
   ]);
-  const degrees = new Map<string, number>();
-  const fanIn = new Map<string, number>();
-  const fanOut = new Map<string, number>();
-  for (const edge of graph.structure_edges.items) {
-    degrees.set(edge.source, (degrees.get(edge.source) ?? 0) + 1);
-    degrees.set(edge.target, (degrees.get(edge.target) ?? 0) + 1);
-    fanOut.set(edge.source, (fanOut.get(edge.source) ?? 0) + 1);
-    fanIn.set(edge.target, (fanIn.get(edge.target) ?? 0) + 1);
-  }
-  const maxDegree = Math.max(1, ...visibleIds.values().map((id) => degrees.get(id) ?? 0));
+  const { degrees, fanIn, fanOut, maxDegree } = useMemo(() => {
+    const nextDegrees = new Map<string, number>();
+    const nextFanIn = new Map<string, number>();
+    const nextFanOut = new Map<string, number>();
+    for (const edge of graph.structure_edges.items) {
+      nextDegrees.set(edge.source, (nextDegrees.get(edge.source) ?? 0) + 1);
+      nextDegrees.set(edge.target, (nextDegrees.get(edge.target) ?? 0) + 1);
+      nextFanOut.set(edge.source, (nextFanOut.get(edge.source) ?? 0) + 1);
+      nextFanIn.set(edge.target, (nextFanIn.get(edge.target) ?? 0) + 1);
+    }
+    const nextMaxDegree = Math.max(
+      1,
+      ...visibleIds.values().map((id) => nextDegrees.get(id) ?? 0),
+    );
+    return {
+      degrees: nextDegrees,
+      fanIn: nextFanIn,
+      fanOut: nextFanOut,
+      maxDegree: nextMaxDegree,
+    };
+  }, [graph.structure_edges.items, visibleIds]);
   const nodeWidth = (id: string) => 92 + ((degrees.get(id) ?? 0) / maxDegree) * 46;
   const selectedModule = displayedModules.find((item) => item.id === selectedId);
   const selectedPackage = displayedPackages.find((item) => item.id === selectedId);
@@ -450,6 +498,48 @@ function StructureGraph({ bundle }: { bundle: RepoBundle }) {
     ...displayedPackages.map((item) => [item.id, item.name] as const),
     ...displayedModules.map((item) => [item.id, item.module_path] as const),
   ]);
+  const couplingLens = useMemo(() =>
+    buildStructureCouplingLens({
+      pairPage: bundle.aggregates.hidden_coupling.data,
+      structureEdgePage: graph.structure_edges,
+      visibleModuleIds: visibleIds,
+      limit: UI_COUPLING_EDGE_LIMIT,
+      analysisStatus: bundle.aggregates.hidden_coupling.meta.status,
+      analysisUnavailableReason:
+        bundle.aggregates.hidden_coupling.meta.unavailable_reason,
+    }), [
+    bundle.aggregates.hidden_coupling.data,
+    bundle.aggregates.hidden_coupling.meta.status,
+    bundle.aggregates.hidden_coupling.meta.unavailable_reason,
+    graph.structure_edges,
+    visibleIds,
+  ]);
+  const focusedPair = couplingLens.pairs.find((pair) =>
+    pair.key === focusedPairKey
+  ) ?? null;
+  const focusedModuleIds = focusedPair
+    ? new Set([focusedPair.leftModuleId, focusedPair.rightModuleId])
+    : null;
+  const couplingNodeCounts = new Map<string, number>();
+  for (const pair of couplingLens.pairs) {
+    couplingNodeCounts.set(
+      pair.leftModuleId,
+      Math.max(couplingNodeCounts.get(pair.leftModuleId) ?? 0, pair.cochangeCount),
+    );
+    couplingNodeCounts.set(
+      pair.rightModuleId,
+      Math.max(couplingNodeCounts.get(pair.rightModuleId) ?? 0, pair.cochangeCount),
+    );
+  }
+  const isContextDimmed = (id: string) =>
+    lens === "hidden_coupling" && focusedModuleIds !== null &&
+    !focusedModuleIds.has(id);
+  const isCouplingFocused = (id: string) =>
+    lens === "hidden_coupling" && focusedModuleIds?.has(id) === true;
+  const inspectCouplingEndpoint = (moduleId: string) => {
+    setSelectedId(moduleId);
+    onInspectModule(moduleId);
+  };
 
   return (
     <div className="repo-view-body">
@@ -463,12 +553,39 @@ function StructureGraph({ bundle }: { bundle: RepoBundle }) {
               onChange={(event) => {
                 setSubtreeId(event.target.value);
                 setSelectedId(event.target.value);
+                setFocusedPairKey(null);
               }}
             >
               <option value={graph.repository.id}>{labels.node_types.repository}</option>
               {selectablePackages.map((item) => <option value={item.id} key={item.id}>{item.name}</option>)}
             </select>
           </label>
+          <fieldset className="repo-graph-lens-picker">
+            <legend>Graph lens</legend>
+            <label>
+              <input
+                type="radio"
+                name={lensGroupName}
+                value="structure"
+                checked={lens === "structure"}
+                onChange={() => {
+                  setLens("structure");
+                  setFocusedPairKey(null);
+                }}
+              />
+              <span>{capability.views.structure_graph.label}</span>
+            </label>
+            <label>
+              <input
+                type="radio"
+                name={lensGroupName}
+                value="hidden_coupling"
+                checked={lens === "hidden_coupling"}
+                onChange={() => setLens("hidden_coupling")}
+              />
+              <span>{capability.views.hidden_coupling.label}</span>
+            </label>
+          </fieldset>
           <div>
             <button type="button" aria-label={`${capability.views.structure_graph.label} −`} onClick={() => setZoom((value) => Math.max(0.75, value - 0.25))}>−</button>
             <output aria-live="polite">{Math.round(zoom * 100)}%</output>
@@ -481,6 +598,13 @@ function StructureGraph({ bundle }: { bundle: RepoBundle }) {
           presentRelations={displayedEdges.map((edge) => edge.relation)}
         />
         <div className="repo-graph-stage" aria-label={capability.views.structure_graph.label}>
+          {lens === "hidden_coupling" && (
+            <div className="repo-graph-active-overlay">
+              <Braces aria-hidden="true" />
+              <span>Active analytical overlay</span>
+              <strong>{capability.views.hidden_coupling.label}</strong>
+            </div>
+          )}
           <div className="repo-graph-viewport" style={{ transform: `scale(${zoom})` }}>
             <svg className="repo-edges" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
               <defs>
@@ -494,8 +618,11 @@ function StructureGraph({ bundle }: { bundle: RepoBundle }) {
                 if (!source || !target) return null;
                 const legend = edgeLegendFor(edge.relation);
                 const direction = edgeDirectionMark(legend, source, target);
+                const dimmed = focusedModuleIds !== null &&
+                  !(focusedModuleIds.has(edge.source) &&
+                    focusedModuleIds.has(edge.target));
                 return (
-                  <g key={edge.id}>
+                  <g className={dimmed ? "context-dimmed" : undefined} key={edge.id}>
                     <line
                       className="ontology-edge"
                       data-edge-family={legend.family}
@@ -540,9 +667,39 @@ function StructureGraph({ bundle }: { bundle: RepoBundle }) {
                   </g>
                 );
               })}
+              {lens === "hidden_coupling" && couplingLens.pairs.map((pair) => {
+                const source = positions.get(pair.leftModuleId);
+                const target = positions.get(pair.rightModuleId);
+                if (!source || !target) return null;
+                const selected = focusedPairKey === pair.key;
+                const dimmed = focusedPair !== null && !selected;
+                return (
+                  <g
+                    className={`${selected ? "selected" : ""} ${dimmed ? "context-dimmed" : ""}`.trim()}
+                    data-coupling-overlay={pair.key}
+                    key={`coupling-${pair.key}`}
+                  >
+                    <line
+                      className="repo-coupling-edge"
+                      x1={source.x}
+                      y1={source.y}
+                      x2={target.x}
+                      y2={target.y}
+                      vectorEffect="non-scaling-stroke"
+                    />
+                    <circle
+                      className="repo-coupling-mark"
+                      cx={(source.x + target.x) / 2}
+                      cy={(source.y + target.y) / 2}
+                      r="1.45"
+                      vectorEffect="non-scaling-stroke"
+                    />
+                  </g>
+                );
+              })}
             </svg>
             <button
-              className={`repo-graph-node ${selectedId === graph.repository.id ? "selected" : ""}`}
+              className={`repo-graph-node ${selectedId === graph.repository.id ? "selected" : ""} ${isContextDimmed(graph.repository.id) ? "context-dimmed" : ""}`}
               data-node-id={graph.repository.id}
               style={{
                 left: `${positions.get(graph.repository.id)!.x}%`,
@@ -552,7 +709,10 @@ function StructureGraph({ bundle }: { bundle: RepoBundle }) {
               }}
               type="button"
               aria-pressed={selectedId === graph.repository.id}
-              onClick={() => setSelectedId(graph.repository.id)}
+              onClick={() => {
+                setSelectedId(graph.repository.id);
+                setFocusedPairKey(null);
+              }}
             >
               <EntityKindMark className="repo-node-kind-icon" kind="project" showLabel={false} />
               <span>{labels.node_types.repository}</span><strong>{graph.repository.label}</strong>
@@ -560,7 +720,10 @@ function StructureGraph({ bundle }: { bundle: RepoBundle }) {
             {displayedPackages.map((item) => {
               const position = positions.get(item.id)!;
               return (
-                <button className={`repo-graph-node ${selectedId === item.id ? "selected" : ""}`} data-node-id={item.id} style={{ left: `${position.x}%`, top: `${position.y}%`, width: `${nodeWidth(item.id)}px`, ...kindHueStyle(entityLegendFor("project")) }} type="button" aria-pressed={selectedId === item.id} key={item.id} onClick={() => setSelectedId(item.id)}>
+                <button className={`repo-graph-node ${selectedId === item.id ? "selected" : ""} ${isContextDimmed(item.id) ? "context-dimmed" : ""}`} data-node-id={item.id} style={{ left: `${position.x}%`, top: `${position.y}%`, width: `${nodeWidth(item.id)}px`, ...kindHueStyle(entityLegendFor("project")) }} type="button" aria-pressed={selectedId === item.id} key={item.id} onClick={() => {
+                  setSelectedId(item.id);
+                  setFocusedPairKey(null);
+                }}>
                   <EntityKindMark className="repo-node-kind-icon" kind="project" showLabel={false} />
                   <span>{labels.node_types.package}</span><strong>{item.name}</strong>
                 </button>
@@ -568,15 +731,130 @@ function StructureGraph({ bundle }: { bundle: RepoBundle }) {
             })}
             {displayedModules.map((item) => {
               const position = positions.get(item.id)!;
+              const couplingCount = couplingNodeCounts.get(item.id);
               return (
-                <button className={`repo-graph-node ${selectedId === item.id ? "selected" : ""}`} data-node-id={item.id} style={{ left: `${position.x}%`, top: `${position.y}%`, width: `${nodeWidth(item.id)}px`, ...kindHueStyle(entityLegendFor("concept")) }} type="button" aria-pressed={selectedId === item.id} key={item.id} onClick={() => setSelectedId(item.id)}>
+                <button className={`repo-graph-node ${selectedId === item.id ? "selected" : ""} ${isContextDimmed(item.id) ? "context-dimmed" : ""} ${isCouplingFocused(item.id) ? "coupling-focused" : ""}`} data-node-id={item.id} style={{ left: `${position.x}%`, top: `${position.y}%`, width: `${nodeWidth(item.id)}px`, ...kindHueStyle(entityLegendFor("concept")) }} type="button" aria-pressed={selectedId === item.id} key={item.id} onClick={() => {
+                  setSelectedId(item.id);
+                  setFocusedPairKey(null);
+                }}>
                   <EntityKindMark className="repo-node-kind-icon" kind="concept" showLabel={false} />
                   <span>{labels.node_types.module}</span><strong>{item.module_path}</strong>
+                  {lens === "hidden_coupling" && couplingCount !== undefined && (
+                    <span
+                      className="repo-graph-overlay-badge"
+                      aria-label={`${capability.views.hidden_coupling.label}: ${labels.metrics.cochange_count} ${formatNumber(couplingCount)}`}
+                    >
+                      <Braces aria-hidden="true" />
+                      <b>{formatNumber(couplingCount)}</b>
+                    </span>
+                  )}
                 </button>
               );
             })}
           </div>
         </div>
+        {lens === "hidden_coupling" && (
+          <section
+            className="repo-coupling-lens"
+            role="region"
+            aria-label={`${capability.views.hidden_coupling.label} lens`}
+          >
+            <header>
+              <div>
+                <span>Candidate evidence · not a dependency claim</span>
+                <strong>{formatNumber(couplingLens.pairs.length)} of {formatNumber(couplingLens.capturedVisiblePairCount)} captured visible pairs shown</strong>
+              </div>
+              <p>
+                <span>{formatAnalysisWindow(bundle.aggregates.hidden_coupling.meta.window, bundle.meta.snapshot.ingested_at)}</span>
+                <span>{formatExactNumber(couplingLens.capturedPairCount)} captured of {couplingLens.declaredPairCount === null ? labels.unavailable : formatExactNumber(couplingLens.declaredPairCount)} declared</span>
+              </p>
+            </header>
+            {couplingLens.coverage === "unavailable"
+              ? (
+                <DataState
+                  className="repo-inline-state"
+                  presentation="inline"
+                  state="unavailable"
+                  title={labels.unavailable}
+                  message={couplingLens.coverageReason ?? "The hidden-coupling aggregate is unavailable."}
+                />
+              )
+              : couplingLens.coverage === "truncated" && (
+              <DataState
+                className="repo-inline-state"
+                presentation="inline"
+                state="truncated"
+                title={labels.truncated}
+                shown={couplingLens.capturedPairCount}
+                bound={bundle.aggregates.hidden_coupling.data.bound.max_items}
+                knownTotal={couplingLens.declaredPairCount ?? undefined}
+                reason={couplingLens.coverageReason ?? "The hidden-coupling aggregate is incomplete."}
+              />
+            )}
+            <p className="repo-coupling-caveat">
+              Co-change is an implicit-boundary candidate, not proof of runtime dependency. Captured rows can include production, test, example, and generated modules.
+            </p>
+            {couplingLens.pairs.length === 0
+              ? couplingLens.coverage === "unavailable"
+              ? (
+                <DataState
+                  className="repo-empty compact"
+                  state="unavailable"
+                  title={`${capability.views.hidden_coupling.label} ${labels.unavailable.toLocaleLowerCase()}`}
+                  message={couplingLens.coverageReason ?? "The bundle does not claim hidden-coupling evidence."}
+                />
+              )
+              : (
+                <DataState
+                  className="repo-empty compact"
+                  state="empty"
+                  title="No captured coupling pair in this visible graph"
+                  message="Choose another package or return to the structure lens."
+                  action={{
+                    label: "Return to structure lens",
+                    onClick: () => {
+                      setLens("structure");
+                      setFocusedPairKey(null);
+                    },
+                  }}
+                />
+              )
+              : (
+                <ol className="repo-coupling-evidence">
+                  {couplingLens.pairs.map((pair) => {
+                    const left = moduleById.get(pair.leftModuleId);
+                    const right = moduleById.get(pair.rightModuleId);
+                    const leftLabel = left?.source_path ?? pair.leftModuleId;
+                    const rightLabel = right?.source_path ?? pair.rightModuleId;
+                    const dependencyMessage = pair.dependencyEvidence === "absent"
+                      ? "No captured direct dependency edge"
+                      : pair.dependencyEvidence === "present"
+                      ? "Captured direct dependency edge"
+                      : `Direct dependency evidence unknown · ${couplingLens.dependencyCoverageReason ?? "structure edge coverage is incomplete"}`;
+                    return (
+                      <li className={focusedPairKey === pair.key ? "selected" : ""} key={pair.key}>
+                        <button
+                          type="button"
+                          className="repo-coupling-focus"
+                          aria-pressed={focusedPairKey === pair.key}
+                          aria-label={`Focus coupling candidate between ${leftLabel} and ${rightLabel}`}
+                          onClick={() => setFocusedPairKey(pair.key)}
+                        >
+                          <Braces aria-hidden="true" />
+                          <span><strong>{labels.metrics.cochange_count}: {formatNumber(pair.cochangeCount)} · {labels.metrics.support}: {formatPercent(pair.support)}</strong>{dependencyMessage}</span>
+                        </button>
+                        <div className="repo-coupling-endpoints">
+                          <ModuleInspectionControl moduleId={pair.leftModuleId} moduleById={moduleById} modulePage={graph.modules} selectedModuleId={selectedModuleId} onInspectModule={inspectCouplingEndpoint} className="compact" />
+                          <span>paired with</span>
+                          <ModuleInspectionControl moduleId={pair.rightModuleId} moduleById={moduleById} modulePage={graph.modules} selectedModuleId={selectedModuleId} onInspectModule={inspectCouplingEndpoint} className="compact" />
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ol>
+              )}
+          </section>
+        )}
         <div className="repo-inspector">
           <div className="repo-inspector-heading">
             <EntityKindMark kind={selectedEntityKind} showLabel={false} />

--- a/apps/kg-editor/src/components/showcase/repository-command-palette.tsx
+++ b/apps/kg-editor/src/components/showcase/repository-command-palette.tsx
@@ -187,7 +187,7 @@ export function RepositoryCommandPalette({
     }
     window.addEventListener("keydown", handleShortcut);
     return () => window.removeEventListener("keydown", handleShortcut);
-  });
+  }, [open]);
 
   useEffect(() => {
     if (open) inputRef.current?.focus();

--- a/apps/kg-editor/src/lib/structure-coupling-lens.test.ts
+++ b/apps/kg-editor/src/lib/structure-coupling-lens.test.ts
@@ -1,0 +1,194 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { parseRepoBundle, type RepoBundle } from "@/lib/repo-bundle";
+import { buildStructureCouplingLens } from "@/lib/structure-coupling-lens";
+
+const goldenPath = resolve(
+  process.cwd(),
+  "../../docs/schemas/examples/khive-repo-v1-khive.json",
+);
+
+function golden(): RepoBundle {
+  return parseRepoBundle(JSON.parse(readFileSync(goldenPath, "utf8")));
+}
+
+function visibleModuleIds(
+  bundle: RepoBundle,
+  packageId: string | null,
+): Set<string> {
+  const packages = packageId === null
+    ? [...bundle.graph.packages.items]
+      .sort((left, right) => left.id.localeCompare(right.id))
+      .slice(0, 8)
+    : bundle.graph.packages.items.filter((item) => item.id === packageId);
+  const packageIds = new Set(packages.map((item) => item.id));
+  return new Set(
+    bundle.graph.modules.items
+      .filter((item) => packageIds.has(item.package_id))
+      .sort((left, right) => left.id.localeCompare(right.id))
+      .slice(0, 42)
+      .map((item) => item.id),
+  );
+}
+
+describe("structure hidden-coupling lens", () => {
+  it("selects a deterministic bounded visible slice from the real snapshot", () => {
+    const bundle = golden();
+    const rootLens = buildStructureCouplingLens({
+      pairPage: bundle.aggregates.hidden_coupling.data,
+      structureEdgePage: bundle.graph.structure_edges,
+      visibleModuleIds: visibleModuleIds(bundle, null),
+      limit: 20,
+      analysisStatus: bundle.aggregates.hidden_coupling.meta.status,
+      analysisUnavailableReason:
+        bundle.aggregates.hidden_coupling.meta.unavailable_reason,
+    });
+    expect(rootLens.capturedVisiblePairCount).toBe(10);
+    expect(rootLens.pairs).toHaveLength(10);
+
+    const databasePackage = bundle.graph.packages.items.find((item) =>
+      item.name === "khive-db"
+    );
+    expect(databasePackage).toBeDefined();
+    const databaseLens = buildStructureCouplingLens({
+      pairPage: bundle.aggregates.hidden_coupling.data,
+      structureEdgePage: bundle.graph.structure_edges,
+      visibleModuleIds: visibleModuleIds(bundle, databasePackage!.id),
+      limit: 20,
+      analysisStatus: bundle.aggregates.hidden_coupling.meta.status,
+      analysisUnavailableReason:
+        bundle.aggregates.hidden_coupling.meta.unavailable_reason,
+    });
+
+    expect(databaseLens.capturedVisiblePairCount).toBe(70);
+    expect(databaseLens.pairs).toHaveLength(20);
+    expect(databaseLens.pairs[0]).toMatchObject({
+      cochangeCount: 24,
+      dependencyEvidence: "absent",
+    });
+    expect(databaseLens.capturedPairCount).toBe(1_000);
+    expect(databaseLens.declaredPairCount).toBe(104_263);
+    expect(databaseLens.coverage).toBe("truncated");
+  });
+
+  it("treats a continuation cursor as incomplete captured evidence", () => {
+    const bundle = golden();
+    const pairPage = {
+      ...bundle.aggregates.hidden_coupling.data,
+      truncated: false,
+      next_cursor: "next-hidden-coupling-page",
+      disclosure: {
+        status: "complete" as const,
+      },
+    };
+    const lens = buildStructureCouplingLens({
+      pairPage,
+      structureEdgePage: bundle.graph.structure_edges,
+      visibleModuleIds: visibleModuleIds(bundle, null),
+      limit: 20,
+      analysisStatus: bundle.aggregates.hidden_coupling.meta.status,
+      analysisUnavailableReason:
+        bundle.aggregates.hidden_coupling.meta.unavailable_reason,
+    });
+
+    expect(lens.coverage).toBe("truncated");
+    expect(lens.coverageReason).toContain("continuation cursor");
+  });
+
+  it("treats an unavailable analysis as unavailable even when the captured page looks complete", () => {
+    const bundle = golden();
+    const pairPage = {
+      ...bundle.aggregates.hidden_coupling.data,
+      truncated: false,
+      next_cursor: null,
+      disclosure: { status: "complete" as const },
+    };
+    const lens = buildStructureCouplingLens({
+      pairPage,
+      structureEdgePage: bundle.graph.structure_edges,
+      visibleModuleIds: visibleModuleIds(bundle, null),
+      limit: 20,
+      analysisStatus: "unavailable",
+      analysisUnavailableReason: "hidden-coupling analysis was not run",
+    });
+
+    expect(lens.coverage).toBe("unavailable");
+    expect(lens.coverageReason).toBe("hidden-coupling analysis was not run");
+    expect(lens.pairs).toHaveLength(0);
+    expect(lens.capturedVisiblePairCount).toBe(0);
+    expect(lens.capturedPairCount).toBe(0);
+    expect(lens.declaredPairCount).toBeNull();
+  });
+
+  it("never turns incomplete structure evidence into an absence claim", () => {
+    const bundle = golden();
+    const databasePackage = bundle.graph.packages.items.find((item) =>
+      item.name === "khive-db"
+    )!;
+    const structureEdgePage = {
+      ...bundle.graph.structure_edges,
+      truncated: true,
+      next_cursor: "next-structure-edge-page",
+      disclosure: {
+        status: "truncated" as const,
+        reason: "structure edge page reached its bound",
+      },
+    };
+    const lens = buildStructureCouplingLens({
+      pairPage: bundle.aggregates.hidden_coupling.data,
+      structureEdgePage,
+      visibleModuleIds: visibleModuleIds(bundle, databasePackage.id),
+      limit: 20,
+      analysisStatus: bundle.aggregates.hidden_coupling.meta.status,
+      analysisUnavailableReason:
+        bundle.aggregates.hidden_coupling.meta.unavailable_reason,
+    });
+
+    expect(lens.pairs).toHaveLength(20);
+    expect(lens.pairs.every((pair) => pair.dependencyEvidence === "unknown"))
+      .toBe(true);
+    expect(lens.dependencyCoverageReason).toBe(
+      "structure edge page reached its bound",
+    );
+  });
+
+  it("reports a captured dependency without changing pair orientation", () => {
+    const draft = structuredClone(golden());
+    const pair = draft.aggregates.hidden_coupling.data.items[0];
+    const existingEdge = draft.graph.structure_edges.items[0];
+    draft.graph.structure_edges = {
+      ...draft.graph.structure_edges,
+      items: [{
+        ...existingEdge,
+        source: pair.left_module_id,
+        target: pair.right_module_id,
+        relation: "depends_on" as const,
+      }],
+      total_count: { status: "available", value: 1 },
+      next_cursor: null,
+      truncated: false,
+      disclosure: { status: "complete" },
+    };
+    const bundle = parseRepoBundle(draft);
+    const lens = buildStructureCouplingLens({
+      pairPage: bundle.aggregates.hidden_coupling.data,
+      structureEdgePage: bundle.graph.structure_edges,
+      visibleModuleIds: new Set([
+        pair.left_module_id,
+        pair.right_module_id,
+      ]),
+      limit: 1,
+      analysisStatus: bundle.aggregates.hidden_coupling.meta.status,
+      analysisUnavailableReason:
+        bundle.aggregates.hidden_coupling.meta.unavailable_reason,
+    });
+
+    expect(lens.pairs[0]).toMatchObject({
+      leftModuleId: pair.left_module_id,
+      rightModuleId: pair.right_module_id,
+      dependencyEvidence: "present",
+    });
+  });
+});

--- a/apps/kg-editor/src/lib/structure-coupling-lens.test.ts
+++ b/apps/kg-editor/src/lib/structure-coupling-lens.test.ts
@@ -14,6 +14,20 @@ function golden(): RepoBundle {
   return parseRepoBundle(JSON.parse(readFileSync(goldenPath, "utf8")));
 }
 
+function deterministicShuffle<T>(items: readonly T[]): T[] {
+  const shuffled = [...items];
+  let seed = 1;
+  for (let index = shuffled.length - 1; index > 0; index--) {
+    seed = (seed * 48271) % 2147483647;
+    const swapIndex = seed % (index + 1);
+    [shuffled[index], shuffled[swapIndex]] = [
+      shuffled[swapIndex],
+      shuffled[index],
+    ];
+  }
+  return shuffled;
+}
+
 function visibleModuleIds(
   bundle: RepoBundle,
   packageId: string | null,
@@ -52,16 +66,23 @@ describe("structure hidden-coupling lens", () => {
       item.name === "khive-db"
     );
     expect(databasePackage).toBeDefined();
-    const databaseLens = buildStructureCouplingLens({
-      pairPage: bundle.aggregates.hidden_coupling.data,
-      structureEdgePage: bundle.graph.structure_edges,
-      visibleModuleIds: visibleModuleIds(bundle, databasePackage!.id),
-      limit: 20,
-      analysisStatus: bundle.aggregates.hidden_coupling.meta.status,
-      analysisUnavailableReason:
-        bundle.aggregates.hidden_coupling.meta.unavailable_reason,
-    });
+    const databaseVisibleModuleIds = visibleModuleIds(
+      bundle,
+      databasePackage!.id,
+    );
+    const basePairPage = bundle.aggregates.hidden_coupling.data;
+    const buildDatabaseLens = (pairPage: typeof basePairPage) =>
+      buildStructureCouplingLens({
+        pairPage,
+        structureEdgePage: bundle.graph.structure_edges,
+        visibleModuleIds: databaseVisibleModuleIds,
+        limit: 20,
+        analysisStatus: bundle.aggregates.hidden_coupling.meta.status,
+        analysisUnavailableReason:
+          bundle.aggregates.hidden_coupling.meta.unavailable_reason,
+      });
 
+    const databaseLens = buildDatabaseLens(basePairPage);
     expect(databaseLens.capturedVisiblePairCount).toBe(70);
     expect(databaseLens.pairs).toHaveLength(20);
     expect(databaseLens.pairs[0]).toMatchObject({
@@ -71,6 +92,24 @@ describe("structure hidden-coupling lens", () => {
     expect(databaseLens.capturedPairCount).toBe(1_000);
     expect(databaseLens.declaredPairCount).toBe(104_263);
     expect(databaseLens.coverage).toBe("truncated");
+
+    // The golden pair page arrives already sorted descending by
+    // cochange_count (producer order), and its visible slice contains
+    // several real cochange/support ties (e.g. ranks 4-5 at count 14,
+    // ranks 7-9 at count 12). Feeding the identical pair set reversed and
+    // shuffled must still select the exact same ordered slice, so the
+    // comparator (not incoming order) is what determines the result.
+    const reversedLens = buildDatabaseLens({
+      ...basePairPage,
+      items: [...basePairPage.items].reverse(),
+    });
+    const shuffledLens = buildDatabaseLens({
+      ...basePairPage,
+      items: deterministicShuffle(basePairPage.items),
+    });
+    const orderedKeys = databaseLens.pairs.map((pair) => pair.key);
+    expect(reversedLens.pairs.map((pair) => pair.key)).toEqual(orderedKeys);
+    expect(shuffledLens.pairs.map((pair) => pair.key)).toEqual(orderedKeys);
   });
 
   it("treats a continuation cursor as incomplete captured evidence", () => {
@@ -162,8 +201,8 @@ describe("structure hidden-coupling lens", () => {
       ...draft.graph.structure_edges,
       items: [{
         ...existingEdge,
-        source: pair.left_module_id,
-        target: pair.right_module_id,
+        source: pair.right_module_id,
+        target: pair.left_module_id,
         relation: "depends_on" as const,
       }],
       total_count: { status: "available", value: 1 },

--- a/apps/kg-editor/src/lib/structure-coupling-lens.ts
+++ b/apps/kg-editor/src/lib/structure-coupling-lens.ts
@@ -1,0 +1,122 @@
+import type { RepoBundle } from "@/lib/repo-bundle";
+
+const pairSeparator = "\u0000";
+
+type CouplingPage = RepoBundle["aggregates"]["hidden_coupling"]["data"];
+type CouplingAnalysisStatus = RepoBundle["aggregates"]["hidden_coupling"]["meta"]["status"];
+type StructureEdgePage = RepoBundle["graph"]["structure_edges"];
+
+export type CouplingDependencyEvidence = "present" | "absent" | "unknown";
+
+export type StructureCouplingPair = Readonly<{
+  key: string;
+  leftModuleId: string;
+  rightModuleId: string;
+  cochangeCount: number;
+  support: number;
+  dependencyEvidence: CouplingDependencyEvidence;
+}>;
+
+export type StructureCouplingLens = Readonly<{
+  pairs: readonly StructureCouplingPair[];
+  capturedVisiblePairCount: number;
+  capturedPairCount: number;
+  declaredPairCount: number | null;
+  coverage: CouplingPage["disclosure"]["status"];
+  coverageReason: string | null;
+  dependencyCoverageReason: string | null;
+}>;
+
+function undirectedPairKey(left: string, right: string): string {
+  return left.localeCompare(right) <= 0
+    ? `${left}${pairSeparator}${right}`
+    : `${right}${pairSeparator}${left}`;
+}
+
+export function buildStructureCouplingLens({
+  pairPage,
+  structureEdgePage,
+  visibleModuleIds,
+  limit,
+  analysisStatus,
+  analysisUnavailableReason,
+}: Readonly<{
+  pairPage: CouplingPage;
+  structureEdgePage: StructureEdgePage;
+  visibleModuleIds: ReadonlySet<string>;
+  limit: number;
+  analysisStatus: CouplingAnalysisStatus;
+  analysisUnavailableReason?: string | null;
+}>): StructureCouplingLens {
+  const boundedLimit = Math.max(0, Math.floor(limit));
+  const analysisUnavailable = analysisStatus === "unavailable";
+  const structureEvidenceComplete =
+    structureEdgePage.disclosure.status === "complete" &&
+    !structureEdgePage.truncated &&
+    structureEdgePage.next_cursor == null;
+  const capturedDependencies = new Set(
+    structureEdgePage.items
+      .filter((edge) => edge.relation === "depends_on")
+      .map((edge) => undirectedPairKey(edge.source, edge.target)),
+  );
+  const visiblePairs = analysisUnavailable ? [] : pairPage.items
+    .filter((pair) =>
+      visibleModuleIds.has(pair.left_module_id) &&
+      visibleModuleIds.has(pair.right_module_id)
+    )
+    .sort((left, right) =>
+      right.cochange_count - left.cochange_count ||
+      right.support - left.support ||
+      left.left_module_id.localeCompare(right.left_module_id) ||
+      left.right_module_id.localeCompare(right.right_module_id)
+    );
+  const pairEvidenceUnavailable = analysisUnavailable ||
+    pairPage.disclosure.status === "unavailable";
+  const pairEvidenceIncomplete = !pairEvidenceUnavailable &&
+    (pairPage.disclosure.status === "truncated" ||
+      pairPage.truncated ||
+      pairPage.next_cursor != null);
+  const coverage = pairEvidenceUnavailable
+    ? "unavailable"
+    : pairEvidenceIncomplete
+    ? "truncated"
+    : "complete";
+  const coverageReason = pairPage.disclosure.reason ??
+    (analysisUnavailable
+      ? (analysisUnavailableReason ??
+        "The hidden-coupling analysis is unavailable.")
+      : pairPage.next_cursor != null
+      ? "The captured hidden-coupling page has a continuation cursor."
+      : pairPage.truncated
+      ? "The captured hidden-coupling page is truncated."
+      : null);
+
+  return {
+    pairs: visiblePairs.slice(0, boundedLimit).map((pair) => {
+      const key = undirectedPairKey(pair.left_module_id, pair.right_module_id);
+      return {
+        key,
+        leftModuleId: pair.left_module_id,
+        rightModuleId: pair.right_module_id,
+        cochangeCount: pair.cochange_count,
+        support: pair.support,
+        dependencyEvidence: structureEvidenceComplete
+          ? capturedDependencies.has(key) ? "present" : "absent"
+          : "unknown",
+      };
+    }),
+    capturedVisiblePairCount: visiblePairs.length,
+    capturedPairCount: analysisUnavailable ? 0 : pairPage.items.length,
+    declaredPairCount: analysisUnavailable ? null : (
+      pairPage.total_count.status === "available"
+        ? pairPage.total_count.value
+        : null
+    ),
+    coverage,
+    coverageReason,
+    dependencyCoverageReason: structureEvidenceComplete
+      ? null
+      : structureEdgePage.disclosure.reason ??
+        "The captured structure-edge page is incomplete.",
+  };
+}


### PR DESCRIPTION
Replaces #1971, rebuilt on current main.

Adds a hidden-coupling lens to the structure graph: a bounded, deterministic selection of the top co-change pairs among currently visible modules (`structure-coupling-lens.ts`), overlaid on the graph without perturbing layout, with per-pair focus (dimming and endpoint highlighting), module-inspector integration, and URL sync preserving the structure-graph view. Coverage semantics are conservative: truncated pair pages report incomplete evidence, incomplete structure-edge coverage reports unknown rather than absent, and an unavailable aggregate renders its reason.

Distinct from the existing hidden-coupling tab (global top-N table): the lens is scoped to the visible slice and cross-checks captured structure edges for direct-dependency evidence. Both surfaces share the capability key by design.

Unit tests (5), component tests (3), and two e2e cases cover selection determinism, coverage semantics, focus behavior, and inspector/URL integration. Full suite 276 passed, typecheck and lint clean.