### PR TITLE
fix(db,runtime,mcp,comm): guard six read-modify-write paths with compare-and-swap

### DIFF
--- a/crates/khive-db/src/stores/entity.rs
+++ b/crates/khive-db/src/stores/entity.rs
@@ -104,6 +104,73 @@ pub fn entity_upsert_statement(entity: &Entity) -> SqlStatement {
     }
 }
 
+/// Full-entity compare-and-swap update used after caller-side normalization
+/// was derived from a read snapshot. Unlike [`entity_upsert_statement`], this
+/// never inserts and cannot overwrite a row whose revision or deletion
+/// marker moved after the snapshot was read. The replacement revision must
+/// also be strictly greater than the persisted snapshot revision; equality
+/// is a refused CAS, never a successful write with an unchanged concurrency
+/// token. Mirrors `note_replace_if_unchanged_statement`
+/// (`crates/khive-db/src/stores/note.rs`).
+pub fn entity_replace_if_unchanged_statement(
+    entity: &Entity,
+    expected_updated_at: i64,
+    expected_deleted_at: Option<i64>,
+) -> SqlStatement {
+    let properties_str = entity
+        .properties
+        .as_ref()
+        .map(|v| serde_json::to_string(v).unwrap_or_default());
+    let tags_str = serde_json::to_string(&entity.tags).unwrap_or_else(|_| "[]".to_string());
+    SqlStatement {
+        sql: "UPDATE entities SET \
+                namespace = ?1, kind = ?2, entity_type = ?3, name = ?4, description = ?5, \
+                properties = ?6, tags = ?7, updated_at = ?8, deleted_at = ?9, \
+                merged_into = ?10, merge_event_id = ?11 \
+              WHERE id = ?12 AND updated_at = ?13 AND deleted_at IS ?14 \
+                AND ?8 > updated_at"
+            .to_string(),
+        params: vec![
+            SqlValue::Text(entity.namespace.clone()),
+            SqlValue::Text(entity.kind.clone()),
+            match &entity.entity_type {
+                Some(t) => SqlValue::Text(t.clone()),
+                None => SqlValue::Null,
+            },
+            SqlValue::Text(entity.name.clone()),
+            match &entity.description {
+                Some(d) => SqlValue::Text(d.clone()),
+                None => SqlValue::Null,
+            },
+            match properties_str {
+                Some(p) => SqlValue::Text(p),
+                None => SqlValue::Null,
+            },
+            SqlValue::Text(tags_str),
+            SqlValue::Integer(entity.updated_at),
+            match entity.deleted_at {
+                Some(d) => SqlValue::Integer(d),
+                None => SqlValue::Null,
+            },
+            match entity.merged_into {
+                Some(u) => SqlValue::Text(u.to_string()),
+                None => SqlValue::Null,
+            },
+            match entity.merge_event_id {
+                Some(u) => SqlValue::Text(u.to_string()),
+                None => SqlValue::Null,
+            },
+            SqlValue::Text(entity.id.to_string()),
+            SqlValue::Integer(expected_updated_at),
+            match expected_deleted_at {
+                Some(value) => SqlValue::Integer(value),
+                None => SqlValue::Null,
+            },
+        ],
+        label: Some("entity-replace-if-unchanged".to_string()),
+    }
+}
+
 /// The exact soft-delete `UPDATE` this store's `delete_entity(Soft)` issues.
 pub fn entity_soft_delete_statement(id: Uuid, deleted_at: i64) -> SqlStatement {
     SqlStatement {
@@ -719,6 +786,25 @@ impl EntityStore for SqlEntityStore {
                 return Err(e);
             }
             Ok(summary)
+        })
+        .await
+    }
+
+    async fn replace_entity_if_unchanged(
+        &self,
+        entity: Entity,
+        expected_updated_at: i64,
+        expected_deleted_at: Option<i64>,
+    ) -> Result<bool, StorageError> {
+        let statement = entity_replace_if_unchanged_statement(
+            &entity,
+            expected_updated_at,
+            expected_deleted_at,
+        );
+        self.with_writer("replace_entity_if_unchanged", move |conn| {
+            let mut stmt = conn.prepare(&statement.sql)?;
+            bind_params(&mut stmt, &statement.params)?;
+            Ok(stmt.raw_execute()? > 0)
         })
         .await
     }

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -300,6 +300,22 @@ pub const EDGE_SYMMETRIC_CONFLICT_PROBE_SQL: &str = "SELECT id FROM graph_edges 
 pub const EDGE_SYMMETRIC_DELETE_NONCANONICAL_SQL: &str =
     "DELETE FROM graph_edges WHERE namespace = ?1 AND id = ?2";
 
+/// Canonical `update_edge`'s guarded variant of
+/// [`EDGE_SYMMETRIC_DELETE_NONCANONICAL_SQL`]: `?3`/`?4` pin the fetched
+/// snapshot's `updated_at`/`deleted_at` so a writer whose edge changed
+/// concurrently after it read that snapshot cannot delete the row out from
+/// under the concurrent write, even though a canonical survivor genuinely
+/// exists at the natural key. Zero affected rows means stale, not
+/// "no conflict" — the caller has already confirmed a conflicting canonical
+/// row exists before running this statement. Deliberately a DIFFERENT
+/// constant from the unguarded one above: merge's predicate-based rewrites
+/// (`khive-runtime::curation`) intentionally keep running the unguarded form
+/// inside their own single writer transaction and must not be changed to
+/// bind this one.
+pub const EDGE_SYMMETRIC_DELETE_NONCANONICAL_GUARDED_SQL: &str =
+    "DELETE FROM graph_edges WHERE namespace = ?1 AND id = ?2 \
+     AND updated_at = ?3 AND deleted_at IS ?4";
+
 /// Case (a) update, guarded on the fetched snapshot's revision and deletion
 /// marker: `?9`/`?10` pin `updated_at`/`deleted_at` as read, and `?5 >
 /// updated_at` requires the replacement revision to strictly advance —
@@ -417,7 +433,14 @@ pub fn edge_symmetric_update_inplace_statement(
 //
 // 1. [`edge_symmetric_delete_if_conflict_statement`]: deletes the requested
 //    (non-canonical) row IF AND ONLY IF a differently-id'd canonical row
-//    exists at the target natural key at THIS moment (guard: 0 or 1 rows).
+//    exists at the target natural key at THIS moment AND the row's own
+//    `updated_at`/`deleted_at` still match the snapshot this plan was built
+//    from (guard: 0 or 1 rows) — a plan built from a since-changed snapshot
+//    must not delete the row just because some other, unrelated conflict
+//    happens to exist; the second statement's own commit-time predicate
+//    (below) then sees `changes() = 0` and fails its `exactly(1)` guard,
+//    aborting the whole atomic unit rather than silently absorbing a
+//    concurrent writer's change.
 // 2. [`edge_symmetric_absorb_or_update_inplace_statement`]: a single
 //    `UPDATE` that no longer trusts an `id = ?2 OR natural-key` predicate
 //    (ADR-099 §B3 — that predicate could
@@ -471,16 +494,20 @@ pub fn edge_symmetric_update_inplace_statement(
 // a value computed before the
 // SAME atomic unit's other ops have run is not a fact this plan can stand
 // behind, so result rendering no longer trusts it.
+#[allow(clippy::too_many_arguments)]
 pub fn edge_symmetric_delete_if_conflict_statement(
     namespace: &str,
     id: Uuid,
     canon_src: Uuid,
     canon_tgt: Uuid,
     relation: EdgeRelation,
+    expected_updated_at_micros: i64,
+    expected_deleted_at_micros: Option<i64>,
 ) -> SqlStatement {
     SqlStatement {
         sql: "DELETE FROM graph_edges \
               WHERE namespace = ?1 AND id = ?2 \
+                AND updated_at = ?6 AND deleted_at IS ?7 \
                 AND EXISTS ( \
                   SELECT 1 FROM graph_edges \
                   WHERE namespace = ?1 AND source_id = ?3 AND target_id = ?4 \
@@ -493,6 +520,11 @@ pub fn edge_symmetric_delete_if_conflict_statement(
             SqlValue::Text(canon_src.to_string()),
             SqlValue::Text(canon_tgt.to_string()),
             SqlValue::Text(relation.to_string()),
+            SqlValue::Integer(expected_updated_at_micros),
+            match expected_deleted_at_micros {
+                Some(value) => SqlValue::Integer(value),
+                None => SqlValue::Null,
+            },
         ],
         label: Some("edge-symmetric-delete-if-conflict".to_string()),
     }

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -127,6 +127,64 @@ pub fn edge_upsert_statement(edge: &Edge) -> SqlStatement {
     }
 }
 
+/// Full-edge compare-and-swap update used after caller-side normalization
+/// was derived from a read snapshot. Unlike [`edge_upsert_statement`], this
+/// never inserts and cannot overwrite a row whose revision or deletion
+/// marker moved after the snapshot was read. The replacement revision must
+/// also be strictly greater than the persisted snapshot revision; equality
+/// is a refused CAS, never a successful write with an unchanged concurrency
+/// token. Mirrors `note_replace_if_unchanged_statement`
+/// (`crates/khive-db/src/stores/note.rs`). `created_at` is deliberately
+/// excluded from the `SET` list, matching the note/entity siblings — a
+/// replacement never rewrites the row's original creation time.
+pub fn edge_replace_if_unchanged_statement(
+    edge: &Edge,
+    expected_updated_at: DateTime<Utc>,
+    expected_deleted_at: Option<DateTime<Utc>>,
+) -> SqlStatement {
+    let (source_id, target_id) =
+        canonical_edge_endpoints(edge.relation, edge.source_id, edge.target_id);
+    let metadata_str = edge
+        .metadata
+        .as_ref()
+        .map(|v| serde_json::to_string(v).unwrap_or_default());
+    SqlStatement {
+        sql: "UPDATE graph_edges SET \
+                namespace = ?1, source_id = ?2, target_id = ?3, relation = ?4, weight = ?5, \
+                updated_at = ?6, deleted_at = ?7, metadata = ?8, target_backend = ?9 \
+              WHERE id = ?10 AND updated_at = ?11 AND deleted_at IS ?12 \
+                AND ?6 > updated_at"
+            .to_string(),
+        params: vec![
+            SqlValue::Text(edge.namespace.clone()),
+            SqlValue::Text(source_id.to_string()),
+            SqlValue::Text(target_id.to_string()),
+            SqlValue::Text(edge.relation.to_string()),
+            SqlValue::Float(edge.weight),
+            SqlValue::Integer(edge.updated_at.timestamp_micros()),
+            match edge.deleted_at {
+                Some(t) => SqlValue::Integer(t.timestamp_micros()),
+                None => SqlValue::Null,
+            },
+            match metadata_str {
+                Some(m) => SqlValue::Text(m),
+                None => SqlValue::Null,
+            },
+            match &edge.target_backend {
+                Some(b) => SqlValue::Text(b.clone()),
+                None => SqlValue::Null,
+            },
+            SqlValue::Text(Uuid::from(edge.id).to_string()),
+            SqlValue::Integer(expected_updated_at.timestamp_micros()),
+            match expected_deleted_at {
+                Some(value) => SqlValue::Integer(value.timestamp_micros()),
+                None => SqlValue::Null,
+            },
+        ],
+        label: Some("edge-replace-if-unchanged".to_string()),
+    }
+}
+
 /// The atomic `link` op's variant of [`edge_upsert_statement`] (ADR-099
 /// §B3). Shares the SAME
 /// `EDGE_NATURAL_KEY_CONFLICT_SET` conflict-arm text — the two builders
@@ -1363,6 +1421,22 @@ impl GraphStore for SqlGraphStore {
             bind_params(&mut stmt, &statement.params)?;
             stmt.raw_execute()?;
             Ok(())
+        })
+        .await
+    }
+
+    async fn replace_edge_if_unchanged(
+        &self,
+        edge: Edge,
+        expected_updated_at: DateTime<Utc>,
+        expected_deleted_at: Option<DateTime<Utc>>,
+    ) -> Result<bool, StorageError> {
+        let statement =
+            edge_replace_if_unchanged_statement(&edge, expected_updated_at, expected_deleted_at);
+        self.with_writer("replace_edge_if_unchanged", move |conn| {
+            let mut stmt = conn.prepare(&statement.sql)?;
+            bind_params(&mut stmt, &statement.params)?;
+            Ok(stmt.raw_execute()? > 0)
         })
         .await
     }

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -408,11 +408,14 @@ pub fn edge_symmetric_update_inplace_statement(
 // Symmetric-relation update DML — atomic-only, commit-time self-guarding
 // variant (ADR-099 §B3).
 //
-// The four builders above are still what canonical `update_edge_symmetric_dml`
-// binds: it probes and branches synchronously INSIDE its own writer-task
-// transaction, with no other op interleaved between its probe and its write,
-// so its branch has no staleness exposure and is left untouched (control
-// group — canonical's tests must stay green).
+// Canonical `update_edge_symmetric_dml` binds the shared SQL constants above
+// directly, not the plan-shape builders — the builders are used by the atomic
+// prepare path. Canonical probes and branches synchronously INSIDE its own
+// writer-task transaction, with no other op interleaved between its probe and
+// its write, so the interleaving exposure the atomic path has does not arise
+// there. Canonical's absorption delete is nonetheless bound to the GUARDED
+// constant, because its snapshot is read before the transaction and can be
+// stale by the time the delete runs.
 //
 // The atomic path is structurally different: its conflict probe runs in the
 // async PREPARE phase, which for a multi-op `--atomic` unit completes for

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -300,10 +300,18 @@ pub const EDGE_SYMMETRIC_CONFLICT_PROBE_SQL: &str = "SELECT id FROM graph_edges 
 pub const EDGE_SYMMETRIC_DELETE_NONCANONICAL_SQL: &str =
     "DELETE FROM graph_edges WHERE namespace = ?1 AND id = ?2";
 
+/// Case (a) update, guarded on the fetched snapshot's revision and deletion
+/// marker: `?9`/`?10` pin `updated_at`/`deleted_at` as read, and `?5 >
+/// updated_at` requires the replacement revision to strictly advance —
+/// mirroring `edge_replace_if_unchanged_statement`'s guard so the symmetric
+/// path cannot silently overwrite a concurrent writer's change between the
+/// snapshot read and this write.
 pub const EDGE_SYMMETRIC_UPDATE_INPLACE_SQL: &str = "UPDATE graph_edges SET \
      source_id = ?1, target_id = ?2, relation = ?3, \
      weight = ?4, updated_at = ?5, metadata = ?6 \
-     WHERE namespace = ?7 AND id = ?8";
+     WHERE namespace = ?7 AND id = ?8 \
+       AND updated_at = ?9 AND deleted_at IS ?10 \
+       AND ?5 > updated_at";
 
 /// Plan-shape builder for [`EDGE_SYMMETRIC_CONFLICT_PROBE_SQL`] — the
 /// async prepare-time conflict probe.
@@ -341,7 +349,8 @@ pub fn edge_symmetric_delete_noncanonical_statement(namespace: &str, id: Uuid) -
 }
 
 /// Plan-shape builder for [`EDGE_SYMMETRIC_UPDATE_INPLACE_SQL`] —
-/// case (a): no conflict, update the requested row in place.
+/// case (a): no conflict, update the requested row in place, guarded on the
+/// fetched snapshot's revision and deletion marker.
 #[allow(clippy::too_many_arguments)]
 pub fn edge_symmetric_update_inplace_statement(
     namespace: &str,
@@ -352,6 +361,8 @@ pub fn edge_symmetric_update_inplace_statement(
     weight: f64,
     updated_at_micros: i64,
     metadata: Option<&str>,
+    expected_updated_at_micros: i64,
+    expected_deleted_at_micros: Option<i64>,
 ) -> SqlStatement {
     SqlStatement {
         sql: EDGE_SYMMETRIC_UPDATE_INPLACE_SQL.to_string(),
@@ -367,6 +378,11 @@ pub fn edge_symmetric_update_inplace_statement(
             },
             SqlValue::Text(namespace.to_string()),
             SqlValue::Text(id.to_string()),
+            SqlValue::Integer(expected_updated_at_micros),
+            match expected_deleted_at_micros {
+                Some(value) => SqlValue::Integer(value),
+                None => SqlValue::Null,
+            },
         ],
         label: Some("edge-symmetric-update-inplace".to_string()),
     }
@@ -482,6 +498,14 @@ pub fn edge_symmetric_delete_if_conflict_statement(
     }
 }
 
+/// `?10`/`?11` pin the fetched snapshot's `updated_at`/`deleted_at` and
+/// `?7 > updated_at` requires the replacement revision to strictly advance —
+/// guarding the in-place arm (`id = ?2`) against a concurrent writer that
+/// changed the row between the snapshot read and this statement. The
+/// absorbed arm (a differently-id'd canonical row) is intentionally left
+/// unguarded on revision: per ADR-039 DO NOTHING it self-assigns every
+/// column, so it is a no-op write regardless of the survivor's current
+/// state.
 #[allow(clippy::too_many_arguments)]
 pub fn edge_symmetric_absorb_or_update_inplace_statement(
     namespace: &str,
@@ -493,6 +517,8 @@ pub fn edge_symmetric_absorb_or_update_inplace_statement(
     updated_at_micros: i64,
     metadata: Option<&str>,
     target_backend: Option<&str>,
+    expected_updated_at_micros: i64,
+    expected_deleted_at_micros: Option<i64>,
 ) -> SqlStatement {
     SqlStatement {
         sql: "UPDATE graph_edges SET \
@@ -506,7 +532,8 @@ pub fn edge_symmetric_absorb_or_update_inplace_statement(
               target_backend = CASE WHEN id = ?2 THEN ?9 ELSE target_backend END \
               WHERE namespace = ?1 \
                 AND ( \
-                  (id = ?2 AND changes() = 0) \
+                  (id = ?2 AND changes() = 0 AND updated_at = ?10 AND deleted_at IS ?11 \
+                      AND ?7 > updated_at) \
                   OR (source_id = ?3 AND target_id = ?4 AND relation = ?5 \
                       AND id != ?2 AND changes() = 1) \
                 )"
@@ -525,6 +552,11 @@ pub fn edge_symmetric_absorb_or_update_inplace_statement(
             },
             match target_backend {
                 Some(b) => SqlValue::Text(b.to_string()),
+                None => SqlValue::Null,
+            },
+            SqlValue::Integer(expected_updated_at_micros),
+            match expected_deleted_at_micros {
+                Some(value) => SqlValue::Integer(value),
                 None => SqlValue::Null,
             },
         ],

--- a/crates/khive-mcp/src/pending_events.rs
+++ b/crates/khive-mcp/src/pending_events.rs
@@ -803,6 +803,8 @@ async fn run_pending_events_on_with_lease(
                             "anonymous:local".to_string()
                         }
                     });
+                #[cfg(test)]
+                race_seam::pause_before_finalize_read().await;
                 let claim =
                     match claim_pending_event(rt, ns_str, id, occurrence_id, &receipt_actor, lease)
                         .await
@@ -832,7 +834,16 @@ async fn run_pending_events_on_with_lease(
                     .is_some_and(|repeat| !matches!(repeat, "daily" | "weekly" | "monthly"))
                 {
                     let error = "scheduled event uses an unsupported repeat expression; only daily, weekly, and monthly are executable";
-                    let mut props = properties.clone().unwrap_or_else(|| json!({}));
+                    summary.failed += 1;
+                    let Some(expected_properties) =
+                        current_properties_for_finalize(rt, ns_str, id, "unsupported-repeat").await
+                    else {
+                        continue;
+                    };
+                    let Some(mut props) = expected_properties_value(&expected_properties, id)
+                    else {
+                        continue;
+                    };
                     props["status"] = json!("failed");
                     let (error_key, error_at_key) = dispatch_error_property_keys(&props);
                     props[error_key] = json!(error);
@@ -843,12 +854,6 @@ async fn run_pending_events_on_with_lease(
                         completed_at,
                         Some(error),
                     );
-                    summary.failed += 1;
-                    let Some(expected_properties) =
-                        current_properties_for_finalize(rt, ns_str, id, "unsupported-repeat").await
-                    else {
-                        continue;
-                    };
                     match finalize_fired_event(
                         rt,
                         ns_str,
@@ -885,7 +890,15 @@ async fn run_pending_events_on_with_lease(
                         eprintln!("[pending-events] dispatch refused for note {id}: {error}");
                     }
                     summary.failed += 1;
-                    let mut props = properties.clone().unwrap_or_else(|| json!({}));
+                    let Some(expected_properties) =
+                        current_properties_for_finalize(rt, ns_str, id, "failed-identity").await
+                    else {
+                        continue;
+                    };
+                    let Some(mut props) = expected_properties_value(&expected_properties, id)
+                    else {
+                        continue;
+                    };
                     props["status"] = json!("failed");
                     props["dispatch_error"] = json!(error);
                     props["dispatch_failed_at"] = json!(Utc::now().to_rfc3339());
@@ -895,11 +908,6 @@ async fn run_pending_events_on_with_lease(
                         updated_at,
                         Some(error),
                     );
-                    let Some(expected_properties) =
-                        current_properties_for_finalize(rt, ns_str, id, "failed-identity").await
-                    else {
-                        continue;
-                    };
                     match finalize_fired_event(
                         rt,
                         ns_str,
@@ -938,7 +946,17 @@ async fn run_pending_events_on_with_lease(
                             grace.num_seconds()
                         );
                     }
-                    let mut props = properties.clone().unwrap_or_else(|| json!({}));
+                    let Some(expected_properties) =
+                        current_properties_for_finalize(rt, ns_str, id, "missed").await
+                    else {
+                        summary.failed += 1;
+                        continue;
+                    };
+                    let Some(mut props) = expected_properties_value(&expected_properties, id)
+                    else {
+                        summary.failed += 1;
+                        continue;
+                    };
                     props["missed_at"] = json!(now.timestamp_micros());
                     match advance_repeat_past_missed(&repeat, trigger_at, now) {
                         Some(next_at) => {
@@ -963,12 +981,6 @@ async fn run_pending_events_on_with_lease(
                         None,
                     );
 
-                    let Some(expected_properties) =
-                        current_properties_for_finalize(rt, ns_str, id, "missed").await
-                    else {
-                        summary.failed += 1;
-                        continue;
-                    };
                     match finalize_fired_event(
                         rt,
                         ns_str,
@@ -1024,7 +1036,16 @@ async fn run_pending_events_on_with_lease(
                         event_type,
                         "pending-events: refusing empty scheduled-event dispatch"
                     );
-                    let mut props = properties.clone().unwrap_or_else(|| json!({}));
+                    summary.failed += 1;
+                    let Some(expected_properties) =
+                        current_properties_for_finalize(rt, ns_str, id, "empty-payload").await
+                    else {
+                        continue;
+                    };
+                    let Some(mut props) = expected_properties_value(&expected_properties, id)
+                    else {
+                        continue;
+                    };
                     let (error_key, error_at_key) = dispatch_error_property_keys(&props);
                     props[error_key] = json!(error);
                     props[error_at_key] = json!(Utc::now().to_rfc3339());
@@ -1035,12 +1056,6 @@ async fn run_pending_events_on_with_lease(
                         completed_at,
                         Some(error),
                     );
-                    summary.failed += 1;
-                    let Some(expected_properties) =
-                        current_properties_for_finalize(rt, ns_str, id, "empty-payload").await
-                    else {
-                        continue;
-                    };
                     match finalize_fired_event(
                         rt,
                         ns_str,
@@ -1068,7 +1083,16 @@ async fn run_pending_events_on_with_lease(
                         scheduled_event_id = %id,
                         "pending-events: refusing non-single scheduled action"
                     );
-                    let mut props = properties.clone().unwrap_or_else(|| json!({}));
+                    summary.failed += 1;
+                    let Some(expected_properties) =
+                        current_properties_for_finalize(rt, ns_str, id, "non-single-action").await
+                    else {
+                        continue;
+                    };
+                    let Some(mut props) = expected_properties_value(&expected_properties, id)
+                    else {
+                        continue;
+                    };
                     props["dispatch_error"] = json!(error);
                     props["dispatch_failed_at"] = json!(Utc::now().to_rfc3339());
                     props["status"] = json!("failed");
@@ -1078,12 +1102,6 @@ async fn run_pending_events_on_with_lease(
                         completed_at,
                         Some(error),
                     );
-                    summary.failed += 1;
-                    let Some(expected_properties) =
-                        current_properties_for_finalize(rt, ns_str, id, "non-single-action").await
-                    else {
-                        continue;
-                    };
                     match finalize_fired_event(
                         rt,
                         ns_str,
@@ -1213,8 +1231,13 @@ async fn run_pending_events_on_with_lease(
                         continue;
                     }
                 };
+                let Some(expected_value) = expected_properties_value(&expected_properties, id)
+                else {
+                    summary.failed += 1;
+                    continue;
+                };
                 let (final_props, disposition) = final_properties_after_dispatch(
-                    properties.clone().unwrap_or_else(|| json!({})),
+                    expected_value,
                     receipt,
                     &completion,
                     trigger_at,
@@ -2250,6 +2273,28 @@ async fn current_note_properties_text(
     }
 }
 
+/// Parses a finalizer's freshly read current-properties CAS snapshot into the
+/// `Value` base a terminal write's field mutations are applied to. Callers
+/// must build their write on this value, not on the page-query snapshot taken
+/// before the claim — a property written between that snapshot and this read
+/// still passes the CAS fence (it is part of what "current" means by the time
+/// this is called) but would otherwise be silently discarded by a write whose
+/// base predates it. Returns `None` (and logs) if the stored text is not
+/// valid JSON; the caller must treat that as a failed finalization.
+fn expected_properties_value(expected_properties: &str, id: uuid::Uuid) -> Option<Value> {
+    match serde_json::from_str(expected_properties) {
+        Ok(value) => Some(value),
+        Err(error) => {
+            tracing::error!(
+                scheduled_event_id = %id,
+                error = %error,
+                "pending-events: could not parse current properties for finalization"
+            );
+            None
+        }
+    }
+}
+
 /// Read the row's raw current properties at the same read boundary as a
 /// pending-action finalization decision, for use as `finalize_fired_event`'s
 /// mandatory exact-properties CAS fence. Returns `None` (and logs) on a read
@@ -3084,6 +3129,44 @@ pub async fn schedule_tick_loop(
                     "schedule drain pass failed: {e}"
                 )));
             }
+        }
+    }
+}
+
+/// Test-only pause point right after a drain iteration's page-query
+/// snapshot (`properties`) and before claim/dispatch/finalization, so a
+/// concurrent property write landing between that snapshot and the
+/// finalizer's later fresh current-properties read can be reproduced
+/// deterministically instead of relying on scheduler luck or sleeps. A
+/// no-op unless the calling task runs inside `PAUSE_GATE.scope(...)`;
+/// production code never establishes that scope, so this costs nothing
+/// outside these regression tests, and it does not exist at all in
+/// non-test builds. Mirrors `khive-runtime::curation::race_seam`.
+#[cfg(test)]
+pub(crate) mod race_seam {
+    use std::sync::Arc;
+    use tokio::sync::Barrier;
+
+    /// Two-phase handshake: `reached` lets the driving test learn the drain
+    /// task has arrived at the pause point (i.e. genuinely parked, not just
+    /// scheduled) before it performs a concurrent write; `release` then lets
+    /// the driving test resume the drain task only once that write has
+    /// landed. A single shared `Barrier` cannot express this — both parties
+    /// would resume together with no window for the test to act in between.
+    #[derive(Clone)]
+    pub(crate) struct PauseGate {
+        pub(crate) reached: Arc<Barrier>,
+        pub(crate) release: Arc<Barrier>,
+    }
+
+    tokio::task_local! {
+        pub(crate) static PAUSE_GATE: PauseGate;
+    }
+
+    pub(crate) async fn pause_before_finalize_read() {
+        if let Ok(gate) = PAUSE_GATE.try_with(Clone::clone) {
+            gate.reached.wait().await;
+            gate.release.wait().await;
         }
     }
 }
@@ -6314,6 +6397,83 @@ mod tests {
             get_note_props(&rt, id).await["status"].as_str(),
             Some("fired")
         );
+    }
+
+    /// Regression test driven through the PRODUCTION
+    /// drain entry point (`run_pending_events_on`) rather than calling
+    /// `final_properties_after_dispatch` directly — this closes a gap a
+    /// primitive-level test cannot: it would still pass unchanged if the
+    /// drain loop's call site reverted to building `final_props` from the
+    /// stale pre-claim `properties` snapshot instead of the freshly read
+    /// `expected_properties`, since it would never invoke that call site at
+    /// all. Uses `race_seam::pause_before_finalize_read` (test-only,
+    /// compiled out of non-test builds) to force the concurrent property
+    /// write to land deterministically between claim/dispatch and the
+    /// finalizer's fresh current-properties read — no sleeps, no reliance on
+    /// scheduler ordering.
+    #[tokio::test]
+    async fn production_drain_preserves_a_property_written_between_claim_and_current_read() {
+        let (_tmp, db_path) = tmp_db();
+        let rt = make_rt(&db_path).await;
+        let id = create_scheduled_event(
+            &rt,
+            "local",
+            &due_rfc3339(),
+            Some("stats()"),
+            None,
+            "schedule",
+        )
+        .await;
+
+        let gate = race_seam::PauseGate {
+            reached: std::sync::Arc::new(tokio::sync::Barrier::new(2)),
+            release: std::sync::Arc::new(tokio::sync::Barrier::new(2)),
+        };
+
+        let drain_task = {
+            let rt = rt.clone();
+            let gate = gate.clone();
+            tokio::spawn(race_seam::PAUSE_GATE.scope(gate, async move {
+                let server = KhiveMcpServer::new(rt.clone()).map_err(|e| anyhow::anyhow!("{e}"))?;
+                run_pending_events_on(&rt, &server, false).await
+            }))
+        };
+
+        // Block until the drain task has genuinely parked at the seam
+        // (before its candidate-page query), THEN write, THEN release it —
+        // guaranteeing the write lands strictly between the drain's
+        // page-query snapshot and its later fresh pre-finalize read.
+        gate.reached.wait().await;
+
+        let mut writer = rt.sql().writer().await.expect("writer");
+        let rows = writer
+            .execute(SqlStatement {
+                sql: "UPDATE notes SET properties = json_set(properties, \
+                      '$.custom', 'added-concurrently') WHERE id = ?1"
+                    .to_string(),
+                params: vec![SqlValue::Text(id.to_string())],
+                label: Some("test_concurrent_property_add".into()),
+            })
+            .await
+            .expect("concurrent write");
+        assert_eq!(rows, 1);
+        drop(writer);
+
+        gate.release.wait().await;
+        let summary = drain_task
+            .await
+            .expect("drain task")
+            .expect("drain must not error");
+        assert_eq!(summary.fired, 1, "the event must have fired: {summary:?}");
+
+        let stored = get_note_props(&rt, id).await;
+        assert_eq!(
+            stored["custom"].as_str(),
+            Some("added-concurrently"),
+            "a property written between claim and the finalizer's current-properties read \
+             must survive finalization, got {stored:?}"
+        );
+        assert_eq!(stored["status"].as_str(), Some("fired"));
     }
 
     /// `schedule.cancel` on a row that is currently `status="firing"` — even

--- a/crates/khive-mcp/src/pending_events.rs
+++ b/crates/khive-mcp/src/pending_events.rs
@@ -844,8 +844,21 @@ async fn run_pending_events_on_with_lease(
                         Some(error),
                     );
                     summary.failed += 1;
-                    match finalize_fired_event(rt, ns_str, id, &props, completed_at, &claim, None)
-                        .await
+                    let Some(expected_properties) =
+                        current_properties_for_finalize(rt, ns_str, id, "unsupported-repeat").await
+                    else {
+                        continue;
+                    };
+                    match finalize_fired_event(
+                        rt,
+                        ns_str,
+                        id,
+                        &props,
+                        completed_at,
+                        &claim,
+                        &expected_properties,
+                    )
+                    .await
                     {
                         Ok(true) => summary.finalized += 1,
                         Ok(false) => summary.skipped_race += 1,
@@ -882,8 +895,21 @@ async fn run_pending_events_on_with_lease(
                         updated_at,
                         Some(error),
                     );
-                    match finalize_fired_event(rt, ns_str, id, &props, updated_at, &claim, None)
-                        .await
+                    let Some(expected_properties) =
+                        current_properties_for_finalize(rt, ns_str, id, "failed-identity").await
+                    else {
+                        continue;
+                    };
+                    match finalize_fired_event(
+                        rt,
+                        ns_str,
+                        id,
+                        &props,
+                        updated_at,
+                        &claim,
+                        &expected_properties,
+                    )
+                    .await
                     {
                         Ok(true) => summary.finalized += 1,
                         Ok(false) => tracing::error!(
@@ -937,8 +963,22 @@ async fn run_pending_events_on_with_lease(
                         None,
                     );
 
-                    match finalize_fired_event(rt, ns_str, id, &props, updated_at, &claim, None)
-                        .await
+                    let Some(expected_properties) =
+                        current_properties_for_finalize(rt, ns_str, id, "missed").await
+                    else {
+                        summary.failed += 1;
+                        continue;
+                    };
+                    match finalize_fired_event(
+                        rt,
+                        ns_str,
+                        id,
+                        &props,
+                        updated_at,
+                        &claim,
+                        &expected_properties,
+                    )
+                    .await
                     {
                         Ok(true) => {
                             summary.missed.push(id);
@@ -996,8 +1036,21 @@ async fn run_pending_events_on_with_lease(
                         Some(error),
                     );
                     summary.failed += 1;
-                    match finalize_fired_event(rt, ns_str, id, &props, completed_at, &claim, None)
-                        .await
+                    let Some(expected_properties) =
+                        current_properties_for_finalize(rt, ns_str, id, "empty-payload").await
+                    else {
+                        continue;
+                    };
+                    match finalize_fired_event(
+                        rt,
+                        ns_str,
+                        id,
+                        &props,
+                        completed_at,
+                        &claim,
+                        &expected_properties,
+                    )
+                    .await
                     {
                         Ok(true) => summary.finalized += 1,
                         Ok(false) => summary.skipped_race += 1,
@@ -1026,8 +1079,21 @@ async fn run_pending_events_on_with_lease(
                         Some(error),
                     );
                     summary.failed += 1;
-                    match finalize_fired_event(rt, ns_str, id, &props, completed_at, &claim, None)
-                        .await
+                    let Some(expected_properties) =
+                        current_properties_for_finalize(rt, ns_str, id, "non-single-action").await
+                    else {
+                        continue;
+                    };
+                    match finalize_fired_event(
+                        rt,
+                        ns_str,
+                        id,
+                        &props,
+                        completed_at,
+                        &claim,
+                        &expected_properties,
+                    )
+                    .await
                     {
                         Ok(true) => summary.finalized += 1,
                         Ok(false) => summary.skipped_race += 1,
@@ -1162,7 +1228,7 @@ async fn run_pending_events_on_with_lease(
                     &final_props,
                     Utc::now().timestamp_micros(),
                     &claim,
-                    Some(&expected_properties),
+                    &expected_properties,
                 )
                 .await
                 {
@@ -2184,6 +2250,37 @@ async fn current_note_properties_text(
     }
 }
 
+/// Read the row's raw current properties at the same read boundary as a
+/// pending-action finalization decision, for use as `finalize_fired_event`'s
+/// mandatory exact-properties CAS fence. Returns `None` (and logs) on a read
+/// error or a vanished row; the caller must treat that as a failed
+/// finalization rather than retry with a stale or synthetic snapshot.
+async fn current_properties_for_finalize(
+    rt: &KhiveRuntime,
+    namespace: &str,
+    id: uuid::Uuid,
+    context: &'static str,
+) -> Option<String> {
+    match current_note_properties_text(rt, namespace, id).await {
+        Ok(Some(text)) => Some(text),
+        Ok(None) => {
+            tracing::error!(
+                scheduled_event_id = %id,
+                "pending-events: row vanished before {context} finalization"
+            );
+            None
+        }
+        Err(error) => {
+            tracing::error!(
+                scheduled_event_id = %id,
+                error = %error,
+                "pending-events: could not read current properties before {context} finalization"
+            );
+            None
+        }
+    }
+}
+
 /// CAS-persist the post-drain state of a claimed event: `firing -> {fired |
 /// pending | missed | failed}` (`pending` is an advanced repeat; `failed` is
 /// the unattributed-generic-action policy state). `claimed_firing_at` is
@@ -2202,6 +2299,15 @@ struct FinalizeGuard<'a> {
     expected_properties: Option<&'a str>,
 }
 
+/// Finalize a row this process's own claim is dispatching, guarded on the
+/// row's exact current properties as well as claim identity. `expected_properties`
+/// is mandatory — not `Option` — so a future branch cannot silently drop the
+/// content fence by passing `None`: the claim token alone is an ownership
+/// fence, not a substitute for detecting a concurrent property writer that
+/// landed between claim and finalization (ADR-106). Callers must read the
+/// row's raw current properties at the same read boundary as their
+/// finalization decision — see `current_note_properties_text` — and pass
+/// that snapshot here.
 async fn finalize_fired_event(
     rt: &KhiveRuntime,
     namespace: &str,
@@ -2209,7 +2315,7 @@ async fn finalize_fired_event(
     properties: &Value,
     updated_at: i64,
     claim: &DispatchClaim,
-    expected_properties: Option<&str>,
+    expected_properties: &str,
 ) -> Result<bool> {
     finalize_firing_event(
         rt,
@@ -2220,7 +2326,7 @@ async fn finalize_fired_event(
         claim,
         FinalizeGuard {
             expired_at: None,
-            expected_properties,
+            expected_properties: Some(expected_properties),
         },
     )
     .await
@@ -5177,6 +5283,7 @@ mod tests {
             *trigger_fixed.offset(),
             &None,
         );
+        let expected_properties = get_raw_note_properties(&rt, id).await;
         assert!(finalize_fired_event(
             &rt,
             "local",
@@ -5184,7 +5291,7 @@ mod tests {
             &final_properties,
             Utc::now().timestamp_micros(),
             &claim,
-            None,
+            &expected_properties,
         )
         .await
         .expect("live owner finalizes"));
@@ -5813,6 +5920,7 @@ mod tests {
 
         // Finalize the fire as the drain would, then confirm the terminal
         // state is "fired" — the cancel never got a chance to overwrite it.
+        let expected_properties = get_raw_note_properties(&rt, id).await;
         let finalized = finalize_fired_event(
             &rt,
             "local",
@@ -5828,7 +5936,7 @@ mod tests {
             }),
             Utc::now().timestamp_micros(),
             &claim,
-            None,
+            &expected_properties,
         )
         .await
         .expect("finalize query");
@@ -6021,6 +6129,7 @@ mod tests {
         // A resumes (unaware it was reclaimed) and attempts to finalize using
         // its own stale claim token. This must be a no-op: it must NOT match
         // B's current firing_at, and must NOT clobber B's live claim.
+        let expected_properties_for_a = get_raw_note_properties(&rt, id).await;
         let a_finalize_result = finalize_fired_event(
             &rt,
             "local",
@@ -6036,7 +6145,7 @@ mod tests {
             }),
             Utc::now().timestamp_micros(),
             &a_claim,
-            None,
+            &expected_properties_for_a,
         )
         .await
         .expect("finalize query must not error");
@@ -6061,6 +6170,7 @@ mod tests {
 
         // B now finalizes with its own (correct) claim token — this must
         // succeed, proving the fix doesn't wedge legitimate finalization.
+        let expected_properties_for_b = get_raw_note_properties(&rt, id).await;
         let b_finalize_result = finalize_fired_event(
             &rt,
             "local",
@@ -6076,7 +6186,7 @@ mod tests {
             }),
             Utc::now().timestamp_micros(),
             &b_claim,
-            None,
+            &expected_properties_for_b,
         )
         .await
         .expect("finalize query must not error");
@@ -6160,7 +6270,7 @@ mod tests {
             &final_props,
             Utc::now().timestamp_micros(),
             &claim,
-            Some(&expected_properties),
+            &expected_properties,
         )
         .await
         .expect("finalize query must not error");
@@ -6192,7 +6302,7 @@ mod tests {
             &final_props,
             Utc::now().timestamp_micros(),
             &claim,
-            Some(&fresh_properties),
+            &fresh_properties,
         )
         .await
         .expect("finalize query must not error");

--- a/crates/khive-mcp/src/pending_events.rs
+++ b/crates/khive-mcp/src/pending_events.rs
@@ -775,8 +775,12 @@ async fn run_pending_events_on_with_lease(
                         .map(|actor| reminder_delivery_action(actor, &content))
                 };
 
-                // ── Determine repeat (read before claim; only informs which
-                // finalize branch runs below, never mutates the row read) ──
+                // ── Determine repeat (read before claim) ──
+                // This value gates ADMISSION only — which finalize branch is
+                // eligible. It must never reach anything WRITTEN: the value the
+                // finalizer schedules from is re-derived at the write, from the
+                // same fresh read the CAS is guarded on. See the re-derivation
+                // just before `final_properties_after_dispatch`.
                 let repeat = properties
                     .as_ref()
                     .and_then(|p| p.get("repeat"))
@@ -1244,6 +1248,55 @@ async fn run_pending_events_on_with_lease(
                     summary.failed += 1;
                     continue;
                 };
+                // Re-derive the SCHEDULING inputs from the fresh read too, not
+                // just the properties blob. `trigger_at`, `trigger_offset` and
+                // `repeat` above came from the pre-claim page snapshot, and
+                // guarding the write on the fresh properties text protects the
+                // blob while still letting a stale scheduling decision be
+                // computed from it: `final_properties_after_dispatch` uses
+                // these three to write the next `trigger_at` and the terminal
+                // `status`. A writer that changed `repeat` or `trigger_at`
+                // between the page snapshot and the fresh read would have its
+                // value retained as the CAS base and then immediately
+                // contradicted by a next-occurrence computed from the value it
+                // replaced.
+                //
+                // The earlier values keep their job: they gate ADMISSION (is
+                // this due, is it inside the grace window), which is a decision
+                // about whether to dispatch at all and is correctly made from
+                // what was observed before the claim. What must not come from
+                // them is anything WRITTEN.
+                let trigger_at_fresh_str = expected_value
+                    .get("trigger_at")
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                let (trigger_at, trigger_offset) = match trigger_at_fresh_str
+                    .parse::<DateTime<FixedOffset>>()
+                {
+                    Ok(fixed) => (fixed.with_timezone(&Utc), *fixed.offset()),
+                    Err(_) => {
+                        // The row's own `trigger_at` stopped being parseable
+                        // between the page read and here. Refuse rather than
+                        // fall back to the stale pair: falling back is
+                        // exactly the silent-overwrite this guard exists to
+                        // prevent, and the dispatch has already happened, so
+                        // the honest outcome is a failed finalization that
+                        // recovery will re-examine.
+                        tracing::error!(
+                            scheduled_event_id = %id,
+                            trigger_at = %trigger_at_fresh_str,
+                            "pending-events: trigger_at not parseable at finalization; refusing \
+                             to finalize from the pre-claim snapshot"
+                        );
+                        summary.failed += 1;
+                        continue;
+                    }
+                };
+                let repeat = expected_value
+                    .get("repeat")
+                    .and_then(Value::as_str)
+                    .map(str::to_string);
+
                 let (final_props, disposition) = final_properties_after_dispatch(
                     expected_value,
                     receipt,
@@ -6485,6 +6538,86 @@ mod tests {
              must survive finalization, got {stored:?}"
         );
         assert_eq!(stored["status"].as_str(), Some("fired"));
+    }
+
+    /// Guarding the finalizer's write on the freshly-read properties protects
+    /// the properties BLOB while still allowing a stale SCHEDULING decision to
+    /// be computed over it. `repeat` and `trigger_at` are parsed from the
+    /// pre-claim candidate page; if the finalizer keeps using those, a writer
+    /// who cancels the repeat in the claim window has their edit retained as
+    /// the CAS base and then immediately contradicted by a next occurrence
+    /// scheduled from the value they replaced.
+    ///
+    /// This fixture makes the two behaviours produce different terminal states
+    /// rather than different timestamps, so the assertion cannot pass by
+    /// rounding: the event is seeded `repeat: "daily"`, and the concurrent
+    /// write clears `repeat` while the drain is parked at the seam. Scheduling
+    /// from the fresh read yields a terminal `fired`; scheduling from the stale
+    /// page yields a rescheduled `pending` with an advanced `trigger_at`.
+    #[tokio::test]
+    async fn production_drain_schedules_from_the_fresh_read_not_the_page_snapshot() {
+        let (_tmp, db_path) = tmp_db();
+        let rt = make_rt(&db_path).await;
+        let id = create_scheduled_event(
+            &rt,
+            "local",
+            &due_rfc3339(),
+            Some("stats()"),
+            Some("daily"),
+            "schedule",
+        )
+        .await;
+
+        let gate = race_seam::PauseGate {
+            reached: std::sync::Arc::new(tokio::sync::Barrier::new(2)),
+            release: std::sync::Arc::new(tokio::sync::Barrier::new(2)),
+        };
+
+        let drain_task = {
+            let rt = rt.clone();
+            let gate = gate.clone();
+            tokio::spawn(race_seam::PAUSE_GATE.scope(gate, async move {
+                let server = KhiveMcpServer::new(rt.clone()).map_err(|e| anyhow::anyhow!("{e}"))?;
+                run_pending_events_on(&rt, &server, false).await
+            }))
+        };
+
+        gate.reached.wait().await;
+
+        let mut writer = rt.sql().writer().await.expect("writer");
+        let rows = writer
+            .execute(SqlStatement {
+                sql:
+                    "UPDATE notes SET properties = json_set(properties, '$.repeat', json('null')) \
+                      WHERE id = ?1"
+                        .to_string(),
+                params: vec![SqlValue::Text(id.to_string())],
+                label: Some("test_concurrent_repeat_clear".into()),
+            })
+            .await
+            .expect("concurrent write");
+        assert_eq!(rows, 1);
+        drop(writer);
+
+        gate.release.wait().await;
+        let summary = drain_task
+            .await
+            .expect("drain task")
+            .expect("drain must not error");
+        assert_eq!(summary.fired, 1, "the event must have fired: {summary:?}");
+
+        let stored = get_note_props(&rt, id).await;
+        assert!(
+            stored.get("repeat").is_none() || stored["repeat"].is_null(),
+            "the concurrent clear of `repeat` must survive finalization, got {stored:?}"
+        );
+        assert_eq!(
+            stored["status"].as_str(),
+            Some("fired"),
+            "finalization must schedule from the repeat it read fresh (cleared, so terminal), \
+             not from the pre-claim page snapshot (\"daily\", which would reschedule to \
+             pending): got {stored:?}"
+        );
     }
 
     /// `schedule.cancel` on a row that is currently `status="firing"` — even

--- a/crates/khive-mcp/src/pending_events.rs
+++ b/crates/khive-mcp/src/pending_events.rs
@@ -844,7 +844,9 @@ async fn run_pending_events_on_with_lease(
                         Some(error),
                     );
                     summary.failed += 1;
-                    match finalize_fired_event(rt, ns_str, id, &props, completed_at, &claim).await {
+                    match finalize_fired_event(rt, ns_str, id, &props, completed_at, &claim, None)
+                        .await
+                    {
                         Ok(true) => summary.finalized += 1,
                         Ok(false) => summary.skipped_race += 1,
                         Err(error) => tracing::error!(
@@ -880,7 +882,9 @@ async fn run_pending_events_on_with_lease(
                         updated_at,
                         Some(error),
                     );
-                    match finalize_fired_event(rt, ns_str, id, &props, updated_at, &claim).await {
+                    match finalize_fired_event(rt, ns_str, id, &props, updated_at, &claim, None)
+                        .await
+                    {
                         Ok(true) => summary.finalized += 1,
                         Ok(false) => tracing::error!(
                             scheduled_event_id = %id,
@@ -933,7 +937,9 @@ async fn run_pending_events_on_with_lease(
                         None,
                     );
 
-                    match finalize_fired_event(rt, ns_str, id, &props, updated_at, &claim).await {
+                    match finalize_fired_event(rt, ns_str, id, &props, updated_at, &claim, None)
+                        .await
+                    {
                         Ok(true) => {
                             summary.missed.push(id);
                             summary.finalized += 1;
@@ -990,7 +996,9 @@ async fn run_pending_events_on_with_lease(
                         Some(error),
                     );
                     summary.failed += 1;
-                    match finalize_fired_event(rt, ns_str, id, &props, completed_at, &claim).await {
+                    match finalize_fired_event(rt, ns_str, id, &props, completed_at, &claim, None)
+                        .await
+                    {
                         Ok(true) => summary.finalized += 1,
                         Ok(false) => summary.skipped_race += 1,
                         Err(error) => tracing::error!(
@@ -1018,7 +1026,9 @@ async fn run_pending_events_on_with_lease(
                         Some(error),
                     );
                     summary.failed += 1;
-                    match finalize_fired_event(rt, ns_str, id, &props, completed_at, &claim).await {
+                    match finalize_fired_event(rt, ns_str, id, &props, completed_at, &claim, None)
+                        .await
+                    {
                         Ok(true) => summary.finalized += 1,
                         Ok(false) => summary.skipped_race += 1,
                         Err(error) => tracing::error!(
@@ -1110,6 +1120,33 @@ async fn run_pending_events_on_with_lease(
                         .await;
                     }
                 }
+                // Re-read the row's CURRENT properties immediately before
+                // finalizing, and guard the terminal write on exact equality
+                // to that read (mirroring `finalize_corrupt_receipt`'s
+                // `selected_properties` guard, #7 in the RMW census). Dispatch
+                // may have run for an arbitrary duration and this same process
+                // may have renewed the lease meanwhile, so the pre-dispatch
+                // `properties` snapshot captured at claim time is expected to
+                // have moved; only a read taken right here — after this
+                // process's own intervening writes have already landed —
+                // can distinguish "nothing else touched this row since I last
+                // looked" from a genuine concurrent writer.
+                let expected_properties = match current_note_properties_text(rt, ns_str, id).await {
+                    Ok(Some(text)) => text,
+                    Ok(None) => {
+                        summary.failed += 1;
+                        continue;
+                    }
+                    Err(error) => {
+                        tracing::error!(
+                            scheduled_event_id = %id,
+                            error = %error,
+                            "pending-events: could not read current properties before finalization"
+                        );
+                        summary.failed += 1;
+                        continue;
+                    }
+                };
                 let (final_props, disposition) = final_properties_after_dispatch(
                     properties.clone().unwrap_or_else(|| json!({})),
                     receipt,
@@ -1125,6 +1162,7 @@ async fn run_pending_events_on_with_lease(
                     &final_props,
                     Utc::now().timestamp_micros(),
                     &claim,
+                    Some(&expected_properties),
                 )
                 .await
                 {
@@ -2102,6 +2140,50 @@ async fn reclaim_stale_firing_events(rt: &KhiveRuntime, now_micros: i64) -> Resu
     Ok(summary)
 }
 
+/// Read a `scheduled_event` note's CURRENT `properties` column, verbatim as
+/// stored (no round-trip through `serde_json` re-serialization), so a caller
+/// can use the exact byte string as an exact-equality CAS guard on a later
+/// write. Returns `Ok(None)` when the row is absent, soft-deleted, or no
+/// longer a `scheduled_event` note.
+async fn current_note_properties_text(
+    rt: &KhiveRuntime,
+    namespace: &str,
+    id: uuid::Uuid,
+) -> Result<Option<String>> {
+    let mut reader = rt
+        .sql()
+        .reader()
+        .await
+        .map_err(|e| anyhow::anyhow!("pending-events: open SQL reader: {e}"))?;
+    let rows = reader
+        .query_all(SqlStatement {
+            sql: "SELECT properties FROM notes \
+                  WHERE id = ?1 AND namespace = ?2 AND kind = 'scheduled_event' \
+                    AND deleted_at IS NULL"
+                .to_string(),
+            params: vec![
+                SqlValue::Text(id.to_string()),
+                SqlValue::Text(namespace.to_string()),
+            ],
+            label: Some("pending_events_current_properties".into()),
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("pending-events: read current properties: {e}"))?;
+    match rows.as_slice() {
+        [] => Ok(None),
+        [row] => match row.get("properties") {
+            Some(SqlValue::Text(value)) => Ok(Some(value.clone())),
+            Some(SqlValue::Null) | None => Ok(None),
+            other => Err(anyhow::anyhow!(
+                "pending-events: unexpected properties column shape: {other:?}"
+            )),
+        },
+        _ => Err(anyhow::anyhow!(
+            "pending-events: multiple rows for scheduled_event {id}"
+        )),
+    }
+}
+
 /// CAS-persist the post-drain state of a claimed event: `firing -> {fired |
 /// pending | missed | failed}` (`pending` is an advanced repeat; `failed` is
 /// the unattributed-generic-action policy state). `claimed_firing_at` is
@@ -2110,6 +2192,16 @@ async fn reclaim_stale_firing_events(rt: &KhiveRuntime, now_micros: i64) -> Resu
 /// Clears `firing_at` on the terminal write. Returns
 /// `Ok(true)` iff exactly one row was updated. See
 /// `crates/khive-mcp/docs/api/pending-events.md`.
+/// Bundles `finalize_firing_event`'s two independent CAS guard inputs — the
+/// recovery-only legacy-stale timing predicate and the exact-properties
+/// equality predicate any caller may supply — into one parameter so the
+/// function stays under clippy's argument-count lint.
+#[derive(Clone, Copy, Default)]
+struct FinalizeGuard<'a> {
+    expired_at: Option<i64>,
+    expected_properties: Option<&'a str>,
+}
+
 async fn finalize_fired_event(
     rt: &KhiveRuntime,
     namespace: &str,
@@ -2117,8 +2209,21 @@ async fn finalize_fired_event(
     properties: &Value,
     updated_at: i64,
     claim: &DispatchClaim,
+    expected_properties: Option<&str>,
 ) -> Result<bool> {
-    finalize_firing_event(rt, namespace, id, properties, updated_at, claim, None).await
+    finalize_firing_event(
+        rt,
+        namespace,
+        id,
+        properties,
+        updated_at,
+        claim,
+        FinalizeGuard {
+            expired_at: None,
+            expected_properties,
+        },
+    )
+    .await
 }
 
 /// Finalize a row selected by the expired-lease recovery pass, but only while
@@ -2141,7 +2246,10 @@ async fn finalize_expired_firing_event(
         properties,
         updated_at,
         claim,
-        Some(snapshot),
+        FinalizeGuard {
+            expired_at: Some(snapshot.expired_at),
+            expected_properties: Some(snapshot.properties),
+        },
     )
     .await
 }
@@ -2153,9 +2261,12 @@ async fn finalize_firing_event(
     properties: &Value,
     updated_at: i64,
     claim: &DispatchClaim,
-    snapshot: Option<RecoverySnapshot<'_>>,
+    guard: FinalizeGuard<'_>,
 ) -> Result<bool> {
-    let expired_at = snapshot.map(|value| value.expired_at);
+    let FinalizeGuard {
+        expired_at,
+        expected_properties,
+    } = guard;
     let legacy_stale_before =
         expired_at.map(|value| value.saturating_sub(LEGACY_STALE_FIRING_TIMEOUT_MICROS));
     let mut properties = properties.clone();
@@ -2202,9 +2313,7 @@ async fn finalize_firing_event(
                 SqlValue::Text(claim.invocation_id.to_string()),
                 expired_at.map_or(SqlValue::Null, SqlValue::Integer),
                 legacy_stale_before.map_or(SqlValue::Null, SqlValue::Integer),
-                snapshot.map_or(SqlValue::Null, |value| {
-                    SqlValue::Text(value.properties.to_string())
-                }),
+                expected_properties.map_or(SqlValue::Null, |value| SqlValue::Text(value.to_string())),
             ],
             label: Some("pending_events_finalize_fired".into()),
         })
@@ -5075,6 +5184,7 @@ mod tests {
             &final_properties,
             Utc::now().timestamp_micros(),
             &claim,
+            None,
         )
         .await
         .expect("live owner finalizes"));
@@ -5718,6 +5828,7 @@ mod tests {
             }),
             Utc::now().timestamp_micros(),
             &claim,
+            None,
         )
         .await
         .expect("finalize query");
@@ -5925,6 +6036,7 @@ mod tests {
             }),
             Utc::now().timestamp_micros(),
             &a_claim,
+            None,
         )
         .await
         .expect("finalize query must not error");
@@ -5964,6 +6076,7 @@ mod tests {
             }),
             Utc::now().timestamp_micros(),
             &b_claim,
+            None,
         )
         .await
         .expect("finalize query must not error");
@@ -5981,6 +6094,115 @@ mod tests {
         assert!(
             final_props.get("firing_at").is_none() || final_props["firing_at"].is_null(),
             "firing_at must be cleared on terminal finalize, got {final_props:?}"
+        );
+    }
+
+    /// Regression for the normal-finalization lost-update race (khive #1753).
+    /// `finalize_fired_event` reads the row's CURRENT properties immediately
+    /// before finalizing (see the call site above `final_properties_after_dispatch`
+    /// in the main drain loop) and must refuse the terminal write if a
+    /// concurrent writer changed properties since that read, even though the
+    /// claim tokens (`firing_at`/`invocation_id`/lease) are still valid —
+    /// those predicates alone do not detect an out-of-band property change.
+    /// This deterministically reproduces "two reads from one revision": the
+    /// snapshot captured here (`expected_properties`) is used for the stale
+    /// finalize attempt AFTER a concurrent write has already landed, so the
+    /// exact-equality predicate must fail. Before threading a real snapshot
+    /// through, normal finalization always called with `snapshot=None`,
+    /// which makes `AND (?9 IS NULL OR properties = ?9)` unconditionally
+    /// true — this test reddens if that call reverts to `None`: the stale
+    /// finalize would then succeed and the concurrent writer's
+    /// `concurrent_marker` field would be silently discarded.
+    #[tokio::test]
+    async fn normal_finalize_refuses_when_a_concurrent_writer_changed_properties_since_the_read() {
+        let (_tmp, db_path) = tmp_db();
+        let rt = make_rt(&db_path).await;
+
+        let past = "2000-01-01T00:00:00Z";
+        let id =
+            create_scheduled_event(&rt, "local", past, Some("stats()"), None, "schedule").await;
+        let claim = claim_for_test(&rt, id, past).await;
+
+        // The finalizer's fresh pre-write read (what `current_note_properties_text`
+        // returns right before finalizing in production).
+        let expected_properties = get_raw_note_properties(&rt, id).await;
+
+        // A concurrent writer mutates the row AFTER that read while leaving
+        // every claim predicate (status/firing_at/invocation_id/lease)
+        // valid — e.g. an external property patch racing the finalizer.
+        let mut writer = rt.sql().writer().await.expect("writer");
+        let rows = writer
+            .execute(SqlStatement {
+                sql: "UPDATE notes SET properties = json_set(properties, \
+                      '$.concurrent_marker', 'yes') WHERE id = ?1"
+                    .to_string(),
+                params: vec![SqlValue::Text(id.to_string())],
+                label: Some("test_concurrent_property_write".into()),
+            })
+            .await
+            .expect("concurrent write");
+        assert_eq!(rows, 1);
+        drop(writer);
+
+        let final_props = json!({
+            "trigger_at": past,
+            "repeat": null,
+            "status": "fired",
+            "event_type": "schedule",
+            "payload": "stats()",
+            "fired_at": Utc::now().to_rfc3339(),
+            "cancelled_at": null,
+        });
+        let finalized = finalize_fired_event(
+            &rt,
+            "local",
+            id,
+            &final_props,
+            Utc::now().timestamp_micros(),
+            &claim,
+            Some(&expected_properties),
+        )
+        .await
+        .expect("finalize query must not error");
+        assert!(
+            !finalized,
+            "finalize must refuse a terminal write when properties changed since the read it guards on"
+        );
+
+        let props_after = get_note_props(&rt, id).await;
+        assert_eq!(
+            props_after["status"].as_str(),
+            Some("firing"),
+            "the row must remain firing, not silently finalized over the concurrent writer's \
+             change: {props_after:?}"
+        );
+        assert_eq!(
+            props_after["concurrent_marker"].as_str(),
+            Some("yes"),
+            "the concurrent writer's field must survive the refused finalize: {props_after:?}"
+        );
+
+        // A finalize guarded on the CURRENT properties (as the real drain
+        // loop does, re-reading right before this call) must still succeed.
+        let fresh_properties = get_raw_note_properties(&rt, id).await;
+        let finalized_fresh = finalize_fired_event(
+            &rt,
+            "local",
+            id,
+            &final_props,
+            Utc::now().timestamp_micros(),
+            &claim,
+            Some(&fresh_properties),
+        )
+        .await
+        .expect("finalize query must not error");
+        assert!(
+            finalized_fresh,
+            "finalize with a fresh snapshot must succeed"
+        );
+        assert_eq!(
+            get_note_props(&rt, id).await["status"].as_str(),
+            Some("fired")
         );
     }
 

--- a/crates/khive-mcp/src/pending_events.rs
+++ b/crates/khive-mcp/src/pending_events.rs
@@ -803,8 +803,6 @@ async fn run_pending_events_on_with_lease(
                             "anonymous:local".to_string()
                         }
                     });
-                #[cfg(test)]
-                race_seam::pause_before_finalize_read().await;
                 let claim =
                     match claim_pending_event(rt, ns_str, id, occurrence_id, &receipt_actor, lease)
                         .await
@@ -1215,6 +1213,16 @@ async fn run_pending_events_on_with_lease(
                 // process's own intervening writes have already landed —
                 // can distinguish "nothing else touched this row since I last
                 // looked" from a genuine concurrent writer.
+                //
+                // The race seam parks HERE, not before the claim: a test that
+                // pauses earlier lands its concurrent write before the
+                // candidate-page snapshot is taken, so the page already carries
+                // that write and the test passes whether finalization rebuilds
+                // from the stale page or from this fresh read. Parked here, the
+                // write is genuinely between the claim and this read, which is
+                // the only window that separates the two behaviours.
+                #[cfg(test)]
+                race_seam::pause_before_finalize_read().await;
                 let expected_properties = match current_note_properties_text(rt, ns_str, id).await {
                     Ok(Some(text)) => text,
                     Ok(None) => {
@@ -6439,10 +6447,13 @@ mod tests {
             }))
         };
 
-        // Block until the drain task has genuinely parked at the seam
-        // (before its candidate-page query), THEN write, THEN release it —
-        // guaranteeing the write lands strictly between the drain's
-        // page-query snapshot and its later fresh pre-finalize read.
+        // Block until the drain task has genuinely parked at the seam — which
+        // sits AFTER the candidate-page query and the claim, immediately
+        // before the fresh pre-finalize read — THEN write, THEN release it.
+        // That placement is what makes the write land strictly between the
+        // page-query snapshot and the fresh read: parked any earlier, the
+        // write would already be inside the page snapshot and the test would
+        // pass whether finalization used the stale page or the fresh read.
         gate.reached.wait().await;
 
         let mut writer = rt.sql().writer().await.expect("writer");

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -2405,10 +2405,37 @@ pub(crate) async fn handle_heartbeat(
         deleted_at: None,
     };
 
-    store
-        .upsert_note(note)
-        .await
-        .map_err(|e| RuntimeError::Internal(format!("heartbeat: upsert_note: {e}")))?;
+    // Guard the read-modify-write: `props` above was carried forward from
+    // `existing`, so a concurrent heartbeat that committed after that read
+    // (e.g. flipping `consecutive_failures`/`last_error`) must not be
+    // silently discarded by this write. A brand-new channel (`existing ==
+    // None`) has no prior state to lose, so it inserts unguarded — the same
+    // shape `replace_note_if_unchanged` uses for every other guarded note
+    // update (khive-runtime's `update_note_from_snapshot_with_embedding_report`).
+    match existing {
+        Some(snapshot) => {
+            let persisted = store
+                .replace_note_if_unchanged(note, snapshot.updated_at, snapshot.deleted_at)
+                .await
+                .map_err(|e| {
+                    RuntimeError::Internal(format!("heartbeat: replace_note_if_unchanged: {e}"))
+                })?;
+            if !persisted {
+                return Err(RuntimeError::Khive(khive_types::KhiveError::conflict(
+                    format!(
+                        "heartbeat: channel {}:{} changed concurrently after it was read; retry",
+                        p.channel_kind, p.channel_slug
+                    ),
+                )));
+            }
+        }
+        None => {
+            store
+                .upsert_note(note)
+                .await
+                .map_err(|e| RuntimeError::Internal(format!("heartbeat: upsert_note: {e}")))?;
+        }
+    }
 
     Ok(json!({
         "ok": true,
@@ -3388,6 +3415,125 @@ mod tests {
             signal.snapshot(),
             generation_after_commit,
             "a deduplicated ingest must not publish a wake"
+        );
+    }
+
+    /// Regression for the heartbeat lost-update race (khive #1753). Two
+    /// readers observe the SAME existing heartbeat row (deterministic: this
+    /// test is the only writer, so two sequential `get_note` calls before
+    /// either write are guaranteed to see one shared revision — no barrier
+    /// needed to force it). Each derives an independent poll outcome from
+    /// that snapshot, mirroring exactly what `handle_heartbeat` builds for a
+    /// "failure" vs. a "success" report, then the two writes commit through
+    /// the SAME `NoteStore::replace_note_if_unchanged` call `handle_heartbeat`
+    /// now uses. Before that guard, `handle_heartbeat` called
+    /// `store.upsert_note` unconditionally, so B's write would also succeed
+    /// and A's `consecutive_failures`/`last_error` update would be silently
+    /// discarded. This reddens if the write in `handle_heartbeat`'s `Some(snapshot)`
+    /// branch reverts to an unconditional `upsert_note`: the second
+    /// `replace_note_if_unchanged` call below would then need to be an
+    /// `upsert_note` too, which always returns `()`/succeeds, so the
+    /// `!... .unwrap()` assertion would fail to compile-flag the regression
+    /// and the final `consecutive_failures`/`last_failure_at` assertions
+    /// would observe B's fields instead of A's.
+    #[tokio::test]
+    async fn concurrent_heartbeats_from_one_revision_only_one_survives() {
+        let runtime = khive_runtime::KhiveRuntime::memory().expect("in-memory runtime");
+        let token = runtime
+            .authorize(khive_runtime::Namespace::parse("local").unwrap())
+            .expect("authorize");
+
+        super::handle_heartbeat(
+            &runtime,
+            &token,
+            json!({
+                "channel_kind": "email",
+                "channel_slug": "race@example.com",
+                "poll_interval_secs": 5,
+                "outcome": "success",
+            }),
+        )
+        .await
+        .expect("seed heartbeat");
+
+        let store = runtime.notes(&token).expect("note store");
+        let id = super::heartbeat_note_id("local", "email", "race@example.com");
+        let snapshot_for_a = store
+            .get_note(id)
+            .await
+            .unwrap()
+            .expect("seeded heartbeat row");
+        let snapshot_for_b = store
+            .get_note(id)
+            .await
+            .unwrap()
+            .expect("seeded heartbeat row");
+        assert_eq!(
+            snapshot_for_a.updated_at, snapshot_for_b.updated_at,
+            "both readers must observe the same pre-write revision for this to be a real race"
+        );
+
+        // Writer A: a "failure" report built from the shared snapshot —
+        // mirrors handle_heartbeat's failure branch exactly.
+        let mut note_a = snapshot_for_a.clone();
+        let mut props_a = note_a.properties.clone().unwrap_or_else(|| json!({}));
+        props_a["last_failure_at"] = json!("2026-08-26T00:00:00Z");
+        props_a["consecutive_failures"] = json!(1);
+        props_a["last_error"] =
+            json!({"class": "timeout", "message": "boom", "at": "2026-08-26T00:00:00Z"});
+        note_a.properties = Some(props_a);
+        note_a.updated_at = snapshot_for_a.updated_at + 1;
+
+        // Writer B: a "success" report ALSO derived from the SAME stale
+        // snapshot — as if B's own internal `get_note` raced A's.
+        let mut note_b = snapshot_for_b.clone();
+        let mut props_b = note_b.properties.clone().unwrap_or_else(|| json!({}));
+        props_b["last_success_at"] = json!("2026-08-26T00:00:01Z");
+        props_b["consecutive_failures"] = json!(0);
+        note_b.properties = Some(props_b);
+        note_b.updated_at = snapshot_for_b.updated_at + 1;
+
+        assert!(
+            store
+                .replace_note_if_unchanged(
+                    note_a,
+                    snapshot_for_a.updated_at,
+                    snapshot_for_a.deleted_at
+                )
+                .await
+                .expect("writer A CAS query"),
+            "the first committer from a shared revision must win"
+        );
+        assert!(
+            !store
+                .replace_note_if_unchanged(
+                    note_b,
+                    snapshot_for_b.updated_at,
+                    snapshot_for_b.deleted_at
+                )
+                .await
+                .expect("writer B CAS query"),
+            "the second committer from the SAME stale revision must be refused, not merged"
+        );
+
+        let final_note = store
+            .get_note(id)
+            .await
+            .unwrap()
+            .expect("heartbeat row still exists");
+        let final_props = final_note.properties.expect("heartbeat properties");
+        assert_eq!(
+            final_props["consecutive_failures"],
+            json!(1),
+            "writer A's failure count must survive: {final_props:?}"
+        );
+        assert_eq!(
+            final_props["last_failure_at"],
+            json!("2026-08-26T00:00:00Z")
+        );
+        assert!(
+            final_props.get("last_success_at") != Some(&json!("2026-08-26T00:00:01Z")),
+            "writer B's success timestamp must not be silently merged into the persisted row: {final_props:?}"
         );
     }
 

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -2391,6 +2391,26 @@ pub(crate) async fn handle_heartbeat(
         .map(|n| n.created_at)
         .unwrap_or_else(|| now.timestamp_micros());
 
+    // `updated_at` is also the optimistic-concurrency revision `replace_note_if_unchanged`
+    // checks with `?10 > updated_at`. Two heartbeats landing in the same stored microsecond,
+    // or a backward wall-clock step, must not report a conflict when no concurrent writer
+    // touched the row — make the replacement revision strictly advance past the existing
+    // snapshot instead of trusting `Utc::now()` alone (mirrors
+    // `update_note_from_snapshot_with_embedding_report`). A brand-new channel has no prior
+    // revision to advance past.
+    let updated_at_micros = match existing.as_ref() {
+        Some(snapshot) => {
+            let minimum = snapshot.updated_at.checked_add(1).ok_or_else(|| {
+                RuntimeError::Internal(format!(
+                    "heartbeat: channel {}:{} updated_at is already at i64::MAX and cannot advance",
+                    p.channel_kind, p.channel_slug
+                ))
+            })?;
+            now.timestamp_micros().max(minimum)
+        }
+        None => now.timestamp_micros(),
+    };
+
     let note = Note {
         id,
         namespace: ns.to_string(),
@@ -2403,7 +2423,7 @@ pub(crate) async fn handle_heartbeat(
         expires_at: None,
         properties: Some(props),
         created_at,
-        updated_at: now.timestamp_micros(),
+        updated_at: updated_at_micros,
         deleted_at: None,
     };
 
@@ -3679,6 +3699,94 @@ mod tests {
                 && final_props["poll_interval_secs"] == json!(9)),
             "both racers' fields must never both land: that would mean the loser's stale \
              write silently succeeded: {final_props:?}"
+        );
+    }
+
+    /// A heartbeat's replacement revision must strictly advance past the
+    /// existing row's own `updated_at`, not just past `Utc::now()`: two
+    /// heartbeats landing in the same stored microsecond, or a backward
+    /// wall-clock step, are the SAME code path as this test forces (the
+    /// fix's `max(now, snapshot+1)` does not distinguish "now == snapshot"
+    /// from "now < snapshot" — both take the `snapshot+1` branch). Before the
+    /// fix, `handle_heartbeat` derived the replacement revision straight from
+    /// `Utc::now().timestamp_micros()`, so forcing the stored snapshot ahead
+    /// of wall-clock time reproduces both scenarios deterministically without
+    /// a clock-injection seam.
+    #[tokio::test]
+    async fn handle_heartbeat_does_not_false_conflict_when_snapshot_is_ahead_of_wall_clock() {
+        let runtime = khive_runtime::KhiveRuntime::memory().expect("in-memory runtime");
+        let token = runtime
+            .authorize(khive_runtime::Namespace::parse("local").unwrap())
+            .expect("authorize");
+
+        super::handle_heartbeat(
+            &runtime,
+            &token,
+            json!({
+                "channel_kind": "email",
+                "channel_slug": "clock-skew@example.com",
+                "outcome": "success",
+            }),
+        )
+        .await
+        .expect("seed heartbeat");
+
+        let store = runtime.notes(&token).expect("note store");
+        let id = super::heartbeat_note_id("local", "email", "clock-skew@example.com");
+        let seeded = store
+            .get_note(id)
+            .await
+            .unwrap()
+            .expect("seeded heartbeat row");
+
+        // Force the stored revision far ahead of any `Utc::now()` the next
+        // handler call will observe — the same condition as an equal-
+        // microsecond write or a backward clock step.
+        let future_updated_at = seeded.updated_at + 60_000_000; // +60s
+        let mut ahead = seeded.clone();
+        ahead.updated_at = future_updated_at;
+        let forced = store
+            .replace_note_if_unchanged(ahead, seeded.updated_at, seeded.deleted_at)
+            .await
+            .expect("test setup: force the snapshot ahead of wall-clock time");
+        assert!(
+            forced,
+            "test setup CAS must succeed against the freshly seeded row"
+        );
+
+        let result = super::handle_heartbeat(
+            &runtime,
+            &token,
+            json!({
+                "channel_kind": "email",
+                "channel_slug": "clock-skew@example.com",
+                "outcome": "failure",
+                "error_class": "timeout",
+                "error_message": "boom",
+            }),
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "a heartbeat with no competing writer must not be refused just because the \
+             stored revision is at or ahead of wall-clock now: {result:?}"
+        );
+
+        let final_note = store
+            .get_note(id)
+            .await
+            .unwrap()
+            .expect("heartbeat row still exists");
+        assert!(
+            final_note.updated_at > future_updated_at,
+            "the replacement revision must still strictly advance past the forced-ahead \
+             snapshot: {final_note:?}"
+        );
+        let final_props = final_note.properties.expect("heartbeat properties");
+        assert_eq!(
+            final_props["consecutive_failures"],
+            json!(1),
+            "the accepted write must actually be the failure report just sent: {final_props:?}"
         );
     }
 

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -3482,6 +3482,12 @@ mod tests {
     /// `!... .unwrap()` assertion would fail to compile-flag the regression
     /// and the final `consecutive_failures`/`last_failure_at` assertions
     /// would observe B's fields instead of A's.
+    ///
+    /// SCOPE: this exercises the STORE PRIMITIVE directly and never invokes
+    /// `handle_heartbeat`, so it stays green if the handler is reverted to an
+    /// unconditional `upsert_note`. The wiring is covered separately by
+    /// `production_handle_heartbeat_refuses_concurrent_stale_writer`; both are
+    /// required, neither substitutes for the other.
     #[tokio::test]
     async fn concurrent_heartbeats_from_one_revision_only_one_survives() {
         let runtime = khive_runtime::KhiveRuntime::memory().expect("in-memory runtime");
@@ -3712,6 +3718,15 @@ mod tests {
     /// `Utc::now().timestamp_micros()`, so forcing the stored snapshot ahead
     /// of wall-clock time reproduces both scenarios deterministically without
     /// a clock-injection seam.
+    ///
+    /// SCOPE: this is a revision-clamp test, NOT CAS regression coverage. Its
+    /// assertion is that the heartbeat write SUCCEEDS, which an unconditional
+    /// `upsert_note` also satisfies, so it stays green if the
+    /// `updated_at = ?13` / `?10 > updated_at` guard is dropped entirely. The
+    /// guard's regression coverage is
+    /// `concurrent_heartbeats_from_one_revision_only_one_survives` (primitive)
+    /// and `production_handle_heartbeat_refuses_concurrent_stale_writer`
+    /// (production wiring); do not count this test toward it.
     #[tokio::test]
     async fn handle_heartbeat_does_not_false_conflict_when_snapshot_is_ahead_of_wall_clock() {
         let runtime = khive_runtime::KhiveRuntime::memory().expect("in-memory runtime");

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -2326,6 +2326,8 @@ pub(crate) async fn handle_heartbeat(
         .get_note(id)
         .await
         .map_err(|e| RuntimeError::Internal(format!("heartbeat: get_note: {e}")))?;
+    #[cfg(test)]
+    race_seam::pause_after_read().await;
 
     let now = Utc::now();
     // A supplied `at` must resolve to an instant before it is stored: the
@@ -3252,6 +3254,30 @@ fn build_references_header(parent_chain: Option<&str>, parent_message_id: &str) 
     tokens.join(" ")
 }
 
+/// Test-only pause point at `handle_heartbeat`'s read/write boundary, so a
+/// race between two concurrent callers of the PRODUCTION handler (not the
+/// underlying `replace_note_if_unchanged` store primitive) can be reproduced
+/// deterministically instead of relying on scheduler luck or sleeps. A no-op
+/// unless the calling task runs inside `AFTER_READ_BARRIER.scope(...)`;
+/// production dispatch never establishes that scope, so `pause_after_read`
+/// costs nothing outside these regression tests, and it does not exist at
+/// all in non-test builds.
+#[cfg(test)]
+mod race_seam {
+    use std::sync::Arc;
+    use tokio::sync::Barrier;
+
+    tokio::task_local! {
+        pub(crate) static AFTER_READ_BARRIER: Arc<Barrier>;
+    }
+
+    pub(crate) async fn pause_after_read() {
+        if let Ok(barrier) = AFTER_READ_BARRIER.try_with(Arc::clone) {
+            barrier.wait().await;
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -3534,6 +3560,125 @@ mod tests {
         assert!(
             final_props.get("last_success_at") != Some(&json!("2026-08-26T00:00:01Z")),
             "writer B's success timestamp must not be silently merged into the persisted row: {final_props:?}"
+        );
+    }
+
+    /// Same race as `concurrent_heartbeats_from_one_revision_only_one_survives`,
+    /// but driven entirely through the PRODUCTION entry point
+    /// (`handle_heartbeat`) rather than `replace_note_if_unchanged` directly.
+    /// This closes a gap the primitive-level test cannot: it would still pass
+    /// unchanged if `handle_heartbeat` were reverted to an unconditional
+    /// `upsert_note`, since it never invokes the handler at all. Uses
+    /// `race_seam::pause_after_read` (test-only, compiled out of non-test
+    /// builds) to force both concurrent callers to observe the identical
+    /// pre-write revision deterministically — no sleeps, no reliance on
+    /// scheduler ordering.
+    #[tokio::test]
+    async fn production_handle_heartbeat_refuses_concurrent_stale_writer() {
+        let runtime =
+            std::sync::Arc::new(khive_runtime::KhiveRuntime::memory().expect("in-memory runtime"));
+        let token = runtime
+            .authorize(khive_runtime::Namespace::parse("local").unwrap())
+            .expect("authorize");
+
+        super::handle_heartbeat(
+            &runtime,
+            &token,
+            json!({
+                "channel_kind": "email",
+                "channel_slug": "production-race@example.com",
+                "poll_interval_secs": 5,
+                "outcome": "success",
+            }),
+        )
+        .await
+        .expect("seed heartbeat");
+
+        let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+
+        let writer_a = {
+            let runtime = std::sync::Arc::clone(&runtime);
+            let token = token.clone();
+            let barrier = std::sync::Arc::clone(&barrier);
+            tokio::spawn(
+                super::race_seam::AFTER_READ_BARRIER.scope(barrier, async move {
+                    super::handle_heartbeat(
+                        &runtime,
+                        &token,
+                        json!({
+                            "channel_kind": "email",
+                            "channel_slug": "production-race@example.com",
+                            "outcome": "failure",
+                            "error_class": "timeout",
+                            "error_message": "boom",
+                        }),
+                    )
+                    .await
+                }),
+            )
+        };
+        let writer_b = {
+            let runtime = std::sync::Arc::clone(&runtime);
+            let token = token.clone();
+            let barrier = std::sync::Arc::clone(&barrier);
+            tokio::spawn(
+                super::race_seam::AFTER_READ_BARRIER.scope(barrier, async move {
+                    super::handle_heartbeat(
+                        &runtime,
+                        &token,
+                        json!({
+                            "channel_kind": "email",
+                            "channel_slug": "production-race@example.com",
+                            "poll_interval_secs": 9,
+                            "outcome": "success",
+                        }),
+                    )
+                    .await
+                }),
+            )
+        };
+
+        let result_a = writer_a.await.expect("writer A task");
+        let result_b = writer_b.await.expect("writer B task");
+        let successes = [result_a.is_ok(), result_b.is_ok()]
+            .into_iter()
+            .filter(|ok| *ok)
+            .count();
+        assert_eq!(
+            successes, 1,
+            "exactly one production caller must win the race; the other must be refused: \
+             a={result_a:?} b={result_b:?}"
+        );
+        let refused = if result_a.is_err() {
+            result_a
+        } else {
+            result_b
+        };
+        match &refused {
+            Err(khive_runtime::RuntimeError::Khive(khive_error)) => {
+                assert_eq!(
+                    khive_error.kind(),
+                    khive_types::ErrorKind::Conflict,
+                    "the losing production caller must surface a typed conflict, not \
+                     silently overwrite: {refused:?}"
+                );
+            }
+            other => panic!("expected a typed conflict error, got {other:?}"),
+        }
+
+        let store = runtime.notes(&token).expect("note store");
+        let id = super::heartbeat_note_id("local", "email", "production-race@example.com");
+        let final_note = store
+            .get_note(id)
+            .await
+            .unwrap()
+            .expect("heartbeat row still exists");
+        let final_props = final_note.properties.expect("heartbeat properties");
+        assert!(
+            !(final_props.get("last_failure_at").is_some()
+                && final_props["poll_interval_secs"] == json!(9)),
+            "both racers' fields must never both land: that would mean the loser's stale \
+             write silently succeeded: {final_props:?}"
         );
     }
 

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -2430,10 +2430,20 @@ pub(crate) async fn handle_heartbeat(
     // Guard the read-modify-write: `props` above was carried forward from
     // `existing`, so a concurrent heartbeat that committed after that read
     // (e.g. flipping `consecutive_failures`/`last_error`) must not be
-    // silently discarded by this write. A brand-new channel (`existing ==
-    // None`) has no prior state to lose, so it inserts unguarded — the same
-    // shape `replace_note_if_unchanged` uses for every other guarded note
-    // update (khive-runtime's `update_note_from_snapshot_with_embedding_report`).
+    // silently discarded by this write — the same shape
+    // `replace_note_if_unchanged` uses for every other guarded note update
+    // (khive-runtime's `update_note_from_snapshot_with_embedding_report`).
+    //
+    // ⚠ The `None` branch is NOT guarded, and being a new row does not make it
+    // safe. The hazard here is not losing prior state, it is two concurrent
+    // FIRST writes: the note id is deterministic per channel, so two heartbeats
+    // racing on a channel's first report can both read `None` and both take
+    // this branch. `upsert_note` rewrites every mutable column on an id
+    // conflict and reports no conflict outcome, so the later write silently
+    // replaces the earlier report. Closing it needs an insert-if-absent
+    // primitive that reports whether it inserted; that primitive does not exist
+    // yet, so this branch is knowingly left unguarded and tracked separately
+    // rather than widened into this change.
     match existing {
         Some(snapshot) => {
             let persisted = store
@@ -3483,11 +3493,15 @@ mod tests {
     /// and the final `consecutive_failures`/`last_failure_at` assertions
     /// would observe B's fields instead of A's.
     ///
-    /// SCOPE: this exercises the STORE PRIMITIVE directly and never invokes
-    /// `handle_heartbeat`, so it stays green if the handler is reverted to an
-    /// unconditional `upsert_note`. The wiring is covered separately by
-    /// `production_handle_heartbeat_refuses_concurrent_stale_writer`; both are
-    /// required, neither substitutes for the other.
+    /// SCOPE: the race here is two direct `replace_note_if_unchanged` calls
+    /// against the STORE PRIMITIVE. `handle_heartbeat` IS invoked, once, at the
+    /// top, and only to seed the row — so reverting the handler's guarded
+    /// branch to an unconditional `upsert_note` changes the seed and not the
+    /// race, and this test stays green. That is measured: under exactly that
+    /// wiring mutation the only test that reddens is
+    /// `production_handle_heartbeat_refuses_concurrent_stale_writer`, which is
+    /// what covers the wiring. Both are required, neither substitutes for the
+    /// other.
     #[tokio::test]
     async fn concurrent_heartbeats_from_one_revision_only_one_survives() {
         let runtime = khive_runtime::KhiveRuntime::memory().expect("in-memory runtime");

--- a/crates/khive-runtime/docs/api/atomic_prepare.md
+++ b/crates/khive-runtime/docs/api/atomic_prepare.md
@@ -55,15 +55,24 @@ entity/note branches' `merge_properties`).
 
 DML shape:
 
-- non-symmetric relation: a single `edge_upsert_statement` call on the patched `Edge` — the same
-  builder `update_edge`'s own non-symmetric branch calls via `graph.upsert_edge(edge.clone())`
-  (`khive-db::stores::graph::SqlGraphStore::upsert_edge`), so parity is exact by construction.
-- symmetric relation (`competes_with`, `composed_with`): `update_edge` does NOT use the upsert
-  builder here, because `upsert_edge` resolves `ON CONFLICT(namespace, id)` first and cannot
-  detect a natural-key collision with a _different_ id. Canonical (`update_edge_symmetric_dml`)
-  runs a conflict probe and branches in Rust inside a single uninterrupted transaction, which is
-  safe there. This atomic path cannot do that (see the in-source invariant note on
-  `prepare_update_edge`).
+- non-symmetric relation: a single guarded `edge_replace_if_unchanged_statement` call on the
+  patched `Edge`, carrying an `AffectedRowGuard::exactly(1)` — the same CAS shape `update_edge`'s
+  own non-symmetric branch runs via `graph.replace_edge_if_unchanged(edge.clone(), expected_updated_at,
+  expected_deleted_at)` (`khive-db::stores::graph::SqlGraphStore::replace_edge_if_unchanged`). Both
+  sides bind the fetched snapshot's `updated_at`/`deleted_at` as the CAS fence and advance
+  `updated_at` to `max(now, snapshot + 1µs)` so the replacement revision strictly increases even
+  inside one clock microsecond; zero affected rows means a concurrent writer moved the edge between
+  read and write, and the caller must roll back rather than silently overwrite it.
+- symmetric relation (`competes_with`, `composed_with`): neither side uses the upsert builder here,
+  because `upsert_edge` resolves `ON CONFLICT(namespace, id)` first and cannot detect a natural-key
+  collision with a _different_ id. Canonical (`update_edge_symmetric_dml`) runs a conflict probe and
+  branches in Rust inside a single uninterrupted transaction, which is safe there. This atomic path
+  cannot do that (see the in-source invariant note on `prepare_update_edge`), so it always emits
+  both `edge_symmetric_delete_if_conflict_statement` and
+  `edge_symmetric_absorb_or_update_inplace_statement`, each carrying its own commit-time predicate
+  bound to the fetched snapshot's `updated_at`/`deleted_at`: a conflicting canonical survivor alone
+  is not sufficient grounds to delete the non-canonical row if that row changed since the snapshot
+  was read.
 
 ## event_append_statements
 

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -39,14 +39,15 @@ use crate::runtime::{KhiveRuntime, NamespaceToken};
 
 use khive_db::stores::attachment::delete_record_attachments_statement;
 use khive_db::stores::entity::{
-    entity_hard_delete_statement, entity_soft_delete_statement, entity_upsert_statement,
+    entity_hard_delete_statement, entity_replace_if_unchanged_statement,
+    entity_soft_delete_statement, entity_upsert_statement,
 };
 use khive_db::stores::event::event_insert_statements;
 use khive_db::stores::event::hard_delete_lineage_warning_statements;
 use khive_db::stores::graph::{
     edge_hard_delete_statement, edge_insert_guarded_by_endpoints_statement,
-    edge_soft_delete_statement, edge_symmetric_absorb_or_update_inplace_statement,
-    edge_symmetric_delete_if_conflict_statement, edge_upsert_statement,
+    edge_replace_if_unchanged_statement, edge_soft_delete_statement,
+    edge_symmetric_absorb_or_update_inplace_statement, edge_symmetric_delete_if_conflict_statement,
     purge_incident_edges_statement,
 };
 use khive_db::stores::note::{
@@ -884,10 +885,14 @@ pub async fn prepare_update_entity_plan(
     id: Uuid,
     patch: crate::curation::EntityPatch,
 ) -> RuntimeResult<AtomicOpPlan> {
-    let (entity, reindex_required, changed_fields) =
+    let (entity, reindex_required, changed_fields, expected_updated_at, expected_deleted_at) =
         runtime.prepare_update_entity(token, id, patch).await?;
     let mut statements = vec![PlanStatement {
-        statement: entity_upsert_statement(&entity),
+        statement: entity_replace_if_unchanged_statement(
+            &entity,
+            expected_updated_at,
+            expected_deleted_at,
+        ),
         guard: Some(AffectedRowGuard::exactly(1)),
     }];
     statements.extend(event_append_statements(
@@ -941,6 +946,9 @@ async fn prepare_update_edge(
     args: &Value,
 ) -> RuntimeResult<AtomicOpPlan> {
     reject_inapplicable_update_fields(args, "edge")?;
+
+    let expected_updated_at = edge.updated_at;
+    let expected_deleted_at = edge.deleted_at;
 
     let relation_raw = optional_str(args, "relation");
     let weight = optional_f64(args, "weight")?;
@@ -1041,11 +1049,18 @@ async fn prepare_update_edge(
             relation: edge.relation,
         });
     } else {
-        // Non-symmetric: bit-for-bit the same builder `graph.upsert_edge`
-        // calls — see doc comment above.
+        // Non-symmetric: guarded replace of the read snapshot rather than
+        // `graph.upsert_edge`'s unconditional natural-key upsert — a zero
+        // affected-row result now means a concurrent writer moved this edge
+        // between PREPARE and commit, and the atomic unit must roll back
+        // instead of silently overwriting it.
         edge.updated_at = now;
         statements.push(PlanStatement {
-            statement: edge_upsert_statement(&edge),
+            statement: edge_replace_if_unchanged_statement(
+                &edge,
+                expected_updated_at,
+                expected_deleted_at,
+            ),
             guard: Some(AffectedRowGuard::exactly(1)),
         });
     }
@@ -3406,6 +3421,173 @@ mod tests {
         let events =
             events_for_target(&runtime, &token, requested_id, EventKind::EdgeUpdated).await;
         assert_eq!(events.len(), 1);
+    }
+
+    /// Regression for khive #1753: an entity atomic update plan is prepared
+    /// from one revision, a concurrent (out-of-plan) writer advances the row
+    /// past that revision before the plan commits, and the plan's guarded
+    /// `entity_replace_if_unchanged_statement` must then affect zero rows —
+    /// which `AffectedRowGuard::exactly(1)` must turn into a whole-unit
+    /// rollback, not a silent overwrite of the concurrent writer's change.
+    /// Before threading the expected revision into the plan's `WHERE`
+    /// predicate, this plan used the unconditional `entity_upsert_statement`,
+    /// which always affects exactly 1 row regardless of staleness — the
+    /// guard could never fire and this test would redden (the outcome would
+    /// be `Committed`, and the concurrent writer's `name` change would be
+    /// lost under the stale plan's `description`-only patch).
+    #[tokio::test]
+    async fn atomic_entity_update_plan_stale_revision_rolls_back_unit() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let entity = runtime
+            .create_entity(
+                &token,
+                "concept",
+                None,
+                "StaleEntityPlanTarget",
+                None,
+                Some(json!({"a": 0})),
+                vec![],
+            )
+            .await
+            .expect("seed entity");
+        let id = entity.id;
+
+        // PREPARE time: build the plan from the current (soon-to-be-stale)
+        // revision.
+        let plan = prepare_update(
+            &runtime,
+            &token,
+            &json!({"id": id.to_string(), "description": "from the stale plan"}),
+            None,
+        )
+        .await
+        .expect("prepare update entity plan");
+
+        // A concurrent writer commits BEFORE the plan runs, advancing the
+        // row's revision past what the plan's guard expects.
+        runtime
+            .update_entity(
+                &token,
+                id,
+                crate::curation::EntityPatch {
+                    name: Some("ConcurrentWriterWon".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("concurrent writer update");
+
+        let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+            .await
+            .expect("the seam call itself must not error; the unit rolls back cleanly");
+        match outcome {
+            crate::atomic_runner::AtomicRunOutcome::RolledBack {
+                failed_op_index, ..
+            } => {
+                assert_eq!(
+                    failed_op_index, 0,
+                    "the sole op's guard must be the one that fails"
+                );
+            }
+            other => panic!(
+                "a stale entity plan must roll back, not silently overwrite the concurrent \
+                 writer's change: {other:?}"
+            ),
+        }
+
+        let after = runtime.get_entity(&token, id).await.expect("get_entity");
+        assert_eq!(
+            after.name, "ConcurrentWriterWon",
+            "the concurrent writer's committed name must survive the rolled-back stale plan"
+        );
+        assert_eq!(
+            after.description, None,
+            "the stale plan's description patch must NOT have landed"
+        );
+    }
+
+    /// Edge counterpart of `atomic_entity_update_plan_stale_revision_rolls_back_unit`:
+    /// a non-symmetric edge atomic update plan prepared from one revision
+    /// must roll back the whole unit when a concurrent writer advances the
+    /// row first, rather than silently overwriting that writer's change.
+    #[tokio::test]
+    async fn atomic_edge_update_plan_stale_revision_rolls_back_unit() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let entities = runtime.entities(&token).expect("entities store");
+        let a = khive_storage::Entity::new("local", "concept", "StaleEdgePlanA");
+        let b = khive_storage::Entity::new("local", "concept", "StaleEdgePlanB");
+        let (a_id, b_id) = (a.id, b.id);
+        entities.upsert_entity(a).await.expect("seed a");
+        entities.upsert_entity(b).await.expect("seed b");
+
+        let edge = runtime
+            .link(&token, a_id, b_id, EdgeRelation::Extends, 0.2, None)
+            .await
+            .expect("seed edge");
+        let edge_id = Uuid::from(edge.id);
+
+        // PREPARE time: build the plan from the current (soon-to-be-stale)
+        // revision.
+        let plan = prepare_update(
+            &runtime,
+            &token,
+            &json!({"id": edge_id.to_string(), "properties": {"note": "from the stale plan"}}),
+            None,
+        )
+        .await
+        .expect("prepare update edge plan");
+
+        // A concurrent writer commits BEFORE the plan runs, advancing the
+        // row's revision past what the plan's guard expects.
+        runtime
+            .update_edge(
+                &token,
+                edge_id,
+                crate::curation::EdgePatch {
+                    weight: Some(0.75),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("concurrent writer update");
+
+        let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+            .await
+            .expect("the seam call itself must not error; the unit rolls back cleanly");
+        match outcome {
+            crate::atomic_runner::AtomicRunOutcome::RolledBack {
+                failed_op_index, ..
+            } => {
+                assert_eq!(
+                    failed_op_index, 0,
+                    "the sole op's guard must be the one that fails"
+                );
+            }
+            other => panic!(
+                "a stale edge plan must roll back, not silently overwrite the concurrent \
+                 writer's change: {other:?}"
+            ),
+        }
+
+        let after = runtime
+            .get_edge(&token, edge_id)
+            .await
+            .expect("get_edge")
+            .expect("edge still exists");
+        assert!(
+            (after.weight - 0.75).abs() < 0.001,
+            "the concurrent writer's committed weight must survive the rolled-back stale plan: {after:?}"
+        );
+        assert!(
+            after.metadata.is_none(),
+            "the stale plan's properties patch must NOT have landed: {after:?}"
+        );
     }
 
     /// A soft-deleted surviving canonical row must not be resurrected by a

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -1010,6 +1010,21 @@ async fn prepare_update_edge(
             .as_ref()
             .map(|v| serde_json::to_string(v).unwrap_or_default());
 
+        // `updated_at` must strictly advance past the snapshot even when two
+        // operations land inside one clock microsecond; saturating to
+        // i64::MAX would let the CAS accept a write without advancing its
+        // revision, so that is not a valid fallback (mirrors the note path).
+        let minimum_updated_at_micros = expected_updated_at
+            .timestamp_micros()
+            .checked_add(1)
+            .ok_or_else(|| {
+                RuntimeError::Internal(format!(
+                    "edge {id} updated_at is already at i64::MAX and cannot advance"
+                ))
+            })?;
+        let symmetric_updated_at_micros = now.timestamp_micros().max(minimum_updated_at_micros);
+        let expected_deleted_at_micros = expected_deleted_at.map(|v| v.timestamp_micros());
+
         statements.push(PlanStatement {
             statement: edge_symmetric_delete_if_conflict_statement(
                 &namespace,
@@ -1031,9 +1046,11 @@ async fn prepare_update_edge(
                 canon_tgt,
                 edge.relation,
                 edge.weight,
-                now.timestamp_micros(),
+                symmetric_updated_at_micros,
                 metadata_str.as_deref(),
                 edge.target_backend.as_deref(),
+                expected_updated_at.timestamp_micros(),
+                expected_deleted_at_micros,
             ),
             guard: Some(AffectedRowGuard::exactly(1)),
         });
@@ -1054,7 +1071,25 @@ async fn prepare_update_edge(
         // affected-row result now means a concurrent writer moved this edge
         // between PREPARE and commit, and the atomic unit must roll back
         // instead of silently overwriting it.
-        edge.updated_at = now;
+        //
+        // `updated_at` must strictly advance past the snapshot even when two
+        // operations land inside one clock microsecond; saturating to
+        // i64::MAX would let the CAS accept a write without advancing its
+        // revision, so that is not a valid fallback (mirrors the note path).
+        let minimum_updated_at_micros = expected_updated_at
+            .timestamp_micros()
+            .checked_add(1)
+            .ok_or_else(|| {
+                RuntimeError::Internal(format!(
+                    "edge {id} updated_at is already at i64::MAX and cannot advance"
+                ))
+            })?;
+        let now_micros = now.timestamp_micros().max(minimum_updated_at_micros);
+        edge.updated_at = chrono::DateTime::from_timestamp_micros(now_micros).ok_or_else(|| {
+            RuntimeError::Internal(format!(
+                "edge {id}: computed updated_at {now_micros} is not a valid timestamp"
+            ))
+        })?;
         statements.push(PlanStatement {
             statement: edge_replace_if_unchanged_statement(
                 &edge,

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -1032,6 +1032,8 @@ async fn prepare_update_edge(
                 canon_src,
                 canon_tgt,
                 edge.relation,
+                expected_updated_at.timestamp_micros(),
+                expected_deleted_at_micros,
             ),
             guard: Some(AffectedRowGuard {
                 expected_min: 0,
@@ -3789,6 +3791,116 @@ mod tests {
         assert_eq!(
             canonical_after.weight, 0.6,
             "the pre-existing canonical row must never have been touched by the aborted update"
+        );
+    }
+
+    /// The symmetric absorption delete's atomic commit-time statement
+    /// (`edge_symmetric_delete_if_conflict_statement`) must refuse a plan
+    /// built from a since-changed snapshot, exactly like the non-symmetric
+    /// `atomic_edge_update_plan_stale_revision_rolls_back_unit` case above —
+    /// even though a genuine canonical survivor exists at the target natural
+    /// key. `E`'s own revision changes (via an unrelated production
+    /// `update_edge` call) AFTER `prepare_update` captured its snapshot but
+    /// BEFORE the plan runs; the whole atomic unit must roll back rather than
+    /// silently absorbing `E` into the survivor and discarding the
+    /// concurrent write.
+    #[tokio::test]
+    async fn atomic_update_edge_symmetric_absorption_plan_stale_revision_rolls_back_unit() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let entities = runtime.entities(&token).expect("entities store");
+        let a = khive_storage::Entity::new("local", "concept", "StaleAbsorbA");
+        let b = khive_storage::Entity::new("local", "concept", "StaleAbsorbB");
+        let (a_id, b_id) = (a.id, b.id);
+        entities.upsert_entity(a).await.expect("seed a");
+        entities.upsert_entity(b).await.expect("seed b");
+
+        // The pre-existing canonical row this plan will try to absorb into.
+        let canonical_edge = runtime
+            .link(&token, a_id, b_id, EdgeRelation::CompetesWith, 0.6, None)
+            .await
+            .expect("seed canonical edge");
+        let canonical_id = Uuid::from(canonical_edge.id);
+
+        // E: the requested edge under test.
+        let requested_edge = runtime
+            .link(&token, a_id, b_id, EdgeRelation::Extends, 0.2, None)
+            .await
+            .expect("seed requested edge");
+        let requested_id = Uuid::from(requested_edge.id);
+
+        // PREPARE time: build the plan from the current (soon-to-be-stale)
+        // revision.
+        let plan = prepare_update(
+            &runtime,
+            &token,
+            &json!({"id": requested_id.to_string(), "relation": "competes_with", "weight": 0.9}),
+            None,
+        )
+        .await
+        .expect("prepare update edge (symmetric absorption)");
+
+        // A concurrent writer commits BEFORE the plan runs, advancing E's
+        // revision past what the plan's guard expects. Relation stays
+        // `extends` (non-symmetric), so this lands via the already-guarded
+        // replace path — independent of the absorption bug under test.
+        let concurrent = runtime
+            .update_edge(
+                &token,
+                requested_id,
+                crate::curation::EdgePatch {
+                    weight: Some(0.77),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("concurrent writer update");
+        assert!((concurrent.weight - 0.77).abs() < 1e-9);
+
+        let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+            .await
+            .expect("the seam call itself must not error; the unit rolls back cleanly");
+        match outcome {
+            crate::atomic_runner::AtomicRunOutcome::RolledBack {
+                failed_op_index, ..
+            } => {
+                assert_eq!(
+                    failed_op_index, 0,
+                    "the sole op's guard must be the one that fails"
+                );
+            }
+            other => panic!(
+                "a stale absorption plan must roll back, not silently absorb E into the \
+                 survivor and discard the concurrent writer's change: {other:?}"
+            ),
+        }
+
+        let requested_after = runtime
+            .get_edge(&token, requested_id)
+            .await
+            .expect("get_edge")
+            .expect("E must still exist after the rolled-back absorption");
+        assert_eq!(
+            requested_after.relation,
+            EdgeRelation::Extends,
+            "E must be untouched by the rolled-back absorption: {requested_after:?}"
+        );
+        assert!(
+            (requested_after.weight - 0.77).abs() < 1e-9,
+            "the concurrent writer's committed weight must survive the rolled-back plan: \
+             {requested_after:?}"
+        );
+
+        let canonical_after = runtime
+            .get_edge(&token, canonical_id)
+            .await
+            .expect("get_edge")
+            .expect("S must still exist after the rolled-back absorption");
+        assert_eq!(
+            canonical_after.weight, 0.6,
+            "the survivor must never have been touched by the aborted absorption"
         );
     }
 

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -4138,11 +4138,26 @@ mod tests {
     /// landed). This test forces the interleaving with a `Barrier` — both
     /// readers are released together, so both `prepare_update_entity` calls
     /// observe the SAME pre-write revision (asserted below) — then commits
-    /// deterministically in a fixed A-then-B order. It reddens if the
-    /// `AND ?8 > updated_at` / `updated_at = ?13` predicate is dropped from
-    /// `entity_replace_if_unchanged_statement`: with an unconditional UPDATE
-    /// (or `entity_upsert_statement`), B's write would also return `true`
-    /// and `b` would be lost from the final properties.
+    /// deterministically in a fixed A-then-B order. It reddens if the guard
+    /// is dropped from `entity_replace_if_unchanged_statement` ENTIRELY: with
+    /// an unconditional UPDATE (or `entity_upsert_statement`), B's write would
+    /// also return `true` and `b` would be lost from the final properties.
+    ///
+    /// It does NOT redden on a single-conjunct removal, and that is measured,
+    /// not assumed: in this fixture `updated_at = ?13` and `?8 > updated_at`
+    /// are each independently sufficient to refuse B, so tautologizing either
+    /// one alone leaves this test green. Attribution to a specific conjunct
+    /// therefore comes from the isolating fixtures —
+    /// `entity_cas_refuses_a_replacement_revision_that_does_not_advance` for
+    /// the strict-advance conjunct, and
+    /// `production_update_entity_refuses_concurrent_stale_writer`, which does
+    /// redden on the `?13`/`?14` half alone.
+    ///
+    /// SCOPE: this exercises the STORE PRIMITIVE directly and never invokes
+    /// `update_entity`, so it stays green if the production caller is reverted
+    /// to an unconditional write. The wiring is covered separately by
+    /// `production_update_entity_refuses_concurrent_stale_writer`; both are
+    /// required, neither substitutes for the other.
     #[tokio::test]
     async fn concurrent_entity_property_patches_from_one_revision_only_one_survives() {
         let rt = Arc::new(rt());
@@ -4332,6 +4347,78 @@ mod tests {
         );
     }
 
+    /// Isolating fixture for the `AND ?8 > updated_at` conjunct of
+    /// `entity_replace_if_unchanged_statement`.
+    ///
+    /// The concurrent-race tests above cannot cover it: in their fixture the
+    /// revision guard (`updated_at = ?13`) and the strict-advance guard
+    /// (`?8 > updated_at`) are each independently sufficient to refuse the
+    /// losing writer, so neither test reddens when only one conjunct is
+    /// removed. Measured by mutation against this suite: tautologizing
+    /// `updated_at = ?13` + `deleted_at IS ?14` reddens only
+    /// `production_update_entity_refuses_concurrent_stale_writer`;
+    /// tautologizing `?8 > updated_at` alone reddened NOTHING in
+    /// `khive-runtime` before this test existed; only defeating all three at
+    /// once reddens the race tests. This test strips the second mechanism:
+    /// it supplies the CORRECT expected revision and deletion marker, so
+    /// `?13`/`?14` are satisfied by construction, and the ONLY thing that can
+    /// refuse the write is the strict-advance conjunct.
+    #[tokio::test]
+    async fn entity_cas_refuses_a_replacement_revision_that_does_not_advance() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let entity = rt
+            .create_entity(
+                &tok,
+                "concept",
+                None,
+                "NonAdvancing",
+                None,
+                Some(serde_json::json!({"a": 0})),
+                vec![],
+            )
+            .await
+            .expect("seed entity");
+        let id = entity.id;
+
+        let (mut replacement, _, _, expected_updated_at, expected_deleted_at) = rt
+            .prepare_update_entity(
+                &tok,
+                id,
+                EntityPatch {
+                    properties: Some(serde_json::json!({"a": 1})),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("prepare update");
+
+        // Force the replacement revision to EQUAL the stored one. `?13`/`?14`
+        // still match exactly, so this is not a stale-snapshot refusal — the
+        // only predicate that can reject it is `?8 > updated_at`.
+        replacement.updated_at = expected_updated_at;
+
+        let store = rt.entities(&tok).expect("entity store");
+        let committed = store
+            .replace_entity_if_unchanged(replacement, expected_updated_at, expected_deleted_at)
+            .await
+            .expect("CAS query");
+        assert!(
+            !committed,
+            "a replacement whose revision does not strictly advance past the stored one must \
+             be refused: without `?8 > updated_at` the CAS would accept a write that leaves \
+             `updated_at` unmoved, so a later writer holding the same snapshot would still \
+             see its expected revision match and overwrite this one"
+        );
+
+        let stored = rt.get_entity(&tok, id).await.expect("read back");
+        assert_eq!(
+            stored.properties,
+            Some(serde_json::json!({"a": 0})),
+            "the refused write must not have landed"
+        );
+    }
+
     /// Regression: the entity CAS requires the replacement revision to be
     /// STRICTLY greater than the stored one. If the replacement is computed
     /// as a raw `Utc::now()` read, a stored revision that is at or ahead of
@@ -4343,6 +4430,15 @@ mod tests {
     /// revision one full second into the future (far outside normal clock
     /// skew) and asserts the update still succeeds instead of surfacing a
     /// spurious conflict.
+    ///
+    /// SCOPE: this is a revision-clamp test, NOT CAS regression coverage. Its
+    /// assertion is that the write SUCCEEDS, which an unconditional UPDATE
+    /// also satisfies, so it stays green if the `updated_at = ?13` /
+    /// `?8 > updated_at` guard is dropped entirely. The guard's regression
+    /// coverage is
+    /// `concurrent_entity_property_patches_from_one_revision_only_one_survives`
+    /// (primitive) and `production_update_entity_refuses_concurrent_stale_writer`
+    /// (production wiring); do not count this test toward it.
     #[tokio::test]
     async fn update_entity_succeeds_when_stored_revision_is_ahead_of_wall_clock() {
         let rt = rt();

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -31,6 +31,18 @@ pub(crate) fn stale_note_snapshot_error(id: Uuid) -> RuntimeError {
     )))
 }
 
+pub(crate) fn stale_entity_snapshot_error(id: Uuid) -> RuntimeError {
+    RuntimeError::Khive(KhiveError::conflict(format!(
+        "entity {id} changed concurrently after it was read; retry with fresh state"
+    )))
+}
+
+pub(crate) fn stale_edge_snapshot_error(id: Uuid) -> RuntimeError {
+    RuntimeError::Khive(KhiveError::conflict(format!(
+        "edge {id} changed concurrently after it was read; retry with fresh state"
+    )))
+}
+
 /// Immutable embedding-registry view for one logical write.
 ///
 /// Document byte budgets are derived from the model name at the embedding seam,
@@ -835,7 +847,7 @@ impl KhiveRuntime {
         token: &NamespaceToken,
         id: Uuid,
         patch: EntityPatch,
-    ) -> RuntimeResult<(Entity, bool, Vec<&'static str>)> {
+    ) -> RuntimeResult<(Entity, bool, Vec<&'static str>, i64, Option<i64>)> {
         crate::secret_gate::reject_reserved_secret_gate_property(patch.properties.as_ref())?;
         if let Some(ref name) = patch.name {
             crate::secret_gate::check(name)?;
@@ -854,6 +866,8 @@ impl KhiveRuntime {
             .get_entity(id)
             .await?
             .ok_or_else(|| RuntimeError::NotFound(format!("entity {id}")))?;
+        let expected_updated_at = entity.updated_at;
+        let expected_deleted_at = entity.deleted_at;
 
         // ADR-014 tri-state: outer `None` = unchanged; `Some(None)` = explicit
         // clear (no vocabulary validation — there is no value to validate);
@@ -900,7 +914,13 @@ impl KhiveRuntime {
         }
 
         entity.updated_at = chrono::Utc::now().timestamp_micros();
-        Ok((entity, reindex_required, changed_fields))
+        Ok((
+            entity,
+            reindex_required,
+            changed_fields,
+            expected_updated_at,
+            expected_deleted_at,
+        ))
     }
 
     pub async fn update_entity(
@@ -921,11 +941,16 @@ impl KhiveRuntime {
         id: Uuid,
         patch: EntityPatch,
     ) -> RuntimeResult<(Entity, crate::retrieval::EmbeddingTruncationReport)> {
-        let (entity, reindex_required, changed_fields) =
+        let (entity, reindex_required, changed_fields, expected_updated_at, expected_deleted_at) =
             self.prepare_update_entity(token, id, patch).await?;
 
         let store = self.entities(token)?;
-        store.upsert_entity(entity.clone()).await?;
+        let persisted = store
+            .replace_entity_if_unchanged(entity.clone(), expected_updated_at, expected_deleted_at)
+            .await?;
+        if !persisted {
+            return Err(stale_entity_snapshot_error(id));
+        }
 
         let embedding_report = if reindex_required {
             self.reindex_entity(token, &entity).await?
@@ -3616,6 +3641,8 @@ pub(crate) fn union_tags(into: &[String], from: &[String]) -> (Vec<String>, usiz
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
     use crate::runtime::{KhiveRuntime, NamespaceToken};
     use khive_storage::types::{Direction, TextFilter, TextQueryMode, TextSearchRequest};
@@ -4017,7 +4044,13 @@ mod tests {
             .await
             .unwrap();
 
-        let (prepared, reindex_required, changed_fields) = rt
+        let (
+            prepared,
+            reindex_required,
+            changed_fields,
+            _expected_updated_at,
+            _expected_deleted_at,
+        ) = rt
             .prepare_update_entity(
                 &tok,
                 entity.id,
@@ -4055,6 +4088,110 @@ mod tests {
             .await
             .expect_err("unregistered entity_type must be rejected");
         assert!(matches!(err, RuntimeError::InvalidInput(_)), "error: {err}");
+    }
+
+    /// Regression for the entity lost-update race (khive #1753): two writers
+    /// read the same entity revision, then commit successive patches to
+    /// independent properties fields. Before the guarded
+    /// `replace_entity_if_unchanged` primitive, `update_entity_with_embedding_report`
+    /// wrote an unconditional `entity_upsert_statement`, so both patches
+    /// "succeeded" and the second silently discarded the first's field
+    /// (`a=1` was overwritten back to `a=0` when B's stale full-row replace
+    /// landed). This test forces the interleaving with a `Barrier` — both
+    /// readers are released together, so both `prepare_update_entity` calls
+    /// observe the SAME pre-write revision (asserted below) — then commits
+    /// deterministically in a fixed A-then-B order. It reddens if the
+    /// `AND ?8 > updated_at` / `updated_at = ?13` predicate is dropped from
+    /// `entity_replace_if_unchanged_statement`: with an unconditional UPDATE
+    /// (or `entity_upsert_statement`), B's write would also return `true`
+    /// and `b` would be lost from the final properties.
+    #[tokio::test]
+    async fn concurrent_entity_property_patches_from_one_revision_only_one_survives() {
+        let rt = Arc::new(rt());
+        let tok = NamespaceToken::local();
+        let entity = rt
+            .create_entity(
+                &tok,
+                "concept",
+                None,
+                "RaceTarget",
+                None,
+                Some(serde_json::json!({"a": 0, "b": 0})),
+                vec![],
+            )
+            .await
+            .expect("seed entity");
+        let id = entity.id;
+
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+
+        let reader_a = {
+            let rt = Arc::clone(&rt);
+            let tok = tok.clone();
+            let barrier = Arc::clone(&barrier);
+            tokio::spawn(async move {
+                barrier.wait().await;
+                rt.prepare_update_entity(
+                    &tok,
+                    id,
+                    EntityPatch {
+                        properties: Some(serde_json::json!({"a": 1})),
+                        ..Default::default()
+                    },
+                )
+                .await
+            })
+        };
+        let reader_b = {
+            let rt = Arc::clone(&rt);
+            let tok = tok.clone();
+            let barrier = Arc::clone(&barrier);
+            tokio::spawn(async move {
+                barrier.wait().await;
+                rt.prepare_update_entity(
+                    &tok,
+                    id,
+                    EntityPatch {
+                        properties: Some(serde_json::json!({"b": 1})),
+                        ..Default::default()
+                    },
+                )
+                .await
+            })
+        };
+
+        let (entity_a, _, _, expected_updated_at_a, expected_deleted_at_a) =
+            reader_a.await.unwrap().expect("reader A prepares");
+        let (entity_b, _, _, expected_updated_at_b, expected_deleted_at_b) =
+            reader_b.await.unwrap().expect("reader B prepares");
+        assert_eq!(
+            expected_updated_at_a, expected_updated_at_b,
+            "both readers must observe the same pre-write revision for this to be a real race"
+        );
+
+        let store = rt.entities(&tok).expect("entity store");
+        assert!(
+            store
+                .replace_entity_if_unchanged(entity_a, expected_updated_at_a, expected_deleted_at_a)
+                .await
+                .expect("writer A CAS query"),
+            "the first committer from a shared revision must win"
+        );
+        assert!(
+            !store
+                .replace_entity_if_unchanged(entity_b, expected_updated_at_b, expected_deleted_at_b)
+                .await
+                .expect("writer B CAS query"),
+            "the second committer from the SAME stale revision must be refused, not merged"
+        );
+
+        let final_entity = rt.get_entity(&tok, id).await.expect("read final entity");
+        assert_eq!(
+            final_entity.properties,
+            Some(serde_json::json!({"a": 1, "b": 0})),
+            "writer B's field must not be silently merged into the persisted row: {:?}",
+            final_entity.properties
+        );
     }
 
     #[tokio::test]

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -4143,15 +4143,27 @@ mod tests {
     /// an unconditional UPDATE (or `entity_upsert_statement`), B's write would
     /// also return `true` and `b` would be lost from the final properties.
     ///
-    /// It does NOT redden on a single-conjunct removal, and that is measured,
-    /// not assumed: in this fixture `updated_at = ?13` and `?8 > updated_at`
-    /// are each independently sufficient to refuse B, so tautologizing either
-    /// one alone leaves this test green. Attribution to a specific conjunct
-    /// therefore comes from the isolating fixtures —
+    /// It does NOT redden when only `?8 > updated_at` is removed: with
+    /// `updated_at = ?13` intact, B is refused by the revision guard whatever
+    /// the clock did, so this fixture cannot see that conjunct disappear.
+    ///
+    /// It cannot ATTRIBUTE a failure to `updated_at = ?13` either, but for a
+    /// different reason, and the difference matters. Both racers take their
+    /// replacement revision from `prepare_update_entity`'s
+    /// `max(now_micros, expected + 1)` above; this test pins the two EXPECTED
+    /// revisions equal, never the two REPLACEMENT revisions. So with
+    /// `updated_at = ?13` removed, whether B is still refused depends on
+    /// whether B's wall-clock read happened to exceed A's committed revision.
+    /// That is a race, not a property of the fixture, and no single run of it
+    /// establishes either answer.
+    ///
+    /// Attribution therefore comes from fixtures that force the question:
     /// `entity_cas_refuses_a_replacement_revision_that_does_not_advance` for
     /// the strict-advance conjunct, and
-    /// `production_update_entity_refuses_concurrent_stale_writer`, which does
-    /// redden on the `?13`/`?14` half alone.
+    /// `production_update_entity_refuses_concurrent_stale_writer` for the
+    /// production wiring. Making this fixture attribute as well would mean
+    /// pinning both replacement revisions to a common `expected + 1`; it is
+    /// deliberately left as a whole-guard test instead.
     ///
     /// SCOPE: this exercises the STORE PRIMITIVE directly and never invokes
     /// `update_entity`, so it stays green if the production caller is reverted

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -25,6 +25,30 @@ use crate::error::{RuntimeError, RuntimeResult};
 use crate::operations::{base_entity_rule_allows, canonical_edge_endpoints, endpoint_matches};
 use crate::runtime::{KhiveRuntime, NamespaceToken};
 
+/// Test-only pause point at the read/write boundary of a guarded
+/// read-modify-write, so a race between two concurrent callers of the same
+/// PRODUCTION entry point (not the underlying store primitive) can be
+/// reproduced deterministically instead of relying on scheduler luck or
+/// sleeps. A no-op unless the calling task runs inside
+/// `AFTER_READ_BARRIER.scope(...)`; production code never establishes that
+/// scope, so `pause_after_read` costs nothing outside these regression
+/// tests, and it does not exist at all in non-test builds.
+#[cfg(test)]
+pub(crate) mod race_seam {
+    use std::sync::Arc;
+    use tokio::sync::Barrier;
+
+    tokio::task_local! {
+        pub(crate) static AFTER_READ_BARRIER: Arc<Barrier>;
+    }
+
+    pub(crate) async fn pause_after_read() {
+        if let Ok(barrier) = AFTER_READ_BARRIER.try_with(Arc::clone) {
+            barrier.wait().await;
+        }
+    }
+}
+
 pub(crate) fn stale_note_snapshot_error(id: Uuid) -> RuntimeError {
     RuntimeError::Khive(KhiveError::conflict(format!(
         "note {id} changed concurrently after it was read; retry with fresh state"
@@ -868,6 +892,8 @@ impl KhiveRuntime {
             .ok_or_else(|| RuntimeError::NotFound(format!("entity {id}")))?;
         let expected_updated_at = entity.updated_at;
         let expected_deleted_at = entity.deleted_at;
+        #[cfg(test)]
+        race_seam::pause_after_read().await;
 
         // ADR-014 tri-state: outer `None` = unchanged; `Some(None)` = explicit
         // clear (no vocabulary validation — there is no value to validate);
@@ -913,7 +939,19 @@ impl KhiveRuntime {
             changed_fields.push("entity_type");
         }
 
-        entity.updated_at = chrono::Utc::now().timestamp_micros();
+        // `updated_at` is also the optimistic-concurrency revision for
+        // full-entity replacement. Make it strictly advance even when two
+        // operations land inside one clock microsecond. Saturation is not a
+        // valid fallback: reusing i64::MAX would make the CAS accept a write
+        // without advancing its revision.
+        let minimum_updated_at = expected_updated_at.checked_add(1).ok_or_else(|| {
+            RuntimeError::Internal(format!(
+                "entity {id} updated_at is already at i64::MAX and cannot advance"
+            ))
+        })?;
+        entity.updated_at = chrono::Utc::now()
+            .timestamp_micros()
+            .max(minimum_updated_at);
         Ok((
             entity,
             reindex_required,
@@ -4192,6 +4230,167 @@ mod tests {
             "writer B's field must not be silently merged into the persisted row: {:?}",
             final_entity.properties
         );
+    }
+
+    /// Same race as `concurrent_entity_property_patches_from_one_revision_only_one_survives`,
+    /// but driven entirely through the PRODUCTION entry point
+    /// (`update_entity_with_embedding_report`) rather than the store's
+    /// `replace_entity_if_unchanged` primitive directly. This closes a gap
+    /// the primitive-level test cannot: it would still pass unchanged if the
+    /// production caller were reverted to an unconditional write, since it
+    /// never invokes that caller at all. Uses `race_seam::pause_after_read`
+    /// (test-only, compiled out of non-test builds) to force both concurrent
+    /// callers to observe the identical pre-write revision deterministically —
+    /// no sleeps, no reliance on scheduler ordering.
+    #[tokio::test]
+    async fn production_update_entity_refuses_concurrent_stale_writer() {
+        let rt = Arc::new(rt());
+        let tok = NamespaceToken::local();
+        let entity = rt
+            .create_entity(
+                &tok,
+                "concept",
+                None,
+                "ProductionRaceTarget",
+                None,
+                Some(serde_json::json!({"a": 0, "b": 0})),
+                vec![],
+            )
+            .await
+            .expect("seed entity");
+        let id = entity.id;
+
+        let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+
+        let writer_a = {
+            let rt = Arc::clone(&rt);
+            let tok = tok.clone();
+            let barrier = std::sync::Arc::clone(&barrier);
+            tokio::spawn(race_seam::AFTER_READ_BARRIER.scope(barrier, async move {
+                rt.update_entity_with_embedding_report(
+                    &tok,
+                    id,
+                    EntityPatch {
+                        properties: Some(serde_json::json!({"a": 1})),
+                        ..Default::default()
+                    },
+                )
+                .await
+            }))
+        };
+        let writer_b = {
+            let rt = Arc::clone(&rt);
+            let tok = tok.clone();
+            let barrier = std::sync::Arc::clone(&barrier);
+            tokio::spawn(race_seam::AFTER_READ_BARRIER.scope(barrier, async move {
+                rt.update_entity_with_embedding_report(
+                    &tok,
+                    id,
+                    EntityPatch {
+                        properties: Some(serde_json::json!({"b": 1})),
+                        ..Default::default()
+                    },
+                )
+                .await
+            }))
+        };
+
+        let result_a = writer_a.await.expect("writer A task");
+        let result_b = writer_b.await.expect("writer B task");
+        let successes = [result_a.is_ok(), result_b.is_ok()]
+            .into_iter()
+            .filter(|ok| *ok)
+            .count();
+        assert_eq!(
+            successes, 1,
+            "exactly one production caller must win the race; the other must be refused: \
+             a={result_a:?} b={result_b:?}"
+        );
+        let refused = if result_a.is_err() {
+            result_a
+        } else {
+            result_b
+        };
+        match &refused {
+            Err(RuntimeError::Khive(khive_error)) => {
+                assert_eq!(
+                    khive_error.kind(),
+                    khive_types::ErrorKind::Conflict,
+                    "the losing production caller must surface a typed conflict, not \
+                     silently overwrite: {refused:?}"
+                );
+            }
+            other => panic!("expected a typed conflict error, got {other:?}"),
+        }
+
+        let final_entity = rt.get_entity(&tok, id).await.expect("read final entity");
+        assert_ne!(
+            final_entity.properties,
+            Some(serde_json::json!({"a": 1, "b": 1})),
+            "both racers' fields must never both land: that would mean the loser's stale \
+             write silently succeeded"
+        );
+    }
+
+    /// Regression: the entity CAS requires the replacement revision to be
+    /// STRICTLY greater than the stored one. If the replacement is computed
+    /// as a raw `Utc::now()` read, a stored revision that is at or ahead of
+    /// wall-clock time (a clock step backward, or — deterministically,
+    /// reproduced here — a stored revision manufactured slightly ahead of
+    /// "now") makes the new value fail to advance, and the CAS refuses a
+    /// write with NO concurrent writer involved at all. The fix must clamp
+    /// the replacement to `max(now, stored + 1)`; this test sets the stored
+    /// revision one full second into the future (far outside normal clock
+    /// skew) and asserts the update still succeeds instead of surfacing a
+    /// spurious conflict.
+    #[tokio::test]
+    async fn update_entity_succeeds_when_stored_revision_is_ahead_of_wall_clock() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let entity = rt
+            .create_entity(
+                &tok,
+                "concept",
+                None,
+                "FutureRevisionTarget",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .expect("seed entity");
+        let id = entity.id;
+
+        let future_micros = chrono::Utc::now().timestamp_micros() + 1_000_000;
+        let pool = rt.backend().pool_arc();
+        let id_str = id.to_string();
+        tokio::task::spawn_blocking(move || {
+            let guard = pool.writer().expect("writer connection");
+            guard
+                .execute(
+                    "UPDATE entities SET updated_at = ?1 WHERE id = ?2",
+                    rusqlite::params![future_micros, id_str],
+                )
+                .expect("force future revision")
+        })
+        .await
+        .expect("join");
+
+        let updated = rt
+            .update_entity(
+                &tok,
+                id,
+                EntityPatch {
+                    description: Some(Some("patched after a forced future revision".to_string())),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect(
+                "update must succeed and advance past the stored revision, not report a \
+                 spurious conflict when nothing else wrote to this row",
+            );
+        assert!(updated.updated_at > future_micros);
     }
 
     #[tokio::test]

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -4362,16 +4362,21 @@ mod tests {
     /// Isolating fixture for the `AND ?8 > updated_at` conjunct of
     /// `entity_replace_if_unchanged_statement`.
     ///
-    /// The concurrent-race tests above cannot cover it: in their fixture the
-    /// revision guard (`updated_at = ?13`) and the strict-advance guard
-    /// (`?8 > updated_at`) are each independently sufficient to refuse the
-    /// losing writer, so neither test reddens when only one conjunct is
-    /// removed. Measured by mutation against this suite: tautologizing
-    /// `updated_at = ?13` + `deleted_at IS ?14` reddens only
-    /// `production_update_entity_refuses_concurrent_stale_writer`;
-    /// tautologizing `?8 > updated_at` alone reddened NOTHING in
-    /// `khive-runtime` before this test existed; only defeating all three at
-    /// once reddens the race tests. This test strips the second mechanism:
+    /// The concurrent-race tests above cannot cover it. What is measured, and
+    /// deterministic: tautologizing `?8 > updated_at` alone reddened NOTHING in
+    /// `khive-runtime` before this test existed, because the revision guard
+    /// (`updated_at = ?13`) refuses the losing writer on its own whatever the
+    /// clock did. Tautologizing `updated_at = ?13` + `deleted_at IS ?14`
+    /// reddens only `production_update_entity_refuses_concurrent_stale_writer`,
+    /// and defeating all three at once reddens the race tests.
+    ///
+    /// What is NOT claimed, because the fixture cannot support it: that the two
+    /// guards are each independently sufficient. The race fixture pins the two
+    /// racers' EXPECTED revisions equal but never their REPLACEMENT revisions,
+    /// which both come from `max(now, expected + 1)`. So with `updated_at = ?13`
+    /// removed, whether strict advance still refuses depends on which clock read
+    /// won — a race, not a property of the fixture. This test strips the second
+    /// mechanism by construction instead:
     /// it supplies the CORRECT expected revision and deletion marker, so
     /// `?13`/`?14` are satisfied by construction, and the ONLY thing that can
     /// refuse the write is the strict-advance conjunct.
@@ -4426,6 +4431,116 @@ mod tests {
         let stored = rt.get_entity(&tok, id).await.expect("read back");
         assert_eq!(
             stored.properties,
+            Some(serde_json::json!({"a": 0})),
+            "the refused write must not have landed"
+        );
+    }
+
+    /// Isolating fixture for the `AND deleted_at IS ?14` conjunct of
+    /// `entity_replace_if_unchanged_statement`.
+    ///
+    /// The revision-based race fixtures cannot reach it, because a soft delete
+    /// does not move the revision: `entity_soft_delete_statement` is
+    /// `SET deleted_at = ?1 WHERE id = ?2 AND deleted_at IS NULL` and never
+    /// touches `updated_at`. So a writer holding a pre-delete snapshot still has
+    /// the CORRECT expected revision after the row is tombstoned, and its
+    /// replacement revision still advances. Every conjunct except `?14` is
+    /// satisfied, and dropping `?14` would let that writer's `deleted_at = NULL`
+    /// land — resurrecting a tombstone, with no revision conflict anywhere to
+    /// signal it.
+    ///
+    /// This fixture does not merely claim that isolation, it asserts it: both
+    /// other conjuncts are checked against the post-delete row before the CAS
+    /// runs, so a future change that makes one of them refuse instead turns this
+    /// test red rather than silently converting it into a whole-guard test.
+    #[tokio::test]
+    async fn entity_cas_refuses_a_stale_replacement_that_would_resurrect_a_tombstone() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let entity = rt
+            .create_entity(
+                &tok,
+                "concept",
+                None,
+                "Tombstoned",
+                None,
+                Some(serde_json::json!({"a": 0})),
+                vec![],
+            )
+            .await
+            .expect("seed entity");
+        let id = entity.id;
+
+        // Snapshot BEFORE the delete: this is the stale writer's view.
+        let (replacement, _, _, expected_updated_at, expected_deleted_at) = rt
+            .prepare_update_entity(
+                &tok,
+                id,
+                EntityPatch {
+                    properties: Some(serde_json::json!({"a": 1})),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("prepare update");
+        assert_eq!(
+            expected_deleted_at, None,
+            "fixture premise: the snapshot must be of a LIVE row"
+        );
+
+        rt.delete_entity(&tok, id, false)
+            .await
+            .expect("soft delete");
+
+        let store = rt.entities(&tok).expect("entity store");
+        let tombstoned = store
+            .get_entity_including_deleted(id)
+            .await
+            .expect("read tombstone")
+            .expect("row still present after soft delete");
+
+        // Prove the isolation rather than asserting it in prose. `?13` matches
+        // because the soft delete left the revision alone, and `?8 > updated_at`
+        // holds because the prepared replacement advanced past it. That leaves
+        // `deleted_at IS ?14` as the only conjunct able to refuse the write.
+        assert_eq!(
+            tombstoned.updated_at, expected_updated_at,
+            "fixture premise: soft delete must NOT move `updated_at`, otherwise \
+             `?13` would refuse and this stops being an isolating fixture"
+        );
+        assert!(
+            replacement.updated_at > tombstoned.updated_at,
+            "fixture premise: the replacement revision must still advance, \
+             otherwise `?8 > updated_at` would refuse and this stops being an \
+             isolating fixture"
+        );
+        assert!(
+            tombstoned.deleted_at.is_some(),
+            "fixture premise: the row must actually be tombstoned"
+        );
+
+        let committed = store
+            .replace_entity_if_unchanged(replacement, expected_updated_at, expected_deleted_at)
+            .await
+            .expect("CAS query");
+        assert!(
+            !committed,
+            "a replacement carrying a pre-delete snapshot must be refused after the row is \
+             soft-deleted: without `deleted_at IS ?14` it would write `deleted_at = NULL` over \
+             the tombstone and silently resurrect a deleted entity"
+        );
+
+        let after = store
+            .get_entity_including_deleted(id)
+            .await
+            .expect("read back")
+            .expect("row present");
+        assert!(
+            after.deleted_at.is_some(),
+            "the tombstone must survive the refused write"
+        );
+        assert_eq!(
+            after.properties,
             Some(serde_json::json!({"a": 0})),
             "the refused write must not have landed"
         );

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -5666,6 +5666,8 @@ impl KhiveRuntime {
             .get_edge(LinkId::from(edge_id))
             .await?
             .ok_or_else(|| crate::RuntimeError::NotFound(format!("edge {edge_id}")))?;
+        let expected_updated_at = edge.updated_at;
+        let expected_deleted_at = edge.deleted_at;
 
         // After fetching, all mutations and validation must use the
         // RECORD's namespace, not the caller's.  Derive record_tok from the stored edge
@@ -5809,10 +5811,21 @@ impl KhiveRuntime {
                 edge.target_id = canon_tgt;
             }
         } else {
-            // Non-symmetric: upsert_edge takes namespace from edge.namespace (not from the
-            // graph store's routing namespace), so this is already record-namespace correct.
-            // `graph` is already self.graph(&record_tok)?.
-            graph.upsert_edge(edge.clone()).await?;
+            // Non-symmetric: replace_edge_if_unchanged takes namespace from edge.namespace
+            // (not from the graph store's routing namespace), so this is already
+            // record-namespace correct. `graph` is already self.graph(&record_tok)?.
+            // Guarded on the fetched snapshot's revision — a concurrent writer that moved
+            // this edge between the fetch above and this write must be refused, not
+            // silently overwritten by a full-row replacement derived from stale state.
+            // `updated_at` must advance past the snapshot: the guard requires the
+            // replacement revision to be strictly greater than the persisted one.
+            edge.updated_at = chrono::Utc::now();
+            let persisted = graph
+                .replace_edge_if_unchanged(edge.clone(), expected_updated_at, expected_deleted_at)
+                .await?;
+            if !persisted {
+                return Err(crate::curation::stale_edge_snapshot_error(edge_id));
+            }
         }
 
         // Audit event: use the record's namespace (record_ns) for the event payload.
@@ -6904,6 +6917,92 @@ mod tests {
             .await
             .unwrap();
         assert!((updated.weight - 0.5).abs() < 0.001);
+    }
+
+    /// Regression for the non-symmetric edge lost-update race (khive #1753).
+    /// Two readers fetch the SAME edge revision (nothing else writes between
+    /// these two `get_edge` calls, so this is a deterministic "two reads from
+    /// one revision", not a timing assumption), each derives an independent
+    /// patch (weight vs. metadata), and the two writes commit in a fixed
+    /// order. Before the guarded `replace_edge_if_unchanged` primitive,
+    /// `update_edge`'s non-symmetric branch called the unconditional
+    /// `graph.upsert_edge`, so both commits "succeeded" and B's write
+    /// silently discarded A's weight change. This reddens if the
+    /// `updated_at = ?11 AND deleted_at IS ?12 AND ?6 > updated_at` predicate
+    /// is dropped from `edge_replace_if_unchanged_statement`: B's write would
+    /// then also return `true` and A's weight update would be lost.
+    #[tokio::test]
+    async fn concurrent_edge_patches_from_one_revision_only_one_survives() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let a = rt
+            .create_entity(&tok, "concept", None, "A", None, None, vec![])
+            .await
+            .unwrap();
+        let b = rt
+            .create_entity(&tok, "concept", None, "B", None, None, vec![])
+            .await
+            .unwrap();
+        let edge = rt
+            .link(&tok, a.id, b.id, EdgeRelation::Extends, 0.5, None)
+            .await
+            .unwrap();
+        let edge_id: Uuid = edge.id.into();
+
+        let graph = rt.graph(&tok).expect("graph store");
+        let snapshot_for_a = graph
+            .get_edge(LinkId::from(edge_id))
+            .await
+            .unwrap()
+            .expect("edge exists");
+        let snapshot_for_b = graph
+            .get_edge(LinkId::from(edge_id))
+            .await
+            .unwrap()
+            .expect("edge exists");
+        assert_eq!(
+            snapshot_for_a.updated_at, snapshot_for_b.updated_at,
+            "both readers must observe the same pre-write revision for this to be a real race"
+        );
+        let expected_updated_at = snapshot_for_a.updated_at;
+        let expected_deleted_at = snapshot_for_a.deleted_at;
+
+        let mut edge_a = snapshot_for_a;
+        edge_a.weight = 0.9;
+        edge_a.updated_at = expected_updated_at + chrono::Duration::microseconds(1);
+
+        let mut edge_b = snapshot_for_b;
+        edge_b.metadata = Some(serde_json::json!({"note": "from B"}));
+        edge_b.updated_at = expected_updated_at + chrono::Duration::microseconds(1);
+
+        assert!(
+            graph
+                .replace_edge_if_unchanged(edge_a, expected_updated_at, expected_deleted_at)
+                .await
+                .expect("writer A CAS query"),
+            "the first committer from a shared revision must win"
+        );
+        assert!(
+            !graph
+                .replace_edge_if_unchanged(edge_b, expected_updated_at, expected_deleted_at)
+                .await
+                .expect("writer B CAS query"),
+            "the second committer from the SAME stale revision must be refused, not merged"
+        );
+
+        let final_edge = graph
+            .get_edge(LinkId::from(edge_id))
+            .await
+            .unwrap()
+            .expect("edge still exists");
+        assert!(
+            (final_edge.weight - 0.9).abs() < 0.001,
+            "writer A's weight change must survive: {final_edge:?}"
+        );
+        assert!(
+            final_edge.metadata.is_none(),
+            "writer B's metadata must not be silently merged into the persisted row: {final_edge:?}"
+        );
     }
 
     /// `updated_at` on this path must use `timestamp_micros()`, matching every other

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -4919,6 +4919,7 @@ pub struct QueryResult {
 }
 
 /// Outcome of [`KhiveRuntime::update_edge_symmetric_dml`]'s in-transaction DML.
+#[derive(Debug)]
 enum SymmetricEdgeUpdateOutcome {
     /// A canonical row already existed (ADR-039 DO NOTHING): the
     /// requested edge was deleted, the existing canonical row (this id)
@@ -5636,11 +5637,27 @@ impl KhiveRuntime {
             // same shared `EDGE_SYMMETRIC_*_SQL` text and must honor the same
             // contract. Return the surviving id unchanged so the caller
             // re-fetches its real (unmodified) attributes.
-            conn.execute(
-                khive_db::stores::graph::EDGE_SYMMETRIC_DELETE_NONCANONICAL_SQL,
-                rusqlite::params![&ns, &edge_id_str],
-            )
-            .map_err(SqliteError::Rusqlite)?;
+            //
+            // Guarded on the fetched snapshot's revision and deletion marker:
+            // a concurrent writer that changed this edge between fetch and
+            // this write must be refused, not silently deleted just because
+            // a canonical survivor happens to exist. Zero affected rows here
+            // means stale, not "no conflict" — the probe above already
+            // confirmed a conflicting canonical row exists.
+            let affected = conn
+                .execute(
+                    khive_db::stores::graph::EDGE_SYMMETRIC_DELETE_NONCANONICAL_GUARDED_SQL,
+                    rusqlite::params![
+                        &ns,
+                        &edge_id_str,
+                        expected_updated_at_micros,
+                        expected_deleted_at_micros,
+                    ],
+                )
+                .map_err(SqliteError::Rusqlite)?;
+            if affected == 0 {
+                return Ok(SymmetricEdgeUpdateOutcome::Stale);
+            }
             Ok(SymmetricEdgeUpdateOutcome::Absorbed(existing_id))
         } else {
             // Case (a): no conflict — update source_id/target_id in-place,
@@ -7276,6 +7293,118 @@ mod tests {
             }
             other => panic!("expected a typed conflict error, got {other:?}"),
         }
+    }
+
+    /// The symmetric absorption delete (case (b): a canonical survivor `S`
+    /// already exists at the target natural key) must refuse a stale writer
+    /// the same way the in-place update arm (case (a)) already does. `E`'s
+    /// own revision advances after a would-be stale writer's snapshot read;
+    /// that snapshot is then fed straight into the exact DML `update_edge`
+    /// runs, reproducing the race deterministically (no scheduler-dependent
+    /// concurrency needed: the outcome depends only on which snapshot the
+    /// delete is guarded against, not on wall-clock interleaving).
+    #[tokio::test]
+    async fn update_edge_symmetric_absorption_refuses_stale_snapshot_when_survivor_exists() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let a = rt
+            .create_entity(&tok, "concept", None, "A", None, None, vec![])
+            .await
+            .unwrap();
+        let b = rt
+            .create_entity(&tok, "concept", None, "B", None, None, vec![])
+            .await
+            .unwrap();
+
+        // Survivor S already owns the canonical natural key before the
+        // stale writer's snapshot is even read.
+        let survivor = rt
+            .link(&tok, a.id, b.id, EdgeRelation::CompetesWith, 0.6, None)
+            .await
+            .unwrap();
+        let survivor_id: Uuid = survivor.id.into();
+
+        // E: the edge a stale writer will try to move onto that same
+        // natural key.
+        let e = rt
+            .link(&tok, a.id, b.id, EdgeRelation::Extends, 0.2, None)
+            .await
+            .unwrap();
+        let e_id: Uuid = e.id.into();
+        let stale_updated_at_micros = e.updated_at.timestamp_micros();
+        let stale_deleted_at_micros = e.deleted_at.map(|t| t.timestamp_micros());
+
+        // A concurrent writer advances E's own revision after that snapshot
+        // was captured.
+        let advanced = rt
+            .update_edge(
+                &tok,
+                e_id,
+                crate::curation::EdgePatch {
+                    weight: Some(0.77),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("concurrent writer update");
+        assert_ne!(
+            advanced.updated_at.timestamp_micros(),
+            stale_updated_at_micros,
+            "test setup: the concurrent write must actually advance the revision"
+        );
+
+        // Reproduce the exact DML `update_edge` runs for the stale writer,
+        // using the snapshot it captured BEFORE the concurrent write above.
+        let pool = rt.backend().pool_arc();
+        let guard = pool.writer().expect("writer guard");
+        let (canon_src, canon_tgt) =
+            canonical_edge_endpoints(EdgeRelation::CompetesWith, a.id, b.id);
+        let outcome = guard
+            .transaction(|conn| {
+                KhiveRuntime::update_edge_symmetric_dml(
+                    conn,
+                    "local",
+                    &e_id.to_string(),
+                    &canon_src.to_string(),
+                    &canon_tgt.to_string(),
+                    "competes_with",
+                    0.9,
+                    None,
+                    stale_updated_at_micros,
+                    stale_deleted_at_micros,
+                )
+            })
+            .expect("dml call must not error");
+        drop(guard);
+        assert!(
+            matches!(outcome, SymmetricEdgeUpdateOutcome::Stale),
+            "a stale writer must be refused, not silently absorbed into the survivor: {outcome:?}"
+        );
+
+        let e_after = rt
+            .get_edge(&tok, e_id)
+            .await
+            .unwrap()
+            .expect("E must still exist after the refused absorption");
+        assert_eq!(
+            e_after.relation,
+            EdgeRelation::Extends,
+            "E must be untouched by the refused absorption: {e_after:?}"
+        );
+        assert!(
+            (e_after.weight - 0.77).abs() < 1e-9,
+            "the concurrent writer's weight must survive the refused absorption: {e_after:?}"
+        );
+
+        let s_after = rt
+            .get_edge(&tok, survivor_id)
+            .await
+            .unwrap()
+            .expect("S must still exist after the refused absorption");
+        assert_eq!(
+            s_after.weight, 0.6,
+            "the survivor must be untouched by the refused absorption: {s_after:?}"
+        );
     }
 
     /// `updated_at` on this path must use `timestamp_micros()`, matching every other

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -4918,6 +4918,21 @@ pub struct QueryResult {
     pub truncated: bool,
 }
 
+/// Outcome of [`KhiveRuntime::update_edge_symmetric_dml`]'s in-transaction DML.
+enum SymmetricEdgeUpdateOutcome {
+    /// A canonical row already existed (ADR-039 DO NOTHING): the
+    /// requested edge was deleted, the existing canonical row (this id)
+    /// left untouched.
+    Absorbed(String),
+    /// No conflict; the requested edge was updated in place.
+    Updated,
+    /// No conflict, but the in-place `UPDATE` matched zero rows because
+    /// the row's revision or deletion marker moved after it was fetched —
+    /// a concurrent writer raced this update and must be refused, not
+    /// silently overwritten by a stale full-row write.
+    Stale,
+}
+
 impl KhiveRuntime {
     // ---- Query operations ----
 
@@ -5550,10 +5565,10 @@ impl KhiveRuntime {
     /// in-place UPDATE (case a, no conflict). Callers own the surrounding transaction
     /// boundary — this function issues DML only, no `BEGIN`/`COMMIT`/`ROLLBACK`.
     ///
-    /// Returns `Ok(Some(existing_id))` when a canonical conflict was absorbed (the
-    /// requested edge was deleted, the existing canonical row left untouched per
-    /// ADR-039 DO NOTHING), or `Ok(None)` when the requested edge was updated in
-    /// place. Shares its DML text with the atomic `prepare_update_edge` symmetric
+    /// The in-place update is guarded on the fetched snapshot's revision and
+    /// deletion marker (mirrors the non-symmetric `replace_edge_if_unchanged`
+    /// guard) and requires the replacement revision to strictly advance.
+    /// Shares its DML text with the atomic `prepare_update_edge` symmetric
     /// branch — see docs/operations.md#update_edge_symmetric_dml.
     #[allow(clippy::too_many_arguments)]
     fn update_edge_symmetric_dml(
@@ -5565,7 +5580,9 @@ impl KhiveRuntime {
         relation_str: &str,
         weight: f64,
         metadata: Option<String>,
-    ) -> Result<Option<String>, SqliteError> {
+        expected_updated_at_micros: i64,
+        expected_deleted_at_micros: Option<i64>,
+    ) -> Result<SymmetricEdgeUpdateOutcome, SqliteError> {
         // `updated_at` is stored in MICROSECONDS on `graph_edges` (every other
         // write path — `edge_upsert_statement`, `edge_soft_delete_statement` —
         // uses `timestamp_micros()`; the column is read back via
@@ -5573,7 +5590,22 @@ impl KhiveRuntime {
         // pre-existing bug in this raw-SQL path, found while unifying it with
         // the atomic builder (which already used `timestamp_micros()`
         // correctly).
-        let now_ts = chrono::Utc::now().timestamp_micros();
+        //
+        // The replacement revision must strictly advance past the snapshot
+        // even when two operations land inside one clock microsecond;
+        // saturating to i64::MAX would let the CAS accept a write without
+        // advancing its revision, so that is not a valid fallback (mirrors
+        // the note path).
+        let minimum_updated_at_micros =
+            expected_updated_at_micros.checked_add(1).ok_or_else(|| {
+                SqliteError::InvalidData(format!(
+                    "update_edge: edge {edge_id_str} updated_at is already at i64::MAX \
+                         and cannot advance"
+                ))
+            })?;
+        let now_ts = chrono::Utc::now()
+            .timestamp_micros()
+            .max(minimum_updated_at_micros);
 
         // Check for a conflicting canonical row (same namespace + natural key,
         // different id). This catches conflicts whether or not endpoints were flipped.
@@ -5609,10 +5641,13 @@ impl KhiveRuntime {
                 rusqlite::params![&ns, &edge_id_str],
             )
             .map_err(SqliteError::Rusqlite)?;
-            Ok(Some(existing_id))
+            Ok(SymmetricEdgeUpdateOutcome::Absorbed(existing_id))
         } else {
             // Case (a): no conflict — update source_id/target_id in-place,
-            // preserving the original edge UUID.
+            // preserving the original edge UUID. Guarded on the fetched
+            // snapshot's revision and deletion marker: a concurrent writer
+            // that moved this edge between fetch and this write must be
+            // refused, not silently overwritten by a stale full-row update.
             let affected = conn
                 .execute(
                     khive_db::stores::graph::EDGE_SYMMETRIC_UPDATE_INPLACE_SQL,
@@ -5625,18 +5660,15 @@ impl KhiveRuntime {
                         metadata,
                         &ns,
                         &edge_id_str,
+                        expected_updated_at_micros,
+                        expected_deleted_at_micros,
                     ],
                 )
                 .map_err(SqliteError::Rusqlite)?;
             if affected == 0 {
-                // The edge row was not found under the record's namespace.
-                // This must never happen because ns = record_ns (fetched above).
-                return Err(SqliteError::InvalidData(format!(
-                    "update_edge: zero rows affected updating edge {edge_id_str} \
-                     in namespace {ns} — row vanished between fetch and update"
-                )));
+                return Ok(SymmetricEdgeUpdateOutcome::Stale);
             }
-            Ok(None)
+            Ok(SymmetricEdgeUpdateOutcome::Updated)
         }
     }
 
@@ -5668,6 +5700,8 @@ impl KhiveRuntime {
             .ok_or_else(|| crate::RuntimeError::NotFound(format!("edge {edge_id}")))?;
         let expected_updated_at = edge.updated_at;
         let expected_deleted_at = edge.deleted_at;
+        #[cfg(test)]
+        crate::curation::race_seam::pause_after_read().await;
 
         // After fetching, all mutations and validation must use the
         // RECORD's namespace, not the caller's.  Derive record_tok from the stored edge
@@ -5732,16 +5766,16 @@ impl KhiveRuntime {
                 .as_ref()
                 .map(|v| serde_json::to_string(v).unwrap_or_default());
 
+            let expected_updated_at_micros = expected_updated_at.timestamp_micros();
+            let expected_deleted_at_micros = expected_deleted_at.map(|v| v.timestamp_micros());
+
             let pool = self.backend().pool_arc();
             // Route through the single-writer task when the write queue is
             // enabled; best-effort lookup degrades to the legacy pool-mutex
             // path (mirrors merge_entity/merge_note above).
             let writer_task = pool.writer_task_handle().ok().flatten();
 
-            // Some(surviving_id) when a canonical conflict was absorbed (the requested
-            // edge was deleted, existing canonical row left untouched per ADR-039 DO
-            // NOTHING), or None when the requested edge was updated in-place.
-            let surviving_id: Option<String> = if let Some(writer_task) = writer_task {
+            let outcome: SymmetricEdgeUpdateOutcome = if let Some(writer_task) = writer_task {
                 writer_task
                     .send(move |conn| {
                         Self::update_edge_symmetric_dml(
@@ -5753,6 +5787,8 @@ impl KhiveRuntime {
                             &relation_str,
                             weight,
                             metadata,
+                            expected_updated_at_micros,
+                            expected_deleted_at_micros,
                         )
                         .map_err(|e| {
                             khive_storage::StorageError::driver(
@@ -5777,6 +5813,8 @@ impl KhiveRuntime {
                             &relation_str,
                             weight,
                             metadata,
+                            expected_updated_at_micros,
+                            expected_deleted_at_micros,
                         )
                     })
                 })
@@ -5787,28 +5825,36 @@ impl KhiveRuntime {
                 .map_err(RuntimeError::Sqlite)?
             };
 
-            if let Some(sid) = surviving_id {
-                // A conflict was absorbed (ADR-039 DO NOTHING): re-fetch the surviving
-                // canonical row so the caller receives its real, UNMODIFIED attributes —
-                // including soft-deleted rows, since the survivor's tombstone state (if
-                // any) must not be resurrected by the absorbed update either. Use
-                // record_tok — the surviving row lives in the same namespace as the
-                // original.
-                let surviving_uuid = Uuid::parse_str(&sid).map_err(|e| {
-                    RuntimeError::Internal(format!("update_edge: surviving id parse failed: {e}"))
-                })?;
-                edge = self
-                    .get_edge_including_deleted(&record_tok, surviving_uuid)
-                    .await?
-                    .ok_or_else(|| {
+            match outcome {
+                SymmetricEdgeUpdateOutcome::Absorbed(sid) => {
+                    // A conflict was absorbed (ADR-039 DO NOTHING): re-fetch the surviving
+                    // canonical row so the caller receives its real, UNMODIFIED attributes —
+                    // including soft-deleted rows, since the survivor's tombstone state (if
+                    // any) must not be resurrected by the absorbed update either. Use
+                    // record_tok — the surviving row lives in the same namespace as the
+                    // original.
+                    let surviving_uuid = Uuid::parse_str(&sid).map_err(|e| {
                         RuntimeError::Internal(format!(
-                            "update_edge: surviving canonical row {surviving_uuid} vanished after update"
+                            "update_edge: surviving id parse failed: {e}"
                         ))
                     })?;
-            } else {
-                // Reflect canonical endpoints in the returned edge (no conflict absorbed).
-                edge.source_id = canon_src;
-                edge.target_id = canon_tgt;
+                    edge = self
+                        .get_edge_including_deleted(&record_tok, surviving_uuid)
+                        .await?
+                        .ok_or_else(|| {
+                            RuntimeError::Internal(format!(
+                                "update_edge: surviving canonical row {surviving_uuid} vanished after update"
+                            ))
+                        })?;
+                }
+                SymmetricEdgeUpdateOutcome::Updated => {
+                    // Reflect canonical endpoints in the returned edge (no conflict absorbed).
+                    edge.source_id = canon_src;
+                    edge.target_id = canon_tgt;
+                }
+                SymmetricEdgeUpdateOutcome::Stale => {
+                    return Err(crate::curation::stale_edge_snapshot_error(edge_id));
+                }
             }
         } else {
             // Non-symmetric: replace_edge_if_unchanged takes namespace from edge.namespace
@@ -5819,7 +5865,27 @@ impl KhiveRuntime {
             // silently overwritten by a full-row replacement derived from stale state.
             // `updated_at` must advance past the snapshot: the guard requires the
             // replacement revision to be strictly greater than the persisted one.
-            edge.updated_at = chrono::Utc::now();
+            // Make it strictly advance even when two operations land inside one
+            // clock microsecond; saturating to i64::MAX would let the CAS accept
+            // a write without advancing its revision, so that is not a valid
+            // fallback (mirrors the note path).
+            let minimum_updated_at_micros = expected_updated_at
+                .timestamp_micros()
+                .checked_add(1)
+                .ok_or_else(|| {
+                RuntimeError::Internal(format!(
+                    "edge {edge_id} updated_at is already at i64::MAX and cannot advance"
+                ))
+            })?;
+            let now_micros = chrono::Utc::now()
+                .timestamp_micros()
+                .max(minimum_updated_at_micros);
+            edge.updated_at =
+                chrono::DateTime::from_timestamp_micros(now_micros).ok_or_else(|| {
+                    RuntimeError::Internal(format!(
+                        "edge {edge_id}: computed updated_at {now_micros} is not a valid timestamp"
+                    ))
+                })?;
             let persisted = graph
                 .replace_edge_if_unchanged(edge.clone(), expected_updated_at, expected_deleted_at)
                 .await?;
@@ -7003,6 +7069,213 @@ mod tests {
             final_edge.metadata.is_none(),
             "writer B's metadata must not be silently merged into the persisted row: {final_edge:?}"
         );
+    }
+
+    /// Same race as `concurrent_edge_patches_from_one_revision_only_one_survives`,
+    /// but driven entirely through the PRODUCTION entry point (`update_edge`,
+    /// non-symmetric branch) rather than `replace_edge_if_unchanged` directly.
+    /// This closes a gap the primitive-level test cannot: it would still pass
+    /// unchanged if `update_edge` were reverted to an unconditional write,
+    /// since it never invokes `update_edge` at all. Uses
+    /// `crate::curation::race_seam::pause_after_read` (test-only, compiled
+    /// out of non-test builds) to force both concurrent callers to observe
+    /// the identical pre-write revision deterministically — no sleeps, no
+    /// reliance on scheduler ordering.
+    #[tokio::test]
+    async fn production_update_edge_non_symmetric_refuses_concurrent_stale_writer() {
+        let rt = std::sync::Arc::new(rt());
+        let tok = NamespaceToken::local();
+        let a = rt
+            .create_entity(&tok, "concept", None, "A", None, None, vec![])
+            .await
+            .unwrap();
+        let b = rt
+            .create_entity(&tok, "concept", None, "B", None, None, vec![])
+            .await
+            .unwrap();
+        let edge = rt
+            .link(&tok, a.id, b.id, EdgeRelation::Extends, 0.5, None)
+            .await
+            .unwrap();
+        let edge_id: Uuid = edge.id.into();
+
+        let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+
+        let writer_a = {
+            let rt = std::sync::Arc::clone(&rt);
+            let tok = tok.clone();
+            let barrier = std::sync::Arc::clone(&barrier);
+            tokio::spawn(crate::curation::race_seam::AFTER_READ_BARRIER.scope(
+                barrier,
+                async move {
+                    rt.update_edge(
+                        &tok,
+                        edge_id,
+                        crate::curation::EdgePatch {
+                            weight: Some(0.9),
+                            ..Default::default()
+                        },
+                    )
+                    .await
+                },
+            ))
+        };
+        let writer_b = {
+            let rt = std::sync::Arc::clone(&rt);
+            let tok = tok.clone();
+            let barrier = std::sync::Arc::clone(&barrier);
+            tokio::spawn(crate::curation::race_seam::AFTER_READ_BARRIER.scope(
+                barrier,
+                async move {
+                    rt.update_edge(
+                        &tok,
+                        edge_id,
+                        crate::curation::EdgePatch {
+                            properties: Some(serde_json::json!({"note": "from B"})),
+                            ..Default::default()
+                        },
+                    )
+                    .await
+                },
+            ))
+        };
+
+        let result_a = writer_a.await.expect("writer A task");
+        let result_b = writer_b.await.expect("writer B task");
+        let successes = [result_a.is_ok(), result_b.is_ok()]
+            .into_iter()
+            .filter(|ok| *ok)
+            .count();
+        assert_eq!(
+            successes, 1,
+            "exactly one production caller must win the race; the other must be refused: \
+             a={result_a:?} b={result_b:?}"
+        );
+        let refused = if result_a.is_err() {
+            result_a
+        } else {
+            result_b
+        };
+        match &refused {
+            Err(RuntimeError::Khive(khive_error)) => {
+                assert_eq!(
+                    khive_error.kind(),
+                    khive_types::ErrorKind::Conflict,
+                    "the losing production caller must surface a typed conflict, not \
+                     silently overwrite: {refused:?}"
+                );
+            }
+            other => panic!("expected a typed conflict error, got {other:?}"),
+        }
+
+        let final_edge = rt
+            .graph(&tok)
+            .expect("graph store")
+            .get_edge(LinkId::from(edge_id))
+            .await
+            .unwrap()
+            .expect("edge still exists");
+        assert!(
+            !((final_edge.weight - 0.9).abs() < 0.001 && final_edge.metadata.is_some()),
+            "both racers' changes must never both land: that would mean the loser's stale \
+             write silently succeeded: {final_edge:?}"
+        );
+    }
+
+    /// Symmetric-relation counterpart of
+    /// `production_update_edge_non_symmetric_refuses_concurrent_stale_writer`:
+    /// two production `update_edge` callers race a `competes_with` edge from
+    /// the same pre-write revision. Before the symmetric CAS guard, the
+    /// in-place `UPDATE` carried no expected-revision predicate, so both
+    /// commits would "succeed" and the second would silently discard the
+    /// first's weight change — this reddens if that guard (or its wiring
+    /// into `update_edge_symmetric_dml`) regresses.
+    #[tokio::test]
+    async fn production_update_edge_symmetric_refuses_concurrent_stale_writer() {
+        let rt = std::sync::Arc::new(rt());
+        let tok = NamespaceToken::local();
+        let a = rt
+            .create_entity(&tok, "concept", None, "A", None, None, vec![])
+            .await
+            .unwrap();
+        let b = rt
+            .create_entity(&tok, "concept", None, "B", None, None, vec![])
+            .await
+            .unwrap();
+        let edge = rt
+            .link(&tok, a.id, b.id, EdgeRelation::CompetesWith, 0.5, None)
+            .await
+            .unwrap();
+        let edge_id: Uuid = edge.id.into();
+
+        let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+
+        let writer_a = {
+            let rt = std::sync::Arc::clone(&rt);
+            let tok = tok.clone();
+            let barrier = std::sync::Arc::clone(&barrier);
+            tokio::spawn(crate::curation::race_seam::AFTER_READ_BARRIER.scope(
+                barrier,
+                async move {
+                    rt.update_edge(
+                        &tok,
+                        edge_id,
+                        crate::curation::EdgePatch {
+                            weight: Some(0.9),
+                            ..Default::default()
+                        },
+                    )
+                    .await
+                },
+            ))
+        };
+        let writer_b = {
+            let rt = std::sync::Arc::clone(&rt);
+            let tok = tok.clone();
+            let barrier = std::sync::Arc::clone(&barrier);
+            tokio::spawn(crate::curation::race_seam::AFTER_READ_BARRIER.scope(
+                barrier,
+                async move {
+                    rt.update_edge(
+                        &tok,
+                        edge_id,
+                        crate::curation::EdgePatch {
+                            weight: Some(0.1),
+                            ..Default::default()
+                        },
+                    )
+                    .await
+                },
+            ))
+        };
+
+        let result_a = writer_a.await.expect("writer A task");
+        let result_b = writer_b.await.expect("writer B task");
+        let successes = [result_a.is_ok(), result_b.is_ok()]
+            .into_iter()
+            .filter(|ok| *ok)
+            .count();
+        assert_eq!(
+            successes, 1,
+            "exactly one production caller must win the symmetric-edge race; the other must \
+             be refused: a={result_a:?} b={result_b:?}"
+        );
+        let refused = if result_a.is_err() {
+            result_a
+        } else {
+            result_b
+        };
+        match &refused {
+            Err(RuntimeError::Khive(khive_error)) => {
+                assert_eq!(
+                    khive_error.kind(),
+                    khive_types::ErrorKind::Conflict,
+                    "the losing production caller must surface a typed conflict, not \
+                     silently overwrite: {refused:?}"
+                );
+            }
+            other => panic!("expected a typed conflict error, got {other:?}"),
+        }
     }
 
     /// `updated_at` on this path must use `timestamp_micros()`, matching every other

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -7014,6 +7014,12 @@ mod tests {
     /// `updated_at = ?11 AND deleted_at IS ?12 AND ?6 > updated_at` predicate
     /// is dropped from `edge_replace_if_unchanged_statement`: B's write would
     /// then also return `true` and A's weight update would be lost.
+    ///
+    /// SCOPE: this exercises the STORE PRIMITIVE directly and never invokes
+    /// `update_edge`, so it stays green if the production caller is reverted
+    /// to an unconditional write. The wiring is covered separately by
+    /// `production_update_edge_non_symmetric_refuses_concurrent_stale_writer`;
+    /// both are required, neither substitutes for the other.
     #[tokio::test]
     async fn concurrent_edge_patches_from_one_revision_only_one_survives() {
         let rt = rt();

--- a/crates/khive-storage/src/entity.rs
+++ b/crates/khive-storage/src/entity.rs
@@ -145,6 +145,31 @@ pub trait EntityStore: Send + Sync + 'static {
     }
     /// Insert or update a batch of entities.
     async fn upsert_entities(&self, entities: Vec<Entity>) -> StorageResult<BatchWriteSummary>;
+    /// Replace an entity only when the persisted row still matches the
+    /// caller's read snapshot.
+    ///
+    /// `expected_updated_at` is the snapshot revision and
+    /// `expected_deleted_at` closes the soft-delete race. The replacement
+    /// entity's `updated_at` must be strictly greater than that persisted
+    /// revision. Returns `false` when the row disappeared, changed, or was
+    /// supplied a non-advancing replacement revision. This is the full-entity
+    /// compare-and-swap seam used when a caller derives coupled fields from
+    /// that snapshot before persistence — mirrors
+    /// [`crate::NoteStore::replace_note_if_unchanged`]. The default returns
+    /// `Unsupported` rather than falling back to an unguarded upsert and
+    /// reintroducing the stale-snapshot race.
+    async fn replace_entity_if_unchanged(
+        &self,
+        _entity: Entity,
+        _expected_updated_at: i64,
+        _expected_deleted_at: Option<i64>,
+    ) -> StorageResult<bool> {
+        Err(crate::StorageError::Unsupported {
+            capability: crate::StorageCapability::Entities,
+            operation: "replace_entity_if_unchanged".into(),
+            message: "this backend does not implement guarded entity replacement".into(),
+        })
+    }
     /// Fetch an entity by UUID, returning `None` if absent.
     async fn get_entity(&self, id: Uuid) -> StorageResult<Option<Entity>>;
     /// Delete an entity by UUID using the specified delete mode.

--- a/crates/khive-storage/src/graph.rs
+++ b/crates/khive-storage/src/graph.rs
@@ -1,6 +1,7 @@
 //! Graph storage capability — edge CRUD and traversal.
 
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use khive_types::EdgeRelation;
 use uuid::Uuid;
 
@@ -20,6 +21,31 @@ pub trait GraphStore: Send + Sync + 'static {
     async fn upsert_edge(&self, edge: Edge) -> StorageResult<()>;
     /// Insert or update a batch of edges.
     async fn upsert_edges(&self, edges: Vec<Edge>) -> StorageResult<BatchWriteSummary>;
+    /// Replace an edge only when the persisted row still matches the
+    /// caller's read snapshot.
+    ///
+    /// `expected_updated_at` is the snapshot revision and
+    /// `expected_deleted_at` closes the soft-delete race. The replacement
+    /// edge's `updated_at` must be strictly greater than that persisted
+    /// revision. Returns `false` when the row disappeared, changed, or was
+    /// supplied a non-advancing replacement revision. This is the full-edge
+    /// compare-and-swap seam used when a caller derives coupled fields from
+    /// that snapshot before persistence — mirrors
+    /// [`crate::NoteStore::replace_note_if_unchanged`]. The default returns
+    /// `Unsupported` rather than falling back to an unguarded upsert and
+    /// reintroducing the stale-snapshot race.
+    async fn replace_edge_if_unchanged(
+        &self,
+        _edge: Edge,
+        _expected_updated_at: DateTime<Utc>,
+        _expected_deleted_at: Option<DateTime<Utc>>,
+    ) -> StorageResult<bool> {
+        Err(StorageError::Unsupported {
+            capability: StorageCapability::Graph,
+            operation: "replace_edge_if_unchanged".into(),
+            message: "this backend does not implement guarded edge replacement".into(),
+        })
+    }
     /// Insert or update a single edge, re-checking that both endpoints still
     /// exist (and are not soft-deleted) as part of the same write, not a
     /// separate prior read. Closes the TOCTOU window between an async


### PR DESCRIPTION
Fixes #1753.

Six production read-modify-write paths read a row, computed a new value from that snapshot, and wrote it back unconditionally. A concurrent writer landing between the read and the write was silently overwritten: no error, no counter, no log. The loser of the race simply lost, and the surviving row looked normal.

Each of the six now goes through a compare-and-swap write. The pattern is the one already established by `replace_note_if_unchanged` (`crates/khive-db/src/stores/note.rs`): the update carries its snapshot's revision in the `WHERE` clause, so a writer whose snapshot has gone stale affects zero rows and finds out, instead of clobbering.

## What changed

Two new shared primitives, mirroring the existing note primitive:

- `replace_entity_if_unchanged`
- `replace_edge_if_unchanged`

Both express the write as `UPDATE ... WHERE id = ? AND updated_at = ? AND deleted_at IS ?` with a monotonic-timestamp condition, and report affected rows so the caller can distinguish "applied" from "someone else moved it".

Threaded through the six sites, each using the guard form appropriate to its layer:

| Site | Crate | Guard form |
|---|---|---|
| Channel heartbeat | `khive-pack-comm` | store primitive |
| Entity update | `khive-runtime` (curation) | store primitive |
| Non-symmetric edge update | `khive-runtime` (operations) | store primitive |
| Atomic entity update plan | `khive-runtime` (atomic_prepare) | guarded statement builder, with an affected-row guard that turns a stale zero-row result into a whole-unit failure |
| Atomic non-symmetric edge update plan | `khive-runtime` (atomic_prepare) | same |
| Schedule finalization | `khive-mcp` | conditional update pinned to the dispatch claim |

Schedule finalization is deliberately not a plain revision check. Its update matches on the claim itself — status, firing timestamp, and dispatch invocation id, with an optional exact-properties equality — and returns success only on exactly one affected row. Pinning the claim rather than the revision is the stronger condition for that path, because it also rejects a finalize from a superseded dispatch.

## Not in scope

`khive-pack-code`'s ingest sites share the same shape and are deferred to their own change; they are a different subsystem with a different concurrency story, and bundling them here would put two independently reviewable subjects in one PR.

No accepted contract changes. Every guard here is an application of an already-ratified mechanism to a new call site, not new policy.

## Tests

Each site has a regression that deterministically reproduces two writers proceeding from one revision and asserts the stale writer is refused rather than merged. The `atomic_prepare` tests additionally assert that a zero-row result fails the enclosing unit rather than passing silently, which is the arm that would otherwise turn a detected race back into a silent one.


The per-site regressions are whole-guard tests, and it is worth saying what that does and does not buy. They cannot attribute a failure to one condition of the guard: both racers take their replacement revision from a wall-clock read, and the fixture pins the two expected revisions equal without pinning the two replacement revisions, so removing the revision-equality condition alone leaves the outcome dependent on which clock read won. What they do establish is that with the revision-equality condition intact they cannot observe the monotonic-timestamp condition disappear at all. Mutating that condition on its own reddened nothing in the crate, so it had no regression coverage. An isolating fixture now covers it directly, supplying a correct snapshot revision and deletion marker so it is the only predicate that can refuse the write, and under that same mutation it is the single test that reddens.

