### PR TITLE
test(cli): isolate Git configuration

### DIFF
--- a/cli/kg/diff_test.ts
+++ b/cli/kg/diff_test.ts
@@ -4,7 +4,12 @@
 
 import { assertEquals } from "@std/assert";
 import { computeDiff, diffMaps, parseRecordMap } from "./diff.ts";
-import { exec } from "../lib/git.ts";
+import { exec as rawExec } from "../lib/git.ts";
+import { isolatedTestEnv } from "../tests/helpers.ts";
+
+// Harness git calls run under the isolated env so host configuration
+// (global hooks, command-scope injection) cannot affect the fixtures.
+const exec = (cmd: string[]) => rawExec(cmd, isolatedTestEnv());
 
 // ─── Test harness ─────────────────────────────────────────────────────────────
 

--- a/cli/kg/log_test.ts
+++ b/cli/kg/log_test.ts
@@ -4,7 +4,12 @@
 
 import { assertEquals } from "@std/assert";
 import { computeLog } from "./log.ts";
-import { exec } from "../lib/git.ts";
+import { exec as rawExec } from "../lib/git.ts";
+import { isolatedTestEnv } from "../tests/helpers.ts";
+
+// Harness git calls run under the isolated env so host configuration
+// (global hooks, command-scope injection) cannot affect the fixtures.
+const exec = (cmd: string[]) => rawExec(cmd, isolatedTestEnv());
 
 // ─── Test harness ─────────────────────────────────────────────────────────────
 

--- a/cli/lib/git.ts
+++ b/cli/lib/git.ts
@@ -13,11 +13,15 @@ export interface ExecResult {
  * Execute a command and return its exit code, stdout, and stderr.
  * Does not throw on non-zero exit — callers decide how to handle failures.
  */
-export async function exec(cmd: string[]): Promise<ExecResult> {
+export async function exec(
+  cmd: string[],
+  env?: Record<string, string>,
+): Promise<ExecResult> {
   const command = new Deno.Command(cmd[0], {
     args: cmd.slice(1),
     stdout: "piped",
     stderr: "piped",
+    ...(env ? { env, clearEnv: true } : {}),
   });
   const output = await command.output();
   return {

--- a/cli/tests/helpers.ts
+++ b/cli/tests/helpers.ts
@@ -19,11 +19,13 @@ export function isolatedTestEnv(
 ): Record<string, string> {
   const env: Record<string, string> = {};
   for (const [key, value] of Object.entries(base)) {
-    // Command-scope config (GIT_CONFIG_COUNT/KEY_*/VALUE_*) bypasses the
-    // global/system file overrides below, and GIT_TEMPLATE_DIR can seed
-    // hooks at `git init` — drop every inherited config-injection variable.
+    // Command-scope config (GIT_CONFIG_COUNT/KEY_*/VALUE_* and the older
+    // GIT_CONFIG_PARAMETERS list) bypasses the global/system file overrides
+    // below, and GIT_TEMPLATE_DIR can seed hooks at `git init` — drop every
+    // inherited config-injection variable.
     if (
       key === "GIT_CONFIG_COUNT" ||
+      key === "GIT_CONFIG_PARAMETERS" ||
       key === "GIT_TEMPLATE_DIR" ||
       key.startsWith("GIT_CONFIG_KEY_") ||
       key.startsWith("GIT_CONFIG_VALUE_")

--- a/cli/tests/helpers.ts
+++ b/cli/tests/helpers.ts
@@ -51,6 +51,9 @@ export async function runCli(args: string[]): Promise<CliResult> {
     args: ["run", "--allow-all", CLI_ENTRY, ...args],
     stdout: "piped",
     stderr: "piped",
+    // clearEnv keeps Deno from merging the parent environment back in —
+    // without it, inherited GIT_CONFIG_PARAMETERS survives the sanitized map.
+    clearEnv: true,
     env: isolatedTestEnv(),
   });
   const { code, stdout, stderr } = await cmd.output();
@@ -138,6 +141,7 @@ export async function makeTempRepo(): Promise<TempRepo> {
     args: ["init", root],
     stdout: "null",
     stderr: "null",
+    clearEnv: true,
     env,
   }).output();
 
@@ -145,6 +149,7 @@ export async function makeTempRepo(): Promise<TempRepo> {
     args: ["-C", root, "config", "user.email", "test@test.com"],
     stdout: "null",
     stderr: "null",
+    clearEnv: true,
     env,
   }).output();
 
@@ -152,6 +157,7 @@ export async function makeTempRepo(): Promise<TempRepo> {
     args: ["-C", root, "config", "user.name", "Test"],
     stdout: "null",
     stderr: "null",
+    clearEnv: true,
     env,
   }).output();
 
@@ -167,6 +173,7 @@ export async function makeTempRepo(): Promise<TempRepo> {
     args: ["-C", root, "add", "-A"],
     stdout: "null",
     stderr: "null",
+    clearEnv: true,
     env,
   }).output();
 
@@ -174,6 +181,7 @@ export async function makeTempRepo(): Promise<TempRepo> {
     args: ["-C", root, "commit", "-m", "init", "--no-gpg-sign"],
     stdout: "null",
     stderr: "null",
+    clearEnv: true,
     env,
   }).output();
 
@@ -192,6 +200,7 @@ export async function runCliIn(cwd: string, args: string[]): Promise<CliResult> 
     cwd,
     stdout: "piped",
     stderr: "piped",
+    clearEnv: true,
     env: isolatedTestEnv(),
   });
   const { code, stdout, stderr } = await cmd.output();

--- a/cli/tests/helpers.ts
+++ b/cli/tests/helpers.ts
@@ -6,11 +6,23 @@ import { join } from "@std/path";
 import { assertEquals, assertMatch } from "@std/assert";
 
 const CLI_ENTRY = new URL("../main.ts", import.meta.url).pathname;
+const NULL_DEVICE = Deno.build.os === "windows" ? "NUL" : "/dev/null";
 
 export interface CliResult {
   code: number;
   stdout: string;
   stderr: string;
+}
+
+export function isolatedTestEnv(
+  base: Record<string, string> = Deno.env.toObject(),
+): Record<string, string> {
+  return {
+    ...base,
+    NO_COLOR: "1",
+    GIT_CONFIG_GLOBAL: NULL_DEVICE,
+    GIT_CONFIG_SYSTEM: NULL_DEVICE,
+  };
 }
 
 /**
@@ -22,7 +34,7 @@ export async function runCli(args: string[]): Promise<CliResult> {
     args: ["run", "--allow-all", CLI_ENTRY, ...args],
     stdout: "piped",
     stderr: "piped",
-    env: { ...Deno.env.toObject(), NO_COLOR: "1" },
+    env: isolatedTestEnv(),
   });
   const { code, stdout, stderr } = await cmd.output();
   return {
@@ -102,24 +114,28 @@ edge_relations:
  */
 export async function makeTempRepo(): Promise<TempRepo> {
   const root = await Deno.makeTempDir({ prefix: "khive_test_" });
+  const env = isolatedTestEnv();
 
   // Init git repo
   await new Deno.Command("git", {
     args: ["init", root],
     stdout: "null",
     stderr: "null",
+    env,
   }).output();
 
   await new Deno.Command("git", {
     args: ["-C", root, "config", "user.email", "test@test.com"],
     stdout: "null",
     stderr: "null",
+    env,
   }).output();
 
   await new Deno.Command("git", {
     args: ["-C", root, "config", "user.name", "Test"],
     stdout: "null",
     stderr: "null",
+    env,
   }).output();
 
   // Create .khive/kg/ structure
@@ -134,12 +150,14 @@ export async function makeTempRepo(): Promise<TempRepo> {
     args: ["-C", root, "add", "-A"],
     stdout: "null",
     stderr: "null",
+    env,
   }).output();
 
   await new Deno.Command("git", {
     args: ["-C", root, "commit", "-m", "init", "--no-gpg-sign"],
     stdout: "null",
     stderr: "null",
+    env,
   }).output();
 
   return {
@@ -157,7 +175,7 @@ export async function runCliIn(cwd: string, args: string[]): Promise<CliResult> 
     cwd,
     stdout: "piped",
     stderr: "piped",
-    env: { ...Deno.env.toObject(), NO_COLOR: "1" },
+    env: isolatedTestEnv(),
   });
   const { code, stdout, stderr } = await cmd.output();
   return {

--- a/cli/tests/helpers.ts
+++ b/cli/tests/helpers.ts
@@ -17,8 +17,23 @@ export interface CliResult {
 export function isolatedTestEnv(
   base: Record<string, string> = Deno.env.toObject(),
 ): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(base)) {
+    // Command-scope config (GIT_CONFIG_COUNT/KEY_*/VALUE_*) bypasses the
+    // global/system file overrides below, and GIT_TEMPLATE_DIR can seed
+    // hooks at `git init` — drop every inherited config-injection variable.
+    if (
+      key === "GIT_CONFIG_COUNT" ||
+      key === "GIT_TEMPLATE_DIR" ||
+      key.startsWith("GIT_CONFIG_KEY_") ||
+      key.startsWith("GIT_CONFIG_VALUE_")
+    ) {
+      continue;
+    }
+    env[key] = value;
+  }
   return {
-    ...base,
+    ...env,
     NO_COLOR: "1",
     GIT_CONFIG_GLOBAL: NULL_DEVICE,
     GIT_CONFIG_SYSTEM: NULL_DEVICE,

--- a/cli/tests/helpers_test.ts
+++ b/cli/tests/helpers_test.ts
@@ -55,6 +55,32 @@ Deno.test("isolated test environment strips command-scope Git configuration", as
   assertEquals(new TextDecoder().decode(sanitized.stdout), "");
 });
 
+Deno.test("isolated test environment strips GIT_CONFIG_PARAMETERS injection", async () => {
+  const hostile = {
+    ...Deno.env.toObject(),
+    GIT_CONFIG_PARAMETERS: "'core.hooksPath=/hostile/hooks'",
+  };
+
+  // Control: the probe must see the injection when nothing sanitizes it.
+  const injected = await new Deno.Command("git", {
+    args: ["config", "--get", "core.hooksPath"],
+    env: hostile,
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  assertEquals(injected.code, 0);
+  assertEquals(new TextDecoder().decode(injected.stdout).trim(), "/hostile/hooks");
+
+  const sanitized = await new Deno.Command("git", {
+    args: ["config", "--get", "core.hooksPath"],
+    env: isolatedTestEnv(hostile),
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  assertEquals(sanitized.code, 1);
+  assertEquals(new TextDecoder().decode(sanitized.stdout), "");
+});
+
 Deno.test("isolated test environment drops GIT_TEMPLATE_DIR hook seeding", async () => {
   const root = await Deno.makeTempDir({ prefix: "khive_git_template_" });
   try {

--- a/cli/tests/helpers_test.ts
+++ b/cli/tests/helpers_test.ts
@@ -47,6 +47,9 @@ Deno.test("isolated test environment strips command-scope Git configuration", as
 
   const sanitized = await new Deno.Command("git", {
     args: ["config", "--get", "core.hooksPath"],
+    // clearEnv: without it Deno merges the parent environment back in, and a
+    // hostile variable inherited by the test process defeats the sanitized map.
+    clearEnv: true,
     env: isolatedTestEnv(hostile),
     stdout: "piped",
     stderr: "piped",
@@ -73,6 +76,9 @@ Deno.test("isolated test environment strips GIT_CONFIG_PARAMETERS injection", as
 
   const sanitized = await new Deno.Command("git", {
     args: ["config", "--get", "core.hooksPath"],
+    // clearEnv: without it Deno merges the parent environment back in, and a
+    // hostile variable inherited by the test process defeats the sanitized map.
+    clearEnv: true,
     env: isolatedTestEnv(hostile),
     stdout: "piped",
     stderr: "piped",
@@ -109,6 +115,7 @@ Deno.test("isolated test environment drops GIT_TEMPLATE_DIR hook seeding", async
     const cleanRepo = join(root, "clean");
     await new Deno.Command("git", {
       args: ["init", cleanRepo],
+      clearEnv: true,
       env: isolatedTestEnv(hostile),
       stdout: "null",
       stderr: "null",

--- a/cli/tests/helpers_test.ts
+++ b/cli/tests/helpers_test.ts
@@ -1,0 +1,28 @@
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { isolatedTestEnv } from "./helpers.ts";
+
+Deno.test("isolated test environment ignores host Git configuration", async () => {
+  const root = await Deno.makeTempDir({ prefix: "khive_git_config_" });
+  try {
+    const globalConfig = join(root, "gitconfig");
+    await Deno.writeTextFile(globalConfig, "[core]\n\thooksPath = /hostile/hooks\n");
+
+    const env = isolatedTestEnv({
+      ...Deno.env.toObject(),
+      GIT_CONFIG_GLOBAL: globalConfig,
+      GIT_CONFIG_SYSTEM: globalConfig,
+    });
+    const result = await new Deno.Command("git", {
+      args: ["config", "--global", "--get", "core.hooksPath"],
+      env,
+      stdout: "piped",
+      stderr: "piped",
+    }).output();
+
+    assertEquals(result.code, 1);
+    assertEquals(new TextDecoder().decode(result.stdout), "");
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});

--- a/cli/tests/helpers_test.ts
+++ b/cli/tests/helpers_test.ts
@@ -26,3 +26,73 @@ Deno.test("isolated test environment ignores host Git configuration", async () =
     await Deno.remove(root, { recursive: true });
   }
 });
+
+Deno.test("isolated test environment strips command-scope Git configuration", async () => {
+  const hostile = {
+    ...Deno.env.toObject(),
+    GIT_CONFIG_COUNT: "1",
+    GIT_CONFIG_KEY_0: "core.hooksPath",
+    GIT_CONFIG_VALUE_0: "/hostile/hooks",
+  };
+
+  // Control: the probe must see the injection when nothing sanitizes it.
+  const injected = await new Deno.Command("git", {
+    args: ["config", "--get", "core.hooksPath"],
+    env: hostile,
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  assertEquals(injected.code, 0);
+  assertEquals(new TextDecoder().decode(injected.stdout).trim(), "/hostile/hooks");
+
+  const sanitized = await new Deno.Command("git", {
+    args: ["config", "--get", "core.hooksPath"],
+    env: isolatedTestEnv(hostile),
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  assertEquals(sanitized.code, 1);
+  assertEquals(new TextDecoder().decode(sanitized.stdout), "");
+});
+
+Deno.test("isolated test environment drops GIT_TEMPLATE_DIR hook seeding", async () => {
+  const root = await Deno.makeTempDir({ prefix: "khive_git_template_" });
+  try {
+    const template = join(root, "template");
+    await Deno.mkdir(join(template, "hooks"), { recursive: true });
+    await Deno.writeTextFile(
+      join(template, "hooks", "pre-commit"),
+      "#!/bin/sh\nexit 0\n",
+    );
+    const hostile = { ...Deno.env.toObject(), GIT_TEMPLATE_DIR: template };
+
+    // Control: an unsanitized init must seed the hook from the template.
+    const seededRepo = join(root, "seeded");
+    await new Deno.Command("git", {
+      args: ["init", seededRepo],
+      env: hostile,
+      stdout: "null",
+      stderr: "null",
+    }).output();
+    assertEquals(
+      await Deno.stat(join(seededRepo, ".git", "hooks", "pre-commit"))
+        .then(() => true, () => false),
+      true,
+    );
+
+    const cleanRepo = join(root, "clean");
+    await new Deno.Command("git", {
+      args: ["init", cleanRepo],
+      env: isolatedTestEnv(hostile),
+      stdout: "null",
+      stderr: "null",
+    }).output();
+    assertEquals(
+      await Deno.stat(join(cleanRepo, ".git", "hooks", "pre-commit"))
+        .then(() => true, () => false),
+      false,
+    );
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary

- Override global and system Git configuration for CLI test subprocesses.
- Apply the same isolated environment to scratch-repository setup commands.
- Preserve the rest of the caller environment while preventing user hooks and aliases from affecting test behavior.

## Verification

- Regression test: `isolated test environment ignores host Git configuration`
- `deno test --allow-all tests/helpers_test.ts`
- `deno test --allow-all tests/behavior/` (70 passed, 1 ignored)
- `deno lint tests/helpers.ts tests/helpers_test.ts`
- `deno check main.ts`
- `deno fmt tests/helpers.ts tests/helpers_test.ts`

Fixes #2108
