### PR TITLE
fix(mcp,runtime): idle-session timeout for stdio bridges; refuse duplicate daemon boot

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2463,6 +2463,7 @@ dependencies = [
  "khive-gate",
  "khive-gate-rego",
  "khive-query",
+ "khive-runtime",
  "khive-score",
  "khive-storage",
  "khive-types",

--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -1152,8 +1152,18 @@ async fn probe_daemon_identity(config_id: &str, namespace: &str, timeout_ms: u64
             // in handle_conn produces ok=true + result=None + error=None.
             //
             // A normal successful dispatch always sets result=Some(_) (never None).
-            // A normal error dispatch sets ok=false. So the sentinel is unambiguous.
-            let is_probe_ack = resp.ok && resp.result.is_none() && resp.error.is_none();
+            // A normal error dispatch sets ok=false. `metrics_only` produces the
+            // exact same ok=true/result=None/error=None shape but carries
+            // metrics=Some(_); a request that itself echoed a request_id would
+            // carry request_id=Some(_). This probe frame sets neither, so both
+            // must come back None too — otherwise a metrics snapshot or an
+            // echoed request_id from an unrelated exchange would be misread as
+            // this probe's own acknowledgement.
+            let is_probe_ack = resp.ok
+                && resp.result.is_none()
+                && resp.error.is_none()
+                && resp.metrics.is_none()
+                && resp.request_id.is_none();
             if is_probe_ack
                 && !resp.version_mismatch
                 && !resp.namespace_mismatch
@@ -4769,6 +4779,64 @@ mod tests {
                  not None (which would cause silent fallback to local dispatch)"
             ),
         }
+
+        clear_daemon_env();
+        std::env::remove_var("KHIVE_LOCK");
+    }
+
+    // ── client-side probe rejects a metrics-only response (#2230) ────────────
+    //
+    // The daemon's `metrics_only` arm answers with `ok=true, result=None,
+    // error=None`, every mismatch flag false, the current protocol version,
+    // and a matching `served_config_id` — the exact same shape the probe-ack
+    // arm produces, differing only in carrying `metrics: Some(...)`. A
+    // well-formed metrics snapshot response must not be misread as this
+    // probe's own acknowledgement, or the client would defer to a peer that
+    // never actually answered the identity probe.
+
+    #[tokio::test]
+    #[serial]
+    async fn probe_daemon_identity_rejects_a_metrics_only_response() {
+        clear_daemon_env();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sock = dir.path().join("khived.sock");
+        let pid_file = dir.path().join("khived.pid");
+        let lock_file = dir.path().join("khived.recovery.lock");
+
+        std::env::set_var("KHIVE_SOCKET", &sock);
+        std::env::set_var("KHIVE_PID", &pid_file);
+        std::env::set_var("KHIVE_LOCK", &lock_file);
+        std::env::remove_var("KHIVE_NO_DAEMON");
+
+        let config_id = "packs=[kg];db=:memory:;embed=none;extra=[];backend=main";
+        let listener = tokio::net::UnixListener::bind(&sock).expect("bind fake daemon socket");
+
+        let response = DaemonResponseFrame {
+            ok: true,
+            result: None,
+            error: None,
+            namespace_mismatch: false,
+            config_mismatch: false,
+            served_config_id: Some(config_id.to_string()),
+            version_mismatch: false,
+            daemon_protocol_version: PROTOCOL_VERSION,
+            metrics: Some(khive_runtime::daemon::MetricsSnapshot::default()),
+            request_id: None,
+        };
+        let fake_handle = tokio::spawn(serve_one_response(listener, response));
+
+        let outcome = probe_daemon_identity(config_id, "test", 2_000).await;
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), fake_handle)
+            .await
+            .expect("fake daemon listener task timed out")
+            .expect("fake daemon listener task panicked");
+
+        assert!(
+            matches!(outcome, ProbeOutcome::Dead),
+            "an otherwise-matching response carrying a metrics snapshot must not be treated \
+             as a probe acknowledgement; got {outcome:?}"
+        );
 
         clear_daemon_env();
         std::env::remove_var("KHIVE_LOCK");

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -1037,24 +1037,36 @@ fn stdio_bridge_idle_timeout_from_env() -> Option<std::time::Duration> {
 /// (an in-flight response always defers idle-close) and the session would
 /// never be reaped.
 ///
-/// Overridable via `KHIVE_BRIDGE_RESPONSE_DEADLINE_SECS`; `0` disables it
-/// (an explicit opt-out, matching `KHIVE_BRIDGE_IDLE_TIMEOUT_SECS=0`). An
-/// unparsable value falls back to the default. Default: 300s (5 minutes) —
+/// Overridable via `KHIVE_BRIDGE_RESPONSE_DEADLINE_SECS`, accepted range
+/// 1..=u64::MAX seconds. Unlike `KHIVE_BRIDGE_IDLE_TIMEOUT_SECS`, this bound
+/// cannot be disabled: `0` is a startup error naming the variable, the
+/// rejected value, and the accepted range, rather than a silent opt-out — a
+/// configuration that restores an unbounded pending write restores the
+/// defect this deadline exists to close (see the type doc above). An
+/// unparsable value falls back to the default rather than erroring, matching
+/// this codebase's other `_from_env` helpers. Default: 300s (5 minutes) —
 /// long enough that legitimately slow verbs and ordinary reader backpressure
 /// never trip it, short enough that a peer that has genuinely stopped
 /// reading does not pin the session's reader-pool admission / DB connection
 /// indefinitely.
-fn stdio_bridge_response_deadline_from_env() -> Option<std::time::Duration> {
+fn stdio_bridge_response_deadline_from_env() -> anyhow::Result<std::time::Duration> {
     const DEFAULT_SECS: u64 = 300;
-    let secs = std::env::var("KHIVE_BRIDGE_RESPONSE_DEADLINE_SECS")
-        .ok()
-        .and_then(|v| v.trim().parse::<u64>().ok())
-        .unwrap_or(DEFAULT_SECS);
+    let secs = match std::env::var("KHIVE_BRIDGE_RESPONSE_DEADLINE_SECS") {
+        Ok(raw) => match raw.trim().parse::<u64>() {
+            Ok(secs) => secs,
+            Err(_) => DEFAULT_SECS,
+        },
+        Err(_) => DEFAULT_SECS,
+    };
     if secs == 0 {
-        None
-    } else {
-        Some(std::time::Duration::from_secs(secs))
+        anyhow::bail!(
+            "KHIVE_BRIDGE_RESPONSE_DEADLINE_SECS=0 is not accepted: the response-delivery \
+             deadline cannot be disabled (a disabled deadline lets a peer that stops reading \
+             pin the bridge's response write forever). Set it to a positive number of seconds \
+             (accepted range: 1..=u64::MAX, default {DEFAULT_SECS})."
+        );
     }
+    Ok(std::time::Duration::from_secs(secs))
 }
 
 impl KhiveMcpServer {
@@ -1452,7 +1464,7 @@ impl KhiveMcpServer {
 
         let root = tokio_util::sync::CancellationToken::new();
         let idle_timeout = stdio_bridge_idle_timeout_from_env();
-        let response_deadline = stdio_bridge_response_deadline_from_env();
+        let response_deadline = stdio_bridge_response_deadline_from_env()?;
         let build_transport = |root: tokio_util::sync::CancellationToken| {
             let (read, write) = stdio();
             crate::transport::CancelOnEofTransport::with_idle_timeout(
@@ -1461,7 +1473,7 @@ impl KhiveMcpServer {
                 )),
                 root,
                 idle_timeout,
-                response_deadline,
+                Some(response_deadline),
             )
         };
 
@@ -1500,11 +1512,12 @@ impl KhiveMcpServer {
 
         let root = tokio_util::sync::CancellationToken::new();
         let (read, write) = stdio();
+        let response_deadline = stdio_bridge_response_deadline_from_env()?;
         let transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
             AsyncRwTransport::new_server(read, write),
             root.clone(),
             stdio_bridge_idle_timeout_from_env(),
-            stdio_bridge_response_deadline_from_env(),
+            Some(response_deadline),
         );
         let service = self.serve_with_ct(transport, root).await?;
         service.waiting().await?;
@@ -7955,5 +7968,39 @@ mod request_read_cancellation_tests {
                 );
             }
         }
+    }
+
+    // ── KHIVE_BRIDGE_RESPONSE_DEADLINE_SECS=0 must not disable the bound ──
+
+    /// #2230: the response-delivery deadline used to treat `0` as "disable
+    /// the bound", mirroring `KHIVE_BRIDGE_IDLE_TIMEOUT_SECS=0`. Unlike the
+    /// idle timeout, an unbounded response-delivery deadline restores the
+    /// exact defect this deadline exists to close (a peer that admits a
+    /// request and stops reading pins the bridge's response write forever)
+    /// — so `0` is now a hard startup error instead of a supported opt-out.
+    #[test]
+    #[serial_test::serial]
+    fn response_deadline_from_env_rejects_zero() {
+        std::env::set_var("KHIVE_BRIDGE_RESPONSE_DEADLINE_SECS", "0");
+        let result = stdio_bridge_response_deadline_from_env();
+        std::env::remove_var("KHIVE_BRIDGE_RESPONSE_DEADLINE_SECS");
+
+        let error = result.expect_err(
+            "KHIVE_BRIDGE_RESPONSE_DEADLINE_SECS=0 must be rejected, not silently accepted \
+             as \"disable the bound\"",
+        );
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("KHIVE_BRIDGE_RESPONSE_DEADLINE_SECS"),
+            "error must name the offending variable: {rendered}"
+        );
+        assert!(
+            rendered.contains("=0"),
+            "error must name the rejected value: {rendered}"
+        );
+        assert!(
+            rendered.contains("1..=u64::MAX"),
+            "error must state the accepted range: {rendered}"
+        );
     }
 }

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -1002,7 +1002,8 @@ fn stdio_serve_mode_for(resumed_generation: Option<u32>) -> StdioServeMode {
 /// This closes only a genuinely idle session: an admitted request with a
 /// response still being written — running long, or delivered slowly to a
 /// backpressured reader — defers the close rather than being cancelled out
-/// from under it.
+/// from under it, up to the separate response-delivery bound documented on
+/// [`stdio_bridge_response_deadline_from_env`].
 ///
 /// Overridable via `KHIVE_BRIDGE_IDLE_TIMEOUT_SECS`; `0` disables it (an
 /// explicit opt-out, e.g. for a debugger holding a session open on purpose).
@@ -1015,6 +1016,37 @@ fn stdio_serve_mode_for(resumed_generation: Option<u32>) -> StdioServeMode {
 fn stdio_bridge_idle_timeout_from_env() -> Option<std::time::Duration> {
     const DEFAULT_SECS: u64 = 3600;
     let secs = std::env::var("KHIVE_BRIDGE_IDLE_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_SECS);
+    if secs == 0 {
+        None
+    } else {
+        Some(std::time::Duration::from_secs(secs))
+    }
+}
+
+/// Response-delivery deadline for a stdio bridge session: the longest a
+/// single response write may stay pending before it is abandoned (see
+/// [`crate::transport::CancelOnEofTransport::send`]) and this session is
+/// closed. Independent of the idle timeout above — it bounds an admitted
+/// request's response write directly, rather than the gap between
+/// requests. Without this bound, a peer that admits a request and then
+/// stops reading its response — while leaving the pipe itself open — keeps
+/// that write pending forever, so the idle timeout would defer indefinitely
+/// (an in-flight response always defers idle-close) and the session would
+/// never be reaped.
+///
+/// Overridable via `KHIVE_BRIDGE_RESPONSE_DEADLINE_SECS`; `0` disables it
+/// (an explicit opt-out, matching `KHIVE_BRIDGE_IDLE_TIMEOUT_SECS=0`). An
+/// unparsable value falls back to the default. Default: 300s (5 minutes) —
+/// long enough that legitimately slow verbs and ordinary reader backpressure
+/// never trip it, short enough that a peer that has genuinely stopped
+/// reading does not pin the session's reader-pool admission / DB connection
+/// indefinitely.
+fn stdio_bridge_response_deadline_from_env() -> Option<std::time::Duration> {
+    const DEFAULT_SECS: u64 = 300;
+    let secs = std::env::var("KHIVE_BRIDGE_RESPONSE_DEADLINE_SECS")
         .ok()
         .and_then(|v| v.trim().parse::<u64>().ok())
         .unwrap_or(DEFAULT_SECS);
@@ -1420,6 +1452,7 @@ impl KhiveMcpServer {
 
         let root = tokio_util::sync::CancellationToken::new();
         let idle_timeout = stdio_bridge_idle_timeout_from_env();
+        let response_deadline = stdio_bridge_response_deadline_from_env();
         let build_transport = |root: tokio_util::sync::CancellationToken| {
             let (read, write) = stdio();
             crate::transport::CancelOnEofTransport::with_idle_timeout(
@@ -1428,6 +1461,7 @@ impl KhiveMcpServer {
                 )),
                 root,
                 idle_timeout,
+                response_deadline,
             )
         };
 
@@ -1470,6 +1504,7 @@ impl KhiveMcpServer {
             AsyncRwTransport::new_server(read, write),
             root.clone(),
             stdio_bridge_idle_timeout_from_env(),
+            stdio_bridge_response_deadline_from_env(),
         );
         let service = self.serve_with_ct(transport, root).await?;
         service.waiting().await?;
@@ -7343,6 +7378,7 @@ mod request_read_cancellation_tests {
             AsyncRwTransport::new_server(read, write),
             root.clone(),
             None,
+            None,
         );
         let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
 
@@ -7397,6 +7433,7 @@ mod request_read_cancellation_tests {
             AsyncRwTransport::new_server(read, write),
             root.clone(),
             Some(Duration::from_millis(50)),
+            None,
         );
         let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
 
@@ -7455,6 +7492,7 @@ mod request_read_cancellation_tests {
             AsyncRwTransport::new_server(read, write),
             root.clone(),
             Some(idle_timeout),
+            None,
         );
         let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
 
@@ -7548,6 +7586,7 @@ mod request_read_cancellation_tests {
             AsyncRwTransport::new_server(server_read, server_write),
             root.clone(),
             Some(idle_timeout),
+            None,
         );
         let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
         let (mut client_read, mut client_write) = tokio::io::split(client_io);
@@ -7614,6 +7653,7 @@ mod request_read_cancellation_tests {
             AsyncRwTransport::new_server(server_read, server_write),
             root.clone(),
             Some(idle_timeout),
+            None,
         );
         let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
 
@@ -7636,6 +7676,80 @@ mod request_read_cancellation_tests {
 
         drop(client_io);
         let _ = tokio::time::timeout(Duration::from_secs(2), running.waiting()).await;
+    }
+
+    /// Regression (#2230): a response write that never resolves — a peer
+    /// that admits a request, then never reads its response and never
+    /// disconnects — must itself be bounded by `response_deadline`, not
+    /// merely deferred by the idle-close check forever. This is the
+    /// assertion that reddens if the response-delivery deadline is removed
+    /// (passed as `None`): `root` would then never be cancelled and the
+    /// poll loop below would exhaust its bound without ever observing
+    /// cancellation.
+    #[tokio::test]
+    async fn stdio_idle_timeout_reaps_a_peer_that_stops_reading_its_response() {
+        use rmcp::transport::async_rw::AsyncRwTransport;
+        use tokio::io::AsyncWriteExt;
+
+        let probe = QuickProbeServer;
+        let root = tokio_util::sync::CancellationToken::new();
+        // Same 8-byte-buffer trick as the test above: the response cannot
+        // fully land without the reader draining it. Unlike that test, this
+        // one never reads from `client_io` and never drops it — the pipe
+        // stays open exactly like a peer that admitted a request and then
+        // simply stopped reading.
+        let (server_io, mut client_io) = tokio::io::duplex(8);
+        let (server_read, server_write) = tokio::io::split(server_io);
+        let response_deadline = Duration::from_millis(150);
+        let transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
+            AsyncRwTransport::new_server(server_read, server_write),
+            root.clone(),
+            None,
+            Some(response_deadline),
+        );
+        let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
+
+        client_io
+            .write_all(
+                b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"probe\",\"arguments\":{}}}\n",
+            )
+            .await
+            .expect("write one real JSON-RPC tool request");
+
+        // The core claim: root cancellation — the actual reaping signal —
+        // must land within `response_deadline` of admission, not merely
+        // "eventually". Polled rather than slept for the full bound so this
+        // resolves as soon as it happens and reddens immediately (via the
+        // assertion below) if the response-delivery deadline stops firing.
+        let bound = response_deadline + Duration::from_millis(500);
+        let poll_deadline = tokio::time::Instant::now() + bound;
+        while !root.is_cancelled() && tokio::time::Instant::now() < poll_deadline {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        assert!(
+            root.is_cancelled(),
+            "the response-delivery deadline must cancel the root token within {bound:?} of \
+             admission — a peer that admits a request and stops reading its response must not \
+             pin the session"
+        );
+
+        // The abandoned write is dropped (not merely deferred) on timeout,
+        // which releases rmcp's internal transport-write lock — so the
+        // post-cancellation drain's `close()` is not itself blocked on that
+        // same stuck write, and `waiting()` resolves promptly rather than
+        // riding out rmcp's multi-second drain window.
+        let reason = tokio::time::timeout(Duration::from_secs(2), running.waiting())
+            .await
+            .expect("rmcp never finished closing after the response-delivery deadline")
+            .expect("rmcp service task panicked");
+        assert!(
+            matches!(
+                reason,
+                rmcp::service::QuitReason::Closed | rmcp::service::QuitReason::Cancelled
+            ),
+            "unexpected rmcp quit reason after the response-delivery deadline: {reason:?}"
+        );
+        drop(client_io);
     }
 
     /// Distinguishes handler behavior by tool name: `"slow"` blocks for
@@ -7695,6 +7809,7 @@ mod request_read_cancellation_tests {
             AsyncRwTransport::new_server(server_read, server_write),
             root.clone(),
             Some(idle_timeout),
+            None,
         );
         let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
         let (mut client_read, mut client_write) = tokio::io::split(client_io);

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -995,6 +995,32 @@ fn stdio_serve_mode_for(resumed_generation: Option<u32>) -> StdioServeMode {
     }
 }
 
+/// Idle timeout for a stdio bridge session (#1921): no request for this long
+/// and the session closes (see [`crate::transport::CancelOnEofTransport`]),
+/// releasing its reader-pool admission and DB connection — a client that
+/// comes back simply respawns the bridge, seamlessly from its perspective.
+///
+/// Overridable via `KHIVE_BRIDGE_IDLE_TIMEOUT_SECS`; `0` disables it (an
+/// explicit opt-out, e.g. for a debugger holding a session open on purpose).
+/// An unparsable value falls back to the default rather than panicking or
+/// disabling the timeout outright, matching this codebase's other
+/// `_from_env` helpers. Default: 3600s (60 minutes) — generous enough that
+/// ordinary gaps between requests in a live session never trip it, short
+/// enough that an abandoned bridge does not pin a reader-pool slot / WAL
+/// connection for hours or days (#1921, #1836).
+fn stdio_bridge_idle_timeout_from_env() -> Option<std::time::Duration> {
+    const DEFAULT_SECS: u64 = 3600;
+    let secs = std::env::var("KHIVE_BRIDGE_IDLE_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_SECS);
+    if secs == 0 {
+        None
+    } else {
+        Some(std::time::Duration::from_secs(secs))
+    }
+}
+
 impl KhiveMcpServer {
     /// Build a server from `runtime.config().packs`. Errors if any pack is unknown or missing deps.
     ///
@@ -1389,13 +1415,15 @@ impl KhiveMcpServer {
         use rmcp::transport::{async_rw::AsyncRwTransport, stdio};
 
         let root = tokio_util::sync::CancellationToken::new();
+        let idle_timeout = stdio_bridge_idle_timeout_from_env();
         let build_transport = |root: tokio_util::sync::CancellationToken| {
             let (read, write) = stdio();
-            crate::transport::CancelOnEofTransport::new(
+            crate::transport::CancelOnEofTransport::with_idle_timeout(
                 crate::daemon::SelfHealOnFlushTransport::new(AsyncRwTransport::new_server(
                     read, write,
                 )),
                 root,
+                idle_timeout,
             )
         };
 
@@ -1434,9 +1462,10 @@ impl KhiveMcpServer {
 
         let root = tokio_util::sync::CancellationToken::new();
         let (read, write) = stdio();
-        let transport = crate::transport::CancelOnEofTransport::new(
+        let transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
             AsyncRwTransport::new_server(read, write),
             root.clone(),
+            stdio_bridge_idle_timeout_from_env(),
         );
         let service = self.serve_with_ct(transport, root).await?;
         service.waiting().await?;
@@ -7306,9 +7335,10 @@ mod request_read_cancellation_tests {
         let root = tokio_util::sync::CancellationToken::new();
         let (server_io, mut client_io) = tokio::io::duplex(16 * 1024);
         let (read, write) = tokio::io::split(server_io);
-        let transport = crate::transport::CancelOnEofTransport::new(
+        let transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
             AsyncRwTransport::new_server(read, write),
             root.clone(),
+            None,
         );
         let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
 
@@ -7342,6 +7372,97 @@ mod request_read_cancellation_tests {
             ),
             "unexpected rmcp quit reason after EOF: {reason:?}"
         );
+    }
+
+    /// #1921: an idle stdio bridge — pipe still open, no request sent — must
+    /// be reaped the same way a real EOF is, not held open indefinitely.
+    #[tokio::test]
+    async fn stdio_idle_timeout_cancels_root_without_eof() {
+        use rmcp::transport::async_rw::AsyncRwTransport;
+
+        let started = Arc::new(tokio::sync::Notify::new());
+        let cancelled = Arc::new(tokio::sync::Notify::new());
+        let probe = EofProbeServer {
+            started: started.clone(),
+            cancelled: cancelled.clone(),
+        };
+        let root = tokio_util::sync::CancellationToken::new();
+        let (server_io, client_io) = tokio::io::duplex(16 * 1024);
+        let (read, write) = tokio::io::split(server_io);
+        let transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
+            AsyncRwTransport::new_server(read, write),
+            root.clone(),
+            Some(Duration::from_millis(50)),
+        );
+        let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
+
+        // Deliberately never write anything and never drop `client_io`: the
+        // pipe stays open exactly like an abandoned bridge's client — this
+        // must still be reaped once the idle timeout elapses.
+        let reason = tokio::time::timeout(Duration::from_secs(2), running.waiting())
+            .await
+            .expect("idle timeout never closed the session")
+            .expect("rmcp service task panicked");
+        assert!(
+            root.is_cancelled(),
+            "idle timeout must cancel the exact root token passed into rmcp"
+        );
+        assert!(
+            matches!(
+                reason,
+                rmcp::service::QuitReason::Closed | rmcp::service::QuitReason::Cancelled
+            ),
+            "unexpected rmcp quit reason after idle timeout: {reason:?}"
+        );
+        drop(client_io);
+    }
+
+    /// #1921 acceptance: a live client with traffic inside every idle window
+    /// must never be reaped, even once total elapsed time exceeds the
+    /// timeout many times over.
+    #[tokio::test]
+    async fn stdio_idle_timeout_does_not_reap_client_with_intermittent_traffic() {
+        use rmcp::transport::async_rw::AsyncRwTransport;
+        use tokio::io::AsyncWriteExt;
+
+        let started = Arc::new(tokio::sync::Notify::new());
+        let cancelled = Arc::new(tokio::sync::Notify::new());
+        let probe = EofProbeServer {
+            started: started.clone(),
+            cancelled: cancelled.clone(),
+        };
+        let root = tokio_util::sync::CancellationToken::new();
+        let (server_io, mut client_io) = tokio::io::duplex(16 * 1024);
+        let (read, write) = tokio::io::split(server_io);
+        let transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
+            AsyncRwTransport::new_server(read, write),
+            root.clone(),
+            Some(Duration::from_millis(150)),
+        );
+        let _running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
+
+        // Five requests spaced well inside the 150ms idle window, totaling
+        // ~200ms — more than the timeout itself, but never a single gap that
+        // exceeds it.
+        for id in 1..=5u32 {
+            client_io
+                .write_all(
+                    format!(
+                        "{{\"jsonrpc\":\"2.0\",\"id\":{id},\"method\":\"tools/call\",\
+                         \"params\":{{\"name\":\"probe\",\"arguments\":{{}}}}}}\n"
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .expect("write request");
+            tokio::time::sleep(Duration::from_millis(40)).await;
+        }
+
+        assert!(
+            !root.is_cancelled(),
+            "intermittent traffic inside every idle window must never trip the idle timeout"
+        );
+        drop(client_io);
     }
 
     #[tokio::test]

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -7417,6 +7417,23 @@ mod request_read_cancellation_tests {
         drop(client_io);
     }
 
+    /// Completes every `tools/call` immediately — unlike [`EofProbeServer`],
+    /// which blocks its handler on cancellation. Used where a test needs
+    /// requests to actually finish (dropping the transport's in-flight
+    /// count back to zero) rather than staying admitted forever.
+    #[derive(Clone)]
+    struct QuickProbeServer;
+
+    impl rmcp::ServerHandler for QuickProbeServer {
+        async fn call_tool(
+            &self,
+            _request: rmcp::model::CallToolRequestParams,
+            _context: rmcp::service::RequestContext<rmcp::RoleServer>,
+        ) -> Result<rmcp::model::CallToolResult, McpError> {
+            Ok(rmcp::model::CallToolResult::success(Vec::new()))
+        }
+    }
+
     /// #1921 acceptance: a live client with traffic inside every idle window
     /// must never be reaped, even once total elapsed time exceeds the
     /// timeout many times over.
@@ -7425,21 +7442,17 @@ mod request_read_cancellation_tests {
         use rmcp::transport::async_rw::AsyncRwTransport;
         use tokio::io::AsyncWriteExt;
 
-        let started = Arc::new(tokio::sync::Notify::new());
-        let cancelled = Arc::new(tokio::sync::Notify::new());
-        let probe = EofProbeServer {
-            started: started.clone(),
-            cancelled: cancelled.clone(),
-        };
+        let probe = QuickProbeServer;
         let root = tokio_util::sync::CancellationToken::new();
         let (server_io, mut client_io) = tokio::io::duplex(16 * 1024);
         let (read, write) = tokio::io::split(server_io);
+        let idle_timeout = Duration::from_millis(150);
         let transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
             AsyncRwTransport::new_server(read, write),
             root.clone(),
-            Some(Duration::from_millis(150)),
+            Some(idle_timeout),
         );
-        let _running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
+        let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
 
         // Five requests spaced well inside the 150ms idle window, totaling
         // ~200ms — more than the timeout itself, but never a single gap that
@@ -7462,7 +7475,111 @@ mod request_read_cancellation_tests {
             !root.is_cancelled(),
             "intermittent traffic inside every idle window must never trip the idle timeout"
         );
+
+        // Real oracle (#2230 review, Low): prove the timeout is actually
+        // armed on this exact transport/config rather than merely assumed.
+        // If the mechanism were silently disabled or ignored, `root` would
+        // never be cancelled here and this test would time out instead of
+        // passing — a stronger guard than the traffic-keeps-it-alive
+        // assertion above, which a disabled timeout would also satisfy.
+        tokio::time::timeout(idle_timeout * 6, running.waiting())
+            .await
+            .expect(
+                "idle timeout never fired once traffic stopped — the timeout \
+                 mechanism is not armed",
+            )
+            .expect("rmcp service task panicked");
+        assert!(
+            root.is_cancelled(),
+            "idle timeout must fire once traffic genuinely stops, proving it \
+             is armed for this test"
+        );
         drop(client_io);
+    }
+
+    #[derive(Clone)]
+    struct SlowProbeServer {
+        started: Arc<tokio::sync::Notify>,
+        delay: Duration,
+    }
+
+    impl rmcp::ServerHandler for SlowProbeServer {
+        fn call_tool(
+            &self,
+            _request: rmcp::model::CallToolRequestParams,
+            _context: rmcp::service::RequestContext<rmcp::RoleServer>,
+        ) -> impl Future<Output = Result<rmcp::model::CallToolResult, McpError>> + Send + '_
+        {
+            let started = self.started.clone();
+            let delay = self.delay;
+            async move {
+                started.notify_one();
+                tokio::time::sleep(delay).await;
+                Ok(rmcp::model::CallToolResult::success(Vec::new()))
+            }
+        }
+    }
+
+    /// High-severity regression (#2230 review): rmcp keeps racing
+    /// `transport.receive()` while an admitted request runs in its own task,
+    /// so a handler that outlives the idle window must still complete and
+    /// return its response rather than being cancelled by the next
+    /// `receive()` timing out.
+    #[tokio::test]
+    async fn stdio_idle_timeout_does_not_cancel_an_admitted_long_running_request() {
+        use rmcp::transport::async_rw::AsyncRwTransport;
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let started = Arc::new(tokio::sync::Notify::new());
+        let handler_delay = Duration::from_millis(300);
+        let idle_timeout = Duration::from_millis(50);
+        let probe = SlowProbeServer {
+            started: started.clone(),
+            delay: handler_delay,
+        };
+        let root = tokio_util::sync::CancellationToken::new();
+        let (server_io, client_io) = tokio::io::duplex(16 * 1024);
+        let (server_read, server_write) = tokio::io::split(server_io);
+        let transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
+            AsyncRwTransport::new_server(server_read, server_write),
+            root.clone(),
+            Some(idle_timeout),
+        );
+        let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
+        let (mut client_read, mut client_write) = tokio::io::split(client_io);
+
+        client_write
+            .write_all(
+                b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"probe\",\"arguments\":{}}}\n",
+            )
+            .await
+            .expect("write one real JSON-RPC tool request");
+
+        tokio::time::timeout(Duration::from_secs(2), started.notified())
+            .await
+            .expect("rmcp never admitted the request handler");
+
+        // The handler keeps running well past several idle windows while the
+        // wire itself sends nothing further — this must not be reaped.
+        tokio::time::sleep(idle_timeout * 4).await;
+        assert!(
+            !root.is_cancelled(),
+            "an admitted in-flight request must not be cancelled by the wire-idle timeout"
+        );
+
+        let mut buf = vec![0u8; 4096];
+        let n = tokio::time::timeout(Duration::from_secs(2), client_read.read(&mut buf))
+            .await
+            .expect("the long-running handler never produced its response")
+            .expect("read error on the client side of the duplex pipe");
+        let response = String::from_utf8_lossy(&buf[..n]);
+        assert!(
+            response.contains("\"id\":1"),
+            "expected a JSON-RPC response for request id=1, got: {response}"
+        );
+
+        drop(client_write);
+        let _ = tokio::time::timeout(Duration::from_secs(2), running.waiting()).await;
     }
 
     #[tokio::test]

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -7586,7 +7586,7 @@ mod request_read_cancellation_tests {
         let _ = tokio::time::timeout(Duration::from_secs(2), running.waiting()).await;
     }
 
-    /// #2230 review round 2 (Medium): a request must stay "in flight" — and
+    /// Regression (#2230): a request must stay "in flight" — and
     /// therefore protected from the idle-close branch — until its response
     /// has actually *finished writing*, not merely been handed to
     /// `inner.send`. rmcp spawns the response send and the framed write
@@ -7668,7 +7668,7 @@ mod request_read_cancellation_tests {
         }
     }
 
-    /// #2230 review round 2 (Medium): while an admitted request is still
+    /// Regression (#2230): while an admitted request is still
     /// running, deferring the idle close must not discard a second request
     /// that arrives fragmented across the deferred window. Before the fix,
     /// each deferral called `self.inner.receive()` fresh; rmcp's line-buffered

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -999,6 +999,10 @@ fn stdio_serve_mode_for(resumed_generation: Option<u32>) -> StdioServeMode {
 /// and the session closes (see [`crate::transport::CancelOnEofTransport`]),
 /// releasing its reader-pool admission and DB connection — a client that
 /// comes back simply respawns the bridge, seamlessly from its perspective.
+/// This closes only a genuinely idle session: an admitted request with a
+/// response still being written — running long, or delivered slowly to a
+/// backpressured reader — defers the close rather than being cancelled out
+/// from under it.
 ///
 /// Overridable via `KHIVE_BRIDGE_IDLE_TIMEOUT_SECS`; `0` disables it (an
 /// explicit opt-out, e.g. for a debugger holding a session open on purpose).
@@ -7576,6 +7580,179 @@ mod request_read_cancellation_tests {
         assert!(
             response.contains("\"id\":1"),
             "expected a JSON-RPC response for request id=1, got: {response}"
+        );
+
+        drop(client_write);
+        let _ = tokio::time::timeout(Duration::from_secs(2), running.waiting()).await;
+    }
+
+    /// #2230 review round 2 (Medium): a request must stay "in flight" — and
+    /// therefore protected from the idle-close branch — until its response
+    /// has actually *finished writing*, not merely been handed to
+    /// `inner.send`. rmcp spawns the response send and the framed write
+    /// awaits the transport writer, so a slow/backpressured reader can leave
+    /// the write pending well after the handler itself already completed.
+    /// Before the fix, `in_flight` was decremented synchronously inside
+    /// `send` before the returned future was even polled, so this scenario
+    /// would have been misread as an idle session and the root token
+    /// cancelled out from under the still-undelivered response.
+    #[tokio::test]
+    async fn stdio_idle_timeout_does_not_cancel_while_a_response_write_is_backpressured() {
+        use rmcp::transport::async_rw::AsyncRwTransport;
+        use tokio::io::AsyncWriteExt;
+
+        let probe = QuickProbeServer;
+        let root = tokio_util::sync::CancellationToken::new();
+        // An 8-byte buffer for the server->client direction: the JSON-RPC
+        // response cannot fully land without the reader draining it, which
+        // this test deliberately never does — that is what keeps the write
+        // pending.
+        let (server_io, mut client_io) = tokio::io::duplex(8);
+        let (server_read, server_write) = tokio::io::split(server_io);
+        let idle_timeout = Duration::from_millis(50);
+        let transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
+            AsyncRwTransport::new_server(server_read, server_write),
+            root.clone(),
+            Some(idle_timeout),
+        );
+        let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
+
+        client_io
+            .write_all(
+                b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"probe\",\"arguments\":{}}}\n",
+            )
+            .await
+            .expect("write one real JSON-RPC tool request");
+
+        // The handler itself finishes almost immediately (`QuickProbeServer`),
+        // but with nobody reading `client_io`, the response write cannot
+        // drain into the 8-byte pipe. This must not be read as idle across
+        // several idle windows.
+        tokio::time::sleep(idle_timeout * 4).await;
+        assert!(
+            !root.is_cancelled(),
+            "an admitted request's still-undelivered response must not be read as an idle session"
+        );
+
+        drop(client_io);
+        let _ = tokio::time::timeout(Duration::from_secs(2), running.waiting()).await;
+    }
+
+    /// Distinguishes handler behavior by tool name: `"slow"` blocks for
+    /// `slow_delay` (keeping `in_flight` above zero across several idle
+    /// windows), `"quick"` (or anything else) completes immediately — used
+    /// to admit a second request while the first is still running.
+    #[derive(Clone)]
+    struct MixedDelayServer {
+        slow_started: Arc<tokio::sync::Notify>,
+        slow_delay: Duration,
+    }
+
+    impl rmcp::ServerHandler for MixedDelayServer {
+        fn call_tool(
+            &self,
+            request: rmcp::model::CallToolRequestParams,
+            _context: rmcp::service::RequestContext<rmcp::RoleServer>,
+        ) -> impl Future<Output = Result<rmcp::model::CallToolResult, McpError>> + Send + '_
+        {
+            let slow_started = self.slow_started.clone();
+            let slow_delay = self.slow_delay;
+            let is_slow = request.name.as_ref() == "slow";
+            async move {
+                if is_slow {
+                    slow_started.notify_one();
+                    tokio::time::sleep(slow_delay).await;
+                }
+                Ok(rmcp::model::CallToolResult::success(Vec::new()))
+            }
+        }
+    }
+
+    /// #2230 review round 2 (Medium): while an admitted request is still
+    /// running, deferring the idle close must not discard a second request
+    /// that arrives fragmented across the deferred window. Before the fix,
+    /// each deferral called `self.inner.receive()` fresh; rmcp's line-buffered
+    /// receive clears its buffer at the start of every call, so a chunk
+    /// already consumed before the timeout fired was silently dropped and
+    /// the remainder parsed as an invalid/garbage line — losing the second
+    /// request even though the session itself correctly stayed open.
+    #[tokio::test]
+    async fn stdio_idle_timeout_preserves_a_fragmented_request_while_another_is_in_flight() {
+        use rmcp::transport::async_rw::AsyncRwTransport;
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let slow_started = Arc::new(tokio::sync::Notify::new());
+        let slow_delay = Duration::from_millis(400);
+        let idle_timeout = Duration::from_millis(50);
+        let probe = MixedDelayServer {
+            slow_started: slow_started.clone(),
+            slow_delay,
+        };
+        let root = tokio_util::sync::CancellationToken::new();
+        let (server_io, client_io) = tokio::io::duplex(16 * 1024);
+        let (server_read, server_write) = tokio::io::split(server_io);
+        let transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
+            AsyncRwTransport::new_server(server_read, server_write),
+            root.clone(),
+            Some(idle_timeout),
+        );
+        let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
+        let (mut client_read, mut client_write) = tokio::io::split(client_io);
+
+        // Admit request 1: the slow handler keeps `in_flight` above zero for
+        // `slow_delay`, so every idle window in between must be deferred
+        // rather than closing the session.
+        client_write
+            .write_all(
+                b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"slow\",\"arguments\":{}}}\n",
+            )
+            .await
+            .expect("write slow request");
+        tokio::time::timeout(Duration::from_secs(2), slow_started.notified())
+            .await
+            .expect("slow handler never started");
+
+        // While request 1 is still in flight, write request 2 split into two
+        // chunks with a gap longer than the idle timeout, so the deferred-
+        // close loop iterates at least once between them.
+        let full = "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\
+                     \"params\":{\"name\":\"quick\",\"arguments\":{}}}\n";
+        let full_bytes = full.as_bytes();
+        let split_at = full_bytes.len() / 2;
+        client_write
+            .write_all(&full_bytes[..split_at])
+            .await
+            .expect("write first half of the fragmented request");
+
+        tokio::time::sleep(idle_timeout * 3).await;
+        assert!(
+            !root.is_cancelled(),
+            "the still-running slow request must defer the idle close across the gap"
+        );
+
+        client_write
+            .write_all(&full_bytes[split_at..])
+            .await
+            .expect("write second half of the fragmented request");
+
+        // Both responses must arrive intact — id=1 once the slow handler
+        // finishes, id=2 as soon as the reassembled line is parsed.
+        let mut buf = vec![0u8; 8192];
+        let mut collected = String::new();
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        while !(collected.contains("\"id\":1") && collected.contains("\"id\":2")) {
+            if tokio::time::Instant::now() >= deadline {
+                panic!("did not receive both responses in time; got: {collected}");
+            }
+            let n = tokio::time::timeout(Duration::from_secs(2), client_read.read(&mut buf))
+                .await
+                .expect("read timed out waiting for a response")
+                .expect("read error on the client side of the duplex pipe");
+            collected.push_str(&String::from_utf8_lossy(&buf[..n]));
+        }
+        assert!(
+            collected.contains("\"id\":2"),
+            "the fragmented second request must be reassembled and answered intact; got: {collected}"
         );
 
         drop(client_write);

--- a/crates/khive-mcp/src/transport.rs
+++ b/crates/khive-mcp/src/transport.rs
@@ -41,9 +41,16 @@ use crate::server::KhiveMcpServer;
 /// outlasts `idle_timeout` (slow verb, large batch) must not have its
 /// session torn down out from under it. `in_flight` counts JSON-RPC
 /// `Request` messages this transport has handed to rmcp minus the
-/// `Response`/`Error` messages it has sent back for them; the idle branch
-/// only treats a quiet window as EOF when that count is zero, i.e. nothing
-/// admitted is still awaiting its response.
+/// `Response`/`Error` messages it has *finished writing* back for them —
+/// not merely handed to `inner.send`, since rmcp spawns the response send
+/// and the underlying framed write awaits the transport writer, so a slow
+/// or stalled reader leaves the write pending well after `send` is called.
+/// The idle branch only treats a quiet window as EOF when that count is
+/// zero, i.e. nothing admitted has an undelivered response. A response
+/// write that fails also decrements the counter (once resolved, one way or
+/// another, it is no longer pending) — the broken transport will surface
+/// through `receive()` returning `None` on its own, so this counter must
+/// not be the thing that gets stuck open forever on a write error.
 pub(crate) struct CancelOnEofTransport<T> {
     inner: T,
     root: tokio_util::sync::CancellationToken,
@@ -79,13 +86,22 @@ where
         &mut self,
         item: rmcp::service::TxJsonRpcMessage<rmcp::RoleServer>,
     ) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send + 'static {
-        if matches!(
+        let is_response = matches!(
             item,
             rmcp::model::JsonRpcMessage::Response(_) | rmcp::model::JsonRpcMessage::Error(_)
-        ) {
-            self.in_flight.fetch_sub(1, Ordering::AcqRel);
+        );
+        let in_flight = self.in_flight.clone();
+        let send = self.inner.send(item);
+        async move {
+            let result = send.await;
+            // Decrement once the write is resolved either way — see the
+            // `in_flight` field doc for why a failed write must not be left
+            // permanently counted as pending.
+            if is_response {
+                in_flight.fetch_sub(1, Ordering::AcqRel);
+            }
+            result
         }
-        self.inner.send(item)
     }
 
     fn receive(
@@ -96,11 +112,22 @@ where
         let idle_timeout = self.idle_timeout;
         let in_flight = self.in_flight.clone();
         async move {
+            // Created once and reused across every retry below: `select!`ing
+            // a *fresh* `self.inner.receive()` each time the idle sleep wins
+            // would drop the in-progress read and restart it next iteration.
+            // rmcp's line-buffered receive clears its buffer at the start of
+            // each call, so restarting mid-read silently discards whatever
+            // prefix of the next request had already arrived before the
+            // deferred timeout — the remainder then parses as garbage.
+            // Racing the sleep against `&mut` this same pinned future keeps
+            // the partial read alive across as many deferrals as it takes.
+            let recv_fut = self.inner.receive();
+            tokio::pin!(recv_fut);
             loop {
                 let message = match idle_timeout {
                     Some(timeout) => {
                         tokio::select! {
-                            message = self.inner.receive() => message,
+                            message = &mut recv_fut => message,
                             () = tokio::time::sleep(timeout) => {
                                 if in_flight.load(Ordering::Acquire) > 0 {
                                     tracing::debug!(
@@ -120,7 +147,7 @@ where
                             }
                         }
                     }
-                    None => self.inner.receive().await,
+                    None => recv_fut.await,
                 };
                 if let Some(rmcp::model::JsonRpcMessage::Request(_)) = &message {
                     in_flight.fetch_add(1, Ordering::AcqRel);

--- a/crates/khive-mcp/src/transport.rs
+++ b/crates/khive-mcp/src/transport.rs
@@ -51,10 +51,26 @@ use crate::server::KhiveMcpServer;
 /// another, it is no longer pending) — the broken transport will surface
 /// through `receive()` returning `None` on its own, so this counter must
 /// not be the thing that gets stuck open forever on a write error.
+///
+/// A response write that never resolves — a peer that admits a request,
+/// then stops reading its response while keeping the pipe open — would
+/// otherwise pin this session (and its reader-pool admission / DB
+/// connection) forever: `in_flight` would never return to zero, so the idle
+/// check above would defer indefinitely. `response_deadline` bounds the
+/// write itself (see [`Self::send`]) rather than the idle check: rmcp's
+/// underlying `AsyncRwTransport` serializes writes through a
+/// `tokio::sync::Mutex` held across the pending write's `.await`, so a
+/// write that never resolves also blocks any later `close()` on the same
+/// transport — merely cancelling the root token would not free that lock.
+/// Timing out the write future instead *drops* it, which releases the
+/// mutex guard the same way any other future cancellation would, so a
+/// subsequent `close()` (part of rmcp's normal post-cancellation drain)
+/// can still proceed.
 pub(crate) struct CancelOnEofTransport<T> {
     inner: T,
     root: tokio_util::sync::CancellationToken,
     idle_timeout: Option<std::time::Duration>,
+    response_deadline: Option<std::time::Duration>,
     in_flight: Arc<AtomicI64>,
 }
 
@@ -62,15 +78,23 @@ impl<T> CancelOnEofTransport<T> {
     /// `idle_timeout`: a `receive()` call that yields no message within this
     /// window is treated as EOF (see the type doc), but only when no
     /// admitted request is still awaiting its response. `None` disables it.
+    ///
+    /// `response_deadline`: the longest a single response write may stay
+    /// pending before it is abandoned (see [`Self::send`]) — independent of
+    /// `idle_timeout`, and meaningful whether or not an idle timeout is
+    /// configured. `None` disables the bound (a response write waits
+    /// unbounded, matching this transport's pre-existing behavior).
     pub(crate) fn with_idle_timeout(
         inner: T,
         root: tokio_util::sync::CancellationToken,
         idle_timeout: Option<std::time::Duration>,
+        response_deadline: Option<std::time::Duration>,
     ) -> Self {
         Self {
             inner,
             root,
             idle_timeout,
+            response_deadline,
             in_flight: Arc::new(AtomicI64::new(0)),
         }
     }
@@ -79,9 +103,18 @@ impl<T> CancelOnEofTransport<T> {
 impl<T> rmcp::transport::Transport<rmcp::RoleServer> for CancelOnEofTransport<T>
 where
     T: rmcp::transport::Transport<rmcp::RoleServer>,
+    T::Error: From<std::io::Error>,
 {
     type Error = T::Error;
 
+    /// Bounds a response/error write by `response_deadline` (requests pass
+    /// straight through, untimed — only a response can leave `in_flight`
+    /// permanently pinned). On timeout the write future is dropped —
+    /// releasing whatever lock the inner transport held across it, see the
+    /// type doc — `in_flight` is decremented the same as any other resolved
+    /// write, and `root` is cancelled directly: the peer has demonstrated it
+    /// is not going to read this response, so there is no reason to wait for
+    /// the next idle tick to notice.
     fn send(
         &mut self,
         item: rmcp::service::TxJsonRpcMessage<rmcp::RoleServer>,
@@ -91,9 +124,30 @@ where
             rmcp::model::JsonRpcMessage::Response(_) | rmcp::model::JsonRpcMessage::Error(_)
         );
         let in_flight = self.in_flight.clone();
+        let root = self.root.clone();
+        let response_deadline = self.response_deadline;
         let send = self.inner.send(item);
         async move {
-            let result = send.await;
+            let result = match (is_response, response_deadline) {
+                (true, Some(deadline)) => match tokio::time::timeout(deadline, send).await {
+                    Ok(result) => result,
+                    Err(_) => {
+                        tracing::warn!(
+                            deadline_secs = deadline.as_secs(),
+                            "stdio bridge response-delivery deadline elapsed while a response \
+                             write was still pending (peer stopped reading); abandoning the \
+                             write and closing this session"
+                        );
+                        root.cancel();
+                        Err(std::io::Error::new(
+                            std::io::ErrorKind::TimedOut,
+                            "response-delivery deadline elapsed before the write completed",
+                        )
+                        .into())
+                    }
+                },
+                _ => send.await,
+            };
             // Decrement once the write is resolved either way — see the
             // `in_flight` field doc for why a failed write must not be left
             // permanently counted as pending.

--- a/crates/khive-mcp/src/transport.rs
+++ b/crates/khive-mcp/src/transport.rs
@@ -6,6 +6,8 @@
 //! before serving, so the serve path never hard-codes a transport enum.
 
 use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 
@@ -33,15 +35,26 @@ use crate::server::KhiveMcpServer;
 /// `None`, which cancels `root` and lets rmcp's normal graceful-close path
 /// tear the session down — the same clean-exit path that already releases
 /// pooled resources on a real disconnect.
+///
+/// Wire-idle is not session-idle: rmcp keeps racing `transport.receive()`
+/// while each admitted request runs in its own task, so a handler that
+/// outlasts `idle_timeout` (slow verb, large batch) must not have its
+/// session torn down out from under it. `in_flight` counts JSON-RPC
+/// `Request` messages this transport has handed to rmcp minus the
+/// `Response`/`Error` messages it has sent back for them; the idle branch
+/// only treats a quiet window as EOF when that count is zero, i.e. nothing
+/// admitted is still awaiting its response.
 pub(crate) struct CancelOnEofTransport<T> {
     inner: T,
     root: tokio_util::sync::CancellationToken,
     idle_timeout: Option<std::time::Duration>,
+    in_flight: Arc<AtomicI64>,
 }
 
 impl<T> CancelOnEofTransport<T> {
     /// `idle_timeout`: a `receive()` call that yields no message within this
-    /// window is treated as EOF (see the type doc). `None` disables it.
+    /// window is treated as EOF (see the type doc), but only when no
+    /// admitted request is still awaiting its response. `None` disables it.
     pub(crate) fn with_idle_timeout(
         inner: T,
         root: tokio_util::sync::CancellationToken,
@@ -51,6 +64,7 @@ impl<T> CancelOnEofTransport<T> {
             inner,
             root,
             idle_timeout,
+            in_flight: Arc::new(AtomicI64::new(0)),
         }
     }
 }
@@ -65,6 +79,12 @@ where
         &mut self,
         item: rmcp::service::TxJsonRpcMessage<rmcp::RoleServer>,
     ) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send + 'static {
+        if matches!(
+            item,
+            rmcp::model::JsonRpcMessage::Response(_) | rmcp::model::JsonRpcMessage::Error(_)
+        ) {
+            self.in_flight.fetch_sub(1, Ordering::AcqRel);
+        }
         self.inner.send(item)
     }
 
@@ -72,30 +92,44 @@ where
         &mut self,
     ) -> impl std::future::Future<Output = Option<rmcp::service::RxJsonRpcMessage<rmcp::RoleServer>>>
            + Send {
-        let receive = self.inner.receive();
         let root = self.root.clone();
         let idle_timeout = self.idle_timeout;
+        let in_flight = self.in_flight.clone();
         async move {
-            let message = match idle_timeout {
-                Some(timeout) => {
-                    tokio::select! {
-                        message = receive => message,
-                        () = tokio::time::sleep(timeout) => {
-                            tracing::info!(
-                                idle_timeout_secs = timeout.as_secs(),
-                                "stdio bridge idle timeout elapsed with no request; \
-                                 closing this session to release its pooled resources"
-                            );
-                            None
+            loop {
+                let message = match idle_timeout {
+                    Some(timeout) => {
+                        tokio::select! {
+                            message = self.inner.receive() => message,
+                            () = tokio::time::sleep(timeout) => {
+                                if in_flight.load(Ordering::Acquire) > 0 {
+                                    tracing::debug!(
+                                        idle_timeout_secs = timeout.as_secs(),
+                                        "stdio bridge idle timeout elapsed but an admitted \
+                                         request is still awaiting its response; deferring \
+                                         session close"
+                                    );
+                                    continue;
+                                }
+                                tracing::info!(
+                                    idle_timeout_secs = timeout.as_secs(),
+                                    "stdio bridge idle timeout elapsed with no request; \
+                                     closing this session to release its pooled resources"
+                                );
+                                None
+                            }
                         }
                     }
+                    None => self.inner.receive().await,
+                };
+                if let Some(rmcp::model::JsonRpcMessage::Request(_)) = &message {
+                    in_flight.fetch_add(1, Ordering::AcqRel);
                 }
-                None => receive.await,
-            };
-            if message.is_none() {
-                root.cancel();
+                if message.is_none() {
+                    root.cancel();
+                }
+                return message;
             }
-            message
         }
     }
 

--- a/crates/khive-mcp/src/transport.rs
+++ b/crates/khive-mcp/src/transport.rs
@@ -11,7 +11,10 @@ use async_trait::async_trait;
 
 use crate::server::KhiveMcpServer;
 
-/// Cancels rmcp's root service token before reporting transport EOF.
+/// Cancels rmcp's root service token before reporting transport EOF — and,
+/// with an idle timeout configured, before reporting a synthetic EOF when no
+/// message has arrived within that window even though the pipe itself stays
+/// open (#1921).
 ///
 /// rmcp otherwise classifies EOF as a graceful close and drains in-flight
 /// handlers for five seconds without cancelling their per-request child
@@ -20,14 +23,35 @@ use crate::server::KhiveMcpServer;
 /// begins. Send and close remain transparent, allowing this wrapper to sit
 /// outside the Unix post-flush self-heal transport without changing its flush
 /// ordering.
+///
+/// An abandoned stdio bridge — a client whose pipe never closes but which
+/// has stopped sending requests — is otherwise indistinguishable from a live
+/// one: nothing reaps it, so it holds its reader-pool admission and DB
+/// connection for as long as the parent process happens to stay alive
+/// (observed up to tens of hours in production). Idle timeout treats "no
+/// request for `idle_timeout`" the same as real EOF: `receive()` yields
+/// `None`, which cancels `root` and lets rmcp's normal graceful-close path
+/// tear the session down — the same clean-exit path that already releases
+/// pooled resources on a real disconnect.
 pub(crate) struct CancelOnEofTransport<T> {
     inner: T,
     root: tokio_util::sync::CancellationToken,
+    idle_timeout: Option<std::time::Duration>,
 }
 
 impl<T> CancelOnEofTransport<T> {
-    pub(crate) fn new(inner: T, root: tokio_util::sync::CancellationToken) -> Self {
-        Self { inner, root }
+    /// `idle_timeout`: a `receive()` call that yields no message within this
+    /// window is treated as EOF (see the type doc). `None` disables it.
+    pub(crate) fn with_idle_timeout(
+        inner: T,
+        root: tokio_util::sync::CancellationToken,
+        idle_timeout: Option<std::time::Duration>,
+    ) -> Self {
+        Self {
+            inner,
+            root,
+            idle_timeout,
+        }
     }
 }
 
@@ -50,8 +74,24 @@ where
            + Send {
         let receive = self.inner.receive();
         let root = self.root.clone();
+        let idle_timeout = self.idle_timeout;
         async move {
-            let message = receive.await;
+            let message = match idle_timeout {
+                Some(timeout) => {
+                    tokio::select! {
+                        message = receive => message,
+                        () = tokio::time::sleep(timeout) => {
+                            tracing::info!(
+                                idle_timeout_secs = timeout.as_secs(),
+                                "stdio bridge idle timeout elapsed with no request; \
+                                 closing this session to release its pooled resources"
+                            );
+                            None
+                        }
+                    }
+                }
+                None => receive.await,
+            };
             if message.is_none() {
                 root.cancel();
             }

--- a/crates/khive-runtime/Cargo.toml
+++ b/crates/khive-runtime/Cargo.toml
@@ -46,6 +46,11 @@ unicode-general-category = { workspace = true }
 sha2 = { workspace = true }
 
 [dev-dependencies]
+# Self-dependency to enable `fault-injection` for integration tests under
+# `tests/`: those link the lib as an external crate, so `#[cfg(test)]` items
+# gated `any(test, feature = "fault-injection")` (e.g. `run_daemon_in_process_test`)
+# are otherwise unreachable from there.
+khive-runtime = { path = ".", features = ["fault-injection"] }
 khive-gate-rego = { version = "0.7.0", path = "../khive-gate-rego" }
 tokio = { workspace = true, features = ["test-util"] }
 tempfile = { workspace = true }

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -1636,8 +1636,13 @@ async fn run_daemon_with_boot_guard_inner<D: DaemonDispatch>(
     // same process, which would self-deadlock on `flock`.
     let _startup_lock = boot_guard;
 
-    if let Some(incumbent_pid) =
-        cleanup_stale_daemon(&sock, &pid_file, allow_same_process_incumbent).await
+    if let Some(incumbent_pid) = cleanup_stale_daemon(
+        &sock,
+        &pid_file,
+        allow_same_process_incumbent,
+        dispatcher.config_id(),
+    )
+    .await
     {
         // #1874: a second daemon must refuse loudly (non-zero exit, pid named)
         // rather than exit `Ok(())` — a silent success here is what let two
@@ -1686,8 +1691,13 @@ async fn run_daemon_with_boot_guard_inner<D: DaemonDispatch>(
                 drop(listener);
                 let _ = std::fs::remove_file(&sock);
             }
-            if pid_file_names_a_reachable_daemon(&pid_file, &sock, allow_same_process_incumbent)
-                .await
+            if pid_file_names_a_reachable_daemon(
+                &pid_file,
+                &sock,
+                allow_same_process_incumbent,
+                dispatcher.config_id(),
+            )
+            .await
             {
                 tracing::info!(
                     "a replacement khived already claimed the pid/socket rendezvous; exiting"
@@ -1986,40 +1996,61 @@ fn pid_can_name_incumbent(pid: u32, current_pid: u32, allow_same_process_incumbe
 #[cfg(unix)]
 const DUPLICATE_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(500);
 
-/// Whether the listener at `sock` actually speaks the khived wire protocol.
+/// Whether the listener at `sock` actually speaks the khived wire protocol
+/// **as the same khived this process would defer to** — identified by
+/// `expected_config_id`.
 ///
 /// A live PID plus an accepting Unix socket is not proof of khived: any
 /// unrelated process that happens to have bound the same path also answers
-/// `connect()`. This sends a bounded `probe_only` frame (the same identity
-/// probe the client-side recovery path uses) and requires a well-formed
-/// [`DaemonResponseFrame`] back. Any frame that parses — even one reporting
-/// `version_mismatch` or `config_mismatch` — proves the peer speaks this
-/// protocol and is therefore a real khived instance that must not be treated
-/// as stale. A connect that succeeds but never answers, times out, or
-/// answers with non-protocol bytes is not khived and falls through to the
-/// stale-socket recovery path instead.
+/// `connect()`. Nor is any well-formed [`DaemonResponseFrame`] proof: a
+/// `config_mismatch`/`version_mismatch` response, or a legacy pre-probe
+/// daemon that falls through to normal dispatch on the empty `ops` string,
+/// both deserialize cleanly without being the unambiguous "yes, alive and
+/// identity-matching" answer this check needs. This sends a bounded
+/// `probe_only` frame (the same identity probe the client-side recovery path
+/// uses, `crates/khive-mcp/src/daemon.rs::probe_daemon_identity`) carrying
+/// this process's own `config_id`, and requires the exact probe-ack sentinel
+/// (`ok=true, result=None, error=None`) plus matching protocol version and
+/// `served_config_id` back — mirroring the client probe's `is_probe_ack`
+/// check so both sides of the protocol agree on what "alive" means. Connect,
+/// write, and read are all inside the one bounded timeout: `UnixStream::connect`
+/// itself awaits write readiness, so a listener with a saturated accept
+/// backlog could otherwise hold this call open past the advertised bound.
+/// A connect that succeeds but never answers, times out, or answers with
+/// non-protocol bytes, a mismatched identity, or a non-ack response is not
+/// treated as the same khived and falls through to the stale-socket recovery
+/// path instead.
 #[cfg(unix)]
-async fn socket_speaks_khived_protocol(sock: &std::path::Path) -> bool {
-    let Ok(mut stream) = UnixStream::connect(sock).await else {
-        return false;
-    };
+async fn socket_speaks_khived_protocol(sock: &std::path::Path, expected_config_id: &str) -> bool {
     let probe = DaemonRequestFrame {
         probe_only: true,
         protocol_version: PROTOCOL_VERSION,
+        config_id: expected_config_id.to_string(),
         ..Default::default()
     };
     let Ok(payload) = serde_json::to_vec(&probe) else {
         return false;
     };
-    tokio::time::timeout(DUPLICATE_PROBE_TIMEOUT, async {
+    let response = tokio::time::timeout(DUPLICATE_PROBE_TIMEOUT, async {
+        let mut stream = UnixStream::connect(sock).await.ok()?;
         write_frame(&mut stream, &payload).await.ok()?;
         let raw = read_frame(&mut stream).await.ok()?;
         serde_json::from_slice::<DaemonResponseFrame>(&raw).ok()
     })
     .await
     .ok()
-    .flatten()
-    .is_some()
+    .flatten();
+
+    let Some(resp) = response else {
+        return false;
+    };
+    let is_probe_ack = resp.ok && resp.result.is_none() && resp.error.is_none();
+    is_probe_ack
+        && !resp.version_mismatch
+        && !resp.namespace_mismatch
+        && !resp.config_mismatch
+        && resp.daemon_protocol_version == PROTOCOL_VERSION
+        && resp.served_config_id.as_deref() == Some(expected_config_id)
 }
 
 /// Check whether `pid_file`/`sock` already name a live, responsive daemon and,
@@ -2035,13 +2066,14 @@ async fn cleanup_stale_daemon(
     sock: &std::path::Path,
     pid_file: &std::path::Path,
     allow_same_process_incumbent: bool,
+    expected_config_id: &str,
 ) -> Option<u32> {
     if let Ok(pid_str) = std::fs::read_to_string(pid_file) {
         if let Ok(pid) = pid_str.trim().parse::<u32>() {
             if pid_can_name_incumbent(pid, std::process::id(), allow_same_process_incumbent)
                 && is_process_running(pid)
                 && sock.exists()
-                && socket_speaks_khived_protocol(sock).await
+                && socket_speaks_khived_protocol(sock, expected_config_id).await
             {
                 return Some(pid);
             }
@@ -2091,6 +2123,7 @@ async fn pid_file_names_a_reachable_daemon(
     pid_file: &std::path::Path,
     sock: &std::path::Path,
     allow_same_process_incumbent: bool,
+    expected_config_id: &str,
 ) -> bool {
     let Ok(pid_str) = std::fs::read_to_string(pid_file) else {
         return false;
@@ -2101,7 +2134,7 @@ async fn pid_file_names_a_reachable_daemon(
     pid_can_name_incumbent(pid, std::process::id(), allow_same_process_incumbent)
         && is_process_running(pid)
         && sock.exists()
-        && socket_speaks_khived_protocol(sock).await
+        && socket_speaks_khived_protocol(sock, expected_config_id).await
 }
 
 #[cfg(unix)]
@@ -3055,8 +3088,8 @@ mod tests {
         });
 
         assert!(
-            socket_speaks_khived_protocol(&sock_path).await,
-            "a real khived answering the probe_only frame must be recognized"
+            socket_speaks_khived_protocol(&sock_path, "probe-test").await,
+            "a real khived answering the probe_only frame with a matching config_id must be recognized"
         );
 
         let _ = tokio::time::timeout(std::time::Duration::from_secs(2), accept_task).await;
@@ -3084,7 +3117,7 @@ mod tests {
         });
 
         let before = tokio::time::Instant::now();
-        let speaks = socket_speaks_khived_protocol(&sock_path).await;
+        let speaks = socket_speaks_khived_protocol(&sock_path, "probe-test").await;
         let elapsed = before.elapsed();
 
         assert!(
@@ -3099,6 +3132,50 @@ mod tests {
         accept_task.abort();
         let _ = accept_task.await;
         drop(held);
+    }
+
+    /// #2230 review round 2 (Medium): a well-formed [`DaemonResponseFrame`]
+    /// that is not the unambiguous probe-ack sentinel — e.g. one reporting a
+    /// `config_mismatch` for a *different* config_id, exactly what a live
+    /// khived serving another store would send back — must not be treated as
+    /// the same live, identity-matching duplicate. Before this fix, any
+    /// frame that merely deserialized was accepted, so this response would
+    /// have been misclassified as "alive" and refused a legitimate boot.
+    #[tokio::test]
+    async fn socket_speaks_khived_protocol_rejects_a_non_ack_or_mismatched_response() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sock_path = dir.path().join("mismatched.sock");
+        let listener = UnixListener::bind(&sock_path).expect("bind fake listener");
+        let accept_task = tokio::spawn(async move {
+            if let Ok((mut stream, _)) = listener.accept().await {
+                let _raw = read_frame(&mut stream).await.expect("read probe frame");
+                let resp = DaemonResponseFrame {
+                    ok: false,
+                    result: None,
+                    error: None,
+                    namespace_mismatch: false,
+                    config_mismatch: true,
+                    served_config_id: Some("someone-elses-config".to_string()),
+                    version_mismatch: false,
+                    daemon_protocol_version: PROTOCOL_VERSION,
+                    metrics: None,
+                    request_id: None,
+                };
+                let payload = serde_json::to_vec(&resp).expect("encode response");
+                write_frame(&mut stream, &payload)
+                    .await
+                    .expect("write response");
+            }
+        });
+
+        let speaks = socket_speaks_khived_protocol(&sock_path, "expected-config").await;
+        assert!(
+            !speaks,
+            "a well-formed but non-ack / identity-mismatched response must not be treated as \
+             the same live khived"
+        );
+
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(2), accept_task).await;
     }
 
     #[tokio::test]

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -2003,23 +2003,29 @@ const DUPLICATE_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_m
 /// A live PID plus an accepting Unix socket is not proof of khived: any
 /// unrelated process that happens to have bound the same path also answers
 /// `connect()`. Nor is any well-formed [`DaemonResponseFrame`] proof: a
-/// `config_mismatch`/`version_mismatch` response, or a legacy pre-probe
-/// daemon that falls through to normal dispatch on the empty `ops` string,
-/// both deserialize cleanly without being the unambiguous "yes, alive and
-/// identity-matching" answer this check needs. This sends a bounded
-/// `probe_only` frame (the same identity probe the client-side recovery path
-/// uses, `crates/khive-mcp/src/daemon.rs::probe_daemon_identity`) carrying
-/// this process's own `config_id`, and requires the exact probe-ack sentinel
-/// (`ok=true, result=None, error=None`) plus matching protocol version and
-/// `served_config_id` back — mirroring the client probe's `is_probe_ack`
-/// check so both sides of the protocol agree on what "alive" means. Connect,
-/// write, and read are all inside the one bounded timeout: `UnixStream::connect`
+/// `config_mismatch`/`version_mismatch` response, a `metrics_only` snapshot
+/// response, or a legacy pre-probe daemon that falls through to normal
+/// dispatch on the empty `ops` string, all deserialize cleanly without being
+/// the unambiguous "yes, alive and identity-matching" answer this check
+/// needs — the daemon's `metrics_only` arm in particular echoes the same
+/// `ok=true, result=None, error=None`, all-mismatch-flags-false, matching
+/// protocol version and `served_config_id` shape as the probe-ack arm, and
+/// is distinguished only by carrying `metrics: Some(...)`. This sends a
+/// bounded `probe_only` frame (the same identity probe the client-side
+/// recovery path uses, `crates/khive-mcp/src/daemon.rs::probe_daemon_identity`)
+/// carrying this process's own `config_id`, and requires the exact
+/// probe-branch shape back: `ok=true`, `result=None`, `error=None`,
+/// `metrics=None`, `request_id=None` (this probe frame never sets one), no
+/// mismatch flags, matching protocol version, and matching
+/// `served_config_id` — mirroring the client probe's `is_probe_ack` check so
+/// both sides of the protocol agree on what "alive" means. Connect, write,
+/// and read are all inside the one bounded timeout: `UnixStream::connect`
 /// itself awaits write readiness, so a listener with a saturated accept
 /// backlog could otherwise hold this call open past the advertised bound.
 /// A connect that succeeds but never answers, times out, or answers with
-/// non-protocol bytes, a mismatched identity, or a non-ack response is not
-/// treated as the same khived and falls through to the stale-socket recovery
-/// path instead.
+/// non-protocol bytes, a mismatched identity, a `metrics_only` snapshot, or
+/// any other non-probe-shaped response is not treated as the same khived
+/// and falls through to the stale-socket recovery path instead.
 #[cfg(unix)]
 async fn socket_speaks_khived_protocol(sock: &std::path::Path, expected_config_id: &str) -> bool {
     let probe = DaemonRequestFrame {
@@ -2044,7 +2050,11 @@ async fn socket_speaks_khived_protocol(sock: &std::path::Path, expected_config_i
     let Some(resp) = response else {
         return false;
     };
-    let is_probe_ack = resp.ok && resp.result.is_none() && resp.error.is_none();
+    let is_probe_ack = resp.ok
+        && resp.result.is_none()
+        && resp.error.is_none()
+        && resp.metrics.is_none()
+        && resp.request_id.is_none();
     is_probe_ack
         && !resp.version_mismatch
         && !resp.namespace_mismatch
@@ -3173,6 +3183,52 @@ mod tests {
             !speaks,
             "a well-formed but non-ack / identity-mismatched response must not be treated as \
              the same live khived"
+        );
+
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(2), accept_task).await;
+    }
+
+    /// Regression (#2230): the daemon's `metrics_only` arm answers with
+    /// `ok=true, result=None, error=None`, every mismatch flag false, the
+    /// current protocol version, and a matching `served_config_id` — the
+    /// exact same shape the probe-ack arm produces, differing only in
+    /// carrying `metrics: Some(...)`. A well-formed metrics snapshot
+    /// response must not be misread as a probe acknowledgement; otherwise a
+    /// client whose only interaction with the socket happened to be a
+    /// metrics poll would be classified as the same live, identity-matching
+    /// khived.
+    #[tokio::test]
+    async fn socket_speaks_khived_protocol_rejects_a_metrics_only_response() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sock_path = dir.path().join("metrics-only.sock");
+        let listener = UnixListener::bind(&sock_path).expect("bind fake listener");
+        let accept_task = tokio::spawn(async move {
+            if let Ok((mut stream, _)) = listener.accept().await {
+                let _raw = read_frame(&mut stream).await.expect("read probe frame");
+                let resp = DaemonResponseFrame {
+                    ok: true,
+                    result: None,
+                    error: None,
+                    namespace_mismatch: false,
+                    config_mismatch: false,
+                    served_config_id: Some("expected-config".to_string()),
+                    version_mismatch: false,
+                    daemon_protocol_version: PROTOCOL_VERSION,
+                    metrics: Some(MetricsSnapshot::default()),
+                    request_id: None,
+                };
+                let payload = serde_json::to_vec(&resp).expect("encode response");
+                write_frame(&mut stream, &payload)
+                    .await
+                    .expect("write response");
+            }
+        });
+
+        let speaks = socket_speaks_khived_protocol(&sock_path, "expected-config").await;
+        assert!(
+            !speaks,
+            "an otherwise-matching response carrying a metrics snapshot must not be treated as \
+             a probe acknowledgement"
         );
 
         let _ = tokio::time::timeout(std::time::Duration::from_secs(2), accept_task).await;

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -1979,6 +1979,49 @@ fn pid_can_name_incumbent(pid: u32, current_pid: u32, allow_same_process_incumbe
     allow_same_process_incumbent || pid != current_pid
 }
 
+/// Bounded timeout for the protocol-identity probe used by duplicate-daemon
+/// detection. Short enough that a hung or foreign listener does not stall
+/// startup; long enough for a live khived under normal load to answer a
+/// `probe_only` frame.
+#[cfg(unix)]
+const DUPLICATE_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(500);
+
+/// Whether the listener at `sock` actually speaks the khived wire protocol.
+///
+/// A live PID plus an accepting Unix socket is not proof of khived: any
+/// unrelated process that happens to have bound the same path also answers
+/// `connect()`. This sends a bounded `probe_only` frame (the same identity
+/// probe the client-side recovery path uses) and requires a well-formed
+/// [`DaemonResponseFrame`] back. Any frame that parses — even one reporting
+/// `version_mismatch` or `config_mismatch` — proves the peer speaks this
+/// protocol and is therefore a real khived instance that must not be treated
+/// as stale. A connect that succeeds but never answers, times out, or
+/// answers with non-protocol bytes is not khived and falls through to the
+/// stale-socket recovery path instead.
+#[cfg(unix)]
+async fn socket_speaks_khived_protocol(sock: &std::path::Path) -> bool {
+    let Ok(mut stream) = UnixStream::connect(sock).await else {
+        return false;
+    };
+    let probe = DaemonRequestFrame {
+        probe_only: true,
+        protocol_version: PROTOCOL_VERSION,
+        ..Default::default()
+    };
+    let Ok(payload) = serde_json::to_vec(&probe) else {
+        return false;
+    };
+    tokio::time::timeout(DUPLICATE_PROBE_TIMEOUT, async {
+        write_frame(&mut stream, &payload).await.ok()?;
+        let raw = read_frame(&mut stream).await.ok()?;
+        serde_json::from_slice::<DaemonResponseFrame>(&raw).ok()
+    })
+    .await
+    .ok()
+    .flatten()
+    .is_some()
+}
+
 /// Check whether `pid_file`/`sock` already name a live, responsive daemon and,
 /// if not, remove the stale rendezvous files so the caller may bind fresh.
 ///
@@ -1998,7 +2041,7 @@ async fn cleanup_stale_daemon(
             if pid_can_name_incumbent(pid, std::process::id(), allow_same_process_incumbent)
                 && is_process_running(pid)
                 && sock.exists()
-                && UnixStream::connect(sock).await.is_ok()
+                && socket_speaks_khived_protocol(sock).await
             {
                 return Some(pid);
             }
@@ -2058,7 +2101,7 @@ async fn pid_file_names_a_reachable_daemon(
     pid_can_name_incumbent(pid, std::process::id(), allow_same_process_incumbent)
         && is_process_running(pid)
         && sock.exists()
-        && UnixStream::connect(sock).await.is_ok()
+        && socket_speaks_khived_protocol(sock).await
 }
 
 #[cfg(unix)]
@@ -2988,6 +3031,74 @@ mod tests {
         let raw = read_frame(&mut client).await.expect("read response frame");
         handle.await.expect("handle_conn task panicked");
         serde_json::from_slice(&raw).expect("decode response frame")
+    }
+
+    /// #2230 review (Medium): duplicate-daemon detection must not treat any
+    /// accepting Unix listener as khived. A real khived (`handle_conn` behind
+    /// a bound socket) must still be recognized by the protocol probe.
+    #[tokio::test]
+    async fn socket_speaks_khived_protocol_accepts_a_real_khived() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sock_path = dir.path().join("real.sock");
+        let listener = UnixListener::bind(&sock_path).expect("bind real listener");
+        let dispatcher = MockDispatch {
+            namespace: "local".to_string(),
+            config_id: "probe-test".to_string(),
+            dispatch_calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            pool: None,
+            dispatch_err: None,
+        };
+        let accept_task = tokio::spawn(async move {
+            if let Ok((stream, _)) = listener.accept().await {
+                handle_conn(stream, dispatcher).await;
+            }
+        });
+
+        assert!(
+            socket_speaks_khived_protocol(&sock_path).await,
+            "a real khived answering the probe_only frame must be recognized"
+        );
+
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(2), accept_task).await;
+    }
+
+    /// #2230 review (Medium): a listener that accepts a connection but never
+    /// answers with a well-formed daemon response — e.g. an unrelated process
+    /// that happens to have bound the same socket path — must not be
+    /// classified as khived, and the probe must not hang past its own
+    /// bounded timeout.
+    #[tokio::test]
+    async fn socket_speaks_khived_protocol_rejects_a_non_protocol_listener() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sock_path = dir.path().join("fake.sock");
+        let listener = UnixListener::bind(&sock_path).expect("bind fake listener");
+        let held = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let held_for_task = held.clone();
+        let accept_task = tokio::spawn(async move {
+            if let Ok((stream, _)) = listener.accept().await {
+                // Accept but never write anything back — the connection stays
+                // open exactly like a foreign process that speaks a different
+                // (or no) protocol on this socket.
+                held_for_task.lock().await.push(stream);
+            }
+        });
+
+        let before = tokio::time::Instant::now();
+        let speaks = socket_speaks_khived_protocol(&sock_path).await;
+        let elapsed = before.elapsed();
+
+        assert!(
+            !speaks,
+            "a listener that accepts but never answers the probe frame must not be treated as khived"
+        );
+        assert!(
+            elapsed < std::time::Duration::from_secs(2),
+            "the probe must be bounded by its own timeout, not hang indefinitely; took {elapsed:?}"
+        );
+
+        accept_task.abort();
+        let _ = accept_task.await;
+        drop(held);
     }
 
     #[tokio::test]

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -3196,7 +3196,9 @@ mod tests {
     /// response must not be misread as a probe acknowledgement; otherwise a
     /// client whose only interaction with the socket happened to be a
     /// metrics poll would be classified as the same live, identity-matching
-    /// khived.
+    /// khived. This response carries `request_id: None`, so it isolates the
+    /// `metrics.is_none()` conjunct — see the sibling test below for the
+    /// `request_id.is_none()` conjunct.
     #[tokio::test]
     async fn socket_speaks_khived_protocol_rejects_a_metrics_only_response() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -3231,7 +3233,56 @@ mod tests {
              a probe acknowledgement"
         );
 
-        let _ = tokio::time::timeout(std::time::Duration::from_secs(2), accept_task).await;
+        tokio::time::timeout(std::time::Duration::from_secs(2), accept_task)
+            .await
+            .expect("fake listener accept task timed out")
+            .expect("fake listener accept task panicked");
+    }
+
+    /// Regression (#2230): sibling of the metrics-only test above, isolating
+    /// the `request_id.is_none()` conjunct. A response with `metrics: None`
+    /// but an echoed `request_id: Some(_)` is otherwise identical to a probe
+    /// acknowledgement and must not be misread as one — a probe frame never
+    /// sets `request_id`, so an echo of one is proof the peer answered a
+    /// different, non-probe request.
+    #[tokio::test]
+    async fn socket_speaks_khived_protocol_rejects_a_response_with_request_id() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sock_path = dir.path().join("request-id.sock");
+        let listener = UnixListener::bind(&sock_path).expect("bind fake listener");
+        let accept_task = tokio::spawn(async move {
+            if let Ok((mut stream, _)) = listener.accept().await {
+                let _raw = read_frame(&mut stream).await.expect("read probe frame");
+                let resp = DaemonResponseFrame {
+                    ok: true,
+                    result: None,
+                    error: None,
+                    namespace_mismatch: false,
+                    config_mismatch: false,
+                    served_config_id: Some("expected-config".to_string()),
+                    version_mismatch: false,
+                    daemon_protocol_version: PROTOCOL_VERSION,
+                    metrics: None,
+                    request_id: Some(42),
+                };
+                let payload = serde_json::to_vec(&resp).expect("encode response");
+                write_frame(&mut stream, &payload)
+                    .await
+                    .expect("write response");
+            }
+        });
+
+        let speaks = socket_speaks_khived_protocol(&sock_path, "expected-config").await;
+        assert!(
+            !speaks,
+            "an otherwise-matching response carrying an echoed request_id must not be treated \
+             as a probe acknowledgement"
+        );
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), accept_task)
+            .await
+            .expect("fake listener accept task timed out")
+            .expect("fake listener accept task panicked");
     }
 
     #[tokio::test]

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -1636,9 +1636,23 @@ async fn run_daemon_with_boot_guard_inner<D: DaemonDispatch>(
     // same process, which would self-deadlock on `flock`.
     let _startup_lock = boot_guard;
 
-    if !cleanup_stale_daemon(&sock, &pid_file, allow_same_process_incumbent).await {
-        tracing::info!("a responsive khived is already running; exiting");
-        return Ok(());
+    if let Some(incumbent_pid) =
+        cleanup_stale_daemon(&sock, &pid_file, allow_same_process_incumbent).await
+    {
+        // #1874: a second daemon must refuse loudly (non-zero exit, pid named)
+        // rather than exit `Ok(())` — a silent success here is what let two
+        // detached daemons coexist on one store with neither side or its
+        // caller ever noticing.
+        tracing::error!(
+            pid = incumbent_pid,
+            socket = ?sock,
+            "refusing to start: a khived instance is already running"
+        );
+        anyhow::bail!(
+            "refusing to start: khived is already running as pid {incumbent_pid}, \
+             serving socket {}. Stop that instance first if you intend to replace it.",
+            sock.display()
+        );
     }
 
     let listener = UnixListener::bind(&sock)?;
@@ -1965,12 +1979,20 @@ fn pid_can_name_incumbent(pid: u32, current_pid: u32, allow_same_process_incumbe
     allow_same_process_incumbent || pid != current_pid
 }
 
+/// Check whether `pid_file`/`sock` already name a live, responsive daemon and,
+/// if not, remove the stale rendezvous files so the caller may bind fresh.
+///
+/// Returns `Some(pid)` when a live incumbent answered on `sock` — the caller
+/// must not clean up or bind, and must refuse to start rather than silently
+/// deferring (#1874: a quiet `Ok(())` here is exactly what let two detached
+/// daemons coexist on one store). Returns `None` when the rendezvous was
+/// stale (or absent) and has been cleared, so the caller may proceed.
 #[cfg(unix)]
 async fn cleanup_stale_daemon(
     sock: &std::path::Path,
     pid_file: &std::path::Path,
     allow_same_process_incumbent: bool,
-) -> bool {
+) -> Option<u32> {
     if let Ok(pid_str) = std::fs::read_to_string(pid_file) {
         if let Ok(pid) = pid_str.trim().parse::<u32>() {
             if pid_can_name_incumbent(pid, std::process::id(), allow_same_process_incumbent)
@@ -1978,7 +2000,7 @@ async fn cleanup_stale_daemon(
                 && sock.exists()
                 && UnixStream::connect(sock).await.is_ok()
             {
-                return false;
+                return Some(pid);
             }
         }
     }
@@ -1992,7 +2014,7 @@ async fn cleanup_stale_daemon(
             tracing::warn!(error = %e, path = ?pid_file, "failed to remove stale PID file");
         }
     }
-    true
+    None
 }
 
 /// Create `pid_file` exclusively (`O_EXCL`) and write this process's PID.

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -3134,7 +3134,7 @@ mod tests {
         drop(held);
     }
 
-    /// #2230 review round 2 (Medium): a well-formed [`DaemonResponseFrame`]
+    /// Regression (#2230): a well-formed [`DaemonResponseFrame`]
     /// that is not the unambiguous probe-ack sentinel — e.g. one reporting a
     /// `config_mismatch` for a *different* config_id, exactly what a live
     /// khived serving another store would send back — must not be treated as

--- a/crates/khive-runtime/tests/duplicate_daemon_refusal.rs
+++ b/crates/khive-runtime/tests/duplicate_daemon_refusal.rs
@@ -1,0 +1,99 @@
+//! Regression test for #1874 — a second `khived` boot attempt against a
+//! store already served by a live daemon must refuse loudly (an `Err` naming
+//! the incumbent pid) rather than silently exit `Ok(())`.
+//!
+//! Before the fix, `run_daemon_with_boot_guard_inner` treated "a live,
+//! responsive incumbent already owns this socket" as ordinary success: it
+//! logged at `info` and returned `Ok(())`. A human (or a supervisor)
+//! starting a second daemon against a store already served by one had no
+//! signal that anything was wrong — both processes ran, each holding its own
+//! WAL connection and read marks, exactly the two-daemon state #1874
+//! describes.
+//!
+//! Unix-only: daemon boot/socket/pid-file machinery is `#[cfg(unix)]` only.
+
+#![cfg(unix)]
+
+use async_trait::async_trait;
+use khive_runtime::daemon::run_daemon_in_process_test;
+use khive_runtime::{DaemonDispatch, RequestIdentity};
+use serial_test::serial;
+
+#[derive(Clone)]
+struct NeverDispatch;
+
+#[async_trait]
+impl DaemonDispatch for NeverDispatch {
+    async fn dispatch(
+        &self,
+        _ops: String,
+        _presentation: Option<String>,
+        _presentation_per_op: Option<Vec<Option<String>>>,
+        _format: Option<String>,
+        _format_per_op: Option<Vec<Option<String>>>,
+        _from_wire: bool,
+        _identity: Option<RequestIdentity>,
+    ) -> Result<String, String> {
+        Err("dispatch not exercised by this test".to_string())
+    }
+
+    async fn warm_all(&self) {}
+
+    fn namespace(&self) -> &str {
+        "test"
+    }
+
+    fn config_id(&self) -> &str {
+        "test-config"
+    }
+}
+
+/// Second boot attempt must fail loudly (`Err`) and name the incumbent's pid
+/// — never silently succeed while a live daemon already owns the socket.
+#[tokio::test]
+#[serial]
+async fn second_daemon_boot_refuses_loudly_while_first_is_live() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::env::set_var("KHIVE_SOCKET", dir.path().join("khived.sock"));
+    std::env::set_var("KHIVE_PID", dir.path().join("khived.pid"));
+    std::env::set_var("KHIVE_LOCK", dir.path().join("khived.recovery.lock"));
+
+    let first = tokio::spawn(run_daemon_in_process_test(NeverDispatch));
+
+    // Poll for the socket to appear rather than a fixed sleep: bind happens
+    // asynchronously inside the spawned task.
+    let sock = dir.path().join("khived.sock");
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+    while !sock.exists() {
+        if tokio::time::Instant::now() >= deadline {
+            panic!("first daemon never bound its socket within the deadline");
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+
+    let second = run_daemon_in_process_test(NeverDispatch).await;
+
+    let err = second.expect_err(
+        "a second boot attempt while the first is live and responsive must return Err, \
+         not silently succeed",
+    );
+    let message = format!("{err:#}");
+    assert!(
+        message.contains(&std::process::id().to_string()),
+        "the refusal must name the incumbent's pid so an operator can act on it, got: {message}"
+    );
+    assert!(
+        message.to_lowercase().contains("already running"),
+        "the refusal must say plainly that a daemon is already running, got: {message}"
+    );
+
+    // The in-process harness serves until aborted (no SIGTERM channel in a
+    // test process) — the same teardown contract used elsewhere for this
+    // entrypoint (see khive-mcp's `InProcessDaemonHandle::stop`).
+    first.abort();
+    let _ = first.await;
+
+    std::env::remove_var("KHIVE_SOCKET");
+    std::env::remove_var("KHIVE_PID");
+    std::env::remove_var("KHIVE_LOCK");
+}


### PR DESCRIPTION
> **Superseded in part — do not merge as-is.**
>
> The stdio-bridge session-lifetime half of this change now lives in #2239, where it was
> revised twice: the idle timeout became opt-in rather than on by default, and an outstanding
> request obligation now expires instead of deferring the idle close for the life of the
> session. The copy of that code on this branch predates both revisions, so merging this PR
> would reintroduce the behaviour those revisions removed.
>
> What remains uniquely here is the duplicate-daemon-boot refusal:
> `crates/khive-runtime/src/daemon.rs`, `crates/khive-mcp/src/daemon.rs`, and
> `crates/khive-runtime/tests/duplicate_daemon_refusal.rs`. Three of the nine commits on this
> branch touch both halves, so the daemon half is not separable at a commit boundary. It will
> be cut onto a fresh branch after #2239 lands, and this PR closed with a pointer to it.
>
> The boot behaviour it implements is specified in ADR-049 Amendment 6 (#2236).

---

Closes #1921, closes #1874; addresses #1836 via the same idle-timeout seam (an idle bridge now releases its pooled resources instead of holding a live WAL connection for its lifetime).

- `CancelOnEofTransport` gains an optional idle timeout (env `KHIVE_BRIDGE_IDLE_TIMEOUT_SECS`, default 3600s, 0 disables): a quiet window past the timeout is treated exactly like client EOF, driving the existing graceful-close path that already tears down the session and its pool handle. An admitted request with a response still being written — running long, or delivered slowly to a backpressured reader — defers that close instead of being cancelled out from under it; a request is only counted as "still awaiting its response" until its write has actually finished, not merely been handed off. Cancellation-safety of racing away the in-flight receive verified against the transport's buffering (state lives in `self`, not the polled-away future). Daemon mode is unaffected (it never reaches `serve_stdio`).
- That deferral is itself bounded by a second, independent knob: `KHIVE_BRIDGE_RESPONSE_DEADLINE_SECS` (default 300s; accepted range is 1 second and up — `0` is rejected at startup, naming the variable, the rejected value, and the accepted range) caps how long a single response write may stay pending before it is abandoned and the session closed anyway. Without it, a peer that admits a request and then simply stops reading its response — while leaving the connection open — would keep that write pending forever and the idle timeout would defer indefinitely, never reaping the session.
- A second `kkernel mcp --daemon` against a store already served by a live, responsive daemon now fails loudly: error names the incumbent pid and socket path, process exits non-zero. The stale-socket recovery path (dead pid or unreachable socket) is unchanged. The liveness probe requires an exact protocol-acknowledgement shape (not just any well-formed response) so it can't mistake an unrelated response — for example a metrics snapshot — from the same daemon for the acknowledgement it's looking for.

Tests: idle timeout cancels without EOF; intermittent traffic is not reaped; an admitted long-running request is not cancelled by wire idleness; a backpressured response write defers idle-close; a response write that never resolves is still reaped within the response-delivery deadline; a `0` response-delivery deadline is rejected at startup rather than accepted as an unbounded opt-out; duplicate boot refuses while the first daemon is live, including against a metrics-only response (verified to fail without the fix). Full khive-runtime suite green; khive-mcp/kkernel checks clean.

