### PR TITLE
fix(kg): distinguish resolver failure from record absence in get

### DIFF
--- a/crates/khive-pack-kg/Cargo.toml
+++ b/crates/khive-pack-kg/Cargo.toml
@@ -31,6 +31,7 @@ tracing = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 criterion = { workspace = true }
 serde_json = { workspace = true }
+khive-runtime = { path = "../khive-runtime", features = ["fault-injection"] }
 khive-pack-formal = { version = "0.7.0", path = "../khive-pack-formal" }
 # Path-only: cyclic dev-dep pair with khive-pack-gtd; cargo strips it at publish.
 khive-pack-gtd = { path = "../khive-pack-gtd" }

--- a/crates/khive-pack-kg/src/handlers/get.rs
+++ b/crates/khive-pack-kg/src/handlers/get.rs
@@ -400,28 +400,26 @@ impl KgPack {
 /// `resolve_name_async` (in `common.rs`) constructs only `Storage`/`NotFound`/`Ambiguous`,
 /// and the only `InvalidInput` the prefix-resolution path can construct is a prefix-miss —
 /// so this list is exhaustive for "no id, keep trying" today. Any other variant
-/// (`Storage`, `Sqlite`, `Internal`, `AmbiguousPrefix`, …) is a failure and propagates.
+/// (`Storage`, `Sqlite`, `Internal`, `Ambiguous`, `AmbiguousPrefix`, …) is a failure and
+/// propagates.
 ///
-/// `Ambiguous` and `AmbiguousPrefix` land in opposite buckets on purpose, which is worth
-/// stating because it reads as an inconsistency otherwise. Name resolution is scoped to the
-/// caller's namespace token, so an ambiguous name really can resolve uniquely on a later arm
-/// carrying a different token — falling through is the behaviour that finds it. Prefix
-/// resolution is namespace-agnostic (`resolve_prefix_unfiltered` passes no namespace
-/// predicate), so every arm issues the identical prefix query and no later arm can do
-/// better; falling through there cannot find anything and only converts a real, reportable
-/// collision into a misleading not-found.
+/// Both ambiguity variants are failures, for the same reason: no later arm can resolve an
+/// ambiguity an earlier arm reported. `dispatch.rs` binds `graph_token = token`, so arms one
+/// and two issue the identical query, and arm three only widens the search to soft-deleted
+/// records — widening can add candidates but never remove the ones that made the name
+/// ambiguous. Falling through therefore cannot find anything; it only converts a real,
+/// reportable collision into a misleading not-found. Prefix resolution reaches the same
+/// place by a different route: `resolve_prefix_unfiltered` passes no namespace predicate at
+/// all, so it is namespace-agnostic by construction.
 fn is_resolution_absence(err: &RuntimeError) -> bool {
     matches!(
         err,
-        RuntimeError::NotFound(_) | RuntimeError::InvalidInput(_) | RuntimeError::Ambiguous(_)
+        RuntimeError::NotFound(_) | RuntimeError::InvalidInput(_)
     )
 }
 
 /// Run `get`'s three-arm id-resolution fallback chain, distinguishing "every arm reported
-/// absence" (`Ok(None)`) from "an arm could not perform its lookup" (`Err`). `Ambiguous`
-/// stays in the absence bucket deliberately: the first two arms differ only in namespace
-/// token, and a name ambiguous in the graph namespace may still resolve uniquely in the
-/// local one — treating it as a failure would regress that cross-namespace disambiguation.
+/// absence" (`Ok(None)`) from "an arm could not perform its lookup" (`Err`).
 async fn resolve_id_through_arms(
     raw_id: &str,
     runtime: &KhiveRuntime,

--- a/crates/khive-pack-kg/src/handlers/get.rs
+++ b/crates/khive-pack-kg/src/handlers/get.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use khive_runtime::{
-    hex_prefix_to_uuid_pattern, NamespaceToken, Resolved, RuntimeError, VerbRegistry,
+    hex_prefix_to_uuid_pattern, KhiveRuntime, NamespaceToken, Resolved, RuntimeError, VerbRegistry,
 };
 use khive_storage::event::Event;
 use khive_storage::types::{SqlRow, SqlStatement, SqlValue};
@@ -38,19 +38,14 @@ impl KgPack {
         // rows — required both for `include_deleted=true` and for the
         // merged_into disclosure below (absorbed entities are soft-deleted, so
         // a live-only prefix scan would miss them before the hint could fire).
-        let id = if let Ok(id) = resolve_uuid_unfiltered(&p.id, &self.runtime, graph_token).await {
-            id
-        } else if let Ok(id) = resolve_uuid_unfiltered(&p.id, &self.runtime, token).await {
-            id
-        } else if let Ok(id) =
-            resolve_uuid_unfiltered_including_deleted(&p.id, &self.runtime, graph_token).await
-        {
-            id
-        } else {
-            if let Some(payload_val) = self.try_get_proposal_payload(token, &p.id).await? {
-                return Ok(payload_val);
+        let id = match resolve_id_through_arms(&p.id, &self.runtime, graph_token, token).await? {
+            Some(id) => id,
+            None => {
+                if let Some(payload_val) = self.try_get_proposal_payload(token, &p.id).await? {
+                    return Ok(payload_val);
+                }
+                return Err(RuntimeError::NotFound(format!("not found: {}", p.id)));
             }
-            return Err(RuntimeError::NotFound(format!("not found: {}", p.id)));
         };
 
         let include_deleted = p.include_deleted.unwrap_or(false);
@@ -395,6 +390,49 @@ impl KgPack {
         }
 
         Ok(Some(result))
+    }
+}
+
+/// Classifies a resolver-arm error as absence (the arm found no single id, so the next
+/// arm is still worth trying) versus failure (the lookup itself could not be performed,
+/// so it must reach the caller as-is instead of being swallowed into a false not-found).
+///
+/// `resolve_name_async` (in `common.rs`) constructs only `Storage`/`NotFound`/`Ambiguous`,
+/// and the only `InvalidInput` the prefix-resolution path can construct is a prefix-miss —
+/// so this list is exhaustive for "no id, keep trying" today. Any other variant
+/// (`Storage`, `Sqlite`, `Internal`, `AmbiguousPrefix`, …) is a failure and propagates.
+fn is_resolution_absence(err: &RuntimeError) -> bool {
+    matches!(
+        err,
+        RuntimeError::NotFound(_) | RuntimeError::InvalidInput(_) | RuntimeError::Ambiguous(_)
+    )
+}
+
+/// Run `get`'s three-arm id-resolution fallback chain, distinguishing "every arm reported
+/// absence" (`Ok(None)`) from "an arm could not perform its lookup" (`Err`). `Ambiguous`
+/// stays in the absence bucket deliberately: the first two arms differ only in namespace
+/// token, and a name ambiguous in the graph namespace may still resolve uniquely in the
+/// local one — treating it as a failure would regress that cross-namespace disambiguation.
+async fn resolve_id_through_arms(
+    raw_id: &str,
+    runtime: &KhiveRuntime,
+    graph_token: &NamespaceToken,
+    token: &NamespaceToken,
+) -> Result<Option<Uuid>, RuntimeError> {
+    match resolve_uuid_unfiltered(raw_id, runtime, graph_token).await {
+        Ok(id) => return Ok(Some(id)),
+        Err(e) if !is_resolution_absence(&e) => return Err(e),
+        Err(_) => {}
+    }
+    match resolve_uuid_unfiltered(raw_id, runtime, token).await {
+        Ok(id) => return Ok(Some(id)),
+        Err(e) if !is_resolution_absence(&e) => return Err(e),
+        Err(_) => {}
+    }
+    match resolve_uuid_unfiltered_including_deleted(raw_id, runtime, graph_token).await {
+        Ok(id) => Ok(Some(id)),
+        Err(e) if !is_resolution_absence(&e) => Err(e),
+        Err(_) => Ok(None),
     }
 }
 

--- a/crates/khive-pack-kg/src/handlers/get.rs
+++ b/crates/khive-pack-kg/src/handlers/get.rs
@@ -397,11 +397,16 @@ impl KgPack {
 /// arm is still worth trying) versus failure (the lookup itself could not be performed,
 /// so it must reach the caller as-is instead of being swallowed into a false not-found).
 ///
-/// `resolve_name_async` (in `common.rs`) constructs only `Storage`/`NotFound`/`Ambiguous`,
-/// and the only `InvalidInput` the prefix-resolution path can construct is a prefix-miss —
-/// so this list is exhaustive for "no id, keep trying" today. Any other variant
-/// (`Storage`, `Sqlite`, `Internal`, `Ambiguous`, `AmbiguousPrefix`, …) is a failure and
-/// propagates.
+/// The absence list is deliberately short rather than exhaustive over what the resolvers can
+/// return, because the classification is failure-by-default: an unenumerated variant is treated
+/// as a failure and propagates. That is the safe direction — a new variant can at worst be
+/// reported rather than silently converted into a missing record.
+///
+/// Of what the resolvers produce today, `resolve_name_async` (in `common.rs`) itself constructs
+/// `Storage`/`NotFound`/`Ambiguous`, and also propagates whatever `runtime.entities(token)?`
+/// yields, so it is not the sole author of its own error type. The only `InvalidInput` the
+/// prefix-resolution path constructs is a prefix-miss. Everything else — `Storage`, `Sqlite`,
+/// `Internal`, `Ambiguous`, `AmbiguousPrefix` — is a failure and reaches the caller as itself.
 ///
 /// Both ambiguity variants are failures, for the same reason: no later arm can resolve an
 /// ambiguity an earlier arm reported. `dispatch.rs` binds `graph_token = token`, so arms one

--- a/crates/khive-pack-kg/src/handlers/get.rs
+++ b/crates/khive-pack-kg/src/handlers/get.rs
@@ -401,6 +401,15 @@ impl KgPack {
 /// and the only `InvalidInput` the prefix-resolution path can construct is a prefix-miss —
 /// so this list is exhaustive for "no id, keep trying" today. Any other variant
 /// (`Storage`, `Sqlite`, `Internal`, `AmbiguousPrefix`, …) is a failure and propagates.
+///
+/// `Ambiguous` and `AmbiguousPrefix` land in opposite buckets on purpose, which is worth
+/// stating because it reads as an inconsistency otherwise. Name resolution is scoped to the
+/// caller's namespace token, so an ambiguous name really can resolve uniquely on a later arm
+/// carrying a different token — falling through is the behaviour that finds it. Prefix
+/// resolution is namespace-agnostic (`resolve_prefix_unfiltered` passes no namespace
+/// predicate), so every arm issues the identical prefix query and no later arm can do
+/// better; falling through there cannot find anything and only converts a real, reportable
+/// collision into a misleading not-found.
 fn is_resolution_absence(err: &RuntimeError) -> bool {
     matches!(
         err,

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -580,6 +580,12 @@ async fn get_ambiguous_name_reports_the_collision_not_a_false_not_found() {
     );
 }
 
+/// NON-DISCRIMINATING CONTROL. This passes on both sides of the error-classification change and
+/// is not regression coverage for it — the discriminating tests are the storage-failure and
+/// ambiguity cases above. It is kept deliberately: it is the arm that would redden if a future
+/// change to the absence/failure split started reporting a genuine miss as an error, which is the
+/// one direction the split must never move. Do not read a green result here as evidence the
+/// classifier works.
 #[tokio::test]
 async fn get_prefix_matching_nothing_with_no_fault_armed_is_not_found() {
     let pack = pack();
@@ -590,8 +596,7 @@ async fn get_prefix_matching_nothing_with_no_fault_armed_is_not_found() {
         .unwrap_err();
     assert!(
         matches!(err, RuntimeError::NotFound(_)),
-        "a prefix matching no record, with no fault armed, must still be NotFound \
-         (proves the fix did not turn absence into an error); got: {err:?}"
+        "a prefix matching no record, with no fault armed, must still be NotFound; got: {err:?}"
     );
 }
 

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -522,7 +522,13 @@ async fn get_nonexistent_id_returns_not_found() {
 #[tokio::test]
 async fn get_prefix_resolver_storage_failure_is_not_reported_as_not_found() {
     let pack = pack();
-    let prefix = "deadbeef";
+    // The fault arm is process-wide and fires once, while tests in this binary run
+    // concurrently — so this prefix must appear in no other test, or whichever test
+    // resolves it first consumes the arm and both tests become nondeterministic.
+    // `deadbeef` is unusable here for exactly that reason: it occurs 43 times across
+    // `crates/`, including a `get` that expects a clean miss. Keep this value unique;
+    // check with `rg <prefix> crates/` before changing it.
+    let prefix = "fa17bad0";
     let _arm = arm_prefix_resolve_fail_scoped(prefix);
 
     let err = pack
@@ -533,6 +539,44 @@ async fn get_prefix_resolver_storage_failure_is_not_reported_as_not_found() {
         matches!(err, RuntimeError::Storage(_)),
         "a storage failure during id resolution must surface as Storage, not be swallowed \
          into a false not-found; got: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn get_ambiguous_name_reports_the_collision_not_a_false_not_found() {
+    let pack = pack();
+    // Duplicate names are permitted by the store (no unique constraint), so this makes
+    // name resolution genuinely ambiguous.
+    for _ in 0..2 {
+        pack.dispatch(
+            "create",
+            json!({"kind": "entity", "name": "GetAmbiguousFixture", "entity_kind": "concept"}),
+        )
+        .await
+        .expect("create must succeed");
+    }
+
+    let err = pack
+        .dispatch("get", json!({"id": "GetAmbiguousFixture"}))
+        .await
+        .unwrap_err();
+
+    // No fallback arm can resolve an ambiguity an earlier arm reported: `dispatch.rs`
+    // binds `graph_token = token`, so arms one and two issue the identical query, and
+    // arm three only widens the search to soft-deleted records, which can add candidates
+    // but never remove the ones causing the collision. Swallowing this as absence would
+    // tell the caller the record does not exist when in fact two of them do.
+    assert!(
+        matches!(err, RuntimeError::Ambiguous(_)),
+        "an ambiguous name must report the collision, not a false not-found; got: {err:?}"
+    );
+    let msg = match &err {
+        RuntimeError::Ambiguous(m) => m.as_str(),
+        _ => unreachable!(),
+    };
+    assert!(
+        msg.contains("GetAmbiguousFixture"),
+        "error must name the ambiguous entity: {msg}"
     );
 }
 

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -8,8 +8,9 @@ use async_trait::async_trait;
 use khive_pack_kg::KgPack;
 use khive_runtime::pack::{HandlerDef, PackRuntime};
 use khive_runtime::{
-    EntityCreateSpec, KhiveRuntime, Namespace, NamespaceToken, ParamDef, RuntimeError,
-    VerbCategory, VerbRegistry, VerbRegistryBuilder, VerifiedActor, Visibility,
+    arm_prefix_resolve_fail_scoped, EntityCreateSpec, KhiveRuntime, Namespace, NamespaceToken,
+    ParamDef, RuntimeError, VerbCategory, VerbRegistry, VerbRegistryBuilder, VerifiedActor,
+    Visibility,
 };
 use khive_storage::{Edge, EdgeRelation, Note, SqlStatement, SqlValue};
 use khive_types::Pack;
@@ -513,6 +514,40 @@ async fn get_nonexistent_id_returns_not_found() {
     assert!(
         matches!(err, RuntimeError::NotFound(_)),
         "get on nonexistent id must be NotFound, got: {err:?}"
+    );
+}
+
+// ---- `get` must distinguish a resolver storage failure from a genuine miss ----
+
+#[tokio::test]
+async fn get_prefix_resolver_storage_failure_is_not_reported_as_not_found() {
+    let pack = pack();
+    let prefix = "deadbeef";
+    let _arm = arm_prefix_resolve_fail_scoped(prefix);
+
+    let err = pack
+        .dispatch("get", json!({"id": prefix}))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, RuntimeError::Storage(_)),
+        "a storage failure during id resolution must surface as Storage, not be swallowed \
+         into a false not-found; got: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn get_prefix_matching_nothing_with_no_fault_armed_is_not_found() {
+    let pack = pack();
+
+    let err = pack
+        .dispatch("get", json!({"id": "abadcafe"}))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, RuntimeError::NotFound(_)),
+        "a prefix matching no record, with no fault armed, must still be NotFound \
+         (proves the fix did not turn absence into an error); got: {err:?}"
     );
 }
 

--- a/crates/khive-runtime/docs/operations.md
+++ b/crates/khive-runtime/docs/operations.md
@@ -90,3 +90,11 @@ External integration test crates enable it via `khive-runtime = { ..., features 
 - `ENTITY_COMPENSATION_FAIL_NS`: entity-create compensation failure injection. The matching
   compensation skips only the entity-row delete; FTS/vector cleanup still runs so tests can
   inspect the exact residual state and combined error contract.
+- `PREFIX_RESOLVE_FAIL_NS`: storage-failure injection for `resolve_prefix_inner`, keyed by the
+  scanned prefix string rather than a namespace — `resolve_prefix_unfiltered` and
+  `resolve_prefix_unfiltered_including_deleted` pass `namespaces: None` by contract, so there is
+  no namespace to key on. Armed via `arm_prefix_resolve_fail_scoped(prefix)`; the next call
+  scanning that exact prefix returns an injected `StorageError::Timeout` instead of running the
+  table scan, then disarms. Used to prove callers that resolve an id through a prefix (e.g. the
+  `get` verb's fallback chain) distinguish a storage fault from a genuine no-match instead of
+  reporting both as not-found.

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -105,8 +105,8 @@ pub use objectives::{
 #[cfg(any(test, feature = "fault-injection"))]
 pub use operations::{
     arm_entity_compensation_fail_scoped, arm_fts_fail_many_partial_scoped,
-    arm_fts_fail_many_scoped, arm_fts_fail_scoped, arm_rollback_cleanup_fail,
-    arm_vector_fail_after, arm_vector_fail_scoped, FaultInjectionArm,
+    arm_fts_fail_many_scoped, arm_fts_fail_scoped, arm_prefix_resolve_fail_scoped,
+    arm_rollback_cleanup_fail, arm_vector_fail_after, arm_vector_fail_scoped, FaultInjectionArm,
 };
 pub use operations::{
     base_entity_endpoint_rules, base_entity_rule_allows, endpoint_matches,

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -83,6 +83,13 @@ static FTS_FAIL_MANY_NS: std::sync::LazyLock<FaultArmSet> =
 #[cfg(any(test, feature = "fault-injection"))]
 static FTS_FAIL_MANY_PARTIAL_NS: std::sync::LazyLock<FaultArmSet> =
     std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+/// `resolve_prefix_inner` storage-failure injection, keyed by the scanned prefix string
+/// rather than a namespace (the `resolve_prefix_unfiltered*` entry points pass
+/// `namespaces: None` by contract, so there is no namespace to key on); see
+/// docs/operations.md#fault-injection-static-state.
+#[cfg(any(test, feature = "fault-injection"))]
+static PREFIX_RESOLVE_FAIL_NS: std::sync::LazyLock<FaultArmSet> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
 
 /// Scoped ownership of a process-wide fault-injection arm.
 #[cfg(any(test, feature = "fault-injection"))]
@@ -220,6 +227,22 @@ pub fn arm_vector_fail_scoped(ns: &str) -> FaultInjectionArm {
 #[cfg(any(test, feature = "fault-injection"))]
 pub fn arm_entity_compensation_fail_scoped(ns: &str) -> FaultInjectionArm {
     arm_fault(&ENTITY_COMPENSATION_FAIL_NS, ns, MAX_FAULT_ARMS)
+}
+
+/// Arm a one-shot storage failure injection for `resolve_prefix_inner` targeting the
+/// exact `prefix` string.
+///
+/// The next `resolve_prefix`/`resolve_prefix_unfiltered`/`resolve_prefix_including_deleted`/
+/// `resolve_prefix_unfiltered_including_deleted` call scanning this `prefix` returns an
+/// injected `StorageError::Timeout` instead of performing the table scan, then disarms.
+/// Keyed by prefix rather than namespace because the unfiltered entry points pass no
+/// namespace at all.
+/// Keep the returned guard alive until the triggering call completes; dropping it
+/// disarms an unconsumed injection.
+/// Available when compiled with `cfg(test)` or `feature = "fault-injection"`.
+#[cfg(any(test, feature = "fault-injection"))]
+pub fn arm_prefix_resolve_fail_scoped(prefix: &str) -> FaultInjectionArm {
+    arm_fault(&PREFIX_RESOLVE_FAIL_NS, prefix, MAX_FAULT_ARMS)
 }
 
 /// Failure injection for `delete_note_row_first_for_compensation`'s post-row-removal
@@ -4204,6 +4227,18 @@ impl KhiveRuntime {
         }
 
         let pattern = format!("{}%", hex_prefix_to_uuid_pattern(prefix));
+
+        // Injection: check PREFIX_RESOLVE_FAIL_NS (armed by
+        // `arm_prefix_resolve_fail_scoped(prefix)`), exercising the storage-failure path
+        // a genuine pool checkout timeout or WAL contention would take.
+        #[cfg(any(test, feature = "fault-injection"))]
+        if consume_fault(&PREFIX_RESOLVE_FAIL_NS, prefix) {
+            return Err(RuntimeError::Storage(
+                khive_storage::StorageError::Timeout {
+                    operation: "resolve_prefix".into(),
+                },
+            ));
+        }
 
         let tables = [
             ("entities", true),

--- a/crates/khive-runtime/tests/fault_injection_api.rs
+++ b/crates/khive-runtime/tests/fault_injection_api.rs
@@ -2,7 +2,7 @@
 
 use khive_runtime::{
     arm_fts_fail_many_partial_scoped, arm_fts_fail_many_scoped, arm_fts_fail_scoped,
-    arm_vector_fail_scoped, FaultInjectionArm,
+    arm_prefix_resolve_fail_scoped, arm_vector_fail_scoped, FaultInjectionArm,
 };
 
 #[test]
@@ -11,4 +11,5 @@ fn scoped_fault_injection_arms_are_exported() {
     let _: fn(&str) -> FaultInjectionArm = arm_fts_fail_many_scoped;
     let _: fn(&str) -> FaultInjectionArm = arm_fts_fail_many_partial_scoped;
     let _: fn(&str) -> FaultInjectionArm = arm_vector_fail_scoped;
+    let _: fn(&str) -> FaultInjectionArm = arm_prefix_resolve_fail_scoped;
 }


### PR DESCRIPTION
## Problem

The `get` verb resolves a caller-supplied id through three fallback resolution arms. All three
were invoked with `if let Ok(...)`, so every error from every arm was discarded and the caller
received a generic `not found` once the chain was exhausted.

That makes two very different outcomes indistinguishable. A record that genuinely does not exist,
and a lookup that could not be performed at all — a pool checkout timeout, a SQLite error,
contention during prefix resolution — both surface as `not found: <id>`. A caller acting on that
answer concludes the data is absent, which for the most frequently used read verb is a
meaningful difference.

## Change

Each arm's error is now classified:

- **Absence** (`NotFound`, `InvalidInput`) — this arm produced no single id, so the next arm is
  still worth trying. Behaviour is unchanged: the chain continues, and if every arm reports
  absence the same `not found` is returned as before, via the same proposal-payload probe.
- **Failure** (everything else) — the lookup itself could not run, or it ran and found a real
  collision, so the error reaches the caller as itself instead of being rewritten into an absence.

No new error variant, response field, or flag is introduced; failures surface through the existing
per-operation error envelope. This is deliberately the smallest change that separates the two
outcomes, and is provisional pending a broader design pass on how incomplete results are signalled
consistently across verbs.

The classification is safe to key on the variant rather than on message text because
`resolve_name_async` constructs only `Storage`, `NotFound` and `Ambiguous`, so the only
`InvalidInput` these resolvers can produce is the prefix-miss. Any unrecognised future variant
falls into the failure bucket, which errs toward reporting a problem rather than inventing an
absence.

### Second observable change

Both ambiguity variants are failures, so an id matching more than one record now reports the
collision instead of `not found`. In practice this is likely the more frequently encountered of
the two improvements.

They are classified the same way because no later arm can resolve an ambiguity an earlier arm
reported. `dispatch.rs` binds `graph_token = token`, so the first two arms issue the identical
query, and the third only widens the search to soft-deleted records — widening can add candidates
but never remove the ones that made the id ambiguous. Prefix resolution reaches the same place by
a different route: it applies no namespace predicate at all.

## Scope

Confined to one call site. The other fifteen `resolve_uuid*` call sites in the pack already
propagate their errors and are untouched by this diff.

## Testing

Adds a prefix-keyed one-shot fault-injection arm to the runtime's internal prefix scan, following
the existing namespace-keyed arms in the same module, so the distinction has direct coverage:

- a storage failure during resolution surfaces as a storage error rather than `not found`
- an id matching two records reports the collision rather than `not found`
- a prefix matching nothing, with no fault armed, still returns `not found`

All three assert on the error variant rather than a message substring. Reverting the
classification fails the ambiguity test with `NotFound` for an id that matches two records, and
leaves the rest of the suite green.

The fault arm is process-wide and fires once, while tests in the binary run concurrently, so its
prefix must not appear in any other test. The test carries a comment saying so, and the value was
chosen by checking it occurs nowhere else under `crates/`.
