### PR TITLE
test(khive-db): make sink construction check deterministic

### DIFF
--- a/crates/khive-db/src/timeout_sink.rs
+++ b/crates/khive-db/src/timeout_sink.rs
@@ -129,6 +129,13 @@ const DRAIN_BATCH_CAP: usize = 256;
 /// writer thread's lifetime at startup, and a no-op when unset.
 const WRITE_DELAY_MS_OVERRIDE_ENV: &str = "KHIVE_WRITER_TIMEOUT_SINK_WRITE_DELAY_MS";
 
+/// Test-harness-only synchronization point for proving that pool construction
+/// does not wait for the sink writer. When set to a directory, the writer
+/// creates `reached`, waits for `release`, then creates `resumed` before its
+/// first sink filesystem operation. The hook is inert unless Cargo's
+/// [`TEST_HARNESS_ENV`] marker is also present.
+const STARTUP_BARRIER_DIR_ENV: &str = "KHIVE_WRITER_TIMEOUT_SINK_STARTUP_BARRIER_DIR";
+
 /// Caller-experienced write latency at or above this bound produces a
 /// `slow_write` sink row. Exists because the ADR-136 write queue converts
 /// what used to be a caller-visible admission FAILURE (a `timeout` row) into
@@ -748,6 +755,8 @@ fn writer_thread_loop(
         return;
     }
 
+    pause_at_startup_barrier_for_test();
+
     // Retention is owned by the writer thread, run once per process
     // lifetime, after the publication gate above and before the first
     // file open — see `prune_expired_sink_files` and the module docs.
@@ -880,6 +889,22 @@ fn write_delay_from_env() -> Duration {
         .and_then(|v| v.parse::<u64>().ok())
         .map(Duration::from_millis)
         .unwrap_or(Duration::ZERO)
+}
+
+fn pause_at_startup_barrier_for_test() {
+    if std::env::var(TEST_HARNESS_ENV).as_deref() != Ok("1") {
+        return;
+    }
+    let Some(dir) = std::env::var_os(STARTUP_BARRIER_DIR_ENV).map(PathBuf::from) else {
+        return;
+    };
+    if std::fs::write(dir.join("reached"), b"reached").is_err() {
+        return;
+    }
+    while !dir.join("release").exists() {
+        thread::sleep(Duration::from_millis(1));
+    }
+    let _ = std::fs::write(dir.join("resumed"), b"resumed");
 }
 
 /// Initialize the process-global sink on first call from a writable file-backed

--- a/crates/khive-db/tests/writer_timeout_sink_stalled.rs
+++ b/crates/khive-db/tests/writer_timeout_sink_stalled.rs
@@ -6,10 +6,64 @@
 //! sharing a process with any other sink test would let whichever pool
 //! boots first (possibly with a healthy directory) win the slot instead.
 
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use khive_db::{ConnectionPool, PoolConfig};
+
+const STARTUP_BARRIER_ENV: &str = "KHIVE_WRITER_TIMEOUT_SINK_STARTUP_BARRIER_DIR";
+const HANG_GUARD_TIMEOUT: Duration = Duration::from_secs(10);
+
+struct SinkStartupBarrier {
+    _dir: tempfile::TempDir,
+    reached: PathBuf,
+    release: PathBuf,
+    resumed: PathBuf,
+}
+
+impl SinkStartupBarrier {
+    fn install() -> Self {
+        let dir = tempfile::tempdir().expect("startup barrier tempdir");
+        std::env::set_var(STARTUP_BARRIER_ENV, dir.path());
+        Self {
+            reached: dir.path().join("reached"),
+            release: dir.path().join("release"),
+            resumed: dir.path().join("resumed"),
+            _dir: dir,
+        }
+    }
+
+    fn wait_for(&self, path: &Path, message: &str) {
+        let started = Instant::now();
+        while !path.exists() {
+            assert!(started.elapsed() < HANG_GUARD_TIMEOUT, "{message}");
+            std::thread::sleep(Duration::from_millis(1));
+        }
+    }
+
+    fn wait_until_reached(&self) {
+        self.wait_for(
+            &self.reached,
+            "sink writer did not reach the injected startup barrier",
+        );
+    }
+
+    fn release(&self) {
+        std::fs::write(&self.release, b"release").expect("release sink startup barrier");
+        self.wait_for(
+            &self.resumed,
+            "sink writer did not resume from the injected startup barrier",
+        );
+    }
+}
+
+impl Drop for SinkStartupBarrier {
+    fn drop(&mut self) {
+        let _ = std::fs::write(&self.release, b"release");
+        std::env::remove_var(STARTUP_BARRIER_ENV);
+    }
+}
 
 /// Point the sink at a directory that can never be created: a regular file
 /// occupies the path a directory needs, so `create_dir_all` fails on every
@@ -29,6 +83,7 @@ fn point_sink_at_unwritable_dir() {
 #[test]
 fn sink_never_adds_measurable_latency_when_its_directory_is_unwritable() {
     point_sink_at_unwritable_dir();
+    let startup_barrier = SinkStartupBarrier::install();
 
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("stalled_sink_test.db");
@@ -38,17 +93,22 @@ fn sink_never_adds_measurable_latency_when_its_directory_is_unwritable() {
         ..PoolConfig::default()
     };
 
-    // Pool construction itself must not touch the sink's filesystem at all
-    // (`init` only resolves a path — pure — and spawns a thread; the thread
-    // does its own first `create_dir_all`/`open` on its own schedule).
-    let construct_start = Instant::now();
-    let pool = Arc::new(ConnectionPool::new(cfg).expect("file-backed pool should open"));
-    let construct_elapsed = construct_start.elapsed();
-    assert!(
-        construct_elapsed < Duration::from_millis(500),
-        "pool construction took {construct_elapsed:?} against an unwritable sink directory — \
-         the sink must never add filesystem-bound latency to pool boot"
+    // Pool construction must finish while the sink writer is paused before
+    // its first filesystem operation. The timeout below is only a hang guard;
+    // synchronization at the injected barrier, not elapsed time, decides the
+    // behavior under test.
+    let (constructed_tx, constructed_rx) = std::sync::mpsc::sync_channel(1);
+    std::thread::spawn(move || {
+        let _ = constructed_tx.send(ConnectionPool::new(cfg));
+    });
+    startup_barrier.wait_until_reached();
+    let pool = Arc::new(
+        constructed_rx
+            .recv_timeout(HANG_GUARD_TIMEOUT)
+            .expect("pool construction blocked on the paused sink writer")
+            .expect("file-backed pool should open"),
     );
+    startup_barrier.release();
 
     // A genuine writer-admission timeout (held writer + tiny checkout_timeout)
     // must still resolve in close to `checkout_timeout`, not measurably more,


### PR DESCRIPTION
## Summary

- add a test-harness-only synchronization point before timeout-sink filesystem work
- prove pool construction completes while the background sink writer is paused
- remove the machine-speed-dependent 500 ms construction assertion without widening a timing budget
- preserve the unwritable-directory and writer-checkout coverage

## Testing

- focused RED/GREEN regression test
- `cargo fmt -p khive-db -- --check`
- `cargo clippy -p khive-db --all-targets -- -D warnings`
- `cargo test -p khive-db`
- `git diff --check`

Fixes #2082
