### PR TITLE
fix(kg-editor): polish repository showcase signals

### DIFF
--- a/apps/kg-editor/src/app/showcase.css
+++ b/apps/kg-editor/src/app/showcase.css
@@ -949,7 +949,7 @@ button.repo-list-row:hover,
 .repo-treemap-module strong { font-size: var(--khive-type-md); white-space: nowrap; }
 .repo-treemap-module span { font-size: var(--khive-type-xs); margin-top: 3px; }
 
-.repo-score-grid { display: grid; gap: 10px; grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.repo-score-grid { align-items: start; display: grid; gap: 10px; grid-template-columns: repeat(3, minmax(0, 1fr)); }
 .repo-score-card { background: var(--khive-color-surface-overlay); border: 1px solid var(--repo-border); border-radius: var(--khive-radius-lg); min-height: 126px; padding: 13px; }
 .repo-score-card > span { color: var(--repo-muted); display: block; font-size: var(--khive-type-sm); min-height: 19px; }
 .repo-score-value { gap: 7px; margin-top: 10px; }

--- a/apps/kg-editor/src/components/showcase/repo-showcase-polish.test.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase-polish.test.tsx
@@ -11,7 +11,6 @@ const goldenPath = resolve(
   process.cwd(),
   "../../docs/schemas/examples/khive-repo-v1-khive.json",
 );
-const showcaseCssPath = resolve(process.cwd(), "src/app/showcase.css");
 
 function golden(): RepoBundle {
   return parseRepoBundle(JSON.parse(readFileSync(goldenPath, "utf8")));
@@ -29,68 +28,109 @@ describe("repository showcase polish", () => {
 
     await user.click(container.querySelector('[data-view-id="scorecard"]')!);
 
-    const ageCard = screen.getByText(bundle.capability.labels.metrics.repository_age)
+    const ageCard = screen
+      .getByText(bundle.capability.labels.metrics.repository_age)
       .closest("article")!;
     expect(within(ageCard).getByText("61 days")).toBeVisible();
 
     const warningIds = new Set(
       bundle.aggregates.scorecard.fields.flatMap((field) =>
-        field.key === "ownership_warnings"
-          && field.value.status === "available"
-          && field.value.value.value_kind === "module_ids"
+        field.key === "ownership_warnings" &&
+        field.value.status === "available" &&
+        field.value.value.value_kind === "module_ids"
           ? field.value.value.value.items
-          : []
+          : [],
       ),
     );
-    const highImpactWarningCount = bundle.aggregates.hotspot_quadrant.data.items
-      .filter((row) =>
-        row.quadrant === "high_churn_high_fan_in" && warningIds.has(row.module_id)
+    const highImpactWarningCount =
+      bundle.aggregates.hotspot_quadrant.data.items.filter(
+        (row) =>
+          row.quadrant === "high_churn_high_fan_in" &&
+          warningIds.has(row.module_id),
       ).length;
     expect(highImpactWarningCount).toBeGreaterThan(0);
     expect(highImpactWarningCount).toBeLessThan(warningIds.size);
-    const warningCard = screen.getByText(
-      bundle.capability.labels.metrics.ownership_warnings,
-    ).closest("article")!;
-    expect(within(warningCard).getByText(highImpactWarningCount.toLocaleString("en")))
-      .toBeVisible();
+    const warningCard = screen
+      .getByText(bundle.capability.labels.metrics.ownership_warnings)
+      .closest("article")!;
+    expect(
+      within(warningCard).getByText(
+        highImpactWarningCount.toLocaleString("en"),
+      ),
+    ).toBeVisible();
     expect(warningCard).toHaveTextContent("High churn · high fan-in tier");
 
-    const symbolCard = screen.getByText(bundle.capability.labels.metrics.symbol_count)
+    const symbolCard = screen
+      .getByText(bundle.capability.labels.metrics.symbol_count)
       .closest("article")!;
     expect(symbolCard).toHaveClass("unavailable");
-    expect(readFileSync(showcaseCssPath, "utf8")).toMatch(
-      /\.repo-score-grid\s*\{[^}]*align-items:\s*start;/,
+  });
+
+  it("withholds the ownership tier when the hotspot page is incomplete", async () => {
+    const raw = JSON.parse(readFileSync(goldenPath, "utf8"));
+    // A cursor-bearing hotspot page may be missing exactly the modules the
+    // tier filter selects; the tier claim must not survive that.
+    raw.aggregates.hotspot_quadrant.data.next_cursor = "hotspot-cursor-1";
+    const bundle = parseRepoBundle(raw);
+    const user = userEvent.setup();
+    const { container } = render(<RepoShowcase bundle={bundle} />);
+
+    await user.click(container.querySelector('[data-view-id="scorecard"]')!);
+
+    const warningIds = new Set(
+      bundle.aggregates.scorecard.fields.flatMap((field) =>
+        field.key === "ownership_warnings" &&
+        field.value.status === "available" &&
+        field.value.value.value_kind === "module_ids"
+          ? field.value.value.value.items
+          : [],
+      ),
     );
+    const warningCard = screen
+      .getByText(bundle.capability.labels.metrics.ownership_warnings)
+      .closest("article")!;
+    expect(warningCard).not.toHaveTextContent("High churn · high fan-in tier");
+    expect(
+      within(warningCard).getByText(warningIds.size.toLocaleString("en")),
+    ).toBeVisible();
   });
 
   it("sorts dependency rows before the display cap and distinguishes the API bar header", async () => {
     const bundle = golden();
     const user = userEvent.setup();
     const { container } = render(<RepoShowcase bundle={bundle} />);
-    const expectedFirst = [...bundle.aggregates.dependency_topology.modules.items]
-      .sort((left, right) =>
-        right.fan_in - left.fan_in
-        || right.cycle_ids.length - left.cycle_ids.length
-        || right.fan_out - left.fan_out
-        || left.module_id.localeCompare(right.module_id)
-      )[0];
+    const expectedFirst = [
+      ...bundle.aggregates.dependency_topology.modules.items,
+    ].sort(
+      (left, right) =>
+        right.fan_in - left.fan_in ||
+        right.cycle_ids.length - left.cycle_ids.length ||
+        right.fan_out - left.fan_out ||
+        left.module_id.localeCompare(right.module_id),
+    )[0];
 
-    await user.click(container.querySelector('[data-view-id="dependency_topology"]')!);
+    await user.click(
+      container.querySelector('[data-view-id="dependency_topology"]')!,
+    );
     let panel = container.querySelector<HTMLElement>(".repo-view-panel")!;
     const dependencyRows = within(panel).getAllByRole("row").slice(1);
     expect(dependencyRows).toHaveLength(200);
     expect(
-      dependencyRows[0].querySelector<HTMLElement>("[data-module-id]")?.dataset.moduleId,
+      dependencyRows[0].querySelector<HTMLElement>("[data-module-id]")?.dataset
+        .moduleId,
     ).toBe(expectedFirst.module_id);
 
     await user.click(container.querySelector('[data-view-id="api_surface"]')!);
     panel = container.querySelector<HTMLElement>(".repo-view-panel")!;
-    expect(within(panel).getAllByRole("columnheader").map((header) => header.textContent))
-      .toEqual([
-        bundle.capability.labels.node_types.module,
-        bundle.capability.labels.metrics.dependent_count,
-        "Relative magnitude",
-      ]);
+    expect(
+      within(panel)
+        .getAllByRole("columnheader")
+        .map((header) => header.textContent),
+    ).toEqual([
+      bundle.capability.labels.node_types.module,
+      bundle.capability.labels.metrics.dependent_count,
+      "Relative magnitude",
+    ]);
   });
 
   it("explains missing history facets and discloses the 100-module browser cap", async () => {
@@ -107,13 +147,21 @@ describe("repository showcase polish", () => {
       bundle.capability.labels.node_types.pull_request,
       bundle.capability.labels.node_types.issue,
     ]) {
-      const card = within(container.querySelector<HTMLElement>(".repo-view-panel")!)
+      const card = within(
+        container.querySelector<HTMLElement>(".repo-view-panel")!,
+      )
         .getByRole("heading", { level: 3, name: label })
         .closest("section")!;
-      expect(card).toHaveTextContent(`No ${label} navigation captured`);
+      // These fixture pages disclose unavailable bounds, so their zero rows
+      // are unknown, not proven absent: the definitive empty label is
+      // reserved for complete, cursor-free pages.
+      expect(card).toHaveTextContent(`${label} capture incomplete`);
+      expect(card).not.toHaveTextContent(`No ${label} navigation captured`);
     }
 
-    const moduleCard = container.querySelector<HTMLElement>("[data-history-modules]")!;
+    const moduleCard = container.querySelector<HTMLElement>(
+      "[data-history-modules]",
+    )!;
     const disclosure = moduleCard.querySelector<HTMLElement>(
       '[data-state="truncated"][data-shown="100"]',
     );
@@ -128,7 +176,10 @@ describe("repository showcase polish", () => {
     const bundle = golden();
     const { container } = render(<RepoShowcase bundle={bundle} />);
 
-    expect(container.querySelector(".repo-capability-strip > div"))
-      .toHaveTextContent(`${bundle.capability.labels.product} · ${bundle.capability.mode}`);
+    expect(
+      container.querySelector(".repo-capability-strip > div"),
+    ).toHaveTextContent(
+      `${bundle.capability.labels.product} · ${bundle.capability.mode}`,
+    );
   });
 });

--- a/apps/kg-editor/src/components/showcase/repo-showcase-polish.test.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase-polish.test.tsx
@@ -1,0 +1,134 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { RepoShowcase } from "@/components/showcase/repo-showcase";
+import { parseRepoBundle, type RepoBundle } from "@/lib/repo-bundle";
+
+const goldenPath = resolve(
+  process.cwd(),
+  "../../docs/schemas/examples/khive-repo-v1-khive.json",
+);
+const showcaseCssPath = resolve(process.cwd(), "src/app/showcase.css");
+
+function golden(): RepoBundle {
+  return parseRepoBundle(JSON.parse(readFileSync(goldenPath, "utf8")));
+}
+
+describe("repository showcase polish", () => {
+  beforeEach(() => {
+    window.history.replaceState(null, "", "/");
+  });
+
+  it("renders scorecard units, a discriminating ownership tier, and compact unavailable cards", async () => {
+    const bundle = golden();
+    const user = userEvent.setup();
+    const { container } = render(<RepoShowcase bundle={bundle} />);
+
+    await user.click(container.querySelector('[data-view-id="scorecard"]')!);
+
+    const ageCard = screen.getByText(bundle.capability.labels.metrics.repository_age)
+      .closest("article")!;
+    expect(within(ageCard).getByText("61 days")).toBeVisible();
+
+    const warningIds = new Set(
+      bundle.aggregates.scorecard.fields.flatMap((field) =>
+        field.key === "ownership_warnings"
+          && field.value.status === "available"
+          && field.value.value.value_kind === "module_ids"
+          ? field.value.value.value.items
+          : []
+      ),
+    );
+    const highImpactWarningCount = bundle.aggregates.hotspot_quadrant.data.items
+      .filter((row) =>
+        row.quadrant === "high_churn_high_fan_in" && warningIds.has(row.module_id)
+      ).length;
+    expect(highImpactWarningCount).toBeGreaterThan(0);
+    expect(highImpactWarningCount).toBeLessThan(warningIds.size);
+    const warningCard = screen.getByText(
+      bundle.capability.labels.metrics.ownership_warnings,
+    ).closest("article")!;
+    expect(within(warningCard).getByText(highImpactWarningCount.toLocaleString("en")))
+      .toBeVisible();
+    expect(warningCard).toHaveTextContent("High churn · high fan-in tier");
+
+    const symbolCard = screen.getByText(bundle.capability.labels.metrics.symbol_count)
+      .closest("article")!;
+    expect(symbolCard).toHaveClass("unavailable");
+    expect(readFileSync(showcaseCssPath, "utf8")).toMatch(
+      /\.repo-score-grid\s*\{[^}]*align-items:\s*start;/,
+    );
+  });
+
+  it("sorts dependency rows before the display cap and distinguishes the API bar header", async () => {
+    const bundle = golden();
+    const user = userEvent.setup();
+    const { container } = render(<RepoShowcase bundle={bundle} />);
+    const expectedFirst = [...bundle.aggregates.dependency_topology.modules.items]
+      .sort((left, right) =>
+        right.fan_in - left.fan_in
+        || right.cycle_ids.length - left.cycle_ids.length
+        || right.fan_out - left.fan_out
+        || left.module_id.localeCompare(right.module_id)
+      )[0];
+
+    await user.click(container.querySelector('[data-view-id="dependency_topology"]')!);
+    let panel = container.querySelector<HTMLElement>(".repo-view-panel")!;
+    const dependencyRows = within(panel).getAllByRole("row").slice(1);
+    expect(dependencyRows).toHaveLength(200);
+    expect(
+      dependencyRows[0].querySelector<HTMLElement>("[data-module-id]")?.dataset.moduleId,
+    ).toBe(expectedFirst.module_id);
+
+    await user.click(container.querySelector('[data-view-id="api_surface"]')!);
+    panel = container.querySelector<HTMLElement>(".repo-view-panel")!;
+    expect(within(panel).getAllByRole("columnheader").map((header) => header.textContent))
+      .toEqual([
+        bundle.capability.labels.node_types.module,
+        bundle.capability.labels.metrics.dependent_count,
+        "Relative magnitude",
+      ]);
+  });
+
+  it("explains missing history facets and discloses the 100-module browser cap", async () => {
+    const bundle = structuredClone(golden());
+    const user = userEvent.setup();
+    bundle.graph.history_navigation.by_module.items = [];
+    const { container } = render(<RepoShowcase bundle={bundle} />);
+
+    await user.click(
+      container.querySelector('[data-view-id="history_structure_navigation"]')!,
+    );
+
+    for (const label of [
+      bundle.capability.labels.node_types.pull_request,
+      bundle.capability.labels.node_types.issue,
+    ]) {
+      const card = within(container.querySelector<HTMLElement>(".repo-view-panel")!)
+        .getByRole("heading", { level: 3, name: label })
+        .closest("section")!;
+      expect(card).toHaveTextContent(`No ${label} navigation captured`);
+    }
+
+    const moduleCard = container.querySelector<HTMLElement>("[data-history-modules]")!;
+    const disclosure = moduleCard.querySelector<HTMLElement>(
+      '[data-state="truncated"][data-shown="100"]',
+    );
+    expect(disclosure).toBeVisible();
+    expect(disclosure).toHaveAttribute(
+      "data-known-total",
+      String(bundle.graph.modules.items.length),
+    );
+  });
+
+  it("visually separates the showcase title from its source mode", () => {
+    const bundle = golden();
+    const { container } = render(<RepoShowcase bundle={bundle} />);
+
+    expect(container.querySelector(".repo-capability-strip > div"))
+      .toHaveTextContent(`${bundle.capability.labels.product} · ${bundle.capability.mode}`);
+  });
+});

--- a/apps/kg-editor/src/components/showcase/repo-showcase-polish.test.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase-polish.test.tsx
@@ -95,6 +95,79 @@ describe("repository showcase polish", () => {
     ).toBeVisible();
   });
 
+  it("withholds the ownership tier when the hotspot analysis is unavailable", async () => {
+    const raw = JSON.parse(readFileSync(goldenPath, "utf8"));
+    // An unavailable analysis can still ship a schema-valid data page;
+    // filtering against it would turn unknown coverage into a false zero
+    // presented as a definitive tier.
+    raw.aggregates.hotspot_quadrant.meta.status = "unavailable";
+    raw.aggregates.hotspot_quadrant.meta.unavailable_reason =
+      "hotspot analysis inputs missing from this export";
+    // The capability view mirrors the aggregate status (schema cross-refine).
+    raw.capability.views.hotspot_quadrant.status = "unavailable";
+    raw.capability.views.hotspot_quadrant.unavailable_reason =
+      "hotspot analysis inputs missing from this export";
+    const bundle = parseRepoBundle(raw);
+    const user = userEvent.setup();
+    const { container } = render(<RepoShowcase bundle={bundle} />);
+
+    await user.click(container.querySelector('[data-view-id="scorecard"]')!);
+
+    const warningCard = screen
+      .getByText(bundle.capability.labels.metrics.ownership_warnings)
+      .closest("article")!;
+    expect(warningCard).not.toHaveTextContent("High churn · high fan-in tier");
+    // The unfiltered warning count still renders (658 in the golden bundle).
+    expect(within(warningCard).getByText("658")).toBeVisible();
+  });
+
+  it("reports the declared total, not the partial floor, for an incomplete ownership page", async () => {
+    const raw = JSON.parse(readFileSync(goldenPath, "utf8"));
+    const field = raw.aggregates.scorecard.fields.find(
+      (candidate: { key: string }) => candidate.key === "ownership_warnings",
+    );
+    // Cursor-bearing page carrying only part of the ID list: the floor is
+    // not the count, but the exporter's declared total still is.
+    field.value.value.value.items = field.value.value.value.items.slice(0, 100);
+    field.value.value.value.next_cursor = "ownership-cursor-1";
+    const bundle = parseRepoBundle(raw);
+    const user = userEvent.setup();
+    const { container } = render(<RepoShowcase bundle={bundle} />);
+
+    await user.click(container.querySelector('[data-view-id="scorecard"]')!);
+
+    const warningCard = screen
+      .getByText(bundle.capability.labels.metrics.ownership_warnings)
+      .closest("article")!;
+    expect(warningCard).not.toHaveTextContent("High churn · high fan-in tier");
+    expect(within(warningCard).getByText("658")).toBeVisible();
+    expect(within(warningCard).queryByText("100")).toBeNull();
+  });
+
+  it("marks the count as a floor when an incomplete ownership page has no declared total", async () => {
+    const raw = JSON.parse(readFileSync(goldenPath, "utf8"));
+    const field = raw.aggregates.scorecard.fields.find(
+      (candidate: { key: string }) => candidate.key === "ownership_warnings",
+    );
+    field.value.value.value.items = field.value.value.value.items.slice(0, 100);
+    field.value.value.value.next_cursor = "ownership-cursor-1";
+    field.value.value.value.total_count = {
+      status: "unavailable",
+      reason: "total not exported",
+    };
+    const bundle = parseRepoBundle(raw);
+    const user = userEvent.setup();
+    const { container } = render(<RepoShowcase bundle={bundle} />);
+
+    await user.click(container.querySelector('[data-view-id="scorecard"]')!);
+
+    const warningCard = screen
+      .getByText(bundle.capability.labels.metrics.ownership_warnings)
+      .closest("article")!;
+    expect(warningCard).not.toHaveTextContent("High churn · high fan-in tier");
+    expect(within(warningCard).getByText("100+")).toBeVisible();
+  });
+
   it("sorts dependency rows before the display cap and distinguishes the API bar header", async () => {
     const bundle = golden();
     const user = userEvent.setup();

--- a/apps/kg-editor/src/components/showcase/repo-showcase.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase.tsx
@@ -97,7 +97,9 @@ function derivedDiamondPoints(x: number, y: number): string {
 }
 
 function formatNumber(value: number): string {
-  return new Intl.NumberFormat("en", { notation: value >= 10_000 ? "compact" : "standard" }).format(value);
+  return new Intl.NumberFormat("en", {
+    notation: value >= 10_000 ? "compact" : "standard",
+  }).format(value);
 }
 
 function formatExactNumber(value: number): string {
@@ -105,7 +107,11 @@ function formatExactNumber(value: number): string {
 }
 
 function formatDate(value: string): string {
-  return new Intl.DateTimeFormat("en", { month: "short", day: "numeric", year: "numeric" }).format(new Date(value));
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(new Date(value));
 }
 
 function formatAnalysisWindow(
@@ -114,9 +120,10 @@ function formatAnalysisWindow(
 ): string {
   if (window.kind === "rolling_days") {
     const duration = window.days == null ? "Rolling" : `${window.days}-day`;
-    const range = window.start && window.end
-      ? ` · ${formatDate(window.start)} to ${formatDate(window.end)}`
-      : "";
+    const range =
+      window.start && window.end
+        ? ` · ${formatDate(window.start)} to ${formatDate(window.end)}`
+        : "";
     return `${duration} analysis window${range}`;
   }
   if (window.kind === "range") {
@@ -129,7 +136,10 @@ function formatAnalysisWindow(
 
 function formatPercent(value: number): string {
   const normalized = value <= 1 ? value : value / 100;
-  return new Intl.NumberFormat("en", { style: "percent", maximumFractionDigits: 1 }).format(normalized);
+  return new Intl.NumberFormat("en", {
+    style: "percent",
+    maximumFractionDigits: 1,
+  }).format(normalized);
 }
 
 function shortSha(value: string): string {
@@ -142,23 +152,36 @@ function moduleName(moduleById: ModuleMap, id: string): string {
 }
 
 function availabilityText<T>(
-  value: { status: "available"; value: T } | { status: "unavailable"; reason: string },
+  value:
+    | { status: "available"; value: T }
+    | { status: "unavailable"; reason: string },
   labels: Labels,
   render: (available: T) => string = String,
 ): string {
-  return value.status === "available" ? render(value.value) : `${labels.unavailable} · ${value.reason}`;
+  return value.status === "available"
+    ? render(value.value)
+    : `${labels.unavailable} · ${value.reason}`;
 }
 
 function isIncompleteRepoPage<T>(page: RepoPage<T>): boolean {
-  return page.disclosure.status !== "unavailable"
-    && (page.truncated || page.next_cursor != null || page.disclosure.status === "truncated");
+  return (
+    page.disclosure.status !== "unavailable" &&
+    (page.truncated ||
+      page.next_cursor != null ||
+      page.disclosure.status === "truncated")
+  );
+}
+
+function isCompleteRepoPage<T>(page: RepoPage<T>): boolean {
+  return (
+    page.disclosure.status === "complete" &&
+    !page.truncated &&
+    page.next_cursor == null
+  );
 }
 
 function isKnownEmptyRepoPage<T>(page: RepoPage<T>): boolean {
-  return page.items.length === 0
-    && page.disclosure.status === "complete"
-    && !page.truncated
-    && page.next_cursor == null;
+  return page.items.length === 0 && isCompleteRepoPage(page);
 }
 
 function ModuleInspectionControl({
@@ -178,11 +201,12 @@ function ModuleInspectionControl({
 }) {
   const moduleNode = moduleById.get(moduleId);
   if (!moduleNode) {
-    const reason = modulePage.disclosure.status === "unavailable"
-      ? `module page is unavailable${modulePage.disclosure.reason ? ` · ${modulePage.disclosure.reason}` : ""}`
-      : isIncompleteRepoPage(modulePage)
-      ? "outside the captured module page"
-      : "bundle integrity mismatch";
+    const reason =
+      modulePage.disclosure.status === "unavailable"
+        ? `module page is unavailable${modulePage.disclosure.reason ? ` · ${modulePage.disclosure.reason}` : ""}`
+        : isIncompleteRepoPage(modulePage)
+          ? "outside the captured module page"
+          : "bundle integrity mismatch";
     return (
       <span
         className="repo-module-reference-missing"
@@ -208,9 +232,19 @@ function ModuleInspectionControl({
   );
 }
 
-function BoundDisclosure<T>({ page, labels }: { page: RepoPage<T>; labels: Labels }) {
-  const total = page.total_count.status === "available" ? formatNumber(page.total_count.value) : labels.unavailable;
-  const reason = page.disclosure.reason ?? (page.truncated ? labels.truncated : undefined);
+function BoundDisclosure<T>({
+  page,
+  labels,
+}: {
+  page: RepoPage<T>;
+  labels: Labels;
+}) {
+  const total =
+    page.total_count.status === "available"
+      ? formatNumber(page.total_count.value)
+      : labels.unavailable;
+  const reason =
+    page.disclosure.reason ?? (page.truncated ? labels.truncated : undefined);
   if (page.disclosure.status === "unavailable") {
     return (
       <DataState
@@ -232,7 +266,11 @@ function BoundDisclosure<T>({ page, labels }: { page: RepoPage<T>; labels: Label
         title={labels.truncated}
         shown={page.items.length}
         bound={page.bound.max_items}
-        knownTotal={page.total_count.status === "available" ? page.total_count.value : undefined}
+        knownTotal={
+          page.total_count.status === "available"
+            ? page.total_count.value
+            : undefined
+        }
         reason={reason ?? "The exported collection reached its declared bound."}
       />
     );
@@ -240,12 +278,20 @@ function BoundDisclosure<T>({ page, labels }: { page: RepoPage<T>; labels: Label
   return (
     <span className="repo-bounded complete">
       <Info aria-hidden="true" />
-      <span>{formatNumber(page.items.length)} / {total}</span>
+      <span>
+        {formatNumber(page.items.length)} / {total}
+      </span>
     </span>
   );
 }
 
-function InlinePageState<T>({ page, labels }: { page: RepoPage<T>; labels: Labels }) {
+function InlinePageState<T>({
+  page,
+  labels,
+}: {
+  page: RepoPage<T>;
+  labels: Labels;
+}) {
   if (page.disclosure.status === "unavailable") {
     return (
       <DataState
@@ -253,7 +299,10 @@ function InlinePageState<T>({ page, labels }: { page: RepoPage<T>; labels: Label
         presentation="inline"
         state="unavailable"
         title={labels.unavailable}
-        message={page.disclosure.reason ?? "This bundle does not claim a complete collection."}
+        message={
+          page.disclosure.reason ??
+          "This bundle does not claim a complete collection."
+        }
       />
     );
   }
@@ -266,8 +315,15 @@ function InlinePageState<T>({ page, labels }: { page: RepoPage<T>; labels: Label
         title={labels.truncated}
         shown={page.items.length}
         bound={page.bound.max_items}
-        knownTotal={page.total_count.status === "available" ? page.total_count.value : undefined}
-        reason={page.disclosure.reason ?? "The exported collection reached its declared bound."}
+        knownTotal={
+          page.total_count.status === "available"
+            ? page.total_count.value
+            : undefined
+        }
+        reason={
+          page.disclosure.reason ??
+          "The exported collection reached its declared bound."
+        }
       />
     );
   }
@@ -329,23 +385,40 @@ function ViewHeader({ capability }: { capability: ViewCapability }) {
     <header className="repo-view-header">
       <div>
         <h2>{capability.label}</h2>
-        {capability.unavailable_reason && <p>{capability.unavailable_reason}</p>}
+        {capability.unavailable_reason && (
+          <p>{capability.unavailable_reason}</p>
+        )}
       </div>
       <div className="repo-view-tags" aria-label={capability.label}>
-        <span className="repo-view-tag"><Layers3 aria-hidden="true" /> <code>{capability.granularity}</code></span>
-        <span className={`repo-view-tag ${capability.join === "join" ? "join" : ""}`}><GitFork aria-hidden="true" /> <code>{capability.join}</code></span>
+        <span className="repo-view-tag">
+          <Layers3 aria-hidden="true" /> <code>{capability.granularity}</code>
+        </span>
+        <span
+          className={`repo-view-tag ${capability.join === "join" ? "join" : ""}`}
+        >
+          <GitFork aria-hidden="true" /> <code>{capability.join}</code>
+        </span>
       </div>
     </header>
   );
 }
 
-function UnavailableView({ capability, labels }: { capability: ViewCapability; labels: Labels }) {
+function UnavailableView({
+  capability,
+  labels,
+}: {
+  capability: ViewCapability;
+  labels: Labels;
+}) {
   return (
     <DataState
       className="repo-empty"
       state="unavailable"
       title={`${capability.label} ${labels.unavailable.toLocaleLowerCase()}`}
-      message={capability.unavailable_reason ?? "This bundle does not claim data for the view."}
+      message={
+        capability.unavailable_reason ??
+        "This bundle does not claim data for the view."
+      }
       context={[`${capability.granularity} · ${capability.join}`]}
     />
   );
@@ -365,7 +438,11 @@ function ViewFrame({
   return (
     <>
       <ViewHeader capability={capability} />
-      {capability.status === "available" || allowPartial ? children : <UnavailableView capability={capability} labels={labels} />}
+      {capability.status === "available" || allowPartial ? (
+        children
+      ) : (
+        <UnavailableView capability={capability} labels={labels} />
+      )}
     </>
   );
 }
@@ -396,9 +473,10 @@ function StructureGraph({
     subtreePackageCount,
     visibleIds,
   } = useMemo(() => {
-    const nextSubtreePackages = subtreeId === graph.repository.id
-      ? graph.packages.items
-      : graph.packages.items.filter((item) => item.id === subtreeId);
+    const nextSubtreePackages =
+      subtreeId === graph.repository.id
+        ? graph.packages.items
+        : graph.packages.items.filter((item) => item.id === subtreeId);
     // Sort by id before truncating so the displayed slice — and therefore the
     // shared seeded layout fed by it — is independent of input array order
     // (ADR-153 D4).
@@ -406,9 +484,12 @@ function StructureGraph({
       .sort((left, right) => left.id.localeCompare(right.id))
       .slice(0, 8);
     const nextSelectablePackages = graph.packages.items.slice(0, UI_ROW_LIMIT);
-    const displayedPackageIds = new Set(nextDisplayedPackages.map((item) => item.id));
-    const nextSubtreeModules = graph.modules.items.filter((item) =>
-      subtreeId === graph.repository.id || item.package_id === subtreeId
+    const displayedPackageIds = new Set(
+      nextDisplayedPackages.map((item) => item.id),
+    );
+    const nextSubtreeModules = graph.modules.items.filter(
+      (item) =>
+        subtreeId === graph.repository.id || item.package_id === subtreeId,
     );
     const nextDisplayedModules = nextSubtreeModules
       .filter((item) => displayedPackageIds.has(item.package_id))
@@ -419,8 +500,9 @@ function StructureGraph({
       ...nextDisplayedPackages.map((item) => item.id),
       ...nextDisplayedModules.map((item) => item.id),
     ]);
-    const visibleEdges = graph.structure_edges.items.filter((edge) =>
-      nextVisibleIds.has(edge.source) && nextVisibleIds.has(edge.target)
+    const visibleEdges = graph.structure_edges.items.filter(
+      (edge) =>
+        nextVisibleIds.has(edge.source) && nextVisibleIds.has(edge.target),
     );
     const nextDisplayedEdges = visibleEdges.slice(0, UI_GRAPH_EDGE_LIMIT);
     const layoutNodes = [
@@ -489,34 +571,41 @@ function StructureGraph({
       maxDegree: nextMaxDegree,
     };
   }, [graph.structure_edges.items, visibleIds]);
-  const nodeWidth = (id: string) => 92 + ((degrees.get(id) ?? 0) / maxDegree) * 46;
-  const selectedModule = displayedModules.find((item) => item.id === selectedId);
-  const selectedPackage = displayedPackages.find((item) => item.id === selectedId);
+  const nodeWidth = (id: string) =>
+    92 + ((degrees.get(id) ?? 0) / maxDegree) * 46;
+  const selectedModule = displayedModules.find(
+    (item) => item.id === selectedId,
+  );
+  const selectedPackage = displayedPackages.find(
+    (item) => item.id === selectedId,
+  );
   const selectedEntityKind = selectedModule ? "concept" : "project";
   const visibleLabel = new Map<string, string>([
     [graph.repository.id, graph.repository.label],
     ...displayedPackages.map((item) => [item.id, item.name] as const),
     ...displayedModules.map((item) => [item.id, item.module_path] as const),
   ]);
-  const couplingLens = useMemo(() =>
-    buildStructureCouplingLens({
-      pairPage: bundle.aggregates.hidden_coupling.data,
-      structureEdgePage: graph.structure_edges,
-      visibleModuleIds: visibleIds,
-      limit: UI_COUPLING_EDGE_LIMIT,
-      analysisStatus: bundle.aggregates.hidden_coupling.meta.status,
-      analysisUnavailableReason:
-        bundle.aggregates.hidden_coupling.meta.unavailable_reason,
-    }), [
-    bundle.aggregates.hidden_coupling.data,
-    bundle.aggregates.hidden_coupling.meta.status,
-    bundle.aggregates.hidden_coupling.meta.unavailable_reason,
-    graph.structure_edges,
-    visibleIds,
-  ]);
-  const focusedPair = couplingLens.pairs.find((pair) =>
-    pair.key === focusedPairKey
-  ) ?? null;
+  const couplingLens = useMemo(
+    () =>
+      buildStructureCouplingLens({
+        pairPage: bundle.aggregates.hidden_coupling.data,
+        structureEdgePage: graph.structure_edges,
+        visibleModuleIds: visibleIds,
+        limit: UI_COUPLING_EDGE_LIMIT,
+        analysisStatus: bundle.aggregates.hidden_coupling.meta.status,
+        analysisUnavailableReason:
+          bundle.aggregates.hidden_coupling.meta.unavailable_reason,
+      }),
+    [
+      bundle.aggregates.hidden_coupling.data,
+      bundle.aggregates.hidden_coupling.meta.status,
+      bundle.aggregates.hidden_coupling.meta.unavailable_reason,
+      graph.structure_edges,
+      visibleIds,
+    ],
+  );
+  const focusedPair =
+    couplingLens.pairs.find((pair) => pair.key === focusedPairKey) ?? null;
   const focusedModuleIds = focusedPair
     ? new Set([focusedPair.leftModuleId, focusedPair.rightModuleId])
     : null;
@@ -524,15 +613,22 @@ function StructureGraph({
   for (const pair of couplingLens.pairs) {
     couplingNodeCounts.set(
       pair.leftModuleId,
-      Math.max(couplingNodeCounts.get(pair.leftModuleId) ?? 0, pair.cochangeCount),
+      Math.max(
+        couplingNodeCounts.get(pair.leftModuleId) ?? 0,
+        pair.cochangeCount,
+      ),
     );
     couplingNodeCounts.set(
       pair.rightModuleId,
-      Math.max(couplingNodeCounts.get(pair.rightModuleId) ?? 0, pair.cochangeCount),
+      Math.max(
+        couplingNodeCounts.get(pair.rightModuleId) ?? 0,
+        pair.cochangeCount,
+      ),
     );
   }
   const isContextDimmed = (id: string) =>
-    lens === "hidden_coupling" && focusedModuleIds !== null &&
+    lens === "hidden_coupling" &&
+    focusedModuleIds !== null &&
     !focusedModuleIds.has(id);
   const isCouplingFocused = (id: string) =>
     lens === "hidden_coupling" && focusedModuleIds?.has(id) === true;
@@ -556,8 +652,14 @@ function StructureGraph({
                 setFocusedPairKey(null);
               }}
             >
-              <option value={graph.repository.id}>{labels.node_types.repository}</option>
-              {selectablePackages.map((item) => <option value={item.id} key={item.id}>{item.name}</option>)}
+              <option value={graph.repository.id}>
+                {labels.node_types.repository}
+              </option>
+              {selectablePackages.map((item) => (
+                <option value={item.id} key={item.id}>
+                  {item.name}
+                </option>
+              ))}
             </select>
           </label>
           <fieldset className="repo-graph-lens-picker">
@@ -587,9 +689,21 @@ function StructureGraph({
             </label>
           </fieldset>
           <div>
-            <button type="button" aria-label={`${capability.views.structure_graph.label} −`} onClick={() => setZoom((value) => Math.max(0.75, value - 0.25))}>−</button>
+            <button
+              type="button"
+              aria-label={`${capability.views.structure_graph.label} −`}
+              onClick={() => setZoom((value) => Math.max(0.75, value - 0.25))}
+            >
+              −
+            </button>
             <output aria-live="polite">{Math.round(zoom * 100)}%</output>
-            <button type="button" aria-label={`${capability.views.structure_graph.label} +`} onClick={() => setZoom((value) => Math.min(1.5, value + 0.25))}>+</button>
+            <button
+              type="button"
+              aria-label={`${capability.views.structure_graph.label} +`}
+              onClick={() => setZoom((value) => Math.min(1.5, value + 0.25))}
+            >
+              +
+            </button>
           </div>
         </div>
         <OntologyLegend
@@ -597,7 +711,10 @@ function StructureGraph({
           presentEntityKinds={["project", "concept"]}
           presentRelations={displayedEdges.map((edge) => edge.relation)}
         />
-        <div className="repo-graph-stage" aria-label={capability.views.structure_graph.label}>
+        <div
+          className="repo-graph-stage"
+          aria-label={capability.views.structure_graph.label}
+        >
           {lens === "hidden_coupling" && (
             <div className="repo-graph-active-overlay">
               <Braces aria-hidden="true" />
@@ -605,10 +722,26 @@ function StructureGraph({
               <strong>{capability.views.hidden_coupling.label}</strong>
             </div>
           )}
-          <div className="repo-graph-viewport" style={{ transform: `scale(${zoom})` }}>
-            <svg className="repo-edges" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
+          <div
+            className="repo-graph-viewport"
+            style={{ transform: `scale(${zoom})` }}
+          >
+            <svg
+              className="repo-edges"
+              viewBox="0 0 100 100"
+              preserveAspectRatio="none"
+              aria-hidden="true"
+            >
               <defs>
-                <marker id="showcase-ontology-arrow" markerHeight="6" markerWidth="6" orient="auto" refX="5" refY="3" viewBox="0 0 6 6">
+                <marker
+                  id="showcase-ontology-arrow"
+                  markerHeight="6"
+                  markerWidth="6"
+                  orient="auto"
+                  refX="5"
+                  refY="3"
+                  viewBox="0 0 6 6"
+                >
                   <path d="M 0 0 L 6 3 L 0 6 z" fill="context-stroke" />
                 </marker>
               </defs>
@@ -618,18 +751,28 @@ function StructureGraph({
                 if (!source || !target) return null;
                 const legend = edgeLegendFor(edge.relation);
                 const direction = edgeDirectionMark(legend, source, target);
-                const dimmed = focusedModuleIds !== null &&
-                  !(focusedModuleIds.has(edge.source) &&
-                    focusedModuleIds.has(edge.target));
+                const dimmed =
+                  focusedModuleIds !== null &&
+                  !(
+                    focusedModuleIds.has(edge.source) &&
+                    focusedModuleIds.has(edge.target)
+                  );
                 return (
-                  <g className={dimmed ? "context-dimmed" : undefined} key={edge.id}>
+                  <g
+                    className={dimmed ? "context-dimmed" : undefined}
+                    key={edge.id}
+                  >
                     <line
                       className="ontology-edge"
                       data-edge-family={legend.family}
                       data-edge-origin={edge.origin}
                       data-edge-treatment={legend.treatment}
                       data-edge-variant={legend.variant}
-                      markerEnd={legend.directed ? "url(#showcase-ontology-arrow)" : undefined}
+                      markerEnd={
+                        legend.directed
+                          ? "url(#showcase-ontology-arrow)"
+                          : undefined
+                      }
                       style={edgeHueStyle(legend)}
                       x1={source.x}
                       y1={source.y}
@@ -653,7 +796,9 @@ function StructureGraph({
                         transform={direction.transform}
                         x={direction.x}
                         y={direction.y}
-                      >›</text>
+                      >
+                        ›
+                      </text>
                     )}
                     {edge.origin === "derived" && (
                       <polygon
@@ -667,36 +812,37 @@ function StructureGraph({
                   </g>
                 );
               })}
-              {lens === "hidden_coupling" && couplingLens.pairs.map((pair) => {
-                const source = positions.get(pair.leftModuleId);
-                const target = positions.get(pair.rightModuleId);
-                if (!source || !target) return null;
-                const selected = focusedPairKey === pair.key;
-                const dimmed = focusedPair !== null && !selected;
-                return (
-                  <g
-                    className={`${selected ? "selected" : ""} ${dimmed ? "context-dimmed" : ""}`.trim()}
-                    data-coupling-overlay={pair.key}
-                    key={`coupling-${pair.key}`}
-                  >
-                    <line
-                      className="repo-coupling-edge"
-                      x1={source.x}
-                      y1={source.y}
-                      x2={target.x}
-                      y2={target.y}
-                      vectorEffect="non-scaling-stroke"
-                    />
-                    <circle
-                      className="repo-coupling-mark"
-                      cx={(source.x + target.x) / 2}
-                      cy={(source.y + target.y) / 2}
-                      r="1.45"
-                      vectorEffect="non-scaling-stroke"
-                    />
-                  </g>
-                );
-              })}
+              {lens === "hidden_coupling" &&
+                couplingLens.pairs.map((pair) => {
+                  const source = positions.get(pair.leftModuleId);
+                  const target = positions.get(pair.rightModuleId);
+                  if (!source || !target) return null;
+                  const selected = focusedPairKey === pair.key;
+                  const dimmed = focusedPair !== null && !selected;
+                  return (
+                    <g
+                      className={`${selected ? "selected" : ""} ${dimmed ? "context-dimmed" : ""}`.trim()}
+                      data-coupling-overlay={pair.key}
+                      key={`coupling-${pair.key}`}
+                    >
+                      <line
+                        className="repo-coupling-edge"
+                        x1={source.x}
+                        y1={source.y}
+                        x2={target.x}
+                        y2={target.y}
+                        vectorEffect="non-scaling-stroke"
+                      />
+                      <circle
+                        className="repo-coupling-mark"
+                        cx={(source.x + target.x) / 2}
+                        cy={(source.y + target.y) / 2}
+                        r="1.45"
+                        vectorEffect="non-scaling-stroke"
+                      />
+                    </g>
+                  );
+                })}
             </svg>
             <button
               className={`repo-graph-node ${selectedId === graph.repository.id ? "selected" : ""} ${isContextDimmed(graph.repository.id) ? "context-dimmed" : ""}`}
@@ -714,18 +860,41 @@ function StructureGraph({
                 setFocusedPairKey(null);
               }}
             >
-              <EntityKindMark className="repo-node-kind-icon" kind="project" showLabel={false} />
-              <span>{labels.node_types.repository}</span><strong>{graph.repository.label}</strong>
+              <EntityKindMark
+                className="repo-node-kind-icon"
+                kind="project"
+                showLabel={false}
+              />
+              <span>{labels.node_types.repository}</span>
+              <strong>{graph.repository.label}</strong>
             </button>
             {displayedPackages.map((item) => {
               const position = positions.get(item.id)!;
               return (
-                <button className={`repo-graph-node ${selectedId === item.id ? "selected" : ""} ${isContextDimmed(item.id) ? "context-dimmed" : ""}`} data-node-id={item.id} style={{ left: `${position.x}%`, top: `${position.y}%`, width: `${nodeWidth(item.id)}px`, ...kindHueStyle(entityLegendFor("project")) }} type="button" aria-pressed={selectedId === item.id} key={item.id} onClick={() => {
-                  setSelectedId(item.id);
-                  setFocusedPairKey(null);
-                }}>
-                  <EntityKindMark className="repo-node-kind-icon" kind="project" showLabel={false} />
-                  <span>{labels.node_types.package}</span><strong>{item.name}</strong>
+                <button
+                  className={`repo-graph-node ${selectedId === item.id ? "selected" : ""} ${isContextDimmed(item.id) ? "context-dimmed" : ""}`}
+                  data-node-id={item.id}
+                  style={{
+                    left: `${position.x}%`,
+                    top: `${position.y}%`,
+                    width: `${nodeWidth(item.id)}px`,
+                    ...kindHueStyle(entityLegendFor("project")),
+                  }}
+                  type="button"
+                  aria-pressed={selectedId === item.id}
+                  key={item.id}
+                  onClick={() => {
+                    setSelectedId(item.id);
+                    setFocusedPairKey(null);
+                  }}
+                >
+                  <EntityKindMark
+                    className="repo-node-kind-icon"
+                    kind="project"
+                    showLabel={false}
+                  />
+                  <span>{labels.node_types.package}</span>
+                  <strong>{item.name}</strong>
                 </button>
               );
             })}
@@ -733,21 +902,40 @@ function StructureGraph({
               const position = positions.get(item.id)!;
               const couplingCount = couplingNodeCounts.get(item.id);
               return (
-                <button className={`repo-graph-node ${selectedId === item.id ? "selected" : ""} ${isContextDimmed(item.id) ? "context-dimmed" : ""} ${isCouplingFocused(item.id) ? "coupling-focused" : ""}`} data-node-id={item.id} style={{ left: `${position.x}%`, top: `${position.y}%`, width: `${nodeWidth(item.id)}px`, ...kindHueStyle(entityLegendFor("concept")) }} type="button" aria-pressed={selectedId === item.id} key={item.id} onClick={() => {
-                  setSelectedId(item.id);
-                  setFocusedPairKey(null);
-                }}>
-                  <EntityKindMark className="repo-node-kind-icon" kind="concept" showLabel={false} />
-                  <span>{labels.node_types.module}</span><strong>{item.module_path}</strong>
-                  {lens === "hidden_coupling" && couplingCount !== undefined && (
-                    <span
-                      className="repo-graph-overlay-badge"
-                      aria-label={`${capability.views.hidden_coupling.label}: ${labels.metrics.cochange_count} ${formatNumber(couplingCount)}`}
-                    >
-                      <Braces aria-hidden="true" />
-                      <b>{formatNumber(couplingCount)}</b>
-                    </span>
-                  )}
+                <button
+                  className={`repo-graph-node ${selectedId === item.id ? "selected" : ""} ${isContextDimmed(item.id) ? "context-dimmed" : ""} ${isCouplingFocused(item.id) ? "coupling-focused" : ""}`}
+                  data-node-id={item.id}
+                  style={{
+                    left: `${position.x}%`,
+                    top: `${position.y}%`,
+                    width: `${nodeWidth(item.id)}px`,
+                    ...kindHueStyle(entityLegendFor("concept")),
+                  }}
+                  type="button"
+                  aria-pressed={selectedId === item.id}
+                  key={item.id}
+                  onClick={() => {
+                    setSelectedId(item.id);
+                    setFocusedPairKey(null);
+                  }}
+                >
+                  <EntityKindMark
+                    className="repo-node-kind-icon"
+                    kind="concept"
+                    showLabel={false}
+                  />
+                  <span>{labels.node_types.module}</span>
+                  <strong>{item.module_path}</strong>
+                  {lens === "hidden_coupling" &&
+                    couplingCount !== undefined && (
+                      <span
+                        className="repo-graph-overlay-badge"
+                        aria-label={`${capability.views.hidden_coupling.label}: ${labels.metrics.cochange_count} ${formatNumber(couplingCount)}`}
+                      >
+                        <Braces aria-hidden="true" />
+                        <b>{formatNumber(couplingCount)}</b>
+                      </span>
+                    )}
                 </button>
               );
             })}
@@ -762,49 +950,74 @@ function StructureGraph({
             <header>
               <div>
                 <span>Candidate evidence · not a dependency claim</span>
-                <strong>{formatNumber(couplingLens.pairs.length)} of {formatNumber(couplingLens.capturedVisiblePairCount)} captured visible pairs shown</strong>
+                <strong>
+                  {formatNumber(couplingLens.pairs.length)} of{" "}
+                  {formatNumber(couplingLens.capturedVisiblePairCount)} captured
+                  visible pairs shown
+                </strong>
               </div>
               <p>
-                <span>{formatAnalysisWindow(bundle.aggregates.hidden_coupling.meta.window, bundle.meta.snapshot.ingested_at)}</span>
-                <span>{formatExactNumber(couplingLens.capturedPairCount)} captured of {couplingLens.declaredPairCount === null ? labels.unavailable : formatExactNumber(couplingLens.declaredPairCount)} declared</span>
+                <span>
+                  {formatAnalysisWindow(
+                    bundle.aggregates.hidden_coupling.meta.window,
+                    bundle.meta.snapshot.ingested_at,
+                  )}
+                </span>
+                <span>
+                  {formatExactNumber(couplingLens.capturedPairCount)} captured
+                  of{" "}
+                  {couplingLens.declaredPairCount === null
+                    ? labels.unavailable
+                    : formatExactNumber(couplingLens.declaredPairCount)}{" "}
+                  declared
+                </span>
               </p>
             </header>
-            {couplingLens.coverage === "unavailable"
-              ? (
-                <DataState
-                  className="repo-inline-state"
-                  presentation="inline"
-                  state="unavailable"
-                  title={labels.unavailable}
-                  message={couplingLens.coverageReason ?? "The hidden-coupling aggregate is unavailable."}
-                />
-              )
-              : couplingLens.coverage === "truncated" && (
+            {couplingLens.coverage === "unavailable" ? (
               <DataState
                 className="repo-inline-state"
                 presentation="inline"
-                state="truncated"
-                title={labels.truncated}
-                shown={couplingLens.capturedPairCount}
-                bound={bundle.aggregates.hidden_coupling.data.bound.max_items}
-                knownTotal={couplingLens.declaredPairCount ?? undefined}
-                reason={couplingLens.coverageReason ?? "The hidden-coupling aggregate is incomplete."}
+                state="unavailable"
+                title={labels.unavailable}
+                message={
+                  couplingLens.coverageReason ??
+                  "The hidden-coupling aggregate is unavailable."
+                }
               />
+            ) : (
+              couplingLens.coverage === "truncated" && (
+                <DataState
+                  className="repo-inline-state"
+                  presentation="inline"
+                  state="truncated"
+                  title={labels.truncated}
+                  shown={couplingLens.capturedPairCount}
+                  bound={bundle.aggregates.hidden_coupling.data.bound.max_items}
+                  knownTotal={couplingLens.declaredPairCount ?? undefined}
+                  reason={
+                    couplingLens.coverageReason ??
+                    "The hidden-coupling aggregate is incomplete."
+                  }
+                />
+              )
             )}
             <p className="repo-coupling-caveat">
-              Co-change is an implicit-boundary candidate, not proof of runtime dependency. Captured rows can include production, test, example, and generated modules.
+              Co-change is an implicit-boundary candidate, not proof of runtime
+              dependency. Captured rows can include production, test, example,
+              and generated modules.
             </p>
-            {couplingLens.pairs.length === 0
-              ? couplingLens.coverage === "unavailable"
-              ? (
+            {couplingLens.pairs.length === 0 ? (
+              couplingLens.coverage === "unavailable" ? (
                 <DataState
                   className="repo-empty compact"
                   state="unavailable"
                   title={`${capability.views.hidden_coupling.label} ${labels.unavailable.toLocaleLowerCase()}`}
-                  message={couplingLens.coverageReason ?? "The bundle does not claim hidden-coupling evidence."}
+                  message={
+                    couplingLens.coverageReason ??
+                    "The bundle does not claim hidden-coupling evidence."
+                  }
                 />
-              )
-              : (
+              ) : (
                 <DataState
                   className="repo-empty compact"
                   state="empty"
@@ -819,66 +1032,135 @@ function StructureGraph({
                   }}
                 />
               )
-              : (
-                <ol className="repo-coupling-evidence">
-                  {couplingLens.pairs.map((pair) => {
-                    const left = moduleById.get(pair.leftModuleId);
-                    const right = moduleById.get(pair.rightModuleId);
-                    const leftLabel = left?.source_path ?? pair.leftModuleId;
-                    const rightLabel = right?.source_path ?? pair.rightModuleId;
-                    const dependencyMessage = pair.dependencyEvidence === "absent"
+            ) : (
+              <ol className="repo-coupling-evidence">
+                {couplingLens.pairs.map((pair) => {
+                  const left = moduleById.get(pair.leftModuleId);
+                  const right = moduleById.get(pair.rightModuleId);
+                  const leftLabel = left?.source_path ?? pair.leftModuleId;
+                  const rightLabel = right?.source_path ?? pair.rightModuleId;
+                  const dependencyMessage =
+                    pair.dependencyEvidence === "absent"
                       ? "No captured direct dependency edge"
                       : pair.dependencyEvidence === "present"
-                      ? "Captured direct dependency edge"
-                      : `Direct dependency evidence unknown · ${couplingLens.dependencyCoverageReason ?? "structure edge coverage is incomplete"}`;
-                    return (
-                      <li className={focusedPairKey === pair.key ? "selected" : ""} key={pair.key}>
-                        <button
-                          type="button"
-                          className="repo-coupling-focus"
-                          aria-pressed={focusedPairKey === pair.key}
-                          aria-label={`Focus coupling candidate between ${leftLabel} and ${rightLabel}`}
-                          onClick={() => setFocusedPairKey(pair.key)}
-                        >
-                          <Braces aria-hidden="true" />
-                          <span><strong>{labels.metrics.cochange_count}: {formatNumber(pair.cochangeCount)} · {labels.metrics.support}: {formatPercent(pair.support)}</strong>{dependencyMessage}</span>
-                        </button>
-                        <div className="repo-coupling-endpoints">
-                          <ModuleInspectionControl moduleId={pair.leftModuleId} moduleById={moduleById} modulePage={graph.modules} selectedModuleId={selectedModuleId} onInspectModule={inspectCouplingEndpoint} className="compact" />
-                          <span>paired with</span>
-                          <ModuleInspectionControl moduleId={pair.rightModuleId} moduleById={moduleById} modulePage={graph.modules} selectedModuleId={selectedModuleId} onInspectModule={inspectCouplingEndpoint} className="compact" />
-                        </div>
-                      </li>
-                    );
-                  })}
-                </ol>
-              )}
+                        ? "Captured direct dependency edge"
+                        : `Direct dependency evidence unknown · ${couplingLens.dependencyCoverageReason ?? "structure edge coverage is incomplete"}`;
+                  return (
+                    <li
+                      className={focusedPairKey === pair.key ? "selected" : ""}
+                      key={pair.key}
+                    >
+                      <button
+                        type="button"
+                        className="repo-coupling-focus"
+                        aria-pressed={focusedPairKey === pair.key}
+                        aria-label={`Focus coupling candidate between ${leftLabel} and ${rightLabel}`}
+                        onClick={() => setFocusedPairKey(pair.key)}
+                      >
+                        <Braces aria-hidden="true" />
+                        <span>
+                          <strong>
+                            {labels.metrics.cochange_count}:{" "}
+                            {formatNumber(pair.cochangeCount)} ·{" "}
+                            {labels.metrics.support}:{" "}
+                            {formatPercent(pair.support)}
+                          </strong>
+                          {dependencyMessage}
+                        </span>
+                      </button>
+                      <div className="repo-coupling-endpoints">
+                        <ModuleInspectionControl
+                          moduleId={pair.leftModuleId}
+                          moduleById={moduleById}
+                          modulePage={graph.modules}
+                          selectedModuleId={selectedModuleId}
+                          onInspectModule={inspectCouplingEndpoint}
+                          className="compact"
+                        />
+                        <span>paired with</span>
+                        <ModuleInspectionControl
+                          moduleId={pair.rightModuleId}
+                          moduleById={moduleById}
+                          modulePage={graph.modules}
+                          selectedModuleId={selectedModuleId}
+                          onInspectModule={inspectCouplingEndpoint}
+                          className="compact"
+                        />
+                      </div>
+                    </li>
+                  );
+                })}
+              </ol>
+            )}
           </section>
         )}
         <div className="repo-inspector">
           <div className="repo-inspector-heading">
             <EntityKindMark kind={selectedEntityKind} showLabel={false} />
             <div>
-              <span>{selectedModule ? labels.node_types.module : selectedPackage ? labels.node_types.package : labels.node_types.repository}</span>
-              <strong>{selectedModule?.module_path ?? selectedPackage?.name ?? graph.repository.label}</strong>
+              <span>
+                {selectedModule
+                  ? labels.node_types.module
+                  : selectedPackage
+                    ? labels.node_types.package
+                    : labels.node_types.repository}
+              </span>
+              <strong>
+                {selectedModule?.module_path ??
+                  selectedPackage?.name ??
+                  graph.repository.label}
+              </strong>
             </div>
             {selectedModule && <code>{selectedModule.source_path}</code>}
           </div>
           <div className="repo-inspector-metrics">
-            <span>{labels.metrics.fan_in}<strong>{formatNumber(fanIn.get(selectedId) ?? 0)}</strong></span>
-            <span>{labels.metrics.fan_out}<strong>{formatNumber(fanOut.get(selectedId) ?? 0)}</strong></span>
+            <span>
+              {labels.metrics.fan_in}
+              <strong>{formatNumber(fanIn.get(selectedId) ?? 0)}</strong>
+            </span>
+            <span>
+              {labels.metrics.fan_out}
+              <strong>{formatNumber(fanOut.get(selectedId) ?? 0)}</strong>
+            </span>
           </div>
         </div>
-        <ul className="repo-edge-list" aria-label={capability.views.structure_graph.label}>
+        <ul
+          className="repo-edge-list"
+          aria-label={capability.views.structure_graph.label}
+        >
           {displayedEdges.map((edge) => (
             <li key={`${edge.id}-accessible`}>
-              <code>{visibleLabel.get(edge.source) ?? edge.source}</code><RelationMark relation={edge.relation} /><code>{visibleLabel.get(edge.target) ?? edge.target}</code><em>{edge.origin === "derived" ? <DerivedEdgeMark label={labels.derived} /> : labels.ingested}</em>
+              <code>{visibleLabel.get(edge.source) ?? edge.source}</code>
+              <RelationMark relation={edge.relation} />
+              <code>{visibleLabel.get(edge.target) ?? edge.target}</code>
+              <em>
+                {edge.origin === "derived" ? (
+                  <DerivedEdgeMark label={labels.derived} />
+                ) : (
+                  labels.ingested
+                )}
+              </em>
             </li>
           ))}
         </ul>
-        <LocalSliceDisclosure shown={displayedEdges.length} total={graph.structure_edges.items.length} label={capability.views.structure_graph.label} labels={labels} />
-        <LocalSliceDisclosure shown={displayedPackages.length} total={subtreePackageCount} label={labels.node_types.package} labels={labels} />
-        <LocalSliceDisclosure shown={displayedModules.length} total={subtreeModuleCount} label={labels.node_types.module} labels={labels} />
+        <LocalSliceDisclosure
+          shown={displayedEdges.length}
+          total={graph.structure_edges.items.length}
+          label={capability.views.structure_graph.label}
+          labels={labels}
+        />
+        <LocalSliceDisclosure
+          shown={displayedPackages.length}
+          total={subtreePackageCount}
+          label={labels.node_types.package}
+          labels={labels}
+        />
+        <LocalSliceDisclosure
+          shown={displayedModules.length}
+          total={subtreeModuleCount}
+          label={labels.node_types.module}
+          labels={labels}
+        />
       </div>
       <BoundDisclosure page={graph.packages} labels={labels} />
       <BoundDisclosure page={graph.modules} labels={labels} />
@@ -893,20 +1175,33 @@ function FacetState({
   labels,
 }: {
   label: string;
-  value: { status: "available"; value: boolean } | { status: "unavailable"; reason: string };
+  value:
+    | { status: "available"; value: boolean }
+    | { status: "unavailable"; reason: string };
   labels: Labels;
 }) {
   return (
     <div className="repo-stat-line">
       <span>{label}</span>
-      <strong aria-label={value.status === "available" ? `${label}: ${String(value.value)}` : labels.unavailable}>
-        {value.status === "available" ? <code>{String(value.value)}</code> : labels.unavailable}
+      <strong
+        aria-label={
+          value.status === "available"
+            ? `${label}: ${String(value.value)}`
+            : labels.unavailable
+        }
+      >
+        {value.status === "available" ? (
+          <code>{String(value.value)}</code>
+        ) : (
+          labels.unavailable
+        )}
       </strong>
     </div>
   );
 }
 
-type HistoryFacetValue = RepoBundle["graph"]["history_navigation"]["by_module"]["items"][number]["pull_requests"];
+type HistoryFacetValue =
+  RepoBundle["graph"]["history_navigation"]["by_module"]["items"][number]["pull_requests"];
 
 function HistoryFacet({
   label,
@@ -927,36 +1222,86 @@ function HistoryFacet({
 }) {
   const page = value?.status === "available" ? value.value : null;
   const rows = page?.items.slice(0, UI_ROW_LIMIT) ?? [];
-  const unavailableReason = value?.status === "unavailable"
-    ? value.reason
-    : !value && parentPage.disclosure.status === "unavailable"
-      ? parentPage.disclosure.reason
-      : null;
+  const unavailableReason =
+    value?.status === "unavailable"
+      ? value.reason
+      : !value && parentPage.disclosure.status === "unavailable"
+        ? parentPage.disclosure.reason
+        : null;
 
   return (
     <section className="repo-card">
-      <div className="repo-card-heading"><h3>{label}</h3></div>
+      <div className="repo-card-heading">
+        <h3>{label}</h3>
+      </div>
       {unavailableReason ? (
-        <DataState className="repo-empty" state="unavailable" title={`${label} ${labels.unavailable.toLocaleLowerCase()}`} message={unavailableReason} />
+        <DataState
+          className="repo-empty"
+          state="unavailable"
+          title={`${label} ${labels.unavailable.toLocaleLowerCase()}`}
+          message={unavailableReason}
+        />
       ) : page && isKnownEmptyRepoPage(page) ? (
-        <DataState className="repo-empty" state="empty" title={`No ${label}`} message={`${label} captured for the selected module belong here.`} action={{ label: "Explore repository structure", onClick: onExploreStructure }} />
+        <DataState
+          className="repo-empty"
+          state="empty"
+          title={`No ${label}`}
+          message={`${label} captured for the selected module belong here.`}
+          action={{
+            label: "Explore repository structure",
+            onClick: onExploreStructure,
+          }}
+        />
       ) : rows.length > 0 ? (
         <div className="repo-list">
           {rows.map((id) => {
             const item = resolveItem(id);
-            return <div className="repo-list-row" key={id}><Icon aria-hidden="true" /><div><strong>{item?.title ?? id}</strong>{item && <span>#{item.number}</span>}</div></div>;
+            return (
+              <div className="repo-list-row" key={id}>
+                <Icon aria-hidden="true" />
+                <div>
+                  <strong>{item?.title ?? id}</strong>
+                  {item && <span>#{item.number}</span>}
+                </div>
+              </div>
+            );
           })}
         </div>
-      ) : (
+      ) : page && isCompleteRepoPage(page) ? (
         <DataState
           className="repo-empty compact"
           state="empty"
           title={`No ${label} navigation captured`}
           message={`The selected module has no captured ${label.toLocaleLowerCase()} links in this bundle.`}
-          action={{ label: "Explore repository structure", onClick: onExploreStructure }}
+          action={{
+            label: "Explore repository structure",
+            onClick: onExploreStructure,
+          }}
+        />
+      ) : (
+        // A zero-row slice of an incomplete or cursor-bearing page is
+        // unknown, not empty: the missing rows may hold exactly this
+        // module's links, so the definitive empty state above is reserved
+        // for complete pages.
+        <DataState
+          className="repo-empty compact"
+          state="truncated"
+          title={`${label} capture incomplete`}
+          message={`This bundle's ${label.toLocaleLowerCase()} page is incomplete, so rows for the selected module may exist beyond what was captured.`}
+          action={{
+            label: "Explore repository structure",
+            onClick: onExploreStructure,
+          }}
         />
       )}
-      {page && <LocalSliceDisclosure shown={rows.length} total={page.items.length} label={label} labels={labels} />}
+      {page && (
+        <LocalSliceDisclosure
+          shown={rows.length}
+          total={page.items.length}
+          label={label}
+          labels={labels}
+        />
+      )}
       {page && <BoundDisclosure page={page} labels={labels} />}
     </section>
   );
@@ -975,62 +1320,169 @@ function HistoryStructure({
     moduleId: string | null;
     commitId: string;
   }>({ moduleId: null, commitId: "" });
-  const selectedCommitId = commitSelection.moduleId === selectedModuleId
-    ? commitSelection.commitId
-    : "";
-  const selectedModuleNavigation = graph.history_navigation.by_module.items.find((item) => item.module_id === selectedModuleId);
-  const selectedCommitNavigation = graph.history_navigation.by_commit.items.find((item) => item.commit_id === selectedCommitId);
-  const linkedCommitIds = new Set(selectedModuleNavigation?.commits.items ?? []);
-  const commits = graph.commits.items.filter((commit) => linkedCommitIds.has(commit.id)).slice(0, UI_ROW_LIMIT);
-  const linkedModuleIds = new Set(selectedCommitNavigation?.modules.items ?? []);
+  const selectedCommitId =
+    commitSelection.moduleId === selectedModuleId
+      ? commitSelection.commitId
+      : "";
+  const selectedModuleNavigation =
+    graph.history_navigation.by_module.items.find(
+      (item) => item.module_id === selectedModuleId,
+    );
+  const selectedCommitNavigation =
+    graph.history_navigation.by_commit.items.find(
+      (item) => item.commit_id === selectedCommitId,
+    );
+  const linkedCommitIds = new Set(
+    selectedModuleNavigation?.commits.items ?? [],
+  );
+  const commits = graph.commits.items
+    .filter((commit) => linkedCommitIds.has(commit.id))
+    .slice(0, UI_ROW_LIMIT);
+  const linkedModuleIds = new Set(
+    selectedCommitNavigation?.modules.items ?? [],
+  );
   const moduleCandidates = selectedCommitId
     ? graph.modules.items.filter((module) => linkedModuleIds.has(module.id))
     : graph.modules.items;
   const modules = moduleCandidates.slice(0, 100);
-  const resolutions = graph.join_resolution.repositories.status === "available"
-    ? graph.join_resolution.repositories.value.slice(0, UI_ROW_LIMIT)
-    : [];
-  const historicalResolutions = graph.join_resolution.historical.status === "available"
-    ? graph.join_resolution.historical.value.slice(0, UI_ROW_LIMIT)
-    : [];
+  const resolutions =
+    graph.join_resolution.repositories.status === "available"
+      ? graph.join_resolution.repositories.value.slice(0, UI_ROW_LIMIT)
+      : [];
+  const historicalResolutions =
+    graph.join_resolution.historical.status === "available"
+      ? graph.join_resolution.historical.value.slice(0, UI_ROW_LIMIT)
+      : [];
 
   return (
     <div className="repo-view-body repo-grid">
       <div className="repo-grid history">
         <section className="repo-card" data-history-modules>
-          <div className="repo-card-heading"><h3>{labels.node_types.module}</h3><p>{formatNumber(modules.length)}</p></div>
+          <div className="repo-card-heading">
+            <h3>{labels.node_types.module}</h3>
+            <p>{formatNumber(modules.length)}</p>
+          </div>
           <div className="repo-list">
             {modules.map((module) => (
-              <button type="button" data-module-id={module.id} aria-label={`Inspect ${module.source_path}`} aria-controls="repository-module-inspector" aria-pressed={selectedModuleId === module.id} className={`repo-list-row ${selectedModuleId === module.id ? "selected" : ""}`} key={module.id} onClick={() => { onInspectModule(module.id); setCommitSelection({ moduleId: module.id, commitId: "" }); }}>
-                <Boxes aria-hidden="true" /><div><strong>{module.module_path}</strong><span>{module.source_path}</span></div>
+              <button
+                type="button"
+                data-module-id={module.id}
+                aria-label={`Inspect ${module.source_path}`}
+                aria-controls="repository-module-inspector"
+                aria-pressed={selectedModuleId === module.id}
+                className={`repo-list-row ${selectedModuleId === module.id ? "selected" : ""}`}
+                key={module.id}
+                onClick={() => {
+                  onInspectModule(module.id);
+                  setCommitSelection({ moduleId: module.id, commitId: "" });
+                }}
+              >
+                <Boxes aria-hidden="true" />
+                <div>
+                  <strong>{module.module_path}</strong>
+                  <span>{module.source_path}</span>
+                </div>
               </button>
             ))}
           </div>
-          <LocalSliceDisclosure shown={modules.length} total={moduleCandidates.length} label={labels.node_types.module} labels={labels} />
+          <LocalSliceDisclosure
+            shown={modules.length}
+            total={moduleCandidates.length}
+            label={labels.node_types.module}
+            labels={labels}
+          />
         </section>
         <section className="repo-card" data-history-commits>
-          <div className="repo-card-heading"><h3>{labels.node_types.commit}</h3><p>{formatNumber(commits.length)}</p></div>
+          <div className="repo-card-heading">
+            <h3>{labels.node_types.commit}</h3>
+            <p>{formatNumber(commits.length)}</p>
+          </div>
           <div className="repo-list">
             {commits.map((commit) => (
-              <button type="button" data-commit-id={commit.id} aria-pressed={selectedCommitId === commit.id} className={`repo-list-row ${selectedCommitId === commit.id ? "selected" : ""}`} key={commit.id} onClick={() => setCommitSelection({ moduleId: selectedModuleId, commitId: commit.id })}>
-                <GitCommitHorizontal aria-hidden="true" /><div><strong>{commit.subject}</strong><span>{commit.author} · {formatDate(commit.committed_at)}</span></div><code>{commit.short_sha}</code>
+              <button
+                type="button"
+                data-commit-id={commit.id}
+                aria-pressed={selectedCommitId === commit.id}
+                className={`repo-list-row ${selectedCommitId === commit.id ? "selected" : ""}`}
+                key={commit.id}
+                onClick={() =>
+                  setCommitSelection({
+                    moduleId: selectedModuleId,
+                    commitId: commit.id,
+                  })
+                }
+              >
+                <GitCommitHorizontal aria-hidden="true" />
+                <div>
+                  <strong>{commit.subject}</strong>
+                  <span>
+                    {commit.author} · {formatDate(commit.committed_at)}
+                  </span>
+                </div>
+                <code>{commit.short_sha}</code>
               </button>
             ))}
-            {commits.length === 0 && (
-              selectedModuleNavigation?.commits.disclosure.status === "unavailable" ||
-              graph.history_navigation.by_module.disclosure.status === "unavailable" ||
-              graph.commits.disclosure.status === "unavailable"
-                ? <DataState className="repo-empty" state="unavailable" title={`${labels.node_types.commit} ${labels.unavailable.toLocaleLowerCase()}`} message={selectedModuleNavigation?.commits.disclosure.reason ?? graph.history_navigation.by_module.disclosure.reason ?? "This bundle does not claim commit navigation."} />
-                : linkedCommitIds.size > 0
-                  ? <DataState className="repo-empty" state="truncated" title={`${labels.node_types.commit} ${labels.truncated.toLocaleLowerCase()}`} shown={commits.length} bound={graph.commits.bound.max_items} knownTotal={linkedCommitIds.size} reason={graph.commits.disclosure.reason ?? "Referenced commits fall outside the captured graph bound."} />
-                  : selectedModuleNavigation && isKnownEmptyRepoPage(selectedModuleNavigation.commits)
-                    ? <DataState className="repo-empty" state="empty" title={`No ${labels.node_types.commit}`} message="Commits captured for the selected module belong here." action={{ label: "Explore repository structure", onClick: onExploreStructure }} />
-                    : null
-            )}
+            {commits.length === 0 &&
+              (selectedModuleNavigation?.commits.disclosure.status ===
+                "unavailable" ||
+              graph.history_navigation.by_module.disclosure.status ===
+                "unavailable" ||
+              graph.commits.disclosure.status === "unavailable" ? (
+                <DataState
+                  className="repo-empty"
+                  state="unavailable"
+                  title={`${labels.node_types.commit} ${labels.unavailable.toLocaleLowerCase()}`}
+                  message={
+                    selectedModuleNavigation?.commits.disclosure.reason ??
+                    graph.history_navigation.by_module.disclosure.reason ??
+                    "This bundle does not claim commit navigation."
+                  }
+                />
+              ) : linkedCommitIds.size > 0 ? (
+                <DataState
+                  className="repo-empty"
+                  state="truncated"
+                  title={`${labels.node_types.commit} ${labels.truncated.toLocaleLowerCase()}`}
+                  shown={commits.length}
+                  bound={graph.commits.bound.max_items}
+                  knownTotal={linkedCommitIds.size}
+                  reason={
+                    graph.commits.disclosure.reason ??
+                    "Referenced commits fall outside the captured graph bound."
+                  }
+                />
+              ) : selectedModuleNavigation &&
+                isKnownEmptyRepoPage(selectedModuleNavigation.commits) ? (
+                <DataState
+                  className="repo-empty"
+                  state="empty"
+                  title={`No ${labels.node_types.commit}`}
+                  message="Commits captured for the selected module belong here."
+                  action={{
+                    label: "Explore repository structure",
+                    onClick: onExploreStructure,
+                  }}
+                />
+              ) : null)}
           </div>
-          <LocalSliceDisclosure shown={commits.length} total={linkedCommitIds.size} label={labels.node_types.commit} labels={labels} />
-          {selectedModuleNavigation && <BoundDisclosure page={selectedModuleNavigation.commits} labels={labels} />}
-          {selectedCommitNavigation && <BoundDisclosure page={selectedCommitNavigation.modules} labels={labels} />}
+          <LocalSliceDisclosure
+            shown={commits.length}
+            total={linkedCommitIds.size}
+            label={labels.node_types.commit}
+            labels={labels}
+          />
+          {selectedModuleNavigation && (
+            <BoundDisclosure
+              page={selectedModuleNavigation.commits}
+              labels={labels}
+            />
+          )}
+          {selectedCommitNavigation && (
+            <BoundDisclosure
+              page={selectedCommitNavigation.modules}
+              labels={labels}
+            />
+          )}
         </section>
       </div>
       <div className="repo-grid two">
@@ -1039,7 +1491,9 @@ function HistoryStructure({
           icon={GitBranch}
           value={selectedModuleNavigation?.pull_requests}
           parentPage={graph.history_navigation.by_module}
-          resolveItem={(id) => graph.pull_requests.items.find((candidate) => candidate.id === id)}
+          resolveItem={(id) =>
+            graph.pull_requests.items.find((candidate) => candidate.id === id)
+          }
           labels={labels}
           onExploreStructure={onExploreStructure}
         />
@@ -1048,53 +1502,174 @@ function HistoryStructure({
           icon={CircleDot}
           value={selectedModuleNavigation?.issues}
           parentPage={graph.history_navigation.by_module}
-          resolveItem={(id) => graph.issues.items.find((candidate) => candidate.id === id)}
+          resolveItem={(id) =>
+            graph.issues.items.find((candidate) => candidate.id === id)
+          }
           labels={labels}
           onExploreStructure={onExploreStructure}
         />
       </div>
       <div className="repo-grid two">
         <section className="repo-card" data-join-resolution>
-          <div className="repo-card-heading"><h3>{labels.derived}</h3><p>{graph.commit_module_edges.bound.order}</p></div>
+          <div className="repo-card-heading">
+            <h3>{labels.derived}</h3>
+            <p>{graph.commit_module_edges.bound.order}</p>
+          </div>
           <div style={{ padding: 14 }}>
-            <span className="repo-derived-badge"><Sparkles aria-hidden="true" /> {labels.derived}</span>
+            <span className="repo-derived-badge">
+              <Sparkles aria-hidden="true" /> {labels.derived}
+            </span>
             {resolutions.map((resolution) => (
               <div key={`${resolution.repository}-${resolution.language}`}>
-                <div className="repo-stat-line"><span>{labels.metrics.resolution}</span><strong>{availabilityText(resolution.resolution_rate, labels, formatPercent)}</strong></div>
-                <div className="repo-stat-line"><span>{labels.metrics.source_files}</span><strong>{formatNumber(resolution.files)}</strong></div>
-                <div className="repo-stat-line"><span>{labels.node_types.module}</span><strong>{formatNumber(resolution.entity_keys)}</strong></div>
-                <ul className="repo-residuals">{resolution.residuals.items.slice(0, UI_RESIDUAL_LIMIT).map((residual) => <li key={`${residual.side}-${residual.source_path}-${residual.module_path}`}>{residual.source_path || residual.module_path} · {residual.reason}</li>)}</ul>
-                <LocalSliceDisclosure shown={Math.min(UI_RESIDUAL_LIMIT, resolution.residuals.items.length)} total={resolution.residuals.items.length} label={labels.metrics.resolution} labels={labels} />
+                <div className="repo-stat-line">
+                  <span>{labels.metrics.resolution}</span>
+                  <strong>
+                    {availabilityText(
+                      resolution.resolution_rate,
+                      labels,
+                      formatPercent,
+                    )}
+                  </strong>
+                </div>
+                <div className="repo-stat-line">
+                  <span>{labels.metrics.source_files}</span>
+                  <strong>{formatNumber(resolution.files)}</strong>
+                </div>
+                <div className="repo-stat-line">
+                  <span>{labels.node_types.module}</span>
+                  <strong>{formatNumber(resolution.entity_keys)}</strong>
+                </div>
+                <ul className="repo-residuals">
+                  {resolution.residuals.items
+                    .slice(0, UI_RESIDUAL_LIMIT)
+                    .map((residual) => (
+                      <li
+                        key={`${residual.side}-${residual.source_path}-${residual.module_path}`}
+                      >
+                        {residual.source_path || residual.module_path} ·{" "}
+                        {residual.reason}
+                      </li>
+                    ))}
+                </ul>
+                <LocalSliceDisclosure
+                  shown={Math.min(
+                    UI_RESIDUAL_LIMIT,
+                    resolution.residuals.items.length,
+                  )}
+                  total={resolution.residuals.items.length}
+                  label={labels.metrics.resolution}
+                  labels={labels}
+                />
                 <BoundDisclosure page={resolution.residuals} labels={labels} />
               </div>
             ))}
             {historicalResolutions.map((historical) => (
               <div key={`${historical.repository}-${historical.language}`}>
-                <div className="repo-stat-line"><span>{labels.metrics.change_frequency}</span><strong>{formatNumber(historical.total_changed_paths)}</strong></div>
-                <div className="repo-stat-line"><span>{labels.metrics.resolution}</span><strong>{formatNumber(historical.matched_rust_paths)} / {formatNumber(historical.rust_in_scope_paths)}</strong></div>
-                <ul className="repo-residuals">{historical.unresolved_rust_paths.items.slice(0, UI_RESIDUAL_LIMIT).map((residual) => <li key={`${residual.commit_sha}-${residual.source_path}`}>{shortSha(residual.commit_sha)} · {residual.source_path} · {residual.reason}</li>)}</ul>
-                <LocalSliceDisclosure shown={Math.min(UI_RESIDUAL_LIMIT, historical.unresolved_rust_paths.items.length)} total={historical.unresolved_rust_paths.items.length} label={labels.metrics.resolution} labels={labels} />
-                <BoundDisclosure page={historical.unresolved_rust_paths} labels={labels} />
+                <div className="repo-stat-line">
+                  <span>{labels.metrics.change_frequency}</span>
+                  <strong>
+                    {formatNumber(historical.total_changed_paths)}
+                  </strong>
+                </div>
+                <div className="repo-stat-line">
+                  <span>{labels.metrics.resolution}</span>
+                  <strong>
+                    {formatNumber(historical.matched_rust_paths)} /{" "}
+                    {formatNumber(historical.rust_in_scope_paths)}
+                  </strong>
+                </div>
+                <ul className="repo-residuals">
+                  {historical.unresolved_rust_paths.items
+                    .slice(0, UI_RESIDUAL_LIMIT)
+                    .map((residual) => (
+                      <li
+                        key={`${residual.commit_sha}-${residual.source_path}`}
+                      >
+                        {shortSha(residual.commit_sha)} · {residual.source_path}{" "}
+                        · {residual.reason}
+                      </li>
+                    ))}
+                </ul>
+                <LocalSliceDisclosure
+                  shown={Math.min(
+                    UI_RESIDUAL_LIMIT,
+                    historical.unresolved_rust_paths.items.length,
+                  )}
+                  total={historical.unresolved_rust_paths.items.length}
+                  label={labels.metrics.resolution}
+                  labels={labels}
+                />
+                <BoundDisclosure
+                  page={historical.unresolved_rust_paths}
+                  labels={labels}
+                />
               </div>
             ))}
-            {graph.join_resolution.repositories.status === "available" && <LocalSliceDisclosure shown={resolutions.length} total={graph.join_resolution.repositories.value.length} label={labels.metrics.resolution} labels={labels} />}
-            {graph.join_resolution.historical.status === "available" && <LocalSliceDisclosure shown={historicalResolutions.length} total={graph.join_resolution.historical.value.length} label={labels.metrics.change_frequency} labels={labels} />}
-            {graph.join_resolution.repositories.status === "unavailable" && <DataState className="repo-empty" state="unavailable" title={`${labels.metrics.resolution} ${labels.unavailable.toLocaleLowerCase()}`} message={graph.join_resolution.repositories.reason} />}
-            {graph.join_resolution.historical.status === "unavailable" && <div className="repo-stat-line"><span>{labels.metrics.change_frequency}</span><strong>{labels.unavailable}</strong></div>}
+            {graph.join_resolution.repositories.status === "available" && (
+              <LocalSliceDisclosure
+                shown={resolutions.length}
+                total={graph.join_resolution.repositories.value.length}
+                label={labels.metrics.resolution}
+                labels={labels}
+              />
+            )}
+            {graph.join_resolution.historical.status === "available" && (
+              <LocalSliceDisclosure
+                shown={historicalResolutions.length}
+                total={graph.join_resolution.historical.value.length}
+                label={labels.metrics.change_frequency}
+                labels={labels}
+              />
+            )}
+            {graph.join_resolution.repositories.status === "unavailable" && (
+              <DataState
+                className="repo-empty"
+                state="unavailable"
+                title={`${labels.metrics.resolution} ${labels.unavailable.toLocaleLowerCase()}`}
+                message={graph.join_resolution.repositories.reason}
+              />
+            )}
+            {graph.join_resolution.historical.status === "unavailable" && (
+              <div className="repo-stat-line">
+                <span>{labels.metrics.change_frequency}</span>
+                <strong>{labels.unavailable}</strong>
+              </div>
+            )}
           </div>
         </section>
         <section className="repo-card" data-history-capabilities>
-          <div className="repo-card-heading"><h3>{view.label}</h3><p>{view.join}</p></div>
+          <div className="repo-card-heading">
+            <h3>{view.label}</h3>
+            <p>{view.join}</p>
+          </div>
           <div style={{ padding: "4px 14px 12px" }}>
-            <FacetState label={labels.node_types.commit} value={view.commit_module_facet} labels={labels} />
-            <FacetState label={labels.node_types.pull_request} value={view.pull_request_module_facet} labels={labels} />
-            <FacetState label={labels.node_types.issue} value={view.issue_module_facet} labels={labels} />
+            <FacetState
+              label={labels.node_types.commit}
+              value={view.commit_module_facet}
+              labels={labels}
+            />
+            <FacetState
+              label={labels.node_types.pull_request}
+              value={view.pull_request_module_facet}
+              labels={labels}
+            />
+            <FacetState
+              label={labels.node_types.issue}
+              value={view.issue_module_facet}
+              labels={labels}
+            />
           </div>
         </section>
       </div>
       <BoundDisclosure page={graph.commit_module_edges} labels={labels} />
-      <BoundDisclosure page={graph.history_navigation.by_module} labels={labels} />
-      <BoundDisclosure page={graph.history_navigation.by_commit} labels={labels} />
+      <BoundDisclosure
+        page={graph.history_navigation.by_module}
+        labels={labels}
+      />
+      <BoundDisclosure
+        page={graph.history_navigation.by_commit}
+        labels={labels}
+      />
       <BoundDisclosure page={graph.modules} labels={labels} />
       <BoundDisclosure page={graph.commits} labels={labels} />
       <BoundDisclosure page={graph.pull_requests} labels={labels} />
@@ -1103,40 +1678,131 @@ function HistoryStructure({
   );
 }
 
-function DependencyTopology({ bundle, moduleById, selectedModuleId, onInspectModule, onExploreStructure }: ViewProps) {
+function DependencyTopology({
+  bundle,
+  moduleById,
+  selectedModuleId,
+  onInspectModule,
+  onExploreStructure,
+}: ViewProps) {
   const analysis = bundle.aggregates.dependency_topology;
   const labels = bundle.capability.labels;
-  const moduleRows = [...analysis.modules.items]
-    .sort((left, right) =>
-      right.fan_in - left.fan_in
-      || right.cycle_ids.length - left.cycle_ids.length
-      || right.fan_out - left.fan_out
-      || left.module_id.localeCompare(right.module_id)
-    )
-    .slice(0, UI_ROW_LIMIT);
+  // Sorting the full page (up to 50k rows) is paid once per bundle, not on
+  // every selection-driven rerender.
+  const moduleRows = useMemo(
+    () =>
+      [...analysis.modules.items]
+        .sort(
+          (left, right) =>
+            right.fan_in - left.fan_in ||
+            right.cycle_ids.length - left.cycle_ids.length ||
+            right.fan_out - left.fan_out ||
+            left.module_id.localeCompare(right.module_id),
+        )
+        .slice(0, UI_ROW_LIMIT),
+    [analysis.modules.items],
+  );
   const cycleRows = analysis.cycles.items.slice(0, UI_ROW_LIMIT);
   return (
     <div className="repo-view-body repo-grid two">
       <section className="repo-card repo-table-wrap">
         <table className="repo-table">
-          <thead><tr><th>{labels.node_types.module}</th><th>{labels.metrics.fan_in}</th><th>{labels.metrics.fan_out}</th><th>{labels.metrics.cycle_count}</th></tr></thead>
-          <tbody>{moduleRows.map((row) => <tr key={row.module_id}><td><ModuleInspectionControl moduleId={row.module_id} moduleById={moduleById} modulePage={bundle.graph.modules} selectedModuleId={selectedModuleId} onInspectModule={onInspectModule} /></td><td>{formatNumber(row.fan_in)}</td><td>{formatNumber(row.fan_out)}</td><td>{formatNumber(row.cycle_ids.length)}</td></tr>)}</tbody>
+          <thead>
+            <tr>
+              <th>{labels.node_types.module}</th>
+              <th>{labels.metrics.fan_in}</th>
+              <th>{labels.metrics.fan_out}</th>
+              <th>{labels.metrics.cycle_count}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {moduleRows.map((row) => (
+              <tr key={row.module_id}>
+                <td>
+                  <ModuleInspectionControl
+                    moduleId={row.module_id}
+                    moduleById={moduleById}
+                    modulePage={bundle.graph.modules}
+                    selectedModuleId={selectedModuleId}
+                    onInspectModule={onInspectModule}
+                  />
+                </td>
+                <td>{formatNumber(row.fan_in)}</td>
+                <td>{formatNumber(row.fan_out)}</td>
+                <td>{formatNumber(row.cycle_ids.length)}</td>
+              </tr>
+            ))}
+          </tbody>
         </table>
-        <LocalSliceDisclosure shown={moduleRows.length} total={analysis.modules.items.length} label={labels.node_types.module} labels={labels} />
+        <LocalSliceDisclosure
+          shown={moduleRows.length}
+          total={analysis.modules.items.length}
+          label={labels.node_types.module}
+          labels={labels}
+        />
         <BoundDisclosure page={analysis.modules} labels={labels} />
       </section>
       <section className="repo-card">
-        <div className="repo-card-heading"><h3>{labels.metrics.cycle_count}</h3><p>{formatNumber(analysis.cycles.items.length)}</p></div>
-        <div className="repo-list">{cycleRows.map((cycle) => <div className="repo-list-row" key={cycle.id}><GitFork aria-hidden="true" /><div><strong>{cycle.id}</strong><span className="repo-cycle-members">SCC members: {cycle.module_ids.map((id, index) => <span key={id}><ModuleInspectionControl moduleId={id} moduleById={moduleById} modulePage={bundle.graph.modules} selectedModuleId={selectedModuleId} onInspectModule={onInspectModule} className="compact" />{index < cycle.module_ids.length - 1 ? " · " : ""}</span>)}</span></div></div>)}</div>
-        {isKnownEmptyRepoPage(analysis.cycles) && <DataState className="repo-empty" state="empty" title="No dependency cycles in this bundle" message="Dependency cycles found by the captured topology analysis belong here." action={{ label: "Explore repository structure", onClick: onExploreStructure }} />}
-        <LocalSliceDisclosure shown={cycleRows.length} total={analysis.cycles.items.length} label={labels.metrics.cycle_count} labels={labels} />
+        <div className="repo-card-heading">
+          <h3>{labels.metrics.cycle_count}</h3>
+          <p>{formatNumber(analysis.cycles.items.length)}</p>
+        </div>
+        <div className="repo-list">
+          {cycleRows.map((cycle) => (
+            <div className="repo-list-row" key={cycle.id}>
+              <GitFork aria-hidden="true" />
+              <div>
+                <strong>{cycle.id}</strong>
+                <span className="repo-cycle-members">
+                  SCC members:{" "}
+                  {cycle.module_ids.map((id, index) => (
+                    <span key={id}>
+                      <ModuleInspectionControl
+                        moduleId={id}
+                        moduleById={moduleById}
+                        modulePage={bundle.graph.modules}
+                        selectedModuleId={selectedModuleId}
+                        onInspectModule={onInspectModule}
+                        className="compact"
+                      />
+                      {index < cycle.module_ids.length - 1 ? " · " : ""}
+                    </span>
+                  ))}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+        {isKnownEmptyRepoPage(analysis.cycles) && (
+          <DataState
+            className="repo-empty"
+            state="empty"
+            title="No dependency cycles in this bundle"
+            message="Dependency cycles found by the captured topology analysis belong here."
+            action={{
+              label: "Explore repository structure",
+              onClick: onExploreStructure,
+            }}
+          />
+        )}
+        <LocalSliceDisclosure
+          shown={cycleRows.length}
+          total={analysis.cycles.items.length}
+          label={labels.metrics.cycle_count}
+          labels={labels}
+        />
         <BoundDisclosure page={analysis.cycles} labels={labels} />
       </section>
     </div>
   );
 }
 
-function HotspotQuadrantView({ bundle, moduleById, selectedModuleId, onInspectModule }: ViewProps) {
+function HotspotQuadrantView({
+  bundle,
+  moduleById,
+  selectedModuleId,
+  onInspectModule,
+}: ViewProps) {
   const analysis = bundle.aggregates.hotspot_quadrant;
   const labels = bundle.capability.labels;
   const rows = analysis.data.items.slice(0, UI_ROW_LIMIT);
@@ -1145,85 +1811,353 @@ function HotspotQuadrantView({ bundle, moduleById, selectedModuleId, onInspectMo
   return (
     <div className="repo-view-body repo-grid">
       <div className="repo-chart">
-        <svg data-visualization="hotspot" viewBox="0 0 100 70" role="img" aria-labelledby="hotspot-title hotspot-desc">
-          <title id="hotspot-title">{bundle.capability.views.hotspot_quadrant.label}</title>
+        <svg
+          data-visualization="hotspot"
+          viewBox="0 0 100 70"
+          role="img"
+          aria-labelledby="hotspot-title hotspot-desc"
+        >
+          <title id="hotspot-title">
+            {bundle.capability.views.hotspot_quadrant.label}
+          </title>
           <desc id="hotspot-desc">{analysis.meta.inputs.join(", ")}</desc>
-          <line className="repo-chart-grid" x1="50" y1="4" x2="50" y2="64" /><line className="repo-chart-grid" x1="8" y1="34" x2="96" y2="34" />
-          <text className="repo-chart-axis" x="50" y="69" textAnchor="middle">{labels.metrics.fan_in}</text>
-          <text className="repo-chart-axis" transform="rotate(-90 2 35)" x="2" y="35" textAnchor="middle">{labels.metrics.change_frequency}</text>
+          <line className="repo-chart-grid" x1="50" y1="4" x2="50" y2="64" />
+          <line className="repo-chart-grid" x1="8" y1="34" x2="96" y2="34" />
+          <text className="repo-chart-axis" x="50" y="69" textAnchor="middle">
+            {labels.metrics.fan_in}
+          </text>
+          <text
+            className="repo-chart-axis"
+            transform="rotate(-90 2 35)"
+            x="2"
+            y="35"
+            textAnchor="middle"
+          >
+            {labels.metrics.change_frequency}
+          </text>
           {rows.map((row) => {
             const x = 8 + (row.fan_in / maxFanIn) * 86;
             const y = 64 - (row.commit_count / maxChanges) * 58;
-            return <circle key={row.module_id} className={`repo-chart-dot ${row.quadrant === "high_churn_high_fan_in" ? "hot" : ""}`} cx={x} cy={y} r="2.3"><title>{moduleName(moduleById, row.module_id)} · {labels.metrics.change_frequency}: {row.commit_count} · {labels.metrics.fan_in}: {row.fan_in} · {labels.hotspot_quadrants[row.quadrant]}</title></circle>;
+            return (
+              <circle
+                key={row.module_id}
+                className={`repo-chart-dot ${row.quadrant === "high_churn_high_fan_in" ? "hot" : ""}`}
+                cx={x}
+                cy={y}
+                r="2.3"
+              >
+                <title>
+                  {moduleName(moduleById, row.module_id)} ·{" "}
+                  {labels.metrics.change_frequency}: {row.commit_count} ·{" "}
+                  {labels.metrics.fan_in}: {row.fan_in} ·{" "}
+                  {labels.hotspot_quadrants[row.quadrant]}
+                </title>
+              </circle>
+            );
           })}
         </svg>
       </div>
       <section className="repo-card repo-table-wrap">
-        <table className="repo-table"><thead><tr><th>{labels.node_types.module}</th><th>{labels.metrics.change_frequency}</th><th>{labels.metrics.fan_in}</th><th>{bundle.capability.views.hotspot_quadrant.label}</th></tr></thead><tbody>{rows.map((row) => <tr key={row.module_id}><td><ModuleInspectionControl moduleId={row.module_id} moduleById={moduleById} modulePage={bundle.graph.modules} selectedModuleId={selectedModuleId} onInspectModule={onInspectModule} /></td><td>{row.commit_count}</td><td>{row.fan_in}</td><td>{labels.hotspot_quadrants[row.quadrant]}</td></tr>)}</tbody></table>
-        <LocalSliceDisclosure shown={rows.length} total={analysis.data.items.length} label={bundle.capability.views.hotspot_quadrant.label} labels={labels} />
+        <table className="repo-table">
+          <thead>
+            <tr>
+              <th>{labels.node_types.module}</th>
+              <th>{labels.metrics.change_frequency}</th>
+              <th>{labels.metrics.fan_in}</th>
+              <th>{bundle.capability.views.hotspot_quadrant.label}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.module_id}>
+                <td>
+                  <ModuleInspectionControl
+                    moduleId={row.module_id}
+                    moduleById={moduleById}
+                    modulePage={bundle.graph.modules}
+                    selectedModuleId={selectedModuleId}
+                    onInspectModule={onInspectModule}
+                  />
+                </td>
+                <td>{row.commit_count}</td>
+                <td>{row.fan_in}</td>
+                <td>{labels.hotspot_quadrants[row.quadrant]}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <LocalSliceDisclosure
+          shown={rows.length}
+          total={analysis.data.items.length}
+          label={bundle.capability.views.hotspot_quadrant.label}
+          labels={labels}
+        />
         <BoundDisclosure page={analysis.data} labels={labels} />
       </section>
     </div>
   );
 }
 
-function HiddenCouplingView({ bundle, moduleById, selectedModuleId, onInspectModule, onExploreStructure }: ViewProps) {
+function HiddenCouplingView({
+  bundle,
+  moduleById,
+  selectedModuleId,
+  onInspectModule,
+  onExploreStructure,
+}: ViewProps) {
   const analysis = bundle.aggregates.hidden_coupling;
   const labels = bundle.capability.labels;
   const rows = analysis.data.items.slice(0, UI_ROW_LIMIT);
   return (
     <div className="repo-view-body">
       <section className="repo-card repo-table-wrap">
-        <table className="repo-table"><thead><tr><th>{labels.node_types.module}</th><th>{labels.node_types.module}</th><th>{labels.metrics.cochange_count}</th><th>{labels.metrics.support}</th></tr></thead><tbody>{rows.map((row) => <tr key={`${row.left_module_id}-${row.right_module_id}`}><td><ModuleInspectionControl moduleId={row.left_module_id} moduleById={moduleById} modulePage={bundle.graph.modules} selectedModuleId={selectedModuleId} onInspectModule={onInspectModule} /></td><td><ModuleInspectionControl moduleId={row.right_module_id} moduleById={moduleById} modulePage={bundle.graph.modules} selectedModuleId={selectedModuleId} onInspectModule={onInspectModule} /></td><td>{formatNumber(row.cochange_count)}</td><td><div className="repo-bar violet" aria-label={`${labels.metrics.support} ${formatPercent(row.support)}`}><span style={{ width: `${Math.min(100, row.support * 100)}%` }} /></div></td></tr>)}</tbody></table>
-        {isKnownEmptyRepoPage(analysis.data) && <DataState className="repo-empty" state="empty" title={`No ${bundle.capability.views.hidden_coupling.label.toLocaleLowerCase()} in this bundle`} message="Module pairs with captured co-change signals belong here." action={{ label: "Explore repository structure", onClick: onExploreStructure }} />}
-        <LocalSliceDisclosure shown={rows.length} total={analysis.data.items.length} label={bundle.capability.views.hidden_coupling.label} labels={labels} />
+        <table className="repo-table">
+          <thead>
+            <tr>
+              <th>{labels.node_types.module}</th>
+              <th>{labels.node_types.module}</th>
+              <th>{labels.metrics.cochange_count}</th>
+              <th>{labels.metrics.support}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={`${row.left_module_id}-${row.right_module_id}`}>
+                <td>
+                  <ModuleInspectionControl
+                    moduleId={row.left_module_id}
+                    moduleById={moduleById}
+                    modulePage={bundle.graph.modules}
+                    selectedModuleId={selectedModuleId}
+                    onInspectModule={onInspectModule}
+                  />
+                </td>
+                <td>
+                  <ModuleInspectionControl
+                    moduleId={row.right_module_id}
+                    moduleById={moduleById}
+                    modulePage={bundle.graph.modules}
+                    selectedModuleId={selectedModuleId}
+                    onInspectModule={onInspectModule}
+                  />
+                </td>
+                <td>{formatNumber(row.cochange_count)}</td>
+                <td>
+                  <div
+                    className="repo-bar violet"
+                    aria-label={`${labels.metrics.support} ${formatPercent(row.support)}`}
+                  >
+                    <span
+                      style={{ width: `${Math.min(100, row.support * 100)}%` }}
+                    />
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {isKnownEmptyRepoPage(analysis.data) && (
+          <DataState
+            className="repo-empty"
+            state="empty"
+            title={`No ${bundle.capability.views.hidden_coupling.label.toLocaleLowerCase()} in this bundle`}
+            message="Module pairs with captured co-change signals belong here."
+            action={{
+              label: "Explore repository structure",
+              onClick: onExploreStructure,
+            }}
+          />
+        )}
+        <LocalSliceDisclosure
+          shown={rows.length}
+          total={analysis.data.items.length}
+          label={bundle.capability.views.hidden_coupling.label}
+          labels={labels}
+        />
         <BoundDisclosure page={analysis.data} labels={labels} />
       </section>
     </div>
   );
 }
 
-function TreemapView({ bundle, moduleById, selectedModuleId, onInspectModule }: ViewProps) {
+function TreemapView({
+  bundle,
+  moduleById,
+  selectedModuleId,
+  onInspectModule,
+}: ViewProps) {
   const analysis = bundle.aggregates.structure_treemap;
   const labels = bundle.capability.labels;
   const rows = analysis.data.items.slice(0, UI_TREEMAP_LIMIT);
-  const maxActivity = Math.max(1, ...rows.map((row) => row.recent_commit_count.status === "available" ? row.recent_commit_count.value : 0));
+  const maxActivity = Math.max(
+    1,
+    ...rows.map((row) =>
+      row.recent_commit_count.status === "available"
+        ? row.recent_commit_count.value
+        : 0,
+    ),
+  );
   return (
     <div className="repo-view-body">
-      <div className="repo-legend"><span><i className="green" />{labels.metrics.source_files}</span><span><i className="red" />{labels.metrics.recent_activity}</span></div>
-      <div className="repo-treemap" role="list" aria-label={bundle.capability.views.structure_treemap.label}>
+      <div className="repo-legend">
+        <span>
+          <i className="green" />
+          {labels.metrics.source_files}
+        </span>
+        <span>
+          <i className="red" />
+          {labels.metrics.recent_activity}
+        </span>
+      </div>
+      <div
+        className="repo-treemap"
+        role="list"
+        aria-label={bundle.capability.views.structure_treemap.label}
+      >
         {rows.map((row) => {
-          const activity = row.recent_commit_count.status === "available" ? row.recent_commit_count.value : 0;
+          const activity =
+            row.recent_commit_count.status === "available"
+              ? row.recent_commit_count.value
+              : 0;
           const span = Math.min(6, Math.max(2, row.source_file_count));
           const moduleNode = moduleById.get(row.module_id);
-          return <div role="listitem" style={{ gridColumn: `span ${span}` }} key={row.module_id}>{moduleNode ? <button type="button" className={`repo-treemap-module ${activity > maxActivity * 0.55 ? "hot" : ""}`} data-module-id={row.module_id} aria-label={`Inspect ${moduleNode.source_path}`} aria-controls="repository-module-inspector" aria-pressed={selectedModuleId === row.module_id} onClick={() => onInspectModule(row.module_id)}><strong>{moduleNode.module_path}</strong><span>{labels.metrics.source_files}: {row.source_file_count}</span><span>{labels.metrics.recent_activity}: {availabilityText(row.recent_commit_count, labels, formatNumber)}</span></button> : <ModuleInspectionControl moduleId={row.module_id} moduleById={moduleById} modulePage={bundle.graph.modules} selectedModuleId={selectedModuleId} onInspectModule={onInspectModule} />}</div>;
+          return (
+            <div
+              role="listitem"
+              style={{ gridColumn: `span ${span}` }}
+              key={row.module_id}
+            >
+              {moduleNode ? (
+                <button
+                  type="button"
+                  className={`repo-treemap-module ${activity > maxActivity * 0.55 ? "hot" : ""}`}
+                  data-module-id={row.module_id}
+                  aria-label={`Inspect ${moduleNode.source_path}`}
+                  aria-controls="repository-module-inspector"
+                  aria-pressed={selectedModuleId === row.module_id}
+                  onClick={() => onInspectModule(row.module_id)}
+                >
+                  <strong>{moduleNode.module_path}</strong>
+                  <span>
+                    {labels.metrics.source_files}: {row.source_file_count}
+                  </span>
+                  <span>
+                    {labels.metrics.recent_activity}:{" "}
+                    {availabilityText(
+                      row.recent_commit_count,
+                      labels,
+                      formatNumber,
+                    )}
+                  </span>
+                </button>
+              ) : (
+                <ModuleInspectionControl
+                  moduleId={row.module_id}
+                  moduleById={moduleById}
+                  modulePage={bundle.graph.modules}
+                  selectedModuleId={selectedModuleId}
+                  onInspectModule={onInspectModule}
+                />
+              )}
+            </div>
+          );
         })}
       </div>
-      <LocalSliceDisclosure shown={rows.length} total={analysis.data.items.length} label={bundle.capability.views.structure_treemap.label} labels={labels} />
+      <LocalSliceDisclosure
+        shown={rows.length}
+        total={analysis.data.items.length}
+        label={bundle.capability.views.structure_treemap.label}
+        labels={labels}
+      />
       <BoundDisclosure page={analysis.data} labels={labels} />
     </div>
   );
 }
 
 type CadencePage = RepoBundle["aggregates"]["cadence_timeline"]["commits"];
-type CadenceSeriesId = "commits" | "issues_opened" | "issues_closed" | "pull_requests_opened" | "pull_requests_merged";
+type CadenceSeriesId =
+  | "commits"
+  | "issues_opened"
+  | "issues_closed"
+  | "pull_requests_opened"
+  | "pull_requests_merged";
 
-function CadenceSeries({ id, page, label, labels, onExploreStructure }: { id: CadenceSeriesId; page: CadencePage; label: string; labels: Labels; onExploreStructure: () => void }) {
+function CadenceSeries({
+  id,
+  page,
+  label,
+  labels,
+  onExploreStructure,
+}: {
+  id: CadenceSeriesId;
+  page: CadencePage;
+  label: string;
+  labels: Labels;
+  onExploreStructure: () => void;
+}) {
   const rows = page.items.slice(0, UI_ROW_LIMIT);
-  const seriesStatus = page.disclosure.status === "complete" && isIncompleteRepoPage(page)
-    ? "truncated"
-    : page.disclosure.status;
+  const seriesStatus =
+    page.disclosure.status === "complete" && isIncompleteRepoPage(page)
+      ? "truncated"
+      : page.disclosure.status;
   return (
-    <section className="repo-card repo-table-wrap" data-cadence-series={id} data-series-status={seriesStatus}>
-      <div className="repo-card-heading"><h3>{label}</h3><p>{page.total_count.status === "available" ? formatNumber(page.total_count.value) : labels.unavailable}</p></div>
+    <section
+      className="repo-card repo-table-wrap"
+      data-cadence-series={id}
+      data-series-status={seriesStatus}
+    >
+      <div className="repo-card-heading">
+        <h3>{label}</h3>
+        <p>
+          {page.total_count.status === "available"
+            ? formatNumber(page.total_count.value)
+            : labels.unavailable}
+        </p>
+      </div>
       {page.disclosure.status === "unavailable" ? (
-        <DataState className="repo-empty compact" state="unavailable" title={`${label} ${labels.unavailable.toLocaleLowerCase()}`} message={page.disclosure.reason ?? "This bundle does not claim cadence data."} />
+        <DataState
+          className="repo-empty compact"
+          state="unavailable"
+          title={`${label} ${labels.unavailable.toLocaleLowerCase()}`}
+          message={
+            page.disclosure.reason ?? "This bundle does not claim cadence data."
+          }
+        />
       ) : isKnownEmptyRepoPage(page) ? (
-        <DataState className="repo-empty compact" state="empty" title={`No ${label.toLocaleLowerCase()} cadence points`} message={`Captured weekly ${label.toLocaleLowerCase()} counts belong here.`} action={{ label: "Explore repository structure", onClick: onExploreStructure }} />
+        <DataState
+          className="repo-empty compact"
+          state="empty"
+          title={`No ${label.toLocaleLowerCase()} cadence points`}
+          message={`Captured weekly ${label.toLocaleLowerCase()} counts belong here.`}
+          action={{
+            label: "Explore repository structure",
+            onClick: onExploreStructure,
+          }}
+        />
       ) : (
-        <table className="repo-table"><thead><tr><th>{labels.metrics.week}</th><th>{label}</th></tr></thead><tbody>{rows.map((point) => <tr key={point.week_start}><td>{point.week_start}</td><td>{formatNumber(point.count)}</td></tr>)}</tbody></table>
+        <table className="repo-table">
+          <thead>
+            <tr>
+              <th>{labels.metrics.week}</th>
+              <th>{label}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((point) => (
+              <tr key={point.week_start}>
+                <td>{point.week_start}</td>
+                <td>{formatNumber(point.count)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       )}
-      <LocalSliceDisclosure shown={rows.length} total={page.items.length} label={label} labels={labels} />
+      <LocalSliceDisclosure
+        shown={rows.length}
+        total={page.items.length}
+        label={label}
+        labels={labels}
+      />
       <BoundDisclosure page={page} labels={labels} />
     </section>
   );
@@ -1239,77 +2173,355 @@ function CadenceView({ bundle, onExploreStructure }: ViewProps) {
   return (
     <div className="repo-view-body repo-grid">
       <div className="repo-chart">
-        <div className="repo-legend"><span><i className="green" />{labels.metrics.commits}</span></div>
-        <svg data-visualization="cadence" viewBox={`0 0 ${width} 70`} role="img" aria-labelledby="cadence-title cadence-desc">
-          <title id="cadence-title">{bundle.capability.views.cadence_timeline.label}</title><desc id="cadence-desc">{analysis.meta.inputs.join(", ")}</desc>
+        <div className="repo-legend">
+          <span>
+            <i className="green" />
+            {labels.metrics.commits}
+          </span>
+        </div>
+        <svg
+          data-visualization="cadence"
+          viewBox={`0 0 ${width} 70`}
+          role="img"
+          aria-labelledby="cadence-title cadence-desc"
+        >
+          <title id="cadence-title">
+            {bundle.capability.views.cadence_timeline.label}
+          </title>
+          <desc id="cadence-desc">{analysis.meta.inputs.join(", ")}</desc>
           {commitRows.map((point, index) => {
             const x = index * 8 + 4;
             const height = (point.count / maxCommits) * 52;
-            return <rect className="repo-chart-bar" key={point.week_start} x={x} y={60 - height} width="5" height={height}><title>{point.week_start} · {labels.metrics.commits}: {point.count}</title></rect>;
+            return (
+              <rect
+                className="repo-chart-bar"
+                key={point.week_start}
+                x={x}
+                y={60 - height}
+                width="5"
+                height={height}
+              >
+                <title>
+                  {point.week_start} · {labels.metrics.commits}: {point.count}
+                </title>
+              </rect>
+            );
           })}
-          <text className="repo-chart-axis" x={width / 2} y="68" textAnchor="middle">{labels.metrics.week}</text>
+          <text
+            className="repo-chart-axis"
+            x={width / 2}
+            y="68"
+            textAnchor="middle"
+          >
+            {labels.metrics.week}
+          </text>
         </svg>
-        <LocalSliceDisclosure shown={commitRows.length} total={analysis.commits.items.length} label={labels.metrics.commits} labels={labels} />
+        <LocalSliceDisclosure
+          shown={commitRows.length}
+          total={analysis.commits.items.length}
+          label={labels.metrics.commits}
+          labels={labels}
+        />
       </div>
       <div className="repo-cadence-series">
-        <CadenceSeries id="commits" page={analysis.commits} label={labels.metrics.commits} labels={labels} onExploreStructure={onExploreStructure} />
-        <CadenceSeries id="issues_opened" page={analysis.issues_opened} label={labels.metrics.issues_opened} labels={labels} onExploreStructure={onExploreStructure} />
-        <CadenceSeries id="issues_closed" page={analysis.issues_closed} label={labels.metrics.issues_closed} labels={labels} onExploreStructure={onExploreStructure} />
-        <CadenceSeries id="pull_requests_opened" page={analysis.pull_requests_opened} label={labels.metrics.pull_requests_opened} labels={labels} onExploreStructure={onExploreStructure} />
-        <CadenceSeries id="pull_requests_merged" page={analysis.pull_requests_merged} label={labels.metrics.pull_requests_merged} labels={labels} onExploreStructure={onExploreStructure} />
+        <CadenceSeries
+          id="commits"
+          page={analysis.commits}
+          label={labels.metrics.commits}
+          labels={labels}
+          onExploreStructure={onExploreStructure}
+        />
+        <CadenceSeries
+          id="issues_opened"
+          page={analysis.issues_opened}
+          label={labels.metrics.issues_opened}
+          labels={labels}
+          onExploreStructure={onExploreStructure}
+        />
+        <CadenceSeries
+          id="issues_closed"
+          page={analysis.issues_closed}
+          label={labels.metrics.issues_closed}
+          labels={labels}
+          onExploreStructure={onExploreStructure}
+        />
+        <CadenceSeries
+          id="pull_requests_opened"
+          page={analysis.pull_requests_opened}
+          label={labels.metrics.pull_requests_opened}
+          labels={labels}
+          onExploreStructure={onExploreStructure}
+        />
+        <CadenceSeries
+          id="pull_requests_merged"
+          page={analysis.pull_requests_merged}
+          label={labels.metrics.pull_requests_merged}
+          labels={labels}
+          onExploreStructure={onExploreStructure}
+        />
       </div>
       <div className="repo-grid two">
-        <section className="repo-card" style={{ padding: 14 }}><span className="repo-eyebrow">{labels.metrics.lead_time}</span><strong>{availabilityText(analysis.pull_request_lead_time_hours, labels, (value) => `${labels.metrics.p50} ${value.p50.toFixed(1)} · ${labels.metrics.p90} ${value.p90.toFixed(1)} · ${labels.metrics.p95} ${value.p95.toFixed(1)}`)}</strong></section>
-        <section className="repo-card"><div className="repo-list">{releaseTags.map((tag) => <div className="repo-list-row" key={`${tag.name}-${tag.target_sha}`}><GitBranch aria-hidden="true" /><div><strong>{tag.name}</strong><span>{availabilityText(tag.committed_at, labels, formatDate)}</span></div><code>{shortSha(tag.target_sha)}</code></div>)}</div><LocalSliceDisclosure shown={releaseTags.length} total={analysis.release_tags.items.length} label={bundle.capability.views.cadence_timeline.label} labels={labels} /><BoundDisclosure page={analysis.release_tags} labels={labels} /></section>
+        <section className="repo-card" style={{ padding: 14 }}>
+          <span className="repo-eyebrow">{labels.metrics.lead_time}</span>
+          <strong>
+            {availabilityText(
+              analysis.pull_request_lead_time_hours,
+              labels,
+              (value) =>
+                `${labels.metrics.p50} ${value.p50.toFixed(1)} · ${labels.metrics.p90} ${value.p90.toFixed(1)} · ${labels.metrics.p95} ${value.p95.toFixed(1)}`,
+            )}
+          </strong>
+        </section>
+        <section className="repo-card">
+          <div className="repo-list">
+            {releaseTags.map((tag) => (
+              <div
+                className="repo-list-row"
+                key={`${tag.name}-${tag.target_sha}`}
+              >
+                <GitBranch aria-hidden="true" />
+                <div>
+                  <strong>{tag.name}</strong>
+                  <span>
+                    {availabilityText(tag.committed_at, labels, formatDate)}
+                  </span>
+                </div>
+                <code>{shortSha(tag.target_sha)}</code>
+              </div>
+            ))}
+          </div>
+          <LocalSliceDisclosure
+            shown={releaseTags.length}
+            total={analysis.release_tags.items.length}
+            label={bundle.capability.views.cadence_timeline.label}
+            labels={labels}
+          />
+          <BoundDisclosure page={analysis.release_tags} labels={labels} />
+        </section>
       </div>
     </div>
   );
 }
 
-function OwnershipView({ bundle, moduleById, selectedModuleId, onInspectModule }: ViewProps) {
+function OwnershipView({
+  bundle,
+  moduleById,
+  selectedModuleId,
+  onInspectModule,
+}: ViewProps) {
   const analysis = bundle.aggregates.ownership;
   const labels = bundle.capability.labels;
   const moduleRows = analysis.modules.items.slice(0, UI_ROW_LIMIT);
-  const repositoryAuthors = analysis.repository_authors.items.slice(0, UI_ROW_LIMIT);
+  const repositoryAuthors = analysis.repository_authors.items.slice(
+    0,
+    UI_ROW_LIMIT,
+  );
   return (
     <div className="repo-view-body repo-grid">
       <div className="repo-grid three">
         <section className="repo-score-card">
           <span>{labels.metrics.author_concentration}</span>
-          <div className="repo-score-value"><Users aria-hidden="true" /><strong>{availabilityText(analysis.repository_author_concentration, labels, formatPercent)}</strong></div>
-          {analysis.repository_author_concentration.status === "unavailable" && <p>{analysis.repository_author_concentration.reason}</p>}
+          <div className="repo-score-value">
+            <Users aria-hidden="true" />
+            <strong>
+              {availabilityText(
+                analysis.repository_author_concentration,
+                labels,
+                formatPercent,
+              )}
+            </strong>
+          </div>
+          {analysis.repository_author_concentration.status ===
+            "unavailable" && (
+            <p>{analysis.repository_author_concentration.reason}</p>
+          )}
         </section>
         <section className="repo-score-card">
           <span>{labels.metrics.bus_factor}</span>
-          <div className="repo-score-value"><ShieldCheck aria-hidden="true" /><strong>{availabilityText(analysis.repository_bus_factor, labels, formatNumber)}</strong></div>
-          {analysis.repository_bus_factor.status === "unavailable" && <p>{analysis.repository_bus_factor.reason}</p>}
+          <div className="repo-score-value">
+            <ShieldCheck aria-hidden="true" />
+            <strong>
+              {availabilityText(
+                analysis.repository_bus_factor,
+                labels,
+                formatNumber,
+              )}
+            </strong>
+          </div>
+          {analysis.repository_bus_factor.status === "unavailable" && (
+            <p>{analysis.repository_bus_factor.reason}</p>
+          )}
         </section>
         <section className="repo-card">
-          <div className="repo-list">{repositoryAuthors.map((author) => <div className="repo-list-row" key={author.author}><Users aria-hidden="true" /><div><strong>{author.author}</strong><span>{labels.metrics.commits}: {formatNumber(author.commits)} · {formatPercent(author.share)}</span></div></div>)}</div>
-          <LocalSliceDisclosure shown={repositoryAuthors.length} total={analysis.repository_authors.items.length} label={labels.metrics.author_concentration} labels={labels} />
+          <div className="repo-list">
+            {repositoryAuthors.map((author) => (
+              <div className="repo-list-row" key={author.author}>
+                <Users aria-hidden="true" />
+                <div>
+                  <strong>{author.author}</strong>
+                  <span>
+                    {labels.metrics.commits}: {formatNumber(author.commits)} ·{" "}
+                    {formatPercent(author.share)}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+          <LocalSliceDisclosure
+            shown={repositoryAuthors.length}
+            total={analysis.repository_authors.items.length}
+            label={labels.metrics.author_concentration}
+            labels={labels}
+          />
           <BoundDisclosure page={analysis.repository_authors} labels={labels} />
         </section>
       </div>
       <section className="repo-card repo-table-wrap">
-        {analysis.modules.disclosure.status === "unavailable" ? <DataState className="repo-empty" state="unavailable" title={`${labels.node_types.module} ${labels.unavailable.toLocaleLowerCase()}`} message={analysis.modules.disclosure.reason ?? "This bundle does not claim ownership modules."} /> : <table className="repo-table"><thead><tr><th>{labels.node_types.module}</th><th>{labels.metrics.commits}</th><th>{labels.metrics.author_concentration}</th><th>{labels.metrics.bus_factor}</th></tr></thead><tbody>{moduleRows.map((row) => <tr key={row.module_id}><td><ModuleInspectionControl moduleId={row.module_id} moduleById={moduleById} modulePage={bundle.graph.modules} selectedModuleId={selectedModuleId} onInspectModule={onInspectModule} /><div>{row.authors.items.slice(0, 8).map((author) => `${author.author} ${formatPercent(author.share)}`).join(" · ")}</div><InlineLocalSlice shown={Math.min(8, row.authors.items.length)} total={row.authors.items.length} labels={labels} /><InlinePageState page={row.authors} labels={labels} /></td><td>{row.commit_count}</td><td>{row.author_concentration.status === "available" ? <div className="repo-bar" aria-label={`${labels.metrics.author_concentration} ${formatPercent(row.author_concentration.value)}`}><span style={{ width: `${Math.min(100, row.author_concentration.value * 100)}%` }} /></div> : availabilityText(row.author_concentration, labels)}</td><td>{availabilityText(row.bus_factor, labels, formatNumber)}</td></tr>)}</tbody></table>}
-        <LocalSliceDisclosure shown={moduleRows.length} total={analysis.modules.items.length} label={labels.node_types.module} labels={labels} />
+        {analysis.modules.disclosure.status === "unavailable" ? (
+          <DataState
+            className="repo-empty"
+            state="unavailable"
+            title={`${labels.node_types.module} ${labels.unavailable.toLocaleLowerCase()}`}
+            message={
+              analysis.modules.disclosure.reason ??
+              "This bundle does not claim ownership modules."
+            }
+          />
+        ) : (
+          <table className="repo-table">
+            <thead>
+              <tr>
+                <th>{labels.node_types.module}</th>
+                <th>{labels.metrics.commits}</th>
+                <th>{labels.metrics.author_concentration}</th>
+                <th>{labels.metrics.bus_factor}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {moduleRows.map((row) => (
+                <tr key={row.module_id}>
+                  <td>
+                    <ModuleInspectionControl
+                      moduleId={row.module_id}
+                      moduleById={moduleById}
+                      modulePage={bundle.graph.modules}
+                      selectedModuleId={selectedModuleId}
+                      onInspectModule={onInspectModule}
+                    />
+                    <div>
+                      {row.authors.items
+                        .slice(0, 8)
+                        .map(
+                          (author) =>
+                            `${author.author} ${formatPercent(author.share)}`,
+                        )
+                        .join(" · ")}
+                    </div>
+                    <InlineLocalSlice
+                      shown={Math.min(8, row.authors.items.length)}
+                      total={row.authors.items.length}
+                      labels={labels}
+                    />
+                    <InlinePageState page={row.authors} labels={labels} />
+                  </td>
+                  <td>{row.commit_count}</td>
+                  <td>
+                    {row.author_concentration.status === "available" ? (
+                      <div
+                        className="repo-bar"
+                        aria-label={`${labels.metrics.author_concentration} ${formatPercent(row.author_concentration.value)}`}
+                      >
+                        <span
+                          style={{
+                            width: `${Math.min(100, row.author_concentration.value * 100)}%`,
+                          }}
+                        />
+                      </div>
+                    ) : (
+                      availabilityText(row.author_concentration, labels)
+                    )}
+                  </td>
+                  <td>
+                    {availabilityText(row.bus_factor, labels, formatNumber)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+        <LocalSliceDisclosure
+          shown={moduleRows.length}
+          total={analysis.modules.items.length}
+          label={labels.node_types.module}
+          labels={labels}
+        />
         <BoundDisclosure page={analysis.modules} labels={labels} />
       </section>
     </div>
   );
 }
 
-function ApiSurfaceView({ bundle, moduleById, selectedModuleId, onInspectModule }: ViewProps) {
+function ApiSurfaceView({
+  bundle,
+  moduleById,
+  selectedModuleId,
+  onInspectModule,
+}: ViewProps) {
   const analysis = bundle.aggregates.api_surface;
   const labels = bundle.capability.labels;
   const rows = analysis.data.items.slice(0, UI_ROW_LIMIT);
   const max = Math.max(1, ...rows.map((row) => row.dependent_count));
   return (
-    <div className="repo-view-body"><section className="repo-card repo-table-wrap"><table className="repo-table"><thead><tr><th>{labels.node_types.module}</th><th>{labels.metrics.dependent_count}</th><th>Relative magnitude</th></tr></thead><tbody>{rows.map((row) => <tr key={row.module_id}><td><ModuleInspectionControl moduleId={row.module_id} moduleById={moduleById} modulePage={bundle.graph.modules} selectedModuleId={selectedModuleId} onInspectModule={onInspectModule} /></td><td>{formatNumber(row.dependent_count)}</td><td><div className="repo-bar"><span style={{ width: `${(row.dependent_count / max) * 100}%` }} /></div></td></tr>)}</tbody></table><LocalSliceDisclosure shown={rows.length} total={analysis.data.items.length} label={bundle.capability.views.api_surface.label} labels={labels} /><BoundDisclosure page={analysis.data} labels={labels} /></section></div>
+    <div className="repo-view-body">
+      <section className="repo-card repo-table-wrap">
+        <table className="repo-table">
+          <thead>
+            <tr>
+              <th>{labels.node_types.module}</th>
+              <th>{labels.metrics.dependent_count}</th>
+              <th>Relative magnitude</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.module_id}>
+                <td>
+                  <ModuleInspectionControl
+                    moduleId={row.module_id}
+                    moduleById={moduleById}
+                    modulePage={bundle.graph.modules}
+                    selectedModuleId={selectedModuleId}
+                    onInspectModule={onInspectModule}
+                  />
+                </td>
+                <td>{formatNumber(row.dependent_count)}</td>
+                <td>
+                  <div className="repo-bar">
+                    <span
+                      style={{ width: `${(row.dependent_count / max) * 100}%` }}
+                    />
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <LocalSliceDisclosure
+          shown={rows.length}
+          total={analysis.data.items.length}
+          label={bundle.capability.views.api_surface.label}
+          labels={labels}
+        />
+        <BoundDisclosure page={analysis.data} labels={labels} />
+      </section>
+    </div>
   );
 }
 
-function scoreLabel(labels: Labels, key: RepoBundle["aggregates"]["scorecard"]["fields"][number]["key"]): string {
+function scoreLabel(
+  labels: Labels,
+  key: RepoBundle["aggregates"]["scorecard"]["fields"][number]["key"],
+): string {
   const keys = {
     repository_age_days: labels.metrics.repository_age,
     package_count: labels.metrics.package_count,
@@ -1349,13 +2561,21 @@ function scorecardModuleIds(
   field: RepoBundle["aggregates"]["scorecard"]["fields"][number],
 ): Readonly<{ items: readonly string[]; tier: string | null }> | null {
   if (
-    field.value.status !== "available"
-    || field.value.value.value_kind !== "module_ids"
+    field.value.status !== "available" ||
+    field.value.value.value_kind !== "module_ids"
   ) {
     return null;
   }
   const items = field.value.value.value.items;
   if (field.key !== "ownership_warnings") {
+    return { items, tier: null };
+  }
+  // The tier filter is definitive only over a complete hotspot page: a
+  // truncated or cursor-bearing page can be missing exactly the modules the
+  // filter selects, turning unknown coverage into a false zero presented as
+  // a definitive tier. Fall back to the unfiltered warning list with no
+  // tier claim.
+  if (!isCompleteRepoPage(bundle.aggregates.hotspot_quadrant.data)) {
     return { items, tier: null };
   }
   const highImpactIds = new Set(
@@ -1369,23 +2589,84 @@ function scorecardModuleIds(
   };
 }
 
-function ScorecardView({ bundle, moduleById, selectedModuleId, onInspectModule }: ViewProps) {
+function ScorecardView({
+  bundle,
+  moduleById,
+  selectedModuleId,
+  onInspectModule,
+}: ViewProps) {
   const analysis = bundle.aggregates.scorecard;
   const labels = bundle.capability.labels;
   const fields = analysis.fields.slice(0, UI_ROW_LIMIT);
   return (
     <div className="repo-view-body">
-      <div className="repo-score-grid">{fields.map((field) => {
-        const moduleIds = scorecardModuleIds(bundle, field);
-        const value = scoreValue(field, labels, moduleIds?.items ?? null);
-        const unavailable = field.value.status === "unavailable";
-        const modulePage = field.value.status === "available"
-          && field.value.value.value_kind === "module_ids"
-          ? field.value.value.value
-          : null;
-        return <article className={`repo-score-card ${unavailable ? "unavailable" : ""}`.trim()} key={field.key}><span>{scoreLabel(labels, field.key)}</span><div className="repo-score-value">{unavailable ? <AlertTriangle aria-hidden="true" /> : <TrendingUp aria-hidden="true" />}<strong>{value}</strong></div>{field.value.status === "unavailable" && <p>{field.value.reason}</p>}{moduleIds?.tier && <p>{moduleIds.tier}</p>}{moduleIds && <><div className="repo-score-modules">{moduleIds.items.slice(0, 8).map((moduleId) => <ModuleInspectionControl key={moduleId} moduleId={moduleId} moduleById={moduleById} modulePage={bundle.graph.modules} selectedModuleId={selectedModuleId} onInspectModule={onInspectModule} className="compact" />)}</div><InlineLocalSlice shown={Math.min(8, moduleIds.items.length)} total={moduleIds.items.length} labels={labels} />{modulePage && <InlinePageState page={modulePage} labels={labels} />}</>}<div className="repo-score-tags"><i>{field.granularity}</i><i>{field.join}</i></div></article>;
-      })}</div>
-      <LocalSliceDisclosure shown={fields.length} total={analysis.fields.length} label={bundle.capability.views.scorecard.label} labels={labels} />
+      <div className="repo-score-grid">
+        {fields.map((field) => {
+          const moduleIds = scorecardModuleIds(bundle, field);
+          const value = scoreValue(field, labels, moduleIds?.items ?? null);
+          const unavailable = field.value.status === "unavailable";
+          const modulePage =
+            field.value.status === "available" &&
+            field.value.value.value_kind === "module_ids"
+              ? field.value.value.value
+              : null;
+          return (
+            <article
+              className={`repo-score-card ${unavailable ? "unavailable" : ""}`.trim()}
+              key={field.key}
+            >
+              <span>{scoreLabel(labels, field.key)}</span>
+              <div className="repo-score-value">
+                {unavailable ? (
+                  <AlertTriangle aria-hidden="true" />
+                ) : (
+                  <TrendingUp aria-hidden="true" />
+                )}
+                <strong>{value}</strong>
+              </div>
+              {field.value.status === "unavailable" && (
+                <p>{field.value.reason}</p>
+              )}
+              {moduleIds?.tier && <p>{moduleIds.tier}</p>}
+              {moduleIds && (
+                <>
+                  <div className="repo-score-modules">
+                    {moduleIds.items.slice(0, 8).map((moduleId) => (
+                      <ModuleInspectionControl
+                        key={moduleId}
+                        moduleId={moduleId}
+                        moduleById={moduleById}
+                        modulePage={bundle.graph.modules}
+                        selectedModuleId={selectedModuleId}
+                        onInspectModule={onInspectModule}
+                        className="compact"
+                      />
+                    ))}
+                  </div>
+                  <InlineLocalSlice
+                    shown={Math.min(8, moduleIds.items.length)}
+                    total={moduleIds.items.length}
+                    labels={labels}
+                  />
+                  {modulePage && (
+                    <InlinePageState page={modulePage} labels={labels} />
+                  )}
+                </>
+              )}
+              <div className="repo-score-tags">
+                <i>{field.granularity}</i>
+                <i>{field.join}</i>
+              </div>
+            </article>
+          );
+        })}
+      </div>
+      <LocalSliceDisclosure
+        shown={fields.length}
+        total={analysis.fields.length}
+        label={bundle.capability.views.scorecard.label}
+        labels={labels}
+      />
     </div>
   );
 }
@@ -1415,7 +2696,11 @@ function ActiveView({
   const labels = bundle.capability.labels;
   const ViewComponent = viewComponents[id];
   return (
-    <ViewFrame capability={capability} labels={labels} allowPartial={id === "ownership"}>
+    <ViewFrame
+      capability={capability}
+      labels={labels}
+      allowPartial={id === "ownership"}
+    >
       <ViewComponent
         bundle={bundle}
         moduleById={moduleById}
@@ -1427,11 +2712,18 @@ function ActiveView({
   );
 }
 
-export function RepoShowcase({ bundle, analysisSource = "curated-static-fallback" }: { bundle: RepoBundle; analysisSource?: ShowcaseBundleSource }) {
+export function RepoShowcase({
+  bundle,
+  analysisSource = "curated-static-fallback",
+}: {
+  bundle: RepoBundle;
+  analysisSource?: ShowcaseBundleSource;
+}) {
   const { repository, snapshot, producer } = bundle.meta;
   const { capability } = bundle;
   const moduleById = useMemo(
-    () => new Map(bundle.graph.modules.items.map((module) => [module.id, module])),
+    () =>
+      new Map(bundle.graph.modules.items.map((module) => [module.id, module])),
     [bundle.graph.modules.items],
   );
   const modulesBySourcePath = useMemo(() => {
@@ -1444,8 +2736,8 @@ export function RepoShowcase({ bundle, analysisSource = "curated-static-fallback
     return result;
   }, [bundle.graph.modules.items]);
   const brief = useMemo(() => buildRepositoryBrief(bundle), [bundle]);
-  const defaultModuleId: string | null = brief.startHere[0]?.moduleId ??
-    bundle.graph.modules.items[0]?.id ?? null;
+  const defaultModuleId: string | null =
+    brief.startHere[0]?.moduleId ?? bundle.graph.modules.items[0]?.id ?? null;
   const [selectedModuleId, setSelectedModuleId] = useState<string | null>(
     defaultModuleId,
   );
@@ -1481,9 +2773,10 @@ export function RepoShowcase({ bundle, analysisSource = "curated-static-fallback
           nextModuleId = null;
           nextUnresolved = {
             path: requestedPath,
-            reason: matches.length === 0
-              ? "The requested source path is not present in this bounded snapshot."
-              : "The requested source path is ambiguous in this snapshot.",
+            reason:
+              matches.length === 0
+                ? "The requested source path is not present in this bounded snapshot."
+                : "The requested source path is ambiguous in this snapshot.",
           };
         }
       }
@@ -1503,37 +2796,39 @@ export function RepoShowcase({ bundle, analysisSource = "curated-static-fallback
       setUnresolvedModule(nextUnresolved);
       setActiveView(nextView);
       setCopyStatus("");
-      setLocationNotice(messages.length
-        ? {
-            title: staleSnapshot
-              ? "Investigation link needs attention"
-              : "Investigation link was repaired",
-            message: messages.join(" "),
-            action: staleSnapshot ? "use-current-snapshot" : "dismiss",
-          }
-        : null);
+      setLocationNotice(
+        messages.length
+          ? {
+              title: staleSnapshot
+                ? "Investigation link needs attention"
+                : "Investigation link was repaired",
+              message: messages.join(" "),
+              action: staleSnapshot ? "use-current-snapshot" : "dismiss",
+            }
+          : null,
+      );
       if (announce) {
         const moduleLabel = nextModuleId
-          ? moduleById.get(nextModuleId)?.source_path ?? "repository overview"
+          ? (moduleById.get(nextModuleId)?.source_path ?? "repository overview")
           : requestedPath
-          ? `unresolved module ${requestedPath}`
-          : "repository overview";
+            ? `unresolved module ${requestedPath}`
+            : "repository overview";
         setNavigationStatus(
           `Restored ${capability.views[nextView].label} for ${moduleLabel}.`,
         );
         if (resolvedModuleRestore) focusAndScrollInspector();
       }
 
-      const canonical = repositoryLocationUrl(
-        new URL(window.location.href),
-        {
-          repository: repository.canonical_url,
-          snapshotSha: parsed.location.snapshotSha ?? snapshot.head_sha,
-          modulePath: requestedPath ??
-            (nextModuleId ? moduleById.get(nextModuleId)?.source_path ?? null : null),
-          view: nextView,
-        },
-      );
+      const canonical = repositoryLocationUrl(new URL(window.location.href), {
+        repository: repository.canonical_url,
+        snapshotSha: parsed.location.snapshotSha ?? snapshot.head_sha,
+        modulePath:
+          requestedPath ??
+          (nextModuleId
+            ? (moduleById.get(nextModuleId)?.source_path ?? null)
+            : null),
+        view: nextView,
+      });
       if (canonical.href !== window.location.href) {
         window.history.replaceState(
           null,
@@ -1565,7 +2860,7 @@ export function RepoShowcase({ bundle, analysisSource = "curated-static-fallback
       repository: repository.canonical_url,
       snapshotSha: snapshot.head_sha,
       modulePath: moduleId
-        ? moduleById.get(moduleId)?.source_path ?? null
+        ? (moduleById.get(moduleId)?.source_path ?? null)
         : missingPath,
       view,
     };
@@ -1680,9 +2975,8 @@ export function RepoShowcase({ bundle, analysisSource = "curated-static-fallback
     const dashboard = dashboardRef.current;
     if (!dashboard) return;
     dashboard.focus({ preventScroll: true });
-    const reduceMotion = window.matchMedia?.(
-      "(prefers-reduced-motion: reduce)",
-    ).matches ?? false;
+    const reduceMotion =
+      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
     dashboard.scrollIntoView?.({
       behavior: reduceMotion ? "auto" : "smooth",
       block: "start",
@@ -1693,9 +2987,8 @@ export function RepoShowcase({ bundle, analysisSource = "curated-static-fallback
     const inspector = moduleInspectorRef.current;
     if (!inspector) return;
     inspector.focus({ preventScroll: true });
-    const reduceMotion = window.matchMedia?.(
-      "(prefers-reduced-motion: reduce)",
-    ).matches ?? false;
+    const reduceMotion =
+      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
     inspector.scrollIntoView?.({
       behavior: reduceMotion ? "auto" : "smooth",
       block: "start",
@@ -1708,14 +3001,90 @@ export function RepoShowcase({ bundle, analysisSource = "curated-static-fallback
     focusAndScrollInspector();
   }
   return (
-    <article className="repo-overview" data-head-sha={snapshot.head_sha} data-analysis-source={analysisSource}>
+    <article
+      className="repo-overview"
+      data-head-sha={snapshot.head_sha}
+      data-analysis-source={analysisSource}
+    >
       <header className="repo-overview-heading">
-        <div className="repo-identity"><span className="repo-avatar"><Package aria-hidden="true" /></span><div><span>{repository.host} · {availabilityText(repository.default_branch, capability.labels)}</span><strong>{repository.owner}/{repository.name}</strong></div></div>
-        <div className="repo-meta-row"><span><GitCommitHorizontal aria-hidden="true" /><code>{shortSha(snapshot.head_sha)}</code></span><span><Clock3 aria-hidden="true" />{formatDate(snapshot.ingested_at)}</span><span><Code2 aria-hidden="true" />{producer.exporter}</span><span><Database aria-hidden="true" />{analysisSource === "khive-db-snapshot" ? "khive DB snapshot" : "curated static fallback"}</span><RepositoryCommandPalette bundle={bundle} activeView={activeView} selectedModuleId={selectedModuleId} onSelectModule={inspectModule} onSelectView={openAnalysis} onCopyLink={copyInvestigationLink} /><button ref={copyLinkRef} type="button" className="repo-copy-link" onClick={copyInvestigationLink}><Copy aria-hidden="true" /> Copy investigation link</button>{copyStatus && <span role="status" className="repo-copy-status">{copyStatus}</span>}</div>
+        <div className="repo-identity">
+          <span className="repo-avatar">
+            <Package aria-hidden="true" />
+          </span>
+          <div>
+            <span>
+              {repository.host} ·{" "}
+              {availabilityText(repository.default_branch, capability.labels)}
+            </span>
+            <strong>
+              {repository.owner}/{repository.name}
+            </strong>
+          </div>
+        </div>
+        <div className="repo-meta-row">
+          <span>
+            <GitCommitHorizontal aria-hidden="true" />
+            <code>{shortSha(snapshot.head_sha)}</code>
+          </span>
+          <span>
+            <Clock3 aria-hidden="true" />
+            {formatDate(snapshot.ingested_at)}
+          </span>
+          <span>
+            <Code2 aria-hidden="true" />
+            {producer.exporter}
+          </span>
+          <span>
+            <Database aria-hidden="true" />
+            {analysisSource === "khive-db-snapshot"
+              ? "khive DB snapshot"
+              : "curated static fallback"}
+          </span>
+          <RepositoryCommandPalette
+            bundle={bundle}
+            activeView={activeView}
+            selectedModuleId={selectedModuleId}
+            onSelectModule={inspectModule}
+            onSelectView={openAnalysis}
+            onCopyLink={copyInvestigationLink}
+          />
+          <button
+            ref={copyLinkRef}
+            type="button"
+            className="repo-copy-link"
+            onClick={copyInvestigationLink}
+          >
+            <Copy aria-hidden="true" /> Copy investigation link
+          </button>
+          {copyStatus && (
+            <span role="status" className="repo-copy-status">
+              {copyStatus}
+            </span>
+          )}
+        </div>
       </header>
-      <section className="repo-capability-strip" aria-label={capability.labels.product}>
-        <div><ShieldCheck aria-hidden="true" /><div><strong>{capability.labels.product}</strong><span aria-hidden="true"> · </span><span>{capability.mode}</span></div></div>
-        <div className="repo-capability-flags">{Object.values(capability.languages).map((language) => <i key={language.label}>{language.label} · {language.module_join ? capability.views.history_structure_navigation.label : capability.labels.unavailable}</i>)}</div>
+      <section
+        className="repo-capability-strip"
+        aria-label={capability.labels.product}
+      >
+        <div>
+          <ShieldCheck aria-hidden="true" />
+          <div>
+            <strong>{capability.labels.product}</strong>
+            <span aria-hidden="true"> · </span>
+            <span>{capability.mode}</span>
+          </div>
+        </div>
+        <div className="repo-capability-flags">
+          {Object.values(capability.languages).map((language) => (
+            <i key={language.label}>
+              {language.label} ·{" "}
+              {language.module_join
+                ? capability.views.history_structure_navigation.label
+                : capability.labels.unavailable}
+            </i>
+          ))}
+        </div>
       </section>
       <span
         className="visually-hidden"
@@ -1732,10 +3101,19 @@ export function RepoShowcase({ bundle, analysisSource = "curated-static-fallback
           aria-label="Investigation link status"
         >
           <AlertTriangle aria-hidden="true" />
-          <span><strong>{locationNotice.title}</strong>{locationNotice.message}</span>
-          {locationNotice.action === "use-current-snapshot"
-            ? <button type="button" onClick={normalizeCurrentLocation}>Use current snapshot</button>
-            : <button type="button" onClick={dismissLocationNotice}>Dismiss</button>}
+          <span>
+            <strong>{locationNotice.title}</strong>
+            {locationNotice.message}
+          </span>
+          {locationNotice.action === "use-current-snapshot" ? (
+            <button type="button" onClick={normalizeCurrentLocation}>
+              Use current snapshot
+            </button>
+          ) : (
+            <button type="button" onClick={dismissLocationNotice}>
+              Dismiss
+            </button>
+          )}
         </aside>
       )}
       <RepositoryTriage
@@ -1763,11 +3141,40 @@ export function RepoShowcase({ bundle, analysisSource = "curated-static-fallback
           {viewOrder.map((id) => {
             const view = capability.views[id];
             const Icon = viewIcons[id];
-            return <button type="button" data-view-id={id} className={activeView === id ? "active" : ""} aria-current={activeView === id ? "page" : undefined} key={id} onClick={() => selectView(id)}><Icon aria-hidden="true" /><span>{view.label}</span><i className={view.status} aria-hidden="true" />{view.status === "unavailable" && <span className="visually-hidden">{capability.labels.unavailable}</span>}</button>;
+            return (
+              <button
+                type="button"
+                data-view-id={id}
+                className={activeView === id ? "active" : ""}
+                aria-current={activeView === id ? "page" : undefined}
+                key={id}
+                onClick={() => selectView(id)}
+              >
+                <Icon aria-hidden="true" />
+                <span>{view.label}</span>
+                <i className={view.status} aria-hidden="true" />
+                {view.status === "unavailable" && (
+                  <span className="visually-hidden">
+                    {capability.labels.unavailable}
+                  </span>
+                )}
+              </button>
+            );
           })}
         </nav>
-        <section className="repo-view-panel" aria-label={capability.views[activeView].label}>
-          <ActiveView key={`${snapshot.head_sha}-${activeView}`} id={activeView} bundle={bundle} moduleById={moduleById} selectedModuleId={selectedModuleId} onInspectModule={inspectModule} onExploreStructure={() => selectView("structure_graph")} />
+        <section
+          className="repo-view-panel"
+          aria-label={capability.views[activeView].label}
+        >
+          <ActiveView
+            key={`${snapshot.head_sha}-${activeView}`}
+            id={activeView}
+            bundle={bundle}
+            moduleById={moduleById}
+            selectedModuleId={selectedModuleId}
+            onInspectModule={inspectModule}
+            onExploreStructure={() => selectView("structure_graph")}
+          />
         </section>
       </div>
     </article>

--- a/apps/kg-editor/src/components/showcase/repo-showcase.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase.tsx
@@ -947,7 +947,15 @@ function HistoryFacet({
             return <div className="repo-list-row" key={id}><Icon aria-hidden="true" /><div><strong>{item?.title ?? id}</strong>{item && <span>#{item.number}</span>}</div></div>;
           })}
         </div>
-      ) : null}
+      ) : (
+        <DataState
+          className="repo-empty compact"
+          state="empty"
+          title={`No ${label} navigation captured`}
+          message={`The selected module has no captured ${label.toLocaleLowerCase()} links in this bundle.`}
+          action={{ label: "Explore repository structure", onClick: onExploreStructure }}
+        />
+      )}
       {page && <LocalSliceDisclosure shown={rows.length} total={page.items.length} label={label} labels={labels} />}
       {page && <BoundDisclosure page={page} labels={labels} />}
     </section>
@@ -975,9 +983,10 @@ function HistoryStructure({
   const linkedCommitIds = new Set(selectedModuleNavigation?.commits.items ?? []);
   const commits = graph.commits.items.filter((commit) => linkedCommitIds.has(commit.id)).slice(0, UI_ROW_LIMIT);
   const linkedModuleIds = new Set(selectedCommitNavigation?.modules.items ?? []);
-  const modules = (selectedCommitId
+  const moduleCandidates = selectedCommitId
     ? graph.modules.items.filter((module) => linkedModuleIds.has(module.id))
-    : graph.modules.items).slice(0, 100);
+    : graph.modules.items;
+  const modules = moduleCandidates.slice(0, 100);
   const resolutions = graph.join_resolution.repositories.status === "available"
     ? graph.join_resolution.repositories.value.slice(0, UI_ROW_LIMIT)
     : [];
@@ -997,7 +1006,7 @@ function HistoryStructure({
               </button>
             ))}
           </div>
-          <LocalSliceDisclosure shown={Math.min(100, modules.length)} total={selectedCommitId ? linkedModuleIds.size : modules.length} label={labels.node_types.module} labels={labels} />
+          <LocalSliceDisclosure shown={modules.length} total={moduleCandidates.length} label={labels.node_types.module} labels={labels} />
         </section>
         <section className="repo-card" data-history-commits>
           <div className="repo-card-heading"><h3>{labels.node_types.commit}</h3><p>{formatNumber(commits.length)}</p></div>
@@ -1097,7 +1106,14 @@ function HistoryStructure({
 function DependencyTopology({ bundle, moduleById, selectedModuleId, onInspectModule, onExploreStructure }: ViewProps) {
   const analysis = bundle.aggregates.dependency_topology;
   const labels = bundle.capability.labels;
-  const moduleRows = analysis.modules.items.slice(0, UI_ROW_LIMIT);
+  const moduleRows = [...analysis.modules.items]
+    .sort((left, right) =>
+      right.fan_in - left.fan_in
+      || right.cycle_ids.length - left.cycle_ids.length
+      || right.fan_out - left.fan_out
+      || left.module_id.localeCompare(right.module_id)
+    )
+    .slice(0, UI_ROW_LIMIT);
   const cycleRows = analysis.cycles.items.slice(0, UI_ROW_LIMIT);
   return (
     <div className="repo-view-body repo-grid two">
@@ -1289,7 +1305,7 @@ function ApiSurfaceView({ bundle, moduleById, selectedModuleId, onInspectModule 
   const rows = analysis.data.items.slice(0, UI_ROW_LIMIT);
   const max = Math.max(1, ...rows.map((row) => row.dependent_count));
   return (
-    <div className="repo-view-body"><section className="repo-card repo-table-wrap"><table className="repo-table"><thead><tr><th>{labels.node_types.module}</th><th>{labels.metrics.dependent_count}</th><th>{labels.metrics.dependent_count}</th></tr></thead><tbody>{rows.map((row) => <tr key={row.module_id}><td><ModuleInspectionControl moduleId={row.module_id} moduleById={moduleById} modulePage={bundle.graph.modules} selectedModuleId={selectedModuleId} onInspectModule={onInspectModule} /></td><td>{formatNumber(row.dependent_count)}</td><td><div className="repo-bar"><span style={{ width: `${(row.dependent_count / max) * 100}%` }} /></div></td></tr>)}</tbody></table><LocalSliceDisclosure shown={rows.length} total={analysis.data.items.length} label={bundle.capability.views.api_surface.label} labels={labels} /><BoundDisclosure page={analysis.data} labels={labels} /></section></div>
+    <div className="repo-view-body"><section className="repo-card repo-table-wrap"><table className="repo-table"><thead><tr><th>{labels.node_types.module}</th><th>{labels.metrics.dependent_count}</th><th>Relative magnitude</th></tr></thead><tbody>{rows.map((row) => <tr key={row.module_id}><td><ModuleInspectionControl moduleId={row.module_id} moduleById={moduleById} modulePage={bundle.graph.modules} selectedModuleId={selectedModuleId} onInspectModule={onInspectModule} /></td><td>{formatNumber(row.dependent_count)}</td><td><div className="repo-bar"><span style={{ width: `${(row.dependent_count / max) * 100}%` }} /></div></td></tr>)}</tbody></table><LocalSliceDisclosure shown={rows.length} total={analysis.data.items.length} label={bundle.capability.views.api_surface.label} labels={labels} /><BoundDisclosure page={analysis.data} labels={labels} /></section></div>
   );
 }
 
@@ -1307,15 +1323,50 @@ function scoreLabel(labels: Labels, key: RepoBundle["aggregates"]["scorecard"]["
   return keys[key];
 }
 
-function scoreValue(field: RepoBundle["aggregates"]["scorecard"]["fields"][number], labels: Labels): string {
+function scoreValue(
+  field: RepoBundle["aggregates"]["scorecard"]["fields"][number],
+  labels: Labels,
+  moduleIds: readonly string[] | null,
+): string {
   if (field.value.status === "unavailable") return labels.unavailable;
   const value = field.value.value;
-  if (value.value_kind === "count") return formatNumber(value.value);
+  if (value.value_kind === "count") {
+    const formatted = formatNumber(value.value);
+    if (field.key === "repository_age_days") {
+      return `${formatted} ${value.value === 1 ? "day" : "days"}`;
+    }
+    return formatted;
+  }
   if (value.value_kind === "ratio") return formatPercent(value.value);
   if (value.value_kind === "module_ids") {
-    return formatNumber(value.value.items.length);
+    return formatNumber(moduleIds?.length ?? value.value.items.length);
   }
   return value.value;
+}
+
+function scorecardModuleIds(
+  bundle: RepoBundle,
+  field: RepoBundle["aggregates"]["scorecard"]["fields"][number],
+): Readonly<{ items: readonly string[]; tier: string | null }> | null {
+  if (
+    field.value.status !== "available"
+    || field.value.value.value_kind !== "module_ids"
+  ) {
+    return null;
+  }
+  const items = field.value.value.value.items;
+  if (field.key !== "ownership_warnings") {
+    return { items, tier: null };
+  }
+  const highImpactIds = new Set(
+    bundle.aggregates.hotspot_quadrant.data.items
+      .filter((row) => row.quadrant === "high_churn_high_fan_in")
+      .map((row) => row.module_id),
+  );
+  return {
+    items: items.filter((moduleId) => highImpactIds.has(moduleId)),
+    tier: "High churn · high fan-in tier",
+  };
 }
 
 function ScorecardView({ bundle, moduleById, selectedModuleId, onInspectModule }: ViewProps) {
@@ -1325,9 +1376,14 @@ function ScorecardView({ bundle, moduleById, selectedModuleId, onInspectModule }
   return (
     <div className="repo-view-body">
       <div className="repo-score-grid">{fields.map((field) => {
-        const value = scoreValue(field, labels);
-        const moduleIds = field.value.status === "available" && field.value.value.value_kind === "module_ids" ? field.value.value.value : null;
-        return <article className="repo-score-card" key={field.key}><span>{scoreLabel(labels, field.key)}</span><div className="repo-score-value">{field.value.status === "unavailable" ? <AlertTriangle aria-hidden="true" /> : <TrendingUp aria-hidden="true" />}<strong>{value}</strong></div>{field.value.status === "unavailable" && <p>{field.value.reason}</p>}{moduleIds && <><div className="repo-score-modules">{moduleIds.items.slice(0, 8).map((moduleId) => <ModuleInspectionControl key={moduleId} moduleId={moduleId} moduleById={moduleById} modulePage={bundle.graph.modules} selectedModuleId={selectedModuleId} onInspectModule={onInspectModule} className="compact" />)}</div><InlineLocalSlice shown={Math.min(8, moduleIds.items.length)} total={moduleIds.items.length} labels={labels} /><InlinePageState page={moduleIds} labels={labels} /></>}<div className="repo-score-tags"><i>{field.granularity}</i><i>{field.join}</i></div></article>;
+        const moduleIds = scorecardModuleIds(bundle, field);
+        const value = scoreValue(field, labels, moduleIds?.items ?? null);
+        const unavailable = field.value.status === "unavailable";
+        const modulePage = field.value.status === "available"
+          && field.value.value.value_kind === "module_ids"
+          ? field.value.value.value
+          : null;
+        return <article className={`repo-score-card ${unavailable ? "unavailable" : ""}`.trim()} key={field.key}><span>{scoreLabel(labels, field.key)}</span><div className="repo-score-value">{unavailable ? <AlertTriangle aria-hidden="true" /> : <TrendingUp aria-hidden="true" />}<strong>{value}</strong></div>{field.value.status === "unavailable" && <p>{field.value.reason}</p>}{moduleIds?.tier && <p>{moduleIds.tier}</p>}{moduleIds && <><div className="repo-score-modules">{moduleIds.items.slice(0, 8).map((moduleId) => <ModuleInspectionControl key={moduleId} moduleId={moduleId} moduleById={moduleById} modulePage={bundle.graph.modules} selectedModuleId={selectedModuleId} onInspectModule={onInspectModule} className="compact" />)}</div><InlineLocalSlice shown={Math.min(8, moduleIds.items.length)} total={moduleIds.items.length} labels={labels} />{modulePage && <InlinePageState page={modulePage} labels={labels} />}</>}<div className="repo-score-tags"><i>{field.granularity}</i><i>{field.join}</i></div></article>;
       })}</div>
       <LocalSliceDisclosure shown={fields.length} total={analysis.fields.length} label={bundle.capability.views.scorecard.label} labels={labels} />
     </div>
@@ -1658,7 +1714,7 @@ export function RepoShowcase({ bundle, analysisSource = "curated-static-fallback
         <div className="repo-meta-row"><span><GitCommitHorizontal aria-hidden="true" /><code>{shortSha(snapshot.head_sha)}</code></span><span><Clock3 aria-hidden="true" />{formatDate(snapshot.ingested_at)}</span><span><Code2 aria-hidden="true" />{producer.exporter}</span><span><Database aria-hidden="true" />{analysisSource === "khive-db-snapshot" ? "khive DB snapshot" : "curated static fallback"}</span><RepositoryCommandPalette bundle={bundle} activeView={activeView} selectedModuleId={selectedModuleId} onSelectModule={inspectModule} onSelectView={openAnalysis} onCopyLink={copyInvestigationLink} /><button ref={copyLinkRef} type="button" className="repo-copy-link" onClick={copyInvestigationLink}><Copy aria-hidden="true" /> Copy investigation link</button>{copyStatus && <span role="status" className="repo-copy-status">{copyStatus}</span>}</div>
       </header>
       <section className="repo-capability-strip" aria-label={capability.labels.product}>
-        <div><ShieldCheck aria-hidden="true" /><div><strong>{capability.labels.product}</strong><span>{capability.mode}</span></div></div>
+        <div><ShieldCheck aria-hidden="true" /><div><strong>{capability.labels.product}</strong><span aria-hidden="true"> · </span><span>{capability.mode}</span></div></div>
         <div className="repo-capability-flags">{Object.values(capability.languages).map((language) => <i key={language.label}>{language.label} · {language.module_join ? capability.views.history_structure_navigation.label : capability.labels.unavailable}</i>)}</div>
       </section>
       <span

--- a/apps/kg-editor/src/components/showcase/repo-showcase.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase.tsx
@@ -1228,6 +1228,12 @@ function HistoryFacet({
       : !value && parentPage.disclosure.status === "unavailable"
         ? parentPage.disclosure.reason
         : null;
+  // One shared recovery affordance for every empty/incomplete branch below,
+  // so the label and handler cannot drift apart across branches.
+  const exploreStructureAction = {
+    label: "Explore repository structure",
+    onClick: onExploreStructure,
+  };
 
   return (
     <section className="repo-card">
@@ -1247,10 +1253,7 @@ function HistoryFacet({
           state="empty"
           title={`No ${label}`}
           message={`${label} captured for the selected module belong here.`}
-          action={{
-            label: "Explore repository structure",
-            onClick: onExploreStructure,
-          }}
+          action={exploreStructureAction}
         />
       ) : rows.length > 0 ? (
         <div className="repo-list">
@@ -1273,25 +1276,20 @@ function HistoryFacet({
           state="empty"
           title={`No ${label} navigation captured`}
           message={`The selected module has no captured ${label.toLocaleLowerCase()} links in this bundle.`}
-          action={{
-            label: "Explore repository structure",
-            onClick: onExploreStructure,
-          }}
+          action={exploreStructureAction}
         />
       ) : (
         // A zero-row slice of an incomplete or cursor-bearing page is
         // unknown, not empty: the missing rows may hold exactly this
         // module's links, so the definitive empty state above is reserved
-        // for complete pages.
+        // for complete pages. The truncated variant is deliberately
+        // non-interactive (no recovery action) per the DataState contract.
         <DataState
           className="repo-empty compact"
           state="truncated"
           title={`${label} capture incomplete`}
-          message={`This bundle's ${label.toLocaleLowerCase()} page is incomplete, so rows for the selected module may exist beyond what was captured.`}
-          action={{
-            label: "Explore repository structure",
-            onClick: onExploreStructure,
-          }}
+          shown={rows.length}
+          reason={`This bundle's ${label.toLocaleLowerCase()} page is incomplete, so rows for the selected module may exist beyond what was captured.`}
         />
       )}
       {page && (
@@ -2538,7 +2536,7 @@ function scoreLabel(
 function scoreValue(
   field: RepoBundle["aggregates"]["scorecard"]["fields"][number],
   labels: Labels,
-  moduleIds: readonly string[] | null,
+  moduleIds: Readonly<{ items: readonly string[]; tier: string | null }> | null,
 ): string {
   if (field.value.status === "unavailable") return labels.unavailable;
   const value = field.value.value;
@@ -2551,7 +2549,20 @@ function scoreValue(
   }
   if (value.value_kind === "ratio") return formatPercent(value.value);
   if (value.value_kind === "module_ids") {
-    return formatNumber(moduleIds?.length ?? value.value.items.length);
+    const page = value.value;
+    // A tier claim only exists over definitive inputs (see
+    // scorecardModuleIds), so its filtered length is a real count.
+    if (moduleIds?.tier != null) return formatNumber(moduleIds.items.length);
+    if (isCompleteRepoPage(page)) {
+      return formatNumber(moduleIds?.items.length ?? page.items.length);
+    }
+    if (page.disclosure.status === "unavailable") return labels.unavailable;
+    // Incomplete page: the item list is a floor, not a count. The declared
+    // total is still definitive when the exporter recorded one; otherwise
+    // say "N+" rather than presenting the floor as exact.
+    return page.total_count.status === "available"
+      ? formatNumber(page.total_count.value)
+      : `${formatNumber(page.items.length)}+`;
   }
   return value.value;
 }
@@ -2566,16 +2577,29 @@ function scorecardModuleIds(
   ) {
     return null;
   }
-  const items = field.value.value.value.items;
+  const page = field.value.value.value;
+  const items = page.items;
   if (field.key !== "ownership_warnings") {
     return { items, tier: null };
   }
-  // The tier filter is definitive only over a complete hotspot page: a
-  // truncated or cursor-bearing page can be missing exactly the modules the
-  // filter selects, turning unknown coverage into a false zero presented as
-  // a definitive tier. Fall back to the unfiltered warning list with no
-  // tier claim.
-  if (!isCompleteRepoPage(bundle.aggregates.hotspot_quadrant.data)) {
+  // The tier filter is definitive only when EVERY input is definitive:
+  // - the hotspot analysis must be AVAILABLE — an unavailable analysis can
+  //   still ship a schema-valid, complete-but-empty data page, and filtering
+  //   against that empty set turns unknown coverage into a false zero
+  //   presented as a definitive tier;
+  // - the hotspot page must be complete — a truncated or cursor-bearing
+  //   page can be missing exactly the modules the filter selects;
+  // - the ownership-warning page itself must be complete — intersecting a
+  //   partial ID list renders a definitive-looking tier count over unknown
+  //   membership.
+  // Anything less falls back to the unfiltered warning list with no tier
+  // claim (and scoreValue then refuses to present its length as exact).
+  const hotspot = bundle.aggregates.hotspot_quadrant;
+  if (
+    hotspot.meta.status !== "available" ||
+    !isCompleteRepoPage(hotspot.data) ||
+    !isCompleteRepoPage(page)
+  ) {
     return { items, tier: null };
   }
   const highImpactIds = new Set(
@@ -2603,7 +2627,7 @@ function ScorecardView({
       <div className="repo-score-grid">
         {fields.map((field) => {
           const moduleIds = scorecardModuleIds(bundle, field);
-          const value = scoreValue(field, labels, moduleIds?.items ?? null);
+          const value = scoreValue(field, labels, moduleIds);
           const unavailable = field.value.status === "unavailable";
           const modulePage =
             field.value.status === "available" &&

--- a/apps/kg-editor/src/components/studio.test.tsx
+++ b/apps/kg-editor/src/components/studio.test.tsx
@@ -217,7 +217,7 @@ describe("KG Studio", () => {
     await user.click(screen.getByRole("button", { name: /Approve locally/i }));
 
     expect(
-      screen.getAllByText(/ADR-102 requires a reviewer outside family:demo-frontier/i),
+      screen.getAllByText(/ADR-102 requires a reviewer outside family:demo-author/i),
     ).toHaveLength(2);
     expect(screen.queryByText(/Local decision: approved/i)).not.toBeInTheDocument();
   });
@@ -227,11 +227,11 @@ describe("KG Studio", () => {
     render(<Studio initialBundle={demoReviewFixture} />);
 
     const reviewer = screen.getByRole("combobox", { name: "Reviewer model family" });
-    await user.selectOptions(reviewer, "family:independent-reasoner");
+    await user.selectOptions(reviewer, "family:demo-reviewer");
     await user.click(screen.getByRole("button", { name: /Approve locally/i }));
     expect(screen.getByText(/Local decision: approved/i)).toBeVisible();
 
-    await user.selectOptions(reviewer, "family:demo-frontier");
+    await user.selectOptions(reviewer, "family:demo-author");
     expect(screen.queryByText(/Local decision: approved/i)).not.toBeInTheDocument();
   });
 

--- a/apps/kg-editor/src/components/studio.tsx
+++ b/apps/kg-editor/src/components/studio.tsx
@@ -79,9 +79,9 @@ const viewLabels: Record<View, string> = {
 };
 
 const reviewerFamilies = [
-  "family:demo-frontier",
-  "family:independent-reasoner",
-  "family:human-curator",
+  "family:demo-author",
+  "family:demo-reviewer",
+  "family:demo-auditor",
 ];
 
 function formatDate(value: string): string {

--- a/apps/kg-editor/src/lib/fixtures/demo-review.ts
+++ b/apps/kg-editor/src/lib/fixtures/demo-review.ts
@@ -35,9 +35,9 @@ export const demoReviewFixture: ReviewBundle = {
   pull_request: {
     number: 184,
     title: "Curate assertion-level provenance and retire the batch-only model",
-    body: "Casey found that corrections are reviewed per assertion while provenance is currently attached only at batch level. This change preserves batch lineage and adds assertion-level evidence anchors.",
+    body: "The demo author found that corrections are reviewed per assertion while provenance is currently attached only at batch level. This change preserves batch lineage and adds assertion-level evidence anchors.",
     state: "open",
-    author: "actor:casey",
+    author: "actor:demo-author",
     created_at: "2026-08-07T17:20:00Z",
     head_sha: "7ea9c6b25e23a64c9b8b602b8a61c5da41f36e1a",
   },
@@ -53,8 +53,8 @@ export const demoReviewFixture: ReviewBundle = {
   change_set: {
     envelope: {
       schema_version: 1,
-      producer: "actor:casey",
-      producer_model_family: "family:demo-frontier",
+      producer: "actor:demo-author",
+      producer_model_family: "family:demo-author",
       staged_at: 1786123200000000,
       batch_id: "demo-enrich-2026-08-07-184",
     },
@@ -203,12 +203,12 @@ export const demoReviewFixture: ReviewBundle = {
   ],
   review_gate: {
     required: true,
-    producer_model_family: "family:demo-frontier",
+    producer_model_family: "family:demo-author",
     reviewer_model_family: null,
     eligible: false,
     approval_ready: false,
     status: "awaiting_independent_reviewer",
-    reason: "Select a reviewer outside family:demo-frontier before approval.",
+    reason: "Select a reviewer outside family:demo-author before approval.",
     persisted: false,
   },
   summary: {
@@ -255,7 +255,7 @@ export const demoReviewFixture: ReviewBundle = {
       id: "review-family",
       label: "Independent reviewer",
       status: "pending",
-      detail: "Select a reviewer outside family:demo-frontier before approval.",
+      detail: "Select a reviewer outside family:demo-author before approval.",
       duration_ms: 0,
     },
     ],
@@ -480,21 +480,21 @@ export const demoReviewFixture: ReviewBundle = {
     {
       sha: "7ea9c6b25e23a64c9b8b602b8a61c5da41f36e1a",
       subject: "kg: stage assertion-level provenance",
-      author: "actor:casey",
+      author: "actor:demo-author",
       created_at: "2026-08-07T17:20:00Z",
       state: "head",
     },
     {
       sha: "4c82e846d657ade7f2f2567618b9e63e80f42ea6",
       subject: "kg: snapshot after source refresh",
-      author: "actor:casey",
+      author: "actor:demo-author",
       created_at: "2026-08-07T15:08:00Z",
       state: "base",
     },
     {
       sha: "d124b53e0ff383b4aa2d872f0c1e7bd1065f2001",
       subject: "kg: resume the snapshot lane",
-      author: "khive-bot",
+      author: "actor:demo-automation",
       created_at: "2026-07-28T02:19:00Z",
       state: "ancestor",
     },
@@ -506,7 +506,7 @@ export const demoReviewFixture: ReviewBundle = {
     items: [
     {
       id: "activity-1",
-      actor: "actor:casey",
+      actor: "actor:demo-author",
       action: "opened this review",
       body: "Seven staged operations from demo-enrich-2026-08-07-184. Four route to tier 2.",
       created_at: "2026-08-07T17:20:00Z",
@@ -514,7 +514,7 @@ export const demoReviewFixture: ReviewBundle = {
     },
     {
       id: "activity-2",
-      actor: "khive/validate",
+      actor: "actor:demo-validator",
       action: "completed semantic checks",
       body: "No error-level findings. Citation freshness produced one non-blocking warning.",
       created_at: "2026-08-07T17:20:01Z",
@@ -522,7 +522,7 @@ export const demoReviewFixture: ReviewBundle = {
     },
     {
       id: "activity-3",
-      actor: "actor:robin",
+      actor: "actor:demo-reviewer",
       action: "left a review note",
       body: "Keep the historical batch model visible; supersession should affect the current view, not erase lineage.",
       created_at: "2026-08-07T17:24:00Z",
@@ -566,7 +566,7 @@ export const demoReviewFixture: ReviewBundle = {
         id: "436254d4",
         score: 0.853,
         memory_type: "semantic",
-        content: "Build the KG editor local-first with the curator persona as the driving committer and make growth reviewable, diffable, and revertible.",
+        content: "Build the KG editor local-first with the demo author as the driving committer and make growth reviewable, diffable, and revertible.",
       },
       {
         id: "b07f238e",

--- a/apps/kg-editor/src/lib/review-bundle.test.ts
+++ b/apps/kg-editor/src/lib/review-bundle.test.ts
@@ -25,7 +25,11 @@ describe("khive.review.v1", () => {
     expect(bundle.snapshot_identity.head_hash).toMatch(/^sha256:/);
     expect(bundle.pull_request.number).toBe(184);
     expect(bundle.change_set.envelope.batch_id).toBe("demo-enrich-2026-08-07-184");
-    expect(bundle.change_set.envelope.producer).toBe("actor:casey");
+    expect(bundle.pull_request.author).toBe("actor:demo-author");
+    expect(bundle.change_set.envelope.producer).toBe("actor:demo-author");
+    expect(JSON.stringify(bundle)).not.toMatch(
+      /actor:casey|actor:robin|family:demo-frontier|curator persona/i,
+    );
     expect(bundle.live_proposal).toBeNull();
   });
 
@@ -48,7 +52,7 @@ describe("khive.review.v1", () => {
     });
 
     expect(stale.pull_request.head_sha).not.toBe(stale.repository.head_sha);
-    expect(canApproveReview(stale, "family:independent-reasoner")).toEqual({
+    expect(canApproveReview(stale, "family:demo-reviewer")).toEqual({
       allowed: false,
       reason: "The pull-request head changed; regenerate the semantic review bundle.",
     });
@@ -115,7 +119,7 @@ describe("khive.review.v1", () => {
       change_set: {
         envelope: {
           schema_version: 1,
-          producer: "actor:casey",
+          producer: "actor:demo-author",
           producer_model_family: "family:demo",
           staged_at: 2_000_000,
           batch_id: "demo-batch-7",
@@ -182,12 +186,12 @@ describe("review gate", () => {
       ),
     ).toEqual({
       allowed: false,
-      reason: "ADR-102 requires a reviewer outside family:demo-frontier.",
+      reason: "ADR-102 requires a reviewer outside family:demo-author.",
     });
   });
 
   it("allows an independent reviewer when no required check failed", () => {
-    expect(canApproveReview(demoReviewFixture, "family:independent-reasoner").allowed).toBe(
+    expect(canApproveReview(demoReviewFixture, "family:demo-reviewer").allowed).toBe(
       true,
     );
   });
@@ -203,14 +207,14 @@ describe("review gate", () => {
       },
     };
 
-    expect(canApproveReview(bundle, "family:independent-reasoner")).toEqual({
+    expect(canApproveReview(bundle, "family:demo-reviewer")).toEqual({
       allowed: false,
       reason: "1 required check failed.",
     });
   });
 
   it("blocks non-reviewer pending checks but resolves the fixture's reviewer check locally", () => {
-    expect(canApproveReview(demoReviewFixture, "family:independent-reasoner").allowed).toBe(
+    expect(canApproveReview(demoReviewFixture, "family:demo-reviewer").allowed).toBe(
       true,
     );
 
@@ -231,7 +235,7 @@ describe("review gate", () => {
       },
     };
 
-    expect(canApproveReview(pending, "family:independent-reasoner")).toEqual({
+    expect(canApproveReview(pending, "family:demo-reviewer")).toEqual({
       allowed: false,
       reason: "1 required check is still pending.",
     });
@@ -249,7 +253,7 @@ describe("review gate", () => {
       },
     };
 
-    expect(canApproveReview(blocked, "family:independent-reasoner")).toEqual({
+    expect(canApproveReview(blocked, "family:demo-reviewer")).toEqual({
       allowed: false,
       reason: "Repository policy has not admitted this semantic review.",
     });
@@ -260,7 +264,7 @@ describe("review gate", () => {
       ...demoReviewFixture,
       pull_request: { ...demoReviewFixture.pull_request, head_sha: "0".repeat(40) },
     });
-    expect(canApproveReview(stale, "family:independent-reasoner").reason).toMatch(
+    expect(canApproveReview(stale, "family:demo-reviewer").reason).toMatch(
       /head changed/i,
     );
 
@@ -280,7 +284,7 @@ describe("review gate", () => {
         },
       ],
     };
-    expect(canApproveReview(invalid, "family:independent-reasoner").reason).toMatch(
+    expect(canApproveReview(invalid, "family:demo-reviewer").reason).toMatch(
       /semantic finding/i,
     );
   });


### PR DESCRIPTION
## Summary

- tier ownership warnings by high churn and high fan-in, add repository-age units, and sort dependency rows before the browser cap
- clarify the API magnitude header, source-mode separator, unavailable scorecards, history empty states, and the 100-module disclosure
- use neutral role-based identities and reviewer groups in the review demo fixture

## Verification

- RED/GREEN: `repository showcase polish` and neutral fixture regressions
- `npm run lint`
- `npm run typecheck`
- `npm test` (20 token-contract tests and 291 Vitest tests)
- `git diff --check`

Fixes #2037
