### PR TITLE
fix(kg-editor): resolve curated deep-link aliases

### DIFF
--- a/apps/kg-editor/src/components/showcase/showcase.test.tsx
+++ b/apps/kg-editor/src/components/showcase/showcase.test.tsx
@@ -180,6 +180,21 @@ describe("materialized repository lookup", () => {
     },
   );
 
+  it("opens a curated analysis-id deep link and canonicalizes it", async () => {
+    window.history.replaceState(null, "", "/?repo=khive");
+
+    const { container } = render(<Showcase />);
+
+    await waitFor(() => expect(container.querySelector(".repo-overview")).toBeVisible());
+    expect(screen.queryByText("Repository lookup could not start")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Public repository URL")).toHaveValue(
+      bundle.meta.repository.canonical_url,
+    );
+    expect(new URL(window.location.href).searchParams.get("repo")).toBe(
+      bundle.meta.repository.canonical_url,
+    );
+  });
+
   it("preserves a direct investigation while canonicalizing a curated alias", async () => {
     const pool = bundle.graph.modules.items.find((module) =>
       module.source_path.endsWith("khive-db/src/pool.rs")

--- a/apps/kg-editor/src/components/showcase/showcase.tsx
+++ b/apps/kg-editor/src/components/showcase/showcase.tsx
@@ -181,7 +181,7 @@ export function Showcase() {
         message: catalogResult.message,
       });
 
-      const parsed = parseRepositoryLocation(originalLocation);
+      const parsed = parseRepositoryLocation(originalLocation, registry);
       const repositoryIssue = parsed.issues.find((issue) =>
         issue.parameter === "repo"
       );

--- a/apps/kg-editor/src/lib/repository-location.test.ts
+++ b/apps/kg-editor/src/lib/repository-location.test.ts
@@ -13,6 +13,15 @@ const repository = "https://github.com/ohdearquant/khive";
 const snapshotSha = "0123456789abcdef0123456789abcdef01234567";
 
 describe("repository investigation location", () => {
+  it("accepts a curated repository alias and stores its canonical URL", () => {
+    const parsed = parseRepositoryLocation(
+      new URL("https://example.test/?repo=khive"),
+    );
+
+    expect(parsed.issues).toEqual([]);
+    expect(parsed.location.repository).toBe(repository);
+  });
+
   it.each(REPOSITORY_VIEW_IDS)(
     "round-trips a shareable %s investigation",
     (view: ViewId) => {

--- a/apps/kg-editor/src/lib/repository-location.ts
+++ b/apps/kg-editor/src/lib/repository-location.ts
@@ -1,5 +1,10 @@
 import type { ViewId } from "@/lib/repo-bundle";
-import { normalizeRepositoryUrl } from "@/lib/showcase-registry";
+import {
+  normalizeRepositoryUrl,
+  resolveShowcaseRepository,
+  SHOWCASE_REGISTRY,
+  type ShowcaseRegistryEntry,
+} from "@/lib/showcase-registry";
 
 export const REPOSITORY_VIEW_IDS = [
   "structure_graph",
@@ -87,14 +92,15 @@ function singleParameter(
 function parseRepository(
   value: string | null,
   issues: RepositoryLocationIssue[],
+  registry: readonly ShowcaseRegistryEntry[],
 ): string | null {
   if (value == null) return null;
-  const normalized = normalizeRepositoryUrl(value);
-  if (!normalized.ok) {
-    issues.push({ parameter: "repo", message: normalized.reason });
+  const lookup = resolveShowcaseRepository(value, registry);
+  if (lookup.status === "invalid") {
+    issues.push({ parameter: "repo", message: lookup.reason });
     return null;
   }
-  return normalized.value;
+  return lookup.normalizedUrl;
 }
 
 function parseSnapshotSha(
@@ -140,7 +146,10 @@ function parseView(
   return value as ViewId;
 }
 
-export function parseRepositoryLocation(url: URL): ParsedRepositoryLocation {
+export function parseRepositoryLocation(
+  url: URL,
+  registry: readonly ShowcaseRegistryEntry[] = SHOWCASE_REGISTRY,
+): ParsedRepositoryLocation {
   const issues: RepositoryLocationIssue[] = [];
   const repository = singleParameter(url, "repo", issues);
   const snapshotSha = singleParameter(url, "at", issues);
@@ -149,7 +158,7 @@ export function parseRepositoryLocation(url: URL): ParsedRepositoryLocation {
 
   return {
     location: {
-      repository: parseRepository(repository, issues),
+      repository: parseRepository(repository, issues, registry),
       snapshotSha: parseSnapshotSha(snapshotSha, issues),
       modulePath: parseModulePath(modulePath, issues),
       view: parseView(view, issues),

--- a/apps/kg-editor/src/lib/showcase-registry.test.ts
+++ b/apps/kg-editor/src/lib/showcase-registry.test.ts
@@ -7,6 +7,16 @@ import {
 } from "@/lib/showcase-registry";
 
 describe("showcase registry", () => {
+  it("resolves a curated analysis id before URL validation", () => {
+    const result = resolveShowcaseRepository("khive");
+
+    expect(result.status).toBe("hit");
+    if (result.status === "hit") {
+      expect(result.entry.id).toBe("github.com/ohdearquant/khive");
+      expect(result.normalizedUrl).toBe("https://github.com/ohdearquant/khive");
+    }
+  });
+
   it.each([
     "https://github.com/ohdearquant/khive",
     "https://github.com/ohdearquant/khive/",

--- a/apps/kg-editor/src/lib/showcase-registry.ts
+++ b/apps/kg-editor/src/lib/showcase-registry.ts
@@ -19,6 +19,7 @@ export const SHOWCASE_REGISTRY: readonly ShowcaseRegistryEntry[] = [
     id: "github.com/ohdearquant/khive",
     canonicalUrl: "https://github.com/ohdearquant/khive",
     aliases: [
+      "khive",
       "https://github.com/ohdearquant/khive",
       "http://github.com/ohdearquant/khive",
       "https://www.github.com/ohdearquant/khive",
@@ -159,6 +160,16 @@ export function resolveShowcaseRepository(
   input: string,
   registry: readonly ShowcaseRegistryEntry[] = SHOWCASE_REGISTRY,
 ): ShowcaseLookup {
+  const candidate = input.trim();
+  for (const entry of registry) {
+    if (!entry.aliases.includes(candidate)) continue;
+
+    const canonical = normalizeRepositoryUrl(entry.canonicalUrl);
+    if (canonical.ok) {
+      return { status: "hit", normalizedUrl: canonical.value, entry };
+    }
+  }
+
   const normalized = normalizeRepositoryUrl(input);
   if (!normalized.ok) return { status: "invalid", reason: normalized.reason };
 


### PR DESCRIPTION
## Summary

- resolve curated repository aliases before public URL validation
- pass the loaded registry into deep-link parsing so catalog-aware aliases canonicalize correctly
- cover registry, location-parser, and rendered deep-link behavior for `/?repo=khive`

## Validation

- `npx vitest run src/lib/showcase-registry.test.ts src/lib/repository-location.test.ts src/components/showcase/showcase.test.tsx`
- `npm run lint`
- `npm run typecheck`
- `npm run test` (290 passed)
- `git diff --check`

Closes #2035
