### PR TITLE
docs(adr-078): Amendment 2 — table-only auto, sibling preservation, elision markers

### DIFF
--- a/docs/adr/ADR-078-output-format-shape-aware-rendering.md
+++ b/docs/adr/ADR-078-output-format-shape-aware-rendering.md
@@ -522,12 +522,17 @@ as data while silently missing fields); identity and decision fields were trunca
 prose (a cut signature or title is unusable); and the kv-block renderer's truncation
 destroyed single-record payloads such as a compose briefing's `markdown` field, while its
 indentation could balloon deep objects past the daemon frame. This amendment revises §3
-so `auto` is safe to adopt as a surface default.
+so `auto` is safe to adopt as a surface default. The amendment is the governing contract
+from its merge; the renderer change implementing it lands as a companion change gated on
+this text, so the shipped renderer may lag the contract in the interim.
 
 **§3(b) is withdrawn.** The flat key-value block renderer is removed. `auto` recognizes
 exactly two shapes: a homogeneous record array renders as a markdown table; every other
-shape — single records, heterogeneous objects, scalars — renders as compact JSON,
-lossless by construction and identical to `format=json` for those shapes.
+shape — single records, heterogeneous objects, scalars — renders as compact JSON of the
+§7-reduced value. The §7 view reductions (`full_id` suppression, namespace elision,
+`properties` dedup) still apply, as they always have in `auto`; beyond those enumerated
+reductions the fallback is lossless by construction — no truncation, no elision, no
+reformatting. Byte-exact output remains `format=json`'s contract (§4).
 
 **§3(a) qualifying condition simplified; per-cell elision replaces disqualification.**
 The original "mostly-scalar key set" condition is superseded: an array of two or more
@@ -545,21 +550,39 @@ values verbatim, other values as compact JSON, untruncated. Pagination and count
 (`has_more`, `offset`, `page_size`, `truncated`) must survive rendering; dropping them
 is a correctness defect, not a verbosity trade.
 
+**Escaping preserves the structure/data boundary.** Stored content is untrusted input
+and the rendered view has structure of its own, so the renderer must keep the two
+separable. In table cells, `|` is escaped and newlines collapse to spaces, so no cell
+value can terminate its cell, add a row, or add a table. In sibling lines, a string
+value containing a newline or carriage return renders as its JSON string literal (one
+line, lossless) instead of verbatim, so no value can fabricate an additional
+`key: value` line or table row. Rendering never interprets content: a value that looks
+like markup, a directive, or an instruction is emitted as data under these rules, and
+consumers must treat it as data. Escaping is a table/sibling concern only — the
+compact-JSON fallback and `format=json` are already closed to injection by JSON string
+encoding.
+
 **Cell truncation exempts identity and decision columns.** Columns named `id`, `kind`,
 `status`, `priority`, `relation`, `title`, `name`, `signature`, `slug`, `assignee`,
 `from`, `to`, `due`, and any column ending in `_id` or `_at` or starting with `due`
-render whole. `PresentationMode::Verbose` disables truncation entirely, as §3(a) already
-specified; the implementation now honors it. The `full=true` request parameter that
+render whole — a cut signature or title is unusable, so these columns trade bytes for
+usability. The exemption is bounded: the daemon's frame cap remains the outer bound on
+total response size, so an exempt column can spend the frame but not exceed it.
+`PresentationMode::Verbose` disables truncation entirely, as §3(a) already
+specified; the implementation must honor it. The `full=true` request parameter that
 §3(a) also named as a truncation override is withdrawn: no request path ever implemented
 it (`RequestParams` carries no such field), and Verbose is the sole override — the same
 phantom-override class Amendment 1 withdrew for `include_full_id`.
 
-**§7 pre-pass gains a scalar hoist.** `trigger_at`, `due`, and `status` values found
+**The table path gains a scalar hoist.** `trigger_at`, `due`, and `status` values found
 inside a record's `properties` object are hoisted to the top level when no top-level
 sibling of that name exists (never overwriting one), so the table renderer can surface
 them as columns. Without the hoist, a scheduled event's row cannot say when it fires or
 whether it is pending — those fields live only inside the nested bag, which renders as
-`{…}`. The hoist is view-only: `json` output and Verbose presentation are unaffected.
+`{…}`. The hoist applies only when the table shape is selected, before column
+enumeration: its sole rationale is table columns, and reshaping a single record's
+compact-JSON fallback would move fields with no column to gain. It is view-only:
+`json` output and Verbose presentation are unaffected.
 
 **§6 consequence.** With the kv-block renderer removed, `table` and `auto` share the
 same dispatch; `table` remains as an explicit spelling of the same contract.

--- a/docs/adr/ADR-078-output-format-shape-aware-rendering.md
+++ b/docs/adr/ADR-078-output-format-shape-aware-rendering.md
@@ -512,6 +512,59 @@ outer-envelope fields. This makes format and presentation misspellings explicit 
 errors instead of silent requests for the server defaults. It does not change the DSL's
 per-verb validation rules or the canonical handler result shape.
 
+## Amendment 2 (2026-08-23): render fidelity — table-only `auto`, sibling preservation, elision markers
+
+A 91-verb output audit of the shipped renderer found four fidelity losses in the `auto`
+path, one of them fail-open: an object envelope's sibling scalars were dropped when a
+record array was found (a `query` page losing `has_more` reads as complete); nested
+objects were stringified into truncated 120-character cells (truncated pseudo-JSON reads
+as data while silently missing fields); identity and decision fields were truncated like
+prose (a cut signature or title is unusable); and the kv-block renderer's truncation
+destroyed single-record payloads such as a compose briefing's `markdown` field, while its
+indentation could balloon deep objects past the daemon frame. This amendment revises §3
+so `auto` is safe to adopt as a surface default.
+
+**§3(b) is withdrawn.** The flat key-value block renderer is removed. `auto` recognizes
+exactly two shapes: a homogeneous record array renders as a markdown table; every other
+shape — single records, heterogeneous objects, scalars — renders as compact JSON,
+lossless by construction and identical to `format=json` for those shapes.
+
+**§3(a) qualifying condition simplified; per-cell elision replaces disqualification.**
+The original "mostly-scalar key set" condition is superseded: an array of two or more
+objects qualifies. Nested values are handled per cell instead of disqualifying the table
+— an object-valued cell renders the constant marker `{…}`, an array containing objects
+renders `[…]`, and an array of scalars renders as compact JSON. A majority-nested gate
+would push high-value listings (task queues whose rows carry a property bag) back to
+compact JSON and forfeit the measured 83–90% listing savings; per-cell elision keeps the
+table win while making elision explicit rather than disguising it as truncated data.
+Full content remains one `format=json` or `get` away.
+
+**Envelope siblings are preserved.** When the record array sits under an object key, the
+remaining top-level keys render as trailing `key: value` lines after the table — string
+values verbatim, other values as compact JSON, untruncated. Pagination and count fields
+(`has_more`, `offset`, `page_size`, `truncated`) must survive rendering; dropping them
+is a correctness defect, not a verbosity trade.
+
+**Cell truncation exempts identity and decision columns.** Columns named `id`, `kind`,
+`status`, `priority`, `relation`, `title`, `name`, `signature`, `slug`, `assignee`,
+`from`, `to`, `due`, and any column ending in `_id` or `_at` or starting with `due`
+render whole. `PresentationMode::Verbose` disables truncation entirely, as §3(a) already
+specified; the implementation now honors it.
+
+**§7 pre-pass gains a scalar hoist.** `trigger_at`, `due`, and `status` values found
+inside a record's `properties` object are hoisted to the top level when no top-level
+sibling of that name exists (never overwriting one), so the table renderer can surface
+them as columns. Without the hoist, a scheduled event's row cannot say when it fires or
+whether it is pending — those fields live only inside the nested bag, which renders as
+`{…}`. The hoist is view-only: `json` output and Verbose presentation are unaffected.
+
+**§6 consequence.** With the kv-block renderer removed, `table` and `auto` share the
+same dispatch; `table` remains as an explicit spelling of the same contract.
+
+The durable fix for listing verbosity remains per-verb response contracts (listings
+project selection fields, acknowledgements return acknowledgements); this amendment makes
+the view layer honest in the interim rather than lossy.
+
 ## References
 
 - ADR-016 (Request DSL) — short-UUID-prefix resolution; `$prev` chain semantics; `RequestParams`

--- a/docs/adr/ADR-078-output-format-shape-aware-rendering.md
+++ b/docs/adr/ADR-078-output-format-shape-aware-rendering.md
@@ -533,7 +533,7 @@ lossless by construction and identical to `format=json` for those shapes.
 The original "mostly-scalar key set" condition is superseded: an array of two or more
 objects qualifies. Nested values are handled per cell instead of disqualifying the table
 — an object-valued cell renders the constant marker `{…}`, an array containing objects
-renders `[…]`, and an array of scalars renders as compact JSON. A majority-nested gate
+or arrays renders `[…]`, and an array of scalars renders as compact JSON. A majority-nested gate
 would push high-value listings (task queues whose rows carry a property bag) back to
 compact JSON and forfeit the measured 83–90% listing savings; per-cell elision keeps the
 table win while making elision explicit rather than disguising it as truncated data.
@@ -549,7 +549,10 @@ is a correctness defect, not a verbosity trade.
 `status`, `priority`, `relation`, `title`, `name`, `signature`, `slug`, `assignee`,
 `from`, `to`, `due`, and any column ending in `_id` or `_at` or starting with `due`
 render whole. `PresentationMode::Verbose` disables truncation entirely, as §3(a) already
-specified; the implementation now honors it.
+specified; the implementation now honors it. The `full=true` request parameter that
+§3(a) also named as a truncation override is withdrawn: no request path ever implemented
+it (`RequestParams` carries no such field), and Verbose is the sole override — the same
+phantom-override class Amendment 1 withdrew for `include_full_id`.
 
 **§7 pre-pass gains a scalar hoist.** `trigger_at`, `due`, and `status` values found
 inside a record's `properties` object are hoisted to the top level when no top-level


### PR DESCRIPTION
## What

Adds **Amendment 2** to ADR-078, documenting the §3 contract change implemented in #2140:

- §3(b) kv-block renderer withdrawn — non-table shapes render as compact JSON, lossless.
- §3(a) qualifying condition simplified (array of 2+ objects); nested values handled per cell with explicit elision markers (`{…}`/`[…]`) instead of disqualifying the table or truncating pseudo-JSON.
- Envelope siblings preserved as trailing `key: value` lines (pagination/count fields are correctness, not verbosity).
- Cell truncation exempts identity/decision columns; Verbose disables truncation (as §3a already specified).
- §7 pre-pass gains a view-only scalar hoist (`trigger_at`/`due`/`status` out of `properties`).
- §6 consequence: `table` and `auto` share dispatch.

Docs-only; the code change is #2140 (kept as a separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
