### PR TITLE
fix(search): filter results by retrieval source

### DIFF
--- a/crates/khive-pack-kg/src/handler_defs.rs
+++ b/crates/khive-pack-kg/src/handler_defs.rs
@@ -579,6 +579,12 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 20] = [
                 description: "Filter to records with any listed tag (kind=\"entity\" or kind=\"note\", OR semantics, case-insensitive). Predicates are applied BEFORE result truncation inside a bounded candidate window (entity tags: SQL-level via EntityFilter; note tags: Rust-level in the alive-set loop). For notes, tags are read from `properties[\"tags\"]` (there is no separate tag column on notes). E.g. [\"rust\", \"ml\"]. Matches ranked beyond the runtime candidate budget (limit × 4 × handler_overfetch) may still be missed — use specific queries to bring matches into the top candidates.",
             },
             ParamDef {
+                name: "source",
+                param_type: "string",
+                required: false,
+                description: "Filter by exact retrieval source: text | vector | both. Applied before the caller limit inside a bounded candidate window; both means the final hit received both text and vector contributions.",
+            },
+            ParamDef {
                 name: "min_score",
                 param_type: "number",
                 required: false,

--- a/crates/khive-pack-kg/src/handlers/params.rs
+++ b/crates/khive-pack-kg/src/handlers/params.rs
@@ -167,6 +167,7 @@ pub(crate) struct SearchParams {
     pub(crate) include_superseded: Option<bool>,
     pub(crate) properties: Option<Value>,
     pub(crate) tags: Option<Vec<String>>,
+    pub(crate) source: Option<String>,
     pub(crate) min_score: Option<f64>,
 }
 

--- a/crates/khive-pack-kg/src/handlers/search.rs
+++ b/crates/khive-pack-kg/src/handlers/search.rs
@@ -11,7 +11,9 @@ use std::time::Instant;
 use serde_json::{json, Value};
 use uuid::Uuid;
 
-use khive_runtime::{micros_to_iso, KhiveRuntime, NamespaceToken, RuntimeError, VerbRegistry};
+use khive_runtime::{
+    micros_to_iso, KhiveRuntime, NamespaceToken, RuntimeError, SearchSource, VerbRegistry,
+};
 use khive_storage::types::PageRequest;
 use khive_storage::EntityFilter;
 
@@ -49,6 +51,7 @@ pub struct ValidatedSearchRequest {
     include_superseded: bool,
     properties: Option<Value>,
     tags: Vec<String>,
+    source: Option<SearchSource>,
     min_score: f64,
 }
 
@@ -72,6 +75,17 @@ impl ValidatedSearchRequest {
         let tags = p.tags.unwrap_or_default();
         let limit = p.limit.unwrap_or(10).min(100);
         let min_score = p.min_score.unwrap_or(0.0).max(0.0);
+        let source = match p.source.as_deref() {
+            None => None,
+            Some("text") => Some(SearchSource::Text),
+            Some("vector") => Some(SearchSource::Vector),
+            Some("both") => Some(SearchSource::Both),
+            Some(_) => {
+                return Err(RuntimeError::InvalidInput(
+                    "source must be one of: text, vector, both".to_string(),
+                ));
+            }
+        };
 
         match resolve_kind_spec(kind_raw, registry)? {
             KindSpec::Entity { specific } => {
@@ -109,6 +123,7 @@ impl ValidatedSearchRequest {
                     include_superseded: false,
                     properties,
                     tags,
+                    source,
                     min_score,
                 })
             }
@@ -138,6 +153,7 @@ impl ValidatedSearchRequest {
                     include_superseded: p.include_superseded.unwrap_or(false),
                     properties,
                     tags,
+                    source,
                     min_score,
                 })
             }
@@ -196,6 +212,11 @@ impl ValidatedSearchRequest {
         &self.tags
     }
 
+    /// Exact retrieval leg membership required by the caller.
+    pub fn source(&self) -> Option<SearchSource> {
+        self.source
+    }
+
     /// Non-negative result-score floor.
     pub fn min_score(&self) -> f64 {
         self.min_score
@@ -203,7 +224,7 @@ impl ValidatedSearchRequest {
 
     /// Bounded backend candidate window used to preserve filtered-result recall.
     pub fn candidate_limit(&self) -> u32 {
-        if self.properties.is_some() || !self.tags.is_empty() {
+        if self.properties.is_some() || !self.tags.is_empty() || self.source.is_some() {
             self.limit.saturating_mul(50).min(FILTERED_SCAN_CAP)
         } else {
             self.limit
@@ -241,6 +262,7 @@ impl KgPack {
             SearchSubstrate::Entity => {
                 let props_filter = request.properties();
                 let tag_filter = (!request.tags().is_empty()).then_some(request.tags());
+                let source_filter = request.source();
                 let hits = self
                     .runtime
                     .hybrid_search(
@@ -288,20 +310,25 @@ impl KgPack {
                             .collect()
                     };
 
-                let filtered_hits = if props_filter.is_some() || tag_filter.is_some() {
-                    hits.into_iter()
-                        .filter(|h| {
-                            let Some((_, props, tags, _)) = entity_meta.get(&h.entity_id) else {
-                                return false;
-                            };
-                            props_filter.is_none_or(|pf| props_match(props.as_ref(), pf))
-                                && tag_filter.is_none_or(|wanted| tags_match_any(tags, wanted))
-                        })
-                        .take(request.limit() as usize)
-                        .collect::<Vec<_>>()
-                } else {
-                    hits
-                };
+                let filtered_hits =
+                    if props_filter.is_some() || tag_filter.is_some() || source_filter.is_some() {
+                        hits.into_iter()
+                            .filter(|h| {
+                                if source_filter.is_some_and(|source| h.source != source) {
+                                    return false;
+                                }
+                                let Some((_, props, tags, _)) = entity_meta.get(&h.entity_id)
+                                else {
+                                    return false;
+                                };
+                                props_filter.is_none_or(|pf| props_match(props.as_ref(), pf))
+                                    && tag_filter.is_none_or(|wanted| tags_match_any(tags, wanted))
+                            })
+                            .take(request.limit() as usize)
+                            .collect::<Vec<_>>()
+                    } else {
+                        hits
+                    };
 
                 let result: Vec<Value> = filtered_hits
                     .iter()
@@ -339,6 +366,7 @@ impl KgPack {
             SearchSubstrate::Note => {
                 let props_filter = request.properties();
                 let tag_filter = (!request.tags().is_empty()).then_some(request.tags());
+                let source_filter = request.source();
                 let hits = self
                     .runtime
                     .search_notes(
@@ -372,35 +400,39 @@ impl KgPack {
                             .collect()
                     };
 
-                let filtered_hits: Vec<_> = if props_filter.is_some() || tag_filter.is_some() {
-                    hits.into_iter()
-                        .filter(|h| {
-                            let Some((_, props, _, _)) = note_meta.get(&h.note_id) else {
-                                return false;
-                            };
-                            let props_ok =
-                                props_filter.is_none_or(|pf| props_match(props.as_ref(), pf));
-                            let tags_ok = tag_filter.is_none_or(|wanted| {
-                                let note_tags: Vec<String> = props
-                                    .as_ref()
-                                    .and_then(|p| p.get("tags"))
-                                    .and_then(Value::as_array)
-                                    .map(|arr| {
-                                        arr.iter()
-                                            .filter_map(Value::as_str)
-                                            .map(str::to_owned)
-                                            .collect()
-                                    })
-                                    .unwrap_or_default();
-                                tags_match_any(&note_tags, wanted)
-                            });
-                            props_ok && tags_ok
-                        })
-                        .take(request.limit() as usize)
-                        .collect()
-                } else {
-                    hits
-                };
+                let filtered_hits: Vec<_> =
+                    if props_filter.is_some() || tag_filter.is_some() || source_filter.is_some() {
+                        hits.into_iter()
+                            .filter(|h| {
+                                if source_filter.is_some_and(|source| h.source != source) {
+                                    return false;
+                                }
+                                let Some((_, props, _, _)) = note_meta.get(&h.note_id) else {
+                                    return false;
+                                };
+                                let props_ok =
+                                    props_filter.is_none_or(|pf| props_match(props.as_ref(), pf));
+                                let tags_ok = tag_filter.is_none_or(|wanted| {
+                                    let note_tags: Vec<String> = props
+                                        .as_ref()
+                                        .and_then(|p| p.get("tags"))
+                                        .and_then(Value::as_array)
+                                        .map(|arr| {
+                                            arr.iter()
+                                                .filter_map(Value::as_str)
+                                                .map(str::to_owned)
+                                                .collect()
+                                        })
+                                        .unwrap_or_default();
+                                    tags_match_any(&note_tags, wanted)
+                                });
+                                props_ok && tags_ok
+                            })
+                            .take(request.limit() as usize)
+                            .collect()
+                    } else {
+                        hits
+                    };
 
                 let result: Vec<Value> = filtered_hits
                     .iter()

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -2392,6 +2392,78 @@ async fn search_kind_entity_still_works_alongside_memory_pack() {
 }
 
 #[tokio::test]
+async fn search_source_filter_is_strict_and_applied_before_limit() {
+    let fixture = pack_with_memory();
+
+    fixture
+        .dispatch(
+            "create",
+            json!({
+                "kind": "entity",
+                "entity_kind": "concept",
+                "name": "SourceFilteredSearchProbe",
+                "description": "text retrieval source filter coverage"
+            }),
+        )
+        .await
+        .expect("create source-filter probe entity");
+
+    let text_result = fixture
+        .dispatch(
+            "search",
+            json!({
+                "kind": "entity",
+                "query": "SourceFilteredSearchProbe",
+                "source": "text",
+                "limit": 1
+            }),
+        )
+        .await
+        .expect("text is a valid source filter");
+    let text_hits = text_result.as_array().expect("search result is an array");
+    assert_eq!(text_hits.len(), 1, "the text hit survives the limit");
+    assert!(text_hits.iter().all(|hit| hit["source"] == "text"));
+
+    let vector_result = fixture
+        .dispatch(
+            "search",
+            json!({
+                "kind": "entity",
+                "query": "SourceFilteredSearchProbe",
+                "source": "vector",
+                "limit": 1
+            }),
+        )
+        .await
+        .expect("vector is a valid source filter");
+    assert_eq!(
+        vector_result,
+        json!([]),
+        "a text-only in-memory hit must not satisfy source=vector"
+    );
+
+    let err = fixture
+        .dispatch(
+            "search",
+            json!({
+                "kind": "entity",
+                "query": "SourceFilteredSearchProbe",
+                "source": "semantic"
+            }),
+        )
+        .await
+        .expect_err("unknown source filters must fail closed");
+    assert!(
+        is_invalid_input(&err),
+        "invalid source must be InvalidInput: {err:?}"
+    );
+    assert!(
+        invalid_input_message(&err).contains("source must be one of: text, vector, both"),
+        "invalid-source error must enumerate the wire values: {err:?}"
+    );
+}
+
+#[tokio::test]
 async fn search_bogus_kind_lists_memory_in_error() {
     // The error message for an unknown kind must list ALL registered kinds,
     // including those contributed by FakeMemoryPack. This proves the error

--- a/crates/kkernel/src/coordinator/dispatch.rs
+++ b/crates/kkernel/src/coordinator/dispatch.rs
@@ -649,15 +649,23 @@ impl SubstrateCoordinator {
                 tokio::pin!(search_fut);
                 match tokio::time::timeout_at(request_deadline.async_at(), &mut search_fut).await {
                     Ok(Ok(note_hits)) => {
-                        let note_hits: Vec<NoteSearchHit> =
-                            note_hits.into_iter().take(limit as usize).collect();
+                        let filtered_note_hits: Vec<NoteSearchHit> = note_hits
+                            .iter()
+                            .filter(|hit| {
+                                request
+                                    .source()
+                                    .is_none_or(|expected| hit.source == expected)
+                            })
+                            .take(limit as usize)
+                            .cloned()
+                            .collect();
                         let backend_result = BackendSearchResult {
                             backend_id: backend_id.clone(),
                             hits: vec![],
-                            note_hits: note_hits.clone(),
+                            note_hits,
                             error: None,
                         };
-                        return (vec![], note_hits, vec![backend_result]);
+                        return (vec![], filtered_note_hits, vec![backend_result]);
                     }
                     Ok(Err(e)) => {
                         let backend_result = BackendSearchResult {
@@ -712,14 +720,23 @@ impl SubstrateCoordinator {
                 tokio::pin!(search_fut);
                 match tokio::time::timeout_at(request_deadline.async_at(), &mut search_fut).await {
                     Ok(Ok(hits)) => {
-                        let hits: Vec<SearchHit> = hits.into_iter().take(limit as usize).collect();
+                        let filtered_hits: Vec<SearchHit> = hits
+                            .iter()
+                            .filter(|hit| {
+                                request
+                                    .source()
+                                    .is_none_or(|expected| hit.source == expected)
+                            })
+                            .take(limit as usize)
+                            .cloned()
+                            .collect();
                         let backend_result = BackendSearchResult {
                             backend_id: backend_id.clone(),
-                            hits: hits.clone(),
+                            hits,
                             note_hits: vec![],
                             error: None,
                         };
-                        return (hits, vec![], vec![backend_result]);
+                        return (filtered_hits, vec![], vec![backend_result]);
                     }
                     Ok(Err(e)) => {
                         let backend_result = BackendSearchResult {
@@ -1003,8 +1020,10 @@ impl SubstrateCoordinator {
             }
         }
 
-        let merged_entities = rrf_merge_entity_hits(entity_ranked_lists, limit as usize);
-        let merged_notes = rrf_merge_note_hits(note_ranked_lists, limit as usize);
+        let merged_entities =
+            rrf_merge_entity_hits_filtered(entity_ranked_lists, limit as usize, request.source());
+        let merged_notes =
+            rrf_merge_note_hits_filtered(note_ranked_lists, limit as usize, request.source());
         (merged_entities, merged_notes, per_backend)
     }
 }
@@ -1040,7 +1059,7 @@ fn backend_search_timeout_ms() -> u64 {
 /// never out-fuse a rank-1 singleton that only one backend saw — truncating
 /// to `limit` per backend removes it before the merge ever sees it.
 /// `request.candidate_limit()` already widens the per-backend fetch for
-/// property/tag filter recall; this widens further (bounded) so unfiltered
+/// request-filter recall; this widens further (bounded) so unfiltered
 /// fan-out searches get the same fairness. The caller's `limit` is applied
 /// exactly once, after the RRF merge (`rrf_merge_entity_hits` /
 /// `rrf_merge_note_hits`).
@@ -1067,7 +1086,16 @@ struct RrfMergeBucket {
 }
 
 /// Merge multiple ranked entity hit lists via Reciprocal Rank Fusion (k=60).
+#[cfg(test)]
 pub(super) fn rrf_merge_entity_hits(lists: Vec<Vec<SearchHit>>, limit: usize) -> Vec<SearchHit> {
+    rrf_merge_entity_hits_filtered(lists, limit, None)
+}
+
+fn rrf_merge_entity_hits_filtered(
+    lists: Vec<Vec<SearchHit>>,
+    limit: usize,
+    source_filter: Option<SearchSource>,
+) -> Vec<SearchHit> {
     const K: f64 = 60.0;
 
     let mut scores: HashMap<Uuid, RrfMergeBucket> = HashMap::new();
@@ -1093,15 +1121,19 @@ pub(super) fn rrf_merge_entity_hits(lists: Vec<Vec<SearchHit>>, limit: usize) ->
 
     let mut merged: Vec<SearchHit> = scores
         .into_iter()
-        .map(|(id, bucket)| {
+        .filter_map(|(id, bucket)| {
+            let source = bucket.source.expect("each bucket gets a source");
+            if source_filter.is_some_and(|expected| source != expected) {
+                return None;
+            }
             let det_score = DeterministicScore::from_f64(bucket.score);
-            SearchHit {
+            Some(SearchHit {
                 entity_id: id,
                 score: det_score,
-                source: bucket.source.expect("each bucket gets a source"),
+                source,
                 title: bucket.title,
                 snippet: bucket.snippet,
-            }
+            })
         })
         .collect();
 
@@ -1111,9 +1143,18 @@ pub(super) fn rrf_merge_entity_hits(lists: Vec<Vec<SearchHit>>, limit: usize) ->
 }
 
 /// Merge multiple ranked note hit lists via Reciprocal Rank Fusion (k=60).
+#[cfg(test)]
 pub(super) fn rrf_merge_note_hits(
     lists: Vec<Vec<NoteSearchHit>>,
     limit: usize,
+) -> Vec<NoteSearchHit> {
+    rrf_merge_note_hits_filtered(lists, limit, None)
+}
+
+fn rrf_merge_note_hits_filtered(
+    lists: Vec<Vec<NoteSearchHit>>,
+    limit: usize,
+    source_filter: Option<SearchSource>,
 ) -> Vec<NoteSearchHit> {
     const K: f64 = 60.0;
 
@@ -1140,15 +1181,19 @@ pub(super) fn rrf_merge_note_hits(
 
     let mut merged: Vec<NoteSearchHit> = scores
         .into_iter()
-        .map(|(id, bucket)| {
+        .filter_map(|(id, bucket)| {
+            let source = bucket.source.expect("each bucket gets a source");
+            if source_filter.is_some_and(|expected| source != expected) {
+                return None;
+            }
             let det_score = DeterministicScore::from_f64(bucket.score);
-            NoteSearchHit {
+            Some(NoteSearchHit {
                 note_id: id,
                 score: det_score,
-                source: bucket.source.expect("each bucket gets a source"),
+                source,
                 title: bucket.title,
                 snippet: bucket.snippet,
-            }
+            })
         })
         .collect();
 

--- a/crates/kkernel/src/coordinator/tests.rs
+++ b/crates/kkernel/src/coordinator/tests.rs
@@ -132,9 +132,11 @@ fn validated_search_reconciles_compatible_granular_kind_fields() {
         "query": "typed request",
         "entity_kind": "concept",
         "entity_type": "algorithm",
+        "source": "text",
     }));
     assert_eq!(entity.kind_filter(), Some("concept"));
     assert_eq!(entity.entity_type(), Some("algorithm"));
+    assert_eq!(entity.source(), Some(SearchSource::Text));
 
     let note = validated_kg_search(serde_json::json!({
         "kind": "observation",
@@ -366,6 +368,71 @@ async fn fan_out_search_single_backend_returns_hits() {
     assert!(!hits.is_empty(), "should find the entity");
     assert_eq!(per_backend.len(), 1, "single backend report");
     assert!(per_backend[0].error.is_none(), "no error");
+}
+
+#[tokio::test]
+async fn fan_out_search_single_backend_applies_source_filter_before_limit() {
+    let coord = SubstrateCoordinator::single(memory_runtime());
+    let ns = Namespace::local();
+    let runtime = coord.primary_runtime().expect("single primary runtime");
+    let token = runtime.authorize(ns.clone()).expect("authorize local");
+
+    runtime
+        .create_entity(
+            &token,
+            "concept",
+            None,
+            "SingleBackendSourceEntity",
+            Some("single backend source filter entity probe"),
+            None,
+            vec![],
+        )
+        .await
+        .expect("create source-filter entity");
+    runtime
+        .create_note(
+            &token,
+            "observation",
+            Some("SingleBackendSourceNote"),
+            "single backend source filter note probe",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .expect("create source-filter note");
+
+    let entity_request = validated_kg_search(serde_json::json!({
+        "kind": "entity",
+        "query": "SingleBackendSourceEntity",
+        "source": "vector",
+        "limit": 1,
+    }));
+    let (entity_hits, _, entity_backends) = coord.fan_out_search(&entity_request, &ns).await;
+    assert!(
+        entity_hits.is_empty(),
+        "single-backend entity results must apply source=vector before limit"
+    );
+    assert!(
+        entity_backends[0].error.is_none(),
+        "source filtering must not turn into a backend error"
+    );
+
+    let note_request = validated_kg_search(serde_json::json!({
+        "kind": "note",
+        "query": "SingleBackendSourceNote",
+        "source": "vector",
+        "limit": 1,
+    }));
+    let (_, note_hits, note_backends) = coord.fan_out_search(&note_request, &ns).await;
+    assert!(
+        note_hits.is_empty(),
+        "single-backend note results must apply source=vector before limit"
+    );
+    assert!(
+        note_backends[0].error.is_none(),
+        "source filtering must not turn into a backend error"
+    );
 }
 
 #[tokio::test]
@@ -982,6 +1049,112 @@ async fn fan_out_search_with_visibility_multi_backend_finds_extra_namespace_row(
     assert!(
         narrow_hits.is_empty(),
         "primary-only visibility (no widening) must not see the tenant-b row"
+    );
+}
+
+#[tokio::test]
+async fn fan_out_search_applies_source_filter_before_rrf_and_limit() {
+    let mut registry = BackendRegistry::new();
+    registry.register(BackendId::new("alpha"), memory_runtime());
+    registry.register(BackendId::new("beta"), memory_runtime());
+
+    let vector_entity = Uuid::from_u128(1);
+    let cross_source_entity = Uuid::from_u128(2);
+    let text_entity = Uuid::from_u128(3);
+    let mut entity_overrides = std::collections::HashMap::new();
+    entity_overrides.insert(
+        "alpha".to_string(),
+        vec![
+            search_hit(vector_entity, SearchSource::Vector),
+            search_hit(cross_source_entity, SearchSource::Text),
+            search_hit(text_entity, SearchSource::Text),
+        ],
+    );
+    entity_overrides.insert(
+        "beta".to_string(),
+        vec![
+            search_hit(vector_entity, SearchSource::Vector),
+            search_hit(cross_source_entity, SearchSource::Vector),
+            search_hit(Uuid::from_u128(4), SearchSource::Text),
+        ],
+    );
+    let entity_coord =
+        SubstrateCoordinator::new(registry).with_entity_hits_override(entity_overrides);
+    let entity_request = validated_kg_search(serde_json::json!({
+        "kind": "entity",
+        "query": "overridden",
+        "source": "text",
+        "limit": 1,
+    }));
+
+    let (entity_hits, _, _) = entity_coord
+        .fan_out_search(&entity_request, &Namespace::local())
+        .await;
+    assert_eq!(
+        entity_hits
+            .iter()
+            .map(|hit| hit.entity_id)
+            .collect::<Vec<_>>(),
+        vec![text_entity],
+        "filtering must drop the top vector hit and the cross-backend Both hit before limit"
+    );
+
+    let both_request = validated_kg_search(serde_json::json!({
+        "kind": "entity",
+        "query": "overridden",
+        "source": "both",
+        "limit": 1,
+    }));
+    let (both_hits, _, _) = entity_coord
+        .fan_out_search(&both_request, &Namespace::local())
+        .await;
+    assert_eq!(
+        both_hits
+            .iter()
+            .map(|hit| hit.entity_id)
+            .collect::<Vec<_>>(),
+        vec![cross_source_entity],
+        "a text hit on one backend and vector hit on another has final source=both"
+    );
+
+    let mut registry = BackendRegistry::new();
+    registry.register(BackendId::new("alpha"), memory_runtime());
+    registry.register(BackendId::new("beta"), memory_runtime());
+    let vector_note = Uuid::from_u128(5);
+    let cross_source_note = Uuid::from_u128(6);
+    let text_note = Uuid::from_u128(7);
+    let mut note_overrides = std::collections::HashMap::new();
+    note_overrides.insert(
+        "alpha".to_string(),
+        vec![
+            note_search_hit(vector_note, SearchSource::Vector),
+            note_search_hit(cross_source_note, SearchSource::Text),
+            note_search_hit(text_note, SearchSource::Text),
+        ],
+    );
+    note_overrides.insert(
+        "beta".to_string(),
+        vec![
+            note_search_hit(vector_note, SearchSource::Vector),
+            note_search_hit(cross_source_note, SearchSource::Vector),
+            note_search_hit(Uuid::from_u128(8), SearchSource::Text),
+        ],
+    );
+    let note_coord = SubstrateCoordinator::new(registry).with_note_hits_override(note_overrides);
+    let note_request = validated_kg_search(serde_json::json!({
+        "kind": "note",
+        "query": "overridden",
+        "source": "text",
+        "limit": 1,
+    }));
+
+    let (_, note_hits, _) = note_coord
+        .fan_out_search(&note_request, &Namespace::local())
+        .await;
+    assert_eq!(
+        note_hits.iter().map(|hit| hit.note_id).collect::<Vec<_>>(),
+        vec![text_note],
+        "note filtering must preserve final-source semantics before limit"
     );
 }
 


### PR DESCRIPTION
## Summary

- accept `source=text|vector|both` on KG search requests and reject unknown values
- apply the source predicate before the caller's result limit in both direct and coordinator search paths, using the existing bounded candidate window
- preserve cross-backend fusion semantics so a hit contributed by text and vector backends can be selected with `source=both`
- document the filter in search help

## Regression coverage

- `search_source_filter_is_strict_and_applied_before_limit`
- `fan_out_search_single_backend_applies_source_filter_before_limit`
- `fan_out_search_applies_source_filter_before_rrf_and_limit`

The focused coordinator RED failed because the single-backend path truncated the unfiltered results. The focused GREEN run passed all 23 matching fan-out tests after filtering before the caller limit.

## Verification

- `cargo fmt -p khive-pack-kg -p kkernel -- --check`
- `cargo clippy -p khive-pack-kg -p kkernel --all-targets -- -D warnings`
- `cargo test -p khive-pack-kg --test integration search_source_filter_is_strict_and_applied_before_limit -- --exact --nocapture`
- `cargo test -p khive-pack-kg -p kkernel`

## Scope

Filtering operates within the existing bounded backend candidate retrieval window; it does not turn a search into an unbounded corpus scan.

Fixes #1962
