### PR TITLE
ci: run workflow contract tests

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -42,6 +42,9 @@ phase_lint() {
 
     echo "=== Writer Census Contract Tests ==="
     python3 "$SCRIPT_DIR/tests/test_writer_census.py"
+
+    echo "=== CI Workflow Contract Tests ==="
+    python3 "$SCRIPT_DIR/tests/test_ci_workflows.py"
 }
 
 phase_no_stubs_scan() {


### PR DESCRIPTION
## Summary

- Run the existing CI workflow contract suite from the lint phase.
- Keep workflow trigger, permission, and benchmark-command assertions enforceable in normal CI.

## Verification

- Regression suite: `scripts/tests/test_ci_workflows.py`
- `python3 scripts/tests/test_ci_workflows.py`
- `sh -n scripts/ci.sh`
- `git diff --check`

Fixes #2131
