### PR TITLE
docs(adr): ADR-109 Amendment 1 — read-only connection tier (Tier-B phase)

### DIFF
--- a/docs/adr/ADR-109-sandboxed-kkernel-gateway.md
+++ b/docs/adr/ADR-109-sandboxed-kkernel-gateway.md
@@ -415,19 +415,49 @@ already consults on every verb. All of it reuses shipped machinery:
    carrying the _actual_ verb and calls `Gate::check` before the pack handler runs; a `Deny`
    returns `PermissionDenied` with a reason (ADR-018, as amended fail-closed by ADR-129). No new
    dispatch path is introduced — this is the same seam the base ADR's rule names.
-2. **The policy is a default-deny Rego policy** naming a closed read-verb allowlist, loaded by
-   the existing `RegoGate` (`from_dir` / `from_policy_str`). This is the base ADR's Fork (c)
+2. **The enforcement invariant is a closed read-verb set held in code, intersected with
+   policy.** Read-only mode installs a composite gate: a verb dispatches only if it is a member
+   of the canonical read-verb set — a closed, machine-checkable list shipped in code — **and**
+   the installed policy allows it. The default-deny Rego policy of the base ADR's Fork (c)
    resolution (constrained Rego on the existing engine, a required default-deny template, and a
-   validation lint that rejects any policy lacking a closed allowlist) applied to the read-only
-   case. Every verb outside the allowlist — every mutating verb — is denied by the default rule,
-   so a verb added to a future pack is denied until explicitly listed, not permitted by omission.
-3. **A launch flag installs it.** `kkernel mcp` gains a flag that sets the process `Gate` to the
-   read-only `RegoGate` instead of `AllowAllGate` for that process's lifetime. This is the base
+   validation lint) is retained as the configurable layer, and it can only _narrow_ the surface
+   further, never widen it: the in-code set membership check runs regardless of what the policy
+   engine returns, so a policy bug, a permissive branch, or an errant allow path cannot
+   authorize a mutation. The validation lint rejects a read-only policy that is not default-deny,
+   that lacks a closed allowlist, or whose allowlist names any verb outside the canonical read
+   set. A verb added by a future pack is denied until explicitly classified and listed, not
+   permitted by omission.
+3. **Membership of the read set is decided by effect, not by name.** The authoritative source
+   is a per-verb effect classification declared where verbs register — registry-level metadata
+   the read-only gate consults at dispatch, not prose documentation (the existing verb-category
+   metadata is documentation-only and does not qualify as an enforcement source). A verb
+   qualifies as read only if its handler performs no persistent state change of any kind.
+   Incidental writes count as mutation: a verb with read-shaped naming that updates state as a
+   side effect — the mark-read class of communication verbs, which the durable-audit ADR already
+   classifies as writers — is a mutating verb for this tier and is excluded from the read set.
+   Any verb without a declared effect classification is treated as mutating (fail-closed), so
+   the writer census cannot rot open as the catalog grows.
+4. **The mode binds to the process boundary it enforces at.** `kkernel mcp` gains a flag that
+   sets the process `Gate` to the composite read-only gate instead of `AllowAllGate` for that
+   process's lifetime. Binding is local by construction: a read-only process dispatches every
+   verb in the process that parsed the flag, and it never forwards verbs to — and never
+   auto-spawns — a shared resident daemon, because a forwarded verb would be checked by the
+   daemon's own gate rather than this one, and the daemon connection protocol carries no gate
+   identity today. Read verbs tolerate this: a read-only connection performs no writes at all
+   (the gate denies mutations before any handler runs), so local dispatch never contends for
+   the resident daemon's writer lane. Extending gate identity into daemon connection admission
+   and spawn configuration — so a restricted client could safely attach to a shared daemon —
+   is structural-gateway work and stays deferred with the untrusted tier. This is the base
    ADR's A2 (mode-flag) process boundary, **not** A1 — see the honest-scope note below.
-4. **Refusal is loud and attributable.** The `Deny` reason states that the verb was refused
-   because the connection is read-only, and the MCP surface returns it as a typed refusal the
-   client can distinguish from an outage — so a client running against a restricted connection
-   reports the restriction rather than misreading it as khive being down.
+5. **Refusal is loud, attributable, and typed on the wire.** The `Deny` reason states that the
+   verb was refused because the connection is read-only, and the MCP surface carries it as a
+   structured refusal object — a machine-readable field naming the refusal class (read-only
+   denial, as distinct from gate-unavailable and from ordinary runtime errors) and the refused
+   verb — never a flat serialized error string a client must parse. Today's wire path
+   serializes authorization refusals into ordinary error strings, so the structured refusal
+   field is in-scope wire work for this amendment, not an existing property being restated. A
+   client running against a restricted connection can therefore report the restriction rather
+   than misreading it as khive being down, without string matching.
 
 ### Honest scope: what this does NOT serve
 
@@ -454,14 +484,23 @@ Concretely, the read-only connection is **not** a containment for a Tier-C untru
 
 ### Implementation plan (Tier-B phase)
 
-- A bundled default-deny read-only Rego policy naming the closed read-verb allowlist, plus the
-  read/mutating classification of the current verb catalog it rests on.
-- The `kkernel mcp` launch flag that installs the read-only `RegoGate`.
+- The per-verb effect classification at the verb-registration seam (point 3), with a
+  completeness lint: every registered verb carries a classification, an unclassified verb is
+  mutating by default, and the mark-read class of incidental writers is classified as mutating
+  with a test pinning that classification.
+- The composite read-only gate (point 2): in-code canonical read-set membership intersected
+  with the policy decision, plus a test that a policy hand-crafted with an extra allow branch
+  for a mutating verb is still denied by the composite gate.
+- A bundled default-deny read-only Rego policy naming the closed read-verb allowlist.
 - The validation lint (base ADR Fork (c)) that rejects a read-only policy which is not
-  default-deny or does not declare a closed allowlist.
-- Confirmation that the `Deny` reason and the MCP-surface refusal are typed and attributable per
-  point 4, with a test that a denied mutating verb returns the read-only refusal (not a generic
-  error) and that an allowed read verb still dispatches.
+  default-deny, does not declare a closed allowlist, or names an allowlist entry outside the
+  canonical read set.
+- The `kkernel mcp` launch flag that installs the composite gate and pins dispatch local
+  (point 4): with the flag set, daemon forwarding and daemon auto-spawn are disabled, with a
+  test asserting a read-only process never opens the daemon connection path.
+- The structured refusal field on the MCP wire (point 5), with tests that a denied mutating
+  verb returns the typed read-only refusal (not a generic error string), that an incidental
+  writer such as a mark-read verb is denied, and that an allowed read verb still dispatches.
 
 ### Consequences of this amendment
 
@@ -471,9 +510,13 @@ Concretely, the read-only connection is **not** a containment for a Tier-C untru
   substituting the weaker A2 form for it.
 - **Negative.** A2's failure mode (a misconfigured launch reverts to the installed base `Gate`)
   is real; this amendment accepts it _only_ for Tier B and says so in the flag's own
-  documentation. The read/mutating verb classification must be maintained as the catalog grows —
-  the default-deny posture makes an unclassified new verb fail safe (denied), which is the
-  correct direction, but a read verb wrongly omitted is a false denial to fix, not a hole.
+  documentation. The effect classification must be maintained as the catalog grows — the
+  fail-closed default (unclassified means mutating) makes a new verb fail safe (denied), which
+  is the correct direction, but a read verb wrongly left unclassified is a false denial to fix,
+  not a hole. Pinning dispatch local means a read-only process forgoes the resident daemon's
+  warm caches and shares the store only through concurrent-reader semantics; acceptable for the
+  observer-shaped Tier-B caller, and revisited only when gate identity reaches the daemon
+  connection protocol.
 
 ## References
 

--- a/docs/adr/ADR-109-sandboxed-kkernel-gateway.md
+++ b/docs/adr/ADR-109-sandboxed-kkernel-gateway.md
@@ -427,37 +427,105 @@ already consults on every verb. All of it reuses shipped machinery:
    that lacks a closed allowlist, or whose allowlist names any verb outside the canonical read
    set. A verb added by a future pack is denied until explicitly classified and listed, not
    permitted by omission.
-3. **Membership of the read set is decided by effect, not by name.** The authoritative source
-   is a per-verb effect classification declared where verbs register — registry-level metadata
-   the read-only gate consults at dispatch, not prose documentation (the existing verb-category
+3. **Membership of the read set is decided by effect, not by name — and effect is judged over
+   the whole dispatch lifecycle, not the handler alone.** The authoritative source is a
+   per-verb effect classification declared where verbs register — registry-level metadata the
+   read-only gate consults at dispatch, not prose documentation (the existing verb-category
    metadata is documentation-only and does not qualify as an enforcement source). A verb
-   qualifies as read only if its handler performs no persistent state change of any kind.
-   Incidental writes count as mutation: a verb with read-shaped naming that updates state as a
-   side effect — the mark-read class of communication verbs, which the durable-audit ADR already
-   classifies as writers — is a mutating verb for this tier and is excluded from the read set.
-   Any verb without a declared effect classification is treated as mutating (fail-closed), so
-   the writer census cannot rot open as the catalog grows.
+   qualifies as read only if **its entire dispatch closure** — the handler, every nested
+   operation the handler invokes, and every dispatch-lifecycle hook that fires for it —
+   performs no persistent domain-state change. The lifecycle write classes are enumerated and
+   each has a defined disposition under read-only mode:
+
+   - **Domain writes** (rows in domain stores: records, edges, notes, messages, profiles,
+     grades, schedule state). Any domain write anywhere in the closure classifies the verb as
+     mutating. Incidental writes count: a verb with read-shaped naming that updates state as a
+     side effect — the mark-read class of communication verbs, which the durable-audit ADR
+     already classifies as writers — is a mutating verb for this tier and is excluded from the
+     read set.
+   - **Adaptive dispatch hooks** (the recall-scoring hooks that fold implicit signals into
+     scoring state when read verbs execute). These are domain-state writes triggered by reads.
+     Under read-only mode they are **suppressed**: the read verb dispatches and returns its
+     result, and the hook's fold is skipped for that dispatch. Suppression is the mode's
+     obligation, not the classification's — a read verb stays classified read, and the mode
+     guarantees its dispatch writes nothing.
+   - **Audit-plane appends** (the runtime's own record of what was dispatched, permitted, or
+     refused). These are **retained** under read-only mode by contract: a restricted
+     connection whose activity left no audit trail would be less observable than an
+     unrestricted one, which is the wrong direction for a security tier. Audit retention is a
+     runtime-plane exemption, named here so it cannot be read as a hole: it records dispatch
+     outcomes and is not reachable as a domain write by any argument the caller controls.
+   - **Non-durable telemetry** (in-memory counters, metrics). Out of scope; no durable state.
+
+   The **canonical read set** is the in-code closed list this classification produces: exactly
+   the registered verbs whose dispatch closure performs no domain write and requires no
+   suppressed hook beyond the adaptive-scoring class above. The code constant is the normative
+   artifact; the bundled read-only policy's allowlist is generated from it and validated
+   against it, so the two cannot drift. Any verb without a declared effect classification is
+   treated as mutating (fail-closed), so the writer census cannot rot open as the catalog
+   grows — and the classification is verified behaviorally, not by declaration alone: the
+   completeness lint gains a census arm that dispatches every read-classified verb against an
+   instrumented store and asserts zero domain writes (audit-plane appends excepted per the
+   taxonomy above).
 4. **The mode binds to the process boundary it enforces at.** `kkernel mcp` gains a flag that
    sets the process `Gate` to the composite read-only gate instead of `AllowAllGate` for that
    process's lifetime. Binding is local by construction: a read-only process dispatches every
    verb in the process that parsed the flag, and it never forwards verbs to — and never
    auto-spawns — a shared resident daemon, because a forwarded verb would be checked by the
    daemon's own gate rather than this one, and the daemon connection protocol carries no gate
-   identity today. Read verbs tolerate this: a read-only connection performs no writes at all
-   (the gate denies mutations before any handler runs), so local dispatch never contends for
-   the resident daemon's writer lane. Extending gate identity into daemon connection admission
+   identity today. Read verbs tolerate this: a read-only connection performs no domain writes
+   (the gate denies mutations before any handler runs, and the adaptive hooks are suppressed
+   per point 3), so local dispatch never contends for the resident daemon's writer lane beyond
+   its own audit-plane appends. Extending gate identity into daemon connection admission
    and spawn configuration — so a restricted client could safely attach to a shared daemon —
    is structural-gateway work and stays deferred with the untrusted tier. This is the base
    ADR's A2 (mode-flag) process boundary, **not** A1 — see the honest-scope note below.
 5. **Refusal is loud, attributable, and typed on the wire.** The `Deny` reason states that the
    verb was refused because the connection is read-only, and the MCP surface carries it as a
-   structured refusal object — a machine-readable field naming the refusal class (read-only
-   denial, as distinct from gate-unavailable and from ordinary runtime errors) and the refused
-   verb — never a flat serialized error string a client must parse. Today's wire path
-   serializes authorization refusals into ordinary error strings, so the structured refusal
-   field is in-scope wire work for this amendment, not an existing property being restated. A
-   client running against a restricted connection can therefore report the restriction rather
-   than misreading it as khive being down, without string matching.
+   structured refusal object, never a flat serialized error string a client must parse.
+   Today's wire path serializes authorization refusals into ordinary error strings, so the
+   structured refusal is in-scope wire work for this amendment, not an existing property being
+   restated. The wire contract is normative:
+
+   **Placement.** The refusal is the per-operation `error` object in the request envelope —
+   the same position where operation failures already carry `code` and `retryable` — so a
+   batch refusing one op reports it beside its siblings' results, and a single-op request
+   carries it as that op's error.
+
+   **Schema.** The refusal error object carries exactly these fields:
+
+   ```json
+   {
+     "code": "read_only_refused",
+     "kind": "permission_denied",
+     "verb": "<the refused verb, as dispatched>",
+     "mode": "read_only",
+     "effect": "mutating" | "unclassified",
+     "retryable": false,
+     "message": "<human-readable refusal, non-normative>"
+   }
+   ```
+
+   `code` is the machine-matching key; `effect` reports why the verb failed set membership
+   (`mutating` = classified as a writer, `unclassified` = fail-closed default); `message` is
+   presentation only and carries no contract. Clients match on `code`, never on `message`.
+
+   **Error mapping.** Three refusal-adjacent conditions map to three distinct wire codes and
+   are never conflated:
+
+   - `PermissionDenied` from the composite gate's membership/policy check →
+     `code: "read_only_refused"`, `retryable: false`. The connection is healthy; the verb is
+     out of contract for this mode.
+   - Gate infrastructure failure (policy engine unavailable, policy failed to load or
+     validate) → `code: "gate_unavailable"`, `kind: "permission_denied"`, `retryable: true`.
+     Fail-closed per the base ADR: the verb is refused, but the client learns the refusal is
+     an infrastructure condition that may clear, not a contract boundary.
+   - Ordinary runtime errors on a permitted read verb keep their existing codes untouched —
+     a read-only connection reports storage timeouts, not-found, and validation errors exactly
+     as an unrestricted one does.
+
+   A client running against a restricted connection can therefore report the restriction
+   rather than misreading it as khive being down, without string matching.
 
 ### Honest scope: what this does NOT serve
 
@@ -488,19 +556,29 @@ Concretely, the read-only connection is **not** a containment for a Tier-C untru
   completeness lint: every registered verb carries a classification, an unclassified verb is
   mutating by default, and the mark-read class of incidental writers is classified as mutating
   with a test pinning that classification.
+- The lifecycle census arm of that lint (point 3): every read-classified verb is dispatched
+  against an instrumented store and asserted to perform zero domain writes, with audit-plane
+  appends excepted per the write-class taxonomy.
+- Adaptive-hook suppression under read-only mode (point 3): a test that a read verb which
+  normally triggers the scoring-fold hook dispatches with the fold skipped, and that the same
+  dispatch outside read-only mode still folds.
 - The composite read-only gate (point 2): in-code canonical read-set membership intersected
   with the policy decision, plus a test that a policy hand-crafted with an extra allow branch
   for a mutating verb is still denied by the composite gate.
-- A bundled default-deny read-only Rego policy naming the closed read-verb allowlist.
+- A bundled default-deny read-only Rego policy whose allowlist is generated from the canonical
+  read-set constant and validated against it.
 - The validation lint (base ADR Fork (c)) that rejects a read-only policy which is not
   default-deny, does not declare a closed allowlist, or names an allowlist entry outside the
   canonical read set.
 - The `kkernel mcp` launch flag that installs the composite gate and pins dispatch local
   (point 4): with the flag set, daemon forwarding and daemon auto-spawn are disabled, with a
   test asserting a read-only process never opens the daemon connection path.
-- The structured refusal field on the MCP wire (point 5), with tests that a denied mutating
-  verb returns the typed read-only refusal (not a generic error string), that an incidental
-  writer such as a mark-read verb is denied, and that an allowed read verb still dispatches.
+- The structured refusal object on the MCP wire (point 5), carrying the normative schema and
+  error mapping above, with tests that a denied mutating verb returns
+  `code: "read_only_refused"` with the refused verb named (not a generic error string), that
+  an incidental writer such as a mark-read verb is denied, that a gate-infrastructure failure
+  returns `code: "gate_unavailable"` with `retryable: true`, and that an allowed read verb
+  still dispatches with its ordinary result and error codes untouched.
 
 ### Consequences of this amendment
 

--- a/docs/adr/ADR-109-sandboxed-kkernel-gateway.md
+++ b/docs/adr/ADR-109-sandboxed-kkernel-gateway.md
@@ -377,6 +377,104 @@ the gateway path.
    appear in any sandboxed contract. Revisited only via a new ADR once the write surface
    ships with demonstrated need. See the resolution under Fork (d) above.
 
+## Amendment 1 (2026-08-24): Phased implementation — the read-only connection tier
+
+**Status of amendment**: Proposed (implements a subset of this ADR; the full sandboxed
+gateway of the base decision remains Proposed and deferred as stated below).
+
+The base ADR specs one caller class — a fully sandboxed, untrusted caller — and resolves its
+process boundary to a structural one (Fork (a), A1: a thin gateway binary, never the
+unconstrained dispatch entry point). That is the right shape for an untrusted caller and it is
+a nontrivial new build. This amendment separates the caller classes by **input provenance** and
+commits to building the smaller, lower-risk one first, on machinery that already ships, while
+keeping the base ADR's structural boundary as the untrusted-tier answer.
+
+### Caller classes by input provenance
+
+The trust question is not _which_ process connects, it is _what input that process has already
+consumed_ by the time it calls a verb:
+
+- **Tier A — trusted.** A caller operating only on operator-directed or first-party
+  instructions. Full verb catalog, subject to whatever `Gate` the deployment installs (status
+  quo; `AllowAllGate` by default).
+- **Tier B — semi-trusted, read-scoped.** A caller trusted to _read_ the graph but which should
+  not _mutate_ it, and whose inputs are first-party (it has not consumed attacker-influenced
+  content). The motivating case is an observer process that reads first-party state to make a
+  decision and must not write back. This amendment builds the control for this tier.
+- **Tier C — untrusted.** A caller that has consumed content it does not control (a fetched
+  page, a third-party document, an external tool result) and could therefore be steered into
+  calling verbs the operator did not intend. This is the base ADR's caller class.
+
+### What this amendment builds: the Tier-B read-only connection
+
+A **read-only connection mode**: a per-process khive connection whose `Gate` denies every
+mutating verb and permits only the read-verb set, enforced at the dispatch seam the runtime
+already consults on every verb. All of it reuses shipped machinery:
+
+1. **Enforcement seam already exists.** `VerbRegistry` dispatch already builds a `GateRequest`
+   carrying the _actual_ verb and calls `Gate::check` before the pack handler runs; a `Deny`
+   returns `PermissionDenied` with a reason (ADR-018, as amended fail-closed by ADR-129). No new
+   dispatch path is introduced — this is the same seam the base ADR's rule names.
+2. **The policy is a default-deny Rego policy** naming a closed read-verb allowlist, loaded by
+   the existing `RegoGate` (`from_dir` / `from_policy_str`). This is the base ADR's Fork (c)
+   resolution (constrained Rego on the existing engine, a required default-deny template, and a
+   validation lint that rejects any policy lacking a closed allowlist) applied to the read-only
+   case. Every verb outside the allowlist — every mutating verb — is denied by the default rule,
+   so a verb added to a future pack is denied until explicitly listed, not permitted by omission.
+3. **A launch flag installs it.** `kkernel mcp` gains a flag that sets the process `Gate` to the
+   read-only `RegoGate` instead of `AllowAllGate` for that process's lifetime. This is the base
+   ADR's A2 (mode-flag) process boundary, **not** A1 — see the honest-scope note below.
+4. **Refusal is loud and attributable.** The `Deny` reason states that the verb was refused
+   because the connection is read-only, and the MCP surface returns it as a typed refusal the
+   client can distinguish from an outage — so a client running against a restricted connection
+   reports the restriction rather than misreading it as khive being down.
+
+### Honest scope: what this does NOT serve
+
+The base ADR **rejected A2 (a launch-flag/config process boundary) outright** for the untrusted
+caller, because a silent misconfiguration (flag omitted, or a bug in flag handling) reverts to
+the full surface, and for an untrusted caller that is an unacceptable failure mode. That
+rejection stands. This amendment uses A2 **only for Tier B**, where the threat being defended
+against is _the operator's own misconfiguration of a trusted-to-read process_, not an adversary
+probing for an escape. For Tier B a launch-flag boundary is proportionate; for Tier C it is not,
+and this amendment does not offer it as one.
+
+Concretely, the read-only connection is **not** a containment for a Tier-C untrusted caller:
+
+- A read-only connection still exposes the read verbs, and read verbs are an exfiltration
+  surface (the base ADR's "Exfiltration via verbs" threat). An untrusted caller should not hold
+  even read access to arbitrary graph state.
+- The control for a Tier-C caller is therefore **absence of a khive connection at all**, decided
+  at the orchestration/deployment layer, not a read-only policy. A caller that has consumed
+  untrusted input is given no khive surface.
+- The one future case where a Tier-C caller legitimately needs _live read_ access is exactly
+  what the base ADR's A1 structural gateway (thin proxy binary, namespace pinning, enforced
+  rate/budget caps) is for. That build stays deferred until such a caller is real; the rate-cap
+  enforcement (base ADR rule 5) is a later phase and is **not** part of this amendment.
+
+### Implementation plan (Tier-B phase)
+
+- A bundled default-deny read-only Rego policy naming the closed read-verb allowlist, plus the
+  read/mutating classification of the current verb catalog it rests on.
+- The `kkernel mcp` launch flag that installs the read-only `RegoGate`.
+- The validation lint (base ADR Fork (c)) that rejects a read-only policy which is not
+  default-deny or does not declare a closed allowlist.
+- Confirmation that the `Deny` reason and the MCP-surface refusal are typed and attributable per
+  point 4, with a test that a denied mutating verb returns the read-only refusal (not a generic
+  error) and that an allowed read verb still dispatches.
+
+### Consequences of this amendment
+
+- **Positive.** Ships a real server-side read-only boundary now, on shipped machinery, closing
+  the gap where a process's read-only-ness depended on client-side configuration alone. Keeps
+  the base ADR's structural boundary honest for the untrusted tier rather than quietly
+  substituting the weaker A2 form for it.
+- **Negative.** A2's failure mode (a misconfigured launch reverts to the installed base `Gate`)
+  is real; this amendment accepts it _only_ for Tier B and says so in the flag's own
+  documentation. The read/mutating verb classification must be maintained as the catalog grows —
+  the default-deny posture makes an unclassified new verb fail safe (denied), which is the
+  correct direction, but a read verb wrongly omitted is a false denial to fix, not a hole.
+
 ## References
 
 - ADR-018 - Authorization Gate; `Gate`, `GateRequest`, `GateDecision`, `Obligation`,

--- a/docs/adr/ADR-109-sandboxed-kkernel-gateway.md
+++ b/docs/adr/ADR-109-sandboxed-kkernel-gateway.md
@@ -456,17 +456,32 @@ already consults on every verb. All of it reuses shipped machinery:
      runtime-plane exemption, named here so it cannot be read as a hole: it records dispatch
      outcomes and is not reachable as a domain write by any argument the caller controls.
    - **Non-durable telemetry** (in-memory counters, metrics). Out of scope; no durable state.
+   - **Deferred writes belong to the dispatch that scheduled them.** A write scheduled by a
+     dispatch but executed after the response returns — a tracked background task, a
+     post-return continuation — is part of that dispatch's effect closure, and the mode's
+     guarantee covers it. Two enforcement paths exist and both are required. A background
+     path that re-enters verb dispatch (the recall pipeline's serve-ledger record is
+     dispatched as a verb from a tracked background task) passes through the same process
+     gate, so its mutating verb is denied under read-only mode; the scheduling site must
+     treat that denial as the mode operating, not an error to escalate — under read-only
+     mode it skips the scheduling or logs the refusal at debug level. A background path
+     that writes a store directly without re-entering dispatch (the recall-telemetry event
+     append) passes no verb gate, so its write site must itself consult the mode and
+     suppress domain writes; fail-closed, a background store write not classified under the
+     taxonomy above is a domain write and is suppressed.
 
    The **canonical read set** is the in-code closed list this classification produces: exactly
-   the registered verbs whose dispatch closure performs no domain write and requires no
-   suppressed hook beyond the adaptive-scoring class above. The code constant is the normative
-   artifact; the bundled read-only policy's allowlist is generated from it and validated
-   against it, so the two cannot drift. Any verb without a declared effect classification is
-   treated as mutating (fail-closed), so the writer census cannot rot open as the catalog
-   grows — and the classification is verified behaviorally, not by declaration alone: the
-   completeness lint gains a census arm that dispatches every read-classified verb against an
-   instrumented store and asserts zero domain writes (audit-plane appends excepted per the
-   taxonomy above).
+   the registered verbs whose dispatch closure — deferred writes included — performs no
+   domain write and requires no suppressed hook beyond the adaptive-scoring class above. The
+   code constant is the normative artifact; the bundled read-only policy's allowlist is
+   generated from it and validated against it, so the two cannot drift. Any verb without a
+   declared effect classification is treated as mutating (fail-closed), so the writer census
+   cannot rot open as the catalog grows — and the classification is verified behaviorally,
+   not by declaration alone: the completeness lint gains a census arm that dispatches every
+   read-classified verb against an instrumented store, **joins the runtime's tracked
+   background tasks for that dispatch before asserting** (the runtime already tracks them;
+   an assertion that races the background lane would pass vacuously), and asserts zero
+   domain writes (audit-plane appends excepted per the taxonomy above).
 4. **The mode binds to the process boundary it enforces at.** `kkernel mcp` gains a flag that
    sets the process `Gate` to the composite read-only gate instead of `AllowAllGate` for that
    process's lifetime. Binding is local by construction: a read-only process dispatches every
@@ -487,45 +502,55 @@ already consults on every verb. All of it reuses shipped machinery:
    structured refusal is in-scope wire work for this amendment, not an existing property being
    restated. The wire contract is normative:
 
-   **Placement.** The refusal is the per-operation `error` object in the request envelope —
-   the same position where operation failures already carry `code` and `retryable` — so a
-   batch refusing one op reports it beside its siblings' results, and a single-op request
-   carries it as that op's error.
+   **Placement.** The request-DSL envelope's per-operation failure entry is
+   `{ "ok": false, "tool": "<verb>", "error": "<string>", "reason"?: "<string>" }` — the
+   `error` field is a human-readable string by contract, and that contract is unchanged
+   here (no existing client's error handling breaks). The refusal adds one structured
+   sibling field on the same entry, following the envelope's existing pattern of typed
+   fields beside the string (`reason` today): a `refusal` object, present exactly when the
+   process gate denied the operation, absent otherwise. A batch refusing one op reports it
+   beside its siblings' results; a single-op request carries it on that op's entry.
 
-   **Schema.** The refusal error object carries exactly these fields:
+   **Schema.** The `refusal` object carries exactly these fields:
 
    ```json
    {
-     "code": "read_only_refused",
-     "kind": "permission_denied",
+     "class": "read_only" | "policy" | "gate_error",
      "verb": "<the refused verb, as dispatched>",
      "mode": "read_only",
-     "effect": "mutating" | "unclassified",
-     "retryable": false,
-     "message": "<human-readable refusal, non-normative>"
+     "effect": "read" | "mutating" | "unclassified"
    }
    ```
 
-   `code` is the machine-matching key; `effect` reports why the verb failed set membership
-   (`mutating` = classified as a writer, `unclassified` = fail-closed default); `message` is
-   presentation only and carries no contract. Clients match on `code`, never on `message`.
+   `class` is the machine-matching key; `effect` is defined for every class and reports the
+   verb's classification (`read` = in the canonical read set, `mutating` = classified as a
+   writer, `unclassified` = fail-closed default). Clients match on `class`, never on the
+   `error` string, which remains presentation-only.
 
-   **Error mapping.** Three refusal-adjacent conditions map to three distinct wire codes and
-   are never conflated:
+   **Class mapping.** The three deny paths the shipped gate contract actually produces map
+   to the three classes and are never conflated:
 
-   - `PermissionDenied` from the composite gate's membership/policy check →
-     `code: "read_only_refused"`, `retryable: false`. The connection is healthy; the verb is
-     out of contract for this mode.
-   - Gate infrastructure failure (policy engine unavailable, policy failed to load or
-     validate) → `code: "gate_unavailable"`, `kind: "permission_denied"`, `retryable: true`.
-     Fail-closed per the base ADR: the verb is refused, but the client learns the refusal is
-     an infrastructure condition that may clear, not a contract boundary.
-   - Ordinary runtime errors on a permitted read verb keep their existing codes untouched —
-     a read-only connection reports storage timeouts, not-found, and validation errors exactly
-     as an unrestricted one does.
+   - Canonical-set membership failure (the verb is `mutating` or `unclassified`) →
+     `class: "read_only"`. The connection is healthy; the verb is out of contract for this
+     mode. This is the common case and the only class a correctly configured deployment
+     emits.
+   - Policy narrowing (the verb is in the canonical read set — `effect: "read"` — but the
+     installed policy's allowlist excludes it) → `class: "policy"`. Distinguishable from
+     `read_only` so an operator can tell a mode boundary from their own policy choice.
+   - Gate evaluation failure at dispatch → `class: "gate_error"`. Per the authorization-gate
+     ADR's shipped contract, policy-load failures are construction time — a broken policy
+     never reaches dispatch because the process refuses to construct the gate — and
+     dispatch-time evaluation uncertainty is already converted by the Rego gate into an
+     explicit deny with a diagnostic reason; only pre-evaluation failures (gate-request
+     serialization) surface as gate errors, and fail-closed (ADR-129) they deny. This class
+     is therefore rare by construction, and no "retryable infrastructure outage" refusal
+     state exists to represent: there is no `gate_unavailable`.
 
-   A client running against a restricted connection can therefore report the restriction
-   rather than misreading it as khive being down, without string matching.
+   Ordinary runtime errors on a permitted read verb are untouched — no `refusal` field, and
+   a read-only connection reports storage timeouts, not-found, and validation errors exactly
+   as an unrestricted one does. A client running against a restricted connection can
+   therefore report the restriction rather than misreading it as khive being down, without
+   string matching.
 
 ### Honest scope: what this does NOT serve
 
@@ -557,11 +582,16 @@ Concretely, the read-only connection is **not** a containment for a Tier-C untru
   mutating by default, and the mark-read class of incidental writers is classified as mutating
   with a test pinning that classification.
 - The lifecycle census arm of that lint (point 3): every read-classified verb is dispatched
-  against an instrumented store and asserted to perform zero domain writes, with audit-plane
+  against an instrumented store, the runtime's tracked background tasks are joined before
+  asserting, and the dispatch is asserted to perform zero domain writes, with audit-plane
   appends excepted per the write-class taxonomy.
 - Adaptive-hook suppression under read-only mode (point 3): a test that a read verb which
   normally triggers the scoring-fold hook dispatches with the fold skipped, and that the same
   dispatch outside read-only mode still folds.
+- Deferred-write suppression under read-only mode (point 3): the recall pipeline's
+  background lane as the pinned case — a test that under read-only mode the serve-ledger
+  verb dispatch is not escalated as an error and the direct telemetry-event append does not
+  write, with the same recall outside read-only mode writing both.
 - The composite read-only gate (point 2): in-code canonical read-set membership intersected
   with the policy decision, plus a test that a policy hand-crafted with an extra allow branch
   for a mutating verb is still denied by the composite gate.
@@ -573,12 +603,12 @@ Concretely, the read-only connection is **not** a containment for a Tier-C untru
 - The `kkernel mcp` launch flag that installs the composite gate and pins dispatch local
   (point 4): with the flag set, daemon forwarding and daemon auto-spawn are disabled, with a
   test asserting a read-only process never opens the daemon connection path.
-- The structured refusal object on the MCP wire (point 5), carrying the normative schema and
-  error mapping above, with tests that a denied mutating verb returns
-  `code: "read_only_refused"` with the refused verb named (not a generic error string), that
-  an incidental writer such as a mark-read verb is denied, that a gate-infrastructure failure
-  returns `code: "gate_unavailable"` with `retryable: true`, and that an allowed read verb
-  still dispatches with its ordinary result and error codes untouched.
+- The structured `refusal` field on the per-operation envelope entry (point 5), carrying the
+  normative schema and class mapping above with the string `error` field unchanged, with
+  tests that a denied mutating verb returns `class: "read_only"` naming the refused verb,
+  that an incidental writer such as a mark-read verb is denied, that a policy-narrowed read
+  verb returns `class: "policy"` with `effect: "read"`, and that an allowed read verb still
+  dispatches with its ordinary result and errors untouched (no `refusal` field).
 
 ### Consequences of this amendment
 


### PR DESCRIPTION
Adds **Amendment 1** to ADR-109, separating the gateway's caller classes by **input provenance** and committing to build the smaller, lower-risk tier first on machinery that already ships.

## What it decides
- **Tier A (trusted)**: full catalog, status quo.
- **Tier B (semi-trusted, read-scoped)**: a caller trusted to read but not mutate, on first-party inputs. This amendment builds its control — a **per-process read-only connection**: a default-deny Rego policy on the existing `RegoGate`, installed via a new `kkernel mcp` launch flag, enforced at the dispatch seam `VerbRegistry` already consults (`GateRequest` with the real verb → `Deny` → `PermissionDenied`), with a typed, attributable refusal.
- **Tier C (untrusted)**: explicitly **not** served by read-only mode — read verbs are an exfiltration surface, so an untrusted caller gets no khive surface at all (orchestration-layer absence), or the base ADR's deferred A1 structural gateway if it genuinely needs live read.

## Honest scope
The read-only connection uses the base ADR's A2 (launch-flag) boundary, which the base ADR rejected for the untrusted tier because it fails open on misconfiguration. That rejection stands; A2 is used here **only for Tier B**, where the threat is operator misconfiguration of a trusted-to-read process, not an adversary. The base ADR's A1 structural gateway and rate-cap enforcement stay deferred as the untrusted-tier answer.

Reuses shipped machinery (per-verb dispatch gate, `RegoGate::from_dir`, `config.gate` install point); the missing piece is the launch flag + bundled policy + validation lint + refusal wording. Docs-only PR.