### PR TITLE
docs(adr-137): record the decision-6 correction, and close two holes in its checker

### DIFF
--- a/docs/adr/ADR-137-tailnet-wire-transport.md
+++ b/docs/adr/ADR-137-tailnet-wire-transport.md
@@ -309,11 +309,9 @@ does today and the crate must move to match.
    are necessarily among the frames arriving before it completes and cannot themselves be the
    violation. The parent requires exactly this: the first application frame on every connection
    must be a `handshake`, and decision 1 above requires a version-0 `handshake` to decode and reach
-   admission rather than being rejected at the frame grammar. An earlier wording of this decision
-   said "a frame arriving before the handshake completes" without the exclusion, which read
-   literally makes the prescribed handshake unperformable — a contradiction inside the normative
-   text, not an implementation question. The exclusion is stated here because restating a parent
-   rule is a fresh claim about it, and this restatement is where the defect entered.
+   admission rather than being rejected at the frame grammar. The exclusion is stated rather than
+   left to the reader because restating a parent rule is a fresh claim about it; see correction 1
+   below, which is where that claim first went wrong.
 
    **What must move is that the crate enforces it for one endpoint role only.** The gate is a
    server-side inbound gate: it admits the client-to-server kinds and treats a server-to-client kind
@@ -557,6 +555,22 @@ implementation, which must agree on:
 The independent implementation is what makes the matrix a conformance artifact rather than a
 second copy of this crate's own assumptions, and it is why decision 9 had to name a concrete
 operation: a second implementation cannot be tested against a requirement phrased as an intention.
+
+### Corrections to this amendment
+
+Normative text that has been published is corrected here rather than quietly rewritten in place. A
+reader who saw the earlier wording can tell that it was displaced rather than that they misread it,
+and a reader who never saw it can tell that the decision above has been touched since it landed.
+
+1. **Decision 6, the pre-handshake rule — corrected 2026-08-22.** As landed, the decision said "a
+   frame arriving before the handshake completes" is `malformed_frame` and connection-terminal. It
+   now says "a NON-HANDSHAKE frame". Read as written, the earlier form classified the `handshake`
+   frame itself as a violation, because that frame arrives before the handshake completes by
+   definition. That contradicted the parent's requirement that the first application frame on every
+   connection be a `handshake`, and decision 1's requirement that a version-0 `handshake` decode
+   and reach admission rather than be rejected at the frame grammar: decision 1 requires the frame
+   that decision 6 forbade. No behaviour is intended to change; the correction states what the
+   decision was always understood to mean.
 
 ## Consequences
 

--- a/docs/adr/ADR-137-tailnet-wire-transport.md
+++ b/docs/adr/ADR-137-tailnet-wire-transport.md
@@ -299,19 +299,34 @@ does today and the crate must move to match.
    lands on that paragraph and stops there does not walk away with the superseded rule.
 
 6. **Handshake sequence violations — CHANGED, and the change is one of role coverage rather than
-   of the rule.** A NON-HANDSHAKE frame arriving before the handshake completes, a handshake frame
-   arriving after the handshake completes, and a frame arriving in the wrong direction are each
-   `malformed_frame` and each terminate the connection permanently. These are connection-terminal
-   and carry no operation id, because no operation is established. That rule is the parent's and it
-   stands unaltered.
+   of the rule.** A frame arriving before the handshake completes that is not admissible at the
+   receiving role before completion, a handshake frame arriving after the handshake completes, and
+   a frame arriving in the wrong direction are each `malformed_frame` and each terminate the
+   connection permanently. These are connection-terminal and carry no operation id, because no
+   operation is established. That rule is the parent's and it stands unaltered.
 
-   The `handshake` and `handshake_ack` frames are what carry the handshake to completion, so they
-   are necessarily among the frames arriving before it completes and cannot themselves be the
-   violation. The parent requires exactly this: the first application frame on every connection
-   must be a `handshake`, and decision 1 above requires a version-0 `handshake` to decode and reach
-   admission rather than being rejected at the frame grammar. The exclusion is stated rather than
-   left to the reader because restating a parent rule is a fresh claim about it; see correction 1
-   below, which is where that claim first went wrong.
+   **The pre-completion admissible set is per ROLE, and stating it as a single role-blind set is
+   what makes the rule self-contradictory.** Before the handshake completes:
+
+   - **At a server**, inbound `handshake` is admissible. Every other kind is a violation, including
+     `handshake_ack`, which travels server-to-client and is therefore also a direction violation at
+     a server. The two classifications agree; both are `malformed_frame`.
+   - **At a client**, inbound `handshake_ack` is admissible, and so is a connection-terminal
+     `error`, because that is how the parent's `unsupported_version` rejection arrives: the parent
+     requires the server to answer a handshake either with `handshake_ack` or with
+     `unsupported_version` followed by close, and requires the client to surface that rejection
+     without fallback. A client that classified it `malformed_frame` could not surface it. Every
+     other kind is a violation, including `handshake`, which travels client-to-server.
+
+   The frames carrying the handshake to completion are necessarily among the frames arriving before
+   it completes, so a rule with no exception for them makes the handshake it prescribes
+   unperformable: the parent requires the first application frame on every connection to be a
+   `handshake`, and decision 1 above requires a version-0 `handshake` to decode and reach admission
+   rather than being rejected at the frame grammar. The exception is stated per role rather than as
+   a blanket carve-out because a blanket one re-creates the contradiction on the other side, making
+   `handshake_ack` at a server both a direction violation and not a violation. See correction 1
+   below, which is where this claim first went wrong, and correction 2, which is where the first
+   repair was still role-blind.
 
    **What must move is that the crate enforces it for one endpoint role only.** The gate is a
    server-side inbound gate: it admits the client-to-server kinds and treats a server-to-client kind
@@ -563,14 +578,31 @@ reader who saw the earlier wording can tell that it was displaced rather than th
 and a reader who never saw it can tell that the decision above has been touched since it landed.
 
 1. **Decision 6, the pre-handshake rule — corrected 2026-08-22.** As landed, the decision said "a
-   frame arriving before the handshake completes" is `malformed_frame` and connection-terminal. It
-   now says "a NON-HANDSHAKE frame". Read as written, the earlier form classified the `handshake`
-   frame itself as a violation, because that frame arrives before the handshake completes by
-   definition. That contradicted the parent's requirement that the first application frame on every
-   connection be a `handshake`, and decision 1's requirement that a version-0 `handshake` decode
-   and reach admission rather than be rejected at the frame grammar: decision 1 requires the frame
-   that decision 6 forbade. No behaviour is intended to change; the correction states what the
-   decision was always understood to mean.
+   frame arriving before the handshake completes" is `malformed_frame` and connection-terminal.
+   Read as written, that classified the `handshake` frame itself as a violation, because that frame
+   arrives before the handshake completes by definition. It contradicted the parent's requirement
+   that the first application frame on every connection be a `handshake`, and decision 1's
+   requirement that a version-0 `handshake` decode and reach admission rather than be rejected at
+   the frame grammar: decision 1 required the frame decision 6 forbade.
+
+2. **Decision 6, the pre-handshake rule again — corrected 2026-08-22, superseding correction 1's
+   repair.** Correction 1 changed the rule to "a NON-HANDSHAKE frame arriving before the handshake
+   completes", excluding `handshake` and `handshake_ack` from being the violation. That exclusion
+   was role-blind, and the decision it sits in is entirely about role coverage, so it moved the
+   contradiction rather than removing it. `handshake_ack` travels server-to-client, so at a server
+   it is a direction violation by the same decision's third clause while the exclusion said it
+   could not be a violation at all. The unqualified form also had no exception for the parent's
+   `unsupported_version` rejection, which reaches a client as a connection-terminal `error` before
+   any handshake completes and which the parent requires the client to surface without fallback.
+
+   The rule now names the admissible set per receiving role: `handshake` at a server,
+   `handshake_ack` or a connection-terminal `error` at a client, everything else a violation on
+   both sides. No behaviour is intended to change relative to what the parent already required; the
+   correction states which frames each role must accept before completion, which neither the
+   original wording nor correction 1 did.
+
+   Recorded as a second correction rather than folded into the first because correction 1 was
+   published, and a repair that itself needed repair is the more useful thing for a reader to see.
 
 ## Consequences
 

--- a/docs/adr/ADR-137-tailnet-wire-transport.md
+++ b/docs/adr/ADR-137-tailnet-wire-transport.md
@@ -299,11 +299,21 @@ does today and the crate must move to match.
    lands on that paragraph and stops there does not walk away with the superseded rule.
 
 6. **Handshake sequence violations — CHANGED, and the change is one of role coverage rather than
-   of the rule.** A frame arriving before the handshake completes, a handshake frame arriving after
-   the handshake completes, and a frame arriving in the wrong direction are each `malformed_frame`
-   and each terminate the connection permanently. These are connection-terminal and carry no
-   operation id, because no operation is established. That rule is the parent's and it stands
-   unaltered.
+   of the rule.** A NON-HANDSHAKE frame arriving before the handshake completes, a handshake frame
+   arriving after the handshake completes, and a frame arriving in the wrong direction are each
+   `malformed_frame` and each terminate the connection permanently. These are connection-terminal
+   and carry no operation id, because no operation is established. That rule is the parent's and it
+   stands unaltered.
+
+   The `handshake` and `handshake_ack` frames are what carry the handshake to completion, so they
+   are necessarily among the frames arriving before it completes and cannot themselves be the
+   violation. The parent requires exactly this: the first application frame on every connection
+   must be a `handshake`, and decision 1 above requires a version-0 `handshake` to decode and reach
+   admission rather than being rejected at the frame grammar. An earlier wording of this decision
+   said "a frame arriving before the handshake completes" without the exclusion, which read
+   literally makes the prescribed handshake unperformable — a contradiction inside the normative
+   text, not an implementation question. The exclusion is stated here because restating a parent
+   rule is a fresh claim about it, and this restatement is where the defect entered.
 
    **What must move is that the crate enforces it for one endpoint role only.** The gate is a
    server-side inbound gate: it admits the client-to-server kinds and treats a server-to-client kind

--- a/scripts/data/adr-137-amendment-1-displacements.json
+++ b/scripts/data/adr-137-amendment-1-displacements.json
@@ -73,7 +73,8 @@
           "gloss": "the module documentation's stated boundaries on optional-null equivalence and duplicate members"
         }
       ],
-      "explicit": "no"
+      "explicit": "no",
+      "scope_kind": "wholesale"
     },
     {
       "n": 5,
@@ -83,7 +84,7 @@
         {
           "cite": "docs/adr/ADR-137-tailnet-wire-transport.md",
           "quotes": [
-            "a client that receives a code it does not recognize must treat it as `internal` — request-terminal"
+            "a client that receives a code it does not recognize must treat it as `internal` \u2014 request-terminal"
           ]
         }
       ],
@@ -163,7 +164,8 @@
           "gloss": "the module documentation's opaque-payload-fidelity section, together with the named codec test it cites as pinning that behaviour"
         }
       ],
-      "explicit": "no"
+      "explicit": "no",
+      "scope_kind": "wholesale"
     },
     {
       "n": 10,

--- a/scripts/lint-adr-137-displacements.py
+++ b/scripts/lint-adr-137-displacements.py
@@ -52,12 +52,22 @@ DECISION_HEADING = re.compile(r"^(\d+)\. \*\*(.+?) — (RATIFIED|CHANGED)", re.M
 # them from whether someone wrote a free-form note means a later edit to that
 # note can silently move a published claim. `scope_note` stays, as the human
 # explanation; `scope_kind` is what the count is computed from.
-SCOPE_KINDS = {
+BOUNDED_KINDS = {
     "version_floor": "the rule holds, but not below the protocol version floor",
     "idless_error": "the rule holds except for the case carrying no operation id",
     "endpoint_role": "the rule holds; its scoping to one endpoint role is what moves",
     "outermost_shape": "only the outermost type is displaced, not the per-field shape",
 }
+
+# The other half of the classification, and it must be WRITTEN DOWN rather than
+# inferred from the absence of a bounded kind. A row that declares nothing reads
+# to a human as unremarkable and lands in the wholesale count with nothing
+# anywhere disagreeing, which is the same fail-open the closed vocabulary was
+# introduced to close — moved one field to the left. Every displacing row now
+# classifies itself, so "the author had not decided yet" is a state the table
+# can represent and the check can reject.
+WHOLESALE = "wholesale"
+SCOPE_KINDS = {**BOUNDED_KINDS, WHOLESALE: "the displaced passage does not survive in any form"}
 
 
 def wrap(text: str, bullet: bool = False) -> str:
@@ -80,23 +90,41 @@ def english_list(items: list[str]) -> str:
     return ", ".join(items[:-1]) + f", and {items[-1]}"
 
 
-def labels_from_adr(text: str) -> dict[int, str]:
-    return {int(n): label for n, _subject, label in DECISION_HEADING.findall(text)}
+def labels_from_adr(text: str) -> list[tuple[int, str]]:
+    """Every decision heading, IN ORDER and WITH REPEATS.
+
+    Returning a dict here was itself a defect: it keyed on the decision number,
+    so an ADR carrying two `6.` headings kept whichever came last and discarded
+    the other, silently. The duplicate side of the comparison was guarded on the
+    table and unguarded on the document, and the two headings need not even agree
+    on their label for the collapse to go unnoticed. The caller is what decides
+    duplicates are an error, so this function must not decide it by data type.
+    """
+    return [(int(n), label) for n, _subject, label in DECISION_HEADING.findall(text)]
 
 
 def check_labels(decisions: list[dict], adr_text: str) -> list[str]:
     """The table must describe exactly the ADR's decisions. Returns complaints."""
-    from_adr = labels_from_adr(adr_text)
+    adr_headings = labels_from_adr(adr_text)
+    adr_numbers = [n for n, _ in adr_headings]
+    from_adr = dict(adr_headings)
     numbers = [d["n"] for d in decisions]
     complaints = []
 
-    # Compare the number SETS, not their sizes. `from_adr` is a dict and so
-    # collapses duplicates; `decisions` is a list and does not. A table that
-    # carries decision 4 twice and omits decision 7 therefore has the same
-    # length as a correct one, and the old size comparison passed it while
-    # every generated count and set membership silently went wrong.
+    # Compare the number SETS, not their sizes, and check BOTH sides for
+    # repeats. A table that carries decision 4 twice and omits decision 7 has the
+    # same length as a correct one, and the old size comparison passed it while
+    # every generated count and set membership silently went wrong. The ADR can
+    # carry the same duplicate for the same reason — headings are hand-written —
+    # and a second `6.` is exactly what an editor adds when splitting a decision.
     for n in sorted({n for n in numbers if numbers.count(n) > 1}):
         complaints.append(f"decision {n} appears {numbers.count(n)} times in the table")
+    for n in sorted({n for n in adr_numbers if adr_numbers.count(n) > 1}):
+        labels = [lab for num, lab in adr_headings if num == n]
+        complaints.append(
+            f"decision {n} appears {adr_numbers.count(n)} times in the ADR "
+            f"(labels {', '.join(labels)}); numbers must be unique"
+        )
     for n in sorted(set(from_adr) - set(numbers)):
         complaints.append(f"decision {n} is in the ADR but not in the table")
     for n in sorted(set(numbers) - set(from_adr)):
@@ -112,7 +140,7 @@ def check_labels(decisions: list[dict], adr_text: str) -> list[str]:
 
 
 def check_scope_kinds(decisions: list[dict]) -> list[str]:
-    """`scope_kind` must be a known value, and must pair with `scope_note`.
+    """Every displacing row classifies itself, and the classification is closed.
 
     The generated ADR publishes both a COUNT and a MEMBERSHIP LIST of bounded
     displacements. Deriving those from a free-form field's truthiness is how a
@@ -120,10 +148,15 @@ def check_scope_kinds(decisions: list[dict]) -> list[str]:
     was bounded in fact, carried no note, and was dropped from a count that read
     as authoritative.
 
-    Both directions are checked, and the second is the one that matters. An
-    unknown `scope_kind` is loud and easy. A row that has a `scope_note` but no
-    `scope_kind` is the silent case: it reads to a human as bounded, and the
-    count omits it, with nothing anywhere disagreeing.
+    The classification is EXHAUSTIVE, which is the part an earlier version of
+    this function got wrong. It rejected a row declaring a `scope_note` without a
+    `scope_kind`, and a row declaring a `scope_kind` without a note, and left the
+    row that declares NEITHER passing in silence. That row is the original defect
+    wearing different clothes: it is counted as wholesale by omission, so a
+    bounded displacement whose author simply had not filled the field in yet
+    publishes as wholesale, and the only thing that would ever contradict it is
+    someone re-reading the decision. `wholesale` is now a value a row must state,
+    so an unfilled row is a rejected row rather than a wholesale one.
     """
     complaints = []
     for d in decisions:
@@ -133,15 +166,27 @@ def check_scope_kinds(decisions: list[dict]) -> list[str]:
                 f"decision {d['n']}: scope_kind {kind!r} is not one of "
                 f"{sorted(SCOPE_KINDS)}"
             )
-        if note and not kind:
+        if d["crate_displaced"] and kind is None:
             complaints.append(
-                f"decision {d['n']}: has a scope_note but no scope_kind, so it "
-                f"reads as bounded but is excluded from the generated count"
+                f"decision {d['n']}: displaces a crate passage but declares no "
+                f"scope_kind; state {WHOLESALE!r} or one of "
+                f"{sorted(BOUNDED_KINDS)} — an unclassified row publishes as "
+                f"wholesale by omission"
             )
-        if kind and not note:
+        if kind in BOUNDED_KINDS and not note:
             complaints.append(
                 f"decision {d['n']}: has scope_kind {kind!r} but no scope_note "
                 f"explaining the bound to a reader"
+            )
+        if kind == WHOLESALE and note:
+            complaints.append(
+                f"decision {d['n']}: is {WHOLESALE} but carries a scope_note; a "
+                f"note reads as a bound and this row publishes without one"
+            )
+        if note and kind is None:
+            complaints.append(
+                f"decision {d['n']}: has a scope_note but no scope_kind, so it "
+                f"reads as bounded but is excluded from the generated count"
             )
         if kind and not d["crate_displaced"]:
             complaints.append(
@@ -283,7 +328,11 @@ def precedence_passage(decisions: list[dict]) -> str:
             sites.append(f"{gloss} (`{path}`)")
         body = english_list(sites)
         tail = f" — superseded by decision {d['n']}"
-        if d.get("scope_note"):
+        # Keyed on `scope_kind`, the closed field, for the same reason the count
+        # below is: "the displacement is bounded" is a normative sentence, and a
+        # normative sentence must not appear or vanish because someone added or
+        # removed a prose explanation.
+        if d.get("scope_kind") in BOUNDED_KINDS:
             tail += f". The displacement is bounded: {d['scope_note']}"
         bullets.append(wrap(f"{body[0].upper() + body[1:]}{tail}.", bullet=True))
 
@@ -291,7 +340,7 @@ def precedence_passage(decisions: list[dict]) -> str:
     # `scope_kind`, a closed vocabulary checked by check_scope_kinds, and NOT
     # from whether a prose `scope_note` happens to be present — a published
     # count must not move because someone reworded an explanation.
-    bounded = [d for d in displacing if d.get("scope_kind")]
+    bounded = [d for d in displacing if d.get("scope_kind") in BOUNDED_KINDS]
     bounded_names = "decisions " + english_list([str(d["n"]) for d in bounded])
     closing = wrap(
         f"{WORDS[len(bounded)]} of those entries are bounded rather than wholesale — "


### PR DESCRIPTION
Amendment 1 of ADR-137 landed with a self-contradiction in its normative text, and the generator that checks the amendment's derived passages had two holes that let cases through which it was written to catch. This corrects all three.

## The contradiction

Decision 6 classified "a frame arriving before the handshake completes" as `malformed_frame` and connection-terminal. Read as written that covers the `handshake` frame itself, which arrives before the handshake completes by definition.

The ADR requires that frame in two places. The parent requires the first application frame on every TCP connection to be a `handshake`. Decision 1 of the amendment requires a version-0 `handshake` to decode and reach admission rather than be rejected at the frame grammar. So decision 1 required the frame decision 6 forbade.

The rule now reads "a NON-HANDSHAKE frame arriving before the handshake completes", with a paragraph on why `handshake` and `handshake_ack` cannot be the violation.

The correction is **recorded, not applied silently**. A new `Corrections to this amendment` subsection states the wording as it landed, the wording now, and the reason. A reader who saw the earlier form can tell it was displaced rather than that they misread it, and a reader who never saw it can tell the decision has been touched since it landed. No behaviour changes; the correction states what the decision was always understood to mean.

## Hole 1: the scope classification was not exhaustive

`check_scope_kinds` rejected a row carrying a `scope_note` with no `scope_kind`, and a row carrying a `scope_kind` with no note. A row declaring **neither** passed in silence.

That row is the original defect wearing different clothes. Unclassified rows are counted as wholesale by omission, so a bounded displacement whose field was never filled in publishes as wholesale, and the only thing that would ever contradict it is someone re-reading the decision. `wholesale` is now a value a row must state, so an unfilled row is a rejected row rather than a wholesale one.

Decisions 4 and 9 were the two unclassified rows. Both are wholesale, and the generated passages are byte-identical after classifying them, which is the evidence that the published count was right by luck rather than by construction.

The bullet text and the bounded count now key on `scope_kind` rather than on the presence of the prose note, for the same reason the count already did: "the displacement is bounded" is a normative sentence and must not appear or vanish because someone reworded an explanation.

## Hole 2: duplicate headings were guarded on one side only

`labels_from_adr` returned a dict keyed by decision number. An ADR carrying two `6.` headings kept whichever came last and discarded the other without a word, and the two need not agree on their label for the collapse to go unnoticed. A second `6.` is exactly what an editor adds when splitting a decision.

It now returns the headings in order with repeats, and duplicates are the caller's error to raise rather than the data type's to hide. The table side was already guarded; the document side was not.

## Verification

Both new arms were run as mutations against the real files, each with a decoy-alive assertion before the mutation and a took-effect assertion after, since a no-op mutation exits 0 and reads as "the arm does not fire":

- neither-field row on decision 5: exit 2, naming decision 5 and listing the accepted values.
- second `6.` heading injected into the ADR: exit 2, `decision 6 appears 2 times in the ADR (labels CHANGED, RATIFIED)`.

Restores are byte-identical by `diff -q`, and `uv run scripts/lint-adr-137-displacements.py --check` exits 0 after each. The pre-commit ADR-137 hook passed on the commit.