### PR TITLE
fix(runtime): enforce authority and mode at the visibility and blob install seams

### DIFF
--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -2616,27 +2616,27 @@ async fn prepare_configured_storage_topology(
         // selection required for verified migration must fail without leaving
         // a new incomplete marker. The blob pack's backend mode governs
         // read-only wrapping during serving boot.
-        let blob_runtime_read_only = if base_config.packs.iter().any(|pack| pack == "blob") {
+        let blob_governing_backend = if base_config.packs.iter().any(|pack| pack == "blob") {
             match khive_cfg.packs.get("blob") {
                 Some(pack) => backends
                     .get(pack.backend.as_str())
+                    .cloned()
                     .ok_or_else(|| {
                         anyhow::anyhow!(
                             "[packs.blob].backend = {:?} references an unknown backend",
                             pack.backend
                         )
-                    })?
-                    .is_read_only(),
-                None => main_backend.is_read_only(),
+                    })?,
+                None => main_backend.clone(),
             }
         } else {
-            main_backend.is_read_only()
+            main_backend.clone()
         };
         resolve_blob_hydrator_for_boot(
             &base_config,
             khive_cfg,
             main_backend.as_ref(),
-            blob_runtime_read_only,
+            blob_governing_backend.as_ref(),
         )?
     } else {
         None
@@ -3458,22 +3458,25 @@ fn resolve_blob_hydrator_for_boot(
     config: &RuntimeConfig,
     khive_cfg: &KhiveConfig,
     backend: &StorageBackend,
-    read_only: bool,
+    governing_backend: &StorageBackend,
 ) -> anyhow::Result<Option<Arc<BlobHydrator>>> {
-    // Resolution stays mode-aware (`read_only` opens an existing root and
-    // never creates one), and construction must be too: `for_mode(read_only
-    // = true)` stamps the hydrator with the read-only guarantee the runtime
-    // install seam checks — a wrapped store inside a plain
-    // `BlobHydrator::new` carries no such marker and a read-only runtime
-    // would refuse it at install. The extra wrap over an already-wrapped
-    // store is documented harmless (reads delegate, mutators refuse).
-    match khive_runtime::resolve_blob_store_for_mode(khive_cfg, backend, read_only) {
-        Ok(store) => Ok(Some(Arc::new(BlobHydrator::for_mode(
-            store,
-            config.blob_hydration_bytes,
-            read_only,
-        )?))),
-        Err(error) if khive_cfg.storage.blob.is_none() => {
+    // Resolution and construction are fused inside the runtime so the mode
+    // is DERIVED from the governing backend's own access mode (the backend
+    // the blob pack maps to, ADR-160 D3) rather than declared here, and the
+    // hydrator comes back stamped as governed — the only kind the shared
+    // install seam accepts. Read-only derivation opens an existing root and
+    // never creates one; the extra wrap over an already-wrapped store is
+    // documented harmless (reads delegate, mutators refuse).
+    match BlobHydrator::resolve_for_governing_backend(
+        khive_cfg,
+        backend,
+        governing_backend,
+        config.blob_hydration_bytes,
+    ) {
+        Ok(hydrator) => Ok(Some(Arc::new(hydrator))),
+        Err(khive_runtime::GovernedBlobError::Resolve(error))
+            if khive_cfg.storage.blob.is_none() =>
+        {
             tracing::debug!(
                 error = %error,
                 "no usable BlobStore for this backend and no [storage.blob] configured; \
@@ -3499,12 +3502,8 @@ pub async fn build_single_backend_runtime(
     let backend = Arc::new(open_single_backend(&config)?);
     prepare_core_schema_for_boot(Arc::clone(&backend), "single backend").await?;
 
-    let hydrator = resolve_blob_hydrator_for_boot(
-        &config,
-        khive_cfg,
-        backend.as_ref(),
-        backend.is_read_only(),
-    )?;
+    let hydrator =
+        resolve_blob_hydrator_for_boot(&config, khive_cfg, backend.as_ref(), backend.as_ref())?;
     crate::attachment_cutover::coordinate_attachment_cutover(
         Arc::clone(&backend),
         hydrator.clone(),
@@ -3546,7 +3545,7 @@ async fn prepare_single_backend_for_schema_admin(
     prepare_core_schema_for_boot(Arc::clone(&backend), "single backend").await?;
 
     let hydrator = if schema_admin_requires_blob_hydrator(Arc::clone(&backend)).await? {
-        resolve_blob_hydrator_for_boot(config, khive_cfg, backend.as_ref(), backend.is_read_only())?
+        resolve_blob_hydrator_for_boot(config, khive_cfg, backend.as_ref(), backend.as_ref())?
     } else {
         None
     };
@@ -3578,8 +3577,7 @@ pub fn install_resolved_blob_store(
     khive_cfg: &KhiveConfig,
     backend: &StorageBackend,
 ) -> anyhow::Result<Option<Arc<BlobHydrator>>> {
-    let hydrator =
-        resolve_blob_hydrator_for_boot(rt.config(), khive_cfg, backend, rt.is_read_only())?;
+    let hydrator = resolve_blob_hydrator_for_boot(rt.config(), khive_cfg, backend, backend)?;
     if let Some(hydrator) = hydrator.as_ref() {
         rt.install_blob_hydrator(Arc::clone(hydrator))?;
     }

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -3571,12 +3571,21 @@ async fn prepare_core_schema_for_boot(
 /// application-assisted V21 attachment cutover. Production host boot should use
 /// [`build_single_backend_runtime`], [`build_server`], or the async multi-backend
 /// builders instead. Calling this helper is sound only when `backend` is the
-/// runtime's backend and its attachment-cutover status is already `Complete`.
+/// runtime's backend and its attachment-cutover status is already `Complete`;
+/// the same-backend precondition is now enforced by identity rather than
+/// documented, since the resolved mode derives from `backend` and a mismatch
+/// would silently resolve the wrong store mode for the receiving runtime.
 pub fn install_resolved_blob_store(
     rt: &KhiveRuntime,
     khive_cfg: &KhiveConfig,
     backend: &StorageBackend,
 ) -> anyhow::Result<Option<Arc<BlobHydrator>>> {
+    if !std::ptr::eq(rt.backend(), backend) {
+        anyhow::bail!(
+            "install_resolved_blob_store requires the runtime's own backend: the supplied \
+             backend reference is not the runtime's"
+        );
+    }
     let hydrator = resolve_blob_hydrator_for_boot(rt.config(), khive_cfg, backend, backend)?;
     if let Some(hydrator) = hydrator.as_ref() {
         rt.install_blob_hydrator(Arc::clone(hydrator))?;

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -2708,9 +2708,14 @@ async fn build_registry_for_multi_backend_inner(
     // hydrator `Arc` on every runtime handle this boot produces. `core()`
     // clones share each runtime's one-shot slot, so they see this same pair.
     if let Some(hydrator) = shared_hydrator {
-        default_runtime.install_blob_hydrator(Arc::clone(&hydrator))?;
+        // The shared install: the hydrator's mode was decided above from the
+        // blob pack's backend, and the receiving handles legitimately mix
+        // modes (a writable blob secondary beside a read-only main is a
+        // documented topology), so each handle's own domain-store mode must
+        // not gate this install.
+        default_runtime.install_shared_blob_hydrator(Arc::clone(&hydrator))?;
         for rt in per_pack_runtimes_local.values() {
-            rt.install_blob_hydrator(Arc::clone(&hydrator))?;
+            rt.install_shared_blob_hydrator(Arc::clone(&hydrator))?;
         }
     }
 
@@ -3455,10 +3460,18 @@ fn resolve_blob_hydrator_for_boot(
     backend: &StorageBackend,
     read_only: bool,
 ) -> anyhow::Result<Option<Arc<BlobHydrator>>> {
+    // Resolution stays mode-aware (`read_only` opens an existing root and
+    // never creates one), and construction must be too: `for_mode(read_only
+    // = true)` stamps the hydrator with the read-only guarantee the runtime
+    // install seam checks — a wrapped store inside a plain
+    // `BlobHydrator::new` carries no such marker and a read-only runtime
+    // would refuse it at install. The extra wrap over an already-wrapped
+    // store is documented harmless (reads delegate, mutators refuse).
     match khive_runtime::resolve_blob_store_for_mode(khive_cfg, backend, read_only) {
-        Ok(store) => Ok(Some(Arc::new(BlobHydrator::new(
+        Ok(store) => Ok(Some(Arc::new(BlobHydrator::for_mode(
             store,
             config.blob_hydration_bytes,
+            read_only,
         )?))),
         Err(error) if khive_cfg.storage.blob.is_none() => {
             tracing::debug!(
@@ -6113,6 +6126,64 @@ region = "us-east-1"
             debug.contains("S3BlobStore"),
             "expected the installed store to be an S3BlobStore, got: {debug}"
         );
+    }
+
+    /// A read-only runtime resolving an EXISTING blob root must be able to
+    /// install it for bounded reads: the boot helper's hydrator carries its
+    /// mode from construction, so the runtime's read-only install seam
+    /// accepts it, serves reads, and refuses mutation. Without the
+    /// mode-aware construction, the install refuses the hydrator the boot
+    /// just resolved and a read-only snapshot cannot serve blobs at all.
+    #[tokio::test]
+    #[serial]
+    async fn install_resolved_blob_store_read_only_runtime_gets_bounded_reads() {
+        let _env = ClearedKhiveEnvGuard::clear();
+        use khive_storage::BlobStore as _;
+        let dir = tempfile::tempdir().expect("temp dir");
+        let main_path = dir.path().join("snapshot.db");
+        prepare_current_snapshot_source(&main_path);
+
+        // Seed an existing root while writable; the read-only boot below
+        // must open it without creating anything.
+        let blob_root = dir.path().join("blobs");
+        let seeded = {
+            let seed_store =
+                khive_db::stores::blob::FsBlobStore::new(blob_root.clone(), 0).expect("seed store");
+            seed_store.put(b"seed".to_vec()).await.expect("seed put")
+        };
+
+        let khive_cfg = KhiveConfig {
+            storage: StorageSectionConfig {
+                blob: Some(BlobConfig::Fs {
+                    root: Some(blob_root.display().to_string()),
+                    floor_bytes: Some(0),
+                }),
+            },
+            ..KhiveConfig::default()
+        };
+        let backend =
+            Arc::new(StorageBackend::sqlite_read_only(&main_path).expect("read-only backend"));
+        assert!(backend.is_read_only());
+        let runtime = khive_runtime::KhiveRuntime::from_backend(
+            Arc::clone(&backend),
+            base_runtime_config_for_multi_backend(),
+        );
+        assert!(runtime.is_read_only());
+
+        let _hydrator = install_resolved_blob_store(&runtime, &khive_cfg, backend.as_ref())
+            .expect("a read-only runtime must install its resolved existing root")
+            .expect("the configured root resolves to a store");
+
+        let installed = runtime.blob_store().expect("installed store");
+        assert!(
+            installed.exists(&seeded).await.expect("exists"),
+            "bounded reads must be served from the existing root"
+        );
+        let err = installed
+            .put(b"post".to_vec())
+            .await
+            .expect_err("mutation must refuse on the read-only snapshot");
+        assert!(err.to_string().contains("read-only"), "{err}");
     }
 
     /// Positive counterpart to `multi_backend_boot_wires_configured_s3_blob_store`:

--- a/crates/khive-runtime/src/blob.rs
+++ b/crates/khive-runtime/src/blob.rs
@@ -36,9 +36,39 @@ pub struct BlobHydrator {
     /// downcast hook, so the wrapper cannot be recognized after the fact —
     /// the guarantee has to travel with the hydrator that made it.
     read_only: bool,
+    /// True only for hydrators built by
+    /// [`Self::resolve_for_governing_backend`], whose mode was derived from a
+    /// governing backend's own access mode rather than declared by the
+    /// caller. The shared install seam accepts only governed hydrators, so a
+    /// hand-paired writable hydrator cannot ride it onto a read-only
+    /// runtime.
+    governed: bool,
     admission: Arc<tokio::sync::Semaphore>,
     budget_bytes: u64,
 }
+
+/// Error from [`BlobHydrator::resolve_for_governing_backend`], split so boot
+/// can distinguish store resolution failures (which fall back to "no blob
+/// configured" when `[storage.blob]` is absent) from budget pairing failures
+/// (always fatal).
+#[derive(Debug)]
+pub enum GovernedBlobError {
+    /// The configured store could not be resolved for the governing mode.
+    Resolve(SqliteError),
+    /// The resolved store could not be paired with the hydration budget.
+    Construct(RuntimeError),
+}
+
+impl std::fmt::Display for GovernedBlobError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Resolve(error) => write!(f, "blob store resolution: {error}"),
+            Self::Construct(error) => write!(f, "blob hydrator construction: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for GovernedBlobError {}
 
 impl BlobHydrator {
     /// Pair the raw store with a budget, refusing every physical mutator:
@@ -85,6 +115,39 @@ impl BlobHydrator {
         }
     }
 
+    /// Resolve the configured store and pair it with the budget under the
+    /// mode of the backend that GOVERNS blob mutability — the backend the
+    /// blob pack maps to (ADR-160 D3), which on single-backend boots is the
+    /// runtime's own backend.
+    ///
+    /// The mode is derived here from `governing_backend`'s own access mode,
+    /// never accepted as a caller-declared flag, and the hydrator is stamped
+    /// as governed. [`crate::KhiveRuntime::install_shared_blob_hydrator`]
+    /// accepts only governed hydrators: a caller wanting a writable shared
+    /// hydrator must actually hold a writable governing backend, which is
+    /// the sanctioned mixed-mode topology rather than a bypass of a
+    /// read-only handle's guarantee.
+    pub fn resolve_for_governing_backend(
+        cfg: &KhiveConfig,
+        resolve_backend: &StorageBackend,
+        governing_backend: &StorageBackend,
+        budget_bytes: u64,
+    ) -> Result<Self, GovernedBlobError> {
+        let read_only = governing_backend.is_read_only();
+        let store = resolve_blob_store_for_mode(cfg, resolve_backend, read_only)
+            .map_err(GovernedBlobError::Resolve)?;
+        let mut hydrator =
+            Self::for_mode(store, budget_bytes, read_only).map_err(GovernedBlobError::Construct)?;
+        hydrator.governed = true;
+        Ok(hydrator)
+    }
+
+    /// Whether this hydrator's mode was derived from a governing backend
+    /// (see [`Self::resolve_for_governing_backend`]).
+    pub(crate) fn is_governed(&self) -> bool {
+        self.governed
+    }
+
     /// Pair one store with one aggregate byte budget.
     pub fn new(store: Arc<dyn BlobStore>, budget_bytes: u64) -> RuntimeResult<Self> {
         let raw = Arc::clone(&store);
@@ -117,6 +180,7 @@ impl BlobHydrator {
             store,
             raw_store,
             read_only: false,
+            governed: false,
             admission: Arc::new(tokio::sync::Semaphore::new(permits)),
             budget_bytes,
         })

--- a/crates/khive-runtime/src/blob.rs
+++ b/crates/khive-runtime/src/blob.rs
@@ -123,10 +123,20 @@ impl BlobHydrator {
     /// The mode is derived here from `governing_backend`'s own access mode,
     /// never accepted as a caller-declared flag, and the hydrator is stamped
     /// as governed. [`crate::KhiveRuntime::install_shared_blob_hydrator`]
-    /// accepts only governed hydrators: a caller wanting a writable shared
-    /// hydrator must actually hold a writable governing backend, which is
-    /// the sanctioned mixed-mode topology rather than a bypass of a
-    /// read-only handle's guarantee.
+    /// accepts only governed hydrators.
+    ///
+    /// Trust model (explicit policy): which backend governs blob mutability
+    /// is a deployment-topology assertion made by the host that wires boot
+    /// (the blob pack's backend, ADR-160 D3), and this seam takes the
+    /// caller's word for it. What the derivation defends against is the
+    /// ACCIDENTAL mode mismatch — a hand-paired writable hydrator drifting
+    /// onto a read-only handle through the shared seam. It does not defend
+    /// against an in-process caller who deliberately misdeclares the
+    /// governing backend, because no runtime seam can: any such caller can
+    /// already open the configured blob root directly (the same config and
+    /// store constructors are public) and mutate it without touching a
+    /// runtime handle. Read-only runtime handles are a wrong-wiring guard,
+    /// not an in-process sandbox.
     pub fn resolve_for_governing_backend(
         cfg: &KhiveConfig,
         resolve_backend: &StorageBackend,

--- a/crates/khive-runtime/src/blob.rs
+++ b/crates/khive-runtime/src/blob.rs
@@ -26,13 +26,56 @@ pub const DEFAULT_BLOB_HYDRATION_BYTES: u64 = 4 * khive_storage::MAX_BLOB_WHOLE_
 #[derive(Debug)]
 pub struct BlobHydrator {
     store: Arc<dyn BlobStore>,
+    /// The store as handed in by the caller, before any read-only wrapping.
+    /// Kept so the install seam can recognize a reinstall of the same raw
+    /// store by pointer identity even when `store` is a wrapper around it.
+    raw_store: Arc<dyn BlobStore>,
+    /// True only for hydrators built through [`Self::new_read_only`], whose
+    /// mutators are refused by construction. The runtime's install seam
+    /// requires this on read-only runtimes: `dyn BlobStore` carries no
+    /// downcast hook, so the wrapper cannot be recognized after the fact —
+    /// the guarantee has to travel with the hydrator that made it.
+    read_only: bool,
     admission: Arc<tokio::sync::Semaphore>,
     budget_bytes: u64,
 }
 
 impl BlobHydrator {
+    /// Pair the raw store with a budget, refusing every physical mutator:
+    /// the store is wrapped so `put`/`delete`/sweeps error while the bounded
+    /// read surface stays available. This is the only constructor a
+    /// read-only runtime's install seam accepts.
+    pub(crate) fn new_read_only(
+        store: Arc<dyn BlobStore>,
+        budget_bytes: u64,
+    ) -> RuntimeResult<Self> {
+        let mut hydrator =
+            Self::new_inner(wrap_read_only(Arc::clone(&store)), store, budget_bytes)?;
+        hydrator.read_only = true;
+        Ok(hydrator)
+    }
+
+    /// Whether this hydrator refuses mutation by construction.
+    pub(crate) fn enforces_read_only(&self) -> bool {
+        self.read_only
+    }
+
+    /// The store exactly as the caller handed it in, before any wrapping.
+    pub(crate) fn raw_store(&self) -> Arc<dyn BlobStore> {
+        Arc::clone(&self.raw_store)
+    }
+
     /// Pair one store with one aggregate byte budget.
     pub fn new(store: Arc<dyn BlobStore>, budget_bytes: u64) -> RuntimeResult<Self> {
+        let raw = Arc::clone(&store);
+        Self::new_inner(store, raw, budget_bytes)
+    }
+
+    fn new_inner(
+        store: Arc<dyn BlobStore>,
+        raw_store: Arc<dyn BlobStore>,
+        budget_bytes: u64,
+    ) -> RuntimeResult<Self> {
         if budget_bytes < khive_storage::MAX_BLOB_WHOLE_BYTES {
             return Err(RuntimeError::InvalidInput(format!(
                 "blob hydration budget must be at least {} bytes, got {budget_bytes}",
@@ -52,6 +95,8 @@ impl BlobHydrator {
         }
         Ok(Self {
             store,
+            raw_store,
+            read_only: false,
             admission: Arc::new(tokio::sync::Semaphore::new(permits)),
             budget_bytes,
         })

--- a/crates/khive-runtime/src/blob.rs
+++ b/crates/khive-runtime/src/blob.rs
@@ -258,6 +258,15 @@ pub fn resolve_blob_store_for_mode(
     Ok(Arc::new(ReadOnlyBlobStore { inner }))
 }
 
+/// Wrap an arbitrary store so every physical mutator is refused while the
+/// bounded read surface stays available. Used by the runtime's install seam
+/// to hold the read-only invariant for stores installed after boot; wrapping
+/// an already-wrapped store is harmless (reads delegate, mutators refuse at
+/// the outer layer).
+pub(crate) fn wrap_read_only(inner: Arc<dyn BlobStore>) -> Arc<dyn BlobStore> {
+    Arc::new(ReadOnlyBlobStore { inner })
+}
+
 #[derive(Debug)]
 struct ReadOnlyBlobStore {
     inner: Arc<dyn BlobStore>,

--- a/crates/khive-runtime/src/blob.rs
+++ b/crates/khive-runtime/src/blob.rs
@@ -65,6 +65,26 @@ impl BlobHydrator {
         Arc::clone(&self.raw_store)
     }
 
+    /// Pair a raw store with a budget under an explicitly declared
+    /// blob-runtime mode. `read_only = true` wraps the store so every
+    /// physical mutator refuses while the bounded read surface stays
+    /// available; `false` is [`Self::new`]. Boot paths that decide the blob
+    /// mode from configuration (the blob pack's backend mode, ADR-160 D3)
+    /// construct through this so the decision travels with the hydrator —
+    /// the install seam can then hold hydrator mode against runtime mode
+    /// instead of trusting the caller's pairing.
+    pub fn for_mode(
+        store: Arc<dyn BlobStore>,
+        budget_bytes: u64,
+        read_only: bool,
+    ) -> RuntimeResult<Self> {
+        if read_only {
+            Self::new_read_only(store, budget_bytes)
+        } else {
+            Self::new(store, budget_bytes)
+        }
+    }
+
     /// Pair one store with one aggregate byte budget.
     pub fn new(store: Arc<dyn BlobStore>, budget_bytes: u64) -> RuntimeResult<Self> {
         let raw = Arc::clone(&store);

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -57,7 +57,7 @@ pub use atomic_runner::{
     CommittedPostCommitEffects,
 };
 pub use blob::{
-    resolve_blob_store, resolve_blob_store_for_mode, BlobHydrator, VerifiedBlob,
+    resolve_blob_store, resolve_blob_store_for_mode, BlobHydrator, GovernedBlobError, VerifiedBlob,
     DEFAULT_BLOB_HYDRATION_BYTES,
 };
 pub use build_info::{BuildInfo, BUILD_INFO, BUILD_VERSION};

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -1080,6 +1080,12 @@ impl KhiveRuntime {
     /// writable store on a read-only runtime; such callers use
     /// [`Self::install_blob_hydrator`], which holds hydrator mode against
     /// this runtime's own.
+    ///
+    /// This gate is a wrong-wiring guard, not an in-process sandbox: which
+    /// backend governs is the boot host's topology assertion, and a caller
+    /// who deliberately selects an unrelated writable backend as governing
+    /// is outside what any runtime seam can enforce (see the trust-model
+    /// note on [`crate::BlobHydrator::resolve_for_governing_backend`]).
     pub fn install_shared_blob_hydrator(
         &self,
         hydrator: Arc<crate::blob::BlobHydrator>,

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -1046,6 +1046,17 @@ impl KhiveRuntime {
                 self.config.blob_hydration_bytes
             )));
         }
+        // The mode gate must sit on THIS seam, not only on `install_blob_store`:
+        // `BlobHydrator::new` is public, so without it a caller pairs a writable
+        // store, installs it here, and `blob_store()` hands mutating pack paths
+        // a writable store on a runtime whose declared mode is read-only.
+        if self.is_read_only() && !hydrator.enforces_read_only() {
+            return Err(RuntimeError::InvalidInput(
+                "this runtime is read-only: install the raw store with install_blob_store, \
+                 which wraps it so every physical mutator refuses"
+                    .to_string(),
+            ));
+        }
         if let Some(current) = self.blob_hydrator.get() {
             return if Arc::ptr_eq(current, &hydrator) {
                 Ok(())
@@ -1085,8 +1096,12 @@ impl KhiveRuntime {
         store: Arc<dyn khive_storage::BlobStore>,
     ) -> RuntimeResult<()> {
         if let Some(current) = self.blob_hydrator.get() {
+            // Reinstalling the same raw store is idempotent in BOTH modes:
+            // on a read-only runtime the installed hydrator wraps the raw
+            // store, so identity is checked against the raw handle the
+            // hydrator remembers, not only the (possibly wrapped) paired one.
             let current_store = current.store();
-            if Arc::ptr_eq(&current_store, &store) {
+            if Arc::ptr_eq(&current_store, &store) || Arc::ptr_eq(&current.raw_store(), &store) {
                 return Ok(());
             }
         }
@@ -1095,16 +1110,12 @@ impl KhiveRuntime {
         // wrapped so every physical mutator refuses while the bounded read
         // surface stays available. Without this, post-boot installation is a
         // writable bypass of the runtime's declared mode.
-        let store = if self.is_read_only() {
-            crate::blob::wrap_read_only(store)
+        let hydrator = if self.is_read_only() {
+            crate::blob::BlobHydrator::new_read_only(store, self.config.blob_hydration_bytes)?
         } else {
-            store
+            crate::blob::BlobHydrator::new(store, self.config.blob_hydration_bytes)?
         };
-        let hydrator = Arc::new(crate::blob::BlobHydrator::new(
-            store,
-            self.config.blob_hydration_bytes,
-        )?);
-        self.install_blob_hydrator(hydrator)
+        self.install_blob_hydrator(Arc::new(hydrator))
     }
 
     /// Return the installed shared blob hydrator, if boot configured one.
@@ -2140,7 +2151,7 @@ mod tests {
             .await
             .expect("seed put through the raw store");
         runtime
-            .install_blob_store(writable)
+            .install_blob_store(writable.clone())
             .expect("read-only install wraps rather than refusing");
 
         let installed = runtime.blob_store().expect("installed store");
@@ -2152,6 +2163,33 @@ mod tests {
             .put(b"post-boot".to_vec())
             .await
             .expect_err("put must refuse on a read-only runtime");
+        assert!(
+            err.to_string().contains("read-only"),
+            "refusal must name the mode: {err}"
+        );
+
+        // Reinstalling the SAME raw store stays idempotent even though the
+        // installed hydrator holds a wrapper around it: identity is checked
+        // against the raw handle the hydrator remembers.
+        runtime
+            .install_blob_store(writable.clone())
+            .expect("reinstalling the same raw store must be idempotent");
+
+        // The hydrator seam holds the mode too: pairing a writable store
+        // with `BlobHydrator::new` and installing it directly must refuse,
+        // or it is a public bypass of everything above.
+        let bypass_root = tempfile::tempdir().unwrap();
+        let bypass_store = Arc::new(
+            khive_db::stores::blob::FsBlobStore::new(bypass_root.path().to_path_buf(), 0)
+                .expect("fs blob store"),
+        );
+        let writable_hydrator = Arc::new(
+            crate::BlobHydrator::new(bypass_store, crate::DEFAULT_BLOB_HYDRATION_BYTES)
+                .expect("construct writable hydrator"),
+        );
+        let err = runtime
+            .install_blob_hydrator(writable_hydrator)
+            .expect_err("a writable hydrator must be refused on a read-only runtime");
         assert!(
             err.to_string().contains("read-only"),
             "refusal must name the mode: {err}"

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -1050,6 +1050,10 @@ impl KhiveRuntime {
         // `BlobHydrator::new` is public, so without it a caller pairs a writable
         // store, installs it here, and `blob_store()` hands mutating pack paths
         // a writable store on a runtime whose declared mode is read-only.
+        // Boot paths installing one hydrator across handles of MIXED modes —
+        // where the blob pack's own backend mode, not each receiving
+        // handle's, governs mutability — go through
+        // [`Self::install_shared_blob_hydrator`] instead.
         if self.is_read_only() && !hydrator.enforces_read_only() {
             return Err(RuntimeError::InvalidInput(
                 "this runtime is read-only: install the raw store with install_blob_store, \
@@ -1057,8 +1061,61 @@ impl KhiveRuntime {
                     .to_string(),
             ));
         }
+        self.install_blob_hydrator_slot(hydrator)
+    }
+
+    /// Install a boot-shared hydrator whose mutability is governed by the
+    /// blob runtime's own mode, not this handle's domain-store mode.
+    ///
+    /// ADR-160 D3 installs one hydrator `Arc` on every runtime handle a boot
+    /// produces, and the documented multi-backend matrix includes a writable
+    /// blob secondary beside a read-only main: there the shared hydrator is
+    /// legitimately writable on a read-only domain handle. The mode decision
+    /// must therefore already be encoded in the hydrator — construct it with
+    /// [`crate::BlobHydrator::for_mode`] from the blob pack's backend mode.
+    /// Direct callers that did not make that configuration decision use
+    /// [`Self::install_blob_hydrator`], which holds hydrator mode against
+    /// this runtime's own.
+    pub fn install_shared_blob_hydrator(
+        &self,
+        hydrator: Arc<crate::blob::BlobHydrator>,
+    ) -> RuntimeResult<()> {
+        if hydrator.budget_bytes() != self.config.blob_hydration_bytes {
+            return Err(RuntimeError::InvalidInput(format!(
+                "blob hydrator budget {} does not match this runtime's resolved budget {}",
+                hydrator.budget_bytes(),
+                self.config.blob_hydration_bytes
+            )));
+        }
+        self.install_blob_hydrator_slot(hydrator)
+    }
+
+    /// Whether `candidate` is the same pairing as the installed `current`:
+    /// the exact `Arc`, or a distinct hydrator allocation over the same raw
+    /// store with the same budget and mode. The latter arises when two
+    /// concurrent first installs each construct a hydrator from one raw
+    /// store — the `OnceLock` loser must read as idempotent, not as a
+    /// conflicting install.
+    fn is_same_blob_pairing(
+        current: &Arc<crate::blob::BlobHydrator>,
+        candidate: &Arc<crate::blob::BlobHydrator>,
+    ) -> bool {
+        Arc::ptr_eq(current, candidate)
+            || (Arc::ptr_eq(&current.raw_store(), &candidate.raw_store())
+                && current.budget_bytes() == candidate.budget_bytes()
+                && current.enforces_read_only() == candidate.enforces_read_only())
+    }
+
+    /// One-shot slot semantics shared by both install seams: first install
+    /// wins, an equivalent pairing is idempotent, a different pairing is
+    /// refused (replacing it would split or reset the aggregate admission
+    /// budget while requests may still hold leases).
+    fn install_blob_hydrator_slot(
+        &self,
+        hydrator: Arc<crate::blob::BlobHydrator>,
+    ) -> RuntimeResult<()> {
         if let Some(current) = self.blob_hydrator.get() {
-            return if Arc::ptr_eq(current, &hydrator) {
+            return if Self::is_same_blob_pairing(current, &hydrator) {
                 Ok(())
             } else {
                 Err(RuntimeError::InvalidInput(
@@ -1075,7 +1132,7 @@ impl KhiveRuntime {
                         "blob hydrator install raced without a visible winner".to_string(),
                     )
                 })?;
-                if Arc::ptr_eq(current, &candidate) {
+                if Self::is_same_blob_pairing(current, &candidate) {
                     Ok(())
                 } else {
                     Err(RuntimeError::InvalidInput(
@@ -2098,8 +2155,9 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn install_blob_store_on_read_only_runtime_refuses_mutators() {
+    /// Build a migrated database and reopen it read-only, returning the
+    /// tempdir that keeps it alive alongside the runtime.
+    fn make_read_only_runtime() -> (tempfile::TempDir, KhiveRuntime) {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("read_only_blob_seam.db");
         let config = RuntimeConfig {
@@ -2137,6 +2195,12 @@ mod tests {
         }
         let runtime = KhiveRuntime::new_readonly(config).expect("read-only boot");
         assert!(runtime.is_read_only());
+        (dir, runtime)
+    }
+
+    #[tokio::test]
+    async fn install_blob_store_on_read_only_runtime_refuses_mutators() {
+        let (_dir, runtime) = make_read_only_runtime();
 
         // Control: the raw store IS writable — seed an object through it —
         // so the refusal below can only come from the install-seam wrap.
@@ -2194,6 +2258,85 @@ mod tests {
             err.to_string().contains("read-only"),
             "refusal must name the mode: {err}"
         );
+    }
+
+    #[tokio::test]
+    async fn mode_aware_hydrator_constructor_satisfies_read_only_install() {
+        // The boot path constructs its hydrator with `for_mode` from the
+        // blob runtime's configured mode; a read-only construction must pass
+        // the read-only install gate, serve bounded reads, refuse mutation,
+        // and treat a second hydrator allocation over the same raw store as
+        // the same pairing (the concurrent-first-install loser shape).
+        let (_dir, runtime) = make_read_only_runtime();
+        let blob_root = tempfile::tempdir().unwrap();
+        let raw = Arc::new(
+            khive_db::stores::blob::FsBlobStore::new(blob_root.path().to_path_buf(), 0)
+                .expect("fs blob store"),
+        ) as Arc<dyn khive_storage::BlobStore>;
+        let seeded = raw.put(b"seed".to_vec()).await.expect("seed put");
+        let hydrator = Arc::new(
+            crate::BlobHydrator::for_mode(
+                Arc::clone(&raw),
+                crate::DEFAULT_BLOB_HYDRATION_BYTES,
+                true,
+            )
+            .expect("mode-aware read-only construction"),
+        );
+        runtime
+            .install_blob_hydrator(hydrator)
+            .expect("a for_mode(read_only) hydrator must pass the read-only gate");
+        let installed = runtime.blob_store().expect("installed store");
+        assert!(installed.exists(&seeded).await.expect("exists"));
+        installed
+            .put(b"post".to_vec())
+            .await
+            .expect_err("mutation must refuse through the wrapped store");
+
+        // A DISTINCT hydrator allocation over the same raw store, budget,
+        // and mode is the same pairing: installing it must be idempotent,
+        // not a conflicting-install error.
+        let twin = Arc::new(
+            crate::BlobHydrator::for_mode(
+                Arc::clone(&raw),
+                crate::DEFAULT_BLOB_HYDRATION_BYTES,
+                true,
+            )
+            .expect("twin construction"),
+        );
+        runtime
+            .install_blob_hydrator(twin)
+            .expect("an equivalent pairing must read as idempotent");
+    }
+
+    #[tokio::test]
+    async fn shared_install_permits_writable_hydrator_on_read_only_handle() {
+        // The documented multi-backend matrix includes a writable blob
+        // secondary beside a read-only main: boot installs ONE writable
+        // hydrator on every handle, including read-only ones. The plain
+        // seam must still refuse that pairing — only the named shared seam
+        // accepts it, and mutation must then actually work.
+        let (_dir, runtime) = make_read_only_runtime();
+        let blob_root = tempfile::tempdir().unwrap();
+        let raw = Arc::new(
+            khive_db::stores::blob::FsBlobStore::new(blob_root.path().to_path_buf(), 0)
+                .expect("fs blob store"),
+        ) as Arc<dyn khive_storage::BlobStore>;
+        let hydrator = Arc::new(
+            crate::BlobHydrator::for_mode(raw, crate::DEFAULT_BLOB_HYDRATION_BYTES, false)
+                .expect("writable construction"),
+        );
+        runtime
+            .install_blob_hydrator(Arc::clone(&hydrator))
+            .expect_err("the plain seam must refuse a writable hydrator on a read-only handle");
+        runtime
+            .install_shared_blob_hydrator(hydrator)
+            .expect("the shared seam carries the blob runtime's own mode");
+        let installed = runtime.blob_store().expect("installed store");
+        let put = installed
+            .put(b"shared-write".to_vec())
+            .await
+            .expect("the shared writable capability must actually mutate");
+        assert!(installed.exists(&put).await.expect("exists"));
     }
 
     /// A `~/`-prefixed `--db`/`KHIVE_DB` override must resolve, boot, and

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -1071,15 +1071,27 @@ impl KhiveRuntime {
     /// produces, and the documented multi-backend matrix includes a writable
     /// blob secondary beside a read-only main: there the shared hydrator is
     /// legitimately writable on a read-only domain handle. The mode decision
-    /// must therefore already be encoded in the hydrator — construct it with
-    /// [`crate::BlobHydrator::for_mode`] from the blob pack's backend mode.
-    /// Direct callers that did not make that configuration decision use
+    /// must therefore already be encoded in the hydrator, and it must have
+    /// been DERIVED, not declared: only hydrators built through
+    /// [`crate::BlobHydrator::resolve_for_governing_backend`] — whose mode
+    /// comes from the governing backend's own access mode — are accepted
+    /// here. A hand-paired hydrator (`BlobHydrator::new` / `for_mode`) is
+    /// refused so a safe downstream caller cannot use this seam to put a
+    /// writable store on a read-only runtime; such callers use
     /// [`Self::install_blob_hydrator`], which holds hydrator mode against
     /// this runtime's own.
     pub fn install_shared_blob_hydrator(
         &self,
         hydrator: Arc<crate::blob::BlobHydrator>,
     ) -> RuntimeResult<()> {
+        if !hydrator.is_governed() {
+            return Err(RuntimeError::InvalidInput(
+                "the shared install seam accepts only hydrators whose mode was derived from a \
+                 governing backend (BlobHydrator::resolve_for_governing_backend); use \
+                 install_blob_hydrator for a hand-paired hydrator"
+                    .to_string(),
+            ));
+        }
         if hydrator.budget_bytes() != self.config.blob_hydration_bytes {
             return Err(RuntimeError::InvalidInput(format!(
                 "blob hydrator budget {} does not match this runtime's resolved budget {}",
@@ -2309,33 +2321,62 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn shared_install_permits_writable_hydrator_on_read_only_handle() {
+    async fn shared_install_permits_governed_writable_hydrator_on_read_only_handle() {
         // The documented multi-backend matrix includes a writable blob
         // secondary beside a read-only main: boot installs ONE writable
         // hydrator on every handle, including read-only ones. The plain
-        // seam must still refuse that pairing — only the named shared seam
-        // accepts it, and mutation must then actually work.
+        // seam must still refuse that pairing, and the shared seam accepts
+        // it ONLY when the hydrator's mode was derived from a governing
+        // backend — a hand-paired writable hydrator is refused too, so a
+        // safe downstream caller cannot use the shared seam to defeat a
+        // read-only handle's guarantee.
         let (_dir, runtime) = make_read_only_runtime();
         let blob_root = tempfile::tempdir().unwrap();
         let raw = Arc::new(
             khive_db::stores::blob::FsBlobStore::new(blob_root.path().to_path_buf(), 0)
                 .expect("fs blob store"),
         ) as Arc<dyn khive_storage::BlobStore>;
-        let hydrator = Arc::new(
+        let hand_paired = Arc::new(
             crate::BlobHydrator::for_mode(raw, crate::DEFAULT_BLOB_HYDRATION_BYTES, false)
                 .expect("writable construction"),
         );
         runtime
-            .install_blob_hydrator(Arc::clone(&hydrator))
+            .install_blob_hydrator(Arc::clone(&hand_paired))
             .expect_err("the plain seam must refuse a writable hydrator on a read-only handle");
         runtime
-            .install_shared_blob_hydrator(hydrator)
-            .expect("the shared seam carries the blob runtime's own mode");
+            .install_shared_blob_hydrator(hand_paired)
+            .expect_err("the shared seam must refuse a hand-paired (ungoverned) hydrator");
+
+        // The sanctioned path: a WRITABLE governing backend (the blob pack's
+        // backend in the mixed-mode topology) derives a governed writable
+        // hydrator, and the shared seam installs it on the read-only handle.
+        let governing = khive_db::StorageBackend::memory().expect("memory backend");
+        let cfg = crate::KhiveConfig {
+            storage: crate::engine_config::StorageSectionConfig {
+                blob: Some(crate::engine_config::BlobConfig::Fs {
+                    root: Some(blob_root.path().to_string_lossy().into_owned()),
+                    floor_bytes: Some(0),
+                }),
+            },
+            ..crate::KhiveConfig::default()
+        };
+        let governed = Arc::new(
+            crate::BlobHydrator::resolve_for_governing_backend(
+                &cfg,
+                &governing,
+                &governing,
+                crate::DEFAULT_BLOB_HYDRATION_BYTES,
+            )
+            .expect("governed construction"),
+        );
+        runtime
+            .install_shared_blob_hydrator(governed)
+            .expect("the shared seam accepts a governed hydrator");
         let installed = runtime.blob_store().expect("installed store");
         let put = installed
             .put(b"shared-write".to_vec())
             .await
-            .expect("the shared writable capability must actually mutate");
+            .expect("the governed writable capability must actually mutate");
         assert!(installed.exists(&put).await.expect("exists"));
     }
 

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -943,6 +943,52 @@ impl KhiveRuntime {
                         );
                     }
                 }
+                // The primary check authorizes writes to `primary` only. Each
+                // extra namespace grants read visibility, so each one takes
+                // its own gate check before it may enter the minted set — a
+                // token must never carry visibility the gate was not asked
+                // about. Any deny or gate error refuses the whole mint,
+                // naming the offending namespace (fail-closed).
+                for extra in &extra_visible {
+                    let extra_req = GateRequest::new(
+                        actor.clone(),
+                        extra.clone(),
+                        "authorize",
+                        serde_json::Value::Null,
+                    );
+                    match self.config.gate.check(&extra_req) {
+                        Ok(ref extra_decision) if extra_decision.is_allow() => {}
+                        Ok(khive_gate::GateDecision::Deny { reason }) => {
+                            return Err(crate::RuntimeError::PermissionDenied {
+                                verb: "authorize".to_string(),
+                                reason: format!(
+                                    "visibility namespace {:?} denied: {reason}",
+                                    extra.as_str()
+                                ),
+                            });
+                        }
+                        Ok(_) => {
+                            return Err(crate::RuntimeError::PermissionDenied {
+                                verb: "authorize".to_string(),
+                                reason: format!(
+                                    "visibility namespace {:?} denied by gate",
+                                    extra.as_str()
+                                ),
+                            });
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                namespace = %extra.as_str(),
+                                error = %crate::secret_gate::bounded_masked_log_text(&e.to_string()),
+                                "authorize_with_visibility: extra-namespace gate check failed (fail-closed)"
+                            );
+                            return Err(crate::RuntimeError::Internal(format!(
+                                "gate error: {}",
+                                e.wire_reason()
+                            )));
+                        }
+                    }
+                }
                 Ok(NamespaceToken::mint_with_visibility(
                     primary,
                     extra_visible,
@@ -1044,6 +1090,16 @@ impl KhiveRuntime {
                 return Ok(());
             }
         }
+        // A read-only runtime holds its mode at this seam, not only during
+        // boot resolution: an arbitrary store installed after launch is
+        // wrapped so every physical mutator refuses while the bounded read
+        // surface stays available. Without this, post-boot installation is a
+        // writable bypass of the runtime's declared mode.
+        let store = if self.is_read_only() {
+            crate::blob::wrap_read_only(store)
+        } else {
+            store
+        };
         let hydrator = Arc::new(crate::blob::BlobHydrator::new(
             store,
             self.config.blob_hydration_bytes,
@@ -1973,6 +2029,132 @@ mod tests {
             khive_db::pool::WriterAcquisitionSnapshot::default(),
             "explicit read-only construction must validate through a reader without ever \
              acquiring the writer"
+        );
+    }
+
+    /// Denies exactly one namespace; every other request is allowed. Lets the
+    /// tests below prove a refusal comes from the per-extra visibility check
+    /// rather than from the primary authorization.
+    #[derive(Debug)]
+    struct DenyNamespaceGate {
+        deny: &'static str,
+    }
+
+    impl khive_gate::Gate for DenyNamespaceGate {
+        fn check(
+            &self,
+            req: &khive_gate::GateRequest,
+        ) -> Result<khive_gate::GateDecision, khive_gate::GateError> {
+            if req.namespace.as_str() == self.deny {
+                Ok(khive_gate::GateDecision::Deny {
+                    reason: "namespace denied by policy".to_string(),
+                })
+            } else {
+                Ok(khive_gate::GateDecision::allow())
+            }
+        }
+    }
+
+    #[test]
+    fn authorize_with_visibility_gate_checks_every_extra_namespace() {
+        let config = RuntimeConfig {
+            db_path: None,
+            packs: vec!["kg".to_string()],
+            brain_profile: None,
+            actor_id: None,
+            gate: Arc::new(DenyNamespaceGate {
+                deny: "lambda:secret",
+            }),
+            ..RuntimeConfig::no_embeddings()
+        };
+        let rt = KhiveRuntime::new(config).expect("memory runtime");
+        let primary = Namespace::parse("lambda:caller").expect("primary");
+        let denied = Namespace::parse("lambda:secret").expect("denied");
+        let allowed = Namespace::parse("lambda:open").expect("allowed");
+
+        // Control: the same mint without the denied namespace succeeds, so
+        // the refusal below can only come from the per-extra check.
+        rt.authorize_with_visibility(primary.clone(), vec![allowed.clone()])
+            .expect("mint with only allowed extras");
+
+        let err = rt
+            .authorize_with_visibility(primary, vec![allowed, denied])
+            .expect_err("a denied extra namespace must refuse the whole mint");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("lambda:secret"),
+            "refusal must name the offending namespace: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn install_blob_store_on_read_only_runtime_refuses_mutators() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("read_only_blob_seam.db");
+        let config = RuntimeConfig {
+            git_write: Default::default(),
+            display_timezone: chrono_tz::Tz::UTC,
+            db_path: Some(path.clone()),
+            blob_hydration_bytes: crate::DEFAULT_BLOB_HYDRATION_BYTES,
+            default_namespace: Namespace::local(),
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            gate: Arc::new(AllowAllGate),
+            packs: vec!["kg".to_string()],
+            backend_id: BackendId::main(),
+            brain_profile: None,
+            visible_namespaces: vec![],
+            allowed_outbound_namespaces: vec![],
+            actor_id: None,
+        };
+        KhiveRuntime::new(config.clone()).expect("create migrated database");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            for suffix in ["-wal", "-shm"] {
+                let mut name = path.file_name().expect("db file name").to_os_string();
+                name.push(suffix);
+                let sidecar = path.parent().expect("db parent dir").join(name);
+                if sidecar.exists() {
+                    let mut permissions = std::fs::metadata(&sidecar)
+                        .expect("sidecar metadata")
+                        .permissions();
+                    permissions.set_mode(0o444);
+                    std::fs::set_permissions(&sidecar, permissions).expect("freeze sidecar");
+                }
+            }
+        }
+        let runtime = KhiveRuntime::new_readonly(config).expect("read-only boot");
+        assert!(runtime.is_read_only());
+
+        // Control: the raw store IS writable — seed an object through it —
+        // so the refusal below can only come from the install-seam wrap.
+        use khive_storage::BlobStore as _;
+        let blob_root = tempfile::tempdir().unwrap();
+        let writable = Arc::new(
+            khive_db::stores::blob::FsBlobStore::new(blob_root.path().to_path_buf(), 0)
+                .expect("fs blob store"),
+        );
+        let seeded = writable
+            .put(b"seed".to_vec())
+            .await
+            .expect("seed put through the raw store");
+        runtime
+            .install_blob_store(writable)
+            .expect("read-only install wraps rather than refusing");
+
+        let installed = runtime.blob_store().expect("installed store");
+        assert!(
+            installed.exists(&seeded).await.expect("exists"),
+            "bounded read surface must stay available"
+        );
+        let err = installed
+            .put(b"post-boot".to_vec())
+            .await
+            .expect_err("put must refuse on a read-only runtime");
+        assert!(
+            err.to_string().contains("read-only"),
+            "refusal must name the mode: {err}"
         );
     }
 


### PR DESCRIPTION
Two enforcement gaps at public runtime seams, each now held at the seam itself:

- **`authorize_with_visibility`**: the gate was consulted once, for the primary (write) namespace, and the minted token then carried every caller-supplied extra namespace unchecked. Each extra namespace grants read visibility, so each one now takes its own gate check before it may enter the minted set. Any deny or gate error refuses the whole mint and names the offending namespace, fail-closed.

- **`install_blob_store`**: a store installed after boot bypassed the runtime's declared access mode — boot-time resolution wraps stores for read-only runtimes, but the post-boot install seam accepted arbitrary writable stores. Incoming stores are now wrapped on read-only runtimes: every physical mutator refuses, the bounded read surface stays available. Wrapping an already-wrapped store is harmless.

Regression tests carry their own controls: the visibility test performs the same mint without the denied namespace (success proves the refusal comes from the per-extra check); the blob test seeds an object through the raw store first (proving the store is writable, so the refusal can only come from the seam).

Gates: khive-runtime lib suite 1332 passed / 0 failed; clippy clean; downstream crates compile.