### PR TITLE
fix(mcp): bound stdio bridge session lifetime

### DIFF
--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -7828,6 +7828,92 @@ mod request_read_cancellation_tests {
         );
     }
 
+    /// Regression: two outstanding obligations under one request id are
+    /// refused, not resolved by guessing.
+    ///
+    /// Retirement matches on request id, so two live entries sharing an id
+    /// make it ambiguous which one a completing response discharges — and both
+    /// resolutions are wrong in opposite directions. Removing the first match
+    /// can leave a *completed* request's instant as the newest entry, so the
+    /// freshness check defers past the older obligation's TTL: the unbounded
+    /// session this whole mechanism exists to close. Removing the last match
+    /// can leave the older instant, so the session closes out from under a
+    /// live handler. The transport cannot tell the two apart, so it refuses
+    /// the second admission instead.
+    ///
+    /// Idle reaping is off and the pipe is deliberately never closed, so the
+    /// refusal is the only thing that can end this session. A build that
+    /// admitted the duplicate would leave `root` uncancelled and this test
+    /// would exhaust its bound.
+    #[tokio::test]
+    async fn stdio_refuses_a_second_outstanding_obligation_under_one_request_id() {
+        use rmcp::transport::async_rw::AsyncRwTransport;
+        use tokio::io::AsyncWriteExt;
+
+        let first_admitted = Arc::new(tokio::sync::Notify::new());
+        let probe = OutOfOrderProbeServer {
+            first_admitted: first_admitted.clone(),
+            calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+        };
+        let root = tokio_util::sync::CancellationToken::new();
+        let (server_io, client_io) = tokio::io::duplex(16 * 1024);
+        let (server_read, server_write) = tokio::io::split(server_io);
+        let transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
+            AsyncRwTransport::new_server(server_read, server_write),
+            root.clone(),
+            // No idle timer: only the duplicate-id refusal can close this.
+            None,
+            None,
+            Some(Duration::from_secs(3600)),
+        );
+        let obligations = transport.in_flight_handle();
+        let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
+        let (_client_read, mut client_write) = tokio::io::split(client_io);
+
+        let request = b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\
+                        \"params\":{\"name\":\"probe\",\"arguments\":{}}}\n";
+        client_write
+            .write_all(request)
+            .await
+            .expect("write the first request");
+        tokio::time::timeout(Duration::from_secs(2), first_admitted.notified())
+            .await
+            .expect("rmcp never admitted the first request");
+
+        // Premise: id 1 is genuinely still outstanding. Without this the second
+        // request would just be a reuse after retirement, which is legitimate
+        // and not what this test is about.
+        assert_eq!(
+            obligations.lock().expect("obligation queue poisoned").len(),
+            1,
+            "fixture premise: the first request must still be outstanding when the duplicate \
+             arrives, otherwise nothing is ambiguous"
+        );
+        assert!(
+            !root.is_cancelled(),
+            "fixture premise: a single outstanding request must not have closed the session"
+        );
+
+        client_write
+            .write_all(request)
+            .await
+            .expect("write the duplicate-id request");
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while !root.is_cancelled() && std::time::Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(
+            root.is_cancelled(),
+            "a second outstanding obligation under an id that already has one must close the \
+             session; admitting it leaves retirement to pick an entry arbitrarily, which \
+             corrupts the freshness check in one direction or the other"
+        );
+
+        drop(client_write);
+        let _ = tokio::time::timeout(Duration::from_secs(2), running.waiting()).await;
+    }
+
     /// Regression: the obligation queue must not grow without bound.
     ///
     /// Retirement is keyed by request id, so it only ever removes the entry

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -995,6 +995,80 @@ fn stdio_serve_mode_for(resumed_generation: Option<u32>) -> StdioServeMode {
     }
 }
 
+/// Idle timeout for a stdio bridge session: no request for this long
+/// and the session closes (see [`crate::transport::CancelOnEofTransport`]),
+/// releasing its reader-pool admission and DB connection — a client that
+/// comes back simply respawns the bridge, seamlessly from its perspective.
+/// This closes only a genuinely idle session: an admitted request with a
+/// response still being written — running long, or delivered slowly to a
+/// backpressured reader — defers the close rather than being cancelled out
+/// from under it, up to the separate response-delivery bound documented on
+/// [`stdio_bridge_response_deadline_from_env`].
+///
+/// Overridable via `KHIVE_BRIDGE_IDLE_TIMEOUT_SECS`; `0` disables it (an
+/// explicit opt-out, e.g. for a debugger holding a session open on purpose).
+/// An unparsable value falls back to the default rather than panicking or
+/// disabling the timeout outright, matching this codebase's other
+/// `_from_env` helpers. Default: 3600s (60 minutes) — generous enough that
+/// ordinary gaps between requests in a live session never trip it, short
+/// enough that an abandoned bridge does not pin a reader-pool slot / WAL
+/// connection for hours or days.
+fn stdio_bridge_idle_timeout_from_env() -> Option<std::time::Duration> {
+    const DEFAULT_SECS: u64 = 3600;
+    let secs = std::env::var("KHIVE_BRIDGE_IDLE_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_SECS);
+    if secs == 0 {
+        None
+    } else {
+        Some(std::time::Duration::from_secs(secs))
+    }
+}
+
+/// Response-delivery deadline for a stdio bridge session: the longest a
+/// single response write may stay pending before it is abandoned (see
+/// [`crate::transport::CancelOnEofTransport::send`]) and this session is
+/// closed. Independent of the idle timeout above — it bounds an admitted
+/// request's response write directly, rather than the gap between
+/// requests. Without this bound, a peer that admits a request and then
+/// stops reading its response — while leaving the pipe itself open — keeps
+/// that write pending forever, so the idle timeout would defer indefinitely
+/// (an in-flight response always defers idle-close) and the session would
+/// never be reaped.
+///
+/// Overridable via `KHIVE_BRIDGE_RESPONSE_DEADLINE_SECS`, accepted range
+/// 1..=u64::MAX seconds. Unlike `KHIVE_BRIDGE_IDLE_TIMEOUT_SECS`, this bound
+/// cannot be disabled: `0` is a startup error naming the variable, the
+/// rejected value, and the accepted range, rather than a silent opt-out — a
+/// configuration that restores an unbounded pending write restores the
+/// defect this deadline exists to close (see the type doc above). An
+/// unparsable value falls back to the default rather than erroring, matching
+/// this codebase's other `_from_env` helpers. Default: 300s (5 minutes) —
+/// long enough that legitimately slow verbs and ordinary reader backpressure
+/// never trip it, short enough that a peer that has genuinely stopped
+/// reading does not pin the session's reader-pool admission / DB connection
+/// indefinitely.
+fn stdio_bridge_response_deadline_from_env() -> anyhow::Result<std::time::Duration> {
+    const DEFAULT_SECS: u64 = 300;
+    let secs = match std::env::var("KHIVE_BRIDGE_RESPONSE_DEADLINE_SECS") {
+        Ok(raw) => match raw.trim().parse::<u64>() {
+            Ok(secs) => secs,
+            Err(_) => DEFAULT_SECS,
+        },
+        Err(_) => DEFAULT_SECS,
+    };
+    if secs == 0 {
+        anyhow::bail!(
+            "KHIVE_BRIDGE_RESPONSE_DEADLINE_SECS=0 is not accepted: the response-delivery \
+             deadline cannot be disabled (a disabled deadline lets a peer that stops reading \
+             pin the bridge's response write forever). Set it to a positive number of seconds \
+             (accepted range: 1..=u64::MAX, default {DEFAULT_SECS})."
+        );
+    }
+    Ok(std::time::Duration::from_secs(secs))
+}
+
 impl KhiveMcpServer {
     /// Build a server from `runtime.config().packs`. Errors if any pack is unknown or missing deps.
     ///
@@ -1409,13 +1483,17 @@ impl KhiveMcpServer {
         use rmcp::transport::{async_rw::AsyncRwTransport, stdio};
 
         let root = tokio_util::sync::CancellationToken::new();
+        let idle_timeout = stdio_bridge_idle_timeout_from_env();
+        let response_deadline = stdio_bridge_response_deadline_from_env()?;
         let build_transport = |root: tokio_util::sync::CancellationToken| {
             let (read, write) = stdio();
-            crate::transport::CancelOnEofTransport::new(
+            crate::transport::CancelOnEofTransport::with_idle_timeout(
                 crate::daemon::SelfHealOnFlushTransport::new(AsyncRwTransport::new_server(
                     read, write,
                 )),
                 root,
+                idle_timeout,
+                Some(response_deadline),
             )
         };
 
@@ -1454,9 +1532,12 @@ impl KhiveMcpServer {
 
         let root = tokio_util::sync::CancellationToken::new();
         let (read, write) = stdio();
-        let transport = crate::transport::CancelOnEofTransport::new(
+        let response_deadline = stdio_bridge_response_deadline_from_env()?;
+        let transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
             AsyncRwTransport::new_server(read, write),
             root.clone(),
+            stdio_bridge_idle_timeout_from_env(),
+            Some(response_deadline),
         );
         let service = self.serve_with_ct(transport, root).await?;
         service.waiting().await?;
@@ -7330,9 +7411,11 @@ mod request_read_cancellation_tests {
         let root = tokio_util::sync::CancellationToken::new();
         let (server_io, mut client_io) = tokio::io::duplex(16 * 1024);
         let (read, write) = tokio::io::split(server_io);
-        let transport = crate::transport::CancelOnEofTransport::new(
+        let transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
             AsyncRwTransport::new_server(read, write),
             root.clone(),
+            None,
+            None,
         );
         let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
 
@@ -7366,6 +7449,466 @@ mod request_read_cancellation_tests {
             ),
             "unexpected rmcp quit reason after EOF: {reason:?}"
         );
+    }
+
+    /// An idle stdio bridge — pipe still open, no request sent — must
+    /// be reaped the same way a real EOF is, not held open indefinitely.
+    #[tokio::test]
+    async fn stdio_idle_timeout_cancels_root_without_eof() {
+        use rmcp::transport::async_rw::AsyncRwTransport;
+
+        let started = Arc::new(tokio::sync::Notify::new());
+        let cancelled = Arc::new(tokio::sync::Notify::new());
+        let probe = EofProbeServer {
+            started: started.clone(),
+            cancelled: cancelled.clone(),
+        };
+        let root = tokio_util::sync::CancellationToken::new();
+        let (server_io, client_io) = tokio::io::duplex(16 * 1024);
+        let (read, write) = tokio::io::split(server_io);
+        let transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
+            AsyncRwTransport::new_server(read, write),
+            root.clone(),
+            Some(Duration::from_millis(50)),
+            None,
+        );
+        let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
+
+        // Deliberately never write anything and never drop `client_io`: the
+        // pipe stays open exactly like an abandoned bridge's client — this
+        // must still be reaped once the idle timeout elapses.
+        let reason = tokio::time::timeout(Duration::from_secs(2), running.waiting())
+            .await
+            .expect("idle timeout never closed the session")
+            .expect("rmcp service task panicked");
+        assert!(
+            root.is_cancelled(),
+            "idle timeout must cancel the exact root token passed into rmcp"
+        );
+        assert!(
+            matches!(
+                reason,
+                rmcp::service::QuitReason::Closed | rmcp::service::QuitReason::Cancelled
+            ),
+            "unexpected rmcp quit reason after idle timeout: {reason:?}"
+        );
+        drop(client_io);
+    }
+
+    /// Completes every `tools/call` immediately — unlike [`EofProbeServer`],
+    /// which blocks its handler on cancellation. Used where a test needs
+    /// requests to actually finish (dropping the transport's in-flight
+    /// count back to zero) rather than staying admitted forever.
+    #[derive(Clone)]
+    struct QuickProbeServer;
+
+    impl rmcp::ServerHandler for QuickProbeServer {
+        async fn call_tool(
+            &self,
+            _request: rmcp::model::CallToolRequestParams,
+            _context: rmcp::service::RequestContext<rmcp::RoleServer>,
+        ) -> Result<rmcp::model::CallToolResult, McpError> {
+            Ok(rmcp::model::CallToolResult::success(Vec::new()))
+        }
+    }
+
+    /// Acceptance: a live client with traffic inside every idle window
+    /// must never be reaped, even once total elapsed time exceeds the
+    /// timeout many times over.
+    #[tokio::test]
+    async fn stdio_idle_timeout_does_not_reap_client_with_intermittent_traffic() {
+        use rmcp::transport::async_rw::AsyncRwTransport;
+        use tokio::io::AsyncWriteExt;
+
+        let probe = QuickProbeServer;
+        let root = tokio_util::sync::CancellationToken::new();
+        let (server_io, mut client_io) = tokio::io::duplex(16 * 1024);
+        let (read, write) = tokio::io::split(server_io);
+        let idle_timeout = Duration::from_millis(150);
+        let transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
+            AsyncRwTransport::new_server(read, write),
+            root.clone(),
+            Some(idle_timeout),
+            None,
+        );
+        let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
+
+        // Five requests spaced well inside the 150ms idle window, totaling
+        // ~200ms — more than the timeout itself, but never a single gap that
+        // exceeds it.
+        for id in 1..=5u32 {
+            client_io
+                .write_all(
+                    format!(
+                        "{{\"jsonrpc\":\"2.0\",\"id\":{id},\"method\":\"tools/call\",\
+                         \"params\":{{\"name\":\"probe\",\"arguments\":{{}}}}}}\n"
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .expect("write request");
+            tokio::time::sleep(Duration::from_millis(40)).await;
+        }
+
+        assert!(
+            !root.is_cancelled(),
+            "intermittent traffic inside every idle window must never trip the idle timeout"
+        );
+
+        // Real oracle: prove the timeout is actually
+        // armed on this exact transport/config rather than merely assumed.
+        // If the mechanism were silently disabled or ignored, `root` would
+        // never be cancelled here and this test would time out instead of
+        // passing — a stronger guard than the traffic-keeps-it-alive
+        // assertion above, which a disabled timeout would also satisfy.
+        tokio::time::timeout(idle_timeout * 6, running.waiting())
+            .await
+            .expect(
+                "idle timeout never fired once traffic stopped — the timeout \
+                 mechanism is not armed",
+            )
+            .expect("rmcp service task panicked");
+        assert!(
+            root.is_cancelled(),
+            "idle timeout must fire once traffic genuinely stops, proving it \
+             is armed for this test"
+        );
+        drop(client_io);
+    }
+
+    #[derive(Clone)]
+    struct SlowProbeServer {
+        started: Arc<tokio::sync::Notify>,
+        delay: Duration,
+    }
+
+    impl rmcp::ServerHandler for SlowProbeServer {
+        fn call_tool(
+            &self,
+            _request: rmcp::model::CallToolRequestParams,
+            _context: rmcp::service::RequestContext<rmcp::RoleServer>,
+        ) -> impl Future<Output = Result<rmcp::model::CallToolResult, McpError>> + Send + '_
+        {
+            let started = self.started.clone();
+            let delay = self.delay;
+            async move {
+                started.notify_one();
+                tokio::time::sleep(delay).await;
+                Ok(rmcp::model::CallToolResult::success(Vec::new()))
+            }
+        }
+    }
+
+    /// High-severity regression: rmcp keeps racing
+    /// `transport.receive()` while an admitted request runs in its own task,
+    /// so a handler that outlives the idle window must still complete and
+    /// return its response rather than being cancelled by the next
+    /// `receive()` timing out.
+    #[tokio::test]
+    async fn stdio_idle_timeout_does_not_cancel_an_admitted_long_running_request() {
+        use rmcp::transport::async_rw::AsyncRwTransport;
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let started = Arc::new(tokio::sync::Notify::new());
+        let handler_delay = Duration::from_millis(300);
+        let idle_timeout = Duration::from_millis(50);
+        let probe = SlowProbeServer {
+            started: started.clone(),
+            delay: handler_delay,
+        };
+        let root = tokio_util::sync::CancellationToken::new();
+        let (server_io, client_io) = tokio::io::duplex(16 * 1024);
+        let (server_read, server_write) = tokio::io::split(server_io);
+        let transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
+            AsyncRwTransport::new_server(server_read, server_write),
+            root.clone(),
+            Some(idle_timeout),
+            None,
+        );
+        let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
+        let (mut client_read, mut client_write) = tokio::io::split(client_io);
+
+        client_write
+            .write_all(
+                b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"probe\",\"arguments\":{}}}\n",
+            )
+            .await
+            .expect("write one real JSON-RPC tool request");
+
+        tokio::time::timeout(Duration::from_secs(2), started.notified())
+            .await
+            .expect("rmcp never admitted the request handler");
+
+        // The handler keeps running well past several idle windows while the
+        // wire itself sends nothing further — this must not be reaped.
+        tokio::time::sleep(idle_timeout * 4).await;
+        assert!(
+            !root.is_cancelled(),
+            "an admitted in-flight request must not be cancelled by the wire-idle timeout"
+        );
+
+        let mut buf = vec![0u8; 4096];
+        let n = tokio::time::timeout(Duration::from_secs(2), client_read.read(&mut buf))
+            .await
+            .expect("the long-running handler never produced its response")
+            .expect("read error on the client side of the duplex pipe");
+        let response = String::from_utf8_lossy(&buf[..n]);
+        assert!(
+            response.contains("\"id\":1"),
+            "expected a JSON-RPC response for request id=1, got: {response}"
+        );
+
+        drop(client_write);
+        let _ = tokio::time::timeout(Duration::from_secs(2), running.waiting()).await;
+    }
+
+    /// Regression: a request must stay "in flight" — and
+    /// therefore protected from the idle-close branch — until its response
+    /// has actually *finished writing*, not merely been handed to
+    /// `inner.send`. rmcp spawns the response send and the framed write
+    /// awaits the transport writer, so a slow/backpressured reader can leave
+    /// the write pending well after the handler itself already completed.
+    /// Before the fix, `in_flight` was decremented synchronously inside
+    /// `send` before the returned future was even polled, so this scenario
+    /// would have been misread as an idle session and the root token
+    /// cancelled out from under the still-undelivered response.
+    #[tokio::test]
+    async fn stdio_idle_timeout_does_not_cancel_while_a_response_write_is_backpressured() {
+        use rmcp::transport::async_rw::AsyncRwTransport;
+        use tokio::io::AsyncWriteExt;
+
+        let probe = QuickProbeServer;
+        let root = tokio_util::sync::CancellationToken::new();
+        // An 8-byte buffer for the server->client direction: the JSON-RPC
+        // response cannot fully land without the reader draining it, which
+        // this test deliberately never does — that is what keeps the write
+        // pending.
+        let (server_io, mut client_io) = tokio::io::duplex(8);
+        let (server_read, server_write) = tokio::io::split(server_io);
+        let idle_timeout = Duration::from_millis(50);
+        let transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
+            AsyncRwTransport::new_server(server_read, server_write),
+            root.clone(),
+            Some(idle_timeout),
+            None,
+        );
+        let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
+
+        client_io
+            .write_all(
+                b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"probe\",\"arguments\":{}}}\n",
+            )
+            .await
+            .expect("write one real JSON-RPC tool request");
+
+        // The handler itself finishes almost immediately (`QuickProbeServer`),
+        // but with nobody reading `client_io`, the response write cannot
+        // drain into the 8-byte pipe. This must not be read as idle across
+        // several idle windows.
+        tokio::time::sleep(idle_timeout * 4).await;
+        assert!(
+            !root.is_cancelled(),
+            "an admitted request's still-undelivered response must not be read as an idle session"
+        );
+
+        drop(client_io);
+        let _ = tokio::time::timeout(Duration::from_secs(2), running.waiting()).await;
+    }
+
+    /// Regression: a response write that never resolves — a peer
+    /// that admits a request, then never reads its response and never
+    /// disconnects — must itself be bounded by `response_deadline`, not
+    /// merely deferred by the idle-close check forever. This is the
+    /// assertion that reddens if the response-delivery deadline is removed
+    /// (passed as `None`): `root` would then never be cancelled and the
+    /// poll loop below would exhaust its bound without ever observing
+    /// cancellation.
+    #[tokio::test]
+    async fn stdio_idle_timeout_reaps_a_peer_that_stops_reading_its_response() {
+        use rmcp::transport::async_rw::AsyncRwTransport;
+        use tokio::io::AsyncWriteExt;
+
+        let probe = QuickProbeServer;
+        let root = tokio_util::sync::CancellationToken::new();
+        // Same 8-byte-buffer trick as the test above: the response cannot
+        // fully land without the reader draining it. Unlike that test, this
+        // one never reads from `client_io` and never drops it — the pipe
+        // stays open exactly like a peer that admitted a request and then
+        // simply stopped reading.
+        let (server_io, mut client_io) = tokio::io::duplex(8);
+        let (server_read, server_write) = tokio::io::split(server_io);
+        let response_deadline = Duration::from_millis(150);
+        let transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
+            AsyncRwTransport::new_server(server_read, server_write),
+            root.clone(),
+            None,
+            Some(response_deadline),
+        );
+        let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
+
+        client_io
+            .write_all(
+                b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"probe\",\"arguments\":{}}}\n",
+            )
+            .await
+            .expect("write one real JSON-RPC tool request");
+
+        // The core claim: root cancellation — the actual reaping signal —
+        // must land within `response_deadline` of admission, not merely
+        // "eventually". Polled rather than slept for the full bound so this
+        // resolves as soon as it happens and reddens immediately (via the
+        // assertion below) if the response-delivery deadline stops firing.
+        let bound = response_deadline + Duration::from_millis(500);
+        let poll_deadline = tokio::time::Instant::now() + bound;
+        while !root.is_cancelled() && tokio::time::Instant::now() < poll_deadline {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        assert!(
+            root.is_cancelled(),
+            "the response-delivery deadline must cancel the root token within {bound:?} of \
+             admission — a peer that admits a request and stops reading its response must not \
+             pin the session"
+        );
+
+        // The abandoned write is dropped (not merely deferred) on timeout,
+        // which releases rmcp's internal transport-write lock — so the
+        // post-cancellation drain's `close()` is not itself blocked on that
+        // same stuck write, and `waiting()` resolves promptly rather than
+        // riding out rmcp's multi-second drain window.
+        let reason = tokio::time::timeout(Duration::from_secs(2), running.waiting())
+            .await
+            .expect("rmcp never finished closing after the response-delivery deadline")
+            .expect("rmcp service task panicked");
+        assert!(
+            matches!(
+                reason,
+                rmcp::service::QuitReason::Closed | rmcp::service::QuitReason::Cancelled
+            ),
+            "unexpected rmcp quit reason after the response-delivery deadline: {reason:?}"
+        );
+        drop(client_io);
+    }
+
+    /// Distinguishes handler behavior by tool name: `"slow"` blocks for
+    /// `slow_delay` (keeping `in_flight` above zero across several idle
+    /// windows), `"quick"` (or anything else) completes immediately — used
+    /// to admit a second request while the first is still running.
+    #[derive(Clone)]
+    struct MixedDelayServer {
+        slow_started: Arc<tokio::sync::Notify>,
+        slow_delay: Duration,
+    }
+
+    impl rmcp::ServerHandler for MixedDelayServer {
+        fn call_tool(
+            &self,
+            request: rmcp::model::CallToolRequestParams,
+            _context: rmcp::service::RequestContext<rmcp::RoleServer>,
+        ) -> impl Future<Output = Result<rmcp::model::CallToolResult, McpError>> + Send + '_
+        {
+            let slow_started = self.slow_started.clone();
+            let slow_delay = self.slow_delay;
+            let is_slow = request.name.as_ref() == "slow";
+            async move {
+                if is_slow {
+                    slow_started.notify_one();
+                    tokio::time::sleep(slow_delay).await;
+                }
+                Ok(rmcp::model::CallToolResult::success(Vec::new()))
+            }
+        }
+    }
+
+    /// Regression: while an admitted request is still
+    /// running, deferring the idle close must not discard a second request
+    /// that arrives fragmented across the deferred window. Before the fix,
+    /// each deferral called `self.inner.receive()` fresh; rmcp's line-buffered
+    /// receive clears its buffer at the start of every call, so a chunk
+    /// already consumed before the timeout fired was silently dropped and
+    /// the remainder parsed as an invalid/garbage line — losing the second
+    /// request even though the session itself correctly stayed open.
+    #[tokio::test]
+    async fn stdio_idle_timeout_preserves_a_fragmented_request_while_another_is_in_flight() {
+        use rmcp::transport::async_rw::AsyncRwTransport;
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let slow_started = Arc::new(tokio::sync::Notify::new());
+        let slow_delay = Duration::from_millis(400);
+        let idle_timeout = Duration::from_millis(50);
+        let probe = MixedDelayServer {
+            slow_started: slow_started.clone(),
+            slow_delay,
+        };
+        let root = tokio_util::sync::CancellationToken::new();
+        let (server_io, client_io) = tokio::io::duplex(16 * 1024);
+        let (server_read, server_write) = tokio::io::split(server_io);
+        let transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
+            AsyncRwTransport::new_server(server_read, server_write),
+            root.clone(),
+            Some(idle_timeout),
+            None,
+        );
+        let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
+        let (mut client_read, mut client_write) = tokio::io::split(client_io);
+
+        // Admit request 1: the slow handler keeps `in_flight` above zero for
+        // `slow_delay`, so every idle window in between must be deferred
+        // rather than closing the session.
+        client_write
+            .write_all(
+                b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"slow\",\"arguments\":{}}}\n",
+            )
+            .await
+            .expect("write slow request");
+        tokio::time::timeout(Duration::from_secs(2), slow_started.notified())
+            .await
+            .expect("slow handler never started");
+
+        // While request 1 is still in flight, write request 2 split into two
+        // chunks with a gap longer than the idle timeout, so the deferred-
+        // close loop iterates at least once between them.
+        let full = "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\
+                     \"params\":{\"name\":\"quick\",\"arguments\":{}}}\n";
+        let full_bytes = full.as_bytes();
+        let split_at = full_bytes.len() / 2;
+        client_write
+            .write_all(&full_bytes[..split_at])
+            .await
+            .expect("write first half of the fragmented request");
+
+        tokio::time::sleep(idle_timeout * 3).await;
+        assert!(
+            !root.is_cancelled(),
+            "the still-running slow request must defer the idle close across the gap"
+        );
+
+        client_write
+            .write_all(&full_bytes[split_at..])
+            .await
+            .expect("write second half of the fragmented request");
+
+        // Both responses must arrive intact — id=1 once the slow handler
+        // finishes, id=2 as soon as the reassembled line is parsed.
+        let mut buf = vec![0u8; 8192];
+        let mut collected = String::new();
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        while !(collected.contains("\"id\":1") && collected.contains("\"id\":2")) {
+            if tokio::time::Instant::now() >= deadline {
+                panic!("did not receive both responses in time; got: {collected}");
+            }
+            let n = tokio::time::timeout(Duration::from_secs(2), client_read.read(&mut buf))
+                .await
+                .expect("read timed out waiting for a response")
+                .expect("read error on the client side of the duplex pipe");
+            collected.push_str(&String::from_utf8_lossy(&buf[..n]));
+        }
+        assert!(
+            collected.contains("\"id\":2"),
+            "the fragmented second request must be reassembled and answered intact; got: {collected}"
+        );
+
+        drop(client_write);
+        let _ = tokio::time::timeout(Duration::from_secs(2), running.waiting()).await;
     }
 
     #[tokio::test]
@@ -7449,5 +7992,39 @@ mod request_read_cancellation_tests {
                 );
             }
         }
+    }
+
+    // ── KHIVE_BRIDGE_RESPONSE_DEADLINE_SECS=0 must not disable the bound ──
+
+    /// The response-delivery deadline used to treat `0` as "disable
+    /// the bound", mirroring `KHIVE_BRIDGE_IDLE_TIMEOUT_SECS=0`. Unlike the
+    /// idle timeout, an unbounded response-delivery deadline restores the
+    /// exact defect this deadline exists to close (a peer that admits a
+    /// request and stops reading pins the bridge's response write forever)
+    /// — so `0` is now a hard startup error instead of a supported opt-out.
+    #[test]
+    #[serial_test::serial]
+    fn response_deadline_from_env_rejects_zero() {
+        std::env::set_var("KHIVE_BRIDGE_RESPONSE_DEADLINE_SECS", "0");
+        let result = stdio_bridge_response_deadline_from_env();
+        std::env::remove_var("KHIVE_BRIDGE_RESPONSE_DEADLINE_SECS");
+
+        let error = result.expect_err(
+            "KHIVE_BRIDGE_RESPONSE_DEADLINE_SECS=0 must be rejected, not silently accepted \
+             as \"disable the bound\"",
+        );
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("KHIVE_BRIDGE_RESPONSE_DEADLINE_SECS"),
+            "error must name the offending variable: {rendered}"
+        );
+        assert!(
+            rendered.contains("=0"),
+            "error must name the rejected value: {rendered}"
+        );
+        assert!(
+            rendered.contains("1..=u64::MAX"),
+            "error must state the accepted range: {rendered}"
+        );
     }
 }

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -7914,6 +7914,115 @@ mod request_read_cancellation_tests {
         let _ = tokio::time::timeout(Duration::from_secs(2), running.waiting()).await;
     }
 
+    /// Regression: an id whose obligation has gone STALE is still a duplicate.
+    ///
+    /// Staleness is a statement about the freshness check, not about the
+    /// handler: rmcp keeps a spawned handler alive independently of this
+    /// receive loop, so an entry past its TTL routinely names a request that
+    /// is still running and has simply not answered yet. If the staleness drop
+    /// runs before the duplicate scan, that entry is gone by the time the scan
+    /// looks, the reused id is admitted as a fresh obligation, and the first of
+    /// the two eventual responses retires the NEW entry by id match — leaving
+    /// the older live handler untracked and the idle branch free to close out
+    /// from under it. Scanning before pruning refuses the reuse instead.
+    ///
+    /// This is the arm the earlier ordering passed: the plain duplicate test
+    /// above uses an hour-long TTL, so its entry is never stale and the two
+    /// orderings are indistinguishable there.
+    ///
+    /// Idle reaping is off and the pipe is never closed, so the refusal is the
+    /// only thing that can end this session.
+    #[tokio::test]
+    async fn stdio_refuses_a_reused_id_whose_obligation_is_already_stale() {
+        use rmcp::transport::async_rw::AsyncRwTransport;
+        use tokio::io::AsyncWriteExt;
+
+        const OBLIGATION_TTL: Duration = Duration::from_millis(100);
+
+        let first_admitted = Arc::new(tokio::sync::Notify::new());
+        let probe = OutOfOrderProbeServer {
+            first_admitted: first_admitted.clone(),
+            // Parks forever on the first call: the handler outlives its TTL.
+            calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+        };
+        let root = tokio_util::sync::CancellationToken::new();
+        let (server_io, client_io) = tokio::io::duplex(16 * 1024);
+        let (server_read, server_write) = tokio::io::split(server_io);
+        let transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
+            AsyncRwTransport::new_server(server_read, server_write),
+            root.clone(),
+            // No idle timer: only the duplicate-id refusal can close this.
+            None,
+            None,
+            Some(OBLIGATION_TTL),
+        );
+        let obligations = transport.in_flight_handle();
+        let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
+        let (_client_read, mut client_write) = tokio::io::split(client_io);
+
+        let request = b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\
+                        \"params\":{\"name\":\"probe\",\"arguments\":{}}}\n";
+        client_write
+            .write_all(request)
+            .await
+            .expect("write the first request");
+        tokio::time::timeout(Duration::from_secs(2), first_admitted.notified())
+            .await
+            .expect("rmcp never admitted the first request");
+
+        tokio::time::sleep(OBLIGATION_TTL * 3).await;
+
+        // Premise, asserted rather than assumed: the entry is still in the
+        // queue AND the transport's own freshness rule already calls it stale.
+        // Both halves matter — a test that only slept would pass against a
+        // build that pruned the entry, since an empty queue also admits the
+        // reuse without closing, which is the very defect under test.
+        {
+            let queue = obligations.lock().expect("obligation queue poisoned");
+            let (id, admitted_at) = queue
+                .front()
+                .expect(
+                    "fixture premise: the unanswered obligation must still be queued when the \
+                     reused id arrives; an empty queue means something pruned it and this test \
+                     can no longer distinguish the orderings",
+                )
+                .clone();
+            assert_eq!(
+                id,
+                rmcp::model::NumberOrString::Number(1),
+                "fixture premise: the queued entry must be the request under test"
+            );
+            assert!(
+                admitted_at.elapsed() >= OBLIGATION_TTL,
+                "fixture premise: the entry must already be STALE by the transport's own rule, \
+                 otherwise this is just the plain duplicate case"
+            );
+        }
+        assert!(
+            !root.is_cancelled(),
+            "fixture premise: a single outstanding request must not have closed the session"
+        );
+
+        client_write
+            .write_all(request)
+            .await
+            .expect("write the request reusing the stale id");
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while !root.is_cancelled() && std::time::Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(
+            root.is_cancelled(),
+            "reusing an id whose obligation is stale but whose handler is still alive must close \
+             the session. Admitting it lets the first response retire the wrong entry, which \
+             leaves a live handler untracked and the idle close free to fire under it."
+        );
+
+        drop(client_write);
+        let _ = tokio::time::timeout(Duration::from_secs(2), running.waiting()).await;
+    }
+
     /// Regression: the obligation queue must not grow without bound.
     ///
     /// Retirement is keyed by request id, so it only ever removes the entry
@@ -8028,13 +8137,12 @@ mod request_read_cancellation_tests {
     /// admissions, on top of the TTL. That is the leak the TTL closes,
     /// reintroduced behind a timer.
     ///
-    /// The fixture makes the gap the discriminator. Request 1 parks forever;
-    /// request 2 is admitted `ADMISSION_GAP` later and completes. Retiring by
-    /// id leaves request 1's instant, so the session closes at roughly
-    /// `OBLIGATION_TTL` after request 1. Retiring oldest-first leaves request
-    /// 2's, so it closes at roughly `ADMISSION_GAP + OBLIGATION_TTL`. The
-    /// assertion sits between the two, far enough from both that it measures
-    /// the guard rather than the scheduler.
+    /// The fixture makes the surviving queue entry the discriminator. Request
+    /// 1 parks forever; request 2 is admitted `ADMISSION_GAP` later and
+    /// completes. Both behaviours leave the queue holding exactly one entry,
+    /// so the test reads WHICH one through the transport's obligation handle:
+    /// retiring by id leaves request 1, retiring oldest-first leaves request
+    /// 2. That comparison is exact and involves no wall clock.
     #[tokio::test]
     async fn stdio_idle_timeout_reaps_on_the_older_obligation_when_a_newer_one_completes_first() {
         use rmcp::transport::async_rw::AsyncRwTransport;
@@ -8046,9 +8154,6 @@ mod request_read_cancellation_tests {
         // out and the session closes before request 2 is ever admitted.
         const ADMISSION_GAP: Duration = Duration::from_millis(1500);
         const OBLIGATION_TTL: Duration = Duration::from_millis(2000);
-        // Correct behaviour closes at ~2000ms after request 1; the defect
-        // closes at ~3500ms. 2750ms is the midpoint, 750ms clear of each.
-        const DISCRIMINATING_DEADLINE: Duration = Duration::from_millis(2750);
 
         let first_admitted = Arc::new(tokio::sync::Notify::new());
         let probe = OutOfOrderProbeServer {
@@ -8065,6 +8170,7 @@ mod request_read_cancellation_tests {
             None,
             Some(OBLIGATION_TTL),
         );
+        let obligations = transport.in_flight_handle();
         let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
         let (mut client_read, mut client_write) = tokio::io::split(client_io);
 
@@ -8106,6 +8212,57 @@ mod request_read_cancellation_tests {
             "expected the SECOND request's response to arrive first, got: {response}"
         );
 
+        // The discriminator is the IDENTITY of the surviving entry, read
+        // straight out of the queue, not when the session happens to close.
+        // Both behaviours leave exactly one entry, so length alone proves
+        // nothing and is used here only to synchronize: retirement runs after
+        // the response write resolves, which is not ordered against the
+        // client's read returning. Once the queue has settled to one entry,
+        // retiring by id leaves request 1 (still outstanding) and retiring
+        // oldest-first leaves request 2 (already completed).
+        //
+        // An earlier version of this test asserted instead that the close
+        // landed before a 2750ms midpoint between the correct ~2000ms and the
+        // defect's ~3500ms. That measured the scheduler as much as the guard:
+        // a loaded worker that delays polling the receive task or the timer by
+        // more than the 750ms margin fails a correct implementation. Nothing
+        // below reads a wall clock.
+        let settle_deadline = Duration::from_secs(10);
+        let settled_at = Instant::now();
+        loop {
+            let len = obligations.lock().expect("obligation queue poisoned").len();
+            if len == 1 {
+                break;
+            }
+            assert!(
+                settled_at.elapsed() < settle_deadline,
+                "the obligation queue never settled to a single entry after the second \
+                 request's response was read; it holds {len}"
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        let surviving = obligations
+            .lock()
+            .expect("obligation queue poisoned")
+            .front()
+            .expect("the queue settled to one entry, so it has a front")
+            .0
+            .clone();
+        assert_eq!(
+            surviving,
+            rmcp::model::NumberOrString::Number(1),
+            "the entry left outstanding must be request 1, whose handler never answered. \
+             Finding request 2 here means the completed request's response retired the OLDEST \
+             entry rather than its own, so the outstanding request's admission instant was \
+             dropped and the idle close would be deferred by the {}ms admission gap on top of \
+             the {}ms TTL.",
+            ADMISSION_GAP.as_millis(),
+            OBLIGATION_TTL.as_millis(),
+        );
+
+        // The close itself is still asserted, bounded generously: this arm is
+        // about the timer firing at all, and a late close fails it only by
+        // exceeding a deadline no correct run approaches.
         let hard_deadline = Duration::from_secs(10);
         while !root.is_cancelled() && admitted_first.elapsed() < hard_deadline {
             tokio::time::sleep(Duration::from_millis(20)).await;
@@ -8113,17 +8270,6 @@ mod request_read_cancellation_tests {
         assert!(
             root.is_cancelled(),
             "the session must close once the older obligation passes its TTL"
-        );
-        let closed_after = admitted_first.elapsed();
-        assert!(
-            closed_after < DISCRIMINATING_DEADLINE,
-            "the session must close on the OLDER obligation's TTL (~{}ms after its admission), \
-             not on the newer completed request's (~{}ms). Closed at {}ms, which means the \
-             completed request's admission instant was left in the queue and the outstanding \
-             one was dropped.",
-            OBLIGATION_TTL.as_millis(),
-            (ADMISSION_GAP + OBLIGATION_TTL).as_millis(),
-            closed_after.as_millis(),
         );
 
         drop(client_write);
@@ -8315,6 +8461,36 @@ mod request_read_cancellation_tests {
         }
     }
 
+    /// Read half that reports how many bytes it has actually handed to its
+    /// caller. `write_all` into a duplex pipe proves only that bytes reached
+    /// the buffer; the invariant in the fragmentation test below is about what
+    /// the server's receive future did with them, so the test needs to observe
+    /// consumption rather than delivery.
+    struct CountingReader<R> {
+        inner: R,
+        delivered: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    impl<R: tokio::io::AsyncRead + Unpin> tokio::io::AsyncRead for CountingReader<R> {
+        fn poll_read(
+            self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+            buf: &mut tokio::io::ReadBuf<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            let this = self.get_mut();
+            let before = buf.filled().len();
+            let poll = std::pin::Pin::new(&mut this.inner).poll_read(cx, buf);
+            if matches!(poll, std::task::Poll::Ready(Ok(()))) {
+                let read = buf.filled().len() - before;
+                if read > 0 {
+                    this.delivered
+                        .fetch_add(read, std::sync::atomic::Ordering::SeqCst);
+                }
+            }
+            poll
+        }
+    }
+
     /// Regression: while an admitted request is still
     /// running, deferring the idle close must not discard a second request
     /// that arrives fragmented across the deferred window. Before the fix,
@@ -8323,6 +8499,12 @@ mod request_read_cancellation_tests {
     /// already consumed before the timeout fired was silently dropped and
     /// the remainder parsed as an invalid/garbage line — losing the second
     /// request even though the session itself correctly stayed open.
+    ///
+    /// The first fragment must be proven CONSUMED before the idle window
+    /// elapses, or the test does not exercise the invariant it names: in any
+    /// execution where the reader had not yet run, a fresh-receive
+    /// implementation discards nothing and passes. `CountingReader` supplies
+    /// that barrier.
     #[tokio::test]
     async fn stdio_idle_timeout_preserves_a_fragmented_request_while_another_is_in_flight() {
         use rmcp::transport::async_rw::AsyncRwTransport;
@@ -8338,6 +8520,11 @@ mod request_read_cancellation_tests {
         let root = tokio_util::sync::CancellationToken::new();
         let (server_io, client_io) = tokio::io::duplex(16 * 1024);
         let (server_read, server_write) = tokio::io::split(server_io);
+        let consumed = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let server_read = CountingReader {
+            inner: server_read,
+            delivered: Arc::clone(&consumed),
+        };
         let transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
             AsyncRwTransport::new_server(server_read, server_write),
             root.clone(),
@@ -8368,10 +8555,26 @@ mod request_read_cancellation_tests {
                      \"params\":{\"name\":\"quick\",\"arguments\":{}}}\n";
         let full_bytes = full.as_bytes();
         let split_at = full_bytes.len() / 2;
+        let baseline = consumed.load(std::sync::atomic::Ordering::SeqCst);
         client_write
             .write_all(&full_bytes[..split_at])
             .await
             .expect("write first half of the fragmented request");
+
+        // Barrier: the fragment must be inside the server's line buffer before
+        // the idle window elapses, otherwise this test proves nothing. Waiting
+        // on the byte counter rather than on a sleep is what makes the
+        // discarded-prefix scenario actually occur on every run.
+        let want = baseline + split_at;
+        let barrier_deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        while consumed.load(std::sync::atomic::Ordering::SeqCst) < want {
+            assert!(
+                tokio::time::Instant::now() < barrier_deadline,
+                "the server never consumed the first fragment: {} of {want} bytes delivered",
+                consumed.load(std::sync::atomic::Ordering::SeqCst),
+            );
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
 
         tokio::time::sleep(idle_timeout * 3).await;
         assert!(

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -995,27 +995,76 @@ fn stdio_serve_mode_for(resumed_generation: Option<u32>) -> StdioServeMode {
     }
 }
 
-/// Idle timeout for a stdio bridge session: no request for this long
-/// and the session closes (see [`crate::transport::CancelOnEofTransport`]),
-/// releasing its reader-pool admission and DB connection — a client that
-/// comes back simply respawns the bridge, seamlessly from its perspective.
+/// Optional idle timeout for a stdio bridge session: when configured, no
+/// request for this long and the session closes (see
+/// [`crate::transport::CancelOnEofTransport`]), releasing its reader-pool
+/// admission and DB connection — a client that comes back simply respawns the
+/// bridge, seamlessly from its perspective.
 /// This closes only a genuinely idle session: an admitted request with a
 /// response still being written — running long, or delivered slowly to a
 /// backpressured reader — defers the close rather than being cancelled out
 /// from under it, up to the separate response-delivery bound documented on
 /// [`stdio_bridge_response_deadline_from_env`].
 ///
-/// Overridable via `KHIVE_BRIDGE_IDLE_TIMEOUT_SECS`; `0` disables it (an
-/// explicit opt-out, e.g. for a debugger holding a session open on purpose).
-/// An unparsable value falls back to the default rather than panicking or
-/// disabling the timeout outright, matching this codebase's other
-/// `_from_env` helpers. Default: 3600s (60 minutes) — generous enough that
-/// ordinary gaps between requests in a live session never trip it, short
-/// enough that an abandoned bridge does not pin a reader-pool slot / WAL
-/// connection for hours or days.
+/// **Off unless configured, and that is a deliberate reading of existing
+/// repository law rather than caution.** ADR-091 enumerates "kill long-lived
+/// reader sessions" among its rejected alternatives, on the ground that
+/// long-lived stdio sessions are live Claude Code instances and closing them
+/// by age is a worse user experience than bounding what they hold underneath
+/// them. Closing a session after an hour of quiet is that rejected policy
+/// whatever the mechanism, because this transport has no signal that
+/// separates an abandoned pipe from a live client that simply has not been
+/// asked anything. Defaulting it on would reverse an accepted decision from
+/// inside an unrelated change, so the default is off and turning it on is an
+/// operator's explicit act — a supervised deployment, a CI harness, or any
+/// context where session churn is cheap and a pinned WAL connection is not.
+/// Making it the default requires amending ADR-091, not a different number
+/// here.
+///
+/// Set `KHIVE_BRIDGE_IDLE_TIMEOUT_SECS` to a positive number of seconds to
+/// enable it. `0`, absent, and unparsable all leave it disabled; unparsable
+/// falls back rather than panicking, matching this codebase's other
+/// `_from_env` helpers, and it falls back to *disabled* because a typo must
+/// never silently start closing live sessions. 3600 is the suggested value
+/// where it is wanted: long enough that ordinary gaps in a live session never
+/// trip it.
 fn stdio_bridge_idle_timeout_from_env() -> Option<std::time::Duration> {
-    const DEFAULT_SECS: u64 = 3600;
     let secs = std::env::var("KHIVE_BRIDGE_IDLE_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(0);
+    if secs == 0 {
+        None
+    } else {
+        Some(std::time::Duration::from_secs(secs))
+    }
+}
+
+/// How long an admitted request whose response has not been written keeps
+/// deferring the idle close.
+///
+/// The idle check must not treat a session with work outstanding as idle, or
+/// it cancels a running handler out from under itself. But rmcp spawns each
+/// request handler and drops the join handle, so a handler that panics never
+/// reaches the response construction that would clear its obligation. Deferring
+/// on an outstanding obligation with no bound therefore hands any panicking
+/// handler the power to disable idle reaping for the life of the session — the
+/// exact unbounded lifetime the idle timeout exists to close, reintroduced
+/// through the guard that protects it.
+///
+/// This bound is separate from the idle window on purpose. Reusing the idle
+/// window would mean a handler that runs longer than one quiet window stops
+/// protecting its own session, which is the guarantee the obligation exists to
+/// provide. It is set far above any real handler and answers a different
+/// question: not "has this session been quiet" but "has this request been
+/// outstanding so long that its handler must be gone".
+///
+/// Overridable via `KHIVE_BRIDGE_REQUEST_OBLIGATION_SECS`; `0` disables the
+/// bound, restoring the unbounded defer. An unparsable value falls back to the
+/// default. Default: 3600s.
+fn stdio_bridge_request_obligation_ttl_from_env() -> Option<std::time::Duration> {
+    const DEFAULT_SECS: u64 = 3600;
+    let secs = std::env::var("KHIVE_BRIDGE_REQUEST_OBLIGATION_SECS")
         .ok()
         .and_then(|v| v.trim().parse::<u64>().ok())
         .unwrap_or(DEFAULT_SECS);
@@ -1494,6 +1543,7 @@ impl KhiveMcpServer {
                 root,
                 idle_timeout,
                 Some(response_deadline),
+                stdio_bridge_request_obligation_ttl_from_env(),
             )
         };
 
@@ -1538,6 +1588,7 @@ impl KhiveMcpServer {
             root.clone(),
             stdio_bridge_idle_timeout_from_env(),
             Some(response_deadline),
+            stdio_bridge_request_obligation_ttl_from_env(),
         );
         let service = self.serve_with_ct(transport, root).await?;
         service.waiting().await?;
@@ -7416,6 +7467,7 @@ mod request_read_cancellation_tests {
             root.clone(),
             None,
             None,
+            Some(Duration::from_secs(3600)),
         );
         let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
 
@@ -7471,6 +7523,7 @@ mod request_read_cancellation_tests {
             root.clone(),
             Some(Duration::from_millis(50)),
             None,
+            Some(Duration::from_secs(3600)),
         );
         let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
 
@@ -7530,6 +7583,7 @@ mod request_read_cancellation_tests {
             root.clone(),
             Some(idle_timeout),
             None,
+            Some(Duration::from_secs(3600)),
         );
         let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
 
@@ -7624,6 +7678,7 @@ mod request_read_cancellation_tests {
             root.clone(),
             Some(idle_timeout),
             None,
+            Some(Duration::from_secs(3600)),
         );
         let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
         let (mut client_read, mut client_write) = tokio::io::split(client_io);
@@ -7662,6 +7717,87 @@ mod request_read_cancellation_tests {
         let _ = tokio::time::timeout(Duration::from_secs(2), running.waiting()).await;
     }
 
+    /// A handler that never answers must not disable idle reaping for the life
+    /// of the session.
+    ///
+    /// rmcp spawns each request handler with `spawn_service_task` and drops the
+    /// join handle, so a panicking handler never reaches the response
+    /// construction that clears its obligation. The observable at this
+    /// transport is exactly "an admitted request whose response never arrives",
+    /// which is what this fixture produces directly — a handler that parks
+    /// forever. Driving a real panic through rmcp would test rmcp's task
+    /// plumbing rather than this guard, and would give the same observable.
+    ///
+    /// Without the obligation TTL the idle branch defers on every window
+    /// forever and this test hangs at its final assertion. With it, the
+    /// obligation stops counting as evidence of life once it is older than the
+    /// TTL, and the next idle window closes the session.
+    #[tokio::test]
+    async fn stdio_idle_timeout_reaps_a_session_whose_handler_never_answers() {
+        use rmcp::transport::async_rw::AsyncRwTransport;
+        use std::time::Instant;
+        use tokio::io::AsyncWriteExt;
+
+        let started = Arc::new(tokio::sync::Notify::new());
+        let idle_timeout = Duration::from_millis(50);
+        // Longer than the idle window, so the obligation genuinely defers at
+        // least one window before ageing out — otherwise this test would pass
+        // even with the freshness check wired to a constant `false`.
+        let obligation_ttl = Duration::from_millis(150);
+        let probe = SlowProbeServer {
+            started: started.clone(),
+            // Far beyond the test's own timeout: the handler never answers.
+            delay: Duration::from_secs(3600),
+        };
+        let root = tokio_util::sync::CancellationToken::new();
+        let (server_io, client_io) = tokio::io::duplex(16 * 1024);
+        let (server_read, server_write) = tokio::io::split(server_io);
+        let transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
+            AsyncRwTransport::new_server(server_read, server_write),
+            root.clone(),
+            Some(idle_timeout),
+            None,
+            Some(obligation_ttl),
+        );
+        let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
+        let (_client_read, mut client_write) = tokio::io::split(client_io);
+
+        client_write
+            .write_all(
+                b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"probe\",\"arguments\":{}}}\n",
+            )
+            .await
+            .expect("write one real JSON-RPC tool request");
+
+        tokio::time::timeout(Duration::from_secs(2), started.notified())
+            .await
+            .expect("rmcp never admitted the request handler");
+
+        // While the obligation is still fresh it must protect the session, or
+        // this test would also pass against a build that simply ignores
+        // in-flight work.
+        tokio::time::sleep(idle_timeout + idle_timeout / 2).await;
+        assert!(
+            !root.is_cancelled(),
+            "a fresh obligation must still defer the idle close"
+        );
+
+        // Past the TTL the obligation stops being evidence of life. The pipe is
+        // deliberately still open: only the timeout can end this session.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !root.is_cancelled() && Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(
+            root.is_cancelled(),
+            "an obligation older than the TTL must stop deferring the idle close, or a \
+             handler that never answers disables idle reaping for the life of the session"
+        );
+
+        drop(client_write);
+        let _ = tokio::time::timeout(Duration::from_secs(2), running.waiting()).await;
+    }
+
     /// Regression: a request must stay "in flight" — and
     /// therefore protected from the idle-close branch — until its response
     /// has actually *finished writing*, not merely been handed to
@@ -7691,6 +7827,7 @@ mod request_read_cancellation_tests {
             root.clone(),
             Some(idle_timeout),
             None,
+            Some(Duration::from_secs(3600)),
         );
         let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
 
@@ -7743,6 +7880,7 @@ mod request_read_cancellation_tests {
             root.clone(),
             None,
             Some(response_deadline),
+            Some(Duration::from_secs(3600)),
         );
         let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
 
@@ -7847,6 +7985,7 @@ mod request_read_cancellation_tests {
             root.clone(),
             Some(idle_timeout),
             None,
+            Some(Duration::from_secs(3600)),
         );
         let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
         let (mut client_read, mut client_write) = tokio::io::split(client_io);

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -7713,6 +7713,10 @@ mod request_read_cancellation_tests {
             "expected a JSON-RPC response for request id=1, got: {response}"
         );
 
+        // The obligation is discharged and the wire is quiet, but the pipe is
+        // still open — so only the timer can end this session now.
+        assert_idle_timer_was_armed(&root, idle_timeout).await;
+
         drop(client_write);
         let _ = tokio::time::timeout(Duration::from_secs(2), running.waiting()).await;
     }
@@ -7798,6 +7802,177 @@ mod request_read_cancellation_tests {
         let _ = tokio::time::timeout(Duration::from_secs(2), running.waiting()).await;
     }
 
+    /// Positive oracle for the "does not cancel" tests.
+    ///
+    /// Each of those asserts a NON-event: that the idle timer did not fire
+    /// while something legitimate was in flight. A non-event passes just as
+    /// well against a build where the timer was never armed at all, so on its
+    /// own such a test cannot tell "correctly deferred" from "never
+    /// configured". This closes that hole from the other side: once whatever
+    /// was protecting the session is gone, the timer must actually close it —
+    /// **with the pipe still open**, so nothing but the timer can be what ended
+    /// the session. Call it before dropping the client side.
+    async fn assert_idle_timer_was_armed(
+        root: &tokio_util::sync::CancellationToken,
+        idle_timeout: Duration,
+    ) {
+        let deadline = std::time::Instant::now() + idle_timeout * 40 + Duration::from_secs(1);
+        while !root.is_cancelled() && std::time::Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(
+            root.is_cancelled(),
+            "the idle timer must close this session once nothing is protecting it, while the \
+             pipe is still open. Without this the non-cancellation assertion above would pass \
+             against a build whose idle timer was never armed."
+        );
+    }
+
+    /// Parks forever on the first call and answers every later one promptly,
+    /// so a test can produce out-of-order response completion: the request
+    /// admitted first stays outstanding while a later one completes.
+    #[derive(Clone)]
+    struct OutOfOrderProbeServer {
+        first_admitted: Arc<tokio::sync::Notify>,
+        calls: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    impl rmcp::ServerHandler for OutOfOrderProbeServer {
+        fn call_tool(
+            &self,
+            _request: rmcp::model::CallToolRequestParams,
+            _context: rmcp::service::RequestContext<rmcp::RoleServer>,
+        ) -> impl Future<Output = Result<rmcp::model::CallToolResult, McpError>> + Send + '_
+        {
+            let first_admitted = self.first_admitted.clone();
+            let calls = self.calls.clone();
+            async move {
+                if calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst) == 0 {
+                    first_admitted.notify_one();
+                    // Never answers. This is the older obligation, and it is
+                    // the one whose TTL must govern when the session closes.
+                    tokio::time::sleep(Duration::from_secs(3600)).await;
+                }
+                Ok(rmcp::model::CallToolResult::success(Vec::new()))
+            }
+        }
+    }
+
+    /// High-severity regression: obligations must be retired by request id,
+    /// not oldest-first.
+    ///
+    /// rmcp spawns each handler and each response send independently, so a
+    /// newer request's response can finish before an older request's. Retiring
+    /// the oldest entry on any completion drops the *outstanding* request's
+    /// admission instant and leaves the *completed* one as the newest entry.
+    /// The freshness test then reads the completed request's timestamp, and the
+    /// idle close is deferred until that later instant ages out — so a handler
+    /// that never answers still delays reaping by the gap between the two
+    /// admissions, on top of the TTL. That is the leak the TTL closes,
+    /// reintroduced behind a timer.
+    ///
+    /// The fixture makes the gap the discriminator. Request 1 parks forever;
+    /// request 2 is admitted `ADMISSION_GAP` later and completes. Retiring by
+    /// id leaves request 1's instant, so the session closes at roughly
+    /// `OBLIGATION_TTL` after request 1. Retiring oldest-first leaves request
+    /// 2's, so it closes at roughly `ADMISSION_GAP + OBLIGATION_TTL`. The
+    /// assertion sits between the two, far enough from both that it measures
+    /// the guard rather than the scheduler.
+    #[tokio::test]
+    async fn stdio_idle_timeout_reaps_on_the_older_obligation_when_a_newer_one_completes_first() {
+        use rmcp::transport::async_rw::AsyncRwTransport;
+        use std::time::Instant;
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        const IDLE_TIMEOUT: Duration = Duration::from_millis(50);
+        // The gap must be SHORTER than the TTL, or request 1's obligation ages
+        // out and the session closes before request 2 is ever admitted.
+        const ADMISSION_GAP: Duration = Duration::from_millis(1500);
+        const OBLIGATION_TTL: Duration = Duration::from_millis(2000);
+        // Correct behaviour closes at ~2000ms after request 1; the defect
+        // closes at ~3500ms. 2750ms is the midpoint, 750ms clear of each.
+        const DISCRIMINATING_DEADLINE: Duration = Duration::from_millis(2750);
+
+        let first_admitted = Arc::new(tokio::sync::Notify::new());
+        let probe = OutOfOrderProbeServer {
+            first_admitted: first_admitted.clone(),
+            calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+        };
+        let root = tokio_util::sync::CancellationToken::new();
+        let (server_io, client_io) = tokio::io::duplex(16 * 1024);
+        let (server_read, server_write) = tokio::io::split(server_io);
+        let transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
+            AsyncRwTransport::new_server(server_read, server_write),
+            root.clone(),
+            Some(IDLE_TIMEOUT),
+            None,
+            Some(OBLIGATION_TTL),
+        );
+        let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
+        let (mut client_read, mut client_write) = tokio::io::split(client_io);
+
+        client_write
+            .write_all(
+                b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"probe\",\"arguments\":{}}}\n",
+            )
+            .await
+            .expect("write the request that will never be answered");
+        tokio::time::timeout(Duration::from_secs(2), first_admitted.notified())
+            .await
+            .expect("rmcp never admitted the first request handler");
+        let admitted_first = Instant::now();
+
+        tokio::time::sleep(ADMISSION_GAP).await;
+        assert!(
+            !root.is_cancelled(),
+            "the first obligation is still inside its TTL and must defer the idle close, \
+             otherwise the second request is never admitted and this test proves nothing"
+        );
+
+        client_write
+            .write_all(
+                b"{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"probe\",\"arguments\":{}}}\n",
+            )
+            .await
+            .expect("write the request that completes first");
+
+        // Read it, so the response WRITE finishes and its obligation is
+        // actually retired — handing the response to `send` is not enough.
+        let mut buf = vec![0u8; 4096];
+        let n = tokio::time::timeout(Duration::from_secs(2), client_read.read(&mut buf))
+            .await
+            .expect("the second handler never produced its response")
+            .expect("read error on the client side of the duplex pipe");
+        let response = String::from_utf8_lossy(&buf[..n]);
+        assert!(
+            response.contains("\"id\":2"),
+            "expected the SECOND request's response to arrive first, got: {response}"
+        );
+
+        let hard_deadline = Duration::from_secs(10);
+        while !root.is_cancelled() && admitted_first.elapsed() < hard_deadline {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(
+            root.is_cancelled(),
+            "the session must close once the older obligation passes its TTL"
+        );
+        let closed_after = admitted_first.elapsed();
+        assert!(
+            closed_after < DISCRIMINATING_DEADLINE,
+            "the session must close on the OLDER obligation's TTL (~{}ms after its admission), \
+             not on the newer completed request's (~{}ms). Closed at {}ms, which means the \
+             completed request's admission instant was left in the queue and the outstanding \
+             one was dropped.",
+            OBLIGATION_TTL.as_millis(),
+            (ADMISSION_GAP + OBLIGATION_TTL).as_millis(),
+            closed_after.as_millis(),
+        );
+
+        drop(client_write);
+        let _ = tokio::time::timeout(Duration::from_secs(2), running.waiting()).await;
+    }
+
     /// Regression: a request must stay "in flight" — and
     /// therefore protected from the idle-close branch — until its response
     /// has actually *finished writing*, not merely been handed to
@@ -7847,6 +8022,32 @@ mod request_read_cancellation_tests {
             !root.is_cancelled(),
             "an admitted request's still-undelivered response must not be read as an idle session"
         );
+
+        // Drain the response so the write completes and its obligation is
+        // retired. Nothing is protecting the session after that, and the pipe
+        // is still open, so the timer must be what closes it.
+        {
+            use tokio::io::AsyncReadExt;
+            let mut buf = vec![0u8; 4096];
+            let mut seen = String::new();
+            // Drain to the frame terminator, not to some substring inside the
+            // frame: `"id":1` lands in the first few bytes, and stopping there
+            // would leave the tail undrained, the write still pending, and the
+            // obligation therefore never retired.
+            while !seen.contains('\n') {
+                let n = tokio::time::timeout(Duration::from_secs(2), client_io.read(&mut buf))
+                    .await
+                    .expect("the backpressured response never drained")
+                    .expect("read error on the client side of the duplex pipe");
+                assert!(n > 0, "the pipe closed before the response fully drained");
+                seen.push_str(&String::from_utf8_lossy(&buf[..n]));
+            }
+            assert!(
+                seen.contains("\"id\":1"),
+                "the drained frame must be the response to the admitted request, got: {seen:?}"
+            );
+        }
+        assert_idle_timer_was_armed(&root, idle_timeout).await;
 
         drop(client_io);
         let _ = tokio::time::timeout(Duration::from_secs(2), running.waiting()).await;
@@ -8045,6 +8246,10 @@ mod request_read_cancellation_tests {
             collected.contains("\"id\":2"),
             "the fragmented second request must be reassembled and answered intact; got: {collected}"
         );
+
+        // Both obligations are discharged and the pipe is still open, so only
+        // the timer can end this session.
+        assert_idle_timer_was_armed(&root, idle_timeout).await;
 
         drop(client_write);
         let _ = tokio::time::timeout(Duration::from_secs(2), running.waiting()).await;

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -7828,6 +7828,77 @@ mod request_read_cancellation_tests {
         );
     }
 
+    /// Regression: the obligation queue must not grow without bound.
+    ///
+    /// Retirement is keyed by request id, so it only ever removes the entry
+    /// whose response was actually written. A request that never produces one
+    /// — a handler that panics, a request the peer cancels — leaves its entry
+    /// behind. Under the earlier oldest-first retirement any completion
+    /// removed *some* entry, so the queue tracked admissions minus
+    /// completions; keying by id means an unanswered request now holds its
+    /// slot for the life of the session unless something drops it.
+    ///
+    /// Nothing here waits on the idle timer: it is disabled, so the only thing
+    /// that can bound this queue is the staleness drop.
+    #[tokio::test]
+    async fn stdio_obligation_queue_drops_entries_past_their_ttl() {
+        use rmcp::transport::async_rw::AsyncRwTransport;
+        use tokio::io::AsyncWriteExt;
+
+        const OBLIGATION_TTL: Duration = Duration::from_millis(100);
+        // Longer than the TTL, so every earlier admission is already stale by
+        // the time the next one arrives and the queue can never hold two.
+        const ADMISSION_GAP: Duration = Duration::from_millis(150);
+        const ADMISSIONS: u32 = 4;
+
+        let probe = SlowProbeServer {
+            started: Arc::new(tokio::sync::Notify::new()),
+            // Never answers, so nothing is ever retired by id.
+            delay: Duration::from_secs(3600),
+        };
+        let root = tokio_util::sync::CancellationToken::new();
+        let (server_io, mut client_io) = tokio::io::duplex(16 * 1024);
+        let (server_read, server_write) = tokio::io::split(server_io);
+        let transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
+            AsyncRwTransport::new_server(server_read, server_write),
+            root.clone(),
+            // Idle reaping off: this test is about the queue, not the timer.
+            None,
+            None,
+            Some(OBLIGATION_TTL),
+        );
+        let obligations = transport.in_flight_handle();
+        let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
+
+        for id in 1..=ADMISSIONS {
+            client_io
+                .write_all(
+                    format!(
+                        "{{\"jsonrpc\":\"2.0\",\"id\":{id},\"method\":\"tools/call\",\
+                         \"params\":{{\"name\":\"probe\",\"arguments\":{{}}}}}}\n"
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .expect("write request");
+            tokio::time::sleep(ADMISSION_GAP).await;
+        }
+
+        let outstanding = obligations.lock().expect("obligation queue poisoned").len();
+        assert!(
+            outstanding <= 1,
+            "an unanswered request must not hold its obligation slot past the TTL: after \
+             {ADMISSIONS} admissions spaced {}ms apart against a {}ms TTL the queue holds \
+             {outstanding} entries. Without the staleness drop it would hold {ADMISSIONS}, one \
+             per admission, and would keep growing for as long as the session lives.",
+            ADMISSION_GAP.as_millis(),
+            OBLIGATION_TTL.as_millis(),
+        );
+
+        drop(client_io);
+        let _ = tokio::time::timeout(Duration::from_secs(2), running.waiting()).await;
+    }
+
     /// Parks forever on the first call and answers every later one promptly,
     /// so a test can produce out-of-order response completion: the request
     /// admitted first stays outstanding while a later one completes.

--- a/crates/khive-mcp/src/transport.rs
+++ b/crates/khive-mcp/src/transport.rs
@@ -5,9 +5,9 @@
 //! transports (e.g. Streamable HTTP) register with [`TransportRegistry::register`]
 //! before serving, so the serve path never hard-codes a transport enum.
 
-use std::collections::BTreeMap;
-use std::sync::atomic::{AtomicI64, Ordering};
-use std::sync::Arc;
+use std::collections::{BTreeMap, VecDeque};
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 use async_trait::async_trait;
 
@@ -52,11 +52,33 @@ use crate::server::KhiveMcpServer;
 /// through `receive()` returning `None` on its own, so this counter must
 /// not be the thing that gets stuck open forever on a write error.
 ///
+/// **An obligation is evidence of life only while it is fresh.** rmcp spawns
+/// each request handler with `spawn_service_task` and drops the join handle
+/// (`rmcp::service`), so a handler that panics never reaches the response
+/// construction that would let this transport decrement. A bare counter would
+/// then stay positive for the life of the process and the idle branch would
+/// defer forever — the precise unbounded lifetime this type exists to close,
+/// reintroduced through its own guard. `in_flight` therefore records the
+/// *instant* each request was admitted, and the idle branch defers only while
+/// the newest outstanding obligation is younger than `obligation_ttl`. An
+/// obligation older than that is not distinguishable, by any signal available
+/// at the transport, from a handler that died without answering.
+///
+/// `obligation_ttl` is deliberately NOT the idle window. Tying the two
+/// together would make a long-running handler stop protecting its own session
+/// after a single quiet window, which is the guarantee this counter exists to
+/// provide. It is its own bound, set well above any real handler, and it
+/// answers a different question: not "has this session been quiet" but "has
+/// this request been outstanding so long that the handler must be gone".
+/// `None` restores the unbounded defer, and with it the leak — it exists for
+/// callers that do not enable idle reaping at all, where the defer decision is
+/// never reached.
+///
 /// A response write that never resolves — a peer that admits a request,
 /// then stops reading its response while keeping the pipe open — would
 /// otherwise pin this session (and its reader-pool admission / DB
-/// connection) forever: `in_flight` would never return to zero, so the idle
-/// check above would defer indefinitely. `response_deadline` bounds the
+/// connection) forever: the obligation would never clear, so the idle
+/// check above would defer for as long as the freshness rule allows. `response_deadline` bounds the
 /// write itself (see [`Self::send`]) rather than the idle check: rmcp's
 /// underlying `AsyncRwTransport` serializes writes through a
 /// `tokio::sync::Mutex` held across the pending write's `.await`, so a
@@ -71,7 +93,13 @@ pub(crate) struct CancelOnEofTransport<T> {
     root: tokio_util::sync::CancellationToken,
     idle_timeout: Option<std::time::Duration>,
     response_deadline: Option<std::time::Duration>,
-    in_flight: Arc<AtomicI64>,
+    /// Admission instants of requests handed to rmcp whose response has not
+    /// finished writing. Ordered oldest-first; see the type doc for why the
+    /// instants matter and not just the count.
+    in_flight: Arc<Mutex<VecDeque<Instant>>>,
+    /// How long an outstanding request keeps deferring the idle close. `None`
+    /// defers without bound. See the type doc.
+    obligation_ttl: Option<std::time::Duration>,
 }
 
 impl<T> CancelOnEofTransport<T> {
@@ -84,18 +112,26 @@ impl<T> CancelOnEofTransport<T> {
     /// `idle_timeout`, and meaningful whether or not an idle timeout is
     /// configured. `None` disables the bound (a response write waits
     /// unbounded, matching this transport's pre-existing behavior).
+    ///
+    /// `obligation_ttl`: how long an admitted request whose response has not
+    /// been written keeps deferring the idle close. `None` defers without
+    /// bound, which is only safe where `idle_timeout` is also `None`, because
+    /// a handler that panics never produces the response that would clear the
+    /// obligation (see the type doc).
     pub(crate) fn with_idle_timeout(
         inner: T,
         root: tokio_util::sync::CancellationToken,
         idle_timeout: Option<std::time::Duration>,
         response_deadline: Option<std::time::Duration>,
+        obligation_ttl: Option<std::time::Duration>,
     ) -> Self {
         Self {
             inner,
             root,
             idle_timeout,
             response_deadline,
-            in_flight: Arc::new(AtomicI64::new(0)),
+            in_flight: Arc::new(Mutex::new(VecDeque::new())),
+            obligation_ttl,
         }
     }
 }
@@ -148,11 +184,16 @@ where
                 },
                 _ => send.await,
             };
-            // Decrement once the write is resolved either way — see the
-            // `in_flight` field doc for why a failed write must not be left
-            // permanently counted as pending.
+            // Clear one obligation once the write is resolved either way — see
+            // the `in_flight` field doc for why a failed write must not be left
+            // permanently counted as pending. The oldest entry is dropped
+            // rather than this request's own: the entries are interchangeable
+            // for the freshness test the idle branch performs, and rmcp does
+            // not guarantee responses resolve in admission order.
             if is_response {
-                in_flight.fetch_sub(1, Ordering::AcqRel);
+                if let Ok(mut q) = in_flight.lock() {
+                    q.pop_front();
+                }
             }
             result
         }
@@ -165,6 +206,7 @@ where
         let root = self.root.clone();
         let idle_timeout = self.idle_timeout;
         let in_flight = self.in_flight.clone();
+        let obligation_ttl = self.obligation_ttl;
         async move {
             // Created once and reused across every retry below: `select!`ing
             // a *fresh* `self.inner.receive()` each time the idle sleep wins
@@ -183,7 +225,21 @@ where
                         tokio::select! {
                             message = &mut recv_fut => message,
                             () = tokio::time::sleep(timeout) => {
-                                if in_flight.load(Ordering::Acquire) > 0 {
+                                // Defer only on a FRESH obligation. The newest
+                                // entry is the test: if even that one predates a
+                                // full idle window, everything outstanding is
+                                // stale and none of it is evidence of life. See
+                                // the type doc for why a bare count cannot be
+                                // trusted here.
+                                let fresh = in_flight
+                                    .lock()
+                                    .ok()
+                                    .and_then(|q| q.back().copied())
+                                    .is_some_and(|newest| match obligation_ttl {
+                                        Some(ttl) => newest.elapsed() < ttl,
+                                        None => true,
+                                    });
+                                if fresh {
                                     tracing::debug!(
                                         idle_timeout_secs = timeout.as_secs(),
                                         "stdio bridge idle timeout elapsed but an admitted \
@@ -191,6 +247,17 @@ where
                                          session close"
                                     );
                                     continue;
+                                }
+                                if in_flight.lock().is_ok_and(|q| !q.is_empty()) {
+                                    tracing::warn!(
+                                        idle_timeout_secs = timeout.as_secs(),
+                                        obligation_ttl_secs =
+                                            obligation_ttl.map(|d| d.as_secs()),
+                                        "stdio bridge closing with admitted requests whose \
+                                         responses never arrived and whose admission is older \
+                                         than the request-obligation TTL; treating them as \
+                                         dead rather than deferring indefinitely"
+                                    );
                                 }
                                 tracing::info!(
                                     idle_timeout_secs = timeout.as_secs(),
@@ -204,7 +271,9 @@ where
                     None => recv_fut.await,
                 };
                 if let Some(rmcp::model::JsonRpcMessage::Request(_)) = &message {
-                    in_flight.fetch_add(1, Ordering::AcqRel);
+                    if let Ok(mut q) = in_flight.lock() {
+                        q.push_back(Instant::now());
+                    }
                 }
                 if message.is_none() {
                     root.cancel();

--- a/crates/khive-mcp/src/transport.rs
+++ b/crates/khive-mcp/src/transport.rs
@@ -106,6 +106,11 @@ pub(crate) struct CancelOnEofTransport<T> {
     /// and defer past the older obligation's TTL. Removing the entry whose id
     /// matches keeps `back()` the genuinely newest outstanding admission,
     /// which is what the freshness rule assumes.
+    ///
+    /// Because retirement is keyed, a request that never produces a response
+    /// would hold its entry for the life of the session. Entries past
+    /// `obligation_ttl` are therefore dropped whenever this queue is touched;
+    /// see [`drop_stale_obligations`].
     in_flight: Arc<Mutex<VecDeque<(rmcp::model::RequestId, Instant)>>>,
     /// How long an outstanding request keeps deferring the idle close. `None`
     /// defers without bound. See the type doc.
@@ -143,6 +148,43 @@ impl<T> CancelOnEofTransport<T> {
             in_flight: Arc::new(Mutex::new(VecDeque::new())),
             obligation_ttl,
         }
+    }
+
+    /// The obligation queue, for tests that need to observe its size.
+    #[cfg(test)]
+    pub(crate) fn in_flight_handle(
+        &self,
+    ) -> Arc<Mutex<VecDeque<(rmcp::model::RequestId, Instant)>>> {
+        self.in_flight.clone()
+    }
+}
+
+/// Drops obligations that are already past their TTL.
+///
+/// An entry older than `obligation_ttl` is, by this transport's own rule, no
+/// longer evidence of life: the freshness check will not defer on it. Keeping
+/// it buys nothing, and keeping it *forever* is a real cost, because
+/// retirement is keyed by request id and so only ever removes the entry whose
+/// response was actually written. A request that never produces one — a
+/// handler that panics, a request the peer cancels — would otherwise hold its
+/// entry for the life of the session, and a long-lived session accumulates one
+/// per such request without bound.
+///
+/// Entries are pushed in admission order, so the stale ones are a prefix.
+///
+/// With no TTL configured there is no notion of staleness and nothing is
+/// dropped. That is the configuration which already restores the unbounded
+/// defer (see the type doc), so it is unbounded in the same way for the same
+/// reason.
+fn drop_stale_obligations(
+    queue: &mut VecDeque<(rmcp::model::RequestId, Instant)>,
+    obligation_ttl: Option<std::time::Duration>,
+) {
+    let Some(ttl) = obligation_ttl else {
+        return;
+    };
+    while queue.front().is_some_and(|(_, at)| at.elapsed() >= ttl) {
+        queue.pop_front();
     }
 }
 
@@ -182,6 +224,7 @@ where
         let in_flight = self.in_flight.clone();
         let root = self.root.clone();
         let response_deadline = self.response_deadline;
+        let obligation_ttl = self.obligation_ttl;
         let send = self.inner.send(item);
         async move {
             let result = match (is_response, response_deadline) {
@@ -209,12 +252,13 @@ where
             // write must not be left permanently counted as pending, and why
             // the entry removed has to be the matching one rather than the
             // oldest. An id-less error matches nothing and removes nothing.
-            if let Some(id) = retire_id {
-                if let Ok(mut q) = in_flight.lock() {
+            if let Ok(mut q) = in_flight.lock() {
+                if let Some(id) = retire_id {
                     if let Some(position) = q.iter().position(|(entry, _)| *entry == id) {
                         q.remove(position);
                     }
                 }
+                drop_stale_obligations(&mut q, obligation_ttl);
             }
             result
         }
@@ -293,6 +337,7 @@ where
                 };
                 if let Some(rmcp::model::JsonRpcMessage::Request(request)) = &message {
                     if let Ok(mut q) = in_flight.lock() {
+                        drop_stale_obligations(&mut q, obligation_ttl);
                         q.push_back((request.id.clone(), Instant::now()));
                     }
                 }

--- a/crates/khive-mcp/src/transport.rs
+++ b/crates/khive-mcp/src/transport.rs
@@ -351,13 +351,27 @@ where
                 // this. A non-conforming one must not be able to corrupt the
                 // session's lifetime accounting from the wire, which is what
                 // makes this the transport's problem rather than the peer's.
+                //
+                // The duplicate scan runs BEFORE the staleness drop, and that
+                // order is load-bearing. A stale entry is an id whose response
+                // was never observed — the handler may still be running, since
+                // rmcp keeps it alive independently of this receive loop until
+                // it constructs its response. Dropping it first would convert
+                // exactly the ambiguous case into a silent re-admission: the
+                // id passes the check, is pushed as a fresh entry, and the
+                // first of the two eventual responses retires the NEW entry by
+                // id match, leaving the older live handler untracked and the
+                // idle branch free to close out from under it. Scanning the
+                // full queue first refuses that reuse instead. It costs
+                // nothing a conforming peer can notice, because an id whose
+                // response WAS written is not in the queue at all.
                 let mut duplicate_id = None;
                 if let Some(rmcp::model::JsonRpcMessage::Request(request)) = &message {
                     if let Ok(mut q) = in_flight.lock() {
-                        drop_stale_obligations(&mut q, obligation_ttl);
                         if q.iter().any(|(entry, _)| *entry == request.id) {
                             duplicate_id = Some(request.id.clone());
                         } else {
+                            drop_stale_obligations(&mut q, obligation_ttl);
                             q.push_back((request.id.clone(), Instant::now()));
                         }
                     }

--- a/crates/khive-mcp/src/transport.rs
+++ b/crates/khive-mcp/src/transport.rs
@@ -6,12 +6,17 @@
 //! before serving, so the serve path never hard-codes a transport enum.
 
 use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 
 use crate::server::KhiveMcpServer;
 
-/// Cancels rmcp's root service token before reporting transport EOF.
+/// Cancels rmcp's root service token before reporting transport EOF — and,
+/// with an idle timeout configured, before reporting a synthetic EOF when no
+/// message has arrived within that window even though the pipe itself stays
+/// open.
 ///
 /// rmcp otherwise classifies EOF as a graceful close and drains in-flight
 /// handlers for five seconds without cancelling their per-request child
@@ -20,42 +25,192 @@ use crate::server::KhiveMcpServer;
 /// begins. Send and close remain transparent, allowing this wrapper to sit
 /// outside the Unix post-flush self-heal transport without changing its flush
 /// ordering.
+///
+/// An abandoned stdio bridge — a client whose pipe never closes but which
+/// has stopped sending requests — is otherwise indistinguishable from a live
+/// one: nothing reaps it, so it holds its reader-pool admission and DB
+/// connection for as long as the parent process happens to stay alive
+/// (observed up to tens of hours in production). Idle timeout treats "no
+/// request for `idle_timeout`" the same as real EOF: `receive()` yields
+/// `None`, which cancels `root` and lets rmcp's normal graceful-close path
+/// tear the session down — the same clean-exit path that already releases
+/// pooled resources on a real disconnect.
+///
+/// Wire-idle is not session-idle: rmcp keeps racing `transport.receive()`
+/// while each admitted request runs in its own task, so a handler that
+/// outlasts `idle_timeout` (slow verb, large batch) must not have its
+/// session torn down out from under it. `in_flight` counts JSON-RPC
+/// `Request` messages this transport has handed to rmcp minus the
+/// `Response`/`Error` messages it has *finished writing* back for them —
+/// not merely handed to `inner.send`, since rmcp spawns the response send
+/// and the underlying framed write awaits the transport writer, so a slow
+/// or stalled reader leaves the write pending well after `send` is called.
+/// The idle branch only treats a quiet window as EOF when that count is
+/// zero, i.e. nothing admitted has an undelivered response. A response
+/// write that fails also decrements the counter (once resolved, one way or
+/// another, it is no longer pending) — the broken transport will surface
+/// through `receive()` returning `None` on its own, so this counter must
+/// not be the thing that gets stuck open forever on a write error.
+///
+/// A response write that never resolves — a peer that admits a request,
+/// then stops reading its response while keeping the pipe open — would
+/// otherwise pin this session (and its reader-pool admission / DB
+/// connection) forever: `in_flight` would never return to zero, so the idle
+/// check above would defer indefinitely. `response_deadline` bounds the
+/// write itself (see [`Self::send`]) rather than the idle check: rmcp's
+/// underlying `AsyncRwTransport` serializes writes through a
+/// `tokio::sync::Mutex` held across the pending write's `.await`, so a
+/// write that never resolves also blocks any later `close()` on the same
+/// transport — merely cancelling the root token would not free that lock.
+/// Timing out the write future instead *drops* it, which releases the
+/// mutex guard the same way any other future cancellation would, so a
+/// subsequent `close()` (part of rmcp's normal post-cancellation drain)
+/// can still proceed.
 pub(crate) struct CancelOnEofTransport<T> {
     inner: T,
     root: tokio_util::sync::CancellationToken,
+    idle_timeout: Option<std::time::Duration>,
+    response_deadline: Option<std::time::Duration>,
+    in_flight: Arc<AtomicI64>,
 }
 
 impl<T> CancelOnEofTransport<T> {
-    pub(crate) fn new(inner: T, root: tokio_util::sync::CancellationToken) -> Self {
-        Self { inner, root }
+    /// `idle_timeout`: a `receive()` call that yields no message within this
+    /// window is treated as EOF (see the type doc), but only when no
+    /// admitted request is still awaiting its response. `None` disables it.
+    ///
+    /// `response_deadline`: the longest a single response write may stay
+    /// pending before it is abandoned (see [`Self::send`]) — independent of
+    /// `idle_timeout`, and meaningful whether or not an idle timeout is
+    /// configured. `None` disables the bound (a response write waits
+    /// unbounded, matching this transport's pre-existing behavior).
+    pub(crate) fn with_idle_timeout(
+        inner: T,
+        root: tokio_util::sync::CancellationToken,
+        idle_timeout: Option<std::time::Duration>,
+        response_deadline: Option<std::time::Duration>,
+    ) -> Self {
+        Self {
+            inner,
+            root,
+            idle_timeout,
+            response_deadline,
+            in_flight: Arc::new(AtomicI64::new(0)),
+        }
     }
 }
 
 impl<T> rmcp::transport::Transport<rmcp::RoleServer> for CancelOnEofTransport<T>
 where
     T: rmcp::transport::Transport<rmcp::RoleServer>,
+    T::Error: From<std::io::Error>,
 {
     type Error = T::Error;
 
+    /// Bounds a response/error write by `response_deadline` (requests pass
+    /// straight through, untimed — only a response can leave `in_flight`
+    /// permanently pinned). On timeout the write future is dropped —
+    /// releasing whatever lock the inner transport held across it, see the
+    /// type doc — `in_flight` is decremented the same as any other resolved
+    /// write, and `root` is cancelled directly: the peer has demonstrated it
+    /// is not going to read this response, so there is no reason to wait for
+    /// the next idle tick to notice.
     fn send(
         &mut self,
         item: rmcp::service::TxJsonRpcMessage<rmcp::RoleServer>,
     ) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send + 'static {
-        self.inner.send(item)
+        let is_response = matches!(
+            item,
+            rmcp::model::JsonRpcMessage::Response(_) | rmcp::model::JsonRpcMessage::Error(_)
+        );
+        let in_flight = self.in_flight.clone();
+        let root = self.root.clone();
+        let response_deadline = self.response_deadline;
+        let send = self.inner.send(item);
+        async move {
+            let result = match (is_response, response_deadline) {
+                (true, Some(deadline)) => match tokio::time::timeout(deadline, send).await {
+                    Ok(result) => result,
+                    Err(_) => {
+                        tracing::warn!(
+                            deadline_secs = deadline.as_secs(),
+                            "stdio bridge response-delivery deadline elapsed while a response \
+                             write was still pending (peer stopped reading); abandoning the \
+                             write and closing this session"
+                        );
+                        root.cancel();
+                        Err(std::io::Error::new(
+                            std::io::ErrorKind::TimedOut,
+                            "response-delivery deadline elapsed before the write completed",
+                        )
+                        .into())
+                    }
+                },
+                _ => send.await,
+            };
+            // Decrement once the write is resolved either way — see the
+            // `in_flight` field doc for why a failed write must not be left
+            // permanently counted as pending.
+            if is_response {
+                in_flight.fetch_sub(1, Ordering::AcqRel);
+            }
+            result
+        }
     }
 
     fn receive(
         &mut self,
     ) -> impl std::future::Future<Output = Option<rmcp::service::RxJsonRpcMessage<rmcp::RoleServer>>>
            + Send {
-        let receive = self.inner.receive();
         let root = self.root.clone();
+        let idle_timeout = self.idle_timeout;
+        let in_flight = self.in_flight.clone();
         async move {
-            let message = receive.await;
-            if message.is_none() {
-                root.cancel();
+            // Created once and reused across every retry below: `select!`ing
+            // a *fresh* `self.inner.receive()` each time the idle sleep wins
+            // would drop the in-progress read and restart it next iteration.
+            // rmcp's line-buffered receive clears its buffer at the start of
+            // each call, so restarting mid-read silently discards whatever
+            // prefix of the next request had already arrived before the
+            // deferred timeout — the remainder then parses as garbage.
+            // Racing the sleep against `&mut` this same pinned future keeps
+            // the partial read alive across as many deferrals as it takes.
+            let recv_fut = self.inner.receive();
+            tokio::pin!(recv_fut);
+            loop {
+                let message = match idle_timeout {
+                    Some(timeout) => {
+                        tokio::select! {
+                            message = &mut recv_fut => message,
+                            () = tokio::time::sleep(timeout) => {
+                                if in_flight.load(Ordering::Acquire) > 0 {
+                                    tracing::debug!(
+                                        idle_timeout_secs = timeout.as_secs(),
+                                        "stdio bridge idle timeout elapsed but an admitted \
+                                         request is still awaiting its response; deferring \
+                                         session close"
+                                    );
+                                    continue;
+                                }
+                                tracing::info!(
+                                    idle_timeout_secs = timeout.as_secs(),
+                                    "stdio bridge idle timeout elapsed with no request; \
+                                     closing this session to release its pooled resources"
+                                );
+                                None
+                            }
+                        }
+                    }
+                    None => recv_fut.await,
+                };
+                if let Some(rmcp::model::JsonRpcMessage::Request(_)) = &message {
+                    in_flight.fetch_add(1, Ordering::AcqRel);
+                }
+                if message.is_none() {
+                    root.cancel();
+                }
+                return message;
             }
-            message
         }
     }
 

--- a/crates/khive-mcp/src/transport.rs
+++ b/crates/khive-mcp/src/transport.rs
@@ -335,11 +335,42 @@ where
                     }
                     None => recv_fut.await,
                 };
+                // A second outstanding obligation under an id that already has
+                // one is refused rather than admitted. Two entries sharing an
+                // id make retirement ambiguous, and BOTH ways of resolving it
+                // are wrong: retiring the first match can leave a completed
+                // request's instant as the newest entry and defer past the
+                // older obligation's TTL (the leak), while retiring the last
+                // match can leave the older instant and close the session out
+                // from under a live handler (the opposite failure). There is
+                // no third choice, because the transport cannot tell the two
+                // apart — the ambiguity has to be refused where it enters.
+                //
+                // MCP requires a request id to be unused within a session
+                // (2025-11-25, "Requests"), so a conforming peer never reaches
+                // this. A non-conforming one must not be able to corrupt the
+                // session's lifetime accounting from the wire, which is what
+                // makes this the transport's problem rather than the peer's.
+                let mut duplicate_id = None;
                 if let Some(rmcp::model::JsonRpcMessage::Request(request)) = &message {
                     if let Ok(mut q) = in_flight.lock() {
                         drop_stale_obligations(&mut q, obligation_ttl);
-                        q.push_back((request.id.clone(), Instant::now()));
+                        if q.iter().any(|(entry, _)| *entry == request.id) {
+                            duplicate_id = Some(request.id.clone());
+                        } else {
+                            q.push_back((request.id.clone(), Instant::now()));
+                        }
                     }
+                }
+                if let Some(id) = duplicate_id {
+                    tracing::warn!(
+                        duplicate_request_id = ?id,
+                        "stdio bridge received a request whose id already has an outstanding \
+                         obligation; the response could not be attributed to either, so this \
+                         session is closed rather than left with corrupt lifetime accounting"
+                    );
+                    root.cancel();
+                    return None;
                 }
                 if message.is_none() {
                     root.cancel();

--- a/crates/khive-mcp/src/transport.rs
+++ b/crates/khive-mcp/src/transport.rs
@@ -93,10 +93,20 @@ pub(crate) struct CancelOnEofTransport<T> {
     root: tokio_util::sync::CancellationToken,
     idle_timeout: Option<std::time::Duration>,
     response_deadline: Option<std::time::Duration>,
-    /// Admission instants of requests handed to rmcp whose response has not
-    /// finished writing. Ordered oldest-first; see the type doc for why the
-    /// instants matter and not just the count.
-    in_flight: Arc<Mutex<VecDeque<Instant>>>,
+    /// Requests handed to rmcp whose response has not finished writing, each
+    /// paired with the instant it was admitted. Ordered oldest-first; see the
+    /// type doc for why the instants matter and not just the count.
+    ///
+    /// Entries are keyed by request id because they are **not**
+    /// interchangeable. rmcp spawns each handler and each response send
+    /// independently, so a newer request's response can finish first. Retiring
+    /// the oldest entry on any completion would then drop a still-outstanding
+    /// request's admission and leave a *completed* one as the newest entry —
+    /// making the freshness test below read the completed request's timestamp
+    /// and defer past the older obligation's TTL. Removing the entry whose id
+    /// matches keeps `back()` the genuinely newest outstanding admission,
+    /// which is what the freshness rule assumes.
+    in_flight: Arc<Mutex<VecDeque<(rmcp::model::RequestId, Instant)>>>,
     /// How long an outstanding request keeps deferring the idle close. `None`
     /// defers without bound. See the type doc.
     obligation_ttl: Option<std::time::Duration>,
@@ -159,6 +169,16 @@ where
             item,
             rmcp::model::JsonRpcMessage::Response(_) | rmcp::model::JsonRpcMessage::Error(_)
         );
+        // Which obligation this write discharges. A `Response` always names
+        // its request. A `JsonRpcError` carries `Option<RequestId>`: the MCP
+        // spec omits the id when the server could not read it (parse error,
+        // invalid request), and such an error answers no admitted request, so
+        // it must retire nothing rather than retire an arbitrary one.
+        let retire_id: Option<rmcp::model::RequestId> = match &item {
+            rmcp::model::JsonRpcMessage::Response(response) => Some(response.id.clone()),
+            rmcp::model::JsonRpcMessage::Error(error) => error.id.clone(),
+            _ => None,
+        };
         let in_flight = self.in_flight.clone();
         let root = self.root.clone();
         let response_deadline = self.response_deadline;
@@ -184,15 +204,16 @@ where
                 },
                 _ => send.await,
             };
-            // Clear one obligation once the write is resolved either way — see
-            // the `in_flight` field doc for why a failed write must not be left
-            // permanently counted as pending. The oldest entry is dropped
-            // rather than this request's own: the entries are interchangeable
-            // for the freshness test the idle branch performs, and rmcp does
-            // not guarantee responses resolve in admission order.
-            if is_response {
+            // Clear THIS request's obligation once the write is resolved
+            // either way — see the `in_flight` field doc for why a failed
+            // write must not be left permanently counted as pending, and why
+            // the entry removed has to be the matching one rather than the
+            // oldest. An id-less error matches nothing and removes nothing.
+            if let Some(id) = retire_id {
                 if let Ok(mut q) = in_flight.lock() {
-                    q.pop_front();
+                    if let Some(position) = q.iter().position(|(entry, _)| *entry == id) {
+                        q.remove(position);
+                    }
                 }
             }
             result
@@ -234,7 +255,7 @@ where
                                 let fresh = in_flight
                                     .lock()
                                     .ok()
-                                    .and_then(|q| q.back().copied())
+                                    .and_then(|q| q.back().map(|(_, at)| *at))
                                     .is_some_and(|newest| match obligation_ttl {
                                         Some(ttl) => newest.elapsed() < ttl,
                                         None => true,
@@ -270,9 +291,9 @@ where
                     }
                     None => recv_fut.await,
                 };
-                if let Some(rmcp::model::JsonRpcMessage::Request(_)) = &message {
+                if let Some(rmcp::model::JsonRpcMessage::Request(request)) = &message {
                     if let Ok(mut q) = in_flight.lock() {
-                        q.push_back(Instant::now());
+                        q.push_back((request.id.clone(), Instant::now()));
                     }
                 }
                 if message.is_none() {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -290,6 +290,35 @@ partial-override mode.
 
 ---
 
+## Stdio bridge session lifetime
+
+Three environment variables bound how long a stdio bridge session and its
+individual writes may live. They are read once at serve time.
+
+| Variable                               | Default      | Effect                                                                                                                                                                                                |
+| -------------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `KHIVE_BRIDGE_IDLE_TIMEOUT_SECS`       | **disabled** | When set to a positive number, a session that receives no request for this many seconds closes, releasing its reader-pool admission and DB connection. `0`, absent, or unparsable leaves it disabled. |
+| `KHIVE_BRIDGE_RESPONSE_DEADLINE_SECS`  | `300`        | The longest a single response write may stay pending before it is abandoned and the session closes. `0` is rejected at startup rather than treated as an opt-out.                                     |
+| `KHIVE_BRIDGE_REQUEST_OBLIGATION_SECS` | `3600`       | How long an admitted request whose response has not been written keeps deferring the idle close. Only reached when the idle timeout is enabled. `0` restores an unbounded defer.                      |
+
+**Idle reaping is off by default, and that is deliberate.**
+[ADR-091](adr/ADR-091-wal-snapshot-lifetime.md) rejects closing long-lived
+reader sessions by age, on the ground that they are live clients and that
+bounding what they hold underneath them is the better fix. This transport has
+no signal separating an abandoned pipe from a live client that has simply not
+been asked anything, so enabling the idle timeout by default would reverse that
+decision. Turn it on where session churn is cheap and a pinned WAL connection
+is not: a supervised deployment, a CI harness, a batch runner.
+
+**Known gap.** The response-delivery deadline covers responses this transport
+writes. It does not cover parse-error responses, which the underlying line
+transport writes directly through its own framed writer without passing through
+the deadline. A peer that sends malformed input and then stops reading can
+leave that one write pending; with the idle timeout enabled it is bounded by
+the idle window, and with the idle timeout disabled it is not bounded. Closing
+that gap requires replacing or adapting the line transport and is tracked
+separately.
+
 ## Troubleshooting a connect failure
 
 **Symptom:** an MCP client (Claude Code, Claude Desktop, Codex, Gemini) reports

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -310,6 +310,15 @@ been asked anything, so enabling the idle timeout by default would reverse that
 decision. Turn it on where session churn is cheap and a pinned WAL connection
 is not: a supervised deployment, a CI harness, a batch runner.
 
+**A session also closes on a duplicate outstanding request id.** MCP requires a
+request id to be unused within a session, and this transport tracks outstanding
+requests by id in order to decide whether a quiet session still has work
+running. Two live requests sharing an id make that undecidable: a completing
+response could discharge either, and picking wrong either keeps a finished
+session alive indefinitely or closes a live one. The second such request is
+therefore refused and the session closes, with the id logged at `WARN`. A
+conforming client never reaches this.
+
 **Known gap.** The response-delivery deadline covers responses this transport
 writes. It does not cover parse-error responses, which the underlying line
 transport writes directly through its own framed writer without passing through

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -313,10 +313,20 @@ is not: a supervised deployment, a CI harness, a batch runner.
 **Known gap.** The response-delivery deadline covers responses this transport
 writes. It does not cover parse-error responses, which the underlying line
 transport writes directly through its own framed writer without passing through
-the deadline. A peer that sends malformed input and then stops reading can
-leave that one write pending; with the idle timeout enabled it is bounded by
-the idle window, and with the idle timeout disabled it is not bounded. Closing
-that gap requires replacing or adapting the line transport and is tracked
+the deadline. A peer that sends malformed input and then stops reading can leave
+that one write pending.
+
+What bounds that pending write depends on what else the session has
+outstanding, and the idle window alone is not the answer:
+
+- Idle timeout disabled: nothing bounds it.
+- Idle timeout enabled, nothing else outstanding: the idle window bounds it.
+- Idle timeout enabled with a request still awaiting its response: the idle
+  close defers while that obligation is fresh, so the bound is the request
+  obligation TTL rather than the idle window. A peer can reach this deliberately
+  by admitting a request and then sending malformed input.
+
+Closing the gap requires replacing or adapting the line transport and is tracked
 separately.
 
 ## Troubleshooting a connect failure

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -319,6 +319,11 @@ session alive indefinitely or closes a live one. The second such request is
 therefore refused and the session closes, with the id logged at `WARN`. A
 conforming client never reaches this.
 
+An id counts as outstanding for this purpose while its entry is still tracked,
+including after it has passed the obligation TTL. Ageing past that TTL means the
+request no longer defers the idle close; it does not mean the request finished,
+and the handler may well still be running. Reuse is refused in that state too.
+
 **Known gap.** The response-delivery deadline covers responses this transport
 writes. It does not cover parse-error responses, which the underlying line
 transport writes directly through its own framed writer without passing through


### PR DESCRIPTION
## Problem

An abandoned stdio bridge session holds resources indefinitely. A client whose pipe never
closes but which stops sending requests pins its reader-pool admission slot and its DB
connection for as long as the parent process lives. Nothing in the session lifetime bounds
that: the only exit was real EOF.

## Change

Two independent bounds, plus the accounting that makes the first one safe.

- **Response-delivery deadline** (`KHIVE_BRIDGE_RESPONSE_DEADLINE_SECS`, default 300s, on by
  default). A response write that never resolves — a peer that admits a request and then
  stops reading while holding the pipe open — is abandoned at the deadline. Timing the write
  out drops it, which releases the writer lock that a later `close()` would otherwise block
  on, and closes the session. `0` is a startup error naming the variable, the value, and the
  accepted range, not a silent opt-out: a disabled deadline restores the unbounded
  pending-write defect the deadline exists to close.
- **Idle-session timeout** (`KHIVE_BRIDGE_IDLE_TIMEOUT_SECS`, **off by default**). When
  configured, a session quiet for that long closes.
- **Request-obligation TTL** (`KHIVE_BRIDGE_REQUEST_OBLIGATION_SECS`, default 3600s). How
  long an admitted request whose response has not been written keeps deferring the idle
  close.

### Why idle reaping is off by default

[ADR-091](docs/adr/ADR-091-wal-snapshot-lifetime.md) lists "kill long-lived reader sessions"
among its rejected alternatives, on the ground that long-lived stdio sessions are live
clients and that bounding what they hold underneath them is the better fix. Closing a session
after an hour of quiet is that rejected policy whatever the mechanism, because this transport
has no signal separating an abandoned pipe from a client that simply has not been asked
anything. Enabling it by default would reverse an accepted decision from inside an unrelated
change. It is an operator's explicit act instead: a supervised deployment, a CI harness, a
batch runner. Making it the default is an ADR-091 amendment, not a different number here.

An unparsable value falls back to *disabled* rather than to an hour, so a typo cannot start
closing live sessions.

### Why the obligation is timestamped rather than counted

The idle check must not treat a session with work outstanding as idle, or it cancels a
running handler out from under itself. But rmcp spawns each request handler with
`spawn_service_task` and drops the join handle, so a handler that panics never reaches the
response construction that clears its obligation. Deferring on an outstanding obligation with
no bound hands any panicking handler the power to disable idle reaping for the life of the
session — the unbounded lifetime the timeout exists to close, reintroduced through its own
guard.

So the transport records each request's admission instant and defers only while the newest
outstanding obligation is younger than the TTL. The TTL is deliberately not the idle window:
tying them together would make a handler that runs longer than one quiet window stop
protecting its own session, which is the guarantee the obligation provides.

### Why obligations are keyed by request id

The freshness rule reads the newest outstanding admission, so the entry it reads has to be
one that is genuinely still outstanding. rmcp spawns each handler and each response send
independently, so a newer request's response can finish before an older request's. Retiring
the oldest entry on any completion — the obvious FIFO reading of "a response arrived, so one
obligation is discharged" — would then retire the older request's admission for the newer
request's completion and leave a *completed* request's instant as the newest entry. The
freshness test would read that instant and keep deferring past the older obligation's TTL,
restoring the unbounded session lifetime this guard exists to close.

Entries are therefore `(RequestId, Instant)` and retirement removes the entry whose id
matches the response or error being written. `JsonRpcError.id` is optional, because a parse
error has no id to echo, so those retire nothing — which is correct: no obligation was ever
admitted for them.

Keying retirement changes what happens to a request that never produces a response at all: a
handler that panics, or a request the peer cancels. Oldest-first retirement removed *some*
entry on every completion, so the queue tracked admissions minus completions. Keyed
retirement removes only the entry whose response was written, so an unanswered request would
hold its slot for the life of the session and a long-lived session would accumulate one per
such request without bound. An entry past the TTL is already not evidence of life — the
freshness check will not defer on it — so keeping it buys nothing, and entries past the TTL
are dropped whenever the queue is touched. They are pushed in admission order, so the stale
ones are a prefix.

A request also counts as in flight until its response has finished *writing*, not merely been
handed to the transport send. rmcp spawns the response send and the framed write awaits the
transport writer, so a backpressured reader leaves the write pending well after the handler
returns; counting that as idle would cancel a session out from under an undelivered response.

The idle check races a single pinned `receive()` future rather than starting a fresh one per
deferred window, so a request arriving fragmented across a window is reassembled instead of
losing its already-read prefix.

## Known gap

The response-delivery deadline covers responses this transport writes. It does not cover
parse-error responses, which the underlying line transport writes directly through its own
framed writer without passing through the deadline. A peer that sends malformed input and
then stops reading can leave that one write pending. What bounds it depends on what else the
session has outstanding, and the idle window alone is not the answer:

- Idle timeout disabled: nothing bounds it.
- Idle timeout enabled, nothing else outstanding: the idle window bounds it.
- Idle timeout enabled with a request still awaiting its response: the idle close defers
  while that obligation is fresh, so the bound is the request-obligation TTL rather than the
  idle window. A peer can reach this deliberately by admitting a request and then sending
  malformed input.

Closing the gap requires replacing or adapting the line transport, which is out of scope here
and documented in `docs/configuration.md`.

## Tests

Ten tests, each asserting an outcome rather than a return value.

| Test | Asserts |
| --- | --- |
| `stdio_idle_timeout_cancels_root_without_eof` | the timeout alone ends the session |
| `stdio_idle_timeout_does_not_reap_client_with_intermittent_traffic` | traffic inside the window keeps it alive |
| `stdio_idle_timeout_does_not_cancel_an_admitted_long_running_request` | a slow handler is not idle |
| `stdio_idle_timeout_does_not_cancel_while_a_response_write_is_backpressured` | a pending write is not idle |
| `stdio_idle_timeout_reaps_a_peer_that_stops_reading_its_response` | the delivery deadline fires and closes |
| `stdio_idle_timeout_preserves_a_fragmented_request_while_another_is_in_flight` | the pinned receive keeps a partial frame |
| `stdio_idle_timeout_reaps_a_session_whose_handler_never_answers` | an obligation past its TTL stops deferring |
| `stdio_idle_timeout_reaps_on_the_older_obligation_when_a_newer_one_completes_first` | out-of-order completion does not extend the session |
| `stdio_obligation_queue_drops_entries_past_their_ttl` | an unanswered request does not hold its slot forever |
| `response_deadline_from_env_rejects_zero` | `=0` is a startup error naming variable, value, and range |

The negative tests are the substance. Without them, a timeout that fires during a slow
handler or a backpressured write passes a "does it time out" check while doing exactly the
damage the feature must not do. The never-answers test asserts the fresh case first, so it
cannot pass against a build that simply ignores in-flight work; wiring the freshness check to
a constant true reddens that test and only that test.

A test that asserts a non-event passes just as well against a build whose timer was never
armed, so each "does not cancel" test also asserts, through a shared helper, that once
nothing is protecting the session the timer does close it — with the pipe still open, so
nothing but the timer can be what ended the session. Forcing the transport to read its idle
timeout as unconfigured reddens every test that configures one and leaves the others green.

The out-of-order test picks timings that separate correct behaviour from the defect rather
than merely exercising the path: two requests admitted 1500ms apart against a 2000ms
obligation TTL, the first parked forever and the second answered promptly. Correct behaviour
closes about 2000ms after the first admission; FIFO retirement closes at about 3500ms, and
the assertion sits between them.

## Gates

At `64f9ff03de7a5b26c9c7b8648e28bed48c1435fd`: `cargo fmt --all --check` clean,
`cargo clippy -p khive-mcp --all-targets -- -D warnings` with no warning or error lines,
`RUSTDOCFLAGS="-D warnings" cargo doc -p khive-mcp --no-deps` clean, and
`cargo test -p khive-mcp --lib` at 438 passed / 0 failed.

