### PR TITLE
fix(kg-editor): bound catalog discovery and strip nested credentials from history writes

### DIFF
--- a/apps/kg-editor/src/components/showcase/showcase.test.tsx
+++ b/apps/kg-editor/src/components/showcase/showcase.test.tsx
@@ -417,7 +417,7 @@ describe("materialized repository lookup", () => {
     const url = new URL(window.location.href);
     expect(url.searchParams.has("access_token")).toBe(false);
     expect(url.hash).toBe("");
-    expect([...url.searchParams.keys()]).toEqual(["repo"]);
+    expect([...url.searchParams.keys()]).toEqual([]);
   });
 
   it("treats an empty repo parameter as invalid instead of falling back to the default entry", async () => {
@@ -497,7 +497,7 @@ describe("materialized repository lookup", () => {
     expect(url.hash).toBe("");
     expect(url.href).not.toContain("SECRET");
     expect(url.href).not.toContain("TOP");
-    expect([...url.searchParams.keys()]).toEqual(["repo"]);
+    expect([...url.searchParams.keys()]).toEqual([]);
   });
 
   it("renders an honest miss when a dynamic-only analysis disappears", async () => {

--- a/apps/kg-editor/src/components/showcase/showcase.test.tsx
+++ b/apps/kg-editor/src/components/showcase/showcase.test.tsx
@@ -226,6 +226,7 @@ describe("materialized repository lookup", () => {
       status: 200,
       headers: new Headers({ "content-length": String(body.byteLength) }),
       arrayBuffer: async () => body.buffer as ArrayBuffer,
+      body: null,
     }));
     mockedCatalog.mockImplementation(() =>
       actualCatalog.loadShowcaseAnalysisCatalog(fetchCatalog)
@@ -455,12 +456,13 @@ describe("materialized repository lookup", () => {
     expect([...url.searchParams.keys()]).toEqual(["repo"]);
   });
 
-  it("drops foreign query parameters and the fragment from history for a registry miss", async () => {
+  it("drops foreign query parameters, the fragment, and a credential nested inside the repo value from history for a registry miss", async () => {
     const repo = "https://github.com/example/not-catalog-registered";
+    const nestedCredentialRepo = `${repo}?access_token=SECRET`;
     window.history.replaceState(
       null,
       "",
-      `/?repo=${encodeURIComponent(repo)}&access_token=secret#fragment`,
+      `/?repo=${encodeURIComponent(nestedCredentialRepo)}&access_token=TOP#frag`,
     );
 
     render(<Showcase />);
@@ -469,9 +471,32 @@ describe("materialized repository lookup", () => {
       await screen.findByText("No curated showcase bundle matches this repository"),
     ).toBeVisible();
     const url = new URL(window.location.href);
+    // The repo value is preserved minus its own nested query/fragment —
+    // the credential inside it must not survive into history.
     expect(url.searchParams.get("repo")).toBe(repo);
     expect(url.searchParams.has("access_token")).toBe(false);
     expect(url.hash).toBe("");
+    expect(url.href).not.toContain("SECRET");
+    expect(url.href).not.toContain("TOP");
+    expect([...url.searchParams.keys()]).toEqual(["repo"]);
+  });
+
+  it("drops a credential nested inside the repo value from history on the invalid branch", async () => {
+    const nestedCredentialRepo = "ftp://example.com/owner/repo?access_token=SECRET";
+    window.history.replaceState(
+      null,
+      "",
+      `/?repo=${encodeURIComponent(nestedCredentialRepo)}&access_token=TOP#frag`,
+    );
+
+    render(<Showcase />);
+
+    expect(await screen.findByText("Repository lookup could not start")).toBeVisible();
+    const url = new URL(window.location.href);
+    expect(url.searchParams.has("access_token")).toBe(false);
+    expect(url.hash).toBe("");
+    expect(url.href).not.toContain("SECRET");
+    expect(url.href).not.toContain("TOP");
     expect([...url.searchParams.keys()]).toEqual(["repo"]);
   });
 

--- a/apps/kg-editor/src/lib/adapters/showcase-analysis-catalog.test.ts
+++ b/apps/kg-editor/src/lib/adapters/showcase-analysis-catalog.test.ts
@@ -7,6 +7,7 @@ import {
   parseShowcaseAnalysisCatalog,
   SHOWCASE_CATALOG_MAX_BYTES,
   SHOWCASE_CATALOG_MAX_ENTRIES,
+  SHOWCASE_CATALOG_TIMEOUT_MS,
 } from "@/lib/adapters/showcase-analysis-catalog";
 import type { ShowcaseRegistryEntry } from "@/lib/showcase-registry";
 
@@ -32,6 +33,29 @@ function catalogResponse(
       ...headers,
     }),
     arrayBuffer: () => Promise.resolve(bytes.buffer as ArrayBuffer),
+    body: null,
+  };
+}
+
+function chunkedCatalogResponse(chunks: readonly Uint8Array<ArrayBuffer>[]) {
+  const stream = new ReadableStream<Uint8Array<ArrayBuffer>>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk);
+      controller.close();
+    },
+  });
+  const arrayBuffer = vi.fn(async () => {
+    throw new Error("arrayBuffer() should not be used when a body stream is available");
+  });
+  return {
+    response: {
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      arrayBuffer,
+      body: stream,
+    },
+    arrayBuffer,
   };
 }
 
@@ -189,6 +213,7 @@ describe("showcase analysis catalog", () => {
         cache: "no-store",
         credentials: "same-origin",
         redirect: "error",
+        signal: expect.any(AbortSignal),
         headers: { authorization: "Bearer operator-secret" },
       });
     } finally {
@@ -203,6 +228,7 @@ describe("showcase analysis catalog", () => {
       cache: "no-store",
       credentials: "same-origin",
       redirect: "error",
+      signal: expect.any(AbortSignal),
     });
   });
 
@@ -219,6 +245,43 @@ describe("showcase analysis catalog", () => {
     await expect(loadShowcaseAnalysisCatalog(fetchCatalog)).resolves.toMatchObject({
       status: "degraded",
     });
+  });
+
+  it("rejects an oversized chunked body with no Content-Length before full materialization", async () => {
+    const chunk = new Uint8Array(64 * 1024).fill(0x20);
+    const { response, arrayBuffer } = chunkedCatalogResponse([
+      chunk,
+      chunk,
+      chunk,
+      chunk,
+      chunk,
+    ]);
+    const fetchCatalog = vi.fn(async () => response);
+
+    await expect(loadShowcaseAnalysisCatalog(fetchCatalog)).resolves.toEqual({
+      status: "degraded",
+      entries: [],
+      message: expect.stringMatching(/catalog.*unavailable/i),
+    });
+    expect(arrayBuffer).not.toHaveBeenCalled();
+  });
+
+  it("resolves to degraded within the timeout bound when the catalog fetch never settles", async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchCatalog = vi.fn(() => new Promise<never>(() => {}));
+      const resultPromise = loadShowcaseAnalysisCatalog(fetchCatalog);
+
+      await vi.advanceTimersByTimeAsync(SHOWCASE_CATALOG_TIMEOUT_MS);
+
+      await expect(resultPromise).resolves.toEqual({
+        status: "degraded",
+        entries: [],
+        message: expect.stringMatching(/catalog.*unavailable/i),
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("merges dynamic and static entries by normalized URL", () => {

--- a/apps/kg-editor/src/lib/adapters/showcase-analysis-catalog.test.ts
+++ b/apps/kg-editor/src/lib/adapters/showcase-analysis-catalog.test.ts
@@ -285,7 +285,7 @@ describe("showcase analysis catalog", () => {
     }
   });
 
-  it("never starts reading the body once the deadline has already fired, even when the fetch resolves late with a body that never completes (kills a writer that installs its abort listener only after the abort event already fired)", async () => {
+  it("never starts reading the body once the deadline has already fired, even when the fetch resolves late with a body that never completes", async () => {
     vi.useFakeTimers();
     try {
       let resolveFetch: (value: unknown) => void = () => {};
@@ -335,7 +335,7 @@ describe("showcase analysis catalog", () => {
     }
   });
 
-  it("attaches a handler to a rejecting reader.cancel() triggered by an in-flight abort, and still settles degraded (kills a writer that discards the cancel() promise with void, leaving it unhandled)", async () => {
+  it("attaches a handler to a rejecting reader.cancel() triggered by an in-flight abort, and still settles degraded", async () => {
     vi.useFakeTimers();
     try {
       const read = vi.fn(() => new Promise(() => {}));

--- a/apps/kg-editor/src/lib/adapters/showcase-analysis-catalog.test.ts
+++ b/apps/kg-editor/src/lib/adapters/showcase-analysis-catalog.test.ts
@@ -5,6 +5,7 @@ import {
   loadShowcaseAnalysisCatalog,
   mergeShowcaseRegistry,
   parseShowcaseAnalysisCatalog,
+  type ShowcaseCatalogFetch,
   SHOWCASE_CATALOG_MAX_BYTES,
   SHOWCASE_CATALOG_MAX_ENTRIES,
   SHOWCASE_CATALOG_TIMEOUT_MS,
@@ -279,6 +280,120 @@ describe("showcase analysis catalog", () => {
         entries: [],
         message: expect.stringMatching(/catalog.*unavailable/i),
       });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("never starts reading the body once the deadline has already fired, even when the fetch resolves late with a body that never completes (kills a writer that installs its abort listener only after the abort event already fired)", async () => {
+    vi.useFakeTimers();
+    try {
+      let resolveFetch: (value: unknown) => void = () => {};
+      const fetchPromise = new Promise((resolve) => {
+        resolveFetch = resolve;
+      });
+      const fetchCatalog = vi.fn(
+        () => fetchPromise,
+      ) as unknown as ShowcaseCatalogFetch;
+      const resultPromise = loadShowcaseAnalysisCatalog(fetchCatalog);
+
+      await vi.advanceTimersByTimeAsync(SHOWCASE_CATALOG_TIMEOUT_MS);
+      await expect(resultPromise).resolves.toEqual({
+        status: "degraded",
+        entries: [],
+        message: expect.stringMatching(/catalog.*unavailable/i),
+      });
+
+      const read = vi.fn(() => new Promise(() => {}));
+      const cancel = vi.fn(async () => {});
+      const getReader = vi.fn(() => ({
+        read,
+        cancel,
+        releaseLock: vi.fn(),
+      }));
+      resolveFetch({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        arrayBuffer: vi.fn(async () => {
+          throw new Error(
+            "arrayBuffer() should not be used when a body stream is available",
+          );
+        }),
+        body: { getReader } as unknown as ReadableStream<
+          Uint8Array<ArrayBuffer>
+        >,
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(getReader).not.toHaveBeenCalled();
+      expect(read).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("attaches a handler to a rejecting reader.cancel() triggered by an in-flight abort, and still settles degraded (kills a writer that discards the cancel() promise with void, leaving it unhandled)", async () => {
+    vi.useFakeTimers();
+    try {
+      const read = vi.fn(() => new Promise(() => {}));
+      let cancelResultHandled = false;
+      const cancel = vi.fn(() => ({
+        catch: (onRejected?: (reason: unknown) => unknown) => {
+          cancelResultHandled = true;
+          return Promise.resolve().then(() =>
+            onRejected?.(new Error("cancel failed"))
+          );
+        },
+        then: (
+          _onFulfilled?: (value: unknown) => unknown,
+          onRejected?: (reason: unknown) => unknown,
+        ) => {
+          cancelResultHandled = true;
+          return Promise.resolve().then(() =>
+            onRejected?.(new Error("cancel failed"))
+          );
+        },
+      }));
+      const getReader = vi.fn(() => ({
+        read,
+        cancel,
+        releaseLock: vi.fn(),
+      }));
+      const response = {
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        arrayBuffer: vi.fn(async () => {
+          throw new Error(
+            "arrayBuffer() should not be used when a body stream is available",
+          );
+        }),
+        body: { getReader } as unknown as ReadableStream<
+          Uint8Array<ArrayBuffer>
+        >,
+      };
+      const fetchCatalog = vi.fn(
+        async () => response,
+      ) as unknown as ShowcaseCatalogFetch;
+
+      const resultPromise = loadShowcaseAnalysisCatalog(fetchCatalog);
+      await vi.advanceTimersByTimeAsync(SHOWCASE_CATALOG_TIMEOUT_MS);
+
+      await expect(resultPromise).resolves.toEqual({
+        status: "degraded",
+        entries: [],
+        message: expect.stringMatching(/catalog.*unavailable/i),
+      });
+
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(cancel).toHaveBeenCalled();
+      expect(cancelResultHandled).toBe(true);
     } finally {
       vi.useRealTimers();
     }

--- a/apps/kg-editor/src/lib/adapters/showcase-analysis-catalog.test.ts
+++ b/apps/kg-editor/src/lib/adapters/showcase-analysis-catalog.test.ts
@@ -139,6 +139,18 @@ describe("showcase analysis catalog", () => {
     })).toThrow(/catalog/i);
   });
 
+  it("rejects a single entry whose canonical URL exceeds the repository length limit", () => {
+    expect(() => parseShowcaseAnalysisCatalog({
+      schema_version: "khive.showcase.catalog.v1",
+      entries: [
+        {
+          analysis_id: "analysis-overlong",
+          canonical_url: `https://github.com/example/${"r".repeat(3000)}`,
+        },
+      ],
+    })).toThrow(/catalog/i);
+  });
+
   it("rejects an empty successful catalog instead of treating it as unconfigured", () => {
     expect(() => parseShowcaseAnalysisCatalog({
       schema_version: "khive.showcase.catalog.v1",

--- a/apps/kg-editor/src/lib/adapters/showcase-analysis-catalog.ts
+++ b/apps/kg-editor/src/lib/adapters/showcase-analysis-catalog.ts
@@ -124,8 +124,20 @@ async function readBoundedCatalogBody(
     return new Uint8Array(buffer);
   }
 
+  if (signal.aborted) {
+    return invalidCatalog();
+  }
+
   const reader = body.getReader();
-  const onAbort = () => void reader.cancel();
+  if (signal.aborted) {
+    await reader.cancel().catch(() => {});
+    reader.releaseLock();
+    return invalidCatalog();
+  }
+
+  const onAbort = () => {
+    reader.cancel().catch(() => {});
+  };
   signal.addEventListener("abort", onAbort, { once: true });
   const chunks: Uint8Array[] = [];
   let total = 0;
@@ -135,7 +147,7 @@ async function readBoundedCatalogBody(
       if (done) break;
       total += value.byteLength;
       if (total > SHOWCASE_CATALOG_MAX_BYTES) {
-        await reader.cancel();
+        await reader.cancel().catch(() => {});
         return invalidCatalog();
       }
       chunks.push(value);

--- a/apps/kg-editor/src/lib/adapters/showcase-analysis-catalog.ts
+++ b/apps/kg-editor/src/lib/adapters/showcase-analysis-catalog.ts
@@ -7,6 +7,7 @@ import {
 
 export const SHOWCASE_CATALOG_MAX_ENTRIES = 64;
 export const SHOWCASE_CATALOG_MAX_BYTES = 256 * 1024;
+export const SHOWCASE_CATALOG_TIMEOUT_MS = 5_000;
 
 const ANALYSIS_ID = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/;
 const CATALOG_SCHEMA = "khive.showcase.catalog.v1";
@@ -31,7 +32,7 @@ export type ShowcaseAnalysisCatalogResult =
 export type ShowcaseCatalogFetch = (
   input: string,
   init?: RequestInit,
-) => Promise<Pick<Response, "ok" | "status" | "headers" | "arrayBuffer">>;
+) => Promise<Pick<Response, "ok" | "status" | "headers" | "arrayBuffer" | "body">>;
 
 function exactKeys(value: object, expected: readonly string[]): boolean {
   return Object.keys(value).sort().join(",") === [...expected].sort().join(",");
@@ -99,54 +100,123 @@ export function parseShowcaseAnalysisCatalog(
   return entries;
 }
 
+function abortRejection(signal: AbortSignal): Promise<never> {
+  return new Promise((_, reject) => {
+    const onAbort = () => reject(new Error("catalog request timed out"));
+    if (signal.aborted) {
+      onAbort();
+      return;
+    }
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+async function readBoundedCatalogBody(
+  response: Pick<Response, "arrayBuffer" | "body">,
+  signal: AbortSignal,
+): Promise<Uint8Array> {
+  const body = response.body;
+  if (!body) {
+    const buffer = await response.arrayBuffer();
+    if (buffer.byteLength > SHOWCASE_CATALOG_MAX_BYTES) {
+      return invalidCatalog();
+    }
+    return new Uint8Array(buffer);
+  }
+
+  const reader = body.getReader();
+  const onAbort = () => void reader.cancel();
+  signal.addEventListener("abort", onAbort, { once: true });
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > SHOWCASE_CATALOG_MAX_BYTES) {
+        await reader.cancel();
+        return invalidCatalog();
+      }
+      chunks.push(value);
+    }
+  } finally {
+    signal.removeEventListener("abort", onAbort);
+    reader.releaseLock();
+  }
+
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+async function fetchCatalogResult(
+  fetchCatalog: ShowcaseCatalogFetch,
+  signal: AbortSignal,
+): Promise<ShowcaseAnalysisCatalogResult> {
+  const accessToken = readOperatorShowcaseAccessToken()?.trim();
+  const response = await fetchCatalog("/api/showcase/analyses", {
+    cache: "no-store",
+    credentials: "same-origin",
+    redirect: "error",
+    signal,
+    ...(accessToken
+      ? { headers: { authorization: `Bearer ${accessToken}` } }
+      : {}),
+  });
+  if (response.status === 404) {
+    return {
+      status: "static-only",
+      entries: [],
+      message: "The server analysis catalog is not configured; curated static repositories remain available.",
+    };
+  }
+  if (!response.ok) {
+    throw new Error(`catalog HTTP ${response.status}`);
+  }
+
+  const declaredLength = Number(response.headers.get("content-length"));
+  if (
+    Number.isFinite(declaredLength) &&
+    declaredLength > SHOWCASE_CATALOG_MAX_BYTES
+  ) {
+    return invalidCatalog();
+  }
+  const bytes = await readBoundedCatalogBody(response, signal);
+  const json = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  const entries = parseShowcaseAnalysisCatalog(JSON.parse(json));
+  return {
+    status: "ready",
+    entries,
+    message: `${entries.length} configured repository ${entries.length === 1 ? "analysis" : "analyses"} discovered.`,
+  };
+}
+
 export async function loadShowcaseAnalysisCatalog(
   fetchCatalog: ShowcaseCatalogFetch = fetch,
 ): Promise<ShowcaseAnalysisCatalogResult> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(
+    () => controller.abort(),
+    SHOWCASE_CATALOG_TIMEOUT_MS,
+  );
   try {
-    const accessToken = readOperatorShowcaseAccessToken()?.trim();
-    const response = await fetchCatalog("/api/showcase/analyses", {
-      cache: "no-store",
-      credentials: "same-origin",
-      redirect: "error",
-      ...(accessToken
-        ? { headers: { authorization: `Bearer ${accessToken}` } }
-        : {}),
-    });
-    if (response.status === 404) {
-      return {
-        status: "static-only",
-        entries: [],
-        message: "The server analysis catalog is not configured; curated static repositories remain available.",
-      };
-    }
-    if (!response.ok) {
-      throw new Error(`catalog HTTP ${response.status}`);
-    }
-
-    const declaredLength = Number(response.headers.get("content-length"));
-    if (
-      Number.isFinite(declaredLength) &&
-      declaredLength > SHOWCASE_CATALOG_MAX_BYTES
-    ) {
-      return invalidCatalog();
-    }
-    const bytes = new Uint8Array(await response.arrayBuffer());
-    if (bytes.byteLength > SHOWCASE_CATALOG_MAX_BYTES) {
-      return invalidCatalog();
-    }
-    const json = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
-    const entries = parseShowcaseAnalysisCatalog(JSON.parse(json));
-    return {
-      status: "ready",
-      entries,
-      message: `${entries.length} configured repository ${entries.length === 1 ? "analysis" : "analyses"} discovered.`,
-    };
+    return await Promise.race([
+      fetchCatalogResult(fetchCatalog, controller.signal),
+      abortRejection(controller.signal),
+    ]);
   } catch {
     return {
       status: "degraded",
       entries: [],
       message: "The server analysis catalog is unavailable; curated static repositories remain available.",
     };
+  } finally {
+    clearTimeout(timeoutId);
   }
 }
 

--- a/apps/kg-editor/src/lib/repository-location.test.ts
+++ b/apps/kg-editor/src/lib/repository-location.test.ts
@@ -217,7 +217,7 @@ describe("repository investigation location", () => {
     expect(url.href).not.toContain("token-fragment");
   });
 
-  it("strips userinfo credentials nested inside the repo value before writing history (kills a writer that only strips literal ? and #)", () => {
+  it("omits the repo param instead of writing a value with authority credentials", () => {
     const url = repositoryLocationUrl(
       new URL("https://example.test/"),
       {
@@ -228,14 +228,12 @@ describe("repository investigation location", () => {
       },
     );
 
-    expect(url.searchParams.get("repo")).toBe(
-      "https://github.com/example/repo",
-    );
+    expect(url.searchParams.has("repo")).toBe(false);
     expect(url.href).not.toContain("SECRET");
     expect(url.href).not.toContain("user:SECRET@");
   });
 
-  it("strips a double-encoded query delimiter from the repo value before writing history (kills a writer whose regex only matches literal ?/#)", () => {
+  it("omits the repo param instead of writing a value with a double-encoded query delimiter", () => {
     const url = repositoryLocationUrl(
       new URL("https://example.test/"),
       {
@@ -247,18 +245,78 @@ describe("repository investigation location", () => {
       },
     );
 
-    expect(url.searchParams.get("repo")).toBe(
-      "https://github.com/example/repo",
-    );
+    expect(url.searchParams.has("repo")).toBe(false);
     expect(url.href).not.toContain("SECRET");
     expect(url.href).not.toContain("%253F");
   });
 
-  it("strips a percent-encoded fragment delimiter from the repo value before writing history (kills a writer whose regex only matches literal ?/#)", () => {
+  it("omits the repo param instead of writing a value with a triple-encoded query delimiter", () => {
     const url = repositoryLocationUrl(
       new URL("https://example.test/"),
       {
-        repository: "https://github.com/example/repo%23access_token=SECRET",
+        repository:
+          "https://github.com/example/repo%25253Faccess_token%25253DSECRET",
+        snapshotSha: null,
+        modulePath: null,
+        view: null,
+      },
+    );
+
+    expect(url.searchParams.has("repo")).toBe(false);
+    expect(url.href).not.toContain("SECRET");
+    expect(url.href).not.toContain("%25253F");
+  });
+
+  it("omits the repo param instead of writing a value with a percent-encoded userinfo delimiter", () => {
+    const url = repositoryLocationUrl(
+      new URL("https://example.test/"),
+      {
+        repository: "https://user%40SECRET@github.com/example/repo",
+        snapshotSha: null,
+        modulePath: null,
+        view: null,
+      },
+    );
+
+    expect(url.searchParams.has("repo")).toBe(false);
+    expect(url.href).not.toContain("SECRET");
+  });
+
+  it("omits the repo param instead of writing a value with backslashes browsers normalize into authority credentials", () => {
+    const url = repositoryLocationUrl(
+      new URL("https://example.test/"),
+      {
+        repository: "https:\\\\user:SECRET@github.com/example/repo",
+        snapshotSha: null,
+        modulePath: null,
+        view: null,
+      },
+    );
+
+    expect(url.searchParams.has("repo")).toBe(false);
+    expect(url.href).not.toContain("SECRET");
+  });
+
+  it("omits the repo param instead of writing a schemeless value", () => {
+    const url = repositoryLocationUrl(
+      new URL("https://example.test/"),
+      {
+        repository: "github.com/example/repo?access_token=SECRET",
+        snapshotSha: null,
+        modulePath: null,
+        view: null,
+      },
+    );
+
+    expect(url.searchParams.has("repo")).toBe(false);
+    expect(url.href).not.toContain("SECRET");
+  });
+
+  it("still round-trips a valid repository URL to its canonical form", () => {
+    const url = repositoryLocationUrl(
+      new URL("https://example.test/"),
+      {
+        repository: "https://www.GitHub.com/Example/Repo.git",
         snapshotSha: null,
         modulePath: null,
         view: null,
@@ -266,10 +324,8 @@ describe("repository investigation location", () => {
     );
 
     expect(url.searchParams.get("repo")).toBe(
-      "https://github.com/example/repo",
+      "https://github.com/Example/Repo",
     );
-    expect(url.href).not.toContain("SECRET");
-    expect(url.href).not.toContain("%23");
   });
 
   it("share form omits a module path carrying a query or fragment delimiter", () => {

--- a/apps/kg-editor/src/lib/repository-location.test.ts
+++ b/apps/kg-editor/src/lib/repository-location.test.ts
@@ -217,6 +217,61 @@ describe("repository investigation location", () => {
     expect(url.href).not.toContain("token-fragment");
   });
 
+  it("strips userinfo credentials nested inside the repo value before writing history (kills a writer that only strips literal ? and #)", () => {
+    const url = repositoryLocationUrl(
+      new URL("https://example.test/"),
+      {
+        repository: "https://user:SECRET@github.com/example/repo",
+        snapshotSha: null,
+        modulePath: null,
+        view: null,
+      },
+    );
+
+    expect(url.searchParams.get("repo")).toBe(
+      "https://github.com/example/repo",
+    );
+    expect(url.href).not.toContain("SECRET");
+    expect(url.href).not.toContain("user:SECRET@");
+  });
+
+  it("strips a double-encoded query delimiter from the repo value before writing history (kills a writer whose regex only matches literal ?/#)", () => {
+    const url = repositoryLocationUrl(
+      new URL("https://example.test/"),
+      {
+        repository:
+          "https://github.com/example/repo%253Faccess_token%253DSECRET",
+        snapshotSha: null,
+        modulePath: null,
+        view: null,
+      },
+    );
+
+    expect(url.searchParams.get("repo")).toBe(
+      "https://github.com/example/repo",
+    );
+    expect(url.href).not.toContain("SECRET");
+    expect(url.href).not.toContain("%253F");
+  });
+
+  it("strips a percent-encoded fragment delimiter from the repo value before writing history (kills a writer whose regex only matches literal ?/#)", () => {
+    const url = repositoryLocationUrl(
+      new URL("https://example.test/"),
+      {
+        repository: "https://github.com/example/repo%23access_token=SECRET",
+        snapshotSha: null,
+        modulePath: null,
+        view: null,
+      },
+    );
+
+    expect(url.searchParams.get("repo")).toBe(
+      "https://github.com/example/repo",
+    );
+    expect(url.href).not.toContain("SECRET");
+    expect(url.href).not.toContain("%23");
+  });
+
   it("share form omits a module path carrying a query or fragment delimiter", () => {
     for (
       const modulePath of [

--- a/apps/kg-editor/src/lib/repository-location.test.ts
+++ b/apps/kg-editor/src/lib/repository-location.test.ts
@@ -130,6 +130,36 @@ describe("repository investigation location", () => {
     expect(url.href).not.toContain("another-secret");
   });
 
+  it("strips a credential nested inside the repo value before writing history", () => {
+    const url = repositoryLocationUrl(
+      new URL("https://example.test/"),
+      {
+        repository: "https://github.com/example/repo?access_token=super-secret",
+        snapshotSha: null,
+        modulePath: null,
+        view: null,
+      },
+    );
+
+    expect(url.searchParams.get("repo")).toBe("https://github.com/example/repo");
+    expect(url.href).not.toContain("super-secret");
+  });
+
+  it("strips a fragment nested inside the repo value before writing history", () => {
+    const url = repositoryLocationUrl(
+      new URL("https://example.test/"),
+      {
+        repository: "https://github.com/example/repo#access_token=super-secret",
+        snapshotSha: null,
+        modulePath: null,
+        view: null,
+      },
+    );
+
+    expect(url.searchParams.get("repo")).toBe("https://github.com/example/repo");
+    expect(url.href).not.toContain("super-secret");
+  });
+
   it("drops a fragment-borne credential instead of preserving it", () => {
     const url = repositoryLocationUrl(
       new URL(

--- a/apps/kg-editor/src/lib/repository-location.test.ts
+++ b/apps/kg-editor/src/lib/repository-location.test.ts
@@ -4,10 +4,12 @@ import type { ViewId } from "@/lib/repo-bundle";
 import {
   investigationShareUrl,
   parseRepositoryLocation,
+  publicRepositoryUrlIssue,
   REPOSITORY_VIEW_IDS,
   type RepositoryLocation,
   repositoryLocationUrl,
 } from "@/lib/repository-location";
+import { normalizeRepositoryUrl } from "@/lib/showcase-registry";
 
 const repository = "https://github.com/ohdearquant/khive";
 const snapshotSha = "0123456789abcdef0123456789abcdef01234567";
@@ -77,7 +79,7 @@ describe("repository investigation location", () => {
     ["query string", `${repository}?tab=readme`],
     ["fragment", `${repository}#readme`],
   ])(
-    "accepts a curated repository URL carrying a %s",
+    "accepts a curated repository URL carrying a %s, parsed to its canonical form",
     (_name, repositoryWithExtras) => {
       const parsed = parseRepositoryLocation(
         new URL(
@@ -86,9 +88,19 @@ describe("repository investigation location", () => {
       );
 
       expect(parsed.issues).toEqual([]);
-      expect(parsed.location.repository).toBe(repositoryWithExtras);
+      expect(parsed.location.repository).toBe(repository);
     },
   );
+
+  it("accepts a deep link whose discarded query is long but whose canonical form is short", () => {
+    const longQuery = `${repository}?${"q".repeat(3000)}`;
+    const parsed = parseRepositoryLocation(
+      new URL(`https://example.test/?repo=${encodeURIComponent(longQuery)}`),
+    );
+
+    expect(parsed.issues).toEqual([]);
+    expect(parsed.location.repository).toBe(repository);
+  });
 
   it("canonicalizes to only the closed location parameters in stable order, dropping every other query parameter", () => {
     const url = repositoryLocationUrl(
@@ -343,6 +355,30 @@ describe("repository investigation location", () => {
     expect(written.searchParams.has("repo")).toBe(false);
     expect(read.location.repository).toBeNull();
     expect(read.issues.map((issue) => issue.parameter)).toContain("repo");
+  });
+
+  it("share link omits a value whose canonical form crosses the limit the input does not", () => {
+    // Canonicalization rewrites http to https, so this input is within the
+    // limit while the value every consumer would store is one character over.
+    const input = `http://example.com/a/${"r".repeat(2027)}`;
+    expect(input.length).toBe(2048);
+    expect(normalizeRepositoryUrl(input).ok).toBe(false);
+
+    const url = investigationShareUrl(new URL("https://example.test/app"), {
+      repository: input,
+      snapshotSha: null,
+      modulePath: null,
+      view: null,
+    });
+
+    expect(url.searchParams.has("repo")).toBe(false);
+  });
+
+  it("bundle validator refuses a value whose canonical form crosses the limit", () => {
+    const input = `http://example.com/a/${"r".repeat(2027)}`;
+
+    expect(publicRepositoryUrlIssue(input)).toBe("The repository URL is too long.");
+    expect(publicRepositoryUrlIssue(repository)).toBeNull();
   });
 
   it("still round-trips a valid repository URL to its canonical form", () => {

--- a/apps/kg-editor/src/lib/repository-location.test.ts
+++ b/apps/kg-editor/src/lib/repository-location.test.ts
@@ -312,6 +312,39 @@ describe("repository investigation location", () => {
     expect(url.href).not.toContain("SECRET");
   });
 
+  it("omits a repository value whose canonical form exceeds the length the reader enforces", () => {
+    const overlong = `https://github.com/example/${"r".repeat(3000)}`;
+    const url = repositoryLocationUrl(
+      new URL("https://example.test/"),
+      {
+        repository: overlong,
+        snapshotSha: null,
+        modulePath: null,
+        view: null,
+      },
+    );
+
+    expect(url.searchParams.has("repo")).toBe(false);
+    expect(url.href.length).toBeLessThan(overlong.length);
+  });
+
+  it("agrees with the reader about which repository values are too long", () => {
+    const overlong = `https://github.com/example/${"r".repeat(3000)}`;
+    const written = repositoryLocationUrl(new URL("https://example.test/"), {
+      repository: overlong,
+      snapshotSha: null,
+      modulePath: null,
+      view: null,
+    });
+    const read = parseRepositoryLocation(
+      new URL(`https://example.test/?repo=${encodeURIComponent(overlong)}`),
+    );
+
+    expect(written.searchParams.has("repo")).toBe(false);
+    expect(read.location.repository).toBeNull();
+    expect(read.issues.map((issue) => issue.parameter)).toContain("repo");
+  });
+
   it("still round-trips a valid repository URL to its canonical form", () => {
     const url = repositoryLocationUrl(
       new URL("https://example.test/"),

--- a/apps/kg-editor/src/lib/repository-location.ts
+++ b/apps/kg-editor/src/lib/repository-location.ts
@@ -183,13 +183,36 @@ export function parseRepositoryLocation(url: URL): ParsedRepositoryLocation {
 // credential such as ?access_token=..., a fragment-borne secret, a tracker
 // value — is never copied forward: the URL is rebuilt from the origin and
 // path only, and every other parameter and the hash are discarded. The same
-// guarantee extends to the repo VALUE itself: a credential nested inside it
-// (e.g. a raw, not-yet-validated `repo` param carrying its own
-// `?access_token=...`) is stripped before the value is written, so it can
-// never survive into history, a referrer header, or a copied link either.
+// guarantee extends to the repo VALUE itself: this writer strips userinfo
+// (a `user:pass@` prefix on the authority) and truncates at the first query
+// or fragment delimiter — whether literal (`?`, `#`) or percent-encoded, at
+// one or two levels of encoding (`%3F`/`%23`, `%253F`/`%2523`) — so neither
+// an embedded credential nor an encoded `?`/`#` that would decode into a
+// live delimiter on a later read can survive into history, a referrer
+// header, or a copied link. `parseRepositoryLocation` never sees this
+// truncated form — it always parses the original, unmodified value, so
+// validation results are unaffected by this history-only guarantee.
+function stripRepositoryUserinfo(value: string): string {
+  const authorityStart = value.indexOf("//");
+  if (authorityStart === -1) return value;
+  const start = authorityStart + 2;
+  const slashIndex = value.indexOf("/", start);
+  const authorityEnd = slashIndex === -1 ? value.length : slashIndex;
+  const authority = value.slice(start, authorityEnd);
+  const atIndex = authority.lastIndexOf("@");
+  if (atIndex === -1) return value;
+  return value.slice(0, start) + authority.slice(atIndex + 1) +
+    value.slice(authorityEnd);
+}
+
+const HISTORY_UNSAFE_DELIMITER = /\?|#|%3f|%23|%253f|%2523/iu;
+
 function historySafeRepositoryValue(value: string): string {
-  const delimiterIndex = value.search(/[?#]/u);
-  return delimiterIndex === -1 ? value : value.slice(0, delimiterIndex);
+  const withoutUserinfo = stripRepositoryUserinfo(value);
+  const delimiterIndex = withoutUserinfo.search(HISTORY_UNSAFE_DELIMITER);
+  return delimiterIndex === -1
+    ? withoutUserinfo
+    : withoutUserinfo.slice(0, delimiterIndex);
 }
 
 export function repositoryLocationUrl(

--- a/apps/kg-editor/src/lib/repository-location.ts
+++ b/apps/kg-editor/src/lib/repository-location.ts
@@ -182,14 +182,25 @@ export function parseRepositoryLocation(url: URL): ParsedRepositoryLocation {
 // URL that arrived with an unrelated query parameter or fragment — a
 // credential such as ?access_token=..., a fragment-borne secret, a tracker
 // value — is never copied forward: the URL is rebuilt from the origin and
-// path only, and every other parameter and the hash are discarded.
+// path only, and every other parameter and the hash are discarded. The same
+// guarantee extends to the repo VALUE itself: a credential nested inside it
+// (e.g. a raw, not-yet-validated `repo` param carrying its own
+// `?access_token=...`) is stripped before the value is written, so it can
+// never survive into history, a referrer header, or a copied link either.
+function historySafeRepositoryValue(value: string): string {
+  const delimiterIndex = value.search(/[?#]/u);
+  return delimiterIndex === -1 ? value : value.slice(0, delimiterIndex);
+}
+
 export function repositoryLocationUrl(
   base: URL,
   location: RepositoryLocation,
 ): URL {
   const url = new URL(base.origin + base.pathname);
   const values: Record<LocationParameter, string | null> = {
-    repo: location.repository,
+    repo: location.repository === null
+      ? null
+      : historySafeRepositoryValue(location.repository),
     at: location.snapshotSha,
     module: location.modulePath,
     view: location.view,
@@ -203,16 +214,15 @@ export function repositoryLocationUrl(
 
 /**
  * The shareable form of an investigation URL. `repositoryLocationUrl`
- * already discards every foreign query parameter and the fragment, but a
- * validated repository URL may legitimately carry a query string or
- * fragment of its OWN (deep-link support keeps those in-browser), so this
- * boundary also applies to the parameter VALUES, not just the parameter
- * names: the shared repository value is normalized to origin + pathname,
- * and a module path carrying a URL query or fragment delimiter is omitted
- * entirely rather than encoded into the value, because encoding preserves
- * — not redacts — whatever the delimiter introduced. `at` and `view` need
- * no value boundary: their parse contracts are a 40-hex SHA and a closed
- * id set.
+ * already discards every foreign query parameter and the fragment, and
+ * strips a repository value's own nested query/fragment before writing it
+ * to history. This share form applies the same value boundary more
+ * strictly still: the shared repository value is normalized to origin +
+ * pathname (not just truncated at the first delimiter), and a module path
+ * carrying a URL query or fragment delimiter is omitted entirely rather
+ * than encoded into the value, because encoding preserves — not redacts —
+ * whatever the delimiter introduced. `at` and `view` need no value
+ * boundary: their parse contracts are a 40-hex SHA and a closed id set.
  */
 export function investigationShareUrl(
   base: URL,

--- a/apps/kg-editor/src/lib/repository-location.ts
+++ b/apps/kg-editor/src/lib/repository-location.ts
@@ -1,5 +1,5 @@
 import type { ViewId } from "@/lib/repo-bundle";
-import { normalizeRepositoryUrl, REPOSITORY_URL_LIMIT } from "@/lib/showcase-registry";
+import { normalizeRepositoryUrl, REPOSITORY_URL_TOO_LONG } from "@/lib/showcase-registry";
 
 export const REPOSITORY_VIEW_IDS = [
   "structure_graph",
@@ -39,22 +39,17 @@ export type ParsedRepositoryLocation = Readonly<{
 }>;
 
 export function publicRepositoryUrlIssue(value: string): string | null {
-  if (value.length > REPOSITORY_URL_LIMIT) {
-    return "The repository URL is too long.";
-  }
-  try {
-    const repository = new URL(value);
-    if (
-      (repository.protocol !== "https:" && repository.protocol !== "http:") ||
-      repository.username ||
-      repository.password
-    ) {
-      return "The repository must be a public HTTP or HTTPS URL.";
-    }
-  } catch {
-    return "The repository must be a public HTTP or HTTPS URL.";
-  }
-  return null;
+  // The field this validates is a canonical URL, so it is judged by the same
+  // normalizer every other consumer uses rather than by a second implementation
+  // of the same rules. Checking the raw string here accepted values the
+  // normalizer refuses, which is how a bundle could carry a repository URL the
+  // reader would later reject. The two public messages are preserved: a length
+  // refusal keeps its own wording, everything else keeps the general one.
+  const normalized = normalizeRepositoryUrl(value);
+  if (normalized.ok) return null;
+  return normalized.reason === REPOSITORY_URL_TOO_LONG
+    ? REPOSITORY_URL_TOO_LONG
+    : "The repository must be a public HTTP or HTTPS URL.";
 }
 
 export function addressableModulePathIssue(value: string): string | null {
@@ -103,16 +98,19 @@ function parseRepository(
   issues: RepositoryLocationIssue[],
 ): string | null {
   if (value == null) return null;
-  if (value.length > REPOSITORY_URL_LIMIT) {
-    issues.push({ parameter: "repo", message: "The repository URL is too long." });
-    return null;
-  }
+  // The canonical value is returned rather than the value as supplied, so that
+  // the reader and the writer agree on one string. Bounding the raw input here
+  // instead contradicted the normalizer, which discards the query and fragment
+  // before measuring: a long-but-legitimate deep link was rewritten to its short
+  // canonical form in history and then rendered invalid from the original URL.
+  // Returning the canonical form also keeps a query-borne credential out of the
+  // parsed location, not only out of the URL that gets written back.
   const normalized = normalizeRepositoryUrl(value);
   if (!normalized.ok) {
     issues.push({ parameter: "repo", message: normalized.reason });
     return null;
   }
-  return value;
+  return normalized.value;
 }
 
 function parseSnapshotSha(
@@ -189,10 +187,15 @@ export function parseRepositoryLocation(url: URL): ParsedRepositoryLocation {
 // canonicalization is, by definition, the repository identity, and is
 // written as-is; a credential placed in a path segment (rather than
 // authority userinfo, which the validator rejects) is out of scope by
-// policy, not by accident. `parseRepositoryLocation` never sees this
-// history-only form — it always parses the original, unmodified value, so
-// validation results are unaffected by this guarantee.
-function historySafeRepositoryValue(value: string): string | null {
+// policy, not by accident. `parseRepositoryLocation` resolves to this same
+// canonical form on the way in, so the reader and the writer agree on one
+// string rather than on two spellings that happen to coincide.
+//
+// This is the only place a repository value is canonicalized for output. The
+// history writer and the share writer both call it, because two copies of
+// these two lines are two things that can drift apart, and drifting apart at
+// exactly this boundary is what this function exists to prevent.
+function canonicalRepositoryValue(value: string): string | null {
   const normalized = normalizeRepositoryUrl(value);
   return normalized.ok ? normalized.value : null;
 }
@@ -205,7 +208,7 @@ export function repositoryLocationUrl(
   const values: Record<LocationParameter, string | null> = {
     repo: location.repository === null
       ? null
-      : historySafeRepositoryValue(location.repository),
+      : canonicalRepositoryValue(location.repository),
     at: location.snapshotSha,
     module: location.modulePath,
     view: location.view,
@@ -221,9 +224,10 @@ export function repositoryLocationUrl(
  * The shareable form of an investigation URL. `repositoryLocationUrl`
  * already discards every foreign query parameter and the fragment, and
  * strips a repository value's own nested query/fragment before writing it
- * to history. This share form applies the same value boundary more
- * strictly still: the shared repository value is normalized to origin +
- * pathname (not just truncated at the first delimiter), and a module path
+ * to history. This share form applies the same value boundary: the shared
+ * repository value goes through the same canonicalization the history writer
+ * uses, so a value that writer would refuse is omitted here too rather than
+ * shared in a form the recipient's reader would reject. A module path
  * carrying a URL query or fragment delimiter is omitted entirely rather
  * than encoded into the value, because encoding preserves — not redacts —
  * whatever the delimiter introduced. `at` and `view` need no value
@@ -235,7 +239,7 @@ export function investigationShareUrl(
 ): URL {
   const url = new URL(`${base.origin}${base.pathname}`);
   if (location.repository) {
-    const repository = shareSafeRepository(location.repository);
+    const repository = canonicalRepositoryValue(location.repository);
     if (repository) url.searchParams.append("repo", repository);
   }
   if (location.snapshotSha) url.searchParams.append("at", location.snapshotSha);
@@ -244,13 +248,4 @@ export function investigationShareUrl(
   }
   if (location.view) url.searchParams.append("view", location.view);
   return url;
-}
-
-function shareSafeRepository(value: string): string | null {
-  try {
-    const repository = new URL(value);
-    return `${repository.origin}${repository.pathname}`;
-  } catch {
-    return null;
-  }
 }

--- a/apps/kg-editor/src/lib/repository-location.ts
+++ b/apps/kg-editor/src/lib/repository-location.ts
@@ -183,36 +183,19 @@ export function parseRepositoryLocation(url: URL): ParsedRepositoryLocation {
 // credential such as ?access_token=..., a fragment-borne secret, a tracker
 // value — is never copied forward: the URL is rebuilt from the origin and
 // path only, and every other parameter and the hash are discarded. The same
-// guarantee extends to the repo VALUE itself: this writer strips userinfo
-// (a `user:pass@` prefix on the authority) and truncates at the first query
-// or fragment delimiter — whether literal (`?`, `#`) or percent-encoded, at
-// one or two levels of encoding (`%3F`/`%23`, `%253F`/`%2523`) — so neither
-// an embedded credential nor an encoded `?`/`#` that would decode into a
-// live delimiter on a later read can survive into history, a referrer
-// header, or a copied link. `parseRepositoryLocation` never sees this
-// truncated form — it always parses the original, unmodified value, so
-// validation results are unaffected by this history-only guarantee.
-function stripRepositoryUserinfo(value: string): string {
-  const authorityStart = value.indexOf("//");
-  if (authorityStart === -1) return value;
-  const start = authorityStart + 2;
-  const slashIndex = value.indexOf("/", start);
-  const authorityEnd = slashIndex === -1 ? value.length : slashIndex;
-  const authority = value.slice(start, authorityEnd);
-  const atIndex = authority.lastIndexOf("@");
-  if (atIndex === -1) return value;
-  return value.slice(0, start) + authority.slice(atIndex + 1) +
-    value.slice(authorityEnd);
-}
-
-const HISTORY_UNSAFE_DELIMITER = /\?|#|%3f|%23|%253f|%2523/iu;
-
-function historySafeRepositoryValue(value: string): string {
-  const withoutUserinfo = stripRepositoryUserinfo(value);
-  const delimiterIndex = withoutUserinfo.search(HISTORY_UNSAFE_DELIMITER);
-  return delimiterIndex === -1
-    ? withoutUserinfo
-    : withoutUserinfo.slice(0, delimiterIndex);
+// guarantee extends to the repo VALUE itself: the writer emits either a
+// value this application's validator (`normalizeRepositoryUrl`) produced, or
+// no `repo` param at all — there is no third case where an unvalidated or
+// partially-sanitized value reaches history. A path segment that survives
+// canonicalization is, by definition, the repository identity, and is
+// written as-is; a credential placed in a path segment (rather than
+// authority userinfo, which the validator rejects) is out of scope by
+// policy, not by accident. `parseRepositoryLocation` never sees this
+// history-only form — it always parses the original, unmodified value, so
+// validation results are unaffected by this guarantee.
+function historySafeRepositoryValue(value: string): string | null {
+  const normalized = normalizeRepositoryUrl(value);
+  return normalized.ok ? normalized.value : null;
 }
 
 export function repositoryLocationUrl(

--- a/apps/kg-editor/src/lib/repository-location.ts
+++ b/apps/kg-editor/src/lib/repository-location.ts
@@ -1,5 +1,5 @@
 import type { ViewId } from "@/lib/repo-bundle";
-import { normalizeRepositoryUrl } from "@/lib/showcase-registry";
+import { normalizeRepositoryUrl, REPOSITORY_URL_LIMIT } from "@/lib/showcase-registry";
 
 export const REPOSITORY_VIEW_IDS = [
   "structure_graph",
@@ -18,7 +18,6 @@ const LOCATION_PARAMETERS = ["repo", "at", "module", "view"] as const;
 const VIEW_IDS = new Set<string>(REPOSITORY_VIEW_IDS);
 const SNAPSHOT_SHA = /^[0-9a-f]{40}$/;
 const MODULE_PATH_LIMIT = 1_024;
-const REPOSITORY_URL_LIMIT = 2_048;
 
 type LocationParameter = (typeof LOCATION_PARAMETERS)[number];
 

--- a/apps/kg-editor/src/lib/showcase-registry.ts
+++ b/apps/kg-editor/src/lib/showcase-registry.ts
@@ -28,6 +28,7 @@ export const SHOWCASE_REGISTRY: readonly ShowcaseRegistryEntry[] = [
 ] as const;
 
 export const REPOSITORY_URL_LIMIT = 2_048;
+export const REPOSITORY_URL_TOO_LONG = "The repository URL is too long.";
 
 export function normalizeRepositoryUrl(input: string):
   | Readonly<{ ok: true; value: string }>
@@ -86,7 +87,7 @@ export function normalizeRepositoryUrl(input: string):
   // apply this same limit, so the writer can no longer store a value the
   // reader would refuse.
   if (value.length > REPOSITORY_URL_LIMIT) {
-    return { ok: false, reason: "The repository URL is too long." };
+    return { ok: false, reason: REPOSITORY_URL_TOO_LONG };
   }
   return { ok: true, value };
 }

--- a/apps/kg-editor/src/lib/showcase-registry.ts
+++ b/apps/kg-editor/src/lib/showcase-registry.ts
@@ -27,6 +27,8 @@ export const SHOWCASE_REGISTRY: readonly ShowcaseRegistryEntry[] = [
   },
 ] as const;
 
+export const REPOSITORY_URL_LIMIT = 2_048;
+
 export function normalizeRepositoryUrl(input: string):
   | Readonly<{ ok: true; value: string }>
   | Readonly<{ ok: false; reason: string }> {
@@ -75,7 +77,18 @@ export function normalizeRepositoryUrl(input: string):
 
   const host = url.hostname.toLowerCase() === "www.github.com" ? "github.com" : url.hostname.toLowerCase();
   const authority = url.port ? `${host}:${url.port}` : host;
-  return { ok: true, value: `https://${authority}/${segments.join("/")}` };
+  const value = `https://${authority}/${segments.join("/")}`;
+  // The bound is on the CANONICAL value rather than the input, because the
+  // canonical form is what every consumer stores: the browser history entry,
+  // the client catalog, and the server configuration. Bounding the input
+  // instead would reject a long-but-legitimate URL whose query and fragment
+  // are discarded here anyway. Callers that validate a value on the way IN
+  // apply this same limit, so the writer can no longer store a value the
+  // reader would refuse.
+  if (value.length > REPOSITORY_URL_LIMIT) {
+    return { ok: false, reason: "The repository URL is too long." };
+  }
+  return { ok: true, value };
 }
 
 export function resolveShowcaseRepository(

--- a/apps/kg-editor/src/lib/showcase-registry.ts
+++ b/apps/kg-editor/src/lib/showcase-registry.ts
@@ -58,7 +58,12 @@ export function normalizeRepositoryUrl(input: string):
   } catch {
     return { ok: false, reason: "The repository URL contains invalid path encoding." };
   }
-  if (segments.length < 2 || segments.some((segment) => segment === "." || segment === "..")) {
+  if (
+    segments.length < 2 ||
+    segments.some((segment) =>
+      segment === "." || segment === ".." || /[%?#\\]/u.test(segment)
+    )
+  ) {
     return { ok: false, reason: "The URL must identify a repository owner and name." };
   }
 


### PR DESCRIPTION
Three hardening fixes on the showcase catalog path:

- Catalog discovery now aborts after a named 5-second bound, with expiry landing in the existing degraded path; the abort signal covers both the fetch and the body read.
- Repository values are truncated at the first query or fragment delimiter before any history or clipboard write, at the single choke point every write site routes through; validation still sees the original value, so parse verdicts are unchanged. The contract comment now states the guarantee it delivers.
- When Content-Length is absent, the body is read through a bounded stream reader that cancels past the 256 KiB cap instead of materializing the full body first.

Audit note: every revision of the shipped showcase registry and bundled analysis data was checked at value granularity; no repository URL ever carried a query or fragment component, so the credential-strip change is purely preventive — no shipped data needs scrubbing.
