### PR TITLE
fix(pack-git): stop materializing a working tree in the digest cache slot

### DIFF
--- a/crates/khive-pack-git/src/cache.rs
+++ b/crates/khive-pack-git/src/cache.rs
@@ -261,39 +261,62 @@ fn ensure_clone_locked(root: &Path, canonical_url: &str) -> Result<PathBuf, Cach
     let repo_dir = root.join(&key);
     let cap = clone_max_bytes();
 
-    // Slots created before `clone` gained `--no-checkout` still carry a
-    // worktree, and nothing else on this path would ever remove it. Such a slot
-    // is replaced whole rather than stripped in place: the removal re-derives
-    // ownership from a descriptor it opens itself, so this change adds no new
-    // destructive traversal.
-    let mut migrated = false;
-    if repo_dir.join(".git").exists() {
+    // Slot state is decided exactly once, in the same breath as the
+    // ownership check; the arms below key on this decision and never ask
+    // the filesystem again. A second `.git` read would answer a question
+    // about whatever occupies that pathname NOW — after our own removal,
+    // or after a foreign process's write in a shared scratch root, that is
+    // not necessarily anything this process owns, and the fetch arm would
+    // then mutate an unowned repository (refs and ownership marker).
+    // `slot_lock` is in-process only, so a foreign writer is not excluded.
+    enum SlotState {
+        /// `.git` present at the decision point, ownership verified,
+        /// no legacy worktree.
+        Owned,
+        /// Legacy slot (pre-`--no-checkout` worktree) replaced whole by our
+        /// own act; the pathname is vacant as far as this process is
+        /// concerned. The removal re-derives ownership from a descriptor it
+        /// opens itself, so migration adds no new destructive traversal.
+        Replaced,
+        /// No slot at the decision point.
+        Absent,
+    }
+    let slot = if repo_dir.join(".git").exists() {
         if !is_owned_entry(&repo_dir) {
             return Err(CacheError::UnsafeToReplace(repo_dir));
         }
-        migrated = migrate_legacy_slot(root, &repo_dir)?;
-    }
-
-    // `!migrated` and not a second `.git.exists()` read on its own. Asking the
-    // filesystem again would answer a question about whatever occupies that
-    // pathname NOW, which after a removal is not necessarily anything this
-    // process owns; the fetch arm below would then operate on it unchecked.
-    if !migrated && repo_dir.join(".git").exists() {
-        fetch(&repo_dir)?;
-        advance_to_fetched_tip(&repo_dir)?;
-        // `repo_dir` was just fetched into and its ownership already
-        // confirmed above; it vanishing here is a real problem (`slot_lock`
-        // excludes a concurrent `ensure_clone`/`refetch_clone`/`reclone` on
-        // this same key, so nothing else in this crate should be touching
-        // it), not a maybe-absent slot, so propagate rather than swallow.
-        let size = dir_size(&repo_dir)?;
-        if size > cap {
-            remove_owned_entry(root, &repo_dir)?;
-            return Err(CacheError::CloneTooLarge { bytes: size, cap });
+        if migrate_legacy_slot(root, &repo_dir)? {
+            SlotState::Replaced
+        } else {
+            SlotState::Owned
         }
-        touch(&repo_dir)?;
     } else {
-        install_fresh_clone(canonical_url, root, &repo_dir, cap)?;
+        SlotState::Absent
+    };
+
+    match slot {
+        SlotState::Owned => {
+            fetch(&repo_dir)?;
+            advance_to_fetched_tip(&repo_dir)?;
+            // `repo_dir` was just fetched into and its ownership already
+            // confirmed above; it vanishing here is a real problem (`slot_lock`
+            // excludes a concurrent `ensure_clone`/`refetch_clone`/`reclone` on
+            // this same key, so nothing else in this crate should be touching
+            // it), not a maybe-absent slot, so propagate rather than swallow.
+            let size = dir_size(&repo_dir)?;
+            if size > cap {
+                remove_owned_entry(root, &repo_dir)?;
+                return Err(CacheError::CloneTooLarge { bytes: size, cap });
+            }
+            touch(&repo_dir)?;
+        }
+        // If a foreign directory appears at the pathname after this decision,
+        // `install_fresh_clone` fails closed: it stages into a private
+        // namespace and installs with a single `rename`, which refuses a
+        // non-empty destination rather than overwriting it.
+        SlotState::Replaced | SlotState::Absent => {
+            install_fresh_clone(canonical_url, root, &repo_dir, cap)?;
+        }
     }
 
     evict_lru(root, &repo_dir)?;
@@ -2118,6 +2141,57 @@ mod tests {
 
         std::env::remove_var("KHIVE_GIT_DIGEST_CACHE_MAX_REPOS");
         std::env::remove_var("KHIVE_GIT_DIGEST_CACHE_MAX_BYTES");
+    }
+
+    /// The install path must fail closed when a foreign (unowned) directory
+    /// occupies the slot pathname: staging plus a single `rename` refuses a
+    /// non-empty destination, so the foreign bytes survive and no ownership
+    /// marker is written. This is the second half of `ensure_clone_locked`'s
+    /// no-re-read guarantee: once the slot state is decided `Absent`, a
+    /// foreign directory appearing at the pathname must not be fetched
+    /// into, overwritten, or claimed.
+    #[test]
+    fn install_fresh_clone_refuses_a_foreign_occupied_slot() {
+        let _guard = ENV_MUTEX.blocking_lock();
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT", dir.path());
+
+        let upstream = dir.path().join("upstream");
+        std::fs::create_dir_all(&upstream).unwrap();
+        test_git(&upstream, &["init", "-q"]);
+        test_git(&upstream, &["config", "user.email", "t@example.com"]);
+        test_git(&upstream, &["config", "user.name", "T"]);
+        std::fs::write(upstream.join("tracked.md"), "content\n").unwrap();
+        test_git(&upstream, &["add", "tracked.md"]);
+        test_git(&upstream, &["commit", "-q", "-m", "commit A"]);
+        let url = upstream.to_str().expect("utf8 path");
+
+        // A foreign process's directory at the slot pathname: it has a
+        // `.git` but no ownership marker, plus a sentinel byte the
+        // assertions below prove survives.
+        let root = scratch_root();
+        prepare_cache_root(&root).expect("cache root");
+        let repo_dir = root.join(cache_key(url));
+        std::fs::create_dir_all(repo_dir.join(".git")).unwrap();
+        std::fs::write(repo_dir.join("foreign.txt"), "foreign\n").unwrap();
+        assert!(
+            !is_owned_entry(&repo_dir),
+            "fixture control: the occupying directory must be unowned"
+        );
+
+        install_fresh_clone(url, &root, &repo_dir, clone_max_bytes())
+            .expect_err("install into an occupied foreign pathname must fail");
+        assert_eq!(
+            std::fs::read_to_string(repo_dir.join("foreign.txt")).expect("sentinel readable"),
+            "foreign\n",
+            "foreign bytes must survive a refused install"
+        );
+        assert!(
+            !repo_dir.join(MARKER_FILE).exists(),
+            "a refused install must never write the ownership marker"
+        );
+
+        std::env::remove_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT");
     }
 
     #[test]

--- a/crates/khive-pack-git/src/cache.rs
+++ b/crates/khive-pack-git/src/cache.rs
@@ -656,6 +656,12 @@ fn git_at_slot(repo: &Path, slot: &ValidatedSlot) -> Command {
     }
     #[cfg(not(unix))]
     {
+        // Pathname-bound fallback: non-Unix targets cannot pass a directory
+        // descriptor to git, so `.git` is re-resolved by name here. This
+        // reopens the symlink-swap TOCTOU the Unix descriptor-pin closes — a
+        // `.git` swapped for a symlink after validation redirects git to an
+        // unowned repository. Windows-safe handle-pinning needs platform APIs
+        // untestable on this CI and is tracked in #2149.
         let _ = slot;
         cmd.arg("--git-dir").arg(repo.join(".git"));
     }
@@ -692,7 +698,9 @@ fn revalidate_owned_slot(repo_dir: &Path) -> Result<ValidatedSlot, CacheError> {
 
 /// Non-unix fallback: pathname re-check at the same call site. Weaker than
 /// the fd-bound form — the explicit `--git-dir` layer still prevents upward
-/// discovery, though not a symlink swapped in after this check.
+/// discovery, though not a symlink swapped in after this check. That
+/// pathname-bound TOCTOU is tracked in #2149; the Windows-safe handle-pin
+/// needs platform APIs untestable on this CI.
 #[cfg(not(unix))]
 fn revalidate_owned_slot(repo_dir: &Path) -> Result<ValidatedSlot, CacheError> {
     if !is_owned_entry(repo_dir) {

--- a/crates/khive-pack-git/src/cache.rs
+++ b/crates/khive-pack-git/src/cache.rs
@@ -261,22 +261,24 @@ fn ensure_clone_locked(root: &Path, canonical_url: &str) -> Result<PathBuf, Cach
     let repo_dir = root.join(&key);
     let cap = clone_max_bytes();
 
+    // Slots created before `clone` gained `--no-checkout` still carry a
+    // worktree, and nothing else on this path would ever remove it. Such a slot
+    // is replaced whole rather than stripped in place: the removal re-derives
+    // ownership from a descriptor it opens itself, so this change adds no new
+    // destructive traversal.
+    let mut migrated = false;
     if repo_dir.join(".git").exists() {
         if !is_owned_entry(&repo_dir) {
             return Err(CacheError::UnsafeToReplace(repo_dir));
         }
-        // Slots created before `clone` gained `--no-checkout` still carry a
-        // worktree, and nothing else on this path would ever remove it. Such a
-        // slot is replaced whole rather than stripped in place: the removal
-        // below re-derives ownership from a descriptor it opens itself, and
-        // after it `.git` is gone, so the fresh no-checkout installer in the
-        // `else` arm is what reinstates the slot.
-        if slot_carries_worktree(&repo_dir)? {
-            remove_owned_entry(root, &repo_dir)?;
-        }
+        migrated = migrate_legacy_slot(root, &repo_dir)?;
     }
 
-    if repo_dir.join(".git").exists() {
+    // `!migrated` and not a second `.git.exists()` read on its own. Asking the
+    // filesystem again would answer a question about whatever occupies that
+    // pathname NOW, which after a removal is not necessarily anything this
+    // process owns; the fetch arm below would then operate on it unchecked.
+    if !migrated && repo_dir.join(".git").exists() {
         fetch(&repo_dir)?;
         advance_to_fetched_tip(&repo_dir)?;
         // `repo_dir` was just fetched into and its ownership already
@@ -334,8 +336,7 @@ fn refetch_clone_locked(root: &Path, canonical_url: &str) -> Result<PathBuf, Cac
     // that no slot carries a worktree, not that no slot acquires one. A fresh
     // install is already the repaired state this path was trying to reach, so
     // there is nothing left to refetch afterwards.
-    if slot_carries_worktree(&repo_dir)? {
-        remove_owned_entry(root, &repo_dir)?;
+    if migrate_legacy_slot(root, &repo_dir)? {
         install_fresh_clone(canonical_url, root, &repo_dir, cap)?;
         evict_lru(root, &repo_dir)?;
         return Ok(repo_dir);
@@ -870,6 +871,7 @@ fn advance_to_fetched_tip(repo: &Path) -> Result<(), CacheError> {
 /// reinstall of a slot that is about to be fetched anyway, and a false negative
 /// leaves the slot exactly as it was before this change. It never decides what
 /// gets deleted; the removal re-derives that from a descriptor it opens itself.
+#[cfg(unix)]
 fn slot_carries_worktree(repo: &Path) -> Result<bool, CacheError> {
     let entries = std::fs::read_dir(repo).map_err(|e| {
         CacheError::Git(format!(
@@ -886,6 +888,38 @@ fn slot_carries_worktree(repo: &Path) -> Result<bool, CacheError> {
         }
         return Ok(true);
     }
+    Ok(false)
+}
+
+/// Replace a legacy worktree-carrying slot, reporting whether it did.
+///
+/// Returns `true` when the slot was removed, which means the caller must treat
+/// the cache key as absent from that point on and must NOT re-derive that fact
+/// by asking the filesystem again: between the removal and any such re-check,
+/// an external writer can create a directory at the same pathname, and the
+/// caller would then fetch into, ref-update, and marker-touch a repository it
+/// never established ownership of. The per-key lock is same-process only, so it
+/// does not exclude that writer. The boolean is the state; the pathname is not.
+///
+/// Migration is Unix-only, and deliberately so rather than incidentally.
+/// Removal goes through `delete_verified_owned_entry`, whose non-Unix body is a
+/// pathname-based recursive delete with no ownership check at all. That body is
+/// pre-existing and reachable on Windows through the size-cap eviction path;
+/// what this function declines to do is widen its reach by adding a second
+/// caller. On a non-Unix target a legacy slot therefore keeps its worktree until
+/// ordinary LRU or cap eviction retires it, which is exactly the behaviour that
+/// target had before this change.
+#[cfg(unix)]
+fn migrate_legacy_slot(root: &Path, repo_dir: &Path) -> Result<bool, CacheError> {
+    if slot_carries_worktree(repo_dir)? {
+        remove_owned_entry(root, repo_dir)?;
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+#[cfg(not(unix))]
+fn migrate_legacy_slot(_root: &Path, _repo_dir: &Path) -> Result<bool, CacheError> {
     Ok(false)
 }
 
@@ -1773,6 +1807,7 @@ mod tests {
     /// produced it: `reset --hard` is exactly what `advance_to_fetched_tip`
     /// used to do. That makes this a test against the real prior behaviour
     /// rather than against a hand-built approximation of it.
+    #[cfg(unix)] // migration is unix-only; see migrate_legacy_slot
     #[test]
     fn an_existing_slot_with_a_worktree_is_migrated_on_next_use() {
         let _guard = ENV_MUTEX.blocking_lock();
@@ -1836,6 +1871,7 @@ mod tests {
     /// the ensure-path test was written to catch, surviving in the path that
     /// test does not execute. Coverage of a migration belongs at every call
     /// site that can present the state, not once per migration.
+    #[cfg(unix)] // migration is unix-only; see migrate_legacy_slot
     #[test]
     fn a_legacy_slot_reached_by_the_repair_path_is_migrated_too() {
         let _guard = ENV_MUTEX.blocking_lock();

--- a/crates/khive-pack-git/src/cache.rs
+++ b/crates/khive-pack-git/src/cache.rs
@@ -696,6 +696,19 @@ fn remove_dir_all_retrying(path: &Path) -> std::io::Result<()> {
 /// the slot's `.git` tree concurrently with a `dir_size`/`evict_lru` walk
 /// (issue #842 flake family). See
 /// crates/khive-pack-git/docs/api/cache.md#clone-git-subprocess-maintenanceautofalse.
+///
+/// `--no-checkout` is what makes `--filter=blob:none` actually hold. Without
+/// it `git clone` checks out the default branch, and the checkout lazily
+/// backfills every blob reachable at `HEAD` — so the filtered clone pays for
+/// the blobs anyway and `dir_size` measures a filtered object store plus a
+/// fully materialized tree. Nothing reads this slot's worktree: every
+/// consumer command is `rev-parse`, `log`, or `remote`, all of which read
+/// refs and the object database. Measured on this repository:
+/// 61.7 MiB with the checkout, 5.6 MiB without, and all four reader commands
+/// return identical output either way.
+///
+/// The flag is only half the fix — see [`advance_to_fetched_tip`], which had
+/// to stop using `reset --hard` for the same reason.
 fn clone(url: &str, dest: &Path) -> Result<(), CacheError> {
     let status = Command::new("git")
         .arg("-c")
@@ -706,6 +719,7 @@ fn clone(url: &str, dest: &Path) -> Result<(), CacheError> {
         .arg("maintenance.auto=false")
         .arg("clone")
         .arg("--filter=blob:none")
+        .arg("--no-checkout")
         .arg(url)
         .arg(dest)
         .env("GIT_TERMINAL_PROMPT", "0")
@@ -720,39 +734,67 @@ fn clone(url: &str, dest: &Path) -> Result<(), CacheError> {
     Ok(())
 }
 
-/// Advance the cache clone's checked-out HEAD to the tip `fetch` just
-/// brought in. `git fetch` updates remote-tracking refs only; without this
-/// step the clone's HEAD stays wherever the original `git clone` (or the
-/// last reclone) left it, and every walk of `HEAD` silently covers stale
-/// history (issue #1644 — measured: a slot whose FETCH_HEAD was minutes old
-/// walked a HEAD three weeks behind and reported a clean empty pass). The
-/// clone is a disposable cache entry this crate owns outright and nothing
-/// ever writes into its worktree, so a hard reset to the fetched default
-/// branch is safe by construction. Failing to advance is a hard error, not
-/// a warning: proceeding would reintroduce the stale-walk defect silently.
+/// Advance the cache clone's `HEAD` to the tip `fetch` just brought in.
+/// `git fetch` updates remote-tracking refs only; without this step the
+/// clone's HEAD stays wherever the original `git clone` (or the last
+/// reclone) left it, and every walk of `HEAD` silently covers stale history
+/// (issue #1644 — measured: a slot whose FETCH_HEAD was minutes old walked a
+/// HEAD three weeks behind and reported a clean empty pass).
+///
+/// This moves a ref rather than resetting a working tree. `reset --hard`
+/// populates the index and the worktree, which on a `--no-checkout` slot
+/// materializes every blob reachable at the new tip and undoes the blob
+/// filter on each pass — measured on this repository: a 5.6 MiB slot became
+/// 62.5 MiB after one `reset --hard`. Nothing reads the worktree, so there
+/// is nothing for the reset to produce except the bytes the filter exists to
+/// avoid.
+///
+/// Failing to advance is a hard error, not a warning: proceeding would
+/// reintroduce the stale-walk defect silently.
 fn advance_to_fetched_tip(repo: &Path) -> Result<(), CacheError> {
     // `origin/HEAD` is created by `git clone`; repair it first in case an
     // older slot predates it or the remote's default branch moved. Best
-    // effort — the reset below is the step that must succeed.
+    // effort — the ref update below is the step that must succeed.
     let _ = Command::new("git")
         .arg("-C")
         .arg(repo)
         .args(["remote", "set-head", "origin", "--auto"])
         .env("GIT_TERMINAL_PROMPT", "0")
         .status();
-    let status = Command::new("git")
-        .arg("-c")
+
+    // A fresh slot's HEAD is a symref to the default branch, so the branch is
+    // what has to move for `rev-parse HEAD` and `log` to resolve at the tip.
+    // A slot whose HEAD is already detached has no branch to move, and there
+    // the HEAD file itself is the target. Both shapes occur: the first is
+    // what `git clone` produces, the second is reachable through repair paths
+    // and through slots older than this code.
+    let symref = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["symbolic-ref", "-q", "HEAD"])
+        .output()
+        .map_err(|e| CacheError::Git(format!("spawning git symbolic-ref: {e}")))?;
+    let branch = String::from_utf8_lossy(&symref.stdout).trim().to_string();
+
+    let mut cmd = Command::new("git");
+    cmd.arg("-c")
         .arg("core.hooksPath=/dev/null")
         .arg("-C")
         .arg(repo)
-        .args(["reset", "--hard", "refs/remotes/origin/HEAD", "--"])
+        .arg("update-ref");
+    if symref.status.success() && !branch.is_empty() {
+        cmd.arg(&branch);
+    } else {
+        cmd.arg("--no-deref").arg("HEAD");
+    }
+    let status = cmd
+        .arg("refs/remotes/origin/HEAD")
         .status()
-        .map_err(|e| CacheError::Git(format!("spawning git reset: {e}")))?;
+        .map_err(|e| CacheError::Git(format!("spawning git update-ref: {e}")))?;
     if !status.success() {
         return Err(CacheError::Git(format!(
             "advancing {} to the fetched tip failed (exit {status}); a stale \
-             checkout would walk stale history, so this pass refuses to \
-             proceed",
+             HEAD would walk stale history, so this pass refuses to proceed",
             repo.display()
         )));
     }
@@ -1543,6 +1585,90 @@ mod tests {
             upstream_tip,
             "re-ensure must advance the checkout to the fetched tip \
              (issue #1644): a stale HEAD walks stale history"
+        );
+
+        std::env::remove_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT");
+    }
+
+    /// Every entry in a cache slot that came from a checkout: everything
+    /// except `.git` and the cache's own `MARKER_FILE`, both of which this
+    /// crate writes itself. Named exclusions rather than a dotfile rule, so a
+    /// checked-out dotfile still counts as a materialized tree.
+    fn worktree_entries(slot: &Path) -> Vec<String> {
+        std::fs::read_dir(slot)
+            .expect("read cache slot")
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|name| name != ".git" && name != MARKER_FILE)
+            .collect()
+    }
+
+    /// Issue #2104 defect 2: the slot is cloned `--filter=blob:none`, but a
+    /// checkout backfills every blob reachable at HEAD and undoes the filter.
+    /// Nothing reads this worktree — every consumer command is `rev-parse`,
+    /// `log`, or `remote` — so the materialized tree is pure cost.
+    ///
+    /// The second half of this test is the one that matters. `--no-checkout`
+    /// alone does not hold: the previous `advance_to_fetched_tip` ran
+    /// `reset --hard`, which repopulates the worktree on the very next
+    /// `ensure_clone` and gives the bytes straight back. So the assertion
+    /// after the re-ensure is what fails if the ref update ever regresses to
+    /// a reset, and the assertion on the fresh clone alone would not catch it.
+    #[test]
+    fn cache_slot_never_materializes_a_working_tree() {
+        let _guard = ENV_MUTEX.blocking_lock();
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT", dir.path());
+
+        let upstream = dir.path().join("upstream");
+        std::fs::create_dir_all(&upstream).unwrap();
+        test_git(&upstream, &["init", "-q"]);
+        test_git(&upstream, &["config", "user.email", "t@example.com"]);
+        test_git(&upstream, &["config", "user.name", "T"]);
+        std::fs::write(upstream.join("tracked.md"), "content\n").unwrap();
+        test_git(&upstream, &["add", "tracked.md"]);
+        test_git(&upstream, &["commit", "-q", "-m", "commit A"]);
+
+        // The upstream itself HAS a working tree, so an empty result from
+        // `worktree_entries` below is a real absence and not a helper that
+        // always returns nothing.
+        assert!(
+            worktree_entries(&upstream).contains(&"tracked.md".to_string()),
+            "control: the upstream must have a materialized tree, else the \
+             assertions below prove nothing"
+        );
+
+        let url = upstream.to_str().expect("utf8 path");
+        let slot = ensure_clone(url).expect("initial clone");
+        assert_eq!(
+            worktree_entries(&slot),
+            Vec::<String>::new(),
+            "a fresh cache slot must not check out a working tree"
+        );
+        assert_eq!(
+            test_head_sha(&slot),
+            test_head_sha(&upstream),
+            "HEAD must still resolve without a checkout"
+        );
+
+        std::fs::write(upstream.join("second.md"), "more\n").unwrap();
+        test_git(&upstream, &["add", "second.md"]);
+        test_git(&upstream, &["commit", "-q", "-m", "commit B"]);
+        let upstream_tip = test_head_sha(&upstream);
+
+        let slot2 = ensure_clone(url).expect("re-ensure existing slot");
+        assert_eq!(slot2, slot, "same cache slot");
+        assert_eq!(
+            test_head_sha(&slot2),
+            upstream_tip,
+            "advancing to the fetched tip must still work without a checkout"
+        );
+        assert_eq!(
+            worktree_entries(&slot2),
+            Vec::<String>::new(),
+            "advancing the slot must move a ref, not reset a working tree: a \
+             `reset --hard` here repopulates the tree and undoes the blob \
+             filter on every pass"
         );
 
         std::env::remove_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT");

--- a/crates/khive-pack-git/src/cache.rs
+++ b/crates/khive-pack-git/src/cache.rs
@@ -27,7 +27,7 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
 
@@ -299,9 +299,9 @@ fn ensure_clone_locked(root: &Path, canonical_url: &str) -> Result<PathBuf, Cach
             // Ownership was proven at the decision point by pathname; prove it
             // again from a descriptor immediately before mutating. See
             // `revalidate_owned_slot` for the two-layer TOCTOU story.
-            revalidate_owned_slot(&repo_dir)?;
-            fetch(&repo_dir)?;
-            advance_to_fetched_tip(&repo_dir)?;
+            let validated = revalidate_owned_slot(&repo_dir)?;
+            fetch(&repo_dir, &validated)?;
+            advance_to_fetched_tip(&repo_dir, &validated)?;
             // `repo_dir` was just fetched into and its ownership already
             // confirmed above; it vanishing here is a real problem (`slot_lock`
             // excludes a concurrent `ensure_clone`/`refetch_clone`/`reclone` on
@@ -373,9 +373,9 @@ fn refetch_clone_locked(root: &Path, canonical_url: &str) -> Result<PathBuf, Cac
     // check above (and the migration between it and here) leave a window a
     // shared-root writer can use — re-prove ownership from a descriptor
     // immediately before the mutation.
-    revalidate_owned_slot(&repo_dir)?;
-    fetch_refetch(&repo_dir)?;
-    advance_to_fetched_tip(&repo_dir)?;
+    let validated = revalidate_owned_slot(&repo_dir)?;
+    fetch_refetch(&repo_dir, &validated)?;
+    advance_to_fetched_tip(&repo_dir, &validated)?;
 
     let size = dir_size(&repo_dir)?;
     if size > cap {
@@ -588,33 +588,95 @@ fn delete_verified_owned_entry(_root: &Path, repo_dir: &Path) -> Result<(), Cach
     remove_dir_all_retrying(repo_dir).map_err(CacheError::Io)
 }
 
+/// A slot the caller just revalidated. On unix it carries the validated
+/// directory descriptor, and every mutating git command is bound to that
+/// descriptor (`fchdir` before exec, relative `--git-dir .git`), so the
+/// command operates on the validated directory OBJECT: a pathname swapped
+/// after validation — including a symlink pointed at an ancestor repository,
+/// which an absolute `--git-dir` would happily follow — is never re-resolved.
+/// Non-unix carries no descriptor and keeps the pathname `--git-dir` form
+/// (weaker; documented at `revalidate_owned_slot`).
+struct ValidatedSlot {
+    #[cfg(unix)]
+    dir: std::fs::File,
+}
+
+#[cfg(unix)]
+impl ValidatedSlot {
+    /// Test-only: bind to a directory WITHOUT the ownership check, so tests
+    /// can prove what a bound command does against a hostile slot shape.
+    #[cfg(test)]
+    fn for_test(dir: &Path) -> Self {
+        Self {
+            dir: unix_fd::open_dir_nofollow(dir).expect("open test slot dir"),
+        }
+    }
+}
+
+/// Start a `git` invocation addressed at the validated slot. Unix: the child
+/// `fchdir`s to the validated descriptor before exec and uses a RELATIVE
+/// `--git-dir .git`. Non-unix: absolute `--git-dir` on the pathname.
+/// Callers that only read the exit status must null stdout themselves — git
+/// ref chatter ("origin/HEAD is unchanged...") otherwise interleaves with
+/// the process's own stdout protocol stream. (Not nulled here: `.output()`
+/// callers need stdout captured, and an explicit null would empty it.)
+fn git_at_slot(repo: &Path, slot: &ValidatedSlot) -> Command {
+    let mut cmd = Command::new("git");
+    #[cfg(unix)]
+    {
+        use std::os::unix::io::AsRawFd;
+        use std::os::unix::process::CommandExt;
+        let fd = slot.dir.as_raw_fd();
+        // SAFETY: `fchdir` is async-signal-safe, and the descriptor outlives
+        // the child's pre-exec window because every caller holds `slot`
+        // across the synchronous wait on the command.
+        unsafe {
+            cmd.pre_exec(move || {
+                if libc::fchdir(fd) == 0 {
+                    Ok(())
+                } else {
+                    Err(std::io::Error::last_os_error())
+                }
+            });
+        }
+        cmd.arg("--git-dir").arg(".git");
+        let _ = repo;
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = slot;
+        cmd.arg("--git-dir").arg(repo.join(".git"));
+    }
+    cmd
+}
+
 /// TOCTOU guard for mutating an Owned slot: re-derive ownership from a
 /// descriptor opened NOW, immediately before the mutation, rather than
 /// trusting the pathname check made at the decision point. A shared-root
-/// writer that swapped the slot (e.g. for an empty directory) between the
-/// decision and the fetch fails this check. The residual pathname window is
-/// closed by the second layer: every mutating git command addresses the slot
-/// with an explicit `--git-dir`, so a vanished slot is a loud error on that
-/// exact path and never an upward discovery into an ancestor repository.
+/// writer that swapped the slot (e.g. for an empty directory, or a symlink)
+/// between the decision and the fetch fails this check (`O_NOFOLLOW` refuses
+/// the symlink outright). The returned handle carries the validated
+/// descriptor so the subsequent git commands stay bound to the same object —
+/// see `ValidatedSlot` and `git_at_slot`.
 #[cfg(unix)]
-fn revalidate_owned_slot(repo_dir: &Path) -> Result<(), CacheError> {
+fn revalidate_owned_slot(repo_dir: &Path) -> Result<ValidatedSlot, CacheError> {
     let fd = unix_fd::open_dir_nofollow(repo_dir)
         .map_err(|_| CacheError::UnsafeToReplace(repo_dir.to_path_buf()))?;
     if !is_owned_entry_via_fd(&fd) {
         return Err(CacheError::UnsafeToReplace(repo_dir.to_path_buf()));
     }
-    Ok(())
+    Ok(ValidatedSlot { dir: fd })
 }
 
 /// Non-unix fallback: pathname re-check at the same call site. Weaker than
-/// the fd-bound form, but the `--git-dir` layer still prevents ancestor
-/// discovery.
+/// the fd-bound form — the explicit `--git-dir` layer still prevents upward
+/// discovery, though not a symlink swapped in after this check.
 #[cfg(not(unix))]
-fn revalidate_owned_slot(repo_dir: &Path) -> Result<(), CacheError> {
+fn revalidate_owned_slot(repo_dir: &Path) -> Result<ValidatedSlot, CacheError> {
     if !is_owned_entry(repo_dir) {
         return Err(CacheError::UnsafeToReplace(repo_dir.to_path_buf()));
     }
-    Ok(())
+    Ok(ValidatedSlot {})
 }
 
 /// fd-relative mirror of `is_owned_entry`: proves ownership against an
@@ -810,6 +872,7 @@ fn clone(url: &str, dest: &Path) -> Result<(), CacheError> {
         .arg(url)
         .arg(dest)
         .env("GIT_TERMINAL_PROMPT", "0")
+        .stdout(Stdio::null())
         .status()
         .map_err(|e| CacheError::Git(format!("spawning git clone: {e}")))?;
     if !status.success() {
@@ -838,18 +901,19 @@ fn clone(url: &str, dest: &Path) -> Result<(), CacheError> {
 ///
 /// Failing to advance is a hard error, not a warning: proceeding would
 /// reintroduce the stale-walk defect silently.
-fn advance_to_fetched_tip(repo: &Path) -> Result<(), CacheError> {
+fn advance_to_fetched_tip(repo: &Path, slot: &ValidatedSlot) -> Result<(), CacheError> {
     // `origin/HEAD` is created by `git clone`; repair it first in case an
     // older slot predates it or the remote's default branch moved. Best
     // effort — the ref update below is the step that must succeed.
-    // `--git-dir`, not `-C`, throughout this function — see `fetch` for the
-    // discovery hazard: these commands mutate refs and must never resolve to
-    // an ancestor repository if the slot vanishes mid-sequence.
-    let _ = Command::new("git")
-        .arg("--git-dir")
-        .arg(repo.join(".git"))
+    // Descriptor-bound `--git-dir` throughout this function — see `fetch`:
+    // these commands mutate refs and must never resolve to an ancestor
+    // repository if the slot vanishes or is symlink-swapped mid-sequence.
+    // (`set-head` also prints "origin/HEAD is unchanged..." to stdout, which
+    // `git_at_slot` nulls so it cannot corrupt the caller's stdout stream.)
+    let _ = git_at_slot(repo, slot)
         .args(["remote", "set-head", "origin", "--auto"])
         .env("GIT_TERMINAL_PROMPT", "0")
+        .stdout(Stdio::null())
         .status();
 
     // A fresh slot's HEAD is a symref to the default branch, so the branch is
@@ -858,19 +922,15 @@ fn advance_to_fetched_tip(repo: &Path) -> Result<(), CacheError> {
     // the HEAD file itself is the target. Both shapes occur: the first is
     // what `git clone` produces, the second is reachable through repair paths
     // and through slots older than this code.
-    let symref = Command::new("git")
-        .arg("--git-dir")
-        .arg(repo.join(".git"))
+    let symref = git_at_slot(repo, slot)
         .args(["symbolic-ref", "-q", "HEAD"])
         .output()
         .map_err(|e| CacheError::Git(format!("spawning git symbolic-ref: {e}")))?;
     let branch = String::from_utf8_lossy(&symref.stdout).trim().to_string();
 
-    let mut cmd = Command::new("git");
+    let mut cmd = git_at_slot(repo, slot);
     cmd.arg("-c")
         .arg("core.hooksPath=/dev/null")
-        .arg("--git-dir")
-        .arg(repo.join(".git"))
         .arg("update-ref");
     if symref.status.success() && !branch.is_empty() {
         cmd.arg(&branch);
@@ -879,6 +939,7 @@ fn advance_to_fetched_tip(repo: &Path) -> Result<(), CacheError> {
     }
     let status = cmd
         .arg("refs/remotes/origin/HEAD")
+        .stdout(Stdio::null())
         .status()
         .map_err(|e| CacheError::Git(format!("spawning git update-ref: {e}")))?;
     if !status.success() {
@@ -987,22 +1048,23 @@ fn migrate_legacy_slot(_root: &Path, _repo_dir: &Path) -> Result<bool, CacheErro
     Ok(false)
 }
 
-fn fetch(repo: &Path) -> Result<(), CacheError> {
-    // `--git-dir` (not `-C`): `-C` runs repository DISCOVERY, which walks
-    // upward when the slot has vanished and can land on an ancestor
-    // repository. An explicit git-dir fails loudly on the exact path instead.
-    let status = Command::new("git")
+fn fetch(repo: &Path, slot: &ValidatedSlot) -> Result<(), CacheError> {
+    // Descriptor-bound `--git-dir` (never `-C`): `-C` runs repository
+    // DISCOVERY, which walks upward when the slot has vanished and can land
+    // on an ancestor repository, and an absolute `--git-dir` still follows a
+    // symlink swapped in after revalidation. `git_at_slot` binds the command
+    // to the validated directory object itself.
+    let status = git_at_slot(repo, slot)
         .arg("-c")
         .arg("core.hooksPath=/dev/null")
         .arg("-c")
         .arg("gc.auto=0")
         .arg("-c")
         .arg("maintenance.auto=false")
-        .arg("--git-dir")
-        .arg(repo.join(".git"))
         .arg("fetch")
         .arg("--prune")
         .env("GIT_TERMINAL_PROMPT", "0")
+        .stdout(Stdio::null())
         .status()
         .map_err(|e| CacheError::Git(format!("spawning git fetch: {e}")))?;
     if !status.success() {
@@ -1017,21 +1079,20 @@ fn fetch(repo: &Path) -> Result<(), CacheError> {
 /// Issue #765 repair primitive: `git fetch --refetch origin` obtains a
 /// complete fresh filtered packfile instead of incrementally trusting the
 /// existing object store.
-fn fetch_refetch(repo: &Path) -> Result<(), CacheError> {
-    let status = Command::new("git")
+fn fetch_refetch(repo: &Path, slot: &ValidatedSlot) -> Result<(), CacheError> {
+    // Descriptor-bound — see `fetch` for the discovery and symlink hazards.
+    let status = git_at_slot(repo, slot)
         .arg("-c")
         .arg("core.hooksPath=/dev/null")
         .arg("-c")
         .arg("gc.auto=0")
         .arg("-c")
         .arg("maintenance.auto=false")
-        // `--git-dir`, not `-C` — see `fetch` for the discovery hazard.
-        .arg("--git-dir")
-        .arg(repo.join(".git"))
         .arg("fetch")
         .arg("--refetch")
         .arg("origin")
         .env("GIT_TERMINAL_PROMPT", "0")
+        .stdout(Stdio::null())
         .status()
         .map_err(|e| CacheError::Git(format!("spawning git fetch --refetch: {e}")))?;
     if !status.success() {
@@ -2262,15 +2323,77 @@ mod tests {
             "an empty directory at the slot pathname must fail revalidation"
         );
 
-        // (b) the fetch itself is bound to the exact git-dir: it errors
-        // instead of walking up to the ancestor.
-        assert!(
-            fetch(&slot).is_err(),
-            "fetch against a vanished slot must fail loudly"
-        );
+        // (b) even a command bound to the hostile directory itself (the
+        // test-only constructor skips the ownership check layer (a) proves)
+        // errors on the missing relative `.git` instead of discovering
+        // upward into the ancestor.
+        #[cfg(unix)]
+        {
+            assert!(
+                fetch(&slot, &ValidatedSlot::for_test(&slot)).is_err(),
+                "fetch against a vanished slot must fail loudly"
+            );
+        }
         assert!(
             !ancestor.join(".git").join("FETCH_HEAD").exists(),
             "the ancestor repository must be untouched by the failed fetch"
+        );
+    }
+
+    /// The descriptor layer binds the git command to the directory OBJECT
+    /// validated by `revalidate_owned_slot`, not to the pathname: after
+    /// validation, the slot pathname is swapped for a symlink pointing at an
+    /// ancestor repository — the shape an absolute `--git-dir` would follow.
+    /// The bound fetch must land in the validated (renamed-aside) directory
+    /// and never touch the ancestor.
+    #[cfg(unix)]
+    #[test]
+    fn a_bound_command_follows_the_validated_object_not_the_swapped_pathname() {
+        let _guard = ENV_MUTEX.blocking_lock();
+        let dir = tempfile::tempdir().expect("tempdir");
+
+        let upstream = dir.path().join("upstream");
+        std::fs::create_dir_all(&upstream).unwrap();
+        test_git(&upstream, &["init", "-q"]);
+        test_git(&upstream, &["config", "user.email", "t@example.com"]);
+        test_git(&upstream, &["config", "user.name", "T"]);
+        std::fs::write(upstream.join("tracked.md"), "content\n").unwrap();
+        test_git(&upstream, &["add", "tracked.md"]);
+        test_git(&upstream, &["commit", "-q", "-m", "commit A"]);
+        let url = upstream.to_str().expect("utf8");
+
+        // Ancestor repository with the same fetchable origin, so that a
+        // symlink-following fetch would SUCCEED into it — without it the
+        // broken form fails for the wrong reason.
+        let ancestor = dir.path().join("ancestor");
+        std::fs::create_dir_all(&ancestor).unwrap();
+        test_git(&ancestor, &["init", "-q"]);
+        test_git(&ancestor, &["remote", "add", "origin", url]);
+        let root = ancestor.join("cache-root");
+        std::fs::create_dir_all(&root).unwrap();
+        let _scratch = ScratchRootGuard::set(&root);
+
+        // A genuine owned slot.
+        let slot = root.join("owned-slot");
+        clone(url, &slot).expect("clone slot");
+        std::fs::write(slot.join(MARKER_FILE), b"").expect("marker");
+
+        let validated = revalidate_owned_slot(&slot).expect("owned slot validates");
+
+        // Post-validation swap: the pathname now points at the ancestor.
+        let moved = root.join("owned-slot-moved");
+        std::fs::rename(&slot, &moved).expect("move validated dir aside");
+        std::os::unix::fs::symlink(&ancestor, &slot).expect("symlink swap");
+
+        fetch(&slot, &validated).expect("bound fetch follows the validated object");
+
+        assert!(
+            !ancestor.join(".git").join("FETCH_HEAD").exists(),
+            "the ancestor repository must never receive the fetch"
+        );
+        assert!(
+            moved.join(".git").join("FETCH_HEAD").exists(),
+            "the fetch must land in the directory that was validated"
         );
     }
 

--- a/crates/khive-pack-git/src/cache.rs
+++ b/crates/khive-pack-git/src/cache.rs
@@ -265,6 +265,11 @@ fn ensure_clone_locked(root: &Path, canonical_url: &str) -> Result<PathBuf, Cach
         if !is_owned_entry(&repo_dir) {
             return Err(CacheError::UnsafeToReplace(repo_dir));
         }
+        // Slots created before `clone` gained `--no-checkout` still carry a
+        // worktree; nothing else on this path would ever remove it. Runs
+        // before `dir_size` below so the cap is checked against the size the
+        // slot actually ends the pass at.
+        strip_legacy_worktree(&repo_dir)?;
         fetch(&repo_dir)?;
         advance_to_fetched_tip(&repo_dir)?;
         // `repo_dir` was just fetched into and its ownership already
@@ -315,6 +320,10 @@ fn refetch_clone_locked(root: &Path, canonical_url: &str) -> Result<PathBuf, Cac
         return Err(CacheError::UnsafeToReplace(repo_dir));
     }
 
+    // Same legacy-slot migration as the `ensure_clone_locked` path: a repair
+    // pass reaches slots that predate `--no-checkout` too, and the invariant is
+    // that no slot carries a worktree, not that no slot acquires one.
+    strip_legacy_worktree(&repo_dir)?;
     fetch_refetch(&repo_dir)?;
     advance_to_fetched_tip(&repo_dir)?;
 
@@ -797,6 +806,80 @@ fn advance_to_fetched_tip(repo: &Path) -> Result<(), CacheError> {
              HEAD would walk stale history, so this pass refuses to proceed",
             repo.display()
         )));
+    }
+    Ok(())
+}
+
+/// Remove a worktree left behind by a slot created before [`clone`] gained
+/// `--no-checkout`.
+///
+/// `--no-checkout` and the ref-only [`advance_to_fetched_tip`] together stop a
+/// slot from *becoming* materialized, and neither one un-materializes a slot
+/// that already is. An installation upgraded across this change keeps every
+/// slot it already had: `ensure_clone_locked` sees a `.git` directory, takes
+/// the existing-slot path, fetches, moves a ref, and touches the marker,
+/// none of which removes a file outside `.git`. Without this step the saving
+/// arrives only when a slot happens to be evicted or recloned, which is to say
+/// on no schedule at all.
+///
+/// This runs before the cap check on purpose. `dir_size` counts the worktree,
+/// so a legacy slot can exceed the cap on exactly the bytes this function is
+/// about to reclaim, and the caller would evict a slot for a size it no longer
+/// has.
+///
+/// The index is removed alongside the files. Leaving a populated index behind
+/// would make every removed path read as a staged deletion to anything that
+/// later ran a status-like command, and dropping it leaves a migrated slot
+/// byte-for-byte in the shape a fresh `--no-checkout` clone produces.
+///
+/// Ownership is the caller's precondition: every call site has already
+/// established `is_owned_entry`, and this function deletes without re-checking,
+/// so it must not be called on a path that has not passed that gate.
+fn strip_legacy_worktree(repo: &Path) -> Result<(), CacheError> {
+    let mut removed_any = false;
+    let entries = std::fs::read_dir(repo).map_err(|e| {
+        CacheError::Git(format!(
+            "reading {} to strip a worktree: {e}",
+            repo.display()
+        ))
+    })?;
+    for entry in entries {
+        let entry = entry
+            .map_err(|e| CacheError::Git(format!("reading an entry of {}: {e}", repo.display())))?;
+        let name = entry.file_name();
+        if name == ".git" || name == MARKER_FILE {
+            continue;
+        }
+        let path = entry.path();
+        // `symlink_metadata` rather than `metadata`: a symlink in the worktree
+        // must be removed as a link, never followed out of the slot.
+        let meta = std::fs::symlink_metadata(&path)
+            .map_err(|e| CacheError::Git(format!("stat of {}: {e}", path.display())))?;
+        let outcome = if meta.is_dir() {
+            std::fs::remove_dir_all(&path)
+        } else {
+            std::fs::remove_file(&path)
+        };
+        outcome.map_err(|e| {
+            CacheError::Git(format!(
+                "removing legacy worktree entry {}: {e}",
+                path.display()
+            ))
+        })?;
+        removed_any = true;
+    }
+
+    if removed_any {
+        match std::fs::remove_file(repo.join(".git").join("index")) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                return Err(CacheError::Git(format!(
+                    "removing the index of migrated slot {}: {e}",
+                    repo.display()
+                )))
+            }
+        }
     }
     Ok(())
 }
@@ -1669,6 +1752,71 @@ mod tests {
             "advancing the slot must move a ref, not reset a working tree: a \
              `reset --hard` here repopulates the tree and undoes the blob \
              filter on every pass"
+        );
+
+        std::env::remove_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT");
+    }
+
+    /// The `--no-checkout` clone and the ref-only advance stop a slot from
+    /// BECOMING materialized. Neither un-materializes a slot that already is,
+    /// so an installation upgraded across that change keeps every worktree it
+    /// already had, on every slot, indefinitely — the existing-slot path
+    /// fetches and moves a ref and touches a marker, and none of those removes
+    /// a file.
+    ///
+    /// The fixture reproduces the legacy state by running the operation that
+    /// produced it: `reset --hard` is exactly what `advance_to_fetched_tip`
+    /// used to do. That makes this a test against the real prior behaviour
+    /// rather than against a hand-built approximation of it.
+    #[test]
+    fn an_existing_slot_with_a_worktree_is_migrated_on_next_use() {
+        let _guard = ENV_MUTEX.blocking_lock();
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT", dir.path());
+
+        let upstream = dir.path().join("upstream");
+        std::fs::create_dir_all(&upstream).unwrap();
+        test_git(&upstream, &["init", "-q"]);
+        test_git(&upstream, &["config", "user.email", "t@example.com"]);
+        test_git(&upstream, &["config", "user.name", "T"]);
+        std::fs::write(upstream.join("tracked.md"), "content\n").unwrap();
+        test_git(&upstream, &["add", "tracked.md"]);
+        test_git(&upstream, &["commit", "-q", "-m", "commit A"]);
+
+        let url = upstream.to_str().expect("utf8 path");
+        let slot = ensure_clone(url).expect("initial clone");
+
+        // Reproduce a pre-`--no-checkout` slot by running the operation that
+        // used to create one.
+        test_git(&slot, &["reset", "--hard"]);
+        assert!(
+            worktree_entries(&slot).contains(&"tracked.md".to_string()),
+            "fixture control: the seeded slot must actually carry a worktree, \
+             otherwise the migration assertion below passes vacuously"
+        );
+        assert!(
+            slot.join(".git").join("index").exists(),
+            "fixture control: the seeded slot must carry a populated index"
+        );
+
+        let slot2 = ensure_clone(url).expect("re-ensure the legacy slot");
+        assert_eq!(slot2, slot, "same cache slot");
+        assert_eq!(
+            worktree_entries(&slot2),
+            Vec::<String>::new(),
+            "an existing slot carrying a worktree must be migrated on next \
+             use; without that the blob saving arrives only when a slot \
+             happens to be evicted or recloned"
+        );
+        assert!(
+            !slot2.join(".git").join("index").exists(),
+            "the index must go with the files, or every removed path reads as \
+             a staged deletion"
+        );
+        assert_eq!(
+            test_head_sha(&slot2),
+            test_head_sha(&upstream),
+            "migration must not damage the slot: HEAD still resolves"
         );
 
         std::env::remove_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT");

--- a/crates/khive-pack-git/src/cache.rs
+++ b/crates/khive-pack-git/src/cache.rs
@@ -266,10 +266,17 @@ fn ensure_clone_locked(root: &Path, canonical_url: &str) -> Result<PathBuf, Cach
             return Err(CacheError::UnsafeToReplace(repo_dir));
         }
         // Slots created before `clone` gained `--no-checkout` still carry a
-        // worktree; nothing else on this path would ever remove it. Runs
-        // before `dir_size` below so the cap is checked against the size the
-        // slot actually ends the pass at.
-        strip_legacy_worktree(&repo_dir)?;
+        // worktree, and nothing else on this path would ever remove it. Such a
+        // slot is replaced whole rather than stripped in place: the removal
+        // below re-derives ownership from a descriptor it opens itself, and
+        // after it `.git` is gone, so the fresh no-checkout installer in the
+        // `else` arm is what reinstates the slot.
+        if slot_carries_worktree(&repo_dir)? {
+            remove_owned_entry(root, &repo_dir)?;
+        }
+    }
+
+    if repo_dir.join(".git").exists() {
         fetch(&repo_dir)?;
         advance_to_fetched_tip(&repo_dir)?;
         // `repo_dir` was just fetched into and its ownership already
@@ -320,14 +327,23 @@ fn refetch_clone_locked(root: &Path, canonical_url: &str) -> Result<PathBuf, Cac
         return Err(CacheError::UnsafeToReplace(repo_dir));
     }
 
+    let cap = clone_max_bytes();
+
     // Same legacy-slot migration as the `ensure_clone_locked` path: a repair
     // pass reaches slots that predate `--no-checkout` too, and the invariant is
-    // that no slot carries a worktree, not that no slot acquires one.
-    strip_legacy_worktree(&repo_dir)?;
+    // that no slot carries a worktree, not that no slot acquires one. A fresh
+    // install is already the repaired state this path was trying to reach, so
+    // there is nothing left to refetch afterwards.
+    if slot_carries_worktree(&repo_dir)? {
+        remove_owned_entry(root, &repo_dir)?;
+        install_fresh_clone(canonical_url, root, &repo_dir, cap)?;
+        evict_lru(root, &repo_dir)?;
+        return Ok(repo_dir);
+    }
+
     fetch_refetch(&repo_dir)?;
     advance_to_fetched_tip(&repo_dir)?;
 
-    let cap = clone_max_bytes();
     let size = dir_size(&repo_dir)?;
     if size > cap {
         // Ownership-guarded removal, not a raw `remove_dir_all` — see
@@ -810,8 +826,8 @@ fn advance_to_fetched_tip(repo: &Path) -> Result<(), CacheError> {
     Ok(())
 }
 
-/// Remove a worktree left behind by a slot created before [`clone`] gained
-/// `--no-checkout`.
+/// Does this slot still carry a worktree left behind by a clone that predates
+/// `--no-checkout`?
 ///
 /// `--no-checkout` and the ref-only [`advance_to_fetched_tip`] together stop a
 /// slot from *becoming* materialized, and neither one un-materializes a slot
@@ -822,24 +838,42 @@ fn advance_to_fetched_tip(repo: &Path) -> Result<(), CacheError> {
 /// arrives only when a slot happens to be evicted or recloned, which is to say
 /// on no schedule at all.
 ///
-/// This runs before the cap check on purpose. `dir_size` counts the worktree,
-/// so a legacy slot can exceed the cap on exactly the bytes this function is
-/// about to reclaim, and the caller would evict a slot for a size it no longer
-/// has.
+/// This is checked before the cap check on purpose. `dir_size` counts the
+/// worktree, so a legacy slot can exceed the cap on exactly the bytes the
+/// migration is about to reclaim, and the caller would otherwise evict a slot
+/// for a size it is no longer going to have.
 ///
-/// The index is removed alongside the files. Leaving a populated index behind
-/// would make every removed path read as a staged deletion to anything that
-/// later ran a status-like command, and dropping it leaves a migrated slot
-/// byte-for-byte in the shape a fresh `--no-checkout` clone produces.
+/// Replacing the slot rather than stripping it also disposes of the index for
+/// free. A populated index left beside a removed worktree would make every
+/// removed path read as a staged deletion to anything that later ran a
+/// status-like command; a reinstalled slot is byte-for-byte what a fresh
+/// `--no-checkout` clone produces, because it is one.
 ///
-/// Ownership is the caller's precondition: every call site has already
-/// established `is_owned_entry`, and this function deletes without re-checking,
-/// so it must not be called on a path that has not passed that gate.
-fn strip_legacy_worktree(repo: &Path) -> Result<(), CacheError> {
-    let mut removed_any = false;
+/// This is a read, and the migration it gates is a whole-slot replacement
+/// through [`remove_owned_entry`] followed by [`install_fresh_clone`] — the
+/// same pair [`reclone_locked`] uses.
+///
+/// Detecting and then deleting in place would be the obvious shape and is the
+/// wrong one. Recursively removing children through the shared cache-key
+/// pathname reintroduces exactly the race `remove_owned_entry` exists to close:
+/// the slot lock is same-process only, so between an ownership check and a
+/// pathname traversal an external writer can replace `<root>/<key>`, and the
+/// traversal then deletes the replacement's children. `remove_owned_entry`
+/// instead opens the slot with `O_DIRECTORY | O_NOFOLLOW`, re-checks ownership
+/// against that descriptor, renames by descriptor into the private staging
+/// namespace, and verifies the moved inode before removing anything. Routing
+/// the migration through it means this change adds no new destructive traversal
+/// at all.
+///
+/// Both error directions of this detector are safe, which is why it is allowed
+/// to be a plain pathname read: a false positive costs one unnecessary
+/// reinstall of a slot that is about to be fetched anyway, and a false negative
+/// leaves the slot exactly as it was before this change. It never decides what
+/// gets deleted; the removal re-derives that from a descriptor it opens itself.
+fn slot_carries_worktree(repo: &Path) -> Result<bool, CacheError> {
     let entries = std::fs::read_dir(repo).map_err(|e| {
         CacheError::Git(format!(
-            "reading {} to strip a worktree: {e}",
+            "reading {} to detect a legacy worktree: {e}",
             repo.display()
         ))
     })?;
@@ -850,38 +884,9 @@ fn strip_legacy_worktree(repo: &Path) -> Result<(), CacheError> {
         if name == ".git" || name == MARKER_FILE {
             continue;
         }
-        let path = entry.path();
-        // `symlink_metadata` rather than `metadata`: a symlink in the worktree
-        // must be removed as a link, never followed out of the slot.
-        let meta = std::fs::symlink_metadata(&path)
-            .map_err(|e| CacheError::Git(format!("stat of {}: {e}", path.display())))?;
-        let outcome = if meta.is_dir() {
-            std::fs::remove_dir_all(&path)
-        } else {
-            std::fs::remove_file(&path)
-        };
-        outcome.map_err(|e| {
-            CacheError::Git(format!(
-                "removing legacy worktree entry {}: {e}",
-                path.display()
-            ))
-        })?;
-        removed_any = true;
+        return Ok(true);
     }
-
-    if removed_any {
-        match std::fs::remove_file(repo.join(".git").join("index")) {
-            Ok(()) => {}
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-            Err(e) => {
-                return Err(CacheError::Git(format!(
-                    "removing the index of migrated slot {}: {e}",
-                    repo.display()
-                )))
-            }
-        }
-    }
-    Ok(())
+    Ok(false)
 }
 
 fn fetch(repo: &Path) -> Result<(), CacheError> {
@@ -1812,6 +1817,67 @@ mod tests {
             !slot2.join(".git").join("index").exists(),
             "the index must go with the files, or every removed path reads as \
              a staged deletion"
+        );
+        assert_eq!(
+            test_head_sha(&slot2),
+            test_head_sha(&upstream),
+            "migration must not damage the slot: HEAD still resolves"
+        );
+
+        std::env::remove_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT");
+    }
+
+    /// The repair path reaches legacy slots too, and it is a separate call
+    /// site from the one above.
+    ///
+    /// Without this test the production call in `refetch_clone_locked` can be
+    /// deleted or reordered while the ensure-path test stays green, which
+    /// leaves repair-triggered legacy slots materialized — the exact defect
+    /// the ensure-path test was written to catch, surviving in the path that
+    /// test does not execute. Coverage of a migration belongs at every call
+    /// site that can present the state, not once per migration.
+    #[test]
+    fn a_legacy_slot_reached_by_the_repair_path_is_migrated_too() {
+        let _guard = ENV_MUTEX.blocking_lock();
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT", dir.path());
+
+        let upstream = dir.path().join("upstream");
+        std::fs::create_dir_all(&upstream).unwrap();
+        test_git(&upstream, &["init", "-q"]);
+        test_git(&upstream, &["config", "user.email", "t@example.com"]);
+        test_git(&upstream, &["config", "user.name", "T"]);
+        std::fs::write(upstream.join("tracked.md"), "content\n").unwrap();
+        test_git(&upstream, &["add", "tracked.md"]);
+        test_git(&upstream, &["commit", "-q", "-m", "commit A"]);
+
+        let url = upstream.to_str().expect("utf8 path");
+        let slot = ensure_clone(url).expect("initial clone");
+
+        // Same seeding operation as the ensure-path test: the thing that
+        // actually produced these slots before `--no-checkout`.
+        test_git(&slot, &["reset", "--hard"]);
+        assert!(
+            worktree_entries(&slot).contains(&"tracked.md".to_string()),
+            "fixture control: the seeded slot must actually carry a worktree, \
+             otherwise the assertion below passes vacuously"
+        );
+        assert!(
+            slot.join(".git").join("index").exists(),
+            "fixture control: the seeded slot must carry a populated index"
+        );
+
+        let slot2 = refetch_clone(url).expect("refetch the legacy slot");
+        assert_eq!(slot2, slot, "same cache slot");
+        assert_eq!(
+            worktree_entries(&slot2),
+            Vec::<String>::new(),
+            "the repair path must migrate a legacy slot as well; it reaches \
+             the same pre-`--no-checkout` slots the ensure path does"
+        );
+        assert!(
+            !slot2.join(".git").join("index").exists(),
+            "the index must not survive the migration on this path either"
         );
         assert_eq!(
             test_head_sha(&slot2),

--- a/crates/khive-pack-git/src/cache.rs
+++ b/crates/khive-pack-git/src/cache.rs
@@ -588,34 +588,46 @@ fn delete_verified_owned_entry(_root: &Path, repo_dir: &Path) -> Result<(), Cach
     remove_dir_all_retrying(repo_dir).map_err(CacheError::Io)
 }
 
-/// A slot the caller just revalidated. On unix it carries the validated
-/// directory descriptor, and every mutating git command is bound to that
-/// descriptor (`fchdir` before exec, relative `--git-dir .git`), so the
-/// command operates on the validated directory OBJECT: a pathname swapped
-/// after validation — including a symlink pointed at an ancestor repository,
-/// which an absolute `--git-dir` would happily follow — is never re-resolved.
+/// A slot the caller just revalidated. On unix it carries a descriptor bound
+/// to the slot's `.git` directory OBJECT, opened `O_NOFOLLOW` relative to the
+/// validated parent, and every git command is bound to it (`fchdir` into the
+/// descriptor before exec, `--git-dir .`), so git never re-resolves the name
+/// `.git` and never resolves the slot pathname either. A swap after
+/// validation — of the slot pathname OR of the `.git` child entry — including
+/// a symlink pointed at an ancestor repository, which a re-resolved `--git-dir
+/// .git` or an absolute `--git-dir` would happily follow, is never seen.
 /// Non-unix carries no descriptor and keeps the pathname `--git-dir` form
 /// (weaker; documented at `revalidate_owned_slot`).
 struct ValidatedSlot {
     #[cfg(unix)]
-    dir: std::fs::File,
+    git_dir: std::fs::File,
 }
 
 #[cfg(unix)]
 impl ValidatedSlot {
-    /// Test-only: bind to a directory WITHOUT the ownership check, so tests
-    /// can prove what a bound command does against a hostile slot shape.
+    /// Test-only: bind WITHOUT the ownership check, so tests can prove what a
+    /// bound command does against a hostile slot shape. Binds the slot's
+    /// `.git` when present (an owned slot); otherwise binds the slot directory
+    /// itself, so a command against a hostile empty slot fails loudly on "not
+    /// a git repository" under an explicit `--git-dir .` rather than
+    /// discovering upward into an ancestor.
     #[cfg(test)]
     fn for_test(dir: &Path) -> Self {
-        Self {
-            dir: unix_fd::open_dir_nofollow(dir).expect("open test slot dir"),
-        }
+        let parent = unix_fd::open_dir_nofollow(dir).expect("open test slot dir");
+        let git_dir =
+            unix_fd::openat_dir_nofollow(&parent, std::ffi::OsStr::new(".git")).unwrap_or(parent);
+        Self { git_dir }
     }
 }
 
 /// Start a `git` invocation addressed at the validated slot. Unix: the child
-/// `fchdir`s to the validated descriptor before exec and uses a RELATIVE
-/// `--git-dir .git`. Non-unix: absolute `--git-dir` on the pathname.
+/// `fchdir`s into the validated `.git` descriptor before exec and uses
+/// `--git-dir .`, so git operates on the descriptor-resolved `.git` object and
+/// never re-resolves the name `.git` (which a relative `--git-dir .git` would,
+/// following a `.git` symlink swapped in after validation). Non-unix: absolute
+/// `--git-dir` on the pathname. All git commands here are ref/git-dir-only
+/// (fetch, remote set-head, symbolic-ref, update-ref); none needs a work tree,
+/// so cwd being the git dir is correct.
 /// Callers that only read the exit status must null stdout themselves — git
 /// ref chatter ("origin/HEAD is unchanged...") otherwise interleaves with
 /// the process's own stdout protocol stream. (Not nulled here: `.output()`
@@ -626,7 +638,7 @@ fn git_at_slot(repo: &Path, slot: &ValidatedSlot) -> Command {
     {
         use std::os::unix::io::AsRawFd;
         use std::os::unix::process::CommandExt;
-        let fd = slot.dir.as_raw_fd();
+        let fd = slot.git_dir.as_raw_fd();
         // SAFETY: `fchdir` is async-signal-safe, and the descriptor outlives
         // the child's pre-exec window because every caller holds `slot`
         // across the synchronous wait on the command.
@@ -639,7 +651,7 @@ fn git_at_slot(repo: &Path, slot: &ValidatedSlot) -> Command {
                 }
             });
         }
-        cmd.arg("--git-dir").arg(".git");
+        cmd.arg("--git-dir").arg(".");
         let _ = repo;
     }
     #[cfg(not(unix))]
@@ -665,7 +677,17 @@ fn revalidate_owned_slot(repo_dir: &Path) -> Result<ValidatedSlot, CacheError> {
     if !is_owned_entry_via_fd(&fd) {
         return Err(CacheError::UnsafeToReplace(repo_dir.to_path_buf()));
     }
-    Ok(ValidatedSlot { dir: fd })
+    // Bind the `.git` child directory itself, opened `O_NOFOLLOW` relative to
+    // the pinned parent. This closes the child-entry race the parent FD alone
+    // left open: after `is_owned_entry_via_fd` confirms `.git` is a directory,
+    // a shared-root writer can still swap `.git` for a symlink at an ancestor
+    // repo, which a later `--git-dir .git` (re-resolved by name) would follow.
+    // `openat_dir_nofollow` refuses that symlink (`ELOOP`) and otherwise pins
+    // the exact `.git` inode, so `git_at_slot`'s `--git-dir .` can never reach
+    // outside the validated slot.
+    let git_dir = unix_fd::openat_dir_nofollow(&fd, std::ffi::OsStr::new(".git"))
+        .map_err(|_| CacheError::UnsafeToReplace(repo_dir.to_path_buf()))?;
+    Ok(ValidatedSlot { git_dir })
 }
 
 /// Non-unix fallback: pathname re-check at the same call site. Weaker than
@@ -2394,6 +2416,68 @@ mod tests {
         assert!(
             moved.join(".git").join("FETCH_HEAD").exists(),
             "the fetch must land in the directory that was validated"
+        );
+    }
+
+    /// The descriptor layer binds git to the validated `.git` OBJECT, not to
+    /// the name `.git`: after validation, the slot's `.git` CHILD ENTRY is
+    /// swapped for a symlink pointing at an ancestor repository's `.git` — the
+    /// shape a re-resolved relative `--git-dir .git` would follow. Binding the
+    /// parent slot alone left this open (the parent pathname is unchanged, so
+    /// only the child entry moves); the fetch must land in the validated
+    /// `.git` and never touch the ancestor.
+    #[cfg(unix)]
+    #[test]
+    fn a_bound_command_follows_the_validated_git_object_not_a_swapped_git_child() {
+        let _guard = ENV_MUTEX.blocking_lock();
+        let dir = tempfile::tempdir().expect("tempdir");
+
+        let upstream = dir.path().join("upstream");
+        std::fs::create_dir_all(&upstream).unwrap();
+        test_git(&upstream, &["init", "-q"]);
+        test_git(&upstream, &["config", "user.email", "t@example.com"]);
+        test_git(&upstream, &["config", "user.name", "T"]);
+        std::fs::write(upstream.join("tracked.md"), "content\n").unwrap();
+        test_git(&upstream, &["add", "tracked.md"]);
+        test_git(&upstream, &["commit", "-q", "-m", "commit A"]);
+        let url = upstream.to_str().expect("utf8");
+
+        // Ancestor repository with the same fetchable origin, so that a
+        // symlink-following fetch would SUCCEED into it — without it the
+        // broken form fails for the wrong reason.
+        let ancestor = dir.path().join("ancestor");
+        std::fs::create_dir_all(&ancestor).unwrap();
+        test_git(&ancestor, &["init", "-q"]);
+        test_git(&ancestor, &["remote", "add", "origin", url]);
+        let root = ancestor.join("cache-root");
+        std::fs::create_dir_all(&root).unwrap();
+        let _scratch = ScratchRootGuard::set(&root);
+
+        // A genuine owned slot.
+        let slot = root.join("owned-slot");
+        clone(url, &slot).expect("clone slot");
+        std::fs::write(slot.join(MARKER_FILE), b"").expect("marker");
+
+        let validated = revalidate_owned_slot(&slot).expect("owned slot validates");
+
+        // Post-validation swap of the CHILD ENTRY: move the real `.git` aside
+        // and point the name `.git` at the ancestor's `.git`. The slot
+        // pathname itself is untouched, so a parent-only binding still lands
+        // here and re-resolves `.git` by name.
+        let real_git = slot.join(".git");
+        let moved_git = slot.join(".git-moved");
+        std::fs::rename(&real_git, &moved_git).expect("move validated .git aside");
+        std::os::unix::fs::symlink(ancestor.join(".git"), &real_git).expect("symlink .git swap");
+
+        fetch(&slot, &validated).expect("bound fetch follows the validated .git object");
+
+        assert!(
+            !ancestor.join(".git").join("FETCH_HEAD").exists(),
+            "the ancestor repository must never receive the fetch"
+        );
+        assert!(
+            moved_git.join("FETCH_HEAD").exists(),
+            "the fetch must land in the .git object that was validated"
         );
     }
 

--- a/crates/khive-pack-git/src/cache.rs
+++ b/crates/khive-pack-git/src/cache.rs
@@ -296,6 +296,10 @@ fn ensure_clone_locked(root: &Path, canonical_url: &str) -> Result<PathBuf, Cach
 
     match slot {
         SlotState::Owned => {
+            // Ownership was proven at the decision point by pathname; prove it
+            // again from a descriptor immediately before mutating. See
+            // `revalidate_owned_slot` for the two-layer TOCTOU story.
+            revalidate_owned_slot(&repo_dir)?;
             fetch(&repo_dir)?;
             advance_to_fetched_tip(&repo_dir)?;
             // `repo_dir` was just fetched into and its ownership already
@@ -365,6 +369,11 @@ fn refetch_clone_locked(root: &Path, canonical_url: &str) -> Result<PathBuf, Cac
         return Ok(repo_dir);
     }
 
+    // Same TOCTOU guard as the `ensure_clone_locked` Owned arm: the pathname
+    // check above (and the migration between it and here) leave a window a
+    // shared-root writer can use — re-prove ownership from a descriptor
+    // immediately before the mutation.
+    revalidate_owned_slot(&repo_dir)?;
     fetch_refetch(&repo_dir)?;
     advance_to_fetched_tip(&repo_dir)?;
 
@@ -577,6 +586,35 @@ fn delete_verified_owned_entry(root: &Path, repo_dir: &Path) -> Result<(), Cache
 #[cfg(not(unix))]
 fn delete_verified_owned_entry(_root: &Path, repo_dir: &Path) -> Result<(), CacheError> {
     remove_dir_all_retrying(repo_dir).map_err(CacheError::Io)
+}
+
+/// TOCTOU guard for mutating an Owned slot: re-derive ownership from a
+/// descriptor opened NOW, immediately before the mutation, rather than
+/// trusting the pathname check made at the decision point. A shared-root
+/// writer that swapped the slot (e.g. for an empty directory) between the
+/// decision and the fetch fails this check. The residual pathname window is
+/// closed by the second layer: every mutating git command addresses the slot
+/// with an explicit `--git-dir`, so a vanished slot is a loud error on that
+/// exact path and never an upward discovery into an ancestor repository.
+#[cfg(unix)]
+fn revalidate_owned_slot(repo_dir: &Path) -> Result<(), CacheError> {
+    let fd = unix_fd::open_dir_nofollow(repo_dir)
+        .map_err(|_| CacheError::UnsafeToReplace(repo_dir.to_path_buf()))?;
+    if !is_owned_entry_via_fd(&fd) {
+        return Err(CacheError::UnsafeToReplace(repo_dir.to_path_buf()));
+    }
+    Ok(())
+}
+
+/// Non-unix fallback: pathname re-check at the same call site. Weaker than
+/// the fd-bound form, but the `--git-dir` layer still prevents ancestor
+/// discovery.
+#[cfg(not(unix))]
+fn revalidate_owned_slot(repo_dir: &Path) -> Result<(), CacheError> {
+    if !is_owned_entry(repo_dir) {
+        return Err(CacheError::UnsafeToReplace(repo_dir.to_path_buf()));
+    }
+    Ok(())
 }
 
 /// fd-relative mirror of `is_owned_entry`: proves ownership against an
@@ -804,9 +842,12 @@ fn advance_to_fetched_tip(repo: &Path) -> Result<(), CacheError> {
     // `origin/HEAD` is created by `git clone`; repair it first in case an
     // older slot predates it or the remote's default branch moved. Best
     // effort — the ref update below is the step that must succeed.
+    // `--git-dir`, not `-C`, throughout this function — see `fetch` for the
+    // discovery hazard: these commands mutate refs and must never resolve to
+    // an ancestor repository if the slot vanishes mid-sequence.
     let _ = Command::new("git")
-        .arg("-C")
-        .arg(repo)
+        .arg("--git-dir")
+        .arg(repo.join(".git"))
         .args(["remote", "set-head", "origin", "--auto"])
         .env("GIT_TERMINAL_PROMPT", "0")
         .status();
@@ -818,8 +859,8 @@ fn advance_to_fetched_tip(repo: &Path) -> Result<(), CacheError> {
     // what `git clone` produces, the second is reachable through repair paths
     // and through slots older than this code.
     let symref = Command::new("git")
-        .arg("-C")
-        .arg(repo)
+        .arg("--git-dir")
+        .arg(repo.join(".git"))
         .args(["symbolic-ref", "-q", "HEAD"])
         .output()
         .map_err(|e| CacheError::Git(format!("spawning git symbolic-ref: {e}")))?;
@@ -828,8 +869,8 @@ fn advance_to_fetched_tip(repo: &Path) -> Result<(), CacheError> {
     let mut cmd = Command::new("git");
     cmd.arg("-c")
         .arg("core.hooksPath=/dev/null")
-        .arg("-C")
-        .arg(repo)
+        .arg("--git-dir")
+        .arg(repo.join(".git"))
         .arg("update-ref");
     if symref.status.success() && !branch.is_empty() {
         cmd.arg(&branch);
@@ -947,6 +988,9 @@ fn migrate_legacy_slot(_root: &Path, _repo_dir: &Path) -> Result<bool, CacheErro
 }
 
 fn fetch(repo: &Path) -> Result<(), CacheError> {
+    // `--git-dir` (not `-C`): `-C` runs repository DISCOVERY, which walks
+    // upward when the slot has vanished and can land on an ancestor
+    // repository. An explicit git-dir fails loudly on the exact path instead.
     let status = Command::new("git")
         .arg("-c")
         .arg("core.hooksPath=/dev/null")
@@ -954,8 +998,8 @@ fn fetch(repo: &Path) -> Result<(), CacheError> {
         .arg("gc.auto=0")
         .arg("-c")
         .arg("maintenance.auto=false")
-        .arg("-C")
-        .arg(repo)
+        .arg("--git-dir")
+        .arg(repo.join(".git"))
         .arg("fetch")
         .arg("--prune")
         .env("GIT_TERMINAL_PROMPT", "0")
@@ -981,8 +1025,9 @@ fn fetch_refetch(repo: &Path) -> Result<(), CacheError> {
         .arg("gc.auto=0")
         .arg("-c")
         .arg("maintenance.auto=false")
-        .arg("-C")
-        .arg(repo)
+        // `--git-dir`, not `-C` — see `fetch` for the discovery hazard.
+        .arg("--git-dir")
+        .arg(repo.join(".git"))
         .arg("fetch")
         .arg("--refetch")
         .arg("origin")
@@ -1735,6 +1780,32 @@ mod tests {
         std::env::remove_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT");
     }
 
+    /// RAII scratch-root override: sets `KHIVE_GIT_DIGEST_SCRATCH_ROOT` and
+    /// restores the previous value on drop, panic included — a bare
+    /// `set_var`/`remove_var` pair leaks a deleted `TempDir` path into later
+    /// tests when an assertion between them fails. Hold alongside the
+    /// `ENV_MUTEX` guard.
+    struct ScratchRootGuard {
+        prev: Option<std::ffi::OsString>,
+    }
+
+    impl ScratchRootGuard {
+        fn set(path: &Path) -> Self {
+            let prev = std::env::var_os("KHIVE_GIT_DIGEST_SCRATCH_ROOT");
+            std::env::set_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT", path);
+            Self { prev }
+        }
+    }
+
+    impl Drop for ScratchRootGuard {
+        fn drop(&mut self) {
+            match self.prev.take() {
+                Some(v) => std::env::set_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT", v),
+                None => std::env::remove_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT"),
+            }
+        }
+    }
+
     /// Every entry in a cache slot that came from a checkout: everything
     /// except `.git` and the cache's own `MARKER_FILE`, both of which this
     /// crate writes itself. Named exclusions rather than a dotfile rule, so a
@@ -1763,7 +1834,7 @@ mod tests {
     fn cache_slot_never_materializes_a_working_tree() {
         let _guard = ENV_MUTEX.blocking_lock();
         let dir = tempfile::tempdir().expect("tempdir");
-        std::env::set_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT", dir.path());
+        let _scratch = ScratchRootGuard::set(dir.path());
 
         let upstream = dir.path().join("upstream");
         std::fs::create_dir_all(&upstream).unwrap();
@@ -1815,8 +1886,6 @@ mod tests {
              `reset --hard` here repopulates the tree and undoes the blob \
              filter on every pass"
         );
-
-        std::env::remove_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT");
     }
 
     /// The `--no-checkout` clone and the ref-only advance stop a slot from
@@ -1835,7 +1904,7 @@ mod tests {
     fn an_existing_slot_with_a_worktree_is_migrated_on_next_use() {
         let _guard = ENV_MUTEX.blocking_lock();
         let dir = tempfile::tempdir().expect("tempdir");
-        std::env::set_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT", dir.path());
+        let _scratch = ScratchRootGuard::set(dir.path());
 
         let upstream = dir.path().join("upstream");
         std::fs::create_dir_all(&upstream).unwrap();
@@ -1881,8 +1950,6 @@ mod tests {
             test_head_sha(&upstream),
             "migration must not damage the slot: HEAD still resolves"
         );
-
-        std::env::remove_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT");
     }
 
     /// The repair path reaches legacy slots too, and it is a separate call
@@ -1899,7 +1966,7 @@ mod tests {
     fn a_legacy_slot_reached_by_the_repair_path_is_migrated_too() {
         let _guard = ENV_MUTEX.blocking_lock();
         let dir = tempfile::tempdir().expect("tempdir");
-        std::env::set_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT", dir.path());
+        let _scratch = ScratchRootGuard::set(dir.path());
 
         let upstream = dir.path().join("upstream");
         std::fs::create_dir_all(&upstream).unwrap();
@@ -1943,8 +2010,6 @@ mod tests {
             test_head_sha(&upstream),
             "migration must not damage the slot: HEAD still resolves"
         );
-
-        std::env::remove_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT");
     }
 
     #[test]
@@ -2147,6 +2212,68 @@ mod tests {
     /// occupies the slot pathname: staging plus a single `rename` refuses a
     /// non-empty destination, so the foreign bytes survive and no ownership
     /// marker is written. This is the second half of `ensure_clone_locked`'s
+    /// TOCTOU regression: a slot swapped for an empty directory between the
+    /// ownership decision and the fetch must (a) fail `revalidate_owned_slot`
+    /// and (b) even if a fetch were issued anyway, fail on the exact path
+    /// rather than discovering upward into an ancestor repository. The
+    /// ancestor here is a real git repository containing the cache root —
+    /// the shape under which `-C` discovery would have fetched into it.
+    #[test]
+    fn a_swapped_slot_is_refused_and_never_reaches_an_ancestor_repo() {
+        let _guard = ENV_MUTEX.blocking_lock();
+        let dir = tempfile::tempdir().expect("tempdir");
+
+        // A fetchable upstream, so that an upward-discovering `git -C` fetch
+        // from inside the ancestor would SUCCEED (creating FETCH_HEAD) —
+        // without it the old `-C` form fails for the wrong reason and this
+        // test could not distinguish the fixed form from the broken one.
+        let upstream = dir.path().join("upstream");
+        std::fs::create_dir_all(&upstream).unwrap();
+        test_git(&upstream, &["init", "-q"]);
+        test_git(&upstream, &["config", "user.email", "t@example.com"]);
+        test_git(&upstream, &["config", "user.name", "T"]);
+        std::fs::write(upstream.join("tracked.md"), "content\n").unwrap();
+        test_git(&upstream, &["add", "tracked.md"]);
+        test_git(&upstream, &["commit", "-q", "-m", "commit A"]);
+
+        // Ancestor repository enclosing the cache root, with that upstream
+        // configured as origin.
+        let ancestor = dir.path().join("ancestor");
+        std::fs::create_dir_all(&ancestor).unwrap();
+        test_git(&ancestor, &["init", "-q"]);
+        test_git(
+            &ancestor,
+            &["remote", "add", "origin", upstream.to_str().expect("utf8")],
+        );
+        let root = ancestor.join("cache-root");
+        std::fs::create_dir_all(&root).unwrap();
+        let _scratch = ScratchRootGuard::set(&root);
+
+        // The swapped-in slot: an empty directory where an owned clone stood.
+        let slot = root.join("swapped-slot");
+        std::fs::create_dir_all(&slot).unwrap();
+
+        // (a) descriptor-bound revalidation refuses it.
+        assert!(
+            matches!(
+                revalidate_owned_slot(&slot),
+                Err(CacheError::UnsafeToReplace(_))
+            ),
+            "an empty directory at the slot pathname must fail revalidation"
+        );
+
+        // (b) the fetch itself is bound to the exact git-dir: it errors
+        // instead of walking up to the ancestor.
+        assert!(
+            fetch(&slot).is_err(),
+            "fetch against a vanished slot must fail loudly"
+        );
+        assert!(
+            !ancestor.join(".git").join("FETCH_HEAD").exists(),
+            "the ancestor repository must be untouched by the failed fetch"
+        );
+    }
+
     /// no-re-read guarantee: once the slot state is decided `Absent`, a
     /// foreign directory appearing at the pathname must not be fetched
     /// into, overwritten, or claimed.
@@ -2154,7 +2281,7 @@ mod tests {
     fn install_fresh_clone_refuses_a_foreign_occupied_slot() {
         let _guard = ENV_MUTEX.blocking_lock();
         let dir = tempfile::tempdir().expect("tempdir");
-        std::env::set_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT", dir.path());
+        let _scratch = ScratchRootGuard::set(dir.path());
 
         let upstream = dir.path().join("upstream");
         std::fs::create_dir_all(&upstream).unwrap();
@@ -2190,8 +2317,6 @@ mod tests {
             !repo_dir.join(MARKER_FILE).exists(),
             "a refused install must never write the ownership marker"
         );
-
-        std::env::remove_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT");
     }
 
     #[test]


### PR DESCRIPTION
Addresses defect 2 of #2104.

## The defect

The scratch clone passes `--filter=blob:none`, but nothing prevented the checkout. `git clone`
checks out the default branch, and that checkout lazily backfills every blob reachable at `HEAD` —
so the filter bought nothing. `dir_size` measured a filtered object store plus a fully materialized
tree, and the per-clone size cap refused work only after paying for all of it.

Nothing reads that tree. Every command this crate issues against a cache slot is `rev-parse`,
`log`, or `remote`, all of which read refs and the object database.

## Both halves are required

1. `clone` passes `--no-checkout`.
2. `advance_to_fetched_tip` moves a ref instead of running `reset --hard`.

The second is not optional, and this is the part worth reviewing. `reset --hard` repopulates the
working tree on the next `ensure_clone` regardless of how the slot was cloned, so `--no-checkout`
alone hands the bytes straight back on the first refresh.

`HEAD` is advanced by updating the branch its symref names, falling back to updating `HEAD` itself
when the slot is already detached. Both shapes occur — the first is what `git clone` produces, the
second is reachable through repair paths and through slots older than this code — and `rev-parse
HEAD` and `log` resolve identically either way.

## Measured

On this repository:

| slot state | size |
|---|---|
| `--filter=blob:none`, with checkout (before) | 61.7 MiB |
| `--filter=blob:none --no-checkout` (after) | 5.6 MiB |
| the 5.6 MiB slot after one `reset --hard` | 62.5 MiB |

The third row is why change 2 exists.

## Test

`cache_slot_never_materializes_a_working_tree` pins both halves against a local upstream. Its
second assertion — the one after the re-ensure — is what catches a regression to `reset --hard`;
the assertion on the fresh clone alone would not, because with the reset restored the slot
repopulates on refresh even though it was cloned `--no-checkout`.

Both arms were verified by mutation, each reddening only its own predicted assertion:

- dropping `--no-checkout` reddens the fresh-clone assertion, printing `["tracked.md"]`
- restoring `reset --hard` reddens the post-re-ensure assertion, printing
  `["tracked.md", "second.md"]`

The test's helper excludes `.git` and the cache's own marker file by name rather than by a dotfile
rule, so a checked-out dotfile would still count as a materialized tree. It also asserts the
upstream has a tree of its own, so an empty result from the helper is a real absence.

The existing `reensure_advances_checkout_to_fetched_tip` test passes unchanged, so the #1644
stale-HEAD guarantee is preserved.

## Scope

Existing slots cloned by older code keep their materialized tree until they are evicted or refused
by the cap; nothing here reaches back to clean them.

Defect 1 (an issues-only ingest should not require a clone at all) and defect 3 (the cap should
bound the transfer rather than refuse after it) are unaffected and remain open.

## Gates

- `cargo test -p khive-pack-git` — 255 + 93 passed, 0 failed
- `cargo clippy -p khive-pack-git --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean


## Legacy slots, and which claims here carry arms

Slots created before `--no-checkout` still carry a worktree, and nothing on the ordinary path
would ever remove it. Such a slot is replaced whole rather than stripped in place: the removal
goes through the existing ownership-guarded remover, which opens the slot with
`O_DIRECTORY | O_NOFOLLOW`, re-checks ownership against that descriptor, renames by descriptor
into a private staging namespace, and verifies the moved inode before deleting anything. This
change therefore adds no new destructive traversal of its own.

Two claims in this PR are supported differently, and the difference is worth stating plainly.

**Carries arms.** The migration behaviour is pinned by tests: a legacy slot reached through the
ordinary path and a legacy slot reached through the repair path both lose their worktree and
index. `cargo clippy -p khive-pack-git --all-targets -- -D warnings` is clean;
`cargo test -p khive-pack-git` passes 93; `cache::tests` passes 39, including both migration
tests.

**Carries eyes only.** After removing a legacy slot, the code no longer re-reads the slot
pathname to decide what to do next; the removal reports whether it happened and the caller
branches on that boolean. The hazard it closes is a window between the removal and a re-read in
which an external writer could occupy the pathname, and the per-key lock is same-process only, so
it does not exclude that writer. No test reaches this: the window is internal to the function and
there is no injection seam, so both migration tests observe the same outcome with or without the
fix. It is verified by reading, not by a reddened arm, and it should be reviewed on that basis.

Migration is gated to unix. It removes through a helper whose non-unix body is a pathname-based
recursive delete with no ownership check. That body is pre-existing and already reachable on
Windows through size-cap eviction; this change declines to widen its reach with a second caller.
On a non-unix target a legacy slot keeps its worktree until ordinary LRU or cap eviction retires
it, which is what that target did before this change.


## Non-Unix child-`.git` pinning (tracked in #2149)

The Unix path pins the child `.git` by descriptor (`openat` `O_NOFOLLOW` +
`fchdir` + `--git-dir .`), closing the symlink-swap TOCTOU on the `.git` entry.
Non-Unix targets cannot pass a directory descriptor to git, so `git_at_slot` and
`revalidate_owned_slot` fall back to resolving `--git-dir <repo>/.git` by
pathname, which stays vulnerable to a `.git` swapped for a symlink after
validation. Both fallback sites now carry an at-site comment stating the
limitation. A Windows-safe handle-pin needs platform handle APIs that cannot be
exercised on this project's macOS/Linux CI, so it is tracked as a follow-up in
#2149 rather than shipped unverified.
