### PR TITLE
docs(adr-137): amendment 1 — close the wire contract before the first consumer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,6 +60,12 @@ repos:
         language: system
         files: ^(docs/.*\.md|crates/(.*/docs/.*\.md|.*/design[^/]*\.md))$
         pass_filenames: false
+      - id: lint-adr-137-displacements
+        name: ADR-137 amendment 1 derived passages match their table
+        entry: uv run scripts/lint-adr-137-displacements.py --check
+        language: system
+        files: ^(docs/adr/ADR-137-.*\.md|scripts/data/adr-137-amendment-1-displacements\.json|scripts/lint-adr-137-displacements\.py)$
+        pass_filenames: false
 
   # TypeScript / Next.js: eslint + prettier (run via pnpm)
   - repo: local

--- a/docs/adr/ADR-137-tailnet-wire-transport.md
+++ b/docs/adr/ADR-137-tailnet-wire-transport.md
@@ -417,7 +417,9 @@ removes. **Where this amendment and the current crate documentation disagree, th
 governs, and the documentation is superseded in the following places:**
 
 - The versioning section restates the parent's compatibility rule in its unbounded form
-  (`crates/khive-wire-protocol/src/lib.rs`) — superseded by decision 1.
+  (`crates/khive-wire-protocol/src/lib.rs`) — superseded by decision 1. The displacement is bounded:
+  the compatibility rule itself is unaltered; what is displaced is its silent assumption that a
+  prior version always exists, which at the floor of `1` makes the initial supported range `[1, 1]`.
 - The module documentation's stated boundaries on optional-null equivalence and duplicate members
   (`crates/khive-wire-protocol/src/lib.rs`) — superseded by decision 4.
 - The module documentation's unknown-error-code paragraphs (`crates/khive-wire-protocol/src/lib.rs`)
@@ -438,8 +440,8 @@ governs, and the documentation is superseded in the following places:**
   The displacement is bounded: the per-field shape of a topic's payload remains the catalog's
   business; only the outermost type is displaced.
 
-Three of those entries are bounded rather than wholesale — decisions 5, 6, and 10 — and in each case
-the bound is the substance. Decision 10's is the one worth spelling out, because it displaces a
+Four of those entries are bounded rather than wholesale — decisions 1, 5, 6, and 10 — and in each
+case the bound is the substance. Decision 10's is the one worth spelling out, because it displaces a
 disclaimer rather than a statement: the crate documentation never says a non-object payload is
 acceptable, it says the shape of `event.payload` is not the crate's business. That is not a weaker
 form of the same thing. A document that disclaims ownership of a rule licenses the absence of that

--- a/docs/adr/ADR-137-tailnet-wire-transport.md
+++ b/docs/adr/ADR-137-tailnet-wire-transport.md
@@ -110,6 +110,10 @@ Wire-level errors are a closed set, distinct from verb-level DSL errors (ADR-016
 
 A connection-terminal error is followed by connection close; a request-terminal error terminates only the operation id it echoes — a request, subscribe, or unsubscribe id — and the connection stays usable. The set is closed within a protocol version: adding a code requires a protocol version bump, and a client that receives a code it does not recognize must treat it as `internal` — request-terminal, retriable only under the caller's own policy — rather than inventing semantics for it.
 
+> **Amended.** Amendment 1, decision 5, supersedes the unrecognized-code sentence above for a code
+> that arrives without an operation id. The rule as written holds for an id-bearing unknown code
+> and is wrong for an id-less one, because a request-terminal outcome needs a request to terminate.
+
 ### Limits and backpressure
 
 Every deployment configures a maximum frame size and a maximum number of in-flight requests per connection. A frame exceeding the configured size is rejected with `frame_too_large` and the connection is closed rather than partially buffered. A request arriving at the in-flight limit is rejected with `in_flight_limit_exceeded`; the connection stays open and the caller may retry after an earlier request completes. Each connection's outbound event queue is bounded; reaching that bound disconnects the subscriber with `subscriber_overflow` rather than growing server memory without limit.
@@ -145,9 +149,18 @@ Cursor scope is per topic; a cursor from one topic has no meaning for another. T
 
 Protocol version numbers are monotonic; a server supports the current version and at least the immediately prior version, and a breaking wire change — including a new frame kind or a new wire error code — is never introduced within a version number.
 
+> **Amended.** Amendment 1, decision 1, bounds the rule above at the version floor: the supported
+> range is `[max(1, current - 1), current]`, so at the current version of `1` there is no prior
+> version and the range is `[1, 1]`. Read without that bound, the sentence would require supporting
+> version `0`, which decision 1 declares invalid.
+
 ### Implementation-phase deliverables
 
 The exact numeric defaults for frame-size and in-flight-request limits, a golden-frame fixture suite, decoder fuzzing, cross-client conformance testing, and the exhaustive per-topic subscription payload catalog (the concrete list of topics and each topic's `payload` field schema, within the envelope this ADR defines above) are implementation-phase deliverables owned by the `khive-wire-protocol` crate maintainer. Enabling TCP subscriptions, or any inbound edge adapter, for any peer class is gated on that conformance suite passing, including conformance coverage of the published topic catalog; this ADR does not authorize enabling subscriptions before the gate is satisfied.
+
+> **Amended.** Amendment 1, decision 2, fixes the frame-size default at 8 MiB, so frame-size is no
+> longer among the deliverables listed above. The in-flight-request limit named in the same sentence
+> is unaffected and remains an implementation-phase deliverable.
 
 ### MCP placement
 
@@ -161,6 +174,378 @@ ADR-109's "Hard rules (not forked)" 1 (closed, explicit verb allowlist), 2 (pinn
 
 This amendment is limited to the gateway's process-boundary transport, ingress identity, and the corresponding dispatch integration. ADR-109 remains the authority for its capability declaration format, authentication resolution, and Phase B relationship (Forks (b), (c), and (d)), which this ADR does not amend. Source: ADR-109, "Decision" and "Resolutions". A future revision of ADR-109 should add a forward reference to this ADR under its "Fork (a): Process boundary" section, naming this ADR as the source of the process-boundary transport it left open.
 
+## Amendment 1: Wire-contract closure before the first consumer
+
+- **Status:** Proposed
+- **Date:** 2026-08-22
+
+### Scope and precedence
+
+The wire crate `khive-wire-protocol` implements framing, envelope grammar, and handshake
+sequencing decisions that this ADR left unstated or stated only in prose. Each such decision is
+an interoperability commitment: a second implementation written from the ADR alone would have no
+way to reproduce it, and would diverge silently rather than fail loudly. This amendment closes
+that gap by promoting each decision to specified behaviour, and, where the implemented behaviour
+is wrong for the contract, by specifying the correct behaviour and requiring the code to move.
+
+This amendment closes only the wire-level ambiguities enumerated below. It does not authorize a
+transport server, an identity mapping store, a deadline executor, or any other feature the parent
+ADR defers; those remain separately tracked. It precedes the first consumer of the crate: at the
+time of writing the crate has no in-tree consumer, so every behaviour named here can still be
+changed without a compatibility break.
+
+Each decision below is marked **RATIFIED** where the implemented behaviour is correct and this
+amendment records it as contract, or **CHANGED** where the contract differs from what the crate
+does today and the crate must move to match.
+
+### Framing and version
+
+1. **Initial version and floor — RATIFIED.** The initial protocol version is `1`. Version `0` is
+   not a valid protocol version. Initial supported range is `[1, 1]`. A handshake naming a version
+   outside the receiver's supported range is rejected rather than negotiated downward.
+
+   **The rejection layer is stated normatively because two layers could plausibly own it.** A
+   version field carrying any non-negative integer **representable as an unsigned 32-bit value**,
+   `0` included, is syntactically well-formed and MUST decode: the decoder's job is grammar, and a
+   receiver that rejected `0` as `malformed_frame` would close the connection on a frame it could
+   have answered. Admission is where the range is enforced: a handshake naming a version outside
+   the receiver's supported range, `0` and `99` alike, is rejected at handshake admission with
+   `unsupported_version`. Version `0` is therefore not special-cased on the receive path; it is out
+   of range like any other unsupported value, and the floor of `1` is what makes it out of range.
+
+   **The wire type is a 32-bit unsigned integer, and that bound is normative rather than
+   incidental.** A JSON integer too large for it, `4294967296` being the boundary case, is a
+   grammar violation and is rejected at decode as `malformed_frame`; it never reaches handshake
+   admission and never produces `unsupported_version`. Saying so is load-bearing: without the
+   bound, "any non-negative integer MUST decode" reads as arbitrary precision, and an
+   implementation built on a bignum type would admit `4294967296` and reject it at admission while
+   this one rejects it at decode. That is a disagreement at exactly the layer this decision
+   settles, so the overflow boundary is a required conformance vector rather than an edge case.
+
+   Locally constructing a version-`0` frame is a separate matter from receiving one. An encoder
+   MUST NOT emit a handshake or handshake acknowledgment naming version `0`; that is a local
+   construction error, not a wire error, and it never reaches a peer. Requiring it keeps a
+   conforming encoder from producing a frame whose only possible outcome at the far end is
+   rejection.
+
+   **This decision bounds the parent's compatibility rule at the floor, and the bound has to be
+   written down because the code already has it and the prose does not.** The parent states that a
+   server supports the current version and at least the immediately prior version. Read literally at
+   a current version of `1`, that sentence requires supporting version `0`, which the same decision
+   declares invalid. The supported range is therefore `[max(1, current - 1), current]`: the lower
+   bound saturates at the floor rather than descending below it, so at version `1` the range is
+   `[1, 1]` and there is no prior version to support. The parent sentence carries an inline note
+   pointing here, and the crate documentation restates the unbounded form in its own versioning
+   section, which the precedence list below names.
+
+   This is the quietest kind of divergence and worth stating for that reason. The implementation
+   already saturates correctly, so nothing fails and no test goes red; only the two prose statements
+   disagree with the decision, and an independent implementer working from either of them would
+   build a receiver that accepts a version the protocol does not define.
+
+2. **Frame ceiling and accounting — RATIFIED. This decision fixes the frame-size default that the
+   parent left deferred.** Frames are length-prefixed with a four-byte big-endian payload length.
+   The configurable size limit counts the serialized bytes of the JSON payload only and excludes the
+   four-byte prefix. The default limit is 8 MiB. An independent absolute ceiling of `u32::MAX`
+   bounds the prefix itself and is not configurable upward.
+
+   The parent lists "the exact numeric defaults for frame-size and in-flight-request limits" among
+   its implementation-phase deliverables, and its Consequences section repeats that "the numeric
+   limit defaults remain implementation-phase deliverables". Ratifying 8 MiB settles the first of
+   those and leaves the second standing: the in-flight-request limit is still an implementation-phase
+   deliverable, and this amendment names no value for it. Separating them is load-bearing rather
+   than tidy. A default left deferred is a default two implementations may choose differently, and a
+   frame that one accepts and the other rejects is an interoperability break with no wire error to
+   explain it. Both parent sentences carry an inline note pointing here.
+
+### Envelope grammar
+
+3. **Operation identifiers — RATIFIED.** An operation id carried on the wire is a non-empty
+   string; the empty string is rejected at decode. The crate MAY retain unrestricted in-memory
+   constructors for test and internal use, provided a frame carrying an empty id is never
+   accepted from the wire.
+
+4. **Envelope member semantics — CHANGED.** The typed frame envelope rejects unknown members,
+   rejects duplicate members, and treats omission as the only representation of an absent optional
+   envelope field; an explicit `null` is rejected rather than read as absence. The crate currently
+   allows duplicate members to collapse under last-wins before field validation runs, which makes
+   acceptance depend on member order: two documents differing only in the order of two duplicate
+   `id` values can classify differently. Duplicate rejection must therefore happen before field
+   validation, so that decision 3 is deterministic across JSON parsers.
+
+   This rule governs the envelope only. The contents of opaque subvalues are exempt, per
+   decision 9.
+
+### Error and sequence semantics
+
+5. **Unknown error codes — CHANGED. This decision supersedes the parent's unknown-code rule.**
+   The parent states under "Wire errors" that a client receiving a code it does not recognize
+   "must treat it as `internal` — request-terminal, retriable only under the caller's own policy".
+   That rule is correct for an unknown code that carries an operation id and wrong for one that
+   does not, because a request-terminal outcome needs a request to terminate. Where this decision
+   and the parent paragraph disagree, this amendment governs.
+
+   Both cases are decided at the decode boundary, so that acceptance never depends on what a
+   consumer does afterwards:
+
+   - **Unknown code WITH an operation id** — surfaced through a fallback that preserves the raw
+     code string for diagnostics, request-terminal against that id, connection stays usable. The
+     fallback frame is not re-encodable: it may be inspected but never relayed onward as though it
+     were understood. This is the parent's rule, kept.
+   - **Unknown code WITHOUT an operation id** — `malformed_frame`, connection-terminal, following
+     decision 6's id-less path. The parent's `internal` classification is superseded here.
+
+   The parent's "Wire errors" paragraph carries an inline note pointing here, so a reader who
+   lands on that paragraph and stops there does not walk away with the superseded rule.
+
+6. **Handshake sequence violations — CHANGED, and the change is one of role coverage rather than
+   of the rule.** A frame arriving before the handshake completes, a handshake frame arriving after
+   the handshake completes, and a frame arriving in the wrong direction are each `malformed_frame`
+   and each terminate the connection permanently. These are connection-terminal and carry no
+   operation id, because no operation is established. That rule is the parent's and it stands
+   unaltered.
+
+   **What must move is that the crate enforces it for one endpoint role only.** The gate is a
+   server-side inbound gate: it admits the client-to-server kinds and treats a server-to-client kind
+   as a direction violation, which is correct for a server and is the exact mirror of what a client
+   needs. A client built on this crate has no gate at all, so a `request` frame arriving at a client
+   — a direction violation by the same rule — is rejected by nothing. The decode path cannot cover
+   the gap, because it is deliberately role-agnostic and state-agnostic: it reads the length prefix
+   and decodes the payload without a direction argument or a handshake state, and it is correct for
+   it to stay that way.
+
+   A conforming implementation MUST therefore enforce the sequence and direction rules on both
+   endpoint roles, with the admissible frame-kind set mirrored per role. Labelling this RATIFIED
+   would have been the more comfortable reading and it would have been false in a way that matters:
+   the implementation fence below turns on the CHANGED set being exactly right, and the conformance
+   matrix requires each vector to name the endpoint direction it is decoded at. A matrix with a
+   direction field, run against a crate that gates one direction, cannot execute half its own rows.
+
+### Server-produced fields
+
+7. **Topic validation boundary — RATIFIED.** The codec accepts any string in a topic position.
+   Catalog authorization is enforced at the server boundary, not in the codec. Codec permissiveness
+   is not permission to produce arbitrary topics: a conforming server emits only catalog-valid
+   topics. Both halves are stated because acceptance of a string must not be mistaken for licence
+   to send one.
+
+8. **Event timestamp boundary — RATIFIED.** The codec accepts any string in `occurred_at`. A
+   conforming server emits RFC 3339. As with decision 7, decoder permissiveness and producer
+   obligation are separate, and an independent implementation must not infer the second from the
+   first.
+
+### Opaque payload fidelity
+
+9. **Opaque subvalue preservation — CHANGED.** The contents of `response.result` and
+   `event.payload` are opaque to this crate. The crate currently documents and tests semantic
+   rather than lexical preservation, so a value that is decoded and re-encoded can come out with
+   members reordered and a number's lexeme changed. That is acceptable for an endpoint that parses
+   the value and wrong for anything that forwards it, and the transport's default must serve the
+   forwarding case, because the fields are declared opaque and no consumer yet constrains them.
+
+   **The conformance operation is decode-then-encode over a single frame, and nothing else.** For
+   a frame decoded from bytes and re-encoded without the holder modifying that subvalue, the bytes
+   of `response.result` and `event.payload` in the output must be identical to the bytes occupying
+   that subvalue's span in the input. Stating the operation is load-bearing: this crate performs no
+   I/O and exposes no "relay", so a requirement phrased against relaying names an operation that
+   does not exist and cannot be tested. Decode-then-encode is the only operation the crate has, and
+   it is the one a forwarding consumer composes.
+
+   **The span is the complete raw byte range of the value, and every byte in it is preserved.** It
+   begins at the first byte of the value's first token and ends at the last byte of its last token.
+   Interior whitespace is inside the span and is preserved with everything else; no normalization
+   is permitted anywhere within it. An earlier draft of this decision allowed an implementation to
+   normalize interior whitespace, which contradicted the byte-exactness it was defining: two
+   implementations could then produce different output from one input and both claim conformance,
+   which is the disagreement the decision exists to remove. Preservation is also the cheaper rule
+   to implement, since an implementation satisfying this decision already holds the raw bytes and
+   normalizing would be extra work.
+
+   Consequences of that span, each stated because it is otherwise implementation-defined:
+
+   - **Preserved,** as part of the raw span: member order, the original lexical form of numbers,
+     string escape sequences as written, interior whitespace, and any duplicate members nested
+     _inside_ the opaque subvalue. Duplicate rejection under decision 4 governs the typed envelope
+     only, and must not be applied recursively into an opaque subvalue.
+   - **Outside the span, and therefore not governed here:** whitespace before the value's first
+     token or after its last, which belongs to the enclosing envelope; envelope formatting
+     generally; and any value the holder constructed locally rather than receiving, which has no
+     source bytes to preserve and is encoded by the ordinary serializer.
+
+   **This requires a representation the current typed structs cannot provide.** `serde_json::Value`
+   discards member order and number lexemes at parse time, so satisfying this decision means
+   carrying the received subvalue as its source bytes (for example a raw-value representation
+   retained alongside, or in place of, the parsed view). An implementation MAY additionally expose
+   a parsed convenience view; it MAY NOT make the parsed view the only representation. This is the
+   concrete work decision 9 fences.
+
+   This requirement does not make envelope formatting byte-stable and does not require whole-frame
+   verbatim forwarding.
+
+### Payload shape
+
+10. **`event.payload` must be a JSON object — CHANGED.** The parent ADR specifies `payload` as "a
+    topic-specific JSON object whose exact field-by-field shape this ADR delegates, by name, to
+    the implementation-phase topic catalog below". The crate types the field as an arbitrary JSON
+    value, so a scalar, array, or `null` payload is accepted on the wire while an implementation
+    written from the ADR would reject it. The object requirement is retained: "field-by-field"
+    presupposes fields, and an object is the only shape a topic catalog can extend compatibly,
+    whereas a scalar payload cannot gain a field without a breaking change.
+
+    **The requirement binds both directions, and saying only "at decode" would leave the contract
+    open on the side that matters more.** A decoder MUST reject a non-object `event.payload`. An
+    encoder MUST also reject one, as a local construction error in the manner of decision 1's
+    version-`0` clause, so a conforming implementation cannot put a frame on the wire that a
+    conforming peer must refuse. The crate currently enforces neither: the encode-side validator
+    matches `Frame::Event` and performs no shape check, so `encode_frame` will emit a scalar,
+    array, or `null` payload today. A decode-only rule would leave exactly that behaviour legal,
+    and the resulting split — one implementation sending what another must reject — is the
+    interoperability failure this amendment exists to prevent. Both directions therefore need
+    conformance vectors.
+
+    This item was found while confirming the others and is recorded here rather than deferred,
+    because an amendment that claims to close the wire contract while leaving a known frame-shape
+    divergence open would misrepresent its own completeness.
+
+### Precedence over the crate documentation
+
+The parent states that the crate's own documentation "is the normative wire specification", which
+makes that documentation a second authority and not merely a description. Six of the ten decisions
+above contradict it as it stands today — decisions 1, 4, 5, 6, 9, and 10 — so a second implementer
+reading the crate docs, exactly as the parent instructs, would build behaviour this amendment
+removes. **Where this amendment and the current crate documentation disagree, this amendment
+governs, and the documentation is superseded in the following places:**
+
+- The versioning section restates the parent's compatibility rule in its unbounded form
+  (`crates/khive-wire-protocol/src/lib.rs`) — superseded by decision 1.
+- The module documentation's stated boundaries on optional-null equivalence and duplicate members
+  (`crates/khive-wire-protocol/src/lib.rs`) — superseded by decision 4.
+- The module documentation's unknown-error-code paragraphs (`crates/khive-wire-protocol/src/lib.rs`)
+  and the wire-error module's own documentation, which quotes the parent's superseded sentence
+  verbatim and presents it as the governing rule (`crates/khive-wire-protocol/src/error.rs`) —
+  superseded by decision 5. The displacement is bounded: for the id-less case only, per that
+  decision's own split.
+- The handshake gate's documentation, which presents a server-side-only gate as the implementation
+  of the sequence rule (`crates/khive-wire-protocol/src/lib.rs`) and the handshake module's own
+  scope statement (`crates/khive-wire-protocol/src/handshake.rs`) — superseded by decision 6. The
+  displacement is bounded: the rule is unaltered; what is displaced is its scoping to one endpoint
+  role.
+- The module documentation's opaque-payload-fidelity section, together with the named codec test it
+  cites as pinning that behaviour (`crates/khive-wire-protocol/src/lib.rs`) — superseded by decision
+  9.
+- The characterization of `event.payload` as data whose shape the crate does not own, as it applies
+  to the outermost type only (`crates/khive-wire-protocol/src/lib.rs`) — superseded by decision 10.
+  The displacement is bounded: the per-field shape of a topic's payload remains the catalog's
+  business; only the outermost type is displaced.
+
+Three of those entries are bounded rather than wholesale — decisions 5, 6, and 10 — and in each case
+the bound is the substance. Decision 10's is the one worth spelling out, because it displaces a
+disclaimer rather than a statement: the crate documentation never says a non-object payload is
+acceptable, it says the shape of `event.payload` is not the crate's business. That is not a weaker
+form of the same thing. A document that disclaims ownership of a rule licenses the absence of that
+rule just as effectively as one that states the permissive version, and the reader who follows the
+disclaimer arrives at the same wrong implementation.
+
+**This list is a debt, not a resolution.** The implementation that ratifies these decisions updates
+the crate documentation in the same change, at which point this section becomes redundant and
+should be deleted rather than left standing as a permanent second source of truth.
+
+### Implementation fences
+
+- An implementation MAY retain unrestricted in-memory constructors, parsed convenience views over
+  opaque values, and server-side topic and timestamp validation, provided the wire behaviour
+  specified above remains observable from outside.
+- An implementation MAY NOT add frame kinds or error codes under this amendment, and MAY NOT fold
+  the separately tracked server, identity-mapping, or deadline work into it.
+- **No first consumer of `khive-wire-protocol` may merge while any decision marked CHANGED above
+  still implements the superseded behaviour.** Those are decisions 4, 5, 6, 9, and 10 — five of the
+  ten.
+  A consumer merged against the old behaviour converts each of them from a free correction into a
+  compatibility break, which is precisely the cost this amendment exists to avoid. Decision 6 is in
+  that set for a different reason than the others: its rule is not changing, its role coverage is,
+  and a consumer that ships a client without the mirrored gate is as hard to correct afterwards as
+  one that ships the wrong rule.
+
+### Conformance
+
+**This is a requirement on ratification, not a description of what exists.** No vector matrix is
+checked in today. `crates/khive-wire-protocol/tests/` holds eleven golden hex fixtures, one
+well-formed frame per kind, and `golden_frames.rs`, which exercises those fixtures and a set of
+malformed-frame cases. That is a useful regression floor and it is not a conformance matrix: it
+carries no negative vectors for the rules this amendment changes, no independent implementation,
+and no agreement criterion between implementations. Saying so plainly is the point of this
+section. An amendment that asserted its own verification in the present tense would hand a reader
+an unlocatable artifact and make every normative claim above unreproducible.
+
+**This amendment MUST NOT be ratified until the matrix is checked in.** The artifact is a set of
+vectors under `crates/khive-wire-protocol/tests/`, plus a runner that executes them against an
+implementation.
+
+**A vector is not a byte string paired with an outcome, because the rules above are stateful and
+they do not all live at the same stage.** Whether a `handshake` frame is legal depends on whether
+the handshake has already completed, and whether a `response` frame is legal depends on which end
+received it — the same bytes classify differently in each case. Two rules above are also split
+across stages on purpose: decision 1 requires version `0` to decode successfully and then be
+rejected at handshake admission, and decisions 1 and 10 both require an encoder to refuse a frame
+that has no wire representation at all. A schema with one outcome field cannot express either.
+
+**Every vector therefore names the stage it exercises**, one of `decode`, `admit`, or `encode`, and
+carries the fields that stage has:
+
+- **Stage `decode`** — endpoint direction, the input bytes, and an expected outcome of _accepted_
+  (yielding a frame) or _rejected_ with a named wire error code and its terminal scope. Grammar
+  only: a value the grammar admits is accepted here even when a later stage will refuse it.
+- **Stage `admit`** — endpoint direction, an ordered sequence of preceding frames or an explicit
+  statement of the gate state the vector begins from, the already-decoded frame under test, and an
+  expected outcome of _admitted_ or _rejected_ with a named wire error code and its terminal scope.
+  A one-frame vector states "fresh connection, handshake not yet completed".
+- **Stage `encode`** — the locally constructed frame under test and an expected outcome of _emitted_
+  (yielding bytes) or _refused as a local construction error_. A refusal at this stage carries no
+  wire error code and no terminal scope, because nothing reached a wire and no connection exists to
+  terminate. A vector that demanded one of an encode case would be unsatisfiable by construction.
+
+**A rule split across stages is covered by one vector per stage, and both are required.** Version
+`0` is the worked example: a `decode` vector asserting _accepted_, and an `admit` vector on the
+resulting frame asserting _rejected, `unsupported_version`, connection-terminal_. Either vector
+alone proves the opposite of decision 1 from the other stage's point of view, which is exactly the
+disagreement the decision was written to settle.
+
+Required coverage, positive and negative, is every rule above, each at the stage or stages that
+rule lives at: boundary frame lengths on both sides of the limit; version zero at both `decode` and
+`admit` per the split above, out-of-range versions at `admit`, and the `4294967296` overflow
+boundary from decision 1 at `decode`; empty operation ids; unknown and duplicate and
+explicitly-null envelope members; both id-bearing and id-less unknown error codes; each of the
+three handshake sequence violations from decision 6, **at `admit` and once per endpoint role**,
+since that decision's whole change is role coverage; arbitrary topic and timestamp strings; opaque
+subvalues that round-trip byte-exactly; a version-`0` handshake at `encode`, expected refused as a
+local construction error per decision 1; and non-object event payloads at both `decode` and
+`encode` per decision 10, the second expected refused as a local construction error.
+
+**Consumed frame length is an agreement criterion for accepted frames only.** A decode error in
+this crate deliberately carries no consumed count: once a frame fails to decode the stream
+position is unrecoverable, the error is connection-terminal, and a transport is required to close
+rather than resynchronize. Asking two implementations to agree on where a rejected frame ended
+would demand a value one of them is designed not to produce, which would make the gate
+unexecutable rather than strict. For rejected frames the agreement criteria are the
+classification and the terminal scope; the length criterion does not apply.
+
+Vectors MUST be run through the Rust crate and through at least one independent JSON
+implementation, which must agree on:
+
+- the outcome of every vector, in that vector's stage vocabulary: accepted or rejected at `decode`,
+  admitted or rejected at `admit`, emitted or refused at `encode`;
+- the wire error code and terminal scope of each `decode` or `admit` rejection. An `encode` refusal
+  has neither, and the two implementations are required to agree only that the frame was refused —
+  how each reports a local construction error is its own business, and demanding a shared spelling
+  for it would export this crate's error type into the contract;
+- consumed frame length, for accepted `decode` vectors only, per the paragraph above;
+- byte-exact opaque-subvalue round trip under the decode-then-encode operation defined in
+  decision 9.
+
+The independent implementation is what makes the matrix a conformance artifact rather than a
+second copy of this crate's own assumptions, and it is why decision 9 had to name a concrete
+operation: a second implementation cannot be tested against a requirement phrased as an intention.
+
 ## Consequences
 
 The daemon gains a location-transparent wire transport while retaining one framing and dispatch contract. The shared crate makes version and frame-kind changes reviewable as protocol changes instead of client-specific conventions.
@@ -168,6 +553,9 @@ The daemon gains a location-transparent wire transport while retaining one frami
 The server becomes responsible for remote identity proof, actor mapping, and peer-class admission. This increases operational responsibility for the mapping table and for availability of `tailscale whois`, but it prevents a remote caller from selecting an actor through frame content, and the one-node-one-boundary rule makes node placement of processes an explicit deployment decision rather than an implicit trust grant.
 
 Subscription delivery becomes part of the same authenticated connection as requests, using the topic namespace, payload envelope, ordering guarantee, and authorization hook this ADR defines in "Protocol contract completeness." Only the exhaustive per-topic payload catalog and the numeric limit defaults remain implementation-phase deliverables, gated on the conformance suite as specified there.
+
+> **Amended.** Amendment 1, decision 2, fixes the frame-size default at 8 MiB. "The numeric limit
+> defaults" in the sentence above now refers to the in-flight-request limit alone.
 
 Remote clients receive explicit endpoint failures rather than implicit local recovery. Deployments must therefore provision an endpoint selector, connection diagnostics, and operator remediation for unavailable remote services.
 

--- a/scripts/data/adr-137-amendment-1-displacements.json
+++ b/scripts/data/adr-137-amendment-1-displacements.json
@@ -1,5 +1,6 @@
 {
   "_source": "Which sentences of ADR-137 and of the khive-wire-protocol crate documentation each Amendment 1 decision displaces. The derived passages of the amendment's 'Precedence over the crate documentation' and 'Implementation fences' sections are generated from this table by scripts/lint-adr-137-displacements.py, which also cross-checks every decision's label against the ADR's own heading text. Rows are established by reading the cited sources directly; a field name is not a reliable key for this work, the call site is.",
+  "_citations": "A cite names a FILE and never a line number. Line numbers were carried here until 2026-08-22 and were measured wrong in two rows: the amendment's own 388 inserted lines moved the ADR under its own table, which is self-invalidating by construction, and nothing consumed the numbers so nothing kept them honest. The locator is now the quote. Every string in `quotes` must appear VERBATIM in the cited file after doc-comment markers are stripped and whitespace is collapsed, and the check resolves each one to a current line number at run time. That normalization is canonicalization of a known syntax, not fuzzy matching: the comparison after it is still exact, because a tolerant match is what let a lowercased quote in decision 2 resolve to an unrelated passage 93 lines away.",
   "_row6_note": "Decision 6 is recorded against the amendment text as it now stands, in which the decision requires the sequence and direction rules on BOTH endpoint roles. An earlier draft of the decision covered the server role only, and under that reading the crate documentation displaced nothing, because the crate already documents a server-side gate. Under the current reading the two statements that scope the gate to the server are exactly what is displaced. The row is stated here so that a reader can see the crate documentation changed status because the decision widened, not because the crate changed.",
   "decisions": [
     {
@@ -8,14 +9,18 @@
       "subject": "Initial version and floor",
       "parent_displaced": [
         {
-          "cite": "docs/adr/ADR-137-tailnet-wire-transport.md:150",
-          "quote": "a server supports the current version and at least the immediately prior version"
+          "cite": "docs/adr/ADR-137-tailnet-wire-transport.md",
+          "quotes": [
+            "Protocol version numbers are monotonic; a server supports the current version and at least the immediately prior version"
+          ]
         }
       ],
       "crate_displaced": [
         {
-          "cite": "crates/khive-wire-protocol/src/lib.rs:251-253",
-          "quote": "A server supports the current version and at least the immediately prior version.",
+          "cite": "crates/khive-wire-protocol/src/lib.rs",
+          "quotes": [
+            "A server supports the current version and at least the immediately prior version"
+          ],
           "gloss": "the versioning section restates the parent's compatibility rule in its unbounded form"
         }
       ],
@@ -27,12 +32,16 @@
       "subject": "Frame ceiling and accounting",
       "parent_displaced": [
         {
-          "cite": "docs/adr/ADR-137-tailnet-wire-transport.md:154",
-          "quote": "the exact numeric defaults for frame-size ... limits"
+          "cite": "docs/adr/ADR-137-tailnet-wire-transport.md",
+          "quotes": [
+            "The exact numeric defaults for frame-size and in-flight-request limits"
+          ]
         },
         {
-          "cite": "docs/adr/ADR-137-tailnet-wire-transport.md:434",
-          "quote": "the numeric limit defaults remain implementation-phase deliverables"
+          "cite": "docs/adr/ADR-137-tailnet-wire-transport.md",
+          "quotes": [
+            "Only the exhaustive per-topic payload catalog and the numeric limit defaults remain implementation-phase deliverables"
+          ]
         }
       ],
       "crate_displaced": [],
@@ -53,8 +62,11 @@
       "parent_displaced": [],
       "crate_displaced": [
         {
-          "cite": "crates/khive-wire-protocol/src/lib.rs:112-121",
-          "quote": "Explicit `null` on an optional field is equivalent to absence ... Duplicate members are last-wins, not rejected.",
+          "cite": "crates/khive-wire-protocol/src/lib.rs",
+          "quotes": [
+            "Explicit `null` on an optional field is equivalent to absence.",
+            "Duplicate members are last-wins, not rejected."
+          ],
           "gloss": "the module documentation's stated boundaries on optional-null equivalence and duplicate members"
         }
       ],
@@ -66,19 +78,25 @@
       "subject": "Unknown error codes",
       "parent_displaced": [
         {
-          "cite": "docs/adr/ADR-137-tailnet-wire-transport.md:111",
-          "quote": "must treat it as `internal` — request-terminal"
+          "cite": "docs/adr/ADR-137-tailnet-wire-transport.md",
+          "quotes": [
+            "a client that receives a code it does not recognize must treat it as `internal` — request-terminal"
+          ]
         }
       ],
       "crate_displaced": [
         {
-          "cite": "crates/khive-wire-protocol/src/lib.rs:204,218-227,243-247",
-          "quote": "an unrecognized code falls back to `internal`, request-terminal",
+          "cite": "crates/khive-wire-protocol/src/lib.rs",
+          "quotes": [
+            "an unrecognized code falls back to `internal`"
+          ],
           "gloss": "the module documentation's unknown-error-code paragraphs"
         },
         {
-          "cite": "crates/khive-wire-protocol/src/error.rs:29-45",
-          "quote": "unknown codes fall back rather than decode-failing and are treated as `internal` despite unknown scope",
+          "cite": "crates/khive-wire-protocol/src/error.rs",
+          "quotes": [
+            "its true scope is unknown to this protocol version, and ADR-137 directs the client to treat it as `internal` rather than reject the frame."
+          ],
           "gloss": "the wire-error module's own documentation, which quotes the parent's superseded sentence verbatim and presents it as the governing rule"
         }
       ],
@@ -92,13 +110,17 @@
       "parent_displaced": [],
       "crate_displaced": [
         {
-          "cite": "crates/khive-wire-protocol/src/lib.rs:172-176",
-          "quote": "implements the server side of this sequence as a type",
+          "cite": "crates/khive-wire-protocol/src/lib.rs",
+          "quotes": [
+            "implements the server side of this sequence as a type"
+          ],
           "gloss": "the handshake gate's documentation, which presents a server-side-only gate as the implementation of the sequence rule"
         },
         {
-          "cite": "crates/khive-wire-protocol/src/handshake.rs:1-2",
-          "quote": "The server-side handshake state machine",
+          "cite": "crates/khive-wire-protocol/src/handshake.rs",
+          "quotes": [
+            "The server-side handshake state machine"
+          ],
           "gloss": "the handshake module's own scope statement"
         }
       ],
@@ -128,8 +150,10 @@
       "parent_displaced": [],
       "crate_displaced": [
         {
-          "cite": "crates/khive-wire-protocol/src/lib.rs:129-145",
-          "quote": "semantic equality, not byte-for-byte",
+          "cite": "crates/khive-wire-protocol/src/lib.rs",
+          "quotes": [
+            "semantic equality, not byte-for-byte"
+          ],
           "gloss": "the module documentation's opaque-payload-fidelity section, together with the named codec test it cites as pinning that behaviour"
         }
       ],
@@ -142,8 +166,10 @@
       "parent_displaced": [],
       "crate_displaced": [
         {
-          "cite": "crates/khive-wire-protocol/src/lib.rs:103-107",
-          "quote": "data, not grammar",
+          "cite": "crates/khive-wire-protocol/src/lib.rs",
+          "quotes": [
+            "data, not grammar"
+          ],
           "gloss": "the characterization of `event.payload` as data whose shape the crate does not own, as it applies to the outermost type only"
         }
       ],

--- a/scripts/data/adr-137-amendment-1-displacements.json
+++ b/scripts/data/adr-137-amendment-1-displacements.json
@@ -1,0 +1,154 @@
+{
+  "_source": "Which sentences of ADR-137 and of the khive-wire-protocol crate documentation each Amendment 1 decision displaces. The derived passages of the amendment's 'Precedence over the crate documentation' and 'Implementation fences' sections are generated from this table by scripts/lint-adr-137-displacements.py, which also cross-checks every decision's label against the ADR's own heading text. Rows are established by reading the cited sources directly; a field name is not a reliable key for this work, the call site is.",
+  "_row6_note": "Decision 6 is recorded against the amendment text as it now stands, in which the decision requires the sequence and direction rules on BOTH endpoint roles. An earlier draft of the decision covered the server role only, and under that reading the crate documentation displaced nothing, because the crate already documents a server-side gate. Under the current reading the two statements that scope the gate to the server are exactly what is displaced. The row is stated here so that a reader can see the crate documentation changed status because the decision widened, not because the crate changed.",
+  "decisions": [
+    {
+      "n": 1,
+      "label": "RATIFIED",
+      "subject": "Initial version and floor",
+      "parent_displaced": [
+        {
+          "cite": "docs/adr/ADR-137-tailnet-wire-transport.md:150",
+          "quote": "a server supports the current version and at least the immediately prior version"
+        }
+      ],
+      "crate_displaced": [
+        {
+          "cite": "crates/khive-wire-protocol/src/lib.rs:251-253",
+          "quote": "A server supports the current version and at least the immediately prior version.",
+          "gloss": "the versioning section restates the parent's compatibility rule in its unbounded form"
+        }
+      ],
+      "explicit": "no"
+    },
+    {
+      "n": 2,
+      "label": "RATIFIED",
+      "subject": "Frame ceiling and accounting",
+      "parent_displaced": [
+        {
+          "cite": "docs/adr/ADR-137-tailnet-wire-transport.md:154",
+          "quote": "the exact numeric defaults for frame-size ... limits"
+        },
+        {
+          "cite": "docs/adr/ADR-137-tailnet-wire-transport.md:434",
+          "quote": "the numeric limit defaults remain implementation-phase deliverables"
+        }
+      ],
+      "crate_displaced": [],
+      "explicit": "no"
+    },
+    {
+      "n": 3,
+      "label": "RATIFIED",
+      "subject": "Operation identifiers",
+      "parent_displaced": [],
+      "crate_displaced": [],
+      "explicit": "n-a"
+    },
+    {
+      "n": 4,
+      "label": "CHANGED",
+      "subject": "Envelope member semantics",
+      "parent_displaced": [],
+      "crate_displaced": [
+        {
+          "cite": "crates/khive-wire-protocol/src/lib.rs:112-121",
+          "quote": "Explicit `null` on an optional field is equivalent to absence ... Duplicate members are last-wins, not rejected.",
+          "gloss": "the module documentation's stated boundaries on optional-null equivalence and duplicate members"
+        }
+      ],
+      "explicit": "no"
+    },
+    {
+      "n": 5,
+      "label": "CHANGED",
+      "subject": "Unknown error codes",
+      "parent_displaced": [
+        {
+          "cite": "docs/adr/ADR-137-tailnet-wire-transport.md:111",
+          "quote": "must treat it as `internal` — request-terminal"
+        }
+      ],
+      "crate_displaced": [
+        {
+          "cite": "crates/khive-wire-protocol/src/lib.rs:204,218-227,243-247",
+          "quote": "an unrecognized code falls back to `internal`, request-terminal",
+          "gloss": "the module documentation's unknown-error-code paragraphs"
+        },
+        {
+          "cite": "crates/khive-wire-protocol/src/error.rs:29-45",
+          "quote": "unknown codes fall back rather than decode-failing and are treated as `internal` despite unknown scope",
+          "gloss": "the wire-error module's own documentation, which quotes the parent's superseded sentence verbatim and presents it as the governing rule"
+        }
+      ],
+      "explicit": "yes",
+      "scope_note": "for the id-less case only, per that decision's own split"
+    },
+    {
+      "n": 6,
+      "label": "CHANGED",
+      "subject": "Handshake sequence violations",
+      "parent_displaced": [],
+      "crate_displaced": [
+        {
+          "cite": "crates/khive-wire-protocol/src/lib.rs:172-176",
+          "quote": "implements the server side of this sequence as a type",
+          "gloss": "the handshake gate's documentation, which presents a server-side-only gate as the implementation of the sequence rule"
+        },
+        {
+          "cite": "crates/khive-wire-protocol/src/handshake.rs:1-2",
+          "quote": "The server-side handshake state machine",
+          "gloss": "the handshake module's own scope statement"
+        }
+      ],
+      "explicit": "yes",
+      "scope_note": "the rule is unaltered; what is displaced is its scoping to one endpoint role"
+    },
+    {
+      "n": 7,
+      "label": "RATIFIED",
+      "subject": "Topic validation boundary",
+      "parent_displaced": [],
+      "crate_displaced": [],
+      "explicit": "n-a"
+    },
+    {
+      "n": 8,
+      "label": "RATIFIED",
+      "subject": "Event timestamp boundary",
+      "parent_displaced": [],
+      "crate_displaced": [],
+      "explicit": "n-a"
+    },
+    {
+      "n": 9,
+      "label": "CHANGED",
+      "subject": "Opaque subvalue preservation",
+      "parent_displaced": [],
+      "crate_displaced": [
+        {
+          "cite": "crates/khive-wire-protocol/src/lib.rs:129-145",
+          "quote": "semantic equality, not byte-for-byte",
+          "gloss": "the module documentation's opaque-payload-fidelity section, together with the named codec test it cites as pinning that behaviour"
+        }
+      ],
+      "explicit": "no"
+    },
+    {
+      "n": 10,
+      "label": "CHANGED",
+      "subject": "`event.payload` must be a JSON object",
+      "parent_displaced": [],
+      "crate_displaced": [
+        {
+          "cite": "crates/khive-wire-protocol/src/lib.rs:103-107",
+          "quote": "data, not grammar",
+          "gloss": "the characterization of `event.payload` as data whose shape the crate does not own, as it applies to the outermost type only"
+        }
+      ],
+      "explicit": "no",
+      "scope_note": "the per-field shape of a topic's payload remains the catalog's business; only the outermost type is displaced"
+    }
+  ]
+}

--- a/scripts/data/adr-137-amendment-1-displacements.json
+++ b/scripts/data/adr-137-amendment-1-displacements.json
@@ -24,7 +24,8 @@
           "gloss": "the versioning section restates the parent's compatibility rule in its unbounded form"
         }
       ],
-      "explicit": "no"
+      "explicit": "no",
+      "scope_note": "the compatibility rule itself is unaltered; what is displaced is its silent assumption that a prior version always exists, which at the floor of `1` makes the initial supported range `[1, 1]`"
     },
     {
       "n": 2,
@@ -88,7 +89,8 @@
         {
           "cite": "crates/khive-wire-protocol/src/lib.rs",
           "quotes": [
-            "an unrecognized code falls back to `internal`"
+            "an unrecognized code falls back to `internal`",
+            "a client that decodes a code it does not recognize treats it as `internal` (request-terminal) rather than inventing semantics for it"
           ],
           "gloss": "the module documentation's unknown-error-code paragraphs"
         },

--- a/scripts/data/adr-137-amendment-1-displacements.json
+++ b/scripts/data/adr-137-amendment-1-displacements.json
@@ -1,5 +1,6 @@
 {
   "_source": "Which sentences of ADR-137 and of the khive-wire-protocol crate documentation each Amendment 1 decision displaces. The derived passages of the amendment's 'Precedence over the crate documentation' and 'Implementation fences' sections are generated from this table by scripts/lint-adr-137-displacements.py, which also cross-checks every decision's label against the ADR's own heading text. Rows are established by reading the cited sources directly; a field name is not a reliable key for this work, the call site is.",
+  "_scope_kinds": "A displacement is bounded when the parent rule survives and only its scope moves. `scope_kind` is a CLOSED vocabulary and is what the generated count and membership list are derived from; `scope_note` is the prose explanation for a reader and is never counted. They were one field until 2026-08-22, when decision 1 turned out to be bounded in fact while carrying no note, so a published count silently omitted it. The checker rejects an unknown kind, a note without a kind, a kind without a note, and a kind on a row that displaces no crate passage.",
   "_citations": "A cite names a FILE and never a line number. Line numbers were carried here until 2026-08-22 and were measured wrong in two rows: the amendment's own 388 inserted lines moved the ADR under its own table, which is self-invalidating by construction, and nothing consumed the numbers so nothing kept them honest. The locator is now the quote. Every string in `quotes` must appear VERBATIM in the cited file after doc-comment markers are stripped and whitespace is collapsed, and the check resolves each one to a current line number at run time. That normalization is canonicalization of a known syntax, not fuzzy matching: the comparison after it is still exact, because a tolerant match is what let a lowercased quote in decision 2 resolve to an unrelated passage 93 lines away.",
   "_row6_note": "Decision 6 is recorded against the amendment text as it now stands, in which the decision requires the sequence and direction rules on BOTH endpoint roles. An earlier draft of the decision covered the server role only, and under that reading the crate documentation displaced nothing, because the crate already documents a server-side gate. Under the current reading the two statements that scope the gate to the server are exactly what is displaced. The row is stated here so that a reader can see the crate documentation changed status because the decision widened, not because the crate changed.",
   "decisions": [
@@ -25,6 +26,7 @@
         }
       ],
       "explicit": "no",
+      "scope_kind": "version_floor",
       "scope_note": "the compatibility rule itself is unaltered; what is displaced is its silent assumption that a prior version always exists, which at the floor of `1` makes the initial supported range `[1, 1]`"
     },
     {
@@ -103,6 +105,7 @@
         }
       ],
       "explicit": "yes",
+      "scope_kind": "idless_error",
       "scope_note": "for the id-less case only, per that decision's own split"
     },
     {
@@ -127,6 +130,7 @@
         }
       ],
       "explicit": "yes",
+      "scope_kind": "endpoint_role",
       "scope_note": "the rule is unaltered; what is displaced is its scoping to one endpoint role"
     },
     {
@@ -176,6 +180,7 @@
         }
       ],
       "explicit": "no",
+      "scope_kind": "outermost_shape",
       "scope_note": "the per-field shape of a topic's payload remains the catalog's business; only the outermost type is displaced"
     }
   ]

--- a/scripts/lint-adr-137-displacements.py
+++ b/scripts/lint-adr-137-displacements.py
@@ -220,11 +220,12 @@ def precedence_passage(decisions: list[dict]) -> str:
     for d in displacing:
         sites = []
         for site in d["crate_displaced"]:
-            # The table carries line ranges; the ADR carries only the file. The
-            # decisions marked CHANGED require editing these very files, so a line
-            # range published here is stale by the time anyone acts on it. The
-            # passage name is what makes the citation findable either way.
-            path = site["cite"].split(":", 1)[0]
+            # The table carries a file path and quoted passages, never a line
+            # number: the decisions marked CHANGED require editing these very
+            # files, so a line published here is stale by the time anyone acts on
+            # it. check_citations rejects a cite carrying one and derives the
+            # current line from the quote at run time, for diagnostics only.
+            path = site["cite"]
             gloss = site.get("gloss") or f"the documentation in `{path}`"
             sites.append(f"{gloss} (`{path}`)")
         body = english_list(sites)

--- a/scripts/lint-adr-137-displacements.py
+++ b/scripts/lint-adr-137-displacements.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Generate and check the derived passages of ADR-137 Amendment 1.
+
+Two sentences in the amendment state quantities and set memberships that a reader
+cannot check without redoing the audit: how many decisions displace the crate
+documentation, which ones they are, and which decisions carry the CHANGED label
+that the implementation fence turns on. Typing those is how they go wrong. This
+script derives all of them from `.khive/displacements.json`, and cross-checks the
+label of every decision against the ADR's own heading text so the table cannot
+drift from the document it describes without the check failing.
+
+  uv run scripts/lint-adr-137-displacements.py           # print the generated passages
+  uv run scripts/lint-adr-137-displacements.py --check   # verify the ADR contains them
+
+--check is the mode the pre-commit hook runs, so an edit to either the ADR or
+the table that leaves the two disagreeing fails before it can be committed.
+
+Exit status is nonzero if a label disagrees, or, under --check, if a generated
+passage is absent from the ADR.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import textwrap
+from pathlib import Path
+
+WIDTH = 100  # the ADR hard-wraps its prose; generated passages must match or the diff lies
+
+ROOT = Path(__file__).resolve().parents[1]
+TABLE = ROOT / "scripts" / "data" / "adr-137-amendment-1-displacements.json"
+ADR = ROOT / "docs" / "adr" / "ADR-137-tailnet-wire-transport.md"
+
+WORDS = {
+    1: "One", 2: "Two", 3: "Three", 4: "Four", 5: "Five",
+    6: "Six", 7: "Seven", 8: "Eight", 9: "Nine", 10: "Ten",
+}
+DECISION_HEADING = re.compile(r"^(\d+)\. \*\*(.+?) — (RATIFIED|CHANGED)", re.M)
+
+
+def wrap(text: str, bullet: bool = False) -> str:
+    return textwrap.fill(
+        text,
+        width=WIDTH,
+        initial_indent="- " if bullet else "",
+        subsequent_indent="  " if bullet else "",
+        break_long_words=False,
+        break_on_hyphens=False,
+    )
+
+
+def english_list(items: list[str]) -> str:
+    """Join as prose: 'a', 'a and b', 'a, b, and c'."""
+    if len(items) == 1:
+        return items[0]
+    if len(items) == 2:
+        return f"{items[0]} and {items[1]}"
+    return ", ".join(items[:-1]) + f", and {items[-1]}"
+
+
+def labels_from_adr(text: str) -> dict[int, str]:
+    return {int(n): label for n, _subject, label in DECISION_HEADING.findall(text)}
+
+
+def check_labels(decisions: list[dict], adr_text: str) -> list[str]:
+    """The table's labels must equal the ADR's own. Returns a list of complaints."""
+    from_adr = labels_from_adr(adr_text)
+    complaints = []
+    if len(from_adr) != len(decisions):
+        complaints.append(
+            f"the ADR carries {len(from_adr)} numbered decisions, the table has {len(decisions)}"
+        )
+    for d in decisions:
+        got = from_adr.get(d["n"])
+        if got is None:
+            complaints.append(f"decision {d['n']} is in the table but not in the ADR")
+        elif got != d["label"]:
+            complaints.append(
+                f"decision {d['n']}: table says {d['label']}, the ADR says {got}"
+            )
+    return complaints
+
+
+def precedence_passage(decisions: list[dict]) -> str:
+    displacing = [d for d in decisions if d["crate_displaced"]]
+    numbers = english_list([str(d["n"]) for d in displacing])
+
+    lead = (
+        f"The parent states that the crate's own documentation \"is the normative wire "
+        f"specification\", which makes that documentation a second authority and not merely a "
+        f"description. {WORDS[len(displacing)]} of the {WORDS[len(decisions)].lower()} decisions "
+        f"above contradict it as it stands today — decisions {numbers} — so a second implementer "
+        f"reading the crate docs, exactly as the parent instructs, would build behaviour this "
+        f"amendment removes. **Where this amendment and the current crate documentation disagree, "
+        f"this amendment governs, and the documentation is superseded in the following places:**"
+    )
+
+    bullets = []
+    for d in displacing:
+        sites = []
+        for site in d["crate_displaced"]:
+            # The table carries line ranges; the ADR carries only the file. The
+            # decisions marked CHANGED require editing these very files, so a line
+            # range published here is stale by the time anyone acts on it. The
+            # passage name is what makes the citation findable either way.
+            path = site["cite"].split(":", 1)[0]
+            gloss = site.get("gloss") or f"the documentation in `{path}`"
+            sites.append(f"{gloss} (`{path}`)")
+        body = english_list(sites)
+        tail = f" — superseded by decision {d['n']}"
+        if d.get("scope_note"):
+            tail += f". The displacement is bounded: {d['scope_note']}"
+        bullets.append(wrap(f"{body[0].upper() + body[1:]}{tail}.", bullet=True))
+
+    # The count of bounded entries is derived, not asserted: it moves whenever a
+    # scope note is added to or removed from the table.
+    bounded = [d for d in displacing if d.get("scope_note")]
+    bounded_names = "decisions " + english_list([str(d["n"]) for d in bounded])
+    closing = wrap(
+        f"{WORDS[len(bounded)]} of those entries are bounded rather than wholesale — "
+        f"{bounded_names} — and in each case the "
+        f"bound is the substance. Decision 10's is the one worth spelling out, because it "
+        f"displaces a disclaimer rather than a statement: the crate documentation never says a "
+        f"non-object payload is acceptable, it says the shape of `event.payload` is not the "
+        f"crate's business. That is not a weaker form of the same thing. A document that disclaims "
+        f"ownership of a rule licenses the absence of that rule just as effectively as one that "
+        f"states the permissive version, and the reader who follows the disclaimer arrives at the "
+        f"same wrong implementation."
+    )
+
+    return wrap(lead) + "\n\n" + "\n".join(bullets) + "\n\n" + closing
+
+
+def fence_passage(decisions: list[dict]) -> str:
+    changed = [d for d in decisions if d["label"] == "CHANGED"]
+    numbers = english_list([str(d["n"]) for d in changed])
+    return wrap(
+        f"**No first consumer of `khive-wire-protocol` may merge while any decision marked "
+        f"CHANGED above still implements the superseded behaviour.** Those are decisions "
+        f"{numbers} — {WORDS[len(changed)].lower()} of the {WORDS[len(decisions)].lower()}.",
+        bullet=True,
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--check", action="store_true")
+    args = ap.parse_args()
+
+    table = json.loads(TABLE.read_text())
+    decisions = table["decisions"]
+    adr_text = ADR.read_text()
+
+    complaints = check_labels(decisions, adr_text)
+    if complaints:
+        print("LABEL MISMATCH between the table and the ADR:", file=sys.stderr)
+        for c in complaints:
+            print(f"  - {c}", file=sys.stderr)
+        return 2
+
+    passages = {
+        "precedence": precedence_passage(decisions),
+        "fence": fence_passage(decisions),
+    }
+
+    if not args.check:
+        for name, text in passages.items():
+            print(f"\n===== {name} =====\n")
+            print(text)
+        return 0
+
+    missing = [n for n, t in passages.items() if t not in adr_text]
+    for name, text in passages.items():
+        state = "MISSING" if name in missing else "present verbatim"
+        print(f"{name}: {state}")
+    if missing:
+        print(
+            "\nThe ADR does not contain the generated text for: "
+            + ", ".join(missing),
+            file=sys.stderr,
+        )
+        return 1
+    print("\nAll derived passages match the table.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lint-adr-137-displacements.py
+++ b/scripts/lint-adr-137-displacements.py
@@ -46,6 +46,19 @@ WORDS = {
 }
 DECISION_HEADING = re.compile(r"^(\d+)\. \*\*(.+?) — (RATIFIED|CHANGED)", re.M)
 
+# A displacement is "bounded" when the parent rule survives and only its scope
+# moves. Membership is a CLOSED vocabulary, not the truthiness of a prose field:
+# the generated ADR publishes the count and the membership list, so deriving
+# them from whether someone wrote a free-form note means a later edit to that
+# note can silently move a published claim. `scope_note` stays, as the human
+# explanation; `scope_kind` is what the count is computed from.
+SCOPE_KINDS = {
+    "version_floor": "the rule holds, but not below the protocol version floor",
+    "idless_error": "the rule holds except for the case carrying no operation id",
+    "endpoint_role": "the rule holds; its scoping to one endpoint role is what moves",
+    "outermost_shape": "only the outermost type is displaced, not the per-field shape",
+}
+
 
 def wrap(text: str, bullet: bool = False) -> str:
     return textwrap.fill(
@@ -94,6 +107,46 @@ def check_labels(decisions: list[dict], adr_text: str) -> list[str]:
         if got is not None and got != d["label"]:
             complaints.append(
                 f"decision {d['n']}: table says {d['label']}, the ADR says {got}"
+            )
+    return complaints
+
+
+def check_scope_kinds(decisions: list[dict]) -> list[str]:
+    """`scope_kind` must be a known value, and must pair with `scope_note`.
+
+    The generated ADR publishes both a COUNT and a MEMBERSHIP LIST of bounded
+    displacements. Deriving those from a free-form field's truthiness is how a
+    published claim moves silently, which already happened once here: decision 1
+    was bounded in fact, carried no note, and was dropped from a count that read
+    as authoritative.
+
+    Both directions are checked, and the second is the one that matters. An
+    unknown `scope_kind` is loud and easy. A row that has a `scope_note` but no
+    `scope_kind` is the silent case: it reads to a human as bounded, and the
+    count omits it, with nothing anywhere disagreeing.
+    """
+    complaints = []
+    for d in decisions:
+        kind, note = d.get("scope_kind"), d.get("scope_note")
+        if kind is not None and kind not in SCOPE_KINDS:
+            complaints.append(
+                f"decision {d['n']}: scope_kind {kind!r} is not one of "
+                f"{sorted(SCOPE_KINDS)}"
+            )
+        if note and not kind:
+            complaints.append(
+                f"decision {d['n']}: has a scope_note but no scope_kind, so it "
+                f"reads as bounded but is excluded from the generated count"
+            )
+        if kind and not note:
+            complaints.append(
+                f"decision {d['n']}: has scope_kind {kind!r} but no scope_note "
+                f"explaining the bound to a reader"
+            )
+        if kind and not d["crate_displaced"]:
+            complaints.append(
+                f"decision {d['n']}: has scope_kind {kind!r} but displaces no "
+                f"crate passage, so it can never appear in the generated count"
             )
     return complaints
 
@@ -234,9 +287,11 @@ def precedence_passage(decisions: list[dict]) -> str:
             tail += f". The displacement is bounded: {d['scope_note']}"
         bullets.append(wrap(f"{body[0].upper() + body[1:]}{tail}.", bullet=True))
 
-    # The count of bounded entries is derived, not asserted: it moves whenever a
-    # scope note is added to or removed from the table.
-    bounded = [d for d in displacing if d.get("scope_note")]
+    # The count of bounded entries is derived, not asserted. It is computed from
+    # `scope_kind`, a closed vocabulary checked by check_scope_kinds, and NOT
+    # from whether a prose `scope_note` happens to be present — a published
+    # count must not move because someone reworded an explanation.
+    bounded = [d for d in displacing if d.get("scope_kind")]
     bounded_names = "decisions " + english_list([str(d["n"]) for d in bounded])
     closing = wrap(
         f"{WORDS[len(bounded)]} of those entries are bounded rather than wholesale — "
@@ -277,6 +332,13 @@ def main() -> int:
     if complaints:
         print("LABEL MISMATCH between the table and the ADR:", file=sys.stderr)
         for c in complaints:
+            print(f"  - {c}", file=sys.stderr)
+        return 2
+
+    scope_complaints = check_scope_kinds(decisions)
+    if scope_complaints:
+        print("SCOPE-KIND MISMATCH in the table:", file=sys.stderr)
+        for c in scope_complaints:
             print(f"  - {c}", file=sys.stderr)
         return 2
 

--- a/scripts/lint-adr-137-displacements.py
+++ b/scripts/lint-adr-137-displacements.py
@@ -5,7 +5,7 @@ Two sentences in the amendment state quantities and set memberships that a reade
 cannot check without redoing the audit: how many decisions displace the crate
 documentation, which ones they are, and which decisions carry the CHANGED label
 that the implementation fence turns on. Typing those is how they go wrong. This
-script derives all of them from `.khive/displacements.json`, and cross-checks the
+script derives all of them from the table (see TABLE below), and cross-checks the
 label of every decision against the ADR's own heading text so the table cannot
 drift from the document it describes without the check failing.
 
@@ -15,8 +15,14 @@ drift from the document it describes without the check failing.
 --check is the mode the pre-commit hook runs, so an edit to either the ADR or
 the table that leaves the two disagreeing fails before it can be committed.
 
-Exit status is nonzero if a label disagrees, or, under --check, if a generated
-passage is absent from the ADR.
+Three things are checked, because each was found unguarded by review:
+  * every quoted passage still exists in the file the row cites (citations),
+  * the table describes exactly the ADR's decision set, with no duplicate or
+    missing decision number (labels),
+  * the ADR contains the generated passages verbatim (--check).
+
+Exit status: 2 if the table and the ADR disagree about decisions or citations,
+1 if --check finds a generated passage absent from the ADR, 0 otherwise.
 """
 
 from __future__ import annotations
@@ -66,22 +72,134 @@ def labels_from_adr(text: str) -> dict[int, str]:
 
 
 def check_labels(decisions: list[dict], adr_text: str) -> list[str]:
-    """The table's labels must equal the ADR's own. Returns a list of complaints."""
+    """The table must describe exactly the ADR's decisions. Returns complaints."""
     from_adr = labels_from_adr(adr_text)
+    numbers = [d["n"] for d in decisions]
     complaints = []
-    if len(from_adr) != len(decisions):
-        complaints.append(
-            f"the ADR carries {len(from_adr)} numbered decisions, the table has {len(decisions)}"
-        )
+
+    # Compare the number SETS, not their sizes. `from_adr` is a dict and so
+    # collapses duplicates; `decisions` is a list and does not. A table that
+    # carries decision 4 twice and omits decision 7 therefore has the same
+    # length as a correct one, and the old size comparison passed it while
+    # every generated count and set membership silently went wrong.
+    for n in sorted({n for n in numbers if numbers.count(n) > 1}):
+        complaints.append(f"decision {n} appears {numbers.count(n)} times in the table")
+    for n in sorted(set(from_adr) - set(numbers)):
+        complaints.append(f"decision {n} is in the ADR but not in the table")
+    for n in sorted(set(numbers) - set(from_adr)):
+        complaints.append(f"decision {n} is in the table but not in the ADR")
+
     for d in decisions:
         got = from_adr.get(d["n"])
-        if got is None:
-            complaints.append(f"decision {d['n']} is in the table but not in the ADR")
-        elif got != d["label"]:
+        if got is not None and got != d["label"]:
             complaints.append(
                 f"decision {d['n']}: table says {d['label']}, the ADR says {got}"
             )
     return complaints
+
+
+def normalize(text: str) -> str:
+    """Strip doc-comment markers and collapse whitespace.
+
+    Canonicalization of a known syntax, not fuzzy matching. The cited crate
+    passages are `//!` doc comments that hard-wrap mid-sentence, so no quoted
+    phrase is a contiguous substring of the raw file; without this, a citation
+    check could only ever be tolerant, and a tolerant one is worse than none.
+    A lowercased quote in decision 2 matched an unrelated passage 93 lines from
+    the intended one, which is the failure this exactness exists to prevent.
+    """
+    return normalize_with_lines(text)[0]
+
+
+def normalize_with_lines(text: str) -> tuple[str, list[tuple[int, int]]]:
+    """Normalize, and return a map from offset in the result to source line.
+
+    The map is what lets a quote report the line it currently occupies. Deriving
+    the line at check time is the whole point: a stored one is invalidated by the
+    next edit to the cited file, which is exactly what happened here.
+    """
+    parts: list[str] = []
+    index: list[tuple[int, int]] = []
+    pos = 0
+    for lineno, raw in enumerate(text.splitlines(), 1):
+        collapsed = re.sub(r"\s+", " ", re.sub(r"^[ \t]*//[/!] ?", "", raw)).strip()
+        if not collapsed:
+            continue
+        index.append((pos, lineno))
+        parts.append(collapsed)
+        pos += len(collapsed) + 1
+    return " ".join(parts), index
+
+
+def line_at(index: list[tuple[int, int]], offset: int) -> int:
+    """The source line containing the given offset in the normalized text."""
+    found = index[0][1] if index else 0
+    for start, lineno in index:
+        if start > offset:
+            break
+        found = lineno
+    return found
+
+
+def check_citations(decisions: list[dict], root: Path) -> tuple[list[str], list[str]]:
+    """Every quoted passage must still exist in the file its row cites.
+
+    Returns (complaints, resolved) where `resolved` reports the line each quote
+    currently occupies. Line numbers are derived here and never stored: the
+    amendment inserts into the very ADR the table cites, so a stored line is
+    invalidated by the edit that makes the citation worth checking.
+    """
+    complaints, resolved = [], []
+    bodies: dict[str, tuple[str, list[tuple[int, int]]]] = {}
+    for d in decisions:
+        for field in ("parent_displaced", "crate_displaced"):
+            for site in d.get(field, []):
+                path = site["cite"]
+                if ":" in path:
+                    complaints.append(
+                        f"decision {d['n']}: cite {path!r} carries a line number; "
+                        f"cite the file and let the quote locate the passage"
+                    )
+                    path = path.split(":", 1)[0]
+                if path not in bodies:
+                    target = root / path
+                    if target.exists():
+                        bodies[path] = normalize_with_lines(target.read_text())
+                    else:
+                        complaints.append(f"decision {d['n']}: cited file {path} does not exist")
+                        bodies[path] = ("", [])
+                body, index = bodies[path]
+                for quote in site["quotes"]:
+                    needle = normalize(quote)
+                    hits = body.count(needle) if needle else 0
+                    if not needle:
+                        complaints.append(f"decision {d['n']}: empty quote for {path}")
+                    elif hits == 1:
+                        line = line_at(index, body.index(needle))
+                        resolved.append(f"  decision {d['n']:<2} {path}:{line}")
+                    elif hits == 0:
+                        complaints.append(
+                            f"decision {d['n']}: {path} no longer contains {quote[:70]!r}"
+                        )
+                    else:
+                        # Ambiguity is fail-open here, not a cosmetic defect. The
+                        # amendment quotes the passages it displaces, in the file it
+                        # cites, so a short quote matches the amendment's own
+                        # quotation as readily as the parent sentence -- and would
+                        # keep matching after the parent sentence was deleted, which
+                        # is the one change this check exists to catch.
+                        lines = []
+                        start = 0
+                        for _ in range(hits):
+                            at = body.index(needle, start)
+                            lines.append(str(line_at(index, at)))
+                            start = at + 1
+                        complaints.append(
+                            f"decision {d['n']}: {path} contains {quote[:50]!r} "
+                            f"{hits} times (lines {', '.join(lines)}); lengthen the quote "
+                            f"until it names one passage"
+                        )
+    return complaints, resolved
 
 
 def precedence_passage(decisions: list[dict]) -> str:
@@ -160,6 +278,19 @@ def main() -> int:
         for c in complaints:
             print(f"  - {c}", file=sys.stderr)
         return 2
+
+    cite_complaints, resolved = check_citations(decisions, ROOT)
+    if cite_complaints:
+        print("CITATION MISMATCH between the table and the cited sources:", file=sys.stderr)
+        for c in cite_complaints:
+            print(f"  - {c}", file=sys.stderr)
+        return 2
+    if not resolved:
+        print("no citations were checked; the table carries no quotes", file=sys.stderr)
+        return 2
+    print(f"citations: {len(resolved)} quoted passages resolve in their cited files")
+    for r in resolved:
+        print(r)
 
     passages = {
         "precedence": precedence_passage(decisions),


### PR DESCRIPTION
Amendment 1 to ADR-137, closing the wire-level decisions the parent left unstated or stated only in prose. It lands before `khive-wire-protocol` has an in-tree consumer, which is the window in which any of these behaviours can still change without a compatibility break.

## What it settles

Ten numbered decisions. Five are recorded as contract because the implemented behaviour is already correct for it. Five require the crate to move: envelope member semantics, the id-less unknown-error-code case, handshake sequence coverage across both endpoint roles, opaque subvalue byte fidelity, and the outermost type of `event.payload`.

Each decision states the behaviour normatively rather than describing what the code does, so a non-Rust client can implement it from the ADR.

## Why the precedence list is in here

The parent makes the crate's own documentation a second normative authority. Six of the ten decisions contradict that documentation as it stands, so the amendment names each superseded passage. Three of those displacements are bounded rather than wholesale, and each entry says where its bound falls.

That list is explicitly a debt. The implementation that ratifies these decisions updates the crate documentation in the same change and deletes the section.

## Structure

The superseded parent paragraphs carry inline notes pointing at the decisions that bound them, so a reader who stops at the parent does not leave holding a replaced rule.

Supersedes #2120, which carried the same amendment with the precedence list and the changed-decision set stated independently of the per-decision entries. Here both are consequences of the entries themselves.

Docs only. No code changes.
