### PR TITLE
fix(pack-comm): validate a supplied heartbeat `at` before storing it

### DIFF
--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -253,16 +253,27 @@ fn thread_id_query_spellings(root: Uuid, selected_raw: Option<&str>) -> Vec<Stri
     spellings
 }
 
+/// Parse a caller-supplied timestamp, rejecting anything that does not
+/// resolve to an instant, with the verb and field named in the error.
+/// Callers own the serialization policy on the parsed value: ingest
+/// re-serializes in UTC, heartbeat preserves the supplied spelling.
+fn parse_supplied_timestamp(
+    verb: &str,
+    field: &str,
+    raw: &str,
+) -> Result<DateTime<chrono::FixedOffset>, RuntimeError> {
+    DateTime::parse_from_rfc3339(raw.trim()).map_err(|error| {
+        RuntimeError::InvalidInput(format!(
+            "{verb}: `{field}` must be a valid RFC 3339 timestamp, got {raw:?}: {error}"
+        ))
+    })
+}
+
 /// Validate an adapter timestamp before it can be certified as a v1 `sent_at`
 /// value, then serialize the instant in one RFC 3339 representation (UTC).
 fn canonicalize_ingest_sent_at(raw: &str) -> Result<String, RuntimeError> {
-    DateTime::parse_from_rfc3339(raw.trim())
+    parse_supplied_timestamp("ingest", "sent_at", raw)
         .map(|timestamp| timestamp.with_timezone(&Utc).to_rfc3339())
-        .map_err(|error| {
-            RuntimeError::InvalidInput(format!(
-                "ingest: `sent_at` must be a valid RFC 3339 timestamp, got {raw:?}: {error}"
-            ))
-        })
 }
 
 /// `send` — create a message note in the caller's namespace (outbound) AND
@@ -2328,11 +2339,7 @@ pub(crate) async fn handle_heartbeat(
     // rule as ingest's `sent_at` (`canonicalize_ingest_sent_at`).
     let at = match p.at.as_deref() {
         Some(raw) => {
-            DateTime::parse_from_rfc3339(raw.trim()).map_err(|error| {
-                RuntimeError::InvalidInput(format!(
-                    "heartbeat: `at` must be a valid RFC 3339 timestamp, got {raw:?}: {error}"
-                ))
-            })?;
+            parse_supplied_timestamp("heartbeat", "at", raw)?;
             raw.trim().to_string()
         }
         None => now.to_rfc3339(),

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -2321,7 +2321,22 @@ pub(crate) async fn handle_heartbeat(
         .map_err(|e| RuntimeError::Internal(format!("heartbeat: get_note: {e}")))?;
 
     let now = Utc::now();
-    let at = p.at.clone().unwrap_or_else(|| now.to_rfc3339());
+    // A supplied `at` must resolve to an instant before it is stored: the
+    // staleness reader parses `last_poll_attempt_at` inside an Option chain,
+    // so an unparseable stored value makes staleness silently unknown and the
+    // channel can never read as stale — failing toward looking healthy. Same
+    // rule as ingest's `sent_at` (`canonicalize_ingest_sent_at`).
+    let at = match p.at.as_deref() {
+        Some(raw) => {
+            DateTime::parse_from_rfc3339(raw.trim()).map_err(|error| {
+                RuntimeError::InvalidInput(format!(
+                    "heartbeat: `at` must be a valid RFC 3339 timestamp, got {raw:?}: {error}"
+                ))
+            })?;
+            raw.trim().to_string()
+        }
+        None => now.to_rfc3339(),
+    };
 
     // `HeartbeatParams` (khive-pack-comm/src/params.rs) carries no free-form
     // `properties` field — every key assigned below is a fixed literal, so no

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -7625,6 +7625,19 @@ async fn heartbeat_rejects_an_unparseable_at_and_preserves_a_valid_one() {
         "the error names the field and the offending value: {msg}"
     );
 
+    // Checked BEFORE the valid heartbeat: both calls share one channel
+    // identity, so a row leaked by the rejected call would be overwritten
+    // below and invisible to any later count.
+    let health = registry
+        .dispatch("comm.health", serde_json::json!({}))
+        .await
+        .expect("health succeeds after the rejected heartbeat");
+    let channels = health["channels"].as_array().expect("channels is array");
+    assert!(
+        channels.is_empty(),
+        "the rejected heartbeat left no row: {channels:?}"
+    );
+
     let mut with_offset = base.clone();
     with_offset["at"] = serde_json::json!("2026-08-24T09:15:00-04:00");
     registry
@@ -7637,7 +7650,11 @@ async fn heartbeat_rejects_an_unparseable_at_and_preserves_a_valid_one() {
         .await
         .expect("health succeeds");
     let channels = health["channels"].as_array().expect("channels is array");
-    assert_eq!(channels.len(), 1, "the rejected heartbeat left no row");
+    assert_eq!(
+        channels.len(),
+        1,
+        "exactly the valid heartbeat's row exists"
+    );
     assert_eq!(
         channels[0]["last_poll_attempt_at"].as_str(),
         Some("2026-08-24T09:15:00-04:00"),

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -7594,6 +7594,57 @@ async fn heartbeat_success_is_visible_via_health() {
     assert_eq!(ch["consecutive_failures"].as_u64(), Some(0));
 }
 
+/// A supplied heartbeat `at` must resolve to an instant before it is stored:
+/// the staleness reader parses `last_poll_attempt_at` inside an Option chain,
+/// so an unparseable stored value would make staleness silently unknown and
+/// the channel could never read as stale. A date-only value is the realistic
+/// wrong shape; a valid offset-carrying value is preserved verbatim (the
+/// offset records the calendar it was stamped in), and the omitted-`at` path
+/// keeps working — the control arms separating "validates" from "rejects
+/// everything".
+#[tokio::test]
+async fn heartbeat_rejects_an_unparseable_at_and_preserves_a_valid_one() {
+    let (registry, _rt) = build_registry_for_ns("local");
+
+    let base = serde_json::json!({
+        "namespace": "local",
+        "channel_kind": "email",
+        "channel_slug": "recipient@example.com",
+        "outcome": "success",
+    });
+
+    let mut date_only = base.clone();
+    date_only["at"] = serde_json::json!("2026-08-24");
+    let err = registry
+        .dispatch("comm.heartbeat", date_only)
+        .await
+        .expect_err("a date-only `at` must be rejected, not stored");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("at") && msg.contains("2026-08-24"),
+        "the error names the field and the offending value: {msg}"
+    );
+
+    let mut with_offset = base.clone();
+    with_offset["at"] = serde_json::json!("2026-08-24T09:15:00-04:00");
+    registry
+        .dispatch("comm.heartbeat", with_offset)
+        .await
+        .expect("a valid offset-carrying `at` is accepted");
+
+    let health = registry
+        .dispatch("comm.health", serde_json::json!({}))
+        .await
+        .expect("health succeeds");
+    let channels = health["channels"].as_array().expect("channels is array");
+    assert_eq!(channels.len(), 1, "the rejected heartbeat left no row");
+    assert_eq!(
+        channels[0]["last_poll_attempt_at"].as_str(),
+        Some("2026-08-24T09:15:00-04:00"),
+        "a valid `at` is stored verbatim, offset spelling preserved"
+    );
+}
+
 /// khive #1383: quarantine is a terminal disposition for one message, not a
 /// channel failure. Healthy heartbeat facts therefore stay healthy while the
 /// read surface reports every live parked row, grouped by the exact transport


### PR DESCRIPTION
## Problem

`comm.heartbeat` stored a caller-supplied `at` verbatim with no validation. The staleness consumer parses `last_poll_attempt_at` inside an Option chain, so an unparseable stored value (a date-only string, arbitrary text) makes staleness silently unknown: the channel can never read as stale. The failure direction is toward looking healthy.

Every sibling writer in this class already validates before storing (`comm.ingest` resolves `sent_at` to an instant; `schedule` validates `trigger_at`), so heartbeat was the one unguarded writer.

## Fix

Validate-then-preserve, matching ingest's `sent_at` pattern: a supplied `at` must parse as RFC 3339 or the call is rejected naming the field and value; a valid value is stored with its offset spelling preserved.

## Test

`heartbeat_rejects_an_unparseable_at_and_preserves_a_valid_one`: a date-only `at` is rejected naming the field and value and leaves no row; a valid offset-bearing value is stored verbatim.