### PR TITLE
fix(db): make schema-terminal assumptions version-agnostic

### DIFF
--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -1007,10 +1007,7 @@ pub fn inspect_schema_is_current(path: &std::path::Path) -> Result<u32, SqliteEr
 /// exact match performs no writes.
 pub fn validate_schema_is_current(conn: &Connection) -> Result<u32, SqliteError> {
     let current_version = read_schema_version(conn)?;
-    let latest_version = MIGRATIONS
-        .last()
-        .map(|migration| migration.version)
-        .unwrap_or(0);
+    let latest_version = latest_schema_version();
 
     if current_version < latest_version {
         return Err(SqliteError::InvalidData(format!(
@@ -1206,7 +1203,7 @@ fn run_migrations_locked(conn: &mut Connection) -> Result<u32, SqliteError> {
     // pre-consolidation V2..V22 ledger — or was written by a newer build. Either
     // way the baseline schema would be silently skipped, leaving the process on a
     // stale schema. Fail loudly instead of corrupting silently.
-    let latest_version = MIGRATIONS.last().map(|m| m.version).unwrap_or(0);
+    let latest_version = latest_schema_version();
     if current_version > latest_version {
         return Err(SqliteError::InvalidData(format!(
             "database schema version {current_version} is ahead of the latest known migration \

--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -151,6 +151,14 @@ const V21_ATTACHMENT_FENCES_UP: &str = include_str!("../sql/021-attachments-b-cl
 /// Core schema version reserved for ADR-121's attachments-first cutover.
 pub const ATTACHMENT_CUTOVER_VERSION: u32 = 21;
 
+/// The latest schema version this build's migration chain produces.
+///
+/// Terminal-version assertions belong on this, not on a hardcoded number:
+/// a literal decays into a wrong claim the next time a migration is added.
+pub fn latest_schema_version() -> u32 {
+    MIGRATIONS.last().map(|m| m.version).unwrap_or(0)
+}
+
 /// DDL for the `ann_write_log` delta table.
 ///
 /// Shared between migration V11 and the belt-and-suspenders creation in
@@ -432,12 +440,15 @@ pub fn attachment_cutover_status(
             }
         }
         Some((state, Some(_))) if state == "complete" => {
-            if version == ATTACHMENT_CUTOVER_VERSION {
+            // Later migrations (V22+) are recorded on top of a completed
+            // cutover in the normal course; only a ledger BELOW V21 beside a
+            // complete marker is an impossible pair.
+            if version >= ATTACHMENT_CUTOVER_VERSION {
                 validate_complete_attachment_schema(conn)?;
                 Ok(AttachmentCutoverStatus::Complete)
             } else {
                 Err(SqliteError::InvalidData(format!(
-                    "attachment cutover is complete but schema ledger is at V{version}, expected V{ATTACHMENT_CUTOVER_VERSION}"
+                    "attachment cutover is complete but schema ledger is at V{version}, below V{ATTACHMENT_CUTOVER_VERSION}"
                 )))
             }
         }
@@ -1022,7 +1033,10 @@ pub fn validate_schema_is_current(conn: &Connection) -> Result<u32, SqliteError>
     // must not accept a history that ordinary boot would reject merely because
     // it cannot repair it in place.
     validate_applied_migration_ledger(conn, current_version)?;
-    if current_version == ATTACHMENT_CUTOVER_VERSION
+    // `>=`, not `==`: later migrations (V22+) record on top of a completed
+    // cutover, and a ledger at the latest version must not exempt the
+    // physical cutover state from validation.
+    if current_version >= ATTACHMENT_CUTOVER_VERSION
         && attachment_cutover_status(conn)? != AttachmentCutoverStatus::Complete
     {
         return Err(SqliteError::InvalidData(

--- a/crates/khive-db/src/migrations_tests.rs
+++ b/crates/khive-db/src/migrations_tests.rs
@@ -891,11 +891,14 @@ fn v4_creates_consolidated_fts_tables() {
 #[test]
 fn rejects_pre_consolidation_ledger() {
     let mut conn = open_memory();
-    // Simulate a database carrying the old, pre-consolidation V1..V22 ledger.
+    // Simulate a database whose recorded version is ahead of everything this
+    // build knows — the pre-consolidation ledger shape, or a newer build's.
+    // Computed from the live chain so the fixture stays ahead when a real
+    // migration lands on the number a literal would have pinned.
     conn.execute_batch(MIGRATION_TRACKING_TABLE).unwrap();
     conn.execute(
-        "INSERT INTO _schema_migrations (version, name, applied_at) VALUES (22, 'legacy', 0)",
-        [],
+        "INSERT INTO _schema_migrations (version, name, applied_at) VALUES (?1, 'legacy', 0)",
+        rusqlite::params![latest_schema_version() + 1],
     )
     .unwrap();
 
@@ -2466,7 +2469,7 @@ fn v21_legacy_refs_remain_pending_until_explicit_stage_and_finalize() {
 #[test]
 fn v21_empty_database_fast_path_is_atomic_and_complete() {
     let mut conn = open_memory();
-    assert_eq!(run_migrations(&mut conn).unwrap(), 21);
+    assert_eq!(run_migrations(&mut conn).unwrap(), latest_schema_version());
     assert_eq!(
         attachment_cutover_status(&conn).unwrap(),
         AttachmentCutoverStatus::Complete

--- a/crates/khive-db/src/migrations_tests.rs
+++ b/crates/khive-db/src/migrations_tests.rs
@@ -889,12 +889,13 @@ fn v4_creates_consolidated_fts_tables() {
 }
 
 #[test]
-fn rejects_pre_consolidation_ledger() {
+fn rejects_ledger_ahead_of_binary_latest() {
     let mut conn = open_memory();
     // Simulate a database whose recorded version is ahead of everything this
-    // build knows — the pre-consolidation ledger shape, or a newer build's.
-    // Computed from the live chain so the fixture stays ahead when a real
-    // migration lands on the number a literal would have pinned.
+    // build knows — a newer build's ledger (historically, the
+    // pre-consolidation shape). Computed from the live chain so the fixture
+    // stays ahead when a real migration lands on the number a literal would
+    // have pinned.
     conn.execute_batch(MIGRATION_TRACKING_TABLE).unwrap();
     conn.execute(
         "INSERT INTO _schema_migrations (version, name, applied_at) VALUES (?1, 'legacy', 0)",

--- a/crates/khive-db/src/stores/blob.rs
+++ b/crates/khive-db/src/stores/blob.rs
@@ -850,6 +850,11 @@ async fn blob_gc_fencing_complete(sql: &dyn SqlAccess) -> StorageResult<bool> {
         return Ok(false);
     }
 
+    // The ledger ceiling is this build's own terminal version: migrations this
+    // binary applied on top of the completed cutover keep the gate open, while
+    // a ledger AHEAD of the binary belongs to a schema epoch whose
+    // attachment/liveness semantics this build never validated — ADR-160
+    // requires that epoch to fail closed before destructive GC.
     let complete = required_nonnegative_count(
         reader
             .query_scalar(SqlStatement {
@@ -860,9 +865,12 @@ async fn blob_gc_fencing_complete(sql: &dyn SqlAccess) -> StorageResult<bool> {
                         AND (SELECT COUNT(*) FROM _schema_migrations \
                              WHERE version = 21 \
                                AND name = 'attachments_first_class') = 1 \
-                        AND (SELECT MAX(version) FROM _schema_migrations) >= 21"
+                        AND (SELECT MAX(version) FROM _schema_migrations) \
+                            BETWEEN 21 AND ?1"
                     .to_string(),
-                params: vec![],
+                params: vec![SqlValue::Integer(i64::from(
+                    crate::migrations::latest_schema_version(),
+                ))],
                 label: Some("blob_gc_cutover_complete".to_string()),
             })
             .await?,
@@ -2502,13 +2510,16 @@ mod tests {
                 "UPDATE _schema_migrations SET name = 'not_attachments_first_class' \
                  WHERE version = 21",
             ),
-            // NOTE: "ledger max version advances past V21" is deliberately NOT
-            // a reject arm. Later migrations record on top of a completed
-            // cutover without disturbing the fencing set, so the gate's
-            // ledger predicate is `MAX(version) >= 21`; the accept-path tests
-            // in this module run against the latest schema and are the
-            // positive control for that semantics. The physical facts the
-            // matrix below removes one at a time are what carry the safety.
+            // NOTE: the ledger predicate is `MAX(version) BETWEEN 21 AND
+            // latest_schema_version()`. Migrations THIS binary applied on top
+            // of the completed cutover keep the gate open (the accept-path
+            // tests in this module run against the latest schema and are the
+            // positive control), while a ledger ahead of the binary's own
+            // terminal version is a different schema epoch and rejects —
+            // covered by `gate_rejects_ledger_ahead_of_binary_latest`, which
+            // ADDS a fact rather than removing one and so lives outside this
+            // matrix. The physical facts the matrix below removes one at a
+            // time are what carry the rest of the safety.
             (
                 "marker_row_deleted",
                 "DELETE FROM attachment_cutover_state WHERE singleton = 1",
@@ -2639,6 +2650,48 @@ mod tests {
                 "case {case}: refusal must leave no fence-probe attachment residue"
             );
         }
+    }
+
+    /// A ledger whose MAX(version) is ahead of this binary's own migration
+    /// chain belongs to a schema epoch this build never validated; ADR-160
+    /// requires destructive GC to fail closed against it. This is the arm the
+    /// removal matrix above cannot host (it ADDS a ledger fact), and it is
+    /// what separates `BETWEEN 21 AND latest` from the fail-open `>= 21`:
+    /// under `>= 21` this fixture passes the gate.
+    #[tokio::test]
+    async fn gate_rejects_ledger_ahead_of_binary_latest() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("khive.db");
+        let backend = crate::StorageBackend::sqlite(&db_path).unwrap();
+        {
+            let mut writer = backend.pool().writer().unwrap();
+            prepare_completed_v21_gc_fixture(writer.conn_mut());
+            // Positive control: the untouched fixture passes.
+        }
+        assert!(
+            blob_gc_fencing_complete(backend.sql().as_ref())
+                .await
+                .unwrap(),
+            "control: completed fixture at the binary's latest version must pass"
+        );
+
+        {
+            let writer = backend.pool().writer().unwrap();
+            writer
+                .conn()
+                .execute(
+                    "INSERT INTO _schema_migrations (version, name, applied_at) \
+                     VALUES (?1, 'future_epoch', 0)",
+                    [i64::from(crate::migrations::latest_schema_version()) + 1],
+                )
+                .unwrap();
+        }
+        assert!(
+            !blob_gc_fencing_complete(backend.sql().as_ref())
+                .await
+                .unwrap(),
+            "a ledger ahead of the binary's latest schema version must fail closed"
+        );
     }
 
     /// A read failure while evaluating the completed-marker/ledger predicate

--- a/crates/khive-db/src/stores/blob.rs
+++ b/crates/khive-db/src/stores/blob.rs
@@ -860,7 +860,7 @@ async fn blob_gc_fencing_complete(sql: &dyn SqlAccess) -> StorageResult<bool> {
                         AND (SELECT COUNT(*) FROM _schema_migrations \
                              WHERE version = 21 \
                                AND name = 'attachments_first_class') = 1 \
-                        AND (SELECT MAX(version) FROM _schema_migrations) = 21"
+                        AND (SELECT MAX(version) FROM _schema_migrations) >= 21"
                     .to_string(),
                 params: vec![],
                 label: Some("blob_gc_cutover_complete".to_string()),
@@ -2430,7 +2430,11 @@ mod tests {
     /// instead of retaining Phase 4a's synthetic future-schema fixture.
     fn prepare_completed_v21_gc_fixture(conn: &mut rusqlite::Connection) {
         let version = crate::run_migrations(conn).expect("prepare canonical completed V21");
-        assert_eq!(version, 21, "empty fixture must take the V21 fast path");
+        assert_eq!(
+            version,
+            crate::migrations::latest_schema_version(),
+            "empty fixture must migrate to the latest schema (which contains the completed V21 cutover)"
+        );
     }
 
     #[tokio::test]
@@ -2498,11 +2502,13 @@ mod tests {
                 "UPDATE _schema_migrations SET name = 'not_attachments_first_class' \
                  WHERE version = 21",
             ),
-            (
-                "ledger_max_version_advances_past_v21",
-                "INSERT INTO _schema_migrations (version, name, applied_at) \
-                 VALUES (22, 'future_migration', 22)",
-            ),
+            // NOTE: "ledger max version advances past V21" is deliberately NOT
+            // a reject arm. Later migrations record on top of a completed
+            // cutover without disturbing the fencing set, so the gate's
+            // ledger predicate is `MAX(version) >= 21`; the accept-path tests
+            // in this module run against the latest schema and are the
+            // positive control for that semantics. The physical facts the
+            // matrix below removes one at a time are what carry the safety.
             (
                 "marker_row_deleted",
                 "DELETE FROM attachment_cutover_state WHERE singleton = 1",

--- a/crates/khive-db/src/stores/blob.rs
+++ b/crates/khive-db/src/stores/blob.rs
@@ -862,6 +862,18 @@ async fn blob_gc_fencing_complete(sql: &dyn SqlAccess) -> StorageResult<bool> {
     // keeps accepting later versions on top of a completed cutover: that is
     // the normal serving course, and the exact-epoch rule is scoped to
     // destructive GC admission.
+    //
+    // "Exact completed V21 epoch" means the WHOLE canonical ledger, not a
+    // V21 terminal row: `version` is the table's PRIMARY KEY, so
+    // COUNT(*) = 21 ∧ MIN = 1 ∧ MAX = 21 holds if and only if the ledger is
+    // exactly the contiguous set {1..21}. A ledger that merely retains a V21
+    // row at MAX(version) = 21 while earlier rows are missing is an
+    // incomplete migration history whose physical schema this gate never
+    // validated — it must fail closed, same as ahead-of-V21. Name-level
+    // canonicality of the below-terminal rows stays boot's job
+    // (`validate_applied_migration_ledger`); this predicate enforces the
+    // structural contiguity a destructive sweep's admission rests on, plus
+    // the named V21 row itself.
     let complete = required_nonnegative_count(
         reader
             .query_scalar(SqlStatement {
@@ -872,6 +884,8 @@ async fn blob_gc_fencing_complete(sql: &dyn SqlAccess) -> StorageResult<bool> {
                         AND (SELECT COUNT(*) FROM _schema_migrations \
                              WHERE version = ?1 \
                                AND name = 'attachments_first_class') = 1 \
+                        AND (SELECT COUNT(*) FROM _schema_migrations) = ?1 \
+                        AND (SELECT MIN(version) FROM _schema_migrations) = 1 \
                         AND (SELECT MAX(version) FROM _schema_migrations) = ?1"
                     .to_string(),
                 params: vec![SqlValue::Integer(i64::from(
@@ -2444,10 +2458,16 @@ mod tests {
     /// instead of retaining Phase 4a's synthetic future-schema fixture.
     fn prepare_completed_v21_gc_fixture(conn: &mut rusqlite::Connection) {
         let version = crate::run_migrations(conn).expect("prepare canonical completed V21");
+        // Pinned to the V21 epoch, NOT to the moving latest version: the GC
+        // gate admits exactly V21, so the day a V22 migration lands this
+        // assert fails LOUDLY here — telling that migration's author to give
+        // these tests a fixture built explicitly through V21 — instead of
+        // silently handing every GC test a ledger the gate rejects.
         assert_eq!(
             version,
-            crate::migrations::latest_schema_version(),
-            "empty fixture must migrate to the latest schema (which contains the completed V21 cutover)"
+            crate::migrations::ATTACHMENT_CUTOVER_VERSION,
+            "GC-gate fixtures need a completed-V21 ledger; a later migration chain \
+             must provide a pinned through-V21 fixture builder for these tests"
         );
     }
 
@@ -2516,16 +2536,19 @@ mod tests {
                 "UPDATE _schema_migrations SET name = 'not_attachments_first_class' \
                  WHERE version = 21",
             ),
-            // NOTE: the ledger predicate is `MAX(version) BETWEEN 21 AND
-            // latest_schema_version()`. Migrations THIS binary applied on top
-            // of the completed cutover keep the gate open (the accept-path
-            // tests in this module run against the latest schema and are the
-            // positive control), while a ledger ahead of the binary's own
-            // terminal version is a different schema epoch and rejects —
-            // covered by `gate_rejects_ledger_ahead_of_binary_latest`, which
-            // ADDS a fact rather than removing one and so lives outside this
-            // matrix. The physical facts the matrix below removes one at a
-            // time are what carry the rest of the safety.
+            // NOTE: the ledger predicate requires the exact contiguous
+            // canonical ledger {1..21} — the named V21 row, COUNT(*) = 21,
+            // MIN(version) = 1, MAX(version) = 21 (version is the PRIMARY
+            // KEY, so together these pin the set exactly). Anything else —
+            // rows missing below V21, or any row above it — is a schema
+            // epoch this gate never validated and fails closed. The
+            // ahead-of-V21 arm ADDS a fact rather than removing one and so
+            // lives outside this matrix, in
+            // `gate_rejects_ledger_ahead_of_binary_latest`.
+            (
+                "below_v21_ledger_rows_deleted",
+                "DELETE FROM _schema_migrations WHERE version < 21",
+            ),
             (
                 "marker_row_deleted",
                 "DELETE FROM attachment_cutover_state WHERE singleton = 1",
@@ -2663,11 +2686,16 @@ mod tests {
     /// only for the EXACT completed V21 epoch, so anything ahead fails
     /// closed. This is the arm the removal matrix above cannot host (it ADDS
     /// a ledger fact), and it separates the exact-epoch predicate from the
-    /// fail-open `>= 21`: under `>= 21` this fixture passes the gate. While
-    /// the binary's terminal version IS 21, this fixture cannot distinguish
-    /// `= 21` from the former `BETWEEN 21 AND terminal` — both refuse a V22
-    /// row — so the exact-epoch property is enforced by the predicate's
-    /// text; the first appended migration makes the distinction observable.
+    /// fail-open `>= 21`: under `>= 21` this fixture passes the gate. The
+    /// appended row is shaped exactly like a row `run_migrations` records —
+    /// canonical name style, real timestamp — because "a migration this same
+    /// binary applied on top" is the case the exact-epoch rule exists for.
+    /// While the binary's terminal version IS 21, this fixture cannot
+    /// distinguish `= 21` from the former `BETWEEN 21 AND terminal` — both
+    /// refuse a V22 row — so the exact-epoch property is enforced by the
+    /// predicate's text and by the contiguity clause the removal matrix
+    /// binds (`below_v21_ledger_rows_deleted`); the first appended migration
+    /// makes the ahead distinction observable.
     #[tokio::test]
     async fn gate_rejects_ledger_ahead_of_binary_latest() {
         let dir = tempfile::tempdir().unwrap();
@@ -2691,7 +2719,7 @@ mod tests {
                 .conn()
                 .execute(
                     "INSERT INTO _schema_migrations (version, name, applied_at) \
-                     VALUES (?1, 'future_epoch', 0)",
+                     VALUES (?1, 'post_cutover_feature', unixepoch())",
                     [i64::from(crate::migrations::latest_schema_version()) + 1],
                 )
                 .unwrap();
@@ -2701,6 +2729,61 @@ mod tests {
                 .await
                 .unwrap(),
             "a ledger ahead of the binary's latest schema version must fail closed"
+        );
+    }
+
+    /// An incomplete migration history must fail closed even when its
+    /// terminal row looks right: delete every ledger row below V21 while
+    /// keeping the V21 row, so the named-row check AND `MAX(version) = 21`
+    /// both still hold. A predicate reading only those two facts admits this
+    /// ledger; only the contiguity clause (COUNT/MIN/MAX over the
+    /// PRIMARY-KEY `version` column) rejects it, so removing that clause
+    /// turns this test red.
+    #[tokio::test]
+    async fn gate_rejects_incomplete_ledger_behind_v21() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("khive.db");
+        let backend = crate::StorageBackend::sqlite(&db_path).unwrap();
+        {
+            let mut writer = backend.pool().writer().unwrap();
+            prepare_completed_v21_gc_fixture(writer.conn_mut());
+        }
+        assert!(
+            blob_gc_fencing_complete(backend.sql().as_ref())
+                .await
+                .unwrap(),
+            "control: the untouched completed fixture must pass"
+        );
+
+        {
+            let writer = backend.pool().writer().unwrap();
+            writer
+                .conn()
+                .execute_batch("DELETE FROM _schema_migrations WHERE version < 21")
+                .unwrap();
+            // The facts the old predicate read are still intact.
+            let (v21_named, max_version): (i64, i64) = writer
+                .conn()
+                .query_row(
+                    "SELECT (SELECT COUNT(*) FROM _schema_migrations \
+                             WHERE version = 21 AND name = 'attachments_first_class'), \
+                            (SELECT MAX(version) FROM _schema_migrations)",
+                    [],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )
+                .unwrap();
+            assert_eq!(
+                (v21_named, max_version),
+                (1, 21),
+                "fixture must keep the named V21 row and MAX(version) = 21 so the \
+                 rejection can only come from the contiguity clause"
+            );
+        }
+        assert!(
+            !blob_gc_fencing_complete(backend.sql().as_ref())
+                .await
+                .unwrap(),
+            "an incomplete ledger behind V21 must fail closed despite a valid terminal row"
         );
     }
 

--- a/crates/khive-db/src/stores/blob.rs
+++ b/crates/khive-db/src/stores/blob.rs
@@ -850,11 +850,18 @@ async fn blob_gc_fencing_complete(sql: &dyn SqlAccess) -> StorageResult<bool> {
         return Ok(false);
     }
 
-    // The ledger ceiling is this build's own terminal version: migrations this
-    // binary applied on top of the completed cutover keep the gate open, while
-    // a ledger AHEAD of the binary belongs to a schema epoch whose
-    // attachment/liveness semantics this build never validated — ADR-160
-    // requires that epoch to fail closed before destructive GC.
+    // The sweep is admitted only for the EXACT completed V21 epoch
+    // (ADR-160 Phase 4a: "report-only and destructive sweeps only for an
+    // exact completed V21 epoch … ahead-of-V21 epochs return typed
+    // Unsupported"). A ledger above V21 — whether ahead of this binary or a
+    // migration this same binary applied — belongs to a schema epoch whose
+    // attachment/liveness semantics this gate never validated, so it fails
+    // closed; the author of a future migration extends the gate in the same
+    // change that proves the new epoch's liveness set, never by default.
+    // General schema validation (`attachment_cutover_status`) deliberately
+    // keeps accepting later versions on top of a completed cutover: that is
+    // the normal serving course, and the exact-epoch rule is scoped to
+    // destructive GC admission.
     let complete = required_nonnegative_count(
         reader
             .query_scalar(SqlStatement {
@@ -863,13 +870,12 @@ async fn blob_gc_fencing_complete(sql: &dyn SqlAccess) -> StorageResult<bool> {
                         AND cutover.state = 'complete' \
                         AND cutover.completed_at IS NOT NULL \
                         AND (SELECT COUNT(*) FROM _schema_migrations \
-                             WHERE version = 21 \
+                             WHERE version = ?1 \
                                AND name = 'attachments_first_class') = 1 \
-                        AND (SELECT MAX(version) FROM _schema_migrations) \
-                            BETWEEN 21 AND ?1"
+                        AND (SELECT MAX(version) FROM _schema_migrations) = ?1"
                     .to_string(),
                 params: vec![SqlValue::Integer(i64::from(
-                    crate::migrations::latest_schema_version(),
+                    crate::migrations::ATTACHMENT_CUTOVER_VERSION,
                 ))],
                 label: Some("blob_gc_cutover_complete".to_string()),
             })
@@ -2652,12 +2658,16 @@ mod tests {
         }
     }
 
-    /// A ledger whose MAX(version) is ahead of this binary's own migration
-    /// chain belongs to a schema epoch this build never validated; ADR-160
-    /// requires destructive GC to fail closed against it. This is the arm the
-    /// removal matrix above cannot host (it ADDS a ledger fact), and it is
-    /// what separates `BETWEEN 21 AND latest` from the fail-open `>= 21`:
-    /// under `>= 21` this fixture passes the gate.
+    /// A ledger whose MAX(version) is above the V21 epoch belongs to a
+    /// schema epoch this gate never validated; ADR-160 admits destructive GC
+    /// only for the EXACT completed V21 epoch, so anything ahead fails
+    /// closed. This is the arm the removal matrix above cannot host (it ADDS
+    /// a ledger fact), and it separates the exact-epoch predicate from the
+    /// fail-open `>= 21`: under `>= 21` this fixture passes the gate. While
+    /// the binary's terminal version IS 21, this fixture cannot distinguish
+    /// `= 21` from the former `BETWEEN 21 AND terminal` — both refuse a V22
+    /// row — so the exact-epoch property is enforced by the predicate's
+    /// text; the first appended migration makes the distinction observable.
     #[tokio::test]
     async fn gate_rejects_ledger_ahead_of_binary_latest() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/kkernel/src/cli.rs
+++ b/crates/kkernel/src/cli.rs
@@ -1416,7 +1416,7 @@ mod tests {
         let migrated = StorageBackend::sqlite(&path).expect("reopen migrated database");
         assert_eq!(
             migrated.prepare_core_schema().unwrap(),
-            ATTACHMENT_CUTOVER_VERSION
+            khive_db::migrations::latest_schema_version()
         );
         let attachment = migrated
             .attachments()
@@ -1498,7 +1498,7 @@ mod tests {
             let conn = backend.pool().reader().expect("inspect completed topology");
             assert_eq!(
                 read_schema_version(conn.conn()).unwrap(),
-                ATTACHMENT_CUTOVER_VERSION
+                khive_db::migrations::latest_schema_version()
             );
             assert_eq!(
                 attachment_cutover_status(conn.conn()).unwrap(),
@@ -1540,7 +1540,7 @@ mod tests {
         );
         assert_eq!(
             read_schema_version(secondary_conn.conn()).unwrap(),
-            ATTACHMENT_CUTOVER_VERSION
+            khive_db::migrations::latest_schema_version()
         );
     }
 
@@ -1570,7 +1570,7 @@ mod tests {
 
     #[tokio::test]
     async fn db_migrate_one_declared_main_uses_its_configured_path() {
-        use khive_db::migrations::{read_schema_version, ATTACHMENT_CUTOVER_VERSION};
+        use khive_db::migrations::read_schema_version;
 
         let tmp = TempDir::new().expect("temp dir");
         let main = tmp.path().join("declared-main.db");
@@ -1591,7 +1591,7 @@ mod tests {
         let conn = backend.pool().reader().unwrap();
         assert_eq!(
             read_schema_version(conn.conn()).unwrap(),
-            ATTACHMENT_CUTOVER_VERSION
+            khive_db::migrations::latest_schema_version()
         );
     }
 


### PR DESCRIPTION
## Problem

Several sites assumed V21 (`attachments_first_class`) is the last migration in the chain. Each
breaks the moment a V22 lands:

- `attachment_cutover_status` treated a `complete` marker beside a ledger above V21 as an
  impossible pair. Only a ledger **below** V21 is one: later migrations record on top of a
  completed cutover in the normal course.
- `validate_schema_is_current` ran the physical cutover-state check only when the ledger was
  exactly 21, so a later version would skip cutover validation entirely.
- Test fixtures pinned terminal-version literals (21, and 22 for the ahead-of-build fixture),
  so the ahead-of-build fixture stops being ahead the day a real V22 lands on that number.

Separately, the blob-GC cutover fence read only `MAX(version) = 21` plus the named V21 row. A
ledger missing rows below V21 satisfies both while carrying an incomplete migration history
this gate never validated.

## Change

Two directions, deliberately opposite, because the two predicates answer different questions.

**Relaxed, where the assumption was that V21 is terminal.** The ledger predicates in
`attachment_cutover_status` and `validate_schema_is_current` become `>= 21`. The physical
facts the reject matrix removes one at a time continue to carry the safety, and the
accept-path tests running at the latest schema are the positive control for the semantics.
Widening `validate_schema_is_current` fails *closed*: at V22+ it now runs a cutover check it
previously skipped.

New `migrations::latest_schema_version()` derives the terminal version from the migration
chain. Terminal-version assertions and the ahead-of-build fixture use it instead of literals,
so they stay correct when a migration is added.

**Tightened, where destructive work is admitted.** ADR-160 Phase 4a admits report-only and
destructive blob-GC sweeps only for an exact completed V21 epoch; ahead-of-V21 epochs are
unsupported. The fence now enforces that as the whole canonical ledger rather than a terminal
row: `version` is the table's PRIMARY KEY, so `COUNT(*) = 21 AND MIN = 1 AND MAX = 21` holds
if and only if the ledger is exactly the contiguous set {1..21}. The V21 literal became a
bound parameter in the same statement.

## Behaviour change at the current schema head

One, and it is the point of the blob.rs half: a database whose ledger is missing rows below
V21 while retaining a named V21 row at `MAX(version) = 21` previously passed the GC fence and
now fails closed. `gate_rejects_incomplete_ledger_behind_v21` is that case, and it asserts the
two facts the old predicate read are still intact so the rejection can only come from the new
contiguity clause.

Every other predicate in this change evaluates identically while V21 is the latest migration.

## Testing

- `cargo test -p khive-db` — all suites green (lib 817 passed).
- `cargo test -p kkernel` — all suites green (lib 444 passed, integration suites included).
- `cargo fmt --check` and `cargo clippy --all-targets --all-features -p khive-db -p kkernel` clean.
