### PR TITLE
fix(runtime,db,storage,comm): guard entity and edge replacement against stale writers

### DIFF
--- a/crates/khive-db/src/stores/entity.rs
+++ b/crates/khive-db/src/stores/entity.rs
@@ -104,6 +104,73 @@ pub fn entity_upsert_statement(entity: &Entity) -> SqlStatement {
     }
 }
 
+/// Full-entity compare-and-swap update used after caller-side normalization
+/// was derived from a read snapshot. Unlike [`entity_upsert_statement`], this
+/// never inserts and cannot overwrite a row whose revision or deletion
+/// marker moved after the snapshot was read. The replacement revision must
+/// also be strictly greater than the persisted snapshot revision; equality
+/// is a refused CAS, never a successful write with an unchanged concurrency
+/// token. Mirrors `note_replace_if_unchanged_statement`
+/// (`crates/khive-db/src/stores/note.rs`).
+pub fn entity_replace_if_unchanged_statement(
+    entity: &Entity,
+    expected_updated_at: i64,
+    expected_deleted_at: Option<i64>,
+) -> SqlStatement {
+    let properties_str = entity
+        .properties
+        .as_ref()
+        .map(|v| serde_json::to_string(v).unwrap_or_default());
+    let tags_str = serde_json::to_string(&entity.tags).unwrap_or_else(|_| "[]".to_string());
+    SqlStatement {
+        sql: "UPDATE entities SET \
+                namespace = ?1, kind = ?2, entity_type = ?3, name = ?4, description = ?5, \
+                properties = ?6, tags = ?7, updated_at = ?8, deleted_at = ?9, \
+                merged_into = ?10, merge_event_id = ?11 \
+              WHERE id = ?12 AND updated_at = ?13 AND deleted_at IS ?14 \
+                AND ?8 > updated_at"
+            .to_string(),
+        params: vec![
+            SqlValue::Text(entity.namespace.clone()),
+            SqlValue::Text(entity.kind.clone()),
+            match &entity.entity_type {
+                Some(t) => SqlValue::Text(t.clone()),
+                None => SqlValue::Null,
+            },
+            SqlValue::Text(entity.name.clone()),
+            match &entity.description {
+                Some(d) => SqlValue::Text(d.clone()),
+                None => SqlValue::Null,
+            },
+            match properties_str {
+                Some(p) => SqlValue::Text(p),
+                None => SqlValue::Null,
+            },
+            SqlValue::Text(tags_str),
+            SqlValue::Integer(entity.updated_at),
+            match entity.deleted_at {
+                Some(d) => SqlValue::Integer(d),
+                None => SqlValue::Null,
+            },
+            match entity.merged_into {
+                Some(u) => SqlValue::Text(u.to_string()),
+                None => SqlValue::Null,
+            },
+            match entity.merge_event_id {
+                Some(u) => SqlValue::Text(u.to_string()),
+                None => SqlValue::Null,
+            },
+            SqlValue::Text(entity.id.to_string()),
+            SqlValue::Integer(expected_updated_at),
+            match expected_deleted_at {
+                Some(value) => SqlValue::Integer(value),
+                None => SqlValue::Null,
+            },
+        ],
+        label: Some("entity-replace-if-unchanged".to_string()),
+    }
+}
+
 /// The exact soft-delete `UPDATE` this store's `delete_entity(Soft)` issues.
 pub fn entity_soft_delete_statement(id: Uuid, deleted_at: i64) -> SqlStatement {
     SqlStatement {
@@ -719,6 +786,25 @@ impl EntityStore for SqlEntityStore {
                 return Err(e);
             }
             Ok(summary)
+        })
+        .await
+    }
+
+    async fn replace_entity_if_unchanged(
+        &self,
+        entity: Entity,
+        expected_updated_at: i64,
+        expected_deleted_at: Option<i64>,
+    ) -> Result<bool, StorageError> {
+        let statement = entity_replace_if_unchanged_statement(
+            &entity,
+            expected_updated_at,
+            expected_deleted_at,
+        );
+        self.with_writer("replace_entity_if_unchanged", move |conn| {
+            let mut stmt = conn.prepare(&statement.sql)?;
+            bind_params(&mut stmt, &statement.params)?;
+            Ok(stmt.raw_execute()? > 0)
         })
         .await
     }

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -127,6 +127,64 @@ pub fn edge_upsert_statement(edge: &Edge) -> SqlStatement {
     }
 }
 
+/// Full-edge compare-and-swap update used after caller-side normalization
+/// was derived from a read snapshot. Unlike [`edge_upsert_statement`], this
+/// never inserts and cannot overwrite a row whose revision or deletion
+/// marker moved after the snapshot was read. The replacement revision must
+/// also be strictly greater than the persisted snapshot revision; equality
+/// is a refused CAS, never a successful write with an unchanged concurrency
+/// token. Mirrors `note_replace_if_unchanged_statement`
+/// (`crates/khive-db/src/stores/note.rs`). `created_at` is deliberately
+/// excluded from the `SET` list, matching the note/entity siblings — a
+/// replacement never rewrites the row's original creation time.
+pub fn edge_replace_if_unchanged_statement(
+    edge: &Edge,
+    expected_updated_at: DateTime<Utc>,
+    expected_deleted_at: Option<DateTime<Utc>>,
+) -> SqlStatement {
+    let (source_id, target_id) =
+        canonical_edge_endpoints(edge.relation, edge.source_id, edge.target_id);
+    let metadata_str = edge
+        .metadata
+        .as_ref()
+        .map(|v| serde_json::to_string(v).unwrap_or_default());
+    SqlStatement {
+        sql: "UPDATE graph_edges SET \
+                namespace = ?1, source_id = ?2, target_id = ?3, relation = ?4, weight = ?5, \
+                updated_at = ?6, deleted_at = ?7, metadata = ?8, target_backend = ?9 \
+              WHERE id = ?10 AND updated_at = ?11 AND deleted_at IS ?12 \
+                AND ?6 > updated_at"
+            .to_string(),
+        params: vec![
+            SqlValue::Text(edge.namespace.clone()),
+            SqlValue::Text(source_id.to_string()),
+            SqlValue::Text(target_id.to_string()),
+            SqlValue::Text(edge.relation.to_string()),
+            SqlValue::Float(edge.weight),
+            SqlValue::Integer(edge.updated_at.timestamp_micros()),
+            match edge.deleted_at {
+                Some(t) => SqlValue::Integer(t.timestamp_micros()),
+                None => SqlValue::Null,
+            },
+            match metadata_str {
+                Some(m) => SqlValue::Text(m),
+                None => SqlValue::Null,
+            },
+            match &edge.target_backend {
+                Some(b) => SqlValue::Text(b.clone()),
+                None => SqlValue::Null,
+            },
+            SqlValue::Text(Uuid::from(edge.id).to_string()),
+            SqlValue::Integer(expected_updated_at.timestamp_micros()),
+            match expected_deleted_at {
+                Some(value) => SqlValue::Integer(value.timestamp_micros()),
+                None => SqlValue::Null,
+            },
+        ],
+        label: Some("edge-replace-if-unchanged".to_string()),
+    }
+}
+
 /// The atomic `link` op's variant of [`edge_upsert_statement`] (ADR-099
 /// §B3). Shares the SAME
 /// `EDGE_NATURAL_KEY_CONFLICT_SET` conflict-arm text — the two builders
@@ -242,10 +300,34 @@ pub const EDGE_SYMMETRIC_CONFLICT_PROBE_SQL: &str = "SELECT id FROM graph_edges 
 pub const EDGE_SYMMETRIC_DELETE_NONCANONICAL_SQL: &str =
     "DELETE FROM graph_edges WHERE namespace = ?1 AND id = ?2";
 
+/// Canonical `update_edge`'s guarded variant of
+/// [`EDGE_SYMMETRIC_DELETE_NONCANONICAL_SQL`]: `?3`/`?4` pin the fetched
+/// snapshot's `updated_at`/`deleted_at` so a writer whose edge changed
+/// concurrently after it read that snapshot cannot delete the row out from
+/// under the concurrent write, even though a canonical survivor genuinely
+/// exists at the natural key. Zero affected rows means stale, not
+/// "no conflict" — the caller has already confirmed a conflicting canonical
+/// row exists before running this statement. Deliberately a DIFFERENT
+/// constant from the unguarded one above: merge's predicate-based rewrites
+/// (`khive-runtime::curation`) intentionally keep running the unguarded form
+/// inside their own single writer transaction and must not be changed to
+/// bind this one.
+pub const EDGE_SYMMETRIC_DELETE_NONCANONICAL_GUARDED_SQL: &str =
+    "DELETE FROM graph_edges WHERE namespace = ?1 AND id = ?2 \
+     AND updated_at = ?3 AND deleted_at IS ?4";
+
+/// Case (a) update, guarded on the fetched snapshot's revision and deletion
+/// marker: `?9`/`?10` pin `updated_at`/`deleted_at` as read, and `?5 >
+/// updated_at` requires the replacement revision to strictly advance —
+/// mirroring `edge_replace_if_unchanged_statement`'s guard so the symmetric
+/// path cannot silently overwrite a concurrent writer's change between the
+/// snapshot read and this write.
 pub const EDGE_SYMMETRIC_UPDATE_INPLACE_SQL: &str = "UPDATE graph_edges SET \
      source_id = ?1, target_id = ?2, relation = ?3, \
      weight = ?4, updated_at = ?5, metadata = ?6 \
-     WHERE namespace = ?7 AND id = ?8";
+     WHERE namespace = ?7 AND id = ?8 \
+       AND updated_at = ?9 AND deleted_at IS ?10 \
+       AND ?5 > updated_at";
 
 /// Plan-shape builder for [`EDGE_SYMMETRIC_CONFLICT_PROBE_SQL`] — the
 /// async prepare-time conflict probe.
@@ -283,7 +365,8 @@ pub fn edge_symmetric_delete_noncanonical_statement(namespace: &str, id: Uuid) -
 }
 
 /// Plan-shape builder for [`EDGE_SYMMETRIC_UPDATE_INPLACE_SQL`] —
-/// case (a): no conflict, update the requested row in place.
+/// case (a): no conflict, update the requested row in place, guarded on the
+/// fetched snapshot's revision and deletion marker.
 #[allow(clippy::too_many_arguments)]
 pub fn edge_symmetric_update_inplace_statement(
     namespace: &str,
@@ -294,6 +377,8 @@ pub fn edge_symmetric_update_inplace_statement(
     weight: f64,
     updated_at_micros: i64,
     metadata: Option<&str>,
+    expected_updated_at_micros: i64,
+    expected_deleted_at_micros: Option<i64>,
 ) -> SqlStatement {
     SqlStatement {
         sql: EDGE_SYMMETRIC_UPDATE_INPLACE_SQL.to_string(),
@@ -309,6 +394,11 @@ pub fn edge_symmetric_update_inplace_statement(
             },
             SqlValue::Text(namespace.to_string()),
             SqlValue::Text(id.to_string()),
+            SqlValue::Integer(expected_updated_at_micros),
+            match expected_deleted_at_micros {
+                Some(value) => SqlValue::Integer(value),
+                None => SqlValue::Null,
+            },
         ],
         label: Some("edge-symmetric-update-inplace".to_string()),
     }
@@ -318,11 +408,14 @@ pub fn edge_symmetric_update_inplace_statement(
 // Symmetric-relation update DML — atomic-only, commit-time self-guarding
 // variant (ADR-099 §B3).
 //
-// The four builders above are still what canonical `update_edge_symmetric_dml`
-// binds: it probes and branches synchronously INSIDE its own writer-task
-// transaction, with no other op interleaved between its probe and its write,
-// so its branch has no staleness exposure and is left untouched (control
-// group — canonical's tests must stay green).
+// Canonical `update_edge_symmetric_dml` binds the shared SQL constants above
+// directly, not the plan-shape builders — the builders are used by the atomic
+// prepare path. Canonical probes and branches synchronously INSIDE its own
+// writer-task transaction, with no other op interleaved between its probe and
+// its write, so the interleaving exposure the atomic path has does not arise
+// there. Canonical's absorption delete is nonetheless bound to the GUARDED
+// constant, because its snapshot is read before the transaction and can be
+// stale by the time the delete runs.
 //
 // The atomic path is structurally different: its conflict probe runs in the
 // async PREPARE phase, which for a multi-op `--atomic` unit completes for
@@ -343,7 +436,14 @@ pub fn edge_symmetric_update_inplace_statement(
 //
 // 1. [`edge_symmetric_delete_if_conflict_statement`]: deletes the requested
 //    (non-canonical) row IF AND ONLY IF a differently-id'd canonical row
-//    exists at the target natural key at THIS moment (guard: 0 or 1 rows).
+//    exists at the target natural key at THIS moment AND the row's own
+//    `updated_at`/`deleted_at` still match the snapshot this plan was built
+//    from (guard: 0 or 1 rows) — a plan built from a since-changed snapshot
+//    must not delete the row just because some other, unrelated conflict
+//    happens to exist; the second statement's own commit-time predicate
+//    (below) then sees `changes() = 0` and fails its `exactly(1)` guard,
+//    aborting the whole atomic unit rather than silently absorbing a
+//    concurrent writer's change.
 // 2. [`edge_symmetric_absorb_or_update_inplace_statement`]: a single
 //    `UPDATE` that no longer trusts an `id = ?2 OR natural-key` predicate
 //    (ADR-099 §B3 — that predicate could
@@ -397,16 +497,20 @@ pub fn edge_symmetric_update_inplace_statement(
 // a value computed before the
 // SAME atomic unit's other ops have run is not a fact this plan can stand
 // behind, so result rendering no longer trusts it.
+#[allow(clippy::too_many_arguments)]
 pub fn edge_symmetric_delete_if_conflict_statement(
     namespace: &str,
     id: Uuid,
     canon_src: Uuid,
     canon_tgt: Uuid,
     relation: EdgeRelation,
+    expected_updated_at_micros: i64,
+    expected_deleted_at_micros: Option<i64>,
 ) -> SqlStatement {
     SqlStatement {
         sql: "DELETE FROM graph_edges \
               WHERE namespace = ?1 AND id = ?2 \
+                AND updated_at = ?6 AND deleted_at IS ?7 \
                 AND EXISTS ( \
                   SELECT 1 FROM graph_edges \
                   WHERE namespace = ?1 AND source_id = ?3 AND target_id = ?4 \
@@ -419,11 +523,24 @@ pub fn edge_symmetric_delete_if_conflict_statement(
             SqlValue::Text(canon_src.to_string()),
             SqlValue::Text(canon_tgt.to_string()),
             SqlValue::Text(relation.to_string()),
+            SqlValue::Integer(expected_updated_at_micros),
+            match expected_deleted_at_micros {
+                Some(value) => SqlValue::Integer(value),
+                None => SqlValue::Null,
+            },
         ],
         label: Some("edge-symmetric-delete-if-conflict".to_string()),
     }
 }
 
+/// `?10`/`?11` pin the fetched snapshot's `updated_at`/`deleted_at` and
+/// `?7 > updated_at` requires the replacement revision to strictly advance —
+/// guarding the in-place arm (`id = ?2`) against a concurrent writer that
+/// changed the row between the snapshot read and this statement. The
+/// absorbed arm (a differently-id'd canonical row) is intentionally left
+/// unguarded on revision: per ADR-039 DO NOTHING it self-assigns every
+/// column, so it is a no-op write regardless of the survivor's current
+/// state.
 #[allow(clippy::too_many_arguments)]
 pub fn edge_symmetric_absorb_or_update_inplace_statement(
     namespace: &str,
@@ -435,6 +552,8 @@ pub fn edge_symmetric_absorb_or_update_inplace_statement(
     updated_at_micros: i64,
     metadata: Option<&str>,
     target_backend: Option<&str>,
+    expected_updated_at_micros: i64,
+    expected_deleted_at_micros: Option<i64>,
 ) -> SqlStatement {
     SqlStatement {
         sql: "UPDATE graph_edges SET \
@@ -448,7 +567,8 @@ pub fn edge_symmetric_absorb_or_update_inplace_statement(
               target_backend = CASE WHEN id = ?2 THEN ?9 ELSE target_backend END \
               WHERE namespace = ?1 \
                 AND ( \
-                  (id = ?2 AND changes() = 0) \
+                  (id = ?2 AND changes() = 0 AND updated_at = ?10 AND deleted_at IS ?11 \
+                      AND ?7 > updated_at) \
                   OR (source_id = ?3 AND target_id = ?4 AND relation = ?5 \
                       AND id != ?2 AND changes() = 1) \
                 )"
@@ -467,6 +587,11 @@ pub fn edge_symmetric_absorb_or_update_inplace_statement(
             },
             match target_backend {
                 Some(b) => SqlValue::Text(b.to_string()),
+                None => SqlValue::Null,
+            },
+            SqlValue::Integer(expected_updated_at_micros),
+            match expected_deleted_at_micros {
+                Some(value) => SqlValue::Integer(value),
                 None => SqlValue::Null,
             },
         ],
@@ -1363,6 +1488,22 @@ impl GraphStore for SqlGraphStore {
             bind_params(&mut stmt, &statement.params)?;
             stmt.raw_execute()?;
             Ok(())
+        })
+        .await
+    }
+
+    async fn replace_edge_if_unchanged(
+        &self,
+        edge: Edge,
+        expected_updated_at: DateTime<Utc>,
+        expected_deleted_at: Option<DateTime<Utc>>,
+    ) -> Result<bool, StorageError> {
+        let statement =
+            edge_replace_if_unchanged_statement(&edge, expected_updated_at, expected_deleted_at);
+        self.with_writer("replace_edge_if_unchanged", move |conn| {
+            let mut stmt = conn.prepare(&statement.sql)?;
+            bind_params(&mut stmt, &statement.params)?;
+            Ok(stmt.raw_execute()? > 0)
         })
         .await
     }

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -66,6 +66,28 @@ pub const NOTE_UPSERT_SQL: &str = "INSERT INTO notes \
        updated_at = excluded.updated_at, \
        deleted_at = excluded.deleted_at";
 
+/// Insert-if-absent counterpart to [`NOTE_UPSERT_SQL`], for a caller whose
+/// read found no row.
+///
+/// Identical column list and parameter order, and deliberately
+/// `DO NOTHING` rather than `DO UPDATE`: the point is that a row already
+/// present must survive untouched, so the losing caller can be told it lost
+/// instead of silently overwriting the winner. `changes()` is then the
+/// answer to "did I insert it", which `DO UPDATE` cannot report.
+pub const NOTE_INSERT_IF_ABSENT_SQL: &str = "INSERT INTO notes \
+     (id, namespace, kind, status, name, content, salience, decay_factor, expires_at, \
+      properties, created_at, updated_at, deleted_at) \
+     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13) \
+     ON CONFLICT(id) DO NOTHING";
+
+/// The exact statement this store's `insert_note_if_absent` issues.
+pub fn note_insert_if_absent_statement(note: &Note) -> SqlStatement {
+    let mut statement = note_upsert_statement(note);
+    statement.sql = NOTE_INSERT_IF_ABSENT_SQL.to_string();
+    statement.label = Some("note-insert-if-absent".to_string());
+    statement
+}
+
 /// The exact true UPSERT this store's `upsert_note` issues.
 pub fn note_upsert_statement(note: &Note) -> SqlStatement {
     let properties_str = note
@@ -884,6 +906,24 @@ impl NoteStore for SqlNoteStore {
             stmt.raw_execute()?;
             assign_note_seq(conn, &id_str)?;
             Ok(())
+        })
+        .await
+    }
+
+    async fn insert_note_if_absent(&self, note: Note) -> Result<bool, StorageError> {
+        let id_str = note.id.to_string();
+        let statement = note_insert_if_absent_statement(&note);
+        self.with_writer_tx("insert_note_if_absent", move |conn| {
+            let mut stmt = conn.prepare_cached(&statement.sql)?;
+            bind_params(&mut stmt, &statement.params)?;
+            let inserted = stmt.raw_execute()? > 0;
+            // Only a real insert needs a sequence number. Assigning one on the
+            // no-op path would write to a row this call did not create, which
+            // is the overwrite this primitive exists to avoid.
+            if inserted {
+                assign_note_seq(conn, &id_str)?;
+            }
+            Ok(inserted)
         })
         .await
     }

--- a/crates/khive-db/src/stores/note_tests.rs
+++ b/crates/khive-db/src/stores/note_tests.rs
@@ -169,6 +169,49 @@ async fn replace_note_cas_requires_new_revision_strictly_greater_than_snapshot()
     assert_eq!(persisted.updated_at, 101);
 }
 
+/// `insert_note_if_absent` reports whether THIS call inserted, and leaves a
+/// row that already exists exactly as it was.
+///
+/// Both halves matter and neither implies the other. An implementation that
+/// upserts and returns `true` satisfies "the row exists afterwards" while
+/// destroying the first writer's content, which is the whole failure being
+/// prevented; one that returns `true` unconditionally reports a win to a
+/// caller that lost. So the loser's return value and the survivor's content
+/// are asserted separately.
+#[tokio::test]
+async fn insert_note_if_absent_reports_the_loser_and_leaves_the_winner_untouched() {
+    let store = setup_memory_store();
+
+    let first = make_note("default", "observation", "first writer");
+    let id = first.id;
+    assert!(
+        store.insert_note_if_absent(first).await.unwrap(),
+        "the first insert on an absent id must report that it inserted"
+    );
+
+    // Same id, different content: the deterministic-id case this primitive
+    // exists for, where a second caller also read absence.
+    let mut second = make_note("default", "insight", "second writer");
+    second.id = id;
+    second.updated_at += 1;
+    assert!(
+        !store.insert_note_if_absent(second).await.unwrap(),
+        "a second insert on an id that now exists must report that it did NOT insert, \
+         rather than reporting success to a caller whose write did not land"
+    );
+
+    let persisted = store.get_note(id).await.unwrap().unwrap();
+    assert_eq!(
+        persisted.content, "first writer",
+        "the pre-existing row must survive byte-for-byte: overwriting it is the behaviour \
+         this primitive exists to avoid, and it is invisible to the return value alone"
+    );
+    assert_eq!(
+        persisted.kind, "observation",
+        "no column of the pre-existing row may be rewritten by the refused insert"
+    );
+}
+
 #[tokio::test]
 async fn test_kind_roundtrip_all_variants() {
     let store = setup_memory_store();

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -2434,16 +2434,16 @@ pub(crate) async fn handle_heartbeat(
     // `replace_note_if_unchanged` uses for every other guarded note update
     // (khive-runtime's `update_note_from_snapshot_with_embedding_report`).
     //
-    // ⚠ The `None` branch is NOT guarded, and being a new row does not make it
-    // safe. The hazard here is not losing prior state, it is two concurrent
-    // FIRST writes: the note id is deterministic per channel, so two heartbeats
-    // racing on a channel's first report can both read `None` and both take
-    // this branch. `upsert_note` rewrites every mutable column on an id
-    // conflict and reports no conflict outcome, so the later write silently
-    // replaces the earlier report. Closing it needs an insert-if-absent
-    // primitive that reports whether it inserted; that primitive does not exist
-    // yet, so this branch is knowingly left unguarded and tracked separately
-    // rather than widened into this change.
+    // The `None` branch needs its own guard, and being a new row is not what
+    // makes it safe. The hazard there is not losing prior state, it is two
+    // concurrent FIRST writes: the note id is deterministic per channel, so two
+    // heartbeats racing on a channel's first report can both read `None` and
+    // both take that branch. `upsert_note` rewrites every mutable column on an
+    // id conflict and reports no conflict outcome, so the later write would
+    // silently replace the earlier report. `insert_note_if_absent` leaves an
+    // existing row untouched and reports whether this call inserted it, so the
+    // loser is told it lost — the same conflict the `Some` arm returns, reached
+    // from the other direction.
     match existing {
         Some(snapshot) => {
             let persisted = store
@@ -2462,10 +2462,17 @@ pub(crate) async fn handle_heartbeat(
             }
         }
         None => {
-            store
-                .upsert_note(note)
-                .await
-                .map_err(|e| RuntimeError::Internal(format!("heartbeat: upsert_note: {e}")))?;
+            let inserted = store.insert_note_if_absent(note).await.map_err(|e| {
+                RuntimeError::Internal(format!("heartbeat: insert_note_if_absent: {e}"))
+            })?;
+            if !inserted {
+                return Err(RuntimeError::Khive(khive_types::KhiveError::conflict(
+                    format!(
+                        "heartbeat: channel {}:{} was first reported concurrently; retry",
+                        p.channel_kind, p.channel_slug
+                    ),
+                )));
+            }
         }
     }
 
@@ -3719,6 +3726,131 @@ mod tests {
                 && final_props["poll_interval_secs"] == json!(9)),
             "both racers' fields must never both land: that would mean the loser's stale \
              write silently succeeded: {final_props:?}"
+        );
+    }
+
+    /// The same production race, but with NO row seeded first, so both callers
+    /// take the `None` arm.
+    ///
+    /// `production_handle_heartbeat_refuses_concurrent_stale_writer` seeds the
+    /// row before racing, so it can only ever exercise the `Some(snapshot)`
+    /// CAS branch — it stays green against a build whose `None` arm is an
+    /// unconditional upsert. That is the first-write race: the heartbeat note
+    /// id is deterministic per channel, so two callers reporting a channel for
+    /// the first time both read absence, and an upsert resolves that by
+    /// overwriting, losing the first report with no error to either caller.
+    #[tokio::test]
+    async fn production_handle_heartbeat_refuses_concurrent_first_writer() {
+        let runtime =
+            std::sync::Arc::new(khive_runtime::KhiveRuntime::memory().expect("in-memory runtime"));
+        let token = runtime
+            .authorize(khive_runtime::Namespace::parse("local").unwrap())
+            .expect("authorize");
+
+        let id = super::heartbeat_note_id("local", "email", "first-write-race@example.com");
+        // The premise this test rests on: nothing is seeded, so both racers
+        // must take the `None` arm. Without this the test could silently
+        // degrade into a copy of the seeded one.
+        assert!(
+            runtime
+                .notes(&token)
+                .expect("note store")
+                .get_note(id)
+                .await
+                .expect("read the heartbeat row")
+                .is_none(),
+            "fixture premise: no heartbeat row may exist for this channel before the race, \
+             otherwise both callers take the guarded `Some` arm and the first-write race is \
+             never exercised"
+        );
+
+        let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+
+        let writer_a = {
+            let runtime = std::sync::Arc::clone(&runtime);
+            let token = token.clone();
+            let barrier = std::sync::Arc::clone(&barrier);
+            tokio::spawn(
+                super::race_seam::AFTER_READ_BARRIER.scope(barrier, async move {
+                    super::handle_heartbeat(
+                        &runtime,
+                        &token,
+                        json!({
+                            "channel_kind": "email",
+                            "channel_slug": "first-write-race@example.com",
+                            "outcome": "failure",
+                            "error_class": "timeout",
+                            "error_message": "boom",
+                        }),
+                    )
+                    .await
+                }),
+            )
+        };
+        let writer_b = {
+            let runtime = std::sync::Arc::clone(&runtime);
+            let token = token.clone();
+            let barrier = std::sync::Arc::clone(&barrier);
+            tokio::spawn(
+                super::race_seam::AFTER_READ_BARRIER.scope(barrier, async move {
+                    super::handle_heartbeat(
+                        &runtime,
+                        &token,
+                        json!({
+                            "channel_kind": "email",
+                            "channel_slug": "first-write-race@example.com",
+                            "poll_interval_secs": 9,
+                            "outcome": "success",
+                        }),
+                    )
+                    .await
+                }),
+            )
+        };
+
+        let result_a = writer_a.await.expect("writer A task");
+        let result_b = writer_b.await.expect("writer B task");
+        let successes = [result_a.is_ok(), result_b.is_ok()]
+            .into_iter()
+            .filter(|ok| *ok)
+            .count();
+        assert_eq!(
+            successes, 1,
+            "exactly one first-writer must win; the other must be refused rather than \
+             silently replacing the winner's report: a={result_a:?} b={result_b:?}"
+        );
+        let refused = if result_a.is_err() {
+            result_a
+        } else {
+            result_b
+        };
+        match &refused {
+            Err(khive_runtime::RuntimeError::Khive(khive_error)) => {
+                assert_eq!(
+                    khive_error.kind(),
+                    khive_types::ErrorKind::Conflict,
+                    "the losing first-writer must surface a typed conflict: {refused:?}"
+                );
+            }
+            other => panic!("expected a typed conflict error, got {other:?}"),
+        }
+
+        let store = runtime.notes(&token).expect("note store");
+        let final_note = store
+            .get_note(id)
+            .await
+            .unwrap()
+            .expect("the winner's heartbeat row must exist");
+        let final_props = final_note.properties.expect("heartbeat properties");
+        // The winner's report must be intact, not a blend of both. Each racer
+        // reports a distinguishing field the other never sends.
+        let is_a = final_props.get("last_failure_at").is_some();
+        let is_b = final_props["poll_interval_secs"] == json!(9);
+        assert!(
+            is_a ^ is_b,
+            "the surviving row must be exactly one racer's report, never both racers' fields \
+             merged, which is what a losing write silently succeeding would produce: \
+             {final_props:?}"
         );
     }
 

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -2326,6 +2326,8 @@ pub(crate) async fn handle_heartbeat(
         .get_note(id)
         .await
         .map_err(|e| RuntimeError::Internal(format!("heartbeat: get_note: {e}")))?;
+    #[cfg(test)]
+    race_seam::pause_after_read().await;
 
     let now = Utc::now();
     // A supplied `at` must resolve to an instant before it is stored: the
@@ -2389,6 +2391,26 @@ pub(crate) async fn handle_heartbeat(
         .map(|n| n.created_at)
         .unwrap_or_else(|| now.timestamp_micros());
 
+    // `updated_at` is also the optimistic-concurrency revision `replace_note_if_unchanged`
+    // checks with `?10 > updated_at`. Two heartbeats landing in the same stored microsecond,
+    // or a backward wall-clock step, must not report a conflict when no concurrent writer
+    // touched the row — make the replacement revision strictly advance past the existing
+    // snapshot instead of trusting `Utc::now()` alone (mirrors
+    // `update_note_from_snapshot_with_embedding_report`). A brand-new channel has no prior
+    // revision to advance past.
+    let updated_at_micros = match existing.as_ref() {
+        Some(snapshot) => {
+            let minimum = snapshot.updated_at.checked_add(1).ok_or_else(|| {
+                RuntimeError::Internal(format!(
+                    "heartbeat: channel {}:{} updated_at is already at i64::MAX and cannot advance",
+                    p.channel_kind, p.channel_slug
+                ))
+            })?;
+            now.timestamp_micros().max(minimum)
+        }
+        None => now.timestamp_micros(),
+    };
+
     let note = Note {
         id,
         namespace: ns.to_string(),
@@ -2401,14 +2423,51 @@ pub(crate) async fn handle_heartbeat(
         expires_at: None,
         properties: Some(props),
         created_at,
-        updated_at: now.timestamp_micros(),
+        updated_at: updated_at_micros,
         deleted_at: None,
     };
 
-    store
-        .upsert_note(note)
-        .await
-        .map_err(|e| RuntimeError::Internal(format!("heartbeat: upsert_note: {e}")))?;
+    // Guard the read-modify-write: `props` above was carried forward from
+    // `existing`, so a concurrent heartbeat that committed after that read
+    // (e.g. flipping `consecutive_failures`/`last_error`) must not be
+    // silently discarded by this write — the same shape
+    // `replace_note_if_unchanged` uses for every other guarded note update
+    // (khive-runtime's `update_note_from_snapshot_with_embedding_report`).
+    //
+    // ⚠ The `None` branch is NOT guarded, and being a new row does not make it
+    // safe. The hazard here is not losing prior state, it is two concurrent
+    // FIRST writes: the note id is deterministic per channel, so two heartbeats
+    // racing on a channel's first report can both read `None` and both take
+    // this branch. `upsert_note` rewrites every mutable column on an id
+    // conflict and reports no conflict outcome, so the later write silently
+    // replaces the earlier report. Closing it needs an insert-if-absent
+    // primitive that reports whether it inserted; that primitive does not exist
+    // yet, so this branch is knowingly left unguarded and tracked separately
+    // rather than widened into this change.
+    match existing {
+        Some(snapshot) => {
+            let persisted = store
+                .replace_note_if_unchanged(note, snapshot.updated_at, snapshot.deleted_at)
+                .await
+                .map_err(|e| {
+                    RuntimeError::Internal(format!("heartbeat: replace_note_if_unchanged: {e}"))
+                })?;
+            if !persisted {
+                return Err(RuntimeError::Khive(khive_types::KhiveError::conflict(
+                    format!(
+                        "heartbeat: channel {}:{} changed concurrently after it was read; retry",
+                        p.channel_kind, p.channel_slug
+                    ),
+                )));
+            }
+        }
+        None => {
+            store
+                .upsert_note(note)
+                .await
+                .map_err(|e| RuntimeError::Internal(format!("heartbeat: upsert_note: {e}")))?;
+        }
+    }
 
     Ok(json!({
         "ok": true,
@@ -3225,6 +3284,30 @@ fn build_references_header(parent_chain: Option<&str>, parent_message_id: &str) 
     tokens.join(" ")
 }
 
+/// Test-only pause point at `handle_heartbeat`'s read/write boundary, so a
+/// race between two concurrent callers of the PRODUCTION handler (not the
+/// underlying `replace_note_if_unchanged` store primitive) can be reproduced
+/// deterministically instead of relying on scheduler luck or sleeps. A no-op
+/// unless the calling task runs inside `AFTER_READ_BARRIER.scope(...)`;
+/// production dispatch never establishes that scope, so `pause_after_read`
+/// costs nothing outside these regression tests, and it does not exist at
+/// all in non-test builds.
+#[cfg(test)]
+mod race_seam {
+    use std::sync::Arc;
+    use tokio::sync::Barrier;
+
+    tokio::task_local! {
+        pub(crate) static AFTER_READ_BARRIER: Arc<Barrier>;
+    }
+
+    pub(crate) async fn pause_after_read() {
+        if let Ok(barrier) = AFTER_READ_BARRIER.try_with(Arc::clone) {
+            barrier.wait().await;
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -3388,6 +3471,351 @@ mod tests {
             signal.snapshot(),
             generation_after_commit,
             "a deduplicated ingest must not publish a wake"
+        );
+    }
+
+    /// Regression for the heartbeat lost-update race (khive #1753). Two
+    /// readers observe the SAME existing heartbeat row (deterministic: this
+    /// test is the only writer, so two sequential `get_note` calls before
+    /// either write are guaranteed to see one shared revision — no barrier
+    /// needed to force it). Each derives an independent poll outcome from
+    /// that snapshot, mirroring exactly what `handle_heartbeat` builds for a
+    /// "failure" vs. a "success" report, then the two writes commit through
+    /// the SAME `NoteStore::replace_note_if_unchanged` call `handle_heartbeat`
+    /// now uses. Before that guard, `handle_heartbeat` called
+    /// `store.upsert_note` unconditionally, so B's write would also succeed
+    /// and A's `consecutive_failures`/`last_error` update would be silently
+    /// discarded. This reddens if the write in `handle_heartbeat`'s `Some(snapshot)`
+    /// branch reverts to an unconditional `upsert_note`: the second
+    /// `replace_note_if_unchanged` call below would then need to be an
+    /// `upsert_note` too, which always returns `()`/succeeds, so the
+    /// `!... .unwrap()` assertion would fail to compile-flag the regression
+    /// and the final `consecutive_failures`/`last_failure_at` assertions
+    /// would observe B's fields instead of A's.
+    ///
+    /// SCOPE: the race here is two direct `replace_note_if_unchanged` calls
+    /// against the STORE PRIMITIVE. `handle_heartbeat` IS invoked, once, at the
+    /// top, and only to seed the row — so reverting the handler's guarded
+    /// branch to an unconditional `upsert_note` changes the seed and not the
+    /// race, and this test stays green. That is measured: under exactly that
+    /// wiring mutation the only test that reddens is
+    /// `production_handle_heartbeat_refuses_concurrent_stale_writer`, which is
+    /// what covers the wiring. Both are required, neither substitutes for the
+    /// other.
+    #[tokio::test]
+    async fn concurrent_heartbeats_from_one_revision_only_one_survives() {
+        let runtime = khive_runtime::KhiveRuntime::memory().expect("in-memory runtime");
+        let token = runtime
+            .authorize(khive_runtime::Namespace::parse("local").unwrap())
+            .expect("authorize");
+
+        super::handle_heartbeat(
+            &runtime,
+            &token,
+            json!({
+                "channel_kind": "email",
+                "channel_slug": "race@example.com",
+                "poll_interval_secs": 5,
+                "outcome": "success",
+            }),
+        )
+        .await
+        .expect("seed heartbeat");
+
+        let store = runtime.notes(&token).expect("note store");
+        let id = super::heartbeat_note_id("local", "email", "race@example.com");
+        let snapshot_for_a = store
+            .get_note(id)
+            .await
+            .unwrap()
+            .expect("seeded heartbeat row");
+        let snapshot_for_b = store
+            .get_note(id)
+            .await
+            .unwrap()
+            .expect("seeded heartbeat row");
+        assert_eq!(
+            snapshot_for_a.updated_at, snapshot_for_b.updated_at,
+            "both readers must observe the same pre-write revision for this to be a real race"
+        );
+
+        // Writer A: a "failure" report built from the shared snapshot —
+        // mirrors handle_heartbeat's failure branch exactly.
+        let mut note_a = snapshot_for_a.clone();
+        let mut props_a = note_a.properties.clone().unwrap_or_else(|| json!({}));
+        props_a["last_failure_at"] = json!("2026-08-26T00:00:00Z");
+        props_a["consecutive_failures"] = json!(1);
+        props_a["last_error"] =
+            json!({"class": "timeout", "message": "boom", "at": "2026-08-26T00:00:00Z"});
+        note_a.properties = Some(props_a);
+        note_a.updated_at = snapshot_for_a.updated_at + 1;
+
+        // Writer B: a "success" report ALSO derived from the SAME stale
+        // snapshot — as if B's own internal `get_note` raced A's.
+        let mut note_b = snapshot_for_b.clone();
+        let mut props_b = note_b.properties.clone().unwrap_or_else(|| json!({}));
+        props_b["last_success_at"] = json!("2026-08-26T00:00:01Z");
+        props_b["consecutive_failures"] = json!(0);
+        note_b.properties = Some(props_b);
+        note_b.updated_at = snapshot_for_b.updated_at + 1;
+
+        assert!(
+            store
+                .replace_note_if_unchanged(
+                    note_a,
+                    snapshot_for_a.updated_at,
+                    snapshot_for_a.deleted_at
+                )
+                .await
+                .expect("writer A CAS query"),
+            "the first committer from a shared revision must win"
+        );
+        assert!(
+            !store
+                .replace_note_if_unchanged(
+                    note_b,
+                    snapshot_for_b.updated_at,
+                    snapshot_for_b.deleted_at
+                )
+                .await
+                .expect("writer B CAS query"),
+            "the second committer from the SAME stale revision must be refused, not merged"
+        );
+
+        let final_note = store
+            .get_note(id)
+            .await
+            .unwrap()
+            .expect("heartbeat row still exists");
+        let final_props = final_note.properties.expect("heartbeat properties");
+        assert_eq!(
+            final_props["consecutive_failures"],
+            json!(1),
+            "writer A's failure count must survive: {final_props:?}"
+        );
+        assert_eq!(
+            final_props["last_failure_at"],
+            json!("2026-08-26T00:00:00Z")
+        );
+        assert!(
+            final_props.get("last_success_at") != Some(&json!("2026-08-26T00:00:01Z")),
+            "writer B's success timestamp must not be silently merged into the persisted row: {final_props:?}"
+        );
+    }
+
+    /// Same race as `concurrent_heartbeats_from_one_revision_only_one_survives`,
+    /// but driven entirely through the PRODUCTION entry point
+    /// (`handle_heartbeat`) rather than `replace_note_if_unchanged` directly.
+    /// This closes a gap the primitive-level test cannot: it would still pass
+    /// unchanged if `handle_heartbeat` were reverted to an unconditional
+    /// `upsert_note`, since it never invokes the handler at all. Uses
+    /// `race_seam::pause_after_read` (test-only, compiled out of non-test
+    /// builds) to force both concurrent callers to observe the identical
+    /// pre-write revision deterministically — no sleeps, no reliance on
+    /// scheduler ordering.
+    #[tokio::test]
+    async fn production_handle_heartbeat_refuses_concurrent_stale_writer() {
+        let runtime =
+            std::sync::Arc::new(khive_runtime::KhiveRuntime::memory().expect("in-memory runtime"));
+        let token = runtime
+            .authorize(khive_runtime::Namespace::parse("local").unwrap())
+            .expect("authorize");
+
+        super::handle_heartbeat(
+            &runtime,
+            &token,
+            json!({
+                "channel_kind": "email",
+                "channel_slug": "production-race@example.com",
+                "poll_interval_secs": 5,
+                "outcome": "success",
+            }),
+        )
+        .await
+        .expect("seed heartbeat");
+
+        let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+
+        let writer_a = {
+            let runtime = std::sync::Arc::clone(&runtime);
+            let token = token.clone();
+            let barrier = std::sync::Arc::clone(&barrier);
+            tokio::spawn(
+                super::race_seam::AFTER_READ_BARRIER.scope(barrier, async move {
+                    super::handle_heartbeat(
+                        &runtime,
+                        &token,
+                        json!({
+                            "channel_kind": "email",
+                            "channel_slug": "production-race@example.com",
+                            "outcome": "failure",
+                            "error_class": "timeout",
+                            "error_message": "boom",
+                        }),
+                    )
+                    .await
+                }),
+            )
+        };
+        let writer_b = {
+            let runtime = std::sync::Arc::clone(&runtime);
+            let token = token.clone();
+            let barrier = std::sync::Arc::clone(&barrier);
+            tokio::spawn(
+                super::race_seam::AFTER_READ_BARRIER.scope(barrier, async move {
+                    super::handle_heartbeat(
+                        &runtime,
+                        &token,
+                        json!({
+                            "channel_kind": "email",
+                            "channel_slug": "production-race@example.com",
+                            "poll_interval_secs": 9,
+                            "outcome": "success",
+                        }),
+                    )
+                    .await
+                }),
+            )
+        };
+
+        let result_a = writer_a.await.expect("writer A task");
+        let result_b = writer_b.await.expect("writer B task");
+        let successes = [result_a.is_ok(), result_b.is_ok()]
+            .into_iter()
+            .filter(|ok| *ok)
+            .count();
+        assert_eq!(
+            successes, 1,
+            "exactly one production caller must win the race; the other must be refused: \
+             a={result_a:?} b={result_b:?}"
+        );
+        let refused = if result_a.is_err() {
+            result_a
+        } else {
+            result_b
+        };
+        match &refused {
+            Err(khive_runtime::RuntimeError::Khive(khive_error)) => {
+                assert_eq!(
+                    khive_error.kind(),
+                    khive_types::ErrorKind::Conflict,
+                    "the losing production caller must surface a typed conflict, not \
+                     silently overwrite: {refused:?}"
+                );
+            }
+            other => panic!("expected a typed conflict error, got {other:?}"),
+        }
+
+        let store = runtime.notes(&token).expect("note store");
+        let id = super::heartbeat_note_id("local", "email", "production-race@example.com");
+        let final_note = store
+            .get_note(id)
+            .await
+            .unwrap()
+            .expect("heartbeat row still exists");
+        let final_props = final_note.properties.expect("heartbeat properties");
+        assert!(
+            !(final_props.get("last_failure_at").is_some()
+                && final_props["poll_interval_secs"] == json!(9)),
+            "both racers' fields must never both land: that would mean the loser's stale \
+             write silently succeeded: {final_props:?}"
+        );
+    }
+
+    /// A heartbeat's replacement revision must strictly advance past the
+    /// existing row's own `updated_at`, not just past `Utc::now()`: two
+    /// heartbeats landing in the same stored microsecond, or a backward
+    /// wall-clock step, are the SAME code path as this test forces (the
+    /// fix's `max(now, snapshot+1)` does not distinguish "now == snapshot"
+    /// from "now < snapshot" — both take the `snapshot+1` branch). Before the
+    /// fix, `handle_heartbeat` derived the replacement revision straight from
+    /// `Utc::now().timestamp_micros()`, so forcing the stored snapshot ahead
+    /// of wall-clock time reproduces both scenarios deterministically without
+    /// a clock-injection seam.
+    ///
+    /// SCOPE: this is a revision-clamp test, NOT CAS regression coverage. Its
+    /// assertion is that the heartbeat write SUCCEEDS, which an unconditional
+    /// `upsert_note` also satisfies, so it stays green if the
+    /// `updated_at = ?13` / `?10 > updated_at` guard is dropped entirely. The
+    /// guard's regression coverage is
+    /// `concurrent_heartbeats_from_one_revision_only_one_survives` (primitive)
+    /// and `production_handle_heartbeat_refuses_concurrent_stale_writer`
+    /// (production wiring); do not count this test toward it.
+    #[tokio::test]
+    async fn handle_heartbeat_does_not_false_conflict_when_snapshot_is_ahead_of_wall_clock() {
+        let runtime = khive_runtime::KhiveRuntime::memory().expect("in-memory runtime");
+        let token = runtime
+            .authorize(khive_runtime::Namespace::parse("local").unwrap())
+            .expect("authorize");
+
+        super::handle_heartbeat(
+            &runtime,
+            &token,
+            json!({
+                "channel_kind": "email",
+                "channel_slug": "clock-skew@example.com",
+                "outcome": "success",
+            }),
+        )
+        .await
+        .expect("seed heartbeat");
+
+        let store = runtime.notes(&token).expect("note store");
+        let id = super::heartbeat_note_id("local", "email", "clock-skew@example.com");
+        let seeded = store
+            .get_note(id)
+            .await
+            .unwrap()
+            .expect("seeded heartbeat row");
+
+        // Force the stored revision far ahead of any `Utc::now()` the next
+        // handler call will observe — the same condition as an equal-
+        // microsecond write or a backward clock step.
+        let future_updated_at = seeded.updated_at + 60_000_000; // +60s
+        let mut ahead = seeded.clone();
+        ahead.updated_at = future_updated_at;
+        let forced = store
+            .replace_note_if_unchanged(ahead, seeded.updated_at, seeded.deleted_at)
+            .await
+            .expect("test setup: force the snapshot ahead of wall-clock time");
+        assert!(
+            forced,
+            "test setup CAS must succeed against the freshly seeded row"
+        );
+
+        let result = super::handle_heartbeat(
+            &runtime,
+            &token,
+            json!({
+                "channel_kind": "email",
+                "channel_slug": "clock-skew@example.com",
+                "outcome": "failure",
+                "error_class": "timeout",
+                "error_message": "boom",
+            }),
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "a heartbeat with no competing writer must not be refused just because the \
+             stored revision is at or ahead of wall-clock now: {result:?}"
+        );
+
+        let final_note = store
+            .get_note(id)
+            .await
+            .unwrap()
+            .expect("heartbeat row still exists");
+        assert!(
+            final_note.updated_at > future_updated_at,
+            "the replacement revision must still strictly advance past the forced-ahead \
+             snapshot: {final_note:?}"
+        );
+        let final_props = final_note.properties.expect("heartbeat properties");
+        assert_eq!(
+            final_props["consecutive_failures"],
+            json!(1),
+            "the accepted write must actually be the failure report just sent: {final_props:?}"
         );
     }
 

--- a/crates/khive-runtime/docs/api/atomic_prepare.md
+++ b/crates/khive-runtime/docs/api/atomic_prepare.md
@@ -55,15 +55,24 @@ entity/note branches' `merge_properties`).
 
 DML shape:
 
-- non-symmetric relation: a single `edge_upsert_statement` call on the patched `Edge` — the same
-  builder `update_edge`'s own non-symmetric branch calls via `graph.upsert_edge(edge.clone())`
-  (`khive-db::stores::graph::SqlGraphStore::upsert_edge`), so parity is exact by construction.
-- symmetric relation (`competes_with`, `composed_with`): `update_edge` does NOT use the upsert
-  builder here, because `upsert_edge` resolves `ON CONFLICT(namespace, id)` first and cannot
-  detect a natural-key collision with a _different_ id. Canonical (`update_edge_symmetric_dml`)
-  runs a conflict probe and branches in Rust inside a single uninterrupted transaction, which is
-  safe there. This atomic path cannot do that (see the in-source invariant note on
-  `prepare_update_edge`).
+- non-symmetric relation: a single guarded `edge_replace_if_unchanged_statement` call on the
+  patched `Edge`, carrying an `AffectedRowGuard::exactly(1)` — the same CAS shape `update_edge`'s
+  own non-symmetric branch runs via `graph.replace_edge_if_unchanged(edge.clone(), expected_updated_at,
+  expected_deleted_at)` (`khive-db::stores::graph::SqlGraphStore::replace_edge_if_unchanged`). Both
+  sides bind the fetched snapshot's `updated_at`/`deleted_at` as the CAS fence and advance
+  `updated_at` to `max(now, snapshot + 1µs)` so the replacement revision strictly increases even
+  inside one clock microsecond; zero affected rows means a concurrent writer moved the edge between
+  read and write, and the caller must roll back rather than silently overwrite it.
+- symmetric relation (`competes_with`, `composed_with`): neither side uses the upsert builder here,
+  because `upsert_edge` resolves `ON CONFLICT(namespace, id)` first and cannot detect a natural-key
+  collision with a _different_ id. Canonical (`update_edge_symmetric_dml`) runs a conflict probe and
+  branches in Rust inside a single uninterrupted transaction, which is safe there. This atomic path
+  cannot do that (see the in-source invariant note on `prepare_update_edge`), so it always emits
+  both `edge_symmetric_delete_if_conflict_statement` and
+  `edge_symmetric_absorb_or_update_inplace_statement`, each carrying its own commit-time predicate
+  bound to the fetched snapshot's `updated_at`/`deleted_at`: a conflicting canonical survivor alone
+  is not sufficient grounds to delete the non-canonical row if that row changed since the snapshot
+  was read.
 
 ## event_append_statements
 

--- a/crates/khive-runtime/docs/operations.md
+++ b/crates/khive-runtime/docs/operations.md
@@ -52,12 +52,28 @@ to the merged non-root node count.
 
 ### update_edge_symmetric_dml
 
-DML text is the single source of truth shared with the atomic `prepare_update_edge` symmetric
-branch (`khive_db::stores::graph::EDGE_SYMMETRIC_CONFLICT_PROBE_SQL` /
-`EDGE_SYMMETRIC_DELETE_NONCANONICAL_SQL` / `EDGE_SYMMETRIC_UPDATE_INPLACE_SQL`): this function
-binds them against `rusqlite::params!` (it runs inside an existing transaction on a borrowed
-`&rusqlite::Connection`), while the atomic path binds the same text via `SqlValue` plan params —
-see the constants' doc comment in `khive-db` for why a single bridge type isn't used for both.
+This function runs inside an existing transaction on a borrowed `&rusqlite::Connection`, so it
+binds SQL against `rusqlite::params!` rather than the `SqlStatement`/`SqlValue` plan shape used
+elsewhere — see the constants' doc comment in `khive-db` for why a single bridge type isn't used
+for both.
+
+It binds `khive_db::stores::graph::EDGE_SYMMETRIC_CONFLICT_PROBE_SQL` for the probe,
+`EDGE_SYMMETRIC_DELETE_NONCANONICAL_GUARDED_SQL` for the absorbed arm, and
+`EDGE_SYMMETRIC_UPDATE_INPLACE_SQL` for the in-place arm.
+
+**Only the probe text is still shared with the atomic path.** The atomic `prepare_update_edge`
+symmetric branch builds its two write statements from
+`edge_symmetric_delete_if_conflict_statement` and
+`edge_symmetric_absorb_or_update_inplace_statement`, which carry their own SQL. They are not
+textual copies of the constants above: the atomic delete additionally requires a surviving row
+at the natural key via an `EXISTS` subquery, and the atomic in-place statement is a single
+two-armed `UPDATE` selected by `changes()` rather than a probe followed by a branch. Changing
+one path's SQL therefore does **not** change the other's, and an edit to either has to be
+mirrored deliberately.
+
+`EDGE_SYMMETRIC_DELETE_NONCANONICAL_SQL` (unguarded) is bound by neither of these. It remains
+in use by merge's predicate-based rewrites in `khive-runtime::curation`, which run inside their
+own single-writer transaction.
 
 ## Fault-injection static state
 

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -822,8 +822,10 @@ pub async fn prepare_update(
             // Decide step lives in curation.rs's `prepare_update_entity` —
             // the SAME function canonical `update_entity` calls. Only the
             // arg-extraction (raw JSON -> `EntityPatch`) and the plan-shape
-            // wiring (domain object -> `PlanStatement` via the shared
-            // `entity_upsert_statement` builder) are atomic-path-specific.
+            // wiring are atomic-path-specific: the domain object becomes a
+            // `PlanStatement` via `entity_replace_if_unchanged_statement`,
+            // whose CAS predicate binds the snapshot's revision and deletion
+            // marker, under an exactly-one affected-row guard.
             reject_inapplicable_update_fields(args, "entity")?;
             let name = entity_name_patch(args)?;
             let description = optional_string_patch(args, "description")?;
@@ -3503,11 +3505,12 @@ mod tests {
         .await
         .expect("prepare update entity plan");
 
-        // Read the plan's OWN bound revisions, so the isolation below is
+        // Read the plan's OWN bound values, so the isolation below is
         // derived from the plan rather than assumed about it. Per
         // `entity_replace_if_unchanged_statement`, `?8` (index 7) is the
-        // replacement revision and `?13` (index 12) the expected one.
-        let (planned_replacement, plan_expected) = {
+        // replacement revision, `?13` (index 12) the expected one, and `?14`
+        // (index 13) the expected deletion marker.
+        let (planned_replacement, plan_expected, plan_expected_deleted) = {
             let statements = match &plan {
                 AtomicOpPlan::Update(p) => p.statements.clone(),
                 other => panic!("expected an Update plan, got {other:?}"),
@@ -3524,7 +3527,12 @@ mod tests {
                 SqlValue::Integer(v) => *v,
                 other => panic!("param {i} must be an integer revision, got {other:?}"),
             };
-            (read(7), read(12))
+            let read_marker = |i: usize| match &cas.statement.params[i] {
+                SqlValue::Null => None,
+                SqlValue::Integer(v) => Some(*v),
+                other => panic!("param {i} must be a deletion marker, got {other:?}"),
+            };
+            (read(7), read(12), read_marker(13))
         };
 
         // A concurrent writer commits BEFORE the plan runs, advancing the
@@ -3579,6 +3587,29 @@ mod tests {
              stored revision, otherwise `?8 > updated_at` would refuse and this stops being \
              a test of the expected-revision guard"
         );
+        // The remaining non-target conjunct. `deleted_at IS ?14` is live in the
+        // same UPDATE, so without this read the fixture would stay green if the
+        // deletion marker were the actual refuser — the refusal would look
+        // identical. Read the row as it stands at DML time, after both the
+        // concurrent writer and the pin.
+        {
+            let stored = runtime
+                .get_entity_including_deleted(&token, id)
+                .await
+                .expect("read the stored row")
+                .expect("the seeded row is present before the plan runs");
+            assert_eq!(
+                stored.updated_at, stored_pinned,
+                "fixture premise: the pin must be what the guard reads, so the stored \
+                 revision is the pinned value and nothing re-advanced it"
+            );
+            assert_eq!(
+                stored.deleted_at, plan_expected_deleted,
+                "fixture premise: the stored deletion marker must MATCH the plan's `?14`, \
+                 otherwise `deleted_at IS ?14` refuses too and this stops being a test of \
+                 the expected-revision guard alone"
+            );
+        }
 
         let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
             .await
@@ -3643,11 +3674,12 @@ mod tests {
         .await
         .expect("prepare update edge plan");
 
-        // Read the plan's OWN bound revisions, so the isolation below is
+        // Read the plan's OWN bound values, so the isolation below is
         // derived from the plan rather than assumed about it. Per
         // `edge_replace_if_unchanged_statement`, `?6` (index 5) is the
-        // replacement revision and `?11` (index 10) the expected one.
-        let (planned_replacement, plan_expected) = {
+        // replacement revision, `?11` (index 10) the expected one, and `?12`
+        // (index 11) the expected deletion marker.
+        let (planned_replacement, plan_expected, plan_expected_deleted) = {
             let statements = match &plan {
                 AtomicOpPlan::Update(p) => p.statements.clone(),
                 other => panic!("expected an Update plan, got {other:?}"),
@@ -3663,7 +3695,12 @@ mod tests {
                 SqlValue::Integer(v) => *v,
                 other => panic!("param {i} must be an integer revision, got {other:?}"),
             };
-            (read(5), read(10))
+            let read_marker = |i: usize| match &cas.statement.params[i] {
+                SqlValue::Null => None,
+                SqlValue::Integer(v) => Some(*v),
+                other => panic!("param {i} must be a deletion marker, got {other:?}"),
+            };
+            (read(5), read(10), read_marker(11))
         };
 
         // A concurrent writer commits BEFORE the plan runs, advancing the
@@ -3715,6 +3752,29 @@ mod tests {
              stored revision, otherwise `?6 > updated_at` would refuse and this stops being \
              a test of the expected-revision guard"
         );
+        // The remaining non-target conjunct, for the same reason as the entity
+        // sibling: `deleted_at IS ?12` is live in the same UPDATE and would
+        // produce an indistinguishable refusal.
+        {
+            let stored = runtime
+                .get_edge_including_deleted(&token, edge_id)
+                .await
+                .expect("read the stored edge")
+                .expect("the seeded edge is present before the plan runs");
+            assert_eq!(
+                stored.updated_at.timestamp_micros(),
+                stored_pinned,
+                "fixture premise: the pin must be what the guard reads, so the stored \
+                 revision is the pinned value and nothing re-advanced it"
+            );
+            assert_eq!(
+                stored.deleted_at.map(|d| d.timestamp_micros()),
+                plan_expected_deleted,
+                "fixture premise: the stored deletion marker must MATCH the plan's `?12`, \
+                 otherwise `deleted_at IS ?12` refuses too and this stops being a test of \
+                 the expected-revision guard alone"
+            );
+        }
 
         let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
             .await
@@ -3980,6 +4040,102 @@ mod tests {
             .await
             .expect("concurrent writer update");
         assert!((concurrent.weight - 0.77).abs() < 1e-9);
+
+        // The guarded delete refuses on THREE independent premises — the
+        // expected revision (`?6`), the expected deletion marker (`?7`), and
+        // the EXISTS survivor at the natural key (`?3`/`?4`/`?5`). All three
+        // produce the same observable, a zero-row delete that rolls the unit
+        // back, so without asserting the other two this fixture cannot say the
+        // revision guard is what refused. Read the plan's own bound values and
+        // check the world against them, immediately before the DML.
+        {
+            let statements = match &plan {
+                AtomicOpPlan::Update(p) => p.statements.clone(),
+                other => panic!("expected an Update plan, got {other:?}"),
+            };
+            // By LABEL, for the same reason as the siblings above.
+            let del = statements
+                .iter()
+                .find(|s| s.statement.label.as_deref() == Some("edge-symmetric-delete-if-conflict"))
+                .expect("the plan must carry the guarded symmetric delete");
+            let text = |i: usize| match &del.statement.params[i] {
+                SqlValue::Text(v) => v.clone(),
+                other => panic!("param {i} must be text, got {other:?}"),
+            };
+            let plan_expected_updated = match &del.statement.params[5] {
+                SqlValue::Integer(v) => *v,
+                other => panic!("param 5 must be the expected revision, got {other:?}"),
+            };
+            let plan_expected_deleted = match &del.statement.params[6] {
+                SqlValue::Null => None,
+                SqlValue::Integer(v) => Some(*v),
+                other => panic!("param 6 must be a deletion marker, got {other:?}"),
+            };
+
+            let requested_now = runtime
+                .get_edge_including_deleted(&token, requested_id)
+                .await
+                .expect("read the requested edge")
+                .expect("the requested edge is present before the plan runs");
+            assert_ne!(
+                requested_now.updated_at.timestamp_micros(),
+                plan_expected_updated,
+                "fixture premise: the concurrent writer must actually have moved the \
+                 revision past the plan's `?6`, otherwise nothing refuses the delete"
+            );
+            assert_eq!(
+                requested_now.deleted_at.map(|d| d.timestamp_micros()),
+                plan_expected_deleted,
+                "fixture premise: the stored deletion marker must MATCH the plan's `?7`, \
+                 otherwise `deleted_at IS ?7` refuses too and the refusal is not \
+                 attributable to the revision guard"
+            );
+
+            // The EXISTS arm. A missing survivor refuses the delete on its own
+            // and looks identical from outside, so the premise has to be that
+            // arm's OWN question. Do not reconstruct it from the seeded row's
+            // endpoints: the natural key the plan binds is the canonical
+            // ordering, which need not equal the order the survivor was stored
+            // in, and a hand-built comparison would be asserting my model of
+            // canonicalisation rather than the predicate. Run the subquery
+            // verbatim against the plan's own bound parameters instead.
+            assert_ne!(
+                canonical_id, requested_id,
+                "fixture premise: the survivor must be a DIFFERENT row, since the EXISTS \
+                 arm excludes the requested id"
+            );
+            let survivors = {
+                let mut reader = runtime.sql().reader().await.expect("sql reader");
+                reader
+                    .query_scalar(SqlStatement {
+                        sql: "SELECT count(*) FROM graph_edges \
+                              WHERE namespace = ?1 AND source_id = ?3 AND target_id = ?4 \
+                                AND relation = ?5 AND id != ?2"
+                            .to_string(),
+                        params: del.statement.params[0..5].to_vec(),
+                        label: Some("test-survivor-exists-premise".to_string()),
+                    })
+                    .await
+                    .expect("run the plan's own EXISTS predicate")
+            };
+            let survivors = match survivors {
+                Some(SqlValue::Integer(n)) => n,
+                other => panic!("count(*) must come back as an integer, got {other:?}"),
+            };
+            assert_eq!(
+                survivors,
+                1,
+                "fixture premise: exactly one survivor must satisfy the plan's own EXISTS \
+                 predicate (namespace {}, source {}, target {}, relation {}, id != {}), \
+                 otherwise the delete refuses on the survivor arm and the refusal is not \
+                 attributable to the revision guard",
+                text(0),
+                text(2),
+                text(3),
+                text(4),
+                text(1),
+            );
+        }
 
         let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
             .await

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -39,14 +39,15 @@ use crate::runtime::{KhiveRuntime, NamespaceToken};
 
 use khive_db::stores::attachment::delete_record_attachments_statement;
 use khive_db::stores::entity::{
-    entity_hard_delete_statement, entity_soft_delete_statement, entity_upsert_statement,
+    entity_hard_delete_statement, entity_replace_if_unchanged_statement,
+    entity_soft_delete_statement, entity_upsert_statement,
 };
 use khive_db::stores::event::event_insert_statements;
 use khive_db::stores::event::hard_delete_lineage_warning_statements;
 use khive_db::stores::graph::{
     edge_hard_delete_statement, edge_insert_guarded_by_endpoints_statement,
-    edge_soft_delete_statement, edge_symmetric_absorb_or_update_inplace_statement,
-    edge_symmetric_delete_if_conflict_statement, edge_upsert_statement,
+    edge_replace_if_unchanged_statement, edge_soft_delete_statement,
+    edge_symmetric_absorb_or_update_inplace_statement, edge_symmetric_delete_if_conflict_statement,
     purge_incident_edges_statement,
 };
 use khive_db::stores::note::{
@@ -884,10 +885,14 @@ pub async fn prepare_update_entity_plan(
     id: Uuid,
     patch: crate::curation::EntityPatch,
 ) -> RuntimeResult<AtomicOpPlan> {
-    let (entity, reindex_required, changed_fields) =
+    let (entity, reindex_required, changed_fields, expected_updated_at, expected_deleted_at) =
         runtime.prepare_update_entity(token, id, patch).await?;
     let mut statements = vec![PlanStatement {
-        statement: entity_upsert_statement(&entity),
+        statement: entity_replace_if_unchanged_statement(
+            &entity,
+            expected_updated_at,
+            expected_deleted_at,
+        ),
         guard: Some(AffectedRowGuard::exactly(1)),
     }];
     statements.extend(event_append_statements(
@@ -941,6 +946,9 @@ async fn prepare_update_edge(
     args: &Value,
 ) -> RuntimeResult<AtomicOpPlan> {
     reject_inapplicable_update_fields(args, "edge")?;
+
+    let expected_updated_at = edge.updated_at;
+    let expected_deleted_at = edge.deleted_at;
 
     let relation_raw = optional_str(args, "relation");
     let weight = optional_f64(args, "weight")?;
@@ -1002,6 +1010,21 @@ async fn prepare_update_edge(
             .as_ref()
             .map(|v| serde_json::to_string(v).unwrap_or_default());
 
+        // `updated_at` must strictly advance past the snapshot even when two
+        // operations land inside one clock microsecond; saturating to
+        // i64::MAX would let the CAS accept a write without advancing its
+        // revision, so that is not a valid fallback (mirrors the note path).
+        let minimum_updated_at_micros = expected_updated_at
+            .timestamp_micros()
+            .checked_add(1)
+            .ok_or_else(|| {
+                RuntimeError::Internal(format!(
+                    "edge {id} updated_at is already at i64::MAX and cannot advance"
+                ))
+            })?;
+        let symmetric_updated_at_micros = now.timestamp_micros().max(minimum_updated_at_micros);
+        let expected_deleted_at_micros = expected_deleted_at.map(|v| v.timestamp_micros());
+
         statements.push(PlanStatement {
             statement: edge_symmetric_delete_if_conflict_statement(
                 &namespace,
@@ -1009,6 +1032,8 @@ async fn prepare_update_edge(
                 canon_src,
                 canon_tgt,
                 edge.relation,
+                expected_updated_at.timestamp_micros(),
+                expected_deleted_at_micros,
             ),
             guard: Some(AffectedRowGuard {
                 expected_min: 0,
@@ -1023,9 +1048,11 @@ async fn prepare_update_edge(
                 canon_tgt,
                 edge.relation,
                 edge.weight,
-                now.timestamp_micros(),
+                symmetric_updated_at_micros,
                 metadata_str.as_deref(),
                 edge.target_backend.as_deref(),
+                expected_updated_at.timestamp_micros(),
+                expected_deleted_at_micros,
             ),
             guard: Some(AffectedRowGuard::exactly(1)),
         });
@@ -1041,11 +1068,36 @@ async fn prepare_update_edge(
             relation: edge.relation,
         });
     } else {
-        // Non-symmetric: bit-for-bit the same builder `graph.upsert_edge`
-        // calls — see doc comment above.
-        edge.updated_at = now;
+        // Non-symmetric: guarded replace of the read snapshot rather than
+        // `graph.upsert_edge`'s unconditional natural-key upsert — a zero
+        // affected-row result now means a concurrent writer moved this edge
+        // between PREPARE and commit, and the atomic unit must roll back
+        // instead of silently overwriting it.
+        //
+        // `updated_at` must strictly advance past the snapshot even when two
+        // operations land inside one clock microsecond; saturating to
+        // i64::MAX would let the CAS accept a write without advancing its
+        // revision, so that is not a valid fallback (mirrors the note path).
+        let minimum_updated_at_micros = expected_updated_at
+            .timestamp_micros()
+            .checked_add(1)
+            .ok_or_else(|| {
+                RuntimeError::Internal(format!(
+                    "edge {id} updated_at is already at i64::MAX and cannot advance"
+                ))
+            })?;
+        let now_micros = now.timestamp_micros().max(minimum_updated_at_micros);
+        edge.updated_at = chrono::DateTime::from_timestamp_micros(now_micros).ok_or_else(|| {
+            RuntimeError::Internal(format!(
+                "edge {id}: computed updated_at {now_micros} is not a valid timestamp"
+            ))
+        })?;
         statements.push(PlanStatement {
-            statement: edge_upsert_statement(&edge),
+            statement: edge_replace_if_unchanged_statement(
+                &edge,
+                expected_updated_at,
+                expected_deleted_at,
+            ),
             guard: Some(AffectedRowGuard::exactly(1)),
         });
     }
@@ -3408,6 +3460,173 @@ mod tests {
         assert_eq!(events.len(), 1);
     }
 
+    /// Regression for khive #1753: an entity atomic update plan is prepared
+    /// from one revision, a concurrent (out-of-plan) writer advances the row
+    /// past that revision before the plan commits, and the plan's guarded
+    /// `entity_replace_if_unchanged_statement` must then affect zero rows —
+    /// which `AffectedRowGuard::exactly(1)` must turn into a whole-unit
+    /// rollback, not a silent overwrite of the concurrent writer's change.
+    /// Before threading the expected revision into the plan's `WHERE`
+    /// predicate, this plan used the unconditional `entity_upsert_statement`,
+    /// which always affects exactly 1 row regardless of staleness — the
+    /// guard could never fire and this test would redden (the outcome would
+    /// be `Committed`, and the concurrent writer's `name` change would be
+    /// lost under the stale plan's `description`-only patch).
+    #[tokio::test]
+    async fn atomic_entity_update_plan_stale_revision_rolls_back_unit() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let entity = runtime
+            .create_entity(
+                &token,
+                "concept",
+                None,
+                "StaleEntityPlanTarget",
+                None,
+                Some(json!({"a": 0})),
+                vec![],
+            )
+            .await
+            .expect("seed entity");
+        let id = entity.id;
+
+        // PREPARE time: build the plan from the current (soon-to-be-stale)
+        // revision.
+        let plan = prepare_update(
+            &runtime,
+            &token,
+            &json!({"id": id.to_string(), "description": "from the stale plan"}),
+            None,
+        )
+        .await
+        .expect("prepare update entity plan");
+
+        // A concurrent writer commits BEFORE the plan runs, advancing the
+        // row's revision past what the plan's guard expects.
+        runtime
+            .update_entity(
+                &token,
+                id,
+                crate::curation::EntityPatch {
+                    name: Some("ConcurrentWriterWon".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("concurrent writer update");
+
+        let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+            .await
+            .expect("the seam call itself must not error; the unit rolls back cleanly");
+        match outcome {
+            crate::atomic_runner::AtomicRunOutcome::RolledBack {
+                failed_op_index, ..
+            } => {
+                assert_eq!(
+                    failed_op_index, 0,
+                    "the sole op's guard must be the one that fails"
+                );
+            }
+            other => panic!(
+                "a stale entity plan must roll back, not silently overwrite the concurrent \
+                 writer's change: {other:?}"
+            ),
+        }
+
+        let after = runtime.get_entity(&token, id).await.expect("get_entity");
+        assert_eq!(
+            after.name, "ConcurrentWriterWon",
+            "the concurrent writer's committed name must survive the rolled-back stale plan"
+        );
+        assert_eq!(
+            after.description, None,
+            "the stale plan's description patch must NOT have landed"
+        );
+    }
+
+    /// Edge counterpart of `atomic_entity_update_plan_stale_revision_rolls_back_unit`:
+    /// a non-symmetric edge atomic update plan prepared from one revision
+    /// must roll back the whole unit when a concurrent writer advances the
+    /// row first, rather than silently overwriting that writer's change.
+    #[tokio::test]
+    async fn atomic_edge_update_plan_stale_revision_rolls_back_unit() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let entities = runtime.entities(&token).expect("entities store");
+        let a = khive_storage::Entity::new("local", "concept", "StaleEdgePlanA");
+        let b = khive_storage::Entity::new("local", "concept", "StaleEdgePlanB");
+        let (a_id, b_id) = (a.id, b.id);
+        entities.upsert_entity(a).await.expect("seed a");
+        entities.upsert_entity(b).await.expect("seed b");
+
+        let edge = runtime
+            .link(&token, a_id, b_id, EdgeRelation::Extends, 0.2, None)
+            .await
+            .expect("seed edge");
+        let edge_id = Uuid::from(edge.id);
+
+        // PREPARE time: build the plan from the current (soon-to-be-stale)
+        // revision.
+        let plan = prepare_update(
+            &runtime,
+            &token,
+            &json!({"id": edge_id.to_string(), "properties": {"note": "from the stale plan"}}),
+            None,
+        )
+        .await
+        .expect("prepare update edge plan");
+
+        // A concurrent writer commits BEFORE the plan runs, advancing the
+        // row's revision past what the plan's guard expects.
+        runtime
+            .update_edge(
+                &token,
+                edge_id,
+                crate::curation::EdgePatch {
+                    weight: Some(0.75),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("concurrent writer update");
+
+        let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+            .await
+            .expect("the seam call itself must not error; the unit rolls back cleanly");
+        match outcome {
+            crate::atomic_runner::AtomicRunOutcome::RolledBack {
+                failed_op_index, ..
+            } => {
+                assert_eq!(
+                    failed_op_index, 0,
+                    "the sole op's guard must be the one that fails"
+                );
+            }
+            other => panic!(
+                "a stale edge plan must roll back, not silently overwrite the concurrent \
+                 writer's change: {other:?}"
+            ),
+        }
+
+        let after = runtime
+            .get_edge(&token, edge_id)
+            .await
+            .expect("get_edge")
+            .expect("edge still exists");
+        assert!(
+            (after.weight - 0.75).abs() < 0.001,
+            "the concurrent writer's committed weight must survive the rolled-back stale plan: {after:?}"
+        );
+        assert!(
+            after.metadata.is_none(),
+            "the stale plan's properties patch must NOT have landed: {after:?}"
+        );
+    }
+
     /// A soft-deleted surviving canonical row must not be resurrected by a
     /// conflicting symmetric-relation update (ADR-039 DO NOTHING; khive#1213):
     /// the requested edge is still deleted (conflict absorbed), but the
@@ -3572,6 +3791,116 @@ mod tests {
         assert_eq!(
             canonical_after.weight, 0.6,
             "the pre-existing canonical row must never have been touched by the aborted update"
+        );
+    }
+
+    /// The symmetric absorption delete's atomic commit-time statement
+    /// (`edge_symmetric_delete_if_conflict_statement`) must refuse a plan
+    /// built from a since-changed snapshot, exactly like the non-symmetric
+    /// `atomic_edge_update_plan_stale_revision_rolls_back_unit` case above —
+    /// even though a genuine canonical survivor exists at the target natural
+    /// key. `E`'s own revision changes (via an unrelated production
+    /// `update_edge` call) AFTER `prepare_update` captured its snapshot but
+    /// BEFORE the plan runs; the whole atomic unit must roll back rather than
+    /// silently absorbing `E` into the survivor and discarding the
+    /// concurrent write.
+    #[tokio::test]
+    async fn atomic_update_edge_symmetric_absorption_plan_stale_revision_rolls_back_unit() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let entities = runtime.entities(&token).expect("entities store");
+        let a = khive_storage::Entity::new("local", "concept", "StaleAbsorbA");
+        let b = khive_storage::Entity::new("local", "concept", "StaleAbsorbB");
+        let (a_id, b_id) = (a.id, b.id);
+        entities.upsert_entity(a).await.expect("seed a");
+        entities.upsert_entity(b).await.expect("seed b");
+
+        // The pre-existing canonical row this plan will try to absorb into.
+        let canonical_edge = runtime
+            .link(&token, a_id, b_id, EdgeRelation::CompetesWith, 0.6, None)
+            .await
+            .expect("seed canonical edge");
+        let canonical_id = Uuid::from(canonical_edge.id);
+
+        // E: the requested edge under test.
+        let requested_edge = runtime
+            .link(&token, a_id, b_id, EdgeRelation::Extends, 0.2, None)
+            .await
+            .expect("seed requested edge");
+        let requested_id = Uuid::from(requested_edge.id);
+
+        // PREPARE time: build the plan from the current (soon-to-be-stale)
+        // revision.
+        let plan = prepare_update(
+            &runtime,
+            &token,
+            &json!({"id": requested_id.to_string(), "relation": "competes_with", "weight": 0.9}),
+            None,
+        )
+        .await
+        .expect("prepare update edge (symmetric absorption)");
+
+        // A concurrent writer commits BEFORE the plan runs, advancing E's
+        // revision past what the plan's guard expects. Relation stays
+        // `extends` (non-symmetric), so this lands via the already-guarded
+        // replace path — independent of the absorption bug under test.
+        let concurrent = runtime
+            .update_edge(
+                &token,
+                requested_id,
+                crate::curation::EdgePatch {
+                    weight: Some(0.77),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("concurrent writer update");
+        assert!((concurrent.weight - 0.77).abs() < 1e-9);
+
+        let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+            .await
+            .expect("the seam call itself must not error; the unit rolls back cleanly");
+        match outcome {
+            crate::atomic_runner::AtomicRunOutcome::RolledBack {
+                failed_op_index, ..
+            } => {
+                assert_eq!(
+                    failed_op_index, 0,
+                    "the sole op's guard must be the one that fails"
+                );
+            }
+            other => panic!(
+                "a stale absorption plan must roll back, not silently absorb E into the \
+                 survivor and discard the concurrent writer's change: {other:?}"
+            ),
+        }
+
+        let requested_after = runtime
+            .get_edge(&token, requested_id)
+            .await
+            .expect("get_edge")
+            .expect("E must still exist after the rolled-back absorption");
+        assert_eq!(
+            requested_after.relation,
+            EdgeRelation::Extends,
+            "E must be untouched by the rolled-back absorption: {requested_after:?}"
+        );
+        assert!(
+            (requested_after.weight - 0.77).abs() < 1e-9,
+            "the concurrent writer's committed weight must survive the rolled-back plan: \
+             {requested_after:?}"
+        );
+
+        let canonical_after = runtime
+            .get_edge(&token, canonical_id)
+            .await
+            .expect("get_edge")
+            .expect("S must still exist after the rolled-back absorption");
+        assert_eq!(
+            canonical_after.weight, 0.6,
+            "the survivor must never have been touched by the aborted absorption"
         );
     }
 

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -3503,6 +3503,30 @@ mod tests {
         .await
         .expect("prepare update entity plan");
 
+        // Read the plan's OWN bound revisions, so the isolation below is
+        // derived from the plan rather than assumed about it. Per
+        // `entity_replace_if_unchanged_statement`, `?8` (index 7) is the
+        // replacement revision and `?13` (index 12) the expected one.
+        let (planned_replacement, plan_expected) = {
+            let statements = match &plan {
+                AtomicOpPlan::Update(p) => p.statements.clone(),
+                other => panic!("expected an Update plan, got {other:?}"),
+            };
+            // Locate by LABEL, never by the guard text. A locator keyed on
+            // `?8 > updated_at` would stop finding the statement in exactly the
+            // mutation run that deletes that conjunct, so the arm would report
+            // on this fixture's locator instead of on the guard.
+            let cas = statements
+                .iter()
+                .find(|s| s.statement.label.as_deref() == Some("entity-replace-if-unchanged"))
+                .expect("the plan must carry the guarded entity replacement");
+            let read = |i: usize| match &cas.statement.params[i] {
+                SqlValue::Integer(v) => *v,
+                other => panic!("param {i} must be an integer revision, got {other:?}"),
+            };
+            (read(7), read(12))
+        };
+
         // A concurrent writer commits BEFORE the plan runs, advancing the
         // row's revision past what the plan's guard expects.
         runtime
@@ -3516,6 +3540,45 @@ mod tests {
             )
             .await
             .expect("concurrent writer update");
+
+        // Pin the stored revision one microsecond BELOW the plan's replacement.
+        // This is what makes the test specific to the guard it names. Both the
+        // plan and the concurrent writer derive their revision from
+        // `max(now, expected + 1)`, so left alone the concurrent write lands at
+        // or past the plan's own replacement and BOTH conjuncts refuse — the
+        // test would then stay green if either guard were deleted. Pinning
+        // leaves `?8 > updated_at` satisfied, so it cannot be the refuser,
+        // while `updated_at = ?13` is violated, which is the single condition
+        // this test names. The shape is reachable in production whenever the
+        // concurrent writer's clock trails the preparing writer's.
+        let stored_pinned = planned_replacement - 1;
+        assert_ne!(
+            stored_pinned, plan_expected,
+            "fixture premise: the pinned revision must differ from the plan's expected \
+             revision, otherwise `updated_at = ?13` would MATCH and nothing would refuse \
+             the plan"
+        );
+        {
+            let mut writer = runtime.sql().writer().await.expect("writer");
+            let affected = writer
+                .execute(SqlStatement {
+                    sql: "UPDATE entities SET updated_at = ?1 WHERE id = ?2".to_string(),
+                    params: vec![
+                        SqlValue::Integer(stored_pinned),
+                        SqlValue::Text(id.to_string()),
+                    ],
+                    label: Some("test-pin-stored-revision".to_string()),
+                })
+                .await
+                .expect("pin the stored revision");
+            assert_eq!(affected, 1, "the pin must touch exactly the seeded row");
+        }
+        assert!(
+            planned_replacement > stored_pinned,
+            "fixture premise: the plan's replacement must still strictly advance past the \
+             stored revision, otherwise `?8 > updated_at` would refuse and this stops being \
+             a test of the expected-revision guard"
+        );
 
         let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
             .await
@@ -3580,6 +3643,29 @@ mod tests {
         .await
         .expect("prepare update edge plan");
 
+        // Read the plan's OWN bound revisions, so the isolation below is
+        // derived from the plan rather than assumed about it. Per
+        // `edge_replace_if_unchanged_statement`, `?6` (index 5) is the
+        // replacement revision and `?11` (index 10) the expected one.
+        let (planned_replacement, plan_expected) = {
+            let statements = match &plan {
+                AtomicOpPlan::Update(p) => p.statements.clone(),
+                other => panic!("expected an Update plan, got {other:?}"),
+            };
+            // Locate by LABEL, never by the guard text — see the entity sibling
+            // above: a locator keyed on the conjunct disappears in exactly the
+            // mutation run that deletes it.
+            let cas = statements
+                .iter()
+                .find(|s| s.statement.label.as_deref() == Some("edge-replace-if-unchanged"))
+                .expect("the plan must carry the guarded edge replacement");
+            let read = |i: usize| match &cas.statement.params[i] {
+                SqlValue::Integer(v) => *v,
+                other => panic!("param {i} must be an integer revision, got {other:?}"),
+            };
+            (read(5), read(10))
+        };
+
         // A concurrent writer commits BEFORE the plan runs, advancing the
         // row's revision past what the plan's guard expects.
         runtime
@@ -3593,6 +3679,42 @@ mod tests {
             )
             .await
             .expect("concurrent writer update");
+
+        // Pin the stored revision one microsecond BELOW the plan's replacement,
+        // for the same reason as the entity sibling above: both the plan and
+        // the concurrent writer derive their revision from
+        // `max(now, expected + 1)`, so left alone BOTH conjuncts refuse and the
+        // test would stay green if either guard were deleted. Pinning leaves
+        // `?6 > updated_at` satisfied, so it cannot be the refuser, while
+        // `updated_at = ?11` is violated — the single condition this test names.
+        let stored_pinned = planned_replacement - 1;
+        assert_ne!(
+            stored_pinned, plan_expected,
+            "fixture premise: the pinned revision must differ from the plan's expected \
+             revision, otherwise `updated_at = ?11` would MATCH and nothing would refuse \
+             the plan"
+        );
+        {
+            let mut writer = runtime.sql().writer().await.expect("writer");
+            let affected = writer
+                .execute(SqlStatement {
+                    sql: "UPDATE graph_edges SET updated_at = ?1 WHERE id = ?2".to_string(),
+                    params: vec![
+                        SqlValue::Integer(stored_pinned),
+                        SqlValue::Text(edge_id.to_string()),
+                    ],
+                    label: Some("test-pin-stored-revision".to_string()),
+                })
+                .await
+                .expect("pin the stored revision");
+            assert_eq!(affected, 1, "the pin must touch exactly the seeded edge");
+        }
+        assert!(
+            planned_replacement > stored_pinned,
+            "fixture premise: the plan's replacement must still strictly advance past the \
+             stored revision, otherwise `?6 > updated_at` would refuse and this stops being \
+             a test of the expected-revision guard"
+        );
 
         let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
             .await

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -3508,9 +3508,10 @@ mod tests {
         // Read the plan's OWN bound values, so the isolation below is
         // derived from the plan rather than assumed about it. Per
         // `entity_replace_if_unchanged_statement`, `?8` (index 7) is the
-        // replacement revision, `?13` (index 12) the expected one, and `?14`
-        // (index 13) the expected deletion marker.
-        let (planned_replacement, plan_expected, plan_expected_deleted) = {
+        // replacement revision, `?12` (index 11) the target id, `?13`
+        // (index 12) the expected revision, and `?14` (index 13) the
+        // expected deletion marker.
+        let (planned_replacement, plan_target_id, plan_expected, plan_expected_deleted) = {
             let statements = match &plan {
                 AtomicOpPlan::Update(p) => p.statements.clone(),
                 other => panic!("expected an Update plan, got {other:?}"),
@@ -3532,8 +3533,24 @@ mod tests {
                 SqlValue::Integer(v) => Some(*v),
                 other => panic!("param {i} must be a deletion marker, got {other:?}"),
             };
-            (read(7), read(12), read_marker(13))
+            let read_text = |i: usize| match &cas.statement.params[i] {
+                SqlValue::Text(v) => v.clone(),
+                other => panic!("param {i} must be a text id, got {other:?}"),
+            };
+            (read(7), read_text(11), read(12), read_marker(13))
         };
+        // The identity conjunct, on the same footing as the revision and the
+        // deletion marker. `id = ?12` is live in the same UPDATE, so a plan
+        // that bound any other row's id would affect zero rows and roll the
+        // unit back for a reason this test does not name — an outcome
+        // indistinguishable from the one it does name.
+        assert_eq!(
+            plan_target_id,
+            id.to_string(),
+            "fixture premise: the plan's `?12` must be the row under test, otherwise \
+             `id = ?12` refuses on identity and the rollback stops being attributable to \
+             the expected-revision guard"
+        );
 
         // A concurrent writer commits BEFORE the plan runs, advancing the
         // row's revision past what the plan's guard expects.
@@ -3616,11 +3633,27 @@ mod tests {
             .expect("the seam call itself must not error; the unit rolls back cleanly");
         match outcome {
             crate::atomic_runner::AtomicRunOutcome::RolledBack {
-                failed_op_index, ..
+                failed_op_index,
+                failure,
             } => {
                 assert_eq!(
                     failed_op_index, 0,
                     "the sole op's guard must be the one that fails"
+                );
+                // Attribution rather than inference. The premises above
+                // establish that every non-target conjunct holds; this names
+                // the statement that actually refused. Without it a unit that
+                // rolled back at some other statement reads identically from
+                // the outside, which is the whole failure mode those premises
+                // were approximating.
+                assert_eq!(
+                    failure,
+                    crate::atomic_runner::AtomicOpFailure::GuardFailed {
+                        statement_label: Some("entity-replace-if-unchanged".to_string()),
+                        expected: crate::atomic_plan::AffectedRowGuard::exactly(1),
+                        observed: 0,
+                    },
+                    "the guarded entity replacement must be the statement whose guard refused"
                 );
             }
             other => panic!(
@@ -3677,9 +3710,10 @@ mod tests {
         // Read the plan's OWN bound values, so the isolation below is
         // derived from the plan rather than assumed about it. Per
         // `edge_replace_if_unchanged_statement`, `?6` (index 5) is the
-        // replacement revision, `?11` (index 10) the expected one, and `?12`
-        // (index 11) the expected deletion marker.
-        let (planned_replacement, plan_expected, plan_expected_deleted) = {
+        // replacement revision, `?10` (index 9) the target id, `?11`
+        // (index 10) the expected revision, and `?12` (index 11) the expected
+        // deletion marker.
+        let (planned_replacement, plan_target_id, plan_expected, plan_expected_deleted) = {
             let statements = match &plan {
                 AtomicOpPlan::Update(p) => p.statements.clone(),
                 other => panic!("expected an Update plan, got {other:?}"),
@@ -3700,8 +3734,22 @@ mod tests {
                 SqlValue::Integer(v) => Some(*v),
                 other => panic!("param {i} must be a deletion marker, got {other:?}"),
             };
-            (read(5), read(10), read_marker(11))
+            let read_text = |i: usize| match &cas.statement.params[i] {
+                SqlValue::Text(v) => v.clone(),
+                other => panic!("param {i} must be a text id, got {other:?}"),
+            };
+            (read(5), read_text(9), read(10), read_marker(11))
         };
+        // The identity conjunct, for the same reason as the entity sibling:
+        // `id = ?10` is live in the same UPDATE and a misbound target refuses
+        // indistinguishably.
+        assert_eq!(
+            plan_target_id,
+            edge_id.to_string(),
+            "fixture premise: the plan's `?10` must be the edge under test, otherwise \
+             `id = ?10` refuses on identity and the rollback stops being attributable to \
+             the expected-revision guard"
+        );
 
         // A concurrent writer commits BEFORE the plan runs, advancing the
         // row's revision past what the plan's guard expects.
@@ -3781,11 +3829,22 @@ mod tests {
             .expect("the seam call itself must not error; the unit rolls back cleanly");
         match outcome {
             crate::atomic_runner::AtomicRunOutcome::RolledBack {
-                failed_op_index, ..
+                failed_op_index,
+                failure,
             } => {
                 assert_eq!(
                     failed_op_index, 0,
                     "the sole op's guard must be the one that fails"
+                );
+                // Attribution rather than inference — see the entity sibling.
+                assert_eq!(
+                    failure,
+                    crate::atomic_runner::AtomicOpFailure::GuardFailed {
+                        statement_label: Some("edge-replace-if-unchanged".to_string()),
+                        expected: crate::atomic_plan::AffectedRowGuard::exactly(1),
+                        observed: 0,
+                    },
+                    "the guarded edge replacement must be the statement whose guard refused"
                 );
             }
             other => panic!(
@@ -4041,13 +4100,94 @@ mod tests {
             .expect("concurrent writer update");
         assert!((concurrent.weight - 0.77).abs() < 1e-9);
 
-        // The guarded delete refuses on THREE independent premises — the
-        // expected revision (`?6`), the expected deletion marker (`?7`), and
-        // the EXISTS survivor at the natural key (`?3`/`?4`/`?5`). All three
-        // produce the same observable, a zero-row delete that rolls the unit
-        // back, so without asserting the other two this fixture cannot say the
-        // revision guard is what refused. Read the plan's own bound values and
-        // check the world against them, immediately before the DML.
+        // Statement 2's in-place arm carries a strict-advance conjunct
+        // (`?7 > updated_at`) beside the expected-revision conjunct
+        // (`updated_at = ?10`) this test names. Both the plan and the
+        // concurrent writer derive their revision from `max(now, expected + 1)`
+        // and the concurrent writer ran LATER, so left alone the stored
+        // revision sits at or past the plan's replacement and BOTH conjuncts
+        // refuse — the test would stay green with either one deleted. Pin the
+        // stored revision one microsecond below the plan's replacement, the
+        // same treatment the entity and edge siblings above already carry.
+        let (absorb_replacement, absorb_expected, absorb_expected_deleted, absorb_ns, absorb_id) = {
+            let statements = match &plan {
+                AtomicOpPlan::Update(p) => p.statements.clone(),
+                other => panic!("expected an Update plan, got {other:?}"),
+            };
+            let s = statements
+                .iter()
+                .find(|st| {
+                    st.statement.label.as_deref() == Some("edge-symmetric-absorb-or-update-inplace")
+                })
+                .expect("the plan must carry the guarded symmetric in-place absorb");
+            let int = |i: usize| match &s.statement.params[i] {
+                SqlValue::Integer(v) => *v,
+                other => panic!("param {i} must be an integer revision, got {other:?}"),
+            };
+            let marker = |i: usize| match &s.statement.params[i] {
+                SqlValue::Null => None,
+                SqlValue::Integer(v) => Some(*v),
+                other => panic!("param {i} must be a deletion marker, got {other:?}"),
+            };
+            let txt = |i: usize| match &s.statement.params[i] {
+                SqlValue::Text(v) => v.clone(),
+                other => panic!("param {i} must be text, got {other:?}"),
+            };
+            (int(6), int(9), marker(10), txt(0), txt(1))
+        };
+        let stored_pinned = absorb_replacement - 1;
+        assert_ne!(
+            stored_pinned, absorb_expected,
+            "fixture premise: the pinned revision must differ from the plan's `?10`, otherwise \
+             `updated_at = ?10` would MATCH and nothing would refuse the in-place arm (and the \
+             guarded delete's `updated_at = ?6`, bound to the same value, would MATCH too and \
+             fire, leaving `changes() = 1` and selecting the absorbed arm instead)"
+        );
+        {
+            let mut writer = runtime.sql().writer().await.expect("writer");
+            let affected = writer
+                .execute(SqlStatement {
+                    sql: "UPDATE graph_edges SET updated_at = ?1 WHERE id = ?2".to_string(),
+                    params: vec![
+                        SqlValue::Integer(stored_pinned),
+                        SqlValue::Text(requested_id.to_string()),
+                    ],
+                    label: Some("test-pin-stored-revision".to_string()),
+                })
+                .await
+                .expect("pin the stored revision");
+            assert_eq!(affected, 1, "the pin must touch exactly the requested edge");
+        }
+        assert!(
+            absorb_replacement > stored_pinned,
+            "fixture premise: the plan's `?7` must still strictly advance past the stored \
+             revision, otherwise `?7 > updated_at` refuses too and the refusal stops being \
+             attributable to `updated_at = ?10`"
+        );
+
+        // A symmetric plan carries TWO guarded statements, and it matters
+        // which one refuses.
+        //
+        //   1. `edge-symmetric-delete-if-conflict`, guarded
+        //      `{expected_min: 0, expected_max: Some(1)}` — a zero-row delete
+        //      SATISFIES this guard. It does not roll the unit back. Its
+        //      effect here is to leave SQLite's `changes()` at 0.
+        //   2. `edge-symmetric-absorb-or-update-inplace`, guarded
+        //      `exactly(1)` — this is the statement that refuses and rolls the
+        //      unit back, through its in-place arm
+        //      `(id = ?2 AND changes() = 0 AND updated_at = ?10 AND
+        //        deleted_at IS ?11 AND ?7 > updated_at)`,
+        //      whose `updated_at = ?10` is the stale-revision guard under
+        //      test. The absorbed arm needs `changes() = 1`, so the delete
+        //      refusing is what selects the in-place arm.
+        //
+        // So the premises come in two layers. The delete's own predicates
+        // (`?6`, `?7`, and the EXISTS survivor at `?3`/`?4`/`?5`) are premised
+        // because they decide WHETHER the delete fires, and therefore which
+        // arm of statement 2 is live. Statement 2's remaining conjuncts are
+        // premised because each of them refuses identically to the revision
+        // guard this test names. Read the plans' own bound values and check
+        // the world against them, immediately before the DML.
         {
             let statements = match &plan {
                 AtomicOpPlan::Update(p) => p.statements.clone(),
@@ -4137,16 +4277,70 @@ mod tests {
             );
         }
 
+        // Statement 2's remaining conjuncts. Each of these refuses the in-place
+        // arm identically to the revision guard this test names, so each has to
+        // be shown satisfied for the attribution to hold.
+        assert_eq!(
+            absorb_ns, "local",
+            "fixture premise: the plan's `?1` must be the namespace the row lives in, \
+             otherwise the outer `namespace = ?1` refuses on its own"
+        );
+        assert_eq!(
+            absorb_id,
+            requested_id.to_string(),
+            "fixture premise: the plan's `?2` must be the edge under test, otherwise the \
+             in-place arm's `id = ?2` refuses on identity"
+        );
+        {
+            let stored = runtime
+                .get_edge_including_deleted(&token, requested_id)
+                .await
+                .expect("read the requested edge")
+                .expect("the requested edge is present before the plan runs");
+            assert_eq!(
+                stored.updated_at.timestamp_micros(),
+                stored_pinned,
+                "fixture premise: the pin must be what the guard reads at DML time, so the \
+                 stored revision is the pinned value and nothing re-advanced it"
+            );
+            assert_eq!(
+                stored.deleted_at.map(|d| d.timestamp_micros()),
+                absorb_expected_deleted,
+                "fixture premise: the stored deletion marker must MATCH the plan's `?11`, \
+                 otherwise `deleted_at IS ?11` refuses too and the refusal stops being \
+                 attributable to `updated_at = ?10`"
+            );
+        }
+
         let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
             .await
             .expect("the seam call itself must not error; the unit rolls back cleanly");
         match outcome {
             crate::atomic_runner::AtomicRunOutcome::RolledBack {
-                failed_op_index, ..
+                failed_op_index,
+                failure,
             } => {
                 assert_eq!(
                     failed_op_index, 0,
                     "the sole op's guard must be the one that fails"
+                );
+                // The decisive attribution, and the reason the two-layer
+                // premise stack above exists: `failed_op_index` cannot
+                // distinguish the two statements, because both live in op 0.
+                // Naming the label is what says the in-place absorb refused
+                // rather than the delete — and the delete's `0..=1` guard
+                // means it CANNOT be the refuser, so a run that reported it
+                // here would be evidence the guards had been rewired.
+                assert_eq!(
+                    failure,
+                    crate::atomic_runner::AtomicOpFailure::GuardFailed {
+                        statement_label: Some(
+                            "edge-symmetric-absorb-or-update-inplace".to_string()
+                        ),
+                        expected: crate::atomic_plan::AffectedRowGuard::exactly(1),
+                        observed: 0,
+                    },
+                    "the guarded in-place absorb must be the statement whose guard refused"
                 );
             }
             other => panic!(

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -4212,6 +4212,26 @@ mod tests {
                 other => panic!("param 6 must be a deletion marker, got {other:?}"),
             };
 
+            // The delete's OWN identity conjuncts. Reading them into the
+            // survivor-count panic message below is not asserting them: point
+            // `?1` or `?2` at a row that does not exist and the delete still
+            // affects zero rows, its `0..=1` guard still accepts that, and
+            // statement 2 still refuses on the pinned stale revision — so the
+            // test stays green while establishing nothing about which row the
+            // named delete attempted.
+            assert_eq!(
+                text(0),
+                "local",
+                "fixture premise: the delete's `?1` must be the namespace the row lives in, \
+                 otherwise `namespace = ?1` refuses on its own"
+            );
+            assert_eq!(
+                text(1),
+                requested_id.to_string(),
+                "fixture premise: the delete's `?2` must be the edge under test, otherwise \
+                 `id = ?2` refuses on identity and the delete never attempted the requested row"
+            );
+
             let requested_now = runtime
                 .get_edge_including_deleted(&token, requested_id)
                 .await

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -25,9 +25,45 @@ use crate::error::{RuntimeError, RuntimeResult};
 use crate::operations::{base_entity_rule_allows, canonical_edge_endpoints, endpoint_matches};
 use crate::runtime::{KhiveRuntime, NamespaceToken};
 
+/// Test-only pause point at the read/write boundary of a guarded
+/// read-modify-write, so a race between two concurrent callers of the same
+/// PRODUCTION entry point (not the underlying store primitive) can be
+/// reproduced deterministically instead of relying on scheduler luck or
+/// sleeps. A no-op unless the calling task runs inside
+/// `AFTER_READ_BARRIER.scope(...)`; production code never establishes that
+/// scope, so `pause_after_read` costs nothing outside these regression
+/// tests, and it does not exist at all in non-test builds.
+#[cfg(test)]
+pub(crate) mod race_seam {
+    use std::sync::Arc;
+    use tokio::sync::Barrier;
+
+    tokio::task_local! {
+        pub(crate) static AFTER_READ_BARRIER: Arc<Barrier>;
+    }
+
+    pub(crate) async fn pause_after_read() {
+        if let Ok(barrier) = AFTER_READ_BARRIER.try_with(Arc::clone) {
+            barrier.wait().await;
+        }
+    }
+}
+
 pub(crate) fn stale_note_snapshot_error(id: Uuid) -> RuntimeError {
     RuntimeError::Khive(KhiveError::conflict(format!(
         "note {id} changed concurrently after it was read; retry with fresh state"
+    )))
+}
+
+pub(crate) fn stale_entity_snapshot_error(id: Uuid) -> RuntimeError {
+    RuntimeError::Khive(KhiveError::conflict(format!(
+        "entity {id} changed concurrently after it was read; retry with fresh state"
+    )))
+}
+
+pub(crate) fn stale_edge_snapshot_error(id: Uuid) -> RuntimeError {
+    RuntimeError::Khive(KhiveError::conflict(format!(
+        "edge {id} changed concurrently after it was read; retry with fresh state"
     )))
 }
 
@@ -835,7 +871,7 @@ impl KhiveRuntime {
         token: &NamespaceToken,
         id: Uuid,
         patch: EntityPatch,
-    ) -> RuntimeResult<(Entity, bool, Vec<&'static str>)> {
+    ) -> RuntimeResult<(Entity, bool, Vec<&'static str>, i64, Option<i64>)> {
         crate::secret_gate::reject_reserved_secret_gate_property(patch.properties.as_ref())?;
         if let Some(ref name) = patch.name {
             crate::secret_gate::check(name)?;
@@ -854,6 +890,10 @@ impl KhiveRuntime {
             .get_entity(id)
             .await?
             .ok_or_else(|| RuntimeError::NotFound(format!("entity {id}")))?;
+        let expected_updated_at = entity.updated_at;
+        let expected_deleted_at = entity.deleted_at;
+        #[cfg(test)]
+        race_seam::pause_after_read().await;
 
         // ADR-014 tri-state: outer `None` = unchanged; `Some(None)` = explicit
         // clear (no vocabulary validation — there is no value to validate);
@@ -899,8 +939,26 @@ impl KhiveRuntime {
             changed_fields.push("entity_type");
         }
 
-        entity.updated_at = chrono::Utc::now().timestamp_micros();
-        Ok((entity, reindex_required, changed_fields))
+        // `updated_at` is also the optimistic-concurrency revision for
+        // full-entity replacement. Make it strictly advance even when two
+        // operations land inside one clock microsecond. Saturation is not a
+        // valid fallback: reusing i64::MAX would make the CAS accept a write
+        // without advancing its revision.
+        let minimum_updated_at = expected_updated_at.checked_add(1).ok_or_else(|| {
+            RuntimeError::Internal(format!(
+                "entity {id} updated_at is already at i64::MAX and cannot advance"
+            ))
+        })?;
+        entity.updated_at = chrono::Utc::now()
+            .timestamp_micros()
+            .max(minimum_updated_at);
+        Ok((
+            entity,
+            reindex_required,
+            changed_fields,
+            expected_updated_at,
+            expected_deleted_at,
+        ))
     }
 
     pub async fn update_entity(
@@ -921,11 +979,16 @@ impl KhiveRuntime {
         id: Uuid,
         patch: EntityPatch,
     ) -> RuntimeResult<(Entity, crate::retrieval::EmbeddingTruncationReport)> {
-        let (entity, reindex_required, changed_fields) =
+        let (entity, reindex_required, changed_fields, expected_updated_at, expected_deleted_at) =
             self.prepare_update_entity(token, id, patch).await?;
 
         let store = self.entities(token)?;
-        store.upsert_entity(entity.clone()).await?;
+        let persisted = store
+            .replace_entity_if_unchanged(entity.clone(), expected_updated_at, expected_deleted_at)
+            .await?;
+        if !persisted {
+            return Err(stale_entity_snapshot_error(id));
+        }
 
         let embedding_report = if reindex_required {
             self.reindex_entity(token, &entity).await?
@@ -3616,6 +3679,8 @@ pub(crate) fn union_tags(into: &[String], from: &[String]) -> (Vec<String>, usiz
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
     use crate::runtime::{KhiveRuntime, NamespaceToken};
     use khive_storage::types::{Direction, TextFilter, TextQueryMode, TextSearchRequest};
@@ -4017,7 +4082,13 @@ mod tests {
             .await
             .unwrap();
 
-        let (prepared, reindex_required, changed_fields) = rt
+        let (
+            prepared,
+            reindex_required,
+            changed_fields,
+            _expected_updated_at,
+            _expected_deleted_at,
+        ) = rt
             .prepare_update_entity(
                 &tok,
                 entity.id,
@@ -4055,6 +4126,494 @@ mod tests {
             .await
             .expect_err("unregistered entity_type must be rejected");
         assert!(matches!(err, RuntimeError::InvalidInput(_)), "error: {err}");
+    }
+
+    /// Regression for the entity lost-update race (khive #1753): two writers
+    /// read the same entity revision, then commit successive patches to
+    /// independent properties fields. Before the guarded
+    /// `replace_entity_if_unchanged` primitive, `update_entity_with_embedding_report`
+    /// wrote an unconditional `entity_upsert_statement`, so both patches
+    /// "succeeded" and the second silently discarded the first's field
+    /// (`a=1` was overwritten back to `a=0` when B's stale full-row replace
+    /// landed). This test forces the interleaving with a `Barrier` — both
+    /// readers are released together, so both `prepare_update_entity` calls
+    /// observe the SAME pre-write revision (asserted below) — then commits
+    /// deterministically in a fixed A-then-B order. It reddens if the guard
+    /// is dropped from `entity_replace_if_unchanged_statement` ENTIRELY: with
+    /// an unconditional UPDATE (or `entity_upsert_statement`), B's write would
+    /// also return `true` and `b` would be lost from the final properties.
+    ///
+    /// It does NOT redden when only `?8 > updated_at` is removed: with
+    /// `updated_at = ?13` intact, B is refused by the revision guard whatever
+    /// the clock did, so this fixture cannot see that conjunct disappear.
+    ///
+    /// It cannot ATTRIBUTE a failure to `updated_at = ?13` either, but for a
+    /// different reason, and the difference matters. Both racers take their
+    /// replacement revision from `prepare_update_entity`'s
+    /// `max(now_micros, expected + 1)` above; this test pins the two EXPECTED
+    /// revisions equal, never the two REPLACEMENT revisions. So with
+    /// `updated_at = ?13` removed, whether B is still refused depends on
+    /// whether B's wall-clock read happened to exceed A's committed revision.
+    /// That is a race, not a property of the fixture, and no single run of it
+    /// establishes either answer.
+    ///
+    /// Attribution therefore comes from fixtures that force the question:
+    /// `entity_cas_refuses_a_replacement_revision_that_does_not_advance` for
+    /// the strict-advance conjunct, and
+    /// `production_update_entity_refuses_concurrent_stale_writer` for the
+    /// production wiring. Making this fixture attribute as well would mean
+    /// pinning both replacement revisions to a common `expected + 1`; it is
+    /// deliberately left as a whole-guard test instead.
+    ///
+    /// SCOPE: this exercises the STORE PRIMITIVE directly and never invokes
+    /// `update_entity`, so it stays green if the production caller is reverted
+    /// to an unconditional write. The wiring is covered separately by
+    /// `production_update_entity_refuses_concurrent_stale_writer`; both are
+    /// required, neither substitutes for the other.
+    #[tokio::test]
+    async fn concurrent_entity_property_patches_from_one_revision_only_one_survives() {
+        let rt = Arc::new(rt());
+        let tok = NamespaceToken::local();
+        let entity = rt
+            .create_entity(
+                &tok,
+                "concept",
+                None,
+                "RaceTarget",
+                None,
+                Some(serde_json::json!({"a": 0, "b": 0})),
+                vec![],
+            )
+            .await
+            .expect("seed entity");
+        let id = entity.id;
+
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+
+        let reader_a = {
+            let rt = Arc::clone(&rt);
+            let tok = tok.clone();
+            let barrier = Arc::clone(&barrier);
+            tokio::spawn(async move {
+                barrier.wait().await;
+                rt.prepare_update_entity(
+                    &tok,
+                    id,
+                    EntityPatch {
+                        properties: Some(serde_json::json!({"a": 1})),
+                        ..Default::default()
+                    },
+                )
+                .await
+            })
+        };
+        let reader_b = {
+            let rt = Arc::clone(&rt);
+            let tok = tok.clone();
+            let barrier = Arc::clone(&barrier);
+            tokio::spawn(async move {
+                barrier.wait().await;
+                rt.prepare_update_entity(
+                    &tok,
+                    id,
+                    EntityPatch {
+                        properties: Some(serde_json::json!({"b": 1})),
+                        ..Default::default()
+                    },
+                )
+                .await
+            })
+        };
+
+        let (entity_a, _, _, expected_updated_at_a, expected_deleted_at_a) =
+            reader_a.await.unwrap().expect("reader A prepares");
+        let (entity_b, _, _, expected_updated_at_b, expected_deleted_at_b) =
+            reader_b.await.unwrap().expect("reader B prepares");
+        assert_eq!(
+            expected_updated_at_a, expected_updated_at_b,
+            "both readers must observe the same pre-write revision for this to be a real race"
+        );
+
+        let store = rt.entities(&tok).expect("entity store");
+        assert!(
+            store
+                .replace_entity_if_unchanged(entity_a, expected_updated_at_a, expected_deleted_at_a)
+                .await
+                .expect("writer A CAS query"),
+            "the first committer from a shared revision must win"
+        );
+        assert!(
+            !store
+                .replace_entity_if_unchanged(entity_b, expected_updated_at_b, expected_deleted_at_b)
+                .await
+                .expect("writer B CAS query"),
+            "the second committer from the SAME stale revision must be refused, not merged"
+        );
+
+        let final_entity = rt.get_entity(&tok, id).await.expect("read final entity");
+        assert_eq!(
+            final_entity.properties,
+            Some(serde_json::json!({"a": 1, "b": 0})),
+            "writer B's field must not be silently merged into the persisted row: {:?}",
+            final_entity.properties
+        );
+    }
+
+    /// Same race as `concurrent_entity_property_patches_from_one_revision_only_one_survives`,
+    /// but driven entirely through the PRODUCTION entry point
+    /// (`update_entity_with_embedding_report`) rather than the store's
+    /// `replace_entity_if_unchanged` primitive directly. This closes a gap
+    /// the primitive-level test cannot: it would still pass unchanged if the
+    /// production caller were reverted to an unconditional write, since it
+    /// never invokes that caller at all. Uses `race_seam::pause_after_read`
+    /// (test-only, compiled out of non-test builds) to force both concurrent
+    /// callers to observe the identical pre-write revision deterministically —
+    /// no sleeps, no reliance on scheduler ordering.
+    #[tokio::test]
+    async fn production_update_entity_refuses_concurrent_stale_writer() {
+        let rt = Arc::new(rt());
+        let tok = NamespaceToken::local();
+        let entity = rt
+            .create_entity(
+                &tok,
+                "concept",
+                None,
+                "ProductionRaceTarget",
+                None,
+                Some(serde_json::json!({"a": 0, "b": 0})),
+                vec![],
+            )
+            .await
+            .expect("seed entity");
+        let id = entity.id;
+
+        let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+
+        let writer_a = {
+            let rt = Arc::clone(&rt);
+            let tok = tok.clone();
+            let barrier = std::sync::Arc::clone(&barrier);
+            tokio::spawn(race_seam::AFTER_READ_BARRIER.scope(barrier, async move {
+                rt.update_entity_with_embedding_report(
+                    &tok,
+                    id,
+                    EntityPatch {
+                        properties: Some(serde_json::json!({"a": 1})),
+                        ..Default::default()
+                    },
+                )
+                .await
+            }))
+        };
+        let writer_b = {
+            let rt = Arc::clone(&rt);
+            let tok = tok.clone();
+            let barrier = std::sync::Arc::clone(&barrier);
+            tokio::spawn(race_seam::AFTER_READ_BARRIER.scope(barrier, async move {
+                rt.update_entity_with_embedding_report(
+                    &tok,
+                    id,
+                    EntityPatch {
+                        properties: Some(serde_json::json!({"b": 1})),
+                        ..Default::default()
+                    },
+                )
+                .await
+            }))
+        };
+
+        let result_a = writer_a.await.expect("writer A task");
+        let result_b = writer_b.await.expect("writer B task");
+        let successes = [result_a.is_ok(), result_b.is_ok()]
+            .into_iter()
+            .filter(|ok| *ok)
+            .count();
+        assert_eq!(
+            successes, 1,
+            "exactly one production caller must win the race; the other must be refused: \
+             a={result_a:?} b={result_b:?}"
+        );
+        let refused = if result_a.is_err() {
+            result_a
+        } else {
+            result_b
+        };
+        match &refused {
+            Err(RuntimeError::Khive(khive_error)) => {
+                assert_eq!(
+                    khive_error.kind(),
+                    khive_types::ErrorKind::Conflict,
+                    "the losing production caller must surface a typed conflict, not \
+                     silently overwrite: {refused:?}"
+                );
+            }
+            other => panic!("expected a typed conflict error, got {other:?}"),
+        }
+
+        let final_entity = rt.get_entity(&tok, id).await.expect("read final entity");
+        assert_ne!(
+            final_entity.properties,
+            Some(serde_json::json!({"a": 1, "b": 1})),
+            "both racers' fields must never both land: that would mean the loser's stale \
+             write silently succeeded"
+        );
+    }
+
+    /// Isolating fixture for the `AND ?8 > updated_at` conjunct of
+    /// `entity_replace_if_unchanged_statement`.
+    ///
+    /// The concurrent-race tests above cannot cover it. What is measured, and
+    /// deterministic: tautologizing `?8 > updated_at` alone reddened NOTHING in
+    /// `khive-runtime` before this test existed, because the revision guard
+    /// (`updated_at = ?13`) refuses the losing writer on its own whatever the
+    /// clock did. Tautologizing `updated_at = ?13` + `deleted_at IS ?14`
+    /// reddens only `production_update_entity_refuses_concurrent_stale_writer`,
+    /// and defeating all three at once reddens the race tests.
+    ///
+    /// What is NOT claimed, because the fixture cannot support it: that the two
+    /// guards are each independently sufficient. The race fixture pins the two
+    /// racers' EXPECTED revisions equal but never their REPLACEMENT revisions,
+    /// which both come from `max(now, expected + 1)`. So with `updated_at = ?13`
+    /// removed, whether strict advance still refuses depends on which clock read
+    /// won — a race, not a property of the fixture. This test strips the second
+    /// mechanism by construction instead:
+    /// it supplies the CORRECT expected revision and deletion marker, so
+    /// `?13`/`?14` are satisfied by construction, and the ONLY thing that can
+    /// refuse the write is the strict-advance conjunct.
+    #[tokio::test]
+    async fn entity_cas_refuses_a_replacement_revision_that_does_not_advance() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let entity = rt
+            .create_entity(
+                &tok,
+                "concept",
+                None,
+                "NonAdvancing",
+                None,
+                Some(serde_json::json!({"a": 0})),
+                vec![],
+            )
+            .await
+            .expect("seed entity");
+        let id = entity.id;
+
+        let (mut replacement, _, _, expected_updated_at, expected_deleted_at) = rt
+            .prepare_update_entity(
+                &tok,
+                id,
+                EntityPatch {
+                    properties: Some(serde_json::json!({"a": 1})),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("prepare update");
+
+        // Force the replacement revision to EQUAL the stored one. `?13`/`?14`
+        // still match exactly, so this is not a stale-snapshot refusal — the
+        // only predicate that can reject it is `?8 > updated_at`.
+        replacement.updated_at = expected_updated_at;
+
+        let store = rt.entities(&tok).expect("entity store");
+        let committed = store
+            .replace_entity_if_unchanged(replacement, expected_updated_at, expected_deleted_at)
+            .await
+            .expect("CAS query");
+        assert!(
+            !committed,
+            "a replacement whose revision does not strictly advance past the stored one must \
+             be refused: without `?8 > updated_at` the CAS would accept a write that leaves \
+             `updated_at` unmoved, so a later writer holding the same snapshot would still \
+             see its expected revision match and overwrite this one"
+        );
+
+        let stored = rt.get_entity(&tok, id).await.expect("read back");
+        assert_eq!(
+            stored.properties,
+            Some(serde_json::json!({"a": 0})),
+            "the refused write must not have landed"
+        );
+    }
+
+    /// Isolating fixture for the `AND deleted_at IS ?14` conjunct of
+    /// `entity_replace_if_unchanged_statement`.
+    ///
+    /// The revision-based race fixtures cannot reach it, because a soft delete
+    /// does not move the revision: `entity_soft_delete_statement` is
+    /// `SET deleted_at = ?1 WHERE id = ?2 AND deleted_at IS NULL` and never
+    /// touches `updated_at`. So a writer holding a pre-delete snapshot still has
+    /// the CORRECT expected revision after the row is tombstoned, and its
+    /// replacement revision still advances. Every conjunct except `?14` is
+    /// satisfied, and dropping `?14` would let that writer's `deleted_at = NULL`
+    /// land — resurrecting a tombstone, with no revision conflict anywhere to
+    /// signal it.
+    ///
+    /// This fixture does not merely claim that isolation, it asserts it: both
+    /// other conjuncts are checked against the post-delete row before the CAS
+    /// runs, so a future change that makes one of them refuse instead turns this
+    /// test red rather than silently converting it into a whole-guard test.
+    #[tokio::test]
+    async fn entity_cas_refuses_a_stale_replacement_that_would_resurrect_a_tombstone() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let entity = rt
+            .create_entity(
+                &tok,
+                "concept",
+                None,
+                "Tombstoned",
+                None,
+                Some(serde_json::json!({"a": 0})),
+                vec![],
+            )
+            .await
+            .expect("seed entity");
+        let id = entity.id;
+
+        // Snapshot BEFORE the delete: this is the stale writer's view.
+        let (replacement, _, _, expected_updated_at, expected_deleted_at) = rt
+            .prepare_update_entity(
+                &tok,
+                id,
+                EntityPatch {
+                    properties: Some(serde_json::json!({"a": 1})),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("prepare update");
+        assert_eq!(
+            expected_deleted_at, None,
+            "fixture premise: the snapshot must be of a LIVE row"
+        );
+
+        rt.delete_entity(&tok, id, false)
+            .await
+            .expect("soft delete");
+
+        let store = rt.entities(&tok).expect("entity store");
+        let tombstoned = store
+            .get_entity_including_deleted(id)
+            .await
+            .expect("read tombstone")
+            .expect("row still present after soft delete");
+
+        // Prove the isolation rather than asserting it in prose. `?13` matches
+        // because the soft delete left the revision alone, and `?8 > updated_at`
+        // holds because the prepared replacement advanced past it. That leaves
+        // `deleted_at IS ?14` as the only conjunct able to refuse the write.
+        assert_eq!(
+            tombstoned.updated_at, expected_updated_at,
+            "fixture premise: soft delete must NOT move `updated_at`, otherwise \
+             `?13` would refuse and this stops being an isolating fixture"
+        );
+        assert!(
+            replacement.updated_at > tombstoned.updated_at,
+            "fixture premise: the replacement revision must still advance, \
+             otherwise `?8 > updated_at` would refuse and this stops being an \
+             isolating fixture"
+        );
+        assert!(
+            tombstoned.deleted_at.is_some(),
+            "fixture premise: the row must actually be tombstoned"
+        );
+
+        let committed = store
+            .replace_entity_if_unchanged(replacement, expected_updated_at, expected_deleted_at)
+            .await
+            .expect("CAS query");
+        assert!(
+            !committed,
+            "a replacement carrying a pre-delete snapshot must be refused after the row is \
+             soft-deleted: without `deleted_at IS ?14` it would write `deleted_at = NULL` over \
+             the tombstone and silently resurrect a deleted entity"
+        );
+
+        let after = store
+            .get_entity_including_deleted(id)
+            .await
+            .expect("read back")
+            .expect("row present");
+        assert!(
+            after.deleted_at.is_some(),
+            "the tombstone must survive the refused write"
+        );
+        assert_eq!(
+            after.properties,
+            Some(serde_json::json!({"a": 0})),
+            "the refused write must not have landed"
+        );
+    }
+
+    /// Regression: the entity CAS requires the replacement revision to be
+    /// STRICTLY greater than the stored one. If the replacement is computed
+    /// as a raw `Utc::now()` read, a stored revision that is at or ahead of
+    /// wall-clock time (a clock step backward, or — deterministically,
+    /// reproduced here — a stored revision manufactured slightly ahead of
+    /// "now") makes the new value fail to advance, and the CAS refuses a
+    /// write with NO concurrent writer involved at all. The fix must clamp
+    /// the replacement to `max(now, stored + 1)`; this test sets the stored
+    /// revision one full second into the future (far outside normal clock
+    /// skew) and asserts the update still succeeds instead of surfacing a
+    /// spurious conflict.
+    ///
+    /// SCOPE: this is a revision-clamp test, NOT CAS regression coverage. Its
+    /// assertion is that the write SUCCEEDS, which an unconditional UPDATE
+    /// also satisfies, so it stays green if the `updated_at = ?13` /
+    /// `?8 > updated_at` guard is dropped entirely. The guard's regression
+    /// coverage is
+    /// `concurrent_entity_property_patches_from_one_revision_only_one_survives`
+    /// (primitive) and `production_update_entity_refuses_concurrent_stale_writer`
+    /// (production wiring); do not count this test toward it.
+    #[tokio::test]
+    async fn update_entity_succeeds_when_stored_revision_is_ahead_of_wall_clock() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let entity = rt
+            .create_entity(
+                &tok,
+                "concept",
+                None,
+                "FutureRevisionTarget",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .expect("seed entity");
+        let id = entity.id;
+
+        let future_micros = chrono::Utc::now().timestamp_micros() + 1_000_000;
+        let pool = rt.backend().pool_arc();
+        let id_str = id.to_string();
+        tokio::task::spawn_blocking(move || {
+            let guard = pool.writer().expect("writer connection");
+            guard
+                .execute(
+                    "UPDATE entities SET updated_at = ?1 WHERE id = ?2",
+                    rusqlite::params![future_micros, id_str],
+                )
+                .expect("force future revision")
+        })
+        .await
+        .expect("join");
+
+        let updated = rt
+            .update_entity(
+                &tok,
+                id,
+                EntityPatch {
+                    description: Some(Some("patched after a forced future revision".to_string())),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect(
+                "update must succeed and advance past the stored revision, not report a \
+                 spurious conflict when nothing else wrote to this row",
+            );
+        assert!(updated.updated_at > future_micros);
     }
 
     #[tokio::test]

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -4410,12 +4410,35 @@ mod tests {
             .await
             .expect("prepare update");
 
-        // Force the replacement revision to EQUAL the stored one. `?13`/`?14`
-        // still match exactly, so this is not a stale-snapshot refusal — the
-        // only predicate that can reject it is `?8 > updated_at`.
+        // Force the replacement revision to EQUAL the stored one, then PROVE the
+        // isolation rather than asserting it in prose. Reading the row back is
+        // what makes `?13` and `?14` observed facts here instead of values
+        // carried out of `prepare_update_entity`'s setup read.
         replacement.updated_at = expected_updated_at;
 
         let store = rt.entities(&tok).expect("entity store");
+        let stored = store
+            .get_entity_including_deleted(id)
+            .await
+            .expect("read stored row")
+            .expect("row present before CAS");
+        assert_eq!(
+            stored.updated_at, expected_updated_at,
+            "fixture premise: nothing moved the stored revision between prepare and CAS, \
+             otherwise `?13` would refuse and this stops being an isolating fixture"
+        );
+        assert_eq!(
+            stored.deleted_at, expected_deleted_at,
+            "fixture premise: the stored deletion marker must still equal the snapshot's, \
+             otherwise `deleted_at IS ?14` would refuse and this stops being an isolating \
+             fixture"
+        );
+        assert_eq!(
+            replacement.updated_at, stored.updated_at,
+            "fixture premise: the replacement revision must NOT advance past the stored one, \
+             which is the single condition under test"
+        );
+
         let committed = store
             .replace_entity_if_unchanged(replacement, expected_updated_at, expected_deleted_at)
             .await

--- a/crates/khive-runtime/src/note_store_guard.rs
+++ b/crates/khive-runtime/src/note_store_guard.rs
@@ -181,6 +181,11 @@ impl NoteStore for PolicyEnforcingNoteStore {
         self.inner.upsert_note(note).await
     }
 
+    async fn insert_note_if_absent(&self, note: Note) -> StorageResult<bool> {
+        reject_if_forged_message_note(&note, "insert_note_if_absent")?;
+        self.inner.insert_note_if_absent(note).await
+    }
+
     async fn replace_note_if_unchanged(
         &self,
         note: Note,

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -7359,6 +7359,31 @@ mod tests {
             "test setup: the concurrent write must actually advance the revision"
         );
 
+        // Prove every non-target premise BEFORE the DML runs. Asserting them
+        // afterwards cannot distinguish "the survivor already held the canonical
+        // key and the conflict predicate refused" from "the survivor appeared
+        // later", and it cannot show which conjunct did the refusing.
+        assert_eq!(
+            stale_deleted_at_micros, None,
+            "fixture premise: the stale snapshot must be of a LIVE edge, otherwise \
+             `deleted_at IS ?14` would refuse and this stops being an isolating fixture"
+        );
+        let survivor_before = rt.get_edge(&tok, survivor_id).await.unwrap().expect(
+            "fixture premise: the survivor must already own the canonical natural key \
+                 before the stale DML runs",
+        );
+        assert_eq!(
+            survivor_before.relation,
+            EdgeRelation::CompetesWith,
+            "fixture premise: the survivor must occupy the canonical natural key this stale \
+             writer is about to target, otherwise there is no conflict to absorb and the \
+             refusal would be attributable to something else: {survivor_before:?}"
+        );
+        assert_ne!(
+            survivor_id, e_id,
+            "fixture premise: the survivor and the stale writer's edge must be distinct rows"
+        );
+
         // Reproduce the exact DML `update_edge` runs for the stale writer,
         // using the snapshot it captured BEFORE the concurrent write above.
         let pool = rt.backend().pool_arc();

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -4918,6 +4918,22 @@ pub struct QueryResult {
     pub truncated: bool,
 }
 
+/// Outcome of [`KhiveRuntime::update_edge_symmetric_dml`]'s in-transaction DML.
+#[derive(Debug)]
+enum SymmetricEdgeUpdateOutcome {
+    /// A canonical row already existed (ADR-039 DO NOTHING): the
+    /// requested edge was deleted, the existing canonical row (this id)
+    /// left untouched.
+    Absorbed(String),
+    /// No conflict; the requested edge was updated in place.
+    Updated,
+    /// No conflict, but the in-place `UPDATE` matched zero rows because
+    /// the row's revision or deletion marker moved after it was fetched —
+    /// a concurrent writer raced this update and must be refused, not
+    /// silently overwritten by a stale full-row write.
+    Stale,
+}
+
 impl KhiveRuntime {
     // ---- Query operations ----
 
@@ -5550,10 +5566,10 @@ impl KhiveRuntime {
     /// in-place UPDATE (case a, no conflict). Callers own the surrounding transaction
     /// boundary — this function issues DML only, no `BEGIN`/`COMMIT`/`ROLLBACK`.
     ///
-    /// Returns `Ok(Some(existing_id))` when a canonical conflict was absorbed (the
-    /// requested edge was deleted, the existing canonical row left untouched per
-    /// ADR-039 DO NOTHING), or `Ok(None)` when the requested edge was updated in
-    /// place. Shares its DML text with the atomic `prepare_update_edge` symmetric
+    /// The in-place update is guarded on the fetched snapshot's revision and
+    /// deletion marker (mirrors the non-symmetric `replace_edge_if_unchanged`
+    /// guard) and requires the replacement revision to strictly advance.
+    /// Shares its DML text with the atomic `prepare_update_edge` symmetric
     /// branch — see docs/operations.md#update_edge_symmetric_dml.
     #[allow(clippy::too_many_arguments)]
     fn update_edge_symmetric_dml(
@@ -5565,7 +5581,9 @@ impl KhiveRuntime {
         relation_str: &str,
         weight: f64,
         metadata: Option<String>,
-    ) -> Result<Option<String>, SqliteError> {
+        expected_updated_at_micros: i64,
+        expected_deleted_at_micros: Option<i64>,
+    ) -> Result<SymmetricEdgeUpdateOutcome, SqliteError> {
         // `updated_at` is stored in MICROSECONDS on `graph_edges` (every other
         // write path — `edge_upsert_statement`, `edge_soft_delete_statement` —
         // uses `timestamp_micros()`; the column is read back via
@@ -5573,7 +5591,22 @@ impl KhiveRuntime {
         // pre-existing bug in this raw-SQL path, found while unifying it with
         // the atomic builder (which already used `timestamp_micros()`
         // correctly).
-        let now_ts = chrono::Utc::now().timestamp_micros();
+        //
+        // The replacement revision must strictly advance past the snapshot
+        // even when two operations land inside one clock microsecond;
+        // saturating to i64::MAX would let the CAS accept a write without
+        // advancing its revision, so that is not a valid fallback (mirrors
+        // the note path).
+        let minimum_updated_at_micros =
+            expected_updated_at_micros.checked_add(1).ok_or_else(|| {
+                SqliteError::InvalidData(format!(
+                    "update_edge: edge {edge_id_str} updated_at is already at i64::MAX \
+                         and cannot advance"
+                ))
+            })?;
+        let now_ts = chrono::Utc::now()
+            .timestamp_micros()
+            .max(minimum_updated_at_micros);
 
         // Check for a conflicting canonical row (same namespace + natural key,
         // different id). This catches conflicts whether or not endpoints were flipped.
@@ -5604,15 +5637,34 @@ impl KhiveRuntime {
             // same shared `EDGE_SYMMETRIC_*_SQL` text and must honor the same
             // contract. Return the surviving id unchanged so the caller
             // re-fetches its real (unmodified) attributes.
-            conn.execute(
-                khive_db::stores::graph::EDGE_SYMMETRIC_DELETE_NONCANONICAL_SQL,
-                rusqlite::params![&ns, &edge_id_str],
-            )
-            .map_err(SqliteError::Rusqlite)?;
-            Ok(Some(existing_id))
+            //
+            // Guarded on the fetched snapshot's revision and deletion marker:
+            // a concurrent writer that changed this edge between fetch and
+            // this write must be refused, not silently deleted just because
+            // a canonical survivor happens to exist. Zero affected rows here
+            // means stale, not "no conflict" — the probe above already
+            // confirmed a conflicting canonical row exists.
+            let affected = conn
+                .execute(
+                    khive_db::stores::graph::EDGE_SYMMETRIC_DELETE_NONCANONICAL_GUARDED_SQL,
+                    rusqlite::params![
+                        &ns,
+                        &edge_id_str,
+                        expected_updated_at_micros,
+                        expected_deleted_at_micros,
+                    ],
+                )
+                .map_err(SqliteError::Rusqlite)?;
+            if affected == 0 {
+                return Ok(SymmetricEdgeUpdateOutcome::Stale);
+            }
+            Ok(SymmetricEdgeUpdateOutcome::Absorbed(existing_id))
         } else {
             // Case (a): no conflict — update source_id/target_id in-place,
-            // preserving the original edge UUID.
+            // preserving the original edge UUID. Guarded on the fetched
+            // snapshot's revision and deletion marker: a concurrent writer
+            // that moved this edge between fetch and this write must be
+            // refused, not silently overwritten by a stale full-row update.
             let affected = conn
                 .execute(
                     khive_db::stores::graph::EDGE_SYMMETRIC_UPDATE_INPLACE_SQL,
@@ -5625,18 +5677,15 @@ impl KhiveRuntime {
                         metadata,
                         &ns,
                         &edge_id_str,
+                        expected_updated_at_micros,
+                        expected_deleted_at_micros,
                     ],
                 )
                 .map_err(SqliteError::Rusqlite)?;
             if affected == 0 {
-                // The edge row was not found under the record's namespace.
-                // This must never happen because ns = record_ns (fetched above).
-                return Err(SqliteError::InvalidData(format!(
-                    "update_edge: zero rows affected updating edge {edge_id_str} \
-                     in namespace {ns} — row vanished between fetch and update"
-                )));
+                return Ok(SymmetricEdgeUpdateOutcome::Stale);
             }
-            Ok(None)
+            Ok(SymmetricEdgeUpdateOutcome::Updated)
         }
     }
 
@@ -5666,6 +5715,10 @@ impl KhiveRuntime {
             .get_edge(LinkId::from(edge_id))
             .await?
             .ok_or_else(|| crate::RuntimeError::NotFound(format!("edge {edge_id}")))?;
+        let expected_updated_at = edge.updated_at;
+        let expected_deleted_at = edge.deleted_at;
+        #[cfg(test)]
+        crate::curation::race_seam::pause_after_read().await;
 
         // After fetching, all mutations and validation must use the
         // RECORD's namespace, not the caller's.  Derive record_tok from the stored edge
@@ -5730,16 +5783,16 @@ impl KhiveRuntime {
                 .as_ref()
                 .map(|v| serde_json::to_string(v).unwrap_or_default());
 
+            let expected_updated_at_micros = expected_updated_at.timestamp_micros();
+            let expected_deleted_at_micros = expected_deleted_at.map(|v| v.timestamp_micros());
+
             let pool = self.backend().pool_arc();
             // Route through the single-writer task when the write queue is
             // enabled; best-effort lookup degrades to the legacy pool-mutex
             // path (mirrors merge_entity/merge_note above).
             let writer_task = pool.writer_task_handle().ok().flatten();
 
-            // Some(surviving_id) when a canonical conflict was absorbed (the requested
-            // edge was deleted, existing canonical row left untouched per ADR-039 DO
-            // NOTHING), or None when the requested edge was updated in-place.
-            let surviving_id: Option<String> = if let Some(writer_task) = writer_task {
+            let outcome: SymmetricEdgeUpdateOutcome = if let Some(writer_task) = writer_task {
                 writer_task
                     .send(move |conn| {
                         Self::update_edge_symmetric_dml(
@@ -5751,6 +5804,8 @@ impl KhiveRuntime {
                             &relation_str,
                             weight,
                             metadata,
+                            expected_updated_at_micros,
+                            expected_deleted_at_micros,
                         )
                         .map_err(|e| {
                             khive_storage::StorageError::driver(
@@ -5775,6 +5830,8 @@ impl KhiveRuntime {
                             &relation_str,
                             weight,
                             metadata,
+                            expected_updated_at_micros,
+                            expected_deleted_at_micros,
                         )
                     })
                 })
@@ -5785,34 +5842,73 @@ impl KhiveRuntime {
                 .map_err(RuntimeError::Sqlite)?
             };
 
-            if let Some(sid) = surviving_id {
-                // A conflict was absorbed (ADR-039 DO NOTHING): re-fetch the surviving
-                // canonical row so the caller receives its real, UNMODIFIED attributes —
-                // including soft-deleted rows, since the survivor's tombstone state (if
-                // any) must not be resurrected by the absorbed update either. Use
-                // record_tok — the surviving row lives in the same namespace as the
-                // original.
-                let surviving_uuid = Uuid::parse_str(&sid).map_err(|e| {
-                    RuntimeError::Internal(format!("update_edge: surviving id parse failed: {e}"))
-                })?;
-                edge = self
-                    .get_edge_including_deleted(&record_tok, surviving_uuid)
-                    .await?
-                    .ok_or_else(|| {
+            match outcome {
+                SymmetricEdgeUpdateOutcome::Absorbed(sid) => {
+                    // A conflict was absorbed (ADR-039 DO NOTHING): re-fetch the surviving
+                    // canonical row so the caller receives its real, UNMODIFIED attributes —
+                    // including soft-deleted rows, since the survivor's tombstone state (if
+                    // any) must not be resurrected by the absorbed update either. Use
+                    // record_tok — the surviving row lives in the same namespace as the
+                    // original.
+                    let surviving_uuid = Uuid::parse_str(&sid).map_err(|e| {
                         RuntimeError::Internal(format!(
-                            "update_edge: surviving canonical row {surviving_uuid} vanished after update"
+                            "update_edge: surviving id parse failed: {e}"
                         ))
                     })?;
-            } else {
-                // Reflect canonical endpoints in the returned edge (no conflict absorbed).
-                edge.source_id = canon_src;
-                edge.target_id = canon_tgt;
+                    edge = self
+                        .get_edge_including_deleted(&record_tok, surviving_uuid)
+                        .await?
+                        .ok_or_else(|| {
+                            RuntimeError::Internal(format!(
+                                "update_edge: surviving canonical row {surviving_uuid} vanished after update"
+                            ))
+                        })?;
+                }
+                SymmetricEdgeUpdateOutcome::Updated => {
+                    // Reflect canonical endpoints in the returned edge (no conflict absorbed).
+                    edge.source_id = canon_src;
+                    edge.target_id = canon_tgt;
+                }
+                SymmetricEdgeUpdateOutcome::Stale => {
+                    return Err(crate::curation::stale_edge_snapshot_error(edge_id));
+                }
             }
         } else {
-            // Non-symmetric: upsert_edge takes namespace from edge.namespace (not from the
-            // graph store's routing namespace), so this is already record-namespace correct.
-            // `graph` is already self.graph(&record_tok)?.
-            graph.upsert_edge(edge.clone()).await?;
+            // Non-symmetric: replace_edge_if_unchanged takes namespace from edge.namespace
+            // (not from the graph store's routing namespace), so this is already
+            // record-namespace correct. `graph` is already self.graph(&record_tok)?.
+            // Guarded on the fetched snapshot's revision — a concurrent writer that moved
+            // this edge between the fetch above and this write must be refused, not
+            // silently overwritten by a full-row replacement derived from stale state.
+            // `updated_at` must advance past the snapshot: the guard requires the
+            // replacement revision to be strictly greater than the persisted one.
+            // Make it strictly advance even when two operations land inside one
+            // clock microsecond; saturating to i64::MAX would let the CAS accept
+            // a write without advancing its revision, so that is not a valid
+            // fallback (mirrors the note path).
+            let minimum_updated_at_micros = expected_updated_at
+                .timestamp_micros()
+                .checked_add(1)
+                .ok_or_else(|| {
+                RuntimeError::Internal(format!(
+                    "edge {edge_id} updated_at is already at i64::MAX and cannot advance"
+                ))
+            })?;
+            let now_micros = chrono::Utc::now()
+                .timestamp_micros()
+                .max(minimum_updated_at_micros);
+            edge.updated_at =
+                chrono::DateTime::from_timestamp_micros(now_micros).ok_or_else(|| {
+                    RuntimeError::Internal(format!(
+                        "edge {edge_id}: computed updated_at {now_micros} is not a valid timestamp"
+                    ))
+                })?;
+            let persisted = graph
+                .replace_edge_if_unchanged(edge.clone(), expected_updated_at, expected_deleted_at)
+                .await?;
+            if !persisted {
+                return Err(crate::curation::stale_edge_snapshot_error(edge_id));
+            }
         }
 
         // Audit event: use the record's namespace (record_ns) for the event payload.
@@ -6904,6 +7000,417 @@ mod tests {
             .await
             .unwrap();
         assert!((updated.weight - 0.5).abs() < 0.001);
+    }
+
+    /// Regression for the non-symmetric edge lost-update race (khive #1753).
+    /// Two readers fetch the SAME edge revision (nothing else writes between
+    /// these two `get_edge` calls, so this is a deterministic "two reads from
+    /// one revision", not a timing assumption), each derives an independent
+    /// patch (weight vs. metadata), and the two writes commit in a fixed
+    /// order. Before the guarded `replace_edge_if_unchanged` primitive,
+    /// `update_edge`'s non-symmetric branch called the unconditional
+    /// `graph.upsert_edge`, so both commits "succeeded" and B's write
+    /// silently discarded A's weight change. This reddens if the
+    /// `updated_at = ?11 AND deleted_at IS ?12 AND ?6 > updated_at` predicate
+    /// is dropped from `edge_replace_if_unchanged_statement`: B's write would
+    /// then also return `true` and A's weight update would be lost.
+    ///
+    /// SCOPE: this exercises the STORE PRIMITIVE directly and never invokes
+    /// `update_edge`, so it stays green if the production caller is reverted
+    /// to an unconditional write. The wiring is covered separately by
+    /// `production_update_edge_non_symmetric_refuses_concurrent_stale_writer`;
+    /// both are required, neither substitutes for the other.
+    #[tokio::test]
+    async fn concurrent_edge_patches_from_one_revision_only_one_survives() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let a = rt
+            .create_entity(&tok, "concept", None, "A", None, None, vec![])
+            .await
+            .unwrap();
+        let b = rt
+            .create_entity(&tok, "concept", None, "B", None, None, vec![])
+            .await
+            .unwrap();
+        let edge = rt
+            .link(&tok, a.id, b.id, EdgeRelation::Extends, 0.5, None)
+            .await
+            .unwrap();
+        let edge_id: Uuid = edge.id.into();
+
+        let graph = rt.graph(&tok).expect("graph store");
+        let snapshot_for_a = graph
+            .get_edge(LinkId::from(edge_id))
+            .await
+            .unwrap()
+            .expect("edge exists");
+        let snapshot_for_b = graph
+            .get_edge(LinkId::from(edge_id))
+            .await
+            .unwrap()
+            .expect("edge exists");
+        assert_eq!(
+            snapshot_for_a.updated_at, snapshot_for_b.updated_at,
+            "both readers must observe the same pre-write revision for this to be a real race"
+        );
+        let expected_updated_at = snapshot_for_a.updated_at;
+        let expected_deleted_at = snapshot_for_a.deleted_at;
+
+        let mut edge_a = snapshot_for_a;
+        edge_a.weight = 0.9;
+        edge_a.updated_at = expected_updated_at + chrono::Duration::microseconds(1);
+
+        let mut edge_b = snapshot_for_b;
+        edge_b.metadata = Some(serde_json::json!({"note": "from B"}));
+        edge_b.updated_at = expected_updated_at + chrono::Duration::microseconds(1);
+
+        assert!(
+            graph
+                .replace_edge_if_unchanged(edge_a, expected_updated_at, expected_deleted_at)
+                .await
+                .expect("writer A CAS query"),
+            "the first committer from a shared revision must win"
+        );
+        assert!(
+            !graph
+                .replace_edge_if_unchanged(edge_b, expected_updated_at, expected_deleted_at)
+                .await
+                .expect("writer B CAS query"),
+            "the second committer from the SAME stale revision must be refused, not merged"
+        );
+
+        let final_edge = graph
+            .get_edge(LinkId::from(edge_id))
+            .await
+            .unwrap()
+            .expect("edge still exists");
+        assert!(
+            (final_edge.weight - 0.9).abs() < 0.001,
+            "writer A's weight change must survive: {final_edge:?}"
+        );
+        assert!(
+            final_edge.metadata.is_none(),
+            "writer B's metadata must not be silently merged into the persisted row: {final_edge:?}"
+        );
+    }
+
+    /// Same race as `concurrent_edge_patches_from_one_revision_only_one_survives`,
+    /// but driven entirely through the PRODUCTION entry point (`update_edge`,
+    /// non-symmetric branch) rather than `replace_edge_if_unchanged` directly.
+    /// This closes a gap the primitive-level test cannot: it would still pass
+    /// unchanged if `update_edge` were reverted to an unconditional write,
+    /// since it never invokes `update_edge` at all. Uses
+    /// `crate::curation::race_seam::pause_after_read` (test-only, compiled
+    /// out of non-test builds) to force both concurrent callers to observe
+    /// the identical pre-write revision deterministically — no sleeps, no
+    /// reliance on scheduler ordering.
+    #[tokio::test]
+    async fn production_update_edge_non_symmetric_refuses_concurrent_stale_writer() {
+        let rt = std::sync::Arc::new(rt());
+        let tok = NamespaceToken::local();
+        let a = rt
+            .create_entity(&tok, "concept", None, "A", None, None, vec![])
+            .await
+            .unwrap();
+        let b = rt
+            .create_entity(&tok, "concept", None, "B", None, None, vec![])
+            .await
+            .unwrap();
+        let edge = rt
+            .link(&tok, a.id, b.id, EdgeRelation::Extends, 0.5, None)
+            .await
+            .unwrap();
+        let edge_id: Uuid = edge.id.into();
+
+        let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+
+        let writer_a = {
+            let rt = std::sync::Arc::clone(&rt);
+            let tok = tok.clone();
+            let barrier = std::sync::Arc::clone(&barrier);
+            tokio::spawn(crate::curation::race_seam::AFTER_READ_BARRIER.scope(
+                barrier,
+                async move {
+                    rt.update_edge(
+                        &tok,
+                        edge_id,
+                        crate::curation::EdgePatch {
+                            weight: Some(0.9),
+                            ..Default::default()
+                        },
+                    )
+                    .await
+                },
+            ))
+        };
+        let writer_b = {
+            let rt = std::sync::Arc::clone(&rt);
+            let tok = tok.clone();
+            let barrier = std::sync::Arc::clone(&barrier);
+            tokio::spawn(crate::curation::race_seam::AFTER_READ_BARRIER.scope(
+                barrier,
+                async move {
+                    rt.update_edge(
+                        &tok,
+                        edge_id,
+                        crate::curation::EdgePatch {
+                            properties: Some(serde_json::json!({"note": "from B"})),
+                            ..Default::default()
+                        },
+                    )
+                    .await
+                },
+            ))
+        };
+
+        let result_a = writer_a.await.expect("writer A task");
+        let result_b = writer_b.await.expect("writer B task");
+        let successes = [result_a.is_ok(), result_b.is_ok()]
+            .into_iter()
+            .filter(|ok| *ok)
+            .count();
+        assert_eq!(
+            successes, 1,
+            "exactly one production caller must win the race; the other must be refused: \
+             a={result_a:?} b={result_b:?}"
+        );
+        let refused = if result_a.is_err() {
+            result_a
+        } else {
+            result_b
+        };
+        match &refused {
+            Err(RuntimeError::Khive(khive_error)) => {
+                assert_eq!(
+                    khive_error.kind(),
+                    khive_types::ErrorKind::Conflict,
+                    "the losing production caller must surface a typed conflict, not \
+                     silently overwrite: {refused:?}"
+                );
+            }
+            other => panic!("expected a typed conflict error, got {other:?}"),
+        }
+
+        let final_edge = rt
+            .graph(&tok)
+            .expect("graph store")
+            .get_edge(LinkId::from(edge_id))
+            .await
+            .unwrap()
+            .expect("edge still exists");
+        assert!(
+            !((final_edge.weight - 0.9).abs() < 0.001 && final_edge.metadata.is_some()),
+            "both racers' changes must never both land: that would mean the loser's stale \
+             write silently succeeded: {final_edge:?}"
+        );
+    }
+
+    /// Symmetric-relation counterpart of
+    /// `production_update_edge_non_symmetric_refuses_concurrent_stale_writer`:
+    /// two production `update_edge` callers race a `competes_with` edge from
+    /// the same pre-write revision. Before the symmetric CAS guard, the
+    /// in-place `UPDATE` carried no expected-revision predicate, so both
+    /// commits would "succeed" and the second would silently discard the
+    /// first's weight change — this reddens if that guard (or its wiring
+    /// into `update_edge_symmetric_dml`) regresses.
+    #[tokio::test]
+    async fn production_update_edge_symmetric_refuses_concurrent_stale_writer() {
+        let rt = std::sync::Arc::new(rt());
+        let tok = NamespaceToken::local();
+        let a = rt
+            .create_entity(&tok, "concept", None, "A", None, None, vec![])
+            .await
+            .unwrap();
+        let b = rt
+            .create_entity(&tok, "concept", None, "B", None, None, vec![])
+            .await
+            .unwrap();
+        let edge = rt
+            .link(&tok, a.id, b.id, EdgeRelation::CompetesWith, 0.5, None)
+            .await
+            .unwrap();
+        let edge_id: Uuid = edge.id.into();
+
+        let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+
+        let writer_a = {
+            let rt = std::sync::Arc::clone(&rt);
+            let tok = tok.clone();
+            let barrier = std::sync::Arc::clone(&barrier);
+            tokio::spawn(crate::curation::race_seam::AFTER_READ_BARRIER.scope(
+                barrier,
+                async move {
+                    rt.update_edge(
+                        &tok,
+                        edge_id,
+                        crate::curation::EdgePatch {
+                            weight: Some(0.9),
+                            ..Default::default()
+                        },
+                    )
+                    .await
+                },
+            ))
+        };
+        let writer_b = {
+            let rt = std::sync::Arc::clone(&rt);
+            let tok = tok.clone();
+            let barrier = std::sync::Arc::clone(&barrier);
+            tokio::spawn(crate::curation::race_seam::AFTER_READ_BARRIER.scope(
+                barrier,
+                async move {
+                    rt.update_edge(
+                        &tok,
+                        edge_id,
+                        crate::curation::EdgePatch {
+                            weight: Some(0.1),
+                            ..Default::default()
+                        },
+                    )
+                    .await
+                },
+            ))
+        };
+
+        let result_a = writer_a.await.expect("writer A task");
+        let result_b = writer_b.await.expect("writer B task");
+        let successes = [result_a.is_ok(), result_b.is_ok()]
+            .into_iter()
+            .filter(|ok| *ok)
+            .count();
+        assert_eq!(
+            successes, 1,
+            "exactly one production caller must win the symmetric-edge race; the other must \
+             be refused: a={result_a:?} b={result_b:?}"
+        );
+        let refused = if result_a.is_err() {
+            result_a
+        } else {
+            result_b
+        };
+        match &refused {
+            Err(RuntimeError::Khive(khive_error)) => {
+                assert_eq!(
+                    khive_error.kind(),
+                    khive_types::ErrorKind::Conflict,
+                    "the losing production caller must surface a typed conflict, not \
+                     silently overwrite: {refused:?}"
+                );
+            }
+            other => panic!("expected a typed conflict error, got {other:?}"),
+        }
+    }
+
+    /// The symmetric absorption delete (case (b): a canonical survivor `S`
+    /// already exists at the target natural key) must refuse a stale writer
+    /// the same way the in-place update arm (case (a)) already does. `E`'s
+    /// own revision advances after a would-be stale writer's snapshot read;
+    /// that snapshot is then fed straight into the exact DML `update_edge`
+    /// runs, reproducing the race deterministically (no scheduler-dependent
+    /// concurrency needed: the outcome depends only on which snapshot the
+    /// delete is guarded against, not on wall-clock interleaving).
+    #[tokio::test]
+    async fn update_edge_symmetric_absorption_refuses_stale_snapshot_when_survivor_exists() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let a = rt
+            .create_entity(&tok, "concept", None, "A", None, None, vec![])
+            .await
+            .unwrap();
+        let b = rt
+            .create_entity(&tok, "concept", None, "B", None, None, vec![])
+            .await
+            .unwrap();
+
+        // Survivor S already owns the canonical natural key before the
+        // stale writer's snapshot is even read.
+        let survivor = rt
+            .link(&tok, a.id, b.id, EdgeRelation::CompetesWith, 0.6, None)
+            .await
+            .unwrap();
+        let survivor_id: Uuid = survivor.id.into();
+
+        // E: the edge a stale writer will try to move onto that same
+        // natural key.
+        let e = rt
+            .link(&tok, a.id, b.id, EdgeRelation::Extends, 0.2, None)
+            .await
+            .unwrap();
+        let e_id: Uuid = e.id.into();
+        let stale_updated_at_micros = e.updated_at.timestamp_micros();
+        let stale_deleted_at_micros = e.deleted_at.map(|t| t.timestamp_micros());
+
+        // A concurrent writer advances E's own revision after that snapshot
+        // was captured.
+        let advanced = rt
+            .update_edge(
+                &tok,
+                e_id,
+                crate::curation::EdgePatch {
+                    weight: Some(0.77),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("concurrent writer update");
+        assert_ne!(
+            advanced.updated_at.timestamp_micros(),
+            stale_updated_at_micros,
+            "test setup: the concurrent write must actually advance the revision"
+        );
+
+        // Reproduce the exact DML `update_edge` runs for the stale writer,
+        // using the snapshot it captured BEFORE the concurrent write above.
+        let pool = rt.backend().pool_arc();
+        let guard = pool.writer().expect("writer guard");
+        let (canon_src, canon_tgt) =
+            canonical_edge_endpoints(EdgeRelation::CompetesWith, a.id, b.id);
+        let outcome = guard
+            .transaction(|conn| {
+                KhiveRuntime::update_edge_symmetric_dml(
+                    conn,
+                    "local",
+                    &e_id.to_string(),
+                    &canon_src.to_string(),
+                    &canon_tgt.to_string(),
+                    "competes_with",
+                    0.9,
+                    None,
+                    stale_updated_at_micros,
+                    stale_deleted_at_micros,
+                )
+            })
+            .expect("dml call must not error");
+        drop(guard);
+        assert!(
+            matches!(outcome, SymmetricEdgeUpdateOutcome::Stale),
+            "a stale writer must be refused, not silently absorbed into the survivor: {outcome:?}"
+        );
+
+        let e_after = rt
+            .get_edge(&tok, e_id)
+            .await
+            .unwrap()
+            .expect("E must still exist after the refused absorption");
+        assert_eq!(
+            e_after.relation,
+            EdgeRelation::Extends,
+            "E must be untouched by the refused absorption: {e_after:?}"
+        );
+        assert!(
+            (e_after.weight - 0.77).abs() < 1e-9,
+            "the concurrent writer's weight must survive the refused absorption: {e_after:?}"
+        );
+
+        let s_after = rt
+            .get_edge(&tok, survivor_id)
+            .await
+            .unwrap()
+            .expect("S must still exist after the refused absorption");
+        assert_eq!(
+            s_after.weight, 0.6,
+            "the survivor must be untouched by the refused absorption: {s_after:?}"
+        );
     }
 
     /// `updated_at` on this path must use `timestamp_micros()`, matching every other

--- a/crates/khive-storage/src/entity.rs
+++ b/crates/khive-storage/src/entity.rs
@@ -145,6 +145,31 @@ pub trait EntityStore: Send + Sync + 'static {
     }
     /// Insert or update a batch of entities.
     async fn upsert_entities(&self, entities: Vec<Entity>) -> StorageResult<BatchWriteSummary>;
+    /// Replace an entity only when the persisted row still matches the
+    /// caller's read snapshot.
+    ///
+    /// `expected_updated_at` is the snapshot revision and
+    /// `expected_deleted_at` closes the soft-delete race. The replacement
+    /// entity's `updated_at` must be strictly greater than that persisted
+    /// revision. Returns `false` when the row disappeared, changed, or was
+    /// supplied a non-advancing replacement revision. This is the full-entity
+    /// compare-and-swap seam used when a caller derives coupled fields from
+    /// that snapshot before persistence — mirrors
+    /// [`crate::NoteStore::replace_note_if_unchanged`]. The default returns
+    /// `Unsupported` rather than falling back to an unguarded upsert and
+    /// reintroducing the stale-snapshot race.
+    async fn replace_entity_if_unchanged(
+        &self,
+        _entity: Entity,
+        _expected_updated_at: i64,
+        _expected_deleted_at: Option<i64>,
+    ) -> StorageResult<bool> {
+        Err(crate::StorageError::Unsupported {
+            capability: crate::StorageCapability::Entities,
+            operation: "replace_entity_if_unchanged".into(),
+            message: "this backend does not implement guarded entity replacement".into(),
+        })
+    }
     /// Fetch an entity by UUID, returning `None` if absent.
     async fn get_entity(&self, id: Uuid) -> StorageResult<Option<Entity>>;
     /// Delete an entity by UUID using the specified delete mode.

--- a/crates/khive-storage/src/graph.rs
+++ b/crates/khive-storage/src/graph.rs
@@ -1,6 +1,7 @@
 //! Graph storage capability — edge CRUD and traversal.
 
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use khive_types::EdgeRelation;
 use uuid::Uuid;
 
@@ -20,6 +21,31 @@ pub trait GraphStore: Send + Sync + 'static {
     async fn upsert_edge(&self, edge: Edge) -> StorageResult<()>;
     /// Insert or update a batch of edges.
     async fn upsert_edges(&self, edges: Vec<Edge>) -> StorageResult<BatchWriteSummary>;
+    /// Replace an edge only when the persisted row still matches the
+    /// caller's read snapshot.
+    ///
+    /// `expected_updated_at` is the snapshot revision and
+    /// `expected_deleted_at` closes the soft-delete race. The replacement
+    /// edge's `updated_at` must be strictly greater than that persisted
+    /// revision. Returns `false` when the row disappeared, changed, or was
+    /// supplied a non-advancing replacement revision. This is the full-edge
+    /// compare-and-swap seam used when a caller derives coupled fields from
+    /// that snapshot before persistence — mirrors
+    /// [`crate::NoteStore::replace_note_if_unchanged`]. The default returns
+    /// `Unsupported` rather than falling back to an unguarded upsert and
+    /// reintroducing the stale-snapshot race.
+    async fn replace_edge_if_unchanged(
+        &self,
+        _edge: Edge,
+        _expected_updated_at: DateTime<Utc>,
+        _expected_deleted_at: Option<DateTime<Utc>>,
+    ) -> StorageResult<bool> {
+        Err(StorageError::Unsupported {
+            capability: StorageCapability::Graph,
+            operation: "replace_edge_if_unchanged".into(),
+            message: "this backend does not implement guarded edge replacement".into(),
+        })
+    }
     /// Insert or update a single edge, re-checking that both endpoints still
     /// exist (and are not soft-deleted) as part of the same write, not a
     /// separate prior read. Closes the TOCTOU window between an async

--- a/crates/khive-storage/src/note.rs
+++ b/crates/khive-storage/src/note.rs
@@ -331,6 +331,31 @@ pub trait NoteStore: Send + Sync + 'static {
             message: "this backend does not implement guarded note replacement".into(),
         })
     }
+    /// Insert a note only if no row already holds its id, reporting whether
+    /// this call is the one that inserted it.
+    ///
+    /// This closes the other half of the read-modify-write race that
+    /// [`NoteStore::replace_note_if_unchanged`] closes. That one protects a
+    /// caller who read an existing row; this one protects a caller who read
+    /// *no* row. Where the id is derived rather than freshly generated — a
+    /// deterministic per-subject id — two callers can both read absence and
+    /// both write, and an upsert resolves that by overwriting, so the first
+    /// caller's write is lost with no error on either side. Returns `false`
+    /// when a row already existed, which the caller maps to a conflict rather
+    /// than to success.
+    ///
+    /// The pre-existing row is left exactly as it is: this must not be
+    /// implemented as an upsert, since overwriting is the behaviour being
+    /// avoided. The default returns `Unsupported` for that reason, rather
+    /// than falling back to `upsert_note` and silently reintroducing the
+    /// race under a name that promises otherwise.
+    async fn insert_note_if_absent(&self, _note: Note) -> StorageResult<bool> {
+        Err(crate::StorageError::Unsupported {
+            capability: crate::StorageCapability::Notes,
+            operation: "insert_note_if_absent".into(),
+            message: "this backend does not implement guarded note insertion".into(),
+        })
+    }
     /// Insert or update a batch of notes.
     async fn upsert_notes(&self, notes: Vec<Note>) -> StorageResult<BatchWriteSummary>;
     /// Fetch a note by UUID, returning `None` if absent.


### PR DESCRIPTION
## Problem

Entity and edge updates follow a read-modify-write shape: load the row, mutate a
field in memory, write the whole row back. Nothing in the write checks that the
stored row still matches what was read, so a concurrent writer's change to a
different field is overwritten with no error and no signal. The caller is told
the write succeeded.

Two conjuncts are needed, not one. Matching on the revision alone is not enough
because a soft delete sets `deleted_at` without moving the revision
(`entity_soft_delete_statement` touches only `deleted_at`). A writer holding a
snapshot taken before the delete therefore still matches on revision, and its
write lands with `deleted_at = NULL`, resurrecting a tombstoned row. No revision
conflict occurs anywhere in that sequence, so nothing detects it.

## What this changes

Adds guarded replacement primitives for entities and edges. A replacement
commits only if the stored row still carries both the revision and the deletion
marker the writer observed, and only if the replacement revision strictly
advances past the stored one. Zero affected rows is surfaced to the caller as a
stale conflict rather than as success, so a refused write is distinguishable
from a write that had nothing to do.

Symmetric edge conflict absorption is guarded on the same terms. Its snapshot is
read before the transaction opens and can be stale by the time the delete runs,
so the absorption delete binds the guarded statement. The atomic plan checks
each statement's affected-row count before applying the next, so a refused
delete cannot be followed by its paired update.

Channel heartbeats advance an existing row through the guarded note replacement.

## Known gap, deliberately not closed here

The heartbeat first-write branch, where two concurrent creators can both take an
unguarded insert, is left unguarded and is documented as such at the call site.
It is tracked in #2237.

## Tests

One isolating fixture per predicate, each supplying the other conjuncts by
construction so a failure attributes to exactly one guard, plus concurrent-race
fixtures at the production entry points.

Each isolating fixture asserts, in the test body, the conjuncts it is not
testing. The tombstone fixture asserts that the soft delete left the revision
unchanged and that the replacement revision strictly advances, before running
the guarded write. So a change that makes a different predicate do the refusing
turns the test red rather than quietly widening its scope, and the fixture
proves its own isolation instead of asserting it in a comment.

## Verification

```
cargo check --workspace --all-targets
cargo test -p khive-runtime -p khive-db -p khive-pack-comm
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
```

All four exit 0 at 2be0e010c5cda733fd1b65af760982cdac0d533e.
