### PR TITLE
fix(runtime): preserve empty strings under properties in Agent presentation

### DIFF
--- a/crates/khive-runtime/src/presentation.rs
+++ b/crates/khive-runtime/src/presentation.rs
@@ -687,6 +687,12 @@ fn transform_field_agent(
         {
             Some(value)
         }
+        // Preserve empty strings under a record's `properties` object: those
+        // keys exist only because a caller wrote them, so `""` there is data
+        // (set-to-empty vs absent, ADR-045 Amendment 3, issue #1995). Empty
+        // arrays and objects under `properties` are still dropped per the
+        // amendment's scope note.
+        Value::String(s) if s.is_empty() && context.inside_properties => Some(value),
         // Drop other empty strings, arrays, objects.
         Value::String(s) if s.is_empty() => None,
         Value::Array(a) if a.is_empty() => None,
@@ -918,6 +924,38 @@ mod tests {
 
     fn agent(v: Value) -> Value {
         present(v, PresentationMode::Agent, NOW)
+    }
+
+    #[test]
+    fn agent_preserves_empty_string_under_properties() {
+        // ADR-045 Amendment 3 (issue #1995): a key under `properties` exists
+        // only because a caller wrote it, so `""` there distinguishes
+        // set-to-empty from absent and must survive Agent mode — at any
+        // nesting depth under `properties`.
+        let v = json!({
+            "id": "a1b2c3d4",
+            "summary": "",
+            "properties": {"k": "", "nested": {"deep": ""}},
+        });
+        let out = agent(v);
+        assert_eq!(out["properties"]["k"], json!(""));
+        assert_eq!(out["properties"]["nested"]["deep"], json!(""));
+        // Control: outside `properties` the empty-string drop still applies.
+        assert!(out.get("summary").is_none());
+    }
+
+    #[test]
+    fn agent_still_drops_empty_containers_under_properties() {
+        // The amendment's scope note keeps the container drop: empty arrays
+        // and objects under `properties` are not carved out.
+        let v = json!({
+            "id": "a1b2c3d4",
+            "properties": {"tags": [], "meta": {}, "kept": "x"},
+        });
+        let out = agent(v);
+        assert!(out["properties"].get("tags").is_none());
+        assert!(out["properties"].get("meta").is_none());
+        assert_eq!(out["properties"]["kept"], json!("x"));
     }
 
     #[test]

--- a/crates/khive-runtime/src/presentation.rs
+++ b/crates/khive-runtime/src/presentation.rs
@@ -600,7 +600,11 @@ fn transform_agent(
             let preserve_list_envelope = is_stable_list_envelope(&map);
             let mut out = Map::new();
             for (k, v) in map {
-                let child_inside_properties = inside_properties || k == "properties";
+                // ADR-045 Amendment 3 scopes the empty-string carve-out to
+                // strings nested under an object-valued `properties`; a
+                // scalar or array `properties` value gets no carve-out.
+                let child_inside_properties =
+                    inside_properties || (k == "properties" && v.is_object());
                 let transformed = transform_field_agent(
                     &k,
                     v,
@@ -942,6 +946,19 @@ mod tests {
         assert_eq!(out["properties"]["nested"]["deep"], json!(""));
         // Control: outside `properties` the empty-string drop still applies.
         assert!(out.get("summary").is_none());
+    }
+
+    #[test]
+    fn agent_drops_scalar_empty_properties_value() {
+        // The carve-out applies only to strings nested under an object-valued
+        // `properties`; a scalar `properties: ""` is the field's own value,
+        // not a caller-written key under it, and drops like any empty string.
+        let v = json!({
+            "id": "a1b2c3d4",
+            "properties": "",
+        });
+        let out = agent(v);
+        assert!(out.get("properties").is_none());
     }
 
     #[test]


### PR DESCRIPTION
Agent presentation dropped every empty string unconditionally, so an update setting a property to `""` echoed back without the key — a successful write read as a deletion (#1995).

A key under a record's `properties` object exists only because a caller wrote it, so `""` there is data: it distinguishes set-to-empty from absent. This guards the empty-string drop with the existing `inside_properties` context, at any nesting depth under `properties`. Empty arrays and objects under `properties` are still dropped, per ADR-045 Amendment 3's scope note (#2193).

Tests: preservation at two nesting depths, plus controls that the drop still applies outside `properties` and to empty containers within it.

Fixes #1995.