### PR TITLE
docs(mcp): distinguish daemon strict-mode axes

### DIFF
--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -36,8 +36,10 @@ use test_harness::{
 
 // ── local-dispatch fallback telemetry ─────────────────────────────────────────
 //
-// Every path below that returns `None` (or is matched as a fallback outcome)
+// Each recordable fallback path below (the paths through `fallback_or_reject`)
 // means the caller silently dispatches locally instead of via the warm daemon.
+// Intentional local bypasses such as the `KHIVE_NO_DAEMON` opt-out are outside
+// this telemetry set by design.
 // A silent fallback is the bug this instrumentation exists to surface: it must
 // always be loud (a structured fallback event — WARN, or ERROR for
 // strict-mode illegitimate reasons) and counted. These are process-global

--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -39,7 +39,8 @@ use test_harness::{
 // Every path below that returns `None` (or is matched as a fallback outcome)
 // means the caller silently dispatches locally instead of via the warm daemon.
 // A silent fallback is the bug this instrumentation exists to surface: it must
-// always be loud (a structured WARN) and counted. These are process-global
+// always be loud (a structured fallback event — WARN, or ERROR for
+// strict-mode illegitimate reasons) and counted. These are process-global
 // production counters (not `#[cfg(test)]`-gated like the instrumentation seams
 // above) — they realize the metric `khive_daemon_fallback_total{reason}`; a
 // future metrics-export slice can read them without touching call sites.
@@ -85,12 +86,13 @@ impl FallbackReason {
         }
     }
 
-    /// Legitimacy tier used only by the `KHIVE_DAEMON_STRICT` event-telemetry
-    /// policy (ADR-049 Amendment 2; see
-    /// `crates/khive-mcp/docs/api/daemon-lifecycle.md` §"Strict-mode fallback
-    /// accounting"). Every tier emits the WARN-level `daemon_fallback` event
-    /// and its per-reason counter; only `Illegitimate` reasons are elevated to
-    /// an error-level event plus `FALLBACK_STRICT_VIOLATIONS` in strict mode.
+    /// Legitimacy tier used only by the `daemon_fallback` event-level policy
+    /// (see `crates/khive-mcp/docs/api/daemon-lifecycle.md` §"Strict-mode
+    /// fallback accounting"; the graduated tiers themselves come from ADR-049
+    /// Amendment 2). Every tier increments its per-reason counter and emits
+    /// exactly one `daemon_fallback` event: WARN normally, escalated to ERROR
+    /// plus `FALLBACK_STRICT_VIOLATIONS` only for `Illegitimate` reasons in
+    /// strict mode.
     fn severity(self) -> FallbackSeverity {
         match self {
             // A real misconfiguration: the client and daemon should have

--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -85,9 +85,9 @@ impl FallbackReason {
         }
     }
 
-    /// Legitimacy tier used by the `KHIVE_DAEMON_STRICT` graduated fail-loud
-    /// policy (SPEC_DRAFT §3 D2). Only `Illegitimate` reasons are elevated by
-    /// strict mode; the other two tiers are always quiet, regardless of mode.
+    /// Legitimacy tier used only by the `KHIVE_DAEMON_STRICT` event-telemetry
+    /// policy (SPEC_DRAFT §3 D2). Only `Illegitimate` reasons are event-elevated;
+    /// the other two tiers stay quiet at event level regardless of mode.
     fn severity(self) -> FallbackSeverity {
         match self {
             // A real misconfiguration: the client and daemon should have
@@ -123,18 +123,23 @@ enum FallbackSeverity {
     Illegitimate,
     /// Historical rollout-transient telemetry tier. These outcomes are now
     /// terminal after a real write, but remain in the closed metrics vocabulary.
-    /// Never elevated, in strict mode or otherwise.
+    /// Never event-elevated, in strict mode or otherwise.
     RolloutTransient,
-    /// No daemon to forward to at all. Never elevated — this is the
-    /// ADR-049-mandated safety net, not a bug.
+    /// No daemon to forward to at all. Never event-elevated — this is the
+    /// ADR-049-mandated safety-net telemetry tier, not a signal that strict
+    /// mode permits local fallback.
     NoDaemon,
 }
 
-/// `KHIVE_DAEMON_STRICT=1` elevates `Illegitimate`-severity fallbacks to an
-/// error-level event (D2-R1, see [`record_fallback`]) and rejects the
-/// request outright instead of completing it locally (#947, see
-/// `fallback_or_reject`). Plain opt-in, default OFF — no hosted-vs-local
-/// auto-detection exists in this codebase. See
+/// `KHIVE_DAEMON_STRICT=1` has two independent effects:
+///
+/// - Behavior: [`fallback_or_reject`] rejects every [`FallbackReason`] instead
+///   of completing the request locally, regardless of severity (#947).
+/// - Telemetry: [`record_fallback`] elevates only `Illegitimate` reasons to an
+///   error-level event with the violation counter (D2-R1); the other severity
+///   tiers remain quiet at event level.
+///
+/// Plain opt-in, default OFF — no hosted-vs-local auto-detection exists. See
 /// `crates/khive-mcp/docs/api/daemon-lifecycle.md`.
 fn is_daemon_strict_mode() -> bool {
     env_truthy("KHIVE_DAEMON_STRICT")

--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -86,8 +86,11 @@ impl FallbackReason {
     }
 
     /// Legitimacy tier used only by the `KHIVE_DAEMON_STRICT` event-telemetry
-    /// policy (SPEC_DRAFT §3 D2). Only `Illegitimate` reasons are event-elevated;
-    /// the other two tiers stay quiet at event level regardless of mode.
+    /// policy (ADR-049 Amendment 2; see
+    /// `crates/khive-mcp/docs/api/daemon-lifecycle.md` §"Strict-mode fallback
+    /// accounting"). Every tier emits the WARN-level `daemon_fallback` event
+    /// and its per-reason counter; only `Illegitimate` reasons are elevated to
+    /// an error-level event plus `FALLBACK_STRICT_VIOLATIONS` in strict mode.
     fn severity(self) -> FallbackSeverity {
         match self {
             // A real misconfiguration: the client and daemon should have
@@ -114,7 +117,7 @@ impl FallbackReason {
 }
 
 /// Legitimacy tier for a [`FallbackReason`], keyed by the graduated fail-loud
-/// policy in SPEC_DRAFT §3 D2. See [`FallbackReason::severity`] for the
+/// policy in ADR-049 Amendment 2. See [`FallbackReason::severity`] for the
 /// per-variant mapping and its rationale.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum FallbackSeverity {
@@ -123,11 +126,11 @@ enum FallbackSeverity {
     Illegitimate,
     /// Historical rollout-transient telemetry tier. These outcomes are now
     /// terminal after a real write, but remain in the closed metrics vocabulary.
-    /// Never event-elevated, in strict mode or otherwise.
+    /// Never elevated past the WARN-level event, in strict mode or otherwise.
     RolloutTransient,
-    /// No daemon to forward to at all. Never event-elevated — this is the
-    /// ADR-049-mandated safety-net telemetry tier, not a signal that strict
-    /// mode permits local fallback.
+    /// No daemon to forward to at all. Never elevated past the WARN-level
+    /// event — this is the ADR-049-mandated safety-net telemetry tier, not a
+    /// signal that strict mode permits local fallback.
     NoDaemon,
 }
 
@@ -137,7 +140,8 @@ enum FallbackSeverity {
 ///   of completing the request locally, regardless of severity (#947).
 /// - Telemetry: [`record_fallback`] elevates only `Illegitimate` reasons to an
 ///   error-level event with the violation counter (D2-R1); the other severity
-///   tiers remain quiet at event level.
+///   tiers remain WARN-level `daemon_fallback` events and do not increment
+///   `FALLBACK_STRICT_VIOLATIONS`.
 ///
 /// Plain opt-in, default OFF — no hosted-vs-local auto-detection exists. See
 /// `crates/khive-mcp/docs/api/daemon-lifecycle.md`.


### PR DESCRIPTION
## Summary

- separate strict mode's unconditional request rejection from its severity-gated event telemetry
- describe rollout-transient and no-daemon tiers as quiet only at the event level
- clarify that the no-daemon telemetry tier does not permit local fallback in strict mode

## Verification

- `rustfmt --check --edition 2021 crates/khive-mcp/src/daemon.rs`
- non-Cargo pre-commit hooks for `crates/khive-mcp/src/daemon.rs`
- `git diff --check`

This is a documentation-only clarification; existing daemon tests already pin rejection for both no-socket and configuration-mismatch reasons.

Fixes #2078
