### PR TITLE
fix(runtime): repair main after crossing range-seek and events-split merges

### DIFF
--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -4407,14 +4407,21 @@ impl KhiveRuntime {
         // so the sidecar scan merges into the same `matches`/`seen` set.
         if matches.len() <= 1 {
             if let Some(sidecar_sql) = self.events_sidecar_sql_read_only()? {
-                let mut params = vec![SqlValue::Text(pattern.clone())];
+                let mut params = vec![SqlValue::Text(lower.clone()), SqlValue::Text(upper.clone())];
                 if let Some(ns) = namespaces {
                     params.extend(ns.iter().map(|n| SqlValue::Text(n.clone())));
                 }
+                let namespace_clause = namespaces.map(|namespaces| {
+                    let placeholders: Vec<String> = (0..namespaces.len())
+                        .map(|index| format!("?{}", index + 3))
+                        .collect();
+                    format!(" AND namespace IN ({})", placeholders.join(", "))
+                });
                 let sql = SqlStatement {
                     sql: format!(
-                        "SELECT id FROM events WHERE id LIKE ?1{ns_clause} LIMIT 2",
-                        ns_clause = ns_clause.as_deref().unwrap_or("")
+                        "SELECT id FROM events \
+                         WHERE id >= ?1 AND id < ?2{namespace_clause} LIMIT 2",
+                        namespace_clause = namespace_clause.as_deref().unwrap_or("")
                     ),
                     params,
                     label: Some("resolve_prefix.events_sidecar".into()),

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -2356,6 +2356,7 @@ mod tests {
             visible_namespaces: vec![],
             allowed_outbound_namespaces: vec![],
             actor_id: None,
+            events_split: None,
         };
         KhiveRuntime::new(config.clone()).expect("create migrated database");
         #[cfg(unix)]


### PR DESCRIPTION
Main stopped compiling after two independently reviewed merges crossed:

- the short-ID range-seek refactor (#2189) removed the `pattern`/`ns_clause` locals that the events-sidecar prefix scan (introduced with the events-split configuration work) still referenced in `resolve_prefix`;
- a test-only `RuntimeConfig` literal predated the new `events_split` field.

Both merges were textually clean, so nothing conflicted at merge time; the break only appears on the combined tree.

This converts the sidecar scan to the same indexed `id >= ?1 AND id < ?2` range and per-index namespace placeholders the main-store statement uses, and completes the config literal with `events_split: None`.

Verification: `cargo test -p khive-runtime --lib` 1365 passed; `cargo check --workspace --tests` clean.