### PR TITLE
fix(kg-editor): preserve showcase navigation state

### DIFF
--- a/apps/kg-editor/src/components/showcase/repo-showcase.test.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase.test.tsx
@@ -405,6 +405,64 @@ describe("repository showcase", () => {
     expect(scrollIntoView).toHaveBeenCalledOnce();
   });
 
+  it("moves focus and scroll position to an analysis selected from the view navigation", async () => {
+    const bundle = golden();
+    const user = userEvent.setup();
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoView,
+    });
+    const { container } = render(<RepoShowcase bundle={bundle} />);
+
+    await user.click(screen.getByRole("button", {
+      name: bundle.capability.views.hidden_coupling.label,
+    }));
+
+    const dashboard = container.querySelector<HTMLElement>(
+      "[data-repository-dashboard]",
+    )!;
+    await waitFor(() => expect(dashboard).toHaveFocus());
+    expect(scrollIntoView).toHaveBeenCalledOnce();
+  });
+
+  it("restores the URL-selected module when returning to the structure graph", async () => {
+    const bundle = golden();
+    const selected = bundle.graph.modules.items.find((module) =>
+      module.source_path.endsWith("khive-db/src/pool.rs")
+    )!;
+    const user = userEvent.setup();
+    const { container } = render(<RepoShowcase bundle={bundle} />);
+    const triage = container.querySelector<HTMLElement>(
+      "[data-repository-triage]",
+    )!;
+
+    await user.type(
+      within(triage).getByRole("searchbox", { name: "Find a module or path" }),
+      selected.source_path,
+    );
+    await user.click(within(triage).getByRole("button", {
+      name: `Inspect ${selected.source_path}`,
+    }));
+    await user.click(screen.getByRole("button", {
+      name: bundle.capability.views.hidden_coupling.label,
+    }));
+    await user.click(screen.getByRole("button", {
+      name: bundle.capability.views.structure_graph.label,
+    }));
+
+    expect(new URL(window.location.href).searchParams.get("module")).toBe(
+      selected.source_path,
+    );
+    expect(screen.getByRole("combobox", {
+      name:
+        `${bundle.capability.labels.node_types.package} · ${bundle.capability.views.structure_graph.label}`,
+    })).toHaveValue(selected.package_id);
+    expect(
+      container.querySelector(`[data-node-id="${selected.id}"]`),
+    ).toHaveAttribute("aria-pressed", "true");
+  });
+
   it("renders an unavailable top-level metric as unavailable text, not a fabricated zero", () => {
     const bundle = structuredClone(golden());
     bundle.aggregates.dependency_topology.meta.status = "unavailable";

--- a/apps/kg-editor/src/components/showcase/repo-showcase.tsx
+++ b/apps/kg-editor/src/components/showcase/repo-showcase.tsx
@@ -62,10 +62,16 @@ type Icon = typeof Network;
 type ModuleMap = Map<string, RepoModule>;
 type AnalysisWindow =
   RepoBundle["aggregates"]["hidden_coupling"]["meta"]["window"];
+type StructureGraphSelection = Readonly<{
+  subtreeId: string;
+  selectedId: string;
+}>;
 type ViewProps = Readonly<{
   bundle: RepoBundle;
   moduleById: ModuleMap;
   selectedModuleId: string | null;
+  structureGraphSelection: StructureGraphSelection;
+  onStructureGraphSelection: (selection: StructureGraphSelection) => void;
   onInspectModule: (moduleId: string) => void;
   onExploreStructure: () => void;
 }>;
@@ -374,13 +380,14 @@ function StructureGraph({
   bundle,
   moduleById,
   selectedModuleId,
+  structureGraphSelection,
+  onStructureGraphSelection,
   onInspectModule,
 }: ViewProps) {
   const { graph, capability } = bundle;
   const labels = capability.labels;
-  const [subtreeId, setSubtreeId] = useState(graph.repository.id);
+  const { subtreeId, selectedId } = structureGraphSelection;
   const [zoom, setZoom] = useState(1);
-  const [selectedId, setSelectedId] = useState(graph.repository.id);
   const [lens, setLens] = useState<"structure" | "hidden_coupling">(
     "structure",
   );
@@ -536,8 +543,11 @@ function StructureGraph({
     !focusedModuleIds.has(id);
   const isCouplingFocused = (id: string) =>
     lens === "hidden_coupling" && focusedModuleIds?.has(id) === true;
+  const selectGraphNode = (nodeId: string) => {
+    onStructureGraphSelection({ subtreeId, selectedId: nodeId });
+  };
   const inspectCouplingEndpoint = (moduleId: string) => {
-    setSelectedId(moduleId);
+    selectGraphNode(moduleId);
     onInspectModule(moduleId);
   };
 
@@ -551,8 +561,10 @@ function StructureGraph({
               aria-label={`${labels.node_types.package} · ${capability.views.structure_graph.label}`}
               value={subtreeId}
               onChange={(event) => {
-                setSubtreeId(event.target.value);
-                setSelectedId(event.target.value);
+                onStructureGraphSelection({
+                  subtreeId: event.target.value,
+                  selectedId: event.target.value,
+                });
                 setFocusedPairKey(null);
               }}
             >
@@ -710,7 +722,7 @@ function StructureGraph({
               type="button"
               aria-pressed={selectedId === graph.repository.id}
               onClick={() => {
-                setSelectedId(graph.repository.id);
+                selectGraphNode(graph.repository.id);
                 setFocusedPairKey(null);
               }}
             >
@@ -721,7 +733,7 @@ function StructureGraph({
               const position = positions.get(item.id)!;
               return (
                 <button className={`repo-graph-node ${selectedId === item.id ? "selected" : ""} ${isContextDimmed(item.id) ? "context-dimmed" : ""}`} data-node-id={item.id} style={{ left: `${position.x}%`, top: `${position.y}%`, width: `${nodeWidth(item.id)}px`, ...kindHueStyle(entityLegendFor("project")) }} type="button" aria-pressed={selectedId === item.id} key={item.id} onClick={() => {
-                  setSelectedId(item.id);
+                  selectGraphNode(item.id);
                   setFocusedPairKey(null);
                 }}>
                   <EntityKindMark className="repo-node-kind-icon" kind="project" showLabel={false} />
@@ -734,7 +746,7 @@ function StructureGraph({
               const couplingCount = couplingNodeCounts.get(item.id);
               return (
                 <button className={`repo-graph-node ${selectedId === item.id ? "selected" : ""} ${isContextDimmed(item.id) ? "context-dimmed" : ""} ${isCouplingFocused(item.id) ? "coupling-focused" : ""}`} data-node-id={item.id} style={{ left: `${position.x}%`, top: `${position.y}%`, width: `${nodeWidth(item.id)}px`, ...kindHueStyle(entityLegendFor("concept")) }} type="button" aria-pressed={selectedId === item.id} key={item.id} onClick={() => {
-                  setSelectedId(item.id);
+                  selectGraphNode(item.id);
                   setFocusedPairKey(null);
                 }}>
                   <EntityKindMark className="repo-node-kind-icon" kind="concept" showLabel={false} />
@@ -1352,6 +1364,8 @@ function ActiveView({
   bundle,
   moduleById,
   selectedModuleId,
+  structureGraphSelection,
+  onStructureGraphSelection,
   onInspectModule,
   onExploreStructure,
 }: ViewProps & { id: ViewId }) {
@@ -1364,6 +1378,8 @@ function ActiveView({
         bundle={bundle}
         moduleById={moduleById}
         selectedModuleId={selectedModuleId}
+        structureGraphSelection={structureGraphSelection}
+        onStructureGraphSelection={onStructureGraphSelection}
         onInspectModule={onInspectModule}
         onExploreStructure={onExploreStructure}
       />
@@ -1393,6 +1409,12 @@ export function RepoShowcase({ bundle, analysisSource = "curated-static-fallback
   const [selectedModuleId, setSelectedModuleId] = useState<string | null>(
     defaultModuleId,
   );
+  const [structureGraphSelection, setStructureGraphSelection] = useState<
+    StructureGraphSelection
+  >({
+    subtreeId: bundle.graph.repository.id,
+    selectedId: bundle.graph.repository.id,
+  });
   const [unresolvedModule, setUnresolvedModule] = useState<Readonly<{
     path: string;
     reason: string;
@@ -1444,6 +1466,40 @@ export function RepoShowcase({ bundle, analysisSource = "curated-static-fallback
       }
 
       setSelectedModuleId(nextModuleId);
+      const restoredModule = resolvedModuleRestore && nextModuleId
+        ? moduleById.get(nextModuleId) ?? null
+        : null;
+      const rootGraphSelection = {
+        subtreeId: bundle.graph.repository.id,
+        selectedId: bundle.graph.repository.id,
+      };
+      const nextGraphSelection = restoredModule
+        ? {
+            subtreeId: restoredModule.package_id,
+            selectedId: restoredModule.id,
+          }
+        : rootGraphSelection;
+      setStructureGraphSelection((current) => {
+        const currentSelectionIsValid =
+          (current.subtreeId === bundle.graph.repository.id ||
+            bundle.graph.packages.items.some((item) =>
+              item.id === current.subtreeId
+            )) &&
+          (current.selectedId === bundle.graph.repository.id ||
+            bundle.graph.packages.items.some((item) =>
+              item.id === current.selectedId
+            ) || moduleById.has(current.selectedId));
+        if (!restoredModule && !announce && currentSelectionIsValid) {
+          return current;
+        }
+        if (
+          current.subtreeId === nextGraphSelection.subtreeId &&
+          current.selectedId === nextGraphSelection.selectedId
+        ) {
+          return current;
+        }
+        return nextGraphSelection;
+      });
       setUnresolvedModule(nextUnresolved);
       setActiveView(nextView);
       setCopyStatus("");
@@ -1473,8 +1529,7 @@ export function RepoShowcase({ bundle, analysisSource = "curated-static-fallback
         {
           repository: repository.canonical_url,
           snapshotSha: parsed.location.snapshotSha ?? snapshot.head_sha,
-          modulePath: requestedPath ??
-            (nextModuleId ? moduleById.get(nextModuleId)?.source_path ?? null : null),
+          modulePath: requestedPath,
           view: nextView,
         },
       );
@@ -1493,6 +1548,8 @@ export function RepoShowcase({ bundle, analysisSource = "curated-static-fallback
     return () => window.removeEventListener("popstate", handlePopState);
   }, [
     capability.views,
+    bundle.graph.packages.items,
+    bundle.graph.repository.id,
     defaultModuleId,
     moduleById,
     modulesBySourcePath,
@@ -1540,11 +1597,18 @@ export function RepoShowcase({ bundle, analysisSource = "curated-static-fallback
     );
   }
 
-  function selectModule(moduleId: string) {
-    if (!moduleById.has(moduleId)) return;
+  function selectModule(moduleId: string, alignStructureGraph = true) {
+    const selected = moduleById.get(moduleId);
+    if (!selected) return;
     pushLocation(moduleId, activeView);
     setNavigationStatus("");
     setSelectedModuleId(moduleId);
+    if (alignStructureGraph) {
+      setStructureGraphSelection({
+        subtreeId: selected.package_id,
+        selectedId: selected.id,
+      });
+    }
     setUnresolvedModule(null);
     setLocationNotice(null);
     setCopyStatus("");
@@ -1651,6 +1715,12 @@ export function RepoShowcase({ bundle, analysisSource = "curated-static-fallback
     selectModule(moduleId);
     focusAndScrollInspector();
   }
+
+  function inspectModuleFromGraph(moduleId: string) {
+    if (!moduleById.has(moduleId)) return;
+    selectModule(moduleId, false);
+    focusAndScrollInspector();
+  }
   return (
     <article className="repo-overview" data-head-sha={snapshot.head_sha} data-analysis-source={analysisSource}>
       <header className="repo-overview-heading">
@@ -1707,11 +1777,11 @@ export function RepoShowcase({ bundle, analysisSource = "curated-static-fallback
           {viewOrder.map((id) => {
             const view = capability.views[id];
             const Icon = viewIcons[id];
-            return <button type="button" data-view-id={id} className={activeView === id ? "active" : ""} aria-current={activeView === id ? "page" : undefined} key={id} onClick={() => selectView(id)}><Icon aria-hidden="true" /><span>{view.label}</span><i className={view.status} aria-hidden="true" />{view.status === "unavailable" && <span className="visually-hidden">{capability.labels.unavailable}</span>}</button>;
+            return <button type="button" data-view-id={id} className={activeView === id ? "active" : ""} aria-current={activeView === id ? "page" : undefined} key={id} onClick={() => openAnalysis(id)}><Icon aria-hidden="true" /><span>{view.label}</span><i className={view.status} aria-hidden="true" />{view.status === "unavailable" && <span className="visually-hidden">{capability.labels.unavailable}</span>}</button>;
           })}
         </nav>
         <section className="repo-view-panel" aria-label={capability.views[activeView].label}>
-          <ActiveView key={`${snapshot.head_sha}-${activeView}`} id={activeView} bundle={bundle} moduleById={moduleById} selectedModuleId={selectedModuleId} onInspectModule={inspectModule} onExploreStructure={() => selectView("structure_graph")} />
+          <ActiveView key={`${snapshot.head_sha}-${activeView}`} id={activeView} bundle={bundle} moduleById={moduleById} selectedModuleId={selectedModuleId} structureGraphSelection={structureGraphSelection} onStructureGraphSelection={setStructureGraphSelection} onInspectModule={activeView === "structure_graph" ? inspectModuleFromGraph : inspectModule} onExploreStructure={() => selectView("structure_graph")} />
         </section>
       </div>
     </article>


### PR DESCRIPTION
## Summary

- route sidebar view changes through the existing analysis focus-and-scroll path
- preserve structure-graph subtree and node selection across view switches
- align explicit module navigation and history restoration with graph state while leaving the implicit repository overview at the root
- retain the existing unknown-view repair notice and canonicalize only explicit module parameters

## Verification

- focused RED/GREEN regressions for view-navigation scroll and module restoration
- `npm run lint`
- `npm run typecheck`
- `npm test` (20 token-contract tests and 289 Vitest tests)
- `git diff --check`

Fixes #2034
