### PR TITLE
fix(runtime): preserve empty property strings

### DIFF
--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -7,6 +7,7 @@
 use async_trait::async_trait;
 use khive_pack_kg::KgPack;
 use khive_runtime::pack::{HandlerDef, PackRuntime};
+use khive_runtime::presentation::{present, PresentationMode};
 use khive_runtime::{
     arm_prefix_resolve_fail_scoped, EntityCreateSpec, KhiveRuntime, Namespace, NamespaceToken,
     ParamDef, RuntimeError, VerbCategory, VerbRegistry, VerbRegistryBuilder, VerifiedActor,
@@ -4018,6 +4019,57 @@ async fn update_entity_without_kind_resolves_from_uuid() {
     assert!(
         desc.contains("updated via UUID inference"),
         "updated entity must carry new description; got: {updated}"
+    );
+}
+
+#[tokio::test]
+async fn update_empty_string_property_survives_agent_echo_and_readback() {
+    let pack = pack();
+    let created = pack
+        .dispatch(
+            "create",
+            json!({
+                "kind": "concept",
+                "name": "Empty property update target",
+                "properties": {"summary": "before"}
+            }),
+        )
+        .await
+        .expect("create must succeed");
+    let id = created["id"].as_str().expect("created id").to_string();
+
+    let updated = pack
+        .dispatch("update", json!({"id": id, "properties": {"summary": ""}}))
+        .await
+        .expect("empty-string property update must succeed");
+    assert_eq!(
+        updated["properties"]["summary"],
+        json!(""),
+        "canonical update response must reflect the stored empty string"
+    );
+
+    let fetched = pack
+        .dispatch("get", json!({"id": id}))
+        .await
+        .expect("readback must succeed");
+    assert_eq!(
+        fetched["properties"]["summary"],
+        json!(""),
+        "canonical readback must retain the empty string"
+    );
+
+    let agent_echo = present(updated, PresentationMode::Agent, 0);
+    assert_eq!(
+        agent_echo["properties"]["summary"],
+        json!(""),
+        "Agent update echo must not render the property as deleted: {agent_echo}"
+    );
+
+    let agent_readback = present(fetched, PresentationMode::Agent, 0);
+    assert_eq!(
+        agent_readback["properties"]["summary"],
+        json!(""),
+        "Agent readback must retain the same empty-string value: {agent_readback}"
     );
 }
 

--- a/crates/khive-runtime/src/presentation.rs
+++ b/crates/khive-runtime/src/presentation.rs
@@ -585,8 +585,9 @@ pub fn present(value: Value, mode: PresentationMode, now_unix_seconds: i64) -> V
 /// Apply the Agent-mode transform to an arbitrary JSON value.
 ///
 /// `inside_properties` is `true` when recursing inside a `"properties"` object.
-/// Caller-supplied payload timestamps (e.g. `trigger_at`) must not be compacted
-/// because they encode domain semantics the agent may need to round-trip.
+/// Caller-supplied empty strings and payload timestamps (e.g. `trigger_at`)
+/// must not be compacted because they encode domain semantics the agent may
+/// need to round-trip.
 fn transform_agent(
     value: Value,
     preserved_nulls: &HashSet<&str>,
@@ -646,13 +647,14 @@ fn transform_agent(
 ///
 /// Returns `None` if the field should be dropped.
 ///
-/// `inside_properties` suppresses timestamp compaction for caller-submitted
-/// payload values nested under a literal `"properties"` key (e.g. `trigger_at`
-/// as returned by `agenda`/`get`). `payload_timestamps` suppresses compaction
-/// by field name regardless of nesting, covering top-level convenience fields
-/// such as the `trigger_at` returned directly in a `schedule.remind`/
-/// `schedule.schedule` create response (#871). Metadata timestamps at the top
-/// level (`created_at`, `updated_at`) are still compacted.
+/// `inside_properties` preserves empty strings and suppresses timestamp
+/// compaction for caller-submitted payload values nested under a literal
+/// `"properties"` key (e.g. `trigger_at` as returned by `agenda`/`get`).
+/// `payload_timestamps` suppresses compaction by field name regardless of
+/// nesting, covering top-level convenience fields such as the `trigger_at`
+/// returned directly in a `schedule.remind`/`schedule.schedule` create
+/// response (#871). Metadata timestamps at the top level (`created_at`,
+/// `updated_at`) are still compacted.
 #[derive(Clone, Copy)]
 struct AgentFieldContext {
     inside_properties: bool,
@@ -687,8 +689,8 @@ fn transform_field_agent(
         {
             Some(value)
         }
-        // Drop other empty strings, arrays, objects.
-        Value::String(s) if s.is_empty() => None,
+        // Caller-owned property strings are data; drop empty strings elsewhere.
+        Value::String(s) if s.is_empty() && !context.inside_properties => None,
         Value::Array(a) if a.is_empty() => None,
         Value::Object(o) if o.is_empty() => None,
         // Truncate score fields.


### PR DESCRIPTION
## Summary

- preserve empty strings nested inside caller-owned `properties` during Agent presentation
- retain existing empty-field compaction for response metadata outside `properties`
- cover update echo and subsequent get readback with a regression test

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p khive-runtime --all-targets -- -D warnings`
- `cargo clippy -p khive-pack-kg --all-targets -- -D warnings`
- `cargo test -p khive-pack-kg`
- `cargo test -p khive-runtime --lib`
- regression: `update_empty_string_property_survives_agent_echo_and_readback`

Fixes #1995
