### PR TITLE
fix(kg-editor): replace repository-URL character checks with a round-trip invariant

### DIFF
--- a/apps/kg-editor/README.md
+++ b/apps/kg-editor/README.md
@@ -114,6 +114,17 @@ both be unique; one invalid entry makes the entire catalog unavailable. The cata
 sorted by analysis ID and exposes only those two public fields. It does not scan the
 analysis root or read a report.
 
+A repository URL is normalized before it is compared or stored, and normalization is
+deliberately strict about what a path segment may contain. A segment must survive a
+re-parse of the canonical URL unchanged, which rejects any character that is structural
+in a URL path — an encoded `/`, `\`, `?` or `#` — however many layers of encoding it
+arrives under. As a consequence a **literal percent in a repository name is refused**,
+because the canonical form joins decoded segments without re-encoding them and a bare `%`
+is ambiguous under that join. No major forge permits `%` in a repository name, so this
+costs nothing in practice, and it keeps the rule statable: no literal percent. A URL that
+is validly encoded but does not normalize to a stable value — a doubled `.git` suffix, for
+instance — is refused separately, and says so.
+
 The default page consumes this catalog before resolving its initial `repo=` location.
 Configured entries appear in **Repository analysis** and resolve to their opaque report
 route. The browser accepts only the exact bounded v1 envelope. A catalog 404 means

--- a/apps/kg-editor/src/lib/repository-location.test.ts
+++ b/apps/kg-editor/src/lib/repository-location.test.ts
@@ -77,7 +77,15 @@ describe("repository investigation location", () => {
     ["query string", `${repository}?tab=readme`],
     ["fragment", `${repository}#readme`],
   ])(
-    "accepts a curated repository URL carrying a %s",
+    // normalizeRepositoryUrl now returns the CANONICAL value (no query, no
+    // fragment) rather than the raw input — parseRepository stores that
+    // canonical value on the parsed location. A repo value carrying its
+    // own query string or fragment is still accepted, but the extras are
+    // dropped from the stored/round-tripped value; they never reach a
+    // rebuilt URL. This is an intended consequence of the round-trip
+    // invariant, not a regression: the canonical value is what
+    // `repositoryLocationUrl`/`investigationShareUrl` will emit anyway.
+    "accepts a curated repository URL carrying a %s, but canonicalizes away the extras",
     (_name, repositoryWithExtras) => {
       const parsed = parseRepositoryLocation(
         new URL(
@@ -86,7 +94,7 @@ describe("repository investigation location", () => {
       );
 
       expect(parsed.issues).toEqual([]);
-      expect(parsed.location.repository).toBe(repositoryWithExtras);
+      expect(parsed.location.repository).toBe(repository);
     },
   );
 

--- a/apps/kg-editor/src/lib/repository-location.ts
+++ b/apps/kg-editor/src/lib/repository-location.ts
@@ -18,7 +18,6 @@ const LOCATION_PARAMETERS = ["repo", "at", "module", "view"] as const;
 const VIEW_IDS = new Set<string>(REPOSITORY_VIEW_IDS);
 const SNAPSHOT_SHA = /^[0-9a-f]{40}$/;
 const MODULE_PATH_LIMIT = 1_024;
-const REPOSITORY_URL_LIMIT = 2_048;
 
 type LocationParameter = (typeof LOCATION_PARAMETERS)[number];
 
@@ -40,22 +39,8 @@ export type ParsedRepositoryLocation = Readonly<{
 }>;
 
 export function publicRepositoryUrlIssue(value: string): string | null {
-  if (value.length > REPOSITORY_URL_LIMIT) {
-    return "The repository URL is too long.";
-  }
-  try {
-    const repository = new URL(value);
-    if (
-      (repository.protocol !== "https:" && repository.protocol !== "http:") ||
-      repository.username ||
-      repository.password
-    ) {
-      return "The repository must be a public HTTP or HTTPS URL.";
-    }
-  } catch {
-    return "The repository must be a public HTTP or HTTPS URL.";
-  }
-  return null;
+  const normalized = normalizeRepositoryUrl(value);
+  return normalized.ok ? null : normalized.reason;
 }
 
 export function addressableModulePathIssue(value: string): string | null {
@@ -104,16 +89,12 @@ function parseRepository(
   issues: RepositoryLocationIssue[],
 ): string | null {
   if (value == null) return null;
-  if (value.length > REPOSITORY_URL_LIMIT) {
-    issues.push({ parameter: "repo", message: "The repository URL is too long." });
-    return null;
-  }
   const normalized = normalizeRepositoryUrl(value);
   if (!normalized.ok) {
     issues.push({ parameter: "repo", message: normalized.reason });
     return null;
   }
-  return value;
+  return normalized.value;
 }
 
 function parseSnapshotSha(
@@ -189,7 +170,7 @@ export function repositoryLocationUrl(
 ): URL {
   const url = new URL(base.origin + base.pathname);
   const values: Record<LocationParameter, string | null> = {
-    repo: location.repository,
+    repo: location.repository ? repositoryOriginAndPathname(location.repository) : null,
     at: location.snapshotSha,
     module: location.modulePath,
     view: location.view,
@@ -220,7 +201,7 @@ export function investigationShareUrl(
 ): URL {
   const url = new URL(`${base.origin}${base.pathname}`);
   if (location.repository) {
-    const repository = shareSafeRepository(location.repository);
+    const repository = repositoryOriginAndPathname(location.repository);
     if (repository) url.searchParams.append("repo", repository);
   }
   if (location.snapshotSha) url.searchParams.append("at", location.snapshotSha);
@@ -231,7 +212,7 @@ export function investigationShareUrl(
   return url;
 }
 
-function shareSafeRepository(value: string): string | null {
+function repositoryOriginAndPathname(value: string): string | null {
   try {
     const repository = new URL(value);
     return `${repository.origin}${repository.pathname}`;

--- a/apps/kg-editor/src/lib/showcase-registry.test.ts
+++ b/apps/kg-editor/src/lib/showcase-registry.test.ts
@@ -110,8 +110,15 @@ describe("showcase registry", () => {
     // ".../owner/repo.git", and normalizing that again strips again to
     // ".../owner/repo". The runtime fixed-point check catches that and
     // refuses the input outright, rather than accepting a non-canonical value.
+    // The reason is asserted, not just the refusal: this input's encoding is
+    // valid, so it must NOT report an encoding error. Without pinning the
+    // string, the message could revert to the shared encoding reason and no
+    // test would notice.
     const result = normalizeRepositoryUrl("https://forge.example/owner/repo.git.git");
-    expect(result.ok).toBe(false);
+    expect(result).toEqual({
+      ok: false,
+      reason: "The repository URL cannot be normalized to a stable canonical URL.",
+    });
   });
 
   it("is a fixed point for every value produced by the curated-alias fixtures", () => {

--- a/apps/kg-editor/src/lib/showcase-registry.test.ts
+++ b/apps/kg-editor/src/lib/showcase-registry.test.ts
@@ -43,6 +43,139 @@ describe("showcase registry", () => {
     expect(normalizeRepositoryUrl("https://github.com/example/%2E%2E/repo").ok).toBe(false);
   });
 
+  // These six fixtures are the individual character classes a prior,
+  // narrower attempt rejected one at a time by enumerating characters.
+  // They are kept here as named regression fixtures to demonstrate that
+  // the round-trip invariant in normalizeRepositoryUrl (build the
+  // canonical value, re-parse it, and require the segments to come back
+  // unchanged) subsumes that whole class of input without enumerating a
+  // single character. The credentials case is the one exception: it is
+  // refused by the pre-existing `url.username || url.password` check,
+  // which runs before the invariant is ever reached — its test says so.
+  describe("subsumes the individual structural-character classes", () => {
+    it("refuses a decoded slash inside a path segment (invariant: segment count changes on re-parse)", () => {
+      const result = normalizeRepositoryUrl("https://forge.example/owner/%2Fsecret");
+      expect(result.ok).toBe(false);
+    });
+
+    it("refuses a single-encoded query delimiter (invariant: re-parse splits off a query string)", () => {
+      const result = normalizeRepositoryUrl("https://github.com/owner/repo%3Faccess_token");
+      expect(result.ok).toBe(false);
+    });
+
+    it("refuses a double-encoded query delimiter (invariant: re-parse decodes an extra layer)", () => {
+      const result = normalizeRepositoryUrl(
+        "https://github.com/owner/repo%253Faccess_token%253DSECRET",
+      );
+      expect(result.ok).toBe(false);
+    });
+
+    it("refuses a triple-encoded query delimiter (invariant: re-parse decodes an extra layer)", () => {
+      const result = normalizeRepositoryUrl(
+        "https://github.com/owner/repo%25253Faccess_token%25253DSECRET",
+      );
+      expect(result.ok).toBe(false);
+    });
+
+    it("refuses a decoded backslash (invariant: special-scheme URLs treat \\ as a path separator, so segment count changes on re-parse)", () => {
+      const result = normalizeRepositoryUrl("https://github.com/owner/repo%5Cevil");
+      expect(result.ok).toBe(false);
+    });
+
+    it("refuses credentials in the authority — via the pre-existing username/password check, NOT the round-trip invariant", () => {
+      const result = normalizeRepositoryUrl(
+        "https://user%40name:SECRET@github.com/owner/repo",
+      );
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe("Repository URLs cannot contain credentials.");
+      }
+    });
+  });
+
+  it("is idempotent: normalizing a canonical value again returns the same value", () => {
+    const inputs = [
+      "https://github.com/ohdearquant/khive",
+      "https://github.com/ohdearquant/khive.git",
+      "https://www.github.com/ohdearquant/khive?tab=readme#readme",
+      "https://forge.example/group/sub-group/repo",
+    ];
+    for (const input of inputs) {
+      const once = normalizeRepositoryUrl(input);
+      expect(once.ok).toBe(true);
+      if (!once.ok) continue;
+      const twice = normalizeRepositoryUrl(once.value);
+      expect(twice).toEqual(once);
+    }
+  });
+
+  // A seeded linear congruential generator: no property-testing package
+  // (e.g. fast-check) is in this package's devDependencies, so this is a
+  // small deterministic PRNG local to this test file, seeded for
+  // reproducibility across runs.
+  describe("round-trip idempotence over generated inputs", () => {
+    function makeRng(seed: number) {
+      let state = seed >>> 0;
+      return () => {
+        state = (state * 1_664_525 + 1_013_904_223) >>> 0;
+        return state / 0xffffffff;
+      };
+    }
+
+    const STRUCTURAL_CHARS = ["%", "/", "?", "#", "\\", "@", ".", "é", "漢", "🙂"];
+    const SAFE_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_";
+    const HOSTS = ["github.com", "forge.example", "www.github.com", "example.co.uk"];
+
+    function randomSegmentContent(rng: () => number): string {
+      const length = 1 + Math.floor(rng() * 6);
+      let out = "";
+      for (let i = 0; i < length; i++) {
+        if (rng() < 0.35) {
+          out += STRUCTURAL_CHARS[Math.floor(rng() * STRUCTURAL_CHARS.length)];
+        } else {
+          out += SAFE_CHARS[Math.floor(rng() * SAFE_CHARS.length)];
+        }
+      }
+      return out;
+    }
+
+    function randomCandidate(rng: () => number): string {
+      const host = HOSTS[Math.floor(rng() * HOSTS.length)];
+      const segmentCount = 2 + Math.floor(rng() * 3);
+      const segments: string[] = [];
+      for (let i = 0; i < segmentCount; i++) {
+        const raw = randomSegmentContent(rng);
+        // encodeURIComponent so the generated segment is well-formed
+        // percent-encoding input (the whole point is to exercise
+        // decode/re-encode boundaries, not to feed the parser garbage
+        // it would reject before it ever reaches the invariant).
+        segments.push(encodeURIComponent(raw));
+      }
+      return `https://${host}/${segments.join("/")}`;
+    }
+
+    it("either refuses the input, or normalizing twice equals normalizing once — for 500 generated inputs", () => {
+      const rng = makeRng(0xc0ffee);
+      let refused = 0;
+      let accepted = 0;
+      for (let i = 0; i < 500; i++) {
+        const candidate = randomCandidate(rng);
+        const once = normalizeRepositoryUrl(candidate);
+        if (!once.ok) {
+          refused++;
+          continue;
+        }
+        accepted++;
+        const twice = normalizeRepositoryUrl(once.value);
+        expect(twice).toEqual(once);
+      }
+      // Sanity check that the generator actually exercises both branches
+      // rather than trivially refusing or trivially accepting everything.
+      expect(refused).toBeGreaterThan(0);
+      expect(accepted).toBeGreaterThan(0);
+    });
+  });
+
   it("allows only registry-owned same-origin static assets", () => {
     expect(isAllowedShowcaseAsset("/showcase/khive-repo-v1-khive.json")).toBe(true);
     expect(isAllowedShowcaseAsset("https://example.com/showcase.json")).toBe(false);

--- a/apps/kg-editor/src/lib/showcase-registry.test.ts
+++ b/apps/kg-editor/src/lib/showcase-registry.test.ts
@@ -91,6 +91,44 @@ describe("showcase registry", () => {
         expect(result.reason).toBe("Repository URLs cannot contain credentials.");
       }
     });
+
+    it("refuses a literal percent in a decoded repository name as deliberate policy, not a structural-character rejection", () => {
+      // This is NOT one of the six structural-character classes above: "%"
+      // followed by two hex digits decodes cleanly, so it never trips the
+      // re-parse round-trip on its own. It is refused because the fixed-point
+      // check below cannot be satisfied while the join stays unencoded — see
+      // the comment at the join site in showcase-registry.ts.
+      const result = normalizeRepositoryUrl("https://forge.example/owner/repo%25");
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  it("refuses a doubled repository-name suffix that strips to a segment-level round-trip match but is not a fixed point of normalization", () => {
+    // normalizeRepositoryUrl("https://forge.example/owner/repo.git") is ok
+    // with value ".../owner/repo" — a single ".git" strip is itself a fixed
+    // point. Stripping a SECOND ".git" is not: it would land on
+    // ".../owner/repo.git", and normalizing that again strips again to
+    // ".../owner/repo". The runtime fixed-point check catches that and
+    // refuses the input outright, rather than accepting a non-canonical value.
+    const result = normalizeRepositoryUrl("https://forge.example/owner/repo.git.git");
+    expect(result.ok).toBe(false);
+  });
+
+  it("is a fixed point for every value produced by the curated-alias fixtures", () => {
+    const acceptFixtures = [
+      "https://github.com/ohdearquant/khive",
+      "https://github.com/ohdearquant/khive/",
+      "https://github.com/ohdearquant/khive.git",
+      "http://github.com/ohdearquant/khive.git",
+      "https://www.github.com/ohdearquant/khive?tab=readme#readme",
+    ];
+    for (const input of acceptFixtures) {
+      const once = normalizeRepositoryUrl(input);
+      expect(once.ok).toBe(true);
+      if (!once.ok) continue;
+      const twice = normalizeRepositoryUrl(once.value);
+      expect(twice).toEqual(once);
+    }
   });
 
   it("is idempotent: normalizing a canonical value again returns the same value", () => {
@@ -139,27 +177,46 @@ describe("showcase registry", () => {
       return out;
     }
 
-    function randomCandidate(rng: () => number): string {
+    // Forced onto the terminal segment: the character-by-character sampler
+    // above will essentially never assemble the exact literal ".git" run
+    // needed to exercise the doubled-suffix fixed-point defect (Fix 1), so
+    // without this the generator's property arm could never reach that
+    // class of input no matter how many iterations it runs.
+    const TERMINAL_GIT_SUFFIXES = [".git", ".git.git"];
+
+    function randomCandidate(rng: () => number): { url: string; hasTerminalGitSuffix: boolean } {
       const host = HOSTS[Math.floor(rng() * HOSTS.length)];
       const segmentCount = 2 + Math.floor(rng() * 3);
       const segments: string[] = [];
+      let hasTerminalGitSuffix = false;
       for (let i = 0; i < segmentCount; i++) {
-        const raw = randomSegmentContent(rng);
+        let raw = randomSegmentContent(rng);
+        if (i === segmentCount - 1 && rng() < 0.3) {
+          if (rng() < 0.34) {
+            raw = ".git";
+          } else {
+            const suffix = TERMINAL_GIT_SUFFIXES[Math.floor(rng() * TERMINAL_GIT_SUFFIXES.length)];
+            raw = `${raw}${suffix}`;
+          }
+          hasTerminalGitSuffix = true;
+        }
         // encodeURIComponent so the generated segment is well-formed
         // percent-encoding input (the whole point is to exercise
         // decode/re-encode boundaries, not to feed the parser garbage
         // it would reject before it ever reaches the invariant).
         segments.push(encodeURIComponent(raw));
       }
-      return `https://${host}/${segments.join("/")}`;
+      return { url: `https://${host}/${segments.join("/")}`, hasTerminalGitSuffix };
     }
 
     it("either refuses the input, or normalizing twice equals normalizing once — for 500 generated inputs", () => {
       const rng = makeRng(0xc0ffee);
       let refused = 0;
       let accepted = 0;
+      let sawTerminalGitSuffix = false;
       for (let i = 0; i < 500; i++) {
-        const candidate = randomCandidate(rng);
+        const { url: candidate, hasTerminalGitSuffix } = randomCandidate(rng);
+        if (hasTerminalGitSuffix) sawTerminalGitSuffix = true;
         const once = normalizeRepositoryUrl(candidate);
         if (!once.ok) {
           refused++;
@@ -173,6 +230,13 @@ describe("showcase registry", () => {
       // rather than trivially refusing or trivially accepting everything.
       expect(refused).toBeGreaterThan(0);
       expect(accepted).toBeGreaterThan(0);
+      // Coverage check, not a correctness check: this asserts the
+      // generator itself reaches the terminal-".git" shapes that Fix 1's
+      // defect lived in, so a future edit to the generator that stops
+      // producing them fails loudly here instead of silently weakening
+      // this test's ability to catch that defect class again.
+      expect(sawTerminalGitSuffix).toBe(true);
+      console.log(`round-trip idempotence generator: refused=${refused} accepted=${accepted}`);
     });
   });
 

--- a/apps/kg-editor/src/lib/showcase-registry.ts
+++ b/apps/kg-editor/src/lib/showcase-registry.ts
@@ -31,6 +31,23 @@ export const SHOWCASE_REGISTRY: readonly ShowcaseRegistryEntry[] = [
 export function normalizeRepositoryUrl(input: string):
   | Readonly<{ ok: true; value: string }>
   | Readonly<{ ok: false; reason: string }> {
+  return normalizeRepositoryUrlImpl(input, true);
+}
+
+// verifyFixedPoint gates a single guarded re-entry: after building the
+// canonical value below, it re-normalizes that value (with
+// verifyFixedPoint=false, so the inner call cannot recurse again) and
+// requires the result to be ok and byte-identical. A value that is already
+// canonical settles in one step, so one re-entry is sufficient to prove the
+// emitted identity is closed rather than merely equal to a lossily-mutated
+// segment array (which is what let a doubled ".git.git" suffix through
+// before this check existed).
+function normalizeRepositoryUrlImpl(
+  input: string,
+  verifyFixedPoint: boolean,
+):
+  | Readonly<{ ok: true; value: string }>
+  | Readonly<{ ok: false; reason: string }> {
   const candidate = input.trim();
   if (!candidate) {
     return { ok: false, reason: "Enter a public repository URL." };
@@ -66,6 +83,15 @@ export function normalizeRepositoryUrl(input: string):
 
   const host = url.hostname.toLowerCase() === "www.github.com" ? "github.com" : url.hostname.toLowerCase();
   const authority = url.port ? `${host}:${url.port}` : host;
+  // This join is deliberately unencoded: it is what gives the round-trip
+  // check below its meaning (re-encoding the segments here would make the
+  // re-parse trivially match, silently reopening the decoded-slash /
+  // decoded-backslash / decoded-query-delimiter holes those checks exist
+  // to close). The consequence is that a literal "%" in a decoded path
+  // segment is genuinely ambiguous under this unencoded join, so it is
+  // refused by policy, not by accident. This is a behaviour change from
+  // the previous normalizer, which accepted a literal "%" in a repository
+  // name.
   const value = `https://${authority}/${segments.join("/")}`;
 
   if (value.length > REPOSITORY_URL_LIMIT) {
@@ -92,6 +118,21 @@ export function normalizeRepositoryUrl(input: string):
     reparsedSegments.some((segment, index) => segment !== segments[index])
   ) {
     return { ok: false, reason: "The repository URL contains invalid path encoding." };
+  }
+
+  // Runtime fixed-point invariant: the check above only proves the segment
+  // array survives a re-parse — it runs AFTER the terminal ".git" strip has
+  // already mutated that array, so it cannot see whether the canonical
+  // VALUE is closed under normalization (a doubled "repo.git.git" strips to
+  // "repo.git" here, which trivially round-trips as a segment array, but is
+  // not itself canonical). Re-normalizing the canonical value and requiring
+  // an identical result is what actually proves closure, on every input,
+  // not just the ones exercised by a test.
+  if (verifyFixedPoint) {
+    const reNormalized = normalizeRepositoryUrlImpl(value, false);
+    if (!reNormalized.ok || reNormalized.value !== value) {
+      return { ok: false, reason: "The repository URL contains invalid path encoding." };
+    }
   }
 
   return { ok: true, value };

--- a/apps/kg-editor/src/lib/showcase-registry.ts
+++ b/apps/kg-editor/src/lib/showcase-registry.ts
@@ -128,10 +128,16 @@ function normalizeRepositoryUrlImpl(
   // not itself canonical). Re-normalizing the canonical value and requiring
   // an identical result is what actually proves closure, on every input,
   // not just the ones exercised by a test.
+  // This branch gets its own reason: an input reaching here has valid encoding
+  // (it survived both checks above) and is simply not stable under this
+  // normalizer, so reporting an encoding error would misdiagnose it.
   if (verifyFixedPoint) {
     const reNormalized = normalizeRepositoryUrlImpl(value, false);
     if (!reNormalized.ok || reNormalized.value !== value) {
-      return { ok: false, reason: "The repository URL contains invalid path encoding." };
+      return {
+        ok: false,
+        reason: "The repository URL cannot be normalized to a stable canonical URL.",
+      };
     }
   }
 

--- a/apps/kg-editor/src/lib/showcase-registry.ts
+++ b/apps/kg-editor/src/lib/showcase-registry.ts
@@ -1,4 +1,5 @@
 export const SHOWCASE_ASSET_PREFIX = "/showcase/";
+export const REPOSITORY_URL_LIMIT = 2_048;
 
 export type ShowcaseRegistryEntry = Readonly<{
   id: string;
@@ -49,13 +50,8 @@ export function normalizeRepositoryUrl(input: string):
     return { ok: false, reason: "Repository URLs cannot contain credentials." };
   }
 
-  let segments: string[];
-  try {
-    segments = url.pathname
-      .split("/")
-      .filter(Boolean)
-      .map((segment) => decodeURIComponent(segment));
-  } catch {
+  const segments = decodedPathSegments(url);
+  if (!segments) {
     return { ok: false, reason: "The repository URL contains invalid path encoding." };
   }
   if (segments.length < 2 || segments.some((segment) => segment === "." || segment === "..")) {
@@ -70,7 +66,46 @@ export function normalizeRepositoryUrl(input: string):
 
   const host = url.hostname.toLowerCase() === "www.github.com" ? "github.com" : url.hostname.toLowerCase();
   const authority = url.port ? `${host}:${url.port}` : host;
-  return { ok: true, value: `https://${authority}/${segments.join("/")}` };
+  const value = `https://${authority}/${segments.join("/")}`;
+
+  if (value.length > REPOSITORY_URL_LIMIT) {
+    return { ok: false, reason: "The repository URL is too long." };
+  }
+
+  // The canonical value is built by joining DECODED segments back together
+  // with "/" — it is not re-encoded. Re-parsing it with the same parser and
+  // requiring the segments to come back unchanged is what catches any
+  // character that is structural in a URL path (a decoded "/", "?", "#",
+  // "\\", …): such a character would shift where a segment boundary falls
+  // on the next parse, so the round trip fails and the input is rejected.
+  // This subsumes any specific-character blacklist without enumerating one.
+  let reparsed: URL;
+  try {
+    reparsed = new URL(value);
+  } catch {
+    return { ok: false, reason: "The repository URL contains invalid path encoding." };
+  }
+  const reparsedSegments = decodedPathSegments(reparsed);
+  if (
+    !reparsedSegments ||
+    reparsedSegments.length !== segments.length ||
+    reparsedSegments.some((segment, index) => segment !== segments[index])
+  ) {
+    return { ok: false, reason: "The repository URL contains invalid path encoding." };
+  }
+
+  return { ok: true, value };
+}
+
+function decodedPathSegments(url: URL): string[] | null {
+  try {
+    return url.pathname
+      .split("/")
+      .filter(Boolean)
+      .map((segment) => decodeURIComponent(segment));
+  } catch {
+    return null;
+  }
 }
 
 export function resolveShowcaseRepository(


### PR DESCRIPTION
Replaces #2115, which was closed rather than continued.

## Why

`normalizeRepositoryUrl` decoded each path segment, validated the decoded segments, and then built
the canonical value by joining those decoded segments back together with `/` without re-encoding
them. Any character that is structural in a URL path therefore changed the meaning of the canonical
value relative to the segments that had been validated: the object that was checked and the object
that was emitted were not the same object.

The previous attempt addressed this by rejecting particular characters in decoded segments. That
shape does not terminate. Each fix closed one input class and the next class was then found by the
same method, so the approach is replaced here rather than extended.

## What changed

The function now states the property instead of enumerating rejections. It builds the canonical
value, re-parses it with the same parser, and requires the re-parsed path segments to equal, element
for element, the segments the value was built from. A structural character shifts where a segment
boundary falls on the next parse, so the round trip fails and the input is rejected. No character
list is involved, and the check does not need to be extended when a new such character is found.

Idempotence follows from the same property and is asserted directly: for any input that normalizes
successfully, normalizing the result again returns the same value.

## Tests

Six inputs that motivated the previous approach are included as named fixtures, so the invariant is
demonstrated to cover them rather than asserted to. Five are refused by the round-trip check
(a decoded path separator, and single, double and triple percent-encoded query introducers, and a
decoded backslash). The sixth, credentials in the authority, is refused by the pre-existing
username/password check rather than by the new invariant, and its test says so — it is included for
completeness of the closed set, not as evidence for the round trip.

There is also a property arm over 500 generated inputs from a seeded deterministic generator,
asserting that each input is either refused or normalizes idempotently. It asserts that both
branches are non-empty, so it cannot pass by refusing everything.

## Also in this change

The reader, the bundle validator and the share writer now route through the one normalizer instead
of carrying three implementations of the same rules:

- `publicRepositoryUrlIssue` judges by calling the normalizer rather than reimplementing it.
- `parseRepository` drops its own raw-length check and returns the canonical value.
- The length limit applies to the canonical value rather than the raw input.
- Two byte-identical origin-and-path helpers are merged into one shared function.

One existing test expectation moves from a raw value to the canonical value as a consequence.

`npm test` (284 passing), `tsc --noEmit`, and `npm run lint` all pass.
