### PR TITLE
chore: quiet new rust 1.98.0 clippy lints across the workspace

### DIFF
--- a/crates/khive-db/src/stores/sparse.rs
+++ b/crates/khive-db/src/stores/sparse.rs
@@ -515,6 +515,9 @@ impl SqliteSparseStore {
                     ));
                 }
 
+                // `as_chunks` is unstable on stable; keep `chunks_exact`
+                // until it lands.
+                #[allow(clippy::chunks_exact_to_as_chunks)]
                 let stored_values: Vec<f32> = values_blob
                     .chunks_exact(4)
                     .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))

--- a/crates/khive-db/src/stores/sparse.rs
+++ b/crates/khive-db/src/stores/sparse.rs
@@ -517,7 +517,7 @@ impl SqliteSparseStore {
 
                 // `as_chunks` is unstable on stable; keep `chunks_exact`
                 // until it lands.
-                #[allow(clippy::chunks_exact_to_as_chunks)]
+                #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
                 let stored_values: Vec<f32> = values_blob
                     .chunks_exact(4)
                     .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))

--- a/crates/khive-pack-knowledge/src/knowledge/compose.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/compose.rs
@@ -312,6 +312,8 @@ pub(super) fn decode_embedding(blob: &[u8]) -> Vec<f32> {
     if !blob.len().is_multiple_of(4) {
         return Vec::new();
     }
+    // `as_chunks` is unstable on stable; keep `chunks_exact` until it lands.
+    #[allow(clippy::chunks_exact_to_as_chunks)]
     blob.chunks_exact(4)
         .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
         .collect()

--- a/crates/khive-pack-knowledge/src/knowledge/compose.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/compose.rs
@@ -313,7 +313,7 @@ pub(super) fn decode_embedding(blob: &[u8]) -> Vec<f32> {
         return Vec::new();
     }
     // `as_chunks` is unstable on stable; keep `chunks_exact` until it lands.
-    #[allow(clippy::chunks_exact_to_as_chunks)]
+    #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
     blob.chunks_exact(4)
         .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
         .collect()

--- a/crates/khive-pack-knowledge/src/knowledge/vamana.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/vamana.rs
@@ -987,7 +987,7 @@ fn decode_ann_dir_name(name: &str) -> Option<(String, String)> {
     }
     let mut bytes = Vec::with_capacity(raw.len() / 2);
     // `as_chunks` is unstable on stable; keep `chunks_exact` until it lands.
-    #[allow(clippy::chunks_exact_to_as_chunks)]
+    #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
     for pair in raw.chunks_exact(2) {
         let hi = (pair[0] as char).to_digit(16)?;
         let lo = (pair[1] as char).to_digit(16)?;
@@ -1516,7 +1516,7 @@ async fn replay_final_states(
                 return Err(format!("final upsert for {uuid}: embedding missing on row"));
             };
             // `as_chunks` is unstable on stable; keep `chunks_exact` until it lands.
-            #[allow(clippy::chunks_exact_to_as_chunks)]
+            #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
             let vec: Vec<f32> = bytes
                 .chunks_exact(4)
                 .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
@@ -1728,7 +1728,7 @@ async fn fetch_fresh_tail_snapshot(
             ));
         }
         // `as_chunks` is unstable on stable; keep `chunks_exact` until it lands.
-        #[allow(clippy::chunks_exact_to_as_chunks)]
+        #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
         let embedding = bytes
             .chunks_exact(4)
             .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
@@ -2455,7 +2455,7 @@ async fn scan_corpus_raw(
             continue;
         }
         // `as_chunks` is unstable on stable; keep `chunks_exact` until it lands.
-        #[allow(clippy::chunks_exact_to_as_chunks)]
+        #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
         let vec: Vec<f32> = bytes
             .chunks_exact(4)
             .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))

--- a/crates/khive-pack-knowledge/src/knowledge/vamana.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/vamana.rs
@@ -986,6 +986,8 @@ fn decode_ann_dir_name(name: &str) -> Option<(String, String)> {
         return None;
     }
     let mut bytes = Vec::with_capacity(raw.len() / 2);
+    // `as_chunks` is unstable on stable; keep `chunks_exact` until it lands.
+    #[allow(clippy::chunks_exact_to_as_chunks)]
     for pair in raw.chunks_exact(2) {
         let hi = (pair[0] as char).to_digit(16)?;
         let lo = (pair[1] as char).to_digit(16)?;
@@ -1513,6 +1515,8 @@ async fn replay_final_states(
             let Some(SqlValue::Blob(bytes)) = row.get("embedding") else {
                 return Err(format!("final upsert for {uuid}: embedding missing on row"));
             };
+            // `as_chunks` is unstable on stable; keep `chunks_exact` until it lands.
+            #[allow(clippy::chunks_exact_to_as_chunks)]
             let vec: Vec<f32> = bytes
                 .chunks_exact(4)
                 .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
@@ -1723,6 +1727,8 @@ async fn fetch_fresh_tail_snapshot(
                 bytes.len()
             ));
         }
+        // `as_chunks` is unstable on stable; keep `chunks_exact` until it lands.
+        #[allow(clippy::chunks_exact_to_as_chunks)]
         let embedding = bytes
             .chunks_exact(4)
             .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
@@ -2448,6 +2454,8 @@ async fn scan_corpus_raw(
         if bytes.len() != dims * 4 {
             continue;
         }
+        // `as_chunks` is unstable on stable; keep `chunks_exact` until it lands.
+        #[allow(clippy::chunks_exact_to_as_chunks)]
         let vec: Vec<f32> = bytes
             .chunks_exact(4)
             .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))

--- a/crates/khive-pack-memory/src/ann.rs
+++ b/crates/khive-pack-memory/src/ann.rs
@@ -1226,6 +1226,8 @@ async fn load_and_build_from_vector_store(
         if bytes.len() != dims * 4 {
             continue;
         }
+        // `as_chunks` is unstable on stable; keep `chunks_exact` until it lands.
+        #[allow(clippy::chunks_exact_to_as_chunks)]
         let vec: Vec<f32> = bytes
             .chunks_exact(4)
             .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
@@ -1747,6 +1749,8 @@ async fn fetch_final_tail_on(
         let Some(bytes) = embedding else {
             return Err(format!("tail upsert {subject}: embedding is not a blob"));
         };
+        // `as_chunks` is unstable on stable; keep `chunks_exact` until it lands.
+        #[allow(clippy::chunks_exact_to_as_chunks)]
         let vector: Vec<f32> = bytes
             .chunks_exact(4)
             .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))

--- a/crates/khive-pack-memory/src/ann.rs
+++ b/crates/khive-pack-memory/src/ann.rs
@@ -1227,7 +1227,7 @@ async fn load_and_build_from_vector_store(
             continue;
         }
         // `as_chunks` is unstable on stable; keep `chunks_exact` until it lands.
-        #[allow(clippy::chunks_exact_to_as_chunks)]
+        #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
         let vec: Vec<f32> = bytes
             .chunks_exact(4)
             .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
@@ -1750,7 +1750,7 @@ async fn fetch_final_tail_on(
             return Err(format!("tail upsert {subject}: embedding is not a blob"));
         };
         // `as_chunks` is unstable on stable; keep `chunks_exact` until it lands.
-        #[allow(clippy::chunks_exact_to_as_chunks)]
+        #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
         let vector: Vec<f32> = bytes
             .chunks_exact(4)
             .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))

--- a/crates/khive-vamana/examples/vec_bench.rs
+++ b/crates/khive-vamana/examples/vec_bench.rs
@@ -1355,7 +1355,7 @@ fn main() {
     // ─── Build caveats ─────────────────────────────────────────────────────
 
     let mut caveats: Vec<String> = vec![
-        format!("{fit_note}"),
+        fit_note.clone(),
         "GT recomputed by brute-force L2 on each subset (provided GT indexes full base — invalid for subsets)".into(),
         "build exponent is Omega(N) floor — sublinear claim is query+update only".into(),
         "latency measured warm-cache on single-node; cold-cache latency is higher".into(),

--- a/crates/khive-vamana/src/distance.rs
+++ b/crates/khive-vamana/src/distance.rs
@@ -16,7 +16,11 @@ pub(crate) fn l2_squared(a: &[f32], b: &[f32]) -> f32 {
     let mut s6 = 0.0f32;
     let mut s7 = 0.0f32;
 
+    // `as_chunks` (clippy's suggested replacement) is unstable on the stable
+    // toolchain this crate builds with; keep `chunks_exact` until it lands.
+    #[allow(clippy::chunks_exact_to_as_chunks)]
     let chunks_a = a.chunks_exact(8);
+    #[allow(clippy::chunks_exact_to_as_chunks)]
     let chunks_b = b.chunks_exact(8);
     let rem_a = chunks_a.remainder();
     let rem_b = chunks_b.remainder();

--- a/crates/khive-vamana/src/distance.rs
+++ b/crates/khive-vamana/src/distance.rs
@@ -18,9 +18,9 @@ pub(crate) fn l2_squared(a: &[f32], b: &[f32]) -> f32 {
 
     // `as_chunks` (clippy's suggested replacement) is unstable on the stable
     // toolchain this crate builds with; keep `chunks_exact` until it lands.
-    #[allow(clippy::chunks_exact_to_as_chunks)]
+    #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
     let chunks_a = a.chunks_exact(8);
-    #[allow(clippy::chunks_exact_to_as_chunks)]
+    #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
     let chunks_b = b.chunks_exact(8);
     let rem_a = chunks_a.remainder();
     let rem_b = chunks_b.remainder();

--- a/crates/khive-vamana/src/external_ids.rs
+++ b/crates/khive-vamana/src/external_ids.rs
@@ -652,7 +652,7 @@ pub fn read_external_ids_sidecar(dir: &std::path::Path) -> Result<([u8; 32], Vec
 
     let mut ids = Vec::with_capacity(count);
     // `as_chunks` is unstable on stable; keep `chunks_exact` until it lands.
-    #[allow(clippy::chunks_exact_to_as_chunks)]
+    #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
     for chunk in id_bytes.chunks_exact(16) {
         let raw: [u8; 16] = chunk.try_into().unwrap();
         ids.push(Uuid::from_bytes(raw));

--- a/crates/khive-vamana/src/external_ids.rs
+++ b/crates/khive-vamana/src/external_ids.rs
@@ -651,6 +651,8 @@ pub fn read_external_ids_sidecar(dir: &std::path::Path) -> Result<([u8; 32], Vec
     }
 
     let mut ids = Vec::with_capacity(count);
+    // `as_chunks` is unstable on stable; keep `chunks_exact` until it lands.
+    #[allow(clippy::chunks_exact_to_as_chunks)]
     for chunk in id_bytes.chunks_exact(16) {
         let raw: [u8; 16] = chunk.try_into().unwrap();
         ids.push(Uuid::from_bytes(raw));

--- a/crates/khive-vamana/src/graph.rs
+++ b/crates/khive-vamana/src/graph.rs
@@ -1834,7 +1834,7 @@ mod tests {
             .with_search_list_size(1);
         let codec = GsSq8Codec::train_flat(&vectors, dim);
         let mut encoded = codec.encode_flat_par(&vectors, dim);
-        encoded.truncate(0); // malformed: expected 2 encoded rows, actual 0
+        encoded.clear(); // malformed: expected 2 encoded rows, actual 0
 
         let result = std::panic::catch_unwind(|| {
             VamanaGraph::build_sq8(&vectors, CodesView::Owned(&encoded), &codec, &cfg)

--- a/crates/khive-vamana/src/index.rs
+++ b/crates/khive-vamana/src/index.rs
@@ -738,7 +738,7 @@ impl VamanaIndex {
             )));
         }
         // `as_chunks` is unstable on stable; keep `chunks_exact` until it lands.
-        #[allow(clippy::chunks_exact_to_as_chunks)]
+        #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
         let vectors: Vec<f32> = vector_bytes
             .chunks_exact(4)
             .map(|bytes| f32::from_le_bytes(bytes.try_into().expect("four-byte chunk")))

--- a/crates/khive-vamana/src/index.rs
+++ b/crates/khive-vamana/src/index.rs
@@ -737,6 +737,8 @@ impl VamanaIndex {
                 vector_bytes.len()
             )));
         }
+        // `as_chunks` is unstable on stable; keep `chunks_exact` until it lands.
+        #[allow(clippy::chunks_exact_to_as_chunks)]
         let vectors: Vec<f32> = vector_bytes
             .chunks_exact(4)
             .map(|bytes| f32::from_le_bytes(bytes.try_into().expect("four-byte chunk")))

--- a/crates/khive-vamana/tests/persistence.rs
+++ b/crates/khive-vamana/tests/persistence.rs
@@ -836,7 +836,7 @@ fn v2_corrupt_reverse_adj_not_inverse_of_graph_triggers_rebuild() {
     let neighbors_start = node0_offset + 4;
     let neighbors_end = neighbors_start + degree0 * 4;
     // `as_chunks` is unstable on stable; keep `chunks_exact` until it lands.
-    #[allow(clippy::chunks_exact_to_as_chunks)]
+    #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
     let already_present = lifecycle_bytes[neighbors_start..neighbors_end]
         .chunks_exact(4)
         .any(|b| u32::from_le_bytes(b.try_into().unwrap()) == phantom_src);

--- a/crates/khive-vamana/tests/persistence.rs
+++ b/crates/khive-vamana/tests/persistence.rs
@@ -835,6 +835,8 @@ fn v2_corrupt_reverse_adj_not_inverse_of_graph_triggers_rebuild() {
     // Verify phantom_src is not already in reverse_adj[0] (must not create a dup).
     let neighbors_start = node0_offset + 4;
     let neighbors_end = neighbors_start + degree0 * 4;
+    // `as_chunks` is unstable on stable; keep `chunks_exact` until it lands.
+    #[allow(clippy::chunks_exact_to_as_chunks)]
     let already_present = lifecycle_bytes[neighbors_start..neighbors_end]
         .chunks_exact(4)
         .any(|b| u32::from_le_bytes(b.try_into().unwrap()) == phantom_src);


### PR DESCRIPTION
clippy 1.98.0 introduces `chunks_exact_to_as_chunks` and `manual_clear`, which fail any `-D warnings` run on a current local toolchain even though the pinned CI toolchain predates them.

- 13 `chunks_exact` sites (12 in `src/`, 1 in an integration test) get a scoped `#[allow(clippy::chunks_exact_to_as_chunks)]` with a note: `as_chunks` is unstable on the stable toolchain this workspace builds with, so the rewrite is deferred until it stabilizes.
- `truncate(0)` becomes `clear()` in one test-fixture helper (identical semantics).
- The vec_bench example passes a prebuilt string instead of reformatting it (`useless_format`).

No behavior changes. Workspace `clippy --all-targets -D warnings` is clean on 1.98.0; khive-vamana suite 218 passed.