### PR TITLE
fix(kg): allow entity type updates

### DIFF
--- a/crates/khive-changeset/docs/api/update.md
+++ b/crates/khive-changeset/docs/api/update.md
@@ -12,7 +12,7 @@ The operation's fields are private so this constructor is the only in-memory con
 
 `UpdatePatch` is tagged by `target` and selects entity, note, or edge fields. An absent field means unchanged. Nullable mutable fields use `Option<Option<T>>`: outer `None` means unchanged, `Some(None)` means explicitly clear to JSON `null`, and `Some(Some(value))` means set.
 
-`EntityPatch` can change name, nullable description, properties, and tags. `NotePatch` can change content, nullable salience/decay factor, properties, and tags. `EdgePatch` can change relation and weight.
+`EntityPatch` can change name, nullable description, nullable `entity_type`, properties, and tags. `NotePatch` can change content, nullable salience/decay factor, properties, and tags. `EdgePatch` can change relation and weight.
 
 An edge patch weight, when present, must be finite and within `[0.0, 1.0]`; custom deserialization enforces the same constraint as link creation and the live edge model.
 

--- a/crates/khive-changeset/src/op.rs
+++ b/crates/khive-changeset/src/op.rs
@@ -228,7 +228,9 @@ pub enum UpdatePatch {
     Edge(EdgePatch),
 }
 
-/// Entity fields to mutate; absent means unchanged and `Some(None)` clears description.
+/// Entity fields to mutate; absent means unchanged and `Some(None)` clears
+/// a nullable field (ADR-014 tri-state, applied to `description` and
+/// `entity_type`).
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct EntityPatch {
@@ -240,6 +242,8 @@ pub struct EntityPatch {
     pub properties: Option<BTreeMap<String, PropertyValue>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tags: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "opt_opt")]
+    pub entity_type: Option<Option<String>>,
 }
 
 /// Note fields to mutate; nested options distinguish unchanged, clear, and set.
@@ -350,6 +354,8 @@ pub struct EntityPreimage {
     pub properties: Option<BTreeMap<String, PropertyValue>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tags: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "opt_opt")]
+    pub entity_type: Option<Option<String>>,
 }
 
 /// Prior note values for exactly the fields touched by [`NotePatch`].
@@ -410,6 +416,11 @@ fn validate_update_congruence(
                 pre.properties.is_some(),
             )?;
             check_touched("tags", p.tags.is_some(), pre.tags.is_some())?;
+            check_touched(
+                "entity_type",
+                p.entity_type.is_some(),
+                pre.entity_type.is_some(),
+            )?;
             Ok(())
         }
         (UpdatePatch::Note(p), UpdatePreimage::Note(pre)) => {
@@ -838,12 +849,14 @@ mod tests {
                 description: None,
                 properties: None,
                 tags: None,
+                entity_type: None,
             }),
             UpdatePreimage::Entity(EntityPreimage {
                 name: None,
                 description: None,
                 properties: None,
                 tags: None,
+                entity_type: None,
             }),
         );
         assert!(result.is_err());

--- a/crates/khive-changeset/tests/roundtrip.rs
+++ b/crates/khive-changeset/tests/roundtrip.rs
@@ -172,12 +172,14 @@ proptest! {
                     description: Some(None),
                     properties: None,
                     tags: None,
+                    entity_type: None,
                 }),
                 UpdatePreimage::Entity(EntityPreimage {
                     name: preimage_name,
                     description: Some(Some("prior-description".to_string())),
                     properties: None,
                     tags: None,
+                    entity_type: None,
                 }),
             )
             .unwrap(),
@@ -408,5 +410,106 @@ fn probe_rejects_unknown_field_inside_delete_preimage() {
     assert!(
         result.is_err(),
         "unknown fields inside full-record preimages must not be silently dropped"
+    );
+}
+
+// ---- ADR-014 tri-state entity_type on the changeset surface ----
+
+fn entity_type_op(patch_type: Option<Option<String>>, preimage_type: Option<Option<String>>) -> Op {
+    let op = UpdateOp::new(
+        Id128::from_u128(1),
+        UpdatePatch::Entity(EntityPatch {
+            name: None,
+            description: None,
+            properties: None,
+            tags: None,
+            entity_type: patch_type,
+        }),
+        UpdatePreimage::Entity(EntityPreimage {
+            name: None,
+            description: None,
+            properties: None,
+            tags: None,
+            entity_type: preimage_type,
+        }),
+    )
+    .expect("congruent entity_type pair must construct");
+    Op::Update(op)
+}
+
+#[test]
+fn update_entity_type_set_roundtrips_through_ndjson() {
+    let cs = ChangeSet::new(
+        Envelope::new("agent:proptest", "family:test", Timestamp::from_secs(1)),
+        vec![entity_type_op(
+            Some(Some("algorithm".to_string())),
+            Some(Some("paper".to_string())),
+        )],
+    );
+    assert_roundtrips_byte_identical(&cs);
+}
+
+#[test]
+fn update_entity_type_clear_roundtrips_through_ndjson() {
+    let cs = ChangeSet::new(
+        Envelope::new("agent:proptest", "family:test", Timestamp::from_secs(1)),
+        vec![entity_type_op(
+            Some(None),
+            Some(Some("algorithm".to_string())),
+        )],
+    );
+    let text = khive_changeset::to_ndjson(&cs).expect("serialize");
+    assert!(
+        text.contains("\"entity_type\":null"),
+        "the clear must be serialized as an explicit null, not dropped: {text}"
+    );
+    assert_roundtrips_byte_identical(&cs);
+}
+
+#[test]
+fn update_entity_type_congruence_rejects_mismatched_preimage() {
+    // patch sets entity_type but the preimage omits the prior value.
+    assert!(
+        UpdateOp::new(
+            Id128::from_u128(1),
+            UpdatePatch::Entity(EntityPatch {
+                name: None,
+                description: None,
+                properties: None,
+                tags: None,
+                entity_type: Some(Some("algorithm".to_string())),
+            }),
+            UpdatePreimage::Entity(EntityPreimage {
+                name: None,
+                description: None,
+                properties: None,
+                tags: None,
+                entity_type: None,
+            }),
+        )
+        .is_err(),
+        "a touched entity_type without a captured prior value must be rejected"
+    );
+    // preimage captures entity_type but the patch leaves it unchanged.
+    assert!(
+        UpdateOp::new(
+            Id128::from_u128(1),
+            UpdatePatch::Entity(EntityPatch {
+                name: None,
+                description: None,
+                properties: None,
+                tags: None,
+                entity_type: None,
+            }),
+            UpdatePreimage::Entity(EntityPreimage {
+                name: None,
+                description: None,
+                properties: None,
+                tags: None,
+                entity_type: Some(Some("algorithm".to_string())),
+            }),
+        )
+        .is_err(),
+        "an unchanged entity_type with a preimage value must be rejected"
     );
 }

--- a/crates/khive-pack-kg/src/apply_worker/tests.rs
+++ b/crates/khive-pack-kg/src/apply_worker/tests.rs
@@ -231,6 +231,7 @@ async fn changeset_adapter_builds_atomic_plans_for_supported_proposal_writes() {
                     description: None,
                     properties: None,
                     tags: None,
+                    entity_type: None,
                 },
             },
             "update",
@@ -297,6 +298,7 @@ async fn apply_worker_atomic_update_preserves_explicit_description_clear() {
             description: Some(None),
             properties: None,
             tags: None,
+            entity_type: None,
         },
     };
     seed_proposal_created_event(&rt, &tok, proposal_id, changeset).await;
@@ -340,6 +342,7 @@ async fn apply_worker_returns_atomic_update_truncation_report() {
             description: Some(Some("x".repeat(MAX_TEXT_BYTES + 1))),
             properties: None,
             tags: None,
+            entity_type: None,
         },
     };
     seed_proposal_created_event(&rt, &tok, proposal_id, changeset).await;
@@ -383,6 +386,7 @@ async fn committed_post_commit_failure_stays_applying_and_is_not_replayed() {
                 description: None,
                 properties: None,
                 tags: None,
+                entity_type: None,
             },
         },
     )

--- a/crates/khive-pack-kg/src/apply_worker/worker.rs
+++ b/crates/khive-pack-kg/src/apply_worker/worker.rs
@@ -387,6 +387,21 @@ impl ProposalApplyWorker {
                 }
                 ProposalChangeset::UpdateEntity { id, patch } => {
                     let entity_id = Uuid::from_u128(id.to_u128());
+                    // ADR-014 parity with the direct update surface: a set
+                    // validates + normalizes against the registered
+                    // vocabulary for the entity's kind; a clear passes
+                    // through untouched.
+                    let entity_type = match &patch.entity_type {
+                        Some(Some(raw)) => {
+                            let entity = self.runtime.get_entity(token, entity_id).await?;
+                            Some(crate::handlers::validate_entity_type(
+                                &entity.kind,
+                                Some(raw.as_str()),
+                                registry,
+                            )?)
+                        }
+                        other => other.clone(),
+                    };
                     let plan = prepare_update_entity_plan(
                         &self.runtime,
                         token,
@@ -396,7 +411,7 @@ impl ProposalApplyWorker {
                             description: patch.description.clone(),
                             properties: patch.properties.clone(),
                             tags: patch.tags.clone(),
-                            entity_type: None,
+                            entity_type,
                         },
                     )
                     .await?;

--- a/crates/khive-pack-kg/src/apply_worker/worker.rs
+++ b/crates/khive-pack-kg/src/apply_worker/worker.rs
@@ -396,6 +396,7 @@ impl ProposalApplyWorker {
                             description: patch.description.clone(),
                             properties: patch.properties.clone(),
                             tags: patch.tags.clone(),
+                            entity_type: None,
                         },
                     )
                     .await?;

--- a/crates/khive-pack-kg/src/handler_defs.rs
+++ b/crates/khive-pack-kg/src/handler_defs.rs
@@ -351,7 +351,7 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 20] = [
     HandlerDef {
         name: "update",
         description: "Patch entity, note, or edge fields. Accepted fields depend on substrate: \
-                       entities accept name/description/properties/tags; notes accept \
+                       entities accept name/description/properties/tags/entity_type; notes accept \
                        name/content/salience/decay_factor/properties; edges accept relation/weight/properties.",
         visibility: Visibility::Verb,
         category: VerbCategory::Declaration,
@@ -423,6 +423,12 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 20] = [
                 param_type: "array of string",
                 required: false,
                 description: "Replace tag list.",
+            },
+            ParamDef {
+                name: "entity_type",
+                param_type: "string",
+                required: false,
+                description: "Registered entity type to set (entities only). The value is validated against the entity kind's closed vocabulary and reindexed.",
             },
         ],
     },

--- a/crates/khive-pack-kg/src/handlers/mod.rs
+++ b/crates/khive-pack-kg/src/handlers/mod.rs
@@ -17,7 +17,9 @@ mod stats;
 mod update;
 mod whoami;
 
-pub(crate) use common::{canonical_entity_kind, canonical_note_kind, parse_relation};
+pub(crate) use common::{
+    canonical_entity_kind, canonical_note_kind, parse_relation, validate_entity_type,
+};
 
 /// ADR-099 B3: real `pub` re-export so kkernel's `--atomic` seam validates through the
 /// SAME canonical param structs the handlers deserialize, reproducing

--- a/crates/khive-pack-kg/src/handlers/params.rs
+++ b/crates/khive-pack-kg/src/handlers/params.rs
@@ -120,6 +120,7 @@ pub struct UpdateParams {
     pub(crate) decay_factor: Option<Option<f64>>,
     pub(crate) properties: Option<Value>,
     pub(crate) tags: Option<Vec<String>>,
+    pub(crate) entity_type: Option<String>,
     pub(crate) relation: Option<String>,
     pub(crate) weight: Option<f64>,
     pub(crate) entity_kind: Option<Value>,

--- a/crates/khive-pack-kg/src/handlers/params.rs
+++ b/crates/khive-pack-kg/src/handlers/params.rs
@@ -120,7 +120,11 @@ pub struct UpdateParams {
     pub(crate) decay_factor: Option<Option<f64>>,
     pub(crate) properties: Option<Value>,
     pub(crate) tags: Option<Vec<String>>,
-    pub(crate) entity_type: Option<String>,
+    /// ADR-014 tri-state: absent = unchanged, JSON `null` = explicit clear,
+    /// string = set (validated against the kind's registered vocabulary).
+    /// Same `Option<Option<T>>` shape as `salience`/`decay_factor` above.
+    #[serde(default, deserialize_with = "tri_string")]
+    pub(crate) entity_type: Option<Option<String>>,
     pub(crate) relation: Option<String>,
     pub(crate) weight: Option<f64>,
     pub(crate) entity_kind: Option<Value>,
@@ -303,5 +307,15 @@ pub(crate) struct ResolveParams {
 }
 
 pub(crate) fn tri_f64<'de, D: Deserializer<'de>>(d: D) -> Result<Option<Option<f64>>, D::Error> {
+    Ok(Some(Option::deserialize(d)?))
+}
+
+/// String analog of [`tri_f64`] (ADR-014 patch-style updates): with the
+/// struct-level `#[serde(default)]`, an absent key deserializes to `None`
+/// (leave unchanged) while a present key keeps its `null`/value distinction
+/// as `Some(None)` (explicit clear) / `Some(Some(s))` (set).
+pub(crate) fn tri_string<'de, D: Deserializer<'de>>(
+    d: D,
+) -> Result<Option<Option<String>>, D::Error> {
     Ok(Some(Option::deserialize(d)?))
 }

--- a/crates/khive-pack-kg/src/handlers/update.rs
+++ b/crates/khive-pack-kg/src/handlers/update.rs
@@ -197,8 +197,18 @@ impl KgPack {
                         )));
                     }
                 }
-                let entity_type =
-                    validate_entity_type(&entity.kind, p.entity_type.as_deref(), registry)?;
+                // ADR-014 tri-state: `Some(None)` is an explicit clear and
+                // bypasses the vocabulary check (runtime applies it);
+                // `Some(Some(raw))` validates + normalizes; `None` unchanged.
+                let entity_type = match &p.entity_type {
+                    Some(None) => Some(None),
+                    Some(Some(raw)) => Some(validate_entity_type(
+                        &entity.kind,
+                        Some(raw.as_str()),
+                        registry,
+                    )?),
+                    None => None,
+                };
                 let patch = EntityPatch {
                     name: string_value(p.name, "name")?,
                     description: description_patch(p.description)?,

--- a/crates/khive-pack-kg/src/handlers/update.rs
+++ b/crates/khive-pack-kg/src/handlers/update.rs
@@ -10,8 +10,8 @@ use khive_runtime::{
 use super::common::{
     description_patch, deser, immutable_event_error, normalize_entity_timestamps,
     optional_string_patch, parse_relation, resolve_kind_spec, resolve_uuid_unfiltered,
-    resolve_uuid_unfiltered_including_deleted, string_value, to_json, DeleteParams, KindSpec,
-    UpdateParams,
+    resolve_uuid_unfiltered_including_deleted, string_value, to_json, validate_entity_type,
+    DeleteParams, KindSpec, UpdateParams,
 };
 use crate::KgPack;
 
@@ -34,7 +34,7 @@ fn reject_inapplicable_fields(spec: &KindSpec, p: &UpdateParams) -> Result<(), R
             } else {
                 None
             };
-            (bad, "name, description, tags, properties")
+            (bad, "name, description, tags, properties, entity_type")
         }
         KindSpec::Note { .. } => {
             let bad = if p.description.is_some() {
@@ -45,6 +45,8 @@ fn reject_inapplicable_fields(spec: &KindSpec, p: &UpdateParams) -> Result<(), R
                 Some("relation")
             } else if p.weight.is_some() {
                 Some("weight")
+            } else if p.entity_type.is_some() {
+                Some("entity_type")
             } else {
                 None
             };
@@ -63,6 +65,8 @@ fn reject_inapplicable_fields(spec: &KindSpec, p: &UpdateParams) -> Result<(), R
                 Some("salience")
             } else if p.decay_factor.is_some() {
                 Some("decay_factor")
+            } else if p.entity_type.is_some() {
+                Some("entity_type")
             } else {
                 None
             };
@@ -193,11 +197,14 @@ impl KgPack {
                         )));
                     }
                 }
+                let entity_type =
+                    validate_entity_type(&entity.kind, p.entity_type.as_deref(), registry)?;
                 let patch = EntityPatch {
                     name: string_value(p.name, "name")?,
                     description: description_patch(p.description)?,
                     properties: p.properties,
                     tags: p.tags,
+                    entity_type,
                 };
                 let (entity, report) = self
                     .runtime

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -4226,6 +4226,273 @@ async fn update_entity_type_is_rejected_for_non_entity_substrates() {
     );
 }
 
+/// ADR-014 tri-state: an explicit JSON `null` clears a stored entity type
+/// (and reindexes), unlike absent (unchanged) — the pre-fix
+/// `Option<String>` collapsed null into absent and could never clear.
+#[tokio::test]
+async fn update_entity_type_null_clears_stored_type() {
+    let pack = pack();
+    let created = pack
+        .dispatch(
+            "create",
+            json!({
+                "kind": "entity",
+                "entity_kind": "concept",
+                "entity_type": "algorithm",
+                "name": "NullClearEntity"
+            }),
+        )
+        .await
+        .expect("create must succeed");
+    let id = created["id"].as_str().expect("id").to_string();
+
+    let updated = pack
+        .dispatch("update", json!({"id": id, "entity_type": null}))
+        .await
+        .expect("entity_type: null must clear the stored type");
+    assert!(
+        updated["entity_type"].is_null(),
+        "entity_type: null must clear the column: {updated}"
+    );
+    assert_eq!(updated["name"], "NullClearEntity");
+
+    let listed = pack
+        .dispatch(
+            "list",
+            json!({"kind": "entity", "entity_kind": "concept", "entity_type": "algorithm"}),
+        )
+        .await
+        .expect("typed list must succeed");
+    assert!(
+        list_items(&listed).iter().all(|item| item["id"] != id),
+        "a cleared entity must drop out of the typed listing: {listed}"
+    );
+}
+
+/// ADR-014 tri-state: a PRESENT `entity_type` key — including JSON `null` —
+/// is inapplicable to note and edge targets and must be rejected (not
+/// silently accepted).
+#[tokio::test]
+async fn update_null_entity_type_rejected_for_note_and_edge() {
+    let pack = pack();
+    let note = pack
+        .dispatch(
+            "create",
+            json!({"kind": "observation", "content": "null type note"}),
+        )
+        .await
+        .expect("create note");
+    let note_err = pack
+        .dispatch("update", json!({"id": note["id"], "entity_type": null}))
+        .await
+        .expect_err("entity_type: null on a note must be rejected");
+    assert!(
+        invalid_input_message(&note_err).contains("not valid for a note"),
+        "error: {note_err}"
+    );
+
+    let source = pack
+        .dispatch(
+            "create",
+            json!({"kind": "concept", "name": "NullTypeEdgeSource"}),
+        )
+        .await
+        .expect("create source");
+    let target = pack
+        .dispatch(
+            "create",
+            json!({"kind": "concept", "name": "NullTypeEdgeTarget"}),
+        )
+        .await
+        .expect("create target");
+    let edge = pack
+        .dispatch(
+            "link",
+            json!({
+                "source_id": source["id"],
+                "target_id": target["id"],
+                "relation": "supports"
+            }),
+        )
+        .await
+        .expect("create edge");
+    let edge_err = pack
+        .dispatch("update", json!({"id": edge["id"], "entity_type": null}))
+        .await
+        .expect_err("entity_type: null on an edge must be rejected");
+    assert!(
+        invalid_input_message(&edge_err).contains("not valid for an edge"),
+        "error: {edge_err}"
+    );
+}
+
+/// ADR-046 parity: a proposal UpdateEntity patch setting `entity_type`
+/// survives propose -> approve -> apply with normalization and persistence.
+#[tokio::test]
+async fn proposal_update_entity_type_apply_sets_and_normalizes() {
+    let pack = pack();
+    let created = pack
+        .dispatch(
+            "create",
+            json!({"kind": "entity", "entity_kind": "concept", "name": "ProposedTyped"}),
+        )
+        .await
+        .expect("create must succeed");
+    let entity_id = created["id"].as_str().expect("id").to_string();
+
+    let propose_result = pack
+        .dispatch(
+            "propose",
+            json!({
+                "title": "SetEntityTypeViaProposal",
+                "description": "Set the entity type through the proposal path",
+                "changeset": {
+                    "kind": "update_entity",
+                    "id": entity_id,
+                    "patch": {"entity_type": " Algorithm "}
+                }
+            }),
+        )
+        .await
+        .expect("propose must succeed");
+    let proposal_id = propose_result["id"].as_str().expect("id").to_string();
+
+    pack.dispatch("review", json!({"id": proposal_id, "decision": "approve"}))
+        .await
+        .expect("review(approve) must succeed");
+
+    let updated = pack
+        .dispatch("get", json!({"id": entity_id}))
+        .await
+        .expect("get");
+    assert_eq!(
+        updated["entity_type"], "algorithm",
+        "proposal apply must normalize + persist entity_type: {updated}"
+    );
+}
+
+/// ADR-014/ADR-046 parity: a proposal patch `entity_type: null` clears the
+/// stored type on apply.
+#[tokio::test]
+async fn proposal_update_entity_type_null_apply_clears() {
+    let pack = pack();
+    let created = pack
+        .dispatch(
+            "create",
+            json!({
+                "kind": "entity",
+                "entity_kind": "concept",
+                "entity_type": "algorithm",
+                "name": "ProposedClear"
+            }),
+        )
+        .await
+        .expect("create must succeed");
+    let entity_id = created["id"].as_str().expect("id").to_string();
+
+    let propose_result = pack
+        .dispatch(
+            "propose",
+            json!({
+                "title": "ClearEntityTypeViaProposal",
+                "description": "Clear the entity type through the proposal path",
+                "changeset": {
+                    "kind": "update_entity",
+                    "id": entity_id,
+                    "patch": {"entity_type": null}
+                }
+            }),
+        )
+        .await
+        .expect("propose must accept entity_type: null");
+    let proposal_id = propose_result["id"].as_str().expect("id").to_string();
+
+    pack.dispatch("review", json!({"id": proposal_id, "decision": "approve"}))
+        .await
+        .expect("review(approve) must succeed");
+
+    let updated = pack
+        .dispatch("get", json!({"id": entity_id}))
+        .await
+        .expect("get");
+    assert!(
+        updated["entity_type"].is_null(),
+        "proposal apply must clear entity_type: {updated}"
+    );
+}
+
+/// ADR-046 parity: an (kind, entity_type) pair the vocabulary rejects is
+/// refused at apply time — the proposal reverts to `approved`, the entity
+/// is unmutated, and no applied event is emitted.
+#[tokio::test]
+async fn proposal_update_invalid_entity_type_pair_reverts() {
+    let pack = pack();
+    let created = pack
+        .dispatch(
+            "create",
+            json!({"kind": "entity", "entity_kind": "concept", "name": "ProposedInvalid"}),
+        )
+        .await
+        .expect("create must succeed");
+    let entity_id = created["id"].as_str().expect("id").to_string();
+
+    let propose_result = pack
+        .dispatch(
+            "propose",
+            json!({
+                "title": "InvalidEntityTypeViaProposal",
+                "description": "Reject an invalid kind and entity type pair on apply",
+                "changeset": {
+                    "kind": "update_entity",
+                    "id": entity_id,
+                    "patch": {"entity_type": "not_registered"}
+                }
+            }),
+        )
+        .await
+        .expect("propose must succeed (validation happens at apply)");
+    let proposal_id = propose_result["id"].as_str().expect("id").to_string();
+
+    pack.dispatch("review", json!({"id": proposal_id, "decision": "approve"}))
+        .await
+        .expect("review(approve) must succeed");
+
+    let entity = pack
+        .dispatch("get", json!({"id": entity_id}))
+        .await
+        .expect("get after failed apply");
+    assert!(
+        entity["entity_type"].is_null(),
+        "a failed apply must not mutate entity_type: {entity}"
+    );
+
+    let events = pack
+        .dispatch(
+            "list",
+            json!({"kind": "event", "event_kind": "proposal_applied", "limit": 10}),
+        )
+        .await
+        .expect("list proposal_applied must succeed");
+    // The apply attempt is still audited, but its recorded result must be the
+    // failure, never a successful application.
+    let items = list_items(&events);
+    assert!(
+        !items.is_empty(),
+        "the failed apply must be audited: {events}"
+    );
+    for item in items {
+        let result = &item["payload"]["result"];
+        assert!(
+            !result["failed"].is_null(),
+            "proposal_applied must record the failed result: {item}"
+        );
+        assert_eq!(
+            result["failed"]["applied_step_count"], 0,
+            "no step may have applied: {item}"
+        );
+    }
+}
+
 /// ADR-014: `delete` without `kind` resolves the substrate from the UUID.
 #[tokio::test]
 async fn delete_entity_without_kind_resolves_from_uuid() {

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -4021,6 +4021,211 @@ async fn update_entity_without_kind_resolves_from_uuid() {
     );
 }
 
+/// A property-only historical type can be promoted into the indexed
+/// `entity_type` column without replacing any unrelated entity fields.
+#[tokio::test]
+async fn update_entity_type_promotes_property_type_into_typed_listing() {
+    let pack = pack();
+
+    let created = pack
+        .dispatch(
+            "create",
+            json!({
+                "kind": "entity",
+                "entity_kind": "concept",
+                "name": "HistoricalAlgorithm",
+                "description": "predates the entity_type column",
+                "properties": {"type": "algorithm", "keep": "preserved"},
+                "tags": ["historical", "control"]
+            }),
+        )
+        .await
+        .expect("create must succeed");
+    let id = created["id"]
+        .as_str()
+        .expect("create response must contain an id")
+        .to_string();
+
+    let before = pack
+        .dispatch(
+            "list",
+            json!({
+                "kind": "entity",
+                "entity_kind": "concept",
+                "entity_type": "algorithm"
+            }),
+        )
+        .await
+        .expect("typed list before backfill must succeed");
+    assert!(
+        list_items(&before).iter().all(|item| item["id"] != id),
+        "a property-only historical type must not satisfy the column-backed filter"
+    );
+
+    let updated = pack
+        .dispatch("update", json!({"id": id, "entity_type": "algorithm"}))
+        .await
+        .expect("update must accept a registered entity_type");
+
+    assert_eq!(updated["entity_type"], "algorithm");
+    assert_eq!(updated["name"], "HistoricalAlgorithm");
+    assert_eq!(updated["description"], "predates the entity_type column");
+    assert_eq!(updated["properties"]["type"], "algorithm");
+    assert_eq!(updated["properties"]["keep"], "preserved");
+    assert_eq!(updated["tags"], json!(["historical", "control"]));
+
+    let after = pack
+        .dispatch(
+            "list",
+            json!({
+                "kind": "entity",
+                "entity_kind": "concept",
+                "entity_type": "algorithm"
+            }),
+        )
+        .await
+        .expect("typed list after backfill must succeed");
+    assert_eq!(
+        list_items(&after)
+            .iter()
+            .filter(|item| item["id"] == id)
+            .count(),
+        1,
+        "the backfilled entity must appear exactly once in typed listing"
+    );
+}
+
+#[tokio::test]
+async fn update_unrelated_entity_field_preserves_entity_type() {
+    let pack = pack();
+    let created = pack
+        .dispatch(
+            "create",
+            json!({
+                "kind": "entity",
+                "entity_kind": "concept",
+                "entity_type": "algorithm",
+                "name": "TypedControl",
+                "properties": {"keep": true},
+                "tags": ["preserve"]
+            }),
+        )
+        .await
+        .expect("create must succeed");
+
+    let updated = pack
+        .dispatch(
+            "update",
+            json!({
+                "id": created["id"],
+                "description": "unrelated patch"
+            }),
+        )
+        .await
+        .expect("unrelated update must succeed");
+
+    assert_eq!(updated["entity_type"], "algorithm");
+    assert_eq!(updated["name"], "TypedControl");
+    assert_eq!(updated["description"], "unrelated patch");
+    assert_eq!(updated["properties"], json!({"keep": true}));
+    assert_eq!(updated["tags"], json!(["preserve"]));
+}
+
+#[tokio::test]
+async fn update_entity_type_rejects_unregistered_value_without_mutating_entity() {
+    let pack = pack();
+    let created = pack
+        .dispatch(
+            "create",
+            json!({
+                "kind": "entity",
+                "entity_kind": "concept",
+                "name": "InvalidTypeControl"
+            }),
+        )
+        .await
+        .expect("create must succeed");
+    let id = created["id"].as_str().expect("id").to_string();
+
+    let err = pack
+        .dispatch("update", json!({"id": id, "entity_type": "not_registered"}))
+        .await
+        .expect_err("an unregistered entity_type must be rejected");
+    let message = invalid_input_message(&err);
+    assert!(message.contains("entity_type"), "error: {message}");
+    assert!(message.contains("not_registered"), "error: {message}");
+    assert!(message.contains("algorithm"), "error: {message}");
+
+    let entity = pack
+        .dispatch("get", json!({"id": id}))
+        .await
+        .expect("rejected update must leave the entity readable");
+    assert!(
+        entity["entity_type"].is_null(),
+        "a rejected update must not mutate entity_type: {entity}"
+    );
+}
+
+#[tokio::test]
+async fn update_entity_type_is_rejected_for_non_entity_substrates() {
+    let pack = pack();
+    let note = pack
+        .dispatch(
+            "create",
+            json!({"kind": "observation", "content": "note control"}),
+        )
+        .await
+        .expect("create note");
+    let note_err = pack
+        .dispatch(
+            "update",
+            json!({"id": note["id"], "entity_type": "algorithm"}),
+        )
+        .await
+        .expect_err("entity_type on a note must be rejected");
+    assert!(
+        invalid_input_message(&note_err).contains("not valid for a note"),
+        "error: {note_err}"
+    );
+
+    let source = pack
+        .dispatch(
+            "create",
+            json!({"kind": "concept", "name": "EntityTypeEdgeSource"}),
+        )
+        .await
+        .expect("create source");
+    let target = pack
+        .dispatch(
+            "create",
+            json!({"kind": "concept", "name": "EntityTypeEdgeTarget"}),
+        )
+        .await
+        .expect("create target");
+    let edge = pack
+        .dispatch(
+            "link",
+            json!({
+                "source_id": source["id"],
+                "target_id": target["id"],
+                "relation": "supports"
+            }),
+        )
+        .await
+        .expect("create edge");
+    let edge_err = pack
+        .dispatch(
+            "update",
+            json!({"id": edge["id"], "entity_type": "algorithm"}),
+        )
+        .await
+        .expect_err("entity_type on an edge must be rejected");
+    assert!(
+        invalid_input_message(&edge_err).contains("not valid for an edge"),
+        "error: {edge_err}"
+    );
+}
+
 /// ADR-014: `delete` without `kind` resolves the substrate from the UUID.
 #[tokio::test]
 async fn delete_entity_without_kind_resolves_from_uuid() {

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -91,6 +91,23 @@ fn optional_create_string(args: &Value, key: &str) -> RuntimeResult<Option<Strin
     }
 }
 
+/// ADR-014 tri-state patch for entity `entity_type`, read from raw JSON to
+/// mirror `UpdateParams.entity_type`'s `tri_string` deserializer (the
+/// kkernel `--atomic` seam deserializes through that struct first, so the
+/// two surfaces cannot diverge): key absent -> `None` (unchanged), key
+/// present as `null` -> `Some(None)` (explicit clear), key present as a
+/// string -> `Some(Some(s))` (set); any other JSON type -> a hard error.
+fn optional_entity_type_patch(args: &Value, key: &str) -> RuntimeResult<Option<Option<String>>> {
+    match obj(args)?.get(key) {
+        None => Ok(None),
+        Some(Value::Null) => Ok(Some(None)),
+        Some(Value::String(value)) => Ok(Some(Some(value.clone()))),
+        Some(other) => Err(RuntimeError::InvalidInput(format!(
+            "{key} must be a string or null, got: {other}"
+        ))),
+    }
+}
+
 /// Nullable-string patch semantics mirroring the actually-reachable behavior
 /// of `khive-pack-kg::handlers::common::optional_string_patch`/
 /// `description_patch`, reimplemented here rather than imported (that
@@ -591,7 +608,9 @@ fn reject_inapplicable_update_fields(args: &Value, substrate: &str) -> RuntimeRe
                 Some("relation")
             } else if present("weight") {
                 Some("weight")
-            } else if present("entity_type") {
+            } else if o.contains_key("entity_type") {
+                // ADR-014 tri-state: a PRESENT key (including JSON `null`,
+                // the explicit clear) is inapplicable to notes.
                 Some("entity_type")
             } else {
                 None
@@ -616,7 +635,9 @@ fn reject_inapplicable_update_fields(args: &Value, substrate: &str) -> RuntimeRe
                 Some("salience")
             } else if present("decay_factor") {
                 Some("decay_factor")
-            } else if present("entity_type") {
+            } else if o.contains_key("entity_type") {
+                // ADR-014 tri-state: a PRESENT key (including JSON `null`,
+                // the explicit clear) is inapplicable to edges.
                 Some("entity_type")
             } else {
                 None
@@ -807,7 +828,7 @@ pub async fn prepare_update(
             let description = optional_string_patch(args, "description")?;
             let properties = optional_properties(args, "properties")?;
             let tags = optional_tags(args)?;
-            let entity_type = optional_create_string(args, "entity_type")?;
+            let entity_type = optional_entity_type_patch(args, "entity_type")?;
 
             prepare_update_entity_plan(
                 runtime,
@@ -4149,5 +4170,146 @@ mod tests {
         let (edge_count, _, _, _) =
             probe_edge_natural_key(&runtime, "local", a_id, x_id, "extends").await;
         assert_eq!(edge_count, 0, "no edge may have been committed");
+    }
+
+    /// ADR-014 tri-state on the atomic path: `entity_type: null` must
+    /// explicitly CLEAR a stored entity type (and reindex), not collapse to
+    /// "unchanged" like the old `optional_create_string` did.
+    #[tokio::test]
+    async fn atomic_update_entity_type_null_clears_stored_type() {
+        let runtime = scratch_runtime();
+        runtime.install_entity_type_validator(std::sync::Arc::new(|kind, entity_type| {
+            let Some(raw) = entity_type else {
+                return Ok(None);
+            };
+            let normalized = raw.trim().to_ascii_lowercase();
+            if kind == "concept" && normalized == "algorithm" {
+                Ok(Some(normalized))
+            } else {
+                Err(RuntimeError::InvalidInput(format!(
+                    "unknown entity_type {raw:?} for {kind:?}; valid: algorithm"
+                )))
+            }
+        }));
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let mut entity = khive_storage::Entity::new("local", "concept", "AtomicNullClear");
+        entity.entity_type = Some("algorithm".to_string());
+        let entity_id = entity.id;
+        runtime
+            .entities(&token)
+            .expect("entities store")
+            .upsert_entity(entity)
+            .await
+            .expect("seed entity");
+
+        let plan = prepare_update(
+            &runtime,
+            &token,
+            &json!({"id": entity_id.to_string(), "entity_type": null}),
+            None,
+        )
+        .await
+        .expect("atomic prepare must accept entity_type: null");
+        let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+            .await
+            .expect("atomic update must run");
+        let post_commit = match outcome {
+            crate::atomic_runner::AtomicRunOutcome::Committed { post_commit } => post_commit,
+            other => panic!("expected Committed, got {other:?}"),
+        };
+        assert_eq!(
+            post_commit.as_slice(),
+            &[PostCommitEffect::ReindexEntity { entity_id }],
+            "a type clear that differs from the prior value must reindex"
+        );
+
+        let updated = runtime
+            .get_entity(&token, entity_id)
+            .await
+            .expect("read updated entity");
+        assert_eq!(
+            updated.entity_type, None,
+            "entity_type: null must clear the stored type"
+        );
+        assert_eq!(updated.name, "AtomicNullClear");
+    }
+
+    /// ADR-014 tri-state on the atomic path: a PRESENT `entity_type` key,
+    /// including JSON `null`, must be rejected on note and edge targets
+    /// (parity with `khive-pack-kg`'s `reject_inapplicable_fields`).
+    #[tokio::test]
+    async fn atomic_update_null_entity_type_rejected_for_note_and_edge() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let note = runtime
+            .create_note(
+                &token,
+                "observation",
+                None,
+                "note body for entity_type guard",
+                Some(0.5),
+                None,
+                vec![],
+            )
+            .await
+            .expect("create note");
+
+        let note_err = prepare_update(
+            &runtime,
+            &token,
+            &json!({"id": note.id.to_string(), "entity_type": null}),
+            Some(crate::atomic_prepare::AtomicUpdateKind::Note { specific: None }),
+        )
+        .await
+        .expect_err("entity_type: null on a note must be rejected");
+        assert!(
+            matches!(note_err, RuntimeError::InvalidInput(ref msg) if msg.contains("entity_type") && msg.contains("not valid for a note")),
+            "expected an InvalidInput naming entity_type for a note, got: {note_err:?}"
+        );
+
+        let source = khive_storage::Entity::new("local", "concept", "AtomicNullTypeEdgeSource");
+        let target = khive_storage::Entity::new("local", "concept", "AtomicNullTypeEdgeTarget");
+        let source_id = source.id;
+        let target_id = target.id;
+        runtime
+            .entities(&token)
+            .expect("entities store")
+            .upsert_entity(source)
+            .await
+            .expect("seed source");
+        runtime
+            .entities(&token)
+            .expect("entities store")
+            .upsert_entity(target)
+            .await
+            .expect("seed target");
+        let edge = runtime
+            .link(
+                &token,
+                source_id,
+                target_id,
+                "supports".parse().expect("relation"),
+                0.5,
+                None,
+            )
+            .await
+            .expect("create edge");
+
+        let edge_err = prepare_update(
+            &runtime,
+            &token,
+            &json!({"id": edge.id.to_string(), "entity_type": null}),
+            Some(crate::atomic_prepare::AtomicUpdateKind::Edge),
+        )
+        .await
+        .expect_err("entity_type: null on an edge must be rejected");
+        assert!(
+            matches!(edge_err, RuntimeError::InvalidInput(ref msg) if msg.contains("entity_type") && msg.contains("not valid for an edge")),
+            "expected an InvalidInput naming entity_type for an edge, got: {edge_err:?}"
+        );
     }
 }

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -580,7 +580,7 @@ fn reject_inapplicable_update_fields(args: &Value, substrate: &str) -> RuntimeRe
             } else {
                 None
             };
-            (bad, "name, description, tags, properties")
+            (bad, "name, description, tags, properties, entity_type")
         }
         "note" => {
             let bad = if present("description") {
@@ -591,6 +591,8 @@ fn reject_inapplicable_update_fields(args: &Value, substrate: &str) -> RuntimeRe
                 Some("relation")
             } else if present("weight") {
                 Some("weight")
+            } else if present("entity_type") {
+                Some("entity_type")
             } else {
                 None
             };
@@ -614,6 +616,8 @@ fn reject_inapplicable_update_fields(args: &Value, substrate: &str) -> RuntimeRe
                 Some("salience")
             } else if present("decay_factor") {
                 Some("decay_factor")
+            } else if present("entity_type") {
+                Some("entity_type")
             } else {
                 None
             };
@@ -803,6 +807,7 @@ pub async fn prepare_update(
             let description = optional_string_patch(args, "description")?;
             let properties = optional_properties(args, "properties")?;
             let tags = optional_tags(args)?;
+            let entity_type = optional_create_string(args, "entity_type")?;
 
             prepare_update_entity_plan(
                 runtime,
@@ -813,6 +818,7 @@ pub async fn prepare_update(
                     description,
                     properties,
                     tags,
+                    entity_type,
                 },
             )
             .await
@@ -857,7 +863,7 @@ pub async fn prepare_update_entity_plan(
     id: Uuid,
     patch: crate::curation::EntityPatch,
 ) -> RuntimeResult<AtomicOpPlan> {
-    let (entity, text_changed, changed_fields) =
+    let (entity, reindex_required, changed_fields) =
         runtime.prepare_update_entity(token, id, patch).await?;
     let mut statements = vec![PlanStatement {
         statement: entity_upsert_statement(&entity),
@@ -875,7 +881,7 @@ pub async fn prepare_update_entity_plan(
             "changed_fields": changed_fields,
         }),
     )?);
-    let post_commit = if text_changed {
+    let post_commit = if reindex_required {
         PostCommitEffect::ReindexEntity { entity_id: id }
     } else {
         PostCommitEffect::None
@@ -1783,6 +1789,72 @@ mod tests {
             .await
             .expect("get_entity");
         assert_eq!(entity.name, "GapFourEntity-renamed");
+    }
+
+    #[tokio::test]
+    async fn atomic_update_entity_type_persists_patch_and_schedules_reindex() {
+        let runtime = scratch_runtime();
+        runtime.install_entity_type_validator(std::sync::Arc::new(|kind, entity_type| {
+            let Some(raw) = entity_type else {
+                return Ok(None);
+            };
+            let normalized = raw.trim().to_ascii_lowercase();
+            if kind == "concept" && normalized == "algorithm" {
+                Ok(Some(normalized))
+            } else {
+                Err(RuntimeError::InvalidInput(format!(
+                    "unknown entity_type {raw:?} for {kind:?}; valid: algorithm"
+                )))
+            }
+        }));
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let mut entity = khive_storage::Entity::new("local", "concept", "AtomicHistorical");
+        entity.description = Some("keep description".to_string());
+        entity.properties = Some(json!({"type": "algorithm", "keep": true}));
+        entity.tags = vec!["keep-tag".to_string()];
+        let entity_id = entity.id;
+        runtime
+            .entities(&token)
+            .expect("entities store")
+            .upsert_entity(entity)
+            .await
+            .expect("seed entity");
+
+        let plan = prepare_update(
+            &runtime,
+            &token,
+            &json!({"id": entity_id.to_string(), "entity_type": " Algorithm "}),
+            None,
+        )
+        .await
+        .expect("atomic prepare must accept a registered entity_type");
+        let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+            .await
+            .expect("atomic update must run");
+        let post_commit = match outcome {
+            crate::atomic_runner::AtomicRunOutcome::Committed { post_commit } => post_commit,
+            other => panic!("expected Committed, got {other:?}"),
+        };
+        assert_eq!(
+            post_commit.as_slice(),
+            &[PostCommitEffect::ReindexEntity { entity_id }],
+            "entity_type patch must schedule the normal entity reindex path"
+        );
+
+        let updated = runtime
+            .get_entity(&token, entity_id)
+            .await
+            .expect("read updated entity");
+        assert_eq!(updated.entity_type.as_deref(), Some("algorithm"));
+        assert_eq!(updated.name, "AtomicHistorical");
+        assert_eq!(updated.description.as_deref(), Some("keep description"));
+        assert_eq!(
+            updated.properties,
+            Some(json!({"type": "algorithm", "keep": true}))
+        );
+        assert_eq!(updated.tags, vec!["keep-tag"]);
     }
 
     /// Symmetric note-substrate case: `description` and `tags` are

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -85,12 +85,16 @@ impl EmbeddingModelPlan {
 /// For `tags` — replace semantics: `Some(vec)` sets tags to exactly `vec`. To add
 /// a tag without losing existing tags, read the entity first, push the new tag,
 /// and pass the full list back.
+///
+/// For `entity_type` — `Some(value)` validates and normalizes `value` through the
+/// installed entity-type registry. `None` leaves the current type unchanged.
 #[derive(Clone, Debug, Default)]
 pub struct EntityPatch {
     pub name: Option<String>,
     pub description: Option<Option<String>>,
     pub properties: Option<Value>,
     pub tags: Option<Vec<String>>,
+    pub entity_type: Option<String>,
 }
 
 /// Policy used when deduplicating two entities.
@@ -816,11 +820,12 @@ impl KhiveRuntime {
     /// Patch-style entity update.
     ///
     /// Only fields set to `Some(_)` are changed. Re-indexes FTS5 (and vectors if configured)
-    /// when `name` or `description` changes; skips re-indexing for property/tag-only patches.
+    /// when `name`, `description`, or `entity_type` changes; skips re-indexing for
+    /// property/tag-only patches.
     ///
     /// Returns `RuntimeError::NotFound` if the entity does not exist or belongs to a different
     /// namespace. Namespace isolation is enforced at the runtime layer.
-    /// Computes the patched `Entity`, `text_changed`, and `changed_fields` without
+    /// Computes the patched `Entity`, `reindex_required`, and `changed_fields` without
     /// writing anything, so both the normal write path and the atomic-prepare path
     /// share one source of truth for what a patched entity looks like.
     pub(crate) async fn prepare_update_entity(
@@ -848,16 +853,21 @@ impl KhiveRuntime {
             .await?
             .ok_or_else(|| RuntimeError::NotFound(format!("entity {id}")))?;
 
-        let mut text_changed = false;
+        let validated_entity_type = match patch.entity_type.as_deref() {
+            Some(raw) => Some(self.validate_entity_type_for_kind(&entity.kind, Some(raw))?),
+            None => None,
+        };
+
+        let mut reindex_required = false;
         let mut changed_fields: Vec<&'static str> = Vec::new();
 
         if let Some(name) = patch.name {
-            text_changed |= entity.name != name;
+            reindex_required |= entity.name != name;
             entity.name = name;
             changed_fields.push("name");
         }
         if let Some(desc_patch) = patch.description {
-            text_changed |= entity.description != desc_patch;
+            reindex_required |= entity.description != desc_patch;
             entity.description = desc_patch;
             changed_fields.push("description");
         }
@@ -874,9 +884,14 @@ impl KhiveRuntime {
             entity.tags = tags;
             changed_fields.push("tags");
         }
+        if let Some(entity_type) = validated_entity_type {
+            reindex_required |= entity.entity_type != entity_type;
+            entity.entity_type = entity_type;
+            changed_fields.push("entity_type");
+        }
 
         entity.updated_at = chrono::Utc::now().timestamp_micros();
-        Ok((entity, text_changed, changed_fields))
+        Ok((entity, reindex_required, changed_fields))
     }
 
     pub async fn update_entity(
@@ -897,13 +912,13 @@ impl KhiveRuntime {
         id: Uuid,
         patch: EntityPatch,
     ) -> RuntimeResult<(Entity, crate::retrieval::EmbeddingTruncationReport)> {
-        let (entity, text_changed, changed_fields) =
+        let (entity, reindex_required, changed_fields) =
             self.prepare_update_entity(token, id, patch).await?;
 
         let store = self.entities(token)?;
         store.upsert_entity(entity.clone()).await?;
 
-        let embedding_report = if text_changed {
+        let embedding_report = if reindex_required {
             self.reindex_entity(token, &entity).await?
         } else {
             crate::retrieval::EmbeddingTruncationReport::default()
@@ -3961,6 +3976,76 @@ mod tests {
         assert_eq!(updated.name, "OriginalName");
         assert_eq!(updated.description.as_deref(), Some("new desc"));
         assert_eq!(updated.properties, Some(serde_json::json!({"k":"v"})));
+    }
+
+    #[tokio::test]
+    async fn update_entity_type_patch_validates_preserves_fields_and_requires_reindex() {
+        let rt = rt();
+        rt.install_entity_type_validator(std::sync::Arc::new(|kind, entity_type| {
+            let Some(raw) = entity_type else {
+                return Ok(None);
+            };
+            let normalized = raw.trim().to_ascii_lowercase();
+            if kind == "concept" && normalized == "algorithm" {
+                Ok(Some(normalized))
+            } else {
+                Err(RuntimeError::InvalidInput(format!(
+                    "unknown entity_type {raw:?} for {kind:?}; valid: algorithm"
+                )))
+            }
+        }));
+        let tok = NamespaceToken::local();
+        let entity = rt
+            .create_entity(
+                &tok,
+                "concept",
+                None,
+                "HistoricalAlgorithm",
+                Some("keep description"),
+                Some(serde_json::json!({"type": "algorithm", "keep": true})),
+                vec!["keep-tag".to_string()],
+            )
+            .await
+            .unwrap();
+
+        let (prepared, reindex_required, changed_fields) = rt
+            .prepare_update_entity(
+                &tok,
+                entity.id,
+                EntityPatch {
+                    entity_type: Some(" Algorithm ".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("registered entity_type must validate");
+
+        assert_eq!(prepared.entity_type.as_deref(), Some("algorithm"));
+        assert_eq!(prepared.name, "HistoricalAlgorithm");
+        assert_eq!(prepared.description.as_deref(), Some("keep description"));
+        assert_eq!(
+            prepared.properties,
+            Some(serde_json::json!({"type": "algorithm", "keep": true}))
+        );
+        assert_eq!(prepared.tags, vec!["keep-tag"]);
+        assert!(
+            reindex_required,
+            "changing entity_type must request the normal entity reindex path"
+        );
+        assert_eq!(changed_fields, vec!["entity_type"]);
+
+        let err = rt
+            .prepare_update_entity(
+                &tok,
+                entity.id,
+                EntityPatch {
+                    entity_type: Some("not_registered".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect_err("unregistered entity_type must be rejected");
+        assert!(matches!(err, RuntimeError::InvalidInput(_)), "error: {err}");
     }
 
     #[tokio::test]

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -86,15 +86,17 @@ impl EmbeddingModelPlan {
 /// a tag without losing existing tags, read the entity first, push the new tag,
 /// and pass the full list back.
 ///
-/// For `entity_type` — `Some(value)` validates and normalizes `value` through the
-/// installed entity-type registry. `None` leaves the current type unchanged.
+/// For `entity_type` — ADR-014 tri-state: `None` leaves the current type
+/// unchanged, `Some(None)` explicitly clears it, and `Some(Some(value))`
+/// validates and normalizes `value` through the installed entity-type
+/// registry.
 #[derive(Clone, Debug, Default)]
 pub struct EntityPatch {
     pub name: Option<String>,
     pub description: Option<Option<String>>,
     pub properties: Option<Value>,
     pub tags: Option<Vec<String>>,
-    pub entity_type: Option<String>,
+    pub entity_type: Option<Option<String>>,
 }
 
 /// Policy used when deduplicating two entities.
@@ -853,8 +855,15 @@ impl KhiveRuntime {
             .await?
             .ok_or_else(|| RuntimeError::NotFound(format!("entity {id}")))?;
 
-        let validated_entity_type = match patch.entity_type.as_deref() {
-            Some(raw) => Some(self.validate_entity_type_for_kind(&entity.kind, Some(raw))?),
+        // ADR-014 tri-state: outer `None` = unchanged; `Some(None)` = explicit
+        // clear (no vocabulary validation — there is no value to validate);
+        // `Some(Some(raw))` = set, validated and normalized.
+        let validated_entity_type = match &patch.entity_type {
+            Some(None) => Some(None),
+            Some(Some(raw)) => Some(Some(
+                self.validate_entity_type_for_kind(&entity.kind, Some(raw))?
+                    .expect("set branch always yields a normalized value"),
+            )),
             None => None,
         };
 
@@ -4013,7 +4022,7 @@ mod tests {
                 &tok,
                 entity.id,
                 EntityPatch {
-                    entity_type: Some(" Algorithm ".to_string()),
+                    entity_type: Some(Some(" Algorithm ".to_string())),
                     ..Default::default()
                 },
             )
@@ -4039,7 +4048,7 @@ mod tests {
                 &tok,
                 entity.id,
                 EntityPatch {
-                    entity_type: Some("not_registered".to_string()),
+                    entity_type: Some(Some("not_registered".to_string())),
                     ..Default::default()
                 },
             )

--- a/crates/khive-types/src/event.rs
+++ b/crates/khive-types/src/event.rs
@@ -528,6 +528,15 @@ pub struct ProposalEntityPatch {
     pub properties: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<Vec<String>>,
+    /// ADR-014 tri-state: absent leaves the type unchanged, `null` explicitly
+    /// clears it, a string sets it (validated against the kind's vocabulary
+    /// at apply time, per ADR-046 parity with the runtime entity update).
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "serde_opt_opt"
+    )]
+    pub entity_type: Option<Option<String>>,
 }
 
 /// Structured draft for adding a new note via a proposal.
@@ -966,6 +975,40 @@ mod tests {
         assert!(
             matches!(cs, ProposalChangeset::UpdateEntity { .. }),
             "expected UpdateEntity"
+        );
+
+        // Tri-state entity_type (ADR-014): absent vs explicit null vs set
+        // must all survive the proposal wire boundary distinctly.
+        for (json, expected) in [
+            (serde_json::json!({}), None),
+            (serde_json::json!({"entity_type": null}), Some(None)),
+            (
+                serde_json::json!({"entity_type": "algorithm"}),
+                Some(Some("algorithm".to_string())),
+            ),
+        ] {
+            let v = serde_json::json!({"kind": "update_entity", "id": uuid, "patch": json});
+            let cs: ProposalChangeset =
+                serde_json::from_value(v).expect("UpdateEntity must deserialize");
+            let ProposalChangeset::UpdateEntity { patch, .. } = cs else {
+                panic!("expected UpdateEntity");
+            };
+            assert_eq!(patch.entity_type, expected, "patch: {json}");
+        }
+
+        // The clear must serialize back as an explicit null.
+        let patch = ProposalEntityPatch {
+            name: None,
+            description: None,
+            properties: None,
+            tags: None,
+            entity_type: Some(None),
+        };
+        let v = serde_json::to_value(&patch).expect("serialize");
+        assert_eq!(v.get("entity_type"), Some(&serde_json::Value::Null));
+        assert!(
+            v.get("name").is_none(),
+            "absent fields must not be serialized"
         );
 
         // AddEdge

--- a/crates/khive-types/src/event.rs
+++ b/crates/khive-types/src/event.rs
@@ -511,7 +511,9 @@ pub struct EntityDraft {
 
 /// Structured patch for modifying an existing entity via a proposal.
 ///
-/// Absent fields mean "leave unchanged". Setting `description` to `null` clears it.
+/// Absent fields mean "leave unchanged". Setting `description` or
+/// `entity_type` to `null` explicitly clears it; a string `entity_type` sets
+/// it, validated against the kind's registered vocabulary at apply time.
 #[cfg(feature = "serde")]
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ProposalEntityPatch {
@@ -592,7 +594,8 @@ pub enum ProposalChangeset {
     AddEntity {
         entity: EntityDraft,
     },
-    /// Modify an existing entity's properties / tags / description.
+    /// Modify an existing entity's properties / tags / description / entity
+    /// type (absent = unchanged, null = clear, string = set-and-validate).
     UpdateEntity {
         id: Id128,
         patch: ProposalEntityPatch,

--- a/docs/adr/ADR-046-event-sourced-proposals.md
+++ b/docs/adr/ADR-046-event-sourced-proposals.md
@@ -99,7 +99,8 @@ pub struct ProposalCreatedPayload {
 pub enum ProposalChangeset {
     /// Add a new entity. Fields validated against ADR-001 + pack kind specs.
     AddEntity { entity: EntityDraft },
-    /// Modify an existing entity's properties / tags / description.
+    /// Modify an existing entity's properties / tags / description / entity type
+    /// (absent = unchanged, null = clear, string = set-and-validate).
     UpdateEntity { id: Uuid, patch: EntityPatch },
     /// Add a new edge. Validated against ADR-002 endpoints + pack EDGE_RULES.
     AddEdge { source: Uuid, target: Uuid, relation: EdgeRelation, weight: Option<f32> },


### PR DESCRIPTION
## Summary

- accept entity_type in entity updates and validate it against the same closed composed vocabulary as create
- persist the normalized type through canonical and atomic patch paths while preserving unrelated fields and scheduling entity reindexing when it changes
- reject entity_type on note and edge updates and cover property-only historical backfill behavior

## Testing

- cargo fmt --all
- cargo clippy -p khive-runtime -p khive-pack-kg --all-targets -- -D warnings
- cargo test -p khive-runtime -p khive-pack-kg

Fixes #1992