### PR TITLE
fix(gtd,mcp): reject unrepresentable due dates and fingerprint the display timezone

### DIFF
--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -600,8 +600,24 @@ pub(crate) fn compute_config_id_with_runtime_policies(
     // Included unconditionally rather than only when non-default. The default
     // is the HOST's zone, not UTC, so "differs from the default" is itself a
     // host-dependent predicate and would make identity depend on where the
-    // fingerprint was computed. The cost is that every existing warm daemon
-    // takes a new identity once, which is a respawn, not a correctness event.
+    // fingerprint was computed.
+    //
+    // The cost, stated as it actually happens: a daemon already warm when this
+    // lands keeps the identity it computed at startup, so a client built from
+    // this code sends an ID that daemon does not recognise. The daemon answers
+    // `config_mismatch` and the client falls back to LOCAL dispatch. It does
+    // not respawn — `FallbackReason::ConfigMismatch` is classified
+    // `FallbackSeverity::Illegitimate`, and the kill-and-respawn path
+    // (#644/#539) governs the protocol/parse reasons, not this one. So until
+    // that daemon is restarted, every request pays a failed forwarding round
+    // trip and loses the daemon's warm indexes and embedders, and each one
+    // increments a counter documented as never expected on a correctly
+    // configured fleet.
+    //
+    // Spelled out because "the daemon takes a new identity" invites the reading
+    // that it restarts itself. It does not, and nothing here makes it: this is
+    // a one-time operational cost that ends when the daemon is restarted, by
+    // whoever restarts it.
     let base = format!(
         "packs=[{}];db={};embed={};extra=[{}];fresh_tail={};blob_hydration_bytes={};backend={};outbound=[{}];git_write={};display_tz={}",
         packs.join(","),
@@ -4056,13 +4072,19 @@ mod tests {
     /// offset between the zones. Identity must separate them.
     #[test]
     fn config_id_differs_when_display_timezone_differs() {
+        // One base, cloned, for the reason spelled out on the test below — and
+        // it matters MORE here. This assertion is `assert_ne!`, so the shared
+        // environment racing between two constructor calls would make it pass
+        // by producing two different `db_path`s, which is a pass that would
+        // survive deleting the fix this test exists to hold.
+        let base = RuntimeConfig::no_embeddings();
         let utc = RuntimeConfig {
             display_timezone: "UTC".parse().expect("UTC is a known IANA zone"),
-            ..RuntimeConfig::no_embeddings()
+            ..base.clone()
         };
         let new_york = RuntimeConfig {
             display_timezone: "America/New_York".parse().expect("known IANA zone"),
-            ..RuntimeConfig::no_embeddings()
+            ..base
         };
 
         assert_ne!(
@@ -4078,13 +4100,25 @@ mod tests {
     /// incidental reason: identical zones must still collapse to one identity.
     #[test]
     fn config_id_matches_when_display_timezone_matches() {
+        // ONE base, cloned — not two constructor calls. `RuntimeConfig::default`
+        // reads `HOME` to build `db_path`, and `db_path` is folded into the id,
+        // so two calls read that variable at two different instants. Other
+        // tests in this binary set and restore `HOME` around their own work
+        // (`config_id_matches_for_tilde_and_equivalent_absolute_db_override` is
+        // one, and it matches the same `config_id` filter), and tests run in
+        // parallel threads against one process-global environment. A mutation
+        // landing between the two calls gave the two configs different paths
+        // and reddened this test for a reason that has nothing to do with
+        // timezones. Cloning one base removes the window: whatever `HOME` is,
+        // both sides read the same one.
+        let base = RuntimeConfig::no_embeddings();
         let a = RuntimeConfig {
             display_timezone: "America/New_York".parse().expect("known IANA zone"),
-            ..RuntimeConfig::no_embeddings()
+            ..base.clone()
         };
         let b = RuntimeConfig {
             display_timezone: "America/New_York".parse().expect("known IANA zone"),
-            ..RuntimeConfig::no_embeddings()
+            ..base
         };
 
         assert_eq!(

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -590,8 +590,20 @@ pub(crate) fn compute_config_id_with_runtime_policies(
     } else {
         format!("{:?}", config.backend_id)
     };
+    // `display_timezone` is part of daemon identity, not merely of rendering
+    // (ADR-169). `gtd.assign` anchors a date-only `due` through
+    // `config.display_timezone` and PERSISTS the resulting instant, so two
+    // runtimes differing only in this field are not interchangeable: a warm
+    // daemon reused across them writes an instant that is wrong by the offset
+    // between the zones, silently and durably.
+    //
+    // Included unconditionally rather than only when non-default. The default
+    // is the HOST's zone, not UTC, so "differs from the default" is itself a
+    // host-dependent predicate and would make identity depend on where the
+    // fingerprint was computed. The cost is that every existing warm daemon
+    // takes a new identity once, which is a respawn, not a correctness event.
     let base = format!(
-        "packs=[{}];db={};embed={};extra=[{}];fresh_tail={};blob_hydration_bytes={};backend={};outbound=[{}];git_write={}",
+        "packs=[{}];db={};embed={};extra=[{}];fresh_tail={};blob_hydration_bytes={};backend={};outbound=[{}];git_write={};display_tz={}",
         packs.join(","),
         db,
         primary,
@@ -601,6 +613,7 @@ pub(crate) fn compute_config_id_with_runtime_policies(
         backend,
         outbound.join(","),
         git_write,
+        config.display_timezone.name(),
     );
 
     // Fold backend topology when non-empty so two configs differing only in
@@ -4034,6 +4047,50 @@ mod tests {
             compute_config_id_with_ann_fresh_tail(&config, None, true),
             compute_config_id_with_ann_fresh_tail(&config, None, false),
             "opposite fresh-tail policies must not share one warm daemon"
+        );
+    }
+
+    /// `gtd.assign` anchors a date-only `due` through `display_timezone` and
+    /// PERSISTS the resulting instant, so a warm daemon reused across two
+    /// runtimes differing only in that field writes an instant wrong by the
+    /// offset between the zones. Identity must separate them.
+    #[test]
+    fn config_id_differs_when_display_timezone_differs() {
+        let utc = RuntimeConfig {
+            display_timezone: "UTC".parse().expect("UTC is a known IANA zone"),
+            ..RuntimeConfig::no_embeddings()
+        };
+        let new_york = RuntimeConfig {
+            display_timezone: "America/New_York".parse().expect("known IANA zone"),
+            ..RuntimeConfig::no_embeddings()
+        };
+
+        assert_ne!(
+            compute_config_id_with_runtime_policies(&utc, None, true, false),
+            compute_config_id_with_runtime_policies(&new_york, None, true, false),
+            "runtimes differing only in display_timezone must not share one warm daemon: \
+             a reused daemon would anchor date-only due values in the wrong zone and \
+             persist the wrong instant"
+        );
+    }
+
+    /// The other direction, so the assertion above cannot pass for an
+    /// incidental reason: identical zones must still collapse to one identity.
+    #[test]
+    fn config_id_matches_when_display_timezone_matches() {
+        let a = RuntimeConfig {
+            display_timezone: "America/New_York".parse().expect("known IANA zone"),
+            ..RuntimeConfig::no_embeddings()
+        };
+        let b = RuntimeConfig {
+            display_timezone: "America/New_York".parse().expect("known IANA zone"),
+            ..RuntimeConfig::no_embeddings()
+        };
+
+        assert_eq!(
+            compute_config_id_with_runtime_policies(&a, None, true, false),
+            compute_config_id_with_runtime_policies(&b, None, true, false),
+            "identical runtimes must share one warm daemon"
         );
     }
 

--- a/crates/khive-pack-gtd/src/handlers.rs
+++ b/crates/khive-pack-gtd/src/handlers.rs
@@ -514,29 +514,18 @@ pub(crate) fn parse_due(value: &str, tz: Tz) -> Result<String, RuntimeError> {
         // `NaiveDateTime`. That is checked inside the resolver, on the one
         // branch that needs the window, and NOT screened for here.
         //
-        // Do not add a pre-screen here. Asking "is this date's +/-48h window
-        // representable" of EVERY date over-rejects, because only the
-        // skipped-midnight branch searches that window and a date whose local
-        // midnight resolves directly never touches it. Measured:
-        // `+262142-12-31` resolves to a single valid instant in UTC,
-        // Pacific/Apia, Pacific/Midway and America/Adak, and `-262143-01-01`
-        // does so in UTC. A screen here rejects all of them. Asking a question
-        // on behalf of a branch that will not run gives a guard a blast radius
-        // wider than the defect it removes.
+        // Do not screen the date here. The resolver is total over every date
+        // `%Y` can produce, and it rejects only when the zone genuinely has no
+        // instant carrying the date. A caller-side range check would ask a
+        // question only one branch of the resolver needs, and so would reject
+        // dates the resolver answers correctly.
         return anchor_date_to_earliest_instant(date, tz)
             .map(|dt| dt.to_rfc3339())
-            .map_err(|why| match why {
-                AnchorFailure::NoInstantCarriesDate => RuntimeError::InvalidInput(format!(
+            .ok_or_else(|| {
+                RuntimeError::InvalidInput(format!(
                     "due date {date} does not exist in the configured display timezone {tz} \
-                     (no instant within {ANCHOR_SEARCH_RADIUS_HOURS}h of local midnight carries \
-                     that local date); got {value:?}"
-                )),
-                AnchorFailure::SearchWindowUnrepresentable => RuntimeError::InvalidInput(format!(
-                    "due date {date} lies outside the range this resolver can represent: its \
-                     local midnight does not exist in {tz}, and resolving that case searches \
-                     {ANCHOR_SEARCH_RADIUS_HOURS}h either side of midnight, which is not \
-                     representable for this date; got {value:?}"
-                )),
+                     (no representable instant carries that local date); got {value:?}"
+                ))
             });
     }
     Err(RuntimeError::InvalidInput(format!(
@@ -550,35 +539,51 @@ pub(crate) fn parse_due(value: &str, tz: Tz) -> Result<String, RuntimeError> {
 const ANCHOR_SEARCH_RADIUS_HOURS: i64 = 48;
 
 /// The `[midnight - radius, midnight + radius]` window the skipped-midnight
-/// branch searches, or `None` when either endpoint is unrepresentable.
+/// branch searches, clamped to the representable range.
 ///
-/// Exists so that `parse_due`'s input validation and the resolver's own
-/// arithmetic are the SAME computation. A separate range check in the caller
-/// would be a second definition of representable, and the two would drift.
-fn anchor_search_window(
-    date: chrono::NaiveDate,
-) -> Option<(chrono::NaiveDateTime, chrono::NaiveDateTime)> {
-    let midnight = date.and_hms_opt(0, 0, 0)?;
+/// Checked arithmetic, because chrono's `-` and `+` PANIC on overflow and
+/// `date` reaches here from a caller. Clamped rather than failing: near the
+/// ends of the range the window is truncated, not absent, and the instants
+/// that remain in it are exactly the ones a search could return anyway.
+fn anchor_search_window(date: chrono::NaiveDate) -> (chrono::NaiveDateTime, chrono::NaiveDateTime) {
+    let midnight = date
+        .and_hms_opt(0, 0, 0)
+        .expect("00:00:00 is a valid time on every date");
     let radius = chrono::Duration::hours(ANCHOR_SEARCH_RADIUS_HOURS);
-    Some((
-        midnight.checked_sub_signed(radius)?,
-        midnight.checked_add_signed(radius)?,
-    ))
+    (
+        midnight
+            .checked_sub_signed(radius)
+            .unwrap_or(chrono::NaiveDateTime::MIN),
+        midnight
+            .checked_add_signed(radius)
+            .unwrap_or(chrono::NaiveDateTime::MAX),
+    )
 }
 
-/// Why [`anchor_date_to_earliest_instant`] could not name an instant.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum AnchorFailure {
-    /// No instant within the searched window carries `date` as its local date.
-    /// For any real zone that means the zone's local calendar skips the date
-    /// whole, since the window is far wider than any real UTC offset.
-    NoInstantCarriesDate,
-    /// `date` is close enough to the end of `NaiveDateTime`'s range that the
-    /// search window does not exist. Reachable ONLY from the skipped-midnight
-    /// branch, which is the only one that searches; it says nothing about
-    /// dates whose local midnight resolves directly, and those still resolve
-    /// at both ends of the representable range.
-    SearchWindowUnrepresentable,
+/// Order the local date at UTC instant `utc`, in `tz`, against `date`.
+///
+/// Total where the obvious spelling is not. `tz.from_utc_datetime(&utc)
+/// .date_naive()` PANICS when the zone's offset pushes the local wall clock
+/// outside `NaiveDateTime`'s range, and both ends are reachable once the search
+/// window is clamped: a positive-offset zone overflows at
+/// `NaiveDateTime::MAX`, a negative-offset zone underflows at `MIN`.
+///
+/// The overflow direction carries the answer. A local time past the top of the
+/// range is later than every representable date, and one below the bottom is
+/// earlier, so the sign of the offset decides the ordering without needing the
+/// date that cannot be built.
+fn local_date_cmp(
+    tz: Tz,
+    utc: chrono::NaiveDateTime,
+    date: chrono::NaiveDate,
+) -> std::cmp::Ordering {
+    use chrono::Offset;
+    let offset_seconds = tz.offset_from_utc_datetime(&utc).fix().local_minus_utc();
+    match utc.checked_add_signed(chrono::Duration::seconds(offset_seconds as i64)) {
+        Some(local) => local.date().cmp(&date),
+        None if offset_seconds > 0 => std::cmp::Ordering::Greater,
+        None => std::cmp::Ordering::Less,
+    }
 }
 
 /// Resolve a calendar date to the earliest instant that belongs to it in
@@ -589,26 +594,20 @@ enum AnchorFailure {
 /// exceptions to it; neither case may be resolved by unwrapping to UTC,
 /// which would silently reintroduce the defect ADR-169 exists to remove.
 ///
-/// Fails when no instant maps to `date` in `tz`, and separately when `date`
-/// sits too close to the end of the representable range for the search window
-/// the skipped-midnight branch needs. Both are absences rather than faults,
-/// but they are DIFFERENT absences and the caller reports different things for
-/// them, so they are distinguished in the type instead of collapsed to `None`
-/// and re-derived by the caller. A caller cannot re-derive them without
-/// over-rejecting: it can only ask its question of every date, while just one
-/// branch here ever needs the answer.
-fn anchor_date_to_earliest_instant(
-    date: chrono::NaiveDate,
-    tz: Tz,
-) -> Result<DateTime<Tz>, AnchorFailure> {
+/// Returns `None` only when no representable instant carries `date` as its
+/// local date in `tz` — the zone's local calendar skips the date entirely, a
+/// case ADR-169 does not name since its own examples are ordinary sub-day
+/// transitions. The function is total over every date `%Y` can parse, so a
+/// caller never needs a range check of its own.
+fn anchor_date_to_earliest_instant(date: chrono::NaiveDate, tz: Tz) -> Option<DateTime<Tz>> {
     let midnight = date
         .and_hms_opt(0, 0, 0)
-        .ok_or(AnchorFailure::SearchWindowUnrepresentable)?;
+        .expect("00:00:00 is a valid time on every date");
     match tz.from_local_datetime(&midnight) {
-        chrono::LocalResult::Single(dt) => Ok(dt),
+        chrono::LocalResult::Single(dt) => Some(dt),
         // Fall-back overlap: two instants map to the same wall-clock time.
         // The earlier one is the least instant whose local date is `date`.
-        chrono::LocalResult::Ambiguous(earliest, _latest) => Ok(earliest),
+        chrono::LocalResult::Ambiguous(earliest, _latest) => Some(earliest),
         // Spring-forward gap (or a larger jump): local midnight does not
         // exist. Solve for the boundary directly rather than projecting to
         // it. Within the window searched below, the local date is a
@@ -658,25 +657,28 @@ fn anchor_date_to_earliest_instant(
         // One-second granularity is required, not one-minute: historical
         // LMT offsets are not whole minutes.
         chrono::LocalResult::None => {
-            // Checked, not bare `-`/`+`: chrono's operators PANIC on overflow,
-            // and `date` is caller-supplied through `parse_due`, so a bare
-            // subtraction here is a reachable panic on a public verb rather
-            // than a validation failure. The check lives HERE, at the only
-            // point that needs the window, which is also why it is not a
-            // pre-condition on the whole function.
-            let (mut lo, mut hi) =
-                anchor_search_window(date).ok_or(AnchorFailure::SearchWindowUnrepresentable)?;
+            let (mut lo, mut hi) = anchor_search_window(date);
+            // The window's lower bound can itself already carry `date`. At the
+            // bottom of the representable range a positive-offset zone has no
+            // representable local midnight, but later local times on that same
+            // date do exist: in `Pacific/Apia` the least representable instant
+            // is local 12:33:04 on chrono's minimum date. That instant IS the
+            // least one carrying the date, so return it rather than reporting
+            // the date as absent.
+            if local_date_cmp(tz, lo, date) == std::cmp::Ordering::Equal {
+                return Some(tz.from_utc_datetime(&lo));
+            }
             // Guard the bisection invariant instead of assuming it. Real UTC
             // offsets stay well inside +/-48h, so a violation here means the
             // zone is outside anything this rule can answer for; fail closed.
-            if tz.from_utc_datetime(&lo).date_naive() >= date
-                || tz.from_utc_datetime(&hi).date_naive() < date
+            if local_date_cmp(tz, lo, date) == std::cmp::Ordering::Greater
+                || local_date_cmp(tz, hi, date) == std::cmp::Ordering::Less
             {
-                return Err(AnchorFailure::NoInstantCarriesDate);
+                return None;
             }
             while hi - lo > chrono::Duration::seconds(1) {
                 let mid = lo + (hi - lo) / 2;
-                if tz.from_utc_datetime(&mid).date_naive() < date {
+                if local_date_cmp(tz, mid, date) == std::cmp::Ordering::Less {
                     lo = mid;
                 } else {
                     hi = mid;
@@ -685,10 +687,8 @@ fn anchor_date_to_earliest_instant(
             // `hi` is now the least instant whose local date is >= `date`.
             // It is > `date` exactly when the zone's local calendar skips
             // the date entirely, which is the documented `None` case.
-            let resolved = tz.from_utc_datetime(&hi);
-            (resolved.date_naive() == date)
-                .then_some(resolved)
-                .ok_or(AnchorFailure::NoInstantCarriesDate)
+            (local_date_cmp(tz, hi, date) == std::cmp::Ordering::Equal)
+                .then(|| tz.from_utc_datetime(&hi))
         }
     }
 }
@@ -739,7 +739,7 @@ mod tz_database_audit {
                 }
 
                 match anchor_date_to_earliest_instant(date, tz) {
-                    Ok(resolved) => {
+                    Some(resolved) => {
                         let previous = resolved - chrono::Duration::seconds(1);
                         if resolved.date_naive() != date {
                             failures.push(format!(
@@ -754,10 +754,10 @@ mod tz_database_audit {
                             ));
                         }
                     }
-                    // This failure is correct only for a date the zone's local calendar skips
-                    // whole. Verify that rather than accepting it: no instant in the searched
-                    // window may carry the requested local date.
-                    Err(AnchorFailure::NoInstantCarriesDate) => {
+                    // `None` is correct only for a date the zone's local calendar skips whole.
+                    // Verify that rather than accepting it: no instant in the searched window
+                    // may carry the requested local date.
+                    None => {
                         skipped_days += 1;
                         let mut found = None;
                         // ONE-SECOND steps, matching the granularity the implementation itself
@@ -771,13 +771,11 @@ mod tz_database_audit {
                         // rare (single digits across the whole sweep), so the finer step costs
                         // nothing measurable.
                         //
-                        // The bounds come from `anchor_search_window`, not from a literal. A
-                        // literal `+/-48h` was here first and was a SECOND definition of the
-                        // searched window: moving `ANCHOR_SEARCH_RADIUS_HOURS` would have left
-                        // this sweep checking the old one, and it would have kept passing while
-                        // checking the wrong thing, which is the failure a sweep cannot report.
-                        let (lo, hi) = anchor_search_window(date)
-                            .expect("1850-2100 is nowhere near the representable bounds");
+                        // The bounds come from `anchor_search_window`, not from a literal, so
+                        // the searched window has one definition. A second literal here would
+                        // let a change to `ANCHOR_SEARCH_RADIUS_HOURS` leave this sweep checking
+                        // the old window while still reporting zero violations.
+                        let (lo, hi) = anchor_search_window(date);
                         let mut probe = lo;
                         while probe <= hi {
                             if tz.from_utc_datetime(&probe).date_naive() == date {
@@ -793,14 +791,6 @@ mod tz_database_audit {
                             ));
                         }
                     }
-                    // Unreachable inside 1850-2100: the window only fails within ~2 days of
-                    // the representable bounds. Asserted rather than assumed, because a sweep
-                    // that silently reclassified dates into this arm would report zero
-                    // violations while having checked nothing.
-                    Err(AnchorFailure::SearchWindowUnrepresentable) => failures.push(format!(
-                        "{tz}: {date} reported an unrepresentable search window, which cannot \
-                         happen inside the swept range"
-                    )),
                 }
 
                 date = date.succ_opt().expect("date in range has a successor");
@@ -1010,28 +1000,67 @@ mod parse_due_tests {
         );
     }
 
-    /// `%Y` accepts chrono's full signed year range, so a caller can name a
-    /// date whose ±48h anchor window runs off the end of `NaiveDateTime`.
-    /// chrono's `-` PANICS there, and this input arrives from a caller through
-    /// a public verb, so the panic was reachable availability denial rather
-    /// than a validation failure. Assert the OUTCOME is a rejection: a test
-    /// that merely called this would "pass" by not panicking, which is the
-    /// weaker claim.
+    /// `%Y` accepts chrono's full signed year range, so a caller can name the
+    /// minimum date, whose ±48h anchor window runs off the end of
+    /// `NaiveDateTime`. chrono's `-` PANICS there, and the input arrives
+    /// through a public verb, so that was reachable availability denial.
+    ///
+    /// The right outcome is not a rejection. In a zone east of UTC the minimum
+    /// date has no representable local midnight, but later local times on it
+    /// do exist, so the date HAS a least representable instant and the
+    /// least-instant contract can be honoured. Assert that instant, which also
+    /// keeps this a panic regression test: bare arithmetic here still aborts.
     #[test]
-    fn date_only_due_with_an_unrepresentable_anchor_window_is_rejected_not_panicked() {
+    fn the_minimum_date_resolves_to_its_least_representable_instant_east_of_utc() {
         let tz: Tz = "Pacific/Apia".parse().expect("known IANA zone");
-        let err = parse_due("-262143-01-01", tz)
-            .expect_err("a date whose anchor window is unrepresentable must be rejected");
-        let msg = err.to_string();
+        let out = parse_due("-262143-01-01", tz)
+            .expect("the minimum date has representable instants in a positive-offset zone");
         assert!(
-            msg.contains("outside the range this resolver can represent"),
-            "must give the real reason, not the skipped-date reason; got: {msg}"
+            out.starts_with("-262143-01-01T12:33:04"),
+            "must be the least representable instant carrying that local date, which is \
+             chrono's minimum instant seen through Apia's +12:33:04 offset; got: {out}"
         );
-        assert!(
-            !msg.contains("does not exist in the configured display timezone"),
-            "must not report this as a zone that skips the date, which is a different \
-             failure with a different cause; got: {msg}"
+    }
+
+    /// The returned instant is not merely valid, it is chrono's minimum. That
+    /// is what makes it the LEAST instant carrying the date: the usual
+    /// one-second-earlier check cannot be written here, because one second
+    /// earlier does not exist.
+    #[test]
+    fn the_minimum_date_anchors_exactly_at_the_minimum_instant_east_of_utc() {
+        let tz: Tz = "Pacific/Apia".parse().expect("known IANA zone");
+        let resolved = super::anchor_date_to_earliest_instant(chrono::NaiveDate::MIN, tz)
+            .expect("the minimum date has representable instants east of UTC");
+        assert_eq!(
+            resolved.naive_utc(),
+            chrono::NaiveDateTime::MIN,
+            "no representable instant precedes this one, so it is the least"
         );
+    }
+
+    /// The same boundary from the other side, and it takes a DIFFERENT path.
+    /// Zone names mislead here: `America/Adak` reads as west of UTC but its
+    /// earliest LMT is +12:13:22, because it crossed the date line. Zones that
+    /// are genuinely negative at the minimum instant have a representable
+    /// local midnight (UTC = midnight + |offset|), so they resolve through the
+    /// direct branch and never reach the lower-bound short-circuit. Offsets
+    /// measured at `NaiveDateTime::MIN`: New York -4:56:02, Los Angeles
+    /// -7:52:58, Honolulu -10:31:26.
+    #[test]
+    fn the_minimum_date_resolves_in_genuinely_negative_offset_zones() {
+        for name in [
+            "America/New_York",
+            "America/Los_Angeles",
+            "Pacific/Honolulu",
+        ] {
+            let tz: Tz = name.parse().expect("known IANA zone");
+            let out = parse_due("-262143-01-01", tz)
+                .unwrap_or_else(|e| panic!("{name}: minimum date must resolve, got {e}"));
+            assert!(
+                out.starts_with("-262143-01-01T00:00:00"),
+                "{name}: a representable local midnight anchors the date directly; got: {out}"
+            );
+        }
     }
 
     /// The guard this replaced asked "is the +/-48h window representable" of
@@ -1085,16 +1114,57 @@ mod parse_due_tests {
     /// place that needs the searched window — the resolver and the all-zone
     /// sweep — calls this one function, so this is the single definition.
     #[test]
-    fn the_search_window_has_one_definition_of_representable() {
-        let min = chrono::NaiveDate::MIN;
-        assert!(
-            super::anchor_search_window(min).is_none(),
-            "the minimum representable date cannot carry a -48h window"
+    fn the_search_window_clamps_at_the_bounds_and_is_exact_elsewhere() {
+        let (lo, hi) = super::anchor_search_window(chrono::NaiveDate::MIN);
+        assert_eq!(
+            lo,
+            chrono::NaiveDateTime::MIN,
+            "the minimum date cannot carry a full -48h window, so the bound clamps \
+             rather than vanishing"
         );
-        let ordinary = chrono::NaiveDate::from_ymd_opt(2026, 8, 23).expect("valid date");
         assert!(
-            super::anchor_search_window(ordinary).is_some(),
-            "an ordinary date must carry the window"
+            hi > chrono::NaiveDateTime::MIN,
+            "the upper bound is exact here"
+        );
+
+        let (_, hi_max) = super::anchor_search_window(chrono::NaiveDate::MAX);
+        assert_eq!(
+            hi_max,
+            chrono::NaiveDateTime::MAX,
+            "and symmetrically at the top of the range"
+        );
+
+        // The must-not-fire half: away from the bounds the window is the real
+        // +/-48h, so the clamp cannot be silently swallowing ordinary dates.
+        let ordinary = chrono::NaiveDate::from_ymd_opt(2026, 8, 23).expect("valid date");
+        let midnight = ordinary.and_hms_opt(0, 0, 0).expect("midnight");
+        let radius = chrono::Duration::hours(super::ANCHOR_SEARCH_RADIUS_HOURS);
+        assert_eq!(
+            super::anchor_search_window(ordinary),
+            (midnight - radius, midnight + radius),
+            "an ordinary date gets the exact window"
+        );
+    }
+
+    /// `local_date_cmp` exists because `date_naive()` PANICS at the bounds.
+    /// Exercise exactly those two spellings' disagreement, or the helper looks
+    /// like ceremony to the next reader.
+    #[test]
+    fn local_date_cmp_is_total_where_date_naive_panics() {
+        let east: Tz = "Pacific/Apia".parse().expect("known IANA zone");
+        assert_eq!(
+            super::local_date_cmp(east, chrono::NaiveDateTime::MAX, chrono::NaiveDate::MAX),
+            std::cmp::Ordering::Greater,
+            "east of UTC the top of the range maps past the last representable date"
+        );
+        // NOT `America/Adak`, whose earliest LMT is +12:13:22 because it
+        // crossed the date line; a zone is chosen here by its MEASURED offset
+        // at the instant under test, never by what its name suggests.
+        let west: Tz = "America/New_York".parse().expect("known IANA zone");
+        assert_eq!(
+            super::local_date_cmp(west, chrono::NaiveDateTime::MIN, chrono::NaiveDate::MIN),
+            std::cmp::Ordering::Less,
+            "west of UTC the bottom of the range maps before the first representable date"
         );
     }
 }

--- a/crates/khive-pack-gtd/src/handlers.rs
+++ b/crates/khive-pack-gtd/src/handlers.rs
@@ -509,6 +509,18 @@ pub(crate) fn parse_due(value: &str, tz: Tz) -> Result<String, RuntimeError> {
     }
     // Fallback: try date-only "YYYY-MM-DD".
     if let Ok(date) = chrono::NaiveDate::parse_from_str(value, "%Y-%m-%d") {
+        // `%Y` accepts the full signed year range chrono can represent, so a
+        // caller can name a date whose anchor window runs off the end of
+        // `NaiveDateTime`. Reject that here rather than letting it reach the
+        // resolver, so the caller gets the real reason instead of the
+        // skipped-date reason, which would be false.
+        if anchor_search_window(date).is_none() {
+            return Err(RuntimeError::InvalidInput(format!(
+                "due date {date} lies outside the range this resolver can represent: \
+                 anchoring searches {ANCHOR_SEARCH_RADIUS_HOURS}h either side of local \
+                 midnight, and that window is not representable for this date; got {value:?}"
+            )));
+        }
         return anchor_date_to_earliest_instant(date, tz)
             .map(|dt| dt.to_rfc3339())
             .ok_or_else(|| {
@@ -523,6 +535,28 @@ pub(crate) fn parse_due(value: &str, tz: Tz) -> Result<String, RuntimeError> {
     )))
 }
 
+/// Half-width of the UTC window the skipped-midnight branch bisects. Real UTC
+/// offsets stay well inside this, so a date whose local midnight cannot carry
+/// the window is outside what this rule can answer for.
+const ANCHOR_SEARCH_RADIUS_HOURS: i64 = 48;
+
+/// The `[midnight - radius, midnight + radius]` window the skipped-midnight
+/// branch searches, or `None` when either endpoint is unrepresentable.
+///
+/// Exists so that `parse_due`'s input validation and the resolver's own
+/// arithmetic are the SAME computation. A separate range check in the caller
+/// would be a second definition of representable, and the two would drift.
+fn anchor_search_window(
+    date: chrono::NaiveDate,
+) -> Option<(chrono::NaiveDateTime, chrono::NaiveDateTime)> {
+    let midnight = date.and_hms_opt(0, 0, 0)?;
+    let radius = chrono::Duration::hours(ANCHOR_SEARCH_RADIUS_HOURS);
+    Some((
+        midnight.checked_sub_signed(radius)?,
+        midnight.checked_add_signed(radius)?,
+    ))
+}
+
 /// Resolve a calendar date to the earliest instant that belongs to it in
 /// `tz` (ADR-169 D1). Midnight is not a total function of date and zone: on a
 /// zone's own transition date local midnight can fail to exist (the clock
@@ -531,10 +565,13 @@ pub(crate) fn parse_due(value: &str, tz: Tz) -> Result<String, RuntimeError> {
 /// exceptions to it; neither case may be resolved by unwrapping to UTC,
 /// which would silently reintroduce the defect ADR-169 exists to remove.
 ///
-/// Returns `None` only when no instant at all maps to `date` in `tz` (the
-/// zone's local calendar skips the date entirely, e.g. a whole-day UTC-offset
-/// jump across the international date line) — a case ADR-169 does not name,
-/// since its own gap/ambiguity examples are ordinary sub-day transitions.
+/// Returns `None` when no instant at all maps to `date` in `tz` (the zone's
+/// local calendar skips the date entirely, e.g. a whole-day UTC-offset jump
+/// across the international date line) — a case ADR-169 does not name, since
+/// its own gap/ambiguity examples are ordinary sub-day transitions — and also
+/// when `date` sits too close to the end of the representable range for its
+/// search window to exist. Both are absences, not errors; the caller
+/// distinguishes them because it needs to say which one happened.
 fn anchor_date_to_earliest_instant(date: chrono::NaiveDate, tz: Tz) -> Option<DateTime<Tz>> {
     let midnight = date.and_hms_opt(0, 0, 0)?;
     match tz.from_local_datetime(&midnight) {
@@ -591,8 +628,13 @@ fn anchor_date_to_earliest_instant(date: chrono::NaiveDate, tz: Tz) -> Option<Da
         // One-second granularity is required, not one-minute: historical
         // LMT offsets are not whole minutes.
         chrono::LocalResult::None => {
-            let mut lo = midnight - chrono::Duration::hours(48);
-            let mut hi = midnight + chrono::Duration::hours(48);
+            // Checked, not bare `-`/`+`: chrono's operators PANIC on overflow,
+            // and `date` is caller-supplied through `parse_due`, so a bare
+            // subtraction here is a reachable panic on a public verb rather
+            // than a validation failure. `parse_due` rejects such dates before
+            // reaching this branch; the checked form keeps this function total
+            // regardless of who calls it.
+            let (mut lo, mut hi) = anchor_search_window(date)?;
             // Guard the bisection invariant instead of assuming it. Real UTC
             // offsets stay well inside +/-48h, so a violation here means the
             // zone is outside anything this rule can answer for; fail closed.
@@ -916,6 +958,57 @@ mod parse_due_tests {
         assert!(
             msg.contains("2011-12-30"),
             "error must name the unparseable due date; got: {msg}"
+        );
+    }
+
+    /// `%Y` accepts chrono's full signed year range, so a caller can name a
+    /// date whose ±48h anchor window runs off the end of `NaiveDateTime`.
+    /// chrono's `-` PANICS there, and this input arrives from a caller through
+    /// a public verb, so the panic was reachable availability denial rather
+    /// than a validation failure. Assert the OUTCOME is a rejection: a test
+    /// that merely called this would "pass" by not panicking, which is the
+    /// weaker claim.
+    #[test]
+    fn date_only_due_with_an_unrepresentable_anchor_window_is_rejected_not_panicked() {
+        let tz: Tz = "Pacific/Apia".parse().expect("known IANA zone");
+        let err = parse_due("-262143-01-01", tz)
+            .expect_err("a date whose anchor window is unrepresentable must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("outside the range this resolver can represent"),
+            "must give the real reason, not the skipped-date reason; got: {msg}"
+        );
+        assert!(
+            !msg.contains("skips this date entirely"),
+            "must not claim the zone skips the date, which is false here; got: {msg}"
+        );
+    }
+
+    /// The must-not-fire half. Without it the assertion above could pass
+    /// against a resolver that rejected every date.
+    #[test]
+    fn an_ordinary_date_still_resolves_after_the_range_guard() {
+        let tz: Tz = "Pacific/Apia".parse().expect("known IANA zone");
+        let out = parse_due("2026-08-23", tz).expect("an ordinary date must still resolve");
+        assert!(
+            out.starts_with("2026-08-23T00:00:00"),
+            "ordinary dates keep anchoring to local midnight; got: {out}"
+        );
+    }
+
+    /// The boundary is a property of the window, not of a magic year, so pin
+    /// it against `anchor_search_window` itself rather than a literal.
+    #[test]
+    fn the_range_guard_and_the_resolver_share_one_definition_of_representable() {
+        let min = chrono::NaiveDate::MIN;
+        assert!(
+            super::anchor_search_window(min).is_none(),
+            "the minimum representable date cannot carry a -48h window"
+        );
+        let ordinary = chrono::NaiveDate::from_ymd_opt(2026, 8, 23).expect("valid date");
+        assert!(
+            super::anchor_search_window(ordinary).is_some(),
+            "an ordinary date must carry the window"
         );
     }
 }

--- a/crates/khive-pack-gtd/src/handlers.rs
+++ b/crates/khive-pack-gtd/src/handlers.rs
@@ -511,14 +511,12 @@ pub(crate) fn parse_due(value: &str, tz: Tz) -> Result<String, RuntimeError> {
     if let Ok(date) = chrono::NaiveDate::parse_from_str(value, "%Y-%m-%d") {
         // `%Y` accepts the full signed year range chrono can represent, so a
         // caller can name a date whose anchor window runs off the end of
-        // `NaiveDateTime`. That is checked inside the resolver, on the one
-        // branch that needs the window, and NOT screened for here.
-        //
-        // Do not screen the date here. The resolver is total over every date
-        // `%Y` can produce, and it rejects only when the zone genuinely has no
-        // instant carrying the date. A caller-side range check would ask a
-        // question only one branch of the resolver needs, and so would reject
-        // dates the resolver answers correctly.
+        // `NaiveDateTime`. The resolver absorbs that by clamping, on the one
+        // branch that needs the window, and is total over every date `%Y` can
+        // produce; it declines only when the zone genuinely has no instant
+        // carrying the date. A range check here would ask a question only that
+        // one branch needs, and so would reject dates the resolver answers
+        // correctly.
         return anchor_date_to_earliest_instant(date, tz)
             .map(|dt| dt.to_rfc3339())
             .ok_or_else(|| {
@@ -534,8 +532,10 @@ pub(crate) fn parse_due(value: &str, tz: Tz) -> Result<String, RuntimeError> {
 }
 
 /// Half-width of the UTC window the skipped-midnight branch bisects. Real UTC
-/// offsets stay well inside this, so a date whose local midnight cannot carry
-/// the window is outside what this rule can answer for.
+/// offsets stay well inside this, so the window always contains the boundary
+/// the search is looking for. A date whose local midnight cannot carry the full
+/// width is still answered: the window clamps to the representable range rather
+/// than being abandoned.
 const ANCHOR_SEARCH_RADIUS_HOURS: i64 = 48;
 
 /// The `[midnight - radius, midnight + radius]` window the skipped-midnight
@@ -1083,11 +1083,12 @@ mod parse_due_tests {
             );
         }
 
-        // The minimum date resolves only where local midnight exists. In zones
-        // east of UTC it does not: converting it to UTC would run off the end
-        // of the range, and chrono-tz reports that as no valid local time, so
-        // the resolver takes the searching branch and correctly reports the
-        // window failure. UTC is the case that must still succeed.
+        // The minimum date takes the SEARCHING branch in zones east of UTC:
+        // converting its local midnight to UTC would run off the end of the
+        // range, and chrono-tz reports that as no valid local time. That case
+        // is asserted above, where it resolves to the least representable
+        // instant. The case here is UTC, where local midnight exists, so the
+        // direct branch must still succeed at the bottom of the range.
         let utc: Tz = "UTC".parse().expect("known IANA zone");
         let out = parse_due("-262143-01-01", utc)
             .expect("the minimum date must resolve in UTC, where its midnight exists");

--- a/crates/khive-pack-gtd/src/handlers.rs
+++ b/crates/khive-pack-gtd/src/handlers.rs
@@ -511,23 +511,32 @@ pub(crate) fn parse_due(value: &str, tz: Tz) -> Result<String, RuntimeError> {
     if let Ok(date) = chrono::NaiveDate::parse_from_str(value, "%Y-%m-%d") {
         // `%Y` accepts the full signed year range chrono can represent, so a
         // caller can name a date whose anchor window runs off the end of
-        // `NaiveDateTime`. Reject that here rather than letting it reach the
-        // resolver, so the caller gets the real reason instead of the
-        // skipped-date reason, which would be false.
-        if anchor_search_window(date).is_none() {
-            return Err(RuntimeError::InvalidInput(format!(
-                "due date {date} lies outside the range this resolver can represent: \
-                 anchoring searches {ANCHOR_SEARCH_RADIUS_HOURS}h either side of local \
-                 midnight, and that window is not representable for this date; got {value:?}"
-            )));
-        }
+        // `NaiveDateTime`. That is checked inside the resolver, on the one
+        // branch that needs the window, and NOT screened for here.
+        //
+        // Do not add a pre-screen here. Asking "is this date's +/-48h window
+        // representable" of EVERY date over-rejects, because only the
+        // skipped-midnight branch searches that window and a date whose local
+        // midnight resolves directly never touches it. Measured:
+        // `+262142-12-31` resolves to a single valid instant in UTC,
+        // Pacific/Apia, Pacific/Midway and America/Adak, and `-262143-01-01`
+        // does so in UTC. A screen here rejects all of them. Asking a question
+        // on behalf of a branch that will not run gives a guard a blast radius
+        // wider than the defect it removes.
         return anchor_date_to_earliest_instant(date, tz)
             .map(|dt| dt.to_rfc3339())
-            .ok_or_else(|| {
-                RuntimeError::InvalidInput(format!(
+            .map_err(|why| match why {
+                AnchorFailure::NoInstantCarriesDate => RuntimeError::InvalidInput(format!(
                     "due date {date} does not exist in the configured display timezone {tz} \
-                     (the zone's local calendar skips this date entirely); got {value:?}"
-                ))
+                     (no instant within {ANCHOR_SEARCH_RADIUS_HOURS}h of local midnight carries \
+                     that local date); got {value:?}"
+                )),
+                AnchorFailure::SearchWindowUnrepresentable => RuntimeError::InvalidInput(format!(
+                    "due date {date} lies outside the range this resolver can represent: its \
+                     local midnight does not exist in {tz}, and resolving that case searches \
+                     {ANCHOR_SEARCH_RADIUS_HOURS}h either side of midnight, which is not \
+                     representable for this date; got {value:?}"
+                )),
             });
     }
     Err(RuntimeError::InvalidInput(format!(
@@ -557,6 +566,21 @@ fn anchor_search_window(
     ))
 }
 
+/// Why [`anchor_date_to_earliest_instant`] could not name an instant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AnchorFailure {
+    /// No instant within the searched window carries `date` as its local date.
+    /// For any real zone that means the zone's local calendar skips the date
+    /// whole, since the window is far wider than any real UTC offset.
+    NoInstantCarriesDate,
+    /// `date` is close enough to the end of `NaiveDateTime`'s range that the
+    /// search window does not exist. Reachable ONLY from the skipped-midnight
+    /// branch, which is the only one that searches; it says nothing about
+    /// dates whose local midnight resolves directly, and those still resolve
+    /// at both ends of the representable range.
+    SearchWindowUnrepresentable,
+}
+
 /// Resolve a calendar date to the earliest instant that belongs to it in
 /// `tz` (ADR-169 D1). Midnight is not a total function of date and zone: on a
 /// zone's own transition date local midnight can fail to exist (the clock
@@ -565,20 +589,26 @@ fn anchor_search_window(
 /// exceptions to it; neither case may be resolved by unwrapping to UTC,
 /// which would silently reintroduce the defect ADR-169 exists to remove.
 ///
-/// Returns `None` when no instant at all maps to `date` in `tz` (the zone's
-/// local calendar skips the date entirely, e.g. a whole-day UTC-offset jump
-/// across the international date line) — a case ADR-169 does not name, since
-/// its own gap/ambiguity examples are ordinary sub-day transitions — and also
-/// when `date` sits too close to the end of the representable range for its
-/// search window to exist. Both are absences, not errors; the caller
-/// distinguishes them because it needs to say which one happened.
-fn anchor_date_to_earliest_instant(date: chrono::NaiveDate, tz: Tz) -> Option<DateTime<Tz>> {
-    let midnight = date.and_hms_opt(0, 0, 0)?;
+/// Fails when no instant maps to `date` in `tz`, and separately when `date`
+/// sits too close to the end of the representable range for the search window
+/// the skipped-midnight branch needs. Both are absences rather than faults,
+/// but they are DIFFERENT absences and the caller reports different things for
+/// them, so they are distinguished in the type instead of collapsed to `None`
+/// and re-derived by the caller. A caller cannot re-derive them without
+/// over-rejecting: it can only ask its question of every date, while just one
+/// branch here ever needs the answer.
+fn anchor_date_to_earliest_instant(
+    date: chrono::NaiveDate,
+    tz: Tz,
+) -> Result<DateTime<Tz>, AnchorFailure> {
+    let midnight = date
+        .and_hms_opt(0, 0, 0)
+        .ok_or(AnchorFailure::SearchWindowUnrepresentable)?;
     match tz.from_local_datetime(&midnight) {
-        chrono::LocalResult::Single(dt) => Some(dt),
+        chrono::LocalResult::Single(dt) => Ok(dt),
         // Fall-back overlap: two instants map to the same wall-clock time.
         // The earlier one is the least instant whose local date is `date`.
-        chrono::LocalResult::Ambiguous(earliest, _latest) => Some(earliest),
+        chrono::LocalResult::Ambiguous(earliest, _latest) => Ok(earliest),
         // Spring-forward gap (or a larger jump): local midnight does not
         // exist. Solve for the boundary directly rather than projecting to
         // it. Within the window searched below, the local date is a
@@ -631,17 +661,18 @@ fn anchor_date_to_earliest_instant(date: chrono::NaiveDate, tz: Tz) -> Option<Da
             // Checked, not bare `-`/`+`: chrono's operators PANIC on overflow,
             // and `date` is caller-supplied through `parse_due`, so a bare
             // subtraction here is a reachable panic on a public verb rather
-            // than a validation failure. `parse_due` rejects such dates before
-            // reaching this branch; the checked form keeps this function total
-            // regardless of who calls it.
-            let (mut lo, mut hi) = anchor_search_window(date)?;
+            // than a validation failure. The check lives HERE, at the only
+            // point that needs the window, which is also why it is not a
+            // pre-condition on the whole function.
+            let (mut lo, mut hi) =
+                anchor_search_window(date).ok_or(AnchorFailure::SearchWindowUnrepresentable)?;
             // Guard the bisection invariant instead of assuming it. Real UTC
             // offsets stay well inside +/-48h, so a violation here means the
             // zone is outside anything this rule can answer for; fail closed.
             if tz.from_utc_datetime(&lo).date_naive() >= date
                 || tz.from_utc_datetime(&hi).date_naive() < date
             {
-                return None;
+                return Err(AnchorFailure::NoInstantCarriesDate);
             }
             while hi - lo > chrono::Duration::seconds(1) {
                 let mid = lo + (hi - lo) / 2;
@@ -655,7 +686,9 @@ fn anchor_date_to_earliest_instant(date: chrono::NaiveDate, tz: Tz) -> Option<Da
             // It is > `date` exactly when the zone's local calendar skips
             // the date entirely, which is the documented `None` case.
             let resolved = tz.from_utc_datetime(&hi);
-            (resolved.date_naive() == date).then_some(resolved)
+            (resolved.date_naive() == date)
+                .then_some(resolved)
+                .ok_or(AnchorFailure::NoInstantCarriesDate)
         }
     }
 }
@@ -706,7 +739,7 @@ mod tz_database_audit {
                 }
 
                 match anchor_date_to_earliest_instant(date, tz) {
-                    Some(resolved) => {
+                    Ok(resolved) => {
                         let previous = resolved - chrono::Duration::seconds(1);
                         if resolved.date_naive() != date {
                             failures.push(format!(
@@ -721,12 +754,11 @@ mod tz_database_audit {
                             ));
                         }
                     }
-                    // `None` is correct only for a date the zone's local calendar skips whole.
-                    // Verify that rather than accepting it: no instant in a generous window may
-                    // carry the requested local date.
-                    None => {
+                    // This failure is correct only for a date the zone's local calendar skips
+                    // whole. Verify that rather than accepting it: no instant in the searched
+                    // window may carry the requested local date.
+                    Err(AnchorFailure::NoInstantCarriesDate) => {
                         skipped_days += 1;
-                        let base = midnight;
                         let mut found = None;
                         // ONE-SECOND steps, matching the granularity the implementation itself
                         // searches at. A coarser step was here first and was wrong in the
@@ -738,8 +770,16 @@ mod tz_database_audit {
                         // that has changed. The window is ~48h either side and skipped days are
                         // rare (single digits across the whole sweep), so the finer step costs
                         // nothing measurable.
-                        let mut probe = base - chrono::Duration::hours(48);
-                        while probe <= base + chrono::Duration::hours(48) {
+                        //
+                        // The bounds come from `anchor_search_window`, not from a literal. A
+                        // literal `+/-48h` was here first and was a SECOND definition of the
+                        // searched window: moving `ANCHOR_SEARCH_RADIUS_HOURS` would have left
+                        // this sweep checking the old one, and it would have kept passing while
+                        // checking the wrong thing, which is the failure a sweep cannot report.
+                        let (lo, hi) = anchor_search_window(date)
+                            .expect("1850-2100 is nowhere near the representable bounds");
+                        let mut probe = lo;
+                        while probe <= hi {
                             if tz.from_utc_datetime(&probe).date_naive() == date {
                                 found = Some(probe);
                                 break;
@@ -748,10 +788,19 @@ mod tz_database_audit {
                         }
                         if let Some(hit) = found {
                             failures.push(format!(
-                                "{tz}: {date} returned None, but {hit}Z has that local date"
+                                "{tz}: {date} was reported as carried by no instant, but {hit}Z \
+                                 has that local date"
                             ));
                         }
                     }
+                    // Unreachable inside 1850-2100: the window only fails within ~2 days of
+                    // the representable bounds. Asserted rather than assumed, because a sweep
+                    // that silently reclassified dates into this arm would report zero
+                    // violations while having checked nothing.
+                    Err(AnchorFailure::SearchWindowUnrepresentable) => failures.push(format!(
+                        "{tz}: {date} reported an unrepresentable search window, which cannot \
+                         happen inside the swept range"
+                    )),
                 }
 
                 date = date.succ_opt().expect("date in range has a successor");
@@ -979,15 +1028,50 @@ mod parse_due_tests {
             "must give the real reason, not the skipped-date reason; got: {msg}"
         );
         assert!(
-            !msg.contains("skips this date entirely"),
-            "must not claim the zone skips the date, which is false here; got: {msg}"
+            !msg.contains("does not exist in the configured display timezone"),
+            "must not report this as a zone that skips the date, which is a different \
+             failure with a different cause; got: {msg}"
+        );
+    }
+
+    /// The guard this replaced asked "is the +/-48h window representable" of
+    /// EVERY date, but only the skipped-midnight branch searches that window.
+    /// So it rejected the extremes of the representable range even where local
+    /// midnight resolves directly to a single instant.
+    ///
+    /// Both ends, and zones on both sides of UTC: the offset's SIGN decides
+    /// which end is at risk, so a single-zone test would confirm one direction
+    /// and infer the other. `Pacific/Apia` is east of UTC, `America/Adak` west.
+    #[test]
+    fn the_extremes_of_the_representable_range_resolve_when_local_midnight_exists() {
+        for name in ["UTC", "Pacific/Apia", "Pacific/Midway", "America/Adak"] {
+            let tz: Tz = name.parse().expect("known IANA zone");
+            let out = parse_due("+262142-12-31", tz)
+                .unwrap_or_else(|e| panic!("{name}: the maximum date must resolve, got {e}"));
+            assert!(
+                out.starts_with("+262142-12-31T00:00:00"),
+                "{name}: the maximum date anchors to its own local midnight; got: {out}"
+            );
+        }
+
+        // The minimum date resolves only where local midnight exists. In zones
+        // east of UTC it does not: converting it to UTC would run off the end
+        // of the range, and chrono-tz reports that as no valid local time, so
+        // the resolver takes the searching branch and correctly reports the
+        // window failure. UTC is the case that must still succeed.
+        let utc: Tz = "UTC".parse().expect("known IANA zone");
+        let out = parse_due("-262143-01-01", utc)
+            .expect("the minimum date must resolve in UTC, where its midnight exists");
+        assert!(
+            out.starts_with("-262143-01-01T00:00:00"),
+            "the minimum date anchors to its own local midnight in UTC; got: {out}"
         );
     }
 
     /// The must-not-fire half. Without it the assertion above could pass
     /// against a resolver that rejected every date.
     #[test]
-    fn an_ordinary_date_still_resolves_after_the_range_guard() {
+    fn an_ordinary_date_still_resolves() {
         let tz: Tz = "Pacific/Apia".parse().expect("known IANA zone");
         let out = parse_due("2026-08-23", tz).expect("an ordinary date must still resolve");
         assert!(
@@ -997,9 +1081,11 @@ mod parse_due_tests {
     }
 
     /// The boundary is a property of the window, not of a magic year, so pin
-    /// it against `anchor_search_window` itself rather than a literal.
+    /// it against `anchor_search_window` itself rather than a literal. Every
+    /// place that needs the searched window — the resolver and the all-zone
+    /// sweep — calls this one function, so this is the single definition.
     #[test]
-    fn the_range_guard_and_the_resolver_share_one_definition_of_representable() {
+    fn the_search_window_has_one_definition_of_representable() {
         let min = chrono::NaiveDate::MIN;
         assert!(
             super::anchor_search_window(min).is_none(),


### PR DESCRIPTION
Two defects on main in the date-only due-date path that arrived with the
configured display timezone.

## 1. Unchecked arithmetic on a caller-supplied date (availability)

`%Y` accepts the full signed year range chrono can represent, so a caller can
name a date whose anchor window runs off the end of `NaiveDateTime`. The
skipped-midnight branch then did bare `-` / `+` on local midnight, and chrono's
operators panic on overflow rather than returning `None`. A date-only due value
near the end of the range therefore panicked inside a public verb instead of
returning a validation error, repeatably.

The window is now computed with `checked_sub_signed` / `checked_add_signed` and
clamped to the representable range rather than failing. Near the ends of the
range the window is truncated, not absent, and the instants left in it are
exactly the ones a search could return.

Clamping alone is not enough, because a date at the bottom of the range can
still be valid. In a zone east of UTC the minimum date has no representable
local midnight, but later local times on that same date do exist, so the date
has a least representable instant and the resolver's contract can be honoured.
The search returns the lower bound directly when that bound already carries the
date.

Measured at `NaiveDateTime::MIN`, rather than argued: `Pacific/Apia` +12:33:04,
`Pacific/Midway` +12:37:12, `America/Adak` +12:13:22 and `America/Anchorage`
+14:00:24 all resolve to that instant, while `America/New_York` -4:56:02,
`America/Los_Angeles` -7:52:58 and `Pacific/Honolulu` -10:31:26 have a
representable local midnight and resolve through the direct branch. A zone's
name is not evidence of the sign: `America/Adak` reads as west of UTC, but its
earliest offset is positive because it crossed the international date line.

Clamping also makes the obvious comparison unsafe, so it is not used. Calling
`date_naive()` on a zone-local datetime panics when the offset pushes the local
wall clock outside `NaiveDateTime`'s range. A positive-offset zone reaches that
at the top of the range, a negative-offset zone at the bottom. The search path
uses a total comparison instead: read the offset, try checked arithmetic, and
when the local datetime cannot be built take the ordering from the overflow
direction, since past the top is later than every representable date and below
the bottom is earlier.

The resolver therefore has a single failure mode: no representable instant
carries this local date. It returns `Option` accordingly, and it is total over
every date `%Y` can parse, so no caller needs a range check of its own.

## 2. Display timezone missing from the warm-daemon configuration fingerprint

Date-only resolution reads `display_timezone`, but the configuration
fingerprint did not hash it, so two runtimes differing only in that setting
produced the same configuration id. A warm daemon could anchor a client's
date-only due value under the wrong zone and persist the wrong instant.

The component is included unconditionally. The default is the host's zone
rather than UTC, so "differs from the default" is host-dependent and cannot be
the condition.

The rollout cost, stated as it actually happens: a daemon already warm when
this lands keeps the identity it computed at startup, so a client built from
this code sends an id that daemon does not recognise. The daemon answers with a
configuration mismatch and the client falls back to local dispatch. It does not
respawn. Until that daemon is restarted, every request pays a failed forwarding
round trip and cannot use the daemon's warm indexes or embedders, and each one
increments a counter documented as never expected on a correctly configured
fleet. Restarting the daemon ends it.

## Tests

Each fix was checked by reverting it and reconciling against the arms predicted
before the run:

- Removing the fingerprint component reddens exactly the differing-zone test;
  the matching-zone test stays green.
- Reverting the resolver's checked arithmetic restores the panic.

Boundary coverage names which path each zone takes, because the two are
different code: east of UTC the minimum date exercises the lower-bound return,
and the assertion is that the resolved instant IS `NaiveDateTime::MIN`. The
usual one-second-earlier check cannot be written there, because one second
earlier does not exist. West of UTC the same date resolves through the direct
branch. A separate test exercises the two cases where the total comparison and
`date_naive()` disagree, so the helper is not mistaken for ceremony.

The searched window has one definition: the all-zone sweep takes its probe
bounds from the same helper the resolver uses, so a change to the radius cannot
leave the sweep checking the old window while still reporting zero violations.
That sweep walks every zone in the pinned database over 1850-2100 and asserts
the least-instant property directly.

The two fingerprint tests each build their configs from one base rather than
from two constructor calls. `RuntimeConfig::default` reads `HOME` to derive
`db_path`, `db_path` is folded into the id, and other tests in this binary set
and restore `HOME` around their own work, so two calls read a mutable global at
two different instants. That perturbation pushes the two ids apart, which fails
the equality test and, more importantly, would let the inequality test pass for
a reason unrelated to timezones.
