### PR TITLE
fix(runtime): separate audit admission refusal from deadline expiry; degrade read verbs under admission pressure

### DIFF
--- a/crates/khive-db/src/diagnostics.rs
+++ b/crates/khive-db/src/diagnostics.rs
@@ -510,18 +510,36 @@ pub struct WriterContentionDiagnostics {
     /// Why `audit_degraded` is unavailable to this caller.
     pub audit_degraded_unavailable_reason: Option<String>,
     /// Per-dispatch audit rows for an explicitly allowlisted, domain-write-free
-    /// read verb (`VerbRegistry::ADMISSION_DEGRADE_SAFE_VERBS`) whose commit was
-    /// skipped under transient audit-lane admission pressure — queue refusal or
-    /// the caller's admission-wait deadline expiring — while the dispatch still
-    /// reported its own successful result (ADR-103 Amendment 3, ADR-133
-    /// Amendment 1). This undercounts `brain.event_counts`'s cost totals for
-    /// exactly the rows counted here. Disjoint from `audit_degraded_rows`,
-    /// which counts pure-observability rows dropped for a different reason
-    /// (persistent commit failure, not admission pressure). `None` under the
-    /// same conditions as `audit_batch_flush_failures`.
-    pub audit_admission_degraded_obligations: Option<u64>,
-    /// Why `audit_admission_degraded_obligations` is unavailable to this caller.
-    pub audit_admission_degraded_obligations_unavailable_reason: Option<String>,
+    /// read verb (`VerbRegistry::ADMISSION_DEGRADE_SAFE_VERBS`) that were
+    /// **refused before they could be enqueued** on the audit lane
+    /// (`AuditTerminalReason::QueueAdmissionExhausted`) while the dispatch
+    /// still reported its own successful result (ADR-103 Amendment 3, ADR-133
+    /// Amendment 1). This is a confirmed, terminal accounting loss: the row
+    /// never shared a generation with anyone and will never commit, so it
+    /// undercounts `brain.event_counts`'s cost totals for exactly the rows
+    /// counted here. Disjoint from `audit_degraded_rows` (a different reason:
+    /// persistent commit failure of a pure-observability row, not admission
+    /// pressure) and from `audit_admission_unresolved_obligations` (a row that
+    /// was enqueued and may still commit). `None` under the same conditions as
+    /// `audit_batch_flush_failures`.
+    pub audit_admission_refused_obligations: Option<u64>,
+    /// Why `audit_admission_refused_obligations` is unavailable to this caller.
+    pub audit_admission_refused_obligations_unavailable_reason: Option<String>,
+    /// Per-dispatch audit rows for an explicitly allowlisted, domain-write-free
+    /// read verb (`VerbRegistry::ADMISSION_DEGRADE_SAFE_VERBS`) that were
+    /// **already enqueued but had not resolved when the caller's admission
+    /// wait deadline elapsed** (`AuditTerminalReason::AdmissionDeadlineExpired`)
+    /// while the dispatch still reported its own successful result (ADR-103
+    /// Amendment 3, ADR-133 Amendment 1). Unlike
+    /// `audit_admission_refused_obligations`, a row counted here is not a
+    /// confirmed loss — it may still be committed by the generation driver
+    /// independently of the caller's timeout — so this field is an upper
+    /// bound on the eventual undercount, not the undercount itself. `None`
+    /// under the same conditions as `audit_batch_flush_failures`.
+    pub audit_admission_unresolved_obligations: Option<u64>,
+    /// Why `audit_admission_unresolved_obligations` is unavailable to this
+    /// caller.
+    pub audit_admission_unresolved_obligations_unavailable_reason: Option<String>,
 }
 
 /// Process-wide audit-batch health counters, supplied by the runtime layer
@@ -537,10 +555,18 @@ pub struct RuntimeAuditBatchMetrics {
     pub degraded_rows: u64,
     /// Monotonic process-lifetime degradation flag.
     pub degraded: bool,
-    /// Admission-degrade-safe read verbs' audit rows dropped under transient
-    /// audit-lane admission pressure (ADR-103 Amendment 3, ADR-133
-    /// Amendment 1). Disjoint from `degraded_rows`.
-    pub admission_degraded_obligations: u64,
+    /// Admission-degrade-safe read verbs' audit rows refused before enqueue
+    /// under transient audit-lane admission pressure (ADR-103 Amendment 3,
+    /// ADR-133 Amendment 1) — a confirmed, terminal accounting loss. Disjoint
+    /// from `degraded_rows` and from `admission_unresolved_obligations`.
+    pub admission_refused_obligations: u64,
+    /// Admission-degrade-safe read verbs' audit rows that were already
+    /// enqueued but had not resolved when the caller's admission wait
+    /// deadline elapsed (ADR-103 Amendment 3, ADR-133 Amendment 1). Not a
+    /// confirmed loss — the row may still commit — so this is an upper bound
+    /// on the eventual undercount. Disjoint from `degraded_rows` and from
+    /// `admission_refused_obligations`.
+    pub admission_unresolved_obligations: u64,
 }
 
 impl WriterContentionDiagnostics {
@@ -581,9 +607,15 @@ impl WriterContentionDiagnostics {
                 .is_none()
                 .then(unavailable_reason)
                 .flatten(),
-            audit_admission_degraded_obligations: runtime_audit_batch_metrics
-                .map(|m| m.admission_degraded_obligations),
-            audit_admission_degraded_obligations_unavailable_reason: runtime_audit_batch_metrics
+            audit_admission_refused_obligations: runtime_audit_batch_metrics
+                .map(|m| m.admission_refused_obligations),
+            audit_admission_refused_obligations_unavailable_reason: runtime_audit_batch_metrics
+                .is_none()
+                .then(unavailable_reason)
+                .flatten(),
+            audit_admission_unresolved_obligations: runtime_audit_batch_metrics
+                .map(|m| m.admission_unresolved_obligations),
+            audit_admission_unresolved_obligations_unavailable_reason: runtime_audit_batch_metrics
                 .is_none()
                 .then(unavailable_reason)
                 .flatten(),
@@ -1106,7 +1138,8 @@ mod tests {
                 flush_failures: 3,
                 degraded_rows: 7,
                 degraded: true,
-                admission_degraded_obligations: 5,
+                admission_refused_obligations: 5,
+                admission_unresolved_obligations: 2,
             }),
         )
         .await
@@ -1124,22 +1157,42 @@ mod tests {
         assert_eq!(
             with_control
                 .writer_contention
-                .audit_admission_degraded_obligations,
+                .audit_admission_refused_obligations,
             Some(5),
-            "an operator must be able to read the admission-degraded obligation count from \
+            "an operator must be able to read the admission-refused obligation count from \
              db_diagnostics without a test-only feature gate (ADR-103 Amendment 3)"
         );
         assert!(with_control
             .writer_contention
-            .audit_admission_degraded_obligations_unavailable_reason
+            .audit_admission_refused_obligations_unavailable_reason
+            .is_none());
+        assert_eq!(
+            with_control
+                .writer_contention
+                .audit_admission_unresolved_obligations,
+            Some(2),
+            "an operator must be able to distinguish enqueued-but-unresolved rows from \
+             confirmed-refused rows (ADR-103 Amendment 3)"
+        );
+        assert!(with_control
+            .writer_contention
+            .audit_admission_unresolved_obligations_unavailable_reason
             .is_none());
         assert!(without_control
             .writer_contention
-            .audit_admission_degraded_obligations
+            .audit_admission_refused_obligations
             .is_none());
         assert!(without_control
             .writer_contention
-            .audit_admission_degraded_obligations_unavailable_reason
+            .audit_admission_refused_obligations_unavailable_reason
+            .is_some());
+        assert!(without_control
+            .writer_contention
+            .audit_admission_unresolved_obligations
+            .is_none());
+        assert!(without_control
+            .writer_contention
+            .audit_admission_unresolved_obligations_unavailable_reason
             .is_some());
 
         // Existing fields must be unaffected by the new ones — additive, not

--- a/crates/khive-db/src/diagnostics.rs
+++ b/crates/khive-db/src/diagnostics.rs
@@ -509,6 +509,19 @@ pub struct WriterContentionDiagnostics {
     pub audit_degraded: Option<bool>,
     /// Why `audit_degraded` is unavailable to this caller.
     pub audit_degraded_unavailable_reason: Option<String>,
+    /// Per-dispatch audit rows for an explicitly allowlisted, domain-write-free
+    /// read verb (`VerbRegistry::ADMISSION_DEGRADE_SAFE_VERBS`) whose commit was
+    /// skipped under transient audit-lane admission pressure — queue refusal or
+    /// the caller's admission-wait deadline expiring — while the dispatch still
+    /// reported its own successful result (ADR-103 Amendment 3, ADR-133
+    /// Amendment 1). This undercounts `brain.event_counts`'s cost totals for
+    /// exactly the rows counted here. Disjoint from `audit_degraded_rows`,
+    /// which counts pure-observability rows dropped for a different reason
+    /// (persistent commit failure, not admission pressure). `None` under the
+    /// same conditions as `audit_batch_flush_failures`.
+    pub audit_admission_degraded_obligations: Option<u64>,
+    /// Why `audit_admission_degraded_obligations` is unavailable to this caller.
+    pub audit_admission_degraded_obligations_unavailable_reason: Option<String>,
 }
 
 /// Process-wide audit-batch health counters, supplied by the runtime layer
@@ -524,6 +537,10 @@ pub struct RuntimeAuditBatchMetrics {
     pub degraded_rows: u64,
     /// Monotonic process-lifetime degradation flag.
     pub degraded: bool,
+    /// Admission-degrade-safe read verbs' audit rows dropped under transient
+    /// audit-lane admission pressure (ADR-103 Amendment 3, ADR-133
+    /// Amendment 1). Disjoint from `degraded_rows`.
+    pub admission_degraded_obligations: u64,
 }
 
 impl WriterContentionDiagnostics {
@@ -561,6 +578,12 @@ impl WriterContentionDiagnostics {
                 .flatten(),
             audit_degraded: runtime_audit_batch_metrics.map(|m| m.degraded),
             audit_degraded_unavailable_reason: runtime_audit_batch_metrics
+                .is_none()
+                .then(unavailable_reason)
+                .flatten(),
+            audit_admission_degraded_obligations: runtime_audit_batch_metrics
+                .map(|m| m.admission_degraded_obligations),
+            audit_admission_degraded_obligations_unavailable_reason: runtime_audit_batch_metrics
                 .is_none()
                 .then(unavailable_reason)
                 .flatten(),
@@ -1083,6 +1106,7 @@ mod tests {
                 flush_failures: 3,
                 degraded_rows: 7,
                 degraded: true,
+                admission_degraded_obligations: 5,
             }),
         )
         .await
@@ -1097,6 +1121,26 @@ mod tests {
             .is_none());
         assert_eq!(with_control.writer_contention.audit_degraded_rows, Some(7));
         assert_eq!(with_control.writer_contention.audit_degraded, Some(true));
+        assert_eq!(
+            with_control
+                .writer_contention
+                .audit_admission_degraded_obligations,
+            Some(5),
+            "an operator must be able to read the admission-degraded obligation count from \
+             db_diagnostics without a test-only feature gate (ADR-103 Amendment 3)"
+        );
+        assert!(with_control
+            .writer_contention
+            .audit_admission_degraded_obligations_unavailable_reason
+            .is_none());
+        assert!(without_control
+            .writer_contention
+            .audit_admission_degraded_obligations
+            .is_none());
+        assert!(without_control
+            .writer_contention
+            .audit_admission_degraded_obligations_unavailable_reason
+            .is_some());
 
         // Existing fields must be unaffected by the new ones — additive, not
         // a reshuffle.

--- a/crates/khive-pack-kg/Cargo.toml
+++ b/crates/khive-pack-kg/Cargo.toml
@@ -31,7 +31,7 @@ tracing = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 criterion = { workspace = true }
 serde_json = { workspace = true }
-khive-runtime = { path = "../khive-runtime", features = ["fault-injection"] }
+khive-runtime = { path = "../khive-runtime", features = ["fault-injection", "test-internals"] }
 khive-pack-formal = { version = "0.7.0", path = "../khive-pack-formal" }
 # Path-only: cyclic dev-dep pair with khive-pack-gtd; cargo strips it at publish.
 khive-pack-gtd = { path = "../khive-pack-gtd" }
@@ -40,6 +40,10 @@ lattice-embed = { workspace = true }
 [[test]]
 name = "integration"
 path = "tests/integration.rs"
+
+[[test]]
+name = "db_diagnostics_admission_obligations"
+path = "tests/db_diagnostics_admission_obligations.rs"
 
 [[test]]
 name = "certificate"

--- a/crates/khive-pack-kg/tests/db_diagnostics_admission_obligations.rs
+++ b/crates/khive-pack-kg/tests/db_diagnostics_admission_obligations.rs
@@ -1,0 +1,276 @@
+//! khive#2228 M3: the `db_diagnostics` verb handler
+//! (`crates/khive-pack-kg/src/handlers/db_diagnostics.rs`) must actually
+//! forward `registry.audit_batch_metrics()` into
+//! `KhiveRuntime::db_diagnostics_with_audit_metrics` — not just have that
+//! forwarding proven for the runtime method in isolation
+//! (`khive-runtime/tests/read_verb_admission_exhaustion.rs`).
+//!
+//! This dispatches the real `db_diagnostics` verb through the same
+//! `VerbRegistry` + `KgPack` path a caller reaches (mirroring
+//! `crates/khive-pack-kg/tests/integration.rs`'s `Fixture`), after a real
+//! degraded admission has made the counters nonzero, and asserts on the
+//! returned wire JSON. If the handler is changed to pass `None` instead of
+//! `registry.audit_batch_metrics()`, this test reddens.
+//!
+//! `db_diagnostics` is deliberately NOT itself in
+//! `VerbRegistry::ADMISSION_DEGRADE_SAFE_VERBS` (it may do WAL-backfilling
+//! physical I/O), so it hard-fails its OWN audit obligation if dispatched
+//! while the audit lane is still saturated. This test therefore saturates
+//! the lane with a gated `EventStore` (not the 3600s fault-injection sleep
+//! `read_verb_admission_exhaustion.rs` uses, which never releases), drives
+//! one degrade-safe read (`whoami`) through the saturated lane to bump the
+//! refused-obligation counter, releases the gate so the lane quiesces, and
+//! only then dispatches `db_diagnostics` — proving the counter it reports
+//! (a process-wide cumulative counter, not reset by quiescing) is the one
+//! `whoami`'s refusal actually produced.
+//!
+//! Lives in its own binary rather than inside `tests/integration.rs`:
+//! `integration.rs` runs thousands of unrelated tests concurrently in one
+//! process, and this mechanism configures its own dedicated `AuditBatch`
+//! with `max_pending_rows: 1` plus a gate that blocks that batch's flush —
+//! isolating it in its own test binary/process removes any risk of
+//! interacting with another test's own audit-batch traffic.
+//!
+//! Requires `--features fault-injection,test-internals` on the
+//! `khive-runtime` dependency (enabled unconditionally for this crate's
+//! dev-dependency in `Cargo.toml`) for `AuditBatch::test_snapshot`/`quiesce`.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::{json, Value};
+
+use khive_pack_kg::KgPack;
+use khive_runtime::audit_batch::{AuditBatchConfig, AuditBatchControl};
+use khive_runtime::pack::{
+    audit_admission_refused_obligation_count, audit_admission_unresolved_obligation_count,
+};
+use khive_runtime::{KhiveRuntime, VerbRegistryBuilder};
+use khive_storage::event::{EventAppendDisposition, IdempotentEventBatchResult};
+use khive_storage::types::{BatchWriteSummary, Page, PageRequest};
+use khive_storage::{Event, EventFilter, EventStore, StorageResult};
+use khive_types::{EventKind, EventOutcome, SubstrateKind};
+
+/// An `EventStore` whose `append_events_idempotent` (the call
+/// `AuditBatch`'s flush uses) blocks until `release()` is called — lets the
+/// test hold the audit lane's in-flight generation open on demand, then let
+/// it go, instead of relying on a fixed sleep.
+#[derive(Default)]
+struct GateEventStore {
+    events: std::sync::Mutex<Vec<Event>>,
+    released: Arc<AtomicBool>,
+}
+
+impl GateEventStore {
+    fn release(&self) {
+        self.released.store(true, Ordering::SeqCst);
+    }
+}
+
+#[async_trait]
+impl EventStore for GateEventStore {
+    async fn append_event(&self, event: Event) -> StorageResult<()> {
+        self.events.lock().unwrap().push(event);
+        Ok(())
+    }
+    async fn append_events(&self, events: Vec<Event>) -> StorageResult<BatchWriteSummary> {
+        let n = events.len() as u64;
+        self.events.lock().unwrap().extend(events);
+        Ok(BatchWriteSummary {
+            attempted: n,
+            affected: n,
+            failed: 0,
+            first_error: String::new(),
+        })
+    }
+    async fn get_event(&self, id: uuid::Uuid) -> StorageResult<Option<Event>> {
+        Ok(self
+            .events
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|e| e.id == id)
+            .cloned())
+    }
+    async fn query_events(
+        &self,
+        _filter: EventFilter,
+        _page: PageRequest,
+    ) -> StorageResult<Page<Event>> {
+        unimplemented!("not exercised by this test")
+    }
+    async fn count_events(&self, _filter: EventFilter) -> StorageResult<u64> {
+        Ok(self.events.lock().unwrap().len() as u64)
+    }
+    fn preflight_event(&self, _event: &Event) -> StorageResult<()> {
+        Ok(())
+    }
+    async fn append_events_idempotent(
+        &self,
+        events: Vec<Event>,
+    ) -> StorageResult<IdempotentEventBatchResult> {
+        while !self.released.load(Ordering::SeqCst) {
+            tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+        }
+        let mut store = self.events.lock().unwrap();
+        let mut rows = Vec::with_capacity(events.len());
+        for event in events {
+            if let Some(existing) = store.iter().find(|e| e.id == event.id) {
+                if *existing == event {
+                    rows.push(EventAppendDisposition::AlreadyPresentIdentical);
+                } else {
+                    rows.push(EventAppendDisposition::IdentityConflict);
+                }
+            } else {
+                store.push(event);
+                rows.push(EventAppendDisposition::Inserted);
+            }
+        }
+        Ok(IdempotentEventBatchResult { rows })
+    }
+    fn supports_idempotent_audit_batch(&self) -> bool {
+        true
+    }
+}
+
+fn mk_event(verb: &str) -> Event {
+    Event::new(
+        "local",
+        verb,
+        EventKind::Audit,
+        SubstrateKind::Event,
+        "test:actor",
+    )
+    .with_outcome(EventOutcome::Success)
+}
+
+/// Polls `condition` every 2ms until it holds or `timeout` elapses
+/// (panicking on elapse) — a correctness-driven wait instead of a
+/// wall-clock guess.
+async fn wait_until(timeout: std::time::Duration, mut condition: impl FnMut() -> bool) {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if condition() {
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "condition did not become true within {timeout:?}"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+    }
+}
+
+#[tokio::test]
+async fn db_diagnostics_verb_reports_real_admission_refused_obligations() {
+    let rt = KhiveRuntime::memory().expect("in-memory runtime must succeed");
+    let store = Arc::new(GateEventStore::default());
+    let mut builder = VerbRegistryBuilder::new();
+    builder.with_event_store(store.clone());
+    builder.with_audit_batch_config(AuditBatchConfig {
+        max_pending_rows: std::num::NonZeroUsize::new(1).unwrap(),
+        ..AuditBatchConfig::default()
+    });
+    builder.register(KgPack::new(rt));
+    let registry = builder.build().expect("registry builds");
+    let audit_batch = registry
+        .audit_batch_handle()
+        .expect("event store configured, so the batch seam is too");
+
+    // Occupant row: submitted directly through the shared `AuditBatch`
+    // (bypassing verb dispatch), it gets picked into the first generation
+    // and then blocks in `GateEventStore::append_events_idempotent` until
+    // released below.
+    let occupant_batch = audit_batch.clone();
+    let occupant = tokio::spawn(async move {
+        occupant_batch
+            .submit(khive_runtime::audit_batch::PreparedAuditRow {
+                event: mk_event("kg.occupant"),
+                producer: khive_runtime::audit_batch::AuditProducer::ConfigLocked,
+            })
+            .await
+    });
+    wait_until(std::time::Duration::from_secs(5), || {
+        let snap = audit_batch.test_snapshot();
+        snap.pending_rows == 0 && snap.in_flight_generation.is_some()
+    })
+    .await;
+
+    // Filler row: with the occupant already drained into the in-flight
+    // generation, this one lands in `state.pending` and stays there
+    // (`max_pending_rows == 1`) until the gate above releases.
+    let filler_batch = audit_batch.clone();
+    let filler = tokio::spawn(async move {
+        filler_batch
+            .submit(khive_runtime::audit_batch::PreparedAuditRow {
+                event: mk_event("kg.filler"),
+                producer: khive_runtime::audit_batch::AuditProducer::ConfigLocked,
+            })
+            .await
+    });
+    wait_until(std::time::Duration::from_secs(5), || {
+        audit_batch.test_snapshot().pending_rows == 1
+    })
+    .await;
+
+    // The audit lane is now saturated. Dispatch a real read verb
+    // (`whoami`, in `ADMISSION_DEGRADE_SAFE_VERBS`) through the registry:
+    // its own best-effort audit row is refused on admission, incrementing
+    // the process-wide refused-obligation counter, while the dispatch
+    // itself still succeeds.
+    let before_refused = audit_admission_refused_obligation_count();
+    let before_unresolved = audit_admission_unresolved_obligation_count();
+    registry
+        .dispatch("whoami", json!({}))
+        .await
+        .expect("a read verb must not fail on audit-lane admission exhaustion");
+    assert_eq!(
+        audit_admission_refused_obligation_count(),
+        before_refused + 1,
+        "whoami's own best-effort audit row must be refused on admission while the lane is saturated"
+    );
+
+    // Release the gate and let the lane quiesce. `db_diagnostics` is NOT
+    // in `ADMISSION_DEGRADE_SAFE_VERBS` (ADR-103/ADR-133: it may do
+    // WAL-backfilling physical I/O), so dispatching it while still
+    // saturated would hard-fail its own audit obligation instead of
+    // reporting anything — this test cares about what it *reports*, so the
+    // lane must be healthy again before that dispatch.
+    store.release();
+    audit_batch
+        .quiesce()
+        .await
+        .expect("the audit lane must quiesce once the gate is released");
+    drop(occupant);
+    drop(filler);
+
+    // Now dispatch the ACTUAL `db_diagnostics` verb through the SAME
+    // registry — the path a real caller reaches, through
+    // `KgPack::handle_db_diagnostics`, not a direct call to
+    // `KhiveRuntime::db_diagnostics_with_audit_metrics` constructed by the
+    // test. This is what closes khive#2228: the handler must forward
+    // `registry.audit_batch_metrics()`, and this assertion reddens if it
+    // is changed to pass `None` instead. The refused-obligation count is
+    // process-wide and cumulative, so it still reflects whoami's refusal
+    // above even though the lane itself is healthy again.
+    let report: Value = registry
+        .dispatch("db_diagnostics", json!({}))
+        .await
+        .expect("db_diagnostics must succeed against an in-memory backend");
+    let writer_contention = report
+        .get("writer_contention")
+        .expect("writer_contention section must be present");
+    assert_eq!(
+        writer_contention.get("audit_admission_refused_obligations"),
+        Some(&Value::from(before_refused + 1)),
+        "the real db_diagnostics verb dispatch must surface the refused-obligation count \
+         accumulated by whoami's admission refusal above: {writer_contention:?}"
+    );
+    assert_eq!(
+        writer_contention.get("audit_admission_unresolved_obligations"),
+        Some(&Value::from(before_unresolved)),
+        "no admission-deadline expiry occurred, so the unresolved counter must be unchanged: \
+         {writer_contention:?}"
+    );
+}

--- a/crates/khive-runtime/docs/api/audit_batch.md
+++ b/crates/khive-runtime/docs/api/audit_batch.md
@@ -46,6 +46,27 @@ Each generation retries transient storage failures (`WriteQueueFull`, `WriterTas
 (`classify_store_error`). `Unsupported("append_events_idempotent")` and any other storage error
 are terminal for the generation, not retried.
 
+## Admission: refusal vs. deadline expiry (khive#2117, khive#2208)
+
+`submit()` can fail on admission two ways that are not interchangeable, so they carry distinct
+`AuditTerminalReason` variants:
+
+- `QueueAdmissionExhausted` — `state.pending.len() >= max_pending_rows` at enqueue time. The row
+  is never pushed and never counted in `submitted_rows`: a pure refusal, safe to retry.
+- `AdmissionDeadlineExpired` — the row was already pushed onto `state.pending` (and counted) when
+  the caller's `tokio::time::timeout(admission_deadline, rx)` elapsed waiting for its generation's
+  outcome. The row is left in place; the generation driver drains and commits (or terminally
+  fails) it independently of this caller's timeout, so the caller cannot tell from the reason
+  alone whether the row eventually landed. Retrying is only safe for an idempotent caller.
+
+`pack.rs::append_audit_event_best_effort` treats both as "audit-lane admission pressure": for a
+`DispatchObligation` row produced by a read-only verb (`VerbCategory::Assertive`), either reason
+degrades to best-effort instead of failing the dispatch — the read performed no domain write, so
+discarding its already-computed result to protect an obligation it does not need as strictly as a
+write does inverts the point of serving it (khive#2147, khive#2217). Every other obligation
+failure, and every failure for a non-read verb, is unaffected — write-side hard-fail semantics are
+unchanged.
+
 ## Supervision and failure ownership (owner ruling R1)
 
 The supervisor loop retains its `JoinHandle` and spawns each generation's commit as its own child

--- a/crates/khive-runtime/docs/api/audit_batch.md
+++ b/crates/khive-runtime/docs/api/audit_batch.md
@@ -53,18 +53,23 @@ are terminal for the generation, not retried.
 
 - `QueueAdmissionExhausted` — `state.pending.len() >= max_pending_rows` at enqueue time. The row
   is never pushed and never counted in `submitted_rows`: a pure refusal, safe to retry.
-- `AdmissionDeadlineExpired` — the row was already pushed onto `state.pending` (and counted) when
-  the caller's `tokio::time::timeout(admission_deadline, rx)` elapsed waiting for its generation's
-  outcome. The row is left in place; the generation driver drains and commits (or terminally
-  fails) it independently of this caller's timeout, so the caller cannot tell from the reason
-  alone whether the row eventually landed. Retrying is only safe for an idempotent caller.
+- `AdmissionDeadlineExpired` — the row was already pushed and counted when the caller's
+  `tokio::time::timeout(admission_deadline, rx)` elapsed waiting for its generation's outcome. By
+  that moment the row may still be sitting in `state.pending`, or the driver may have already
+  drained it into an in-flight generation — either way it remains enqueued and unresolved, and the
+  generation driver commits (or terminally fails) it independently of this caller's timeout, so the
+  caller cannot tell from the reason alone whether the row eventually landed, or even which of
+  those two states it was in. Retrying is only safe for an idempotent caller.
 
 `pack.rs::append_audit_event_best_effort` treats both as "audit-lane admission pressure": for a
-`DispatchObligation` row produced by a read-only verb (`VerbCategory::Assertive`), either reason
-degrades to best-effort instead of failing the dispatch — the read performed no domain write, so
-discarding its already-computed result to protect an obligation it does not need as strictly as a
-write does inverts the point of serving it (khive#2147, khive#2217). Every other obligation
-failure, and every failure for a non-read verb, is unaffected — write-side hard-fail semantics are
+`DispatchObligation` row produced by a verb that is both `VerbCategory::Assertive` AND explicitly
+opted in via `VerbRegistry::ADMISSION_DEGRADE_SAFE_VERBS` (an explicit, fail-closed allowlist —
+`Assertive` alone is not a sound proxy, since some Assertive handlers have their own
+accounting-bearing side effects; see that constant's doc comment), either reason degrades to
+best-effort instead of failing the dispatch — the read performed no domain write, so discarding
+its already-computed result to protect an obligation it does not need as strictly as a write does
+inverts the point of serving it (khive#2147, khive#2217). Every other obligation failure, and
+every failure for a non-opted-in verb, is unaffected — write-side hard-fail semantics are
 unchanged.
 
 ## Supervision and failure ownership (owner ruling R1)

--- a/crates/khive-runtime/src/audit_batch.rs
+++ b/crates/khive-runtime/src/audit_batch.rs
@@ -102,8 +102,21 @@ pub enum AuditTerminalReason {
     PreflightRejected,
     /// The batch is `Closing` or `Closed`; new admission is refused.
     AdmissionClosed,
-    /// `AuditBatchConfig::max_pending_rows` was reached.
+    /// `AuditBatchConfig::max_pending_rows` was reached before this row was
+    /// enqueued. The row was never counted as submitted and never shared a
+    /// generation with anyone — safe to retry, and doing so applies the
+    /// obligation at most once.
     QueueAdmissionExhausted,
+    /// The row was already enqueued (counted in `submitted_rows`,
+    /// `state.pending`) when this caller's `AuditBatchConfig::admission_deadline`
+    /// elapsed waiting for its generation's outcome. Unlike
+    /// [`Self::QueueAdmissionExhausted`], the row was not refused: it stays
+    /// queued and is drained and committed (or terminally failed) by the
+    /// generation driver independently of this caller's timeout, so the
+    /// caller cannot tell from this reason alone whether the row eventually
+    /// committed. Retrying is only safe for an idempotent caller — the prior
+    /// submission may still land.
+    AdmissionDeadlineExpired,
     /// A row shared this generation's id with a previously stored row whose
     /// columns or observation projection did not match exactly.
     IdentityConflict,
@@ -669,7 +682,13 @@ impl AuditBatchControl for AuditBatch {
         match tokio::time::timeout(self.config.admission_deadline, rx).await {
             Ok(Ok(result)) => result,
             Ok(Err(_recv_error)) => Err(AuditTerminalReason::DriverJoinLost),
-            Err(_elapsed) => Err(AuditTerminalReason::QueueAdmissionExhausted),
+            // The row was already pushed onto `state.pending` above (and
+            // `submitted_rows` incremented) before this wait began — this is
+            // a deadline elapsing on an enqueued row, not a queue-full
+            // refusal, so it gets its own terminal reason (khive#2117,
+            // khive#2208). The row is left in place for the driver to drain;
+            // this arm performs no removal.
+            Err(_elapsed) => Err(AuditTerminalReason::AdmissionDeadlineExpired),
         }
     }
 

--- a/crates/khive-runtime/src/audit_batch.rs
+++ b/crates/khive-runtime/src/audit_batch.rs
@@ -163,8 +163,10 @@ pub enum AuditCommitOutcome {
 }
 
 /// Production-visible snapshot of [`AuditBatch::health_metrics`]. See there
-/// for field semantics; mirrors `khive_db::diagnostics::RuntimeAuditBatchMetrics`
-/// one-for-one so the registry owner can convert without loss.
+/// for field semantics. `khive_db::diagnostics::RuntimeAuditBatchMetrics` carries
+/// these three fields plus `admission_degraded_obligations`, which is sourced
+/// from a process-wide counter outside `AuditBatch` rather than from this
+/// struct — see `VerbRegistry::audit_batch_metrics`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AuditBatchHealthMetrics {
     pub flush_failures: u64,

--- a/crates/khive-runtime/src/audit_batch.rs
+++ b/crates/khive-runtime/src/audit_batch.rs
@@ -118,7 +118,12 @@ pub enum AuditTerminalReason {
     /// caller cannot tell from this reason alone whether the row eventually
     /// committed, or even which of those two states it was in when the
     /// deadline elapsed. Retrying is only safe for an idempotent caller —
-    /// the prior submission may still land.
+    /// the prior submission may still land. When this reason degrades an
+    /// admission-degrade-safe read's own audit obligation, it is counted
+    /// separately from [`Self::QueueAdmissionExhausted`] — see
+    /// `pack::audit_admission_unresolved_obligation_count` — precisely
+    /// because a row counted here may still commit, unlike one refused
+    /// before enqueue.
     AdmissionDeadlineExpired,
     /// A row shared this generation's id with a previously stored row whose
     /// columns or observation projection did not match exactly.
@@ -164,9 +169,10 @@ pub enum AuditCommitOutcome {
 
 /// Production-visible snapshot of [`AuditBatch::health_metrics`]. See there
 /// for field semantics. `khive_db::diagnostics::RuntimeAuditBatchMetrics` carries
-/// these three fields plus `admission_degraded_obligations`, which is sourced
-/// from a process-wide counter outside `AuditBatch` rather than from this
-/// struct — see `VerbRegistry::audit_batch_metrics`.
+/// these three fields plus `admission_refused_obligations` and
+/// `admission_unresolved_obligations`, which are sourced from process-wide
+/// counters outside `AuditBatch` rather than from this struct — see
+/// `VerbRegistry::audit_batch_metrics`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AuditBatchHealthMetrics {
     pub flush_failures: u64,

--- a/crates/khive-runtime/src/audit_batch.rs
+++ b/crates/khive-runtime/src/audit_batch.rs
@@ -107,15 +107,18 @@ pub enum AuditTerminalReason {
     /// generation with anyone — safe to retry, and doing so applies the
     /// obligation at most once.
     QueueAdmissionExhausted,
-    /// The row was already enqueued (counted in `submitted_rows`,
-    /// `state.pending`) when this caller's `AuditBatchConfig::admission_deadline`
-    /// elapsed waiting for its generation's outcome. Unlike
-    /// [`Self::QueueAdmissionExhausted`], the row was not refused: it stays
-    /// queued and is drained and committed (or terminally failed) by the
-    /// generation driver independently of this caller's timeout, so the
+    /// The row was already enqueued (counted in `submitted_rows`) when this
+    /// caller's `AuditBatchConfig::admission_deadline` elapsed waiting for
+    /// its generation's outcome. Unlike [`Self::QueueAdmissionExhausted`],
+    /// the row was not refused: by the moment the deadline fires it may
+    /// still be sitting in `state.pending`, or the driver may have already
+    /// drained it into an in-flight generation — either way it remains
+    /// enqueued and unresolved, and is committed (or terminally failed) by
+    /// the generation driver independently of this caller's timeout, so the
     /// caller cannot tell from this reason alone whether the row eventually
-    /// committed. Retrying is only safe for an idempotent caller — the prior
-    /// submission may still land.
+    /// committed, or even which of those two states it was in when the
+    /// deadline elapsed. Retrying is only safe for an idempotent caller —
+    /// the prior submission may still land.
     AdmissionDeadlineExpired,
     /// A row shared this generation's id with a previously stored row whose
     /// columns or observation projection did not match exactly.

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -3654,16 +3654,19 @@ async fn persist_git_digest_receipt(
 /// neither a swallowed observability failure nor a propagated obligation
 /// failure.
 ///
-/// `is_read_only_verb` (khive#2147/khive#2217) narrows that obligation for
-/// one specific case: a `DispatchSucceeded`/`DispatchFailed` row for a verb
-/// that [`VerbRegistry::admission_degrade_safe`] has explicitly opted in
-/// (Assertive alone is not a sufficient signal — see that method's doc)
-/// performs no domain write, so this row's own admission being transiently
-/// refused or timed out (`AuditTerminalReason::QueueAdmissionExhausted` /
-/// `AdmissionDeadlineExpired`) degrades to best-effort instead of failing the
-/// dispatch — the caller-visible read result is preserved. Every other
-/// obligation failure, and every failure for a non-opted-in verb, is
-/// unaffected.
+/// `degrade_allowlisted` (khive#2147/khive#2217) narrows that obligation for
+/// one specific case: a *successful* dispatch (`AuditProducer::DispatchSucceeded`)
+/// for a verb that [`VerbRegistry::admission_degrade_safe`] has explicitly
+/// opted in (Assertive alone is not a sufficient signal — see that method's
+/// doc) performs no domain write, so this row's own admission being
+/// transiently refused or timed out (`AuditTerminalReason::QueueAdmissionExhausted`
+/// / `AdmissionDeadlineExpired`) degrades to best-effort instead of failing
+/// the dispatch — the caller-visible read result is preserved. This function
+/// derives eligibility from `producer` itself rather than trusting the
+/// caller's `degrade_allowlisted` answer in isolation, so a `DispatchFailed`
+/// row can never take the degrade path no matter what a caller passes: every
+/// failed dispatch, every write verb, every gate-denial/unknown-verb/git.digest
+/// row stays strictly obligation-bearing.
 ///
 /// When the registry has an audit-batch seam configured (it is whenever
 /// `store` is), the row routes through
@@ -3678,13 +3681,15 @@ async fn append_audit_event_best_effort(
     event: Event,
     verb: &str,
     producer: crate::audit_batch::AuditProducer,
-    is_read_only_verb: bool,
+    degrade_allowlisted: bool,
 ) -> Result<(), RuntimeError> {
     use crate::audit_batch::{
-        classify, AuditBatchControl, AuditProductionClass, AuditTerminalReason,
+        classify, AuditBatchControl, AuditProducer, AuditProductionClass, AuditTerminalReason,
     };
 
     let is_obligation = classify(producer) == AuditProductionClass::DispatchObligation;
+    let admission_degrade_eligible =
+        degrade_allowlisted && producer == AuditProducer::DispatchSucceeded;
 
     if let Some(audit_batch) = audit_batch {
         if let Err(reason) = audit_batch
@@ -3707,7 +3712,7 @@ async fn append_audit_event_best_effort(
                 // `AdmissionDeadlineExpired` was already enqueued and may still
                 // commit later — see `AuditTerminalReason::AdmissionDeadlineExpired`'s
                 // own doc.
-                if is_read_only_verb {
+                if admission_degrade_eligible {
                     match reason {
                         AuditTerminalReason::QueueAdmissionExhausted => {
                             AUDIT_ADMISSION_REFUSED_OBLIGATIONS

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -1323,6 +1323,13 @@ impl VerbRegistry {
     /// `KhiveRuntime::db_diagnostics_with_audit_metrics` so an operator can
     /// see flush failures and pure-observability degradation instead of the
     /// permanently-unavailable placeholder a bare `KhiveRuntime` reports.
+    ///
+    /// `admission_degraded_obligations` is sourced separately from
+    /// [`audit_admission_degraded_obligation_count`] rather than from
+    /// `batch.health_metrics()`: it counts a decision made in
+    /// `append_audit_event_best_effort` (ADR-103 Amendment 3 / ADR-133
+    /// Amendment 1), not a property of the batch itself, so it is process-wide
+    /// like the rest of this struct's fields rather than per-`AuditBatch`.
     pub fn audit_batch_metrics(&self) -> Option<khive_db::diagnostics::RuntimeAuditBatchMetrics> {
         self.audit_batch.as_ref().map(|batch| {
             let m = batch.health_metrics();
@@ -1330,6 +1337,7 @@ impl VerbRegistry {
                 flush_failures: m.flush_failures,
                 degraded_rows: m.degraded_rows,
                 degraded: m.degraded,
+                admission_degraded_obligations: audit_admission_degraded_obligation_count(),
             }
         })
     }
@@ -1390,6 +1398,17 @@ impl VerbRegistry {
     ///   also races admission pressure.
     /// - `db_diagnostics` may backfill WAL frames via a PASSIVE checkpoint
     ///   probe — physical I/O, not a pure in-memory read.
+    ///
+    /// What membership here means, precisely: the verb performs no domain
+    /// mutation, so its OWN per-dispatch audit/accounting row may be dropped
+    /// under transient admission pressure without the caller losing a
+    /// meaningful result (ADR-103 Amendment 3, ADR-133 Amendment 1). It does
+    /// NOT mean the handler is free of every event-plane write: `search`
+    /// still fires its own best-effort `SearchExecuted` telemetry, and
+    /// `context` still records a one-time `ConfigLocked` event, both on
+    /// independent code paths this mechanism never touches — those events
+    /// commit or fail on their own terms, unaffected by whether this
+    /// dispatch's own audit row degrades.
     ///
     /// Every entry here MUST be declared `VerbCategory::Assertive` in
     /// `khive-pack-kg/src/handler_defs.rs` — enforced by the
@@ -3409,8 +3428,12 @@ pub(crate) fn audit_obligation_append_failure_count() -> u64 {
 /// [`AUDIT_OBLIGATION_APPEND_FAILURES`] either — that counter's contract is
 /// "most call sites fold this failure into the dispatch's own error", which
 /// is exactly the propagation this admission-degrade path exists to avoid.
-/// Test-only reader for now: no production consumer reads it yet, but the
-/// mechanism tests need to observe it directly — including the
+/// Read in production by [`VerbRegistry::audit_batch_metrics`], which feeds
+/// it into `khive_db::diagnostics::RuntimeAuditBatchMetrics::admission_degraded_obligations`
+/// and from there into the `db_diagnostics` verb's
+/// `writer_contention.audit_admission_degraded_obligations` field (ADR-103
+/// Amendment 3) — an operator can read this counter without a test-only
+/// feature gate. The mechanism tests also read it directly, including the
 /// admission-pressure regression tests in `tests/read_verb_admission_exhaustion.rs`,
 /// which (like `khive-runtime/src/audit_batch.rs`'s own `test_internals`
 /// module) need it as `pub`, not `pub(crate)`, since they compile as a
@@ -3418,7 +3441,6 @@ pub(crate) fn audit_obligation_append_failure_count() -> u64 {
 static AUDIT_ADMISSION_DEGRADED_OBLIGATIONS: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(0);
 
-#[cfg(any(test, feature = "test-internals"))]
 pub fn audit_admission_degraded_obligation_count() -> u64 {
     AUDIT_ADMISSION_DEGRADED_OBLIGATIONS.load(std::sync::atomic::Ordering::Relaxed)
 }
@@ -3822,6 +3844,17 @@ pub(crate) mod tests {
     use crate::ActorRef;
     use khive_types::Pack;
 
+    /// Verbs known, by prior review (khive#2147/khive#2217 round 1), to have
+    /// their own accounting-bearing side effect despite being declared
+    /// `VerbCategory::Assertive` — see [`VerbRegistry::ADMISSION_DEGRADE_SAFE_VERBS`]'s
+    /// doc for why each is excluded. `VerbCategory::Assertive` alone cannot
+    /// distinguish these from a genuinely side-effect-free read (that is the
+    /// whole reason the allowlist exists instead of a bare category check),
+    /// so this denylist is the mechanizable guard against silently
+    /// reintroducing one of them: a category-only census would stay green if
+    /// either name were re-added to the allowlist.
+    const KNOWN_INCIDENTAL_WRITE_VERBS: &[&str] = &["memory.recall", "db_diagnostics"];
+
     /// khive-runtime links no real pack crates in its own test binary (see
     /// the comment on `CommProbeFactory` below), so
     /// [`VerbRegistry::ADMISSION_DEGRADE_SAFE_VERBS`] cannot be checked
@@ -3832,6 +3865,21 @@ pub(crate) mod tests {
     /// `reclassify_from_live_source`. Every entry in the allowlist is
     /// currently declared in that one file; a verb from a different pack
     /// would need this scan extended to that pack's source first.
+    ///
+    /// This test proves category membership (`VerbCategory::Assertive`) and
+    /// non-membership in [`KNOWN_INCIDENTAL_WRITE_VERBS`]. It does NOT prove
+    /// general effect-purity: an Assertive handler may still emit its own
+    /// observability/config events on an independent, best-effort background
+    /// path (`search`'s `SearchExecuted` telemetry, `context`'s one-time
+    /// `ConfigLocked` event) that this test does not inspect and that this
+    /// PR's admission-degrade mechanism does not touch — those events commit
+    /// or fail on their own path regardless of what happens to this
+    /// dispatch's own audit row. Proving general effect-purity would require
+    /// an explicit per-handler effect/accounting capability tag, which is
+    /// out of scope here (see ADR-103 Amendment 3's "why this is accepted"
+    /// section); this census instead locks down the two properties that are
+    /// mechanizable today: declared category, and the one known-bad-name
+    /// regression class.
     #[test]
     fn admission_degrade_safe_verbs_are_registered_assertive() {
         let path = concat!(
@@ -3842,6 +3890,12 @@ pub(crate) mod tests {
             std::fs::read_to_string(path).unwrap_or_else(|e| panic!("failed to read {path}: {e}"));
 
         for verb in VerbRegistry::ADMISSION_DEGRADE_SAFE_VERBS {
+            assert!(
+                !KNOWN_INCIDENTAL_WRITE_VERBS.contains(verb),
+                "admission-degrade-safe verb {verb:?} is a known incidental-write verb \
+                 (khive#2147/khive#2217 round 1); it must not be re-added to \
+                 ADMISSION_DEGRADE_SAFE_VERBS even though it is VerbCategory::Assertive"
+            );
             // Anchored to exactly 8 leading spaces: that is the indentation
             // `HandlerDef { name: ... }` top-level fields use in this file,
             // versus 16 for a nested `ParamDef { name: ... }` — several

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -1378,18 +1378,59 @@ impl VerbRegistry {
         })
     }
 
-    /// Whether `verb`'s declared [`VerbCategory`] is `Assertive` — the
-    /// speech-act tag for handlers that "retrieve and present facts" (`get`,
-    /// `list`, `search`, `recall`, `gtd.tasks`, ...) rather than committing a
-    /// domain change. Unknown verbs are conservatively `false`.
+    /// Explicit, fail-closed opt-in for admission-pressure audit degradation
+    /// (khive#2147/khive#2217). `VerbCategory::Assertive` alone is NOT a
+    /// sound proxy for "safe to drop this dispatch's own audit row under
+    /// audit-lane admission pressure": several Assertive handlers have
+    /// their own accounting-bearing side effects. Two known examples,
+    /// deliberately excluded here:
+    /// - `memory.recall` dispatches `brain.record_serve` as a background
+    ///   write; degrading `memory.recall`'s row raises the risk that a
+    ///   serve goes unaccounted for if the ledger dispatch itself later
+    ///   also races admission pressure.
+    /// - `db_diagnostics` may backfill WAL frames via a PASSIVE checkpoint
+    ///   probe — physical I/O, not a pure in-memory read.
+    ///
+    /// Every entry here MUST be declared `VerbCategory::Assertive` in
+    /// `khive-pack-kg/src/handler_defs.rs` — enforced by the
+    /// `admission_degrade_safe_verbs_are_registered_assertive` census test
+    /// below, which re-derives the classification from that file's live
+    /// source rather than trusting this list's own claim. Adding a verb
+    /// from a different pack requires extending that test's source scan,
+    /// not just this list.
+    const ADMISSION_DEGRADE_SAFE_VERBS: &'static [&'static str] = &[
+        "get",
+        "list",
+        "stats",
+        "search",
+        "neighbors",
+        "traverse",
+        "context",
+        "query",
+        "resolve",
+        "whoami",
+        "verbs",
+    ];
+
+    /// Whether `verb` is both declared [`VerbCategory::Assertive`] (the
+    /// speech-act tag for handlers that "retrieve and present facts" rather
+    /// than committing a domain change) AND explicitly opted in to
+    /// admission-pressure audit degradation via
+    /// [`Self::ADMISSION_DEGRADE_SAFE_VERBS`]. Unknown or non-opted-in verbs
+    /// are conservatively `false` — fail-closed, so a new Assertive handler
+    /// hard-fails its audit obligation like any write until someone
+    /// deliberately reviews it and adds it to the allowlist.
     ///
     /// Used only to decide whether a dispatch's own audit-obligation row may
     /// degrade to best-effort on transient audit-lane admission pressure
     /// (`append_audit_event_best_effort`) — a read that performed no domain
     /// write must not fail the caller just because the audit lane is
-    /// momentarily saturated (khive#2147, khive#2217). Never used for
-    /// permission checking, transport routing, or return-shape selection.
-    fn verb_is_read_only(&self, verb: &str) -> bool {
+    /// momentarily saturated. Never used for permission checking, transport
+    /// routing, or return-shape selection.
+    fn admission_degrade_safe(&self, verb: &str) -> bool {
+        if !Self::ADMISSION_DEGRADE_SAFE_VERBS.contains(&verb) {
+            return false;
+        }
         self.packs
             .iter()
             .find_map(|pack| pack.handlers().iter().find(|h| h.name == verb))
@@ -1743,7 +1784,7 @@ impl VerbRegistry {
             event,
             verb,
             producer,
-            self.verb_is_read_only(verb),
+            self.admission_degrade_safe(verb),
         )
         .await
     }
@@ -2179,7 +2220,7 @@ impl VerbRegistry {
                                             storage_event,
                                             verb,
                                             crate::audit_batch::AuditProducer::DispatchSucceeded,
-                                            handler_def.category == VerbCategory::Assertive,
+                                            self.admission_degrade_safe(verb),
                                         )
                                         .await
                                     }
@@ -2202,7 +2243,7 @@ impl VerbRegistry {
                                             storage_event,
                                             verb,
                                             crate::audit_batch::AuditProducer::DispatchSucceeded,
-                                            handler_def.category == VerbCategory::Assertive,
+                                            self.admission_degrade_safe(verb),
                                         )
                                         .await
                                     }
@@ -2258,7 +2299,7 @@ impl VerbRegistry {
                                     storage_event,
                                     verb,
                                     producer,
-                                    handler_def.category == VerbCategory::Assertive,
+                                    self.admission_degrade_safe(verb),
                                 )
                                 .await
                             }
@@ -3354,6 +3395,34 @@ pub(crate) fn audit_obligation_append_failure_count() -> u64 {
     AUDIT_OBLIGATION_APPEND_FAILURES.load(std::sync::atomic::Ordering::Relaxed)
 }
 
+/// Process-wide count of `DispatchObligation` rows whose commit was skipped
+/// under transient audit-lane admission pressure for an
+/// [`VerbRegistry::admission_degrade_safe`] verb (khive#2147/khive#2217).
+/// Deliberately its own counter, disjoint from both
+/// [`AUDIT_APPEND_FAILURES`] and [`AUDIT_OBLIGATION_APPEND_FAILURES`]: this
+/// case is neither. It is not [`AUDIT_APPEND_FAILURES`] — that counter's own
+/// contract (`khive-db`'s `WriterContentionDiagnostics::audit_append_failures`
+/// doc) says an obligation-bearing row's commit failure "either fail[s] the
+/// dispatch... or [is] tracked by the runtime's own separate
+/// obligation-failure counter instead", and this dispatch does neither: it
+/// reports the caller's already-computed success with no error. It is not
+/// [`AUDIT_OBLIGATION_APPEND_FAILURES`] either — that counter's contract is
+/// "most call sites fold this failure into the dispatch's own error", which
+/// is exactly the propagation this admission-degrade path exists to avoid.
+/// Test-only reader for now: no production consumer reads it yet, but the
+/// mechanism tests need to observe it directly — including the
+/// admission-pressure regression tests in `tests/read_verb_admission_exhaustion.rs`,
+/// which (like `khive-runtime/src/audit_batch.rs`'s own `test_internals`
+/// module) need it as `pub`, not `pub(crate)`, since they compile as a
+/// separate external binary outside this crate.
+static AUDIT_ADMISSION_DEGRADED_OBLIGATIONS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+#[cfg(any(test, feature = "test-internals"))]
+pub fn audit_admission_degraded_obligation_count() -> u64 {
+    AUDIT_ADMISSION_DEGRADED_OBLIGATIONS.load(std::sync::atomic::Ordering::Relaxed)
+}
+
 const GIT_DIGEST_RECEIPT_FAILURE: &str =
     "git_digest_receipt_persist_failed: git.digest writes may have committed, but no durable \
      success receipt was confirmed; inspect ingest state before retrying";
@@ -3528,17 +3597,22 @@ async fn persist_git_digest_receipt(
 /// failure is logged and counted but never returned, matching the pre-ADR-133
 /// best-effort contract.
 ///
-/// Every failure — obligation or observability — increments the
-/// process-wide diagnostics counter above.
+/// Every failure — obligation or observability — increments one of the
+/// process-wide diagnostics counters above; the one exception is the
+/// admission-degrade case below, which increments its own dedicated
+/// [`AUDIT_ADMISSION_DEGRADED_OBLIGATIONS`] counter instead — it is neither
+/// a swallowed observability failure nor a propagated obligation failure.
 ///
 /// `is_read_only_verb` (khive#2147/khive#2217) narrows that obligation for
 /// one specific case: a `DispatchSucceeded`/`DispatchFailed` row for a verb
-/// whose category is `VerbCategory::Assertive` performs no domain write, so
-/// this row's own admission being transiently refused or timed out
-/// (`AuditTerminalReason::QueueAdmissionExhausted` /
+/// that [`VerbRegistry::admission_degrade_safe`] has explicitly opted in
+/// (Assertive alone is not a sufficient signal — see that method's doc)
+/// performs no domain write, so this row's own admission being transiently
+/// refused or timed out (`AuditTerminalReason::QueueAdmissionExhausted` /
 /// `AdmissionDeadlineExpired`) degrades to best-effort instead of failing the
 /// dispatch — the caller-visible read result is preserved. Every other
-/// obligation failure, and every failure for a non-read verb, is unaffected.
+/// obligation failure, and every failure for a non-opted-in verb, is
+/// unaffected.
 ///
 /// When the registry has an audit-batch seam configured (it is whenever
 /// `store` is), the row routes through
@@ -3581,7 +3655,8 @@ async fn append_audit_event_best_effort(
                         | AuditTerminalReason::AdmissionDeadlineExpired
                 );
                 if is_read_only_verb && admission_pressure {
-                    AUDIT_APPEND_FAILURES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    AUDIT_ADMISSION_DEGRADED_OBLIGATIONS
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                     tracing::warn!(
                         verb,
                         reason = ?reason,
@@ -3746,6 +3821,59 @@ pub(crate) mod tests {
     use super::*;
     use crate::ActorRef;
     use khive_types::Pack;
+
+    /// khive-runtime links no real pack crates in its own test binary (see
+    /// the comment on `CommProbeFactory` below), so
+    /// [`VerbRegistry::ADMISSION_DEGRADE_SAFE_VERBS`] cannot be checked
+    /// against a live registered `HandlerDef` here. Instead this
+    /// re-derives each opted-in verb's classification from
+    /// `khive-pack-kg/src/handler_defs.rs`'s live source — the same
+    /// fail-closed pattern as `adr133_writer_census.rs`'s
+    /// `reclassify_from_live_source`. Every entry in the allowlist is
+    /// currently declared in that one file; a verb from a different pack
+    /// would need this scan extended to that pack's source first.
+    #[test]
+    fn admission_degrade_safe_verbs_are_registered_assertive() {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../khive-pack-kg/src/handler_defs.rs"
+        );
+        let source =
+            std::fs::read_to_string(path).unwrap_or_else(|e| panic!("failed to read {path}: {e}"));
+
+        for verb in VerbRegistry::ADMISSION_DEGRADE_SAFE_VERBS {
+            // Anchored to exactly 8 leading spaces: that is the indentation
+            // `HandlerDef { name: ... }` top-level fields use in this file,
+            // versus 16 for a nested `ParamDef { name: ... }` — several
+            // handlers (e.g. `search`) declare a `query`/`kind`/... param
+            // whose own `name:` field would otherwise collide with a verb
+            // of the same name declared later in the file.
+            let needle = format!("\n        name: \"{verb}\",");
+            let name_pos = source.find(&needle).unwrap_or_else(|| {
+                panic!(
+                    "admission-degrade-safe verb {verb:?} has no top-level `HandlerDef` in \
+                     khive-pack-kg/src/handler_defs.rs; update the allowlist or this \
+                     census's source path"
+                )
+            });
+            // Each `HandlerDef` literal in this file declares `category:`
+            // shortly after `name:`, well before the next handler's own
+            // `name:` field — bound the scan to the text up to the next
+            // `HandlerDef {` (or EOF) so a later handler's category can
+            // never be misattributed to this one.
+            let block_end = source[name_pos..]
+                .find("HandlerDef {")
+                .map(|offset| name_pos + offset)
+                .unwrap_or(source.len());
+            let block = &source[name_pos..block_end];
+            assert!(
+                block.contains("VerbCategory::Assertive"),
+                "admission-degrade-safe verb {verb:?} is declared in \
+                 khive-pack-kg/src/handler_defs.rs but is not VerbCategory::Assertive; \
+                 admission degradation must not silently apply to a write-capable verb"
+            );
+        }
+    }
 
     static COMM_PROBE_GRANTED: std::sync::atomic::AtomicBool =
         std::sync::atomic::AtomicBool::new(false);

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -1324,12 +1324,14 @@ impl VerbRegistry {
     /// see flush failures and pure-observability degradation instead of the
     /// permanently-unavailable placeholder a bare `KhiveRuntime` reports.
     ///
-    /// `admission_degraded_obligations` is sourced separately from
-    /// [`audit_admission_degraded_obligation_count`] rather than from
-    /// `batch.health_metrics()`: it counts a decision made in
+    /// `admission_refused_obligations` and `admission_unresolved_obligations`
+    /// are sourced separately from [`audit_admission_refused_obligation_count`]
+    /// and [`audit_admission_unresolved_obligation_count`] rather than from
+    /// `batch.health_metrics()`: they count a decision made in
     /// `append_audit_event_best_effort` (ADR-103 Amendment 3 / ADR-133
-    /// Amendment 1), not a property of the batch itself, so it is process-wide
-    /// like the rest of this struct's fields rather than per-`AuditBatch`.
+    /// Amendment 1), not a property of the batch itself, so they are
+    /// process-wide like the rest of this struct's fields rather than
+    /// per-`AuditBatch`.
     pub fn audit_batch_metrics(&self) -> Option<khive_db::diagnostics::RuntimeAuditBatchMetrics> {
         self.audit_batch.as_ref().map(|batch| {
             let m = batch.health_metrics();
@@ -1337,7 +1339,8 @@ impl VerbRegistry {
                 flush_failures: m.flush_failures,
                 degraded_rows: m.degraded_rows,
                 degraded: m.degraded,
-                admission_degraded_obligations: audit_admission_degraded_obligation_count(),
+                admission_refused_obligations: audit_admission_refused_obligation_count(),
+                admission_unresolved_obligations: audit_admission_unresolved_obligation_count(),
             }
         })
     }
@@ -3414,10 +3417,11 @@ pub(crate) fn audit_obligation_append_failure_count() -> u64 {
     AUDIT_OBLIGATION_APPEND_FAILURES.load(std::sync::atomic::Ordering::Relaxed)
 }
 
-/// Process-wide count of `DispatchObligation` rows whose commit was skipped
-/// under transient audit-lane admission pressure for an
+/// Process-wide count of `DispatchObligation` rows **refused before they
+/// could be enqueued** (`AuditTerminalReason::QueueAdmissionExhausted`) for an
 /// [`VerbRegistry::admission_degrade_safe`] verb (khive#2147/khive#2217).
-/// Deliberately its own counter, disjoint from both
+/// This is a confirmed, terminal accounting loss: the row never shared a
+/// generation with anyone and will never commit. Disjoint from both
 /// [`AUDIT_APPEND_FAILURES`] and [`AUDIT_OBLIGATION_APPEND_FAILURES`]: this
 /// case is neither. It is not [`AUDIT_APPEND_FAILURES`] — that counter's own
 /// contract (`khive-db`'s `WriterContentionDiagnostics::audit_append_failures`
@@ -3428,21 +3432,44 @@ pub(crate) fn audit_obligation_append_failure_count() -> u64 {
 /// [`AUDIT_OBLIGATION_APPEND_FAILURES`] either — that counter's contract is
 /// "most call sites fold this failure into the dispatch's own error", which
 /// is exactly the propagation this admission-degrade path exists to avoid.
+/// Also disjoint from [`AUDIT_ADMISSION_UNRESOLVED_OBLIGATIONS`] — that
+/// counter's row was enqueued and may still commit; this one's was not.
 /// Read in production by [`VerbRegistry::audit_batch_metrics`], which feeds
-/// it into `khive_db::diagnostics::RuntimeAuditBatchMetrics::admission_degraded_obligations`
+/// it into `khive_db::diagnostics::RuntimeAuditBatchMetrics::admission_refused_obligations`
 /// and from there into the `db_diagnostics` verb's
-/// `writer_contention.audit_admission_degraded_obligations` field (ADR-103
+/// `writer_contention.audit_admission_refused_obligations` field (ADR-103
 /// Amendment 3) — an operator can read this counter without a test-only
 /// feature gate. The mechanism tests also read it directly, including the
 /// admission-pressure regression tests in `tests/read_verb_admission_exhaustion.rs`,
 /// which (like `khive-runtime/src/audit_batch.rs`'s own `test_internals`
 /// module) need it as `pub`, not `pub(crate)`, since they compile as a
 /// separate external binary outside this crate.
-static AUDIT_ADMISSION_DEGRADED_OBLIGATIONS: std::sync::atomic::AtomicU64 =
+static AUDIT_ADMISSION_REFUSED_OBLIGATIONS: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(0);
 
-pub fn audit_admission_degraded_obligation_count() -> u64 {
-    AUDIT_ADMISSION_DEGRADED_OBLIGATIONS.load(std::sync::atomic::Ordering::Relaxed)
+pub fn audit_admission_refused_obligation_count() -> u64 {
+    AUDIT_ADMISSION_REFUSED_OBLIGATIONS.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Process-wide count of `DispatchObligation` rows that were **already
+/// enqueued but had not resolved by the time the caller's admission wait
+/// deadline elapsed** (`AuditTerminalReason::AdmissionDeadlineExpired`) for an
+/// [`VerbRegistry::admission_degrade_safe`] verb (khive#2147/khive#2217).
+/// Unlike [`AUDIT_ADMISSION_REFUSED_OBLIGATIONS`], a row counted here is not
+/// a confirmed loss: per `AuditTerminalReason::AdmissionDeadlineExpired`'s own
+/// doc, the row may still be committed (or terminally failed) by the
+/// generation driver independently of the caller's timeout, so this counter
+/// is an upper bound on the eventual undercount, not the undercount itself.
+/// Read in production by [`VerbRegistry::audit_batch_metrics`], which feeds
+/// it into `khive_db::diagnostics::RuntimeAuditBatchMetrics::admission_unresolved_obligations`
+/// and from there into the `db_diagnostics` verb's
+/// `writer_contention.audit_admission_unresolved_obligations` field (ADR-103
+/// Amendment 3).
+static AUDIT_ADMISSION_UNRESOLVED_OBLIGATIONS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+pub fn audit_admission_unresolved_obligation_count() -> u64 {
+    AUDIT_ADMISSION_UNRESOLVED_OBLIGATIONS.load(std::sync::atomic::Ordering::Relaxed)
 }
 
 const GIT_DIGEST_RECEIPT_FAILURE: &str =
@@ -3621,9 +3648,11 @@ async fn persist_git_digest_receipt(
 ///
 /// Every failure — obligation or observability — increments one of the
 /// process-wide diagnostics counters above; the one exception is the
-/// admission-degrade case below, which increments its own dedicated
-/// [`AUDIT_ADMISSION_DEGRADED_OBLIGATIONS`] counter instead — it is neither
-/// a swallowed observability failure nor a propagated obligation failure.
+/// admission-degrade case below, which increments one of its own dedicated
+/// [`AUDIT_ADMISSION_REFUSED_OBLIGATIONS`] /
+/// [`AUDIT_ADMISSION_UNRESOLVED_OBLIGATIONS`] counters instead — it is
+/// neither a swallowed observability failure nor a propagated obligation
+/// failure.
 ///
 /// `is_read_only_verb` (khive#2147/khive#2217) narrows that obligation for
 /// one specific case: a `DispatchSucceeded`/`DispatchFailed` row for a verb
@@ -3671,21 +3700,42 @@ async fn append_audit_event_best_effort(
                 // obligation the read never needed as strictly as a write does.
                 // Any other reason (a definite store/durability failure) still
                 // fails the dispatch for reads exactly as it does for writes.
-                let admission_pressure = matches!(
-                    reason,
-                    AuditTerminalReason::QueueAdmissionExhausted
-                        | AuditTerminalReason::AdmissionDeadlineExpired
-                );
-                if is_read_only_verb && admission_pressure {
-                    AUDIT_ADMISSION_DEGRADED_OBLIGATIONS
-                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                    tracing::warn!(
-                        verb,
-                        reason = ?reason,
-                        "read verb's audit obligation degraded under audit-lane admission \
-                         pressure; dispatch still reports its own result (non-fatal)"
-                    );
-                    return Ok(());
+                //
+                // The two admission-pressure reasons are not the same fact and
+                // are counted on separate counters: `QueueAdmissionExhausted`
+                // never enqueued, so it is a confirmed terminal loss, while
+                // `AdmissionDeadlineExpired` was already enqueued and may still
+                // commit later — see `AuditTerminalReason::AdmissionDeadlineExpired`'s
+                // own doc.
+                if is_read_only_verb {
+                    match reason {
+                        AuditTerminalReason::QueueAdmissionExhausted => {
+                            AUDIT_ADMISSION_REFUSED_OBLIGATIONS
+                                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                            tracing::warn!(
+                                verb,
+                                reason = ?reason,
+                                "read verb's audit obligation row was refused before \
+                                 enqueue under audit-lane admission pressure; dispatch \
+                                 still reports its own result (non-fatal)"
+                            );
+                            return Ok(());
+                        }
+                        AuditTerminalReason::AdmissionDeadlineExpired => {
+                            AUDIT_ADMISSION_UNRESOLVED_OBLIGATIONS
+                                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                            tracing::warn!(
+                                verb,
+                                reason = ?reason,
+                                "read verb's audit obligation row was still enqueued and \
+                                 unresolved when the caller's admission wait deadline \
+                                 elapsed; it may still commit. Dispatch still reports its \
+                                 own result (non-fatal)"
+                            );
+                            return Ok(());
+                        }
+                        _ => {}
+                    }
                 }
                 AUDIT_OBLIGATION_APPEND_FAILURES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 tracing::error!(
@@ -7269,6 +7319,22 @@ pub(crate) mod tests {
         assert!(bare_report
             .writer_contention
             .audit_degraded_unavailable_reason
+            .is_some());
+        assert!(bare_report
+            .writer_contention
+            .audit_admission_refused_obligations
+            .is_none());
+        assert!(bare_report
+            .writer_contention
+            .audit_admission_refused_obligations_unavailable_reason
+            .is_some());
+        assert!(bare_report
+            .writer_contention
+            .audit_admission_unresolved_obligations
+            .is_none());
+        assert!(bare_report
+            .writer_contention
+            .audit_admission_unresolved_obligations_unavailable_reason
             .is_some());
     }
 

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -599,6 +599,20 @@ impl VerbRegistryBuilder {
         self
     }
 
+    /// Override the ADR-133 audit-batch seam's tunables, applied when
+    /// `build()` lazily constructs the batch from `event_store`.
+    /// `None` (the default) uses `AuditBatchConfig::default()`. Exposed for
+    /// tests that need to force a small `max_pending_rows` or a short
+    /// `admission_deadline` to exercise admission-pressure paths
+    /// deterministically (khive#2117, khive#2147, khive#2208, khive#2217).
+    pub fn with_audit_batch_config(
+        &mut self,
+        config: crate::audit_batch::AuditBatchConfig,
+    ) -> &mut Self {
+        self.audit_batch_config = Some(config);
+        self
+    }
+
     /// Mark audit persistence unavailable because its backend is read-only.
     ///
     /// No `EventStore` is retained, so dispatch never attempts a write that is
@@ -1320,6 +1334,16 @@ impl VerbRegistry {
         })
     }
 
+    /// Test/diagnostic-only accessor for the underlying ADR-133 audit-batch
+    /// seam. `None` when no `EventStore` was configured (the batch is lazily
+    /// constructed from one). Exposed so admission-pressure mechanism tests
+    /// can saturate and drain the SAME instance a real dispatch uses
+    /// (khive#2117, khive#2147, khive#2208, khive#2217) instead of testing a
+    /// look-alike.
+    pub fn audit_batch_handle(&self) -> Option<Arc<crate::audit_batch::AuditBatch>> {
+        self.audit_batch.clone()
+    }
+
     /// Stop admitting new audit rows and wait for every already-accepted row
     /// to reach a terminal state (ADR-133).
     ///
@@ -1352,6 +1376,24 @@ impl VerbRegistry {
                 "message": "operation completed, but its dispatch audit event was not persisted because the audit backend is read-only",
             })
         })
+    }
+
+    /// Whether `verb`'s declared [`VerbCategory`] is `Assertive` — the
+    /// speech-act tag for handlers that "retrieve and present facts" (`get`,
+    /// `list`, `search`, `recall`, `gtd.tasks`, ...) rather than committing a
+    /// domain change. Unknown verbs are conservatively `false`.
+    ///
+    /// Used only to decide whether a dispatch's own audit-obligation row may
+    /// degrade to best-effort on transient audit-lane admission pressure
+    /// (`append_audit_event_best_effort`) — a read that performed no domain
+    /// write must not fail the caller just because the audit lane is
+    /// momentarily saturated (khive#2147, khive#2217). Never used for
+    /// permission checking, transport routing, or return-shape selection.
+    fn verb_is_read_only(&self, verb: &str) -> bool {
+        self.packs
+            .iter()
+            .find_map(|pack| pack.handlers().iter().find(|h| h.name == verb))
+            .is_some_and(|handler| handler.category == VerbCategory::Assertive)
     }
 
     /// Return the help schema envelope for a verb.
@@ -1540,6 +1582,7 @@ impl VerbRegistry {
                             event,
                             verb,
                             crate::audit_batch::AuditProducer::GateDenied,
+                            false,
                         )
                         .await;
                     }
@@ -1694,8 +1737,15 @@ impl VerbRegistry {
         } else {
             crate::audit_batch::AuditProducer::DispatchFailed
         };
-        append_audit_event_best_effort(self.audit_batch.as_ref(), store, event, verb, producer)
-            .await
+        append_audit_event_best_effort(
+            self.audit_batch.as_ref(),
+            store,
+            event,
+            verb,
+            producer,
+            self.verb_is_read_only(verb),
+        )
+        .await
     }
 
     fn gate_request_with_identity(
@@ -1745,6 +1795,7 @@ impl VerbRegistry {
                 event,
                 gate_req.verb.as_str(),
                 crate::audit_batch::AuditProducer::GateUnavailable,
+                false,
             )
             .await;
         }
@@ -1870,6 +1921,7 @@ impl VerbRegistry {
                                 storage_event,
                                 "config.lock",
                                 crate::audit_batch::AuditProducer::ConfigLocked,
+                                false,
                             )
                             .await;
                         }
@@ -1917,6 +1969,7 @@ impl VerbRegistry {
                             storage_event,
                             verb,
                             crate::audit_batch::AuditProducer::GateDenied,
+                            false,
                         )
                         .await;
                     }
@@ -2126,6 +2179,7 @@ impl VerbRegistry {
                                             storage_event,
                                             verb,
                                             crate::audit_batch::AuditProducer::DispatchSucceeded,
+                                            handler_def.category == VerbCategory::Assertive,
                                         )
                                         .await
                                     }
@@ -2148,6 +2202,7 @@ impl VerbRegistry {
                                             storage_event,
                                             verb,
                                             crate::audit_batch::AuditProducer::DispatchSucceeded,
+                                            handler_def.category == VerbCategory::Assertive,
                                         )
                                         .await
                                     }
@@ -2203,6 +2258,7 @@ impl VerbRegistry {
                                     storage_event,
                                     verb,
                                     producer,
+                                    handler_def.category == VerbCategory::Assertive,
                                 )
                                 .await
                             }
@@ -2341,6 +2397,7 @@ impl VerbRegistry {
                     storage_event,
                     verb,
                     crate::audit_batch::AuditProducer::UnknownVerb,
+                    false,
                 )
                 .await;
             }
@@ -3474,6 +3531,15 @@ async fn persist_git_digest_receipt(
 /// Every failure — obligation or observability — increments the
 /// process-wide diagnostics counter above.
 ///
+/// `is_read_only_verb` (khive#2147/khive#2217) narrows that obligation for
+/// one specific case: a `DispatchSucceeded`/`DispatchFailed` row for a verb
+/// whose category is `VerbCategory::Assertive` performs no domain write, so
+/// this row's own admission being transiently refused or timed out
+/// (`AuditTerminalReason::QueueAdmissionExhausted` /
+/// `AdmissionDeadlineExpired`) degrades to best-effort instead of failing the
+/// dispatch — the caller-visible read result is preserved. Every other
+/// obligation failure, and every failure for a non-read verb, is unaffected.
+///
 /// When the registry has an audit-batch seam configured (it is whenever
 /// `store` is), the row routes through
 /// [`crate::audit_batch::AuditBatchControl::submit`] instead of taking its
@@ -3487,8 +3553,11 @@ async fn append_audit_event_best_effort(
     event: Event,
     verb: &str,
     producer: crate::audit_batch::AuditProducer,
+    is_read_only_verb: bool,
 ) -> Result<(), RuntimeError> {
-    use crate::audit_batch::{classify, AuditBatchControl, AuditProductionClass};
+    use crate::audit_batch::{
+        classify, AuditBatchControl, AuditProductionClass, AuditTerminalReason,
+    };
 
     let is_obligation = classify(producer) == AuditProductionClass::DispatchObligation;
 
@@ -3498,6 +3567,29 @@ async fn append_audit_event_best_effort(
             .await
         {
             if is_obligation {
+                // khive#2147/khive#2217: a read verb performs no domain write, so
+                // when the audit-lane's OWN admission is merely under transient
+                // pressure (the row was refused before enqueue, or the caller's
+                // wait deadline elapsed on a row that is still likely to commit),
+                // failing the read discards a valid result to protect an
+                // obligation the read never needed as strictly as a write does.
+                // Any other reason (a definite store/durability failure) still
+                // fails the dispatch for reads exactly as it does for writes.
+                let admission_pressure = matches!(
+                    reason,
+                    AuditTerminalReason::QueueAdmissionExhausted
+                        | AuditTerminalReason::AdmissionDeadlineExpired
+                );
+                if is_read_only_verb && admission_pressure {
+                    AUDIT_APPEND_FAILURES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    tracing::warn!(
+                        verb,
+                        reason = ?reason,
+                        "read verb's audit obligation degraded under audit-lane admission \
+                         pressure; dispatch still reports its own result (non-fatal)"
+                    );
+                    return Ok(());
+                }
                 AUDIT_OBLIGATION_APPEND_FAILURES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 tracing::error!(
                     verb,

--- a/crates/khive-runtime/tests/adr133_audit_batch.rs
+++ b/crates/khive-runtime/tests/adr133_audit_batch.rs
@@ -625,3 +625,139 @@ async fn d1c_ambiguous_ack_retry_persists_exactly_one_accounting_row() {
         "one ambiguous attempt, then one retry that observes the row already committed"
     );
 }
+
+/// khive#2117/khive#2208: `QueueAdmissionExhausted` must mean only the
+/// pre-enqueue refusal — `state.pending.len() >= max_pending_rows` — never
+/// the deadline-elapsed case covered by the next test. A row refused here
+/// was never pushed onto `state.pending` and never incremented
+/// `submitted_rows`, so retrying it applies the obligation at most once.
+///
+/// The armed sleep fault holds the supervisor inside its first (and only)
+/// generation for the test's duration, so nothing ever drains
+/// `state.pending` after the one-row capacity fills — the refusal below is
+/// deterministic, not a timing race against the driver.
+#[serial]
+#[tokio::test]
+async fn queue_admission_exhausted_row_is_never_enqueued() {
+    let store = FakeStore::new();
+    let batch = AuditBatch::new(
+        store.clone(),
+        AuditBatchConfig {
+            max_pending_rows: std::num::NonZeroUsize::new(1).unwrap(),
+            ..AuditBatchConfig::default()
+        },
+    );
+    fault_injection::arm_supervisor_sleep_before_spawn();
+    let occupant_batch = batch.clone();
+    let occupant = tokio::spawn(async move {
+        occupant_batch
+            .submit(PreparedAuditRow {
+                event: mk_event("kg.occupant"),
+                producer: AuditProducer::DispatchSucceeded,
+            })
+            .await
+    });
+    // Let the supervisor drain the occupant row into the armed sleep,
+    // freeing `state.pending` back to 0 before the fill row claims the
+    // configured one-row capacity.
+    tokio::time::sleep(std::time::Duration::from_millis(80)).await;
+    let filler_batch = batch.clone();
+    let filler = tokio::spawn(async move {
+        filler_batch
+            .submit(PreparedAuditRow {
+                event: mk_event("kg.filler"),
+                producer: AuditProducer::DispatchSucceeded,
+            })
+            .await
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(80)).await;
+
+    let before = batch.test_snapshot();
+    let refused = batch
+        .submit(PreparedAuditRow {
+            event: mk_event("kg.refused"),
+            producer: AuditProducer::DispatchSucceeded,
+        })
+        .await;
+    assert_eq!(refused, Err(AuditTerminalReason::QueueAdmissionExhausted));
+    let after = batch.test_snapshot();
+    assert_eq!(
+        after.submitted_rows, before.submitted_rows,
+        "a queue-full refusal must never increment submitted_rows — the row was never enqueued"
+    );
+    assert_eq!(
+        after.pending_rows, before.pending_rows,
+        "a queue-full refusal must not grow state.pending"
+    );
+
+    // Safe to retry: refused again, deterministically, with no side effect
+    // from the first refusal.
+    let retried = batch
+        .submit(PreparedAuditRow {
+            event: mk_event("kg.refused"),
+            producer: AuditProducer::DispatchSucceeded,
+        })
+        .await;
+    assert_eq!(retried, Err(AuditTerminalReason::QueueAdmissionExhausted));
+
+    drop(occupant);
+    drop(filler);
+}
+
+/// khive#2117/khive#2208: a caller whose `admission_deadline` elapses on a
+/// row that was already enqueued gets a distinct reason from queue-full —
+/// `AdmissionDeadlineExpired` — and the row itself is left in
+/// `state.pending`/`submitted_rows` exactly as if the caller had not timed
+/// out, because the generation driver (once it eventually runs) drains and
+/// commits it independently of this caller's wait. The two prior assertions
+/// against `queue_admission_exhausted_row_is_never_enqueued` above are the
+/// negative space this test fills in: same seam, opposite enqueue outcome.
+#[serial]
+#[tokio::test]
+async fn admission_deadline_expired_row_stays_enqueued() {
+    let store = FakeStore::new();
+    let batch = AuditBatch::new(
+        store.clone(),
+        AuditBatchConfig {
+            admission_deadline: std::time::Duration::from_millis(30),
+            ..AuditBatchConfig::default()
+        },
+    );
+    fault_injection::arm_supervisor_sleep_before_spawn();
+    let occupant_batch = batch.clone();
+    let occupant = tokio::spawn(async move {
+        occupant_batch
+            .submit(PreparedAuditRow {
+                event: mk_event("kg.occupant"),
+                producer: AuditProducer::DispatchSucceeded,
+            })
+            .await
+    });
+    // Let the supervisor drain the occupant row into the armed sleep before
+    // this test's row is submitted, so the row below is the one waiting
+    // behind the stuck generation rather than racing to be drained itself.
+    tokio::time::sleep(std::time::Duration::from_millis(80)).await;
+
+    let before = batch.test_snapshot();
+    let stuck = batch
+        .submit(PreparedAuditRow {
+            event: mk_event("kg.stuck"),
+            producer: AuditProducer::DispatchSucceeded,
+        })
+        .await;
+    assert_eq!(stuck, Err(AuditTerminalReason::AdmissionDeadlineExpired));
+    let after = batch.test_snapshot();
+    assert_eq!(
+        after.submitted_rows,
+        before.submitted_rows + 1,
+        "a deadline-expired row WAS enqueued and counted — unlike a queue-full refusal"
+    );
+    assert_eq!(
+        after.pending_rows,
+        before.pending_rows + 1,
+        "the row remains queued after the caller's own wait times out; the driver, not this \
+         arm, is responsible for eventually draining it"
+    );
+
+    drop(occupant);
+}

--- a/crates/khive-runtime/tests/read_verb_admission_exhaustion.rs
+++ b/crates/khive-runtime/tests/read_verb_admission_exhaustion.rs
@@ -107,6 +107,53 @@ impl EventStore for MemoryEventStore {
     }
 }
 
+/// Minimal pack exercising one allowlisted read (`get`, `Assertive`) whose
+/// dispatch always fails — used to prove a FAILED allowlisted read never
+/// takes the admission-degrade path (khive#2228 M1): only a *successful*
+/// dispatch of an allowlisted read may degrade its audit obligation, never a
+/// `DispatchFailed` one.
+struct BetaPack;
+
+impl Pack for BetaPack {
+    const NAME: &'static str = "beta";
+    const NOTE_KINDS: &'static [&'static str] = &[];
+    const ENTITY_KINDS: &'static [&'static str] = &[];
+    const HANDLERS: &'static [HandlerDef] = &[HandlerDef {
+        name: "get",
+        description: "get a widget (always fails, for regression coverage)",
+        visibility: Visibility::Verb,
+        category: VerbCategory::Assertive,
+        params: &[],
+    }];
+}
+
+#[async_trait]
+impl PackRuntime for BetaPack {
+    fn name(&self) -> &str {
+        Self::NAME
+    }
+    fn note_kinds(&self) -> &'static [&'static str] {
+        Self::NOTE_KINDS
+    }
+    fn entity_kinds(&self) -> &'static [&'static str] {
+        Self::ENTITY_KINDS
+    }
+    fn handlers(&self) -> &'static [HandlerDef] {
+        Self::HANDLERS
+    }
+    async fn dispatch(
+        &self,
+        _verb: &str,
+        _params: Value,
+        _registry: &khive_runtime::pack::VerbRegistry,
+        _token: &NamespaceToken,
+    ) -> Result<Value, RuntimeError> {
+        Err(RuntimeError::NotFound(
+            "widget intentionally missing for test".into(),
+        ))
+    }
+}
+
 /// Minimal pack exercising one read (`list`, `Assertive`) and one write
 /// (`create`, `Commissive`) verb, neither doing any real domain work.
 struct AlphaPack;
@@ -413,6 +460,160 @@ async fn read_verb_dispatch_survives_audit_lane_admission_deadline_expiry() {
             .audit_admission_unresolved_obligations,
         Some(audit_admission_unresolved_obligation_count()),
         "the real db_diagnostics handler path must surface the unresolved-obligation count"
+    );
+
+    drop(occupant);
+}
+
+/// khive#2228 M1: a FAILED dispatch of an allowlisted read verb must stay on
+/// the strict obligation path even when the audit lane is under the exact
+/// same `QueueAdmissionExhausted` pressure that degrades a *successful*
+/// allowlisted read's obligation in
+/// `read_verb_dispatch_survives_audit_lane_admission_exhaustion` above. The
+/// dispatch itself still surfaces its original handler error (unrelated to
+/// audit accounting), but the admission-degrade counters must not move for
+/// this row — a `DispatchFailed` producer is never admission-degrade
+/// eligible, no matter what `VerbRegistry::admission_degrade_safe` says
+/// about the verb name alone.
+#[serial]
+#[tokio::test]
+async fn failed_allowlisted_read_does_not_degrade_on_admission_exhaustion() {
+    let store = Arc::new(MemoryEventStore::default());
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(BetaPack);
+    builder.with_event_store(store);
+    builder.with_audit_batch_config(AuditBatchConfig {
+        max_pending_rows: std::num::NonZeroUsize::new(1).unwrap(),
+        ..AuditBatchConfig::default()
+    });
+    let registry = builder.build().expect("registry builds");
+    let audit_batch = registry
+        .audit_batch_handle()
+        .expect("event store configured, so the batch seam is too");
+
+    fault_injection::arm_supervisor_sleep_before_spawn();
+    let occupant_batch = audit_batch.clone();
+    let occupant = tokio::spawn(async move {
+        occupant_batch
+            .submit(PreparedAuditRow {
+                event: mk_event("kg.occupant"),
+                producer: AuditProducer::ConfigLocked,
+            })
+            .await
+    });
+    wait_until(std::time::Duration::from_secs(5), || {
+        let snap = audit_batch.test_snapshot();
+        snap.pending_rows == 0 && snap.in_flight_generation.is_some()
+    })
+    .await;
+
+    let filler_batch = audit_batch.clone();
+    let filler = tokio::spawn(async move {
+        filler_batch
+            .submit(PreparedAuditRow {
+                event: mk_event("kg.filler"),
+                producer: AuditProducer::ConfigLocked,
+            })
+            .await
+    });
+    wait_until(std::time::Duration::from_secs(5), || {
+        audit_batch.test_snapshot().pending_rows == 1
+    })
+    .await;
+
+    // The audit lane is now saturated. `get` is on `ADMISSION_DEGRADE_SAFE_VERBS`
+    // and registered `Assertive`, so `admission_degrade_safe("get")` is true —
+    // but BetaPack's handler always returns `Err`, so the producer is
+    // `DispatchFailed`. That must stay obligation-bearing: the dispatch fails
+    // with its own handler error (via `fold_audit_obligation`/the direct
+    // handler error path), and the admission-degrade counters must not move.
+    let before_refused = audit_admission_refused_obligation_count();
+    let before_unresolved = audit_admission_unresolved_obligation_count();
+    let err = registry
+        .dispatch("get", Value::Null)
+        .await
+        .expect_err("a failed allowlisted read must still surface its handler error");
+    assert!(
+        err.to_string().contains("widget intentionally missing"),
+        "the original handler error must be preserved, not replaced by an audit error: {err}"
+    );
+    assert_eq!(
+        audit_admission_refused_obligation_count(),
+        before_refused,
+        "a DispatchFailed row must never be counted on the admission-degrade \
+         refused counter, even for an allowlisted verb name"
+    );
+    assert_eq!(
+        audit_admission_unresolved_obligation_count(),
+        before_unresolved,
+        "a DispatchFailed row must never be counted on the admission-degrade \
+         unresolved counter, even for an allowlisted verb name"
+    );
+
+    drop(occupant);
+    drop(filler);
+}
+
+/// khive#2228 M1: the `AdmissionDeadlineExpired` counterpart of
+/// `failed_allowlisted_read_does_not_degrade_on_admission_exhaustion` above —
+/// a FAILED allowlisted read's own audit row enqueues and then times out
+/// waiting on its admission deadline, rather than being refused before
+/// enqueue. That must also stay obligation-bearing: no admission-degrade
+/// counter may move for a `DispatchFailed` producer.
+#[serial]
+#[tokio::test]
+async fn failed_allowlisted_read_does_not_degrade_on_admission_deadline_expiry() {
+    let store = Arc::new(MemoryEventStore::default());
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(BetaPack);
+    builder.with_event_store(store);
+    builder.with_audit_batch_config(AuditBatchConfig {
+        max_pending_rows: std::num::NonZeroUsize::new(4).unwrap(),
+        admission_deadline: std::time::Duration::from_millis(30),
+        ..AuditBatchConfig::default()
+    });
+    let registry = builder.build().expect("registry builds");
+    let audit_batch = registry
+        .audit_batch_handle()
+        .expect("event store configured, so the batch seam is too");
+
+    fault_injection::arm_supervisor_sleep_before_spawn();
+    let occupant_batch = audit_batch.clone();
+    let occupant = tokio::spawn(async move {
+        occupant_batch
+            .submit(PreparedAuditRow {
+                event: mk_event("kg.occupant"),
+                producer: AuditProducer::ConfigLocked,
+            })
+            .await
+    });
+    wait_until(std::time::Duration::from_secs(5), || {
+        let snap = audit_batch.test_snapshot();
+        snap.pending_rows == 0 && snap.in_flight_generation.is_some()
+    })
+    .await;
+
+    let before_refused = audit_admission_refused_obligation_count();
+    let before_unresolved = audit_admission_unresolved_obligation_count();
+    let err = registry
+        .dispatch("get", Value::Null)
+        .await
+        .expect_err("a failed allowlisted read must still surface its handler error");
+    assert!(
+        err.to_string().contains("widget intentionally missing"),
+        "the original handler error must be preserved, not replaced by an audit error: {err}"
+    );
+    assert_eq!(
+        audit_admission_refused_obligation_count(),
+        before_refused,
+        "a DispatchFailed row must never be counted on the admission-degrade \
+         refused counter, even for an allowlisted verb name"
+    );
+    assert_eq!(
+        audit_admission_unresolved_obligation_count(),
+        before_unresolved,
+        "a DispatchFailed row must never be counted on the admission-degrade \
+         unresolved counter, even for an allowlisted verb name"
     );
 
     drop(occupant);

--- a/crates/khive-runtime/tests/read_verb_admission_exhaustion.rs
+++ b/crates/khive-runtime/tests/read_verb_admission_exhaustion.rs
@@ -1,0 +1,257 @@
+//! khive#2147/khive#2217: a read dispatch must still return its result once
+//! the shared audit-lane's own admission is exhausted, instead of discarding
+//! an already-computed read to protect an audit obligation the read never
+//! needed as strictly as a write does.
+//!
+//! Lives in its own binary (mirroring `tests/adr133_audit_batch.rs`) rather
+//! than inside `khive-runtime/src/pack.rs`'s `mod tests`: that module
+//! compiles into the crate's single `--lib` unit-test binary alongside
+//! ~1300 other tests running concurrently across many OS threads, and this
+//! mechanism needs a background supervisor task to actually get scheduled
+//! within a bounded wait — under heavy suite-wide parallelism that wait is
+//! not reliable. A dedicated binary with no unrelated concurrent tests
+//! removes that source of flakiness.
+//!
+//! Requires `--features fault-injection,test-internals` (same as
+//! `tests/adr133_audit_batch.rs`).
+
+#![cfg(all(feature = "fault-injection", feature = "test-internals"))]
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+use khive_runtime::audit_batch::{
+    fault_injection, AuditBatchConfig, AuditBatchControl, AuditProducer, PreparedAuditRow,
+};
+use khive_runtime::pack::{HandlerDef, PackRuntime, VerbRegistryBuilder};
+use khive_runtime::runtime::NamespaceToken;
+use khive_runtime::RuntimeError;
+use khive_storage::types::{BatchWriteSummary, Page, PageRequest};
+use khive_storage::{Event, EventFilter, EventStore, StorageResult};
+use khive_types::pack::{Pack, Visibility};
+use khive_types::{EventKind, EventOutcome, SubstrateKind, VerbCategory};
+
+#[derive(Default)]
+struct MemoryEventStore {
+    events: std::sync::Mutex<Vec<Event>>,
+}
+
+#[async_trait]
+impl EventStore for MemoryEventStore {
+    async fn append_event(&self, event: Event) -> StorageResult<()> {
+        self.events.lock().unwrap().push(event);
+        Ok(())
+    }
+    async fn append_events(&self, events: Vec<Event>) -> StorageResult<BatchWriteSummary> {
+        let n = events.len() as u64;
+        self.events.lock().unwrap().extend(events);
+        Ok(BatchWriteSummary {
+            attempted: n,
+            affected: n,
+            failed: 0,
+            first_error: String::new(),
+        })
+    }
+    async fn get_event(&self, id: uuid::Uuid) -> StorageResult<Option<Event>> {
+        Ok(self
+            .events
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|e| e.id == id)
+            .cloned())
+    }
+    async fn query_events(
+        &self,
+        _filter: EventFilter,
+        _page: PageRequest,
+    ) -> StorageResult<Page<Event>> {
+        unimplemented!("not exercised by this test")
+    }
+    async fn count_events(&self, _filter: EventFilter) -> StorageResult<u64> {
+        Ok(self.events.lock().unwrap().len() as u64)
+    }
+    fn preflight_event(&self, _event: &Event) -> StorageResult<()> {
+        Ok(())
+    }
+    async fn append_events_idempotent(
+        &self,
+        events: Vec<Event>,
+    ) -> StorageResult<khive_storage::event::IdempotentEventBatchResult> {
+        let mut store = self.events.lock().unwrap();
+        let mut rows = Vec::with_capacity(events.len());
+        for event in events {
+            if let Some(existing) = store.iter().find(|e| e.id == event.id) {
+                if *existing == event {
+                    rows.push(
+                        khive_storage::event::EventAppendDisposition::AlreadyPresentIdentical,
+                    );
+                } else {
+                    rows.push(khive_storage::event::EventAppendDisposition::IdentityConflict);
+                }
+            } else {
+                store.push(event);
+                rows.push(khive_storage::event::EventAppendDisposition::Inserted);
+            }
+        }
+        Ok(khive_storage::event::IdempotentEventBatchResult { rows })
+    }
+    fn supports_idempotent_audit_batch(&self) -> bool {
+        true
+    }
+}
+
+/// Minimal pack exercising one read (`list`, `Assertive`) and one write
+/// (`create`, `Commissive`) verb, neither doing any real domain work.
+struct AlphaPack;
+
+impl Pack for AlphaPack {
+    const NAME: &'static str = "alpha";
+    const NOTE_KINDS: &'static [&'static str] = &[];
+    const ENTITY_KINDS: &'static [&'static str] = &[];
+    const HANDLERS: &'static [HandlerDef] = &[
+        HandlerDef {
+            name: "create",
+            description: "create a widget",
+            visibility: Visibility::Verb,
+            category: VerbCategory::Commissive,
+            params: &[],
+        },
+        HandlerDef {
+            name: "list",
+            description: "list widgets",
+            visibility: Visibility::Verb,
+            category: VerbCategory::Assertive,
+            params: &[],
+        },
+    ];
+}
+
+#[async_trait]
+impl PackRuntime for AlphaPack {
+    fn name(&self) -> &str {
+        Self::NAME
+    }
+    fn note_kinds(&self) -> &'static [&'static str] {
+        Self::NOTE_KINDS
+    }
+    fn entity_kinds(&self) -> &'static [&'static str] {
+        Self::ENTITY_KINDS
+    }
+    fn handlers(&self) -> &'static [HandlerDef] {
+        Self::HANDLERS
+    }
+    async fn dispatch(
+        &self,
+        verb: &str,
+        _params: Value,
+        _registry: &khive_runtime::pack::VerbRegistry,
+        _token: &NamespaceToken,
+    ) -> Result<Value, RuntimeError> {
+        Ok(serde_json::json!({ "pack": "alpha", "verb": verb }))
+    }
+}
+
+fn mk_event(verb: &str) -> Event {
+    Event::new(
+        "local",
+        verb,
+        EventKind::Audit,
+        SubstrateKind::Event,
+        "test:actor",
+    )
+    .with_outcome(EventOutcome::Success)
+}
+
+/// Polls `condition` every 2ms until it holds or `timeout` elapses
+/// (panicking on elapse) — a correctness-driven wait instead of a
+/// wall-clock guess.
+async fn wait_until(timeout: std::time::Duration, mut condition: impl FnMut() -> bool) {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if condition() {
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "condition did not become true within {timeout:?}"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+    }
+}
+
+#[tokio::test]
+async fn read_verb_dispatch_survives_audit_lane_admission_exhaustion() {
+    let store = Arc::new(MemoryEventStore::default());
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(AlphaPack);
+    builder.with_event_store(store);
+    builder.with_audit_batch_config(AuditBatchConfig {
+        max_pending_rows: std::num::NonZeroUsize::new(1).unwrap(),
+        ..AuditBatchConfig::default()
+    });
+    let registry = builder.build().expect("registry builds");
+    let audit_batch = registry
+        .audit_batch_handle()
+        .expect("event store configured, so the batch seam is too");
+
+    // Hold the supervisor inside its first generation for the test's
+    // duration, so submitting up to `max_pending_rows` (1) directly through
+    // the shared `AuditBatch` leaves admission synchronously refused
+    // (`QueueAdmissionExhausted`, no wait) for any further row.
+    fault_injection::arm_supervisor_sleep_before_spawn();
+    let occupant_batch = audit_batch.clone();
+    let occupant = tokio::spawn(async move {
+        occupant_batch
+            .submit(PreparedAuditRow {
+                event: mk_event("kg.occupant"),
+                producer: AuditProducer::ConfigLocked,
+            })
+            .await
+    });
+    wait_until(std::time::Duration::from_secs(5), || {
+        let snap = audit_batch.test_snapshot();
+        snap.pending_rows == 0 && snap.in_flight_generation.is_some()
+    })
+    .await;
+
+    let filler_batch = audit_batch.clone();
+    let filler = tokio::spawn(async move {
+        filler_batch
+            .submit(PreparedAuditRow {
+                event: mk_event("kg.filler"),
+                producer: AuditProducer::ConfigLocked,
+            })
+            .await
+    });
+    wait_until(std::time::Duration::from_secs(5), || {
+        audit_batch.test_snapshot().pending_rows == 1
+    })
+    .await;
+
+    // The audit lane is now saturated (`state.pending.len() ==
+    // max_pending_rows`): a `create` (write) dispatched now still fails —
+    // the existing write-side hard-fail obligation semantics are unchanged.
+    registry
+        .dispatch("create", Value::Null)
+        .await
+        .expect_err("a write's obligation failure still fails the dispatch when saturated");
+
+    // The read must still succeed: its own audit row is refused on
+    // admission (immediate `QueueAdmissionExhausted`, no wait), but that
+    // failure degrades to best-effort instead of discarding the read's
+    // already-computed result.
+    let result = registry
+        .dispatch("list", Value::Null)
+        .await
+        .expect("a read verb must not fail on audit-lane admission exhaustion");
+    assert_eq!(
+        result,
+        serde_json::json!({ "pack": "alpha", "verb": "list" })
+    );
+
+    drop(occupant);
+    drop(filler);
+}

--- a/crates/khive-runtime/tests/read_verb_admission_exhaustion.rs
+++ b/crates/khive-runtime/tests/read_verb_admission_exhaustion.rs
@@ -25,13 +25,16 @@ use serde_json::Value;
 use khive_runtime::audit_batch::{
     fault_injection, AuditBatchConfig, AuditBatchControl, AuditProducer, PreparedAuditRow,
 };
-use khive_runtime::pack::{HandlerDef, PackRuntime, VerbRegistryBuilder};
+use khive_runtime::pack::{
+    audit_admission_degraded_obligation_count, HandlerDef, PackRuntime, VerbRegistryBuilder,
+};
 use khive_runtime::runtime::NamespaceToken;
 use khive_runtime::RuntimeError;
 use khive_storage::types::{BatchWriteSummary, Page, PageRequest};
 use khive_storage::{Event, EventFilter, EventStore, StorageResult};
 use khive_types::pack::{Pack, Visibility};
 use khive_types::{EventKind, EventOutcome, SubstrateKind, VerbCategory};
+use serial_test::serial;
 
 #[derive(Default)]
 struct MemoryEventStore {
@@ -182,6 +185,10 @@ async fn wait_until(timeout: std::time::Duration, mut condition: impl FnMut() ->
     }
 }
 
+// Both tests in this file arm `fault_injection`'s process-global
+// `SUPERVISOR_SLEEP_BEFORE_SPAWN` flag; running them concurrently races one
+// test's arm against the other's supervisor loop consuming it.
+#[serial]
 #[tokio::test]
 async fn read_verb_dispatch_survives_audit_lane_admission_exhaustion() {
     let store = Arc::new(MemoryEventStore::default());
@@ -243,6 +250,7 @@ async fn read_verb_dispatch_survives_audit_lane_admission_exhaustion() {
     // admission (immediate `QueueAdmissionExhausted`, no wait), but that
     // failure degrades to best-effort instead of discarding the read's
     // already-computed result.
+    let before_degraded = audit_admission_degraded_obligation_count();
     let result = registry
         .dispatch("list", Value::Null)
         .await
@@ -251,7 +259,88 @@ async fn read_verb_dispatch_survives_audit_lane_admission_exhaustion() {
         result,
         serde_json::json!({ "pack": "alpha", "verb": "list" })
     );
+    assert_eq!(
+        audit_admission_degraded_obligation_count(),
+        before_degraded + 1,
+        "a queue-refusal degrade must count on its own dedicated counter, not \
+         AUDIT_APPEND_FAILURES or AUDIT_OBLIGATION_APPEND_FAILURES"
+    );
 
     drop(occupant);
     drop(filler);
+}
+
+/// khive#2117/khive#2208 + khive#2147/khive#2217 combined: a read dispatch
+/// must also survive its own audit row's admission *deadline* elapsing, not
+/// just an immediate queue-full refusal — the two `AuditTerminalReason`
+/// variants are distinct call sites in `append_audit_event_best_effort` and
+/// this exercises the one `read_verb_dispatch_survives_audit_lane_admission_exhaustion`
+/// above does not: `AdmissionDeadlineExpired` on a row that was already
+/// enqueued (`state.pending`), rather than `QueueAdmissionExhausted` before
+/// enqueue.
+// Both tests in this file arm `fault_injection`'s process-global
+// `SUPERVISOR_SLEEP_BEFORE_SPAWN` flag; running them concurrently races one
+// test's arm against the other's supervisor loop consuming it.
+#[serial]
+#[tokio::test]
+async fn read_verb_dispatch_survives_audit_lane_admission_deadline_expiry() {
+    let store = Arc::new(MemoryEventStore::default());
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(AlphaPack);
+    builder.with_event_store(store);
+    builder.with_audit_batch_config(AuditBatchConfig {
+        // Room for the occupant row plus this test's own "list" row, so the
+        // "list" row is never refused on admission — it must enqueue and
+        // then wait out its own short deadline instead.
+        max_pending_rows: std::num::NonZeroUsize::new(4).unwrap(),
+        admission_deadline: std::time::Duration::from_millis(30),
+        ..AuditBatchConfig::default()
+    });
+    let registry = builder.build().expect("registry builds");
+    let audit_batch = registry
+        .audit_batch_handle()
+        .expect("event store configured, so the batch seam is too");
+
+    // Hold the supervisor inside its first generation for the test's
+    // duration, mirroring the queue-full test above: an occupant row is
+    // drained into the armed sleep, so any row submitted afterward sits in
+    // `state.pending`, undrained, until its own `admission_deadline` elapses.
+    fault_injection::arm_supervisor_sleep_before_spawn();
+    let occupant_batch = audit_batch.clone();
+    let occupant = tokio::spawn(async move {
+        occupant_batch
+            .submit(PreparedAuditRow {
+                event: mk_event("kg.occupant"),
+                producer: AuditProducer::ConfigLocked,
+            })
+            .await
+    });
+    wait_until(std::time::Duration::from_secs(5), || {
+        let snap = audit_batch.test_snapshot();
+        snap.pending_rows == 0 && snap.in_flight_generation.is_some()
+    })
+    .await;
+
+    // The read's own audit row now enqueues behind the stalled generation
+    // (the queue has room, so this is not `QueueAdmissionExhausted`) and
+    // waits out its 30ms `admission_deadline` — `AdmissionDeadlineExpired`.
+    // That failure must still degrade to best-effort: the dispatch reports
+    // its own already-computed result rather than discarding it.
+    let before_degraded = audit_admission_degraded_obligation_count();
+    let result = registry
+        .dispatch("list", Value::Null)
+        .await
+        .expect("a read verb must not fail when its own audit row's admission deadline elapses");
+    assert_eq!(
+        result,
+        serde_json::json!({ "pack": "alpha", "verb": "list" })
+    );
+    assert_eq!(
+        audit_admission_degraded_obligation_count(),
+        before_degraded + 1,
+        "a deadline-expiry degrade must count on its own dedicated counter too, not just \
+         the queue-refusal arm"
+    );
+
+    drop(occupant);
 }

--- a/crates/khive-runtime/tests/read_verb_admission_exhaustion.rs
+++ b/crates/khive-runtime/tests/read_verb_admission_exhaustion.rs
@@ -265,6 +265,21 @@ async fn read_verb_dispatch_survives_audit_lane_admission_exhaustion() {
         "a queue-refusal degrade must count on its own dedicated counter, not \
          AUDIT_APPEND_FAILURES or AUDIT_OBLIGATION_APPEND_FAILURES"
     );
+    // The raw process-wide counter is an internal detail; what an operator
+    // actually reads is `db_diagnostics`, fed by `VerbRegistry::audit_batch_metrics()`
+    // (ADR-103 Amendment 3 / ADR-133 Amendment 1). Prove the threading, not
+    // just the counter increment: this assertion reddens if
+    // `RuntimeAuditBatchMetrics::admission_degraded_obligations` regresses to
+    // a hardcoded 0 or is dropped from the struct.
+    assert_eq!(
+        registry
+            .audit_batch_metrics()
+            .expect("event store configured, so the batch seam is too")
+            .admission_degraded_obligations,
+        audit_admission_degraded_obligation_count(),
+        "VerbRegistry::audit_batch_metrics() must surface the same admission-degraded count \
+         the production db_diagnostics verb reports"
+    );
 
     drop(occupant);
     drop(filler);

--- a/crates/khive-runtime/tests/read_verb_admission_exhaustion.rs
+++ b/crates/khive-runtime/tests/read_verb_admission_exhaustion.rs
@@ -26,10 +26,11 @@ use khive_runtime::audit_batch::{
     fault_injection, AuditBatchConfig, AuditBatchControl, AuditProducer, PreparedAuditRow,
 };
 use khive_runtime::pack::{
-    audit_admission_degraded_obligation_count, HandlerDef, PackRuntime, VerbRegistryBuilder,
+    audit_admission_refused_obligation_count, audit_admission_unresolved_obligation_count,
+    HandlerDef, PackRuntime, VerbRegistryBuilder,
 };
 use khive_runtime::runtime::NamespaceToken;
-use khive_runtime::RuntimeError;
+use khive_runtime::{KhiveRuntime, RuntimeError};
 use khive_storage::types::{BatchWriteSummary, Page, PageRequest};
 use khive_storage::{Event, EventFilter, EventStore, StorageResult};
 use khive_types::pack::{Pack, Visibility};
@@ -249,8 +250,11 @@ async fn read_verb_dispatch_survives_audit_lane_admission_exhaustion() {
     // The read must still succeed: its own audit row is refused on
     // admission (immediate `QueueAdmissionExhausted`, no wait), but that
     // failure degrades to best-effort instead of discarding the read's
-    // already-computed result.
-    let before_degraded = audit_admission_degraded_obligation_count();
+    // already-computed result. A queue refusal is a confirmed, terminal
+    // loss — the row never enqueued — so it counts on the "refused" counter,
+    // not the "unresolved" one used by the deadline-expiry test below.
+    let before_refused = audit_admission_refused_obligation_count();
+    let before_unresolved = audit_admission_unresolved_obligation_count();
     let result = registry
         .dispatch("list", Value::Null)
         .await
@@ -260,25 +264,52 @@ async fn read_verb_dispatch_survives_audit_lane_admission_exhaustion() {
         serde_json::json!({ "pack": "alpha", "verb": "list" })
     );
     assert_eq!(
-        audit_admission_degraded_obligation_count(),
-        before_degraded + 1,
+        audit_admission_refused_obligation_count(),
+        before_refused + 1,
         "a queue-refusal degrade must count on its own dedicated counter, not \
          AUDIT_APPEND_FAILURES or AUDIT_OBLIGATION_APPEND_FAILURES"
+    );
+    assert_eq!(
+        audit_admission_unresolved_obligation_count(),
+        before_unresolved,
+        "a queue refusal must never be counted on the deadline-expiry counter"
     );
     // The raw process-wide counter is an internal detail; what an operator
     // actually reads is `db_diagnostics`, fed by `VerbRegistry::audit_batch_metrics()`
     // (ADR-103 Amendment 3 / ADR-133 Amendment 1). Prove the threading, not
     // just the counter increment: this assertion reddens if
-    // `RuntimeAuditBatchMetrics::admission_degraded_obligations` regresses to
+    // `RuntimeAuditBatchMetrics::admission_refused_obligations` regresses to
     // a hardcoded 0 or is dropped from the struct.
+    let metrics = registry
+        .audit_batch_metrics()
+        .expect("event store configured, so the batch seam is too");
     assert_eq!(
-        registry
-            .audit_batch_metrics()
-            .expect("event store configured, so the batch seam is too")
-            .admission_degraded_obligations,
-        audit_admission_degraded_obligation_count(),
-        "VerbRegistry::audit_batch_metrics() must surface the same admission-degraded count \
+        metrics.admission_refused_obligations,
+        audit_admission_refused_obligation_count(),
+        "VerbRegistry::audit_batch_metrics() must surface the same admission-refused count \
          the production db_diagnostics verb reports"
+    );
+
+    // Drive the SAME production path the `db_diagnostics` verb handler uses
+    // (`crates/khive-pack-kg/src/handlers/db_diagnostics.rs` calls exactly
+    // this `KhiveRuntime` method with exactly this `registry.audit_batch_metrics()`
+    // value) so this assertion reddens if that forwarding is ever dropped in
+    // favor of passing `None`.
+    let rt = KhiveRuntime::memory().expect("memory runtime should create");
+    let report = rt
+        .db_diagnostics_with_audit_metrics(Some(metrics))
+        .await
+        .expect("diagnostics succeed");
+    assert_eq!(
+        report.writer_contention.audit_admission_refused_obligations,
+        Some(audit_admission_refused_obligation_count()),
+        "the real db_diagnostics handler path must surface the refused-obligation count"
+    );
+    assert_eq!(
+        report
+            .writer_contention
+            .audit_admission_unresolved_obligations,
+        Some(audit_admission_unresolved_obligation_count()),
     );
 
     drop(occupant);
@@ -340,8 +371,11 @@ async fn read_verb_dispatch_survives_audit_lane_admission_deadline_expiry() {
     // (the queue has room, so this is not `QueueAdmissionExhausted`) and
     // waits out its 30ms `admission_deadline` — `AdmissionDeadlineExpired`.
     // That failure must still degrade to best-effort: the dispatch reports
-    // its own already-computed result rather than discarding it.
-    let before_degraded = audit_admission_degraded_obligation_count();
+    // its own already-computed result rather than discarding it. Unlike a
+    // queue refusal, the row was already enqueued and may still commit, so
+    // this must count on the "unresolved" counter, not "refused".
+    let before_refused = audit_admission_refused_obligation_count();
+    let before_unresolved = audit_admission_unresolved_obligation_count();
     let result = registry
         .dispatch("list", Value::Null)
         .await
@@ -351,10 +385,34 @@ async fn read_verb_dispatch_survives_audit_lane_admission_deadline_expiry() {
         serde_json::json!({ "pack": "alpha", "verb": "list" })
     );
     assert_eq!(
-        audit_admission_degraded_obligation_count(),
-        before_degraded + 1,
+        audit_admission_unresolved_obligation_count(),
+        before_unresolved + 1,
         "a deadline-expiry degrade must count on its own dedicated counter too, not just \
          the queue-refusal arm"
+    );
+    assert_eq!(
+        audit_admission_refused_obligation_count(),
+        before_refused,
+        "a deadline expiry must never be counted on the queue-refusal counter"
+    );
+
+    // Drive the same production forwarding path as the queue-refusal test
+    // above: this reddens if `db_diagnostics_with_audit_metrics` stops
+    // forwarding the unresolved count into `writer_contention`.
+    let metrics = registry
+        .audit_batch_metrics()
+        .expect("event store configured, so the batch seam is too");
+    let rt = KhiveRuntime::memory().expect("memory runtime should create");
+    let report = rt
+        .db_diagnostics_with_audit_metrics(Some(metrics))
+        .await
+        .expect("diagnostics succeed");
+    assert_eq!(
+        report
+            .writer_contention
+            .audit_admission_unresolved_obligations,
+        Some(audit_admission_unresolved_obligation_count()),
+        "the real db_diagnostics handler path must surface the unresolved-obligation count"
     );
 
     drop(occupant);

--- a/docs/adr/ADR-103-resource-attribution-model.md
+++ b/docs/adr/ADR-103-resource-attribution-model.md
@@ -126,8 +126,11 @@ A fifth value requires an ADR amendment, matching how the existing closed taxono
 
 ### (b) A `cost` sub-schema as payload enrichment of the existing audit row — no new row
 
-Every dispatch already produces one `EventKind::Audit` row. This design adds a `resource`
-object to that row's existing JSON `payload`, with no new row and no migration:
+Every dispatch already produces one `EventKind::Audit` row. (Amendment 3 narrows this for one
+bounded case — transient audit-lane admission pressure on a fixed, named set of read verbs — where
+the row may be dropped best-effort instead of committing; see that amendment for the exact scope.)
+This design adds a `resource` object to that row's existing JSON `payload`, with no new row and no
+migration:
 
 ```jsonc
 // events.payload for the existing per-dispatch EventKind::Audit row, gains:
@@ -601,18 +604,25 @@ Adding fields is non-breaking" (`crates/khive-gate/src/audit.rs:10-11`). `resour
 `cost_unit` within it, is exactly this kind of additive field: no schema migration, no
 change to any existing field's meaning.
 
-**Absence has exactly two meanings.** An audit row with no `resource.cost_unit` field is
-one of:
+**Absence has exactly three meanings** (the third added by Amendment 3). An audit row with no
+`resource.cost_unit` field is one of:
 
 1. A pre-amendment event, written before a producer emitted this field.
 2. A dispatch that errored. The deferred audit path persists an `Error`-outcome row
    (`crates/khive-runtime/src/pack.rs:1260-1274`) with no successful handler `Value` to
    read `item_count` from, so `resource.cost_unit` is omitted rather than computed for
    any failed or incomplete dispatch.
+3. A successful dispatch of one of Amendment 3's named read verbs whose audit row was dropped
+   best-effort under transient audit-lane admission pressure. Unlike (1) and (2), the caller
+   received a successful result — see Amendment 3 for the exact scope and the counters that make
+   this case distinguishable from the other two.
 
 Because this amendment keeps Decision (b)'s every-dispatch scope, there is no third
 "verb not yet covered" case: every dispatch that resolves `Ok` gets a `resource.cost_unit`
-value, embedding-bearing or not. A missing value is never inferred, defaulted to zero, or
+value, embedding-bearing or not — except the bounded admission-pressure case Amendment 3 adds for
+a fixed, named set of read verbs, where the row (and the `resource.cost_unit` value it would have
+carried) may be absent because it was dropped best-effort, not because the verb is uncovered. A
+missing value outside that named case is never inferred, defaulted to zero, or
 backfilled after the fact. This mirrors the absence-is-exclusion convention
 `counts_by_work_class` already applies to `work_class`: a row with no `work_class` is
 skipped, not counted into a default bucket.
@@ -911,19 +921,34 @@ dispatch. The caller still receives the read's successful result.
 
 **Consequence, stated precisely:** `brain.event_counts`'s `total_cost_unit` and
 `cost_unit_by_verb` aggregation (Amendment 1) undercount those eleven verbs by the `cost_unit` of
-every row dropped this way. The loss is:
+every row dropped this way — but the two terminal reasons above are not the same fact, and
+conflating them into one counter would report a number no operator could act on:
+
+- **`QueueAdmissionExhausted`** never enqueued the row: it is a confirmed, terminal accounting
+  loss. It will never commit.
+- **`AdmissionDeadlineExpired`** already enqueued the row before the caller's wait elapsed: the
+  generation driver still commits or terminally fails it independently of the caller's timeout, so
+  at the moment the dispatch returns, whether that row eventually contributes to
+  `brain.event_counts` is unresolved, not known-lost. A count of these rows is an upper bound on
+  the eventual undercount, not the undercount itself.
+
+The loss is:
 
 - **Bounded to the allowlisted verb set.** No other Assertive handler, and no write of any kind,
   is affected — see "What does not change" below.
 - **Bounded to transient audit-lane admission pressure**, not persistent store failure. A
   persistent commit failure for one of these rows is unaffected by this amendment and is handled
   exactly as any other row of its class.
-- **Counted and exported**, not silent. Every drop increments a dedicated process-wide counter
-  (`AUDIT_ADMISSION_DEGRADED_OBLIGATIONS` in `crates/khive-runtime/src/pack.rs`) that is threaded
-  through `VerbRegistry::audit_batch_metrics()` into
-  `khive_db::diagnostics::WriterContentionDiagnostics::audit_admission_degraded_obligations`,
-  visible on the `db_diagnostics` verb — an operator can read the undercount directly instead of
-  inferring it from a cost-total discrepancy.
+- **Counted and exported on two disjoint counters, not silent and not conflated.** Every
+  `QueueAdmissionExhausted` drop increments a dedicated process-wide counter
+  (`AUDIT_ADMISSION_REFUSED_OBLIGATIONS` in `crates/khive-runtime/src/pack.rs`); every
+  `AdmissionDeadlineExpired` drop increments a separate one
+  (`AUDIT_ADMISSION_UNRESOLVED_OBLIGATIONS`). Both are threaded through
+  `VerbRegistry::audit_batch_metrics()` into
+  `khive_db::diagnostics::WriterContentionDiagnostics::audit_admission_refused_obligations` and
+  `audit_admission_unresolved_obligations` respectively, visible on the `db_diagnostics` verb — an
+  operator can read the confirmed loss and the unresolved upper bound separately, instead of a
+  single number that cannot distinguish an eventual undercount of zero from one of N.
 
 ### What does not change
 

--- a/docs/adr/ADR-103-resource-attribution-model.md
+++ b/docs/adr/ADR-103-resource-attribution-model.md
@@ -887,3 +887,56 @@ accepted placement for future implementation, not a shipped operator knob.
 - Neutral: `work_class`, quota mechanism, phase-span events, and the staged landing
   plan are all unchanged; the response-envelope addition is additive for tolerant
   JSON consumers (Part 3's scoped compatibility statement).
+
+## Amendment 3 (2026-08-26): Admission-Pressure Read-Cost Undercount for an Explicit Allowlist
+
+**Status**: Accepted, implemented alongside PR #2228 (khive#2147/khive#2217/khive#2208).
+
+Decision (b) established that accounting rides the per-dispatch audit row: `resource.cost_unit`
+lives in the same `EventKind::Audit` row the dispatch's own audit obligation writes
+(`ADR-103:127-152`), and Consequences already states that row "is the daemon's default
+construction" with no second row (`ADR-103:401-406`). This amendment narrows what "the row
+commits" guarantees for one bounded case: transient admission pressure on the audit lane
+itself, for a fixed, named set of read verbs.
+
+### The narrowed guarantee
+
+Under audit-lane admission pressure — `AuditTerminalReason::QueueAdmissionExhausted` (the row was
+refused before it could be enqueued) or `AuditTerminalReason::AdmissionDeadlineExpired` (the
+caller's bounded wait for the row's commit elapsed while the row was still pending or in-flight) —
+the per-dispatch audit row for a verb on `VerbRegistry::ADMISSION_DEGRADE_SAFE_VERBS`
+(`crates/khive-runtime/src/pack.rs`: `get`, `list`, `stats`, `search`, `neighbors`, `traverse`,
+`context`, `query`, `resolve`, `whoami`, `verbs`) may be dropped best-effort instead of failing the
+dispatch. The caller still receives the read's successful result.
+
+**Consequence, stated precisely:** `brain.event_counts`'s `total_cost_unit` and
+`cost_unit_by_verb` aggregation (Amendment 1) undercount those eleven verbs by the `cost_unit` of
+every row dropped this way. The loss is:
+
+- **Bounded to the allowlisted verb set.** No other Assertive handler, and no write of any kind,
+  is affected — see "What does not change" below.
+- **Bounded to transient audit-lane admission pressure**, not persistent store failure. A
+  persistent commit failure for one of these rows is unaffected by this amendment and is handled
+  exactly as any other row of its class.
+- **Counted and exported**, not silent. Every drop increments a dedicated process-wide counter
+  (`AUDIT_ADMISSION_DEGRADED_OBLIGATIONS` in `crates/khive-runtime/src/pack.rs`) that is threaded
+  through `VerbRegistry::audit_batch_metrics()` into
+  `khive_db::diagnostics::WriterContentionDiagnostics::audit_admission_degraded_obligations`,
+  visible on the `db_diagnostics` verb — an operator can read the undercount directly instead of
+  inferring it from a cost-total discrepancy.
+
+### What does not change
+
+Writes and every Assertive handler NOT on the allowlist keep hard-fail semantics: a persistent or
+admission-pressure commit failure on their audit row still fails the dispatch. This amendment does
+not touch `DispatchFailed`, `DispatchObligation` rows for write verbs, gate-denial rows,
+unknown-verb rows, or `git.digest` receipts — all of those remain obligation-bearing with no
+degradation path.
+
+### Why this is accepted rather than fixed by splitting the row
+
+The alternative — a dedicated accounting row separate from the read-observability row — was
+considered and rejected for this PR as new storage-and-plumbing machinery. See the companion
+amendment in `docs/adr/ADR-133-incidental-writes-off-the-request-hot-path.md` ("Amendment 1") for
+the corresponding narrowing of that record's D4/INV-1 language, which this same PR's change
+requires.

--- a/docs/adr/ADR-133-incidental-writes-off-the-request-hot-path.md
+++ b/docs/adr/ADR-133-incidental-writes-off-the-request-hot-path.md
@@ -609,3 +609,50 @@ at the production seam.
 
 **Sample audit events.** Rejected: sampling changes what the audit trail means, and under ADR-103
 it would change what usage gets accounted.
+
+## Amendment 1 (2026-08-26): A Named, Bounded Exception to D4/INV-1 for Admission-Pressure Reads
+
+**Status**: Accepted, implemented alongside PR #2228 (khive#2147/khive#2217/khive#2208).
+
+D2 states: _"A dispatch must not report success when the record that accounts for, authorizes, or
+audits it did not commit"_ (`ADR-133:297-298`), and D4/INV-1 states the same as a system-wide
+invariant: _"Accounting-, authorization-, and security-audit-bearing records are written exactly
+once: never dropped, never volatile at return, never falsely acknowledged, never duplicated"_
+(`ADR-133:436-438`), with failure mode 3 named explicitly as _"Falsely acknowledged — the operation
+reports success when the record did not commit"_ (`ADR-133:375`).
+
+This amendment qualifies both sentences for one narrow, named case: the eleven read verbs on
+`VerbRegistry::ADMISSION_DEGRADE_SAFE_VERBS` (`crates/khive-runtime/src/pack.rs`; the full list and
+rationale are in ADR-103 Amendment 3), and only when the row's own commit did not happen because
+the audit lane's admission was transiently exhausted or the caller's bounded wait for it elapsed —
+`AuditTerminalReason::QueueAdmissionExhausted` or `AdmissionDeadlineExpired`, never a persistent
+commit failure. For that verb set and those two terminal reasons, the dispatch reports its
+already-computed successful read result while its own audit/accounting row is dropped best-effort.
+This is exactly failure mode 3 (falsely acknowledged) for an accounting-bearing row, deliberately
+permitted for this bounded case.
+
+**Why this is a scoped exception and not a reopening of D4/INV-1 generally:**
+
+- It applies to reads only. A read verb performs no domain write; the value being protected by
+  D2's "must not report success" rule is the accounting record of work already done, not
+  correctness of a mutation. Losing that accounting record loses a count, not state.
+- It applies to two specific terminal reasons, not persistent store failure. A persistently
+  failing store still fails these dispatches exactly as D2 requires for any other
+  accounting-bearing row — the exception exists only for the audit lane's own transient
+  admission pressure, not for durability loss.
+- It is opt-in per verb, fail-closed by default (`VerbRegistry::admission_degrade_safe`): an
+  unclassified or newly added Assertive handler is NOT eligible until someone deliberately reviews
+  it and adds it to the allowlist, preserving D5/INV-2's "unclassified resolves to the stricter
+  handling" posture for everything not on the list.
+- The resulting loss is counted, not silent — see ADR-103 Amendment 3's diagnostics requirement.
+
+**What does not change:** D4/INV-1 continues to hold without qualification for every write, every
+non-allowlisted Assertive handler, gate-denial rows, unknown-verb rows, and `git.digest` receipts.
+D2's "must not report success" sentence is unqualified for a persistent commit failure on any row,
+including the eleven allowlisted verbs — the exception is admission pressure specifically, not
+store failure generally.
+
+This amendment does not revisit "Split the audit row so accounting lives in its own record" from
+Alternatives considered above — that remains rejected for the reasons stated there (a migration,
+and it breaks the response/audit-payload identity property). The accepted trade here is a bounded,
+measured undercount over that redesign.

--- a/docs/adr/ADR-133-incidental-writes-off-the-request-hot-path.md
+++ b/docs/adr/ADR-133-incidental-writes-off-the-request-hot-path.md
@@ -116,7 +116,11 @@ draft readable two incompatible ways.
 **Scope of that clause, which an earlier draft got wrong by stating it without qualification.** It
 binds unconditionally for **obligation-bearing rows** (accounting, authorization, security audit):
 such a dispatch never returns success without its row committed, and a persistent commit failure
-fails it.
+fails it. Amendment 1 below carves out one narrow, named exception to this binding: for the
+`VerbRegistry::ADMISSION_DEGRADE_SAFE_VERBS` read set, and only when the row's own commit did not
+happen because the audit lane's admission was transiently exhausted or the caller's bounded wait
+for it elapsed (never a persistent commit failure), the dispatch reports its already-computed
+result without waiting on that row.
 
 For **pure observability rows** it binds on the success path only. The dispatch waits for the batch
 in the normal case — so observability rows are batched, share the acquisition reduction, and are
@@ -350,8 +354,11 @@ prerequisite before any consumer may depend on the row for a resource-usage outc
 
 Under D1 this is satisfied by the ordinary path rather than by an exemption from it: a dispatch
 already waits for its batch to commit, and for this class D1's waiting clause binds
-unconditionally — the observability carve-out does not reach an accounting-bearing row. An earlier
-draft achieved the same property by
+unconditionally — the observability carve-out does not reach an accounting-bearing row. (Amendment
+1's admission-pressure exception is a separate, narrower carve-out than the observability one: it
+applies only to the named allowlisted read verbs and only to the two transient admission-pressure
+terminal reasons, never to a persistent commit failure.) An earlier draft achieved the same
+property by
 excluding accounting rows from batching altogether, which would have removed the acquisition
 reduction in exactly the high-concurrency deployment that motivates this record, since under
 ADR-103 the usage object rides _every_ per-dispatch audit row. Stating the obligation instead of
@@ -618,18 +625,33 @@ D2 states: _"A dispatch must not report success when the record that accounts fo
 audits it did not commit"_ (`ADR-133:297-298`), and D4/INV-1 states the same as a system-wide
 invariant: _"Accounting-, authorization-, and security-audit-bearing records are written exactly
 once: never dropped, never volatile at return, never falsely acknowledged, never duplicated"_
-(`ADR-133:436-438`), with failure mode 3 named explicitly as _"Falsely acknowledged — the operation
-reports success when the record did not commit"_ (`ADR-133:375`).
+(`ADR-133:436-438`), with failure mode 3 named explicitly as _"**Falsely acknowledged** — the
+operation reports success when the record did not commit"_ (`ADR-133:375`).
 
 This amendment qualifies both sentences for one narrow, named case: the eleven read verbs on
 `VerbRegistry::ADMISSION_DEGRADE_SAFE_VERBS` (`crates/khive-runtime/src/pack.rs`; the full list and
-rationale are in ADR-103 Amendment 3), and only when the row's own commit did not happen because
-the audit lane's admission was transiently exhausted or the caller's bounded wait for it elapsed —
-`AuditTerminalReason::QueueAdmissionExhausted` or `AdmissionDeadlineExpired`, never a persistent
-commit failure. For that verb set and those two terminal reasons, the dispatch reports its
-already-computed successful read result while its own audit/accounting row is dropped best-effort.
-This is exactly failure mode 3 (falsely acknowledged) for an accounting-bearing row, deliberately
-permitted for this bounded case.
+rationale are in ADR-103 Amendment 3), and only when the row's own commit did not resolve before
+the dispatch returned because the audit lane's admission was transiently exhausted or the caller's
+bounded wait for it elapsed — `AuditTerminalReason::QueueAdmissionExhausted` or
+`AdmissionDeadlineExpired`, never a persistent commit failure. For that verb set and those two
+terminal reasons, the dispatch reports its already-computed successful read result without waiting
+on its own audit/accounting row. The two reasons are not the same fact, though, and this amendment
+does not treat them as one:
+
+- **`QueueAdmissionExhausted`** — the row was refused before it could be enqueued. It never shares a
+  generation with anyone and will never commit. This is exactly failure mode 3 (falsely
+  acknowledged) for an accounting-bearing row: the dispatch reports success and the record is a
+  confirmed, terminal non-commit.
+- **`AdmissionDeadlineExpired`** — the row was already enqueued when the caller's bounded wait
+  elapsed. It is not dropped: the generation driver still commits or terminally fails it,
+  independently of the caller's timeout, so at the moment the dispatch returns its outcome is
+  unresolved rather than known-lost. This amendment permits the dispatch to return before that
+  resolution is known, which is still a departure from D2/D4's "must not report success before
+  commit" language, but it is a weaker claim than failure mode 3 as originally defined — the record
+  is not (yet) known false, only not yet confirmed.
+
+Both are counted on separate diagnostics counters precisely so an operator can tell a confirmed
+loss from an unresolved one — see ADR-103 Amendment 3.
 
 **Why this is a scoped exception and not a reopening of D4/INV-1 generally:**
 


### PR DESCRIPTION
## Summary

Read dispatches must not fail just because the audit lane's own admission is
transiently exhausted. Before this change, `append_audit_event_best_effort`
treated a `QueueAdmissionExhausted` or `AdmissionDeadlineExpired` outcome on a
dispatch's own audit row the same as any other obligation failure: it failed
the caller's already-computed successful read to protect a row the read never
needed as strictly as a write does.

This PR fixes that for a fixed, explicit allowlist of read verbs, distinguishes
queue refusal from deadline expiry in the audit batch, makes the resulting
accounting loss a counted production diagnostic, and amends the accepted
resource-attribution and incidental-write contracts to state the trade-off
explicitly instead of leaving it implicit.

## What changed

- **An explicit, fail-closed allowlist**, not a bare category check.
  `VerbRegistry::ADMISSION_DEGRADE_SAFE_VERBS` names exactly eleven verbs:
  `get`, `list`, `stats`, `search`, `neighbors`, `traverse`, `context`, `query`,
  `resolve`, `whoami`, `verbs`. A verb must be both declared
  `VerbCategory::Assertive` *and* on this list before its own per-dispatch
  audit row is eligible to degrade under admission pressure. `VerbCategory::Assertive`
  alone is not a safe proxy — two Assertive handlers are deliberately excluded:
  `memory.recall` (dispatches a background accounting write of its own) and
  `db_diagnostics` (performs physical checkpoint I/O). A census test
  (`admission_degrade_safe_verbs_are_registered_assertive`) re-derives each
  allowlisted verb's category from the live pack source and asserts neither
  excluded verb can be silently re-added.
- **Every other verb keeps hard-fail semantics.** Writes, non-allowlisted
  Assertive handlers, gate-denial rows, unknown-verb rows, and `git.digest`
  receipts are unaffected: a persistent or admission-pressure commit failure
  on their audit row still fails the dispatch, exactly as before this PR.
- **Queue refusal and deadline expiry are handled explicitly and distinctly**
  in the audit batch, rather than collapsed into one failure shape.
- **The accounting consequence is explicit and measured, not silent.** Under
  admission pressure, an allowlisted verb's audit row — which under ADR-103
  also carries the `resource.cost_unit` accounting payload — is dropped
  best-effort while the caller still receives the read's successful result.
  This means `brain.event_counts`'s cost totals undercount those eleven verbs
  by whatever was dropped this way. That loss is now visible: every drop
  increments a dedicated counter that is threaded through
  `VerbRegistry::audit_batch_metrics()` into
  `db_diagnostics`'s `writer_contention.audit_admission_degraded_obligations`
  field, so an operator can read the undercount directly instead of inferring
  it from a cost-total discrepancy.
- **The accepted contract is amended, not silently reinterpreted.** ADR-103
  gains Amendment 3, and ADR-133 gains Amendment 1, both stating precisely
  what is and is not permitted: the exception is scoped to the eleven
  allowlisted verbs and to the two admission-pressure terminal reasons
  (never a persistent store failure), and it does not touch any write or any
  non-allowlisted handler.

## Where to look

- `crates/khive-runtime/src/pack.rs` — the allowlist, the opt-in check, the
  admission-degrade branch in `append_audit_event_best_effort`, the
  now-production-visible `AUDIT_ADMISSION_DEGRADED_OBLIGATIONS` counter, and
  the census test.
- `crates/khive-runtime/src/audit_batch.rs` — the `QueueAdmissionExhausted` /
  `AdmissionDeadlineExpired` distinction.
- `crates/khive-db/src/diagnostics.rs` — the new
  `audit_admission_degraded_obligations` diagnostics field.
- `crates/khive-runtime/tests/read_verb_admission_exhaustion.rs` — end-to-end
  coverage for both the queue-refusal and deadline-expiry paths, including an
  assertion that the production diagnostics accessor reports the same count
  as the raw counter.
- `docs/adr/ADR-103-resource-attribution-model.md` (Amendment 3) and
  `docs/adr/ADR-133-incidental-writes-off-the-request-hot-path.md`
  (Amendment 1) — the contract amendments.
