### PR TITLE
test(gtd): trigger the all-zone timezone sweep when the chrono-tz pin moves, and pin its probe granularity

### DIFF
--- a/.github/workflows/tz-database-audit.yml
+++ b/.github/workflows/tz-database-audit.yml
@@ -8,11 +8,15 @@ name: Timezone Database Audit
 # where a gap begins.
 #
 # The all-zone sweep exists to re-derive that. It is `#[ignore]`d because it
-# walks every zone and costs ~50s, which is the wrong trade on every ordinary
-# PR and the right one exactly when the pin moves. This workflow supplies the
-# trigger, so the duty is enforced rather than remembered: it runs on any PR
-# touching a manifest or lockfile that can carry a chrono-tz version, and on
-# the gtd pack that holds both the resolver and the sweep.
+# walks every zone and costs 48.28s in the debug profile CI uses (measured
+# 2026-08-23; the same sweep is 3.08s with --release, and the job still runs
+# debug because the trigger is a lockfile change, which invalidates the build
+# cache, so a release run would pay a cold optimized rebuild to save 45s of
+# sweep). That is the wrong trade on every ordinary PR and the right one
+# exactly when the pin moves. This workflow supplies the trigger, so the duty
+# is enforced rather than remembered: it runs on any PR touching a manifest or
+# lockfile that can carry a chrono-tz version, and on the source of the gtd
+# pack, which holds both the resolver and the sweep.
 #
 # What this does NOT gate: ordinary correctness of the resolver, which the
 # crate's normal (non-ignored) tests cover on every PR through the main CI job.
@@ -24,7 +28,11 @@ on:
       - "crates/Cargo.lock"
       - "crates/khive-merge/Cargo.lock"
       - "crates/khive-runtime/Cargo.toml"
-      - "crates/khive-pack-gtd/**"
+      # Source only. The resolver and the sweep both live under src/, so a
+      # README, a bench, or a doc change in this crate cannot affect the
+      # result and should not pay for the run.
+      - "crates/khive-pack-gtd/src/**"
+      - "crates/khive-pack-gtd/Cargo.toml"
       - ".github/workflows/tz-database-audit.yml"
 
 # Declared rather than inherited. With no `permissions:` block a workflow gets
@@ -49,6 +57,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          # The next steps build and run code from the pull request, so the
+          # checkout must not leave a usable token behind for them to read.
+          # The trigger is `pull_request` and the job declares `contents: read`
+          # on a public repository, so what a leak would yield is small; that
+          # bounds the damage, it does not make persisting the credential
+          # correct. Matches unlocked-dependencies.yml, which does the same.
+          persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@1.95.0
 

--- a/.github/workflows/tz-database-audit.yml
+++ b/.github/workflows/tz-database-audit.yml
@@ -27,6 +27,14 @@ on:
       - "crates/khive-pack-gtd/**"
       - ".github/workflows/tz-database-audit.yml"
 
+# Declared rather than inherited. With no `permissions:` block a workflow gets
+# the repository's default GITHUB_TOKEN scopes, so its actual authority is set
+# by a repository setting this file cannot see and does not track. This job
+# checks out, builds and runs one test; read access to the contents is the
+# whole of what it needs.
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/tz-database-audit.yml
+++ b/.github/workflows/tz-database-audit.yml
@@ -1,0 +1,71 @@
+name: Timezone Database Audit
+
+# Date-only values (task due dates) resolve against a configured display
+# timezone by searching the UTC axis for the least instant carrying a local
+# date. That search is correct only with respect to the zone data chrono-tz
+# bundles, so the bundled data is an input to the resolver, not an inert
+# dependency: moving the pin can change which dates have no local midnight and
+# where a gap begins.
+#
+# The all-zone sweep exists to re-derive that. It is `#[ignore]`d because it
+# walks every zone and costs ~50s, which is the wrong trade on every ordinary
+# PR and the right one exactly when the pin moves. This workflow supplies the
+# trigger, so the duty is enforced rather than remembered: it runs on any PR
+# touching a manifest or lockfile that can carry a chrono-tz version, and on
+# the gtd pack that holds both the resolver and the sweep.
+#
+# What this does NOT gate: ordinary correctness of the resolver, which the
+# crate's normal (non-ignored) tests cover on every PR through the main CI job.
+
+on:
+  pull_request:
+    paths:
+      - "crates/Cargo.toml"
+      - "crates/Cargo.lock"
+      - "crates/khive-merge/Cargo.lock"
+      - "crates/khive-runtime/Cargo.toml"
+      - "crates/khive-pack-gtd/**"
+      - ".github/workflows/tz-database-audit.yml"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  tz-database-audit:
+    name: Timezone Database Audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: crates
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dtolnay/rust-toolchain@1.95.0
+
+      - name: Pin the real toolchain bin on PATH
+        run: dirname "$(rustup which cargo)" >> "$GITHUB_PATH"
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: crates
+          cache-on-failure: true
+
+      - name: Report the resolved chrono-tz version
+        run: |
+          set -euo pipefail
+          # Printed so a failure is diagnosable from the log alone: the sweep's
+          # result is only meaningful against a named version of the zone data.
+          # Read from the lockfile rather than `cargo tree`, and with no `|| true`:
+          # a step that cannot fail cannot report, and this one should fail loudly
+          # if the dependency it is named for is not in the graph at all.
+          grep -A1 '^name = "chrono-tz"' Cargo.lock
+
+      - name: Run the all-zone sweep
+        run: |
+          set -euo pipefail
+          # --ignored, not --include-ignored: this job exists to run exactly the
+          # sweep, and including the ordinary tests here would let a failure in
+          # one be reported as a failure of the other.
+          cargo test -p khive-pack-gtd --lib tz_database_audit -- --ignored

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ test:
 # the resolver. Wired to CI on the manifests that carry that pin, so the
 # duty is triggered rather than remembered.
 tz-audit:
-	cd crates && $(CARGO) test -p khive-pack-gtd --lib tz_database_audit -- --ignored
+	cd crates && cargo test -p khive-pack-gtd --lib tz_database_audit -- --ignored
 
 contract-test:
 	cd crates && cargo build --release -p kkernel

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ override CARGO_VALUE := $(value CARGO)
 unexport CARGO
 export CARGO_VALUE
 
-.PHONY: check clippy test contract-test fmt fmt-check build build-local verify-local-artifact validate-make-inputs fleet-build fleet-check clean ci docs-check publish publish-dry local check-fwd bench-1m bench-1m-ci hold-time-gate eval-retrieval-gold-check
+.PHONY: check clippy test contract-test fmt fmt-check build build-local verify-local-artifact validate-make-inputs fleet-build fleet-check clean ci docs-check publish publish-dry local check-fwd bench-1m bench-1m-ci hold-time-gate eval-retrieval-gold-check tz-audit
 
 check:
 	cd crates && cargo check --workspace
@@ -51,7 +51,11 @@ test:
 	cd crates && cargo test --workspace
 
 # The all-zone chrono-tz sweep. Ignored by default because it walks every
-# zone in the bundled database and costs ~50s; it exists to be RUN when the
+# zone in the bundled database and costs 48.28s in the debug profile, against
+# 3.08s with --release (both measured 2026-08-23). Debug is kept because the
+# occasion to run this is a chrono-tz pin move, which invalidates the build
+# cache, so an optimized run would pay a cold rebuild to save 45s. It exists
+# to be RUN when the
 # chrono-tz pin moves, which is when the bundled zone data can change under
 # the resolver. Wired to CI on the manifests that carry that pin, so the
 # duty is triggered rather than remembered.

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,14 @@ clippy:
 test:
 	cd crates && cargo test --workspace
 
+# The all-zone chrono-tz sweep. Ignored by default because it walks every
+# zone in the bundled database and costs ~50s; it exists to be RUN when the
+# chrono-tz pin moves, which is when the bundled zone data can change under
+# the resolver. Wired to CI on the manifests that carry that pin, so the
+# duty is triggered rather than remembered.
+tz-audit:
+	cd crates && $(CARGO) test -p khive-pack-gtd --lib tz_database_audit -- --ignored
+
 contract-test:
 	cd crates && cargo build --release -p kkernel
 	python3 tests/contract_test.py

--- a/crates/khive-pack-gtd/src/handlers.rs
+++ b/crates/khive-pack-gtd/src/handlers.rs
@@ -622,6 +622,110 @@ fn anchor_date_to_earliest_instant(date: chrono::NaiveDate, tz: Tz) -> Option<Da
 mod tz_database_audit {
     use super::*;
 
+    /// Search a window around `base` at `step` granularity for any instant whose local date is
+    /// `target`, returning the first hit.
+    ///
+    /// Generic over the date lookup rather than over `TimeZone`, and that is the whole point. The
+    /// only thing `step` decides is whether a local-date interval SHORTER THAN THE STEP can hide
+    /// between two probes, and the pinned `chrono-tz` table contains no such interval — so the real
+    /// database cannot exercise the one property this function's granularity governs. Taking the
+    /// lookup as a closure lets a fabricated calendar do it instead, which is why
+    /// `a_sub_step_interval_is_missed_by_a_coarse_probe` below can go red against a coarse step and
+    /// green against a fine one without touching the pinned data or the production signature.
+    /// The probe granularity, as a function rather than a literal at the call site, so that the
+    /// sweep below and the synthetic arm read the SAME value. Inline the literal in both places and
+    /// the arm pins only itself: someone coarsening the sweep would leave the arm green while
+    /// reintroducing exactly the defect it exists to catch. Coarsen this and
+    /// `a_sub_step_interval_is_missed_by_a_coarse_probe` goes red.
+    fn probe_step() -> chrono::Duration {
+        chrono::Duration::seconds(1)
+    }
+
+    fn find_instant_carrying_date(
+        base: chrono::NaiveDateTime,
+        radius: chrono::Duration,
+        step: chrono::Duration,
+        target: chrono::NaiveDate,
+        local_date_at: impl Fn(chrono::NaiveDateTime) -> chrono::NaiveDate,
+    ) -> Option<chrono::NaiveDateTime> {
+        let mut probe = base - radius;
+        while probe <= base + radius {
+            if local_date_at(probe) == target {
+                return Some(probe);
+            }
+            probe += step;
+        }
+        None
+    }
+
+    /// The discriminating arm for the probe granularity.
+    ///
+    /// A fabricated calendar in which one local date exists for THIRTY SECONDS. A one-minute probe
+    /// steps straight over it and reports that no instant carries that date, which is the failure
+    /// this granularity exists to prevent and is invisible against the real table. A one-second
+    /// probe finds it. Synthetic data is the correct fixture here precisely because the pinned
+    /// database has no transition of this shape: an assertion that cannot be made to fail is not an
+    /// assertion, and the alternative was shipping the finer step on argument alone.
+    #[test]
+    fn a_sub_step_interval_is_missed_by_a_coarse_probe() {
+        let base = chrono::NaiveDate::from_ymd_opt(2000, 1, 2)
+            .expect("base date")
+            .and_hms_opt(0, 0, 0)
+            .expect("midnight");
+        let target = chrono::NaiveDate::from_ymd_opt(2000, 1, 2).expect("target date");
+        let before = chrono::NaiveDate::from_ymd_opt(2000, 1, 1).expect("previous date");
+        let after = chrono::NaiveDate::from_ymd_opt(2000, 1, 3).expect("next date");
+
+        // `target` occupies [base + 10s, base + 40s) and nothing else does. The window is offset
+        // from every whole minute in the search so a coarse probe lands either side of it.
+        let window_start = base + chrono::Duration::seconds(10);
+        let window_end = base + chrono::Duration::seconds(40);
+        let calendar = move |probe: chrono::NaiveDateTime| {
+            if probe >= window_start && probe < window_end {
+                target
+            } else if probe < window_start {
+                before
+            } else {
+                after
+            }
+        };
+
+        // Guard the fixture itself: the interval must actually be shorter than the coarse step,
+        // otherwise this test would pass for a reason that has nothing to do with granularity.
+        assert!(
+            window_end - window_start < chrono::Duration::minutes(1),
+            "fixture is not sub-step: the interval must be shorter than the coarse probe"
+        );
+
+        // The radius is a whole number of minutes, so a one-minute probe lands on base exactly and
+        // steps to base + 60s, straddling the window. That is why the coarse arm misses
+        // deterministically rather than by luck, and the assertion below fails loudly if it ever
+        // stops being true.
+        let radius = chrono::Duration::hours(48);
+        let coarse = find_instant_carrying_date(
+            base,
+            radius,
+            chrono::Duration::minutes(1),
+            target,
+            calendar,
+        );
+        // The FINE arm reads the same `probe_step()` the sweep passes, so coarsening the sweep's
+        // granularity reddens this test.
+        let fine = find_instant_carrying_date(base, radius, probe_step(), target, calendar);
+
+        assert!(
+            coarse.is_none(),
+            "the one-minute probe found {coarse:?}, so this fixture does not discriminate and \
+             the arm proves nothing"
+        );
+        let hit = fine.expect("the one-second probe must find the 30-second window");
+        assert_eq!(
+            calendar(hit),
+            target,
+            "the one-second probe returned {hit}, whose local date is not the target"
+        );
+    }
+
     /// Sweep every zone in the pinned `chrono-tz` over 1850-2100 and assert that
     /// `anchor_date_to_earliest_instant` returns the LEAST instant of the requested local date.
     ///
@@ -684,26 +788,23 @@ mod tz_database_audit {
                     // carry the requested local date.
                     None => {
                         skipped_days += 1;
-                        let base = midnight;
-                        let mut found = None;
                         // ONE-SECOND steps, matching the granularity the implementation itself
                         // searches at. A coarser step was here first and was wrong in the
                         // reassuring direction: a local-date interval shorter than the step can
                         // sit between two probes, so the search reports "no instant carries this
-                        // date" without having looked at the instants that would. The current
-                        // pinned table happens to contain no such interval, but that is a
-                        // property of today's data, and this test exists to be run against data
-                        // that has changed. The window is ~48h either side and skipped days are
-                        // rare (single digits across the whole sweep), so the finer step costs
-                        // nothing measurable.
-                        let mut probe = base - chrono::Duration::hours(48);
-                        while probe <= base + chrono::Duration::hours(48) {
-                            if tz.from_utc_datetime(&probe).date_naive() == date {
-                                found = Some(probe);
-                                break;
-                            }
-                            probe += chrono::Duration::seconds(1);
-                        }
+                        // date" without having looked at the instants that would. The pinned table
+                        // happens to contain no such interval, which is exactly why the step size
+                        // is pinned by `a_sub_step_interval_is_missed_by_a_coarse_probe` against a
+                        // fabricated calendar rather than by this sweep. Skipped days are rare
+                        // (single digits across the whole sweep), so the finer step costs nothing
+                        // measurable.
+                        let found = find_instant_carrying_date(
+                            midnight,
+                            chrono::Duration::hours(48),
+                            probe_step(),
+                            date,
+                            |probe| tz.from_utc_datetime(&probe).date_naive(),
+                        );
                         if let Some(hit) = found {
                             failures.push(format!(
                                 "{tz}: {date} returned None, but {hit}Z has that local date"


### PR DESCRIPTION
The all-zone timezone sweep asserts that date-only resolution returns the least
instant carrying a local date, across every zone in the bundled `chrono-tz`
database. It is `#[ignore]`d because it walks the whole database, which is the
wrong cost on an ordinary pull request and the right one exactly when the
bundled zone data changes under the resolver.

That made it a remembered duty rather than a triggered one. This adds the
trigger.

## The bundled zone data is an input, not an inert dependency

Moving the `chrono-tz` pin can change which dates have no local midnight and
where a gap begins, so it can change the resolver's answers without changing a
line of the resolver. A workflow now runs the sweep on any pull request
touching a manifest or lockfile that can carry that version, and on the pack
holding both the resolver and the sweep. `make tz-audit` runs the same thing
locally.

The job prints the resolved `chrono-tz` version before running, read from the
lockfile and with no `|| true`, because a step that cannot fail cannot report:
the sweep's result only means something against a named version of the zone
data. It runs `--ignored` rather than `--include-ignored`, so a failure in an
ordinary test cannot be reported as a failure of the sweep.

This does not gate ordinary resolver correctness. The crate's normal tests
cover that on every pull request through the main job.

## The probe granularity is pinned by a test that can fail

The sweep's skipped-day branch probes the search window for an instant carrying
the requested local date. The step size matters: a local-date interval shorter
than the step can sit between two probes, so a coarse probe reports that no
instant carries the date without having looked at the instants that would. That
failure is invisible against the real database, which contains no interval of
that shape.

So the step is pinned against a fabricated calendar in which one local date
exists for thirty seconds. A one-minute probe steps over it and finds nothing; a
one-second probe finds it. The fixture guards itself, asserting that the
interval really is shorter than the coarse step, so the test cannot pass for a
reason unrelated to granularity. Synthetic data is the right fixture precisely
because the real table has no such transition: an assertion that cannot be made
to fail is not an assertion, and the alternative was shipping the finer step on
argument alone.

Pinning it needed the probe extracted into a helper that takes the calendar as a
parameter, which is what lets the test substitute a fabricated one.

## Note on the search window

The helper takes the window as bounds rather than a centre and a radius. The
bounds come from `anchor_search_window`, the same function the resolver uses, so
the searched window has a single definition and a change to the radius cannot
leave this probe checking the old window while still reporting no violations.
That also keeps the helper free of bare `-` and `+` on `NaiveDateTime`, which
abort at the ends of the representable range rather than returning `None`; the
step is checked for the same reason, so overflowing past the end of the range
ends the search instead of the process.

## The workflow declares its own token scope

With no `permissions:` block a workflow inherits the repository's default
`GITHUB_TOKEN` scopes, so its actual authority is set by a repository setting
the file neither states nor tracks, and changing that setting would widen it
with no diff for a reviewer to see. This job checks out, builds, and runs one
test, so it declares `contents: read` and nothing else.

That default is currently read-only, so this is about making the property
reviewable rather than closing an open hole. Three other workflows are in the
same position and are left alone here, since they are pre-existing and unrelated
to this change.

## Verification

The sweep runs green at this tree: 597 zones over 91311 dates each, 4299 gap
dates, 818 folds, 7 whole days a zone's calendar skips, and zero violations.
The granularity test's coarse arm fails and its fine arm passes, which is the
discrimination the test exists to provide.
