### PR TITLE
fix(db): bound cached-reader WAL pin via read-transaction age eviction

### DIFF
--- a/crates/khive-db/docs/api/checkpoint.md
+++ b/crates/khive-db/docs/api/checkpoint.md
@@ -137,14 +137,33 @@ DEFERRED`-then-reuse path used by multi-call GQL/SPARQL cursors and any
 caller-issued `BEGIN`) reads `PoolConfig::read_tx_max_age` — the same
 `KHIVE_TX_MAX_AGE_SECS` value this sweep uses — on every reuse of the handle.
 Once the admitted transaction's age reaches that bound, the next call is
-refused, the transaction is rolled back, and the connection is returned to
-the pool ready for a fresh snapshot; the refusal is `StorageError::Transaction`
-(`is_retryable() == true`) and is counted in
-`checkpoint::read_tx_max_age_evictions()` (surfaced as
-`checkpoint_counters.read_tx_max_age_evictions` in `db_diagnostics`). This
-bounds how long a periodically-reused reader (a long-lived MCP session that
-keeps calling in) can keep extending its pin, closing the #1812/#1876 gap for
-that case. It does **not** cover a transaction abandoned mid-flight with no
+refused and the transaction is rolled back. Two outcomes are possible,
+distinguished by dedicated `StorageError` variants (both
+`is_retryable() == true` and both counted in
+`checkpoint::read_tx_max_age_evictions()`, surfaced as
+`checkpoint_counters.read_tx_max_age_evictions` in `db_diagnostics`):
+
+- **Clean rollback** — `ROLLBACK` succeeds and autocommit is restored. The
+  connection is returned to the pool ready for a fresh snapshot, and the
+  refusal is `StorageError::ReadTransactionAgeEvicted { operation,
+  max_age_secs }`.
+- **Failed cleanup** — `ROLLBACK` is denied (e.g. by an authorizer hook) or
+  errors outright, or it reports success without actually restoring
+  autocommit. The poisoned connection is discarded instead of being returned
+  to the pool, and the refusal is
+  `StorageError::ReadTransactionAgeEvictionCleanupFailed { operation,
+  max_age_secs, message }`, whose `message` names which of the two cleanup
+  failures occurred. The age check itself still ran before any read on the
+  connection, so retrying on a fresh connection remains just as safe as the
+  clean-rollback case.
+
+Both variants map to the same retryable `read_tx_age_evicted` wire stage at
+the MCP boundary (`khive_runtime::error::READ_TX_AGE_EVICTED_STAGE`); the
+rendered `message` field is what a caller reads to tell the two outcomes
+apart. This bounds how long a periodically-reused reader (a long-lived MCP
+session that keeps calling in) can keep extending its pin, closing the
+#1812/#1876 gap for that case. It does **not** cover a transaction abandoned
+mid-flight with no
 further calls at all: `rusqlite::Connection` is thread-owned and not `Sync`,
 and a genuinely idle connection has no in-flight statement for
 `sqlite3_interrupt` to act on, so reaching *that* connection from outside

--- a/crates/khive-db/docs/api/checkpoint.md
+++ b/crates/khive-db/docs/api/checkpoint.md
@@ -127,9 +127,30 @@ below→above crossing (same debounce idiom as the WAL-pressure ladder — a
 sustained stale span logs once per rung, not once per tick), also re-arming
 both rungs if the oldest entry's identity changes between ticks so a
 departed span's latched state cannot suppress its replacement. This is
-visibility, not reclamation: nothing here force-closes a stale span,
-matching the ADR's own accepted gap for a transaction "held idle across an
-await with no further calls."
+visibility, not reclamation: nothing in `TxAgeSweepState` force-closes a
+stale span, matching the ADR's own accepted gap for a transaction "held idle
+across an await with no further calls."
+
+**The cooperative stale-op guard does exist for one span shape (#1846).**
+`sql_bridge.rs`'s cached-reader explicit read transaction (the `BEGIN
+DEFERRED`-then-reuse path used by multi-call GQL/SPARQL cursors and any
+caller-issued `BEGIN`) reads `PoolConfig::read_tx_max_age` — the same
+`KHIVE_TX_MAX_AGE_SECS` value this sweep uses — on every reuse of the handle.
+Once the admitted transaction's age reaches that bound, the next call is
+refused, the transaction is rolled back, and the connection is returned to
+the pool ready for a fresh snapshot; the refusal is `StorageError::Transaction`
+(`is_retryable() == true`) and is counted in
+`checkpoint::read_tx_max_age_evictions()` (surfaced as
+`checkpoint_counters.read_tx_max_age_evictions` in `db_diagnostics`). This
+bounds how long a periodically-reused reader (a long-lived MCP session that
+keeps calling in) can keep extending its pin, closing the #1812/#1876 gap for
+that case. It does **not** cover a transaction abandoned mid-flight with no
+further calls at all: `rusqlite::Connection` is thread-owned and not `Sync`,
+and a genuinely idle connection has no in-flight statement for
+`sqlite3_interrupt` to act on, so reaching *that* connection from outside
+would need a live, forcibly-interruptible handle registry the pool does not
+keep today. That remains open design work, not something this change
+attempts.
 
 ## Metrics read-surface (load/perf harness)
 

--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -101,6 +101,13 @@ static CHECKPOINT_LIFECYCLE_APPEND_FAILURES: AtomicU64 = AtomicU64::new(0);
 /// was full, closed, or could not serialize the payload.
 static CHECKPOINT_LIFECYCLE_ENQUEUE_DROPS: AtomicU64 = AtomicU64::new(0);
 
+/// Count of cached-reader explicit read transactions rolled back on reuse
+/// for exceeding `read_tx_max_age` (#1846), across this process's lifetime.
+/// Unlike the Plank 1 sweep above, this is reclamation, not just visibility:
+/// each count here is a WAL snapshot that was actually released rather than
+/// merely logged as stale. See `sql_bridge.rs::execute_standalone_read`.
+static READ_TX_MAX_AGE_EVICTIONS: AtomicU64 = AtomicU64::new(0);
+
 /// One backend-scoped observation produced by the periodic checkpoint task's
 /// own PASSIVE pass. Logical frame counts and the physical `-wal` allocation
 /// are intentionally separate: SQLite may retain/reuse the sidecar after the
@@ -244,6 +251,21 @@ pub fn checkpoint_lifecycle_append_failures() -> u64 {
     CHECKPOINT_LIFECYCLE_APPEND_FAILURES.load(Ordering::Relaxed)
 }
 
+/// Total cached-reader read transactions rolled back on reuse for exceeding
+/// `read_tx_max_age` (#1846), across this process's lifetime.
+pub fn read_tx_max_age_evictions() -> u64 {
+    READ_TX_MAX_AGE_EVICTIONS.load(Ordering::Relaxed)
+}
+
+/// Records one cached-reader read transaction rolled back on reuse for
+/// exceeding `read_tx_max_age`. Called from `sql_bridge.rs` at the point the
+/// rollback is issued, regardless of whether the rollback itself succeeds —
+/// this counts the eviction *attempt*, matching the `truncate_attempts`
+/// naming convention above.
+pub(crate) fn note_read_tx_max_age_eviction() {
+    READ_TX_MAX_AGE_EVICTIONS.fetch_add(1, Ordering::Relaxed);
+}
+
 /// Total checkpoint lifecycle transitions rejected before append.
 pub fn checkpoint_lifecycle_enqueue_drops() -> u64 {
     CHECKPOINT_LIFECYCLE_ENQUEUE_DROPS.load(Ordering::Relaxed)
@@ -294,6 +316,7 @@ pub(crate) fn reset_checkpoint_metrics_for_tests() {
     CHECKPOINT_LIFECYCLE_APPEND_ATTEMPTS.store(0, Ordering::Relaxed);
     CHECKPOINT_LIFECYCLE_APPEND_FAILURES.store(0, Ordering::Relaxed);
     CHECKPOINT_LIFECYCLE_ENQUEUE_DROPS.store(0, Ordering::Relaxed);
+    READ_TX_MAX_AGE_EVICTIONS.store(0, Ordering::Relaxed);
 }
 
 /// Outcome of a single checkpoint attempt.
@@ -399,9 +422,16 @@ pub struct CheckpointConfig {
     pub tx_warn_secs: Duration,
 
     /// ADR-091 Plank 1 hard cap: age past which the same sweep escalates the
-    /// oldest registry entry to `tracing::error!`. This is visibility only —
-    /// nothing here can force-close a stale span; see
-    /// `crates/khive-db/docs/design.md` for why.
+    /// oldest registry entry to `tracing::error!`. The sweep itself is
+    /// visibility only — nothing in `TxAgeSweepState` force-closes a stale
+    /// span. `sql_bridge.rs`'s cached-reader read-transaction path shares
+    /// this exact value (via `PoolConfig::read_tx_max_age`, #1846) to
+    /// actually roll back and evict an explicit read transaction the next
+    /// time its handle is reused past this age — reclamation for the
+    /// "reused periodically" case, not the "held idle with no further calls"
+    /// case the ADR named as its accepted gap; see
+    /// `crates/khive-db/docs/api/checkpoint.md`'s Plank 1 section for the
+    /// distinction and why the latter remains open design work.
     ///
     /// Overridable via `KHIVE_TX_MAX_AGE_SECS`.
     /// Default: 120 seconds.
@@ -507,7 +537,7 @@ impl CheckpointConfig {
 /// together rather than silently honored. Resetting both to the caller's
 /// defaults (rather than just clamping one) avoids guessing which of the two
 /// the operator actually meant to change.
-fn tx_age_thresholds_from_env(
+pub(crate) fn tx_age_thresholds_from_env(
     default_warn: Duration,
     default_max: Duration,
 ) -> (Duration, Duration) {

--- a/crates/khive-db/src/diagnostics.rs
+++ b/crates/khive-db/src/diagnostics.rs
@@ -134,6 +134,10 @@ pub struct CheckpointCounters {
     pub checkpoint_lifecycle_append_attempts: u64,
     pub checkpoint_lifecycle_append_failures: u64,
     pub checkpoint_lifecycle_enqueue_drops: u64,
+    /// Cached-reader read transactions rolled back on reuse for exceeding
+    /// `read_tx_max_age` (#1846) — the count of WAL snapshots actually
+    /// released by that bound, not merely logged as stale.
+    pub read_tx_max_age_evictions: u64,
 }
 
 /// Snapshot the process-global ADR-091 counters.
@@ -152,6 +156,7 @@ pub fn checkpoint_counters() -> CheckpointCounters {
         checkpoint_lifecycle_append_attempts: checkpoint::checkpoint_lifecycle_append_attempts(),
         checkpoint_lifecycle_append_failures: checkpoint::checkpoint_lifecycle_append_failures(),
         checkpoint_lifecycle_enqueue_drops: checkpoint::checkpoint_lifecycle_enqueue_drops(),
+        read_tx_max_age_evictions: checkpoint::read_tx_max_age_evictions(),
     }
 }
 
@@ -1296,6 +1301,7 @@ mod tests {
             "checkpoint_lifecycle_append_attempts",
             "checkpoint_lifecycle_append_failures",
             "checkpoint_lifecycle_enqueue_drops",
+            "read_tx_max_age_evictions",
         ] {
             assert!(counters.get(key).is_some(), "counter {key} must be present");
         }
@@ -1430,6 +1436,7 @@ mod tests {
             checkpoint_lifecycle_append_attempts: 0,
             checkpoint_lifecycle_append_failures: 0,
             checkpoint_lifecycle_enqueue_drops: 0,
+            read_tx_max_age_evictions: 0,
         };
         let json = serde_json::to_value(counters).expect("serializes");
         assert!(json["last_observed_wal_pages"].is_null());

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -281,6 +281,16 @@ pub struct PoolConfig {
     ///
     /// Overridable via `KHIVE_WRITE_ADMISSION_DEADLINE_MS`.
     pub write_admission_deadline_ms: u64,
+    /// Maximum age an explicit cached-reader read transaction
+    /// (`sql_bridge`'s `BEGIN`-then-reuse path) may reach before its next use
+    /// is refused and it is rolled back instead of extending its WAL
+    /// snapshot further (#1846). Shares `KHIVE_TX_MAX_AGE_SECS` with the
+    /// ADR-091 Plank 1 visibility sweep in `checkpoint.rs` so one knob
+    /// governs both when an operator is warned about a stale reader and when
+    /// that reader's snapshot is actually released.
+    ///
+    /// Overridable via `KHIVE_TX_MAX_AGE_SECS`. Default: 120 seconds.
+    pub read_tx_max_age: Duration,
 }
 
 /// ADR-131 Decision 2's validated range for `write_admission_deadline_ms`.
@@ -333,6 +343,11 @@ impl Default for PoolConfig {
                 .ok()
                 .and_then(|v| v.parse::<u64>().ok())
                 .unwrap_or(DEFAULT_WRITE_ADMISSION_DEADLINE_MS),
+            read_tx_max_age: crate::checkpoint::tx_age_thresholds_from_env(
+                Duration::from_secs(30),
+                Duration::from_secs(120),
+            )
+            .1,
         }
     }
 }

--- a/crates/khive-db/src/sql_bridge.rs
+++ b/crates/khive-db/src/sql_bridge.rs
@@ -8,6 +8,7 @@
 
 use std::any::Any;
 use std::sync::Arc;
+use std::time::Instant;
 
 use async_trait::async_trait;
 
@@ -893,6 +894,12 @@ const CACHED_READ_TRANSACTION_LABEL: &str = "sql_bridge_cached_read_transaction"
 struct CachedReadTransaction {
     _slot: OwnedSemaphorePermit,
     _tx_handle: khive_storage::tx_registry::TxHandle,
+    /// When this explicit `BEGIN` was admitted. Read on every subsequent
+    /// reuse of the owning cached-reader handle (#1846): a transaction whose
+    /// age has crossed `read_tx_max_age` is rolled back instead of being
+    /// extended by another call, bounding how long any one reader can pin
+    /// the WAL snapshot regardless of how many further requests it makes.
+    opened_at: Instant,
 }
 
 struct StandaloneHandle {
@@ -1034,6 +1041,7 @@ where
         });
     };
     let origin = pool.origin();
+    let read_tx_max_age = pool.config().read_tx_max_age;
     let (owned_handle, result) = crate::read_cancellation::run_interruptible_read(
         StorageCapability::Sql,
         operation,
@@ -1062,6 +1070,50 @@ where
                           its transaction was rolled back before releasing the reader permit"
                         .into(),
                 })
+            } else if cached_reader
+                && entered_with_transaction
+                && owned_handle
+                    .read_transaction_slot
+                    .as_ref()
+                    .is_some_and(|tx| tx.opened_at.elapsed() >= read_tx_max_age)
+            {
+                // #1846: this handle's admitted read transaction has pinned a
+                // WAL snapshot for at least `read_tx_max_age` — reject the
+                // continuation and roll it back instead of extending the pin
+                // for another call, regardless of what the caller asked for.
+                crate::checkpoint::note_read_tx_max_age_eviction();
+                match owned_handle.conn.execute_batch("ROLLBACK") {
+                    Ok(()) if owned_handle.conn.is_autocommit() => {
+                        drop(owned_handle.read_transaction_slot.take());
+                        Err(StorageError::Transaction {
+                            operation: operation.into(),
+                            message: format!(
+                                "cached read-only transaction exceeded the maximum read-transaction \
+                                 age ({}s) and was rolled back; retry to open a fresh read snapshot",
+                                read_tx_max_age.as_secs()
+                            ),
+                        })
+                    }
+                    Ok(()) => {
+                        restore_handle = false;
+                        Err(StorageError::Transaction {
+                            operation: operation.into(),
+                            message: "expired read transaction rollback did not restore \
+                                  autocommit; the connection was discarded"
+                                .into(),
+                        })
+                    }
+                    Err(error) => {
+                        restore_handle = false;
+                        Err(StorageError::Transaction {
+                            operation: operation.into(),
+                            message: format!(
+                                "failed to roll back an expired read transaction ({error}); \
+                                 the connection was discarded"
+                            ),
+                        })
+                    }
+                }
             } else if cached_reader && entered_with_transaction {
                 match transaction_control {
                     None | Some(CachedReadTransactionControl::Finish(_)) => {
@@ -1211,6 +1263,7 @@ where
                             owned_handle.read_transaction_slot = Some(CachedReadTransaction {
                                 _slot: slot,
                                 _tx_handle: tx_handle,
+                                opened_at: Instant::now(),
                             });
                         }
                         None => {
@@ -3926,6 +3979,88 @@ mod tests {
             })
             .await
             .expect("a new operation must run after the transactional handle drops");
+    }
+
+    /// #1846 regression: a cached-reader explicit read transaction that is
+    /// never explicitly finished (a stuck/leaked caller that keeps reusing
+    /// the handle without COMMIT/ROLLBACK) would otherwise pin the WAL
+    /// snapshot open for as long as the caller kept calling in. Without the
+    /// age check this reddens: the second `query_all` would return the row
+    /// materialized inside the still-open transaction instead of an error,
+    /// and `tx_registry::oldest_for` would keep reporting the same span
+    /// open past `read_tx_max_age`.
+    #[tokio::test]
+    #[serial_test::serial(tx_registry)]
+    async fn expired_cached_reader_transaction_is_rolled_back_on_reuse() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = PoolConfig {
+            path: Some(dir.path().join("sql_bridge_reader_tx_max_age.db")),
+            max_readers: 1,
+            checkout_timeout: std::time::Duration::from_millis(20),
+            read_tx_max_age: std::time::Duration::from_millis(20),
+            ..PoolConfig::default()
+        };
+        let pool = Arc::new(ConnectionPool::new(config).unwrap());
+        let origin_view = database_tx_view(&pool);
+        let bridge = SqlBridge::new(Arc::clone(&pool), true);
+        let mut reader = bridge.reader().await.unwrap();
+
+        reader
+            .query_all(SqlStatement {
+                sql: "BEGIN DEFERRED".into(),
+                params: vec![],
+                label: None,
+            })
+            .await
+            .expect("begin admitted transaction");
+        reader
+            .query_all(SqlStatement {
+                sql: "SELECT * FROM sqlite_schema".into(),
+                params: vec![],
+                label: None,
+            })
+            .await
+            .expect("materialize read snapshot");
+        assert!(
+            khive_storage::tx_registry::oldest_for(&origin_view).is_some(),
+            "the open transaction must be registered before it ages out"
+        );
+
+        tokio::time::sleep(std::time::Duration::from_millis(40)).await;
+
+        let evictions_before = crate::checkpoint::read_tx_max_age_evictions();
+        let error = reader
+            .query_all(SqlStatement {
+                sql: "SELECT * FROM sqlite_schema".into(),
+                params: vec![],
+                label: None,
+            })
+            .await
+            .expect_err("reusing a transaction past read_tx_max_age must be refused");
+        assert!(
+            error.is_retryable(),
+            "an evicted-transaction error must be retryable so the caller can open a fresh \
+             snapshot: {error}"
+        );
+        assert_eq!(
+            crate::checkpoint::read_tx_max_age_evictions(),
+            evictions_before + 1,
+            "the eviction must be counted in the #1846 diagnostics gauge"
+        );
+        assert!(
+            khive_storage::tx_registry::oldest_for(&origin_view).is_none(),
+            "the expired transaction must be rolled back and deregistered rather than \
+             continuing to pin the WAL snapshot"
+        );
+
+        reader
+            .query_all(SqlStatement {
+                sql: "SELECT * FROM sqlite_schema".into(),
+                params: vec![],
+                label: None,
+            })
+            .await
+            .expect("the handle must remain usable for a fresh autocommit read after eviction");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/khive-db/src/sql_bridge.rs
+++ b/crates/khive-db/src/sql_bridge.rs
@@ -1092,21 +1092,18 @@ where
                     }
                     Ok(()) => {
                         restore_handle = false;
-                        Err(StorageError::Transaction {
+                        Err(StorageError::ReadTransactionAgeEvictionCleanupFailed {
                             operation: operation.into(),
-                            message: "expired read transaction rollback did not restore \
-                                  autocommit; the connection was discarded"
-                                .into(),
+                            max_age_secs: read_tx_max_age.as_secs(),
+                            message: "rollback did not restore autocommit".into(),
                         })
                     }
                     Err(error) => {
                         restore_handle = false;
-                        Err(StorageError::Transaction {
+                        Err(StorageError::ReadTransactionAgeEvictionCleanupFailed {
                             operation: operation.into(),
-                            message: format!(
-                                "failed to roll back an expired read transaction ({error}); \
-                                 the connection was discarded"
-                            ),
+                            max_age_secs: read_tx_max_age.as_secs(),
+                            message: format!("rollback failed: {error}"),
                         })
                     }
                 }
@@ -4038,6 +4035,22 @@ mod tests {
             "an evicted-transaction error must be retryable so the caller can open a fresh \
              snapshot: {error}"
         );
+        match &error {
+            StorageError::ReadTransactionAgeEvicted {
+                operation,
+                max_age_secs,
+            } => {
+                assert_eq!(operation.as_ref(), "query_all");
+                assert_eq!(
+                    *max_age_secs, 0,
+                    "a 20ms read_tx_max_age truncates to 0 whole seconds"
+                );
+            }
+            other => panic!(
+                "a clean age-triggered rollback must surface the dedicated \
+                 ReadTransactionAgeEvicted variant, not a generic classification: {other:?}"
+            ),
+        }
         assert_eq!(
             crate::checkpoint::read_tx_max_age_evictions(),
             evictions_before + 1,
@@ -4150,10 +4163,29 @@ mod tests {
             "even a failed cleanup rollback must remain classified retryable so callers open a \
              fresh handle: {error}"
         );
-        assert!(
-            error.to_string().contains("failed to roll back"),
-            "the failure must be attributable to the denied ROLLBACK, not silent success: {error}"
-        );
+        match &error {
+            StorageError::ReadTransactionAgeEvictionCleanupFailed {
+                operation,
+                max_age_secs,
+                message,
+            } => {
+                assert_eq!(operation.as_ref(), "query_all");
+                assert_eq!(
+                    *max_age_secs, 0,
+                    "a 20ms read_tx_max_age truncates to 0 whole seconds"
+                );
+                assert!(
+                    message.contains("rollback failed"),
+                    "the failure must be attributable to the denied ROLLBACK, not silent \
+                     success: {message}"
+                );
+            }
+            other => panic!(
+                "a denied cleanup rollback must surface the dedicated \
+                 ReadTransactionAgeEvictionCleanupFailed variant, not a generic Transaction \
+                 error the caller cannot machine-detect: {other:?}"
+            ),
+        }
         assert_eq!(
             crate::checkpoint::read_tx_max_age_evictions(),
             evictions_before + 1,

--- a/crates/khive-db/src/sql_bridge.rs
+++ b/crates/khive-db/src/sql_bridge.rs
@@ -1085,13 +1085,9 @@ where
                 match owned_handle.conn.execute_batch("ROLLBACK") {
                     Ok(()) if owned_handle.conn.is_autocommit() => {
                         drop(owned_handle.read_transaction_slot.take());
-                        Err(StorageError::Transaction {
+                        Err(StorageError::ReadTransactionAgeEvicted {
                             operation: operation.into(),
-                            message: format!(
-                                "cached read-only transaction exceeded the maximum read-transaction \
-                                 age ({}s) and was rolled back; retry to open a fresh read snapshot",
-                                read_tx_max_age.as_secs()
-                            ),
+                            max_age_secs: read_tx_max_age.as_secs(),
                         })
                     }
                     Ok(()) => {
@@ -4061,6 +4057,138 @@ mod tests {
             })
             .await
             .expect("the handle must remain usable for a fresh autocommit read after eviction");
+    }
+
+    /// #1846 follow-up: the age-eviction branch
+    /// has a rollback-failure path distinct from
+    /// `failed_cached_reader_rollback_deregisters_only_when_connection_is_discarded`
+    /// above (which covers an explicit caller-issued `ROLLBACK`, not the
+    /// age-triggered cleanup rollback). When SQLite denies the age-triggered
+    /// `ROLLBACK`, the branch must still discard the poisoned connection,
+    /// deregister the expired transaction span, and release the reader
+    /// admission permit rather than leaking either.
+    #[tokio::test]
+    #[serial_test::serial(tx_registry)]
+    async fn expired_cached_reader_transaction_rollback_denial_discards_connection_and_releases_admission(
+    ) {
+        use rusqlite::hooks::{AuthAction, AuthContext, Authorization, TransactionOperation};
+
+        fn deny_rollback(ctx: AuthContext<'_>) -> Authorization {
+            match ctx.action {
+                AuthAction::Transaction {
+                    operation: TransactionOperation::Rollback,
+                } => Authorization::Deny,
+                _ => Authorization::Allow,
+            }
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let config = PoolConfig {
+            path: Some(
+                dir.path()
+                    .join("sql_bridge_reader_tx_max_age_rollback_denied.db"),
+            ),
+            max_readers: 1,
+            checkout_timeout: std::time::Duration::from_millis(20),
+            read_tx_max_age: std::time::Duration::from_millis(20),
+            ..PoolConfig::default()
+        };
+        let pool = Arc::new(ConnectionPool::new(config).unwrap());
+        let origin_view = database_tx_view(&pool);
+        let conn = open_standalone_reader(&pool).unwrap();
+        let mut reader = SqliteReader {
+            handle: Some(StandaloneHandle {
+                conn,
+                _retained_slot: None,
+                read_transaction_slot: None,
+            }),
+            pool: Arc::clone(&pool),
+        };
+
+        reader
+            .query_all(SqlStatement {
+                sql: "BEGIN DEFERRED".into(),
+                params: vec![],
+                label: None,
+            })
+            .await
+            .expect("begin admitted transaction");
+        reader
+            .query_all(SqlStatement {
+                sql: "SELECT * FROM sqlite_schema".into(),
+                params: vec![],
+                label: None,
+            })
+            .await
+            .expect("materialize read snapshot");
+        assert!(
+            khive_storage::tx_registry::oldest_for(&origin_view).is_some(),
+            "the open transaction must be registered before it ages out"
+        );
+
+        reader
+            .handle
+            .as_ref()
+            .expect("reader must retain its connection")
+            .conn
+            .authorizer(Some(deny_rollback))
+            .unwrap();
+
+        tokio::time::sleep(std::time::Duration::from_millis(40)).await;
+
+        let evictions_before = crate::checkpoint::read_tx_max_age_evictions();
+        let error = reader
+            .query_all(SqlStatement {
+                sql: "SELECT * FROM sqlite_schema".into(),
+                params: vec![],
+                label: None,
+            })
+            .await
+            .expect_err("a denied rollback on an expired transaction must surface an error");
+        assert!(
+            error.is_retryable(),
+            "even a failed cleanup rollback must remain classified retryable so callers open a \
+             fresh handle: {error}"
+        );
+        assert!(
+            error.to_string().contains("failed to roll back"),
+            "the failure must be attributable to the denied ROLLBACK, not silent success: {error}"
+        );
+        assert_eq!(
+            crate::checkpoint::read_tx_max_age_evictions(),
+            evictions_before + 1,
+            "the eviction attempt must still be counted even though cleanup failed"
+        );
+        assert!(
+            khive_storage::tx_registry::oldest_for(&origin_view).is_none(),
+            "a denied rollback must discard the connection and deregister the expired \
+             transaction span rather than leaking it"
+        );
+        assert_eq!(
+            pool.sql_bridge_reader_slots().available_permits(),
+            1,
+            "discarding the poisoned connection must release the reader admission slot"
+        );
+
+        let reuse = reader
+            .query_all(SqlStatement {
+                sql: "SELECT * FROM sqlite_schema".into(),
+                params: vec![],
+                label: None,
+            })
+            .await;
+        let message = match reuse {
+            Err(StorageError::Pool { message, .. }) => message,
+            other => panic!(
+                "reusing this discarded reader must fail loudly with 'connection already \
+                 consumed' rather than silently reopening; got {other:?}"
+            ),
+        };
+        assert!(
+            message.contains("connection already consumed"),
+            "expected the discarded reader's reuse error to name the pinned failure; got \
+             {message:?}"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -1896,6 +1896,13 @@ impl khive_types::Pack for ErrorInjectPack {
             category: VerbCategory::Assertive,
             params: &[],
         },
+        HandlerDef {
+            name: "read_tx_age_evicted",
+            description: "returns a typed cached-reader read-transaction age eviction error",
+            visibility: Visibility::Verb,
+            category: VerbCategory::Assertive,
+            params: &[],
+        },
     ];
 }
 
@@ -1949,6 +1956,14 @@ impl PackRuntime for ErrorInjectPack {
                 khive_storage::StorageError::AdmissionTimeout {
                     operation: "sql_bridge.writer_handle".into(),
                     timeout_ms: 30_000,
+                },
+            ));
+        }
+        if verb == "read_tx_age_evicted" {
+            return Err(RuntimeError::Storage(
+                khive_storage::StorageError::ReadTransactionAgeEvicted {
+                    operation: "sql_bridge.cached_reader".into(),
+                    max_age_secs: 120,
                 },
             ));
         }
@@ -2198,6 +2213,46 @@ async fn storage_admission_timeout_survives_storage_runtime_and_mcp_wire() -> an
             "retry_after_ms": serde_json::Value::Null,
         }),
         "an admission deadline that expired before acquisition must stay a retryable resource failure on the wire"
+    );
+
+    Ok(())
+}
+
+/// #1846 / PR #2229 follow-up: a cached read-only transaction evicted for
+/// pinning a WAL snapshot past `read_tx_max_age` must remain a
+/// machine-detectable retryable failure once it crosses the normal MCP
+/// dispatch boundary — not just at the direct `StorageError::is_retryable()`
+/// call site. Without `RuntimeError::retryable_failure_context()` special-
+/// casing `StorageError::ReadTransactionAgeEvicted`, this would flatten to
+/// `runtime_error_value`'s plain-string fallback and lose `retryable: true`.
+#[tokio::test]
+async fn read_tx_age_evicted_survives_storage_runtime_and_mcp_wire() -> anyhow::Result<()> {
+    let client = connect_error_inject().await?;
+    let result = call(
+        &client,
+        "request",
+        serde_json::json!({"ops": "read_tx_age_evicted()"}),
+    )
+    .await?;
+    let body: serde_json::Value = serde_json::from_str(&first_text(&result))?;
+    let first = &body["results"][0];
+
+    assert_eq!(first["ok"], false, "expected op failure: {first}");
+    assert_eq!(
+        first["error"],
+        serde_json::json!({
+            "kind": "unavailable",
+            "code": "read_tx_age_evicted",
+            "stage": "read_tx_age_evicted",
+            "message": "storage: cached read-only transaction exceeded the maximum read-transaction age (120s) during sql_bridge.cached_reader and was rolled back; retry to open a fresh read snapshot",
+            "retryable": true,
+            "timeout_ms": 120_000,
+            "capability": "sql",
+            "operation": "sql_bridge.cached_reader",
+            "scope": serde_json::Value::Null,
+            "retry_after_ms": serde_json::Value::Null,
+        }),
+        "a read-age eviction must stay a caller-visible retryable unavailable on the wire"
     );
 
     Ok(())

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -1903,6 +1903,14 @@ impl khive_types::Pack for ErrorInjectPack {
             category: VerbCategory::Assertive,
             params: &[],
         },
+        HandlerDef {
+            name: "read_tx_age_eviction_cleanup_failed",
+            description: "returns a typed cached-reader read-transaction age eviction error \
+                whose cleanup rollback was denied or failed",
+            visibility: Visibility::Verb,
+            category: VerbCategory::Assertive,
+            params: &[],
+        },
     ];
 }
 
@@ -1964,6 +1972,15 @@ impl PackRuntime for ErrorInjectPack {
                 khive_storage::StorageError::ReadTransactionAgeEvicted {
                     operation: "sql_bridge.cached_reader".into(),
                     max_age_secs: 120,
+                },
+            ));
+        }
+        if verb == "read_tx_age_eviction_cleanup_failed" {
+            return Err(RuntimeError::Storage(
+                khive_storage::StorageError::ReadTransactionAgeEvictionCleanupFailed {
+                    operation: "sql_bridge.cached_reader".into(),
+                    max_age_secs: 120,
+                    message: "rollback failed: disk I/O error".into(),
                 },
             ));
         }
@@ -2253,6 +2270,48 @@ async fn read_tx_age_evicted_survives_storage_runtime_and_mcp_wire() -> anyhow::
             "retry_after_ms": serde_json::Value::Null,
         }),
         "a read-age eviction must stay a caller-visible retryable unavailable on the wire"
+    );
+
+    Ok(())
+}
+
+/// PR #2229 round-2 follow-up: a cached read-only transaction's age-eviction
+/// rollback can also be denied or fail outright rather than cleanly
+/// restoring autocommit. That cleanup-failure outcome must reach the MCP
+/// wire as the same retryable `read_tx_age_evicted` stage as a clean
+/// eviction — not fall back to `runtime_error_value`'s plain-string
+/// classification, which is what happens if the production branch regresses
+/// to generic `StorageError::Transaction`.
+#[tokio::test]
+async fn read_tx_age_eviction_cleanup_failure_survives_storage_runtime_and_mcp_wire(
+) -> anyhow::Result<()> {
+    let client = connect_error_inject().await?;
+    let result = call(
+        &client,
+        "request",
+        serde_json::json!({"ops": "read_tx_age_eviction_cleanup_failed()"}),
+    )
+    .await?;
+    let body: serde_json::Value = serde_json::from_str(&first_text(&result))?;
+    let first = &body["results"][0];
+
+    assert_eq!(first["ok"], false, "expected op failure: {first}");
+    assert_eq!(
+        first["error"],
+        serde_json::json!({
+            "kind": "unavailable",
+            "code": "read_tx_age_evicted",
+            "stage": "read_tx_age_evicted",
+            "message": "storage: cached read-only transaction exceeded the maximum read-transaction age (120s) during sql_bridge.cached_reader but could not be cleanly rolled back (rollback failed: disk I/O error); the connection was discarded, retry to open a fresh read snapshot",
+            "retryable": true,
+            "timeout_ms": 120_000,
+            "capability": "sql",
+            "operation": "sql_bridge.cached_reader",
+            "scope": serde_json::Value::Null,
+            "retry_after_ms": serde_json::Value::Null,
+        }),
+        "a denied/failed cleanup rollback must stay a caller-visible retryable unavailable on \
+         the wire, distinguishable in the message from a clean eviction"
     );
 
     Ok(())

--- a/crates/khive-runtime/src/error.rs
+++ b/crates/khive-runtime/src/error.rs
@@ -31,7 +31,12 @@ pub const STORAGE_ADMISSION_TIMEOUT_STAGE: &str = "storage_admission_timeout";
 /// rolled back after pinning a WAL snapshot past the configured
 /// `read_tx_max_age` bound (#1846). Always safe to retry: the eviction only
 /// ever fires on a read-only handle, so no side effect can exist for a
-/// retry to duplicate.
+/// retry to duplicate. Shared by both
+/// [`khive_storage::StorageError::ReadTransactionAgeEvicted`] (clean
+/// rollback) and
+/// [`khive_storage::StorageError::ReadTransactionAgeEvictionCleanupFailed`]
+/// (rollback denied or failed outright) — the rendered `message` field
+/// distinguishes the two; retry behavior is identical for both.
 pub const READ_TX_AGE_EVICTED_STAGE: &str = "read_tx_age_evicted";
 
 /// Stable ADR-131:251 `scope` discriminator carried on a
@@ -637,6 +642,23 @@ impl RuntimeError {
                 retry_after_ms: None,
             });
         }
+        if let Self::Storage(
+            khive_storage::StorageError::ReadTransactionAgeEvictionCleanupFailed {
+                operation,
+                max_age_secs,
+                ..
+            },
+        ) = self
+        {
+            return Some(RetryableFailureContext {
+                stage: READ_TX_AGE_EVICTED_STAGE,
+                timeout: Duration::from_secs(*max_age_secs),
+                capability: Some(khive_storage::StorageCapability::Sql),
+                operation: Some(operation.to_string()),
+                scope: None,
+                retry_after_ms: None,
+            });
+        }
         None
     }
 }
@@ -790,5 +812,61 @@ mod channel_ingest_failure_class_tests {
         });
         assert!(mid_flight.admission_failure_context().is_none());
         assert!(mid_flight.retryable_failure_context().is_none());
+    }
+
+    /// Binds both age-eviction outcomes a cached-reader rollback can produce
+    /// (clean rollback vs. failed/denied cleanup) to the same retryable wire
+    /// stage: a regression that reverted either branch back to generic
+    /// `StorageError::Transaction` would drop this match arm entirely and
+    /// fail here, since `Transaction` does have a `retryable_failure_context`
+    /// mapping distinct from `super::READ_TX_AGE_EVICTED_STAGE`.
+    #[test]
+    fn both_read_tx_age_eviction_outcomes_map_to_the_same_retryable_stage() {
+        let clean = RuntimeError::Storage(khive_storage::StorageError::ReadTransactionAgeEvicted {
+            operation: "query_all".into(),
+            max_age_secs: 120,
+        });
+        let clean_context = clean
+            .retryable_failure_context()
+            .expect("a clean age eviction must be typed-retryable");
+        assert_eq!(clean_context.stage, super::READ_TX_AGE_EVICTED_STAGE);
+        assert_eq!(clean_context.timeout, Duration::from_secs(120));
+        assert_eq!(clean_context.operation.as_deref(), Some("query_all"));
+        assert_eq!(
+            clean_context.capability,
+            Some(khive_storage::StorageCapability::Sql)
+        );
+
+        let cleanup_failed = RuntimeError::Storage(
+            khive_storage::StorageError::ReadTransactionAgeEvictionCleanupFailed {
+                operation: "query_all".into(),
+                max_age_secs: 120,
+                message: "rollback failed: disk I/O error".into(),
+            },
+        );
+        let cleanup_failed_context = cleanup_failed
+            .retryable_failure_context()
+            .expect("a failed cleanup rollback must remain typed-retryable");
+        assert_eq!(
+            cleanup_failed_context.stage,
+            super::READ_TX_AGE_EVICTED_STAGE
+        );
+        assert_eq!(cleanup_failed_context.timeout, Duration::from_secs(120));
+        assert_eq!(
+            cleanup_failed_context.operation.as_deref(),
+            Some("query_all")
+        );
+        assert_eq!(
+            cleanup_failed_context.capability,
+            Some(khive_storage::StorageCapability::Sql)
+        );
+
+        assert_ne!(
+            clean.to_string(),
+            cleanup_failed.to_string(),
+            "the rendered message must distinguish a clean eviction from a failed cleanup even \
+             though both map to the same wire stage"
+        );
+        assert!(cleanup_failed.to_string().contains("rollback failed"));
     }
 }

--- a/crates/khive-runtime/src/error.rs
+++ b/crates/khive-runtime/src/error.rs
@@ -27,6 +27,13 @@ pub const WRITER_TASK_BEGIN_BUSY_STAGE: &str = "writer_task_begin_busy";
 /// failure is safe to retry.
 pub const STORAGE_ADMISSION_TIMEOUT_STAGE: &str = "storage_admission_timeout";
 
+/// Stable wire code/stage for a cached read-only transaction proactively
+/// rolled back after pinning a WAL snapshot past the configured
+/// `read_tx_max_age` bound (#1846). Always safe to retry: the eviction only
+/// ever fires on a read-only handle, so no side effect can exist for a
+/// retry to duplicate.
+pub const READ_TX_AGE_EVICTED_STAGE: &str = "read_tx_age_evicted";
+
 /// Stable ADR-131:251 `scope` discriminator carried on a
 /// [`WRITER_QUEUE_SATURATED_STAGE`] failure — distinguishes write-queue
 /// admission saturation from other `unavailable` failure kinds that share
@@ -606,17 +613,31 @@ impl RuntimeError {
         if let Some(context) = self.admission_failure_context() {
             return Some(context.into());
         }
-        let Self::Storage(khive_storage::StorageError::WriterTaskBusy { timeout_ms }) = self else {
-            return None;
-        };
-        Some(RetryableFailureContext {
-            stage: WRITER_TASK_BEGIN_BUSY_STAGE,
-            timeout: Duration::from_millis(*timeout_ms),
-            capability: None,
-            operation: Some("writer_task_begin".to_string()),
-            scope: None,
-            retry_after_ms: None,
-        })
+        if let Self::Storage(khive_storage::StorageError::WriterTaskBusy { timeout_ms }) = self {
+            return Some(RetryableFailureContext {
+                stage: WRITER_TASK_BEGIN_BUSY_STAGE,
+                timeout: Duration::from_millis(*timeout_ms),
+                capability: None,
+                operation: Some("writer_task_begin".to_string()),
+                scope: None,
+                retry_after_ms: None,
+            });
+        }
+        if let Self::Storage(khive_storage::StorageError::ReadTransactionAgeEvicted {
+            operation,
+            max_age_secs,
+        }) = self
+        {
+            return Some(RetryableFailureContext {
+                stage: READ_TX_AGE_EVICTED_STAGE,
+                timeout: Duration::from_secs(*max_age_secs),
+                capability: Some(khive_storage::StorageCapability::Sql),
+                operation: Some(operation.to_string()),
+                scope: None,
+                retry_after_ms: None,
+            });
+        }
+        None
     }
 }
 

--- a/crates/khive-storage/docs/api/error-taxonomy.md
+++ b/crates/khive-storage/docs/api/error-taxonomy.md
@@ -148,6 +148,43 @@ MCP emits `code`/`stage` of `storage_admission_timeout` with the failing
 `scope`, and `retry_after_ms` are null: the handle-slot and reader-checkout
 budgets are capability-neutral and no separate backoff policy is defined.
 
+## Typed cached-reader read-transaction age eviction
+
+`sql_bridge`'s cached-reader read path proactively rolls back an admitted
+read transaction once it has pinned a WAL snapshot past the configured
+`read_tx_max_age` (#1846). Two typed, capability-neutral, `is_retryable() ==
+true` variants report the outcome, both public and both introduced by this
+change:
+
+- `StorageError::ReadTransactionAgeEvicted { operation, max_age_secs }` — the
+  `ROLLBACK` succeeded and autocommit was restored; the connection returns to
+  the pool ready for a fresh read snapshot.
+- `StorageError::ReadTransactionAgeEvictionCleanupFailed { operation,
+  max_age_secs, message }` — the `ROLLBACK` was denied or errored, or it
+  reported success without actually restoring autocommit. The connection is
+  discarded instead of being returned to the pool. `message` names which of
+  the two cleanup failures occurred.
+
+Both are always safe to retry: the age check runs before any read on the
+connection, so no side effect exists for a retry to duplicate, regardless of
+which cleanup outcome followed. Both are distinct from the generic
+`StorageError::Transaction` variant, whose other cases (write-side ambiguity,
+unrelated rollback failures) are not uniformly safe to retry — callers must
+not detect this condition by parsing rendered text.
+
+MCP maps both variants to the same `code`/`stage` of `read_tx_age_evicted`
+(`khive_runtime::error::READ_TX_AGE_EVICTED_STAGE`), the failing `operation`,
+`capability: "sql"`, `retryable: true`, and `timeout_ms` set to
+`max_age_secs * 1000`. `scope` and `retry_after_ms` are null. The rendered
+`message` field is the only wire-visible way to distinguish a clean eviction
+from a failed cleanup.
+
+`StorageError` is a public enum without `#[non_exhaustive]`, so adding these
+two variants is a Rust source-compatibility change for downstream code that
+exhaustively matches every variant; those matches must add
+`ReadTransactionAgeEvicted` and `ReadTransactionAgeEvictionCleanupFailed`
+arms.
+
 ## `is_fts5_syntax_error`
 
 `TextSearch::search` returns the same `Driver` variant for a malformed MATCH

--- a/crates/khive-storage/src/error.rs
+++ b/crates/khive-storage/src/error.rs
@@ -154,6 +154,28 @@ pub enum StorageError {
         max_age_secs: u64,
     },
 
+    /// A cached read-only handle's admitted transaction pinned a WAL
+    /// snapshot past `read_tx_max_age`, and the proactive rollback used to
+    /// end the eviction (#1846) did not restore autocommit, or the rollback
+    /// itself failed. The connection is discarded either way rather than
+    /// returned to the pool. The age check that triggered this still ran
+    /// before any read on the connection, so — exactly like
+    /// [`StorageError::ReadTransactionAgeEvicted`] — retrying the caller's
+    /// operation on a fresh connection is always safe; this variant exists
+    /// only to keep that guarantee distinguishable from a clean eviction in
+    /// the rendered message and to keep [`StorageError::Transaction`] (whose
+    /// other cases are not uniformly safe to retry) out of this path.
+    #[error(
+        "cached read-only transaction exceeded the maximum read-transaction age \
+         ({max_age_secs}s) during {operation} but could not be cleanly rolled back \
+         ({message}); the connection was discarded, retry to open a fresh read snapshot"
+    )]
+    ReadTransactionAgeEvictionCleanupFailed {
+        operation: Cow<'static, str>,
+        max_age_secs: u64,
+        message: String,
+    },
+
     #[error("serialization failure in {capability:?}: {message}")]
     Serialization {
         capability: StorageCapability,
@@ -264,6 +286,7 @@ impl StorageError {
             | Self::AdmissionTimeout { .. }
             | Self::Transaction { .. }
             | Self::ReadTransactionAgeEvicted { .. }
+            | Self::ReadTransactionAgeEvictionCleanupFailed { .. }
             | Self::WriteQueueFull { .. }
             | Self::WriterTaskBusy { .. }
             | Self::WriterTaskTerminated { .. }
@@ -281,6 +304,7 @@ impl StorageError {
                 | Self::AdmissionTimeout { .. }
                 | Self::Transaction { .. }
                 | Self::ReadTransactionAgeEvicted { .. }
+                | Self::ReadTransactionAgeEvictionCleanupFailed { .. }
                 | Self::WriteQueueFull { .. }
                 | Self::WriterTaskBusy { .. }
         )

--- a/crates/khive-storage/src/error.rs
+++ b/crates/khive-storage/src/error.rs
@@ -136,6 +136,24 @@ pub enum StorageError {
         message: String,
     },
 
+    /// A cached read-only handle's admitted transaction pinned a WAL
+    /// snapshot past the configured `read_tx_max_age` bound and was
+    /// proactively rolled back so the next call can open a fresh snapshot
+    /// (#1846). Distinct from the generic [`StorageError::Transaction`]
+    /// variant — which also covers failed-cleanup and write-side ambiguity
+    /// cases that are not uniformly safe to retry — so callers (and MCP
+    /// dispatch) can recognize this specific, always-safe-to-retry
+    /// condition by variant rather than by parsing rendered text.
+    #[error(
+        "cached read-only transaction exceeded the maximum read-transaction age \
+         ({max_age_secs}s) during {operation} and was rolled back; retry to open a fresh \
+         read snapshot"
+    )]
+    ReadTransactionAgeEvicted {
+        operation: Cow<'static, str>,
+        max_age_secs: u64,
+    },
+
     #[error("serialization failure in {capability:?}: {message}")]
     Serialization {
         capability: StorageCapability,
@@ -245,6 +263,7 @@ impl StorageError {
             | Self::Timeout { .. }
             | Self::AdmissionTimeout { .. }
             | Self::Transaction { .. }
+            | Self::ReadTransactionAgeEvicted { .. }
             | Self::WriteQueueFull { .. }
             | Self::WriterTaskBusy { .. }
             | Self::WriterTaskTerminated { .. }
@@ -261,6 +280,7 @@ impl StorageError {
                 | Self::Timeout { .. }
                 | Self::AdmissionTimeout { .. }
                 | Self::Transaction { .. }
+                | Self::ReadTransactionAgeEvicted { .. }
                 | Self::WriteQueueFull { .. }
                 | Self::WriterTaskBusy { .. }
         )


### PR DESCRIPTION
Addresses #1846 (fixed); bounds the demonstrated case of #1876; improves #1812. #1417's idle-TRUNCATE trigger is analyzed as follow-up design, not changed here.

A cached reader holding an explicit `BEGIN`-then-reuse read transaction could pin its WAL snapshot forever, freezing PASSIVE checkpoint progress while the log grew without bound. `PoolConfig::read_tx_max_age` (env `KHIVE_TX_MAX_AGE_SECS`, default 120s — the same knob the existing age sweep logs against) now bounds that pin: on next reuse past the age cap the transaction is rolled back, the admission slot and registry span release, and the connection returns to the pool, so a retry opens a fresh snapshot.

## What the caller receives

Every age-eviction outcome is a typed, retryable error — not the generic `StorageError::Transaction` it used to be. There are two of them, and the distinction is the cleanup result, not the eviction itself:

- **`StorageError::ReadTransactionAgeEvicted`** — the rollback succeeded and autocommit was restored. The connection is clean and reusable.
- **`StorageError::ReadTransactionAgeEvictionCleanupFailed`** — the eviction happened but its cleanup did not complete, either because the rollback returned without restoring autocommit or because the rollback itself failed. The two causes stay distinguishable in the error's `message`. The affected connection is discarded rather than returned to the pool.

Both report `is_retryable() == true`, carry no capability requirement, and cross the MCP wire on the **same** stage (`read_tx_age_evicted`, `kind: "unavailable"`, `retryable: true`), so a client's retry logic treats them identically and does not need to learn a second code. The split exists so operators can tell a clean eviction from a connection that had to be thrown away; it is deliberately not a behavioral fork for callers.

**Source compatibility:** `StorageError` is not `#[non_exhaustive]`, so adding a variant is a breaking change for any downstream exhaustive `match` on it. In-tree matches are updated in this PR.

## Diagnostics

New `checkpoint_counters.read_tx_max_age_evictions` counter. Both outcomes are counted.

## Behavior note

Only the explicit BEGIN-then-reuse path is affected; autocommit reads are untouched. A transaction that legitimately needs longer than the cap must restart on its next use, or the operator raises the env knob at the cost of a larger worst-case WAL. A connection abandoned with zero further calls is out of reach of this cooperative check (connection ownership is thread-local); that tail case is stated in `docs/api/checkpoint.md` as follow-up.

## Tests

- `sql_bridge` regression proving the eviction fires past the cap, the span leaves the registry, the counter advances, and the handle stays usable; verified to fail with the age check disabled.
- Per-variant assertions binding each producer arm to its exact typed variant, so a regression to the generic error reddens.
- An MCP integration test driving the **cleanup-failure** variant through the real in-process transport and asserting the exact wire JSON (`kind`, `code`/`stage`, `retryable`, `timeout_ms`, `capability`, and a message naming the rollback failure). The prior test covered only the clean-eviction variant.

Full khive-db suite green.
