### PR TITLE
fix(kg-editor): preserve analysis deep-link aliases

### DIFF
--- a/apps/kg-editor/src/components/showcase/showcase.test.tsx
+++ b/apps/kg-editor/src/components/showcase/showcase.test.tsx
@@ -195,6 +195,28 @@ describe("materialized repository lookup", () => {
     );
   });
 
+  it("keeps a curated analysis-id deep link addressable while catalog discovery is pending", async () => {
+    let releaseCatalog: (() => void) | undefined;
+    mockedCatalog.mockImplementation(() => new Promise((resolveCatalog) => {
+      releaseCatalog = () => resolveCatalog({
+        status: "ready",
+        entries: [defaultCatalogEntry],
+        message: "1 configured repository analysis discovered.",
+      });
+    }));
+    window.history.replaceState(null, "", "/?repo=khive");
+
+    const { container } = render(<Showcase />);
+
+    expect(new URL(window.location.href).searchParams.get("repo")).toBe("khive");
+    expect(releaseCatalog).toBeDefined();
+    releaseCatalog?.();
+    await waitFor(() => expect(container.querySelector(".repo-overview")).toBeVisible());
+    expect(new URL(window.location.href).searchParams.get("repo")).toBe(
+      bundle.meta.repository.canonical_url,
+    );
+  });
+
   it("preserves a direct investigation while canonicalizing a curated alias", async () => {
     const pool = bundle.graph.modules.items.find((module) =>
       module.source_path.endsWith("khive-db/src/pool.rs")

--- a/apps/kg-editor/src/components/showcase/showcase.tsx
+++ b/apps/kg-editor/src/components/showcase/showcase.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/lib/adapters/showcase-analysis-catalog";
 import type { RepoBundle } from "@/lib/repo-bundle";
 import {
+  isShowcaseAnalysisId,
   resolveShowcaseRepository,
   type ShowcaseRegistryEntry,
 } from "@/lib/showcase-registry";
@@ -114,6 +115,14 @@ function replaceRepositoryQuery(
       : (current.searchParams.get("view") as RepositoryLocation["view"]),
   };
   const url = repositoryLocationUrl(current, location);
+  // Catalog analysis IDs are safe bounded tokens, but they are not URLs, so
+  // the generic location serializer intentionally omits them. Keep that one
+  // token class addressable while asynchronous catalog discovery decides
+  // which canonical repository it names; all unrelated parameters and the
+  // hash remain scrubbed by repositoryLocationUrl above.
+  if (repository && isShowcaseAnalysisId(repository) && !url.searchParams.has("repo")) {
+    url.searchParams.set("repo", repository);
+  }
   window.history.replaceState(null, "", `${url.pathname}${url.search}`);
 }
 

--- a/apps/kg-editor/src/lib/adapters/showcase-analysis-catalog.test.ts
+++ b/apps/kg-editor/src/lib/adapters/showcase-analysis-catalog.test.ts
@@ -8,7 +8,10 @@ import {
   SHOWCASE_CATALOG_MAX_BYTES,
   SHOWCASE_CATALOG_MAX_ENTRIES,
 } from "@/lib/adapters/showcase-analysis-catalog";
-import type { ShowcaseRegistryEntry } from "@/lib/showcase-registry";
+import {
+  resolveShowcaseRepository,
+  type ShowcaseRegistryEntry,
+} from "@/lib/showcase-registry";
 
 const staticEntry: ShowcaseRegistryEntry = {
   id: "github.com/example/repository",
@@ -236,6 +239,7 @@ describe("showcase analysis catalog", () => {
     expect(registry).toStrictEqual([
       {
         ...staticEntry,
+        aliases: [...staticEntry.aliases, "legacy-static-id"],
         analysisId: "configured-analysis",
       },
       {
@@ -256,5 +260,41 @@ describe("showcase analysis catalog", () => {
         analysisId: undefined,
       },
     ]);
+  });
+
+  it("lets a catalog entry claiming the legacy static ID win the deep-link lookup", () => {
+    const merged = mergeShowcaseRegistry([
+      {
+        analysis_id: "legacy-static-id",
+        canonical_url: "https://github.com/example/other",
+      },
+    ], [staticEntry]);
+
+    expect(merged[0]?.aliases).not.toContain("legacy-static-id");
+    const lookup = resolveShowcaseRepository("legacy-static-id", merged);
+    expect(lookup.status).toBe("hit");
+    expect(lookup.status === "hit" && lookup.entry.id).toBe(
+      "analysis:legacy-static-id",
+    );
+  });
+
+  it("keeps the legacy static ID as an alias when the catalog renames the same repository", () => {
+    const merged = mergeShowcaseRegistry([
+      {
+        analysis_id: "renamed-analysis",
+        canonical_url: "https://github.com/example/repository",
+      },
+    ], [staticEntry]);
+
+    expect(merged).toStrictEqual([
+      {
+        ...staticEntry,
+        aliases: [...staticEntry.aliases, "legacy-static-id"],
+        analysisId: "renamed-analysis",
+      },
+    ]);
+    const lookup = resolveShowcaseRepository("legacy-static-id", merged);
+    expect(lookup.status).toBe("hit");
+    expect(lookup.status === "hit" && lookup.entry.id).toBe(staticEntry.id);
   });
 });

--- a/apps/kg-editor/src/lib/adapters/showcase-analysis-catalog.test.ts
+++ b/apps/kg-editor/src/lib/adapters/showcase-analysis-catalog.test.ts
@@ -248,10 +248,11 @@ describe("showcase analysis catalog", () => {
     ]);
   });
 
-  it("removes legacy analysis IDs when the catalog does not configure them", () => {
+  it("turns a cleared static analysis ID into a derived lookup alias", () => {
     expect(mergeShowcaseRegistry([], [staticEntry])).toEqual([
       {
         ...staticEntry,
+        aliases: [...staticEntry.aliases, "legacy-static-id"],
         analysisId: undefined,
       },
     ]);

--- a/apps/kg-editor/src/lib/adapters/showcase-analysis-catalog.test.ts
+++ b/apps/kg-editor/src/lib/adapters/showcase-analysis-catalog.test.ts
@@ -278,6 +278,29 @@ describe("showcase analysis catalog", () => {
     );
   });
 
+  it("strips a catalog-claimed ID from another static entry's pre-existing aliases", () => {
+    const earlierEntry: ShowcaseRegistryEntry = {
+      id: "github.com/example/earlier",
+      canonicalUrl: "https://github.com/example/earlier",
+      aliases: ["legacy-static-id", "https://github.com/example/earlier"],
+      assetPath: "/showcase/earlier.json",
+      analysisId: undefined,
+    };
+    const merged = mergeShowcaseRegistry([
+      {
+        analysis_id: "legacy-static-id",
+        canonical_url: "https://github.com/example/other",
+      },
+    ], [earlierEntry, staticEntry]);
+
+    expect(merged[0]?.aliases).not.toContain("legacy-static-id");
+    const lookup = resolveShowcaseRepository("legacy-static-id", merged);
+    expect(lookup.status).toBe("hit");
+    expect(lookup.status === "hit" && lookup.entry.id).toBe(
+      "analysis:legacy-static-id",
+    );
+  });
+
   it("keeps the legacy static ID as an alias when the catalog renames the same repository", () => {
     const merged = mergeShowcaseRegistry([
       {

--- a/apps/kg-editor/src/lib/adapters/showcase-analysis-catalog.ts
+++ b/apps/kg-editor/src/lib/adapters/showcase-analysis-catalog.ts
@@ -154,8 +154,13 @@ export function mergeShowcaseRegistry(
   catalog: readonly ShowcaseAnalysisCatalogEntry[],
   staticRegistry: readonly ShowcaseRegistryEntry[] = SHOWCASE_REGISTRY,
 ): readonly ShowcaseRegistryEntry[] {
+  // Catalog analysis IDs are authoritative for lookup: any static alias that
+  // collides with a claimed ID is dropped so first-match-wins resolution can
+  // reach the catalog's entry.
+  const catalogClaimedIds = new Set(catalog.map((entry) => entry.analysis_id));
   const merged: ShowcaseRegistryEntry[] = staticRegistry.map((entry) => ({
     ...entry,
+    aliases: entry.aliases.filter((alias) => !catalogClaimedIds.has(alias)),
     analysisId: undefined,
   }));
   const staticByUrl = new Map<string, number>();
@@ -183,7 +188,6 @@ export function mergeShowcaseRegistry(
       analysisId: entry.analysis_id,
     });
   }
-  const catalogClaimedIds = new Set(catalog.map((entry) => entry.analysis_id));
   for (const [index, staticEntry] of staticRegistry.entries()) {
     const entry = merged[index];
     const legacyId = staticEntry.analysisId;

--- a/apps/kg-editor/src/lib/adapters/showcase-analysis-catalog.ts
+++ b/apps/kg-editor/src/lib/adapters/showcase-analysis-catalog.ts
@@ -183,17 +183,20 @@ export function mergeShowcaseRegistry(
       analysisId: entry.analysis_id,
     });
   }
+  const catalogClaimedIds = new Set(catalog.map((entry) => entry.analysis_id));
   for (const [index, staticEntry] of staticRegistry.entries()) {
     const entry = merged[index];
+    const legacyId = staticEntry.analysisId;
     if (
       entry &&
-      entry.analysisId === undefined &&
-      isShowcaseAnalysisId(staticEntry.analysisId) &&
-      !entry.aliases.includes(staticEntry.analysisId)
+      isShowcaseAnalysisId(legacyId) &&
+      !catalogClaimedIds.has(legacyId) &&
+      entry.analysisId !== legacyId &&
+      !entry.aliases.includes(legacyId)
     ) {
       merged[index] = {
         ...entry,
-        aliases: [...entry.aliases, staticEntry.analysisId],
+        aliases: [...entry.aliases, legacyId],
       };
     }
   }

--- a/apps/kg-editor/src/lib/adapters/showcase-analysis-catalog.ts
+++ b/apps/kg-editor/src/lib/adapters/showcase-analysis-catalog.ts
@@ -1,5 +1,6 @@
 import { readOperatorShowcaseAccessToken } from "@/lib/adapters/preferred-showcase-source";
 import {
+  isShowcaseAnalysisId,
   normalizeRepositoryUrl,
   SHOWCASE_REGISTRY,
   type ShowcaseRegistryEntry,
@@ -8,7 +9,6 @@ import {
 export const SHOWCASE_CATALOG_MAX_ENTRIES = 64;
 export const SHOWCASE_CATALOG_MAX_BYTES = 256 * 1024;
 
-const ANALYSIS_ID = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/;
 const CATALOG_SCHEMA = "khive.showcase.catalog.v1";
 
 export type ShowcaseAnalysisCatalogEntry = Readonly<{
@@ -75,7 +75,7 @@ export function parseShowcaseAnalysisCatalog(
     const analysisId = Reflect.get(candidate, "analysis_id");
     const canonicalUrl = Reflect.get(candidate, "canonical_url");
     if (
-      typeof analysisId !== "string" || !ANALYSIS_ID.test(analysisId) ||
+      !isShowcaseAnalysisId(analysisId) ||
       typeof canonicalUrl !== "string"
     ) {
       return invalidCatalog();
@@ -182,6 +182,20 @@ export function mergeShowcaseRegistry(
       assetPath: undefined,
       analysisId: entry.analysis_id,
     });
+  }
+  for (const [index, staticEntry] of staticRegistry.entries()) {
+    const entry = merged[index];
+    if (
+      entry &&
+      entry.analysisId === undefined &&
+      isShowcaseAnalysisId(staticEntry.analysisId) &&
+      !entry.aliases.includes(staticEntry.analysisId)
+    ) {
+      merged[index] = {
+        ...entry,
+        aliases: [...entry.aliases, staticEntry.analysisId],
+      };
+    }
   }
   return merged;
 }

--- a/apps/kg-editor/src/lib/showcase-registry.test.ts
+++ b/apps/kg-editor/src/lib/showcase-registry.test.ts
@@ -4,6 +4,7 @@ import {
   isAllowedShowcaseAsset,
   normalizeRepositoryUrl,
   resolveShowcaseRepository,
+  SHOWCASE_REGISTRY,
 } from "@/lib/showcase-registry";
 
 describe("showcase registry", () => {
@@ -14,6 +15,29 @@ describe("showcase registry", () => {
     if (result.status === "hit") {
       expect(result.entry.id).toBe("github.com/ohdearquant/khive");
       expect(result.normalizedUrl).toBe("https://github.com/ohdearquant/khive");
+    }
+  });
+
+  it("derives the lookup token from analysisId instead of a duplicated alias", () => {
+    const registry = [{
+      id: "github.com/example/repository",
+      canonicalUrl: "https://github.com/example/repository",
+      aliases: ["https://github.com/example/repository"],
+      analysisId: "configured-analysis",
+    }] as const;
+
+    const result = resolveShowcaseRepository("configured-analysis", registry);
+
+    expect(result.status).toBe("hit");
+    if (result.status === "hit") {
+      expect(result.entry).toBe(registry[0]);
+      expect(result.normalizedUrl).toBe("https://github.com/example/repository");
+    }
+  });
+
+  it("does not duplicate static analysis IDs in the hand-maintained alias list", () => {
+    for (const entry of SHOWCASE_REGISTRY) {
+      if (entry.analysisId) expect(entry.aliases).not.toContain(entry.analysisId);
     }
   });
 

--- a/apps/kg-editor/src/lib/showcase-registry.ts
+++ b/apps/kg-editor/src/lib/showcase-registry.ts
@@ -1,5 +1,6 @@
 export const SHOWCASE_ASSET_PREFIX = "/showcase/";
 export const REPOSITORY_URL_LIMIT = 2_048;
+const SHOWCASE_ANALYSIS_ID = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/;
 
 export type ShowcaseRegistryEntry = Readonly<{
   id: string;
@@ -19,7 +20,6 @@ export const SHOWCASE_REGISTRY: readonly ShowcaseRegistryEntry[] = [
     id: "github.com/ohdearquant/khive",
     canonicalUrl: "https://github.com/ohdearquant/khive",
     aliases: [
-      "khive",
       "https://github.com/ohdearquant/khive",
       "http://github.com/ohdearquant/khive",
       "https://www.github.com/ohdearquant/khive",
@@ -162,7 +162,9 @@ export function resolveShowcaseRepository(
 ): ShowcaseLookup {
   const candidate = input.trim();
   for (const entry of registry) {
-    if (!entry.aliases.includes(candidate)) continue;
+    const analysisIdMatches = isShowcaseAnalysisId(entry.analysisId) &&
+      entry.analysisId === candidate;
+    if (!analysisIdMatches && !entry.aliases.includes(candidate)) continue;
 
     const canonical = normalizeRepositoryUrl(entry.canonicalUrl);
     if (canonical.ok) {
@@ -198,6 +200,9 @@ export function isAllowedShowcaseAsset(
 export function isAllowedShowcaseAnalysis(
   entry: ShowcaseRegistryEntry,
 ): entry is ShowcaseRegistryEntry & Readonly<{ analysisId: string }> {
-  return typeof entry.analysisId === "string" &&
-    /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/.test(entry.analysisId);
+  return isShowcaseAnalysisId(entry.analysisId);
+}
+
+export function isShowcaseAnalysisId(value: unknown): value is string {
+  return typeof value === "string" && SHOWCASE_ANALYSIS_ID.test(value);
 }


### PR DESCRIPTION
## Summary

- keep bounded analysis-ID deep links in browser history while catalog discovery is pending
- resolve analysis IDs directly from the registry instead of duplicating them in hand-maintained aliases
- retain static fallback aliases when no materialized catalog entry is configured

## Validation

- focused RED/GREEN: 58 tests passed
- npm run lint
- npm run typecheck
- npm test (20 token-contract tests and 294 Vitest tests)
- git diff --check
- pre-commit hooks

Fixes #2198