### PR TITLE
fix(storage): typed retryable classification for admission timeouts

### DIFF
--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -1077,6 +1077,16 @@ impl ConnectionPool {
         &self.config
     }
 
+    /// The typed admission failure for a pooled reader checkout that
+    /// exhausted `checkout_timeout`: no reader was acquired, so the
+    /// operation never started and a retry cannot duplicate a side effect.
+    pub(crate) fn reader_admission_timeout(&self, operation: &'static str) -> StorageError {
+        StorageError::AdmissionTimeout {
+            operation: operation.into(),
+            timeout_ms: u64::try_from(self.config.checkout_timeout.as_millis()).unwrap_or(u64::MAX),
+        }
+    }
+
     /// Pool-wide permits for file-backed raw-SQL reader opens and active reads.
     pub(crate) fn sql_bridge_reader_slots(&self) -> Arc<Semaphore> {
         Arc::clone(&self.sql_bridge_reader_slots)

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -17,6 +17,7 @@ use crate::error::SqliteError;
 use crate::writer_task::WriterTaskHandle;
 use khive_storage::error::StorageError;
 use khive_storage::tx_registry::{DbIdentity, TxOrigin};
+use khive_storage::StorageCapability;
 
 const CACHE_SIZE_KIB: &str = "-65536";
 const MMAP_SIZE_BYTES: &str = "1073741824";
@@ -1084,6 +1085,34 @@ impl ConnectionPool {
         StorageError::AdmissionTimeout {
             operation: operation.into(),
             timeout_ms: u64::try_from(self.config.checkout_timeout.as_millis()).unwrap_or(u64::MAX),
+        }
+    }
+
+    /// Classify an error returned by [`Self::reader_until`] at checkout.
+    ///
+    /// `reader_until` executes no SQL — it only checks out a connection — so
+    /// the only `SQLITE_BUSY` it can produce is [`pool_exhausted_error`],
+    /// raised when `checkout_timeout` elapses with no reader available. That is
+    /// a genuine admission wait that ended before any work began, so it maps to
+    /// the retryable [`StorageError::AdmissionTimeout`]. Every other checkout
+    /// error (e.g. [`Self::ensure_pooled_writer_active`] returning
+    /// `InvalidData` for a retired pooled writer) is an opaque driver failure
+    /// and stays non-retryable. Keeping this beside `pool_exhausted_error` is
+    /// what lets the call site avoid sniffing an error shape it does not own.
+    pub(crate) fn classify_reader_checkout_error(
+        &self,
+        operation: &'static str,
+        error: SqliteError,
+    ) -> StorageError {
+        let is_pool_exhausted = matches!(
+            &error,
+            SqliteError::Rusqlite(rusqlite::Error::SqliteFailure(code, _))
+                if code.code == rusqlite::ErrorCode::DatabaseBusy
+        );
+        if is_pool_exhausted {
+            self.reader_admission_timeout(operation)
+        } else {
+            StorageError::driver(StorageCapability::Sql, "pool_reader", error)
         }
     }
 

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -1088,31 +1088,47 @@ impl ConnectionPool {
         }
     }
 
-    /// Classify an error returned by [`Self::reader_until`] at checkout.
+    /// Resolve a [`Self::reader_until`] outcome into a checked-out guard or
+    /// the canonical refusal. This is the single home of the checkout
+    /// tri-state; call sites must not re-derive any arm of it:
     ///
-    /// `reader_until` executes no SQL — it only checks out a connection — so
-    /// the only `SQLITE_BUSY` it can produce is [`pool_exhausted_error`],
-    /// raised when `checkout_timeout` elapses with no reader available. That is
-    /// a genuine admission wait that ended before any work began, so it maps to
-    /// the retryable [`StorageError::AdmissionTimeout`]. Every other checkout
-    /// error (e.g. [`Self::ensure_pooled_writer_active`] returning
-    /// `InvalidData` for a retired pooled writer) is an opaque driver failure
-    /// and stays non-retryable. Keeping this beside `pool_exhausted_error` is
-    /// what lets the call site avoid sniffing an error shape it does not own.
-    pub(crate) fn classify_reader_checkout_error(
+    /// - `Ok(Some)` — a reader was checked out.
+    /// - `Ok(None)` — `should_stop()` fired: the request was cancelled or hit
+    ///   its deadline before checkout. NOT an admission wait, so it maps to
+    ///   the non-retryable [`StorageError::Timeout`] — emitting the retryable
+    ///   `AdmissionTimeout` here would invite an immediate retry of a request
+    ///   its caller already abandoned, into a possibly saturated pool.
+    /// - `Err` carrying the pool's own `SQLITE_BUSY` — `reader_until` executes
+    ///   no SQL, so the only `SQLITE_BUSY` it can produce is
+    ///   [`pool_exhausted_error`], raised when `checkout_timeout` elapses with
+    ///   no reader available. A genuine admission wait that ended before any
+    ///   work began maps to the retryable [`StorageError::AdmissionTimeout`].
+    /// - any other `Err` (e.g. [`Self::ensure_pooled_writer_active`] returning
+    ///   `InvalidData` for a retired pooled writer) — an opaque driver failure
+    ///   under the caller's capability, non-retryable.
+    pub(crate) fn resolve_reader_checkout<'p>(
         &self,
+        capability: StorageCapability,
         operation: &'static str,
-        error: SqliteError,
-    ) -> StorageError {
-        let is_pool_exhausted = matches!(
-            &error,
-            SqliteError::Rusqlite(rusqlite::Error::SqliteFailure(code, _))
-                if code.code == rusqlite::ErrorCode::DatabaseBusy
-        );
-        if is_pool_exhausted {
-            self.reader_admission_timeout(operation)
-        } else {
-            StorageError::driver(StorageCapability::Sql, "pool_reader", error)
+        outcome: Result<Option<ReaderGuard<'p>>, SqliteError>,
+    ) -> Result<ReaderGuard<'p>, StorageError> {
+        match outcome {
+            Ok(Some(guard)) => Ok(guard),
+            Ok(None) => Err(StorageError::Timeout {
+                operation: operation.into(),
+            }),
+            Err(error) => {
+                let is_pool_exhausted = matches!(
+                    &error,
+                    SqliteError::Rusqlite(rusqlite::Error::SqliteFailure(code, _))
+                        if code.code == rusqlite::ErrorCode::DatabaseBusy
+                );
+                if is_pool_exhausted {
+                    Err(self.reader_admission_timeout(operation))
+                } else {
+                    Err(StorageError::driver(capability, operation, error))
+                }
+            }
         }
     }
 
@@ -3915,5 +3931,69 @@ mod tests {
         let (identity_again, canonical_again) = mint_db_identity(&db_path).unwrap();
         assert_eq!(identity, identity_again);
         assert_eq!(canonical, canonical_again);
+    }
+
+    /// The checkout tri-state, arm by arm, at its single home. Each refusal
+    /// arm asserts the classification it must NOT collapse into, because the
+    /// historical defect was exactly a pairwise swap: cancellation surfaced as
+    /// the retryable `AdmissionTimeout` while genuine pool exhaustion surfaced
+    /// as a non-retryable `Driver` failure.
+    #[test]
+    fn resolve_reader_checkout_maps_each_arm_distinctly() {
+        let pool = ConnectionPool::new(PoolConfig {
+            path: None,
+            ..PoolConfig::default()
+        })
+        .unwrap();
+
+        let guard = pool
+            .resolve_reader_checkout(
+                StorageCapability::Sql,
+                "arm_checked_out",
+                pool.reader_until(|| false),
+            )
+            .expect("an uncontended checkout must pass the guard through");
+        drop(guard);
+
+        let Err(cancelled) =
+            pool.resolve_reader_checkout(StorageCapability::Sql, "arm_cancelled", Ok(None))
+        else {
+            panic!("a cancelled checkout must be refused");
+        };
+        assert!(
+            matches!(cancelled, StorageError::Timeout { .. }),
+            "cancellation/deadline before checkout must be the non-retryable \
+             Timeout, got {cancelled:?}"
+        );
+
+        let Err(exhausted) = pool.resolve_reader_checkout(
+            StorageCapability::Sql,
+            "arm_exhausted",
+            Err(pool_exhausted_error(Duration::from_millis(5), 1)),
+        ) else {
+            panic!("an exhausted checkout must be refused");
+        };
+        assert!(
+            matches!(exhausted, StorageError::AdmissionTimeout { .. }),
+            "the pool's own SQLITE_BUSY (checkout_timeout exhausted) must be \
+             the retryable AdmissionTimeout, got {exhausted:?}"
+        );
+
+        let Err(opaque) = pool.resolve_reader_checkout(
+            StorageCapability::Entities,
+            "arm_driver",
+            Err(SqliteError::InvalidData("retired pooled writer".into())),
+        ) else {
+            panic!("an opaque checkout error must be refused");
+        };
+        assert!(
+            matches!(
+                &opaque,
+                StorageError::Driver { capability, .. }
+                    if *capability == StorageCapability::Entities
+            ),
+            "any other checkout error must stay a non-retryable Driver failure \
+             under the caller's capability, got {opaque:?}"
+        );
     }
 }

--- a/crates/khive-db/src/sql_bridge.rs
+++ b/crates/khive-db/src/sql_bridge.rs
@@ -779,8 +779,9 @@ async fn acquire_handle_slot(
 ) -> Result<OwnedSemaphorePermit, StorageError> {
     tokio::time::timeout(timeout, slots.acquire_owned())
         .await
-        .map_err(|_| StorageError::Timeout {
+        .map_err(|_| StorageError::AdmissionTimeout {
             operation: operation.into(),
+            timeout_ms: u64::try_from(timeout.as_millis()).unwrap_or(u64::MAX),
         })?
         .map_err(|error| StorageError::Pool {
             operation: operation.into(),
@@ -1779,9 +1780,7 @@ where
                 .map_err(|error| {
                     StorageError::driver(StorageCapability::Sql, "pool_reader", error)
                 })?
-                .ok_or_else(|| StorageError::Timeout {
-                    operation: operation.into(),
-                })?;
+                .ok_or_else(|| pool.reader_admission_timeout(operation))?;
             scope.with_pooled_reader(&mut guard, |conn| query(scope, conn))
         },
     )
@@ -2533,7 +2532,7 @@ impl khive_storage::SqlAccess for SqlBridge {
             // Contract: this acquire waits on the pool-wide one-permit
             // writer-handle budget — the same permit a live `writer()` handle
             // holds for its lifetime — so it times out with
-            // `StorageError::Timeout` after `checkout_timeout` while a writer
+            // `StorageError::AdmissionTimeout` after `checkout_timeout` while a writer
             // handle is checked out (and a `writer()` call times out while
             // this unit runs). Callers must not hold a boxed writer handle
             // across an `atomic_unit()` call on the same pool; drop the
@@ -2726,7 +2725,7 @@ mod tests {
             .await
             .expect("cancelled reader checkout waited for the five-second pool timeout")
             .expect("checkout task panicked");
-        assert!(matches!(result, Err(StorageError::Timeout { .. })));
+        assert!(matches!(result, Err(StorageError::AdmissionTimeout { .. })));
 
         drop(held_reader);
         tokio::time::sleep(std::time::Duration::from_millis(25)).await;
@@ -3366,7 +3365,7 @@ mod tests {
         };
         assert!(matches!(
             writer_error,
-            StorageError::Timeout { ref operation }
+            StorageError::AdmissionTimeout { ref operation, .. }
                 if operation.as_ref() == "sql_bridge.writer_handle"
         ));
         drop(writer);
@@ -3449,7 +3448,7 @@ mod tests {
         assert!(
             matches!(
                 &blocked,
-                Err(StorageError::Timeout { operation })
+                Err(StorageError::AdmissionTimeout { operation, .. })
                     if operation.as_ref() == "sql_bridge.reader_operation"
             ),
             "a second logical read must contend with the admitted transaction; got {blocked:?}"
@@ -4816,7 +4815,7 @@ mod tests {
         let contender = bridge.writer().await;
         let retained_slot = matches!(
             &contender,
-            Err(StorageError::Timeout { operation })
+            Err(StorageError::AdmissionTimeout { operation, .. })
                 if operation.as_ref() == "sql_bridge.writer_handle"
         );
         drop(contender);
@@ -5927,7 +5926,7 @@ mod tests {
         assert!(
             matches!(
                 &blocked,
-                Err(StorageError::Timeout { operation })
+                Err(StorageError::AdmissionTimeout { operation, .. })
                     if operation.as_ref() == "sql_bridge.atomic_unit_handle"
             ),
             "atomic_unit must time out on the shared writer permit while a \
@@ -6387,7 +6386,7 @@ mod tests {
         assert!(
             matches!(
                 &starved,
-                Err(StorageError::Timeout { operation })
+                Err(StorageError::AdmissionTimeout { operation, .. })
                     if operation.as_ref() == "sql_bridge.reader_open"
             ),
             "queue-backed read with reader permits saturated must time out \

--- a/crates/khive-db/src/sql_bridge.rs
+++ b/crates/khive-db/src/sql_bridge.rs
@@ -1775,29 +1775,14 @@ where
         StorageCapability::Sql,
         operation,
         move |scope| {
-            // `reader_until` reports three distinct outcomes that must NOT be
-            // collapsed:
-            //   Ok(Some) -> a reader was checked out.
-            //   Ok(None) -> `should_stop()` fired: the request was cancelled or
-            //     hit its deadline. This is NOT an admission wait, so it must
-            //     not emit the retryable AdmissionTimeout (which would invite an
-            //     immediate retry into a saturated pool). Keep the original
-            //     Timeout classification for the cancellation path.
-            //   Err(..)  -> checkout failed. `classify_reader_checkout_error`
-            //     maps an exhausted `checkout_timeout` (the pool's own
-            //     SQLITE_BUSY) to the retryable AdmissionTimeout and anything
-            //     else to a driver failure. The earlier chain mapped every
-            //     Err to Driver, so a genuine admission expiry never reached
-            //     AdmissionTimeout.
-            let mut guard = match pool.reader_until(|| scope.should_stop()) {
-                Ok(Some(guard)) => guard,
-                Ok(None) => {
-                    return Err(StorageError::Timeout {
-                        operation: operation.into(),
-                    })
-                }
-                Err(error) => return Err(pool.classify_reader_checkout_error(operation, error)),
-            };
+            // Checkout tri-state (cancelled -> Timeout, admission expiry ->
+            // retryable AdmissionTimeout, other -> Driver) lives in ONE place:
+            // `ConnectionPool::resolve_reader_checkout`.
+            let mut guard = pool.resolve_reader_checkout(
+                StorageCapability::Sql,
+                operation,
+                pool.reader_until(|| scope.should_stop()),
+            )?;
             scope.with_pooled_reader(&mut guard, |conn| query(scope, conn))
         },
     )

--- a/crates/khive-db/src/sql_bridge.rs
+++ b/crates/khive-db/src/sql_bridge.rs
@@ -772,16 +772,32 @@ fn map_rusqlite_err(e: rusqlite::Error, op: &'static str) -> StorageError {
     StorageError::driver(StorageCapability::Sql, op, e)
 }
 
+/// How an elapsed handle-slot deadline is classified. ADR-005 pins the
+/// raw-SQL reader admission paths (`sql_bridge.reader_open` and
+/// `sql_bridge.reader_operation`) to `StorageError::Timeout`; every other
+/// handle slot reports the typed `AdmissionTimeout`.
+#[derive(Clone, Copy)]
+enum SlotTimeoutClass {
+    Admission,
+    ReaderContract,
+}
+
 async fn acquire_handle_slot(
     slots: Arc<Semaphore>,
     timeout: std::time::Duration,
     operation: &'static str,
+    class: SlotTimeoutClass,
 ) -> Result<OwnedSemaphorePermit, StorageError> {
     tokio::time::timeout(timeout, slots.acquire_owned())
         .await
-        .map_err(|_| StorageError::AdmissionTimeout {
-            operation: operation.into(),
-            timeout_ms: u64::try_from(timeout.as_millis()).unwrap_or(u64::MAX),
+        .map_err(|_| match class {
+            SlotTimeoutClass::Admission => StorageError::AdmissionTimeout {
+                operation: operation.into(),
+                timeout_ms: u64::try_from(timeout.as_millis()).unwrap_or(u64::MAX),
+            },
+            SlotTimeoutClass::ReaderContract => StorageError::Timeout {
+                operation: operation.into(),
+            },
         })?
         .map_err(|error| StorageError::Pool {
             operation: operation.into(),
@@ -921,6 +937,7 @@ async fn open_cached_reader_handle(
             pool.sql_bridge_reader_slots(),
             pool.config().checkout_timeout,
             "sql_bridge.reader_open",
+            SlotTimeoutClass::ReaderContract,
         ),
     )
     .await??;
@@ -992,6 +1009,7 @@ where
                 pool.sql_bridge_reader_slots(),
                 pool.config().checkout_timeout,
                 "sql_bridge.reader_operation",
+                SlotTimeoutClass::ReaderContract,
             )
             .await?,
         )
@@ -1003,6 +1021,7 @@ where
                     pool.sql_bridge_reader_slots(),
                     pool.config().checkout_timeout,
                     "sql_bridge.reader_operation",
+                    SlotTimeoutClass::ReaderContract,
                 ),
             )
             .await??,
@@ -2433,6 +2452,7 @@ impl khive_storage::SqlAccess for SqlBridge {
                     self.pool.sql_bridge_writer_slots(),
                     self.pool.config().checkout_timeout,
                     "sql_bridge.writer_handle",
+                    SlotTimeoutClass::Admission,
                 )
                 .await?;
                 let (conn, handle_slot) =
@@ -2544,6 +2564,7 @@ impl khive_storage::SqlAccess for SqlBridge {
                 self.pool.sql_bridge_writer_slots(),
                 self.pool.config().checkout_timeout,
                 "sql_bridge.atomic_unit_handle",
+                SlotTimeoutClass::Admission,
             )
             .await?;
             let (conn, handle_slot) =
@@ -3505,10 +3526,11 @@ mod tests {
         assert!(
             matches!(
                 &blocked,
-                Err(StorageError::AdmissionTimeout { operation, .. })
+                Err(StorageError::Timeout { operation })
                     if operation.as_ref() == "sql_bridge.reader_operation"
             ),
-            "a second logical read must contend with the admitted transaction; got {blocked:?}"
+            "a second logical read must contend with the admitted transaction \
+             and time out with the ADR-005 reader contract error; got {blocked:?}"
         );
 
         reader
@@ -5016,6 +5038,7 @@ mod tests {
             pool.sql_bridge_writer_slots(),
             pool.config().checkout_timeout,
             "sql_bridge.writer_handle",
+            SlotTimeoutClass::Admission,
         )
         .await
         .unwrap();
@@ -5108,6 +5131,7 @@ mod tests {
             pool.sql_bridge_writer_slots(),
             pool.config().checkout_timeout,
             "sql_bridge.writer_handle",
+            SlotTimeoutClass::Admission,
         )
         .await
         .unwrap();
@@ -5682,6 +5706,7 @@ mod tests {
             pool.sql_bridge_writer_slots(),
             pool.config().checkout_timeout,
             "sql_bridge.writer_handle",
+            SlotTimeoutClass::Admission,
         )
         .await
         .unwrap();
@@ -5780,6 +5805,7 @@ mod tests {
             pool.sql_bridge_writer_slots(),
             pool.config().checkout_timeout,
             "sql_bridge.writer_handle",
+            SlotTimeoutClass::Admission,
         )
         .await
         .unwrap();
@@ -5882,6 +5908,7 @@ mod tests {
             pool.sql_bridge_writer_slots(),
             pool.config().checkout_timeout,
             "sql_bridge.writer_handle",
+            SlotTimeoutClass::Admission,
         )
         .await
         .unwrap();
@@ -6443,11 +6470,12 @@ mod tests {
         assert!(
             matches!(
                 &starved,
-                Err(StorageError::AdmissionTimeout { operation, .. })
+                Err(StorageError::Timeout { operation })
                     if operation.as_ref() == "sql_bridge.reader_open"
             ),
             "queue-backed read with reader permits saturated must time out \
-             on the reader budget; got {starved:?}"
+             on the reader budget with the ADR-005 reader contract error; \
+             got {starved:?}"
         );
         drop(held);
 

--- a/crates/khive-db/src/sql_bridge.rs
+++ b/crates/khive-db/src/sql_bridge.rs
@@ -1775,12 +1775,29 @@ where
         StorageCapability::Sql,
         operation,
         move |scope| {
-            let mut guard = pool
-                .reader_until(|| scope.should_stop())
-                .map_err(|error| {
-                    StorageError::driver(StorageCapability::Sql, "pool_reader", error)
-                })?
-                .ok_or_else(|| pool.reader_admission_timeout(operation))?;
+            // `reader_until` reports three distinct outcomes that must NOT be
+            // collapsed:
+            //   Ok(Some) -> a reader was checked out.
+            //   Ok(None) -> `should_stop()` fired: the request was cancelled or
+            //     hit its deadline. This is NOT an admission wait, so it must
+            //     not emit the retryable AdmissionTimeout (which would invite an
+            //     immediate retry into a saturated pool). Keep the original
+            //     Timeout classification for the cancellation path.
+            //   Err(..)  -> checkout failed. `classify_reader_checkout_error`
+            //     maps an exhausted `checkout_timeout` (the pool's own
+            //     SQLITE_BUSY) to the retryable AdmissionTimeout and anything
+            //     else to a driver failure. The earlier chain mapped every
+            //     Err to Driver, so a genuine admission expiry never reached
+            //     AdmissionTimeout.
+            let mut guard = match pool.reader_until(|| scope.should_stop()) {
+                Ok(Some(guard)) => guard,
+                Ok(None) => {
+                    return Err(StorageError::Timeout {
+                        operation: operation.into(),
+                    })
+                }
+                Err(error) => return Err(pool.classify_reader_checkout_error(operation, error)),
+            };
             scope.with_pooled_reader(&mut guard, |conn| query(scope, conn))
         },
     )
@@ -2725,7 +2742,10 @@ mod tests {
             .await
             .expect("cancelled reader checkout waited for the five-second pool timeout")
             .expect("checkout task panicked");
-        assert!(matches!(result, Err(StorageError::AdmissionTimeout { .. })));
+        // Cancellation is NOT an admission wait: it must stay the non-admission
+        // Timeout, never the retryable AdmissionTimeout, so a cancelled request
+        // does not signal clients to retry into a saturated pool.
+        assert!(matches!(result, Err(StorageError::Timeout { .. })));
 
         drop(held_reader);
         tokio::time::sleep(std::time::Duration::from_millis(25)).await;
@@ -2741,6 +2761,58 @@ mod tests {
             value, 0,
             "a DML statement started after its pre-admission checkout was cancelled"
         );
+        assert_eq!(
+            pool.available_readers(),
+            1,
+            "reader checkout leaked a permit"
+        );
+    }
+
+    /// A pooled-reader checkout that exhausts `checkout_timeout` WITHOUT any
+    /// cancellation is a genuine admission wait and must surface as the
+    /// retryable AdmissionTimeout. Before the fix, `reader_until`'s
+    /// pool-exhausted error was mapped to `StorageError::Driver`, so a
+    /// saturated pooled read stayed a non-retryable driver failure and the new
+    /// AdmissionTimeout branch (reachable only for `Ok(None)` cancellation) was
+    /// dead for real timeouts.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn pooled_reader_checkout_timeout_is_a_retryable_admission_timeout() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = PoolConfig {
+            path: Some(dir.path().join("sql_bridge_reader_admission_timeout.db")),
+            max_readers: 1,
+            checkout_timeout: std::time::Duration::from_millis(200),
+            ..PoolConfig::default()
+        };
+        let pool = Arc::new(ConnectionPool::new(config).unwrap());
+        pool.writer()
+            .unwrap()
+            .conn()
+            .execute_batch(
+                "CREATE TABLE reader_admission_probe(value INTEGER NOT NULL); \
+                 INSERT INTO reader_admission_probe VALUES (0);",
+            )
+            .unwrap();
+        // Hold the sole pooled reader so the contending checkout cannot succeed
+        // and must run `checkout_timeout` to exhaustion — no cancellation.
+        let held_reader = pool.reader().expect("hold the sole pooled reader");
+
+        let bridge = SqlBridge::new(Arc::clone(&pool), false);
+        let mut contender = bridge.reader().await.unwrap();
+        let blocked = contender
+            .query_row(SqlStatement {
+                sql: "SELECT value FROM reader_admission_probe".into(),
+                params: vec![],
+                label: Some("reader-admission-timeout-probe".into()),
+            })
+            .await;
+        assert!(
+            matches!(blocked, Err(StorageError::AdmissionTimeout { .. })),
+            "an exhausted pooled-reader checkout must be a retryable AdmissionTimeout; got {blocked:?}"
+        );
+
+        drop(held_reader);
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
         assert_eq!(
             pool.available_readers(),
             1,

--- a/crates/khive-db/src/stores/agents.rs
+++ b/crates/khive-db/src/stores/agents.rs
@@ -289,12 +289,11 @@ impl SqlAgentStore {
                 StorageCapability::Sql,
                 op,
                 move |scope| {
-                    let mut guard = pool
-                        .reader_until(|| scope.should_stop())
-                        .map_err(|e| map_sqlite_err(e, op))?
-                        .ok_or_else(|| StorageError::Timeout {
-                            operation: op.into(),
-                        })?;
+                    let mut guard = pool.resolve_reader_checkout(
+                        StorageCapability::Sql,
+                        op,
+                        pool.reader_until(|| scope.should_stop()),
+                    )?;
                     scope.run_pooled_reader(&mut guard, |conn| f(conn).map_err(|e| map_err(e, op)))
                 },
             )

--- a/crates/khive-db/src/stores/attachment.rs
+++ b/crates/khive-db/src/stores/attachment.rs
@@ -171,10 +171,11 @@ impl SqlAttachmentStore {
                 StorageCapability::Attachments,
                 operation,
                 move |scope| {
-                    let mut guard = pool
-                        .reader_until(|| scope.should_stop())
-                        .map_err(|error| map_sqlite_err(error, operation))?
-                        .ok_or_else(|| pool.reader_admission_timeout(operation))?;
+                    let mut guard = pool.resolve_reader_checkout(
+                        StorageCapability::Attachments,
+                        operation,
+                        pool.reader_until(|| scope.should_stop()),
+                    )?;
                     scope.run_pooled_reader(&mut guard, |conn| {
                         f(conn).map_err(|error| map_err(error, operation))
                     })

--- a/crates/khive-db/src/stores/attachment.rs
+++ b/crates/khive-db/src/stores/attachment.rs
@@ -174,9 +174,7 @@ impl SqlAttachmentStore {
                     let mut guard = pool
                         .reader_until(|| scope.should_stop())
                         .map_err(|error| map_sqlite_err(error, operation))?
-                        .ok_or_else(|| StorageError::Timeout {
-                            operation: operation.into(),
-                        })?;
+                        .ok_or_else(|| pool.reader_admission_timeout(operation))?;
                     scope.run_pooled_reader(&mut guard, |conn| {
                         f(conn).map_err(|error| map_err(error, operation))
                     })

--- a/crates/khive-db/src/stores/entity.rs
+++ b/crates/khive-db/src/stores/entity.rs
@@ -295,9 +295,7 @@ impl SqlEntityStore {
                     let mut guard = pool
                         .reader_until(|| scope.should_stop())
                         .map_err(|e| map_sqlite_err(e, op))?
-                        .ok_or_else(|| StorageError::Timeout {
-                            operation: op.into(),
-                        })?;
+                        .ok_or_else(|| pool.reader_admission_timeout(op))?;
                     scope.run_pooled_reader(&mut guard, |conn| f(conn).map_err(|e| map_err(e, op)))
                 },
             )

--- a/crates/khive-db/src/stores/entity.rs
+++ b/crates/khive-db/src/stores/entity.rs
@@ -292,10 +292,11 @@ impl SqlEntityStore {
                 StorageCapability::Entities,
                 op,
                 move |scope| {
-                    let mut guard = pool
-                        .reader_until(|| scope.should_stop())
-                        .map_err(|e| map_sqlite_err(e, op))?
-                        .ok_or_else(|| pool.reader_admission_timeout(op))?;
+                    let mut guard = pool.resolve_reader_checkout(
+                        StorageCapability::Entities,
+                        op,
+                        pool.reader_until(|| scope.should_stop()),
+                    )?;
                     scope.run_pooled_reader(&mut guard, |conn| f(conn).map_err(|e| map_err(e, op)))
                 },
             )

--- a/crates/khive-db/src/stores/entity_tests.rs
+++ b/crates/khive-db/src/stores/entity_tests.rs
@@ -1773,3 +1773,61 @@ fn batch_write_refreshes_writer_task_after_construction_outside_runtime() {
             );
         });
 }
+
+/// Both refusal arms of the pooled-reader checkout, exercised through a typed
+/// store. The typed-store paths previously inverted the pair: genuine pool
+/// exhaustion surfaced as a non-retryable Driver failure while a cancelled
+/// request surfaced as the retryable AdmissionTimeout — so a saturated read
+/// was never retried and an abandoned one was.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pooled_entity_read_classifies_exhaustion_and_cancellation_distinctly() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = PoolConfig {
+        path: Some(dir.path().join("entity_checkout_classes.db")),
+        max_readers: 1,
+        checkout_timeout: Duration::from_millis(200),
+        ..PoolConfig::default()
+    };
+    let pool = Arc::new(ConnectionPool::new(config).unwrap());
+    pool.writer()
+        .unwrap()
+        .conn()
+        .execute_batch(&format!("{ENTITIES_DDL}\n{TEST_ATTACHMENTS_DDL}"))
+        .unwrap();
+    // `is_file_backed = false` over a file pool forces the pooled-reader
+    // branch, so the checkout contends on the single pooled reader held below.
+    let store = SqlEntityStore::new(Arc::clone(&pool), false);
+    let held_reader = pool.reader().expect("hold the sole pooled reader");
+
+    // Admission expiry with no cancellation: `checkout_timeout` runs to
+    // exhaustion and must surface as the retryable AdmissionTimeout.
+    let exhausted = store.get_entity(Uuid::new_v4()).await.unwrap_err();
+    assert!(
+        matches!(exhausted, StorageError::AdmissionTimeout { .. }),
+        "pool exhaustion through a typed store must be the retryable \
+         AdmissionTimeout, got {exhausted:?}"
+    );
+
+    // Cancellation before checkout: must return promptly as the non-retryable
+    // Timeout, never AdmissionTimeout, and never wait out `checkout_timeout`.
+    let cancel_store = SqlEntityStore::new(Arc::clone(&pool), false);
+    let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+    let waiting = tokio::spawn(khive_storage::scope_request_read_cancellation(
+        cancel_rx,
+        async move { cancel_store.get_entity(Uuid::new_v4()).await },
+    ));
+    tokio::task::yield_now().await;
+    cancel_tx.send(true).unwrap();
+    let cancelled = tokio::time::timeout(Duration::from_millis(100), waiting)
+        .await
+        .expect("cancelled checkout waited for the pool checkout timeout")
+        .expect("checkout task panicked")
+        .unwrap_err();
+    assert!(
+        matches!(cancelled, StorageError::Timeout { .. }),
+        "cancellation before checkout through a typed store must be the \
+         non-retryable Timeout, got {cancelled:?}"
+    );
+
+    drop(held_reader);
+}

--- a/crates/khive-db/src/stores/event.rs
+++ b/crates/khive-db/src/stores/event.rs
@@ -154,12 +154,11 @@ impl SqlEventStore {
                 StorageCapability::Events,
                 op,
                 move |scope| {
-                    let mut guard = pool
-                        .reader_until(|| scope.should_stop())
-                        .map_err(|e| map_sqlite_err(e, op))?
-                        .ok_or_else(|| StorageError::Timeout {
-                            operation: op.into(),
-                        })?;
+                    let mut guard = pool.resolve_reader_checkout(
+                        StorageCapability::Events,
+                        op,
+                        pool.reader_until(|| scope.should_stop()),
+                    )?;
                     scope.run_pooled_reader(&mut guard, |conn| f(conn).map_err(|e| map_err(e, op)))
                 },
             )

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -597,12 +597,11 @@ impl SqlGraphStore {
                 StorageCapability::Graph,
                 op,
                 move |scope| {
-                    let mut guard = pool
-                        .reader_until(|| scope.should_stop())
-                        .map_err(|e| map_sqlite_err(e, op))?
-                        .ok_or_else(|| StorageError::Timeout {
-                            operation: op.into(),
-                        })?;
+                    let mut guard = pool.resolve_reader_checkout(
+                        StorageCapability::Graph,
+                        op,
+                        pool.reader_until(|| scope.should_stop()),
+                    )?;
                     scope.run_pooled_reader(&mut guard, |conn| f(conn).map_err(|e| map_err(e, op)))
                 },
             )

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -436,9 +436,7 @@ impl SqlNoteStore {
                     let mut guard = pool
                         .reader_until(|| scope.should_stop())
                         .map_err(|e| map_sqlite_err(e, op))?
-                        .ok_or_else(|| StorageError::Timeout {
-                            operation: op.into(),
-                        })?;
+                        .ok_or_else(|| pool.reader_admission_timeout(op))?;
                     scope.run_pooled_reader(&mut guard, |conn| f(conn).map_err(|e| map_err(e, op)))
                 },
             )

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -433,10 +433,11 @@ impl SqlNoteStore {
                 StorageCapability::Notes,
                 op,
                 move |scope| {
-                    let mut guard = pool
-                        .reader_until(|| scope.should_stop())
-                        .map_err(|e| map_sqlite_err(e, op))?
-                        .ok_or_else(|| pool.reader_admission_timeout(op))?;
+                    let mut guard = pool.resolve_reader_checkout(
+                        StorageCapability::Notes,
+                        op,
+                        pool.reader_until(|| scope.should_stop()),
+                    )?;
                     scope.run_pooled_reader(&mut guard, |conn| f(conn).map_err(|e| map_err(e, op)))
                 },
             )

--- a/crates/khive-db/src/stores/sparse.rs
+++ b/crates/khive-db/src/stores/sparse.rs
@@ -294,10 +294,11 @@ impl SqliteSparseStore {
                 StorageCapability::Sparse,
                 op,
                 move |scope| {
-                    let mut guard = pool
-                        .reader_until(|| scope.should_stop())
-                        .map_err(|e| map_sqlite_err(e, op))?
-                        .ok_or_else(|| pool.reader_admission_timeout(op))?;
+                    let mut guard = pool.resolve_reader_checkout(
+                        StorageCapability::Sparse,
+                        op,
+                        pool.reader_until(|| scope.should_stop()),
+                    )?;
                     scope.run_pooled_reader(&mut guard, |conn| f(conn).map_err(|e| map_err(e, op)))
                 },
             )

--- a/crates/khive-db/src/stores/sparse.rs
+++ b/crates/khive-db/src/stores/sparse.rs
@@ -297,9 +297,7 @@ impl SqliteSparseStore {
                     let mut guard = pool
                         .reader_until(|| scope.should_stop())
                         .map_err(|e| map_sqlite_err(e, op))?
-                        .ok_or_else(|| StorageError::Timeout {
-                            operation: op.into(),
-                        })?;
+                        .ok_or_else(|| pool.reader_admission_timeout(op))?;
                     scope.run_pooled_reader(&mut guard, |conn| f(conn).map_err(|e| map_err(e, op)))
                 },
             )

--- a/crates/khive-db/src/stores/text.rs
+++ b/crates/khive-db/src/stores/text.rs
@@ -277,10 +277,11 @@ impl Fts5TextSearch {
                 StorageCapability::Text,
                 op,
                 move |scope| {
-                    let mut guard = pool
-                        .reader_until(|| scope.should_stop())
-                        .map_err(|e| map_sqlite_err(e, op))?
-                        .ok_or_else(|| pool.reader_admission_timeout(op))?;
+                    let mut guard = pool.resolve_reader_checkout(
+                        StorageCapability::Text,
+                        op,
+                        pool.reader_until(|| scope.should_stop()),
+                    )?;
                     scope.run_pooled_reader(&mut guard, |conn| f(conn).map_err(|e| map_err(e, op)))
                 },
             )

--- a/crates/khive-db/src/stores/text.rs
+++ b/crates/khive-db/src/stores/text.rs
@@ -280,9 +280,7 @@ impl Fts5TextSearch {
                     let mut guard = pool
                         .reader_until(|| scope.should_stop())
                         .map_err(|e| map_sqlite_err(e, op))?
-                        .ok_or_else(|| StorageError::Timeout {
-                            operation: op.into(),
-                        })?;
+                        .ok_or_else(|| pool.reader_admission_timeout(op))?;
                     scope.run_pooled_reader(&mut guard, |conn| f(conn).map_err(|e| map_err(e, op)))
                 },
             )

--- a/crates/khive-db/src/stores/vectors.rs
+++ b/crates/khive-db/src/stores/vectors.rs
@@ -390,12 +390,11 @@ impl SqliteVecStore {
                 StorageCapability::Vectors,
                 op,
                 move |scope| {
-                    let mut guard = pool
-                        .reader_until(|| scope.should_stop())
-                        .map_err(|e| map_sqlite_err(e, op))?
-                        .ok_or_else(|| StorageError::Timeout {
-                            operation: op.into(),
-                        })?;
+                    let mut guard = pool.resolve_reader_checkout(
+                        StorageCapability::Vectors,
+                        op,
+                        pool.reader_until(|| scope.should_stop()),
+                    )?;
                     scope.run_pooled_reader(&mut guard, |conn| f(conn).map_err(|e| map_err(e, op)))
                 },
             )

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -1947,7 +1947,7 @@ impl PackRuntime for ErrorInjectPack {
         if verb == "storage_admission_timeout" {
             return Err(RuntimeError::Storage(
                 khive_storage::StorageError::AdmissionTimeout {
-                    operation: "sql_bridge.reader_open".into(),
+                    operation: "sql_bridge.writer_handle".into(),
                     timeout_ms: 30_000,
                 },
             ));
@@ -2189,11 +2189,11 @@ async fn storage_admission_timeout_survives_storage_runtime_and_mcp_wire() -> an
             "kind": "unavailable",
             "code": "storage_admission_timeout",
             "stage": "storage_admission_timeout",
-            "message": "storage: admission timeout during sql_bridge.reader_open after 30000ms",
+            "message": "storage: admission timeout during sql_bridge.writer_handle after 30000ms",
             "retryable": true,
             "timeout_ms": 30_000,
             "capability": serde_json::Value::Null,
-            "operation": "sql_bridge.reader_open",
+            "operation": "sql_bridge.writer_handle",
             "scope": serde_json::Value::Null,
             "retry_after_ms": serde_json::Value::Null,
         }),

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -1889,6 +1889,13 @@ impl khive_types::Pack for ErrorInjectPack {
             category: VerbCategory::Assertive,
             params: &[],
         },
+        HandlerDef {
+            name: "storage_admission_timeout",
+            description: "returns a typed storage-admission timeout error",
+            visibility: Visibility::Verb,
+            category: VerbCategory::Assertive,
+            params: &[],
+        },
     ];
 }
 
@@ -1935,6 +1942,14 @@ impl PackRuntime for ErrorInjectPack {
         if verb == "writer_task_busy" {
             return Err(RuntimeError::Storage(
                 khive_storage::StorageError::WriterTaskBusy { timeout_ms: 175 },
+            ));
+        }
+        if verb == "storage_admission_timeout" {
+            return Err(RuntimeError::Storage(
+                khive_storage::StorageError::AdmissionTimeout {
+                    operation: "sql_bridge.reader_open".into(),
+                    timeout_ms: 30_000,
+                },
             ));
         }
         let err = KhiveError::unavailable("downstream service offline")
@@ -2146,6 +2161,43 @@ async fn writer_task_busy_survives_storage_runtime_and_mcp_wire() -> anyhow::Res
             "retry_after_ms": serde_json::Value::Null,
         }),
         "BEGIN contention must remain distinguishable and safely retryable"
+    );
+
+    Ok(())
+}
+
+/// A bounded storage-admission wait (reader/writer handle slot or pooled
+/// reader checkout) that elapsed acquired nothing and started nothing, so it
+/// must cross the MCP boundary as a retryable `unavailable` — never as the
+/// caller's invalid input.
+#[tokio::test]
+async fn storage_admission_timeout_survives_storage_runtime_and_mcp_wire() -> anyhow::Result<()> {
+    let client = connect_error_inject().await?;
+    let result = call(
+        &client,
+        "request",
+        serde_json::json!({"ops": "storage_admission_timeout()"}),
+    )
+    .await?;
+    let body: serde_json::Value = serde_json::from_str(&first_text(&result))?;
+    let first = &body["results"][0];
+
+    assert_eq!(first["ok"], false, "expected op failure: {first}");
+    assert_eq!(
+        first["error"],
+        serde_json::json!({
+            "kind": "unavailable",
+            "code": "storage_admission_timeout",
+            "stage": "storage_admission_timeout",
+            "message": "storage: admission timeout during sql_bridge.reader_open after 30000ms",
+            "retryable": true,
+            "timeout_ms": 30_000,
+            "capability": serde_json::Value::Null,
+            "operation": "sql_bridge.reader_open",
+            "scope": serde_json::Value::Null,
+            "retry_after_ms": serde_json::Value::Null,
+        }),
+        "an admission deadline that expired before acquisition must stay a retryable resource failure on the wire"
     );
 
     Ok(())

--- a/crates/khive-pack-git/src/handlers.rs
+++ b/crates/khive-pack-git/src/handlers.rs
@@ -2101,12 +2101,12 @@ mod tests {
 
     #[test]
     fn digest_failure_preserves_storage_class_and_flattens_the_rest() {
-        // A storage-class failure inside the ingest chain (here: a reader
-        // admission timeout under load) must surface typed, not as the
-        // caller's invalid input.
+        // A storage-class failure inside the ingest chain (here: a
+        // writer-handle admission timeout under load) must surface typed,
+        // not as the caller's invalid input.
         let admission = anyhow::Error::new(RuntimeError::Storage(
             khive_storage::StorageError::AdmissionTimeout {
-                operation: "sql_bridge.reader_open".into(),
+                operation: "sql_bridge.writer_handle".into(),
                 timeout_ms: 30_000,
             },
         ));
@@ -2117,7 +2117,7 @@ mod tests {
                 RuntimeError::Storage(khive_storage::StorageError::AdmissionTimeout {
                     operation,
                     timeout_ms: 30_000,
-                }) if operation.as_ref() == "sql_bridge.reader_open"
+                }) if operation.as_ref() == "sql_bridge.writer_handle"
             ),
             "storage-class ingest failure must stay typed; got {recovered:?}"
         );

--- a/crates/khive-pack-git/src/handlers.rs
+++ b/crates/khive-pack-git/src/handlers.rs
@@ -25,6 +25,23 @@ use crate::source::{
 };
 use crate::GitPack;
 
+/// Recover the typed error when a digest ingest/resolution failure chain
+/// carries a storage-class failure (for example a reader admission timeout
+/// under concurrent load), so resource exhaustion is not reported as the
+/// caller's invalid input. Every other failure keeps the established
+/// invalid-input shape.
+fn digest_failure_to_runtime(e: anyhow::Error) -> RuntimeError {
+    let e = match e.downcast::<RuntimeError>() {
+        Ok(rte @ RuntimeError::Storage(_)) => return rte,
+        Ok(other) => return RuntimeError::InvalidInput(other.to_string()),
+        Err(e) => e,
+    };
+    match e.downcast::<khive_storage::StorageError>() {
+        Ok(se) => RuntimeError::Storage(se),
+        Err(e) => RuntimeError::InvalidInput(e.to_string()),
+    }
+}
+
 /// Issue #765 bounded repair policy: at most one refetch, then at most one
 /// reclone. See crates/khive-pack-git/docs/api/handlers.md#remoterecoverystage.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -157,7 +174,7 @@ impl GitPack {
             Some(raw) => {
                 let id = resolve_project_id(self.runtime(), raw)
                     .await
-                    .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?
+                    .map_err(digest_failure_to_runtime)?
                     .ok_or_else(|| {
                         RuntimeError::InvalidInput(format!(
                             "project {raw:?} did not resolve to an entity"
@@ -201,7 +218,7 @@ impl GitPack {
                 .await
             }
         }
-        .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
+        .map_err(digest_failure_to_runtime)?;
 
         if !resolution.slug_duplicates.is_empty() {
             report.warnings.push(format!(
@@ -301,7 +318,7 @@ async fn resolve_or_create_project(
 
     let slug_matches = find_projects_by_slug(runtime, token, &identity)
         .await
-        .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
+        .map_err(digest_failure_to_runtime)?;
     if let Some((id, duplicates)) = slug_matches.split_first() {
         let selected = *id;
         // issue #6 item 2: a step-1 slug match used to return immediately
@@ -314,7 +331,7 @@ async fn resolve_or_create_project(
             &mut slug_duplicates,
             find_normalized_noncanonical_matches(runtime, token, &identity)
                 .await
-                .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?
+                .map_err(digest_failure_to_runtime)?
                 .into_iter()
                 .map(|(candidate, _)| candidate)
                 .filter(|candidate| *candidate != selected),
@@ -329,7 +346,7 @@ async fn resolve_or_create_project(
 
     let exact_matches = find_projects_by_legacy_repo_url(runtime, token, &repo_url)
         .await
-        .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
+        .map_err(digest_failure_to_runtime)?;
     if let Some((id, duplicates)) = exact_matches.split_first() {
         let id = *id;
         crate::dispatch_from_token(
@@ -354,7 +371,7 @@ async fn resolve_or_create_project(
             &mut slug_duplicates,
             find_normalized_noncanonical_matches(runtime, token, &identity)
                 .await
-                .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?
+                .map_err(digest_failure_to_runtime)?
                 .into_iter()
                 .map(|(candidate, _)| candidate)
                 .filter(|candidate| *candidate != id),
@@ -373,7 +390,7 @@ async fn resolve_or_create_project(
     // stale slug instead of excluding the anchor and minting a duplicate.
     let normalized_matches = find_normalized_noncanonical_matches(runtime, token, &identity)
         .await
-        .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
+        .map_err(digest_failure_to_runtime)?;
     if let Some(((selected, selected_repo_url), duplicates)) = normalized_matches.split_first() {
         let selected = *selected;
         crate::dispatch_from_token(
@@ -401,7 +418,7 @@ async fn resolve_or_create_project(
 
     let orphan = find_orphaned_anchor(runtime, token, &identity, &repo_url)
         .await
-        .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
+        .map_err(digest_failure_to_runtime)?;
 
     let resp = crate::dispatch_from_token(
         registry,
@@ -451,7 +468,7 @@ async fn find_projects_by_slug(
     identity: &str,
 ) -> anyhow::Result<Vec<Uuid>> {
     let sql = runtime.sql();
-    let mut r = sql.reader().await.map_err(|e| anyhow!("{e}"))?;
+    let mut r = sql.reader().await.map_err(anyhow::Error::new)?;
     let rows = r
         .query_all(SqlStatement {
             sql: "SELECT id FROM entities WHERE kind='project' AND namespace=?1 \
@@ -466,7 +483,7 @@ async fn find_projects_by_slug(
             label: Some("git_digest_find_projects_by_slug".into()),
         })
         .await
-        .map_err(|e| anyhow!("{e}"))?;
+        .map_err(anyhow::Error::new)?;
     Ok(rows
         .iter()
         .filter_map(|r| match r.get("id") {
@@ -492,7 +509,7 @@ async fn find_projects_by_legacy_repo_url(
     repo_url: &str,
 ) -> anyhow::Result<Vec<Uuid>> {
     let sql = runtime.sql();
-    let mut r = sql.reader().await.map_err(|e| anyhow!("{e}"))?;
+    let mut r = sql.reader().await.map_err(anyhow::Error::new)?;
     let rows = r
         .query_all(SqlStatement {
             sql: "SELECT id FROM entities WHERE kind='project' AND namespace=?1 \
@@ -508,7 +525,7 @@ async fn find_projects_by_legacy_repo_url(
             label: Some("git_digest_find_projects_by_legacy_repo_url".into()),
         })
         .await
-        .map_err(|e| anyhow!("{e}"))?;
+        .map_err(anyhow::Error::new)?;
     Ok(rows
         .iter()
         .filter_map(|r| match r.get("id") {
@@ -530,7 +547,7 @@ async fn find_projects_without_canonical_slug(
     identity: &str,
 ) -> anyhow::Result<Vec<(Uuid, String)>> {
     let sql = runtime.sql();
-    let mut r = sql.reader().await.map_err(|e| anyhow!("{e}"))?;
+    let mut r = sql.reader().await.map_err(anyhow::Error::new)?;
     let rows = r
         .query_all(SqlStatement {
             sql: "SELECT id, json_extract(properties,'$.repo_url') AS repo_url \
@@ -548,7 +565,7 @@ async fn find_projects_without_canonical_slug(
             label: Some("git_digest_find_projects_without_canonical_slug".into()),
         })
         .await
-        .map_err(|e| anyhow!("{e}"))?;
+        .map_err(anyhow::Error::new)?;
     Ok(rows
         .iter()
         .filter_map(|r| {
@@ -577,7 +594,7 @@ async fn find_soft_deleted_projects_without_canonical_slug(
     identity: &str,
 ) -> anyhow::Result<Vec<(Uuid, String, i64)>> {
     let sql = runtime.sql();
-    let mut r = sql.reader().await.map_err(|e| anyhow!("{e}"))?;
+    let mut r = sql.reader().await.map_err(anyhow::Error::new)?;
     let rows = r
         .query_all(SqlStatement {
             sql: "SELECT id, deleted_at, json_extract(properties,'$.repo_url') AS repo_url \
@@ -594,7 +611,7 @@ async fn find_soft_deleted_projects_without_canonical_slug(
             label: Some("git_digest_find_soft_deleted_projects_without_canonical_slug".into()),
         })
         .await
-        .map_err(|e| anyhow!("{e}"))?;
+        .map_err(anyhow::Error::new)?;
     Ok(rows
         .iter()
         .filter_map(|r| {
@@ -694,7 +711,7 @@ async fn find_orphaned_anchor(
     repo_url: &str,
 ) -> anyhow::Result<Option<OrphanSignal>> {
     let sql = runtime.sql();
-    let mut r = sql.reader().await.map_err(|e| anyhow!("{e}"))?;
+    let mut r = sql.reader().await.map_err(anyhow::Error::new)?;
     let rows = r
         .query_all(SqlStatement {
             sql: "SELECT id, deleted_at FROM entities WHERE kind='project' AND namespace=?1 \
@@ -710,7 +727,7 @@ async fn find_orphaned_anchor(
             label: Some("git_digest_find_orphaned_anchor".into()),
         })
         .await
-        .map_err(|e| anyhow!("{e}"))?;
+        .map_err(anyhow::Error::new)?;
     let mut dead_projects: Vec<(Uuid, i64)> = rows
         .iter()
         .filter_map(|r| {
@@ -733,9 +750,7 @@ async fn find_orphaned_anchor(
     // Extend the tombstone scan with the same normalize-and-compare step
     // the live step-2 path already uses, scoped to soft-deleted rows.
     let normalized_tombstones =
-        find_soft_deleted_projects_without_canonical_slug(runtime, token, identity)
-            .await
-            .map_err(|e| anyhow!("{e}"))?;
+        find_soft_deleted_projects_without_canonical_slug(runtime, token, identity).await?;
     let mut already_matched: std::collections::HashSet<Uuid> =
         dead_projects.iter().map(|(id, _)| *id).collect();
     for (id, candidate_repo_url, deleted_at) in normalized_tombstones {
@@ -772,7 +787,7 @@ async fn find_orphaned_anchor(
                 label: Some("git_digest_count_orphaned_notes".into()),
             })
             .await
-            .map_err(|e| anyhow!("{e}"))?;
+            .map_err(anyhow::Error::new)?;
         let annotated_note_count = match count {
             Some(SqlValue::Integer(n)) => n as u64,
             _ => 0,
@@ -2081,6 +2096,53 @@ mod tests {
                 None,
                 "arbitrary malformed value must not become identity evidence: {malformed}"
             );
+        }
+    }
+
+    #[test]
+    fn digest_failure_preserves_storage_class_and_flattens_the_rest() {
+        // A storage-class failure inside the ingest chain (here: a reader
+        // admission timeout under load) must surface typed, not as the
+        // caller's invalid input.
+        let admission = anyhow::Error::new(RuntimeError::Storage(
+            khive_storage::StorageError::AdmissionTimeout {
+                operation: "sql_bridge.reader_open".into(),
+                timeout_ms: 30_000,
+            },
+        ));
+        let recovered = digest_failure_to_runtime(admission);
+        assert!(
+            matches!(
+                &recovered,
+                RuntimeError::Storage(khive_storage::StorageError::AdmissionTimeout {
+                    operation,
+                    timeout_ms: 30_000,
+                }) if operation.as_ref() == "sql_bridge.reader_open"
+            ),
+            "storage-class ingest failure must stay typed; got {recovered:?}"
+        );
+
+        // A bare StorageError (no RuntimeError wrapper) is recovered too.
+        let bare = anyhow::Error::new(khive_storage::StorageError::Timeout {
+            operation: "search".into(),
+        });
+        assert!(matches!(
+            digest_failure_to_runtime(bare),
+            RuntimeError::Storage(khive_storage::StorageError::Timeout { .. })
+        ));
+
+        // Non-storage runtime failures keep the established invalid-input
+        // shape, message intact.
+        let not_found = anyhow::Error::new(RuntimeError::NotFound("proj-x".to_string()));
+        match digest_failure_to_runtime(not_found) {
+            RuntimeError::InvalidInput(msg) => assert!(msg.contains("proj-x"), "{msg}"),
+            other => panic!("non-storage failure must flatten to InvalidInput, got {other:?}"),
+        }
+
+        // Plain anyhow context errors keep the established shape as well.
+        match digest_failure_to_runtime(anyhow!("gh probe failed")) {
+            RuntimeError::InvalidInput(msg) => assert_eq!(msg, "gh probe failed"),
+            other => panic!("untyped failure must flatten to InvalidInput, got {other:?}"),
         }
     }
 }

--- a/crates/khive-pack-git/src/ingest.rs
+++ b/crates/khive-pack-git/src/ingest.rs
@@ -713,7 +713,7 @@ async fn resolve_id(
     runtime
         .resolve_prefix_unfiltered(raw)
         .await
-        .map_err(|e| anyhow!("{e}"))
+        .map_err(anyhow::Error::new)
 }
 
 /// Resolve `raw` (a full UUID or an 8+ hex prefix) to an existing `project`
@@ -727,7 +727,7 @@ pub async fn resolve_project_id(runtime: &KhiveRuntime, raw: &str) -> Result<Opt
     runtime
         .resolve_prefix_unfiltered(raw)
         .await
-        .map_err(|e| anyhow!("{e}"))
+        .map_err(anyhow::Error::new)
 }
 
 /// Find an existing `issue` or `pull_request` note by `properties.number`
@@ -996,7 +996,7 @@ async fn find_commit_by_sha(
     sha: &str,
 ) -> Result<Option<Uuid>> {
     let sql = runtime.sql();
-    let mut r = sql.reader().await.map_err(|e| anyhow!("{e}"))?;
+    let mut r = sql.reader().await.map_err(anyhow::Error::new)?;
     let row = r
         .query_row(SqlStatement {
             sql: "SELECT id FROM notes WHERE kind='commit' AND namespace=?1 \
@@ -1009,7 +1009,7 @@ async fn find_commit_by_sha(
             label: Some("git_ingest_find_commit_by_sha".into()),
         })
         .await
-        .map_err(|e| anyhow!("{e}"))?;
+        .map_err(anyhow::Error::new)?;
     Ok(row.and_then(|r| row_uuid(&r)))
 }
 
@@ -1024,7 +1024,7 @@ async fn find_by_number(
     number: u64,
 ) -> Result<Option<Uuid>> {
     let sql = runtime.sql();
-    let mut r = sql.reader().await.map_err(|e| anyhow!("{e}"))?;
+    let mut r = sql.reader().await.map_err(anyhow::Error::new)?;
     let row = r
         .query_row(SqlStatement {
             sql: "SELECT id FROM notes WHERE kind=?1 AND namespace=?2 \
@@ -1040,7 +1040,7 @@ async fn find_by_number(
             label: Some("git_ingest_find_by_number".into()),
         })
         .await
-        .map_err(|e| anyhow!("{e}"))?;
+        .map_err(anyhow::Error::new)?;
     Ok(row.and_then(|r| row_uuid(&r)))
 }
 
@@ -1083,7 +1083,7 @@ async fn find_document_for_path(
     let namespace = token.namespace().as_str().to_string();
     let like_pattern = format!("%{}", escape_like(path));
 
-    let mut r = sql.reader().await.map_err(|e| anyhow!("{e}"))?;
+    let mut r = sql.reader().await.map_err(anyhow::Error::new)?;
     let row = r
         .query_row(SqlStatement {
             sql: "SELECT id FROM entities WHERE kind='document' AND namespace=?1 \
@@ -1103,7 +1103,7 @@ async fn find_document_for_path(
             label: Some("git_ingest_find_document_for_path".into()),
         })
         .await
-        .map_err(|e| anyhow!("{e}"))?;
+        .map_err(anyhow::Error::new)?;
     Ok(row.and_then(|r| row_uuid(&r)))
 }
 
@@ -1117,7 +1117,7 @@ async fn load_code_modules_by_snapshot_path(
     source_revision: &str,
 ) -> Result<HashMap<String, Option<Uuid>>> {
     let sql = runtime.sql();
-    let mut r = sql.reader().await.map_err(|e| anyhow!("{e}"))?;
+    let mut r = sql.reader().await.map_err(anyhow::Error::new)?;
     let rows = r
         .query_all(SqlStatement {
             sql: "SELECT id, json_extract(properties,'$.source_path') AS source_path \
@@ -1134,7 +1134,7 @@ async fn load_code_modules_by_snapshot_path(
             label: Some("git_ingest_load_code_modules_by_snapshot_path".into()),
         })
         .await
-        .map_err(|e| anyhow!("{e}"))?;
+        .map_err(anyhow::Error::new)?;
 
     let mut modules: HashMap<String, Option<Uuid>> = HashMap::new();
     for row in rows {
@@ -1161,7 +1161,7 @@ async fn read_cursor(
     kind: &str,
 ) -> Result<Option<String>> {
     let sql = runtime.sql();
-    let mut r = sql.reader().await.map_err(|e| anyhow!("{e}"))?;
+    let mut r = sql.reader().await.map_err(anyhow::Error::new)?;
     let row = r
         .query_row(SqlStatement {
             sql: "SELECT cursor_value FROM git_mirror_cursor WHERE project_id=?1 AND kind=?2"
@@ -1173,7 +1173,7 @@ async fn read_cursor(
             label: Some("git_ingest_read_cursor".into()),
         })
         .await
-        .map_err(|e| anyhow!("{e}"))?;
+        .map_err(anyhow::Error::new)?;
     Ok(row.and_then(|r| match r.get("cursor_value") {
         Some(SqlValue::Text(s)) => Some(s.clone()),
         _ => None,
@@ -1190,7 +1190,7 @@ async fn write_cursor(
     value: &str,
 ) -> Result<()> {
     let sql = runtime.sql();
-    let mut w = sql.writer().await.map_err(|e| anyhow!("{e}"))?;
+    let mut w = sql.writer().await.map_err(anyhow::Error::new)?;
     w.execute(SqlStatement {
         sql: "INSERT INTO git_mirror_cursor(project_id, kind, cursor_value, updated_at) \
               VALUES(?1, ?2, ?3, ?4) \
@@ -1207,7 +1207,7 @@ async fn write_cursor(
         label: Some("git_ingest_write_cursor".into()),
     })
     .await
-    .map_err(|e| anyhow!("{e}"))?;
+    .map_err(anyhow::Error::new)?;
     Ok(())
 }
 
@@ -2123,7 +2123,7 @@ async fn count_commit_notes_for_project(
     project_id: Uuid,
 ) -> Result<u64> {
     let sql = runtime.sql();
-    let mut r = sql.reader().await.map_err(|e| anyhow!("{e}"))?;
+    let mut r = sql.reader().await.map_err(anyhow::Error::new)?;
     let row = r
         .query_scalar(SqlStatement {
             sql: "SELECT COUNT(*) FROM notes n \
@@ -2138,7 +2138,7 @@ async fn count_commit_notes_for_project(
             label: Some("git_ingest_count_commit_notes".into()),
         })
         .await
-        .map_err(|e| anyhow!("{e}"))?;
+        .map_err(anyhow::Error::new)?;
     match row {
         Some(SqlValue::Integer(n)) => Ok(n as u64),
         _ => Ok(0),

--- a/crates/khive-retrieval/src/adapters/storage.rs
+++ b/crates/khive-retrieval/src/adapters/storage.rs
@@ -21,7 +21,7 @@ use crate::hybrid::{KeywordSearch, VectorSearch};
 /// Convert a `StorageError` into a `RetrievalError`.
 ///
 /// Maps storage-level errors to the closest retrieval error variant:
-/// - Timeout errors -> `QueryTimeout` (transient, retryable)
+/// - Timeout / AdmissionTimeout errors -> `QueryTimeout` (transient, retryable)
 /// - InvalidInput errors -> `InvalidQuery` (permanent)
 /// - Keyword-context errors -> `Bm25` (permanent)
 /// - Everything else -> `Hnsw` (permanent)
@@ -32,7 +32,11 @@ pub(super) fn storage_err_to_retrieval(
     use khive_storage::StorageError;
 
     match err {
-        StorageError::Timeout { .. } => {
+        // Both timeout shapes are transient. AdmissionTimeout in particular is
+        // retryable at the storage layer (the operation never began); dropping
+        // it into the permanent Hnsw/Bm25 arm below would erase that signal and
+        // turn a saturated-pool retry into a hard failure.
+        StorageError::Timeout { .. } | StorageError::AdmissionTimeout { .. } => {
             // Storage timeouts are transient — map to QueryTimeout so retry logic works.
             RetrievalError::QueryTimeout { elapsed_ms: 0 }
         }
@@ -415,6 +419,28 @@ mod tests {
         assert!(
             ret.is_transient(),
             "QueryTimeout must be classified as transient for retry logic"
+        );
+    }
+
+    #[test]
+    fn storage_err_admission_timeout_maps_to_query_timeout() {
+        use khive_storage::StorageError;
+        // AdmissionTimeout is retryable at the storage layer (the operation
+        // never began). It must reach the transient QueryTimeout arm, not fall
+        // through to the permanent Hnsw/Bm25 default, otherwise a saturated-pool
+        // condition becomes a hard retrieval failure.
+        let err = StorageError::AdmissionTimeout {
+            operation: std::borrow::Cow::Borrowed("search"),
+            timeout_ms: 30_000,
+        };
+        let ret = storage_err_to_retrieval(err, "vector search");
+        assert!(
+            matches!(ret, RetrievalError::QueryTimeout { .. }),
+            "storage AdmissionTimeout must map to QueryTimeout (transient), got: {ret:?}"
+        );
+        assert!(
+            ret.is_transient(),
+            "AdmissionTimeout must remain transient through the retrieval adapter"
         );
     }
 

--- a/crates/khive-runtime/src/error.rs
+++ b/crates/khive-runtime/src/error.rs
@@ -743,7 +743,7 @@ mod channel_ingest_failure_class_tests {
     #[test]
     fn storage_admission_timeout_is_a_retryable_admission_failure() {
         let admission = RuntimeError::Storage(khive_storage::StorageError::AdmissionTimeout {
-            operation: "sql_bridge.reader_open".into(),
+            operation: "sql_bridge.writer_handle".into(),
             timeout_ms: 30_000,
         });
         let context = admission
@@ -751,7 +751,10 @@ mod channel_ingest_failure_class_tests {
             .expect("a storage admission timeout happens before the operation starts");
         assert_eq!(context.stage, super::STORAGE_ADMISSION_TIMEOUT_STAGE);
         assert_eq!(context.timeout, Duration::from_millis(30_000));
-        assert_eq!(context.operation.as_deref(), Some("sql_bridge.reader_open"));
+        assert_eq!(
+            context.operation.as_deref(),
+            Some("sql_bridge.writer_handle")
+        );
         assert_eq!(context.scope, None);
         assert_eq!(context.retry_after_ms, None);
         assert_eq!(

--- a/crates/khive-runtime/src/error.rs
+++ b/crates/khive-runtime/src/error.rs
@@ -21,6 +21,12 @@ pub const WRITER_QUEUE_SATURATED_STAGE: &str = "writer_queue_saturated";
 /// queue accepted a request but before its operation closure ran.
 pub const WRITER_TASK_BEGIN_BUSY_STAGE: &str = "writer_task_begin_busy";
 
+/// Stable wire code/stage for a bounded storage-admission wait (a
+/// reader/writer handle slot or a pooled reader checkout) that elapsed
+/// before anything was acquired. The operation never started, so the
+/// failure is safe to retry.
+pub const STORAGE_ADMISSION_TIMEOUT_STAGE: &str = "storage_admission_timeout";
+
 /// Stable ADR-131:251 `scope` discriminator carried on a
 /// [`WRITER_QUEUE_SATURATED_STAGE`] failure — distinguishes write-queue
 /// admission saturation from other `unavailable` failure kinds that share
@@ -29,15 +35,17 @@ pub const WRITER_TASK_BEGIN_BUSY_STAGE: &str = "writer_task_begin_busy";
 /// ADR-131-defined scope and carries `None`).
 pub const WRITER_ADMISSION_SCOPE: &str = "writer_admission";
 
-/// Structured context for a pre-execution write-admission failure: either a
-/// finite-wait pooled writer checkout timeout or a bounded write-queue
-/// enqueue timeout. Both happen before SQLite executes the request, so both
+/// Structured context for a pre-execution admission failure: a finite-wait
+/// pooled writer checkout timeout, a bounded write-queue enqueue timeout, or
+/// a bounded storage-admission wait (reader/writer handle slot or pooled
+/// reader checkout). All happen before SQLite executes the request, so all
 /// are safe to classify as retryable — the request was never accepted, let
 /// alone started.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AdmissionFailureContext {
-    /// Stable wire stage/code: one of [`WRITER_POOL_CHECKOUT_TIMEOUT_STAGE`]
-    /// or [`WRITER_QUEUE_SATURATED_STAGE`].
+    /// Stable wire stage/code: one of [`WRITER_POOL_CHECKOUT_TIMEOUT_STAGE`],
+    /// [`WRITER_QUEUE_SATURATED_STAGE`], or
+    /// [`STORAGE_ADMISSION_TIMEOUT_STAGE`].
     pub stage: &'static str,
     /// The configured deadline that elapsed.
     pub timeout: Duration,
@@ -575,6 +583,20 @@ impl RuntimeError {
                 retry_after_ms: Some(*timeout_ms),
             });
         }
+        if let Self::Storage(khive_storage::StorageError::AdmissionTimeout {
+            operation,
+            timeout_ms,
+        }) = self
+        {
+            return Some(AdmissionFailureContext {
+                stage: STORAGE_ADMISSION_TIMEOUT_STAGE,
+                timeout: Duration::from_millis(*timeout_ms),
+                capability: None,
+                operation: Some(operation.to_string()),
+                scope: None,
+                retry_after_ms: None,
+            });
+        }
         None
     }
 
@@ -716,5 +738,33 @@ mod channel_ingest_failure_class_tests {
             },
             "a rendered message resembling SecretDetected must remain Unknown unless its typed variant is SecretDetected"
         );
+    }
+
+    #[test]
+    fn storage_admission_timeout_is_a_retryable_admission_failure() {
+        let admission = RuntimeError::Storage(khive_storage::StorageError::AdmissionTimeout {
+            operation: "sql_bridge.reader_open".into(),
+            timeout_ms: 30_000,
+        });
+        let context = admission
+            .admission_failure_context()
+            .expect("a storage admission timeout happens before the operation starts");
+        assert_eq!(context.stage, super::STORAGE_ADMISSION_TIMEOUT_STAGE);
+        assert_eq!(context.timeout, Duration::from_millis(30_000));
+        assert_eq!(context.operation.as_deref(), Some("sql_bridge.reader_open"));
+        assert_eq!(context.scope, None);
+        assert_eq!(context.retry_after_ms, None);
+        assert_eq!(
+            admission.channel_ingest_failure_class(),
+            ChannelIngestFailureClass::Retryable { reason: "Storage" }
+        );
+
+        // The general mid-flight timeout stays unclassified: it proves
+        // nothing about whether work was in flight when the deadline expired.
+        let mid_flight = RuntimeError::Storage(khive_storage::StorageError::Timeout {
+            operation: "sql_bridge.reader_open".into(),
+        });
+        assert!(mid_flight.admission_failure_context().is_none());
+        assert!(mid_flight.retryable_failure_context().is_none());
     }
 }

--- a/crates/khive-storage/docs/api/error-taxonomy.md
+++ b/crates/khive-storage/docs/api/error-taxonomy.md
@@ -137,6 +137,12 @@ flight when the deadline expired; only the admission variant is promoted to
 a structured retryable failure, and only by its typed variant, never by
 rendered-message matching.
 
+One carve-out: the raw-SQL reader admission paths (`sql_bridge.reader_open`
+and `sql_bridge.reader_operation`) keep returning `StorageError::Timeout` on
+saturation, as the ADR-005 reader-admission amendment requires. The typed
+admission variant covers the writer-handle, atomic-unit, and pooled-reader
+checkout budgets.
+
 MCP emits `code`/`stage` of `storage_admission_timeout` with the failing
 `operation`, the elapsed `timeout_ms`, and `retryable: true`. `capability`,
 `scope`, and `retry_after_ms` are null: the handle-slot and reader-checkout

--- a/crates/khive-storage/docs/api/error-taxonomy.md
+++ b/crates/khive-storage/docs/api/error-taxonomy.md
@@ -126,6 +126,22 @@ MCP preserves this proof with `code`/`stage` set to
 backoff policy is defined. Other `BEGIN IMMEDIATE` failures retain the generic
 pool error and are not promoted by rendered-message matching.
 
+## Typed storage-admission timeout
+
+`StorageError::AdmissionTimeout { operation, timeout_ms }` means a bounded
+wait for storage admission — a reader/writer handle slot or a pooled reader
+checkout — elapsed before anything was acquired. The operation never started,
+so retrying cannot duplicate a side effect. This is distinct from
+`StorageError::Timeout`, which makes no claim about whether work was in
+flight when the deadline expired; only the admission variant is promoted to
+a structured retryable failure, and only by its typed variant, never by
+rendered-message matching.
+
+MCP emits `code`/`stage` of `storage_admission_timeout` with the failing
+`operation`, the elapsed `timeout_ms`, and `retryable: true`. `capability`,
+`scope`, and `retry_after_ms` are null: the handle-slot and reader-checkout
+budgets are capability-neutral and no separate backoff policy is defined.
+
 ## `is_fts5_syntax_error`
 
 `TextSearch::search` returns the same `Driver` variant for a malformed MATCH

--- a/crates/khive-storage/docs/design.md
+++ b/crates/khive-storage/docs/design.md
@@ -121,7 +121,8 @@ Key design constraints:
   implemented.
 - `StorageError::Driver` wraps backend-specific errors.
 - `StorageError::NotFound` / `AlreadyExists` for ID-based lookups.
-- Pool, Timeout, Transaction errors are retryable (`is_retryable() == true`).
+- Pool, Timeout, AdmissionTimeout, Transaction errors are retryable
+  (`is_retryable() == true`).
 
 ## Consistency Notes
 

--- a/crates/khive-storage/src/error.rs
+++ b/crates/khive-storage/src/error.rs
@@ -118,6 +118,18 @@ pub enum StorageError {
     #[error("timeout during {operation}")]
     Timeout { operation: Cow<'static, str> },
 
+    /// A bounded wait for storage admission (a reader/writer handle slot or a
+    /// pooled reader checkout) elapsed before anything was acquired. The
+    /// operation never started, so retrying cannot duplicate a side effect —
+    /// distinct from [`StorageError::Timeout`], which makes no claim about
+    /// whether work was in flight when the deadline expired.
+    #[error("admission timeout during {operation} after {timeout_ms}ms")]
+    AdmissionTimeout {
+        operation: Cow<'static, str>,
+        /// The configured admission deadline that elapsed, in milliseconds.
+        timeout_ms: u64,
+    },
+
     #[error("sql transaction failure during {operation}: {message}")]
     Transaction {
         operation: Cow<'static, str>,
@@ -231,6 +243,7 @@ impl StorageError {
             | Self::BlobDigestMismatch { .. } => Some(StorageCapability::Blob),
             Self::Pool { .. }
             | Self::Timeout { .. }
+            | Self::AdmissionTimeout { .. }
             | Self::Transaction { .. }
             | Self::WriteQueueFull { .. }
             | Self::WriterTaskBusy { .. }
@@ -246,6 +259,7 @@ impl StorageError {
             self,
             Self::Pool { .. }
                 | Self::Timeout { .. }
+                | Self::AdmissionTimeout { .. }
                 | Self::Transaction { .. }
                 | Self::WriteQueueFull { .. }
                 | Self::WriterTaskBusy { .. }


### PR DESCRIPTION
## Problem

Under concurrent load, a bounded storage-admission wait that expires (for
example `sql_bridge.reader_open` exhausting its 30s checkout budget inside
`git.digest`) surfaces to callers as `invalid input: timeout during
sql_bridge.reader_open`. Two defects compound:

1. `StorageError::Timeout` makes no distinction between an admission wait
   that acquired nothing and a mid-flight deadline, so the runtime's
   retryable-failure classification cannot cover it (`retryable_failure_context`
   covers writer-side classes only), and
2. `git.digest` flattens its entire ingest/resolution error chain to
   `RuntimeError::InvalidInput` via `anyhow!("{e}")` stringification plus a
   blanket `map_err`, so even a typed storage failure reads as the caller's
   bad input.

A retrying consumer keying on the error class treats the failure as permanent
and drops the request, exactly when a retry would have succeeded.

## Fix

- **khive-storage**: new `StorageError::AdmissionTimeout { operation,
  timeout_ms }` — a bounded admission wait (reader/writer handle slot or
  pooled reader checkout) that elapsed before anything was acquired. The
  operation never started, so retry cannot duplicate a side effect.
  `is_retryable()` and `capability()` cover it.
- **khive-db**: the admission mints now produce the typed variant with the
  configured deadline: `acquire_handle_slot` (reader-open / writer-handle /
  atomic-unit slots) and the pooled reader checkout
  (`ConnectionPool::reader_admission_timeout`, used by sql_bridge and the
  entity/note/text/sparse/attachment stores). Mid-flight
  `StorageError::Timeout` semantics are unchanged.
- **khive-runtime**: `admission_failure_context` classifies the new variant
  under a stable `storage_admission_timeout` stage, so the MCP wire emits
  `kind: unavailable, retryable: true` with the failing operation and the
  elapsed deadline — the same structured shape the writer-side admission
  failures already use.
- **khive-pack-git**: the digest path preserves typed storage-class failures
  (`digest_failure_to_runtime` recovers `RuntimeError`/`StorageError` from
  the anyhow chain; the `anyhow!("{e}")` conversions become type-preserving
  `anyhow::Error::new`). Every non-storage failure keeps the established
  invalid-input shape and message.

## Tests

- `khive-db`: the six existing admission-arm tests now pin the typed variant
  (they failed on the old variant before the assertions were updated, which
  doubles as proof the converted mints are the admission ones).
- `khive-runtime`: `storage_admission_timeout_is_a_retryable_admission_failure`
  pins stage/deadline/operation and the retryable ingest class, and pins that
  plain `Timeout` remains unclassified.
- `khive-mcp`: `storage_admission_timeout_survives_storage_runtime_and_mcp_wire`
  pins the exact wire contract.
- `khive-pack-git`: `digest_failure_preserves_storage_class_and_flattens_the_rest`
  covers typed passthrough, bare-StorageError recovery, and the unchanged
  invalid-input fallbacks. Mutation controls: no-opping the digest classifier
  or the runtime classification arm makes the corresponding test fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
