### PR TITLE
fix(kg): attribute rejected edge endpoints

### DIFF
--- a/crates/khive-pack-kg/src/handlers/common.rs
+++ b/crates/khive-pack-kg/src/handlers/common.rs
@@ -503,6 +503,12 @@ pub(crate) async fn enrich_allowlist_error(
             relation.as_str()
         ));
     }
+    let source_short: String = source_id.to_string().chars().take(8).collect();
+    let target_short: String = target_id.to_string().chars().take(8).collect();
+    msg.push_str(&format!(
+        " Endpoint resolution: source {source_short} resolved as {src_kind}; \
+         target {target_short} resolved as {tgt_kind}."
+    ));
     msg
 }
 

--- a/crates/khive-pack-kg/src/handlers/common.rs
+++ b/crates/khive-pack-kg/src/handlers/common.rs
@@ -479,15 +479,26 @@ pub(crate) async fn enrich_allowlist_error(
         &tgt_kind,
         tgt_entity_type.as_deref(),
     );
+    // The typed subtype participates in rule matching (EntityOfType pack
+    // rules), so the label must carry it: two base-identical endpoints can
+    // have different legal sets.
+    let src_label = match src_entity_type.as_deref() {
+        Some(t) => format!("{src_kind}/{t}"),
+        None => src_kind.clone(),
+    };
+    let tgt_label = match tgt_entity_type.as_deref() {
+        Some(t) => format!("{tgt_kind}/{t}"),
+        None => tgt_kind.clone(),
+    };
     let mut msg = if valid.is_empty() {
         format!(
-            "Invalid relation {:?} for {src_kind}\u{2192}{tgt_kind}. \
-             No valid relations exist for {src_kind}\u{2192}{tgt_kind} in the current edge rules.",
+            "Invalid relation {:?} for {src_label}\u{2192}{tgt_label}. \
+             No valid relations exist for {src_label}\u{2192}{tgt_label} in the current edge rules.",
             relation.as_str()
         )
     } else {
         format!(
-            "Invalid relation {:?} for {src_kind}\u{2192}{tgt_kind}. \
+            "Invalid relation {:?} for {src_label}\u{2192}{tgt_label}. \
              Valid relations: {}",
             relation.as_str(),
             valid.join(", ")
@@ -506,10 +517,55 @@ pub(crate) async fn enrich_allowlist_error(
     let source_short: String = source_id.to_string().chars().take(8).collect();
     let target_short: String = target_id.to_string().chars().take(8).collect();
     msg.push_str(&format!(
-        " Endpoint resolution: source {source_short} resolved as {src_kind}; \
-         target {target_short} resolved as {tgt_kind}."
+        " Endpoint resolution: source {source_short} resolved as {src_label}; \
+         target {target_short} resolved as {tgt_label}."
     ));
     msg
+}
+
+/// Attribute an atomic bulk `link` allowlist rejection to the offending entry.
+///
+/// `link_many` validates per-spec but its error does not say which entry
+/// failed. Re-derive it: the acceptance set from
+/// [`valid_relations_for_entity_pair`] equals the validator's acceptance set
+/// for a typed pair (proven by the generative cross-check test in
+/// `handlers/tests.rs`), so the first spec whose relation falls outside its
+/// pair's set is the entry the validator rejected. Falls back to the original
+/// message if no spec re-identifies (e.g. a concurrent endpoint mutation).
+pub(crate) async fn enrich_bulk_atomic_allowlist_error(
+    original: &str,
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    specs: &[khive_runtime::operations::LinkSpec],
+) -> String {
+    for (idx, spec) in specs.iter().enumerate() {
+        let Ok(src) = runtime.get_entity(token, spec.source_id).await else {
+            continue;
+        };
+        let Ok(tgt) = runtime.get_entity(token, spec.target_id).await else {
+            continue;
+        };
+        let valid = valid_relations_for_entity_pair(
+            runtime,
+            &src.kind,
+            src.entity_type.as_deref(),
+            &tgt.kind,
+            tgt.entity_type.as_deref(),
+        );
+        if !valid.contains(&spec.relation.as_str()) {
+            let enriched = enrich_allowlist_error(
+                original,
+                runtime,
+                token,
+                spec.source_id,
+                spec.target_id,
+                spec.relation,
+            )
+            .await;
+            return format!("entry {idx}: {enriched}");
+        }
+    }
+    original.to_string()
 }
 
 pub(crate) const IMMUTABLE_EVENT_MSG: &str =

--- a/crates/khive-pack-kg/src/handlers/common.rs
+++ b/crates/khive-pack-kg/src/handlers/common.rs
@@ -537,8 +537,10 @@ pub(crate) async fn enrich_bulk_atomic_allowlist_error(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
     specs: &[khive_runtime::operations::LinkSpec],
+    entry_indices: &[usize],
 ) -> String {
-    for (idx, spec) in specs.iter().enumerate() {
+    for (pos, spec) in specs.iter().enumerate() {
+        let idx = entry_indices.get(pos).copied().unwrap_or(pos);
         let Ok(src) = runtime.get_entity(token, spec.source_id).await else {
             continue;
         };

--- a/crates/khive-pack-kg/src/handlers/link.rs
+++ b/crates/khive-pack-kg/src/handlers/link.rs
@@ -5,8 +5,8 @@ use serde_json::{json, Value};
 use khive_runtime::{merge_entry_metadata, LinkSpec, NamespaceToken, RuntimeError, VerbRegistry};
 
 use super::common::{
-    deser, enrich_allowlist_error, format_edge_output, parse_relation, resolve_uuid_unfiltered,
-    to_json, validate_weight, LinkParams,
+    deser, enrich_allowlist_error, enrich_bulk_atomic_allowlist_error, format_edge_output,
+    parse_relation, resolve_uuid_unfiltered, to_json, validate_weight, LinkParams,
 };
 use crate::KgPack;
 
@@ -66,7 +66,18 @@ impl KgPack {
                 registry
                     .validate_link_hooks(&self.runtime, token, &specs)
                     .await?;
-                let edges = self.runtime.link_many(token, specs).await?;
+                let edges = match self.runtime.link_many(token, specs.clone()).await {
+                    Ok(edges) => edges,
+                    Err(RuntimeError::InvalidInput(ref msg))
+                        if msg.contains("not in the base endpoint allowlist") =>
+                    {
+                        let enriched =
+                            enrich_bulk_atomic_allowlist_error(msg, &self.runtime, token, &specs)
+                                .await;
+                        return Err(RuntimeError::InvalidInput(enriched));
+                    }
+                    Err(e) => return Err(e),
+                };
                 let mut resp = serde_json::json!({
                     "attempted": attempted,
                     "created": edges.len(),
@@ -157,6 +168,20 @@ impl KgPack {
                         .await
                     {
                         Ok(edge) => results.push(to_json(&edge)?),
+                        Err(RuntimeError::InvalidInput(ref msg))
+                            if msg.contains("not in the base endpoint allowlist") =>
+                        {
+                            let enriched = enrich_allowlist_error(
+                                msg,
+                                &self.runtime,
+                                token,
+                                source,
+                                target,
+                                relation,
+                            )
+                            .await;
+                            error_list.push(json!({"index": idx, "error": enriched}));
+                        }
                         Err(e) => error_list.push(json!({"index": idx, "error": format!("{e}")})),
                     }
                 }

--- a/crates/khive-pack-kg/src/handlers/link.rs
+++ b/crates/khive-pack-kg/src/handlers/link.rs
@@ -30,9 +30,13 @@ impl KgPack {
             let atomic = p.atomic.unwrap_or(true);
             if atomic {
                 let mut specs = Vec::with_capacity(attempted);
+                // Caller entry index per spec: duplicate-skips shift spec
+                // positions, so error attribution must map back to the
+                // caller's entry list.
+                let mut entry_indices = Vec::with_capacity(attempted);
                 let mut seen = std::collections::HashSet::new();
                 let mut skipped = 0usize;
-                for entry in entries {
+                for (idx, entry) in entries.into_iter().enumerate() {
                     let source =
                         resolve_uuid_unfiltered(&entry.source_id, &self.runtime, token).await?;
                     let target =
@@ -54,6 +58,7 @@ impl KgPack {
                     }
                     let weight = validate_weight(entry.weight)?;
                     let metadata = merge_entry_metadata(entry.metadata, entry.dependency_kind)?;
+                    entry_indices.push(idx);
                     specs.push(LinkSpec {
                         namespace: Some(token.namespace().as_str().to_owned()),
                         source_id: source,
@@ -71,9 +76,14 @@ impl KgPack {
                     Err(RuntimeError::InvalidInput(ref msg))
                         if msg.contains("not in the base endpoint allowlist") =>
                     {
-                        let enriched =
-                            enrich_bulk_atomic_allowlist_error(msg, &self.runtime, token, &specs)
-                                .await;
+                        let enriched = enrich_bulk_atomic_allowlist_error(
+                            msg,
+                            &self.runtime,
+                            token,
+                            &specs,
+                            &entry_indices,
+                        )
+                        .await;
                         return Err(RuntimeError::InvalidInput(enriched));
                     }
                     Err(e) => return Err(e),

--- a/crates/khive-pack-kg/src/handlers/tests.rs
+++ b/crates/khive-pack-kg/src/handlers/tests.rs
@@ -1032,9 +1032,16 @@ async fn bulk_link_errors_receive_endpoint_attribution_in_both_modes() {
     let registry = builder.build().expect("kg registry builds");
     rt.install_edge_rules(registry.all_edge_rules());
 
-    // Entry 0 is legal, entry 1 is the allowlist rejection — proving the
-    // attribution names the offending entry, not just the first one.
+    // Entry 0 is legal, entry 1 is a duplicate of entry 0 (skipped by dedup,
+    // shifting spec positions off caller indices), entry 2 is the allowlist
+    // rejection — proving the attribution names the CALLER's entry index,
+    // not the post-dedup spec position.
     let links = json!([
+        {
+            "source_id": concept_a.id.to_string(),
+            "target_id": concept_b.id.to_string(),
+            "relation": "extends",
+        },
         {
             "source_id": concept_a.id.to_string(),
             "target_id": concept_b.id.to_string(),
@@ -1053,8 +1060,8 @@ async fn bulk_link_errors_receive_endpoint_attribution_in_both_modes() {
         .expect_err("atomic bulk with an illegal entry must be rejected")
         .to_string();
     assert!(
-        atomic_err.contains("entry 1:"),
-        "atomic error must name the offending entry index: {atomic_err}"
+        atomic_err.contains("entry 2:"),
+        "atomic error must name the caller's entry index across dedup skips: {atomic_err}"
     );
     assert!(
         atomic_err.contains(&format!("source {doc_short} resolved as document")),
@@ -1074,8 +1081,8 @@ async fn bulk_link_errors_receive_endpoint_attribution_in_both_modes() {
         .as_str()
         .expect("error string");
     assert_eq!(
-        non_atomic["errors"][0]["index"], 1,
-        "non-atomic error must keep the entry index"
+        non_atomic["errors"][0]["index"], 2,
+        "non-atomic error must keep the caller's entry index"
     );
     assert!(
         entry_err.contains(&format!("source {doc_short} resolved as document")),

--- a/crates/khive-pack-kg/src/handlers/tests.rs
+++ b/crates/khive-pack-kg/src/handlers/tests.rs
@@ -931,6 +931,158 @@ async fn link_invalid_relation_error_attributes_each_resolved_kind_to_short_id()
     );
 }
 
+#[tokio::test]
+async fn link_invalid_relation_error_attributes_typed_entity_subtypes() {
+    use crate::KgPack;
+    use khive_pack_formal::FormalPack;
+    use khive_runtime::{KhiveRuntime, VerbRegistryBuilder};
+
+    let rt = KhiveRuntime::memory().expect("in-memory runtime");
+    let token = rt.authorize(khive_runtime::Namespace::local()).unwrap();
+    let source = rt
+        .create_entity(
+            &token,
+            "concept",
+            Some("theorem"),
+            "Src theorem",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .expect("create typed source");
+    let target = rt
+        .create_entity(
+            &token,
+            "concept",
+            Some("definition"),
+            "Tgt definition",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .expect("create typed target");
+    let source_short: String = source.id.to_string().chars().take(8).collect();
+    let target_short: String = target.id.to_string().chars().take(8).collect();
+
+    let pack = KgPack::new(rt.clone());
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    builder.register(FormalPack::new(rt.clone()));
+    let registry = builder.build().expect("kg+formal registry builds");
+    rt.install_edge_rules(registry.all_edge_rules());
+
+    let error = pack
+        .handle_link(
+            &token,
+            json!({
+                "source_id": source.id.to_string(),
+                "target_id": target.id.to_string(),
+                "relation": "implements",
+            }),
+            &registry,
+        )
+        .await
+        .expect_err("concept/theorem->concept/definition implements must be rejected")
+        .to_string();
+
+    assert!(
+        error.contains(&format!(
+            "source {source_short} resolved as concept/theorem"
+        )),
+        "source label must carry the typed subtype: {error}"
+    );
+    assert!(
+        error.contains(&format!(
+            "target {target_short} resolved as concept/definition"
+        )),
+        "target label must carry the typed subtype: {error}"
+    );
+    assert!(
+        error.contains("for concept/theorem\u{2192}concept/definition"),
+        "relation description must name the typed pair: {error}"
+    );
+}
+
+#[tokio::test]
+async fn bulk_link_errors_receive_endpoint_attribution_in_both_modes() {
+    use crate::KgPack;
+    use khive_runtime::{KhiveRuntime, VerbRegistryBuilder};
+
+    let rt = KhiveRuntime::memory().expect("in-memory runtime");
+    let token = rt.authorize(khive_runtime::Namespace::local()).unwrap();
+    let concept_a = rt
+        .create_entity(&token, "concept", None, "A", None, None, vec![])
+        .await
+        .expect("create concept a");
+    let concept_b = rt
+        .create_entity(&token, "concept", None, "B", None, None, vec![])
+        .await
+        .expect("create concept b");
+    let document = rt
+        .create_entity(&token, "document", None, "Doc", None, None, vec![])
+        .await
+        .expect("create document");
+    let doc_short: String = document.id.to_string().chars().take(8).collect();
+
+    let pack = KgPack::new(rt.clone());
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    let registry = builder.build().expect("kg registry builds");
+    rt.install_edge_rules(registry.all_edge_rules());
+
+    // Entry 0 is legal, entry 1 is the allowlist rejection — proving the
+    // attribution names the offending entry, not just the first one.
+    let links = json!([
+        {
+            "source_id": concept_a.id.to_string(),
+            "target_id": concept_b.id.to_string(),
+            "relation": "extends",
+        },
+        {
+            "source_id": document.id.to_string(),
+            "target_id": concept_a.id.to_string(),
+            "relation": "extends",
+        },
+    ]);
+
+    let atomic_err = pack
+        .handle_link(&token, json!({"links": links, "atomic": true}), &registry)
+        .await
+        .expect_err("atomic bulk with an illegal entry must be rejected")
+        .to_string();
+    assert!(
+        atomic_err.contains("entry 1:"),
+        "atomic error must name the offending entry index: {atomic_err}"
+    );
+    assert!(
+        atomic_err.contains(&format!("source {doc_short} resolved as document")),
+        "atomic error must attribute the offending resolved endpoints: {atomic_err}"
+    );
+
+    let non_atomic = pack
+        .handle_link(&token, json!({"links": links, "atomic": false}), &registry)
+        .await
+        .expect("non-atomic bulk returns per-entry errors");
+    assert_eq!(
+        non_atomic["created"], 1,
+        "legal entry must still be created"
+    );
+    assert_eq!(non_atomic["failed"], 1, "illegal entry must fail");
+    let entry_err = non_atomic["errors"][0]["error"]
+        .as_str()
+        .expect("error string");
+    assert_eq!(
+        non_atomic["errors"][0]["index"], 1,
+        "non-atomic error must keep the entry index"
+    );
+    assert!(
+        entry_err.contains(&format!("source {doc_short} resolved as document")),
+        "non-atomic error must attribute the resolved endpoints: {entry_err}"
+    );
+}
+
 fn configured_kg_endpoint_test_surface() -> (
     khive_runtime::KhiveRuntime,
     khive_runtime::NamespaceToken,
@@ -1005,14 +1157,15 @@ async fn bulk_link_symmetric_rejection_preserves_requested_pair_in_both_modes() 
                 .to_string()
         };
 
+        // Bulk allowlist errors are now enriched like the singleton path; the
+        // #1606 invariant is unchanged — the diagnostic must name the
+        // caller-ordered pair, never the UUID-canonical reverse pair.
         assert!(
-            message.contains(
-                "currently legal relations for concept -> project under the loaded endpoint rules: none"
-            ),
+            message.contains("No valid relations exist for concept\u{2192}project"),
             "atomic={atomic} must diagnose the caller-ordered pair; got: {message}"
         );
         assert!(
-            !message.contains("currently legal relations for project -> concept"),
+            !message.contains("project\u{2192}concept") && !message.contains("project -> concept"),
             "atomic={atomic} must not diagnose the UUID-canonical reverse pair; got: {message}"
         );
     }

--- a/crates/khive-pack-kg/src/handlers/tests.rs
+++ b/crates/khive-pack-kg/src/handlers/tests.rs
@@ -883,6 +883,54 @@ async fn link_invalid_relation_error_suggests_valid_relations() {
     );
 }
 
+#[tokio::test]
+async fn link_invalid_relation_error_attributes_each_resolved_kind_to_short_id() {
+    use crate::KgPack;
+    use khive_runtime::{KhiveRuntime, VerbRegistryBuilder};
+
+    let rt = KhiveRuntime::memory().expect("in-memory runtime");
+    let token = rt.authorize(khive_runtime::Namespace::local()).unwrap();
+    let source = rt
+        .create_entity(&token, "document", None, "Source", None, None, vec![])
+        .await
+        .expect("create source document");
+    let target = rt
+        .create_entity(&token, "concept", None, "Target", None, None, vec![])
+        .await
+        .expect("create target concept");
+    let source_short: String = source.id.to_string().chars().take(8).collect();
+    let target_short: String = target.id.to_string().chars().take(8).collect();
+
+    let pack = KgPack::new(rt.clone());
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    let registry = builder.build().expect("kg registry builds");
+    rt.install_edge_rules(registry.all_edge_rules());
+
+    let error = pack
+        .handle_link(
+            &token,
+            json!({
+                "source_id": source.id.to_string(),
+                "target_id": target.id.to_string(),
+                "relation": "extends",
+            }),
+            &registry,
+        )
+        .await
+        .expect_err("document->concept extends must be rejected")
+        .to_string();
+
+    assert!(
+        error.contains(&format!("source {source_short} resolved as document")),
+        "source id must be attributed to its resolved kind: {error}"
+    );
+    assert!(
+        error.contains(&format!("target {target_short} resolved as concept")),
+        "target id must be attributed to its resolved kind: {error}"
+    );
+}
+
 fn configured_kg_endpoint_test_surface() -> (
     khive_runtime::KhiveRuntime,
     khive_runtime::NamespaceToken,


### PR DESCRIPTION
## Summary

- attribute each rejected edge endpoint's short id to its resolved entity kind
- retain the existing relation allowlist and corrective hint without changing validation outcomes
- cover distinct source/target kinds through the real link handler path

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p khive-pack-kg --all-targets -- -D warnings`
- `cargo test -p khive-pack-kg`

This change is limited to endpoint error enrichment; ops-file summary behavior is unchanged.

Fixes #1966
