### PR TITLE
docs: add missing crate design overviews

### DIFF
--- a/crates/khive-channel-telegram/docs/design.md
+++ b/crates/khive-channel-telegram/docs/design.md
@@ -1,0 +1,42 @@
+# khive-channel-telegram Design
+
+## Purpose
+
+`khive-channel-telegram` adapts the transport-neutral `khive-channel::Channel` contract to the
+Telegram Bot API. It uses the `sendMessage` and long-polling `getUpdates` HTTPS/JSON methods
+directly, without a Telegram SDK.
+
+## Key types
+
+- `TelegramChannelConfig` is the environment-only configuration: bot token, authorized maintainer
+  chat id, routable maintainer slug, and inbound namespace.
+- `TelegramChannel` implements `Channel`, converts authenticated text updates to
+  `ChannelEnvelope`, and owns the confirmed and pending `getUpdates` offsets.
+- The crate-private `TelegramConnector` trait isolates the two Bot API calls. The live
+  `reqwest` implementation is replaced by deterministic mocks in unit tests.
+- `TelegramUpdate`, `TelegramMessage`, and `TelegramChat` model only the response fields the
+  adapter consumes; other Telegram JSON fields are intentionally ignored.
+
+## Configuration
+
+The adapter requires `KHIVE_TELEGRAM_BOT_TOKEN` and a numeric
+`KHIVE_TELEGRAM_MAINTAINER_CHAT_ID`. `KHIVE_TELEGRAM_MAINTAINER_SLUG` defaults to `maintainer`, and
+`KHIVE_TELEGRAM_INGEST_NAMESPACE` defaults to `local`. No filesystem configuration is read.
+
+## Invariants
+
+- V1 is a single-maintainer channel. Inbound updates from any other chat id and updates without
+  text are dropped without creating an envelope. Outbound addresses other than the configured
+  `telegram:<maintainer_slug>` are logged and dropped, never redirected to the maintainer.
+- Bot tokens must not appear in diagnostics. `TelegramChannelConfig` has a manual `Debug`
+  implementation that masks the token, and connector errors remove request URLs containing it.
+- `poll` uses Telegram's offset watermark and ignores its timestamp argument. A fetched batch only
+  records a `pending_offset`; `commit_offset` advances the confirmed offset after every authorized
+  envelope from that batch has durably passed through `comm.ingest`.
+- Until `commit_offset` runs, the next poll repeats the previous offset. This is intentional
+  at-least-once delivery, made safe by the stable external id `tg:<chat_id>:<update_id>` and the
+  communication store's unique deduplication index.
+- The in-memory offset is not restart-durable. Restart recovery relies on Telegram redelivery and
+  the durable external-id deduplication boundary.
+- Production uses a 25-second Bot API long poll with a longer client timeout. Tests inject a
+  connector or test-only base URL and do not make live Telegram calls.

--- a/crates/khive-channel-telegram/docs/design.md
+++ b/crates/khive-channel-telegram/docs/design.md
@@ -26,8 +26,10 @@ The adapter requires `KHIVE_TELEGRAM_BOT_TOKEN` and a numeric
 ## Invariants
 
 - V1 is a single-maintainer channel. Inbound updates from any other chat id and updates without
-  text are dropped without creating an envelope. Outbound addresses other than the configured
-  `telegram:<maintainer_slug>` are logged and dropped, never redirected to the maintainer.
+  text are dropped without creating an envelope. Outbound delivery accepts the configured
+  maintainer address in two spellings — `telegram:<maintainer_slug>` or the bare
+  `<maintainer_slug>` (the kind prefix is stripped when present, not required) — and every other
+  address is logged and dropped, never redirected to the maintainer.
 - Bot tokens must not appear in diagnostics. `TelegramChannelConfig` has a manual `Debug`
   implementation that masks the token, and connector errors remove request URLs containing it.
 - `poll` uses Telegram's offset watermark and ignores its timestamp argument. A fetched batch only

--- a/crates/khive-channel/docs/design.md
+++ b/crates/khive-channel/docs/design.md
@@ -1,0 +1,48 @@
+# khive-channel Design
+
+## Purpose
+
+`khive-channel` is the transport-neutral boundary between khive's communication runtime and
+concrete message adapters. It defines how outbound messages are delivered, how inbound messages
+are polled, and how configured adapters are registered. Persistence, authorization policy, and
+`comm.ingest` dispatch remain outside this crate.
+
+## Key types
+
+- `Channel` is the asynchronous adapter contract. Implementations expose a stable transport
+  `kind`, an optional per-credential `slug`, outbound `send`, and inbound `poll`/`poll_page`.
+- `ChannelEnvelope` carries normalized addresses, content, transport metadata, deduplication and
+  thread-correlation identifiers, and email reply headers across the adapter/runtime boundary.
+- `QuarantineReplay` retains byte-exact inbound transport content in memory until durable handling
+  decides whether it must be quarantined.
+- `ChannelCheckpoint`, `StoredChannelCheckpoint`, and `ChannelPollPage` represent durable,
+  transport-neutral high-water progress for checkpoint-aware polling.
+- `ChannelRegistry` owns adapters by their `(kind, slug)` identity and exposes iteration and exact
+  composite lookup.
+- `ChannelError` is the shared configuration, transport, authentication, authorization, and
+  envelope-validation error taxonomy.
+
+## Invariants
+
+- A channel's durable identity is the composite `(kind, slug)`. Distinct credentials of the same
+  transport kind must coexist; registering the same composite identity replaces the old adapter.
+- `ChannelRegistry::get(kind)` is only deterministic for the common one-credential-per-kind case.
+  Code that selects among multiple credentials must use `get_by_slug`.
+- The `Channel` trait intentionally does not require `Debug`: concrete adapters may contain
+  credentials that must not become log output through a derived implementation.
+- Adapters provide stable external deduplication keys when their transport can do so. Atomic
+  deduplication belongs to `comm.ingest`, not to an adapter's polling loop.
+- A checkpoint is advanced only after every envelope represented by its page has been durably
+  handled. The default `poll_page` is stateless and preserves compatibility with adapters that
+  implement only `poll`.
+- Exact quarantine bytes never travel through serialized `ChannelEnvelope` metadata. The replay
+  field is skipped by serde, and its `Debug` output reveals only the byte count and notification
+  target.
+- `new_thread_correlation_id` returns a canonical hyphenated UUID suitable for external message
+  headers; it does not itself create or resolve an internal thread.
+
+## Runtime relationship
+
+The MCP server owns an `Arc<ChannelRegistry>`, polls its adapters, and forwards accepted envelopes
+to the communication pack. Concrete transports such as `khive-channel-email` and
+`khive-channel-telegram` depend on this crate; this crate does not depend on any one transport.

--- a/crates/khive-pack-agent/docs/design.md
+++ b/crates/khive-pack-agent/docs/design.md
@@ -1,0 +1,39 @@
+# khive-pack-agent Design
+
+## Purpose
+
+`khive-pack-agent` owns the agent-facing wire surface defined by ADR-142: `agent.spawn`,
+`agent.observe`, `agent.suspend`, `agent.resume`, and `agent.kill`. The runtime owns agent process
+records and their durable table; this pack validates parameters and delegates every read and write
+through `khive_storage::AgentStore`.
+
+## Key types and modules
+
+- `AgentPack` holds the injected `Arc<dyn AgentStore>` and implements both the static `Pack`
+  contract and runtime dispatch.
+- `pack.rs` defines the five visible handler descriptions and maps verb names to handlers.
+- `handlers.rs` validates wire parameters, computes spawn fingerprints, serializes records, and
+  applies the shared runtime lifecycle transition table.
+- `vocab.rs` intentionally contributes no note or entity kinds: an agent is a runtime-owned
+  process record, not a graph substrate record.
+- `AgentRecord`, `AgentState`, `TerminalReason`, and transition helpers come from the shared type
+  and runtime crates so storage and the verb surface use the same state model.
+
+## Invariants
+
+- The pack never opens a khive database connection. All process-table access goes through the
+  injected `AgentStore` trait object.
+- `AgentPack` is registered manually with `RegistryBuilder::register`, not through inventory.
+  Inventory factories receive only `KhiveRuntime`, which does not expose the required store under
+  this contract.
+- `agent.spawn` requires non-empty `provider` and `task`. Its fingerprint covers the semantic
+  spawn inputs, while a caller idempotency key is scoped to the owning actor. Reusing a key with
+  different inputs fails instead of silently returning the earlier agent.
+- At most one non-terminal record may bind a `(provider, provider_session_id)` pair.
+- Spawn captures the caller's actor and namespace context in the process record. Native in-process
+  dispatch is marked with the distinguished `native` peer class.
+- Lifecycle changes use the shared transition table. Suspend is legal from running, resume from
+  suspended, and kill from any non-terminal state. Already-suspended, already-running, and
+  already-terminal kill requests are idempotent no-ops where defined by that table.
+- `agent.suspend` does not create a session checkpoint. It reports the checkpoint id already stored
+  on the process record; checkpoint content is outside this verb's input surface.

--- a/crates/khive-pack-blob/docs/design.md
+++ b/crates/khive-pack-blob/docs/design.md
@@ -1,0 +1,43 @@
+# khive-pack-blob Design
+
+## Purpose
+
+`khive-pack-blob` exposes the runtime's installed content-addressed blob service through three MCP
+verbs: `blob.put`, `blob.get`, and `blob.stat`. It is a thin wire adapter over `BlobStore` and
+`BlobHydrator`; it does not implement a storage backend, schema, or graph vocabulary.
+
+## Key types and modules
+
+- `BlobPack` holds the `KhiveRuntime` used to resolve the installed store and shared hydrator.
+- `pack.rs` declares the three agent-visible verbs, inventory-registers the factory, and dispatches
+  calls to `handlers.rs`.
+- `handlers.rs` validates base64 payloads, strict content references and optional ranges, enforces
+  memory/wire bounds, and shapes verb responses.
+- `ContentRef` is the canonical lowercase-hex BLAKE3 identity supplied by `khive-storage`.
+- `vocab.rs` contributes no entity or note kinds; typed artifact/reference modeling is a separate
+  layer.
+
+## Verb contracts
+
+- `blob.put(bytes)` decodes base64, stores the bytes, and returns `{content_ref, size}`. Content
+  addressing makes identical puts idempotent.
+- `blob.get(content_ref, range?)` verifies and hydrates the complete object through the runtime's
+  shared admission controller, then optionally slices it and returns base64 bytes.
+- `blob.stat(content_ref)` reports existence and size through metadata only; it neither hydrates
+  bytes nor implies a lease or reservation.
+
+## Invariants
+
+- The verb surface accepts bytes, never a server-local file path. This prevents a remote caller
+  from turning `blob.put` into host-file exfiltration.
+- Put and whole-object hydration share ADR-111's 64 MiB object ceiling, giving filesystem and S3
+  backends the same externally visible acceptance limit.
+- A `blob.get` response must also fit the daemon frame limit after base64 expansion. Callers use a
+  smaller range when a whole object cannot fit on the wire, even though range slicing currently
+  happens after full verified hydration.
+- `blob.get` uses digest-verified hydration; `blob.stat` deliberately does not claim digest
+  verification because it never reads the content.
+- `blob.put` is unavailable on a read-only runtime. Reads remain available when a store is
+  installed.
+- Physical deletion and orphan sweeping remain administrator-only operations and are not pack
+  verbs.

--- a/crates/khive-pack-moodboard/docs/design.md
+++ b/crates/khive-pack-moodboard/docs/design.md
@@ -1,0 +1,59 @@
+# khive-pack-moodboard Design
+
+## Purpose
+
+`khive-pack-moodboard` is an opt-in experimental pack for raster ingest, exact visual retrieval,
+and actor-scoped pairwise preference learning over Khive substrates. It combines BlobStore content,
+graph entities, identity-bound vector tables, a governed Lattice vision checkpoint, and durable
+preference provenance. It does not register a text embedding provider.
+
+## Storage and identity model
+
+- Original image bytes live in the configured `BlobStore` and are identified by `ContentRef`.
+- Graph identity and metadata live in artifact entities. The pack registers `visual_asset`,
+  `moodboard`, and `moodboard_model` as artifact subtypes; it adds no base entity or note kind.
+- Visual descriptors live in named vector tables whose identity includes the checkpoint,
+  preprocessing, prompt, and descriptor fingerprints. In multi-backend setups, graph entities use
+  the shared core store while vectors stay on the pack-selected runtime.
+- Immutable serve, judgment, and model publication events retain actor, board, descriptor, feature,
+  source-report, pair-selection, and model-artifact provenance.
+
+## Key types and modules
+
+- `MoodboardPack` binds one `KhiveRuntime` and one lazily initialized `VisionModelState`; the pack
+  requires the `kg` pack.
+- `model.rs` verifies checkpoint identity, controls model loading/inference concurrency, and defines
+  immutable descriptor identities.
+- `preprocess.rs` validates and normalizes PNG, JPEG, and WebP rasters into the governed inference
+  rendition.
+- `handlers.rs` implements `moodboard.model`, `moodboard.ingest`, and `moodboard.search`.
+- `preference.rs` defines the fixed ten-feature schema, deterministic pairwise fitting,
+  calibration, split policy, and FANN model bundle.
+- `preference_handlers.rs` implements `moodboard.serve`, `moodboard.judge`,
+  `moodboard.train_preference`, and `moodboard.preference`.
+- `preference_artifact.rs` authenticates persisted model bundles, FANN network attachments, and
+  immutable publication evidence, including the legacy attachment cutover checks.
+
+## Invariants
+
+- Raster admission fails closed before expensive allocation. Decoded input is limited to supported
+  formats, non-zero dimensions, an 8192-pixel source side, a 256 MiB post-decode working budget,
+  and a 64 MiB encoded object ceiling at the verb boundary.
+- Preprocessing is deterministic: alpha is composited onto the fixed RGB `[128,128,128]` matte,
+  images are downscaled without upscaling to a maximum side of 448, dimensions are padded to a
+  multiple of 32, and the inference rendition is encoded as PNG.
+- Ingest stores original bytes, reuses content identity safely under striped locks, and writes the
+  descriptor only into its exact immutable vector space. Search re-derives the query descriptor
+  from canonical BlobStore bytes and compares it only within that space.
+- Descriptor embeddings must have the configured dimension, contain only finite values, and have a
+  valid norm. Checkpoint files and identities are verified before weights are served.
+- Preference features are a closed, ordered ten-value schema in `[0,1]`; its canonical bytes and
+  hash are identity-bearing. A preference model is fenced to one namespace, actor, board,
+  descriptor space, and feature schema.
+- A serve records the exact two result occurrences and deterministic side-randomization provenance.
+  A judgment names those displayed occurrences; exact retries are idempotent, while conflicting
+  retries fail.
+- Training snapshots actor-scoped evidence, keeps unordered pairs in deterministic 70/15/15
+  groups, fits a deterministic zero-intercept logistic objective, calibrates temperature and a tie
+  band, and persists a hashed FANN network plus authenticated bundle. Serving re-verifies both
+  artifacts before inference.

--- a/crates/khive-repo-showcase/docs/design.md
+++ b/crates/khive-repo-showcase/docs/design.md
@@ -1,0 +1,51 @@
+# khive-repo-showcase Design
+
+## Purpose
+
+`khive-repo-showcase` is an offline, read-only exporter for deterministic `khive.repo.v1`
+repository showcase bundles. It joins a repository snapshot with khive history and code-map
+databases, builds bounded graph and analysis views, and emits a closed JSON model plus its JSON
+Schema.
+
+## Key types and modules
+
+- `ExportRequest` identifies the clone, history database, map database, generation time,
+  repository URL, source provenance, default-branch disclosure, and per-section bounds.
+- `RepoBundle` is the closed top-level wire model: metadata, graph, aggregates, and capability
+  catalog. `SchemaVersion` is fixed to `khive.repo.v1`.
+- `Page`, `Disclosure`, `Availability`, and `SourceCoverage` distinguish complete, truncated,
+  stopped, skipped, unknown, and unavailable data instead of treating missing evidence as empty.
+- `RepoGraph` contains repository/package/module/symbol/history nodes, typed edges, navigation, and
+  join-resolution evidence. `RepoAggregates` contains dependency, hotspot, coupling, treemap,
+  cadence, ownership, API-surface, and scorecard analyses.
+- `export.rs` validates inputs, composes the snapshot, produces canonical bytes, and persists them
+  atomically. `read.rs` opens both SQLite inputs read-only.
+- `join.rs` derives stable natural ids and resolves repository, Cargo/module, history, tag, and
+  changed-path evidence. `aggregate.rs` computes deterministic bounded views from the joined graph.
+- `ExportError` keeps missing data, ambiguous repository identity, malformed source records, git,
+  SQLite, serialization, and persistence failures distinct.
+
+## Invariants
+
+- Source SQLite databases are opened with read-only/no-mutex flags. Repository inspection invokes
+  non-interactive git with optional locks, automatic maintenance, hooks, and ambient git context
+  disabled; the exporter does not mutate the clone.
+- The bundle is tied to an exact 40-character HEAD SHA and explicit pipeline provenance. Mutable
+  default-branch refs are never inferred from the clone; unavailable metadata is represented as
+  unavailable.
+- Public wire structs reject unknown fields, constrained scalar wrappers validate on decode, and
+  the generated JSON Schema describes the same Rust model.
+- Natural ids are SHA-256 hashes over a domain-separated schema version, node kind, and canonical
+  components. Producers use explicit stable sort orders and ordered collections so equal inputs
+  yield equal output bytes.
+- Every page carries its bound, order, total-count availability, truncation bit, cursor, and
+  disclosure status. Missing source coverage must degrade view capability explicitly, never appear
+  as a silently complete empty collection.
+- Caller-provided bounds are validated against schema maxima before source expansion. Aggregates
+  are computed from the full admitted source sets and then bounded for output, preserving analysis
+  meaning under pagination.
+- `canonical_bytes` emits the compact serialized bundle followed by one newline.
+  `write_canonical_atomic` writes and syncs a temporary file in the destination directory before
+  persisting it over the destination.
+- History repository matching must resolve to exactly one project. Zero or ambiguous matches fail
+  with typed errors rather than joining unrelated data.

--- a/crates/khive-wire-protocol/docs/design.md
+++ b/crates/khive-wire-protocol/docs/design.md
@@ -1,0 +1,54 @@
+# khive-wire-protocol Design
+
+## Purpose
+
+`khive-wire-protocol` is the normative, transport-independent implementation of ADR-137's khive
+frame protocol. It defines the closed frame grammar, length-prefixed codec, handshake state
+machine, protocol versions, and wire-error taxonomy. It performs no socket or asynchronous I/O.
+
+## Key types and modules
+
+- `Frame` is the internally tagged JSON union for the eleven protocol frame kinds.
+  `OperationId` rejects empty ids, and `Cursor` is the ordered event cursor type.
+- `FrameCodec` and the free encode/decode functions operate on complete in-memory frames.
+  `CodecError` preserves the exact framing or grammar failure and maps it to a wire error code.
+- `HandshakeGate` is the forward-only server-side admission state machine. `HandshakeOutcome`
+  distinguishes an accepted handshake, a version rejection, and an ordinary admitted frame.
+- `ProtocolVersion`, `SupportedVersions`, and `CURRENT_VERSION` define compatibility boundaries.
+- `WireErrorCode` and `TerminalScope` define whether a wire failure closes the connection or only
+  terminates the operation id it echoes.
+
+## Framing and grammar
+
+Each frame is a four-byte big-endian `u32` JSON-payload length followed by exactly that many payload
+bytes. The length excludes its own prefix. The default payload limit is 8 MiB; a `FrameCodec` may
+use a different explicit bound for both encode and decode.
+
+The JSON payload is an object with a string `kind` discriminant. Version 1 recognizes
+`handshake`, `handshake_ack`, `request`, `response`, `error`, `cancel`, `subscribe`,
+`subscribe_ack`, `unsubscribe`, `unsubscribe_ack`, and `event`. Kinds and the fields belonging to
+each kind are closed. The opaque `response.result` and `event.payload` values remain ordinary JSON
+data and are not part of that field grammar.
+
+## Invariants
+
+- The codec does not buffer partial reads. A transport supplies one complete frame, or uses
+  `decode_with_consumed` to split a larger received buffer. After a decode error, stream position
+  is not recoverable; the connection must not attempt frame resynchronization.
+- Unknown kinds, missing discriminants, invalid required fields, empty operation ids, oversized
+  frames, and unknown fields are rejected. Optional explicit `null` decodes as absence, duplicate
+  object members follow serde JSON's last-value-wins behavior, and opaque values preserve semantic
+  rather than byte-for-byte equality.
+- A handshake must be the first application frame. Once completed, the server-side gate admits
+  only client-to-server kinds; duplicate handshakes and server-only inbound frames close the gate.
+  `HandshakeGate` is deliberately not `Clone`, so its per-connection state cannot move backward.
+- Connection-terminal errors carry no operation id. Request-terminal errors carry the id they
+  terminate. The rule is enforced on encode and on every `Frame` decode path.
+- An unrecognized wire error code decodes as `internal` while retaining the raw code for
+  diagnostics. That fallback frame cannot be re-encoded because doing so would discard the newer
+  code; a transparent relay must retain raw bytes instead.
+- Version 0 does not exist. Supported ranges are inclusive, non-inverted, and cannot name a version
+  newer than the grammar implemented by this crate. A breaking kind, field, or error-code change
+  requires a protocol-version bump.
+- Transport identity, peer authorization, request-DSL semantics, and per-topic event payload
+  catalogs belong to higher layers and are intentionally not defined here.

--- a/crates/khive-wire-protocol/docs/design.md
+++ b/crates/khive-wire-protocol/docs/design.md
@@ -43,7 +43,9 @@ data and are not part of that field grammar.
   only client-to-server kinds; duplicate handshakes and server-only inbound frames close the gate.
   `HandshakeGate` is deliberately not `Clone`, so its per-connection state cannot move backward.
 - Connection-terminal errors carry no operation id. Request-terminal errors carry the id they
-  terminate. The rule is enforced on encode and on every `Frame` decode path.
+  terminate. The rule is enforced on encode and, for recognized (closed-set) codes, on every
+  `Frame` decode path. An unknown code's scope is unknowable in this protocol version, so
+  unknown codes bypass scope validation on decode.
 - An unrecognized wire error code decodes as `internal` while retaining the raw code for
   diagnostics. That fallback frame cannot be re-encoded because doing so would discard the newer
   code; a transparent relay must retain raw bytes instead.


### PR DESCRIPTION
Summary:
- add design documentation for the seven crates that lacked a docs directory
- describe each crate's purpose, key types, boundaries, and operational invariants
- derive the guidance from the current module-level contracts and public surfaces

Validation:
- git diff --check
- deno fmt --check on all seven design documents
- document structure and non-empty-file assertions

Fixes #1909