### PR TITLE
fix(ci): declare benchmark workflow permissions

### DIFF
--- a/.github/workflows/bench-1m.yml
+++ b/.github/workflows/bench-1m.yml
@@ -56,6 +56,9 @@ on:
         required: false
         default: ""
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/bench-pipeline.yml
+++ b/.github/workflows/bench-pipeline.yml
@@ -29,6 +29,9 @@ on:
       - "scripts/perf/bench_pipeline_daemon.py"
       - ".github/workflows/bench-pipeline.yml"
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
## Summary

- Declare explicit read-only repository-content permissions for the one-million-row benchmark workflow.
- Declare the same least-privilege permissions for the pipeline benchmark workflow.
- Leave the reusable component workflow's caller-provided permissions unchanged.

## Verification

- `python3 scripts/tests/test_ci_workflows.py`
- Direct permission-contract assertions for both changed workflows
- Pre-commit YAML validation
- `git diff --check HEAD^ HEAD`

No regression test was added because this change is limited to CI configuration.

Fixes #2134
