### PR TITLE
perf: use indexed ranges for short-ID resolution

### DIFF
--- a/crates/khive-pack-knowledge/src/knowledge/crud.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/crud.rs
@@ -3,7 +3,7 @@
 use serde_json::{json, Value};
 use uuid::Uuid;
 
-use khive_runtime::{hex_prefix_to_uuid_pattern, KhiveRuntime, NamespaceToken, RuntimeError};
+use khive_runtime::{uuid_prefix_bounds, KhiveRuntime, NamespaceToken, RuntimeError};
 use khive_storage::types::{SqlStatement, SqlValue};
 
 use super::schema::{
@@ -16,6 +16,24 @@ use super::util::{
     tags_to_json, validate_atom_content,
 };
 use super::KnowledgeHandlers;
+
+fn knowledge_get_prefix_statement(prefix: &str) -> Option<SqlStatement> {
+    let (lower, upper) = uuid_prefix_bounds(prefix)?;
+    Some(SqlStatement {
+        // A domain's FTS mirror atom has the same UUID. UNION (rather than
+        // UNION ALL) deduplicates that legitimate cross-table duplicate so
+        // one domain is not reported as an ambiguous prefix.
+        sql: "SELECT id FROM knowledge_domains \
+              WHERE id >= ?1 AND id < ?2 AND deleted_at IS NULL \
+              UNION \
+              SELECT id FROM knowledge_atoms \
+              WHERE id >= ?1 AND id < ?2 AND deleted_at IS NULL \
+              ORDER BY id LIMIT 2"
+            .into(),
+        params: vec![SqlValue::Text(lower), SqlValue::Text(upper)],
+        label: Some("knowledge.get.resolve_prefix".into()),
+    })
+}
 
 impl KnowledgeHandlers {
     pub(crate) async fn upsert_atoms(
@@ -490,24 +508,14 @@ impl KnowledgeHandlers {
             }
 
             if id.len() >= 8 && id.chars().all(|c| c.is_ascii_hexdigit()) {
-                let pattern = format!("{}%", hex_prefix_to_uuid_pattern(&id));
-                // A domain's FTS mirror atom has the same UUID. UNION (rather than
-                // UNION ALL) deduplicates that legitimate cross-table duplicate so
-                // one domain is not reported as an ambiguous prefix.
-                let rows = reader
-                    .query_all(SqlStatement {
-                        sql: "SELECT id FROM knowledge_domains \
-                              WHERE id LIKE ?1 AND deleted_at IS NULL \
-                              UNION \
-                              SELECT id FROM knowledge_atoms \
-                              WHERE id LIKE ?1 AND deleted_at IS NULL \
-                              ORDER BY id LIMIT 2"
-                            .into(),
-                        params: vec![SqlValue::Text(pattern)],
-                        label: Some("knowledge.get.resolve_prefix".into()),
-                    })
-                    .await
-                    .map_err(|e| sql_err("get by prefix", e))?;
+                let rows = if let Some(statement) = knowledge_get_prefix_statement(&id) {
+                    reader
+                        .query_all(statement)
+                        .await
+                        .map_err(|e| sql_err("get by prefix", e))?
+                } else {
+                    Vec::new()
+                };
                 let matches: Vec<String> =
                     rows.iter().filter_map(|row| row_str(row, "id")).collect();
                 match matches.as_slice() {
@@ -983,6 +991,49 @@ mod tests {
     // requiring a live DB connection.
 
     use khive_runtime::secret_gate::check;
+    use khive_runtime::{KhiveRuntime, VerbRegistryBuilder};
+    use khive_storage::SqlValue;
+
+    #[tokio::test]
+    async fn get_prefix_query_plan_uses_primary_key_range_seeks() {
+        let runtime = KhiveRuntime::memory().expect("memory runtime");
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
+        builder.register(crate::KnowledgePack::new(runtime.clone()));
+        let registry = builder.build().expect("registry builds");
+        registry.apply_schema_plans(runtime.backend());
+
+        let mut reader = runtime.sql().reader().await.expect("prefix plan reader");
+        let rows = reader
+            .explain(
+                super::knowledge_get_prefix_statement("0b6cf134")
+                    .expect("valid compact UUID prefix"),
+            )
+            .await
+            .expect("explain knowledge prefix query");
+        let details: Vec<String> = rows
+            .iter()
+            .filter_map(|row| match row.get("detail") {
+                Some(SqlValue::Text(detail)) => Some(detail.clone()),
+                _ => None,
+            })
+            .collect();
+
+        assert!(
+            ["knowledge_domains", "knowledge_atoms"]
+                .iter()
+                .all(|table| {
+                    details.iter().any(|detail| {
+                        detail.contains(&format!("SEARCH {table}"))
+                            && detail.contains("id>?")
+                            && detail.contains("id<?")
+                    }) && !details
+                        .iter()
+                        .any(|detail| detail.contains(&format!("SCAN {table}")))
+                }),
+            "knowledge.get short-id tables must use primary-key range seeks: {details:?}"
+        );
+    }
 
     #[test]
     fn atom_body_with_fake_aws_key_is_blocked() {

--- a/crates/khive-pack-knowledge/tests/integration.rs
+++ b/crates/khive-pack-knowledge/tests/integration.rs
@@ -1183,6 +1183,68 @@ async fn get_rejects_ambiguous_prefix_across_distinct_knowledge_records() {
 }
 
 #[tokio::test]
+async fn get_prefix_range_preserves_boundaries_ambiguity_and_not_found() {
+    const IDS: [&str; 4] = [
+        "0abcdefe-ffff-4fff-8fff-ffffffffffff",
+        "0abcdeff-0000-4000-8000-000000000001",
+        "0abcdeff-1000-4000-8000-000000000002",
+        "0abcdf00-0000-4000-8000-000000000003",
+    ];
+
+    let runtime = rt();
+    let f = pack(runtime.clone());
+    let statements = IDS
+        .iter()
+        .enumerate()
+        .map(|(index, id)| SqlStatement {
+            sql: "INSERT INTO knowledge_atoms \
+                  (id, namespace, slug, name, content, created_at, updated_at) \
+                  VALUES (?1, 'local', ?2, ?3, 'range control content', 1, 1)"
+                .into(),
+            params: vec![
+                SqlValue::Text((*id).into()),
+                SqlValue::Text(format!("range-control-{index}")),
+                SqlValue::Text(format!("Range Control {index}")),
+            ],
+            label: Some("test.knowledge_get.range_control".into()),
+        })
+        .collect();
+    let mut writer = runtime.sql().writer().await.expect("knowledge writer");
+    writer
+        .execute_batch(statements)
+        .await
+        .expect("seed range controls");
+    drop(writer);
+
+    let unique = f
+        .dispatch("knowledge.get", json!({ "id": "0abcdeff0" }))
+        .await
+        .expect("ninth compact digit must exclude adjacent UUIDs");
+    assert_eq!(unique["id"], IDS[1]);
+
+    let ambiguous = f
+        .dispatch("knowledge.get", json!({ "id": "0abcdeff" }))
+        .await
+        .expect_err("both UUIDs inside the eight-digit range must be ambiguous");
+    assert!(
+        matches!(
+            ambiguous,
+            RuntimeError::AmbiguousPrefix { ref matches, .. } if matches.len() == 2
+        ),
+        "the two in-range records must remain ambiguous: {ambiguous:?}"
+    );
+
+    let missing = f
+        .dispatch("knowledge.get", json!({ "id": "0abcdeff2" }))
+        .await
+        .expect_err("adjacent UUIDs must not become prefix hits");
+    assert!(
+        matches!(missing, RuntimeError::InvalidInput(ref message) if message.contains("no knowledge record matches prefix")),
+        "a range containing only adjacent UUIDs must remain not found: {missing:?}"
+    );
+}
+
+#[tokio::test]
 async fn get_by_id_is_namespace_agnostic_and_loads_sections_from_stored_namespace() {
     let f = pack(rt());
     let foreign_namespace = "identifier-contract-foreign";

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -111,8 +111,8 @@ pub use operations::{
 };
 pub use operations::{
     base_entity_endpoint_rules, base_entity_rule_allows, endpoint_matches,
-    hex_prefix_to_uuid_pattern, merge_entry_metadata, EdgeEndpointKind, EntityCreateSpec, LinkSpec,
-    NoteSearchHit, QueryResult, Resolved,
+    hex_prefix_to_uuid_pattern, merge_entry_metadata, uuid_prefix_bounds, EdgeEndpointKind,
+    EntityCreateSpec, LinkSpec, NoteSearchHit, QueryResult, Resolved,
 };
 pub use pack::{
     resolve_explicit_namespace, ChannelIngestCapability, DispatchHook, HandlerDef,

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -315,6 +315,118 @@ pub fn hex_prefix_to_uuid_pattern(prefix: &str) -> String {
     out
 }
 
+/// Return the inclusive lower and exclusive upper bounds for a UUID prefix
+/// stored as a canonical lowercase UUID string under SQLite's BINARY collation.
+///
+/// Compact hexadecimal prefixes and prefixes of the canonical dashed spelling
+/// are accepted. The returned bounds are canonicalized to lowercase; malformed
+/// dashed spellings and prefixes longer than one UUID fail closed. The upper
+/// bound is the shortest lexicographic successor, so a trailing run of `f`
+/// digits carries into the preceding digit. `g` is the exclusive sentinel when
+/// the prefix is all `f`, because canonical UUID strings contain only `0`-`f`.
+pub fn uuid_prefix_bounds(prefix: &str) -> Option<(String, String)> {
+    const HYPHEN_POSITIONS: [usize; 4] = [8, 13, 18, 23];
+
+    let compact = if prefix.contains('-') {
+        if prefix.len() > 36 {
+            return None;
+        }
+        let mut compact = String::with_capacity(32);
+        for (index, byte) in prefix.bytes().enumerate() {
+            if HYPHEN_POSITIONS.contains(&index) {
+                if byte != b'-' {
+                    return None;
+                }
+            } else if byte.is_ascii_hexdigit() {
+                compact.push(char::from(byte.to_ascii_lowercase()));
+            } else {
+                return None;
+            }
+        }
+        compact
+    } else {
+        if prefix.is_empty()
+            || prefix.len() > 32
+            || !prefix.bytes().all(|byte| byte.is_ascii_hexdigit())
+        {
+            return None;
+        }
+        prefix.to_ascii_lowercase()
+    };
+
+    if compact.is_empty() || compact.len() > 32 {
+        return None;
+    }
+
+    let lower = hex_prefix_to_uuid_pattern(&compact);
+    let mut successor = compact.into_bytes();
+    let mut carried_past_start = true;
+    for index in (0..successor.len()).rev() {
+        let next = match successor[index] {
+            b'0'..=b'8' | b'a'..=b'e' => Some(successor[index] + 1),
+            b'9' => Some(b'a'),
+            b'f' => None,
+            _ => return None,
+        };
+        if let Some(next) = next {
+            successor[index] = next;
+            successor.truncate(index + 1);
+            carried_past_start = false;
+            break;
+        }
+    }
+
+    let upper = if carried_past_start {
+        "g".to_string()
+    } else {
+        let compact_upper = String::from_utf8(successor).ok()?;
+        hex_prefix_to_uuid_pattern(&compact_upper)
+    };
+    Some((lower, upper))
+}
+
+fn resolve_prefix_statement(
+    table: &str,
+    has_deleted_at: bool,
+    include_deleted: bool,
+    namespaces: Option<&[String]>,
+    lower: &str,
+    upper: &str,
+) -> SqlStatement {
+    let namespace_clause = namespaces.map(|namespaces| {
+        let placeholders: Vec<String> = (0..namespaces.len())
+            .map(|index| format!("?{}", index + 3))
+            .collect();
+        format!(" AND namespace IN ({})", placeholders.join(", "))
+    });
+    let deleted_filter = if has_deleted_at && !include_deleted {
+        " AND deleted_at IS NULL"
+    } else {
+        ""
+    };
+    let mut params = vec![
+        SqlValue::Text(lower.to_owned()),
+        SqlValue::Text(upper.to_owned()),
+    ];
+    if let Some(namespaces) = namespaces {
+        params.extend(
+            namespaces
+                .iter()
+                .map(|namespace| SqlValue::Text(namespace.clone())),
+        );
+    }
+
+    SqlStatement {
+        sql: format!(
+            "SELECT id FROM {table} \
+             WHERE id >= ?1 AND id < ?2{namespace_clause}{deleted_filter} LIMIT 2",
+            namespace_clause = namespace_clause.as_deref().unwrap_or("")
+        ),
+        params,
+        label: Some("resolve_prefix".into()),
+    }
+}
+
 fn text_preview(text: &str, max_chars: usize) -> Option<String> {
     let trimmed = text.trim();
     if trimmed.is_empty() {
@@ -4195,9 +4307,9 @@ impl KhiveRuntime {
         self.resolve_prefix_inner(None, prefix, true).await
     }
 
-    /// Shared prefix-scan implementation over an explicit namespace set.
+    /// Shared indexed prefix-range lookup over an explicit namespace set.
     ///
-    /// `namespaces` selects the scan scope: `Some(&[ns])` reproduces the
+    /// `namespaces` selects the lookup scope: `Some(&[ns])` reproduces the
     /// historical primary-only behaviour (`resolve_prefix` /
     /// `resolve_prefix_including_deleted`); `None` applies
     /// no namespace predicate at all (`resolve_prefix_unfiltered*`).
@@ -4212,21 +4324,15 @@ impl KhiveRuntime {
         prefix: &str,
         include_deleted: bool,
     ) -> RuntimeResult<Option<Uuid>> {
-        use khive_storage::types::{SqlStatement, SqlValue};
-
         // Every caller is expected to pre-validate hex-only input, but this is
         // the single choke point every `resolve_prefix*` variant funnels
         // through, so re-validate here too. A prefix containing anything other
-        // than hex digits and
-        // canonical hyphen separators (`%`, `_`, or other LIKE-wildcard /
+        // than hex digits and canonical hyphen separators (`%`, `_`, or other
         // injection-shaped input) never matches a real id and is rejected
-        // before it can reach the LIKE pattern, instead of relying on bound
-        // params alone to neutralize wildcard semantics.
+        // before it can reach the range query.
         if !prefix.chars().all(|c| c.is_ascii_hexdigit() || c == '-') {
             return Ok(None);
         }
-
-        let pattern = format!("{}%", hex_prefix_to_uuid_pattern(prefix));
 
         // Injection: check PREFIX_RESOLVE_FAIL_NS (armed by
         // `arm_prefix_resolve_fail_scoped(prefix)`), exercising the storage-failure path
@@ -4240,6 +4346,10 @@ impl KhiveRuntime {
             ));
         }
 
+        let Some((lower, upper)) = uuid_prefix_bounds(prefix) else {
+            return Ok(None);
+        };
+
         let tables = [
             ("entities", true),
             ("notes", true),
@@ -4247,14 +4357,9 @@ impl KhiveRuntime {
             ("graph_edges", false),
         ];
 
-        let ns_clause = namespaces.map(|ns| {
-            let placeholders: Vec<String> = (0..ns.len()).map(|i| format!("?{}", i + 2)).collect();
-            format!(" AND namespace IN ({})", placeholders.join(", "))
-        });
-
         // A UUID can legitimately exist in more than one scanned table
         // (e.g. an entity id string that also happens to be an edge id — the
-        // scan is purely a text-prefix LIKE across independent tables, not a
+        // lookup is a text-prefix range across independent tables, not a
         // substrate-exclusive lookup). Without dedup, a single record hit
         // twice across tables inflated `matches.len()` past 1 and produced a
         // false `AmbiguousPrefix` naming the SAME UUID twice. `seen` tracks
@@ -4265,23 +4370,14 @@ impl KhiveRuntime {
         let mut reader = self.sql().reader().await.map_err(RuntimeError::Storage)?;
 
         for (table, has_deleted_at) in tables {
-            let deleted_filter = if has_deleted_at && !include_deleted {
-                " AND deleted_at IS NULL"
-            } else {
-                ""
-            };
-            let mut params = vec![SqlValue::Text(pattern.clone())];
-            if let Some(ns) = namespaces {
-                params.extend(ns.iter().map(|n| SqlValue::Text(n.clone())));
-            }
-            let sql = SqlStatement {
-                sql: format!(
-                    "SELECT id FROM {table} WHERE id LIKE ?1{ns_clause}{deleted_filter} LIMIT 2",
-                    ns_clause = ns_clause.as_deref().unwrap_or("")
-                ),
-                params,
-                label: Some("resolve_prefix".into()),
-            };
+            let sql = resolve_prefix_statement(
+                table,
+                has_deleted_at,
+                include_deleted,
+                namespaces,
+                &lower,
+                &upper,
+            );
             match reader.query_all(sql).await {
                 Ok(rows) => {
                     for row in rows {
@@ -6131,13 +6227,62 @@ mod tests {
     use crate::runtime::{KhiveRuntime, NamespaceToken};
     use crate::{ActorRef, Namespace};
     use async_trait::async_trait;
-    use khive_storage::types::PathNode;
+    use khive_storage::types::{PathNode, SqlValue};
     use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService, MAX_TEXT_BYTES};
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::Arc;
 
     fn rt() -> KhiveRuntime {
         KhiveRuntime::memory().unwrap()
+    }
+
+    #[tokio::test]
+    async fn resolve_prefix_query_plan_uses_primary_key_range_seeks() {
+        let rt = rt();
+        let mut reader = rt.sql().reader().await.expect("prefix plan reader");
+        let mut plans = Vec::new();
+        let (lower, upper) =
+            super::uuid_prefix_bounds("0b6cf134").expect("valid compact UUID prefix");
+
+        for (table, has_deleted_at) in [
+            ("entities", true),
+            ("notes", true),
+            ("events", false),
+            ("graph_edges", false),
+        ] {
+            let rows = reader
+                .explain(super::resolve_prefix_statement(
+                    table,
+                    has_deleted_at,
+                    false,
+                    None,
+                    &lower,
+                    &upper,
+                ))
+                .await
+                .expect("explain prefix query");
+            let details: Vec<String> = rows
+                .iter()
+                .filter_map(|row| match row.get("detail") {
+                    Some(SqlValue::Text(detail)) => Some(detail.clone()),
+                    _ => None,
+                })
+                .collect();
+            plans.push((table, details));
+        }
+
+        assert!(
+            plans.iter().all(|(table, details)| {
+                details.iter().any(|detail| {
+                    detail.contains(&format!("SEARCH {table}"))
+                        && detail.contains("id>?")
+                        && detail.contains("id<?")
+                }) && !details
+                    .iter()
+                    .any(|detail| detail.contains(&format!("SCAN {table}")))
+            }),
+            "every short-id table must use a primary-key range seek: {plans:?}"
+        );
     }
 
     #[test]
@@ -8732,6 +8877,44 @@ mod tests {
         assert_eq!(hex_prefix_to_uuid_pattern(partial), partial);
     }
 
+    #[test]
+    fn uuid_prefix_bounds_are_canonical_lowercase_half_open_ranges() {
+        assert_eq!(
+            super::uuid_prefix_bounds("0ABCDEFF"),
+            Some(("0abcdeff".into(), "0abcdf".into()))
+        );
+        assert_eq!(
+            super::uuid_prefix_bounds("aabbccdd1"),
+            Some(("aabbccdd-1".into(), "aabbccdd-2".into()))
+        );
+        assert_eq!(
+            super::uuid_prefix_bounds("AABBCCDD-19FF"),
+            Some(("aabbccdd-19ff".into(), "aabbccdd-1a".into()))
+        );
+        assert_eq!(
+            super::uuid_prefix_bounds("ffffffff"),
+            Some(("ffffffff".into(), "g".into()))
+        );
+    }
+
+    #[test]
+    fn uuid_prefix_bounds_reject_malformed_or_overlong_input() {
+        for invalid in [
+            "",
+            "aabbccdd_",
+            "aabbccdd1-",
+            "aabbccdd-11111",
+            "aabbccdd--",
+            "aabbccdd112240008000000000000ab1f",
+        ] {
+            assert_eq!(
+                super::uuid_prefix_bounds(invalid),
+                None,
+                "invalid prefix {invalid:?} must fail closed"
+            );
+        }
+    }
+
     #[tokio::test]
     async fn resolve_prefix_compact_9_to_31_char_matches() {
         let rt = rt();
@@ -8842,6 +9025,41 @@ mod tests {
                 "boundary prefix of len {len} should resolve"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn resolve_prefix_range_preserves_boundaries_ambiguity_and_not_found() {
+        use khive_storage::entity::Entity;
+
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let ids = [
+            "0abcdefe-ffff-4fff-8fff-ffffffffffff",
+            "0abcdeff-0000-4000-8000-000000000001",
+            "0abcdeff-1000-4000-8000-000000000002",
+            "0abcdf00-0000-4000-8000-000000000003",
+        ];
+        let store = rt.entities(&tok).unwrap();
+        for (index, id) in ids.into_iter().enumerate() {
+            let mut entity = Entity::new("local", "concept", format!("RangeControl{index}"));
+            entity.id = Uuid::parse_str(id).unwrap();
+            store.upsert_entity(entity).await.unwrap();
+        }
+
+        let unique = rt.resolve_prefix(&tok, "0abcdeff0").await.unwrap();
+        assert_eq!(unique, Some(Uuid::parse_str(ids[1]).unwrap()));
+
+        let ambiguous = rt.resolve_prefix(&tok, "0abcdeff").await.unwrap_err();
+        assert!(
+            matches!(
+                ambiguous,
+                RuntimeError::AmbiguousPrefix { ref matches, .. } if matches.len() == 2
+            ),
+            "the two in-range UUIDs must remain ambiguous: {ambiguous:?}"
+        );
+
+        let missing = rt.resolve_prefix(&tok, "0abcdeff2").await.unwrap();
+        assert_eq!(missing, None, "adjacent UUIDs must not become prefix hits");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- canonicalize validated UUID prefixes into lowercase inclusive/exclusive bounds
- use BINARY primary-key range seeks for runtime and `knowledge.get` short-ID resolution while preserving namespace, deletion, deduplication, ambiguity, exact-ID, and exact-slug behavior
- cover the production query builders with real-schema query-plan regressions and semantic boundary, ambiguity, and not-found controls

## Query-plan evidence

Before, all six prefix paths used `SCAN` (6 `SCAN`, 0 bounded `SEARCH`):

- `SCAN entities USING INDEX idx_entities_namespace_name_ci`
- `SCAN notes`
- `SCAN events USING COVERING INDEX sqlite_autoindex_events_1`
- `SCAN graph_edges USING COVERING INDEX idx_graph_edges_id_unique`
- `SCAN knowledge_domains USING INDEX sqlite_autoindex_knowledge_domains_1`
- `SCAN knowledge_atoms USING INDEX sqlite_autoindex_knowledge_atoms_1`

After, all six paths use `SEARCH ... (id>? AND id<?)` (0 `SCAN`, 6 bounded `SEARCH`):

- entities: planner row `(4, 0, 163)`, `SEARCH entities USING INDEX sqlite_autoindex_entities_1 (id>? AND id<?)`
- notes: planner row `(4, 0, 163)`, `SEARCH notes USING INDEX sqlite_autoindex_notes_1 (id>? AND id<?)`
- events: planner row `(3, 0, 149)`, `SEARCH events USING COVERING INDEX sqlite_autoindex_events_1 (id>? AND id<?)`
- graph edges: planner row `(3, 0, 150)`, `SEARCH graph_edges USING COVERING INDEX idx_graph_edges_id_unique (id>? AND id<?)`
- knowledge domains: planner row `(9, 5, 163)`, `SEARCH knowledge_domains USING INDEX sqlite_autoindex_knowledge_domains_1 (id>? AND id<?)`
- knowledge atoms: planner row `(30, 26, 163)`, `SEARCH knowledge_atoms USING INDEX sqlite_autoindex_knowledge_atoms_1 (id>? AND id<?)`

Issue #1925 is subsumed by making the advertised short-prefix path use this indexed bounded lookup. Timeout taxonomy and reader-pool behavior are unchanged.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p khive-runtime -p khive-pack-knowledge --all-targets -- -D warnings`
- `cargo test -p khive-runtime -p khive-pack-knowledge`

Fixes #2067
Fixes #1925
