### PR TITLE
docs(adr): amend ADR-009, ADR-014, ADR-099 for guarded stale-snapshot writes

### DIFF
--- a/docs/adr/ADR-009-backend-architecture.md
+++ b/docs/adr/ADR-009-backend-architecture.md
@@ -307,3 +307,89 @@ read-only mode.
 - `crates/khive-db/src/backend.rs`: `StorageBackend` — the concrete SQLite connection
   wrapper providing `Arc<dyn Trait>` accessors.
 - Backend contract tests: trait-specific suites exercising the advertised capabilities.
+
+## Amendment — Guarded replacement for full-row updates (#1753)
+
+This amendment qualifies the following accepted text:
+
+> “`khive-storage` trait surface unchanged by this ADR.”
+
+and:
+
+> “`upsert_edge` uses `INSERT ... ON CONFLICT DO UPDATE` (not `DO NOTHING`).”
+
+### Decision
+
+The storage contract adds guarded full-row replacement for entities and edges, alongside the
+existing note replacement primitive:
+
+- `EntityStore::replace_entity_if_unchanged` accepts a complete replacement entity and the
+  revision read during preparation. Its write is an update-only compare-and-swap: the entity id,
+  expected revision, and expected deletion state must still match, and the replacement revision
+  must strictly advance the expected revision.
+- `GraphStore::replace_edge_if_unchanged` provides the corresponding contract for a complete edge
+  replacement. It compares the edge id, expected revision, and expected deletion state before
+  replacing the row; it does not insert a missing edge or silently apply a stale replacement.
+- Exactly one affected row is a successful guarded replacement. A missing row, changed revision or
+  deletion state, or non-advancing replacement is a distinct optimistic-concurrency conflict,
+  surfaced at the storage boundary as `StorageError::Conflict`. It is not `NotFound`, an input
+  error, or an undifferentiated backend-driver failure. Callers must not blindly retry the stale
+  full row; they must read current state and explicitly reapply or abandon their intended change.
+
+The existing `NoteStore::replace_note_if_unchanged` remains available as the note precedent. Its
+current public result is `false` for a refused compare-and-swap, and its strict revision and
+deletion-marker predicate remains the reference semantics (`crates/khive-storage/src/note.rs:309-321`;
+`crates/khive-db/src/stores/note.rs:114-175,891-905`). This amendment does not remove or repurpose
+that method. Backends that do not implement either new method may return the existing
+`StorageError::Unsupported` default; they must not fall back to an unguarded upsert.
+
+`StorageError::Conflict` already exists as a public storage error (`crates/khive-storage/src/error.rs:59-64`),
+so this amendment does not require a new error variant. If implementation chooses to introduce a
+new public error variant instead, adding that variant is a source-compatibility event: downstream
+code with exhaustive matches must handle it. The new trait methods likewise require downstream
+storage implementations to add an implementation or use an explicitly documented default.
+
+### Existing operations and semantics that do not change
+
+The ordinary `upsert_entity` and `upsert_edge` operations remain insert-or-update operations and
+remain usable when the caller intentionally wants their existing behavior. The entity statement
+continues to write the full entity row (`crates/khive-db/src/stores/entity.rs:57-82`) and the edge
+statement continues to use its existing id and natural-key conflict arms
+(`crates/khive-db/src/stores/graph.rs:90-124`); their SQLite conflict behavior is not silently
+changed into compare-and-swap. Batch upserts, reads, deletes, cross-backend rules, the SQL schema,
+and the MCP wire surface are unchanged. Guarded replacement is an additional opt-in storage seam.
+
+### Scope
+
+This change covers these six production-graph sites:
+
+1. Runtime entity curation (`crates/khive-runtime/src/curation.rs:853-928`).
+2. Runtime non-symmetric edge curation (`crates/khive-runtime/src/operations.rs:5662-5816`).
+3. Atomic entity plans (`crates/khive-runtime/src/atomic_prepare.rs:804-892`).
+4. Atomic non-symmetric edge plans (`crates/khive-runtime/src/atomic_prepare.rs:863-1050`).
+5. `comm.heartbeat` channel-health persistence (`crates/khive-pack-comm/src/handlers.rs:2321-2411`;
+   dispatch at `crates/khive-pack-comm/src/pack.rs:291-292`).
+6. Normal scheduled-event finalization (`crates/khive-mcp/src/pending_events.rs:1113-1128,2149-2213`).
+
+The 19 code-map sites in `khive-pack-code` are not covered by this amendment. They are tracked
+separately in public issue #2231.
+
+The source confirms why these sites need the additional seam: entity curation currently reads and
+then calls the unguarded entity upsert (`crates/khive-runtime/src/curation.rs:852-856,918-928`),
+and the non-symmetric edge path currently calls the unguarded edge upsert
+(`crates/khive-runtime/src/operations.rs:5811-5816`). The guarded methods close that
+read-to-replacement race without changing the ordinary upsert contract.
+
+### Rejected alternatives
+
+- Relying on the write queue alone is insufficient. The entity store routes a write through the
+  pool-wide writer task (`crates/khive-db/src/stores/entity.rs:182-205`), while `get_entity` uses a
+  separate reader (`crates/khive-db/src/stores/entity.rs:726-742`); that does not bind the earlier
+  read to the later replacement. The guarded predicate is the required safety boundary.
+- Blindly retrying a stale row is rejected because it can overwrite the intervening change again.
+- Replacing a whole-document race with an unconditional `SET properties = ?` is rejected; it
+  still permits a stale document to overwrite concurrent changes.
+
+No open design question remains within this storage amendment: the conflict is a typed storage
+outcome, ordinary upserts retain their existing semantics, and the six-site boundary above is
+explicit.

--- a/docs/adr/ADR-009-backend-architecture.md
+++ b/docs/adr/ADR-009-backend-architecture.md
@@ -361,15 +361,30 @@ and the MCP wire surface are unchanged. Guarded replacement is an additional opt
 
 ### Scope
 
-This change covers these six production-graph sites:
+This change covers these eight production-graph sites:
 
 1. Runtime entity curation (`crates/khive-runtime/src/curation.rs:853-928`).
 2. Runtime non-symmetric edge curation (`crates/khive-runtime/src/operations.rs:5662-5816`).
-3. Atomic entity plans (`crates/khive-runtime/src/atomic_prepare.rs:804-892`).
-4. Atomic non-symmetric edge plans (`crates/khive-runtime/src/atomic_prepare.rs:863-1050`).
-5. `comm.heartbeat` channel-health persistence (`crates/khive-pack-comm/src/handlers.rs:2321-2411`;
+3. Runtime symmetric edge curation (`crates/khive-runtime/src/operations.rs:5559-5639,5747-5771`),
+   which replaces both directed rows in place.
+4. Atomic entity plans (`crates/khive-runtime/src/atomic_prepare.rs:804-892`).
+5. Atomic non-symmetric edge plans (`crates/khive-runtime/src/atomic_prepare.rs:863-1050`).
+6. Atomic symmetric edge plans (`crates/khive-runtime/src/atomic_prepare.rs:1000-1040`).
+7. `comm.heartbeat` channel-health persistence (`crates/khive-pack-comm/src/handlers.rs:2321-2411`;
    dispatch at `crates/khive-pack-comm/src/pack.rs:291-292`).
-6. Normal scheduled-event finalization (`crates/khive-mcp/src/pending_events.rs:1113-1128,2149-2213`).
+8. Scheduled-event finalization (`crates/khive-mcp/src/pending_events.rs:1113-1128,2149-2213`),
+   covering every finalization branch rather than the normal dispatch path alone.
+
+Sites 3 and 6 are the symmetric edge paths. They are in scope because they replace rows through the
+same unguarded full-row statement (`crates/khive-db/src/stores/graph.rs:303-306`, whose `WHERE`
+clause pins only namespace and id) as the non-symmetric paths. Excluding them would leave the
+contract stated here true of one edge path and false of the other, which is not a contract.
+
+Site 8 covers all six finalization branches, not only the normal one. The pre-action, error, missed
+and non-action branches finalize on claim identity alone; the guard stated here binds the serialized
+properties snapshot as well, because a claim token is an ownership fence and not a content fence, so
+a property writer landing between claim and finalization is otherwise overwritten while the
+finalizer reports success.
 
 The 19 code-map sites in `khive-pack-code` are not covered by this amendment. They are tracked
 separately in public issue #2231.

--- a/docs/adr/ADR-014-curation-operations.md
+++ b/docs/adr/ADR-014-curation-operations.md
@@ -671,15 +671,30 @@ conclude no typed conflict is produced.
 
 ### Scope
 
-This change covers these six production-graph sites:
+This change covers these eight production-graph sites:
 
 1. Runtime entity curation (`crates/khive-runtime/src/curation.rs:853-928`).
 2. Runtime non-symmetric edge curation (`crates/khive-runtime/src/operations.rs:5662-5816`).
-3. Atomic entity plans (`crates/khive-runtime/src/atomic_prepare.rs:804-892`).
-4. Atomic non-symmetric edge plans (`crates/khive-runtime/src/atomic_prepare.rs:863-1050`).
-5. `comm.heartbeat` channel-health persistence (`crates/khive-pack-comm/src/handlers.rs:2321-2411`;
+3. Runtime symmetric edge curation (`crates/khive-runtime/src/operations.rs:5559-5639,5747-5771`),
+   which replaces both directed rows in place.
+4. Atomic entity plans (`crates/khive-runtime/src/atomic_prepare.rs:804-892`).
+5. Atomic non-symmetric edge plans (`crates/khive-runtime/src/atomic_prepare.rs:863-1050`).
+6. Atomic symmetric edge plans (`crates/khive-runtime/src/atomic_prepare.rs:1000-1040`).
+7. `comm.heartbeat` channel-health persistence (`crates/khive-pack-comm/src/handlers.rs:2321-2411`;
    dispatch at `crates/khive-pack-comm/src/pack.rs:291-292`).
-6. Normal scheduled-event finalization (`crates/khive-mcp/src/pending_events.rs:1113-1128,2149-2213`).
+8. Scheduled-event finalization (`crates/khive-mcp/src/pending_events.rs:1113-1128,2149-2213`),
+   covering every finalization branch rather than the normal dispatch path alone.
+
+Sites 3 and 6 are the symmetric edge paths. They are in scope because they replace rows through the
+same unguarded full-row statement (`crates/khive-db/src/stores/graph.rs:303-306`, whose `WHERE`
+clause pins only namespace and id) as the non-symmetric paths. Excluding them would leave the
+contract stated here true of one edge path and false of the other, which is not a contract.
+
+Site 8 covers all six finalization branches, not only the normal one. The pre-action, error, missed
+and non-action branches finalize on claim identity alone; the guard stated here binds the serialized
+properties snapshot as well, because a claim token is an ownership fence and not a content fence, so
+a property writer landing between claim and finalization is otherwise overwritten while the
+finalizer reports success.
 
 The 19 code-map sites in `khive-pack-code` are not covered by this amendment. They are tracked
 separately in public issue #2231.

--- a/docs/adr/ADR-014-curation-operations.md
+++ b/docs/adr/ADR-014-curation-operations.md
@@ -600,3 +600,93 @@ never specify `substrate` directly.
 - ADR-016: Request DSL — verb surface that exposes curation to agents.
 - ADR-101: KG Change-Set Model — full preimages for destructive merge operations.
 - ADR-038: Events — event substrate for audit trail.
+
+## Amendment — Refusable stale-snapshot curation (#1753)
+
+This amendment qualifies the following accepted text:
+
+> “**Patch semantics, not replace.** Updates express intent (change this field) rather than
+> forcing fetch-modify-write round trips.”
+
+and the update validation steps:
+
+> “6. Persist via upsert_entity.”
+
+> “5. Persist via upsert_edge with DO UPDATE semantics (ADR-009).”
+
+### Decision
+
+Curation updates retain patch semantics, validation, property merging, tag replacement, edge
+relation validation, and index-maintenance behavior. The persistence failure mode changes for a
+caller whose patch was derived from a stale full-row snapshot: the caller receives a distinct
+optimistic-concurrency conflict instead of silently overwriting the newer row.
+
+For the six production-graph sites in scope, a full-row replacement carries the revision read
+before patch application into the shared guarded store operation. The operation succeeds only if
+the row still has that revision and deletion state and the replacement revision strictly advances
+it. A conflict performs no curation update; the caller must fetch current state and explicitly
+choose whether to reapply, merge, or abandon the requested patch. A stale full row is never
+blindly retried, and the write queue is not treated as a substitute for this guard.
+
+The patch is still interpreted exactly as documented: entity properties are merged at the top
+level with patch values winning, nested objects at patched keys are replaced rather than
+recursively merged, and tags are replaced when supplied. Edge properties retain their documented
+wholesale replacement semantics (`docs/adr/ADR-014-curation-operations.md:80-101`; edge write
+application at `crates/khive-runtime/src/operations.rs:5701-5704`). A guarded refusal changes the
+failure mode, not these patch semantics. Merge policy, description `content_strategy`, edge
+natural-key handling, validation ordering, audit meaning for successful operations, and
+post-transaction reindex behavior are not changed. In particular, this amendment does not change
+merge behavior; it makes stale curation updates refusable.
+
+### Current behavior being corrected
+
+The entity curation preparation reads the entity, applies the patch, and regenerates its revision
+(`crates/khive-runtime/src/curation.rs:852-903`); the current write then calls the unguarded
+`upsert_entity` (`crates/khive-runtime/src/curation.rs:918-928`). The non-symmetric edge curation
+likewise reads the edge and applies the patch (`crates/khive-runtime/src/operations.rs:5662-5704`)
+before calling unguarded `upsert_edge` (`crates/khive-runtime/src/operations.rs:5811-5816`).
+Those paths are the full-row stale-snapshot cases addressed here.
+
+The existing note curation path is already refusable: it rechecks the snapshot and calls
+`replace_note_if_unchanged`, refusing a changed row rather than persisting stale derivations
+(`crates/khive-runtime/src/curation.rs:1587-1623`). This amendment does not weaken or replace that
+behavior.
+
+### Caller contract
+
+Callers of the affected curation operations must handle the typed conflict response as a normal
+concurrency outcome. They must not interpret it as proof that the record never existed, and they
+must not resubmit the stale full row without a fresh read. A caller that wants a merged result must
+read the current record, recompute the documented patch or merge from that state, and submit the
+new revision as a new guarded attempt.
+
+### Scope
+
+This change covers these six production-graph sites:
+
+1. Runtime entity curation (`crates/khive-runtime/src/curation.rs:853-928`).
+2. Runtime non-symmetric edge curation (`crates/khive-runtime/src/operations.rs:5662-5816`).
+3. Atomic entity plans (`crates/khive-runtime/src/atomic_prepare.rs:804-892`).
+4. Atomic non-symmetric edge plans (`crates/khive-runtime/src/atomic_prepare.rs:863-1050`).
+5. `comm.heartbeat` channel-health persistence (`crates/khive-pack-comm/src/handlers.rs:2321-2411`;
+   dispatch at `crates/khive-pack-comm/src/pack.rs:291-292`).
+6. Normal scheduled-event finalization (`crates/khive-mcp/src/pending_events.rs:1113-1128,2149-2213`).
+
+The 19 code-map sites in `khive-pack-code` are not covered by this amendment. They are tracked
+separately in public issue #2231.
+
+### Rejected alternatives
+
+The following do not satisfy the curation contract and are rejected:
+
+- Relying only on the write queue, because the entity store's writer-task routing
+  (`crates/khive-db/src/stores/entity.rs:182-205`) is separate from its entity reader
+  (`crates/khive-db/src/stores/entity.rs:726-742`) and therefore does not protect the read
+  snapshot that produced the replacement.
+- Blind retry of a stale row, because it converts a detected conflict back into a silent
+  last-writer-wins overwrite.
+- Unconditional `SET properties = ?` for a document race, because a complete stale document can
+  still erase a concurrent change even when the SQL is described as a patch.
+
+No open design question remains within this curation amendment. The intended patch and merge
+semantics remain fixed; only stale full-row persistence becomes explicitly refusable.

--- a/docs/adr/ADR-014-curation-operations.md
+++ b/docs/adr/ADR-014-curation-operations.md
@@ -660,6 +660,15 @@ must not resubmit the stale full row without a fresh read. A caller that wants a
 read the current record, recompute the documented patch or merge from that state, and submit the
 new revision as a new guarded attempt.
 
+The conflict travels on the existing error taxonomy rather than a new one. A refused write returns
+`ErrorKind::Conflict`, which serializes as `kind: "conflict"` and carries HTTP status 409. That
+taxonomy is closed, so the value is stable across versions and both in-process and over-the-wire
+callers may branch on it directly rather than parsing message text. This is why the wire surface is
+unchanged: the distinction a caller needs already existed, and no new error kind is added. Note that
+the guarded entity and edge paths reach it through `KhiveError::conflict`, not through
+`StorageError::Conflict`, which the note path used; a reader searching only for the latter will
+conclude no typed conflict is produced.
+
 ### Scope
 
 This change covers these six production-graph sites:

--- a/docs/adr/ADR-099-bulk-apply-atomic-units.md
+++ b/docs/adr/ADR-099-bulk-apply-atomic-units.md
@@ -849,15 +849,30 @@ turn them into prepare-time row lists.
 
 ### Scope
 
-This change covers these six production-graph sites:
+This change covers these eight production-graph sites:
 
 1. Runtime entity curation (`crates/khive-runtime/src/curation.rs:853-928`).
 2. Runtime non-symmetric edge curation (`crates/khive-runtime/src/operations.rs:5662-5816`).
-3. Atomic entity plans (`crates/khive-runtime/src/atomic_prepare.rs:804-892`).
-4. Atomic non-symmetric edge plans (`crates/khive-runtime/src/atomic_prepare.rs:863-1050`).
-5. `comm.heartbeat` channel-health persistence (`crates/khive-pack-comm/src/handlers.rs:2321-2411`;
+3. Runtime symmetric edge curation (`crates/khive-runtime/src/operations.rs:5559-5639,5747-5771`),
+   which replaces both directed rows in place.
+4. Atomic entity plans (`crates/khive-runtime/src/atomic_prepare.rs:804-892`).
+5. Atomic non-symmetric edge plans (`crates/khive-runtime/src/atomic_prepare.rs:863-1050`).
+6. Atomic symmetric edge plans (`crates/khive-runtime/src/atomic_prepare.rs:1000-1040`).
+7. `comm.heartbeat` channel-health persistence (`crates/khive-pack-comm/src/handlers.rs:2321-2411`;
    dispatch at `crates/khive-pack-comm/src/pack.rs:291-292`).
-6. Normal scheduled-event finalization (`crates/khive-mcp/src/pending_events.rs:1113-1128,2149-2213`).
+8. Scheduled-event finalization (`crates/khive-mcp/src/pending_events.rs:1113-1128,2149-2213`),
+   covering every finalization branch rather than the normal dispatch path alone.
+
+Sites 3 and 6 are the symmetric edge paths. They are in scope because they replace rows through the
+same unguarded full-row statement (`crates/khive-db/src/stores/graph.rs:303-306`, whose `WHERE`
+clause pins only namespace and id) as the non-symmetric paths. Excluding them would leave the
+contract stated here true of one edge path and false of the other, which is not a contract.
+
+Site 8 covers all six finalization branches, not only the normal one. The pre-action, error, missed
+and non-action branches finalize on claim identity alone; the guard stated here binds the serialized
+properties snapshot as well, because a claim token is an ownership fence and not a content fence, so
+a property writer landing between claim and finalization is otherwise overwritten while the
+finalizer reports success.
 
 The 19 code-map sites in `khive-pack-code` are not covered by this amendment. They are tracked
 separately in public issue #2231.

--- a/docs/adr/ADR-099-bulk-apply-atomic-units.md
+++ b/docs/adr/ADR-099-bulk-apply-atomic-units.md
@@ -792,3 +792,87 @@ Mutation-sensitive tests pin the decision:
 
 This operator-only CLI flag does not change the MCP/HTTP/raw DSL wire protocol, its 1 MiB limit,
 or the additive typed Rust host API stability statement in Amendment 3.
+
+## Amendment — Revision guards on prepared full-row plans (#1753)
+
+This amendment qualifies the following accepted rule:
+
+> “**Affected-row guards wherever prepare assumed row existence.** Any plan statement whose
+> prepare-time validation asserted that a target row exists ... carries an expected-effect guard
+> checked in apply.”
+
+It also clarifies the relationship between that rule and the existing plan statement contract:
+
+> “a present `guard` is checked against the affected-row count of applying `statement` alone.”
+
+### Current gap
+
+The current `PlanStatement` guard checks only the affected-row count of its own statement
+(`crates/khive-runtime/src/atomic_plan.rs:26-39,58-63`). The entity update plan currently emits an
+unconditional full entity upsert with `AffectedRowGuard::exactly(1)`
+(`crates/khive-runtime/src/atomic_prepare.rs:887-892`). The non-symmetric edge update plan does
+the same with a full edge upsert (`crates/khive-runtime/src/atomic_prepare.rs:1043-1050`). Those
+upserts can affect exactly one row even when the row changed after preparation: the entity SQL is
+an unconditional `INSERT OR REPLACE` (`crates/khive-db/src/stores/entity.rs:57-82`), and the edge
+SQL has unconditional conflict-update arms (`crates/khive-db/src/stores/graph.rs:90-124`). Thus
+`AffectedRowGuard::exactly(1)` is satisfied by a blind overwrite; it does not currently prove that
+the plan's read revision is still current.
+
+### Decision
+
+Prepared full-row entity and edge replacement plans carry the read revision captured during the
+prepare pass, together with the expected deletion state where applicable. Their apply statements
+use the shared guarded replacement operations from ADR-009. The in-transaction predicate checks
+the target id, expected revision, and expected deletion state, and requires the replacement
+revision to strictly advance the expected revision.
+
+`AffectedRowGuard::exactly(1)` remains an execution-effect guard on the guarded statement. It is
+not the concurrency predicate and is not removed; it now verifies that the guarded replacement
+actually matched one row. Zero affected rows means the row moved under the plan (it disappeared,
+its revision or deletion state changed, or the replacement revision did not advance). That plan
+operation fails with the distinct storage conflict result, its SAVEPOINT is rolled back, and the
+whole atomic unit rolls back. No blind retry is performed inside the atomic runner.
+
+This closes the gap between ADR-099's existing requirement for in-transaction predicate guards
+and the prior implementation. It does not replace predicate-based plans: whenever a write's scope
+depends on current state, the plan still evaluates that scope inside the transaction so earlier
+operations in the same unit remain visible (`docs/adr/ADR-099-bulk-apply-atomic-units.md:196-201`).
+
+### Atomic behavior that does not change
+
+The two-phase prepare/commit structure, synchronous-DML requirement inside `atomic_unit`,
+per-operation SAVEPOINTs, whole-file rollback, admissible-verb rules, response envelope, op-count
+guard, post-commit side effects, and non-atomic bulk-apply behavior are unchanged. The MCP
+`request` wire contract is unchanged. Predicate-based merge rewrites continue to be evaluated in
+the transaction; this amendment adds revision predicates to full-row replacements and does not
+turn them into prepare-time row lists.
+
+### Scope
+
+This change covers these six production-graph sites:
+
+1. Runtime entity curation (`crates/khive-runtime/src/curation.rs:853-928`).
+2. Runtime non-symmetric edge curation (`crates/khive-runtime/src/operations.rs:5662-5816`).
+3. Atomic entity plans (`crates/khive-runtime/src/atomic_prepare.rs:804-892`).
+4. Atomic non-symmetric edge plans (`crates/khive-runtime/src/atomic_prepare.rs:863-1050`).
+5. `comm.heartbeat` channel-health persistence (`crates/khive-pack-comm/src/handlers.rs:2321-2411`;
+   dispatch at `crates/khive-pack-comm/src/pack.rs:291-292`).
+6. Normal scheduled-event finalization (`crates/khive-mcp/src/pending_events.rs:1113-1128,2149-2213`).
+
+The 19 code-map sites in `khive-pack-code` are not covered by this amendment. They are tracked
+separately in public issue #2231.
+
+### Explicitly rejected approaches
+
+- Relying on the write queue alone is rejected: the entity store routes writes through the
+  pool-wide writer task (`crates/khive-db/src/stores/entity.rs:182-205`) while entity reads use a
+  separate reader (`crates/khive-db/src/stores/entity.rs:726-742`), so it cannot bind a
+  prepare-time read to a later write.
+- Blind retry of a stale row is rejected: it would allow the same stale plan to overwrite the
+  intervening update after the conflict was detected.
+- Unconditional `SET properties = ?` for a document race is rejected: it does not carry the
+  expected revision and therefore leaves the lost-update window intact.
+
+No open design question remains within this atomic-unit amendment. The affected-row guard remains
+an effect check, the revision predicate becomes the stale-plan check, and a zero-row guarded apply
+is a unit failure with rollback.


### PR DESCRIPTION
## Summary

Amends three accepted ADRs to record a decision they currently leave undefined: what a write does
when the row it is updating has changed since it was read.

Six production paths read a row, computed a new value from that snapshot, and wrote the whole row
back unconditionally. A concurrent writer landing between the read and the write was overwritten
with no error, no counter, and no log entry, so the loss was invisible to the caller and to
operators. The ADRs governing those paths describe the operations but never state a concurrency
contract for them, which is why three separate layers each chose "last write wins" independently.

These amendments state the contract. They are documentation only: no code changes here.

## What each amendment decides

**ADR-009 (backend architecture)** — full-row replacement at the store layer is a guarded
operation. A replacement pins the revision it was derived from and the deletion state, the new
revision must strictly advance, and the affected-row count is returned to the caller rather than
discarded. Records the existing note-store primitive as the precedent the new entity and edge
primitives follow, and lists the operations whose semantics are unchanged.

**ADR-014 (curation operations)** — curation writes derived from a stale snapshot are refused
rather than applied. Defines the caller contract: the refusal is distinguishable from a permanent
failure, a caller may re-read and retry, and nothing auto-retries a stale full row. This is a
caller-visible behavior change and is the reason the amendment is worth writing down rather than
leaving to the implementation.

**ADR-099 (bulk apply atomic units)** — prepared full-row plans carry revision guards, and a plan
whose guard matches zero rows fails its enclosing atomic unit rather than passing silently. The
atomic-unit boundary and rollback behavior are unchanged; the amendment closes the case where a
guard fires and the unit continued anyway, which would turn a detected conflict back into a silent
one.

Each amendment records the alternatives that were rejected and why, so a later reader can see the
fork rather than re-derive it.

## Scope

Documentation only, 260 lines added across three files, no existing text removed. The
implementation these amendments govern is a separate change and is gated on this one, since
ADR-014 changes behavior a caller can observe.
