### PR TITLE
feat(runtime): events-daemon split — audit lane leaves the domain store (ADR-170)

### DIFF
--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -3946,7 +3946,7 @@ pub fn resolve_runtime_config_with_db_anchor(
     };
 
     // ADR-170: events-daemon split. Every file-backed resolution routes event
-    // persistence to `events.db` beside the main store, in DIRECT (embedded)
+    // persistence to the events database beside the main store, in DIRECT
     // mode: this resolver serves one-shot hosts (`kkernel exec`, `reindex`,
     // ingest) and tests, which have no events daemon to talk to. Resident
     // daemon hosts upgrade the resolved config to socket forwarding
@@ -4372,7 +4372,7 @@ mod tests {
             .events_split
             .as_ref()
             .expect("file-backed resolution must configure the events split");
-        assert_eq!(split.db_path, dir.path().join("events.db"));
+        assert_eq!(split.db_path, dir.path().join("khive.events.db"));
         assert_eq!(
             split.socket_path, None,
             "the shared resolver must emit direct mode; only daemon hosts upgrade"
@@ -4382,7 +4382,7 @@ mod tests {
         let split = resolved.events_split.as_ref().expect("split still set");
         assert_eq!(
             split.socket_path.as_deref(),
-            Some(dir.path().join("khive-events.sock").as_path()),
+            Some(dir.path().join("khive.events.sock").as_path()),
             "daemon upgrade must derive the socket beside the events db, not globally"
         );
 

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -389,6 +389,21 @@ fn start_daemon_components_if_daemon(
     if !args.daemon {
         return 0;
     }
+    // ADR-170: the main daemon supervises the events daemon — spawn it when
+    // the events socket is unreachable, respawn if it dies. Both paths come
+    // from the server's own resolved events-split config, so the supervised
+    // daemon and the forwarding clients cannot anchor at diverging paths;
+    // a socket is present exactly when this host upgraded to forwarding
+    // (`enable_events_forwarding_for_daemon`), and the `KHIVE_EVENTS_SPLIT=0`
+    // kill-switch already produced no split at resolution.
+    #[cfg(unix)]
+    if let Some(split) = server.events_split_config() {
+        if let Some(socket) = split.socket_path.clone() {
+            khive_runtime::daemon::track_background_task(
+                khive_runtime::events_split::supervise_events_daemon(split.db_path.clone(), socket),
+            );
+        }
+    }
     crate::components::start_daemon_components_with_schedule(server, schedule_rt)
 }
 
@@ -2516,6 +2531,33 @@ async fn prepare_configured_storage_topology(
     // database files.
     validate_effective_backend_alias_modes(&effective_backends)?;
 
+    // ADR-170: the events split must anchor beside the store that actually
+    // holds this deployment's data. The resolver derived it from
+    // `base_config.db_path`, which for declared-backend configs is the
+    // materialized `$HOME/.khive/khive.db` default rather than the declared
+    // main backend — re-anchor beside main's declared file here, preserving
+    // the resolver/daemon-host mode decision (direct vs forwarding) by
+    // re-deriving the socket beside the moved events db. An in-memory main
+    // (including a force-memory override) carries no event-plane split.
+    if let Some(split) = base_config.events_split.take() {
+        let main_path = effective_backends
+            .iter()
+            .find(|b| b.name == BackendId::MAIN && b.kind == BackendKind::Sqlite)
+            .and_then(|b| b.path.as_ref());
+        if let Some(main_path) = main_path {
+            let expanded = khive_runtime::expand_tilde(main_path);
+            let db_path = khive_runtime::events_split::events_db_path_beside(&expanded);
+            let socket_path = split
+                .socket_path
+                .is_some()
+                .then(|| khive_runtime::events_split::events_socket_path_beside(&db_path));
+            base_config.events_split = Some(khive_runtime::events_split::EventsSplitConfig {
+                db_path,
+                socket_path,
+            });
+        }
+    }
+
     // Open each declared backend, deduplicating SQLite backends by canonical
     // path (ADR-028 §8). Schema preparation is deliberately deferred until
     // after main is identified: every distinct secondary must be inventoried
@@ -2981,6 +3023,13 @@ pub async fn build_server_with_explicit_namespace(
         },
         brain_profile: args.brain_profile.clone(),
     })?;
+    let config = {
+        let mut config = config;
+        if args.daemon {
+            enable_events_forwarding_for_daemon(&mut config);
+        }
+        config
+    };
 
     // Regression fence: `config.db_path` must agree with what the canonical
     // resolver derives from this same `--db` input, or `config_id` (computed
@@ -3896,9 +3945,50 @@ pub fn resolve_runtime_config_with_db_anchor(
         resolved
     };
 
+    // ADR-170: events-daemon split. Every file-backed resolution routes event
+    // persistence to `events.db` beside the main store, in DIRECT (embedded)
+    // mode: this resolver serves one-shot hosts (`kkernel exec`, `reindex`,
+    // ingest) and tests, which have no events daemon to talk to. Resident
+    // daemon hosts upgrade the resolved config to socket forwarding
+    // themselves — see [`enable_events_forwarding_for_daemon`] — because
+    // only they supervise an events daemon at the derived socket.
+    // In-memory resolutions (tests) keep the legacy main-store event plane.
+    // `KHIVE_EVENTS_SPLIT=0` is the deployment kill-switch back to legacy.
+    let resolved = {
+        let mut resolved = resolved;
+        let kill_switch = std::env::var("KHIVE_EVENTS_SPLIT").is_ok_and(|v| v.trim() == "0");
+        if !kill_switch {
+            if let Some(main_db) = resolved.db_path.as_deref() {
+                resolved.events_split = Some(khive_runtime::events_split::EventsSplitConfig {
+                    db_path: khive_runtime::events_split::events_db_path_beside(main_db),
+                    socket_path: None,
+                });
+            }
+        }
+        resolved
+    };
+
     // Tier-3 env fallback: KHIVE_BRAIN_PROFILE is applied AFTER CLI (tier-1) and
     // config-file (tier-2) so that a project or global TOML always wins over the env var.
     Ok((apply_env_brain_profile(resolved), db_anchor))
+}
+
+/// Upgrade a resolved config's event plane from direct (embedded) mode to
+/// socket forwarding — the resident-daemon half of the ADR-170 split.
+///
+/// `resolve_runtime_config_with_db_anchor` always resolves the event plane in
+/// direct mode because most of its callers (one-shot CLI, tests) have no
+/// events daemon. The two daemon hosts (`build_server_with_explicit_namespace`
+/// under `--daemon`, and `kkernel mcp`'s multi-backend arm) call this after
+/// resolution; they are exactly the processes that also supervise an events
+/// daemon at the derived socket (`start_daemon_components_if_daemon`), so the
+/// socket this routes to is the one that same host keeps alive.
+pub fn enable_events_forwarding_for_daemon(config: &mut RuntimeConfig) {
+    if let Some(split) = config.events_split.as_mut() {
+        split.socket_path = Some(khive_runtime::events_split::events_socket_path_beside(
+            &split.db_path,
+        ));
+    }
 }
 
 /// Apply `KHIVE_BRAIN_PROFILE` env var as the tier-3 fallback for `brain_profile`.
@@ -4248,6 +4338,67 @@ mod tests {
         })
         .expect("resolve config")
         .packs
+    }
+
+    /// ADR-170 host-class contract: the shared resolver must emit the events
+    /// split in DIRECT mode (socket-less), because most of its callers —
+    /// one-shot CLI hosts and every test that builds a server — have no
+    /// events daemon to forward to. A resolver that emits a socket here
+    /// routes those hosts' events at a daemon that does not exist: appends
+    /// are silently dropped and synchronous provenance reads fail closed
+    /// (measured: the schedule drain refused to dispatch a due event).
+    /// Resident daemon hosts get forwarding only through the explicit
+    /// upgrade, at a socket derived beside the events db (never a global
+    /// socket, which would cross-wire a second database's events).
+    #[test]
+    #[serial]
+    fn resolver_emits_direct_events_mode_and_daemon_upgrade_derives_socket_beside_db() {
+        let _env = ClearedKhiveEnvGuard::clear();
+        let dir = tempfile::tempdir().expect("temp dir");
+        let db = dir.path().join("khive.db");
+        let mut resolved = resolve_runtime_config(RuntimeConfigInputs {
+            db: Some(db.to_str().expect("utf8")),
+            config: None,
+            namespace: Namespace::parse("local").expect("ns"),
+            namespace_explicit: false,
+            actor_explicit: false,
+            no_embed: true,
+            packs: Some(kg_test_packs()),
+            brain_profile: None,
+        })
+        .expect("resolve config");
+
+        let split = resolved
+            .events_split
+            .as_ref()
+            .expect("file-backed resolution must configure the events split");
+        assert_eq!(split.db_path, dir.path().join("events.db"));
+        assert_eq!(
+            split.socket_path, None,
+            "the shared resolver must emit direct mode; only daemon hosts upgrade"
+        );
+
+        enable_events_forwarding_for_daemon(&mut resolved);
+        let split = resolved.events_split.as_ref().expect("split still set");
+        assert_eq!(
+            split.socket_path.as_deref(),
+            Some(dir.path().join("khive-events.sock").as_path()),
+            "daemon upgrade must derive the socket beside the events db, not globally"
+        );
+
+        // In-memory resolutions carry no event-plane split at all.
+        let in_memory = resolve_runtime_config(RuntimeConfigInputs {
+            db: Some(":memory:"),
+            config: None,
+            namespace: Namespace::parse("local").expect("ns"),
+            namespace_explicit: false,
+            actor_explicit: false,
+            no_embed: true,
+            packs: Some(kg_test_packs()),
+            brain_profile: None,
+        })
+        .expect("resolve in-memory config");
+        assert!(in_memory.events_split.is_none());
     }
 
     #[test]

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -1300,6 +1300,18 @@ impl KhiveMcpServer {
     }
 
     /// Fingerprint of the runtime config this server's registry was built for.
+    /// The resolved events-split config of the default-backend runtime, if
+    /// any (ADR-170). Daemon supervision derives the events daemon's
+    /// db/socket from this exact value so the supervised daemon and the
+    /// forwarding clients cannot anchor at diverging paths.
+    pub(crate) fn events_split_config(
+        &self,
+    ) -> Option<&khive_runtime::events_split::EventsSplitConfig> {
+        self.runtime
+            .as_ref()
+            .and_then(|rt| rt.config().events_split.as_ref())
+    }
+
     pub fn config_id(&self) -> &str {
         &self.config_id
     }
@@ -4080,10 +4092,12 @@ mod tests {
         let base = RuntimeConfig::no_embeddings();
         let utc = RuntimeConfig {
             display_timezone: "UTC".parse().expect("UTC is a known IANA zone"),
+            events_split: None,
             ..base.clone()
         };
         let new_york = RuntimeConfig {
             display_timezone: "America/New_York".parse().expect("known IANA zone"),
+            events_split: None,
             ..base
         };
 
@@ -4114,10 +4128,12 @@ mod tests {
         let base = RuntimeConfig::no_embeddings();
         let a = RuntimeConfig {
             display_timezone: "America/New_York".parse().expect("known IANA zone"),
+            events_split: None,
             ..base.clone()
         };
         let b = RuntimeConfig {
             display_timezone: "America/New_York".parse().expect("known IANA zone"),
+            events_split: None,
             ..base
         };
 

--- a/crates/khive-pack-brain/src/fold_gate.rs
+++ b/crates/khive-pack-brain/src/fold_gate.rs
@@ -523,6 +523,7 @@ mod tests {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            events_split: None,
             db_path: Some(db_path),
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -631,6 +632,7 @@ mod tests {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            events_split: None,
             db_path: Some(db_path),
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -2841,25 +2841,69 @@ pub(crate) async fn fetch_event_counts_window_exhaustive(
         )));
     }
 
+    // Keyset pagination, not offset pagination: every page is fetched at
+    // offset 0 with the window's upper bound (`before`) walked downward to
+    // just past the oldest row already collected. Offset pagination makes the
+    // store materialize and discard an offset-sized prefix per page — O(N²)
+    // rows over the loop, and quadratically worse against the split event
+    // plane (ADR-170), where each side must produce the full prefix for the
+    // merge. Keyset keeps every page O(page_size) on both stores.
+    //
+    // `before` is exclusive at microsecond granularity and `created_at` is
+    // not unique, so consecutive windows deliberately overlap on the boundary
+    // microsecond (`before = oldest_seen + 1`) and rows already collected at
+    // that timestamp are dropped by id. A page that admits nothing new means
+    // one microsecond holds more rows than a whole page — no keyset window
+    // can advance past it — so it is rejected loudly instead of looping.
     let mut items: Vec<Event> = Vec::new();
-    let mut offset: u64 = 0;
+    let mut filter = base_filter.clone();
+    let mut boundary_ts: Option<i64> = None;
+    let mut boundary_ids: std::collections::HashSet<uuid::Uuid> = std::collections::HashSet::new();
     loop {
         let page = store
             .query_events(
-                base_filter.clone(),
+                filter.clone(),
                 PageRequest {
-                    offset,
+                    offset: 0,
                     limit: page_size,
                 },
             )
             .await
             .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
         let page_len = page.items.len() as u64;
-        items.extend(page.items);
+        let mut admitted = 0u64;
+        for event in page.items {
+            if boundary_ts == Some(event.created_at) && boundary_ids.contains(&event.id) {
+                continue;
+            }
+            items.push(event);
+            admitted += 1;
+        }
         if page_len < page_size as u64 {
             break;
         }
-        offset += page_size as u64;
+        if admitted == 0 {
+            return Err(RuntimeError::InvalidInput(format!(
+                "brain.event_counts cannot paginate past a single-microsecond cluster of more \
+                 than {page_size} events at created_at={:?}; narrow the window or add filters",
+                boundary_ts
+            )));
+        }
+        let oldest = items
+            .last()
+            .expect("admitted > 0 implies items is non-empty")
+            .created_at;
+        boundary_ts = Some(oldest);
+        boundary_ids = items
+            .iter()
+            .rev()
+            .take_while(|e| e.created_at == oldest)
+            .map(|e| e.id)
+            .collect();
+        // Half-open upper bound: `created_at < oldest + 1` re-admits the
+        // boundary microsecond for the id-dedup above without skipping any
+        // row that shares it.
+        filter.before = Some(oldest.saturating_add(1));
     }
 
     let truncated = (items.len() as u64) < window_event_total;

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -2396,6 +2396,7 @@ fn make_pack_with_actor(actor_id: &str) -> (BrainPack, KhiveRuntime) {
     let rt = KhiveRuntime::new(khive_runtime::RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        events_split: None,
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-pack-brain/tests/adr133_serve_batch.rs
+++ b/crates/khive-pack-brain/tests/adr133_serve_batch.rs
@@ -17,6 +17,7 @@ fn file_backed_runtime(db_path: std::path::PathBuf) -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        events_split: None,
         db_path: Some(db_path),
         default_namespace: Namespace::local(),
         embedding_model: None,

--- a/crates/khive-pack-brain/tests/resolve_actor.rs
+++ b/crates/khive-pack-brain/tests/resolve_actor.rs
@@ -14,6 +14,7 @@ fn runtime_with_actor(actor_id: Option<&str>) -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        events_split: None,
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -3320,6 +3320,7 @@ mod tests {
         let runtime = super::KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            events_split: None,
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::parse(&ns).unwrap(),
@@ -3847,6 +3848,7 @@ mod tests {
         let runtime = super::KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            events_split: None,
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::parse(&ns).unwrap(),
@@ -3964,6 +3966,7 @@ mod tests {
             let runtime = super::KhiveRuntime::new(RuntimeConfig {
                 git_write: Default::default(),
                 display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+                events_split: None,
                 db_path: None,
                 blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
                 default_namespace: Namespace::parse(&ns).unwrap(),

--- a/crates/khive-pack-comm/src/message.rs
+++ b/crates/khive-pack-comm/src/message.rs
@@ -454,6 +454,7 @@ mod tests {
         let runtime = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            events_split: None,
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::parse(&sender_ns).unwrap(),
@@ -532,6 +533,7 @@ mod tests {
         let runtime = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            events_split: None,
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::parse(ns).unwrap(),
@@ -675,6 +677,7 @@ mod tests {
         let runtime = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            events_split: None,
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::parse(&sender_ns).unwrap(),
@@ -837,6 +840,7 @@ mod tests {
         let runtime = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            events_split: None,
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),

--- a/crates/khive-pack-comm/tests/adr133_read_flags.rs
+++ b/crates/khive-pack-comm/tests/adr133_read_flags.rs
@@ -17,6 +17,7 @@ fn file_backed_registry(
     let rt = KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        events_split: None,
         db_path: Some(db_path),
         default_namespace: Namespace::local(),
         embedding_model: None,

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -3539,6 +3539,7 @@ fn build_crossns_registry(
     let config = RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        events_split: None,
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::parse(dispatch_ns).unwrap(),
@@ -4480,6 +4481,7 @@ fn build_actor_registry(
     let config = RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        events_split: None,
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
@@ -4645,6 +4647,7 @@ allowed_outbound_namespaces = ["lambda:khive", "lambda:atlas"]
     let base = RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        events_split: None,
         db_path: None,
         embedding_model: None,
         additional_embedding_models: vec![],
@@ -4774,6 +4777,7 @@ async fn t_c2_gate_receives_configured_actor_not_anonymous() {
     let config = RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        events_split: None,
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
@@ -4890,6 +4894,7 @@ async fn i199_anonymous_inbox_cannot_read_messages_addressed_to_other_actor() {
     let config_anon = RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        events_split: None,
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-pack-comm/tests/probe.rs
+++ b/crates/khive-pack-comm/tests/probe.rs
@@ -1011,6 +1011,7 @@ async fn probe_backfills_pre_existing_messages_across_v6_to_v7_upgrade() {
     let config = RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        events_split: None,
         db_path: Some(path.clone()),
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
@@ -1196,6 +1197,7 @@ async fn probe_repairs_partial_notes_seq_left_by_original_v7_on_reopen() {
     let config = RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        events_split: None,
         db_path: Some(path.clone()),
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-pack-git/tests/acceptance.rs
+++ b/crates/khive-pack-git/tests/acceptance.rs
@@ -7271,6 +7271,7 @@ async fn ingest_over_cap_commit_embedding_is_semantically_retrievable() {
     let rt = KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        events_split: None,
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-pack-knowledge/benches/knowledge_bench.rs
+++ b/crates/khive-pack-knowledge/benches/knowledge_bench.rs
@@ -21,6 +21,7 @@ fn build_runtime() -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        events_split: None,
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-pack-knowledge/benches/search_latency.rs
+++ b/crates/khive-pack-knowledge/benches/search_latency.rs
@@ -28,6 +28,7 @@ fn rt_with_embedder() -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        events_split: None,
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-pack-knowledge/src/handlers.rs
+++ b/crates/khive-pack-knowledge/src/handlers.rs
@@ -929,6 +929,7 @@ mod tests {
         let rt = KhiveRuntime::new(khive_runtime::RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            events_split: None,
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),

--- a/crates/khive-pack-knowledge/src/knowledge/ann_degrade_tests.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/ann_degrade_tests.rs
@@ -171,6 +171,7 @@ fn rt_with_fake_embedder() -> KhiveRuntime {
     let rt = KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        events_split: None,
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
@@ -193,6 +194,7 @@ fn rt_with_controlled_ranking(fail_fresh_rerank: bool) -> KhiveRuntime {
     let rt = KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        events_split: None,
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
@@ -219,6 +221,7 @@ fn file_rt_with_fake_embedder(db_path: std::path::PathBuf) -> KhiveRuntime {
     let rt = KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        events_split: None,
         db_path: Some(db_path),
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-pack-knowledge/src/knowledge/suggest_ranking_tests.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/suggest_ranking_tests.rs
@@ -168,6 +168,7 @@ fn rt_with_fixture_embedder() -> KhiveRuntime {
     let rt = KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        events_split: None,
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-pack-knowledge/src/knowledge/vamana.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/vamana.rs
@@ -4256,6 +4256,7 @@ mod tests {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            events_split: None,
             db_path,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),

--- a/crates/khive-pack-knowledge/tests/bench.rs
+++ b/crates/khive-pack-knowledge/tests/bench.rs
@@ -28,6 +28,7 @@ fn rt_with_embedder() -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        events_split: None,
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-pack-knowledge/tests/feedback.rs
+++ b/crates/khive-pack-knowledge/tests/feedback.rs
@@ -22,6 +22,7 @@ fn make_rt(brain_profile: Option<String>, with_brain: bool) -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        events_split: None,
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         embedding_model: None,
@@ -40,6 +41,7 @@ fn make_rt_with_actor(actor: &str) -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        events_split: None,
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-pack-knowledge/tests/fixes.rs
+++ b/crates/khive-pack-knowledge/tests/fixes.rs
@@ -1630,6 +1630,7 @@ fn rt_with_default_embedder() -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        events_split: None,
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
@@ -2307,6 +2308,7 @@ mod embed_failure_tests {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            events_split: None,
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -2495,6 +2497,7 @@ mod embed_failure_tests {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            events_split: None,
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -2811,6 +2814,7 @@ mod ann_bypass_regression {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            events_split: None,
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -3410,6 +3414,7 @@ mod edit_inline_reembed {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            events_split: None,
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -3815,6 +3820,7 @@ mod ann_type_filter_regression {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            events_split: None,
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -4221,6 +4227,7 @@ mod compose_explain_sections {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            events_split: None,
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),

--- a/crates/khive-pack-knowledge/tests/integration.rs
+++ b/crates/khive-pack-knowledge/tests/integration.rs
@@ -1840,6 +1840,7 @@ async fn index_reembed_paging_sweep_covers_equal_created_at_in_order() {
     let rt = KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        events_split: None,
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
@@ -3998,6 +3999,7 @@ mod kg_blend {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            events_split: None,
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -4628,6 +4630,7 @@ mod kg_blend {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            events_split: None,
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),

--- a/crates/khive-pack-knowledge/tests/search_candidate_refill.rs
+++ b/crates/khive-pack-knowledge/tests/search_candidate_refill.rs
@@ -144,6 +144,7 @@ fn runtime_with_embedder() -> KhiveRuntime {
     let runtime = KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        events_split: None,
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-pack-moodboard/src/preference_handlers.rs
+++ b/crates/khive-pack-moodboard/src/preference_handlers.rs
@@ -1603,6 +1603,7 @@ mod tests {
         RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            events_split: None,
             db_path: Some(db_path.to_path_buf()),
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),

--- a/crates/khive-pack-session/src/mirror/ingest.rs
+++ b/crates/khive-pack-session/src/mirror/ingest.rs
@@ -1104,6 +1104,7 @@ mod tests {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            events_split: None,
             db_path: Some(db_path),
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),

--- a/crates/khive-pack-session/src/mirror/service.rs
+++ b/crates/khive-pack-session/src/mirror/service.rs
@@ -2626,6 +2626,7 @@ mod cursor_retry_tests {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            events_split: None,
             db_path: Some(db_path),
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),

--- a/crates/khive-pack-session/tests/integration.rs
+++ b/crates/khive-pack-session/tests/integration.rs
@@ -22,6 +22,7 @@ fn file_rt(db_path: std::path::PathBuf) -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        events_split: None,
         db_path: Some(db_path),
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-runtime/src/audit_batch.rs
+++ b/crates/khive-runtime/src/audit_batch.rs
@@ -363,6 +363,13 @@ fn classify_store_error(err: &StorageError) -> RetryDecision {
         StorageError::WriteQueueFull { .. } | StorageError::WriterTaskBusy { .. } => {
             RetryDecision::Retry
         }
+        // Transient availability conditions, not judgments on the batch. The
+        // events-daemon forwarding lane (ADR-170) reports an unreachable or
+        // stalled daemon as `Pool`/`Timeout`; the direct SQL path reports
+        // acquisition pressure the same way. Both are exactly what the
+        // configured bounded retries exist for — treating them as terminal
+        // would abandon a generation on the first blip of a daemon restart.
+        StorageError::Pool { .. } | StorageError::Timeout { .. } => RetryDecision::Retry,
         StorageError::WriterTaskTerminated { request_state } => match request_state {
             WriterTaskRequestState::NotStarted | WriterTaskRequestState::TransactionRolledBack => {
                 RetryDecision::Retry

--- a/crates/khive-runtime/src/config.rs
+++ b/crates/khive-runtime/src/config.rs
@@ -317,7 +317,7 @@ pub struct RuntimeConfig {
     /// the host zone cannot be determined) via [`resolve_default_display_timezone`].
     pub display_timezone: chrono_tz::Tz,
     /// Events-daemon split (ADR-170). `None` = legacy behavior: events persist
-    /// in the main store. `Some` routes event persistence to `events.db` —
+    /// in the main store. `Some` routes event persistence to the events database —
     /// forwarded over the events daemon socket in daemon deployments, opened
     /// directly in embedded/one-shot contexts. Populated by the transport
     /// hosts (khive-mcp serve, kkernel exec); tests and in-memory runtimes

--- a/crates/khive-runtime/src/config.rs
+++ b/crates/khive-runtime/src/config.rs
@@ -316,6 +316,13 @@ pub struct RuntimeConfig {
     /// resolves once to the host's local IANA zone (falling back to UTC when
     /// the host zone cannot be determined) via [`resolve_default_display_timezone`].
     pub display_timezone: chrono_tz::Tz,
+    /// Events-daemon split (ADR-170). `None` = legacy behavior: events persist
+    /// in the main store. `Some` routes event persistence to `events.db` —
+    /// forwarded over the events daemon socket in daemon deployments, opened
+    /// directly in embedded/one-shot contexts. Populated by the transport
+    /// hosts (khive-mcp serve, kkernel exec); tests and in-memory runtimes
+    /// leave it `None`.
+    pub events_split: Option<crate::events_split::EventsSplitConfig>,
 }
 
 /// Parse a comma- or whitespace-separated pack list from a single string.
@@ -401,6 +408,7 @@ impl Default for RuntimeConfig {
             actor_id,
             git_write: crate::engine_config::GitWriteSectionConfig::default(),
             display_timezone: resolve_default_display_timezone(),
+            events_split: None,
         }
     }
 }

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -317,7 +317,7 @@ fn socket_identity(path: &std::path::Path) -> Option<SocketIdentity> {
 /// `getpeereid(2)` on macOS/BSD, `SO_PEERCRED` on Linux. Both report the peer's
 /// credentials as recorded by the kernel at connect time.
 #[cfg(unix)]
-fn peer_uid(stream: &UnixStream) -> std::io::Result<u32> {
+pub(crate) fn peer_uid(stream: &UnixStream) -> std::io::Result<u32> {
     use std::os::fd::AsRawFd;
     let fd = stream.as_raw_fd();
 
@@ -396,7 +396,7 @@ fn peer_uid(stream: &UnixStream) -> std::io::Result<u32> {
 /// multiple uids needs a code change and a gated ADR — which is precisely the
 /// decision that should be impossible to make by accident.
 #[cfg(unix)]
-fn uid_is_permitted(peer: u32, daemon_euid: u32) -> bool {
+pub(crate) fn uid_is_permitted(peer: u32, daemon_euid: u32) -> bool {
     peer == daemon_euid
 }
 

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -1371,7 +1371,7 @@ pub async fn run_daemon_in_process_test<D: DaemonDispatch>(dispatcher: D) -> any
 /// umask-default 0755 stays acceptable; shared sticky directories like
 /// `/tmp` do not.
 #[cfg(unix)]
-fn ensure_socket_dir_is_trusted(parent: &std::path::Path) -> anyhow::Result<()> {
+pub(crate) fn ensure_socket_dir_is_trusted(parent: &std::path::Path) -> anyhow::Result<()> {
     // SAFETY: `geteuid` is always successful and takes no arguments.
     let daemon_euid = unsafe { libc::geteuid() } as u32;
 

--- a/crates/khive-runtime/src/events_split.rs
+++ b/crates/khive-runtime/src/events_split.rs
@@ -1124,6 +1124,85 @@ mod tests {
         assert_eq!(seen, expected);
     }
 
+    /// Mechanized co-residency guard: the amendment's load-bearing claim is
+    /// that every class a raw-SQL consumer of the legacy `events` table
+    /// depends on still LANDS in that table. Two of the three enumerated
+    /// consumers (kg projection guard, graph-query union) fail silently if
+    /// the classification drifts, so the classification is guarded here by
+    /// the consumers' own access pattern — a raw SQL read against the legacy
+    /// backend — rather than by enumeration. Arm 1 reddens if plain appends
+    /// (the provenance/domain class) ever stop reaching the legacy table.
+    /// Arm 2 is the boundary's other face and doubles as the positive
+    /// control for the instrument: the same query DOES find lane-routed rows
+    /// on the lane's own backend, so an empty arm-1 result could not be a
+    /// broken query.
+    #[tokio::test]
+    async fn raw_sql_consumers_of_the_legacy_events_table_still_see_plain_appends() {
+        use khive_storage::types::{SqlStatement, SqlValue};
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let legacy_backend =
+            direct_backend_for(&dir.path().join("legacy-guard.db")).expect("legacy backend");
+        let lane_backend =
+            direct_backend_for(&dir.path().join("lane-guard.db")).expect("lane backend");
+        let split = SplitEventStore::new(
+            legacy_backend
+                .events_for_namespace("local")
+                .expect("legacy store"),
+            lane_backend
+                .events_for_namespace("local")
+                .expect("lane store"),
+        );
+
+        // The schedule pack's creator-provenance write is a plain append; the
+        // audit flusher's write is an idempotent batch. Route one of each.
+        let provenance = test_event("local");
+        let provenance_id = provenance.id;
+        split.append_event(provenance).await.expect("plain append");
+        let audit = test_event("local");
+        let audit_id = audit.id;
+        split
+            .append_events_idempotent(vec![audit])
+            .await
+            .expect("idempotent append");
+
+        let count_by_raw_sql = |backend: Arc<StorageBackend>, id: Uuid| async move {
+            let mut reader = backend.sql().reader().await.expect("sql reader");
+            let rows = reader
+                .query_all(SqlStatement {
+                    sql: "SELECT actor FROM events WHERE id = ?1".to_string(),
+                    params: vec![SqlValue::Text(id.to_string())],
+                    label: None,
+                })
+                .await
+                .expect("raw events query");
+            rows.len()
+        };
+
+        // Arm 1: the co-residency contract. A raw-SQL consumer of the legacy
+        // table finds the plain-append row there.
+        assert_eq!(
+            count_by_raw_sql(Arc::clone(&legacy_backend), provenance_id).await,
+            1,
+            "plain appends must stay visible to raw-SQL consumers of the legacy events table"
+        );
+        // Arm 2a: the moved class is genuinely gone from the legacy table —
+        // this is the silent-failure face of the boundary, held visible.
+        assert_eq!(
+            count_by_raw_sql(Arc::clone(&legacy_backend), audit_id).await,
+            0,
+            "audit-lane rows must not land in the legacy events table"
+        );
+        // Arm 2b: positive control for the instrument — the identical query
+        // finds the moved row on the lane backend, so arm 2a's zero (and any
+        // future arm-1 zero) is a routing fact, not a dead query.
+        assert_eq!(
+            count_by_raw_sql(Arc::clone(&lane_backend), audit_id).await,
+            1,
+            "the raw query must prove it can find rows where they actually live"
+        );
+    }
+
     /// End to end over the real socket: the idempotent lane returns true
     /// dispositions, and the row is readable back through the same store.
     #[tokio::test]

--- a/crates/khive-runtime/src/events_split.rs
+++ b/crates/khive-runtime/src/events_split.rs
@@ -1,0 +1,1312 @@
+//! Events-daemon split (ADR-170): the audit lane leaves the domain store.
+//!
+//! The ADR-133 idempotent audit batch is the measured bulk of event write
+//! volume, and in a single-store deployment its rows queue on the same SQLite
+//! writer lane as domain mutations. This module moves that lane into a
+//! dedicated events daemon that owns `events.db`, reachable over a Unix
+//! socket with the same length-prefixed framing and peer-uid admission the
+//! main daemon socket uses. Plain event appends stay on the domain store —
+//! the legacy `events` table has raw-SQL consumers (schedule provenance, kg
+//! projection guards, graph-query substrate unions) whose correctness
+//! depends on finding those rows there.
+//!
+//! Cooperating pieces:
+//!
+//! - [`run_events_daemon`] — the server loop the `events-daemon` subcommand
+//!   runs: binds the events socket, owns the only resident writer of
+//!   `events.db`, and serves append/read requests through the ordinary
+//!   `SqlEventStore`.
+//! - [`EventsSplitClient`] — one per domain process. Plain appends ride a
+//!   bounded in-memory queue drained by a background forwarder
+//!   (fire-and-forget; overflow or a dead daemon drops the batch, counts it,
+//!   and logs — the loss-tolerant durability class made concrete; unused by
+//!   the default routing until telemetry producers opt in). Idempotent
+//!   audit-batch appends and reads are synchronous framed round-trips with
+//!   bounded timeouts, because their callers are background flushers or query
+//!   paths, never the dispatch hot path.
+//! - [`ForwardingEventStore`] — the lane-side [`EventStore`] over the socket.
+//!   Preflight validation delegates to an in-memory `SqlEventStore`, so the
+//!   ADR-133 audit-batch seam keeps its pre-enqueue shape check without any
+//!   I/O on the dispatch path.
+//! - [`SplitEventStore`] — the per-namespace handle
+//!   [`crate::runtime::KhiveRuntime::events`] returns when the split is
+//!   configured: routes the idempotent lane to the events store, plain
+//!   appends to the legacy store, and merges reads across both.
+//!
+//! Domain availability never depends on events-daemon liveness: every failure
+//! path here degrades (drop + count + log, or a typed storage error for the
+//! synchronous lanes) instead of blocking the caller.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use khive_db::StorageBackend;
+use khive_storage::event::IdempotentEventBatchResult;
+use khive_storage::{
+    BatchWriteSummary, Event, EventFilter, EventStore, Page, PageRequest, StorageError,
+    StorageResult,
+};
+use serde::{Deserialize, Serialize};
+
+use tokio::net::{UnixListener, UnixStream};
+use uuid::Uuid;
+
+use crate::daemon::{read_frame, write_frame};
+
+/// Bump whenever the request or response frame shape changes incompatibly.
+/// The server rejects frames whose version it does not speak, so a skewed
+/// client gets a typed refusal instead of a deserialization panic.
+pub const EVENTS_PROTOCOL_VERSION: u32 = 1;
+
+/// Default bound on the fire-and-forget append queue, in batches. The loss
+/// window on overflow is this depth times the batch size in flight; the value
+/// is deliberately generous because entries are pointers, not rows.
+pub const DEFAULT_APPEND_QUEUE_BATCHES: usize = 4096;
+
+/// Timeout for one synchronous round-trip (idempotent appends, reads).
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Reconnect backoff for the background forwarder after a failed connect.
+const FORWARDER_BACKOFF: Duration = Duration::from_secs(2);
+
+/// Default events database file, beside the main database file.
+pub fn events_db_path_beside(main_db: &Path) -> PathBuf {
+    main_db
+        .parent()
+        .map(|dir| dir.join("events.db"))
+        .unwrap_or_else(|| PathBuf::from("events.db"))
+}
+
+/// Events daemon socket path, beside the events database it serves.
+///
+/// Derived from the db path (not a process-global location) so every events
+/// database gets its own daemon and socket: a global socket would route
+/// events from any second database (another seat, a test tempdir) to
+/// whichever daemon happens to own it, persisting them beside the wrong
+/// main store.
+pub fn events_socket_path_beside(events_db: &Path) -> PathBuf {
+    events_db
+        .parent()
+        .map(|dir| dir.join("khive-events.sock"))
+        .unwrap_or_else(|| PathBuf::from("khive-events.sock"))
+}
+
+/// How a runtime reaches event storage when the split is configured.
+#[derive(Debug, Clone)]
+pub struct EventsSplitConfig {
+    /// The events database file. The events daemon is its only writer in
+    /// daemon deployments; embedded mode writes it directly.
+    pub db_path: PathBuf,
+    /// `Some(socket)` = forward appends to the events daemon at this socket
+    /// (daemon deployments). `None` = embedded mode: open `db_path` directly
+    /// in-process (one-shot CLI, tests).
+    pub socket_path: Option<PathBuf>,
+}
+
+// ---------------------------------------------------------------------------
+// Process-global handles
+// ---------------------------------------------------------------------------
+//
+// One events-split client (or one direct backend) per process, whatever the
+// number of runtimes and clones — the same shape as the daemon module's other
+// process-global state. Keyed by path so tests exercising two distinct paths
+// in one process stay isolated.
+
+type ClientMap = std::collections::HashMap<PathBuf, Arc<EventsSplitClient>>;
+type BackendMap = std::collections::HashMap<PathBuf, Arc<StorageBackend>>;
+
+fn client_registry() -> &'static std::sync::Mutex<ClientMap> {
+    static REGISTRY: std::sync::OnceLock<std::sync::Mutex<ClientMap>> = std::sync::OnceLock::new();
+    REGISTRY.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+fn direct_backend_registry() -> &'static std::sync::Mutex<BackendMap> {
+    static REGISTRY: std::sync::OnceLock<std::sync::Mutex<BackendMap>> = std::sync::OnceLock::new();
+    REGISTRY.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+/// The process-wide client for `socket_path`, created (and its forwarder
+/// spawned) on first use. Requires a tokio runtime context on first call.
+pub fn client_for(socket_path: &Path) -> crate::error::RuntimeResult<Arc<EventsSplitClient>> {
+    let mut registry = client_registry()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if let Some(existing) = registry.get(socket_path) {
+        return Ok(Arc::clone(existing));
+    }
+    let client = EventsSplitClient::new(socket_path.to_path_buf())?;
+    registry.insert(socket_path.to_path_buf(), Arc::clone(&client));
+    Ok(client)
+}
+
+/// The process-wide direct (embedded-mode) backend for `db_path`, opened
+/// read-write on first use.
+pub fn direct_backend_for(db_path: &Path) -> crate::error::RuntimeResult<Arc<StorageBackend>> {
+    let mut registry = direct_backend_registry()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if let Some(existing) = registry.get(db_path) {
+        return Ok(Arc::clone(existing));
+    }
+    let backend = Arc::new(StorageBackend::sqlite(db_path)?);
+    registry.insert(db_path.to_path_buf(), Arc::clone(&backend));
+    Ok(backend)
+}
+
+/// Forwarding metrics for the process-wide client at `socket_path`, if one
+/// exists. `None` means the split never initialized in this process.
+pub fn forwarding_metrics(socket_path: &Path) -> Option<EventsForwardingMetrics> {
+    let registry = client_registry()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    registry.get(socket_path).map(|client| client.metrics())
+}
+
+// ---------------------------------------------------------------------------
+// Wire protocol
+// ---------------------------------------------------------------------------
+
+/// Request frame sent from a domain process to the events daemon.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum EventsRequest {
+    /// Fire-and-forget append lane. The daemon replies with a summary, but the
+    /// forwarder treats a failed reply as a counted drop, never an error to
+    /// the original caller.
+    AppendEvents {
+        protocol_version: u32,
+        namespace: String,
+        events: Vec<Event>,
+    },
+    /// ADR-133 audit-batch lane: real dispositions come back.
+    AppendEventsIdempotent {
+        protocol_version: u32,
+        namespace: String,
+        events: Vec<Event>,
+    },
+    GetEvent {
+        protocol_version: u32,
+        namespace: String,
+        id: Uuid,
+    },
+    QueryEvents {
+        protocol_version: u32,
+        namespace: String,
+        filter: EventFilter,
+        page: PageRequest,
+    },
+    CountEvents {
+        protocol_version: u32,
+        namespace: String,
+        filter: EventFilter,
+    },
+}
+
+impl EventsRequest {
+    fn protocol_version(&self) -> u32 {
+        match self {
+            Self::AppendEvents {
+                protocol_version, ..
+            }
+            | Self::AppendEventsIdempotent {
+                protocol_version, ..
+            }
+            | Self::GetEvent {
+                protocol_version, ..
+            }
+            | Self::QueryEvents {
+                protocol_version, ..
+            }
+            | Self::CountEvents {
+                protocol_version, ..
+            } => *protocol_version,
+        }
+    }
+
+    fn namespace(&self) -> &str {
+        match self {
+            Self::AppendEvents { namespace, .. }
+            | Self::AppendEventsIdempotent { namespace, .. }
+            | Self::GetEvent { namespace, .. }
+            | Self::QueryEvents { namespace, .. }
+            | Self::CountEvents { namespace, .. } => namespace,
+        }
+    }
+}
+
+/// Response frame from the events daemon.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum EventsResponse {
+    Appended {
+        summary: BatchWriteSummary,
+    },
+    Idempotent {
+        result: IdempotentEventBatchResult,
+    },
+    Event {
+        event: Option<Event>,
+    },
+    Pageful {
+        page: Page<Event>,
+    },
+    Count {
+        count: u64,
+    },
+    /// Typed refusal. `retryable` distinguishes transient daemon-side
+    /// conditions from contract errors (bad frame, version skew).
+    Error {
+        message: String,
+        retryable: bool,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Server side
+// ---------------------------------------------------------------------------
+
+/// Advisory lock guaranteeing at most one events daemon per socket path.
+/// Held for the daemon's lifetime; a second daemon exits instead of stealing
+/// the socket path from the live one.
+pub struct EventsDaemonGuard {
+    _file: std::fs::File,
+}
+
+/// Try to become the events daemon for `socket_path`. `None` = another
+/// events daemon already holds the lock.
+pub fn try_acquire_events_daemon_guard(socket_path: &Path) -> Option<EventsDaemonGuard> {
+    let lock_path = socket_path.with_extension("lock");
+    if let Some(parent) = lock_path.parent() {
+        std::fs::create_dir_all(parent).ok()?;
+    }
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .write(true)
+        .open(&lock_path)
+        .ok()?;
+    use std::os::fd::AsRawFd;
+    // SAFETY: `fd` is a live descriptor owned by `file` for the duration of
+    // the call; `flock` reads nothing else.
+    let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+    if rc == 0 {
+        Some(EventsDaemonGuard { _file: file })
+    } else {
+        None
+    }
+}
+
+/// Supervise the events daemon from the main daemon process: probe the
+/// socket periodically and (re)spawn the daemon subcommand when unreachable.
+///
+/// The spawned command contract is fixed here once: the current executable
+/// re-invoked as `events-daemon --db <db> --socket <socket>` — the subcommand
+/// the kernel binary registers for [`run_events_daemon`]. The child holds the
+/// per-socket advisory lock, so a probe/spawn race resolves to one survivor.
+pub async fn supervise_events_daemon(db_path: PathBuf, socket_path: PathBuf) {
+    const PROBE_INTERVAL: Duration = Duration::from_secs(15);
+    let mut respawns: u64 = 0;
+    loop {
+        let reachable = UnixStream::connect(&socket_path).await.is_ok();
+        if !reachable {
+            match std::env::current_exe() {
+                Ok(exe) => {
+                    let spawned = std::process::Command::new(exe)
+                        .arg("events-daemon")
+                        .arg("--db")
+                        .arg(&db_path)
+                        .arg("--socket")
+                        .arg(&socket_path)
+                        .stdin(std::process::Stdio::null())
+                        .stdout(std::process::Stdio::null())
+                        .stderr(std::process::Stdio::null())
+                        .spawn();
+                    match spawned {
+                        Ok(child) => {
+                            respawns += 1;
+                            tracing::info!(
+                                pid = child.id(),
+                                respawns,
+                                socket = %socket_path.display(),
+                                "spawned events daemon"
+                            );
+                        }
+                        Err(error) => {
+                            tracing::warn!(error = %error, "failed to spawn events daemon");
+                        }
+                    }
+                }
+                Err(error) => {
+                    tracing::warn!(error = %error, "cannot resolve current executable for events daemon spawn");
+                }
+            }
+        }
+        tokio::time::sleep(PROBE_INTERVAL).await;
+    }
+}
+
+/// Serve the events daemon loop on `socket_path`, owning `db_path`.
+///
+/// Binds the socket (removing a stale path first), then accepts connections
+/// for the process lifetime. Each connection is served sequentially:
+/// same-uid admission, then a read-frame → dispatch → write-frame loop until
+/// the peer disconnects. All storage goes through `SqlEventStore` on a
+/// backend opened read-write against `db_path`; the events schema is ensured
+/// once at boot.
+pub async fn run_events_daemon(db_path: &Path, socket_path: &Path) -> anyhow::Result<()> {
+    let Some(_guard) = try_acquire_events_daemon_guard(socket_path) else {
+        tracing::info!(
+            socket = %socket_path.display(),
+            "another events daemon holds the lock; exiting"
+        );
+        return Ok(());
+    };
+    let backend = Arc::new(StorageBackend::sqlite(db_path)?);
+    // Ensure the schema once, loudly, before accepting traffic.
+    backend.events()?;
+
+    if socket_path.exists() {
+        std::fs::remove_file(socket_path)?;
+    }
+    if let Some(parent) = socket_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let listener = UnixListener::bind(socket_path)?;
+    let daemon_euid = unsafe { libc::geteuid() };
+    tracing::info!(
+        socket = %socket_path.display(),
+        db = %db_path.display(),
+        "events daemon listening"
+    );
+
+    loop {
+        let (stream, _addr) = match listener.accept().await {
+            Ok(pair) => pair,
+            Err(error) => {
+                tracing::warn!(error = %error, "events daemon accept failed");
+                continue;
+            }
+        };
+        match crate::daemon::peer_uid(&stream) {
+            Ok(uid) if crate::daemon::uid_is_permitted(uid, daemon_euid) => {}
+            Ok(uid) => {
+                tracing::warn!(peer_uid = uid, "events daemon rejected foreign-uid peer");
+                continue;
+            }
+            Err(error) => {
+                tracing::warn!(error = %error, "events daemon could not read peer credentials");
+                continue;
+            }
+        }
+        let backend = Arc::clone(&backend);
+        crate::daemon::spawn_tracked_task(async move {
+            serve_events_conn(stream, backend).await;
+        });
+    }
+}
+
+async fn serve_events_conn(mut stream: UnixStream, backend: Arc<StorageBackend>) {
+    loop {
+        let payload = match read_frame(&mut stream).await {
+            Ok(bytes) => bytes,
+            // Includes clean EOF on peer disconnect.
+            Err(_) => return,
+        };
+        let response = match serde_json::from_slice::<EventsRequest>(&payload) {
+            Ok(request) => dispatch_events_request(request, &backend).await,
+            Err(error) => EventsResponse::Error {
+                message: format!("events daemon could not parse request frame: {error}"),
+                retryable: false,
+            },
+        };
+        let bytes = match serde_json::to_vec(&response) {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                tracing::error!(error = %error, "events daemon response serialization failed");
+                return;
+            }
+        };
+        if write_frame(&mut stream, &bytes).await.is_err() {
+            return;
+        }
+    }
+}
+
+async fn dispatch_events_request(
+    request: EventsRequest,
+    backend: &StorageBackend,
+) -> EventsResponse {
+    if request.protocol_version() != EVENTS_PROTOCOL_VERSION {
+        return EventsResponse::Error {
+            message: format!(
+                "events protocol version mismatch: daemon speaks {}, client sent {}",
+                EVENTS_PROTOCOL_VERSION,
+                request.protocol_version()
+            ),
+            retryable: false,
+        };
+    }
+    let store = match backend.events_for_namespace(request.namespace()) {
+        Ok(store) => store,
+        Err(error) => {
+            return EventsResponse::Error {
+                message: format!("events store unavailable: {error}"),
+                retryable: true,
+            };
+        }
+    };
+    match request {
+        EventsRequest::AppendEvents { events, .. } => match store.append_events(events).await {
+            Ok(summary) => EventsResponse::Appended { summary },
+            Err(error) => storage_error_response(&error),
+        },
+        EventsRequest::AppendEventsIdempotent { events, .. } => {
+            match store.append_events_idempotent(events).await {
+                Ok(result) => EventsResponse::Idempotent { result },
+                Err(error) => storage_error_response(&error),
+            }
+        }
+        EventsRequest::GetEvent { id, .. } => match store.get_event(id).await {
+            Ok(event) => EventsResponse::Event { event },
+            Err(error) => storage_error_response(&error),
+        },
+        EventsRequest::QueryEvents { filter, page, .. } => {
+            match store.query_events(filter, page).await {
+                Ok(page) => EventsResponse::Pageful { page },
+                Err(error) => storage_error_response(&error),
+            }
+        }
+        EventsRequest::CountEvents { filter, .. } => match store.count_events(filter).await {
+            Ok(count) => EventsResponse::Count { count },
+            Err(error) => storage_error_response(&error),
+        },
+    }
+}
+
+fn storage_error_response(error: &StorageError) -> EventsResponse {
+    EventsResponse::Error {
+        message: error.to_string(),
+        retryable: matches!(
+            error,
+            StorageError::Pool { .. }
+                | StorageError::Timeout { .. }
+                | StorageError::WriteQueueFull { .. }
+        ),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Client side
+// ---------------------------------------------------------------------------
+
+/// Counters describing the fire-and-forget lane's degradation. Zero drops is
+/// the healthy state; any non-zero `dropped_batches` means the loss-tolerant
+/// contract was exercised and says so.
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct EventsForwardingMetrics {
+    pub forwarded_batches: u64,
+    pub forwarded_events: u64,
+    pub dropped_batches: u64,
+    pub dropped_events: u64,
+}
+
+#[derive(Debug, Default)]
+struct ForwardingCounters {
+    forwarded_batches: AtomicU64,
+    forwarded_events: AtomicU64,
+    dropped_batches: AtomicU64,
+    dropped_events: AtomicU64,
+}
+
+/// One per domain process: the connection to the events daemon plus the
+/// bounded fire-and-forget append queue.
+pub struct EventsSplitClient {
+    socket_path: PathBuf,
+    append_tx: tokio::sync::mpsc::Sender<(String, Vec<Event>)>,
+    counters: Arc<ForwardingCounters>,
+    /// Flipped by the forwarder while the daemon is unreachable so the drop
+    /// log fires once per outage, not once per batch.
+    outage_logged: Arc<AtomicBool>,
+    /// Serializes synchronous round-trips over one persistent connection.
+    request_conn: tokio::sync::Mutex<Option<UnixStream>>,
+    /// In-memory validator backing `preflight_event` without I/O.
+    preflight_store: Arc<dyn EventStore>,
+}
+
+impl std::fmt::Debug for EventsSplitClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EventsSplitClient")
+            .field("socket_path", &self.socket_path)
+            .finish_non_exhaustive()
+    }
+}
+
+impl EventsSplitClient {
+    /// Build the client and spawn its background forwarder.
+    pub fn new(socket_path: PathBuf) -> crate::error::RuntimeResult<Arc<Self>> {
+        Self::new_with_queue_depth(socket_path, DEFAULT_APPEND_QUEUE_BATCHES)
+    }
+
+    /// [`Self::new`] with an explicit fire-and-forget queue bound. Tests use a
+    /// tiny depth to exercise the overflow drop arm deterministically.
+    pub fn new_with_queue_depth(
+        socket_path: PathBuf,
+        queue_depth: usize,
+    ) -> crate::error::RuntimeResult<Arc<Self>> {
+        let preflight_backend = StorageBackend::memory()?;
+        let preflight_store = preflight_backend.events()?;
+        // The in-memory backend must outlive the store handle; the store holds
+        // the pool Arc internally, so dropping the backend wrapper here is fine.
+
+        let (append_tx, append_rx) =
+            tokio::sync::mpsc::channel::<(String, Vec<Event>)>(queue_depth.max(1));
+        let counters = Arc::new(ForwardingCounters::default());
+        let outage_logged = Arc::new(AtomicBool::new(false));
+
+        let client = Arc::new(Self {
+            socket_path: socket_path.clone(),
+            append_tx,
+            counters: Arc::clone(&counters),
+            outage_logged: Arc::clone(&outage_logged),
+            request_conn: tokio::sync::Mutex::new(None),
+            preflight_store,
+        });
+
+        crate::daemon::spawn_tracked_task(run_forwarder(
+            socket_path,
+            append_rx,
+            counters,
+            outage_logged,
+        ));
+        Ok(client)
+    }
+
+    /// Snapshot of the fire-and-forget lane's health.
+    pub fn metrics(&self) -> EventsForwardingMetrics {
+        EventsForwardingMetrics {
+            forwarded_batches: self.counters.forwarded_batches.load(Ordering::Relaxed),
+            forwarded_events: self.counters.forwarded_events.load(Ordering::Relaxed),
+            dropped_batches: self.counters.dropped_batches.load(Ordering::Relaxed),
+            dropped_events: self.counters.dropped_events.load(Ordering::Relaxed),
+        }
+    }
+
+    /// Enqueue a batch on the fire-and-forget lane. Never blocks; a full
+    /// queue is a counted, logged drop.
+    fn enqueue(&self, namespace: &str, events: Vec<Event>) {
+        let count = events.len() as u64;
+        match self.append_tx.try_send((namespace.to_string(), events)) {
+            Ok(()) => {}
+            Err(_) => {
+                self.counters
+                    .dropped_batches
+                    .fetch_add(1, Ordering::Relaxed);
+                self.counters
+                    .dropped_events
+                    .fetch_add(count, Ordering::Relaxed);
+                if !self.outage_logged.swap(true, Ordering::Relaxed) {
+                    tracing::warn!(
+                        dropped_events = count,
+                        "events append queue full; dropping loss-tolerant events until it drains"
+                    );
+                }
+            }
+        }
+    }
+
+    /// One synchronous framed round-trip with a bounded timeout, reusing (or
+    /// re-establishing) the persistent request connection.
+    async fn round_trip(&self, request: &EventsRequest) -> StorageResult<EventsResponse> {
+        let op = "events daemon round-trip";
+        let payload = serde_json::to_vec(request).map_err(|error| StorageError::Serialization {
+            capability: khive_storage::StorageCapability::Events,
+            message: format!("events request serialization failed: {error}"),
+        })?;
+
+        let mut guard = self.request_conn.lock().await;
+        let attempt = async {
+            if guard.is_none() {
+                *guard = Some(UnixStream::connect(&self.socket_path).await?);
+            }
+            let stream = guard.as_mut().expect("connection populated above");
+            write_frame(stream, &payload).await?;
+            let bytes = read_frame(stream).await?;
+            std::io::Result::Ok(bytes)
+        };
+        let bytes = match tokio::time::timeout(REQUEST_TIMEOUT, attempt).await {
+            Ok(Ok(bytes)) => bytes,
+            Ok(Err(error)) => {
+                // Dead connection: forget it so the next call reconnects.
+                *guard = None;
+                return Err(StorageError::Pool {
+                    operation: op.into(),
+                    message: format!(
+                        "events daemon unreachable at {}: {error}",
+                        self.socket_path.display()
+                    ),
+                });
+            }
+            Err(_elapsed) => {
+                *guard = None;
+                return Err(StorageError::Timeout {
+                    operation: op.into(),
+                });
+            }
+        };
+        drop(guard);
+
+        serde_json::from_slice::<EventsResponse>(&bytes).map_err(|error| {
+            StorageError::Serialization {
+                capability: khive_storage::StorageCapability::Events,
+                message: format!("events response deserialization failed: {error}"),
+            }
+        })
+    }
+}
+
+/// The background fire-and-forget forwarder: drains the bounded queue into
+/// framed appends on its own connection, reconnecting with backoff. A batch
+/// that cannot be delivered is dropped and counted — never retried, never
+/// blocking the queue behind it.
+async fn run_forwarder(
+    socket_path: PathBuf,
+    mut rx: tokio::sync::mpsc::Receiver<(String, Vec<Event>)>,
+    counters: Arc<ForwardingCounters>,
+    outage_logged: Arc<AtomicBool>,
+) {
+    let mut conn: Option<UnixStream> = None;
+    while let Some((namespace, events)) = rx.recv().await {
+        let count = events.len() as u64;
+        let request = EventsRequest::AppendEvents {
+            protocol_version: EVENTS_PROTOCOL_VERSION,
+            namespace,
+            events,
+        };
+        let payload = match serde_json::to_vec(&request) {
+            Ok(payload) => payload,
+            Err(error) => {
+                counters.dropped_batches.fetch_add(1, Ordering::Relaxed);
+                counters.dropped_events.fetch_add(count, Ordering::Relaxed);
+                tracing::error!(error = %error, "events forwarder serialization failed; batch dropped");
+                continue;
+            }
+        };
+
+        let delivered = deliver_batch(&socket_path, &mut conn, &payload).await;
+        if delivered {
+            counters.forwarded_batches.fetch_add(1, Ordering::Relaxed);
+            counters
+                .forwarded_events
+                .fetch_add(count, Ordering::Relaxed);
+            if outage_logged.swap(false, Ordering::Relaxed) {
+                tracing::info!("events daemon reachable again; forwarding resumed");
+            }
+        } else {
+            counters.dropped_batches.fetch_add(1, Ordering::Relaxed);
+            counters.dropped_events.fetch_add(count, Ordering::Relaxed);
+            if !outage_logged.swap(true, Ordering::Relaxed) {
+                tracing::warn!(
+                    socket = %socket_path.display(),
+                    "events daemon unreachable; dropping loss-tolerant events until it returns"
+                );
+            }
+            tokio::time::sleep(FORWARDER_BACKOFF).await;
+        }
+    }
+}
+
+/// Try to deliver one framed append over the forwarder connection,
+/// (re)connecting at most once. Returns whether the daemon acknowledged.
+async fn deliver_batch(socket_path: &Path, conn: &mut Option<UnixStream>, payload: &[u8]) -> bool {
+    for _attempt in 0..2u8 {
+        if conn.is_none() {
+            match UnixStream::connect(socket_path).await {
+                Ok(stream) => *conn = Some(stream),
+                Err(_) => return false,
+            }
+        }
+        let stream = conn.as_mut().expect("connection populated above");
+        let ok = async {
+            write_frame(stream, payload).await?;
+            let bytes = read_frame(stream).await?;
+            std::io::Result::Ok(bytes)
+        }
+        .await;
+        match ok {
+            Ok(bytes) => {
+                return !matches!(
+                    serde_json::from_slice::<EventsResponse>(&bytes),
+                    Ok(EventsResponse::Error { .. }) | Err(_)
+                );
+            }
+            Err(_) => {
+                // Stale connection (daemon restarted): drop it and retry once
+                // with a fresh connect; a second failure is a real outage.
+                *conn = None;
+            }
+        }
+    }
+    false
+}
+
+// ---------------------------------------------------------------------------
+// The per-namespace EventStore handle
+// ---------------------------------------------------------------------------
+
+/// [`EventStore`] implementation the runtime hands out when the events split
+/// runs in daemon mode. Appends are fire-and-forget through the client's
+/// bounded queue; the ADR-133 idempotent lane and all reads are synchronous
+/// round-trips to the events daemon.
+#[derive(Debug)]
+pub struct ForwardingEventStore {
+    namespace: String,
+    client: Arc<EventsSplitClient>,
+}
+
+impl ForwardingEventStore {
+    pub fn new(namespace: impl Into<String>, client: Arc<EventsSplitClient>) -> Self {
+        Self {
+            namespace: namespace.into(),
+            client,
+        }
+    }
+
+    fn unexpected(&self, op: &'static str, response: EventsResponse) -> StorageError {
+        match response {
+            EventsResponse::Error { message, retryable } => {
+                if retryable {
+                    StorageError::Pool {
+                        operation: op.into(),
+                        message,
+                    }
+                } else {
+                    StorageError::InvalidInput {
+                        capability: khive_storage::StorageCapability::Events,
+                        operation: op.into(),
+                        message,
+                    }
+                }
+            }
+            other => StorageError::Serialization {
+                capability: khive_storage::StorageCapability::Events,
+                message: format!("events daemon returned mismatched response for {op}: {other:?}"),
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl EventStore for ForwardingEventStore {
+    async fn append_event(&self, event: Event) -> StorageResult<()> {
+        self.client.enqueue(&self.namespace, vec![event]);
+        Ok(())
+    }
+
+    async fn append_events(&self, events: Vec<Event>) -> StorageResult<BatchWriteSummary> {
+        let attempted = events.len() as u64;
+        self.client.enqueue(&self.namespace, events);
+        // Fire-and-forget: the hand-off succeeded or was counted as a drop;
+        // either way the caller's contract is "accepted for forwarding".
+        Ok(BatchWriteSummary {
+            attempted,
+            affected: attempted,
+            failed: 0,
+            first_error: String::new(),
+        })
+    }
+
+    async fn get_event(&self, id: Uuid) -> StorageResult<Option<Event>> {
+        let request = EventsRequest::GetEvent {
+            protocol_version: EVENTS_PROTOCOL_VERSION,
+            namespace: self.namespace.clone(),
+            id,
+        };
+        match self.client.round_trip(&request).await? {
+            EventsResponse::Event { event } => Ok(event),
+            other => Err(self.unexpected("get_event", other)),
+        }
+    }
+
+    async fn query_events(
+        &self,
+        filter: EventFilter,
+        page: PageRequest,
+    ) -> StorageResult<Page<Event>> {
+        let request = EventsRequest::QueryEvents {
+            protocol_version: EVENTS_PROTOCOL_VERSION,
+            namespace: self.namespace.clone(),
+            filter,
+            page,
+        };
+        match self.client.round_trip(&request).await? {
+            EventsResponse::Pageful { page } => Ok(page),
+            other => Err(self.unexpected("query_events", other)),
+        }
+    }
+
+    async fn count_events(&self, filter: EventFilter) -> StorageResult<u64> {
+        let request = EventsRequest::CountEvents {
+            protocol_version: EVENTS_PROTOCOL_VERSION,
+            namespace: self.namespace.clone(),
+            filter,
+        };
+        match self.client.round_trip(&request).await? {
+            EventsResponse::Count { count } => Ok(count),
+            other => Err(self.unexpected("count_events", other)),
+        }
+    }
+
+    fn preflight_event(&self, event: &Event) -> StorageResult<()> {
+        // Same validation code path as the daemon-side store, zero I/O.
+        self.client.preflight_store.preflight_event(event)
+    }
+
+    async fn append_events_idempotent(
+        &self,
+        events: Vec<Event>,
+    ) -> StorageResult<IdempotentEventBatchResult> {
+        let request = EventsRequest::AppendEventsIdempotent {
+            protocol_version: EVENTS_PROTOCOL_VERSION,
+            namespace: self.namespace.clone(),
+            events,
+        };
+        match self.client.round_trip(&request).await? {
+            EventsResponse::Idempotent { result } => Ok(result),
+            other => Err(self.unexpected("append_events_idempotent", other)),
+        }
+    }
+
+    fn supports_idempotent_audit_batch(&self) -> bool {
+        true
+    }
+}
+
+/// The store the runtime hands out when the events split is configured:
+/// routes by APPEND CLASS rather than moving the whole event plane.
+///
+/// - The ADR-133 idempotent audit-batch lane — the measured bulk of event
+///   write volume (verb-dispatch audit plus the config-lock rows that ride
+///   the same flusher) — goes to the events lane (`events.db`, forwarded or
+///   direct).
+/// - Plain appends stay on the legacy store, because the legacy `events`
+///   table has raw-SQL consumers whose correctness depends on finding those
+///   rows there: the schedule drain's creator-provenance fence, the kg
+///   projection worker's guarded event INSERT (transactional with main-db
+///   state), and GraphQuery's cross-substrate UNION. Those events are
+///   low-volume domain facts; the split's contention relief does not need
+///   them moved, and moving them breaks the consumers by construction.
+/// - Reads merge both stores so trait-level consumers
+///   (`brain.event_counts`, event getters) observe one event plane.
+pub struct SplitEventStore {
+    legacy: Arc<dyn EventStore>,
+    lane: Arc<dyn EventStore>,
+}
+
+impl std::fmt::Debug for SplitEventStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SplitEventStore").finish_non_exhaustive()
+    }
+}
+
+impl SplitEventStore {
+    pub fn new(legacy: Arc<dyn EventStore>, lane: Arc<dyn EventStore>) -> Self {
+        Self { legacy, lane }
+    }
+}
+
+#[async_trait]
+impl EventStore for SplitEventStore {
+    async fn append_event(&self, event: Event) -> StorageResult<()> {
+        self.legacy.append_event(event).await
+    }
+
+    async fn append_events(&self, events: Vec<Event>) -> StorageResult<BatchWriteSummary> {
+        self.legacy.append_events(events).await
+    }
+
+    async fn get_event(&self, id: Uuid) -> StorageResult<Option<Event>> {
+        // Domain events (legacy) are the likelier and cheaper hit; fall back
+        // to the lane for audit-batch rows.
+        if let Some(event) = self.legacy.get_event(id).await? {
+            return Ok(Some(event));
+        }
+        self.lane.get_event(id).await
+    }
+
+    async fn query_events(
+        &self,
+        filter: EventFilter,
+        page: PageRequest,
+    ) -> StorageResult<Page<Event>> {
+        // Offset pagination cannot be split across two stores: fetch each
+        // store's prefix covering the requested window, merge in the stores'
+        // shared order (created_at DESC, id DESC), then window in memory.
+        let prefix = PageRequest {
+            offset: 0,
+            limit: page
+                .offset
+                .saturating_add(u64::from(page.limit))
+                .min(u64::from(u32::MAX)) as u32,
+        };
+        let legacy = self
+            .legacy
+            .query_events(filter.clone(), prefix.clone())
+            .await?;
+        let lane = self.lane.query_events(filter, prefix).await?;
+        let total = match (legacy.total, lane.total) {
+            (Some(a), Some(b)) => Some(a + b),
+            _ => None,
+        };
+        let mut items = legacy.items;
+        items.extend(lane.items);
+        items.sort_by(|a, b| {
+            b.created_at
+                .cmp(&a.created_at)
+                .then_with(|| b.id.cmp(&a.id))
+        });
+        let items = items
+            .into_iter()
+            .skip(page.offset as usize)
+            .take(page.limit as usize)
+            .collect();
+        Ok(Page { items, total })
+    }
+
+    async fn count_events(&self, filter: EventFilter) -> StorageResult<u64> {
+        let legacy = self.legacy.count_events(filter.clone()).await?;
+        let lane = self.lane.count_events(filter).await?;
+        Ok(legacy + lane)
+    }
+
+    fn preflight_event(&self, event: &Event) -> StorageResult<()> {
+        // Validation is store-independent; the lane's implementation is the
+        // local zero-I/O validator in forwarding mode.
+        self.lane.preflight_event(event)
+    }
+
+    async fn append_events_idempotent(
+        &self,
+        events: Vec<Event>,
+    ) -> StorageResult<IdempotentEventBatchResult> {
+        self.lane.append_events_idempotent(events).await
+    }
+
+    fn supports_idempotent_audit_batch(&self) -> bool {
+        self.lane.supports_idempotent_audit_batch()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use khive_storage::event::EventAppendDisposition;
+    use khive_types::{EventKind, SubstrateKind};
+
+    fn test_event(namespace: &str) -> Event {
+        Event::new(
+            namespace,
+            "test.verb",
+            EventKind::Audit,
+            SubstrateKind::Event,
+            "actor:test",
+        )
+    }
+
+    /// Boot a real events daemon on temp paths, poll until its socket accepts.
+    async fn boot_daemon(dir: &tempfile::TempDir) -> (PathBuf, PathBuf) {
+        let db = dir.path().join("events.db");
+        let socket = dir.path().join("events.sock");
+        let (db_clone, socket_clone) = (db.clone(), socket.clone());
+        tokio::spawn(async move {
+            let _ = run_events_daemon(&db_clone, &socket_clone).await;
+        });
+        for _ in 0..100 {
+            if UnixStream::connect(&socket).await.is_ok() {
+                return (db, socket);
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        panic!("events daemon did not come up on {}", socket.display());
+    }
+
+    /// The split store's routing contract: plain appends land ONLY in the
+    /// legacy store (whose raw-SQL consumers depend on finding them there),
+    /// the idempotent audit lane lands ONLY in the events lane, and reads
+    /// merge both sides into one event plane.
+    #[tokio::test]
+    async fn split_store_routes_plain_to_legacy_idempotent_to_lane_and_merges_reads() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let legacy_backend =
+            direct_backend_for(&dir.path().join("legacy.db")).expect("legacy backend");
+        let lane_backend = direct_backend_for(&dir.path().join("lane.db")).expect("lane backend");
+        let legacy = legacy_backend
+            .events_for_namespace("local")
+            .expect("legacy store");
+        let lane = lane_backend
+            .events_for_namespace("local")
+            .expect("lane store");
+        let split = SplitEventStore::new(Arc::clone(&legacy), Arc::clone(&lane));
+
+        let plain = test_event("local");
+        let plain_id = plain.id;
+        split.append_event(plain).await.expect("plain append");
+
+        let audit = test_event("local");
+        let audit_id = audit.id;
+        let result = split
+            .append_events_idempotent(vec![audit])
+            .await
+            .expect("idempotent append");
+        assert_eq!(result.rows, vec![EventAppendDisposition::Inserted]);
+
+        // Routing: each row is in exactly its own side.
+        assert!(legacy
+            .get_event(plain_id)
+            .await
+            .expect("legacy get")
+            .is_some());
+        assert!(lane.get_event(plain_id).await.expect("lane get").is_none());
+        assert!(legacy
+            .get_event(audit_id)
+            .await
+            .expect("legacy get")
+            .is_none());
+        assert!(lane.get_event(audit_id).await.expect("lane get").is_some());
+
+        // Merged reads observe one event plane whichever side holds the row.
+        assert!(split
+            .get_event(plain_id)
+            .await
+            .expect("split get")
+            .is_some());
+        assert!(split
+            .get_event(audit_id)
+            .await
+            .expect("split get")
+            .is_some());
+        assert_eq!(
+            split
+                .count_events(EventFilter::default())
+                .await
+                .expect("split count"),
+            2
+        );
+        let page = split
+            .query_events(
+                EventFilter::default(),
+                PageRequest {
+                    offset: 0,
+                    limit: 10,
+                },
+            )
+            .await
+            .expect("split query");
+        let ids: Vec<Uuid> = page.items.iter().map(|e| e.id).collect();
+        assert!(ids.contains(&plain_id) && ids.contains(&audit_id));
+
+        // Windowing across the merge: page size 1 at offsets 0 and 1 yields
+        // the two rows exactly once each.
+        let mut seen = Vec::new();
+        for offset in 0..2 {
+            let page = split
+                .query_events(EventFilter::default(), PageRequest { offset, limit: 1 })
+                .await
+                .expect("windowed query");
+            assert_eq!(page.items.len(), 1);
+            seen.push(page.items[0].id);
+        }
+        seen.sort();
+        let mut expected = vec![plain_id, audit_id];
+        expected.sort();
+        assert_eq!(seen, expected);
+    }
+
+    /// End to end over the real socket: the idempotent lane returns true
+    /// dispositions, and the row is readable back through the same store.
+    #[tokio::test]
+    async fn idempotent_append_round_trips_through_the_daemon() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (_db, socket) = boot_daemon(&dir).await;
+        let client = EventsSplitClient::new(socket).expect("client");
+        let store = ForwardingEventStore::new("local", client);
+
+        let event = test_event("local");
+        let id = event.id;
+        let result = store
+            .append_events_idempotent(vec![event.clone()])
+            .await
+            .expect("idempotent append over socket");
+        assert_eq!(result.rows, vec![EventAppendDisposition::Inserted]);
+
+        // Retry of the identical row reports AlreadyPresentIdentical — the
+        // daemon ran the real idempotent path, not a blind re-insert.
+        let retry = store
+            .append_events_idempotent(vec![event])
+            .await
+            .expect("idempotent retry");
+        assert_eq!(
+            retry.rows,
+            vec![EventAppendDisposition::AlreadyPresentIdentical]
+        );
+
+        let fetched = store.get_event(id).await.expect("get over socket");
+        assert_eq!(fetched.map(|e| e.id), Some(id));
+        let count = store
+            .count_events(EventFilter::default())
+            .await
+            .expect("count over socket");
+        assert_eq!(count, 1);
+    }
+
+    /// The fire-and-forget lane delivers to the daemon store: enqueue returns
+    /// immediately and the row becomes visible to a subsequent count.
+    #[tokio::test]
+    async fn fire_and_forget_append_lands_in_the_daemon_store() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (_db, socket) = boot_daemon(&dir).await;
+        let client = EventsSplitClient::new(socket).expect("client");
+        let store = ForwardingEventStore::new("local", Arc::clone(&client));
+
+        store
+            .append_event(test_event("local"))
+            .await
+            .expect("append_event is fire-and-forget");
+
+        // Poll for BOTH effects: the row landing daemon-side and the
+        // forwarder's own counter — the row can be visible a beat before the
+        // forwarder task is rescheduled to record the delivery.
+        let mut count = 0;
+        let mut metrics = client.metrics();
+        for _ in 0..100 {
+            count = store
+                .count_events(EventFilter::default())
+                .await
+                .expect("count over socket");
+            metrics = client.metrics();
+            if count == 1 && metrics.forwarded_events >= 1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert_eq!(count, 1, "forwarded event must land in the daemon store");
+        assert_eq!(metrics.dropped_events, 0);
+        assert!(metrics.forwarded_events >= 1, "delivery must be counted");
+    }
+
+    /// R4 overflow arm: with the daemon dead, appends beyond the queue bound
+    /// are DROPPED and counted while every append still returns Ok — the
+    /// domain path proceeds. The drop counter is the loss-tolerance contract.
+    #[tokio::test]
+    async fn queue_overflow_drops_and_counts_but_never_errors() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dead_socket = dir.path().join("nobody-home.sock");
+        let client = EventsSplitClient::new_with_queue_depth(dead_socket, 2).expect("client");
+        let store = ForwardingEventStore::new("local", Arc::clone(&client));
+
+        for _ in 0..20 {
+            store
+                .append_event(test_event("local"))
+                .await
+                .expect("append_event must not error under overflow");
+        }
+        let metrics = client.metrics();
+        assert!(
+            metrics.dropped_events > 0,
+            "overflow must register in the drop counter, got {metrics:?}"
+        );
+    }
+
+    /// R4 dead-socket arm: synchronous lanes fail with a typed retryable
+    /// storage error (never hang, never a generic panic), and the offline
+    /// preflight validator keeps working with zero I/O.
+    #[tokio::test]
+    async fn dead_socket_reads_fail_typed_and_preflight_stays_local() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dead_socket = dir.path().join("nobody-home.sock");
+        let client = EventsSplitClient::new(dead_socket).expect("client");
+        let store = ForwardingEventStore::new("local", client);
+
+        let error = store
+            .get_event(Uuid::new_v4())
+            .await
+            .expect_err("read against a dead socket must fail");
+        assert!(
+            matches!(error, StorageError::Pool { .. }),
+            "expected the typed unreachable error, got {error:?}"
+        );
+
+        // The audit-batch seam contract: preflight is local and functional
+        // with the daemon down.
+        assert!(store.supports_idempotent_audit_batch());
+        store
+            .preflight_event(&test_event("local"))
+            .expect("offline preflight validates a well-formed event");
+    }
+
+    /// Version-skew arm: a frame carrying an unknown protocol version gets a
+    /// typed non-retryable refusal, not a deserialization failure.
+    #[tokio::test]
+    async fn protocol_version_skew_is_a_typed_refusal() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (_db, socket) = boot_daemon(&dir).await;
+
+        let mut stream = UnixStream::connect(&socket).await.expect("connect");
+        let request = EventsRequest::CountEvents {
+            protocol_version: EVENTS_PROTOCOL_VERSION + 1,
+            namespace: "local".into(),
+            filter: EventFilter::default(),
+        };
+        let payload = serde_json::to_vec(&request).expect("serialize");
+        write_frame(&mut stream, &payload).await.expect("write");
+        let bytes = read_frame(&mut stream).await.expect("read");
+        let response: EventsResponse = serde_json::from_slice(&bytes).expect("parse");
+        match response {
+            EventsResponse::Error { message, retryable } => {
+                assert!(!retryable, "version skew is not retryable");
+                assert!(message.contains("protocol version"), "message: {message}");
+            }
+            other => panic!("expected a typed refusal, got {other:?}"),
+        }
+    }
+
+    /// The per-socket daemon guard is exclusive while held and reusable after
+    /// release — the mechanism that keeps a supervisor respawn race down to
+    /// one surviving daemon.
+    #[test]
+    fn events_daemon_guard_is_exclusive_then_reusable() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let socket = dir.path().join("events.sock");
+        let first = try_acquire_events_daemon_guard(&socket).expect("first acquire");
+        assert!(
+            try_acquire_events_daemon_guard(&socket).is_none(),
+            "second acquire must fail while the first guard is held"
+        );
+        drop(first);
+        assert!(
+            try_acquire_events_daemon_guard(&socket).is_some(),
+            "acquire must succeed again after the guard is released"
+        );
+    }
+
+    /// Embedded (direct) mode: the process-global backend writes and reads
+    /// `events.db` without any daemon.
+    #[tokio::test]
+    async fn direct_mode_appends_and_reads_without_a_daemon() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = dir.path().join("events.db");
+        let backend = direct_backend_for(&db).expect("direct backend");
+        let store = backend.events_for_namespace("local").expect("store");
+        store
+            .append_event(test_event("local"))
+            .await
+            .expect("direct append");
+        let count = store
+            .count_events(EventFilter::default())
+            .await
+            .expect("count");
+        assert_eq!(count, 1);
+    }
+}

--- a/crates/khive-runtime/src/events_split.rs
+++ b/crates/khive-runtime/src/events_split.rs
@@ -3,8 +3,8 @@
 //! The ADR-133 idempotent audit batch is the measured bulk of event write
 //! volume, and in a single-store deployment its rows queue on the same SQLite
 //! writer lane as domain mutations. This module moves that lane into a
-//! dedicated events daemon that owns `events.db`, reachable over a Unix
-//! socket with the same length-prefixed framing and peer-uid admission the
+//! dedicated events daemon that owns the events database, reachable over a
+//! Unix socket with the same length-prefixed framing and peer-uid admission the
 //! main daemon socket uses. Plain event appends stay on the domain store —
 //! the legacy `events` table has raw-SQL consumers (schedule provenance, kg
 //! projection guards, graph-query substrate unions) whose correctness
@@ -13,8 +13,8 @@
 //! Cooperating pieces:
 //!
 //! - [`run_events_daemon`] — the server loop the `events-daemon` subcommand
-//!   runs: binds the events socket, owns the only resident writer of
-//!   `events.db`, and serves append/read requests through the ordinary
+//!   runs: binds the events socket, owns the only resident writer of the
+//!   events database, and serves append/read requests through the ordinary
 //!   `SqlEventStore`.
 //! - [`EventsSplitClient`] — one per domain process. Plain appends ride a
 //!   bounded in-memory queue drained by a background forwarder
@@ -38,8 +38,10 @@
 //! synchronous lanes) instead of blocking the caller.
 
 use std::path::{Path, PathBuf};
+#[cfg(unix)]
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
+#[cfg(unix)]
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -51,9 +53,11 @@ use khive_storage::{
 };
 use serde::{Deserialize, Serialize};
 
+#[cfg(unix)]
 use tokio::net::{UnixListener, UnixStream};
 use uuid::Uuid;
 
+#[cfg(unix)]
 use crate::daemon::{read_frame, write_frame};
 
 /// Bump whenever the request or response frame shape changes incompatibly.
@@ -64,34 +68,49 @@ pub const EVENTS_PROTOCOL_VERSION: u32 = 1;
 /// Default bound on the fire-and-forget append queue, in batches. The loss
 /// window on overflow is this depth times the batch size in flight; the value
 /// is deliberately generous because entries are pointers, not rows.
+#[cfg(unix)]
 pub const DEFAULT_APPEND_QUEUE_BATCHES: usize = 4096;
 
 /// Timeout for one synchronous round-trip (idempotent appends, reads).
+/// Covers the WHOLE attempt — connect, peer verification, write, read —
+/// because each round-trip owns its connection (no shared lock to wait on
+/// outside the clock).
+#[cfg(unix)]
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Reconnect backoff for the background forwarder after a failed connect.
+#[cfg(unix)]
 const FORWARDER_BACKOFF: Duration = Duration::from_secs(2);
 
 /// Default events database file, beside the main database file.
+///
+/// The name is derived from the main database's file stem (`khive.db` →
+/// `khive.events.db`), never a fixed name in the parent directory: two
+/// independent databases that happen to share a directory (`a.db`, `b.db`)
+/// must each get their own event plane, not silently share one.
 pub fn events_db_path_beside(main_db: &Path) -> PathBuf {
-    main_db
-        .parent()
-        .map(|dir| dir.join("events.db"))
-        .unwrap_or_else(|| PathBuf::from("events.db"))
+    let mut name = main_db
+        .file_stem()
+        .map(std::ffi::OsStr::to_os_string)
+        .unwrap_or_else(|| std::ffi::OsString::from("khive"));
+    name.push(".events.db");
+    match main_db.parent() {
+        Some(dir) => dir.join(&name),
+        None => PathBuf::from(name),
+    }
 }
 
 /// Events daemon socket path, beside the events database it serves.
 ///
-/// Derived from the db path (not a process-global location) so every events
-/// database gets its own daemon and socket: a global socket would route
-/// events from any second database (another seat, a test tempdir) to
-/// whichever daemon happens to own it, persisting them beside the wrong
-/// main store.
+/// Derived from the events db path (not a process-global location, not a
+/// fixed name in the parent directory) so every events database gets its own
+/// daemon and socket: a shared socket would route events from any second
+/// database (another seat, a test tempdir) to whichever daemon happens to
+/// own it, persisting them beside the wrong main store. `khive.events.db`
+/// yields `khive.events.sock`; the daemon's advisory lock is the same path
+/// with a `.lock` extension.
 pub fn events_socket_path_beside(events_db: &Path) -> PathBuf {
-    events_db
-        .parent()
-        .map(|dir| dir.join("khive-events.sock"))
-        .unwrap_or_else(|| PathBuf::from("khive-events.sock"))
+    events_db.with_extension("sock")
 }
 
 /// How a runtime reaches event storage when the split is configured.
@@ -115,9 +134,14 @@ pub struct EventsSplitConfig {
 // process-global state. Keyed by path so tests exercising two distinct paths
 // in one process stay isolated.
 
+#[cfg(unix)]
 type ClientMap = std::collections::HashMap<PathBuf, Arc<EventsSplitClient>>;
-type BackendMap = std::collections::HashMap<PathBuf, Arc<StorageBackend>>;
+/// Keyed by (path, read_only): a read-only open and a writable open of the
+/// same file are different pools with different guarantees and must never be
+/// handed out interchangeably.
+type BackendMap = std::collections::HashMap<(PathBuf, bool), Arc<StorageBackend>>;
 
+#[cfg(unix)]
 fn client_registry() -> &'static std::sync::Mutex<ClientMap> {
     static REGISTRY: std::sync::OnceLock<std::sync::Mutex<ClientMap>> = std::sync::OnceLock::new();
     REGISTRY.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
@@ -130,6 +154,7 @@ fn direct_backend_registry() -> &'static std::sync::Mutex<BackendMap> {
 
 /// The process-wide client for `socket_path`, created (and its forwarder
 /// spawned) on first use. Requires a tokio runtime context on first call.
+#[cfg(unix)]
 pub fn client_for(socket_path: &Path) -> crate::error::RuntimeResult<Arc<EventsSplitClient>> {
     let mut registry = client_registry()
         .lock()
@@ -145,19 +170,42 @@ pub fn client_for(socket_path: &Path) -> crate::error::RuntimeResult<Arc<EventsS
 /// The process-wide direct (embedded-mode) backend for `db_path`, opened
 /// read-write on first use.
 pub fn direct_backend_for(db_path: &Path) -> crate::error::RuntimeResult<Arc<StorageBackend>> {
+    direct_backend(db_path, false)
+}
+
+/// The process-wide direct backend for `db_path`, opened READ-ONLY on first
+/// use. The file must already exist — this constructor never creates or
+/// schema-initializes an events database, which is what a read-only runtime's
+/// no-DB-creation contract requires of its event lane.
+pub fn direct_backend_read_only_for(
+    db_path: &Path,
+) -> crate::error::RuntimeResult<Arc<StorageBackend>> {
+    direct_backend(db_path, true)
+}
+
+fn direct_backend(
+    db_path: &Path,
+    read_only: bool,
+) -> crate::error::RuntimeResult<Arc<StorageBackend>> {
     let mut registry = direct_backend_registry()
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    if let Some(existing) = registry.get(db_path) {
+    let key = (db_path.to_path_buf(), read_only);
+    if let Some(existing) = registry.get(&key) {
         return Ok(Arc::clone(existing));
     }
-    let backend = Arc::new(StorageBackend::sqlite(db_path)?);
-    registry.insert(db_path.to_path_buf(), Arc::clone(&backend));
+    let backend = Arc::new(if read_only {
+        StorageBackend::sqlite_read_only(db_path)?
+    } else {
+        StorageBackend::sqlite(db_path)?
+    });
+    registry.insert(key, Arc::clone(&backend));
     Ok(backend)
 }
 
 /// Forwarding metrics for the process-wide client at `socket_path`, if one
 /// exists. `None` means the split never initialized in this process.
+#[cfg(unix)]
 pub fn forwarding_metrics(socket_path: &Path) -> Option<EventsForwardingMetrics> {
     let registry = client_registry()
         .lock()
@@ -271,12 +319,14 @@ pub enum EventsResponse {
 /// Advisory lock guaranteeing at most one events daemon per socket path.
 /// Held for the daemon's lifetime; a second daemon exits instead of stealing
 /// the socket path from the live one.
+#[cfg(unix)]
 pub struct EventsDaemonGuard {
     _file: std::fs::File,
 }
 
 /// Try to become the events daemon for `socket_path`. `None` = another
 /// events daemon already holds the lock.
+#[cfg(unix)]
 pub fn try_acquire_events_daemon_guard(socket_path: &Path) -> Option<EventsDaemonGuard> {
     let lock_path = socket_path.with_extension("lock");
     if let Some(parent) = lock_path.parent() {
@@ -306,12 +356,56 @@ pub fn try_acquire_events_daemon_guard(socket_path: &Path) -> Option<EventsDaemo
 /// re-invoked as `events-daemon --db <db> --socket <socket>` — the subcommand
 /// the kernel binary registers for [`run_events_daemon`]. The child holds the
 /// per-socket advisory lock, so a probe/spawn race resolves to one survivor.
+///
+/// Lifecycle: the loop observes the process-wide daemon shutdown token, so
+/// `drain()` never waits on it forever, and it retains the handle of the
+/// child it spawned — reaping it with `try_wait` on every probe (no zombie
+/// accumulation during a persistent startup failure) and never stacking a
+/// second spawn on a still-live child. On shutdown, a child this supervisor
+/// spawned is killed and reaped; a pre-existing events daemon it never
+/// spawned is left alone.
+///
+/// The reachability probe uses the peer-verified connect: a socket answered
+/// by a foreign-uid process is treated as UNREACHABLE (and logged loudly),
+/// so a pre-bound spoof socket triggers a real-daemon spawn instead of being
+/// reported healthy.
+#[cfg(unix)]
 pub async fn supervise_events_daemon(db_path: PathBuf, socket_path: PathBuf) {
     const PROBE_INTERVAL: Duration = Duration::from_secs(15);
+    let shutdown = crate::daemon::daemon_shutdown_token();
+    let mut child: Option<std::process::Child> = None;
     let mut respawns: u64 = 0;
     loop {
-        let reachable = UnixStream::connect(&socket_path).await.is_ok();
-        if !reachable {
+        // Reap first: a child that exited (crashed, lost the advisory lock
+        // race, refused an untrusted directory) must not linger as a zombie,
+        // and clearing the slot is what re-arms the spawn below.
+        if let Some(c) = child.as_mut() {
+            match c.try_wait() {
+                Ok(Some(status)) => {
+                    tracing::info!(%status, "events daemon child exited");
+                    child = None;
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    tracing::warn!(error = %error, "cannot poll events daemon child; dropping handle");
+                    child = None;
+                }
+            }
+        }
+
+        let reachable = match connect_verified(&socket_path).await {
+            Ok(_stream) => true,
+            Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => {
+                tracing::warn!(
+                    socket = %socket_path.display(),
+                    error = %error,
+                    "events socket answered by a foreign uid; treating as unreachable"
+                );
+                false
+            }
+            Err(_) => false,
+        };
+        if !reachable && child.is_none() {
             match std::env::current_exe() {
                 Ok(exe) => {
                     let spawned = std::process::Command::new(exe)
@@ -325,14 +419,15 @@ pub async fn supervise_events_daemon(db_path: PathBuf, socket_path: PathBuf) {
                         .stderr(std::process::Stdio::null())
                         .spawn();
                     match spawned {
-                        Ok(child) => {
+                        Ok(spawned_child) => {
                             respawns += 1;
                             tracing::info!(
-                                pid = child.id(),
+                                pid = spawned_child.id(),
                                 respawns,
                                 socket = %socket_path.display(),
                                 "spawned events daemon"
                             );
+                            child = Some(spawned_child);
                         }
                         Err(error) => {
                             tracing::warn!(error = %error, "failed to spawn events daemon");
@@ -344,7 +439,18 @@ pub async fn supervise_events_daemon(db_path: PathBuf, socket_path: PathBuf) {
                 }
             }
         }
-        tokio::time::sleep(PROBE_INTERVAL).await;
+        tokio::select! {
+            _ = shutdown.cancelled() => break,
+            _ = tokio::time::sleep(PROBE_INTERVAL) => {}
+        }
+    }
+    if let Some(mut c) = child.take() {
+        // Our child, our cleanup: the events daemon holds no volatile queue
+        // state (SQLite is the durability), and the next daemon host's
+        // supervisor respawns it.
+        let _ = c.kill();
+        let _ = c.wait();
+        tracing::info!("events daemon child stopped with supervisor shutdown");
     }
 }
 
@@ -356,6 +462,14 @@ pub async fn supervise_events_daemon(db_path: PathBuf, socket_path: PathBuf) {
 /// the peer disconnects. All storage goes through `SqlEventStore` on a
 /// backend opened read-write against `db_path`; the events schema is ensured
 /// once at boot.
+///
+/// Bind-path trust mirrors the main daemon socket: the socket directory must
+/// pass the same ownership/mode/swap-resistance validation, and the bound
+/// socket entry is chmod'd 0600 fail-closed. Pathname reachability is not
+/// identity — clients additionally verify the peer uid on every connect —
+/// but a hardened bind path is what keeps the *bind* itself out of another
+/// user's hands.
+#[cfg(unix)]
 pub async fn run_events_daemon(db_path: &Path, socket_path: &Path) -> anyhow::Result<()> {
     let Some(_guard) = try_acquire_events_daemon_guard(socket_path) else {
         tracing::info!(
@@ -368,13 +482,31 @@ pub async fn run_events_daemon(db_path: &Path, socket_path: &Path) -> anyhow::Re
     // Ensure the schema once, loudly, before accepting traffic.
     backend.events()?;
 
+    if let Some(parent) = socket_path.parent() {
+        std::fs::create_dir_all(parent)?;
+        crate::daemon::ensure_socket_dir_is_trusted(parent)?;
+    }
     if socket_path.exists() {
         std::fs::remove_file(socket_path)?;
     }
-    if let Some(parent) = socket_path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
     let listener = UnixListener::bind(socket_path)?;
+    {
+        use std::os::unix::fs::PermissionsExt;
+        // Fail closed, same contract as the main daemon socket: if the entry
+        // cannot be made owner-only, drop the listener and remove it rather
+        // than serve a world-reachable socket the design never covered.
+        if let Err(e) =
+            std::fs::set_permissions(socket_path, std::fs::Permissions::from_mode(0o600))
+        {
+            drop(listener);
+            let _ = std::fs::remove_file(socket_path);
+            anyhow::bail!(
+                "refusing to serve events: cannot chmod 0600 {}: {e}. The events socket must \
+                 be owner-only.",
+                socket_path.display()
+            );
+        }
+    }
     let daemon_euid = unsafe { libc::geteuid() };
     tracing::info!(
         socket = %socket_path.display(),
@@ -408,6 +540,7 @@ pub async fn run_events_daemon(db_path: &Path, socket_path: &Path) -> anyhow::Re
     }
 }
 
+#[cfg(unix)]
 async fn serve_events_conn(mut stream: UnixStream, backend: Arc<StorageBackend>) {
     loop {
         let payload = match read_frame(&mut stream).await {
@@ -435,6 +568,7 @@ async fn serve_events_conn(mut stream: UnixStream, backend: Arc<StorageBackend>)
     }
 }
 
+#[cfg(unix)]
 async fn dispatch_events_request(
     request: EventsRequest,
     backend: &StorageBackend,
@@ -486,6 +620,7 @@ async fn dispatch_events_request(
     }
 }
 
+#[cfg(unix)]
 fn storage_error_response(error: &StorageError) -> EventsResponse {
     EventsResponse::Error {
         message: error.to_string(),
@@ -502,9 +637,35 @@ fn storage_error_response(error: &StorageError) -> EventsResponse {
 // Client side
 // ---------------------------------------------------------------------------
 
+/// Connect to the events socket and verify who answered. Pathname
+/// reachability is not identity: any process that can write the directory can
+/// pre-bind the path. The kernel-reported peer uid is the one identity the
+/// far side cannot choose, so every client connect — round-trips, the
+/// forwarder, the supervisor probe — refuses a socket answered by a foreign
+/// uid before a single frame is written.
+#[cfg(unix)]
+async fn connect_verified(socket_path: &Path) -> std::io::Result<UnixStream> {
+    let stream = UnixStream::connect(socket_path).await?;
+    // SAFETY: `geteuid` is always successful and takes no arguments.
+    let own_euid = unsafe { libc::geteuid() } as u32;
+    let peer = crate::daemon::peer_uid(&stream)?;
+    if !crate::daemon::uid_is_permitted(peer, own_euid) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            format!(
+                "events socket {} answered by uid {peer}, not this process's uid {own_euid}; \
+                 refusing to exchange event frames with an unowned daemon",
+                socket_path.display()
+            ),
+        ));
+    }
+    Ok(stream)
+}
+
 /// Counters describing the fire-and-forget lane's degradation. Zero drops is
 /// the healthy state; any non-zero `dropped_batches` means the loss-tolerant
 /// contract was exercised and says so.
+#[cfg(unix)]
 #[derive(Debug, Clone, Copy, Serialize)]
 pub struct EventsForwardingMetrics {
     pub forwarded_batches: u64,
@@ -513,6 +674,7 @@ pub struct EventsForwardingMetrics {
     pub dropped_events: u64,
 }
 
+#[cfg(unix)]
 #[derive(Debug, Default)]
 struct ForwardingCounters {
     forwarded_batches: AtomicU64,
@@ -523,6 +685,12 @@ struct ForwardingCounters {
 
 /// One per domain process: the connection to the events daemon plus the
 /// bounded fire-and-forget append queue.
+///
+/// Synchronous round-trips each own a fresh connection: there is no shared
+/// request connection and no lock in front of one, so concurrent reads and
+/// audit flushes never queue behind a single stalled call, and the round-trip
+/// timeout bounds each caller's whole attempt.
+#[cfg(unix)]
 pub struct EventsSplitClient {
     socket_path: PathBuf,
     append_tx: tokio::sync::mpsc::Sender<(String, Vec<Event>)>,
@@ -530,12 +698,11 @@ pub struct EventsSplitClient {
     /// Flipped by the forwarder while the daemon is unreachable so the drop
     /// log fires once per outage, not once per batch.
     outage_logged: Arc<AtomicBool>,
-    /// Serializes synchronous round-trips over one persistent connection.
-    request_conn: tokio::sync::Mutex<Option<UnixStream>>,
     /// In-memory validator backing `preflight_event` without I/O.
     preflight_store: Arc<dyn EventStore>,
 }
 
+#[cfg(unix)]
 impl std::fmt::Debug for EventsSplitClient {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("EventsSplitClient")
@@ -544,6 +711,7 @@ impl std::fmt::Debug for EventsSplitClient {
     }
 }
 
+#[cfg(unix)]
 impl EventsSplitClient {
     /// Build the client and spawn its background forwarder.
     pub fn new(socket_path: PathBuf) -> crate::error::RuntimeResult<Arc<Self>> {
@@ -571,7 +739,6 @@ impl EventsSplitClient {
             append_tx,
             counters: Arc::clone(&counters),
             outage_logged: Arc::clone(&outage_logged),
-            request_conn: tokio::sync::Mutex::new(None),
             preflight_store,
         });
 
@@ -617,8 +784,10 @@ impl EventsSplitClient {
         }
     }
 
-    /// One synchronous framed round-trip with a bounded timeout, reusing (or
-    /// re-establishing) the persistent request connection.
+    /// One synchronous framed round-trip with a bounded timeout, on its own
+    /// fresh connection. No connection is shared between concurrent callers,
+    /// so no caller ever waits on another's stall, and `REQUEST_TIMEOUT`
+    /// bounds the whole attempt — connect, peer verification, write, read.
     async fn round_trip(&self, request: &EventsRequest) -> StorageResult<EventsResponse> {
         let op = "events daemon round-trip";
         let payload = serde_json::to_vec(request).map_err(|error| StorageError::Serialization {
@@ -626,21 +795,15 @@ impl EventsSplitClient {
             message: format!("events request serialization failed: {error}"),
         })?;
 
-        let mut guard = self.request_conn.lock().await;
         let attempt = async {
-            if guard.is_none() {
-                *guard = Some(UnixStream::connect(&self.socket_path).await?);
-            }
-            let stream = guard.as_mut().expect("connection populated above");
-            write_frame(stream, &payload).await?;
-            let bytes = read_frame(stream).await?;
+            let mut stream = connect_verified(&self.socket_path).await?;
+            write_frame(&mut stream, &payload).await?;
+            let bytes = read_frame(&mut stream).await?;
             std::io::Result::Ok(bytes)
         };
         let bytes = match tokio::time::timeout(REQUEST_TIMEOUT, attempt).await {
             Ok(Ok(bytes)) => bytes,
             Ok(Err(error)) => {
-                // Dead connection: forget it so the next call reconnects.
-                *guard = None;
                 return Err(StorageError::Pool {
                     operation: op.into(),
                     message: format!(
@@ -650,13 +813,11 @@ impl EventsSplitClient {
                 });
             }
             Err(_elapsed) => {
-                *guard = None;
                 return Err(StorageError::Timeout {
                     operation: op.into(),
                 });
             }
         };
-        drop(guard);
 
         serde_json::from_slice::<EventsResponse>(&bytes).map_err(|error| {
             StorageError::Serialization {
@@ -671,6 +832,7 @@ impl EventsSplitClient {
 /// framed appends on its own connection, reconnecting with backoff. A batch
 /// that cannot be delivered is dropped and counted — never retried, never
 /// blocking the queue behind it.
+#[cfg(unix)]
 async fn run_forwarder(
     socket_path: PathBuf,
     mut rx: tokio::sync::mpsc::Receiver<(String, Vec<Event>)>,
@@ -720,10 +882,13 @@ async fn run_forwarder(
 
 /// Try to deliver one framed append over the forwarder connection,
 /// (re)connecting at most once. Returns whether the daemon acknowledged.
+/// Connections are peer-verified: a socket answered by a foreign uid is a
+/// failed connect, never a delivery target.
+#[cfg(unix)]
 async fn deliver_batch(socket_path: &Path, conn: &mut Option<UnixStream>, payload: &[u8]) -> bool {
     for _attempt in 0..2u8 {
         if conn.is_none() {
-            match UnixStream::connect(socket_path).await {
+            match connect_verified(socket_path).await {
                 Ok(stream) => *conn = Some(stream),
                 Err(_) => return false,
             }
@@ -760,12 +925,14 @@ async fn deliver_batch(socket_path: &Path, conn: &mut Option<UnixStream>, payloa
 /// runs in daemon mode. Appends are fire-and-forget through the client's
 /// bounded queue; the ADR-133 idempotent lane and all reads are synchronous
 /// round-trips to the events daemon.
+#[cfg(unix)]
 #[derive(Debug)]
 pub struct ForwardingEventStore {
     namespace: String,
     client: Arc<EventsSplitClient>,
 }
 
+#[cfg(unix)]
 impl ForwardingEventStore {
     pub fn new(namespace: impl Into<String>, client: Arc<EventsSplitClient>) -> Self {
         Self {
@@ -798,6 +965,7 @@ impl ForwardingEventStore {
     }
 }
 
+#[cfg(unix)]
 #[async_trait]
 impl EventStore for ForwardingEventStore {
     async fn append_event(&self, event: Event) -> StorageResult<()> {
@@ -889,7 +1057,7 @@ impl EventStore for ForwardingEventStore {
 ///
 /// - The ADR-133 idempotent audit-batch lane — the measured bulk of event
 ///   write volume (verb-dispatch audit plus the config-lock rows that ride
-///   the same flusher) — goes to the events lane (`events.db`, forwarded or
+///   the same flusher) — goes to the events lane (the events database, forwarded or
 ///   direct).
 /// - Plain appends stay on the legacy store, because the legacy `events`
 ///   table has raw-SQL consumers whose correctness depends on finding those
@@ -1016,6 +1184,7 @@ mod tests {
     }
 
     /// Boot a real events daemon on temp paths, poll until its socket accepts.
+    #[cfg(unix)]
     async fn boot_daemon(dir: &tempfile::TempDir) -> (PathBuf, PathBuf) {
         let db = dir.path().join("events.db");
         let socket = dir.path().join("events.sock");
@@ -1205,6 +1374,7 @@ mod tests {
 
     /// End to end over the real socket: the idempotent lane returns true
     /// dispositions, and the row is readable back through the same store.
+    #[cfg(unix)]
     #[tokio::test]
     async fn idempotent_append_round_trips_through_the_daemon() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -1242,6 +1412,7 @@ mod tests {
 
     /// The fire-and-forget lane delivers to the daemon store: enqueue returns
     /// immediately and the row becomes visible to a subsequent count.
+    #[cfg(unix)]
     #[tokio::test]
     async fn fire_and_forget_append_lands_in_the_daemon_store() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -1278,6 +1449,7 @@ mod tests {
     /// R4 overflow arm: with the daemon dead, appends beyond the queue bound
     /// are DROPPED and counted while every append still returns Ok — the
     /// domain path proceeds. The drop counter is the loss-tolerance contract.
+    #[cfg(unix)]
     #[tokio::test]
     async fn queue_overflow_drops_and_counts_but_never_errors() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -1301,6 +1473,7 @@ mod tests {
     /// R4 dead-socket arm: synchronous lanes fail with a typed retryable
     /// storage error (never hang, never a generic panic), and the offline
     /// preflight validator keeps working with zero I/O.
+    #[cfg(unix)]
     #[tokio::test]
     async fn dead_socket_reads_fail_typed_and_preflight_stays_local() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -1327,6 +1500,7 @@ mod tests {
 
     /// Version-skew arm: a frame carrying an unknown protocol version gets a
     /// typed non-retryable refusal, not a deserialization failure.
+    #[cfg(unix)]
     #[tokio::test]
     async fn protocol_version_skew_is_a_typed_refusal() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -1354,6 +1528,7 @@ mod tests {
     /// The per-socket daemon guard is exclusive while held and reusable after
     /// release — the mechanism that keeps a supervisor respawn race down to
     /// one surviving daemon.
+    #[cfg(unix)]
     #[test]
     fn events_daemon_guard_is_exclusive_then_reusable() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -1368,6 +1543,130 @@ mod tests {
             try_acquire_events_daemon_guard(&socket).is_some(),
             "acquire must succeed again after the guard is released"
         );
+    }
+
+    /// Issue-8-class control: sidecar paths derive from the MAIN database's
+    /// own filename, so two independent databases sharing one directory get
+    /// disjoint event planes and sockets instead of silently cross-wiring.
+    #[test]
+    fn sidecar_paths_derive_from_the_main_db_name() {
+        let a = events_db_path_beside(Path::new("/tmp/a.db"));
+        let b = events_db_path_beside(Path::new("/tmp/b.db"));
+        assert_eq!(a, PathBuf::from("/tmp/a.events.db"));
+        assert_eq!(b, PathBuf::from("/tmp/b.events.db"));
+        assert_ne!(a, b, "independent databases must not share an events db");
+        let sock_a = events_socket_path_beside(&a);
+        let sock_b = events_socket_path_beside(&b);
+        assert_eq!(sock_a, PathBuf::from("/tmp/a.events.sock"));
+        assert_ne!(
+            sock_a, sock_b,
+            "independent databases must not share an events socket"
+        );
+    }
+
+    /// A read-only file-backed runtime with the split configured must never
+    /// create or schema-initialize an events database. Missing events db →
+    /// `events()` serves the legacy store alone and leaves the filesystem
+    /// untouched; a pre-existing events db (minted by an earlier writable
+    /// host) is opened read-only and its rows merge into reads.
+    /// (unix-gated for the sidecar-freeze harness step only.)
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn read_only_runtime_never_creates_an_events_db() {
+        use crate::{KhiveRuntime, Namespace, RuntimeConfig};
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let main_db = dir.path().join("main.db");
+        // Materialize + migrate the main database with a writable runtime.
+        drop(
+            KhiveRuntime::new(RuntimeConfig {
+                db_path: Some(main_db.clone()),
+                ..RuntimeConfig::no_embeddings()
+            })
+            .expect("create main db"),
+        );
+        let events_db = events_db_path_beside(&main_db);
+        assert!(!events_db.exists(), "precondition: no events db yet");
+
+        // Freeze the WAL sidecars the writable runtime left behind — the
+        // read-only opener refuses a snapshot with a writable -shm.
+        {
+            use std::os::unix::fs::PermissionsExt;
+            for suffix in ["-wal", "-shm"] {
+                let mut name = main_db.file_name().expect("db file name").to_os_string();
+                name.push(suffix);
+                let sidecar = main_db.parent().expect("db parent dir").join(name);
+                if sidecar.exists() {
+                    let mut permissions = std::fs::metadata(&sidecar)
+                        .expect("sidecar metadata")
+                        .permissions();
+                    permissions.set_mode(0o444);
+                    std::fs::set_permissions(&sidecar, permissions).expect("freeze sidecar");
+                }
+            }
+        }
+
+        let split_config = |db: PathBuf| RuntimeConfig {
+            db_path: Some(main_db.clone()),
+            events_split: Some(EventsSplitConfig {
+                db_path: db,
+                socket_path: None,
+            }),
+            ..RuntimeConfig::no_embeddings()
+        };
+
+        // Arm 1: read-only runtime, no events db on disk. Reads work through
+        // the legacy store and nothing is minted.
+        let ro =
+            KhiveRuntime::new_readonly(split_config(events_db.clone())).expect("read-only runtime");
+        let token = ro.authorize(Namespace::local()).expect("token");
+        let store = ro.events(&token).expect("events store");
+        let count = store
+            .count_events(EventFilter::default())
+            .await
+            .expect("count through legacy-only plane");
+        assert_eq!(count, 0);
+        assert!(
+            !events_db.exists(),
+            "a read-only runtime must not mint the events database"
+        );
+
+        // Arm 2: a writable host mints the events db and lands a lane row;
+        // the read-only runtime then opens it read-only and merges the row.
+        // The writer is scoped (not the process-global registry) and its WAL
+        // sidecars frozen after drop — the read-only opener rightly refuses a
+        // snapshot with a live writer, and that refusal is not this test's
+        // subject.
+        {
+            let lane_backend = StorageBackend::sqlite(&events_db).expect("writable lane");
+            lane_backend
+                .events_for_namespace("local")
+                .expect("lane store")
+                .append_event(test_event("local"))
+                .await
+                .expect("seed lane row");
+        }
+        {
+            use std::os::unix::fs::PermissionsExt;
+            for suffix in ["-wal", "-shm"] {
+                let mut name = events_db.file_name().expect("db file name").to_os_string();
+                name.push(suffix);
+                let sidecar = events_db.parent().expect("db parent dir").join(name);
+                if sidecar.exists() {
+                    let mut permissions = std::fs::metadata(&sidecar)
+                        .expect("sidecar metadata")
+                        .permissions();
+                    permissions.set_mode(0o444);
+                    std::fs::set_permissions(&sidecar, permissions).expect("freeze sidecar");
+                }
+            }
+        }
+        let store = ro.events(&token).expect("events store with lane present");
+        let count = store
+            .count_events(EventFilter::default())
+            .await
+            .expect("merged count");
+        assert_eq!(count, 1, "the pre-existing lane row must merge into reads");
     }
 
     /// Embedded (direct) mode: the process-global backend writes and reads

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -20,6 +20,7 @@ pub mod daemon;
 pub mod embedder_registry;
 pub mod engine_config;
 pub mod error;
+pub mod events_split;
 pub mod fusion;
 pub mod graph_traversal;
 mod note_store_guard;

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -622,7 +622,7 @@ impl KhiveRuntime {
     ///
     /// When the events-daemon split (ADR-170) is configured, the store routes
     /// by append class: the ADR-133 idempotent audit-batch lane — the
-    /// measured bulk of event write volume — persists to `events.db`
+    /// measured bulk of event write volume — persists to the events database
     /// (forwarded over the events daemon socket in daemon deployments, or
     /// opened directly in embedded/one-shot contexts), while plain appends
     /// stay on this runtime's backend, keeping every raw-SQL consumer of the
@@ -638,12 +638,33 @@ impl KhiveRuntime {
             None => Ok(legacy),
             Some(split) => {
                 let lane: Arc<dyn EventStore> = match &split.socket_path {
+                    #[cfg(unix)]
                     Some(socket) => {
                         let client = crate::events_split::client_for(socket)?;
                         Arc::new(crate::events_split::ForwardingEventStore::new(
                             token.namespace().as_str(),
                             client,
                         ))
+                    }
+                    #[cfg(not(unix))]
+                    Some(_socket) => {
+                        return Err(RuntimeError::InvalidInput(
+                            "events-daemon socket forwarding requires a Unix platform; \
+                             configure the events split in direct mode here"
+                                .to_string(),
+                        ));
+                    }
+                    None if self.backend.is_read_only() => {
+                        // A read-only runtime must not create or
+                        // schema-initialize an events database. No events.db
+                        // on disk means no lane rows exist — serve the legacy
+                        // store alone rather than minting the file to read
+                        // nothing from it.
+                        if !split.db_path.exists() {
+                            return Ok(legacy);
+                        }
+                        crate::events_split::direct_backend_read_only_for(&split.db_path)?
+                            .events_for_namespace(token.namespace().as_str())?
                     }
                     None => crate::events_split::direct_backend_for(&split.db_path)?
                         .events_for_namespace(token.namespace().as_str())?,

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -619,10 +619,40 @@ impl KhiveRuntime {
     }
 
     /// Get an EventStore scoped to the token's namespace.
+    ///
+    /// When the events-daemon split (ADR-170) is configured, the store routes
+    /// by append class: the ADR-133 idempotent audit-batch lane — the
+    /// measured bulk of event write volume — persists to `events.db`
+    /// (forwarded over the events daemon socket in daemon deployments, or
+    /// opened directly in embedded/one-shot contexts), while plain appends
+    /// stay on this runtime's backend, keeping every raw-SQL consumer of the
+    /// legacy `events` table (schedule provenance, kg projection guards,
+    /// GraphQuery's substrate union) correct by construction. Reads merge
+    /// both stores. Unconfigured runtimes (tests, in-memory) keep the legacy
+    /// main-store behavior.
     pub fn events(&self, token: &NamespaceToken) -> RuntimeResult<Arc<dyn EventStore>> {
-        Ok(self
+        let legacy = self
             .backend
-            .events_for_namespace(token.namespace().as_str())?)
+            .events_for_namespace(token.namespace().as_str())?;
+        match &self.config.events_split {
+            None => Ok(legacy),
+            Some(split) => {
+                let lane: Arc<dyn EventStore> = match &split.socket_path {
+                    Some(socket) => {
+                        let client = crate::events_split::client_for(socket)?;
+                        Arc::new(crate::events_split::ForwardingEventStore::new(
+                            token.namespace().as_str(),
+                            client,
+                        ))
+                    }
+                    None => crate::events_split::direct_backend_for(&split.db_path)?
+                        .events_for_namespace(token.namespace().as_str())?,
+                };
+                Ok(Arc::new(crate::events_split::SplitEventStore::new(
+                    legacy, lane,
+                )))
+            }
+        }
     }
 
     /// Get the raw SQL access capability (for ad-hoc queries).
@@ -1787,6 +1817,7 @@ mod tests {
         let config = RuntimeConfig {
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
+            events_split: None,
             db_path: Some(path),
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -1813,6 +1844,7 @@ mod tests {
         let config = RuntimeConfig {
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
+            events_split: None,
             db_path: None,
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -1837,6 +1869,7 @@ mod tests {
         let config = RuntimeConfig {
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
+            events_split: None,
             db_path: Some(path.clone()),
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::parse("test").unwrap(),
@@ -1865,6 +1898,7 @@ mod tests {
         let base = RuntimeConfig {
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
+            events_split: None,
             db_path: Some(path.clone()),
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -1935,6 +1969,7 @@ mod tests {
         let config = RuntimeConfig {
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
+            events_split: None,
             db_path: Some(path.clone()),
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -2018,6 +2053,7 @@ mod tests {
             let make_config = |db_path: std::path::PathBuf| RuntimeConfig {
                 git_write: Default::default(),
                 display_timezone: chrono_tz::Tz::UTC,
+                events_split: None,
                 db_path: Some(db_path),
                 blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
                 default_namespace: Namespace::local(),
@@ -2065,6 +2101,7 @@ mod tests {
         let config = RuntimeConfig {
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
+            events_split: None,
             db_path: None,
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -2232,6 +2269,7 @@ mod tests {
         let base = RuntimeConfig {
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
+            events_split: None,
             db_path: None,
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -2259,6 +2297,7 @@ mod tests {
         let base = RuntimeConfig {
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
+            events_split: None,
             db_path: None,
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::parse("lambda:base").unwrap(),
@@ -2294,6 +2333,7 @@ mod tests {
         let base = RuntimeConfig {
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
+            events_split: None,
             db_path: None,
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::parse("lambda:base").unwrap(),
@@ -2321,6 +2361,7 @@ mod tests {
         let base = RuntimeConfig {
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
+            events_split: None,
             db_path: None,
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -2366,6 +2407,7 @@ mod tests {
         let base = RuntimeConfig {
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
+            events_split: None,
             db_path: None,
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -2398,6 +2440,7 @@ mod tests {
         let base = RuntimeConfig {
             git_write: Default::default(),
             display_timezone: "Asia/Tokyo".parse().unwrap(),
+            events_split: None,
             db_path: None,
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -2544,6 +2587,7 @@ mod tests {
         RuntimeConfig {
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
+            events_split: None,
             db_path: None,
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -2623,6 +2667,7 @@ mod tests {
         let main_config = RuntimeConfig {
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
+            events_split: None,
             db_path: None,
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -2762,6 +2807,7 @@ mod tests {
             RuntimeConfig {
                 git_write: Default::default(),
                 display_timezone: chrono_tz::Tz::UTC,
+                events_split: None,
                 db_path: None,
                 blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
                 default_namespace: Namespace::local(),

--- a/crates/khive-runtime/tests/adr133_audit_batch.rs
+++ b/crates/khive-runtime/tests/adr133_audit_batch.rs
@@ -29,6 +29,10 @@ use serial_test::serial;
 
 struct FakeStore {
     fail_next: AtomicUsize,
+    /// Armed N times: the next N `append_events_idempotent` calls fail with
+    /// `StorageError::Pool` — the shape the ADR-170 forwarding lane reports
+    /// for an unreachable events daemon.
+    fail_pool_next: AtomicUsize,
     calls: AtomicU64,
     rows: Mutex<Vec<Event>>,
     /// Armed once: the next `append_events_idempotent` call commits its rows
@@ -42,6 +46,7 @@ impl FakeStore {
     fn new() -> Arc<Self> {
         Arc::new(Self {
             fail_next: AtomicUsize::new(0),
+            fail_pool_next: AtomicUsize::new(0),
             calls: AtomicU64::new(0),
             rows: Mutex::new(Vec::new()),
             ambiguous_ack_once: std::sync::atomic::AtomicBool::new(false),
@@ -98,6 +103,13 @@ impl EventStore for FakeStore {
         if self.fail_next.load(Ordering::SeqCst) > 0 {
             self.fail_next.fetch_sub(1, Ordering::SeqCst);
             return Err(StorageError::WriterTaskBusy { timeout_ms: 1 });
+        }
+        if self.fail_pool_next.load(Ordering::SeqCst) > 0 {
+            self.fail_pool_next.fetch_sub(1, Ordering::SeqCst);
+            return Err(StorageError::Pool {
+                operation: "append_events_idempotent".into(),
+                message: "events daemon unreachable (simulated transient outage)".into(),
+            });
         }
         let ambiguous = self
             .ambiguous_ack_once
@@ -301,6 +313,29 @@ async fn d1_retry_table_uses_typed_request_state() {
         store.calls.load(Ordering::SeqCst),
         2,
         "one failure then one successful retry"
+    );
+}
+
+/// A transient forwarding failure (`StorageError::Pool`, the shape the
+/// ADR-170 events-daemon lane reports while the daemon restarts) must use the
+/// configured bounded retries, not abandon the generation on first failure.
+#[serial]
+#[tokio::test]
+async fn d1_transient_forwarding_failure_is_retried_not_terminal() {
+    let store = FakeStore::new();
+    store.fail_pool_next.store(1, Ordering::SeqCst);
+    let batch = AuditBatch::new(store.clone(), AuditBatchConfig::default());
+    let outcome = batch
+        .submit(PreparedAuditRow {
+            event: mk_event("kg.create"),
+            producer: AuditProducer::DispatchSucceeded,
+        })
+        .await;
+    assert_eq!(outcome, Ok(AuditCommitOutcome::Committed));
+    assert_eq!(
+        store.calls.load(Ordering::SeqCst),
+        2,
+        "one transient Pool failure then one successful retry"
     );
 }
 

--- a/crates/khive-runtime/tests/integration.rs
+++ b/crates/khive-runtime/tests/integration.rs
@@ -1940,6 +1940,7 @@ async fn file_backed_runtime_persists() {
         let config = RuntimeConfig {
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
+            events_split: None,
             db_path: Some(path.clone()),
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -1965,6 +1966,7 @@ async fn file_backed_runtime_persists() {
         let config = RuntimeConfig {
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
+            events_split: None,
             db_path: Some(path.clone()),
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -2588,6 +2590,7 @@ mod embedder_registry_tests {
         KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
+            events_split: None,
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -2742,6 +2745,7 @@ mod embedder_registry_tests {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
+            events_split: None,
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),

--- a/crates/kkernel/src/cli.rs
+++ b/crates/kkernel/src/cli.rs
@@ -93,6 +93,12 @@ enum Command {
     /// warm Unix-socket server; `--transport` selects a registered transport).
     Mcp(khive_mcp::args::Args),
 
+    /// Serve the dedicated events daemon (ADR-170): the resident writer of
+    /// `events.db`, receiving observational events over its own Unix socket
+    /// so telemetry never queues on the domain store's writer lane. Normally
+    /// spawned and supervised by `kkernel mcp --daemon`, not run by hand.
+    EventsDaemon(EventsDaemonArgs),
+
     /// Inspect registered backends.
     #[command(subcommand)]
     Backend(BackendCommand),
@@ -108,6 +114,21 @@ enum Command {
     /// Validate and ingest a `findings.json` audit sweep into the graph as
     /// `finding` notes (ADR-085 Amendment 3).
     CodeIngest(code_ingest::CodeIngestArgs),
+}
+
+/// Arguments for the dedicated events daemon (ADR-170).
+#[derive(clap::Parser, Debug)]
+struct EventsDaemonArgs {
+    /// Events database file. Defaults to `events.db` beside the resolved main
+    /// database (`--db`/`KHIVE_DB` resolution applies to the MAIN database;
+    /// this flag names the events file itself).
+    #[arg(long)]
+    db: Option<PathBuf>,
+
+    /// Unix socket path to bind. Defaults to `khive-events.sock` beside the
+    /// main daemon socket.
+    #[arg(long)]
+    socket: Option<PathBuf>,
 }
 
 /// Database schema lifecycle subcommands.
@@ -289,6 +310,24 @@ pub async fn cli_main() -> Result<()> {
             }
             result
         }
+        Command::EventsDaemon(a) => {
+            let db = match a.db {
+                Some(db) => db,
+                None => {
+                    let main_db = khive_runtime::resolve_db_anchor(None).ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "events-daemon: no main database resolvable to anchor events.db; \
+                             pass --db explicitly"
+                        )
+                    })?;
+                    khive_runtime::events_split::events_db_path_beside(&main_db)
+                }
+            };
+            let socket = a
+                .socket
+                .unwrap_or_else(|| khive_runtime::events_split::events_socket_path_beside(&db));
+            khive_runtime::events_split::run_events_daemon(&db, &socket).await
+        }
         Command::Mcp(a) => {
             let transport_registry = khive_mcp::transport::TransportRegistry::with_builtins();
 
@@ -372,6 +411,17 @@ pub async fn cli_main() -> Result<()> {
                             brain_profile: a.brain_profile.clone(),
                         },
                     )?;
+                // ADR-170: this arm is a resident daemon host when `--daemon`
+                // is set — it supervises an events daemon at the derived
+                // socket (`start_daemon_components_if_daemon`), so upgrade
+                // the resolved event plane from direct mode to forwarding.
+                let base_cfg = {
+                    let mut base_cfg = base_cfg;
+                    if a.daemon {
+                        khive_mcp::serve::enable_events_forwarding_for_daemon(&mut base_cfg);
+                    }
+                    base_cfg
+                };
 
                 // #667: acquire the boot/recovery lock before building the
                 // coordinator server — that construction runs migrations and

--- a/crates/kkernel/src/cli.rs
+++ b/crates/kkernel/src/cli.rs
@@ -94,9 +94,10 @@ enum Command {
     Mcp(khive_mcp::args::Args),
 
     /// Serve the dedicated events daemon (ADR-170): the resident writer of
-    /// `events.db`, receiving observational events over its own Unix socket
-    /// so telemetry never queues on the domain store's writer lane. Normally
-    /// spawned and supervised by `kkernel mcp --daemon`, not run by hand.
+    /// the events database, receiving observational events over its own Unix
+    /// socket so telemetry never queues on the domain store's writer lane.
+    /// Normally spawned and supervised by `kkernel mcp --daemon`, not run by
+    /// hand.
     EventsDaemon(EventsDaemonArgs),
 
     /// Inspect registered backends.
@@ -119,14 +120,14 @@ enum Command {
 /// Arguments for the dedicated events daemon (ADR-170).
 #[derive(clap::Parser, Debug)]
 struct EventsDaemonArgs {
-    /// Events database file. Defaults to `events.db` beside the resolved main
-    /// database (`--db`/`KHIVE_DB` resolution applies to the MAIN database;
-    /// this flag names the events file itself).
+    /// Events database file. Defaults to `<main-stem>.events.db` beside the
+    /// resolved main database (`--db`/`KHIVE_DB` resolution applies to the
+    /// MAIN database; this flag names the events file itself).
     #[arg(long)]
     db: Option<PathBuf>,
 
-    /// Unix socket path to bind. Defaults to `khive-events.sock` beside the
-    /// main daemon socket.
+    /// Unix socket path to bind. Defaults to the events database path with a
+    /// `.sock` extension, beside that database.
     #[arg(long)]
     socket: Option<PathBuf>,
 }
@@ -310,14 +311,15 @@ pub async fn cli_main() -> Result<()> {
             }
             result
         }
+        #[cfg(unix)]
         Command::EventsDaemon(a) => {
             let db = match a.db {
                 Some(db) => db,
                 None => {
                     let main_db = khive_runtime::resolve_db_anchor(None).ok_or_else(|| {
                         anyhow::anyhow!(
-                            "events-daemon: no main database resolvable to anchor events.db; \
-                             pass --db explicitly"
+                            "events-daemon: no main database resolvable to anchor the events \
+                             database; pass --db explicitly"
                         )
                     })?;
                     khive_runtime::events_split::events_db_path_beside(&main_db)
@@ -327,6 +329,10 @@ pub async fn cli_main() -> Result<()> {
                 .socket
                 .unwrap_or_else(|| khive_runtime::events_split::events_socket_path_beside(&db));
             khive_runtime::events_split::run_events_daemon(&db, &socket).await
+        }
+        #[cfg(not(unix))]
+        Command::EventsDaemon(_) => {
+            anyhow::bail!("the events daemon requires a Unix platform (Unix-socket transport)")
         }
         Command::Mcp(a) => {
             let transport_registry = khive_mcp::transport::TransportRegistry::with_builtins();

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -1764,6 +1764,19 @@ pub async fn run_exec(args: ExecArgs) -> Result<()> {
             brain_profile: None,
         })?;
 
+    // ADR-170 embedded mode: `kkernel exec`'s in-process fallback is a
+    // one-shot — a socket forwarder would be reaped at process exit before
+    // delivering, losing every event. The shared resolver already emits
+    // direct (socket-less) mode for exactly this class of host; only the
+    // resident daemon entrypoints upgrade to forwarding
+    // (`enable_events_forwarding_for_daemon`). SQLite's per-file
+    // cross-process exclusion covers direct appends overlapping a running
+    // events daemon.
+    debug_assert!(cfg
+        .events_split
+        .as_ref()
+        .is_none_or(|split| split.socket_path.is_none()));
+
     // Apply the explicit actor only AFTER the shared resolver has loaded the
     // project/config/environment fallbacks. This makes the CLI value the true
     // highest-precedence tier without coupling identity to storage namespace.

--- a/docs/adr/ADR-170-events-daemon-split.md
+++ b/docs/adr/ADR-170-events-daemon-split.md
@@ -1,4 +1,4 @@
-# ADR-170: Dedicated events daemon — observational writes leave the domain store
+# ADR-170: Dedicated events daemon — the audit lane leaves the domain store
 
 - Status: Proposed
 - Date: 2026-08-24
@@ -35,7 +35,27 @@ brain pack's readers on the same trait.
 ## Decision
 
 Split event persistence into a dedicated events daemon that owns a separate
-SQLite file. Observational writes leave the domain store entirely.
+SQLite file, routed **by append class** rather than moving the whole event
+plane.
+
+**Why not the whole plane.** The legacy `events` table is not a pure
+observational sink: it has raw-SQL consumers whose correctness depends on
+event rows being co-resident with domain state in one file. Enumerated during
+implementation: the schedule drain's creator-provenance fence (a raw query
+that fail-closes dispatch when the provenance event is absent), the kg
+projection worker's guarded `INSERT INTO events … SELECT … WHERE` (a
+single-statement write whose guard reads main-store state), and the graph
+query compiler's cross-substrate UNION (`entities`/`notes`/`events`/
+`graph_edges` in one SQL statement, including event rows reachable as graph
+endpoints). Moving every event to another file breaks each of these by
+construction — the first one was caught as a hard test failure, the others
+would have failed silently. The write classes divide cleanly instead: the
+ADR-133 idempotent audit-batch lane (verb-dispatch audit rows plus the
+config-lock records that ride the same flusher — ~62,600 of the ~76,600
+measured rows, ~82%) has none of these consumers, while the plain-append
+classes (channel lifecycle, embedder lifecycle, phase/checkpoint,
+recall/search/feedback, pack provenance) are low-volume domain-adjacent facts
+that stay put.
 
 1. **Events daemon.** A new subcommand of the same binary runs an events daemon
    that owns `events.db` beside the main store, writes to it through the existing
@@ -45,39 +65,56 @@ SQLite file. Observational writes leave the domain store entirely.
    point 4, whose short direct appends SQLite's per-file cross-process exclusion
    already serializes.
 
-2. **Forwarding event store (writes).** In the domain process, a
-   socket-forwarding implementation of `EventStore` replaces the local one for
-   appends: events enter a bounded in-memory queue drained by a background
-   forwarder that ships framed batches to the events daemon. The hand-off is
-   fire-and-forget. On queue overflow or a dead socket the append is **dropped**,
-   a degradation counter increments, and the drop reason is logged. The domain
-   request path never blocks on, and shares no lock with, event persistence.
+2. **Split event store (writes).** In the domain process, the `EventStore`
+   the runtime hands out routes by append class. The idempotent audit-batch
+   surface (`append_events_idempotent`, ADR-133) goes to the events lane as a
+   synchronous framed round-trip, preserving the batch's per-row idempotency
+   dispositions; the flusher already batches and already runs off the request
+   path, so the round-trip amortizes across the batch. Plain appends
+   (`append_event`/`append_events`) stay on the domain store unchanged. A
+   fire-and-forget path to the events daemon also ships — a bounded in-memory
+   queue drained by a background forwarder; on queue overflow or a dead
+   socket the append is **dropped**, a degradation counter increments, and
+   the drop reason is logged — for producers that later opt their telemetry
+   class into the lane explicitly (channel lifecycle is the first candidate).
    The bounded-queue drop policy is the loss-tolerant durability class made
    concrete: the loss window is the queue depth plus the flush interval, both
-   configuration with defaults stated in code.
+   configuration with defaults stated in code. The domain request path never
+   shares a writer lock with the audit lane.
 
-3. **Reads.** `query_events`, `count_events`, and `get_event` open `events.db`
-   read-only from the reading process. SQLite WAL supports one writer process and
-   many reader processes natively. Read connections are short-lived so they do
-   not pin WAL checkpoints.
+3. **Reads.** Trait-level reads (`query_events`, `count_events`, `get_event`)
+   merge both stores, so consumers on the trait observe one event plane
+   whichever side holds a row; windowed queries re-sort the merged prefix in
+   the stores' shared order before applying the requested window. The lane
+   side of a read is a framed round-trip in daemon deployments and a direct
+   open in embedded mode. Raw-SQL readers of the legacy `events` table keep
+   reading exactly the rows that never moved.
 
 4. **Embedded mode.** One-shot CLI and test contexts without a daemon use the
-   in-process `SqlEventStore` against `events.db` directly. SQLite's per-file
-   cross-process exclusion covers the rare overlap with a running events daemon;
-   every event transaction is a short append.
+   in-process `SqlEventStore` against `events.db` directly for the lane side.
+   SQLite's per-file cross-process exclusion covers the rare overlap with a
+   running events daemon; every event transaction is a short append. The
+   shared config resolver emits this socket-less mode for every file-backed
+   resolution; only resident daemon hosts upgrade the resolved config to
+   socket forwarding, because only they supervise an events daemon. The
+   socket path is derived beside the events database it serves — a
+   process-global socket location would route a second database's events to
+   whichever daemon owned it.
 
 5. **Lifecycle.** The domain daemon spawns and supervises the events daemon at
    startup. If the events daemon dies, the domain daemon keeps serving, drops
    events loudly (counter + log), and attempts respawn with backoff. Domain
    availability never depends on events-daemon liveness.
 
-6. **Cutover.** New events go to `events.db` from the first boot of this code.
-   Rows written before the cutover remain in the main store and are not unioned
-   into windowed event queries; recent-window queries converge on the new store
-   immediately, and the orphaned history ages out of query windows. This is
-   acceptable for the telemetry durability class and is stated here rather than
-   hidden. A backfill tool can follow if history proves needed. Storage tenure
-   of the legacy rows is likewise explicit: they age in place in the main store
+6. **Cutover.** New audit-lane rows go to `events.db` from the first boot of
+   this code; the plain-append classes keep writing the domain store, so
+   nothing that reads them observes a cutover at all. Audit rows written
+   before the cutover remain in the main store; because trait-level reads
+   merge both stores, windowed queries still see them until they age out of
+   query windows. Raw-SQL consumers of the main `events` table lose sight of
+   post-cutover audit rows — acceptable for the telemetry durability class
+   and stated here rather than hidden. Storage tenure of the legacy audit
+   rows is likewise explicit: they age in place in the main store
    indefinitely — nothing deletes them as part of this change — until an
    operator runs a purge or backfill tool, which ships separately if wanted.
 
@@ -86,8 +123,10 @@ SQLite file. Observational writes leave the domain store entirely.
 **Positive.**
 
 - Effective writer lanes double: SQLite's single-writer constraint is per file,
-  so the ~96% observational share of write traffic stops competing with domain
-  mutations at all.
+  so the audit lane — ~82% of measured event rows, and the one-per-dispatch
+  class that scales with load — stops competing with domain mutations at all.
+  The remaining plain-append classes (~14,000 rows/day measured) stay on the
+  domain store and can migrate later by explicit producer-side opt-in.
 - Failure domains separate: an events-side stall (index build, checkpoint, disk
   pressure on the events file) can no longer time out a domain write, and vice
   versa.

--- a/docs/adr/ADR-170-events-daemon-split.md
+++ b/docs/adr/ADR-170-events-daemon-split.md
@@ -13,7 +13,10 @@ the main store (audit rows one-per-dispatch at ~72% of them, channel-poll lifecy
 config-lock records, embedder lifecycle, phase and checkpoint records, recall/search/
 feedback events) against ~2,540 domain-mutation dispatches in the same window — a
 roughly 30:1 ratio. By dispatch count, ~96% of main-store write traffic is
-observational.
+observational. Producing query:
+`brain.event_counts(since="2026-08-23T12:00:00Z", exhaustive=true)` — an exact,
+non-sampled full-window aggregate (76,624 events); the domain-mutation figure is
+the sum of that call's `counts_by_verb` entries for mutating verbs.
 
 Under load this shows up as `writer_task_begin_busy` refusals (ADR-067 Amendment 4)
 on domain writes: operations that take under 10ms uncontended time out behind
@@ -37,8 +40,10 @@ SQLite file. Observational writes leave the domain store entirely.
 1. **Events daemon.** A new subcommand of the same binary runs an events daemon
    that owns `events.db` beside the main store, writes to it through the existing
    `SqlEventStore`, and binds its own Unix socket using the same framing and
-   peer-uid admission as the existing daemon socket. It is the only writer of
-   `events.db` in daemon deployments.
+   peer-uid admission as the existing daemon socket. It is the only **resident**
+   writer of `events.db`; the sole exception is the daemonless embedded mode of
+   point 4, whose short direct appends SQLite's per-file cross-process exclusion
+   already serializes.
 
 2. **Forwarding event store (writes).** In the domain process, a
    socket-forwarding implementation of `EventStore` replaces the local one for
@@ -71,7 +76,10 @@ SQLite file. Observational writes leave the domain store entirely.
    into windowed event queries; recent-window queries converge on the new store
    immediately, and the orphaned history ages out of query windows. This is
    acceptable for the telemetry durability class and is stated here rather than
-   hidden. A backfill tool can follow if history proves needed.
+   hidden. A backfill tool can follow if history proves needed. Storage tenure
+   of the legacy rows is likewise explicit: they age in place in the main store
+   indefinitely — nothing deletes them as part of this change — until an
+   operator runs a purge or backfill tool, which ships separately if wanted.
 
 ## Consequences
 

--- a/docs/adr/ADR-170-events-daemon-split.md
+++ b/docs/adr/ADR-170-events-daemon-split.md
@@ -58,10 +58,11 @@ recall/search/feedback, pack provenance) are low-volume domain-adjacent facts
 that stay put.
 
 1. **Events daemon.** A new subcommand of the same binary runs an events daemon
-   that owns `events.db` beside the main store, writes to it through the existing
+   that owns the events database (`<main-stem>.events.db`, named after the main
+   database file it sits beside), writes to it through the existing
    `SqlEventStore`, and binds its own Unix socket using the same framing and
    peer-uid admission as the existing daemon socket. It is the only **resident**
-   writer of `events.db`; the sole exception is the daemonless embedded mode of
+   writer of that file; the sole exception is the daemonless embedded mode of
    point 4, whose short direct appends SQLite's per-file cross-process exclusion
    already serializes.
 
@@ -106,7 +107,7 @@ that stay put.
    reading exactly the rows that never moved.
 
 4. **Embedded mode.** One-shot CLI and test contexts without a daemon use the
-   in-process `SqlEventStore` against `events.db` directly for the lane side.
+   in-process `SqlEventStore` against the events database directly for the lane side.
    SQLite's per-file cross-process exclusion covers the rare overlap with a
    running events daemon; every event transaction is a short append. The
    shared config resolver emits this socket-less mode for every file-backed
@@ -121,7 +122,7 @@ that stay put.
    events loudly (counter + log), and attempts respawn with backoff. Domain
    availability never depends on events-daemon liveness.
 
-6. **Cutover.** New audit-lane rows go to `events.db` from the first boot of
+6. **Cutover.** New audit-lane rows go to the events database from the first boot of
    this code; the plain-append classes keep writing the domain store, so
    nothing that reads them observes a cutover at all. Audit rows written
    before the cutover remain in the main store; because trait-level reads
@@ -177,7 +178,7 @@ this daemon's drop policy.
   consumers of the stream need.
 - **Central broker for the event stream.** Rejected: re-centralizes what this
   change decomposes; consumers can tail the events store directly.
-- **Multi-process direct writes to `events.db` (no daemon).** Rejected for the
+- **Multi-process direct writes to the events database (no daemon).** Rejected for the
   hot path: reintroduces cross-process writer contention on the busiest file.
   Retained only for the rare embedded mode.
 

--- a/docs/adr/ADR-170-events-daemon-split.md
+++ b/docs/adr/ADR-170-events-daemon-split.md
@@ -82,6 +82,21 @@ that stay put.
    configuration with defaults stated in code. The domain request path never
    shares a writer lock with the audit lane.
 
+   Outage semantics for the synchronous audit lane are bounded at both ends,
+   stated here because an unstated retry policy is either a silent drop or an
+   unbounded buffer. On a failed round-trip the audit flusher retries a
+   generation up to its configured attempt cap with a short backoff
+   (defaults: 3 attempts, 20ms), then fails that generation terminally — its
+   rows are dropped with a terminal reason surfaced to submitters, not
+   retried forever. The flusher's pending buffer is hard-capped
+   (default 4096 rows); at the cap new submissions are refused with an
+   explicit admission-exhausted outcome rather than growing without bound.
+   So during an events-daemon outage the loss is: in-flight generations after
+   retry exhaustion, plus refused admissions at the cap — the same
+   loss-tolerant durability class as the fire-and-forget queue, reached by a
+   different mechanism — and the supervisor's respawn probe bounds how long
+   an outage lasts.
+
 3. **Reads.** Trait-level reads (`query_events`, `count_events`, `get_event`)
    merge both stores, so consumers on the trait observe one event plane
    whichever side holds a row; windowed queries re-sort the merged prefix in
@@ -116,7 +131,11 @@ that stay put.
    and stated here rather than hidden. Storage tenure of the legacy audit
    rows is likewise explicit: they age in place in the main store
    indefinitely — nothing deletes them as part of this change — until an
-   operator runs a purge or backfill tool, which ships separately if wanted.
+   operator runs a purge tool, which ships separately. That follow-up is
+   worth scheduling rather than optional: at the measured audit rate
+   (~55,000 rows/day historically) the accumulated legacy audit tonnage is a
+   material share of main-store size, and reclaiming it is the second half
+   of this ADR's contention-and-size argument.
 
 ## Consequences
 

--- a/docs/adr/ADR-170-events-daemon-split.md
+++ b/docs/adr/ADR-170-events-daemon-split.md
@@ -1,0 +1,133 @@
+# ADR-170: Dedicated events daemon — observational writes leave the domain store
+
+- Status: Proposed
+- Date: 2026-08-24
+
+## Context
+
+khive runs as a single daemon over a single SQLite file. SQLite serializes writers
+per file, so every write — domain mutations and observational telemetry alike —
+queues on one writer lane. The event plane (ADR-103) makes the observational share
+dominant: a 24-hour production window measured ~76,600 event-plane rows written to
+the main store (audit rows one-per-dispatch at ~72% of them, channel-poll lifecycle,
+config-lock records, embedder lifecycle, phase and checkpoint records, recall/search/
+feedback events) against ~2,540 domain-mutation dispatches in the same window — a
+roughly 30:1 ratio. By dispatch count, ~96% of main-store write traffic is
+observational.
+
+Under load this shows up as `writer_task_begin_busy` refusals (ADR-067 Amendment 4)
+on domain writes: operations that take under 10ms uncontended time out behind
+telemetry. The two write classes also carry different durability requirements —
+domain mutations must not be lost; observational rows tolerate losing the last few
+seconds on a crash. One writer lane cannot price those classes differently.
+
+The existing daemon already demonstrates the process boundary this ADR needs: a
+Unix socket with length-prefixed frames and peer-uid admission
+(`crates/khive-runtime/src/daemon.rs`), and all event persistence already flows
+through one seam, the `EventStore` trait
+(`crates/khive-storage/src/event.rs`) implemented by `SqlEventStore`
+(`crates/khive-db/src/stores/event.rs`), with batched writers (ADR-133) and the
+brain pack's readers on the same trait.
+
+## Decision
+
+Split event persistence into a dedicated events daemon that owns a separate
+SQLite file. Observational writes leave the domain store entirely.
+
+1. **Events daemon.** A new subcommand of the same binary runs an events daemon
+   that owns `events.db` beside the main store, writes to it through the existing
+   `SqlEventStore`, and binds its own Unix socket using the same framing and
+   peer-uid admission as the existing daemon socket. It is the only writer of
+   `events.db` in daemon deployments.
+
+2. **Forwarding event store (writes).** In the domain process, a
+   socket-forwarding implementation of `EventStore` replaces the local one for
+   appends: events enter a bounded in-memory queue drained by a background
+   forwarder that ships framed batches to the events daemon. The hand-off is
+   fire-and-forget. On queue overflow or a dead socket the append is **dropped**,
+   a degradation counter increments, and the drop reason is logged. The domain
+   request path never blocks on, and shares no lock with, event persistence.
+   The bounded-queue drop policy is the loss-tolerant durability class made
+   concrete: the loss window is the queue depth plus the flush interval, both
+   configuration with defaults stated in code.
+
+3. **Reads.** `query_events`, `count_events`, and `get_event` open `events.db`
+   read-only from the reading process. SQLite WAL supports one writer process and
+   many reader processes natively. Read connections are short-lived so they do
+   not pin WAL checkpoints.
+
+4. **Embedded mode.** One-shot CLI and test contexts without a daemon use the
+   in-process `SqlEventStore` against `events.db` directly. SQLite's per-file
+   cross-process exclusion covers the rare overlap with a running events daemon;
+   every event transaction is a short append.
+
+5. **Lifecycle.** The domain daemon spawns and supervises the events daemon at
+   startup. If the events daemon dies, the domain daemon keeps serving, drops
+   events loudly (counter + log), and attempts respawn with backoff. Domain
+   availability never depends on events-daemon liveness.
+
+6. **Cutover.** New events go to `events.db` from the first boot of this code.
+   Rows written before the cutover remain in the main store and are not unioned
+   into windowed event queries; recent-window queries converge on the new store
+   immediately, and the orphaned history ages out of query windows. This is
+   acceptable for the telemetry durability class and is stated here rather than
+   hidden. A backfill tool can follow if history proves needed.
+
+## Consequences
+
+**Positive.**
+
+- Effective writer lanes double: SQLite's single-writer constraint is per file,
+  so the ~96% observational share of write traffic stops competing with domain
+  mutations at all.
+- Failure domains separate: an events-side stall (index build, checkpoint, disk
+  pressure on the events file) can no longer time out a domain write, and vice
+  versa.
+- Durability classes become code: the drop policy at the bounded queue is the
+  loss-tolerant contract, not an annotation.
+
+**Negative / accepted.**
+
+- A new loss mode exists by design: events dropped under overflow or during an
+  events-daemon outage are gone. The degradation counter and log line are the
+  mandatory visibility for it; the counter is surfaced through the existing
+  diagnostics surface so a silent-drop deployment is observable.
+- Pre-cutover event history is invisible to windowed queries against the new
+  store.
+- The binary grows a subcommand and the deployment grows a supervised child
+  process.
+
+**Compliance note.** Audit rows on this plane are operational telemetry. Any
+future audit class with retention or non-loss requirements is a domain write by
+definition and must ride the domain store's transaction, not this lane; adopting
+such a class requires revisiting the event-kind classification, not loosening
+this daemon's drop policy.
+
+## Alternatives considered
+
+- **In-process side lane (separate file, same process).** Rejected: removes lock
+  sharing but keeps one failure domain — a stall in the shared process still
+  takes both planes down — and does not create the process boundary later
+  consumers of the stream need.
+- **Central broker for the event stream.** Rejected: re-centralizes what this
+  change decomposes; consumers can tail the events store directly.
+- **Multi-process direct writes to `events.db` (no daemon).** Rejected for the
+  hot path: reintroduces cross-process writer contention on the busiest file.
+  Retained only for the rare embedded mode.
+
+## Forward
+
+A follow-up daemon consuming this stream (recall-weighting state, computed off
+the event feed, answering small read-only coefficient queries, degrading soft
+when unavailable) builds on the same socket pattern and the same durability
+reasoning. It is deliberately out of scope here; validating the hand-off
+primitive on the events lane comes first.
+
+## References
+
+- ADR-067 (write-owner daemon; Amendment 4: writer-begin busy contract)
+- ADR-103 (event plane)
+- ADR-133 (durable audit batching)
+- `crates/khive-storage/src/event.rs` (`EventStore` seam)
+- `crates/khive-db/src/stores/event.rs` (`SqlEventStore`)
+- `crates/khive-runtime/src/daemon.rs` (socket framing and admission pattern)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -186,6 +186,7 @@ The same head-binding governs review: a verdict authorizes only the exact commit
 | [ADR-167](ADR-167-service-provenance-and-kind-classification.md)        | Service Provenance and Service/Concept Classification                                                      |
 | [ADR-168](ADR-168-event-retention-classes.md)                           | Event Retention Classes and Sealed Archival                                                                |
 | [ADR-169](ADR-169-timezone-correct-timestamps.md)                       | Timezone-Correct Timestamps: Date-Only Values and a Configured Display Timezone                            |
+| [ADR-170](ADR-170-events-daemon-split.md)                               | Dedicated events daemon — observational writes leave the domain store                                      |
 
 <!-- END GENERATED ADR CATALOG -->
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -186,7 +186,7 @@ The same head-binding governs review: a verdict authorizes only the exact commit
 | [ADR-167](ADR-167-service-provenance-and-kind-classification.md)        | Service Provenance and Service/Concept Classification                                                      |
 | [ADR-168](ADR-168-event-retention-classes.md)                           | Event Retention Classes and Sealed Archival                                                                |
 | [ADR-169](ADR-169-timezone-correct-timestamps.md)                       | Timezone-Correct Timestamps: Date-Only Values and a Configured Display Timezone                            |
-| [ADR-170](ADR-170-events-daemon-split.md)                               | Dedicated events daemon — observational writes leave the domain store                                      |
+| [ADR-170](ADR-170-events-daemon-split.md)                               | Dedicated events daemon — the audit lane leaves the domain store                                           |
 
 <!-- END GENERATED ADR CATALOG -->
 


### PR DESCRIPTION
Implements ADR-170 (#2151): a dedicated events daemon owning `events.db`, with event persistence routed by append class.

## What moves, what stays

- The ADR-133 idempotent audit-batch lane — the measured bulk of event write volume (~82% of rows in a 24h production window, and the one-per-dispatch class that scales with load) — persists to `events.db`, owned by a supervised events daemon on its own Unix socket (same framing and peer-uid admission as the main daemon socket).
- Plain event appends stay on the domain store. The legacy `events` table has raw-SQL consumers whose correctness depends on co-resident rows: the schedule drain's creator-provenance fence, the kg projection worker's guarded event INSERT (transactional with main-store state), and the graph query compiler's cross-substrate UNION. Moving the whole plane breaks them by construction; the first was caught as a hard test failure during implementation, the others would have failed silently.
- Trait-level reads (`get_event`, `query_events`, `count_events`) merge both stores, so consumers on the `EventStore` trait observe one event plane.

## Host classes

The shared config resolver emits embedded (socket-less) mode for every file-backed resolution — one-shot CLI hosts and tests have no events daemon. The resident daemon entrypoints upgrade the resolved config to socket forwarding and supervise the events daemon from that same resolved config, so forwarding clients and the supervisor cannot anchor at diverging paths. Multi-backend boots re-anchor the split beside the declared main backend. Socket paths derive beside the events database they serve, never from a process-global location. `KHIVE_EVENTS_SPLIT=0` is the deployment kill-switch back to legacy behavior.

## Testing

- New: split-store routing (plain→legacy, idempotent→lane, merged + windowed reads), socket round-trip idempotency dispositions, fire-and-forget delivery, queue-overflow drop accounting, dead-socket typed errors with local preflight, protocol-skew refusal, daemon guard exclusivity, direct mode, resolver/daemon-upgrade contract.
- Full workspace `cargo check --all-targets`; khive-runtime (1316), khive-mcp (427), kkernel, and all touched pack suites pass; clippy and rustdoc clean under `-D warnings`.

Stacked on #2151 (ADR); the two ADR commits at the base of this branch belong to that PR and this one reduces to the implementation once it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)