### PR TITLE
feat(runtime): anchor date-only values to a configured display timezone (ADR-169 steps 1-3)

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2173,6 +2173,7 @@ version = "0.7.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "chrono-tz",
  "criterion",
  "inventory",
  "khive-pack-kg",
@@ -2452,6 +2453,8 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
+ "chrono-tz",
+ "iana-time-zone",
  "inventory",
  "khive-db",
  "khive-fold",

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -86,6 +86,8 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1.10", features = ["v4", "v5", "serde"] }
 chrono = { version = "0.4", default-features = false, features = ["serde", "clock"] }
+chrono-tz = "0.10"
+iana-time-zone = "0.1"
 async-trait = "0.1"
 clap = { version = "4.5", features = ["derive", "env"] }
 dotenvy = "0.15"

--- a/crates/khive-merge/Cargo.lock
+++ b/crates/khive-merge/Cargo.lock
@@ -255,6 +255,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,7 +503,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1255,6 +1265,8 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
+ "chrono-tz",
+ "iana-time-zone",
  "inventory",
  "khive-db",
  "khive-fold",
@@ -1571,6 +1583,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1693,7 +1723,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1869,7 +1899,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1928,7 +1958,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2134,6 +2164,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2241,7 +2277,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2758,7 +2794,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/khive-pack-brain/src/fold_gate.rs
+++ b/crates/khive-pack-brain/src/fold_gate.rs
@@ -522,6 +522,7 @@ mod tests {
 
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
+            display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             db_path: Some(db_path),
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -629,6 +630,7 @@ mod tests {
         let db_path = dir.path().join(db_name);
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
+            display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             db_path: Some(db_path),
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -2395,6 +2395,7 @@ fn make_pack_with_actor(actor_id: &str) -> (BrainPack, KhiveRuntime) {
     // absent on CI runners and fails entity creation with ModelInitialization.
     let rt = KhiveRuntime::new(khive_runtime::RuntimeConfig {
         git_write: Default::default(),
+        display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-pack-brain/tests/adr133_serve_batch.rs
+++ b/crates/khive-pack-brain/tests/adr133_serve_batch.rs
@@ -16,6 +16,7 @@ use serde_json::json;
 fn file_backed_runtime(db_path: std::path::PathBuf) -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
+        display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         db_path: Some(db_path),
         default_namespace: Namespace::local(),
         embedding_model: None,

--- a/crates/khive-pack-brain/tests/resolve_actor.rs
+++ b/crates/khive-pack-brain/tests/resolve_actor.rs
@@ -13,6 +13,7 @@ use serde_json::json;
 fn runtime_with_actor(actor_id: Option<&str>) -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
+        display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -3319,6 +3319,7 @@ mod tests {
         let ns = format!("ingest-dedup-{}", Uuid::new_v4().simple());
         let runtime = super::KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
+            display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::parse(&ns).unwrap(),
@@ -3845,6 +3846,7 @@ mod tests {
         let ns = format!("mark-read-cas-{}", Uuid::new_v4().simple());
         let runtime = super::KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
+            display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::parse(&ns).unwrap(),
@@ -3961,6 +3963,7 @@ mod tests {
             let ns = format!("mark-read-non-object-{case}-{}", Uuid::new_v4().simple());
             let runtime = super::KhiveRuntime::new(RuntimeConfig {
                 git_write: Default::default(),
+                display_timezone: khive_runtime::config::resolve_default_display_timezone(),
                 db_path: None,
                 blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
                 default_namespace: Namespace::parse(&ns).unwrap(),

--- a/crates/khive-pack-comm/src/message.rs
+++ b/crates/khive-pack-comm/src/message.rs
@@ -453,6 +453,7 @@ mod tests {
 
         let runtime = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
+            display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::parse(&sender_ns).unwrap(),
@@ -530,6 +531,7 @@ mod tests {
 
         let runtime = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
+            display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::parse(ns).unwrap(),
@@ -672,6 +674,7 @@ mod tests {
 
         let runtime = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
+            display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::parse(&sender_ns).unwrap(),
@@ -833,6 +836,7 @@ mod tests {
 
         let runtime = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
+            display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),

--- a/crates/khive-pack-comm/tests/adr133_read_flags.rs
+++ b/crates/khive-pack-comm/tests/adr133_read_flags.rs
@@ -16,6 +16,7 @@ fn file_backed_registry(
 ) -> (khive_runtime::VerbRegistry, KhiveRuntime) {
     let rt = KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
+        display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         db_path: Some(db_path),
         default_namespace: Namespace::local(),
         embedding_model: None,

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -3538,6 +3538,7 @@ fn build_crossns_registry(
 ) -> (VerbRegistry, KhiveRuntime) {
     let config = RuntimeConfig {
         git_write: Default::default(),
+        display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::parse(dispatch_ns).unwrap(),
@@ -4478,6 +4479,7 @@ fn build_actor_registry(
 ) -> (VerbRegistry, KhiveRuntime) {
     let config = RuntimeConfig {
         git_write: Default::default(),
+        display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
@@ -4642,6 +4644,7 @@ allowed_outbound_namespaces = ["lambda:khive", "lambda:atlas"]
 
     let base = RuntimeConfig {
         git_write: Default::default(),
+        display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         db_path: None,
         embedding_model: None,
         additional_embedding_models: vec![],
@@ -4770,6 +4773,7 @@ async fn t_c2_gate_receives_configured_actor_not_anonymous() {
     let backend = shared_backend();
     let config = RuntimeConfig {
         git_write: Default::default(),
+        display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
@@ -4885,6 +4889,7 @@ async fn i199_anonymous_inbox_cannot_read_messages_addressed_to_other_actor() {
     // An anonymous (unconfigured) caller on the same backend must NOT see B's message.
     let config_anon = RuntimeConfig {
         git_write: Default::default(),
+        display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-pack-comm/tests/probe.rs
+++ b/crates/khive-pack-comm/tests/probe.rs
@@ -1010,6 +1010,7 @@ async fn probe_backfills_pre_existing_messages_across_v6_to_v7_upgrade() {
     // `run_migrations` to latest, including V7's backfill.
     let config = RuntimeConfig {
         git_write: Default::default(),
+        display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         db_path: Some(path.clone()),
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
@@ -1194,6 +1195,7 @@ async fn probe_repairs_partial_notes_seq_left_by_original_v7_on_reopen() {
     // fixed anti-join lazy bootstrap.
     let config = RuntimeConfig {
         git_write: Default::default(),
+        display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         db_path: Some(path.clone()),
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-pack-git/tests/acceptance.rs
+++ b/crates/khive-pack-git/tests/acceptance.rs
@@ -7270,6 +7270,7 @@ async fn ingest_over_cap_commit_embedding_is_semantically_retrievable() {
     let _guard = ENV_MUTEX.lock().await;
     let rt = KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
+        display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-pack-gtd/Cargo.toml
+++ b/crates/khive-pack-gtd/Cargo.toml
@@ -23,6 +23,7 @@ async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }
+chrono-tz = { workspace = true }
 uuid = { workspace = true }
 tracing = { workspace = true }
 

--- a/crates/khive-pack-gtd/src/handlers.rs
+++ b/crates/khive-pack-gtd/src/handlers.rs
@@ -556,14 +556,27 @@ fn anchor_date_to_earliest_instant(date: chrono::NaiveDate, tz: Tz) -> Option<Da
         // the offset goes from +12:13:22 to -11:46:38 — and the pinned
         // chrono-tz table holds 107 such date-decreasing transitions. What
         // makes the bisection sound is that none of them falls inside a
-        // window this branch searches: over every date in the pinned table
-        // for which `from_local_datetime` returns `None` (4311 of them), an
-        // enumeration of the generated transition tables found no
-        // date-decrease in any search window, no disagreement between the
-        // bisection result and the true first instant, and no bound-guard
-        // trip. Re-derive that when the chrono-tz pin moves; a violation
-        // would cost the LEAST-instant property, while the same-date check
-        // at the end still keeps a wrong DATE from being returned.
+        // window this branch searches.
+        //
+        // That is checked rather than argued, and it is checked as the
+        // CONCLUSION rather than the premise. `every_gap_date_resolves_to_the
+        // _least_instant` sweeps every zone in the pinned database over
+        // 1850-2100 and asserts directly that one second before the returned
+        // instant is a different local date — the least-instant property
+        // itself, which is what a monotonicity violation would cost. At the
+        // current pin it reports 597 zones over 91311 dates each, 4299 gap
+        // dates, 818 folds, 7 whole days a zone's calendar skips, and zero
+        // violations, in about three seconds. Those counts are printed by the
+        // test rather than asserted, because their magnitudes are the
+        // database's business and only their reaching zero would mean the
+        // sweep broke. Run it whenever the chrono-tz pin moves:
+        //
+        //   cargo test -p khive-pack-gtd --lib --release -- --ignored --nocapture
+        //
+        // It is ignored by default because it is an all-zone sweep, not
+        // because it is optional. A violation costs the LEAST-instant
+        // property only; the same-date check at the end of this branch keeps
+        // a wrong DATE from being returned regardless.
         //
         // The earlier implementation instead read the offset in effect at
         // noon on the previous calendar date and projected local midnight
@@ -602,6 +615,139 @@ fn anchor_date_to_earliest_instant(date: chrono::NaiveDate, tz: Tz) -> Option<Da
             let resolved = tz.from_utc_datetime(&hi);
             (resolved.date_naive() == date).then_some(resolved)
         }
+    }
+}
+
+#[cfg(test)]
+mod tz_database_audit {
+    use super::*;
+
+    /// Sweep every zone in the pinned `chrono-tz` over 1850-2100 and assert that
+    /// `anchor_date_to_earliest_instant` returns the LEAST instant of the requested local date.
+    ///
+    /// This is the re-derivation duty the gap branch's comment names, and it exists because the
+    /// comment used to assert a premise instead: that a local date is monotonically non-decreasing
+    /// in UTC time. That premise is false globally — zones that crossed the international date line
+    /// run the local calendar backwards, `America/Adak` at 1867-10-19T00:31:13Z being one — and a
+    /// true premise supporting a wrong inference reads as verified, so this checks the inference.
+    ///
+    /// The property asserted is direct and needs no transition table: for the returned instant `r`,
+    /// `r` has the requested local date and `r - 1s` does not. Anything less than the least instant
+    /// fails the first half; anything more fails the second.
+    ///
+    /// Ignored by default because it is an all-zone sweep, not because it is optional:
+    ///
+    ///   cargo test -p khive-pack-gtd --lib --release -- --ignored --nocapture
+    #[test]
+    #[ignore = "all-zone chrono-tz sweep; run on a pin bump (see the command in the doc comment)"]
+    fn every_gap_date_resolves_to_the_least_instant() {
+        let start = chrono::NaiveDate::from_ymd_opt(1850, 1, 1).expect("start date");
+        let end = chrono::NaiveDate::from_ymd_opt(2100, 1, 1).expect("end date");
+
+        let mut zones = 0usize;
+        let mut gaps = 0usize;
+        let mut folds = 0usize;
+        let mut skipped_days = 0usize;
+        let mut failures: Vec<String> = Vec::new();
+
+        for tz in chrono_tz::TZ_VARIANTS.iter().copied() {
+            zones += 1;
+            let mut date = start;
+            while date < end {
+                let midnight = date.and_hms_opt(0, 0, 0).expect("midnight");
+                match tz.from_local_datetime(&midnight) {
+                    chrono::LocalResult::Single(_) => {}
+                    chrono::LocalResult::Ambiguous(_, _) => folds += 1,
+                    chrono::LocalResult::None => gaps += 1,
+                }
+
+                match anchor_date_to_earliest_instant(date, tz) {
+                    Some(resolved) => {
+                        let previous = resolved - chrono::Duration::seconds(1);
+                        if resolved.date_naive() != date {
+                            failures.push(format!(
+                                "{tz}: {date} resolved to {resolved}, whose local date is \
+                                 {}",
+                                resolved.date_naive()
+                            ));
+                        } else if tz.from_utc_datetime(&previous.naive_utc()).date_naive() == date {
+                            failures.push(format!(
+                                "{tz}: {date} resolved to {resolved}, but one second earlier is \
+                                 still {date} — not the least instant"
+                            ));
+                        }
+                    }
+                    // `None` is correct only for a date the zone's local calendar skips whole.
+                    // Verify that rather than accepting it: no instant in a generous window may
+                    // carry the requested local date.
+                    None => {
+                        skipped_days += 1;
+                        let base = midnight;
+                        let mut found = None;
+                        let mut probe = base - chrono::Duration::hours(48);
+                        while probe <= base + chrono::Duration::hours(48) {
+                            if tz.from_utc_datetime(&probe).date_naive() == date {
+                                found = Some(probe);
+                                break;
+                            }
+                            probe += chrono::Duration::minutes(1);
+                        }
+                        if let Some(hit) = found {
+                            failures.push(format!(
+                                "{tz}: {date} returned None, but {hit}Z has that local date"
+                            ));
+                        }
+                    }
+                }
+
+                date = date.succ_opt().expect("date in range has a successor");
+            }
+        }
+
+        println!(
+            "swept {zones} zones over {} dates each: {gaps} gaps, {folds} folds, \
+             {skipped_days} whole days skipped by a zone's calendar, {} violations",
+            (end - start).num_days(),
+            failures.len()
+        );
+
+        // The substantive result is asserted FIRST, deliberately. An earlier version put the
+        // population checks above this one and guessed their thresholds; one guess was wrong
+        // (it demanded thousands of fold dates against an actual 818), the test failed on the
+        // guess, and the property it exists to check never ran. A bound nobody measured is not
+        // a safety net, it is a second thing that can be wrong.
+        assert!(
+            failures.is_empty(),
+            "{} least-instant violations, first 10:\n{}",
+            failures.len(),
+            failures
+                .iter()
+                .take(10)
+                .cloned()
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+
+        // Then assert the sweep actually examined something, so an audit that silently swept
+        // nothing cannot pass by finding nothing. These are floors at zero for each SHAPE the
+        // sweep must exercise rather than guesses at a magnitude: a shape reaching zero means
+        // the traversal broke, and any number above zero is the database's business.
+        assert!(
+            zones > 500,
+            "expected the full zone database, swept {zones}"
+        );
+        assert!(
+            gaps > 0,
+            "no gap dates found -- the sweep did not reach a transition"
+        );
+        assert!(
+            folds > 0,
+            "no fold dates found -- the sweep did not reach a transition"
+        );
+        assert!(
+            skipped_days > 0,
+            "no whole-day skips found -- the None-return path was never exercised"
+        );
     }
 }
 

--- a/crates/khive-pack-gtd/src/handlers.rs
+++ b/crates/khive-pack-gtd/src/handlers.rs
@@ -544,10 +544,26 @@ fn anchor_date_to_earliest_instant(date: chrono::NaiveDate, tz: Tz) -> Option<Da
         chrono::LocalResult::Ambiguous(earliest, _latest) => Some(earliest),
         // Spring-forward gap (or a larger jump): local midnight does not
         // exist. Solve for the boundary directly rather than projecting to
-        // it. The local date is a monotonically non-decreasing function of
-        // UTC time, so the least instant whose local date is `date` is the
-        // bisection point on the UTC axis between "still the previous date"
-        // and "already this date".
+        // it. Within the window searched below, the local date is a
+        // non-decreasing function of UTC time, so the least instant whose
+        // local date is `date` is the bisection point on the UTC axis
+        // between "still the previous date" and "already this date".
+        //
+        // That premise is SCOPED to this window on purpose: it is not true
+        // globally. Zones that crossed the international date line run the
+        // local calendar backwards at the crossing — `America/Adak` at
+        // 1867-10-19T00:31:13Z moves from local 1867-10-19 to 1867-10-18 as
+        // the offset goes from +12:13:22 to -11:46:38 — and the pinned
+        // chrono-tz table holds 107 such date-decreasing transitions. What
+        // makes the bisection sound is that none of them falls inside a
+        // window this branch searches: over every date in the pinned table
+        // for which `from_local_datetime` returns `None` (4311 of them), an
+        // enumeration of the generated transition tables found no
+        // date-decrease in any search window, no disagreement between the
+        // bisection result and the true first instant, and no bound-guard
+        // trip. Re-derive that when the chrono-tz pin moves; a violation
+        // would cost the LEAST-instant property, while the same-date check
+        // at the end still keeps a wrong DATE from being returned.
         //
         // The earlier implementation instead read the offset in effect at
         // noon on the previous calendar date and projected local midnight

--- a/crates/khive-pack-gtd/src/handlers.rs
+++ b/crates/khive-pack-gtd/src/handlers.rs
@@ -13,7 +13,8 @@
 
 use std::str::FromStr;
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Offset, TimeZone, Utc};
+use chrono_tz::Tz;
 use serde::Deserialize;
 use serde_json::{json, Value};
 use uuid::Uuid;
@@ -492,30 +493,174 @@ pub fn render_task(note: &khive_storage::note::Note) -> Value {
 
 /// Parse a user-supplied due-date string as an ISO-8601 / RFC 3339 timestamp.
 ///
-/// Accepts full RFC 3339 (e.g. `2026-06-01T00:00:00Z`) or date-only
-/// (e.g. `2026-06-01`) by appending midnight UTC if necessary.
-/// Returns the canonical RFC 3339 string stored in `properties.due`.
-/// Shared with `hook.rs`.
-pub(crate) fn parse_due(value: &str) -> Result<String, RuntimeError> {
-    // Try full RFC 3339 / ISO-8601 with time zone first.
+/// Accepts full RFC 3339 (e.g. `2026-06-01T00:00:00Z`) — normalized to UTC and
+/// otherwise unaffected by `tz` — or date-only (e.g. `2026-06-01`), which
+/// resolves to the earliest instant that belongs to that calendar date in
+/// `tz` (ADR-169 D1). Returns the canonical RFC 3339 string stored in
+/// `properties.due`, in `tz`'s offset spelling for the date-only case
+/// (ADR-169 D5) — the value remains a single absolute instant; the offset
+/// records which calendar the date was anchored in.
+pub(crate) fn parse_due(value: &str, tz: Tz) -> Result<String, RuntimeError> {
+    // Try full RFC 3339 / ISO-8601 with time zone first. Already carries an
+    // explicit offset or `Z`, so it is unaffected by `tz` and keeps its
+    // existing UTC normalization.
     if let Ok(dt) = DateTime::parse_from_rfc3339(value) {
         return Ok(dt.with_timezone(&Utc).to_rfc3339());
     }
-    // Fallback: try date-only "YYYY-MM-DD", treat as midnight UTC.
+    // Fallback: try date-only "YYYY-MM-DD".
     if let Ok(date) = chrono::NaiveDate::parse_from_str(value, "%Y-%m-%d") {
-        let dt = date
-            .and_hms_opt(0, 0, 0)
-            .map(|ndt| DateTime::<Utc>::from_naive_utc_and_offset(ndt, Utc))
+        return anchor_date_to_earliest_instant(date, tz)
+            .map(|dt| dt.to_rfc3339())
             .ok_or_else(|| {
                 RuntimeError::InvalidInput(format!(
-                "due must be ISO-8601 (e.g., 2026-06-01T00:00:00Z or 2026-06-01); got {value:?}"
-            ))
-            })?;
-        return Ok(dt.to_rfc3339());
+                    "due date {date} does not exist in the configured display timezone {tz} \
+                     (the zone's local calendar skips this date entirely); got {value:?}"
+                ))
+            });
     }
     Err(RuntimeError::InvalidInput(format!(
         "due must be ISO-8601 (e.g., 2026-06-01T00:00:00Z or 2026-06-01); got {value:?}"
     )))
+}
+
+/// Resolve a calendar date to the earliest instant that belongs to it in
+/// `tz` (ADR-169 D1). Midnight is not a total function of date and zone: on a
+/// zone's own transition date local midnight can fail to exist (the clock
+/// jumps over it) or occur twice (the clock repeats it). Both are one rule —
+/// take the least instant whose local date, in `tz`, is `date` — not two
+/// exceptions to it; neither case may be resolved by unwrapping to UTC,
+/// which would silently reintroduce the defect ADR-169 exists to remove.
+///
+/// Returns `None` only when no instant at all maps to `date` in `tz` (the
+/// zone's local calendar skips the date entirely, e.g. a whole-day UTC-offset
+/// jump across the international date line) — a case ADR-169 does not name,
+/// since its own gap/ambiguity examples are ordinary sub-day transitions.
+fn anchor_date_to_earliest_instant(date: chrono::NaiveDate, tz: Tz) -> Option<DateTime<Tz>> {
+    let midnight = date.and_hms_opt(0, 0, 0)?;
+    match tz.from_local_datetime(&midnight) {
+        chrono::LocalResult::Single(dt) => Some(dt),
+        // Fall-back overlap: two instants map to the same wall-clock time.
+        // The earlier one is the least instant whose local date is `date`.
+        chrono::LocalResult::Ambiguous(earliest, _latest) => Some(earliest),
+        // Spring-forward gap (or a larger jump): local midnight does not
+        // exist. Find the transition by probing a point on the previous
+        // calendar date guaranteed to fall outside any transition (noon),
+        // reading the offset in effect there, and using it to project
+        // `midnight` to the UTC instant it would have been under that
+        // still-prior offset. Because the local date is a monotonically
+        // non-decreasing function of UTC time, re-deriving the actual local
+        // time at that UTC instant (an unconditional, never-ambiguous
+        // UTC->local conversion) lands exactly on the first instant that
+        // exists on `date` — the moment the new offset regime begins.
+        chrono::LocalResult::None => {
+            let prev_noon = date.pred_opt()?.and_hms_opt(12, 0, 0)?;
+            let offset_before = match tz.offset_from_local_datetime(&prev_noon) {
+                chrono::LocalResult::Single(o) => o,
+                chrono::LocalResult::Ambiguous(o, _) => o,
+                chrono::LocalResult::None => return None,
+            };
+            let candidate_utc =
+                midnight - chrono::Duration::seconds(offset_before.fix().local_minus_utc() as i64);
+            let resolved = tz.from_utc_datetime(&candidate_utc);
+            (resolved.date_naive() == date).then_some(resolved)
+        }
+    }
+}
+
+#[cfg(test)]
+mod parse_due_tests {
+    use super::*;
+
+    // America/New_York (used for the west-of-UTC and general DST coverage in
+    // tests/assign.rs) never transitions at local midnight, so it cannot
+    // exercise LocalResult::None or ::Ambiguous — a "DST test" against it
+    // passes without touching the rule ADR-169 D1 actually specifies. The
+    // zones and dates below are ADR-169's own worked table (measured against
+    // the IANA database) of zones that DO transition at 00:00.
+
+    #[test]
+    fn date_only_due_resolves_to_first_instant_when_local_midnight_does_not_exist_havana() {
+        let tz: Tz = "America/Havana".parse().expect("known IANA zone");
+        let result = parse_due("2021-03-14", tz).expect(
+            "a gap date must resolve to the first instant of that date, not error (ADR-169 D1)",
+        );
+        let parsed = DateTime::parse_from_rfc3339(&result).unwrap();
+        assert_eq!(
+            parsed.date_naive(),
+            chrono::NaiveDate::from_ymd_opt(2021, 3, 14).unwrap(),
+            "got {result}"
+        );
+        assert!(
+            parsed.time() > chrono::NaiveTime::from_hms_opt(0, 0, 0).unwrap(),
+            "local midnight does not exist on this date, so the resolved instant must be \
+             strictly after 00:00 — proving the gap was bridged forward, not unwrapped to UTC; \
+             got {result}"
+        );
+    }
+
+    #[test]
+    fn date_only_due_resolves_to_first_instant_when_local_midnight_does_not_exist_santiago() {
+        let tz: Tz = "America/Santiago".parse().expect("known IANA zone");
+        let result = parse_due("2021-09-05", tz).expect(
+            "a gap date must resolve to the first instant of that date, not error (ADR-169 D1)",
+        );
+        let parsed = DateTime::parse_from_rfc3339(&result).unwrap();
+        assert_eq!(
+            parsed.date_naive(),
+            chrono::NaiveDate::from_ymd_opt(2021, 9, 5).unwrap(),
+            "got {result}"
+        );
+        assert!(
+            parsed.time() > chrono::NaiveTime::from_hms_opt(0, 0, 0).unwrap(),
+            "got {result}"
+        );
+    }
+
+    #[test]
+    fn date_only_due_picks_the_earlier_instant_when_local_midnight_occurs_twice_havana() {
+        let tz: Tz = "America/Havana".parse().expect("known IANA zone");
+        let date = chrono::NaiveDate::from_ymd_opt(2020, 11, 1).unwrap();
+        let midnight = date.and_hms_opt(0, 0, 0).unwrap();
+        // Derived directly from chrono_tz, independent of parse_due, so this
+        // is a cross-check against the library's own contract rather than a
+        // restatement of parse_due's internals.
+        let (earliest, latest) = match tz.from_local_datetime(&midnight) {
+            chrono::LocalResult::Ambiguous(a, b) => (a, b),
+            other => panic!(
+                "2020-11-01 in America/Havana must be ambiguous per ADR-169's worked table; \
+                 got {other:?}"
+            ),
+        };
+        assert!(
+            earliest < latest,
+            "sanity: chrono's `earliest` must be chronologically first"
+        );
+
+        let result =
+            parse_due("2020-11-01", tz).expect("an ambiguous date must resolve, not error");
+        let parsed = DateTime::parse_from_rfc3339(&result).unwrap();
+        assert_eq!(
+            parsed, earliest,
+            "parse_due must pick the earlier of the two midnight instants (ADR-169 D1); got {result}"
+        );
+    }
+
+    // Pacific/Apia jumped from UTC-11 to UTC+13 on 2011-12-30, skipping that
+    // calendar date entirely in local time — not a sub-day gap but a
+    // whole-day one, which ADR-169 D1's worked examples do not name. No
+    // instant anywhere maps to this date in this zone, so parse_due errors
+    // rather than silently resolving to a neighboring date under a
+    // mislabeled due-date.
+    #[test]
+    fn date_only_due_in_a_skipped_local_day_is_rejected() {
+        let tz: Tz = "Pacific/Apia".parse().expect("known IANA zone");
+        let err = parse_due("2011-12-30", tz).expect_err("2011-12-30 never existed in Apia");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("2011-12-30"),
+            "error must name the unparseable due date; got: {msg}"
+        );
+    }
 }
 
 fn ts_to_rfc(micros: i64) -> String {

--- a/crates/khive-pack-gtd/src/handlers.rs
+++ b/crates/khive-pack-gtd/src/handlers.rs
@@ -648,12 +648,14 @@ mod tz_database_audit {
         let mut gaps = 0usize;
         let mut folds = 0usize;
         let mut skipped_days = 0usize;
+        let mut dates_examined = 0usize;
         let mut failures: Vec<String> = Vec::new();
 
         for tz in chrono_tz::TZ_VARIANTS.iter().copied() {
             zones += 1;
             let mut date = start;
             while date < end {
+                dates_examined += 1;
                 let midnight = date.and_hms_opt(0, 0, 0).expect("midnight");
                 match tz.from_local_datetime(&midnight) {
                     chrono::LocalResult::Single(_) => {}
@@ -684,13 +686,23 @@ mod tz_database_audit {
                         skipped_days += 1;
                         let base = midnight;
                         let mut found = None;
+                        // ONE-SECOND steps, matching the granularity the implementation itself
+                        // searches at. A coarser step was here first and was wrong in the
+                        // reassuring direction: a local-date interval shorter than the step can
+                        // sit between two probes, so the search reports "no instant carries this
+                        // date" without having looked at the instants that would. The current
+                        // pinned table happens to contain no such interval, but that is a
+                        // property of today's data, and this test exists to be run against data
+                        // that has changed. The window is ~48h either side and skipped days are
+                        // rare (single digits across the whole sweep), so the finer step costs
+                        // nothing measurable.
                         let mut probe = base - chrono::Duration::hours(48);
                         while probe <= base + chrono::Duration::hours(48) {
                             if tz.from_utc_datetime(&probe).date_naive() == date {
                                 found = Some(probe);
                                 break;
                             }
-                            probe += chrono::Duration::minutes(1);
+                            probe += chrono::Duration::seconds(1);
                         }
                         if let Some(hit) = found {
                             failures.push(format!(
@@ -729,12 +741,29 @@ mod tz_database_audit {
         );
 
         // Then assert the sweep actually examined something, so an audit that silently swept
-        // nothing cannot pass by finding nothing. These are floors at zero for each SHAPE the
-        // sweep must exercise rather than guesses at a magnitude: a shape reaching zero means
-        // the traversal broke, and any number above zero is the database's business.
-        assert!(
-            zones > 500,
-            "expected the full zone database, swept {zones}"
+        // nothing cannot pass by finding nothing.
+        //
+        // TRAVERSAL counts are exact, because they are ours: the number of zones and the number
+        // of dates per zone are fixed by this test's own range and by the pinned table's length,
+        // so anything else means the loop did not run. A floor here would have accepted a
+        // 501-zone subset of 597 as "the full database".
+        //
+        // TRANSITION counts stay floors at zero per SHAPE. Those belong to the database, not to
+        // us, and this test exists to be run when the database changes; pinning 4299 gaps would
+        // make a legitimate pin bump fail for a reason that has nothing to do with the property
+        // under test. Zero for a shape means the traversal never reached that kind of date.
+        let expected_dates = (end - start).num_days() as usize;
+        assert_eq!(
+            zones,
+            chrono_tz::TZ_VARIANTS.len(),
+            "swept {zones} zones but the pinned table has {}",
+            chrono_tz::TZ_VARIANTS.len()
+        );
+        assert_eq!(
+            dates_examined,
+            zones * expected_dates,
+            "expected {zones} zones x {expected_dates} dates = {}, examined {dates_examined}",
+            zones * expected_dates
         );
         assert!(
             gaps > 0,

--- a/crates/khive-pack-gtd/src/handlers.rs
+++ b/crates/khive-pack-gtd/src/handlers.rs
@@ -13,7 +13,7 @@
 
 use std::str::FromStr;
 
-use chrono::{DateTime, Offset, TimeZone, Utc};
+use chrono::{DateTime, TimeZone, Utc};
 use chrono_tz::Tz;
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -543,25 +543,47 @@ fn anchor_date_to_earliest_instant(date: chrono::NaiveDate, tz: Tz) -> Option<Da
         // The earlier one is the least instant whose local date is `date`.
         chrono::LocalResult::Ambiguous(earliest, _latest) => Some(earliest),
         // Spring-forward gap (or a larger jump): local midnight does not
-        // exist. Find the transition by probing a point on the previous
-        // calendar date guaranteed to fall outside any transition (noon),
-        // reading the offset in effect there, and using it to project
-        // `midnight` to the UTC instant it would have been under that
-        // still-prior offset. Because the local date is a monotonically
-        // non-decreasing function of UTC time, re-deriving the actual local
-        // time at that UTC instant (an unconditional, never-ambiguous
-        // UTC->local conversion) lands exactly on the first instant that
-        // exists on `date` — the moment the new offset regime begins.
+        // exist. Solve for the boundary directly rather than projecting to
+        // it. The local date is a monotonically non-decreasing function of
+        // UTC time, so the least instant whose local date is `date` is the
+        // bisection point on the UTC axis between "still the previous date"
+        // and "already this date".
+        //
+        // The earlier implementation instead read the offset in effect at
+        // noon on the previous calendar date and projected local midnight
+        // forward under it. That is correct only when the gap BEGINS at
+        // local midnight. It need not: for `America/Toronto` on 1919-03-31
+        // the clock jumped from 23:30 on the previous date to 00:30, so the
+        // first instant belonging to the date is 00:30 local (04:30Z), while
+        // the projection under the prior -05:00 offset returned 01:00 local
+        // (05:00Z) — thirty minutes late, and late in a way that still
+        // passed a same-date check. Six IANA zones share that transition.
+        //
+        // One-second granularity is required, not one-minute: historical
+        // LMT offsets are not whole minutes.
         chrono::LocalResult::None => {
-            let prev_noon = date.pred_opt()?.and_hms_opt(12, 0, 0)?;
-            let offset_before = match tz.offset_from_local_datetime(&prev_noon) {
-                chrono::LocalResult::Single(o) => o,
-                chrono::LocalResult::Ambiguous(o, _) => o,
-                chrono::LocalResult::None => return None,
-            };
-            let candidate_utc =
-                midnight - chrono::Duration::seconds(offset_before.fix().local_minus_utc() as i64);
-            let resolved = tz.from_utc_datetime(&candidate_utc);
+            let mut lo = midnight - chrono::Duration::hours(48);
+            let mut hi = midnight + chrono::Duration::hours(48);
+            // Guard the bisection invariant instead of assuming it. Real UTC
+            // offsets stay well inside +/-48h, so a violation here means the
+            // zone is outside anything this rule can answer for; fail closed.
+            if tz.from_utc_datetime(&lo).date_naive() >= date
+                || tz.from_utc_datetime(&hi).date_naive() < date
+            {
+                return None;
+            }
+            while hi - lo > chrono::Duration::seconds(1) {
+                let mid = lo + (hi - lo) / 2;
+                if tz.from_utc_datetime(&mid).date_naive() < date {
+                    lo = mid;
+                } else {
+                    hi = mid;
+                }
+            }
+            // `hi` is now the least instant whose local date is >= `date`.
+            // It is > `date` exactly when the zone's local calendar skips
+            // the date entirely, which is the documented `None` case.
+            let resolved = tz.from_utc_datetime(&hi);
             (resolved.date_naive() == date).then_some(resolved)
         }
     }
@@ -613,6 +635,50 @@ mod parse_due_tests {
         assert!(
             parsed.time() > chrono::NaiveTime::from_hms_opt(0, 0, 0).unwrap(),
             "got {result}"
+        );
+    }
+
+    // The two tests above assert only that the resolved time is after 00:00.
+    // That is too weak to separate "the first instant on this date" from "some
+    // instant on this date": both zones' gaps begin exactly at local midnight,
+    // so a projection under the previous offset and a true least-instant search
+    // agree there and either implementation passes. The test below uses a zone
+    // whose gap begins BEFORE midnight, where the two rules give different
+    // answers, and asserts the least-instant property itself.
+    #[test]
+    fn date_only_due_resolves_to_the_least_instant_when_the_gap_begins_before_midnight_toronto() {
+        let tz: Tz = "America/Toronto".parse().expect("known IANA zone");
+        // On 1919-03-31 the clock jumped from 23:30 on the previous date to
+        // 00:30, so local midnight never occurred and the first instant of the
+        // date is 00:30 -04:00 = 04:30Z. Reading the previous day's offset
+        // (-05:00) and projecting midnight forward gives 05:00Z instead, which
+        // is on the right date and thirty minutes late.
+        let result = parse_due("1919-03-31", tz)
+            .expect("a gap date must resolve to the first instant of that date (ADR-169 D1)");
+        let parsed = DateTime::parse_from_rfc3339(&result).unwrap();
+
+        assert_eq!(
+            parsed.to_utc(),
+            chrono::NaiveDate::from_ymd_opt(1919, 3, 31)
+                .unwrap()
+                .and_hms_opt(4, 30, 0)
+                .unwrap()
+                .and_utc(),
+            "must be the FIRST instant of the date (04:30Z), not the instant local midnight \
+             would have had under the previous offset (05:00Z); got {result}"
+        );
+
+        // The least-instant property, asserted directly rather than by
+        // comparing against a constant: one second earlier must already be a
+        // different local date. This is what fails for the projected answer,
+        // since 04:59:59Z is still 1919-03-31 locally.
+        let one_second_earlier = parsed.to_utc() - chrono::Duration::seconds(1);
+        assert_ne!(
+            tz.from_utc_datetime(&one_second_earlier.naive_utc())
+                .date_naive(),
+            chrono::NaiveDate::from_ymd_opt(1919, 3, 31).unwrap(),
+            "the instant one second before the resolved one must belong to a different local \
+             date, or the resolved instant was not the least one; got {result}"
         );
     }
 

--- a/crates/khive-pack-gtd/src/task_create.rs
+++ b/crates/khive-pack-gtd/src/task_create.rs
@@ -380,7 +380,10 @@ pub(crate) async fn prepare_task_create(
         obj.insert("assignee".into(), json!(assignee));
     }
     if let Some(ref due) = input.due {
-        obj.insert("due".into(), json!(parse_due(due)?));
+        obj.insert(
+            "due".into(),
+            json!(parse_due(due, runtime.config().display_timezone)?),
+        );
     }
     if let Some(ref start) = input.start {
         obj.insert("start".into(), json!(start));

--- a/crates/khive-pack-gtd/tests/assign.rs
+++ b/crates/khive-pack-gtd/tests/assign.rs
@@ -2,7 +2,8 @@
 
 mod common;
 
-use common::{assign, pack, rt};
+use chrono::{DateTime, NaiveDate};
+use common::{assign, pack, rt, rt_with_timezone};
 use serde_json::json;
 
 #[tokio::test]
@@ -138,6 +139,116 @@ async fn assign_due_date_only_accepted() {
     let due = resp["due"].as_str().expect("due must be a string");
     chrono::DateTime::parse_from_rfc3339(due)
         .unwrap_or_else(|e| panic!("due not RFC 3339: {due} — {e}"));
+}
+
+// ADR-169: date-only `due` anchors to the configured `[display] timezone`
+// (not UTC), so `gtd.assign(due="2026-08-23")` stores the calendar date the
+// caller typed regardless of which side of UTC the configured zone sits on.
+// Assertions check the resulting calendar date (`.date_naive()` on the
+// parsed offset datetime, never converted to UTC first) — never a
+// hard-coded offset string, which would pass in one DST season and silently
+// break in the other.
+
+#[tokio::test]
+async fn assign_due_date_only_anchors_to_configured_zone_west_of_utc() {
+    let pack = pack(rt_with_timezone("America/New_York"));
+    let resp = assign(&pack, json!({"title": "west of utc", "due": "2026-06-15"})).await;
+    let due = resp["due"].as_str().expect("due must be a string");
+    let parsed = DateTime::parse_from_rfc3339(due)
+        .unwrap_or_else(|e| panic!("due not RFC 3339: {due} — {e}"));
+    assert_eq!(
+        parsed.date_naive(),
+        NaiveDate::from_ymd_opt(2026, 6, 15).unwrap(),
+        "calendar date must be the date the caller typed, not shifted by anchoring to UTC; got {due}"
+    );
+    assert!(
+        parsed.offset().local_minus_utc() < 0,
+        "America/New_York must anchor with a negative (west-of-UTC) offset; got {due}"
+    );
+}
+
+#[tokio::test]
+async fn assign_due_date_only_anchors_to_configured_zone_east_of_utc() {
+    let pack = pack(rt_with_timezone("Asia/Tokyo"));
+    let resp = assign(&pack, json!({"title": "east of utc", "due": "2026-06-15"})).await;
+    let due = resp["due"].as_str().expect("due must be a string");
+    let parsed = DateTime::parse_from_rfc3339(due)
+        .unwrap_or_else(|e| panic!("due not RFC 3339: {due} — {e}"));
+    assert_eq!(
+        parsed.date_naive(),
+        NaiveDate::from_ymd_opt(2026, 6, 15).unwrap(),
+        "calendar date must be the date the caller typed, not shifted by anchoring to UTC; got {due}"
+    );
+    assert!(
+        parsed.offset().local_minus_utc() > 0,
+        "Asia/Tokyo must anchor with a positive (east-of-UTC) offset; got {due}"
+    );
+}
+
+#[tokio::test]
+async fn assign_due_date_only_anchors_correctly_across_a_dst_transition() {
+    let pack = pack(rt_with_timezone("America/New_York"));
+
+    // 2026-03-08 is the US spring-forward date (America/New_York EST->EDT);
+    // 2026-03-09 is the day immediately after. Midnight itself is never
+    // inside the 2am gap on either date, so both anchor unambiguously, but
+    // the two calendar dates fall on opposite sides of the transition and
+    // must resolve to different UTC offsets.
+    let before = assign(&pack, json!({"title": "before dst", "due": "2026-03-08"})).await;
+    let after = assign(&pack, json!({"title": "after dst", "due": "2026-03-09"})).await;
+
+    let due_before = before["due"].as_str().expect("due must be a string");
+    let due_after = after["due"].as_str().expect("due must be a string");
+    let parsed_before = DateTime::parse_from_rfc3339(due_before)
+        .unwrap_or_else(|e| panic!("due not RFC 3339: {due_before} — {e}"));
+    let parsed_after = DateTime::parse_from_rfc3339(due_after)
+        .unwrap_or_else(|e| panic!("due not RFC 3339: {due_after} — {e}"));
+
+    assert_eq!(
+        parsed_before.date_naive(),
+        NaiveDate::from_ymd_opt(2026, 3, 8).unwrap(),
+        "got {due_before}"
+    );
+    assert_eq!(
+        parsed_after.date_naive(),
+        NaiveDate::from_ymd_opt(2026, 3, 9).unwrap(),
+        "got {due_after}"
+    );
+    assert_ne!(
+        parsed_before.offset().local_minus_utc(),
+        parsed_after.offset().local_minus_utc(),
+        "the two dates straddle America/New_York's spring-forward transition and must \
+         anchor to different UTC offsets (EST before, EDT after); got {due_before} and {due_after}"
+    );
+}
+
+#[tokio::test]
+async fn assign_due_with_explicit_offset_is_unaffected_by_configured_zone() {
+    // A value that already carries an explicit offset keeps its existing UTC
+    // normalization regardless of [display] timezone (ADR-169 scope: parse
+    // sites only anchor date-ONLY input).
+    let ny = pack(rt_with_timezone("America/New_York"));
+    let tokyo = pack(rt_with_timezone("Asia/Tokyo"));
+    let body = json!({"title": "explicit offset", "due": "2026-08-23T09:30:00-04:00"});
+
+    let resp_ny = assign(&ny, body.clone()).await;
+    let resp_tokyo = assign(&tokyo, body).await;
+
+    let due_ny = resp_ny["due"].as_str().expect("due must be a string");
+    let due_tokyo = resp_tokyo["due"].as_str().expect("due must be a string");
+    assert_eq!(
+        due_ny, due_tokyo,
+        "an explicit-offset due must normalize identically regardless of the configured \
+         display timezone"
+    );
+
+    let parsed = DateTime::parse_from_rfc3339(due_ny)
+        .unwrap_or_else(|e| panic!("due not RFC 3339: {due_ny} — {e}"));
+    assert_eq!(
+        parsed,
+        DateTime::parse_from_rfc3339("2026-08-23T09:30:00-04:00").unwrap(),
+        "explicit-offset due must denote the same instant as written; got {due_ny}"
+    );
 }
 
 #[tokio::test]

--- a/crates/khive-pack-gtd/tests/common/mod.rs
+++ b/crates/khive-pack-gtd/tests/common/mod.rs
@@ -11,6 +11,25 @@ pub fn rt() -> KhiveRuntime {
     KhiveRuntime::memory().expect("memory runtime")
 }
 
+/// An in-memory runtime configured with a specific `[display] timezone`
+/// (ADR-169), for tests that exercise date-only `due` anchoring.
+// REASON: used by assign.rs tests only; each test binary sees its own dead_code analysis
+#[allow(dead_code)]
+pub fn rt_with_timezone(tz: &str) -> KhiveRuntime {
+    let display_timezone = tz
+        .parse()
+        .unwrap_or_else(|e| panic!("{tz:?} must be a valid IANA zone name: {e}"));
+    KhiveRuntime::new(khive_runtime::RuntimeConfig {
+        display_timezone,
+        db_path: None,
+        packs: vec!["kg".to_string()],
+        brain_profile: None,
+        actor_id: None,
+        ..khive_runtime::RuntimeConfig::no_embeddings()
+    })
+    .expect("memory runtime with configured display timezone")
+}
+
 /// Test fixture: a `VerbRegistry` containing a freshly registered `GtdPack`,
 /// with pass-through metadata methods so existing tests keep working.
 pub struct Fixture {

--- a/crates/khive-pack-knowledge/benches/knowledge_bench.rs
+++ b/crates/khive-pack-knowledge/benches/knowledge_bench.rs
@@ -20,6 +20,7 @@ use khive_types::Namespace;
 fn build_runtime() -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
+        display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-pack-knowledge/benches/search_latency.rs
+++ b/crates/khive-pack-knowledge/benches/search_latency.rs
@@ -27,6 +27,7 @@ use std::sync::Arc;
 fn rt_with_embedder() -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
+        display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-pack-knowledge/src/handlers.rs
+++ b/crates/khive-pack-knowledge/src/handlers.rs
@@ -928,6 +928,7 @@ mod tests {
         // runners and fails entity creation with `ModelInitialization`.
         let rt = KhiveRuntime::new(khive_runtime::RuntimeConfig {
             git_write: Default::default(),
+            display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),

--- a/crates/khive-pack-knowledge/src/knowledge/ann_degrade_tests.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/ann_degrade_tests.rs
@@ -170,6 +170,7 @@ impl EmbedderProvider for ControlledRankingProvider {
 fn rt_with_fake_embedder() -> KhiveRuntime {
     let rt = KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
+        display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
@@ -191,6 +192,7 @@ fn rt_with_fake_embedder() -> KhiveRuntime {
 fn rt_with_controlled_ranking(fail_fresh_rerank: bool) -> KhiveRuntime {
     let rt = KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
+        display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
@@ -216,6 +218,7 @@ fn rt_with_controlled_ranking(fail_fresh_rerank: bool) -> KhiveRuntime {
 fn file_rt_with_fake_embedder(db_path: std::path::PathBuf) -> KhiveRuntime {
     let rt = KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
+        display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         db_path: Some(db_path),
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-pack-knowledge/src/knowledge/suggest_ranking_tests.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/suggest_ranking_tests.rs
@@ -167,6 +167,7 @@ impl EmbedderProvider for FixtureEmbedProvider {
 fn rt_with_fixture_embedder() -> KhiveRuntime {
     let rt = KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
+        display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-pack-knowledge/src/knowledge/vamana.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/vamana.rs
@@ -4255,6 +4255,7 @@ mod tests {
     fn rt_with_embedder(db_path: Option<std::path::PathBuf>) -> KhiveRuntime {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
+            display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             db_path,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),

--- a/crates/khive-pack-knowledge/tests/bench.rs
+++ b/crates/khive-pack-knowledge/tests/bench.rs
@@ -27,6 +27,7 @@ use std::sync::Arc;
 fn rt_with_embedder() -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
+        display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-pack-knowledge/tests/feedback.rs
+++ b/crates/khive-pack-knowledge/tests/feedback.rs
@@ -21,6 +21,7 @@ fn make_rt(brain_profile: Option<String>, with_brain: bool) -> KhiveRuntime {
     };
     KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
+        display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         embedding_model: None,
@@ -38,6 +39,7 @@ fn make_rt(brain_profile: Option<String>, with_brain: bool) -> KhiveRuntime {
 fn make_rt_with_actor(actor: &str) -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
+        display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-pack-knowledge/tests/fixes.rs
+++ b/crates/khive-pack-knowledge/tests/fixes.rs
@@ -1629,6 +1629,7 @@ fn rt_with_default_embedder() -> KhiveRuntime {
 
     KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
+        display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
@@ -2305,6 +2306,7 @@ mod embed_failure_tests {
     fn rt_with_fake(fake: impl EmbedderProvider + 'static) -> KhiveRuntime {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
+            display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -2492,6 +2494,7 @@ mod embed_failure_tests {
 
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
+            display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -2807,6 +2810,7 @@ mod ann_bypass_regression {
     fn rt_with_correct_embedder() -> KhiveRuntime {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
+            display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -3405,6 +3409,7 @@ mod edit_inline_reembed {
     fn rt_with_embedder() -> KhiveRuntime {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
+            display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -3809,6 +3814,7 @@ mod ann_type_filter_regression {
     fn rt_with_embedder() -> KhiveRuntime {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
+            display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -4214,6 +4220,7 @@ mod compose_explain_sections {
     fn rt_with_embedder() -> KhiveRuntime {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
+            display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),

--- a/crates/khive-pack-knowledge/tests/integration.rs
+++ b/crates/khive-pack-knowledge/tests/integration.rs
@@ -1839,6 +1839,7 @@ async fn index_reembed_paging_sweep_covers_equal_created_at_in_order() {
     let recorded = Arc::new(Mutex::new(Vec::<String>::new()));
     let rt = KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
+        display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
@@ -3996,6 +3997,7 @@ mod kg_blend {
     fn rt_with_marker_embedder() -> KhiveRuntime {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
+            display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -4625,6 +4627,7 @@ mod kg_blend {
     fn rt_with_failing_blend_embedder() -> KhiveRuntime {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
+            display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),

--- a/crates/khive-pack-knowledge/tests/search_candidate_refill.rs
+++ b/crates/khive-pack-knowledge/tests/search_candidate_refill.rs
@@ -143,6 +143,7 @@ impl EmbedderProvider for RefillVectorProvider {
 fn runtime_with_embedder() -> KhiveRuntime {
     let runtime = KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
+        display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-pack-moodboard/src/preference_handlers.rs
+++ b/crates/khive-pack-moodboard/src/preference_handlers.rs
@@ -1602,6 +1602,7 @@ mod tests {
     fn persistent_runtime_config(db_path: &Path, actor_id: &str) -> RuntimeConfig {
         RuntimeConfig {
             git_write: Default::default(),
+            display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             db_path: Some(db_path.to_path_buf()),
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),

--- a/crates/khive-pack-session/src/mirror/ingest.rs
+++ b/crates/khive-pack-session/src/mirror/ingest.rs
@@ -1103,6 +1103,7 @@ mod tests {
         let db_path = dir.path().join("test.db");
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
+            display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             db_path: Some(db_path),
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),

--- a/crates/khive-pack-session/src/mirror/service.rs
+++ b/crates/khive-pack-session/src/mirror/service.rs
@@ -2625,6 +2625,7 @@ mod cursor_retry_tests {
         let db_path = dir.path().join("test.db");
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
+            display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             db_path: Some(db_path),
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),

--- a/crates/khive-pack-session/tests/integration.rs
+++ b/crates/khive-pack-session/tests/integration.rs
@@ -21,6 +21,7 @@ use tempfile::TempDir;
 fn file_rt(db_path: std::path::PathBuf) -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
+        display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         db_path: Some(db_path),
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-runtime/Cargo.toml
+++ b/crates/khive-runtime/Cargo.toml
@@ -32,6 +32,8 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
+chrono-tz = { workspace = true }
+iana-time-zone = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 lattice-embed = { workspace = true }

--- a/crates/khive-runtime/src/config.rs
+++ b/crates/khive-runtime/src/config.rs
@@ -310,6 +310,12 @@ pub struct RuntimeConfig {
     /// instead of re-running config discovery (which would ignore an
     /// explicit `--config` path not also exported as `KHIVE_CONFIG`).
     pub git_write: crate::engine_config::GitWriteSectionConfig,
+    /// Resolved rendering timezone (ADR-169), consumed today by date-only
+    /// `parse_due` anchoring. Populated from `[display] timezone` in
+    /// `khive.toml` by [`runtime_config_from_khive_config`]; when absent,
+    /// resolves once to the host's local IANA zone (falling back to UTC when
+    /// the host zone cannot be determined) via [`resolve_default_display_timezone`].
+    pub display_timezone: chrono_tz::Tz,
 }
 
 /// Parse a comma- or whitespace-separated pack list from a single string.
@@ -339,6 +345,18 @@ fn ann_fresh_tail_enabled_from_value(value: Option<&str>) -> bool {
 pub fn ann_fresh_tail_enabled_from_env() -> bool {
     let value = std::env::var("KHIVE_ANN_FRESH_TAIL").ok();
     ann_fresh_tail_enabled_from_value(value.as_deref())
+}
+
+/// Resolve the host's local IANA zone name once, for [`RuntimeConfig`]'s
+/// default `display_timezone` (ADR-169). Falls back to UTC when the host
+/// zone cannot be determined (e.g. `TZ`/`/etc/localtime` unreadable) or does
+/// not parse as a known `chrono_tz::Tz` — this must never panic or block
+/// construction of a default `RuntimeConfig`.
+pub fn resolve_default_display_timezone() -> chrono_tz::Tz {
+    iana_time_zone::get_timezone()
+        .ok()
+        .and_then(|name| name.parse::<chrono_tz::Tz>().ok())
+        .unwrap_or(chrono_tz::Tz::UTC)
 }
 
 impl Default for RuntimeConfig {
@@ -382,6 +400,7 @@ impl Default for RuntimeConfig {
             allowed_outbound_namespaces: vec![],
             actor_id,
             git_write: crate::engine_config::GitWriteSectionConfig::default(),
+            display_timezone: resolve_default_display_timezone(),
         }
     }
 }
@@ -719,6 +738,17 @@ pub fn runtime_config_from_khive_config(
         .blob_hydration_bytes
         .unwrap_or(base.blob_hydration_bytes);
 
+    // KhiveConfig::validate() guarantees a present timezone parses as a valid
+    // chrono_tz::Tz, so the fallback to base.display_timezone below is only
+    // reachable for an unvalidated caller-constructed KhiveConfig, not a
+    // config loaded via KhiveConfig::load.
+    let display_timezone = khive_cfg
+        .display
+        .timezone
+        .as_deref()
+        .and_then(|s| s.parse::<chrono_tz::Tz>().ok())
+        .unwrap_or(base.display_timezone);
+
     if khive_cfg.engines.is_empty() {
         return RuntimeConfig {
             default_namespace,
@@ -728,6 +758,7 @@ pub fn runtime_config_from_khive_config(
             actor_id,
             git_write,
             blob_hydration_bytes,
+            display_timezone,
             ..base
         };
     }
@@ -764,7 +795,21 @@ pub fn runtime_config_from_khive_config(
         actor_id,
         git_write,
         blob_hydration_bytes,
+        display_timezone,
         ..base
+    }
+}
+
+#[cfg(test)]
+mod display_timezone_tests {
+    use super::resolve_default_display_timezone;
+
+    // The host's actual zone is environment-dependent (CI runners are
+    // typically UTC), so this only asserts the resolver always produces some
+    // valid, non-panicking Tz — never that it matches a specific zone.
+    #[test]
+    fn resolve_default_display_timezone_never_panics() {
+        let _tz = resolve_default_display_timezone();
     }
 }
 

--- a/crates/khive-runtime/src/engine_config.rs
+++ b/crates/khive-runtime/src/engine_config.rs
@@ -85,6 +85,11 @@ pub enum ConfigError {
         "[gate] configuration is not supported by this build; refusing to start because the requested caller-enrollment policy would not be enforced"
     )]
     UnsupportedGateSection,
+
+    #[error(
+        "[display] timezone {timezone:?} is not a recognized IANA zone name (e.g. \"America/New_York\", \"UTC\")"
+    )]
+    InvalidDisplayTimezone { timezone: String },
 }
 
 // ---- Config structs ----
@@ -357,6 +362,7 @@ pub struct GitWriteSectionConfig {
 /// - `[runtime]`: runtime knobs (pack selection, brain profile, output format)
 /// - `[[backends]]`: storage backend declarations (ADR-028)
 /// - `[packs.<name>]`: per-pack backend assignments (ADR-028)
+/// - `[display]`: rendering timezone (ADR-169)
 ///
 /// Unknown keys are silently ignored by serde for forward compatibility. The
 /// security-sensitive `[gate]` exception is detected by [`KhiveConfig::load`]
@@ -415,6 +421,12 @@ pub struct KhiveConfig {
     /// Amendment 2: `[storage.blob]`'s `fs`/`s3` selector).
     #[serde(default)]
     pub storage: StorageSectionConfig,
+
+    /// Rendering timezone configuration (ADR-169). Absent `timezone` resolves
+    /// to the host's local zone at [`RuntimeConfig`](crate::RuntimeConfig)
+    /// construction time.
+    #[serde(default)]
+    pub display: DisplaySectionConfig,
 }
 
 /// `[runtime]` section in `khive.toml`.
@@ -456,6 +468,24 @@ pub struct RuntimeSectionConfig {
     /// directly through `RuntimeConfig`).
     #[serde(default)]
     pub blob_hydration_bytes: Option<u64>,
+}
+
+/// `[display]` section in `khive.toml` — the timezone khive anchors date-only
+/// input to (ADR-169 Implementation step 1).
+///
+/// ```toml
+/// [display]
+/// timezone = "America/New_York"
+/// ```
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct DisplaySectionConfig {
+    /// IANA zone name (e.g. `"America/New_York"`, `"Asia/Tokyo"`, `"UTC"`).
+    /// Validated at load time against `chrono_tz::Tz`'s zone table — an
+    /// unrecognized name is a startup error, not a silent fallback. Absent →
+    /// the host's local zone, resolved once via `iana-time-zone` and falling
+    /// back to UTC when the host zone cannot be determined.
+    #[serde(default)]
+    pub timezone: Option<String>,
 }
 
 impl KhiveConfig {
@@ -784,6 +814,16 @@ impl KhiveConfig {
                         defined: defined.join(", "),
                     });
                 }
+            }
+        }
+
+        // Validate [display] timezone (ADR-169): an unrecognized IANA zone
+        // name is a startup error, not a silent fallback to the host zone.
+        if let Some(tz) = self.display.timezone.as_deref() {
+            if tz.trim().is_empty() || tz.parse::<chrono_tz::Tz>().is_err() {
+                return Err(ConfigError::InvalidDisplayTimezone {
+                    timezone: tz.to_string(),
+                });
             }
         }
 
@@ -2358,5 +2398,70 @@ backend = "gcs"
         );
         let err = KhiveConfig::load(Some(&path)).expect_err("unknown backend must be rejected");
         assert!(matches!(err, ConfigError::Parse { .. }), "got {err:?}");
+    }
+
+    // ── [display] section (ADR-169) ──────────────────────────────────────────
+
+    // No [display] section at all -> None, resolved to the host zone downstream.
+    #[test]
+    fn test_no_display_section_defaults_to_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_toml(&dir, "# no display section\n");
+        let cfg = KhiveConfig::load(Some(&path))
+            .expect("no error")
+            .expect("file found");
+        assert!(cfg.display.timezone.is_none());
+    }
+
+    #[test]
+    fn test_display_timezone_valid_iana_name_parses() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_toml(
+            &dir,
+            r#"
+[display]
+timezone = "America/New_York"
+"#,
+        );
+        let cfg = KhiveConfig::load(Some(&path))
+            .expect("no error")
+            .expect("file found");
+        assert_eq!(cfg.display.timezone.as_deref(), Some("America/New_York"));
+    }
+
+    #[test]
+    fn test_display_timezone_unrecognized_name_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_toml(
+            &dir,
+            r#"
+[display]
+timezone = "Mars/Olympus_Mons"
+"#,
+        );
+        let err = KhiveConfig::load(Some(&path))
+            .expect_err("an unrecognized IANA zone name must fail at load, not silently fall back");
+        assert!(
+            matches!(err, ConfigError::InvalidDisplayTimezone { ref timezone } if timezone == "Mars/Olympus_Mons"),
+            "expected InvalidDisplayTimezone, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_display_timezone_empty_string_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_toml(
+            &dir,
+            r#"
+[display]
+timezone = ""
+"#,
+        );
+        let err =
+            KhiveConfig::load(Some(&path)).expect_err("an empty timezone string must be rejected");
+        assert!(
+            matches!(err, ConfigError::InvalidDisplayTimezone { .. }),
+            "expected InvalidDisplayTimezone, got {err:?}"
+        );
     }
 }

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -1786,6 +1786,7 @@ mod tests {
         let path = dir.path().join("test.db");
         let config = RuntimeConfig {
             git_write: Default::default(),
+            display_timezone: chrono_tz::Tz::UTC,
             db_path: Some(path),
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -1811,6 +1812,7 @@ mod tests {
         let backend = Arc::new(StorageBackend::memory().expect("memory backend"));
         let config = RuntimeConfig {
             git_write: Default::default(),
+            display_timezone: chrono_tz::Tz::UTC,
             db_path: None,
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -1834,6 +1836,7 @@ mod tests {
         let path = dir.path().join("test.db");
         let config = RuntimeConfig {
             git_write: Default::default(),
+            display_timezone: chrono_tz::Tz::UTC,
             db_path: Some(path.clone()),
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::parse("test").unwrap(),
@@ -1861,6 +1864,7 @@ mod tests {
         let path = dir.path().join("read_only_runtime.db");
         let base = RuntimeConfig {
             git_write: Default::default(),
+            display_timezone: chrono_tz::Tz::UTC,
             db_path: Some(path.clone()),
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -1930,6 +1934,7 @@ mod tests {
         let path = dir.path().join("explicit_read_only_runtime.db");
         let config = RuntimeConfig {
             git_write: Default::default(),
+            display_timezone: chrono_tz::Tz::UTC,
             db_path: Some(path.clone()),
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -2012,6 +2017,7 @@ mod tests {
 
             let make_config = |db_path: std::path::PathBuf| RuntimeConfig {
                 git_write: Default::default(),
+                display_timezone: chrono_tz::Tz::UTC,
                 db_path: Some(db_path),
                 blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
                 default_namespace: Namespace::local(),
@@ -2058,6 +2064,7 @@ mod tests {
         let backend = Arc::new(StorageBackend::memory().expect("memory backend"));
         let config = RuntimeConfig {
             git_write: Default::default(),
+            display_timezone: chrono_tz::Tz::UTC,
             db_path: None,
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -2224,6 +2231,7 @@ mod tests {
         // asserts the write-routing invariant only.
         let base = RuntimeConfig {
             git_write: Default::default(),
+            display_timezone: chrono_tz::Tz::UTC,
             db_path: None,
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -2250,6 +2258,7 @@ mod tests {
     fn runtime_config_from_khive_config_empty_actor_id_keeps_base_namespace() {
         let base = RuntimeConfig {
             git_write: Default::default(),
+            display_timezone: chrono_tz::Tz::UTC,
             db_path: None,
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::parse("lambda:base").unwrap(),
@@ -2284,6 +2293,7 @@ mod tests {
     fn runtime_config_from_khive_config_absent_actor_id_keeps_base_namespace() {
         let base = RuntimeConfig {
             git_write: Default::default(),
+            display_timezone: chrono_tz::Tz::UTC,
             db_path: None,
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::parse("lambda:base").unwrap(),
@@ -2310,6 +2320,7 @@ mod tests {
     fn runtime_config_from_khive_config_actor_id_with_engines() {
         let base = RuntimeConfig {
             git_write: Default::default(),
+            display_timezone: chrono_tz::Tz::UTC,
             db_path: None,
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -2346,6 +2357,67 @@ mod tests {
              writes pin to local; engine config is still applied"
         );
         assert!(result.embedding_model.is_some());
+    }
+
+    // ---- [display] timezone (ADR-169) wiring tests ----
+
+    #[test]
+    fn runtime_config_from_khive_config_display_timezone_overrides_base() {
+        let base = RuntimeConfig {
+            git_write: Default::default(),
+            display_timezone: chrono_tz::Tz::UTC,
+            db_path: None,
+            blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
+            default_namespace: Namespace::local(),
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            gate: Arc::new(AllowAllGate),
+            packs: vec!["kg".to_string()],
+            backend_id: BackendId::main(),
+            brain_profile: None,
+            visible_namespaces: vec![],
+            allowed_outbound_namespaces: vec![],
+            actor_id: None,
+        };
+        let cfg = KhiveConfig {
+            display: crate::engine_config::DisplaySectionConfig {
+                timezone: Some("America/New_York".to_string()),
+            },
+            ..KhiveConfig::default()
+        };
+        let result = runtime_config_from_khive_config(&cfg, base);
+        assert_eq!(
+            result.display_timezone,
+            "America/New_York".parse::<chrono_tz::Tz>().unwrap(),
+            "[display] timezone in khive.toml must override base.display_timezone"
+        );
+    }
+
+    #[test]
+    fn runtime_config_from_khive_config_absent_display_timezone_keeps_base() {
+        let base = RuntimeConfig {
+            git_write: Default::default(),
+            display_timezone: "Asia/Tokyo".parse().unwrap(),
+            db_path: None,
+            blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
+            default_namespace: Namespace::local(),
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            gate: Arc::new(AllowAllGate),
+            packs: vec!["kg".to_string()],
+            backend_id: BackendId::main(),
+            brain_profile: None,
+            visible_namespaces: vec![],
+            allowed_outbound_namespaces: vec![],
+            actor_id: None,
+        };
+        let cfg = KhiveConfig::default(); // no [display] section
+        let result = runtime_config_from_khive_config(&cfg, base);
+        assert_eq!(
+            result.display_timezone,
+            "Asia/Tokyo".parse::<chrono_tz::Tz>().unwrap(),
+            "absent [display] timezone must preserve base.display_timezone unchanged"
+        );
     }
 
     // ---- base.actor_id (env-resolved actor) preservation tests ----
@@ -2471,6 +2543,7 @@ mod tests {
     fn secondary_config() -> RuntimeConfig {
         RuntimeConfig {
             git_write: Default::default(),
+            display_timezone: chrono_tz::Tz::UTC,
             db_path: None,
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -2549,6 +2622,7 @@ mod tests {
 
         let main_config = RuntimeConfig {
             git_write: Default::default(),
+            display_timezone: chrono_tz::Tz::UTC,
             db_path: None,
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -2687,6 +2761,7 @@ mod tests {
             backend,
             RuntimeConfig {
                 git_write: Default::default(),
+                display_timezone: chrono_tz::Tz::UTC,
                 db_path: None,
                 blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
                 default_namespace: Namespace::local(),

--- a/crates/khive-runtime/tests/integration.rs
+++ b/crates/khive-runtime/tests/integration.rs
@@ -1939,6 +1939,7 @@ async fn file_backed_runtime_persists() {
     {
         let config = RuntimeConfig {
             git_write: Default::default(),
+            display_timezone: chrono_tz::Tz::UTC,
             db_path: Some(path.clone()),
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -1963,6 +1964,7 @@ async fn file_backed_runtime_persists() {
     {
         let config = RuntimeConfig {
             git_write: Default::default(),
+            display_timezone: chrono_tz::Tz::UTC,
             db_path: Some(path.clone()),
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -2585,6 +2587,7 @@ mod embedder_registry_tests {
     fn memory_rt_no_model() -> KhiveRuntime {
         KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
+            display_timezone: chrono_tz::Tz::UTC,
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -2738,6 +2741,7 @@ mod embedder_registry_tests {
         use khive_runtime::RuntimeConfig;
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
+            display_timezone: chrono_tz::Tz::UTC,
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -333,6 +333,24 @@ permissions on the socket/config paths).
 
 ---
 
+## `[display]` — rendering timezone (ADR-169)
+
+`[display] timezone` names the IANA zone (e.g. `"America/New_York"`) khive
+anchors date-only input to. Absent → the host's local zone, resolved once and
+falling back to UTC when it cannot be determined. An unrecognized zone name is
+a config-load error, not a silent fallback.
+
+Storage stays instant-based regardless of this setting: a date-only value like
+`gtd.assign(due="2026-08-23")` is anchored to midnight in the configured zone
+and stored with that zone's UTC offset (e.g. `2026-08-23T00:00:00-04:00` for a
+caller anchored at UTC-4) rather than midnight UTC. A value that already
+carries an explicit offset or `Z` is unaffected. See
+[ADR-169](adr/ADR-169-timezone-correct-timestamps.md) for the full decision
+record, including which rendering-surface work this setting does and does not
+cover yet.
+
+---
+
 ## References
 
 - [docs/khive-config-example.toml](khive-config-example.toml): full annotated

--- a/docs/khive-config-example.toml
+++ b/docs/khive-config-example.toml
@@ -21,6 +21,7 @@
 # Sections in this file:
 #   [actor]         default identity + namespace read/write scope
 #   [runtime]       brain profile + default output format
+#   [display]       rendering timezone (ADR-169)
 #   [gate]          reserved; rejected by this build (do not configure)
 #   [[engines]]     embedding engines (replaces the KHIVE_EMBEDDING_MODEL env pair)
 #   [[backends]]    named storage backends (ADR-028)
@@ -29,7 +30,7 @@
 #
 # ADR references: ADR-031 (multi-engine retrieval), ADR-035 (unified khive.toml),
 # ADR-028 (pack-scoped backends), ADR-007 (namespace / actor model), ADR-078 (output
-# format).
+# format), ADR-169 (timezone-correct timestamps).
 
 # ── [actor] — identity and namespace scope ──────────────────────────────────────
 #
@@ -86,6 +87,24 @@
 # (ADR-160). Default: 268435456 (256 MiB). Values below 67108864 (64 MiB)
 # are rejected because every valid portable blob request must be reservable.
 # blob_hydration_bytes = 268435456
+
+# ── [display] — rendering timezone (ADR-169) ──────────────────────────────────────
+#
+# The timezone khive anchors date-only input to. Absent → the host's local zone,
+# resolved once via the OS/`TZ` environment (falling back to UTC when it cannot be
+# determined). Storage stays instant-based either way: this setting controls the
+# CALENDAR used to interpret a bare `YYYY-MM-DD` at parse time (e.g. `gtd.assign`'s
+# `due` field), not how already-explicit timestamps are stored or rendered.
+#
+# A value that already carries an explicit offset or `Z` is unaffected by this
+# setting. As of this build, [display] governs date-only anchoring only — the
+# rendering-surface work described in ADR-169's Mechanism section (making every
+# timestamp field honor this zone on the way out) is tracked separately.
+
+[display]
+# IANA zone name. Validated at load time — an unrecognized name is a startup
+# error, not a silent fallback to the host zone.
+# timezone = "America/New_York"
 
 # ── [gate] — reserved authorization surface ───────────────────────────────────────
 #


### PR DESCRIPTION
Implements steps 1-3 of ADR-169, which merged to main as e9edceb7.

## What changes

A date-only value like `2026-06-01` denotes a calendar date, not an instant. `parse_due`
previously resolved it by attaching UTC directly, so a user west of Greenwich got a due date that
lands on the previous day in their own calendar. It now anchors to a configured display timezone.

- **`[display]` config section** with an optional `timezone`. An unrecognized IANA zone name is a
  startup error, not a silent fallback to the host zone. When unset, the zone resolves once from
  the host and falls back to UTC if that is unavailable or unparseable.
- **`RuntimeConfig.display_timezone`**, resolved once and reachable from parse sites.
- **`parse_due` anchors date-only input.** Values carrying an explicit offset or `Z` are unchanged
  and still normalize to UTC.

## The anchor is total, and that is the substance

Midnight is not a function of date and zone alone. On a zone's transition date local midnight can
fail to exist, or occur twice. Both are handled as one rule, the least instant whose local date in
that zone is the given date, rather than as two exceptions to a midnight rule. Neither case is
resolved by unwrapping to UTC, which would silently reintroduce the defect this change removes. A
date the zone's calendar skips entirely is rejected with a message naming the zone.

## Tests use zones that actually exhibit the cases

`America/Havana` 2021-03-14 has no local midnight; `America/Santiago` 2021-09-05 has none;
`America/Havana` 2020-11-01 has two, the earlier at `-04:00`. `America/New_York` never transitions
at local midnight, so a gap or fold test written against it passes without exercising the rule at
all. It is used only where the property under test is the sign of the offset, or that two dates
straddling a transition anchor at different offsets.

## Scope

Steps 4 and 6 of the ADR are deliberately NOT in this PR:

- **Step 4**: `parse_rfc3339_micros` in khive-pack-brain anchors `brain.event_counts` date-only
  `since`/`until` with `.and_utc()`, the same defect on a different verb, and adds a rule this one
  does not need: a date-only exclusive bound must roll to the next day's earliest instant, or the
  named day is silently dropped from a half-open window. `RuntimeConfig.display_timezone` is
  already reachable from it.
- **Step 6**: an ordering and range-comparison audit. Mixed-offset RFC 3339 strings do not sort
  correctly as raw text; the ADR names a prior incident in the scheduler path where exactly this
  bit.

`RuntimeConfig` gains a required field, so construction sites across the packs are updated
mechanically: 47 identical lines, no removals.

## Gates

`cargo fmt --check`, `cargo clippy -p khive-runtime -p khive-pack-gtd --all-targets -- -D warnings`,
and `cargo test -p khive-runtime -p khive-pack-gtd` all pass. Ripple crates and
`cargo check --workspace --all-targets` also verified.