### PR TITLE
feat(runtime): brain-split configuration and fold-cursor migration

### DIFF
--- a/crates/khive-db/sql/022-brain-fold-cursor.sql
+++ b/crates/khive-db/sql/022-brain-fold-cursor.sql
@@ -3,12 +3,27 @@
 -- One row per tailed event source. The first phase of the brain-state
 -- decomposition (ADR-171) tails a single source — the domain store's own
 -- `events` table, source = 'main' — and later phases add the audit-lane
--- store as a second row. The cursor advances by compare-and-set on
--- `last_rowid` INSIDE the same transaction as the fold it covers, so a
--- worker that loses the race aborts its whole unit and every feedback
--- event folds exactly once, however many processes run a worker.
+-- store as a second row. The cursor advances by compare-and-set INSIDE the
+-- same transaction as the fold it covers, so a worker that loses the race
+-- aborts its whole unit and every feedback event folds exactly once,
+-- however many processes run a worker.
+--
+-- The cursor is a (rowid, event id) witness pair, per ADR-171's replay
+-- protocol. `events` is a rowid table with a TEXT primary key, so its rowid
+-- is an authoritative insertion-order high-water mark that timestamps are
+-- not (a delayed transaction lands with a later rowid even when its
+-- `created_at` is older) — but an implicit rowid is renumbered by `VACUUM`,
+-- so a bare rowid cursor could silently skip or re-fold rows after routine
+-- maintenance. `last_event_id` witnesses that `last_rowid` still denotes
+-- the same event: before trusting the seek position a worker validates the
+-- witness; on mismatch it rebases by resolving the witness id's current
+-- rowid and resumes past it; if the witnessed row is gone entirely
+-- (tenure-purged) it resumes from the oldest remaining row — rewind, never
+-- skip, because re-folding tolerant classes is recoverable noise while a
+-- silent gap is unmeasurable loss.
 CREATE TABLE IF NOT EXISTS brain_fold_cursor (
-    source     TEXT PRIMARY KEY,
-    last_rowid INTEGER NOT NULL,
-    updated_at INTEGER NOT NULL
+    source        TEXT PRIMARY KEY,
+    last_rowid    INTEGER NOT NULL,
+    last_event_id TEXT NOT NULL,
+    updated_at    INTEGER NOT NULL
 );

--- a/crates/khive-db/sql/022-brain-fold-cursor.sql
+++ b/crates/khive-db/sql/022-brain-fold-cursor.sql
@@ -1,0 +1,14 @@
+-- V22: durable checkpoint cursor for the asynchronous brain fold worker.
+--
+-- One row per tailed event source. The first phase of the brain-state
+-- decomposition (ADR-171) tails a single source — the domain store's own
+-- `events` table, source = 'main' — and later phases add the audit-lane
+-- store as a second row. The cursor advances by compare-and-set on
+-- `last_rowid` INSIDE the same transaction as the fold it covers, so a
+-- worker that loses the race aborts its whole unit and every feedback
+-- event folds exactly once, however many processes run a worker.
+CREATE TABLE IF NOT EXISTS brain_fold_cursor (
+    source     TEXT PRIMARY KEY,
+    last_rowid INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+);

--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -148,6 +148,8 @@ const V21_STAGE_UP: &str = include_str!("../sql/021-attachments-a-stage.sql");
 
 const V21_ATTACHMENT_FENCES_UP: &str = include_str!("../sql/021-attachments-b-claim-fences.sql");
 
+const V22_UP: &str = include_str!("../sql/022-brain-fold-cursor.sql");
+
 /// Core schema version reserved for ADR-121's attachments-first cutover.
 pub const ATTACHMENT_CUTOVER_VERSION: u32 = 21;
 
@@ -303,6 +305,11 @@ pub const MIGRATIONS: &[VersionedMigration] = &[
         // The runner special-cases it below; exposing the stage DDL here keeps
         // the ledger entry self-describing for migration inspection tooling.
         up: V21_STAGE_UP,
+    },
+    VersionedMigration {
+        version: 22,
+        name: "brain_fold_cursor",
+        up: V22_UP,
     },
 ];
 

--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -151,6 +151,14 @@ const V21_ATTACHMENT_FENCES_UP: &str = include_str!("../sql/021-attachments-b-cl
 /// Core schema version reserved for ADR-121's attachments-first cutover.
 pub const ATTACHMENT_CUTOVER_VERSION: u32 = 21;
 
+/// The latest schema version this build's migration chain produces.
+///
+/// Terminal-version assertions belong on this, not on a hardcoded number:
+/// a literal decays into a wrong claim the next time a migration is added.
+pub fn latest_schema_version() -> u32 {
+    MIGRATIONS.last().map(|m| m.version).unwrap_or(0)
+}
+
 /// DDL for the `ann_write_log` delta table.
 ///
 /// Shared between migration V11 and the belt-and-suspenders creation in
@@ -432,12 +440,15 @@ pub fn attachment_cutover_status(
             }
         }
         Some((state, Some(_))) if state == "complete" => {
-            if version == ATTACHMENT_CUTOVER_VERSION {
+            // Later migrations (V22+) are recorded on top of a completed
+            // cutover in the normal course; only a ledger BELOW V21 beside a
+            // complete marker is an impossible pair.
+            if version >= ATTACHMENT_CUTOVER_VERSION {
                 validate_complete_attachment_schema(conn)?;
                 Ok(AttachmentCutoverStatus::Complete)
             } else {
                 Err(SqliteError::InvalidData(format!(
-                    "attachment cutover is complete but schema ledger is at V{version}, expected V{ATTACHMENT_CUTOVER_VERSION}"
+                    "attachment cutover is complete but schema ledger is at V{version}, below V{ATTACHMENT_CUTOVER_VERSION}"
                 )))
             }
         }
@@ -1022,7 +1033,10 @@ pub fn validate_schema_is_current(conn: &Connection) -> Result<u32, SqliteError>
     // must not accept a history that ordinary boot would reject merely because
     // it cannot repair it in place.
     validate_applied_migration_ledger(conn, current_version)?;
-    if current_version == ATTACHMENT_CUTOVER_VERSION
+    // `>=`, not `==`: later migrations (V22+) record on top of a completed
+    // cutover, and a ledger at the latest version must not exempt the
+    // physical cutover state from validation.
+    if current_version >= ATTACHMENT_CUTOVER_VERSION
         && attachment_cutover_status(conn)? != AttachmentCutoverStatus::Complete
     {
         return Err(SqliteError::InvalidData(

--- a/crates/khive-db/src/migrations_tests.rs
+++ b/crates/khive-db/src/migrations_tests.rs
@@ -891,11 +891,14 @@ fn v4_creates_consolidated_fts_tables() {
 #[test]
 fn rejects_pre_consolidation_ledger() {
     let mut conn = open_memory();
-    // Simulate a database carrying the old, pre-consolidation V1..V22 ledger.
+    // Simulate a database whose recorded version is ahead of everything this
+    // build knows — the pre-consolidation ledger shape, or a newer build's.
+    // Computed from the live chain so the fixture stays ahead when a real
+    // migration lands on the number a literal would have pinned.
     conn.execute_batch(MIGRATION_TRACKING_TABLE).unwrap();
     conn.execute(
-        "INSERT INTO _schema_migrations (version, name, applied_at) VALUES (22, 'legacy', 0)",
-        [],
+        "INSERT INTO _schema_migrations (version, name, applied_at) VALUES (?1, 'legacy', 0)",
+        rusqlite::params![latest_schema_version() + 1],
     )
     .unwrap();
 
@@ -2466,7 +2469,7 @@ fn v21_legacy_refs_remain_pending_until_explicit_stage_and_finalize() {
 #[test]
 fn v21_empty_database_fast_path_is_atomic_and_complete() {
     let mut conn = open_memory();
-    assert_eq!(run_migrations(&mut conn).unwrap(), 21);
+    assert_eq!(run_migrations(&mut conn).unwrap(), latest_schema_version());
     assert_eq!(
         attachment_cutover_status(&conn).unwrap(),
         AttachmentCutoverStatus::Complete

--- a/crates/khive-db/src/stores/blob.rs
+++ b/crates/khive-db/src/stores/blob.rs
@@ -860,7 +860,7 @@ async fn blob_gc_fencing_complete(sql: &dyn SqlAccess) -> StorageResult<bool> {
                         AND (SELECT COUNT(*) FROM _schema_migrations \
                              WHERE version = 21 \
                                AND name = 'attachments_first_class') = 1 \
-                        AND (SELECT MAX(version) FROM _schema_migrations) = 21"
+                        AND (SELECT MAX(version) FROM _schema_migrations) >= 21"
                     .to_string(),
                 params: vec![],
                 label: Some("blob_gc_cutover_complete".to_string()),
@@ -2430,7 +2430,11 @@ mod tests {
     /// instead of retaining Phase 4a's synthetic future-schema fixture.
     fn prepare_completed_v21_gc_fixture(conn: &mut rusqlite::Connection) {
         let version = crate::run_migrations(conn).expect("prepare canonical completed V21");
-        assert_eq!(version, 21, "empty fixture must take the V21 fast path");
+        assert_eq!(
+            version,
+            crate::migrations::latest_schema_version(),
+            "empty fixture must migrate to the latest schema (which contains the completed V21 cutover)"
+        );
     }
 
     #[tokio::test]
@@ -2498,11 +2502,13 @@ mod tests {
                 "UPDATE _schema_migrations SET name = 'not_attachments_first_class' \
                  WHERE version = 21",
             ),
-            (
-                "ledger_max_version_advances_past_v21",
-                "INSERT INTO _schema_migrations (version, name, applied_at) \
-                 VALUES (22, 'future_migration', 22)",
-            ),
+            // NOTE: "ledger max version advances past V21" is deliberately NOT
+            // a reject arm. Later migrations record on top of a completed
+            // cutover without disturbing the fencing set, so the gate's
+            // ledger predicate is `MAX(version) >= 21`; the accept-path tests
+            // in this module run against the latest schema and are the
+            // positive control for that semantics. The physical facts the
+            // matrix below removes one at a time are what carry the safety.
             (
                 "marker_row_deleted",
                 "DELETE FROM attachment_cutover_state WHERE singleton = 1",

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -4080,10 +4080,12 @@ mod tests {
         let base = RuntimeConfig::no_embeddings();
         let utc = RuntimeConfig {
             display_timezone: "UTC".parse().expect("UTC is a known IANA zone"),
+            brain_split: None,
             ..base.clone()
         };
         let new_york = RuntimeConfig {
             display_timezone: "America/New_York".parse().expect("known IANA zone"),
+            brain_split: None,
             ..base
         };
 
@@ -4114,10 +4116,12 @@ mod tests {
         let base = RuntimeConfig::no_embeddings();
         let a = RuntimeConfig {
             display_timezone: "America/New_York".parse().expect("known IANA zone"),
+            brain_split: None,
             ..base.clone()
         };
         let b = RuntimeConfig {
             display_timezone: "America/New_York".parse().expect("known IANA zone"),
+            brain_split: None,
             ..base
         };
 

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -641,7 +641,18 @@ pub(crate) fn compute_config_id_with_runtime_policies(
         .map(encode_backend_topology)
         .unwrap_or_default();
 
-    format!("{base}{topology}")
+    // Fold the brain-split mode when configured (ADR-171): a runtime folding
+    // feedback asynchronously and one folding synchronously must never share
+    // a warm daemon. Skipped when `None` — the universal state until the
+    // fold worker lands — preserving byte-identity with the pre-change
+    // fingerprint, exactly like the topology component above.
+    let brain_split = config
+        .brain_split
+        .as_ref()
+        .map(|cfg| format!(";brain_split={cfg:?}"))
+        .unwrap_or_default();
+
+    format!("{base}{topology}{brain_split}")
 }
 
 /// Reserved syntax in the legacy topology spelling.
@@ -4063,6 +4074,29 @@ mod tests {
             compute_config_id_with_ann_fresh_tail(&config, None, true),
             compute_config_id_with_ann_fresh_tail(&config, None, false),
             "opposite fresh-tail policies must not share one warm daemon"
+        );
+    }
+
+    /// A runtime folding feedback asynchronously (ADR-171 split) and one
+    /// folding synchronously must never share a warm daemon; and because the
+    /// component is skipped when `None`, every existing daemon identity is
+    /// byte-preserved until the fold worker lands.
+    #[test]
+    fn config_id_separates_brain_split_from_legacy_fold() {
+        let base = RuntimeConfig::no_embeddings();
+        let split = RuntimeConfig {
+            brain_split: Some(khive_runtime::brain_split::BrainSplitConfig::default()),
+            ..base.clone()
+        };
+        let legacy_id = compute_config_id_with_runtime_policies(&base, None, true, false);
+        assert_ne!(
+            compute_config_id_with_runtime_policies(&split, None, true, false),
+            legacy_id,
+            "split and legacy fold semantics must not share one warm daemon"
+        );
+        assert!(
+            !legacy_id.contains("brain_split"),
+            "None must contribute no component, preserving pre-change identities"
         );
     }
 

--- a/crates/khive-pack-brain/src/fold_gate.rs
+++ b/crates/khive-pack-brain/src/fold_gate.rs
@@ -523,6 +523,7 @@ mod tests {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            brain_split: None,
             db_path: Some(db_path),
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -631,6 +632,7 @@ mod tests {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            brain_split: None,
             db_path: Some(db_path),
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -2413,6 +2413,7 @@ fn make_pack_with_actor(actor_id: &str) -> (BrainPack, KhiveRuntime) {
     let rt = KhiveRuntime::new(khive_runtime::RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        brain_split: None,
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-pack-brain/tests/adr133_serve_batch.rs
+++ b/crates/khive-pack-brain/tests/adr133_serve_batch.rs
@@ -17,6 +17,7 @@ fn file_backed_runtime(db_path: std::path::PathBuf) -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        brain_split: None,
         db_path: Some(db_path),
         default_namespace: Namespace::local(),
         embedding_model: None,

--- a/crates/khive-pack-brain/tests/resolve_actor.rs
+++ b/crates/khive-pack-brain/tests/resolve_actor.rs
@@ -14,6 +14,7 @@ fn runtime_with_actor(actor_id: Option<&str>) -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        brain_split: None,
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -3338,6 +3338,7 @@ mod tests {
         let runtime = super::KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            brain_split: None,
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::parse(&ns).unwrap(),
@@ -3865,6 +3866,7 @@ mod tests {
         let runtime = super::KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            brain_split: None,
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::parse(&ns).unwrap(),
@@ -3982,6 +3984,7 @@ mod tests {
             let runtime = super::KhiveRuntime::new(RuntimeConfig {
                 git_write: Default::default(),
                 display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+                brain_split: None,
                 db_path: None,
                 blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
                 default_namespace: Namespace::parse(&ns).unwrap(),

--- a/crates/khive-pack-comm/src/message.rs
+++ b/crates/khive-pack-comm/src/message.rs
@@ -454,6 +454,7 @@ mod tests {
         let runtime = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            brain_split: None,
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::parse(&sender_ns).unwrap(),
@@ -532,6 +533,7 @@ mod tests {
         let runtime = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            brain_split: None,
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::parse(ns).unwrap(),
@@ -675,6 +677,7 @@ mod tests {
         let runtime = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            brain_split: None,
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::parse(&sender_ns).unwrap(),
@@ -837,6 +840,7 @@ mod tests {
         let runtime = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            brain_split: None,
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),

--- a/crates/khive-pack-comm/tests/adr133_read_flags.rs
+++ b/crates/khive-pack-comm/tests/adr133_read_flags.rs
@@ -17,6 +17,7 @@ fn file_backed_registry(
     let rt = KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        brain_split: None,
         db_path: Some(db_path),
         default_namespace: Namespace::local(),
         embedding_model: None,

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -3539,6 +3539,7 @@ fn build_crossns_registry(
     let config = RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        brain_split: None,
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::parse(dispatch_ns).unwrap(),
@@ -4480,6 +4481,7 @@ fn build_actor_registry(
     let config = RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        brain_split: None,
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
@@ -4645,6 +4647,7 @@ allowed_outbound_namespaces = ["lambda:khive", "lambda:atlas"]
     let base = RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        brain_split: None,
         db_path: None,
         embedding_model: None,
         additional_embedding_models: vec![],
@@ -4774,6 +4777,7 @@ async fn t_c2_gate_receives_configured_actor_not_anonymous() {
     let config = RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        brain_split: None,
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
@@ -4890,6 +4894,7 @@ async fn i199_anonymous_inbox_cannot_read_messages_addressed_to_other_actor() {
     let config_anon = RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        brain_split: None,
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-pack-comm/tests/probe.rs
+++ b/crates/khive-pack-comm/tests/probe.rs
@@ -1011,6 +1011,7 @@ async fn probe_backfills_pre_existing_messages_across_v6_to_v7_upgrade() {
     let config = RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        brain_split: None,
         db_path: Some(path.clone()),
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
@@ -1196,6 +1197,7 @@ async fn probe_repairs_partial_notes_seq_left_by_original_v7_on_reopen() {
     let config = RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        brain_split: None,
         db_path: Some(path.clone()),
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-pack-git/tests/acceptance.rs
+++ b/crates/khive-pack-git/tests/acceptance.rs
@@ -7271,6 +7271,7 @@ async fn ingest_over_cap_commit_embedding_is_semantically_retrievable() {
     let rt = KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        brain_split: None,
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-pack-knowledge/benches/knowledge_bench.rs
+++ b/crates/khive-pack-knowledge/benches/knowledge_bench.rs
@@ -21,6 +21,7 @@ fn build_runtime() -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        brain_split: None,
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-pack-knowledge/benches/search_latency.rs
+++ b/crates/khive-pack-knowledge/benches/search_latency.rs
@@ -28,6 +28,7 @@ fn rt_with_embedder() -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        brain_split: None,
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-pack-knowledge/src/handlers.rs
+++ b/crates/khive-pack-knowledge/src/handlers.rs
@@ -929,6 +929,7 @@ mod tests {
         let rt = KhiveRuntime::new(khive_runtime::RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            brain_split: None,
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),

--- a/crates/khive-pack-knowledge/src/knowledge/ann_degrade_tests.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/ann_degrade_tests.rs
@@ -171,6 +171,7 @@ fn rt_with_fake_embedder() -> KhiveRuntime {
     let rt = KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        brain_split: None,
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
@@ -193,6 +194,7 @@ fn rt_with_controlled_ranking(fail_fresh_rerank: bool) -> KhiveRuntime {
     let rt = KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        brain_split: None,
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
@@ -219,6 +221,7 @@ fn file_rt_with_fake_embedder(db_path: std::path::PathBuf) -> KhiveRuntime {
     let rt = KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        brain_split: None,
         db_path: Some(db_path),
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-pack-knowledge/src/knowledge/suggest_ranking_tests.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/suggest_ranking_tests.rs
@@ -168,6 +168,7 @@ fn rt_with_fixture_embedder() -> KhiveRuntime {
     let rt = KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        brain_split: None,
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-pack-knowledge/src/knowledge/vamana.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/vamana.rs
@@ -4256,6 +4256,7 @@ mod tests {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            brain_split: None,
             db_path,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),

--- a/crates/khive-pack-knowledge/tests/bench.rs
+++ b/crates/khive-pack-knowledge/tests/bench.rs
@@ -28,6 +28,7 @@ fn rt_with_embedder() -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        brain_split: None,
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-pack-knowledge/tests/feedback.rs
+++ b/crates/khive-pack-knowledge/tests/feedback.rs
@@ -22,6 +22,7 @@ fn make_rt(brain_profile: Option<String>, with_brain: bool) -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        brain_split: None,
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         embedding_model: None,
@@ -40,6 +41,7 @@ fn make_rt_with_actor(actor: &str) -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        brain_split: None,
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-pack-knowledge/tests/fixes.rs
+++ b/crates/khive-pack-knowledge/tests/fixes.rs
@@ -1630,6 +1630,7 @@ fn rt_with_default_embedder() -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        brain_split: None,
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
@@ -2307,6 +2308,7 @@ mod embed_failure_tests {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            brain_split: None,
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -2495,6 +2497,7 @@ mod embed_failure_tests {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            brain_split: None,
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -2811,6 +2814,7 @@ mod ann_bypass_regression {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            brain_split: None,
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -3410,6 +3414,7 @@ mod edit_inline_reembed {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            brain_split: None,
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -3815,6 +3820,7 @@ mod ann_type_filter_regression {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            brain_split: None,
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -4221,6 +4227,7 @@ mod compose_explain_sections {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            brain_split: None,
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),

--- a/crates/khive-pack-knowledge/tests/integration.rs
+++ b/crates/khive-pack-knowledge/tests/integration.rs
@@ -1840,6 +1840,7 @@ async fn index_reembed_paging_sweep_covers_equal_created_at_in_order() {
     let rt = KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        brain_split: None,
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),
@@ -3998,6 +3999,7 @@ mod kg_blend {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            brain_split: None,
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -4628,6 +4630,7 @@ mod kg_blend {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            brain_split: None,
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),

--- a/crates/khive-pack-knowledge/tests/search_candidate_refill.rs
+++ b/crates/khive-pack-knowledge/tests/search_candidate_refill.rs
@@ -144,6 +144,7 @@ fn runtime_with_embedder() -> KhiveRuntime {
     let runtime = KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        brain_split: None,
         db_path: None,
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-pack-moodboard/src/preference_handlers.rs
+++ b/crates/khive-pack-moodboard/src/preference_handlers.rs
@@ -1603,6 +1603,7 @@ mod tests {
         RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            brain_split: None,
             db_path: Some(db_path.to_path_buf()),
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),

--- a/crates/khive-pack-session/src/mirror/ingest.rs
+++ b/crates/khive-pack-session/src/mirror/ingest.rs
@@ -1104,6 +1104,7 @@ mod tests {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            brain_split: None,
             db_path: Some(db_path),
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),

--- a/crates/khive-pack-session/src/mirror/service.rs
+++ b/crates/khive-pack-session/src/mirror/service.rs
@@ -2626,6 +2626,7 @@ mod cursor_retry_tests {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            brain_split: None,
             db_path: Some(db_path),
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),

--- a/crates/khive-pack-session/tests/integration.rs
+++ b/crates/khive-pack-session/tests/integration.rs
@@ -22,6 +22,7 @@ fn file_rt(db_path: std::path::PathBuf) -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+        brain_split: None,
         db_path: Some(db_path),
         blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
         default_namespace: Namespace::local(),

--- a/crates/khive-runtime/src/brain_split.rs
+++ b/crates/khive-runtime/src/brain_split.rs
@@ -1,0 +1,17 @@
+//! Brain-state decomposition configuration (ADR-171).
+//!
+//! Phase 1 decouples the durable feedback fold from verb dispatch: with the
+//! split configured, feedback verbs commit only their public event-plane row
+//! and an asynchronous worker in the brain pack folds from a durable cursor.
+//! Later phases add the separate `brain.db` store and the brain daemon; this
+//! config grows their fields (database path, socket) when they land.
+
+/// `None` on [`crate::RuntimeConfig::brain_split`] = legacy behavior: the
+/// feedback fold runs synchronously inside verb dispatch, in the same
+/// transaction as the public event append. `Some` = the decoupled fold.
+///
+/// Populated by the transport hosts' config resolver (with the
+/// `KHIVE_BRAIN_SPLIT=0` environment kill-switch restoring legacy behavior);
+/// tests and in-memory runtimes leave it `None`.
+#[derive(Debug, Clone, Default)]
+pub struct BrainSplitConfig {}

--- a/crates/khive-runtime/src/brain_split.rs
+++ b/crates/khive-runtime/src/brain_split.rs
@@ -1,17 +1,18 @@
 //! Brain-state decomposition configuration (ADR-171).
 //!
-//! Phase 1 decouples the durable feedback fold from verb dispatch: with the
-//! split configured, feedback verbs commit only their public event-plane row
-//! and an asynchronous worker in the brain pack folds from a durable cursor.
-//! Later phases add the separate `brain.db` store and the brain daemon; this
-//! config grows their fields (database path, socket) when they land.
+//! Forward-deployed seam for the fold-decoupling worker: when that worker
+//! lands, `Some` on [`crate::RuntimeConfig::brain_split`] will route feedback
+//! through the event plane, folded asynchronously from the durable
+//! `brain_fold_cursor` (V22). Later phases grow this struct with the
+//! separate `brain.db` store and brain-daemon fields (database path, socket).
 
-/// `None` on [`crate::RuntimeConfig::brain_split`] = legacy behavior: the
-/// feedback fold runs synchronously inside verb dispatch, in the same
-/// transaction as the public event append. `Some` = the decoupled fold.
+/// Configuration for the decoupled brain fold (ADR-171).
 ///
-/// Populated by the transport hosts' config resolver (with the
-/// `KHIVE_BRAIN_SPLIT=0` environment kill-switch restoring legacy behavior);
-/// tests and in-memory runtimes leave it `None`.
+/// In this tree the field is a forward-deployed marker: nothing populates it
+/// and populating it changes no behavior yet — the feedback fold still runs
+/// synchronously inside verb dispatch. The fold worker that consumes it is
+/// the next change in the series; until then the only live consumer is the
+/// daemon configuration fingerprint, which already distinguishes `Some` from
+/// `None` so a warm daemon can never straddle the two once the worker lands.
 #[derive(Debug, Clone, Default)]
 pub struct BrainSplitConfig {}

--- a/crates/khive-runtime/src/config.rs
+++ b/crates/khive-runtime/src/config.rs
@@ -316,6 +316,13 @@ pub struct RuntimeConfig {
     /// resolves once to the host's local IANA zone (falling back to UTC when
     /// the host zone cannot be determined) via [`resolve_default_display_timezone`].
     pub display_timezone: chrono_tz::Tz,
+    /// Brain fold decoupling (ADR-171 phase 1). `None` = legacy behavior:
+    /// the feedback fold runs synchronously inside verb dispatch. `Some`
+    /// routes feedback through the event plane, folded asynchronously by the
+    /// brain pack's fold worker under a durable cursor. Populated by the
+    /// transport hosts' resolver (kill-switch `KHIVE_BRAIN_SPLIT=0`); tests
+    /// and in-memory runtimes leave it `None`.
+    pub brain_split: Option<crate::brain_split::BrainSplitConfig>,
 }
 
 /// Parse a comma- or whitespace-separated pack list from a single string.
@@ -401,6 +408,7 @@ impl Default for RuntimeConfig {
             actor_id,
             git_write: crate::engine_config::GitWriteSectionConfig::default(),
             display_timezone: resolve_default_display_timezone(),
+            brain_split: None,
         }
     }
 }

--- a/crates/khive-runtime/src/config.rs
+++ b/crates/khive-runtime/src/config.rs
@@ -316,12 +316,12 @@ pub struct RuntimeConfig {
     /// resolves once to the host's local IANA zone (falling back to UTC when
     /// the host zone cannot be determined) via [`resolve_default_display_timezone`].
     pub display_timezone: chrono_tz::Tz,
-    /// Brain fold decoupling (ADR-171 phase 1). `None` = legacy behavior:
-    /// the feedback fold runs synchronously inside verb dispatch. `Some`
-    /// routes feedback through the event plane, folded asynchronously by the
-    /// brain pack's fold worker under a durable cursor. Populated by the
-    /// transport hosts' resolver (kill-switch `KHIVE_BRAIN_SPLIT=0`); tests
-    /// and in-memory runtimes leave it `None`.
+    /// Brain fold decoupling (ADR-171 phase 1) — forward-deployed seam.
+    /// Nothing populates this field yet and `Some` changes no behavior in
+    /// this tree: the feedback fold still runs synchronously inside verb
+    /// dispatch. The asynchronous fold worker that consumes it is the next
+    /// change in the series; the daemon configuration fingerprint already
+    /// separates `Some` from `None` (see `compute_config_id`).
     pub brain_split: Option<crate::brain_split::BrainSplitConfig>,
 }
 

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -11,6 +11,7 @@ pub mod atomic_prepare;
 pub mod atomic_runner;
 pub mod audit_batch;
 pub mod blob;
+pub mod brain_split;
 pub mod build_info;
 pub mod config;
 pub mod config_ledger;

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -1787,6 +1787,7 @@ mod tests {
         let config = RuntimeConfig {
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
+            brain_split: None,
             db_path: Some(path),
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -1813,6 +1814,7 @@ mod tests {
         let config = RuntimeConfig {
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
+            brain_split: None,
             db_path: None,
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -1837,6 +1839,7 @@ mod tests {
         let config = RuntimeConfig {
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
+            brain_split: None,
             db_path: Some(path.clone()),
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::parse("test").unwrap(),
@@ -1865,6 +1868,7 @@ mod tests {
         let base = RuntimeConfig {
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
+            brain_split: None,
             db_path: Some(path.clone()),
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -1935,6 +1939,7 @@ mod tests {
         let config = RuntimeConfig {
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
+            brain_split: None,
             db_path: Some(path.clone()),
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -2018,6 +2023,7 @@ mod tests {
             let make_config = |db_path: std::path::PathBuf| RuntimeConfig {
                 git_write: Default::default(),
                 display_timezone: chrono_tz::Tz::UTC,
+                brain_split: None,
                 db_path: Some(db_path),
                 blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
                 default_namespace: Namespace::local(),
@@ -2065,6 +2071,7 @@ mod tests {
         let config = RuntimeConfig {
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
+            brain_split: None,
             db_path: None,
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -2232,6 +2239,7 @@ mod tests {
         let base = RuntimeConfig {
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
+            brain_split: None,
             db_path: None,
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -2259,6 +2267,7 @@ mod tests {
         let base = RuntimeConfig {
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
+            brain_split: None,
             db_path: None,
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::parse("lambda:base").unwrap(),
@@ -2294,6 +2303,7 @@ mod tests {
         let base = RuntimeConfig {
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
+            brain_split: None,
             db_path: None,
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::parse("lambda:base").unwrap(),
@@ -2321,6 +2331,7 @@ mod tests {
         let base = RuntimeConfig {
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
+            brain_split: None,
             db_path: None,
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -2366,6 +2377,7 @@ mod tests {
         let base = RuntimeConfig {
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
+            brain_split: None,
             db_path: None,
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -2398,6 +2410,7 @@ mod tests {
         let base = RuntimeConfig {
             git_write: Default::default(),
             display_timezone: "Asia/Tokyo".parse().unwrap(),
+            brain_split: None,
             db_path: None,
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -2544,6 +2557,7 @@ mod tests {
         RuntimeConfig {
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
+            brain_split: None,
             db_path: None,
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -2623,6 +2637,7 @@ mod tests {
         let main_config = RuntimeConfig {
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
+            brain_split: None,
             db_path: None,
             blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -2762,6 +2777,7 @@ mod tests {
             RuntimeConfig {
                 git_write: Default::default(),
                 display_timezone: chrono_tz::Tz::UTC,
+                brain_split: None,
                 db_path: None,
                 blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
                 default_namespace: Namespace::local(),

--- a/crates/khive-runtime/tests/integration.rs
+++ b/crates/khive-runtime/tests/integration.rs
@@ -1940,6 +1940,7 @@ async fn file_backed_runtime_persists() {
         let config = RuntimeConfig {
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
+            brain_split: None,
             db_path: Some(path.clone()),
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -1965,6 +1966,7 @@ async fn file_backed_runtime_persists() {
         let config = RuntimeConfig {
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
+            brain_split: None,
             db_path: Some(path.clone()),
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -2588,6 +2590,7 @@ mod embedder_registry_tests {
         KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
+            brain_split: None,
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),
@@ -2742,6 +2745,7 @@ mod embedder_registry_tests {
         let rt = KhiveRuntime::new(RuntimeConfig {
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
+            brain_split: None,
             db_path: None,
             blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
             default_namespace: Namespace::local(),

--- a/crates/kkernel/src/cli.rs
+++ b/crates/kkernel/src/cli.rs
@@ -1416,7 +1416,7 @@ mod tests {
         let migrated = StorageBackend::sqlite(&path).expect("reopen migrated database");
         assert_eq!(
             migrated.prepare_core_schema().unwrap(),
-            ATTACHMENT_CUTOVER_VERSION
+            khive_db::migrations::latest_schema_version()
         );
         let attachment = migrated
             .attachments()
@@ -1498,7 +1498,7 @@ mod tests {
             let conn = backend.pool().reader().expect("inspect completed topology");
             assert_eq!(
                 read_schema_version(conn.conn()).unwrap(),
-                ATTACHMENT_CUTOVER_VERSION
+                khive_db::migrations::latest_schema_version()
             );
             assert_eq!(
                 attachment_cutover_status(conn.conn()).unwrap(),
@@ -1540,7 +1540,7 @@ mod tests {
         );
         assert_eq!(
             read_schema_version(secondary_conn.conn()).unwrap(),
-            ATTACHMENT_CUTOVER_VERSION
+            khive_db::migrations::latest_schema_version()
         );
     }
 
@@ -1570,7 +1570,7 @@ mod tests {
 
     #[tokio::test]
     async fn db_migrate_one_declared_main_uses_its_configured_path() {
-        use khive_db::migrations::{read_schema_version, ATTACHMENT_CUTOVER_VERSION};
+        use khive_db::migrations::read_schema_version;
 
         let tmp = TempDir::new().expect("temp dir");
         let main = tmp.path().join("declared-main.db");
@@ -1591,7 +1591,7 @@ mod tests {
         let conn = backend.pool().reader().unwrap();
         assert_eq!(
             read_schema_version(conn.conn()).unwrap(),
-            ATTACHMENT_CUTOVER_VERSION
+            khive_db::migrations::latest_schema_version()
         );
     }
 


### PR DESCRIPTION
First slice of the brain feedback-fold decoupling (ADR-171 phase 1). This lands the inert machinery only — nothing reads the new configuration yet, and no dispatch behavior changes.

- **V22 migration `brain_fold_cursor`**: one durable checkpoint row per tailed event source, advanced by compare-and-set inside the same transaction as the fold it covers, so each feedback event folds exactly once across any number of worker processes.
- **`RuntimeConfig.brain_split: Option<BrainSplitConfig>`** (new `brain_split` module): `None` — the value every construction site in this PR uses — keeps today's behavior, the feedback fold running synchronously inside verb dispatch. `Some` is wired up by the follow-up PR that adds the fold worker.
- Mechanical field additions at every `RuntimeConfig` struct-literal construction site across the workspace.

Stacked on #2177, which makes the schema-terminal predicates version-agnostic so a V22 can land at all; this PR is the first consumer of that fix.

## Testing

- `cargo fmt --check --all`, `cargo clippy --workspace --all-targets --all-features` clean.
- Full suites green for khive-db, khive-runtime, khive-mcp, kkernel, and the five touched pack crates — kkernel's migration assertions now exercise the chain at V22.