### PR TITLE
docs(adr): ADR-109 Amendment 1 — read-only connection tier (Tier-B phase)

### DIFF
--- a/docs/adr/ADR-109-sandboxed-kkernel-gateway.md
+++ b/docs/adr/ADR-109-sandboxed-kkernel-gateway.md
@@ -415,19 +415,49 @@ already consults on every verb. All of it reuses shipped machinery:
    carrying the _actual_ verb and calls `Gate::check` before the pack handler runs; a `Deny`
    returns `PermissionDenied` with a reason (ADR-018, as amended fail-closed by ADR-129). No new
    dispatch path is introduced — this is the same seam the base ADR's rule names.
-2. **The policy is a default-deny Rego policy** naming a closed read-verb allowlist, loaded by
-   the existing `RegoGate` (`from_dir` / `from_policy_str`). This is the base ADR's Fork (c)
+2. **The enforcement invariant is a closed read-verb set held in code, intersected with
+   policy.** Read-only mode installs a composite gate: a verb dispatches only if it is a member
+   of the canonical read-verb set — a closed, machine-checkable list shipped in code — **and**
+   the installed policy allows it. The default-deny Rego policy of the base ADR's Fork (c)
    resolution (constrained Rego on the existing engine, a required default-deny template, and a
-   validation lint that rejects any policy lacking a closed allowlist) applied to the read-only
-   case. Every verb outside the allowlist — every mutating verb — is denied by the default rule,
-   so a verb added to a future pack is denied until explicitly listed, not permitted by omission.
-3. **A launch flag installs it.** `kkernel mcp` gains a flag that sets the process `Gate` to the
-   read-only `RegoGate` instead of `AllowAllGate` for that process's lifetime. This is the base
+   validation lint) is retained as the configurable layer, and it can only _narrow_ the surface
+   further, never widen it: the in-code set membership check runs regardless of what the policy
+   engine returns, so a policy bug, a permissive branch, or an errant allow path cannot
+   authorize a mutation. The validation lint rejects a read-only policy that is not default-deny,
+   that lacks a closed allowlist, or whose allowlist names any verb outside the canonical read
+   set. A verb added by a future pack is denied until explicitly classified and listed, not
+   permitted by omission.
+3. **Membership of the read set is decided by effect, not by name.** The authoritative source
+   is a per-verb effect classification declared where verbs register — registry-level metadata
+   the read-only gate consults at dispatch, not prose documentation (the existing verb-category
+   metadata is documentation-only and does not qualify as an enforcement source). A verb
+   qualifies as read only if its handler performs no persistent state change of any kind.
+   Incidental writes count as mutation: a verb with read-shaped naming that updates state as a
+   side effect — the mark-read class of communication verbs, which the durable-audit ADR already
+   classifies as writers — is a mutating verb for this tier and is excluded from the read set.
+   Any verb without a declared effect classification is treated as mutating (fail-closed), so
+   the writer census cannot rot open as the catalog grows.
+4. **The mode binds to the process boundary it enforces at.** `kkernel mcp` gains a flag that
+   sets the process `Gate` to the composite read-only gate instead of `AllowAllGate` for that
+   process's lifetime. Binding is local by construction: a read-only process dispatches every
+   verb in the process that parsed the flag, and it never forwards verbs to — and never
+   auto-spawns — a shared resident daemon, because a forwarded verb would be checked by the
+   daemon's own gate rather than this one, and the daemon connection protocol carries no gate
+   identity today. Read verbs tolerate this: a read-only connection performs no writes at all
+   (the gate denies mutations before any handler runs), so local dispatch never contends for
+   the resident daemon's writer lane. Extending gate identity into daemon connection admission
+   and spawn configuration — so a restricted client could safely attach to a shared daemon —
+   is structural-gateway work and stays deferred with the untrusted tier. This is the base
    ADR's A2 (mode-flag) process boundary, **not** A1 — see the honest-scope note below.
-4. **Refusal is loud and attributable.** The `Deny` reason states that the verb was refused
-   because the connection is read-only, and the MCP surface returns it as a typed refusal the
-   client can distinguish from an outage — so a client running against a restricted connection
-   reports the restriction rather than misreading it as khive being down.
+5. **Refusal is loud, attributable, and typed on the wire.** The `Deny` reason states that the
+   verb was refused because the connection is read-only, and the MCP surface carries it as a
+   structured refusal object — a machine-readable field naming the refusal class (read-only
+   denial, as distinct from gate-unavailable and from ordinary runtime errors) and the refused
+   verb — never a flat serialized error string a client must parse. Today's wire path
+   serializes authorization refusals into ordinary error strings, so the structured refusal
+   field is in-scope wire work for this amendment, not an existing property being restated. A
+   client running against a restricted connection can therefore report the restriction rather
+   than misreading it as khive being down, without string matching.
 
 ### Honest scope: what this does NOT serve
 
@@ -454,14 +484,23 @@ Concretely, the read-only connection is **not** a containment for a Tier-C untru
 
 ### Implementation plan (Tier-B phase)
 
-- A bundled default-deny read-only Rego policy naming the closed read-verb allowlist, plus the
-  read/mutating classification of the current verb catalog it rests on.
-- The `kkernel mcp` launch flag that installs the read-only `RegoGate`.
+- The per-verb effect classification at the verb-registration seam (point 3), with a
+  completeness lint: every registered verb carries a classification, an unclassified verb is
+  mutating by default, and the mark-read class of incidental writers is classified as mutating
+  with a test pinning that classification.
+- The composite read-only gate (point 2): in-code canonical read-set membership intersected
+  with the policy decision, plus a test that a policy hand-crafted with an extra allow branch
+  for a mutating verb is still denied by the composite gate.
+- A bundled default-deny read-only Rego policy naming the closed read-verb allowlist.
 - The validation lint (base ADR Fork (c)) that rejects a read-only policy which is not
-  default-deny or does not declare a closed allowlist.
-- Confirmation that the `Deny` reason and the MCP-surface refusal are typed and attributable per
-  point 4, with a test that a denied mutating verb returns the read-only refusal (not a generic
-  error) and that an allowed read verb still dispatches.
+  default-deny, does not declare a closed allowlist, or names an allowlist entry outside the
+  canonical read set.
+- The `kkernel mcp` launch flag that installs the composite gate and pins dispatch local
+  (point 4): with the flag set, daemon forwarding and daemon auto-spawn are disabled, with a
+  test asserting a read-only process never opens the daemon connection path.
+- The structured refusal field on the MCP wire (point 5), with tests that a denied mutating
+  verb returns the typed read-only refusal (not a generic error string), that an incidental
+  writer such as a mark-read verb is denied, and that an allowed read verb still dispatches.
 
 ### Consequences of this amendment
 
@@ -471,9 +510,13 @@ Concretely, the read-only connection is **not** a containment for a Tier-C untru
   substituting the weaker A2 form for it.
 - **Negative.** A2's failure mode (a misconfigured launch reverts to the installed base `Gate`)
   is real; this amendment accepts it _only_ for Tier B and says so in the flag's own
-  documentation. The read/mutating verb classification must be maintained as the catalog grows —
-  the default-deny posture makes an unclassified new verb fail safe (denied), which is the
-  correct direction, but a read verb wrongly omitted is a false denial to fix, not a hole.
+  documentation. The effect classification must be maintained as the catalog grows — the
+  fail-closed default (unclassified means mutating) makes a new verb fail safe (denied), which
+  is the correct direction, but a read verb wrongly left unclassified is a false denial to fix,
+  not a hole. Pinning dispatch local means a read-only process forgoes the resident daemon's
+  warm caches and shares the store only through concurrent-reader semantics; acceptable for the
+  observer-shaped Tier-B caller, and revisited only when gate identity reaches the daemon
+  connection protocol.
 
 ## References
 

--- a/docs/adr/ADR-109-sandboxed-kkernel-gateway.md
+++ b/docs/adr/ADR-109-sandboxed-kkernel-gateway.md
@@ -515,7 +515,7 @@ already consults on every verb. All of it reuses shipped machinery:
 
    ```json
    {
-     "class": "read_only" | "policy" | "gate_error",
+     "class": "read_only" | "denied",
      "verb": "<the refused verb, as dispatched>",
      "mode": "read_only",
      "effect": "read" | "mutating" | "unclassified"
@@ -527,24 +527,26 @@ already consults on every verb. All of it reuses shipped machinery:
    writer, `unclassified` = fail-closed default). Clients match on `class`, never on the
    `error` string, which remains presentation-only.
 
-   **Class mapping.** The three deny paths the shipped gate contract actually produces map
-   to the three classes and are never conflated:
+   **Class mapping.** `class` is decided by WHICH gate refused, in dispatch order, so every
+   refusal lands in exactly one class by construction:
 
-   - Canonical-set membership failure (the verb is `mutating` or `unclassified`) →
-     `class: "read_only"`. The connection is healthy; the verb is out of contract for this
-     mode. This is the common case and the only class a correctly configured deployment
-     emits.
-   - Policy narrowing (the verb is in the canonical read set — `effect: "read"` — but the
-     installed policy's allowlist excludes it) → `class: "policy"`. Distinguishable from
-     `read_only` so an operator can tell a mode boundary from their own policy choice.
-   - Gate evaluation failure at dispatch → `class: "gate_error"`. Per the authorization-gate
-     ADR's shipped contract, policy-load failures are construction time — a broken policy
-     never reaches dispatch because the process refuses to construct the gate — and
-     dispatch-time evaluation uncertainty is already converted by the Rego gate into an
-     explicit deny with a diagnostic reason; only pre-evaluation failures (gate-request
-     serialization) surface as gate errors, and fail-closed (ADR-129) they deny. This class
-     is therefore rare by construction, and no "retryable infrastructure outage" refusal
-     state exists to represent: there is no `gate_unavailable`.
+   - `class: "read_only"` — the process-mode check this amendment adds refused the verb
+     (its `effect` is `mutating` or `unclassified`). The mode check runs before the
+     authorization gate and is this amendment's own code, so it can attribute itself
+     deterministically. The connection is healthy; the verb is out of contract for this
+     mode.
+   - `class: "denied"` — the authorization gate refused a verb the mode admitted
+     (`effect: "read"`). This class deliberately claims no finer provenance, because the
+     shipped gate seam carries none: the gate returns a deny decision with a diagnostic
+     reason string for policy narrowing and for fail-closed evaluation outcomes alike
+     (dispatch-time evaluation uncertainty is converted to an explicit deny per the
+     authorization-gate ADR, and policy-load failures never reach dispatch — a broken
+     policy fails gate construction). A wire class that promised to distinguish "your
+     policy said no" from "the gate errored" would be asserting provenance the deny
+     decision does not carry. Splitting `denied` is deferred work, gated on the gate seam
+     itself growing typed deny provenance; until then the diagnostic reason string is the
+     only finer signal and remains presentation-only. No "retryable infrastructure outage"
+     refusal state exists to represent: there is no `gate_unavailable`.
 
    Ordinary runtime errors on a permitted read verb are untouched — no `refusal` field, and
    a read-only connection reports storage timeouts, not-found, and validation errors exactly
@@ -607,7 +609,7 @@ Concretely, the read-only connection is **not** a containment for a Tier-C untru
   normative schema and class mapping above with the string `error` field unchanged, with
   tests that a denied mutating verb returns `class: "read_only"` naming the refused verb,
   that an incidental writer such as a mark-read verb is denied, that a policy-narrowed read
-  verb returns `class: "policy"` with `effect: "read"`, and that an allowed read verb still
+  verb returns `class: "denied"` with `effect: "read"`, and that an allowed read verb still
   dispatches with its ordinary result and errors untouched (no `refusal` field).
 
 ### Consequences of this amendment

--- a/docs/adr/ADR-109-sandboxed-kkernel-gateway.md
+++ b/docs/adr/ADR-109-sandboxed-kkernel-gateway.md
@@ -449,6 +449,14 @@ already consults on every verb. All of it reuses shipped machinery:
      result, and the hook's fold is skipped for that dispatch. Suppression is the mode's
      obligation, not the classification's — a read verb stays classified read, and the mode
      guarantees its dispatch writes nothing.
+   - **Store-internal index maintenance** (the ANN lifecycle: recall-triggered index
+     rebuilds, consumer-watermark rows, checkpoint and compaction). These are persistent
+     writes triggered from the read path that never enter verb dispatch, so no verb gate —
+     composite or otherwise — can see them; a gate-only process mode would admit them. They
+     are suppressed at the storage layer: read-only mode opens the backing store read-only
+     (point 4), and the store's own read-only guard is the same one the index lifecycle
+     already honors. A recall under read-only mode returns its result without maintaining
+     the index.
    - **Audit-plane appends** (the runtime's own record of what was dispatched, permitted, or
      refused). These are **retained** under read-only mode by contract: a restricted
      connection whose activity left no audit trail would be less observable than an
@@ -472,7 +480,8 @@ already consults on every verb. All of it reuses shipped machinery:
 
    The **canonical read set** is the in-code closed list this classification produces: exactly
    the registered verbs whose dispatch closure — deferred writes included — performs no
-   domain write and requires no suppressed hook beyond the adaptive-scoring class above. The
+   domain write and requires no suppression beyond the adaptive-scoring and
+   index-maintenance classes above. The
    code constant is the normative artifact; the bundled read-only policy's allowlist is
    generated from it and validated against it, so the two cannot drift. Any verb without a
    declared effect classification is treated as mutating (fail-closed), so the writer census
@@ -482,13 +491,36 @@ already consults on every verb. All of it reuses shipped machinery:
    background tasks for that dispatch before asserting** (the runtime already tracks them;
    an assertion that races the background lane would pass vacuously), and asserts zero
    domain writes (audit-plane appends excepted per the taxonomy above).
+
+   **Synthetic gate-plane operations are enumerated, not defaulted.** The runtime issues
+   gate checks for operations that are not registered verbs — today, the synthetic
+   authorization it performs before attaching its own audit event plumbing. The fail-closed
+   default above governs unclassified _verbs_; a synthetic operation the runtime itself
+   issues is instead explicitly enumerated and classified alongside the verb classification.
+   The audit-attachment authorization classifies as a gate-plane read: it performs no domain
+   write, and denying it would silently detach the audit plane — inverting the
+   audit-retention contract above, and doing so without any refusal a caller would see. An
+   unenumerated synthetic operation remains fail-closed mutating, so the enumeration cannot
+   rot open as new synthetic operations appear.
 4. **The mode binds to the process boundary it enforces at.** `kkernel mcp` gains a flag that
    sets the process `Gate` to the composite read-only gate instead of `AllowAllGate` for that
    process's lifetime. Binding is local by construction: a read-only process dispatches every
    verb in the process that parsed the flag, and it never forwards verbs to — and never
    auto-spawns — a shared resident daemon, because a forwarded verb would be checked by the
    daemon's own gate rather than this one, and the daemon connection protocol carries no gate
-   identity today. Read verbs tolerate this: a read-only connection performs no domain writes
+   identity today. The same reasoning bars the process from BEING the daemon: daemon mode
+   hosts components that write stores directly without entering verb dispatch (the scheduler's
+   pending-event path appends notes outside `VerbRegistry` today), so a verb-dispatch gate
+   cannot bound them. The read-only flag therefore **rejects daemon mode at startup** —
+   `--read-only` combined with `--daemon` is a launch error, refused before any component
+   starts — and the invariant is stated generally so it survives new components: a read-only
+   process admits no component that writes a store outside verb dispatch; a component that
+   cannot demonstrate that is not started in this mode. The mode also binds the **storage
+   layer**, not the gate alone: the flag opens the backing store read-only, so store-layer
+   maintenance that no verb gate can see (the index-maintenance class in point 3) is
+   suppressed by the same guard the storage engine already honors. A launch that cannot open
+   the store read-only fails; it does not fall back to a writable handle. Read verbs
+   tolerate this: a read-only connection performs no domain writes
    (the gate denies mutations before any handler runs, and the adaptive hooks are suppressed
    per point 3), so local dispatch never contends for the resident daemon's writer lane beyond
    its own audit-plane appends. Extending gate identity into daemon connection admission
@@ -503,13 +535,15 @@ already consults on every verb. All of it reuses shipped machinery:
    restated. The wire contract is normative:
 
    **Placement.** The request-DSL envelope's per-operation failure entry is
-   `{ "ok": false, "tool": "<verb>", "error": "<string>", "reason"?: "<string>" }` — the
-   `error` field is a human-readable string by contract, and that contract is unchanged
-   here (no existing client's error handling breaks). The refusal adds one structured
-   sibling field on the same entry, following the envelope's existing pattern of typed
-   fields beside the string (`reason` today): a `refusal` object, present exactly when the
-   process gate denied the operation, absent otherwise. A batch refusing one op reports it
-   beside its siblings' results; a single-op request carries it on that op's entry.
+   `{ "ok": false, "tool": "<verb>", "error": <value>, "reason"?: "<string>" }` — the
+   `error` field is a JSON value, not a fixed string: the serializer emits a plain string
+   for most failures and a structured object for khive-typed and retryable failures. This
+   amendment does not touch that field in either shape (no existing client's error handling
+   breaks). The refusal adds one structured sibling field on the same entry, following the
+   envelope's existing pattern of typed fields beside `error` (`reason` today): a `refusal`
+   object, present exactly when the process gate denied the operation, absent otherwise. A
+   batch refusing one op reports it beside its siblings' results; a single-op request
+   carries it on that op's entry.
 
    **Schema.** The `refusal` object carries exactly these fields:
 
@@ -525,7 +559,7 @@ already consults on every verb. All of it reuses shipped machinery:
    `class` is the machine-matching key; `effect` is defined for every class and reports the
    verb's classification (`read` = in the canonical read set, `mutating` = classified as a
    writer, `unclassified` = fail-closed default). Clients match on `class`, never on the
-   `error` string, which remains presentation-only.
+   `error` value, which remains presentation-only.
 
    **Class mapping.** `class` is decided by WHICH gate refused, in dispatch order, so every
    refusal lands in exactly one class by construction:
@@ -536,17 +570,24 @@ already consults on every verb. All of it reuses shipped machinery:
      deterministically. The connection is healthy; the verb is out of contract for this
      mode.
    - `class: "denied"` — the authorization gate refused a verb the mode admitted
-     (`effect: "read"`). This class deliberately claims no finer provenance, because the
-     shipped gate seam carries none: the gate returns a deny decision with a diagnostic
-     reason string for policy narrowing and for fail-closed evaluation outcomes alike
-     (dispatch-time evaluation uncertainty is converted to an explicit deny per the
-     authorization-gate ADR, and policy-load failures never reach dispatch — a broken
-     policy fails gate construction). A wire class that promised to distinguish "your
-     policy said no" from "the gate errored" would be asserting provenance the deny
-     decision does not carry. Splitting `denied` is deferred work, gated on the gate seam
-     itself growing typed deny provenance; until then the diagnostic reason string is the
-     only finer signal and remains presentation-only. No "retryable infrastructure outage"
-     refusal state exists to represent: there is no `gate_unavailable`.
+     (`effect: "read"`). This class deliberately claims no finer provenance than the deny
+     decision itself carries: the gate returns a deny with a diagnostic reason string for
+     policy narrowing and for policy-evaluation outcomes that resolve to deny alike, and
+     policy-load failures never reach dispatch — a broken policy fails gate construction.
+     A wire class that promised to distinguish "your policy said no" from finer deny causes
+     would be asserting provenance the deny decision does not carry. Splitting `denied` is
+     deferred work, gated on the gate seam itself growing typed deny provenance; until then
+     the diagnostic reason string is the only finer signal and remains presentation-only.
+
+   A gate **infrastructure error is not a refusal and is not in this schema**. When
+   `Gate::check` itself fails (returns an error rather than a decision), the runtime aborts
+   dispatch with its existing distinct `GateUnavailable` error — inherited from the
+   authorization-audit contract, not converted to a deny — and that outcome travels the
+   ordinary per-operation error path: no `refusal` object, the standard error entry, exactly
+   as every other dispatch-aborting infrastructure failure does today. The two-class
+   `refusal.class` set is therefore complete over what it covers — deny decisions — and the
+   gate-outage branch keeps its own already-typed representation instead of being flattened
+   into either class.
 
    Ordinary runtime errors on a permitted read verb are untouched — no `refusal` field, and
    a read-only connection reports storage timeouts, not-found, and validation errors exactly
@@ -605,12 +646,27 @@ Concretely, the read-only connection is **not** a containment for a Tier-C untru
 - The `kkernel mcp` launch flag that installs the composite gate and pins dispatch local
   (point 4): with the flag set, daemon forwarding and daemon auto-spawn are disabled, with a
   test asserting a read-only process never opens the daemon connection path.
+- The daemon-mode rejection (point 4): `--read-only` combined with `--daemon` is a launch
+  error, with an end-to-end test asserting the process exits before any component starts —
+  no scheduler, no store handle, no partial startup.
+- The storage-layer binding (point 4): the flag opens the backing store read-only, with a
+  test that a launch which cannot open the store read-only fails rather than falling back
+  to a writable handle.
+- Store-maintenance suppression under the storage binding (points 3-4): index-maintenance
+  writes that no verb gate can see — the ANN rebuild/watermark/compaction lifecycle
+  triggered from the read path — with a test that a recall under read-only mode returns its
+  result while performing no persistent index write, and the same recall outside read-only
+  mode still maintains the index.
+- The synthetic-operation enumeration (point 3): a test that the audit-attachment
+  authorization is permitted under read-only mode and audit appends survive, and that an
+  unenumerated synthetic operation is denied.
 - The structured `refusal` field on the per-operation envelope entry (point 5), carrying the
-  normative schema and class mapping above with the string `error` field unchanged, with
-  tests that a denied mutating verb returns `class: "read_only"` naming the refused verb,
-  that an incidental writer such as a mark-read verb is denied, that a policy-narrowed read
-  verb returns `class: "denied"` with `effect: "read"`, and that an allowed read verb still
-  dispatches with its ordinary result and errors untouched (no `refusal` field).
+  normative schema and class mapping above with the `error` field untouched in both its
+  existing shapes, with tests that a denied mutating verb returns `class: "read_only"`
+  naming the refused verb, that an incidental writer such as a mark-read verb is denied,
+  that a policy-narrowed read verb returns `class: "denied"` with `effect: "read"`, and
+  that an allowed read verb still dispatches with its ordinary result and errors untouched
+  (no `refusal` field).
 
 ### Consequences of this amendment
 
@@ -632,8 +688,8 @@ Concretely, the read-only connection is **not** a containment for a Tier-C untru
 
 - ADR-018 - Authorization Gate; `Gate`, `GateRequest`, `GateDecision`, `Obligation`,
   `PackGatePolicy`; this ADR's rate enforcement and gateway-specific validation refusals are
-  scoped additions. Gate infrastructure-error refusal is inherited from ADR-129, not a scoped
-  delta from ADR-018.
+  scoped additions. Gate infrastructure-error handling is inherited from ADR-129, not a
+  scoped delta from ADR-018.
 - ADR-018 Amendment 1 - canonical verb identity; the allowlist check in rule 1 depends on
   the same canonicalization step to avoid an alias-based bypass
 - ADR-016 - Request DSL; the wire surface the gateway's pre-dispatch check intercepts

--- a/docs/adr/ADR-109-sandboxed-kkernel-gateway.md
+++ b/docs/adr/ADR-109-sandboxed-kkernel-gateway.md
@@ -458,11 +458,14 @@ already consults on every verb. All of it reuses shipped machinery:
      already honors. A recall under read-only mode returns its result without maintaining
      the index.
    - **Audit-plane appends** (the runtime's own record of what was dispatched, permitted, or
-     refused). These are **retained** under read-only mode by contract: a restricted
-     connection whose activity left no audit trail would be less observable than an
-     unrestricted one, which is the wrong direction for a security tier. Audit retention is a
-     runtime-plane exemption, named here so it cannot be read as a hole: it records dispatch
-     outcomes and is not reachable as a domain write by any argument the caller controls.
+     refused). These are runtime-plane, not domain writes: they record dispatch outcomes and
+     are not reachable as a domain write by any argument the caller controls. On a read-only
+     backing store they follow ADR-028 Amendment A2 rule 5 verbatim: the registry omits the
+     `EventStore` rather than attempting a known-failing append, and every successful
+     non-help operation carries the envelope-level advisory
+     `audit_persistence_skipped_read_only`. The observability obligation is discharged by
+     that per-response advisory — the skip is visible to every caller on every operation —
+     not by a write no read-only store can accept.
    - **Non-durable telemetry** (in-memory counters, metrics). Out of scope; no durable state.
    - **Deferred writes belong to the dispatch that scheduled them.** A write scheduled by a
      dispatch but executed after the response returns — a tracked background task, a
@@ -493,15 +496,20 @@ already consults on every verb. All of it reuses shipped machinery:
    domain writes (audit-plane appends excepted per the taxonomy above).
 
    **Synthetic gate-plane operations are enumerated, not defaulted.** The runtime issues
-   gate checks for operations that are not registered verbs — today, the synthetic
-   authorization it performs before attaching its own audit event plumbing. The fail-closed
-   default above governs unclassified _verbs_; a synthetic operation the runtime itself
-   issues is instead explicitly enumerated and classified alongside the verb classification.
-   The audit-attachment authorization classifies as a gate-plane read: it performs no domain
-   write, and denying it would silently detach the audit plane — inverting the
-   audit-retention contract above, and doing so without any refusal a caller would see. An
-   unenumerated synthetic operation remains fail-closed mutating, so the enumeration cannot
-   rot open as new synthetic operations appear.
+   gate checks for operations that are not registered verbs. The fail-closed default above
+   governs unclassified _verbs_; a synthetic operation the runtime itself issues is instead
+   explicitly enumerated and classified alongside the verb classification. Today the sole
+   synthetic string is `"authorize"`, and ADR-129 Amendment 1 already classifies it: a
+   pseudo-verb is checked against the full authority its result grants, which for the
+   token-minting path is **Write** on the primary namespace. This amendment does not
+   reclassify it. Under read-only mode the Write check therefore denies both of its
+   consumers, and both denials are the mode operating correctly: token minting is refused —
+   the honest semantics of a read+write token, the consequence ADR-129 itself names — and
+   the audit-attachment authorization never passes, which detaches nothing, because the
+   registry has already omitted the `EventStore` per the audit taxonomy above and the
+   per-response advisory makes that skip visible to every caller. An unenumerated synthetic
+   operation remains fail-closed mutating, so the enumeration cannot rot open as new
+   synthetic operations appear.
 4. **The mode binds to the process boundary it enforces at.** `kkernel mcp` gains a flag that
    sets the process `Gate` to the composite read-only gate instead of `AllowAllGate` for that
    process's lifetime. Binding is local by construction: a read-only process dispatches every
@@ -522,8 +530,9 @@ already consults on every verb. All of it reuses shipped machinery:
    the store read-only fails; it does not fall back to a writable handle. Read verbs
    tolerate this: a read-only connection performs no domain writes
    (the gate denies mutations before any handler runs, and the adaptive hooks are suppressed
-   per point 3), so local dispatch never contends for the resident daemon's writer lane beyond
-   its own audit-plane appends. Extending gate identity into daemon connection admission
+   per point 3, and audit persistence is skipped with the ADR-028 A2 advisory per the
+   taxonomy above), so local dispatch never contends for the resident daemon's writer lane
+   at all. Extending gate identity into daemon connection admission
    and spawn configuration — so a restricted client could safely attach to a shared daemon —
    is structural-gateway work and stays deferred with the untrusted tier. This is the base
    ADR's A2 (mode-flag) process boundary, **not** A1 — see the honest-scope note below.

--- a/docs/adr/ADR-109-sandboxed-kkernel-gateway.md
+++ b/docs/adr/ADR-109-sandboxed-kkernel-gateway.md
@@ -427,37 +427,105 @@ already consults on every verb. All of it reuses shipped machinery:
    that lacks a closed allowlist, or whose allowlist names any verb outside the canonical read
    set. A verb added by a future pack is denied until explicitly classified and listed, not
    permitted by omission.
-3. **Membership of the read set is decided by effect, not by name.** The authoritative source
-   is a per-verb effect classification declared where verbs register — registry-level metadata
-   the read-only gate consults at dispatch, not prose documentation (the existing verb-category
+3. **Membership of the read set is decided by effect, not by name — and effect is judged over
+   the whole dispatch lifecycle, not the handler alone.** The authoritative source is a
+   per-verb effect classification declared where verbs register — registry-level metadata the
+   read-only gate consults at dispatch, not prose documentation (the existing verb-category
    metadata is documentation-only and does not qualify as an enforcement source). A verb
-   qualifies as read only if its handler performs no persistent state change of any kind.
-   Incidental writes count as mutation: a verb with read-shaped naming that updates state as a
-   side effect — the mark-read class of communication verbs, which the durable-audit ADR already
-   classifies as writers — is a mutating verb for this tier and is excluded from the read set.
-   Any verb without a declared effect classification is treated as mutating (fail-closed), so
-   the writer census cannot rot open as the catalog grows.
+   qualifies as read only if **its entire dispatch closure** — the handler, every nested
+   operation the handler invokes, and every dispatch-lifecycle hook that fires for it —
+   performs no persistent domain-state change. The lifecycle write classes are enumerated and
+   each has a defined disposition under read-only mode:
+
+   - **Domain writes** (rows in domain stores: records, edges, notes, messages, profiles,
+     grades, schedule state). Any domain write anywhere in the closure classifies the verb as
+     mutating. Incidental writes count: a verb with read-shaped naming that updates state as a
+     side effect — the mark-read class of communication verbs, which the durable-audit ADR
+     already classifies as writers — is a mutating verb for this tier and is excluded from the
+     read set.
+   - **Adaptive dispatch hooks** (the recall-scoring hooks that fold implicit signals into
+     scoring state when read verbs execute). These are domain-state writes triggered by reads.
+     Under read-only mode they are **suppressed**: the read verb dispatches and returns its
+     result, and the hook's fold is skipped for that dispatch. Suppression is the mode's
+     obligation, not the classification's — a read verb stays classified read, and the mode
+     guarantees its dispatch writes nothing.
+   - **Audit-plane appends** (the runtime's own record of what was dispatched, permitted, or
+     refused). These are **retained** under read-only mode by contract: a restricted
+     connection whose activity left no audit trail would be less observable than an
+     unrestricted one, which is the wrong direction for a security tier. Audit retention is a
+     runtime-plane exemption, named here so it cannot be read as a hole: it records dispatch
+     outcomes and is not reachable as a domain write by any argument the caller controls.
+   - **Non-durable telemetry** (in-memory counters, metrics). Out of scope; no durable state.
+
+   The **canonical read set** is the in-code closed list this classification produces: exactly
+   the registered verbs whose dispatch closure performs no domain write and requires no
+   suppressed hook beyond the adaptive-scoring class above. The code constant is the normative
+   artifact; the bundled read-only policy's allowlist is generated from it and validated
+   against it, so the two cannot drift. Any verb without a declared effect classification is
+   treated as mutating (fail-closed), so the writer census cannot rot open as the catalog
+   grows — and the classification is verified behaviorally, not by declaration alone: the
+   completeness lint gains a census arm that dispatches every read-classified verb against an
+   instrumented store and asserts zero domain writes (audit-plane appends excepted per the
+   taxonomy above).
 4. **The mode binds to the process boundary it enforces at.** `kkernel mcp` gains a flag that
    sets the process `Gate` to the composite read-only gate instead of `AllowAllGate` for that
    process's lifetime. Binding is local by construction: a read-only process dispatches every
    verb in the process that parsed the flag, and it never forwards verbs to — and never
    auto-spawns — a shared resident daemon, because a forwarded verb would be checked by the
    daemon's own gate rather than this one, and the daemon connection protocol carries no gate
-   identity today. Read verbs tolerate this: a read-only connection performs no writes at all
-   (the gate denies mutations before any handler runs), so local dispatch never contends for
-   the resident daemon's writer lane. Extending gate identity into daemon connection admission
+   identity today. Read verbs tolerate this: a read-only connection performs no domain writes
+   (the gate denies mutations before any handler runs, and the adaptive hooks are suppressed
+   per point 3), so local dispatch never contends for the resident daemon's writer lane beyond
+   its own audit-plane appends. Extending gate identity into daemon connection admission
    and spawn configuration — so a restricted client could safely attach to a shared daemon —
    is structural-gateway work and stays deferred with the untrusted tier. This is the base
    ADR's A2 (mode-flag) process boundary, **not** A1 — see the honest-scope note below.
 5. **Refusal is loud, attributable, and typed on the wire.** The `Deny` reason states that the
    verb was refused because the connection is read-only, and the MCP surface carries it as a
-   structured refusal object — a machine-readable field naming the refusal class (read-only
-   denial, as distinct from gate-unavailable and from ordinary runtime errors) and the refused
-   verb — never a flat serialized error string a client must parse. Today's wire path
-   serializes authorization refusals into ordinary error strings, so the structured refusal
-   field is in-scope wire work for this amendment, not an existing property being restated. A
-   client running against a restricted connection can therefore report the restriction rather
-   than misreading it as khive being down, without string matching.
+   structured refusal object, never a flat serialized error string a client must parse.
+   Today's wire path serializes authorization refusals into ordinary error strings, so the
+   structured refusal is in-scope wire work for this amendment, not an existing property being
+   restated. The wire contract is normative:
+
+   **Placement.** The refusal is the per-operation `error` object in the request envelope —
+   the same position where operation failures already carry `code` and `retryable` — so a
+   batch refusing one op reports it beside its siblings' results, and a single-op request
+   carries it as that op's error.
+
+   **Schema.** The refusal error object carries exactly these fields:
+
+   ```json
+   {
+     "code": "read_only_refused",
+     "kind": "permission_denied",
+     "verb": "<the refused verb, as dispatched>",
+     "mode": "read_only",
+     "effect": "mutating" | "unclassified",
+     "retryable": false,
+     "message": "<human-readable refusal, non-normative>"
+   }
+   ```
+
+   `code` is the machine-matching key; `effect` reports why the verb failed set membership
+   (`mutating` = classified as a writer, `unclassified` = fail-closed default); `message` is
+   presentation only and carries no contract. Clients match on `code`, never on `message`.
+
+   **Error mapping.** Three refusal-adjacent conditions map to three distinct wire codes and
+   are never conflated:
+
+   - `PermissionDenied` from the composite gate's membership/policy check →
+     `code: "read_only_refused"`, `retryable: false`. The connection is healthy; the verb is
+     out of contract for this mode.
+   - Gate infrastructure failure (policy engine unavailable, policy failed to load or
+     validate) → `code: "gate_unavailable"`, `kind: "permission_denied"`, `retryable: true`.
+     Fail-closed per the base ADR: the verb is refused, but the client learns the refusal is
+     an infrastructure condition that may clear, not a contract boundary.
+   - Ordinary runtime errors on a permitted read verb keep their existing codes untouched —
+     a read-only connection reports storage timeouts, not-found, and validation errors exactly
+     as an unrestricted one does.
+
+   A client running against a restricted connection can therefore report the restriction
+   rather than misreading it as khive being down, without string matching.
 
 ### Honest scope: what this does NOT serve
 
@@ -488,19 +556,29 @@ Concretely, the read-only connection is **not** a containment for a Tier-C untru
   completeness lint: every registered verb carries a classification, an unclassified verb is
   mutating by default, and the mark-read class of incidental writers is classified as mutating
   with a test pinning that classification.
+- The lifecycle census arm of that lint (point 3): every read-classified verb is dispatched
+  against an instrumented store and asserted to perform zero domain writes, with audit-plane
+  appends excepted per the write-class taxonomy.
+- Adaptive-hook suppression under read-only mode (point 3): a test that a read verb which
+  normally triggers the scoring-fold hook dispatches with the fold skipped, and that the same
+  dispatch outside read-only mode still folds.
 - The composite read-only gate (point 2): in-code canonical read-set membership intersected
   with the policy decision, plus a test that a policy hand-crafted with an extra allow branch
   for a mutating verb is still denied by the composite gate.
-- A bundled default-deny read-only Rego policy naming the closed read-verb allowlist.
+- A bundled default-deny read-only Rego policy whose allowlist is generated from the canonical
+  read-set constant and validated against it.
 - The validation lint (base ADR Fork (c)) that rejects a read-only policy which is not
   default-deny, does not declare a closed allowlist, or names an allowlist entry outside the
   canonical read set.
 - The `kkernel mcp` launch flag that installs the composite gate and pins dispatch local
   (point 4): with the flag set, daemon forwarding and daemon auto-spawn are disabled, with a
   test asserting a read-only process never opens the daemon connection path.
-- The structured refusal field on the MCP wire (point 5), with tests that a denied mutating
-  verb returns the typed read-only refusal (not a generic error string), that an incidental
-  writer such as a mark-read verb is denied, and that an allowed read verb still dispatches.
+- The structured refusal object on the MCP wire (point 5), carrying the normative schema and
+  error mapping above, with tests that a denied mutating verb returns
+  `code: "read_only_refused"` with the refused verb named (not a generic error string), that
+  an incidental writer such as a mark-read verb is denied, that a gate-infrastructure failure
+  returns `code: "gate_unavailable"` with `retryable: true`, and that an allowed read verb
+  still dispatches with its ordinary result and error codes untouched.
 
 ### Consequences of this amendment
 

--- a/docs/adr/ADR-109-sandboxed-kkernel-gateway.md
+++ b/docs/adr/ADR-109-sandboxed-kkernel-gateway.md
@@ -504,16 +504,28 @@ already consults on every verb. All of it reuses shipped machinery:
    token-minting path is **Write** on the primary namespace. This amendment does not
    reclassify it. The composite read-only gate nevertheless carries an explicit enumerated
    admission for `"authorize"`: token minting is permitted under read-only mode. That is a
-   mode-local admission decision, not a reclassification, and it is safe for three reasons,
-   each a property of the boundary the mode binds to (point 4). A `NamespaceToken` is a
-   process-internal object — it is not serializable, and its sealed constructor prevents
-   construction outside the authorization path — so the authority it nominally grants
-   cannot leave the read-only process. Every verb dispatched inside that process passes
-   the same composite gate, so no mutating verb can be exercised through a minted token.
-   And a write that bypasses verb dispatch — a runtime-API call made by code holding the
-   token — is refused by the read-only backing store; on that path the storage-layer
+   mode-local admission decision, not a reclassification, and its safety rests on the
+   boundary the mode binds to (point 4), stated honestly: token provenance is NOT part of
+   the defense. A `NamespaceToken` is not serializable, so the authority it nominally
+   grants cannot leave the read-only process — but inside the process it is an ordinary
+   derivable object (the public `NamespaceToken::with_namespace` mints a token for an
+   arbitrary namespace from any existing token, with no gate check), so the mode must hold
+   against ANY token existing in-process, however obtained. It does, on two layers. Every
+   verb dispatched inside the process passes the same composite gate, so no mutating verb
+   can be exercised through any token. And a write that bypasses verb dispatch — a
+   runtime-API call made by code holding a token — is refused by the storage layer,
+   because point 4 binds EVERY process-owned store read-only; on that path the storage
    binding, not a mint refusal, is the enforcement, and it holds whether or not a token
-   exists. Denying the mint would add no enforcement to any of these paths while breaking
+   exists. Two conditions ride the admission. First, it does not waive ADR-129
+   Amendment 1's read-scope verification: minting a token whose visibility set widens
+   beyond the primary namespace requires the gate to verify Read authority on the primary
+   AND on each extra namespace, and an implementation that presents only the primary to
+   the gate does not satisfy this amendment. The shipped `authorize_with_visibility` does
+   exactly that today; that is a conformance defect against ADR-129 independent of this
+   mode, tracked separately, and this admission does not paper over it. Second, the
+   admission is valid only in a process whose every store is bound read-only per point 4;
+   in a mixed topology it does not apply, and point 4 makes such a launch refuse to
+   start. Denying the mint would add no enforcement to any of these paths while breaking
    an admitted read verb: coordinator-backed `search` fans out by minting a per-backend
    token for each backend runtime (`authorize_with_visibility`, which issues this same
    `"authorize"` gate check), so a mint denial fails every coordinator-backed search. The
@@ -536,10 +548,14 @@ already consults on every verb. All of it reuses shipped machinery:
    starts — and the invariant is stated generally so it survives new components: a read-only
    process admits no component that writes a store outside verb dispatch; a component that
    cannot demonstrate that is not started in this mode. The mode also binds the **storage
-   layer**, not the gate alone: the flag opens the backing store read-only, so store-layer
-   maintenance that no verb gate can see (the index-maintenance class in point 3) is
-   suppressed by the same guard the storage engine already honors. A launch that cannot open
-   the store read-only fails; it does not fall back to a writable handle. Read verbs
+   layer**, not the gate alone, and it binds ALL of it: the flag opens every process-owned
+   store read-only — the main backing store, every secondary/namespace backend the process
+   constructs, and the blob store — so store-layer maintenance that no verb gate can see
+   (the index-maintenance class in point 3) is suppressed by the same guard the storage
+   engine already honors, and no runtime-API write path lands on a writable store. A mixed
+   topology — any process-owned store writable while the mode is on — is a launch error,
+   refused before any component starts, exactly as daemon mode is. A launch that cannot
+   open a store read-only fails; it does not fall back to a writable handle. Read verbs
    tolerate this: a read-only connection performs no domain writes
    (the gate denies mutations before any handler runs, and the adaptive hooks are suppressed
    per point 3, and audit persistence is skipped with the ADR-028 A2 advisory per the
@@ -670,9 +686,13 @@ Concretely, the read-only connection is **not** a containment for a Tier-C untru
 - The daemon-mode rejection (point 4): `--read-only` combined with `--daemon` is a launch
   error, with an end-to-end test asserting the process exits before any component starts —
   no scheduler, no store handle, no partial startup.
-- The storage-layer binding (point 4): the flag opens the backing store read-only, with a
-  test that a launch which cannot open the store read-only fails rather than falling back
-  to a writable handle.
+- The storage-layer binding (point 4): the flag opens every process-owned store read-only
+  — main backing store, secondary/namespace backends, blob store — with a test that a
+  launch which cannot open a store read-only fails rather than falling back to a writable
+  handle, a test that a mixed topology (any process-owned store writable) is refused at
+  launch, and direct-runtime mutation coverage: a write attempted through a minted token
+  via the runtime API — bypassing verb dispatch — is refused at the storage layer for
+  EACH process-owned store class (backend SQL write, secondary-backend write, blob put).
 - Store-maintenance suppression under the storage binding (points 3-4): index-maintenance
   writes that no verb gate can see — the ANN rebuild/watermark/compaction lifecycle
   triggered from the read path — with a test that a recall under read-only mode returns its
@@ -682,9 +702,11 @@ Concretely, the read-only connection is **not** a containment for a Tier-C untru
   admission holds under read-only mode — coordinator-backed `search` returns results, no
   audit append is attempted because the registry omits the `EventStore`, and every
   successful non-help operation carries the `audit_persistence_skipped_read_only`
-  advisory; a test that a write attempted through a minted token is refused at the
-  storage layer (the backstop the admission relies on); and a test that an unenumerated
-  synthetic operation is denied.
+  advisory; a test that minting with an `extra_visible` namespace the principal lacks
+  Read authority on is denied (the ADR-129 read-scope condition the admission carries);
+  and a test that an unenumerated synthetic operation is denied. The token-mediated
+  write-refusal arms live under the storage-layer binding criterion above, per store
+  class.
 - The structured `refusal` field on the per-operation envelope entry (point 5), carrying the
   normative schema and class mapping above with the `error` field untouched in both its
   existing shapes, with tests that a denied mutating verb returns `class: "read_only"`

--- a/docs/adr/ADR-109-sandboxed-kkernel-gateway.md
+++ b/docs/adr/ADR-109-sandboxed-kkernel-gateway.md
@@ -377,6 +377,104 @@ the gateway path.
    appear in any sandboxed contract. Revisited only via a new ADR once the write surface
    ships with demonstrated need. See the resolution under Fork (d) above.
 
+## Amendment 1 (2026-08-24): Phased implementation — the read-only connection tier
+
+**Status of amendment**: Proposed (implements a subset of this ADR; the full sandboxed
+gateway of the base decision remains Proposed and deferred as stated below).
+
+The base ADR specs one caller class — a fully sandboxed, untrusted caller — and resolves its
+process boundary to a structural one (Fork (a), A1: a thin gateway binary, never the
+unconstrained dispatch entry point). That is the right shape for an untrusted caller and it is
+a nontrivial new build. This amendment separates the caller classes by **input provenance** and
+commits to building the smaller, lower-risk one first, on machinery that already ships, while
+keeping the base ADR's structural boundary as the untrusted-tier answer.
+
+### Caller classes by input provenance
+
+The trust question is not _which_ process connects, it is _what input that process has already
+consumed_ by the time it calls a verb:
+
+- **Tier A — trusted.** A caller operating only on operator-directed or first-party
+  instructions. Full verb catalog, subject to whatever `Gate` the deployment installs (status
+  quo; `AllowAllGate` by default).
+- **Tier B — semi-trusted, read-scoped.** A caller trusted to _read_ the graph but which should
+  not _mutate_ it, and whose inputs are first-party (it has not consumed attacker-influenced
+  content). The motivating case is an observer process that reads first-party state to make a
+  decision and must not write back. This amendment builds the control for this tier.
+- **Tier C — untrusted.** A caller that has consumed content it does not control (a fetched
+  page, a third-party document, an external tool result) and could therefore be steered into
+  calling verbs the operator did not intend. This is the base ADR's caller class.
+
+### What this amendment builds: the Tier-B read-only connection
+
+A **read-only connection mode**: a per-process khive connection whose `Gate` denies every
+mutating verb and permits only the read-verb set, enforced at the dispatch seam the runtime
+already consults on every verb. All of it reuses shipped machinery:
+
+1. **Enforcement seam already exists.** `VerbRegistry` dispatch already builds a `GateRequest`
+   carrying the _actual_ verb and calls `Gate::check` before the pack handler runs; a `Deny`
+   returns `PermissionDenied` with a reason (ADR-018, as amended fail-closed by ADR-129). No new
+   dispatch path is introduced — this is the same seam the base ADR's rule names.
+2. **The policy is a default-deny Rego policy** naming a closed read-verb allowlist, loaded by
+   the existing `RegoGate` (`from_dir` / `from_policy_str`). This is the base ADR's Fork (c)
+   resolution (constrained Rego on the existing engine, a required default-deny template, and a
+   validation lint that rejects any policy lacking a closed allowlist) applied to the read-only
+   case. Every verb outside the allowlist — every mutating verb — is denied by the default rule,
+   so a verb added to a future pack is denied until explicitly listed, not permitted by omission.
+3. **A launch flag installs it.** `kkernel mcp` gains a flag that sets the process `Gate` to the
+   read-only `RegoGate` instead of `AllowAllGate` for that process's lifetime. This is the base
+   ADR's A2 (mode-flag) process boundary, **not** A1 — see the honest-scope note below.
+4. **Refusal is loud and attributable.** The `Deny` reason states that the verb was refused
+   because the connection is read-only, and the MCP surface returns it as a typed refusal the
+   client can distinguish from an outage — so a client running against a restricted connection
+   reports the restriction rather than misreading it as khive being down.
+
+### Honest scope: what this does NOT serve
+
+The base ADR **rejected A2 (a launch-flag/config process boundary) outright** for the untrusted
+caller, because a silent misconfiguration (flag omitted, or a bug in flag handling) reverts to
+the full surface, and for an untrusted caller that is an unacceptable failure mode. That
+rejection stands. This amendment uses A2 **only for Tier B**, where the threat being defended
+against is _the operator's own misconfiguration of a trusted-to-read process_, not an adversary
+probing for an escape. For Tier B a launch-flag boundary is proportionate; for Tier C it is not,
+and this amendment does not offer it as one.
+
+Concretely, the read-only connection is **not** a containment for a Tier-C untrusted caller:
+
+- A read-only connection still exposes the read verbs, and read verbs are an exfiltration
+  surface (the base ADR's "Exfiltration via verbs" threat). An untrusted caller should not hold
+  even read access to arbitrary graph state.
+- The control for a Tier-C caller is therefore **absence of a khive connection at all**, decided
+  at the orchestration/deployment layer, not a read-only policy. A caller that has consumed
+  untrusted input is given no khive surface.
+- The one future case where a Tier-C caller legitimately needs _live read_ access is exactly
+  what the base ADR's A1 structural gateway (thin proxy binary, namespace pinning, enforced
+  rate/budget caps) is for. That build stays deferred until such a caller is real; the rate-cap
+  enforcement (base ADR rule 5) is a later phase and is **not** part of this amendment.
+
+### Implementation plan (Tier-B phase)
+
+- A bundled default-deny read-only Rego policy naming the closed read-verb allowlist, plus the
+  read/mutating classification of the current verb catalog it rests on.
+- The `kkernel mcp` launch flag that installs the read-only `RegoGate`.
+- The validation lint (base ADR Fork (c)) that rejects a read-only policy which is not
+  default-deny or does not declare a closed allowlist.
+- Confirmation that the `Deny` reason and the MCP-surface refusal are typed and attributable per
+  point 4, with a test that a denied mutating verb returns the read-only refusal (not a generic
+  error) and that an allowed read verb still dispatches.
+
+### Consequences of this amendment
+
+- **Positive.** Ships a real server-side read-only boundary now, on shipped machinery, closing
+  the gap where a process's read-only-ness depended on client-side configuration alone. Keeps
+  the base ADR's structural boundary honest for the untrusted tier rather than quietly
+  substituting the weaker A2 form for it.
+- **Negative.** A2's failure mode (a misconfigured launch reverts to the installed base `Gate`)
+  is real; this amendment accepts it _only_ for Tier B and says so in the flag's own
+  documentation. The read/mutating verb classification must be maintained as the catalog grows —
+  the default-deny posture makes an unclassified new verb fail safe (denied), which is the
+  correct direction, but a read verb wrongly omitted is a false denial to fix, not a hole.
+
 ## References
 
 - ADR-018 - Authorization Gate; `Gate`, `GateRequest`, `GateDecision`, `Obligation`,

--- a/docs/adr/ADR-109-sandboxed-kkernel-gateway.md
+++ b/docs/adr/ADR-109-sandboxed-kkernel-gateway.md
@@ -502,14 +502,26 @@ already consults on every verb. All of it reuses shipped machinery:
    synthetic string is `"authorize"`, and ADR-129 Amendment 1 already classifies it: a
    pseudo-verb is checked against the full authority its result grants, which for the
    token-minting path is **Write** on the primary namespace. This amendment does not
-   reclassify it. Under read-only mode the Write check therefore denies both of its
-   consumers, and both denials are the mode operating correctly: token minting is refused —
-   the honest semantics of a read+write token, the consequence ADR-129 itself names — and
-   the audit-attachment authorization never passes, which detaches nothing, because the
-   registry has already omitted the `EventStore` per the audit taxonomy above and the
-   per-response advisory makes that skip visible to every caller. An unenumerated synthetic
-   operation remains fail-closed mutating, so the enumeration cannot rot open as new
-   synthetic operations appear.
+   reclassify it. The composite read-only gate nevertheless carries an explicit enumerated
+   admission for `"authorize"`: token minting is permitted under read-only mode. That is a
+   mode-local admission decision, not a reclassification, and it is safe for three reasons,
+   each a property of the boundary the mode binds to (point 4). A `NamespaceToken` is a
+   process-internal object — it is not serializable, and its sealed constructor prevents
+   construction outside the authorization path — so the authority it nominally grants
+   cannot leave the read-only process. Every verb dispatched inside that process passes
+   the same composite gate, so no mutating verb can be exercised through a minted token.
+   And a write that bypasses verb dispatch — a runtime-API call made by code holding the
+   token — is refused by the read-only backing store; on that path the storage-layer
+   binding, not a mint refusal, is the enforcement, and it holds whether or not a token
+   exists. Denying the mint would add no enforcement to any of these paths while breaking
+   an admitted read verb: coordinator-backed `search` fans out by minting a per-backend
+   token for each backend runtime (`authorize_with_visibility`, which issues this same
+   `"authorize"` gate check), so a mint denial fails every coordinator-backed search. The
+   audit-attachment authorization passes under the same admission and attaches nothing,
+   because the registry has already omitted the `EventStore` per the audit taxonomy above
+   and the per-response advisory makes that skip visible to every caller. An unenumerated
+   synthetic operation remains fail-closed mutating, so the enumeration cannot rot open as
+   new synthetic operations appear.
 4. **The mode binds to the process boundary it enforces at.** `kkernel mcp` gains a flag that
    sets the process `Gate` to the composite read-only gate instead of `AllowAllGate` for that
    process's lifetime. Binding is local by construction: a read-only process dispatches every
@@ -666,9 +678,13 @@ Concretely, the read-only connection is **not** a containment for a Tier-C untru
   triggered from the read path — with a test that a recall under read-only mode returns its
   result while performing no persistent index write, and the same recall outside read-only
   mode still maintains the index.
-- The synthetic-operation enumeration (point 3): a test that the audit-attachment
-  authorization is permitted under read-only mode and audit appends survive, and that an
-  unenumerated synthetic operation is denied.
+- The synthetic-operation enumeration (point 3): a test that the enumerated `"authorize"`
+  admission holds under read-only mode — coordinator-backed `search` returns results, no
+  audit append is attempted because the registry omits the `EventStore`, and every
+  successful non-help operation carries the `audit_persistence_skipped_read_only`
+  advisory; a test that a write attempted through a minted token is refused at the
+  storage layer (the backstop the admission relies on); and a test that an unenumerated
+  synthetic operation is denied.
 - The structured `refusal` field on the per-operation envelope entry (point 5), carrying the
   normative schema and class mapping above with the `error` field untouched in both its
   existing shapes, with tests that a denied mutating verb returns `class: "read_only"`

--- a/docs/adr/ADR-109-sandboxed-kkernel-gateway.md
+++ b/docs/adr/ADR-109-sandboxed-kkernel-gateway.md
@@ -456,17 +456,32 @@ already consults on every verb. All of it reuses shipped machinery:
      runtime-plane exemption, named here so it cannot be read as a hole: it records dispatch
      outcomes and is not reachable as a domain write by any argument the caller controls.
    - **Non-durable telemetry** (in-memory counters, metrics). Out of scope; no durable state.
+   - **Deferred writes belong to the dispatch that scheduled them.** A write scheduled by a
+     dispatch but executed after the response returns — a tracked background task, a
+     post-return continuation — is part of that dispatch's effect closure, and the mode's
+     guarantee covers it. Two enforcement paths exist and both are required. A background
+     path that re-enters verb dispatch (the recall pipeline's serve-ledger record is
+     dispatched as a verb from a tracked background task) passes through the same process
+     gate, so its mutating verb is denied under read-only mode; the scheduling site must
+     treat that denial as the mode operating, not an error to escalate — under read-only
+     mode it skips the scheduling or logs the refusal at debug level. A background path
+     that writes a store directly without re-entering dispatch (the recall-telemetry event
+     append) passes no verb gate, so its write site must itself consult the mode and
+     suppress domain writes; fail-closed, a background store write not classified under the
+     taxonomy above is a domain write and is suppressed.
 
    The **canonical read set** is the in-code closed list this classification produces: exactly
-   the registered verbs whose dispatch closure performs no domain write and requires no
-   suppressed hook beyond the adaptive-scoring class above. The code constant is the normative
-   artifact; the bundled read-only policy's allowlist is generated from it and validated
-   against it, so the two cannot drift. Any verb without a declared effect classification is
-   treated as mutating (fail-closed), so the writer census cannot rot open as the catalog
-   grows — and the classification is verified behaviorally, not by declaration alone: the
-   completeness lint gains a census arm that dispatches every read-classified verb against an
-   instrumented store and asserts zero domain writes (audit-plane appends excepted per the
-   taxonomy above).
+   the registered verbs whose dispatch closure — deferred writes included — performs no
+   domain write and requires no suppressed hook beyond the adaptive-scoring class above. The
+   code constant is the normative artifact; the bundled read-only policy's allowlist is
+   generated from it and validated against it, so the two cannot drift. Any verb without a
+   declared effect classification is treated as mutating (fail-closed), so the writer census
+   cannot rot open as the catalog grows — and the classification is verified behaviorally,
+   not by declaration alone: the completeness lint gains a census arm that dispatches every
+   read-classified verb against an instrumented store, **joins the runtime's tracked
+   background tasks for that dispatch before asserting** (the runtime already tracks them;
+   an assertion that races the background lane would pass vacuously), and asserts zero
+   domain writes (audit-plane appends excepted per the taxonomy above).
 4. **The mode binds to the process boundary it enforces at.** `kkernel mcp` gains a flag that
    sets the process `Gate` to the composite read-only gate instead of `AllowAllGate` for that
    process's lifetime. Binding is local by construction: a read-only process dispatches every
@@ -487,45 +502,55 @@ already consults on every verb. All of it reuses shipped machinery:
    structured refusal is in-scope wire work for this amendment, not an existing property being
    restated. The wire contract is normative:
 
-   **Placement.** The refusal is the per-operation `error` object in the request envelope —
-   the same position where operation failures already carry `code` and `retryable` — so a
-   batch refusing one op reports it beside its siblings' results, and a single-op request
-   carries it as that op's error.
+   **Placement.** The request-DSL envelope's per-operation failure entry is
+   `{ "ok": false, "tool": "<verb>", "error": "<string>", "reason"?: "<string>" }` — the
+   `error` field is a human-readable string by contract, and that contract is unchanged
+   here (no existing client's error handling breaks). The refusal adds one structured
+   sibling field on the same entry, following the envelope's existing pattern of typed
+   fields beside the string (`reason` today): a `refusal` object, present exactly when the
+   process gate denied the operation, absent otherwise. A batch refusing one op reports it
+   beside its siblings' results; a single-op request carries it on that op's entry.
 
-   **Schema.** The refusal error object carries exactly these fields:
+   **Schema.** The `refusal` object carries exactly these fields:
 
    ```json
    {
-     "code": "read_only_refused",
-     "kind": "permission_denied",
+     "class": "read_only" | "policy" | "gate_error",
      "verb": "<the refused verb, as dispatched>",
      "mode": "read_only",
-     "effect": "mutating" | "unclassified",
-     "retryable": false,
-     "message": "<human-readable refusal, non-normative>"
+     "effect": "read" | "mutating" | "unclassified"
    }
    ```
 
-   `code` is the machine-matching key; `effect` reports why the verb failed set membership
-   (`mutating` = classified as a writer, `unclassified` = fail-closed default); `message` is
-   presentation only and carries no contract. Clients match on `code`, never on `message`.
+   `class` is the machine-matching key; `effect` is defined for every class and reports the
+   verb's classification (`read` = in the canonical read set, `mutating` = classified as a
+   writer, `unclassified` = fail-closed default). Clients match on `class`, never on the
+   `error` string, which remains presentation-only.
 
-   **Error mapping.** Three refusal-adjacent conditions map to three distinct wire codes and
-   are never conflated:
+   **Class mapping.** The three deny paths the shipped gate contract actually produces map
+   to the three classes and are never conflated:
 
-   - `PermissionDenied` from the composite gate's membership/policy check →
-     `code: "read_only_refused"`, `retryable: false`. The connection is healthy; the verb is
-     out of contract for this mode.
-   - Gate infrastructure failure (policy engine unavailable, policy failed to load or
-     validate) → `code: "gate_unavailable"`, `kind: "permission_denied"`, `retryable: true`.
-     Fail-closed per the base ADR: the verb is refused, but the client learns the refusal is
-     an infrastructure condition that may clear, not a contract boundary.
-   - Ordinary runtime errors on a permitted read verb keep their existing codes untouched —
-     a read-only connection reports storage timeouts, not-found, and validation errors exactly
-     as an unrestricted one does.
+   - Canonical-set membership failure (the verb is `mutating` or `unclassified`) →
+     `class: "read_only"`. The connection is healthy; the verb is out of contract for this
+     mode. This is the common case and the only class a correctly configured deployment
+     emits.
+   - Policy narrowing (the verb is in the canonical read set — `effect: "read"` — but the
+     installed policy's allowlist excludes it) → `class: "policy"`. Distinguishable from
+     `read_only` so an operator can tell a mode boundary from their own policy choice.
+   - Gate evaluation failure at dispatch → `class: "gate_error"`. Per the authorization-gate
+     ADR's shipped contract, policy-load failures are construction time — a broken policy
+     never reaches dispatch because the process refuses to construct the gate — and
+     dispatch-time evaluation uncertainty is already converted by the Rego gate into an
+     explicit deny with a diagnostic reason; only pre-evaluation failures (gate-request
+     serialization) surface as gate errors, and fail-closed (ADR-129) they deny. This class
+     is therefore rare by construction, and no "retryable infrastructure outage" refusal
+     state exists to represent: there is no `gate_unavailable`.
 
-   A client running against a restricted connection can therefore report the restriction
-   rather than misreading it as khive being down, without string matching.
+   Ordinary runtime errors on a permitted read verb are untouched — no `refusal` field, and
+   a read-only connection reports storage timeouts, not-found, and validation errors exactly
+   as an unrestricted one does. A client running against a restricted connection can
+   therefore report the restriction rather than misreading it as khive being down, without
+   string matching.
 
 ### Honest scope: what this does NOT serve
 
@@ -557,11 +582,16 @@ Concretely, the read-only connection is **not** a containment for a Tier-C untru
   mutating by default, and the mark-read class of incidental writers is classified as mutating
   with a test pinning that classification.
 - The lifecycle census arm of that lint (point 3): every read-classified verb is dispatched
-  against an instrumented store and asserted to perform zero domain writes, with audit-plane
+  against an instrumented store, the runtime's tracked background tasks are joined before
+  asserting, and the dispatch is asserted to perform zero domain writes, with audit-plane
   appends excepted per the write-class taxonomy.
 - Adaptive-hook suppression under read-only mode (point 3): a test that a read verb which
   normally triggers the scoring-fold hook dispatches with the fold skipped, and that the same
   dispatch outside read-only mode still folds.
+- Deferred-write suppression under read-only mode (point 3): the recall pipeline's
+  background lane as the pinned case — a test that under read-only mode the serve-ledger
+  verb dispatch is not escalated as an error and the direct telemetry-event append does not
+  write, with the same recall outside read-only mode writing both.
 - The composite read-only gate (point 2): in-code canonical read-set membership intersected
   with the policy decision, plus a test that a policy hand-crafted with an extra allow branch
   for a mutating verb is still denied by the composite gate.
@@ -573,12 +603,12 @@ Concretely, the read-only connection is **not** a containment for a Tier-C untru
 - The `kkernel mcp` launch flag that installs the composite gate and pins dispatch local
   (point 4): with the flag set, daemon forwarding and daemon auto-spawn are disabled, with a
   test asserting a read-only process never opens the daemon connection path.
-- The structured refusal object on the MCP wire (point 5), carrying the normative schema and
-  error mapping above, with tests that a denied mutating verb returns
-  `code: "read_only_refused"` with the refused verb named (not a generic error string), that
-  an incidental writer such as a mark-read verb is denied, that a gate-infrastructure failure
-  returns `code: "gate_unavailable"` with `retryable: true`, and that an allowed read verb
-  still dispatches with its ordinary result and error codes untouched.
+- The structured `refusal` field on the per-operation envelope entry (point 5), carrying the
+  normative schema and class mapping above with the string `error` field unchanged, with
+  tests that a denied mutating verb returns `class: "read_only"` naming the refused verb,
+  that an incidental writer such as a mark-read verb is denied, that a policy-narrowed read
+  verb returns `class: "policy"` with `effect: "read"`, and that an allowed read verb still
+  dispatches with its ordinary result and errors untouched (no `refusal` field).
 
 ### Consequences of this amendment
 


### PR DESCRIPTION
Supersedes #2150, carrying the same amendment with the refusal wire contract narrowed to match the shipped gate seam.

Amendment 1 adds the Tier-B read-only connection tier to ADR-109: a process-mode gate composed ahead of the installed authorization gate, a lifecycle-wide effect classification for writes (including background/deferred writes joined to the dispatch closure), and a structured refusal object on the per-operation envelope entry.

What changed relative to the superseded PR: the refusal `class` field previously promised three values (`read_only`/`policy`/`gate_error`), attributing deny provenance the gate seam does not carry — the authorization gate returns one deny decision shape for policy narrowing and fail-closed evaluation outcomes alike. The contract now defines two classes decided by which gate refused, in dispatch order: `read_only` (the process-mode check, which can attribute itself) and `denied` (the authorization gate, claiming no finer provenance). Splitting `denied` is recorded as deferred work gated on typed deny provenance in the gate seam itself.