### PR TITLE
docs(adr): ADR-049 Amendment 6 — incumbent classification at boot

### DIFF
--- a/docs/adr/ADR-049-khived-daemon.md
+++ b/docs/adr/ADR-049-khived-daemon.md
@@ -328,3 +328,133 @@ is not consulted as request cancellation state, preserving repeated daemon-run
 tests. A blocking write that ignores async abort continues to own its SQLite
 connection until its blocking closure exits; the daemon never interrupts that
 write or reports a retryable read timeout for it.
+
+## Amendment 6 (2026-08-26): incumbent classification at boot
+
+Boot answers one question — "may I clean up the rendezvous and bind?" — and the
+convergence invariant above requires that the answer be governed by whether a
+daemon is **live**, never by whether it is one this process would choose to talk
+to. This amendment separates those two questions and enumerates the states boot
+must distinguish.
+
+### Liveness and acceptability are different questions
+
+- **Liveness**: is a process serving this socket right now? Answered by the
+  connect and by whether anything comes back at all.
+- **Acceptability**: is that process a peer this client can share the rendezvous
+  with? Answered by identity — protocol version and `config_id`.
+
+Unlink-and-rebind is licensed by a negative answer to **liveness only**. It is
+never licensed by a negative answer to acceptability, because an unacceptable
+peer that is alive still owns the socket. Removing its rendezvous files does not
+stop it, and binding a second listener beside it violates the "exactly one live,
+identity-matching daemon" convergence requirement directly.
+
+A probe predicate that returns a bare boolean invites the collapse, because a
+single bit cannot carry the difference between "nothing is there" and "something
+is there that I may not use". Boot classification therefore returns a
+disposition, not a boolean:
+
+```
+MayBind
+Refuse { pid: Option<u32>, reason: RefusalReason }
+```
+
+`MayBind` is the only value that permits binding a listener.
+
+### Incumbent states
+
+`PID live` means the recorded pid names a running process. `connect` is the
+bounded probe connect. `response` is what came back within the probe deadline.
+
+Exit codes are normative because supervisors read them: a supervisor configured
+to restart only on unsuccessful exit treats exit 0 as a deliberate stop.
+**Configuration-class** refusals — an operator must act, and restarting cannot
+help — exit 0. **State-class** refusals — transient or unclassified, where a
+retry may succeed — exit nonzero.
+
+| #  | State                                         | Observable                                                | Disposition                                                                                   | Exit    |
+| -- | --------------------------------------------- | --------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ------- |
+| 1  | Exact acknowledgement                         | connect ok, probe ack, identity matches                   | Refuse to start; report the incumbent pid                                                     | 0       |
+| 2  | Protocol-version mismatch                     | connect ok, `version_mismatch`                            | Refuse; name both versions and the remedy. Never unlink                                       | 0       |
+| 3  | Config mismatch                               | connect ok, `config_mismatch`, `served_config_id` present | Refuse by default; name the first differing field without values. Opt-in replacement only     | 0       |
+| 4  | Metrics-only reply                            | connect ok, reply carries metrics                         | Refuse to start                                                                               | 0       |
+| 5  | Silent connect                                | connect ok, no parseable response within the deadline     | Refuse; distinct error "connected but did not answer"                                         | nonzero |
+| 6  | Malformed reply                               | connect ok, bytes returned, frame does not parse          | Refuse to start                                                                               | nonzero |
+| 7  | Connection refused, pid live                  | `ECONNREFUSED`, pid running                               | Refuse; name the pid                                                                          | nonzero |
+| 8  | Connection refused, pid dead                  | `ECONNREFUSED`, pid not running                           | Clean up and bind                                                                             | —       |
+| 9  | No socket, pid dead                           | socket absent, pid not running or pid file absent         | Clean up and bind                                                                             | —       |
+| 10 | No socket, pid live                           | socket absent, pid running                                | Refuse; name the pid, unless the pid is this process and same-process incumbency is permitted | 0       |
+| 11 | Other connect error (`EACCES`, `ENOTSOCK`, …) | connect fails, not refused                                | Refuse; name the errno                                                                        | nonzero |
+
+Only states 8 and 9 are genuinely stale. Collapsing any of 2, 3, 5, 6, 7, 10 or
+11 into "clean up and bind" is the defect this amendment forbids.
+
+Every state above is reachable from the boot probe except **state 4**. The boot
+probe's request frame does not set the metrics flag, and the daemon's
+metrics reply is gated on that flag in the requesting frame, so a metrics-only
+reply cannot be elicited by boot. State 4 is retained as a defensive
+classification because a reply carrying metrics is unambiguous proof of life
+whatever elicited it, and misreading it as absence would be the same defect.
+
+Two consequences of the existing contract are worth stating because they are
+easy to invert:
+
+- **State 3 is not automatic replacement.** The Consequences section's
+  description of the daemon as disposable, in the sense that killing and
+  respawning it is safe, licenses replacement being _safe_. It does not make
+  replacement something boot performs unprompted. Disposable does not mean
+  auto-replaced at boot.
+- **State 10 is a clean exit.** The convergence requirement already anticipates
+  multiple launch attempts and lets the daemon-side fence choose the sole owner,
+  so losing that fence is legitimate rather than an error. Blocking and
+  re-probing belong to the client-side recoverer, never to daemon boot.
+
+### Replacing a live incumbent
+
+Removal of a live incumbent is operator-elected and available only through an
+explicit `--replace-incumbent` opt-in. Every step is required:
+
+1. Classify. Proceed only from states 1 through 4, where a daemon identity was
+   positively read. Never from 5, 6, 7, 10 or 11 — those have not established
+   what would be killed.
+2. Signal `SIGTERM` to the recorded pid.
+3. Wait, bounded, for process death. Death is **observed**, never assumed.
+4. On timeout, refuse: leave the socket intact and name the pid. Never escalate
+   to `SIGKILL` implicitly, and never unlink a socket whose owner is still
+   alive.
+5. Only after observed death, remove the socket and pid file, then bind.
+
+Step 3 is the substance. Removing a rendezvous file is not a way to stop a
+process.
+
+### Test obligations
+
+One test per state, each asserting the **outcome** rather than the return value.
+For every refuse state that must assert: the incumbent is still alive, the
+socket still exists, and no second listener was bound. A test that checks only
+the returned error passes while the socket is unlinked underneath a live
+process, which is precisely the failure being prevented. Each refuse state also
+asserts its exit code, since an otherwise-correct refusal carrying the wrong
+code either drives a supervisor restart loop or silently retires a retryable
+state.
+
+Two further tests are required because their absence is what allowed the
+collapse:
+
+- A test that starts a real live incumbent and drives each non-acknowledgement
+  class against it, asserting that startup never leaves two live daemons.
+- A `--replace-incumbent` timeout test in which the incumbent ignores `SIGTERM`,
+  asserting refusal with the socket intact.
+
+Each state's guard carries a mutation control: defeat the guard, confirm that
+exactly that state's test fails, and restore from a snapshot rather than by
+reapplying an inverse edit.
+
+### What is unchanged
+
+The convergence requirement, the client-side recoverer lock, the daemon-side
+boot fence, the exactly-once recovery boundary of Amendment 3, and the socket
+accessibility narrowing of Amendment 4 all stand as written. This amendment
+constrains only what boot may conclude from a probe result, and what it may do
+about it.

--- a/docs/adr/ADR-049-khived-daemon.md
+++ b/docs/adr/ADR-049-khived-daemon.md
@@ -444,22 +444,32 @@ published cannot be re-observed differently, so no retry reaches a different
 classification and it exits 0. State 7 is nonzero on the state 8 reading: a peer
 that did not answer within the deadline may answer within the next one.
 
-> **OPEN — states 9 and 12 are not separated by the rule as written, and this
-> amendment does not settle it.** The two arise from the same instant of the
-> same race and only the socket separates them: no socket with a live foreign
-> pid is state 12 and exits 0, while a socket present and refusing with a live
-> pid is state 9 and exits 4. The rule above does not license that split. From
-> state 12 a retry reaches a binding outcome if the recorded pid dies before
-> binding (state 11), and from state 9 it reaches one on the same condition
-> (state 10), so "can a later attempt observe a different classification" is
-> true of both. The state 12 rationale below argues instead from the _expected_
-> trajectory — the peer is already booting and will own the rendezvous, so a
-> restart loop is the likely result — and that argument applies to state 9's
-> not-yet-bound half just as well. Either the rule needs a second clause that
-> names the discriminator, or one of the two codes is wrong. Resolving it by
-> asserting a distinction between them is what this note exists to prevent;
-> the contract is normative for supervisors, so it is a decision to be taken
-> and recorded, not inferred. Tracked before Amendment 6 is treated as settled.
+**Second clause: where a live recorded pid is shared, the socket names that
+pid's trajectory.** Asking only whether a later attempt observes a different
+classification is necessary but not sufficient, because it is true of both
+states 9 and 12. They arise from the same instant of the same race and only the
+socket separates them, so on the first clause alone the split between exit 4 and
+exit 0 is unlicensed. What licenses it is which classification the trajectory
+leads to: binding by this process, or refusal by an owner.
+
+A socket present with a live recorded pid that refuses connections is a daemon
+_past_ its listener. The lifecycle rule above requires that on SIGTERM/SIGINT a
+daemon stop accepting, drain in-flight requests, and only then remove the socket
+and the PID file, so a refusing socket with its owner still alive is that daemon
+draining, and its next state is death. That death lands in whichever of the two
+genuinely stale states applies: state 11 when the drain completed its own
+cleanup, state 10 when the socket outlived the process. Both are states this
+process resolves by cleaning up and binding, so the resolver is a later attempt
+of this process and nonzero stands. State 9 keeps exit 4.
+
+A live recorded pid with no socket is _before_ its listener. Its next state is
+ownership, which a later attempt observes as state 1, so the resolver is the
+other process, and a supervisor restart loop is the harm the code has to avoid.
+State 12 keeps exit 0.
+
+The bind-to-listen gap does reach state 9, for at most one attempt, and it is
+harmless there: the retry meets state 1 and exits 0, at a cost of one supervisor
+restart.
 
 **Codes are numeric and distinct, not merely "nonzero".** A supervisor and an
 end-to-end test both need to tell these apart, and "nonzero" is a class, not a

--- a/docs/adr/ADR-049-khived-daemon.md
+++ b/docs/adr/ADR-049-khived-daemon.md
@@ -340,12 +340,35 @@ write or reports a retryable read timeout for it.
 
 **This amendment specifies a contract that current code does not satisfy.** It
 is normative, not descriptive: every rule below states what boot must do, and
-none of it should be read as an account of what boot does today. The present
-implementation reduces the probe to a boolean that is true only for an exact
-acknowledgement, and treats everything else — including replies from
-demonstrably live daemons — as grounds for removing the rendezvous. Bringing the
+none of it should be read as an account of what boot does today. Bringing the
 code to this contract is a prerequisite for the guarantees stated here, not a
 consequence of recording them.
+
+What boot does today is further from this contract than a collapsed
+classification. `cleanup_stale_daemon` in `crates/khive-runtime/src/daemon.rs`
+sends no probe at all: it reads the pid file, and keeps the rendezvous only if
+the pid parses, names a process that is running, the socket path exists, and a
+plain connect to it succeeds. Any other outcome unlinks both the socket and the
+pid file. So there is no reply to classify on this path, and the states below
+have no counterpart in it.
+
+That matters in a specific direction. Because the predicate is conjunctive and
+begins at the pid file, a **live** daemon whose pid file is missing, truncated,
+unreadable, or holding a pid the check declines to accept falls through to the
+unlink branch and has its socket removed underneath it, purely on the strength
+of a file that is not the thing being tested for liveness. In the other
+direction, once all four conjuncts hold the rendezvous is kept whatever the
+peer would have replied, because nothing asks it. The amendment's
+classification replaces this predicate; it does not refine it.
+
+A boolean probe of the shape this amendment breaks apart does exist, but it
+answers a different question. `probe_daemon_identity` in
+`crates/khive-mcp/src/daemon.rs` collapses ack shape, three mismatch flags,
+protocol version, and served config id into one condition, and its callers ask
+whether a _client_ may dispatch to the daemon or must fall back — including its
+own boot fence, which is not the daemon-boot rendezvous decision governed here.
+It is the closest existing analogue to the classification below and a useful
+reference for implementers, but it is not the predicate this amendment changes.
 
 Boot answers one question — "may I clean up the rendezvous and bind?" — and the
 convergence invariant above requires that the answer be governed by whether a
@@ -435,7 +458,7 @@ old value reads a retired code rather than silently inheriting a reused one.
 | #   | State                                             | Observable                                                                                                                                                           | Disposition                                                                                                                                                                                            | Exit |
 | --- | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---- |
 | 1   | Exact acknowledgement                             | connect ok, probe ack, identity matches                                                                                                                              | Refuse to start; report the incumbent pid                                                                                                                                                              | 0    |
-| 2   | Protocol-version mismatch                         | connect ok, `version_mismatch`                                                                                                                                       | Refuse; name both versions and the remedy. Never unlink                                                                                                                                                | 0    |
+| 2   | Protocol-version mismatch                         | connect ok, and either `version_mismatch` set OR `daemon_protocol_version` unequal to this build's — the two are independent fields, see the precedence rules below  | Refuse; name both versions and the remedy. Never unlink                                                                                                                                                | 0    |
 | 3   | Config mismatch                                   | connect ok, `config_mismatch` set — `served_config_id` may be absent, and is not part of this predicate                                                              | Refuse by default; name the first differing field without values when `served_config_id` is present, otherwise say identity was not echoed. Never unlink; replacing the incumbent is out of scope here | 0    |
 | 4   | Metrics-only reply                                | connect ok, reply carries metrics                                                                                                                                    | Refuse to start                                                                                                                                                                                        | 0    |
 | 5   | Identity unresolved                               | connect ok, reply HAS ack shape, no mismatch flag set, `served_config_id` ABSENT                                                                                     | Refuse to start; name the pid and that identity could not be established                                                                                                                               | 6    |
@@ -698,10 +721,24 @@ writing this one and should not be rediscovered:
   recipe therefore has to define an explicit valid baseline frame and override
   only the distinguishing fields per row.
 - State 13 is not observable at the listener-count element: the socket path is
-  present but not connectable, so no fixture can count who holds it. Either give
-  13 a seam whose owner is known, or exempt it from the four-element rule and
-  name a testable substitute — never waive the element that detects the
-  double-bind while still calling it mandatory.
+  present but not connectable, so no fixture can count who holds it. It is
+  exempt from that one element, and the substitute is fixed here rather than
+  left to the recipe, because an open-ended "testable substitute" readmits
+  exactly the test this section excludes everywhere else — one that asserts the
+  returned error and nothing about what boot did.
+
+  The substitute is a seam recording boot's **attempts**: how many times it
+  tried to bind the socket, and how many times it tried to unlink either
+  rendezvous path. A conforming state-13 test asserts both counts are zero and
+  that the socket and pid paths are unchanged by stat, in addition to the exit
+  code. Attempt counts rather than outcomes, because the failure being excluded
+  is boot _trying_ and being defeated by the environment, which is
+  indistinguishable from boot correctly refusing if only the end state is read.
+  The connect error alone is never sufficient: it describes what boot saw, not
+  what boot then did.
+
+  Never waive the element that detects the double-bind while still calling it
+  mandatory.
 
 Two obligations belong to this classification contract rather than to the
 fixture recipe, and both are required here because their absence is what allowed

--- a/docs/adr/ADR-049-khived-daemon.md
+++ b/docs/adr/ADR-049-khived-daemon.md
@@ -99,9 +99,16 @@ Warm becomes **non-blocking**, benefiting both modes:
 - Request frame: the serialized `RequestParams` (`ops`, `presentation`, `presentation_per_op`)
   plus the client's resolved namespace. Response frame: the JSON string the registry produces
   — byte-identical to what local dispatch returns.
-- Lifecycle: on startup, clean up a stale socket/PID (dead PID or unresponsive socket) as the
-  old daemon did. On SIGTERM/SIGINT, stop accepting, drain in-flight requests
-  (`KHIVE_DRAIN_TIMEOUT_SECS`, default 10), remove socket + PID, exit.
+- Lifecycle: on startup, clean up a stale socket/PID. **"Stale" is defined by the
+  incumbent state table in Amendment 6 and nowhere else**: only the states that
+  table marks "clean up and bind" are stale. In particular a socket that accepts
+  a connection and then stays silent is NOT stale — it is a live peer that did
+  not answer, and the amendment requires refusing and leaving the rendezvous
+  intact. The earlier phrasing of this rule, "dead PID or unresponsive socket",
+  is superseded: it reads a connected-but-silent peer as cleanable, which is the
+  exact collapse the amendment forbids. On SIGTERM/SIGINT, stop accepting, drain
+  in-flight requests (`KHIVE_DRAIN_TIMEOUT_SECS`, default 10), remove socket +
+  PID, exit.
 
 ### Scope boundary (what this ADR deliberately excludes)
 
@@ -378,50 +385,120 @@ bounded probe connect. `response` is what came back within the probe deadline.
 
 Exit codes are normative because supervisors read them: a supervisor configured
 to restart only on unsuccessful exit treats exit 0 as a deliberate stop.
-**Configuration-class** refusals — an operator must act, and restarting cannot
-help — exit 0. **State-class** refusals — transient or unclassified, where a
-retry may succeed — exit nonzero.
 
-| #  | State                                         | Observable                                                                                                                                                               | Disposition                                                                                   | Exit    |
-| -- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------- | ------- |
-| 1  | Exact acknowledgement                         | connect ok, probe ack, identity matches                                                                                                                                  | Refuse to start; report the incumbent pid                                                     | 0       |
-| 2  | Protocol-version mismatch                     | connect ok, `version_mismatch`                                                                                                                                           | Refuse; name both versions and the remedy. Never unlink                                       | 0       |
-| 3  | Config mismatch                               | connect ok, `config_mismatch`, `served_config_id` present                                                                                                                | Refuse by default; name the first differing field without values. Opt-in replacement only     | 0       |
-| 4  | Metrics-only reply                            | connect ok, reply carries metrics                                                                                                                                        | Refuse to start                                                                               | 0       |
-| 5  | Parseable non-acknowledgement                 | connect ok, frame deserializes, shape is not the probe ack (any of `result`/`error`/`request_id` present, or no mismatch flag set but the reply is otherwise not an ack) | Refuse to start; name the observed shape                                                      | 0       |
-| 6  | Identity unresolved                           | connect ok, otherwise ack-shaped, `served_config_id` absent or unequal with no mismatch flag set                                                                         | Refuse to start; name the pid and that identity could not be established                      | 0       |
-| 7  | Silent connect                                | connect ok, no parseable response within the deadline                                                                                                                    | Refuse; distinct error "connected but did not answer"                                         | nonzero |
-| 8  | Malformed reply                               | connect ok, bytes returned, frame does not parse                                                                                                                         | Refuse to start                                                                               | nonzero |
-| 9  | Connection refused, pid live                  | `ECONNREFUSED`, pid running                                                                                                                                              | Refuse; name the pid                                                                          | nonzero |
-| 10 | Connection refused, pid dead                  | `ECONNREFUSED`, pid not running                                                                                                                                          | Clean up and bind                                                                             | —       |
-| 11 | No socket, pid dead                           | socket absent, pid not running or pid file absent                                                                                                                        | Clean up and bind                                                                             | —       |
-| 12 | No socket, pid live                           | socket absent, pid running                                                                                                                                               | Refuse; name the pid, unless the pid is this process and same-process incumbency is permitted | 0       |
-| 13 | Other connect error (`EACCES`, `ENOTSOCK`, …) | connect fails, not refused                                                                                                                                               | Refuse; name the errno                                                                        | nonzero |
+**The class rule is "who resolves it", not "how long it lasts".** A refusal
+exits 0 when the condition can only be resolved by something other than a later
+retry of this process — an operator changing configuration, or another process
+that already owns the rendezvous. A refusal exits nonzero when the resolver IS a
+later retry of this process, so that a supervisor restart is the remedy.
+
+Transience is not the test. A rollout in which an older daemon answers the probe
+can last hours and still exits 0, because no number of restarts of this process
+ends it. A peer caught between fork and bind lasts milliseconds and also exits
+0, because the other process is the one that resolves it. Conversely a reply
+that failed to parse may be a one-off and exits nonzero, because retrying is
+exactly what might succeed.
+
+**Codes are numeric and distinct, not merely "nonzero".** A supervisor and an
+end-to-end test both need to tell these apart, and "nonzero" is a class, not a
+value:
+
+| Exit | Meaning                                                            | States                |
+| ---- | ------------------------------------------------------------------ | --------------------- |
+| 0    | Refused; resolver is an operator or another process                | 1, 2, 3, 4, 6, 12, 14 |
+| 1    | Reserved for unclassified failure; never emitted by classification | —                     |
+| 2    | Refused; connected but the peer did not answer                     | 7                     |
+| 3    | Refused; the peer's reply did not parse                            | 8                     |
+| 4    | Refused; connection refused while the recorded pid is running      | 9                     |
+| 5    | Refused; connect failed for a reason other than refusal            | 13                    |
+| 6    | Refused; the peer answered but its identity could not be resolved  | 5                     |
+
+Exit 1 is reserved so that an unclassified crash can never be mistaken for a
+classified refusal. States 10 and 11 have no exit code because they proceed to
+bind rather than refusing.
+
+| #  | State                                         | Observable                                                                                                                         | Disposition                                                                                                                     | Exit |
+| -- | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ---- |
+| 1  | Exact acknowledgement                         | connect ok, probe ack, identity matches                                                                                            | Refuse to start; report the incumbent pid                                                                                       | 0    |
+| 2  | Protocol-version mismatch                     | connect ok, `version_mismatch`                                                                                                     | Refuse; name both versions and the remedy. Never unlink                                                                         | 0    |
+| 3  | Config mismatch                               | connect ok, `config_mismatch`, `served_config_id` present                                                                          | Refuse by default; name the first differing field without values. Opt-in replacement only                                       | 0    |
+| 4  | Metrics-only reply                            | connect ok, reply carries metrics                                                                                                  | Refuse to start                                                                                                                 | 0    |
+| 5  | Identity unresolved                           | connect ok, reply HAS ack shape, no mismatch flag set, `served_config_id` absent or unequal                                        | Refuse to start; name the pid and that identity could not be established                                                        | 6    |
+| 6  | Parseable non-acknowledgement                 | connect ok, frame deserializes, reply does NOT have ack shape                                                                      | Refuse to start; name the observed shape                                                                                        | 0    |
+| 7  | Silent connect                                | connect ok, no parseable response within the deadline                                                                              | Refuse; distinct error "connected but did not answer"                                                                           | 2    |
+| 8  | Malformed reply                               | connect ok, bytes returned, frame does not parse                                                                                   | Refuse to start                                                                                                                 | 3    |
+| 9  | Connection refused, pid live                  | `ECONNREFUSED`, pid running                                                                                                        | Refuse; name the pid                                                                                                            | 4    |
+| 10 | Connection refused, no live listener          | `ECONNREFUSED`, and the recorded pid is not running OR no usable pid record exists (file absent, empty, or not parseable as a pid) | Clean up and bind                                                                                                               | —    |
+| 11 | No socket, pid dead                           | socket absent, pid not running or pid file absent                                                                                  | Clean up and bind                                                                                                               | —    |
+| 12 | No socket, pid live                           | socket absent, pid running                                                                                                         | Refuse; name the pid. If the pid is this process and same-process incumbency is permitted, the disposition is `MayBind` instead | 0    |
+| 13 | Other connect error (`EACCES`, `ENOTSOCK`, …) | connect fails, not refused                                                                                                         | Refuse; name the errno                                                                                                          | 5    |
+| 14 | Namespace mismatch                            | connect ok, `namespace_mismatch`                                                                                                   | Refuse; name both namespaces. Never unlink                                                                                      | 0    |
 
 Only states 10 and 11 are genuinely stale. Collapsing any other state into
 "clean up and bind" is the defect this amendment forbids.
 
-**Precedence.** A single reply can satisfy more than one row. Classification is
-by first match in table order, so a reply carrying both a mismatch flag and an
-unexpected shape is classified by the mismatch, which is the more specific and
-more actionable diagnosis. Any reply that reaches the end of the response rows
-without matching is state 5; state 5 is the catch-all for "a live peer answered
-and it was not an acknowledgement", and it must never fall through to cleanup.
+**Ack shape is syntactic and is defined independently of identity.** A reply
+"has ack shape" when, and only when, `ok` is set and every one of `result`,
+`error`, `metrics`, and `request_id` is absent. Nothing about protocol version,
+namespace, or `config_id` participates in that test. Identity is evaluated
+separately, and only on replies that already have ack shape. Keeping the two
+apart is what makes states 5 and 6 distinguishable at all; a definition of
+"shape" that folded identity into it would make state 5 unreachable, because
+every identity failure would also read as a shape failure.
+
+**Precedence — evaluation order, which row numbers do NOT determine.** Row
+numbers in the table above are stable labels, not an order. A single observation
+can satisfy more than one row, so classification takes the FIRST match in this
+order:
+
+1. No socket → state 11 or 12, by whether the recorded pid is running.
+2. Connect fails → state 9, 10, or 13, by errno and pid record.
+3. Connect succeeds, nothing parseable within the deadline → state 7.
+4. Bytes returned that do not deserialize → state 8.
+5. Frame deserializes and carries a mismatch flag → state 2 (version), 14
+   (namespace), or 3 (config). A reply carrying more than one flag is classified
+   by the first of those three that is set, because version mismatch subsumes
+   the rest: a peer on another protocol cannot be trusted to have evaluated
+   namespace or config at all.
+6. Frame deserializes, has ack shape, identity matches → state 1.
+7. Frame deserializes, carries metrics → state 4.
+8. Frame deserializes, has ack shape, no mismatch flag, identity absent or
+   unequal → state 5.
+9. Frame deserializes, does not have ack shape → state 6. This is the catch-all
+   and it is evaluated LAST among response rows. It must never fall through to
+   cleanup.
+
+State 5 is evaluated before the state 6 catch-all deliberately. Under a naive
+first-match-by-row-number rule the catch-all would absorb every state-5 reply,
+because a reply with no `served_config_id` can be described as "not an
+acknowledgement" — and a conforming implementation could then never produce the
+state-5 diagnosis the table promises.
 
 **States 5 and 6 are the ones an enumeration drawn from a single build will
-miss**, so they are stated explicitly. A daemon built before the probe frame
-existed deserializes the frame, ignores the unknown probe field, dispatches the
-empty operation string, and returns an ordinary success or error response. That
-response is well-formed, comes from a demonstrably live process, and is not an
-acknowledgement. Nothing about it is malformed, silent, or mismatched, so
-without state 5 a conforming implementation has no disposition for it and may
-classify it as stale. During any rollout in which two daemon builds exist on one
-machine, this is not a corner case; it is the expected observation.
+miss**, so they are stated explicitly, along with what actually produces them.
 
-State 6 covers the same hazard on the identity axis: a reply that is otherwise
-ack-shaped but whose `served_config_id` is absent or does not match, while no
-mismatch flag is set. Identity that cannot be established is not identity that
-was refuted, and neither is death.
+State 6's motivating case is a live peer that answers with something well-formed
+that is not an acknowledgement. **It is NOT produced by the daemon builds that
+precede the probe frame in this repository, and an earlier draft of this
+amendment said otherwise.** The pre-probe daemon declares `PROTOCOL_VERSION = 1`
+and its request handler tests the frame's protocol version FIRST, returning a
+`version_mismatch` response before the namespace check and before any dispatch;
+the probing build declares version 4. A version-4 probe against that peer
+therefore produces **state 2**, not state 6, and a test fixture built from the
+earlier description would have been testing a peer that does not exist. The
+state-6 fixture must instead be a peer speaking the SAME protocol version that
+does not recognise `probe_only` — it deserializes the frame, ignores the unknown
+field, dispatches the empty operation string, and returns an ordinary success or
+error response. That reply is well-formed, comes from a demonstrably live
+process, and is not an acknowledgement, so without state 6 a conforming
+implementation has no disposition for it and may classify it as stale.
+
+State 5 covers the same hazard on the identity axis: a reply that has ack shape
+but whose `served_config_id` is absent or does not match, while no mismatch flag
+is set. Identity that cannot be established is not identity that was refuted,
+and neither is death. It exits nonzero rather than 0 because a peer that has not
+yet published its identity may publish it before the next attempt, which makes a
+retry of this process the resolver.
 
 Every state above is reachable from the boot probe except **state 4**. The boot
 probe's request frame does not set the metrics flag, and the daemon's
@@ -438,21 +515,27 @@ easy to invert:
   respawning it is safe, licenses replacement being _safe_. It does not make
   replacement something boot performs unprompted. Disposable does not mean
   auto-replaced at boot.
-- **State 12 is a clean exit, and it is the one exception to the class rule.**
-  The convergence requirement already anticipates multiple launch attempts and
-  lets the daemon-side fence choose the sole owner, so losing that fence is
+- **State 12 is a clean exit, and it is where the class rule came from.** The
+  convergence requirement already anticipates multiple launch attempts and lets
+  the daemon-side fence choose the sole owner, so losing that fence is
   legitimate rather than an error. Blocking and re-probing belong to the
   client-side recoverer, never to daemon boot.
 
-  This deserves stating plainly because state 12 is transient — a peer between
-  fork and bind — and the class rule above would otherwise put a transient
-  condition in the state class and exit nonzero. The distinguishing invariant is
-  **who is expected to resolve it**, not how long it lasts: in every state-class
-  case the resolver is a later retry of _this_ process, so a supervisor restart
-  is the remedy. In state 12 the resolver is the _other_ process, which is
-  already booting and will own the rendezvous; restarting this one cannot help
-  and a restart loop is the likely result. Exit 0 encodes "someone else has
-  this", not "nothing is wrong".
+  State 12 is transient — a peer between fork and bind — and an earlier draft of
+  this amendment classed refusals by transience, which put state 12 in the
+  retryable class and exited nonzero. It was wrong, and working out why is what
+  produced the rule now stated above: the resolver of state 12 is the _other_
+  process, which is already booting and will own the rendezvous. Restarting this
+  one cannot help, and a restart loop is the likely result. Exit 0 encodes
+  "someone else has this", not "nothing is wrong".
+
+  **The same-process case has its own disposition.** When the recorded pid is
+  this process and same-process incumbency is permitted, boot has not lost the
+  fence to anyone — it IS the incumbent — so the disposition is `MayBind` and
+  there is no exit at all. That is the only branch in the whole table where a
+  live pid yields `MayBind`, and it is licensed solely by the pid being this
+  process. A harness must assert the pid identity, not merely that binding
+  succeeded, or it cannot tell this branch from a collapse into cleanup.
 
 ### Replacing a live incumbent
 
@@ -466,20 +549,42 @@ this amendment deliberately leaves to the implementing change.
 Removal of a live incumbent is operator-elected and gated behind an explicit
 `--replace-incumbent` opt-in. Every step is required:
 
-1. Classify. Proceed only from states 1 through 4, where a daemon identity was
-   positively read. Never from states 5 through 9, 12, or 13 — those have either
-   not established what would be killed, or not established that anything is
-   there at all. State 6 in particular is excluded precisely because an identity
-   that could not be resolved is not an identity that was refuted.
-2. Signal `SIGTERM` to the recorded pid.
-3. Wait, bounded, for process death. Death is **observed**, never assumed.
-4. On timeout, refuse: leave the socket intact and name the pid. Never escalate
+1. Classify. Proceed only from states 1 through 4 and 14, where a daemon
+   identity was positively read. Never from states 5 through 9, 12, or 13 —
+   those have either not established what would be killed, or not established
+   that anything is there at all. State 5 in particular is excluded precisely
+   because an identity that could not be resolved is not an identity that was
+   refuted.
+2. **Bind the pid to the socket.** The classification above proves that
+   _something_ live is serving the socket and what protocol and configuration it
+   speaks. It does not prove that the process named by the pid file is that
+   something. A pid file can be stale or its pid reused while an unrelated
+   process answers on the socket, and signalling on that evidence kills a
+   process this boot never contacted. Replacement therefore requires the probe
+   acknowledgement to carry the **serving process's own pid** (`served_pid`),
+   and requires it to equal the recorded pid. The responder self-reporting is
+   what makes this portable: peer-credential lookups on a unix socket are
+   spelled differently on each platform and are not available everywhere, while
+   a field in the reply is available wherever the protocol is.
+
+   If the acknowledgement carries no `served_pid`, or it does not equal the
+   recorded pid, **replacement is unavailable** — refuse and name both values.
+   Do not fall back to signalling the recorded pid. An ownership check that
+   degrades to "signal it anyway" is not a check.
+3. Signal `SIGTERM` to the pid established in step 2.
+4. Wait, bounded, for process death. Death is **observed**, never assumed.
+5. On timeout, refuse: leave the socket intact and name the pid. Never escalate
    to `SIGKILL` implicitly, and never unlink a socket whose owner is still
    alive.
-5. Only after observed death, remove the socket and pid file, then bind.
+6. Only after observed death, remove the socket and pid file, then bind.
 
-Step 3 is the substance. Removing a rendezvous file is not a way to stop a
-process.
+Steps 2 and 4 are the substance. Step 4 because removing a rendezvous file is
+not a way to stop a process; step 2 because every other step is careful about
+_how_ the incumbent is stopped while assuming _which_ process it is.
+
+`served_pid` does not exist on the response frame today. Adding it is part of
+implementing this section, and until it exists `--replace-incumbent` cannot be
+built to this contract.
 
 ### Test obligations
 
@@ -502,6 +607,42 @@ explicitly. Without all four, a test can be green while proving nothing:
 | **Probe input**              | The frame boot sends, so a test cannot accidentally exercise a different state than the one it names.                                                                                    |
 | **Rendezvous postcondition** | Whether the socket file and pid file still exist afterwards, asserted by stat, not inferred from the absence of an error.                                                                |
 | **Listener count**           | How many processes hold the socket after boot returns. This is the assertion that actually detects the double-bind, and no other element substitutes for it.                             |
+
+**The four elements, instantiated per state.** Stating the requirement without
+instantiating it leaves the test author to invent fixtures, and an invented
+fixture is exactly how a test ends up green against the wrong branch. Every row
+below is binding. `boot frame` means the standard probe: `probe_only` set, this
+build's `protocol_version`, this build's `config_id`. "scripted listener" means
+a socket bound by the test that replies with the literal frame given and nothing
+else.
+
+| #   | Peer setup                                                                                                                  | Probe input | Rendezvous postcondition              | Listeners after                                         | Exit |
+| --- | --------------------------------------------------------------------------------------------------------------------------- | ----------- | ------------------------------------- | ------------------------------------------------------- | ---- |
+| 1   | Real daemon, same version, same `config_id`                                                                                 | boot frame  | socket + pid file unchanged           | 1 (incumbent)                                           | 0    |
+| 2   | Scripted listener replying `{ok:false, version_mismatch:true, daemon_protocol_version:<other>}`                             | boot frame  | socket + pid file unchanged           | 1 (scripted)                                            | 0    |
+| 3   | Scripted listener replying `{ok:false, config_mismatch:true, served_config_id:<other>}`                                     | boot frame  | socket + pid file unchanged           | 1 (scripted)                                            | 0    |
+| 4   | Scripted listener replying with `metrics` populated. **Synthetic**: the real boot frame cannot elicit this                  | boot frame  | socket + pid file unchanged           | 1 (scripted)                                            | 0    |
+| 5   | Scripted listener replying `{ok:true}` with `served_config_id` ABSENT and no mismatch flag                                  | boot frame  | socket + pid file unchanged           | 1 (scripted)                                            | 6    |
+| 6   | Scripted listener replying `{ok:true, result:<any JSON>}` — ack-shape test fails on `result`                                | boot frame  | socket + pid file unchanged           | 1 (scripted)                                            | 0    |
+| 7   | Scripted listener that accepts the connection and writes nothing until past the probe deadline                              | boot frame  | socket + pid file unchanged           | 1 (scripted)                                            | 2    |
+| 8   | Scripted listener that writes bytes which are not a valid frame                                                             | boot frame  | socket + pid file unchanged           | 1 (scripted)                                            | 3    |
+| 9   | Socket file present with nothing bound to it; pid file names a live process (a sleeper is fine)                             | boot frame  | socket + pid file unchanged           | 0                                                       | 4    |
+| 10  | Socket file present with nothing bound; pid file names a dead pid, **and a second case with the pid file removed entirely** | boot frame  | socket + pid file REPLACED            | 1 (this process)                                        | —    |
+| 11  | No socket file; pid file names a dead pid or is absent                                                                      | boot frame  | socket + pid file created             | 1 (this process)                                        | —    |
+| 12  | No socket file; pid file names a live process that is NOT this one                                                          | boot frame  | pid file unchanged, no socket created | 1 (that process)                                        | 0    |
+| 12a | No socket file; pid file names THIS process, same-process incumbency permitted                                              | boot frame  | socket created by this process        | 1 (this process)                                        | —    |
+| 13  | Socket path present but not connectable for a reason other than refusal (e.g. mode 000 → `EACCES`)                          | boot frame  | socket + pid file unchanged           | not observable — assert the postcondition and exit only | 5    |
+| 14  | Scripted listener replying `{ok:false, namespace_mismatch:true}`                                                            | boot frame  | socket + pid file unchanged           | 1 (scripted)                                            | 0    |
+
+Row 12a is the `MayBind` branch and it is the only row where a live pid ends in
+binding. Its test asserts that the pid it matched is this process's own, not
+merely that a bind succeeded: without that assertion the row is
+indistinguishable from a collapse into cleanup, which is the defect the whole
+table exists to prevent.
+
+Row 13's listener count is stated as not observable rather than given a number,
+because a socket that cannot be connected to also cannot be interrogated for who
+holds it. Writing a number there would be a fabricated assertion.
 
 Two states need their mechanism named because the general recipe does not reach
 them. **State 4** cannot be elicited by the real boot probe, so its test is

--- a/docs/adr/ADR-049-khived-daemon.md
+++ b/docs/adr/ADR-049-khived-daemon.md
@@ -361,14 +361,26 @@ direction, once all four conjuncts hold the rendezvous is kept whatever the
 peer would have replied, because nothing asks it. The amendment's
 classification replaces this predicate; it does not refine it.
 
-A boolean probe of the shape this amendment breaks apart does exist, but it
-answers a different question. `probe_daemon_identity` in
-`crates/khive-mcp/src/daemon.rs` collapses ack shape, three mismatch flags,
-protocol version, and served config id into one condition, and its callers ask
-whether a _client_ may dispatch to the daemon or must fall back — including its
-own boot fence, which is not the daemon-boot rendezvous decision governed here.
-It is the closest existing analogue to the classification below and a useful
-reference for implementers, but it is not the predicate this amendment changes.
+A probe that collapses the distinctions this amendment draws does exist, but it
+answers a different question and it is not itself a boolean.
+`probe_daemon_identity` in `crates/khive-mcp/src/daemon.rs` returns a four-way
+`ProbeOutcome` — `Alive`, `Dead`, `Timeout`, and a lock-contended variant — so
+its callers can already separate a slow peer, and an unconfirmable peer boot,
+from a dead or mismatched one. What is collapsed is narrower: reaching `Alive`
+requires one boolean, `is_probe_ack`, conjoined with three mismatch flags,
+protocol version, and served config id, and everything failing that conjunction
+lands in the single `Dead` bucket. Its callers ask whether a _client_ may
+dispatch to the daemon or must fall back — including its own boot fence, which
+is not the daemon-boot rendezvous decision governed here.
+
+Its ack test is also weaker than the definition below, and deliberately so for
+its own purpose: `is_probe_ack` is `ok && result.is_none() && error.is_none()`,
+which does **not** exclude a reply carrying `metrics` or a `request_id`. An
+implementer must not read that predicate as an implementation of Amendment 6's
+ack shape; under this amendment a metrics-bearing reply is state 4 and never an
+acknowledgement. The function is the closest existing analogue to the
+classification below and a useful reference, but it is not the predicate this
+amendment changes, and its ack sentinel is not the one this amendment defines.
 
 Boot answers one question — "may I clean up the rendezvous and bind?" — and the
 convergence invariant above requires that the answer be governed by whether a
@@ -417,10 +429,37 @@ later retry of this process, so that a supervisor restart is the remedy.
 
 Transience is not the test. A rollout in which an older daemon answers the probe
 can last hours and still exits 0, because no number of restarts of this process
-ends it. A peer caught between fork and bind lasts milliseconds and also exits
-0, because the other process is the one that resolves it. Conversely a reply
-that failed to parse may be a one-off and exits nonzero, because retrying is
-exactly what might succeed.
+ends it. A peer caught between fork and bind lasts milliseconds and **in state
+12** also exits 0, because the other process is the one that resolves it.
+Conversely a reply that failed to parse may be a one-off and exits nonzero,
+because retrying is exactly what might succeed.
+
+**What "who resolves it" asks, stated once.** Nonzero asks whether a later
+attempt of this process can observe a _different classification_, not whether
+this attempt could have bound. That is the reading states 5 and 8 already use: a
+peer that has not published its identity may publish it before the next probe,
+and a reply that failed to parse may parse next time, so in both the retry is
+the resolver. State 15 is the counter-case — an identity the peer positively
+published cannot be re-observed differently, so no retry reaches a different
+classification and it exits 0. State 7 is nonzero on the state 8 reading: a peer
+that did not answer within the deadline may answer within the next one.
+
+> **OPEN — states 9 and 12 are not separated by the rule as written, and this
+> amendment does not settle it.** The two arise from the same instant of the
+> same race and only the socket separates them: no socket with a live foreign
+> pid is state 12 and exits 0, while a socket present and refusing with a live
+> pid is state 9 and exits 4. The rule above does not license that split. From
+> state 12 a retry reaches a binding outcome if the recorded pid dies before
+> binding (state 11), and from state 9 it reaches one on the same condition
+> (state 10), so "can a later attempt observe a different classification" is
+> true of both. The state 12 rationale below argues instead from the _expected_
+> trajectory — the peer is already booting and will own the rendezvous, so a
+> restart loop is the likely result — and that argument applies to state 9's
+> not-yet-bound half just as well. Either the rule needs a second clause that
+> names the discriminator, or one of the two codes is wrong. Resolving it by
+> asserting a distinction between them is what this note exists to prevent;
+> the contract is normative for supervisors, so it is a decision to be taken
+> and recorded, not inferred. Tracked before Amendment 6 is treated as settled.
 
 **Codes are numeric and distinct, not merely "nonzero".** A supervisor and an
 end-to-end test both need to tell these apart, and "nonzero" is a class, not a
@@ -685,8 +724,13 @@ state.
 
 Where a state's test runs below process level, the exit code is asserted against
 the value the classification maps to rather than against a real process exit,
-and at least one end-to-end test per exit class asserts a real process exit code
-so the mapping itself is covered.
+and at least one end-to-end test per **emitted** exit class asserts a real
+process exit code so the mapping itself is covered. The emitted classes are 0,
+2, 3, 4, and 6. Codes 1 and 5 are reserved and unemitted by classification, so
+they are deliberately not exercised as classification outcomes; requiring an
+end-to-end test for them would require producing an outcome this document
+forbids. A test that asserts no classified refusal ever exits 1 or 5 is welcome
+but belongs to the reserved-code guarantee, not to this per-class obligation.
 
 "One test per state" is not by itself enough to tell a conforming test from one
 that checks an error value, so each state's test declares four things

--- a/docs/adr/ADR-049-khived-daemon.md
+++ b/docs/adr/ADR-049-khived-daemon.md
@@ -403,36 +403,48 @@ exactly what might succeed.
 end-to-end test both need to tell these apart, and "nonzero" is a class, not a
 value:
 
-| Exit | Meaning                                                            | States                |
-| ---- | ------------------------------------------------------------------ | --------------------- |
-| 0    | Refused; resolver is an operator or another process                | 1, 2, 3, 4, 6, 12, 14 |
-| 1    | Reserved for unclassified failure; never emitted by classification | —                     |
-| 2    | Refused; connected but the peer did not answer                     | 7                     |
-| 3    | Refused; the peer's reply did not parse                            | 8                     |
-| 4    | Refused; connection refused while the recorded pid is running      | 9                     |
-| 5    | Refused; connect failed for a reason other than refusal            | 13                    |
-| 6    | Refused; the peer answered but its identity could not be resolved  | 5                     |
+| Exit | Meaning                                                            | States                    |
+| ---- | ------------------------------------------------------------------ | ------------------------- |
+| 0    | Refused; resolver is an operator or another process                | 1, 2, 3, 4, 6, 12, 13, 14 |
+| 1    | Reserved for unclassified failure; never emitted by classification | —                         |
+| 2    | Refused; connected but the peer did not answer                     | 7                         |
+| 3    | Refused; the peer's reply did not parse                            | 8                         |
+| 4    | Refused; connection refused while the recorded pid is running      | 9                         |
+| 5    | Reserved; formerly state 13, retired by this amendment             | —                         |
+| 6    | Refused; the peer answered but its identity could not be resolved  | 5                         |
 
 Exit 1 is reserved so that an unclassified crash can never be mistaken for a
 classified refusal. States 10 and 11 have no exit code because they proceed to
 bind rather than refusing.
 
-| #  | State                                         | Observable                                                                                                                         | Disposition                                                                                                                                          | Exit |
-| -- | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ---- |
-| 1  | Exact acknowledgement                         | connect ok, probe ack, identity matches                                                                                            | Refuse to start; report the incumbent pid                                                                                                            | 0    |
-| 2  | Protocol-version mismatch                     | connect ok, `version_mismatch`                                                                                                     | Refuse; name both versions and the remedy. Never unlink                                                                                              | 0    |
-| 3  | Config mismatch                               | connect ok, `config_mismatch`, `served_config_id` present                                                                          | Refuse by default; name the first differing field without values. Opt-in replacement only                                                            | 0    |
-| 4  | Metrics-only reply                            | connect ok, reply carries metrics                                                                                                  | Refuse to start                                                                                                                                      | 0    |
-| 5  | Identity unresolved                           | connect ok, reply HAS ack shape, no mismatch flag set, `served_config_id` absent or unequal                                        | Refuse to start; name the pid and that identity could not be established                                                                             | 6    |
-| 6  | Parseable non-acknowledgement                 | connect ok, frame deserializes, reply does NOT have ack shape                                                                      | Refuse to start; name the observed shape                                                                                                             | 0    |
-| 7  | Silent connect                                | connect ok, no parseable response within the deadline                                                                              | Refuse; distinct error "connected but did not answer"                                                                                                | 2    |
-| 8  | Malformed reply                               | connect ok, bytes returned, frame does not parse                                                                                   | Refuse to start                                                                                                                                      | 3    |
-| 9  | Connection refused, pid live                  | `ECONNREFUSED`, pid running                                                                                                        | Refuse; name the pid                                                                                                                                 | 4    |
-| 10 | Connection refused, no live listener          | `ECONNREFUSED`, and the recorded pid is not running OR no usable pid record exists (file absent, empty, or not parseable as a pid) | Clean up and bind                                                                                                                                    | —    |
-| 11 | No socket, pid dead                           | socket absent, pid not running or pid file absent                                                                                  | Clean up and bind                                                                                                                                    | —    |
-| 12 | No socket, pid live                           | socket absent, pid running                                                                                                         | Refuse; name the pid AND its command line. If the pid is this process and same-process incumbency is permitted, the disposition is `MayBind` instead | 0    |
-| 13 | Other connect error (`EACCES`, `ENOTSOCK`, …) | connect fails, not refused                                                                                                         | Refuse; name the errno                                                                                                                               | 5    |
-| 14 | Namespace mismatch (legacy peers only)        | connect ok, `namespace_mismatch` — no conforming daemon sets this since ADR-096 Fork 1                                             | Refuse; name both namespaces. Never unlink, never replace                                                                                            | 0    |
+**State 13 moved from exit 5 to exit 0, and exit 5 is retired rather than
+reused.** An earlier draft gave state 13 a nonzero code on the reasoning that a
+connect failure is a fault. That contradicted two rules of this document at
+once. Amendment 4 classifies every non-`ENOENT`, non-`ECONNREFUSED` connect
+error — `EACCES` and `EPERM` among them — as `Unreachable` and forbids retry,
+kill, and spawn on it; the class rule above assigns nonzero precisely when a
+later retry of this process is the resolver. A sandbox or filesystem-policy
+denial is resolved by an operator changing that policy, and no number of
+supervisor restarts ends it, so exit 0 is what the class rule requires. Exit 5
+is left defined and unemitted, like exit 1, so that a supervisor keyed on the
+old value reads a retired code rather than silently inheriting a reused one.
+
+| #  | State                                             | Observable                                                                                                                                            | Disposition                                                                                                                                                         | Exit |
+| -- | ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---- |
+| 1  | Exact acknowledgement                             | connect ok, probe ack, identity matches                                                                                                               | Refuse to start; report the incumbent pid                                                                                                                           | 0    |
+| 2  | Protocol-version mismatch                         | connect ok, `version_mismatch`                                                                                                                        | Refuse; name both versions and the remedy. Never unlink                                                                                                             | 0    |
+| 3  | Config mismatch                                   | connect ok, `config_mismatch` set — `served_config_id` may be absent, and is not part of this predicate                                               | Refuse by default; name the first differing field without values when `served_config_id` is present, otherwise say identity was not echoed. Opt-in replacement only | 0    |
+| 4  | Metrics-only reply                                | connect ok, reply carries metrics                                                                                                                     | Refuse to start                                                                                                                                                     | 0    |
+| 5  | Identity unresolved                               | connect ok, reply HAS ack shape, no mismatch flag set, `served_config_id` absent or unequal                                                           | Refuse to start; name the pid and that identity could not be established                                                                                            | 6    |
+| 6  | Parseable non-acknowledgement                     | connect ok, frame deserializes, reply does NOT have ack shape                                                                                         | Refuse to start; name the observed shape                                                                                                                            | 0    |
+| 7  | Silent connect                                    | connect ok, no parseable response within the deadline                                                                                                 | Refuse; distinct error "connected but did not answer"                                                                                                               | 2    |
+| 8  | Malformed reply                                   | connect ok, bytes returned, frame does not parse                                                                                                      | Refuse to start                                                                                                                                                     | 3    |
+| 9  | Connection refused, pid live                      | `ECONNREFUSED`, pid running                                                                                                                           | Refuse; name the pid                                                                                                                                                | 4    |
+| 10 | Connection refused, no live listener              | `ECONNREFUSED`, and the recorded pid is not running OR no usable pid record exists (file absent, empty, or not parseable as a pid)                    | Clean up and bind                                                                                                                                                   | —    |
+| 11 | No socket, pid dead                               | socket absent, pid not running or pid file absent                                                                                                     | Clean up and bind                                                                                                                                                   | —    |
+| 12 | No socket, pid live                               | socket absent, pid running                                                                                                                            | Refuse; name the pid AND its command line. If the pid is this process and same-process incumbency is permitted, the disposition is `MayBind` instead                | 0    |
+| 13 | Other connect error (`EACCES`, `ENOTSOCK`, …)     | connect fails, not refused                                                                                                                            | Refuse; name the errno. Never retry, kill, or spawn (Amendment 4)                                                                                                   | 0    |
+| 14 | Namespace mismatch (**defensive**, not reachable) | connect ok, `namespace_mismatch` — no conforming daemon sets this since ADR-096 Fork 1, and a peer old enough to set it fails the version check first | Refuse; name both namespaces. Never unlink, never replace                                                                                                           | 0    |
 
 Only states 10 and 11 are genuinely stale. Collapsing any other state into
 "clean up and bind" is the defect this amendment forbids.
@@ -455,11 +467,23 @@ order:
 2. Connect fails → state 9, 10, or 13, by errno and pid record.
 3. Connect succeeds, nothing parseable within the deadline → state 7.
 4. Bytes returned that do not deserialize → state 8.
-5. Frame deserializes and carries a mismatch flag → state 2 (version), 14
+5. Frame deserializes and either carries a mismatch flag or reports a
+   `daemon_protocol_version` unequal to this build's → state 2 (version), 14
    (namespace), or 3 (config). A reply carrying more than one flag is classified
    by the first of those three that is set, because version mismatch subsumes
    the rest: a peer on another protocol cannot be trusted to have evaluated
    namespace or config at all.
+
+   **An unequal `daemon_protocol_version` is state 2 even when
+   `version_mismatch` is unset.** The two are independent fields on the
+   response, so an older peer that does not recognise this build's version can
+   answer ack-shaped, carrying the current `config_id`, no flag set, and its own
+   lower version. The current client already carries a separate guard for that
+   exact shape (`crates/khive-mcp/src/daemon.rs`), so it is observed rather than
+   hypothetical. Routing it to state 5 would call a positively refuted protocol
+   identity an unresolved configuration identity, and would give it a
+   retry-resolved exit code when no retry of this process can raise the peer's
+   version.
 6. Frame deserializes, has ack shape, identity matches → state 1.
 7. Frame deserializes, carries metrics → state 4.
 8. Frame deserializes, has ack shape, no mismatch flag, identity absent or
@@ -500,12 +524,26 @@ and neither is death. It exits nonzero rather than 0 because a peer that has not
 yet published its identity may publish it before the next attempt, which makes a
 retry of this process the resolver.
 
-Every state above is reachable from the boot probe except **state 4**. The boot
-probe's request frame does not set the metrics flag, and the daemon's
+Every state above is reachable from the boot probe except **states 4 and 14**.
+The boot probe's request frame does not set the metrics flag, and the daemon's
 metrics reply is gated on that flag in the requesting frame, so a metrics-only
 reply cannot be elicited by boot. State 4 is retained as a defensive
 classification because a reply carrying metrics is unambiguous proof of life
 whatever elicited it, and misreading it as absence would be the same defect.
+
+**State 14 is defensive on the same footing, and an earlier draft of this
+amendment called it a live legacy observation.** That description does not
+survive the version history it appeals to. The pre-Fork-1 daemon declares
+protocol version 2 and tests protocol mismatch BEFORE the namespace check;
+ADR-096 Fork 1 bumped the version to 3 and removed the namespace reject
+outright; this build probes at version 4. So the only peer that still sets
+`namespace_mismatch` is one that answers a version-4 probe by reaching its
+protocol-mismatch branch first, which produces **state 2**. There is no
+conforming version at which a real peer produces state 14. It is retained
+exactly as state 4 is — because a frame that sets the flag is unambiguous proof
+of a live process whatever produced it, and reading it as absence would be the
+same defect — and its no-unlink, no-replace disposition stands unchanged, which
+is the whole reason retaining it costs nothing.
 
 Two consequences of the existing contract are worth stating because they are
 easy to invert:
@@ -578,27 +616,42 @@ Removal of a live incumbent is operator-elected and gated behind an explicit
    `!resp_other.namespace_mismatch` with the message "ADR-096 Fork 1 removed the
    namespace_mismatch reject"; no serve-side site sets the field true, while the
    sibling `config_mismatch` and `version_mismatch` fields both have such
-   sites). State 14 therefore survives only as a legacy observation — a peer
-   predating that change, still running, still setting the flag — and the one
+   sites). State 14 therefore survives only as a defensive classification, not
+   as a live legacy observation: a peer old enough to still set the flag is also
+   old enough to fail this build's version check first, so it answers with
+   `version_mismatch` and lands in state 2 instead. The one
    thing that must never be done on the word of an obsolete signal is to kill
    the process that sent it. Refuse, name both namespaces, leave the rendezvous
    alone.
-2. **Bind the pid to the socket.** The classification above proves that
-   _something_ live is serving the socket and what protocol and configuration it
-   speaks. It does not prove that the process named by the pid file is that
-   something. A pid file can be stale or its pid reused while an unrelated
-   process answers on the socket, and signalling on that evidence kills a
-   process this boot never contacted. Replacement therefore requires the probe
-   acknowledgement to carry the **serving process's own pid** (`served_pid`),
-   and requires it to equal the recorded pid. The responder self-reporting is
-   what makes this portable: peer-credential lookups on a unix socket are
-   spelled differently on each platform and are not available everywhere, while
-   a field in the reply is available wherever the protocol is.
+2. **Bind the pid to the socket, on evidence the incumbent cannot author.** The
+   classification above proves that _something_ live is serving the socket and
+   what protocol and configuration it speaks. It does not prove that the process
+   named by the pid file is that something. A pid file can be stale or its pid
+   reused while an unrelated process answers on the socket, and signalling on
+   that evidence kills a process this boot never contacted.
 
-   If the acknowledgement carries no `served_pid`, or it does not equal the
-   recorded pid, **replacement is unavailable** — refuse and name both values.
-   Do not fall back to signalling the recorded pid. An ownership check that
-   degrades to "signal it anyway" is not a check.
+   **An earlier draft of this amendment required the acknowledgement to carry
+   the serving process's own pid (`served_pid`) and justified that as the
+   portable choice. It was wrong twice over.** It was circular: the threat this
+   step exists to answer is an unrelated process answering on the socket, and
+   the remedy asked exactly that process to name itself — a same-uid squatter
+   supplies the recorded integer and passes. And its portability premise was
+   false in this repository, which already performs the platform-specific
+   peer-credential lookup the draft called unavailable: `peer_uid` reads
+   `getpeereid(2)` on macOS/BSD and `SO_PEERCRED` on Linux
+   (`crates/khive-runtime/src/daemon.rs`), is used on the accept path, and
+   carries a regression test asserting it reports the connecting process's uid.
+
+   The binding evidence is therefore the **kernel's answer for the peer of the
+   probe connection**, never a field the responder fills in: the peer pid from
+   `SO_PEERCRED` on Linux or `LOCAL_PEERPID` on macOS, required to equal the
+   recorded pid. Where the platform exposes no peer pid, **replacement is
+   unavailable on that platform** — refuse and say so. Where the lookup fails,
+   or the peer pid does not equal the recorded pid, replacement is likewise
+   unavailable — refuse and name both values. Do not fall back to signalling the
+   recorded pid, and do not fall back to a responder-supplied value. An
+   ownership check that degrades to "signal it anyway" is not a check, and one
+   the suspect can answer about itself is not evidence.
 3. Signal `SIGTERM` to the pid established in step 2.
 4. Wait, bounded, for process death. Death is **observed**, never assumed.
 5. On timeout, refuse: leave the socket intact and name the pid. Never escalate
@@ -610,9 +663,13 @@ Steps 2 and 4 are the substance. Step 4 because removing a rendezvous file is
 not a way to stop a process; step 2 because every other step is careful about
 _how_ the incumbent is stopped while assuming _which_ process it is.
 
-`served_pid` does not exist on the response frame today. Adding it is part of
-implementing this section, and until it exists `--replace-incumbent` cannot be
-built to this contract.
+Neither the peer-pid lookup nor any equivalent exists on the probe path today:
+`peer_uid` establishes only the peer's uid, and `LOCAL_PEERPID` is not spelled
+anywhere in this repository. Adding a peer-pid lookup beside `peer_uid`, and
+carrying its result out to the classification, is part of implementing this
+section; until it exists `--replace-incumbent` cannot be built to this contract.
+`served_pid` is named above only to record what was rejected, and must not be
+added to the response frame.
 
 ### Test obligations
 
@@ -641,8 +698,17 @@ instantiating it leaves the test author to invent fixtures, and an invented
 fixture is exactly how a test ends up green against the wrong branch. Every row
 below is binding. `boot frame` means the standard probe: `probe_only` set, this
 build's `protocol_version`, this build's `config_id`. "scripted listener" means
-a socket bound by the test that replies with the literal frame given and nothing
-else.
+a socket bound by the test that replies with the frame given and nothing else.
+
+**The frames below show only the fields that distinguish each case; they are not
+complete wire frames, and a harness must not transmit them literally.**
+`DaemonResponseFrame` declares `namespace_mismatch` with no `serde` default
+(`crates/khive-runtime/src/daemon.rs`), unlike its `config_mismatch`,
+`served_config_id`, `version_mismatch`, and `daemon_protocol_version` siblings.
+A row transmitted as written therefore fails to deserialize at the client, and
+rows 2, 3, 5, 6, and 14 would every one of them classify as state 8 — the exact
+state they exist to be distinguished from. Each fixture serializes a **complete**
+frame: the fields shown set as shown, every remaining field at its zero value.
 
 | #   | Peer setup                                                                                                                  | Probe input | Rendezvous postcondition              | Listeners after                                         | Exit |
 | --- | --------------------------------------------------------------------------------------------------------------------------- | ----------- | ------------------------------------- | ------------------------------------------------------- | ---- |
@@ -659,7 +725,7 @@ else.
 | 11  | No socket file; pid file names a dead pid or is absent                                                                      | boot frame  | socket + pid file created             | 1 (this process)                                        | —    |
 | 12  | No socket file; pid file names a live process that is NOT this one                                                          | boot frame  | pid file unchanged, no socket created | 1 (that process)                                        | 0    |
 | 12a | No socket file; pid file names THIS process, same-process incumbency permitted                                              | boot frame  | socket created by this process        | 1 (this process)                                        | —    |
-| 13  | Socket path present but not connectable for a reason other than refusal (e.g. mode 000 → `EACCES`)                          | boot frame  | socket + pid file unchanged           | not observable — assert the postcondition and exit only | 5    |
+| 13  | Socket path present but not connectable for a reason other than refusal (e.g. mode 000 → `EACCES`)                          | boot frame  | socket + pid file unchanged           | not observable — assert the postcondition and exit only | 0    |
 | 14  | Scripted listener replying `{ok:false, namespace_mismatch:true}`                                                            | boot frame  | socket + pid file unchanged           | 1 (scripted)                                            | 0    |
 
 Row 12a is the `MayBind` branch and it is the only row where a live pid ends in

--- a/docs/adr/ADR-049-khived-daemon.md
+++ b/docs/adr/ADR-049-khived-daemon.md
@@ -623,35 +623,56 @@ Removal of a live incumbent is operator-elected and gated behind an explicit
    thing that must never be done on the word of an obsolete signal is to kill
    the process that sent it. Refuse, name both namespaces, leave the rendezvous
    alone.
-2. **Bind the pid to the socket, on evidence the incumbent cannot author.** The
+2. **Bind the pid to the socket, and state what that binding is worth.** The
    classification above proves that _something_ live is serving the socket and
    what protocol and configuration it speaks. It does not prove that the process
    named by the pid file is that something. A pid file can be stale or its pid
    reused while an unrelated process answers on the socket, and signalling on
    that evidence kills a process this boot never contacted.
 
-   **An earlier draft of this amendment required the acknowledgement to carry
-   the serving process's own pid (`served_pid`) and justified that as the
-   portable choice. It was wrong twice over.** It was circular: the threat this
-   step exists to answer is an unrelated process answering on the socket, and
-   the remedy asked exactly that process to name itself — a same-uid squatter
-   supplies the recorded integer and passes. And its portability premise was
-   false in this repository, which already performs the platform-specific
-   peer-credential lookup the draft called unavailable: `peer_uid` reads
+   **The hazard this step guards is accidental pid reuse, and naming it is what
+   makes the evidence legible.** The acknowledgement must carry the serving
+   process's own pid (`served_pid`), and it must equal the recorded pid. That
+   binds socket to process for the accidental case, which is the case that
+   actually occurs: a pid recycled onto an unrelated process is a process that
+   does not speak this protocol, so it never produces an acknowledgement at all
+   — it lands in state 6, 7, or 8, and replacement is unavailable from every one
+   of those. The daemon that does answer reports its own true pid, which fails
+   the equality check against a stale record. Neither path signals.
+
+   **What `served_pid` alone does not establish is resistance to a process that
+   deliberately lies**, and that limit is worth stating precisely rather than
+   leaving a reader to assume the field is an ownership proof. A same-uid
+   process can bind the socket and return whatever integer it likes. That
+   process is already inside this daemon's trust boundary: the accept path
+   admits peers by same-uid check rather than same-principal
+   (`crates/khive-runtime/src/daemon.rs`), and anything able to squat the
+   rendezvous could signal the daemon directly without involving this sequence
+   at all. So `served_pid` is not load-bearing against a deliberate liar, and
+   this section does not claim it is.
+
+   **Where the platform exposes a kernel peer pid, replacement requires it too,
+   and refuses on any disagreement.** `SO_PEERCRED` on Linux and
+   `LOCAL_PEERPID` on macOS both report the peer of a connected unix socket, and
+   the repository already performs the sibling lookup for uid — `peer_uid` reads
    `getpeereid(2)` on macOS/BSD and `SO_PEERCRED` on Linux
    (`crates/khive-runtime/src/daemon.rs`), is used on the accept path, and
    carries a regression test asserting it reports the connecting process's uid.
+   The kernel pid must equal both `served_pid` and the recorded pid. This turns
+   the self-report into a cross-check wherever a cross-check is available, and a
+   disagreement between the two is itself disqualifying: refuse and name all
+   three values.
 
-   The binding evidence is therefore the **kernel's answer for the peer of the
-   probe connection**, never a field the responder fills in: the peer pid from
-   `SO_PEERCRED` on Linux or `LOCAL_PEERPID` on macOS, required to equal the
-   recorded pid. Where the platform exposes no peer pid, **replacement is
-   unavailable on that platform** — refuse and say so. Where the lookup fails,
-   or the peer pid does not equal the recorded pid, replacement is likewise
-   unavailable — refuse and name both values. Do not fall back to signalling the
-   recorded pid, and do not fall back to a responder-supplied value. An
-   ownership check that degrades to "signal it anyway" is not a check, and one
-   the suspect can answer about itself is not evidence.
+   Both platforms this daemon targets expose such a lookup, so in practice the
+   cross-check is required everywhere khived runs. A platform exposing neither
+   would fall back to `served_pid` alone, and an implementer should know that
+   this is the weakest evidence anywhere in this section.
+
+   If the acknowledgement carries no `served_pid`, or it does not equal the
+   recorded pid, or an available kernel peer pid disagrees with either,
+   **replacement is unavailable** — refuse and name the values. Do not fall back
+   to signalling the recorded pid. An ownership check that degrades to "signal
+   it anyway" is not a check.
 3. Signal `SIGTERM` to the pid established in step 2.
 4. Wait, bounded, for process death. Death is **observed**, never assumed.
 5. On timeout, refuse: leave the socket intact and name the pid. Never escalate
@@ -663,13 +684,13 @@ Steps 2 and 4 are the substance. Step 4 because removing a rendezvous file is
 not a way to stop a process; step 2 because every other step is careful about
 _how_ the incumbent is stopped while assuming _which_ process it is.
 
-Neither the peer-pid lookup nor any equivalent exists on the probe path today:
-`peer_uid` establishes only the peer's uid, and `LOCAL_PEERPID` is not spelled
-anywhere in this repository. Adding a peer-pid lookup beside `peer_uid`, and
-carrying its result out to the classification, is part of implementing this
-section; until it exists `--replace-incumbent` cannot be built to this contract.
-`served_pid` is named above only to record what was rejected, and must not be
-added to the response frame.
+Neither half of that evidence exists today. `served_pid` is not a field on the
+response frame, and no peer-pid lookup sits on the probe path: `peer_uid`
+establishes only the peer's uid, and `LOCAL_PEERPID` is not spelled anywhere in
+this repository. Implementing this section means adding both — the field to the
+response frame, and a peer-pid lookup beside `peer_uid` whose result reaches the
+classification — and until both exist `--replace-incumbent` cannot be built to
+this contract.
 
 ### Test obligations
 
@@ -759,6 +780,17 @@ collapse:
   class against it, asserting that startup never leaves two live daemons.
 - A `--replace-incumbent` timeout test in which the incumbent ignores `SIGTERM`,
   asserting refusal with the socket intact.
+- A `--replace-incumbent` test in which the acknowledgement carries a
+  `served_pid` that does not equal the recorded pid, asserting that **no signal
+  is sent** — the assertion is on the absence of the signal, not merely on the
+  refusal, because a sequence that signals and then reports refusal passes an
+  error-value check while doing the exact damage this step exists to prevent.
+  A sibling case with `served_pid` absent entirely, asserting the same.
+- A `--replace-incumbent` test on a platform exposing a kernel peer pid, in
+  which the kernel pid and a truthful `served_pid` agree and replacement
+  proceeds, paired with one in which they disagree and no signal is sent. The
+  disagreeing case is what proves the cross-check is read at all; without it the
+  agreeing case passes whether or not the kernel lookup is wired up.
 
 Each state's guard carries a mutation control: defeat the guard, confirm that
 exactly that state's test fails, and restore from a snapshot rather than by

--- a/docs/adr/ADR-049-khived-daemon.md
+++ b/docs/adr/ADR-049-khived-daemon.md
@@ -698,6 +698,17 @@ writing this one and should not be rediscovered:
   name a testable substitute — never waive the element that detects the
   double-bind while still calling it mandatory.
 
+Two obligations belong to this classification contract rather than to the
+fixture recipe, and both are required here because their absence is what allowed
+the collapse this amendment corrects:
+
+- A test that starts a real live incumbent and drives each non-acknowledgement
+  class against it, asserting that startup never leaves two live daemons.
+
+Each state's guard carries a mutation control: defeat the guard, confirm that
+exactly that state's test fails, and restore from a snapshot rather than by
+reapplying an inverse edit.
+
 ### What is unchanged
 
 The convergence requirement, the client-side recoverer lock, the daemon-side

--- a/docs/adr/ADR-049-khived-daemon.md
+++ b/docs/adr/ADR-049-khived-daemon.md
@@ -417,22 +417,22 @@ Exit 1 is reserved so that an unclassified crash can never be mistaken for a
 classified refusal. States 10 and 11 have no exit code because they proceed to
 bind rather than refusing.
 
-| #  | State                                         | Observable                                                                                                                         | Disposition                                                                                                                     | Exit |
-| -- | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ---- |
-| 1  | Exact acknowledgement                         | connect ok, probe ack, identity matches                                                                                            | Refuse to start; report the incumbent pid                                                                                       | 0    |
-| 2  | Protocol-version mismatch                     | connect ok, `version_mismatch`                                                                                                     | Refuse; name both versions and the remedy. Never unlink                                                                         | 0    |
-| 3  | Config mismatch                               | connect ok, `config_mismatch`, `served_config_id` present                                                                          | Refuse by default; name the first differing field without values. Opt-in replacement only                                       | 0    |
-| 4  | Metrics-only reply                            | connect ok, reply carries metrics                                                                                                  | Refuse to start                                                                                                                 | 0    |
-| 5  | Identity unresolved                           | connect ok, reply HAS ack shape, no mismatch flag set, `served_config_id` absent or unequal                                        | Refuse to start; name the pid and that identity could not be established                                                        | 6    |
-| 6  | Parseable non-acknowledgement                 | connect ok, frame deserializes, reply does NOT have ack shape                                                                      | Refuse to start; name the observed shape                                                                                        | 0    |
-| 7  | Silent connect                                | connect ok, no parseable response within the deadline                                                                              | Refuse; distinct error "connected but did not answer"                                                                           | 2    |
-| 8  | Malformed reply                               | connect ok, bytes returned, frame does not parse                                                                                   | Refuse to start                                                                                                                 | 3    |
-| 9  | Connection refused, pid live                  | `ECONNREFUSED`, pid running                                                                                                        | Refuse; name the pid                                                                                                            | 4    |
-| 10 | Connection refused, no live listener          | `ECONNREFUSED`, and the recorded pid is not running OR no usable pid record exists (file absent, empty, or not parseable as a pid) | Clean up and bind                                                                                                               | —    |
-| 11 | No socket, pid dead                           | socket absent, pid not running or pid file absent                                                                                  | Clean up and bind                                                                                                               | —    |
-| 12 | No socket, pid live                           | socket absent, pid running                                                                                                         | Refuse; name the pid. If the pid is this process and same-process incumbency is permitted, the disposition is `MayBind` instead | 0    |
-| 13 | Other connect error (`EACCES`, `ENOTSOCK`, …) | connect fails, not refused                                                                                                         | Refuse; name the errno                                                                                                          | 5    |
-| 14 | Namespace mismatch                            | connect ok, `namespace_mismatch`                                                                                                   | Refuse; name both namespaces. Never unlink                                                                                      | 0    |
+| #  | State                                         | Observable                                                                                                                         | Disposition                                                                                                                                          | Exit |
+| -- | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ---- |
+| 1  | Exact acknowledgement                         | connect ok, probe ack, identity matches                                                                                            | Refuse to start; report the incumbent pid                                                                                                            | 0    |
+| 2  | Protocol-version mismatch                     | connect ok, `version_mismatch`                                                                                                     | Refuse; name both versions and the remedy. Never unlink                                                                                              | 0    |
+| 3  | Config mismatch                               | connect ok, `config_mismatch`, `served_config_id` present                                                                          | Refuse by default; name the first differing field without values. Opt-in replacement only                                                            | 0    |
+| 4  | Metrics-only reply                            | connect ok, reply carries metrics                                                                                                  | Refuse to start                                                                                                                                      | 0    |
+| 5  | Identity unresolved                           | connect ok, reply HAS ack shape, no mismatch flag set, `served_config_id` absent or unequal                                        | Refuse to start; name the pid and that identity could not be established                                                                             | 6    |
+| 6  | Parseable non-acknowledgement                 | connect ok, frame deserializes, reply does NOT have ack shape                                                                      | Refuse to start; name the observed shape                                                                                                             | 0    |
+| 7  | Silent connect                                | connect ok, no parseable response within the deadline                                                                              | Refuse; distinct error "connected but did not answer"                                                                                                | 2    |
+| 8  | Malformed reply                               | connect ok, bytes returned, frame does not parse                                                                                   | Refuse to start                                                                                                                                      | 3    |
+| 9  | Connection refused, pid live                  | `ECONNREFUSED`, pid running                                                                                                        | Refuse; name the pid                                                                                                                                 | 4    |
+| 10 | Connection refused, no live listener          | `ECONNREFUSED`, and the recorded pid is not running OR no usable pid record exists (file absent, empty, or not parseable as a pid) | Clean up and bind                                                                                                                                    | —    |
+| 11 | No socket, pid dead                           | socket absent, pid not running or pid file absent                                                                                  | Clean up and bind                                                                                                                                    | —    |
+| 12 | No socket, pid live                           | socket absent, pid running                                                                                                         | Refuse; name the pid AND its command line. If the pid is this process and same-process incumbency is permitted, the disposition is `MayBind` instead | 0    |
+| 13 | Other connect error (`EACCES`, `ENOTSOCK`, …) | connect fails, not refused                                                                                                         | Refuse; name the errno                                                                                                                               | 5    |
+| 14 | Namespace mismatch (legacy peers only)        | connect ok, `namespace_mismatch` — no conforming daemon sets this since ADR-096 Fork 1                                             | Refuse; name both namespaces. Never unlink, never replace                                                                                            | 0    |
 
 Only states 10 and 11 are genuinely stale. Collapsing any other state into
 "clean up and bind" is the defect this amendment forbids.
@@ -529,6 +529,19 @@ easy to invert:
   one cannot help, and a restart loop is the likely result. Exit 0 encodes
   "someone else has this", not "nothing is wrong".
 
+  **The refusal must name the pid AND its command line**, because the class rule
+  has one failure mode and this is it. A pid file can outlive its writer and the
+  number be reused by an unrelated long-lived process. That reads as state 12
+  forever: the pid is live, so it is never cleaned; the disposition is exit 0, so
+  a supervisor configured to restart only on unsuccessful exit never retries. The
+  boot is wedged, permanently, and correctly according to every rule above —
+  because the one thing the rules cannot check is whether the live pid is a
+  khived at all. Printing the command line beside the pid is what lets an
+  operator see in one line that the incumbent is not a khived, which is the only
+  evidence that distinguishes a genuine race from a stale rendezvous with a
+  recycled pid. A refusal that prints the bare number leaves them with nothing to
+  act on and no signal that anything is wrong.
+
   **The same-process case has its own disposition.** When the recorded pid is
   this process and same-process incumbency is permitted, boot has not lost the
   fence to anyone — it IS the incumbent — so the disposition is `MayBind` and
@@ -549,12 +562,27 @@ this amendment deliberately leaves to the implementing change.
 Removal of a live incumbent is operator-elected and gated behind an explicit
 `--replace-incumbent` opt-in. Every step is required:
 
-1. Classify. Proceed only from states 1 through 4 and 14, where a daemon
-   identity was positively read. Never from states 5 through 9, 12, or 13 —
-   those have either not established what would be killed, or not established
-   that anything is there at all. State 5 in particular is excluded precisely
-   because an identity that could not be resolved is not an identity that was
-   refuted.
+1. Classify. Proceed only from states 1 through 4, where a daemon identity was
+   positively read. Never from states 5 through 9 or 12 through 14 — those have
+   either not established what would be killed, or not established that anything
+   is there at all. State 5 in particular is excluded precisely because an
+   identity that could not be resolved is not an identity that was refuted.
+
+   **State 14 is deliberately NOT on this list, and an earlier draft of this
+   amendment had it there.** The reasoning that put it there was that a daemon
+   serving a different namespace is an incumbent like any other. That reasoning
+   is obsolete: ADR-096 Fork 1 removed the namespace reject outright, so a
+   correctly built daemon serves a differently-namespaced frame rather than
+   refusing it, and `namespace_mismatch` is never set on any serve path
+   (`crates/khive-mcp/src/daemon.rs`, the ADR-096 Fork 1 test asserts
+   `!resp_other.namespace_mismatch` with the message "ADR-096 Fork 1 removed the
+   namespace_mismatch reject"; no serve-side site sets the field true, while the
+   sibling `config_mismatch` and `version_mismatch` fields both have such
+   sites). State 14 therefore survives only as a legacy observation — a peer
+   predating that change, still running, still setting the flag — and the one
+   thing that must never be done on the word of an obsolete signal is to kill
+   the process that sent it. Refuse, name both namespaces, leave the rendezvous
+   alone.
 2. **Bind the pid to the socket.** The classification above proves that
    _something_ live is serving the socket and what protocol and configuration it
    speaks. It does not prove that the process named by the pid file is that

--- a/docs/adr/ADR-049-khived-daemon.md
+++ b/docs/adr/ADR-049-khived-daemon.md
@@ -660,6 +660,11 @@ asserts its exit code, since an otherwise-correct refusal carrying the wrong
 code either drives a supervisor restart loop or silently retires a retryable
 state.
 
+Where a state's test runs below process level, the exit code is asserted against
+the value the classification maps to rather than against a real process exit,
+and at least one end-to-end test per exit class asserts a real process exit code
+so the mapping itself is covered.
+
 "One test per state" is not by itself enough to tell a conforming test from one
 that checks an error value, so each state's test declares four things
 explicitly. Without all four, a test can be green while proving nothing:

--- a/docs/adr/ADR-049-khived-daemon.md
+++ b/docs/adr/ADR-049-khived-daemon.md
@@ -472,14 +472,22 @@ not reopened from the same premise:
    cannot be a peer caught between fork and bind: the pid file does not exist
    yet at that point in boot.
 
-2. **Shutdown runs the other way.** The lifecycle rule earlier in this document
-   has SIGTERM/SIGINT stop accepting, drain in-flight requests, then remove
-   socket and PID file, in that order. The window in which the socket is gone
-   while the pid file still names a live process is therefore LATE SHUTDOWN, not
-   early boot. Read against the code, a state 12 observation is at least as
-   consistent with a daemon about to exit — whose next state is 11, which this
-   process resolves by binding — as with one about to bind. That reading argues
-   for nonzero, the opposite of what the table gives it.
+2. **Shutdown runs the other way, but a conforming boot cannot observe it.** The
+   lifecycle rule earlier in this document has SIGTERM/SIGINT stop accepting,
+   drain in-flight requests, then remove socket and PID file, in that order. An
+   earlier version of this note inferred from that ordering that a state 12
+   observation is at least as consistent with a daemon about to exit as with one
+   about to bind, and that the reading therefore argues for nonzero. **That
+   inference does not survive the locking, and is withdrawn.** Shutdown unlinks
+   only while holding the recovery lock, and when it cannot acquire that lock it
+   skips the unlink entirely rather than proceeding unlocked
+   (`crates/khive-runtime/src/daemon.rs:1856-1870`); the two unlinks themselves
+   are adjacent syscalls inside that critical section (`:1888-1892`). Daemon boot
+   must hold the same exclusive lock across cleanup, bind and pid-write
+   (`daemon.rs:186-195` and `:268-281`). A conforming competing boot therefore
+   blocks until both files are gone, and cannot observe the orderly
+   socket-gone/pid-live interval at all. The shutdown ordering stands as a fact.
+   It licenses nothing about state 12, in either direction.
 
 3. **A live recorded pid proves nothing about ownership, in either state.**
    Liveness is `kill(pid, 0)` (`daemon.rs:1943-1996`) and the incumbent check is
@@ -491,8 +499,11 @@ not reopened from the same premise:
    pid may belong to an unrelated long-lived process; the withdrawn clause
    forgot it.
 
-Neither state licenses a trajectory reading, then, and these exit codes are
-normative for supervisors. **The codes in the table below are UNCHANGED and
+What is left, once the boot window is impossible and the shutdown window is
+unobservable, is fact 3: the observation that actually persists in either state
+is a recorded pid that has been reused by an unrelated live process, which no
+retry of this process ever resolves. Neither state licenses a trajectory
+reading, then, and these exit codes are normative for supervisors. **The codes in the table below are UNCHANGED and
 remain what implementations follow.** What is open is their justification, and
 it is tracked here rather than asserted. Resolving it is deliberately out of
 scope for this amendment: the classification is already the improvement over the

--- a/docs/adr/ADR-049-khived-daemon.md
+++ b/docs/adr/ADR-049-khived-daemon.md
@@ -331,6 +331,15 @@ write or reports a retryable read timeout for it.
 
 ## Amendment 6 (2026-08-26): incumbent classification at boot
 
+**This amendment specifies a contract that current code does not satisfy.** It
+is normative, not descriptive: every rule below states what boot must do, and
+none of it should be read as an account of what boot does today. The present
+implementation reduces the probe to a boolean that is true only for an exact
+acknowledgement, and treats everything else — including replies from
+demonstrably live daemons — as grounds for removing the rendezvous. Bringing the
+code to this contract is a prerequisite for the guarantees stated here, not a
+consequence of recording them.
+
 Boot answers one question — "may I clean up the rendezvous and bind?" — and the
 convergence invariant above requires that the answer be governed by whether a
 daemon is **live**, never by whether it is one this process would choose to talk
@@ -373,22 +382,46 @@ to restart only on unsuccessful exit treats exit 0 as a deliberate stop.
 help — exit 0. **State-class** refusals — transient or unclassified, where a
 retry may succeed — exit nonzero.
 
-| #  | State                                         | Observable                                                | Disposition                                                                                   | Exit    |
-| -- | --------------------------------------------- | --------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ------- |
-| 1  | Exact acknowledgement                         | connect ok, probe ack, identity matches                   | Refuse to start; report the incumbent pid                                                     | 0       |
-| 2  | Protocol-version mismatch                     | connect ok, `version_mismatch`                            | Refuse; name both versions and the remedy. Never unlink                                       | 0       |
-| 3  | Config mismatch                               | connect ok, `config_mismatch`, `served_config_id` present | Refuse by default; name the first differing field without values. Opt-in replacement only     | 0       |
-| 4  | Metrics-only reply                            | connect ok, reply carries metrics                         | Refuse to start                                                                               | 0       |
-| 5  | Silent connect                                | connect ok, no parseable response within the deadline     | Refuse; distinct error "connected but did not answer"                                         | nonzero |
-| 6  | Malformed reply                               | connect ok, bytes returned, frame does not parse          | Refuse to start                                                                               | nonzero |
-| 7  | Connection refused, pid live                  | `ECONNREFUSED`, pid running                               | Refuse; name the pid                                                                          | nonzero |
-| 8  | Connection refused, pid dead                  | `ECONNREFUSED`, pid not running                           | Clean up and bind                                                                             | —       |
-| 9  | No socket, pid dead                           | socket absent, pid not running or pid file absent         | Clean up and bind                                                                             | —       |
-| 10 | No socket, pid live                           | socket absent, pid running                                | Refuse; name the pid, unless the pid is this process and same-process incumbency is permitted | 0       |
-| 11 | Other connect error (`EACCES`, `ENOTSOCK`, …) | connect fails, not refused                                | Refuse; name the errno                                                                        | nonzero |
+| #  | State                                         | Observable                                                                                                                                                               | Disposition                                                                                   | Exit    |
+| -- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------- | ------- |
+| 1  | Exact acknowledgement                         | connect ok, probe ack, identity matches                                                                                                                                  | Refuse to start; report the incumbent pid                                                     | 0       |
+| 2  | Protocol-version mismatch                     | connect ok, `version_mismatch`                                                                                                                                           | Refuse; name both versions and the remedy. Never unlink                                       | 0       |
+| 3  | Config mismatch                               | connect ok, `config_mismatch`, `served_config_id` present                                                                                                                | Refuse by default; name the first differing field without values. Opt-in replacement only     | 0       |
+| 4  | Metrics-only reply                            | connect ok, reply carries metrics                                                                                                                                        | Refuse to start                                                                               | 0       |
+| 5  | Parseable non-acknowledgement                 | connect ok, frame deserializes, shape is not the probe ack (any of `result`/`error`/`request_id` present, or no mismatch flag set but the reply is otherwise not an ack) | Refuse to start; name the observed shape                                                      | 0       |
+| 6  | Identity unresolved                           | connect ok, otherwise ack-shaped, `served_config_id` absent or unequal with no mismatch flag set                                                                         | Refuse to start; name the pid and that identity could not be established                      | 0       |
+| 7  | Silent connect                                | connect ok, no parseable response within the deadline                                                                                                                    | Refuse; distinct error "connected but did not answer"                                         | nonzero |
+| 8  | Malformed reply                               | connect ok, bytes returned, frame does not parse                                                                                                                         | Refuse to start                                                                               | nonzero |
+| 9  | Connection refused, pid live                  | `ECONNREFUSED`, pid running                                                                                                                                              | Refuse; name the pid                                                                          | nonzero |
+| 10 | Connection refused, pid dead                  | `ECONNREFUSED`, pid not running                                                                                                                                          | Clean up and bind                                                                             | —       |
+| 11 | No socket, pid dead                           | socket absent, pid not running or pid file absent                                                                                                                        | Clean up and bind                                                                             | —       |
+| 12 | No socket, pid live                           | socket absent, pid running                                                                                                                                               | Refuse; name the pid, unless the pid is this process and same-process incumbency is permitted | 0       |
+| 13 | Other connect error (`EACCES`, `ENOTSOCK`, …) | connect fails, not refused                                                                                                                                               | Refuse; name the errno                                                                        | nonzero |
 
-Only states 8 and 9 are genuinely stale. Collapsing any of 2, 3, 5, 6, 7, 10 or
-11 into "clean up and bind" is the defect this amendment forbids.
+Only states 10 and 11 are genuinely stale. Collapsing any other state into
+"clean up and bind" is the defect this amendment forbids.
+
+**Precedence.** A single reply can satisfy more than one row. Classification is
+by first match in table order, so a reply carrying both a mismatch flag and an
+unexpected shape is classified by the mismatch, which is the more specific and
+more actionable diagnosis. Any reply that reaches the end of the response rows
+without matching is state 5; state 5 is the catch-all for "a live peer answered
+and it was not an acknowledgement", and it must never fall through to cleanup.
+
+**States 5 and 6 are the ones an enumeration drawn from a single build will
+miss**, so they are stated explicitly. A daemon built before the probe frame
+existed deserializes the frame, ignores the unknown probe field, dispatches the
+empty operation string, and returns an ordinary success or error response. That
+response is well-formed, comes from a demonstrably live process, and is not an
+acknowledgement. Nothing about it is malformed, silent, or mismatched, so
+without state 5 a conforming implementation has no disposition for it and may
+classify it as stale. During any rollout in which two daemon builds exist on one
+machine, this is not a corner case; it is the expected observation.
+
+State 6 covers the same hazard on the identity axis: a reply that is otherwise
+ack-shaped but whose `served_config_id` is absent or does not match, while no
+mismatch flag is set. Identity that cannot be established is not identity that
+was refuted, and neither is death.
 
 Every state above is reachable from the boot probe except **state 4**. The boot
 probe's request frame does not set the metrics flag, and the daemon's
@@ -405,19 +438,39 @@ easy to invert:
   respawning it is safe, licenses replacement being _safe_. It does not make
   replacement something boot performs unprompted. Disposable does not mean
   auto-replaced at boot.
-- **State 10 is a clean exit.** The convergence requirement already anticipates
-  multiple launch attempts and lets the daemon-side fence choose the sole owner,
-  so losing that fence is legitimate rather than an error. Blocking and
-  re-probing belong to the client-side recoverer, never to daemon boot.
+- **State 12 is a clean exit, and it is the one exception to the class rule.**
+  The convergence requirement already anticipates multiple launch attempts and
+  lets the daemon-side fence choose the sole owner, so losing that fence is
+  legitimate rather than an error. Blocking and re-probing belong to the
+  client-side recoverer, never to daemon boot.
+
+  This deserves stating plainly because state 12 is transient — a peer between
+  fork and bind — and the class rule above would otherwise put a transient
+  condition in the state class and exit nonzero. The distinguishing invariant is
+  **who is expected to resolve it**, not how long it lasts: in every state-class
+  case the resolver is a later retry of _this_ process, so a supervisor restart
+  is the remedy. In state 12 the resolver is the _other_ process, which is
+  already booting and will own the rendezvous; restarting this one cannot help
+  and a restart loop is the likely result. Exit 0 encodes "someone else has
+  this", not "nothing is wrong".
 
 ### Replacing a live incumbent
 
-Removal of a live incumbent is operator-elected and available only through an
-explicit `--replace-incumbent` opt-in. Every step is required:
+This section specifies a capability that **does not exist yet**. No replacement
+flag is present on any current command surface, and nothing here describes
+maintained behaviour. It is written as a contract so that the capability, when
+built, is built with the safety sequence rather than acquiring it afterwards.
+Implementing it requires naming the owning subcommand and its parsing, which
+this amendment deliberately leaves to the implementing change.
+
+Removal of a live incumbent is operator-elected and gated behind an explicit
+`--replace-incumbent` opt-in. Every step is required:
 
 1. Classify. Proceed only from states 1 through 4, where a daemon identity was
-   positively read. Never from 5, 6, 7, 10 or 11 — those have not established
-   what would be killed.
+   positively read. Never from states 5 through 9, 12, or 13 — those have either
+   not established what would be killed, or not established that anything is
+   there at all. State 6 in particular is excluded precisely because an identity
+   that could not be resolved is not an identity that was refuted.
 2. Signal `SIGTERM` to the recorded pid.
 3. Wait, bounded, for process death. Death is **observed**, never assumed.
 4. On timeout, refuse: leave the socket intact and name the pid. Never escalate
@@ -438,6 +491,31 @@ process, which is precisely the failure being prevented. Each refuse state also
 asserts its exit code, since an otherwise-correct refusal carrying the wrong
 code either drives a supervisor restart loop or silently retires a retryable
 state.
+
+"One test per state" is not by itself enough to tell a conforming test from one
+that checks an error value, so each state's test declares four things
+explicitly. Without all four, a test can be green while proving nothing:
+
+| Element                      | What it fixes                                                                                                                                                                            |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Peer setup**               | Exactly what the fixture puts behind the socket: a real daemon, a synthetic listener with a scripted reply, or nothing. Names which, and for a scripted reply, the exact response frame. |
+| **Probe input**              | The frame boot sends, so a test cannot accidentally exercise a different state than the one it names.                                                                                    |
+| **Rendezvous postcondition** | Whether the socket file and pid file still exist afterwards, asserted by stat, not inferred from the absence of an error.                                                                |
+| **Listener count**           | How many processes hold the socket after boot returns. This is the assertion that actually detects the double-bind, and no other element substitutes for it.                             |
+
+Two states need their mechanism named because the general recipe does not reach
+them. **State 4** cannot be elicited by the real boot probe, so its test is
+explicitly synthetic: a scripted listener that returns a metrics-carrying reply.
+The test asserts the classification, and must be labelled synthetic so a later
+reader does not mistake it for evidence that boot can reach the state. **States
+10 and 11** are the two that bind, so their postcondition is inverted: the test
+asserts the rendezvous was replaced and that exactly one listener — this process
+— holds it afterwards.
+
+Where a state's test runs below process level, the exit code is asserted against
+the value the classification maps to rather than against a real process exit,
+and at least one end-to-end test per exit class asserts a real process exit code
+so the mapping itself is covered.
 
 Two further tests are required because their absence is what allowed the
 collapse:

--- a/docs/adr/ADR-049-khived-daemon.md
+++ b/docs/adr/ADR-049-khived-daemon.md
@@ -429,10 +429,16 @@ later retry of this process, so that a supervisor restart is the remedy.
 
 Transience is not the test. A rollout in which an older daemon answers the probe
 can last hours and still exits 0, because no number of restarts of this process
-ends it. A peer caught between fork and bind lasts milliseconds and **in state
-12** also exits 0, because the other process is the one that resolves it.
-Conversely a reply that failed to parse may be a one-off and exits nonzero,
-because retrying is exactly what might succeed.
+ends it. Conversely a reply that failed to parse may be a one-off and exits
+nonzero, because retrying is exactly what might succeed. How long a condition
+lasts and who resolves it are independent properties, and only the second one is
+the test.
+
+An earlier draft made that point with a peer caught between fork and bind,
+offered as the short-lived case that still exits 0. That example is withdrawn:
+the code publishes the socket before the pid file, so no observation of a
+booting peer produces state 12 at all. The open note below records the reading
+at source.
 
 **What "who resolves it" asks, stated once.** Nonzero asks whether a later
 attempt of this process can observe a _different classification_, not whether
@@ -444,32 +450,54 @@ published cannot be re-observed differently, so no retry reaches a different
 classification and it exits 0. State 7 is nonzero on the state 8 reading: a peer
 that did not answer within the deadline may answer within the next one.
 
-**Second clause: where a live recorded pid is shared, the socket names that
-pid's trajectory.** Asking only whether a later attempt observes a different
+**OPEN: the split between exit 4 and exit 0 for states 9 and 12 is currently
+unlicensed.** Asking only whether a later attempt observes a different
 classification is necessary but not sufficient, because it is true of both
-states 9 and 12. They arise from the same instant of the same race and only the
-socket separates them, so on the first clause alone the split between exit 4 and
-exit 0 is unlicensed. What licenses it is which classification the trajectory
-leads to: binding by this process, or refusal by an owner.
+states. They arise from the same instant of the same race and only the socket
+separates them, so the class rule alone does not say which of them gets a
+retryable code.
 
-A socket present with a live recorded pid that refuses connections is a daemon
-_past_ its listener. The lifecycle rule above requires that on SIGTERM/SIGINT a
-daemon stop accepting, drain in-flight requests, and only then remove the socket
-and the PID file, so a refusing socket with its owner still alive is that daemon
-draining, and its next state is death. That death lands in whichever of the two
-genuinely stale states applies: state 11 when the drain completed its own
-cleanup, state 10 when the socket outlived the process. Both are states this
-process resolves by cleaning up and binding, so the resolver is a later attempt
-of this process and nonzero stands. State 9 keeps exit 4.
+An earlier version of this section supplied that license with a trajectory
+argument: a socket present with a live refusing owner was said to be a daemon
+_past_ its listener, and a live recorded pid with no socket a peer _before_ its
+listener, whose next state is ownership. **That argument is withdrawn.** Three
+facts, each read at source, are why. They are recorded here so the question is
+not reopened from the same premise:
 
-A live recorded pid with no socket is _before_ its listener. Its next state is
-ownership, which a later attempt observes as state 1, so the resolver is the
-other process, and a supervisor restart loop is the harm the code has to avoid.
-State 12 keeps exit 0.
+1. **Boot publishes the socket before the pid file.** In
+   `crates/khive-runtime/src/daemon.rs`, `UnixListener::bind(&sock)` is at line
+   1644 and `write_pid_file_exclusive(&pid_file)` at line 1662, with only the
+   chmod and the socket-identity capture between them. A booting peer therefore
+   has a socket before it has a pid record, so "no socket, live recorded pid"
+   cannot be a peer caught between fork and bind: the pid file does not exist
+   yet at that point in boot.
 
-The bind-to-listen gap does reach state 9, for at most one attempt, and it is
-harmless there: the retry meets state 1 and exits 0, at a cost of one supervisor
-restart.
+2. **Shutdown runs the other way.** The lifecycle rule earlier in this document
+   has SIGTERM/SIGINT stop accepting, drain in-flight requests, then remove
+   socket and PID file, in that order. The window in which the socket is gone
+   while the pid file still names a live process is therefore LATE SHUTDOWN, not
+   early boot. Read against the code, a state 12 observation is at least as
+   consistent with a daemon about to exit — whose next state is 11, which this
+   process resolves by binding — as with one about to bind. That reading argues
+   for nonzero, the opposite of what the table gives it.
+
+3. **A live recorded pid proves nothing about ownership, in either state.**
+   Liveness is `kill(pid, 0)` (`daemon.rs:1943-1996`) and the incumbent check is
+   a plain connect. Neither establishes that the recorded pid owns the socket,
+   or that it is a khived at all. So a state 9 observation does not license
+   "past its listener" either: daemon A can bind, write pid p, crash before
+   cleanup, leave a socket that refuses connections, and the OS can reuse p for
+   an unrelated live process. This document already says elsewhere that a live
+   pid may belong to an unrelated long-lived process; the withdrawn clause
+   forgot it.
+
+Neither state licenses a trajectory reading, then, and these exit codes are
+normative for supervisors. **The codes in the table below are UNCHANGED and
+remain what implementations follow.** What is open is their justification, and
+it is tracked here rather than asserted. Resolving it is deliberately out of
+scope for this amendment: the classification is already the improvement over the
+code, and inventing a second mechanism to replace a refuted one, in the round
+that refuted it, is how the first one got here.
 
 **Codes are numeric and distinct, not merely "nonzero".** A supervisor and an
 end-to-end test both need to tell these apart, and "nonzero" is a class, not a
@@ -517,7 +545,7 @@ old value reads a retired code rather than silently inheriting a reused one.
 | 9   | Connection refused, pid live                      | `ECONNREFUSED`, pid running                                                                                                                                          | Refuse; name the pid                                                                                                                                                                                   | 4    |
 | 10  | Connection refused, no live listener              | `ECONNREFUSED`, and the recorded pid is not running OR no usable pid record exists (file absent, empty, or not parseable as a pid)                                   | Clean up and bind                                                                                                                                                                                      | —    |
 | 11  | No socket, no live pid                            | socket absent, and the recorded pid is not running OR no usable pid record exists (file absent, empty, or not parseable as a pid) — the same predicate state 10 uses | Clean up and bind                                                                                                                                                                                      | —    |
-| 12  | No socket, pid live, FOREIGN pid                  | socket absent, pid running, and the pid is NOT this process                                                                                                          | Refuse; name the pid AND its command line                                                                                                                                                              | 0    |
+| 12  | No socket, pid live, incumbency not permitted     | socket absent, pid running, and EITHER the pid is not this process OR same-process incumbency is not permitted                                                       | Refuse; name the pid AND its command line                                                                                                                                                              | 0    |
 | 12s | No socket, pid live, THIS process                 | socket absent, pid running, the pid IS this process, and same-process incumbency is permitted                                                                        | `MayBind` — boot has not lost the fence to anyone, so it proceeds to bind                                                                                                                              | —    |
 | 13  | Other connect error (`EACCES`, `ENOTSOCK`, …)     | connect fails, not refused                                                                                                                                           | Refuse; name the errno. Never retry, kill, or spawn (Amendment 4)                                                                                                                                      | 0    |
 | 14  | Namespace mismatch (**defensive**, not reachable) | connect ok, `namespace_mismatch` — no conforming daemon sets this since ADR-096 Fork 1, and a peer old enough to set it fails the version check first                | Refuse; name both namespaces. Never unlink, never replace                                                                                                                                              | 0    |
@@ -542,7 +570,9 @@ order:
 
 1. No socket → state 11 if there is no live recorded pid; otherwise state 12s
    if that pid is this process and same-process incumbency is permitted, else
-   state 12.
+   state 12. That `else` is exhaustive by construction, and state 12's predicate
+   admits everything it carries: the foreign-pid case, and the same-process case
+   where incumbency is not permitted.
 2. Connect fails → state 9, 10, or 13, by errno and pid record.
 3. Connect succeeds, nothing parseable within the deadline → state 7.
 4. Bytes returned that do not deserialize → state 8.
@@ -666,13 +696,15 @@ easy to invert:
   legitimate rather than an error. Blocking and re-probing belong to the
   client-side recoverer, never to daemon boot.
 
-  State 12 is transient — a peer between fork and bind — and an earlier draft of
-  this amendment classed refusals by transience, which put state 12 in the
-  retryable class and exited nonzero. It was wrong, and working out why is what
-  produced the rule now stated above: the resolver of state 12 is the _other_
-  process, which is already booting and will own the rendezvous. Restarting this
-  one cannot help, and a restart loop is the likely result. Exit 0 encodes
-  "someone else has this", not "nothing is wrong".
+  An earlier draft of this amendment classed refusals by transience, which put
+  state 12 in the retryable class and exited nonzero. It was wrong, and working
+  out why is what produced the rule now stated above: where the resolver is the
+  _other_ process, restarting this one cannot help, and a restart loop is the
+  likely result. Exit 0 encodes "someone else has this", not "nothing is wrong".
+  That same draft called state 12 transient, a peer between fork and bind. That
+  description is withdrawn for the reason recorded in the open note above, and
+  the exit code now rests on the class rule with its justification tracked as
+  open, not on that mechanism.
 
   **The refusal must name the pid AND its command line**, because the class rule
   has one failure mode and this is it. A pid file can outlive its writer and the
@@ -687,16 +719,30 @@ easy to invert:
   recycled pid. A refusal that prints the bare number leaves them with nothing to
   act on and no signal that anything is wrong.
 
-  **The same-process case is state 12s, not an exception buried in state 12.**
-  When the recorded pid is this process and same-process incumbency is
-  permitted, boot has not lost the fence to anyone — it IS the incumbent — so
-  the disposition is `MayBind` and there is no exit at all. An earlier draft
-  wrote that as a conditional clause inside state 12's disposition, which left
-  an implementer following the exit enumeration with no named outcome for it
-  while state 12's own exit 0 was correct only for the foreign-pid half. It is
-  its own row now, and the precedence names it. It remains the only state where
-  a live recorded pid yields `MayBind`, licensed solely by that pid being this
-  process.
+  **The same-process case splits on whether incumbency is permitted, and both
+  halves are classified.** When the recorded pid is this process and
+  same-process incumbency IS permitted, boot has not lost the fence to anyone —
+  it IS the incumbent — so the disposition is `MayBind`, there is no exit at
+  all, and that is state 12s. An earlier draft wrote that as a conditional
+  clause inside state 12's disposition, which left an implementer following the
+  exit enumeration with no named outcome for it; it is its own row now, and the
+  precedence names it.
+
+  When same-process incumbency is NOT permitted, the observation is state 12 and
+  refuses. **That is the production path**, not a corner: `run_daemon` is called
+  with `allow_same_process_incumbent = false`
+  (`crates/khive-runtime/src/daemon.rs:1327`; the `true` path at `:1348` is the
+  in-process test entry). A previous version of state 12's predicate required
+  the pid NOT be this process, which left that production-reachable observation
+  routed by precedence into a state whose own predicate it failed, with no
+  disposition and no exit code covering it — an unclassified observation inside
+  a table whose whole claim is that classification is closed. State 12's
+  predicate now admits it, and the disposition needs no special case: naming the
+  pid and its command line prints this process's own line, which is exactly the
+  tell an operator needs to see that boot refused itself rather than a stranger.
+
+  12s remains the only state in which a live recorded pid yields `MayBind`,
+  licensed solely by that pid being this process with incumbency permitted.
 
 ### Replacing a live incumbent — out of scope
 

--- a/docs/adr/ADR-049-khived-daemon.md
+++ b/docs/adr/ADR-049-khived-daemon.md
@@ -500,10 +500,13 @@ not reopened from the same premise:
    forgot it.
 
 What is left, once the boot window is impossible and the shutdown window is
-unobservable, is fact 3: the observation that actually persists in either state
-is a recorded pid that has been reused by an unrelated live process, which no
-retry of this process ever resolves. Neither state licenses a trajectory
-reading, then, and these exit codes are normative for supervisors. **The codes in the table below are UNCHANGED and
+unobservable, is fact 3, and fact 3 is a statement about what cannot be known
+rather than about what is happening. Ownership and trajectory are both unproven
+in either state. Pid reuse is one explanation the observation admits and the one
+that no retry of this process ever resolves, but the facts do not establish that
+it is the explanation in any given case, and nothing here should be read as
+saying they do. Neither state licenses a trajectory reading, then, and these
+exit codes are normative for supervisors. **The codes in the table below are UNCHANGED and
 remain what implementations follow.** What is open is their justification, and
 it is tracked here rather than asserted. Resolving it is deliberately out of
 scope for this amendment: the classification is already the improvement over the

--- a/docs/adr/ADR-049-khived-daemon.md
+++ b/docs/adr/ADR-049-khived-daemon.md
@@ -429,22 +429,22 @@ supervisor restarts ends it, so exit 0 is what the class rule requires. Exit 5
 is left defined and unemitted, like exit 1, so that a supervisor keyed on the
 old value reads a retired code rather than silently inheriting a reused one.
 
-| #  | State                                             | Observable                                                                                                                                            | Disposition                                                                                                                                                         | Exit |
-| -- | ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---- |
-| 1  | Exact acknowledgement                             | connect ok, probe ack, identity matches                                                                                                               | Refuse to start; report the incumbent pid                                                                                                                           | 0    |
-| 2  | Protocol-version mismatch                         | connect ok, `version_mismatch`                                                                                                                        | Refuse; name both versions and the remedy. Never unlink                                                                                                             | 0    |
-| 3  | Config mismatch                                   | connect ok, `config_mismatch` set — `served_config_id` may be absent, and is not part of this predicate                                               | Refuse by default; name the first differing field without values when `served_config_id` is present, otherwise say identity was not echoed. Opt-in replacement only | 0    |
-| 4  | Metrics-only reply                                | connect ok, reply carries metrics                                                                                                                     | Refuse to start                                                                                                                                                     | 0    |
-| 5  | Identity unresolved                               | connect ok, reply HAS ack shape, no mismatch flag set, `served_config_id` absent or unequal                                                           | Refuse to start; name the pid and that identity could not be established                                                                                            | 6    |
-| 6  | Parseable non-acknowledgement                     | connect ok, frame deserializes, reply does NOT have ack shape                                                                                         | Refuse to start; name the observed shape                                                                                                                            | 0    |
-| 7  | Silent connect                                    | connect ok, no parseable response within the deadline                                                                                                 | Refuse; distinct error "connected but did not answer"                                                                                                               | 2    |
-| 8  | Malformed reply                                   | connect ok, bytes returned, frame does not parse                                                                                                      | Refuse to start                                                                                                                                                     | 3    |
-| 9  | Connection refused, pid live                      | `ECONNREFUSED`, pid running                                                                                                                           | Refuse; name the pid                                                                                                                                                | 4    |
-| 10 | Connection refused, no live listener              | `ECONNREFUSED`, and the recorded pid is not running OR no usable pid record exists (file absent, empty, or not parseable as a pid)                    | Clean up and bind                                                                                                                                                   | —    |
-| 11 | No socket, pid dead                               | socket absent, pid not running or pid file absent                                                                                                     | Clean up and bind                                                                                                                                                   | —    |
-| 12 | No socket, pid live                               | socket absent, pid running                                                                                                                            | Refuse; name the pid AND its command line. If the pid is this process and same-process incumbency is permitted, the disposition is `MayBind` instead                | 0    |
-| 13 | Other connect error (`EACCES`, `ENOTSOCK`, …)     | connect fails, not refused                                                                                                                            | Refuse; name the errno. Never retry, kill, or spawn (Amendment 4)                                                                                                   | 0    |
-| 14 | Namespace mismatch (**defensive**, not reachable) | connect ok, `namespace_mismatch` — no conforming daemon sets this since ADR-096 Fork 1, and a peer old enough to set it fails the version check first | Refuse; name both namespaces. Never unlink, never replace                                                                                                           | 0    |
+| #  | State                                             | Observable                                                                                                                                                           | Disposition                                                                                                                                                                                            | Exit |
+| -- | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---- |
+| 1  | Exact acknowledgement                             | connect ok, probe ack, identity matches                                                                                                                              | Refuse to start; report the incumbent pid                                                                                                                                                              | 0    |
+| 2  | Protocol-version mismatch                         | connect ok, `version_mismatch`                                                                                                                                       | Refuse; name both versions and the remedy. Never unlink                                                                                                                                                | 0    |
+| 3  | Config mismatch                                   | connect ok, `config_mismatch` set — `served_config_id` may be absent, and is not part of this predicate                                                              | Refuse by default; name the first differing field without values when `served_config_id` is present, otherwise say identity was not echoed. Never unlink; replacing the incumbent is out of scope here | 0    |
+| 4  | Metrics-only reply                                | connect ok, reply carries metrics                                                                                                                                    | Refuse to start                                                                                                                                                                                        | 0    |
+| 5  | Identity unresolved                               | connect ok, reply HAS ack shape, no mismatch flag set, `served_config_id` absent or unequal                                                                          | Refuse to start; name the pid and that identity could not be established                                                                                                                               | 6    |
+| 6  | Parseable non-acknowledgement                     | connect ok, frame deserializes, reply does NOT have ack shape                                                                                                        | Refuse to start; name the observed shape                                                                                                                                                               | 0    |
+| 7  | Silent connect                                    | connect ok, no parseable response within the deadline                                                                                                                | Refuse; distinct error "connected but did not answer"                                                                                                                                                  | 2    |
+| 8  | Malformed reply                                   | connect ok, bytes returned, frame does not parse                                                                                                                     | Refuse to start                                                                                                                                                                                        | 3    |
+| 9  | Connection refused, pid live                      | `ECONNREFUSED`, pid running                                                                                                                                          | Refuse; name the pid                                                                                                                                                                                   | 4    |
+| 10 | Connection refused, no live listener              | `ECONNREFUSED`, and the recorded pid is not running OR no usable pid record exists (file absent, empty, or not parseable as a pid)                                   | Clean up and bind                                                                                                                                                                                      | —    |
+| 11 | No socket, no live pid                            | socket absent, and the recorded pid is not running OR no usable pid record exists (file absent, empty, or not parseable as a pid) — the same predicate state 10 uses | Clean up and bind                                                                                                                                                                                      | —    |
+| 12 | No socket, pid live                               | socket absent, pid running                                                                                                                                           | Refuse; name the pid AND its command line. If the pid is this process and same-process incumbency is permitted, the disposition is `MayBind` instead                                                   | 0    |
+| 13 | Other connect error (`EACCES`, `ENOTSOCK`, …)     | connect fails, not refused                                                                                                                                           | Refuse; name the errno. Never retry, kill, or spawn (Amendment 4)                                                                                                                                      | 0    |
+| 14 | Namespace mismatch (**defensive**, not reachable) | connect ok, `namespace_mismatch` — no conforming daemon sets this since ADR-096 Fork 1, and a peer old enough to set it fails the version check first                | Refuse; name both namespaces. Never unlink, never replace                                                                                                                                              | 0    |
 
 Only states 10 and 11 are genuinely stale. Collapsing any other state into
 "clean up and bind" is the defect this amendment forbids.
@@ -588,109 +588,28 @@ easy to invert:
   process. A harness must assert the pid identity, not merely that binding
   succeeded, or it cannot tell this branch from a collapse into cleanup.
 
-### Replacing a live incumbent
+### Replacing a live incumbent — out of scope
 
-This section specifies a capability that **does not exist yet**. No replacement
-flag is present on any current command surface, and nothing here describes
-maintained behaviour. It is written as a contract so that the capability, when
-built, is built with the safety sequence rather than acquiring it afterwards.
-Implementing it requires naming the owning subcommand and its parsing, which
-this amendment deliberately leaves to the implementing change.
+Replacement of a live incumbent is out of scope for this amendment and will be
+specified in its own ADR when the capability is built. Nothing in this amendment
+authorises signalling a process. That ADR inherits three named open items, all
+of which surfaced in review of this one and should not have to be rediscovered:
 
-Removal of a live incumbent is operator-elected and gated behind an explicit
-`--replace-incumbent` opt-in. Every step is required:
-
-1. Classify. Proceed only from states 1 through 4, where a daemon identity was
-   positively read. Never from states 5 through 9 or 12 through 14 — those have
-   either not established what would be killed, or not established that anything
-   is there at all. State 5 in particular is excluded precisely because an
-   identity that could not be resolved is not an identity that was refuted.
-
-   **State 14 is deliberately NOT on this list, and an earlier draft of this
-   amendment had it there.** The reasoning that put it there was that a daemon
-   serving a different namespace is an incumbent like any other. That reasoning
-   is obsolete: ADR-096 Fork 1 removed the namespace reject outright, so a
-   correctly built daemon serves a differently-namespaced frame rather than
-   refusing it, and `namespace_mismatch` is never set on any serve path
-   (`crates/khive-mcp/src/daemon.rs`, the ADR-096 Fork 1 test asserts
-   `!resp_other.namespace_mismatch` with the message "ADR-096 Fork 1 removed the
-   namespace_mismatch reject"; no serve-side site sets the field true, while the
-   sibling `config_mismatch` and `version_mismatch` fields both have such
-   sites). State 14 therefore survives only as a defensive classification, not
-   as a live legacy observation: a peer old enough to still set the flag is also
-   old enough to fail this build's version check first, so it answers with
-   `version_mismatch` and lands in state 2 instead. The one
-   thing that must never be done on the word of an obsolete signal is to kill
-   the process that sent it. Refuse, name both namespaces, leave the rendezvous
-   alone.
-2. **Bind the pid to the socket, and state what that binding is worth.** The
-   classification above proves that _something_ live is serving the socket and
-   what protocol and configuration it speaks. It does not prove that the process
-   named by the pid file is that something. A pid file can be stale or its pid
-   reused while an unrelated process answers on the socket, and signalling on
-   that evidence kills a process this boot never contacted.
-
-   **The hazard this step guards is accidental pid reuse, and naming it is what
-   makes the evidence legible.** The acknowledgement must carry the serving
-   process's own pid (`served_pid`), and it must equal the recorded pid. That
-   binds socket to process for the accidental case, which is the case that
-   actually occurs: a pid recycled onto an unrelated process is a process that
-   does not speak this protocol, so it never produces an acknowledgement at all
-   — it lands in state 6, 7, or 8, and replacement is unavailable from every one
-   of those. The daemon that does answer reports its own true pid, which fails
-   the equality check against a stale record. Neither path signals.
-
-   **What `served_pid` alone does not establish is resistance to a process that
-   deliberately lies**, and that limit is worth stating precisely rather than
-   leaving a reader to assume the field is an ownership proof. A same-uid
-   process can bind the socket and return whatever integer it likes. That
-   process is already inside this daemon's trust boundary: the accept path
-   admits peers by same-uid check rather than same-principal
-   (`crates/khive-runtime/src/daemon.rs`), and anything able to squat the
-   rendezvous could signal the daemon directly without involving this sequence
-   at all. So `served_pid` is not load-bearing against a deliberate liar, and
-   this section does not claim it is.
-
-   **Where the platform exposes a kernel peer pid, replacement requires it too,
-   and refuses on any disagreement.** `SO_PEERCRED` on Linux and
-   `LOCAL_PEERPID` on macOS both report the peer of a connected unix socket, and
-   the repository already performs the sibling lookup for uid — `peer_uid` reads
-   `getpeereid(2)` on macOS/BSD and `SO_PEERCRED` on Linux
-   (`crates/khive-runtime/src/daemon.rs`), is used on the accept path, and
-   carries a regression test asserting it reports the connecting process's uid.
-   The kernel pid must equal both `served_pid` and the recorded pid. This turns
-   the self-report into a cross-check wherever a cross-check is available, and a
-   disagreement between the two is itself disqualifying: refuse and name all
-   three values.
-
-   Both platforms this daemon targets expose such a lookup, so in practice the
-   cross-check is required everywhere khived runs. A platform exposing neither
-   would fall back to `served_pid` alone, and an implementer should know that
-   this is the weakest evidence anywhere in this section.
-
-   If the acknowledgement carries no `served_pid`, or it does not equal the
-   recorded pid, or an available kernel peer pid disagrees with either,
-   **replacement is unavailable** — refuse and name the values. Do not fall back
-   to signalling the recorded pid. An ownership check that degrades to "signal
-   it anyway" is not a check.
-3. Signal `SIGTERM` to the pid established in step 2.
-4. Wait, bounded, for process death. Death is **observed**, never assumed.
-5. On timeout, refuse: leave the socket intact and name the pid. Never escalate
-   to `SIGKILL` implicitly, and never unlink a socket whose owner is still
-   alive.
-6. Only after observed death, remove the socket and pid file, then bind.
-
-Steps 2 and 4 are the substance. Step 4 because removing a rendezvous file is
-not a way to stop a process; step 2 because every other step is careful about
-_how_ the incumbent is stopped while assuming _which_ process it is.
-
-Neither half of that evidence exists today. `served_pid` is not a field on the
-response frame, and no peer-pid lookup sits on the probe path: `peer_uid`
-establishes only the peer's uid, and `LOCAL_PEERPID` is not spelled anywhere in
-this repository. Implementing this section means adding both — the field to the
-response frame, and a peer-pid lookup beside `peer_uid` whose result reaches the
-classification — and until both exist `--replace-incumbent` cannot be built to
-this contract.
+- **Ownership evidence.** A destructive action needs a kernel-authenticated peer
+  pid. A self-reported pid on the response frame is not resistant to a same-uid
+  peer that lies, so it cannot on its own license signalling.
+- **The step-6 unlink race.** Removing the socket and pid file after observed
+  death can delete a rendezvous a _new_ owner created in the interval. The
+  existing recovery guard at `crates/khive-mcp/src/daemon.rs:1038-1075` rechecks
+  the pid file and a live socket before unlinking; a replacement sequence needs
+  an equivalent recheck, plus a lock held through cleanup and bind.
+- **Platform reach.** A kernel peer-pid primitive is not available everywhere
+  this daemon compiles, so "both platforms expose such a lookup" is not a claim
+  the tree supports. `peer_uid` at `crates/khive-runtime/src/daemon.rs:319-375`
+  is `#[cfg(unix)]` with three arms: `getpeereid` on Apple targets, `SO_PEERCRED`
+  on Linux, and a third arm returning `ErrorKind::Unsupported` for every other
+  Unix. The new ADR must say what replacement does on that third arm rather than
+  degrading to a self-reported value.
 
 ### Test obligations
 
@@ -731,23 +650,23 @@ rows 2, 3, 5, 6, and 14 would every one of them classify as state 8 — the exac
 state they exist to be distinguished from. Each fixture serializes a **complete**
 frame: the fields shown set as shown, every remaining field at its zero value.
 
-| #   | Peer setup                                                                                                                  | Probe input | Rendezvous postcondition              | Listeners after                                         | Exit |
-| --- | --------------------------------------------------------------------------------------------------------------------------- | ----------- | ------------------------------------- | ------------------------------------------------------- | ---- |
-| 1   | Real daemon, same version, same `config_id`                                                                                 | boot frame  | socket + pid file unchanged           | 1 (incumbent)                                           | 0    |
-| 2   | Scripted listener replying `{ok:false, version_mismatch:true, daemon_protocol_version:<other>}`                             | boot frame  | socket + pid file unchanged           | 1 (scripted)                                            | 0    |
-| 3   | Scripted listener replying `{ok:false, config_mismatch:true, served_config_id:<other>}`                                     | boot frame  | socket + pid file unchanged           | 1 (scripted)                                            | 0    |
-| 4   | Scripted listener replying with `metrics` populated. **Synthetic**: the real boot frame cannot elicit this                  | boot frame  | socket + pid file unchanged           | 1 (scripted)                                            | 0    |
-| 5   | Scripted listener replying `{ok:true}` with `served_config_id` ABSENT and no mismatch flag                                  | boot frame  | socket + pid file unchanged           | 1 (scripted)                                            | 6    |
-| 6   | Scripted listener replying `{ok:true, result:<any JSON>}` — ack-shape test fails on `result`                                | boot frame  | socket + pid file unchanged           | 1 (scripted)                                            | 0    |
-| 7   | Scripted listener that accepts the connection and writes nothing until past the probe deadline                              | boot frame  | socket + pid file unchanged           | 1 (scripted)                                            | 2    |
-| 8   | Scripted listener that writes bytes which are not a valid frame                                                             | boot frame  | socket + pid file unchanged           | 1 (scripted)                                            | 3    |
-| 9   | Socket file present with nothing bound to it; pid file names a live process (a sleeper is fine)                             | boot frame  | socket + pid file unchanged           | 0                                                       | 4    |
-| 10  | Socket file present with nothing bound; pid file names a dead pid, **and a second case with the pid file removed entirely** | boot frame  | socket + pid file REPLACED            | 1 (this process)                                        | —    |
-| 11  | No socket file; pid file names a dead pid or is absent                                                                      | boot frame  | socket + pid file created             | 1 (this process)                                        | —    |
-| 12  | No socket file; pid file names a live process that is NOT this one                                                          | boot frame  | pid file unchanged, no socket created | 1 (that process)                                        | 0    |
-| 12a | No socket file; pid file names THIS process, same-process incumbency permitted                                              | boot frame  | socket created by this process        | 1 (this process)                                        | —    |
-| 13  | Socket path present but not connectable for a reason other than refusal (e.g. mode 000 → `EACCES`)                          | boot frame  | socket + pid file unchanged           | not observable — assert the postcondition and exit only | 0    |
-| 14  | Scripted listener replying `{ok:false, namespace_mismatch:true}`                                                            | boot frame  | socket + pid file unchanged           | 1 (scripted)                                            | 0    |
+| #   | Peer setup                                                                                                                                                                                                                                               | Probe input | Rendezvous postcondition              | Listeners after                                              | Exit |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- | ------------------------------------- | ------------------------------------------------------------ | ---- |
+| 1   | Real daemon, same version, same `config_id`                                                                                                                                                                                                              | boot frame  | socket + pid file unchanged           | 1 (incumbent)                                                | 0    |
+| 2   | Scripted listener replying `{ok:false, version_mismatch:true, daemon_protocol_version:<other>}`                                                                                                                                                          | boot frame  | socket + pid file unchanged           | 1 (scripted)                                                 | 0    |
+| 3   | Scripted listener replying `{ok:false, config_mismatch:true, served_config_id:<other>}`                                                                                                                                                                  | boot frame  | socket + pid file unchanged           | 1 (scripted)                                                 | 0    |
+| 4   | Scripted listener replying with `metrics` populated. **Synthetic**: the real boot frame cannot elicit this                                                                                                                                               | boot frame  | socket + pid file unchanged           | 1 (scripted)                                                 | 0    |
+| 5   | Scripted listener replying `{ok:true}` with `served_config_id` ABSENT and no mismatch flag                                                                                                                                                               | boot frame  | socket + pid file unchanged           | 1 (scripted)                                                 | 6    |
+| 6   | Scripted listener replying `{ok:true, result:"legacy-result"}` — the value must be a JSON string, because the wire field is `Option<String>`; a non-string value fails to deserialize and lands in row 8. Ack-shape test fails on `result` being present | boot frame  | socket + pid file unchanged           | 1 (scripted)                                                 | 0    |
+| 7   | Scripted listener that accepts the connection and writes nothing until past the probe deadline                                                                                                                                                           | boot frame  | socket + pid file unchanged           | 1 (scripted)                                                 | 2    |
+| 8   | Scripted listener that writes bytes which are not a valid frame                                                                                                                                                                                          | boot frame  | socket + pid file unchanged           | 1 (scripted)                                                 | 3    |
+| 9   | Socket file present with nothing bound to it; pid file names a live process (a sleeper is fine)                                                                                                                                                          | boot frame  | socket + pid file unchanged           | 0                                                            | 4    |
+| 10  | Socket file present with nothing bound; pid file names a dead pid, **plus a case each for the pid file removed, empty, and not parseable as a pid** — the four cases of state 10's "no usable pid record" predicate                                      | boot frame  | socket + pid file REPLACED            | 1 (this process)                                             | —    |
+| 11  | No socket file; pid file names a dead pid, **plus a case each for the pid file removed, empty, and not parseable as a pid** — the same four cases as row 10                                                                                              | boot frame  | socket + pid file created             | 1 (this process)                                             | —    |
+| 12  | No socket file; pid file names a live process that is NOT this one                                                                                                                                                                                       | boot frame  | pid file unchanged, no socket created | 0 — the pid names a live process, not a listener (cf. row 9) | 0    |
+| 12a | No socket file; pid file names THIS process, same-process incumbency permitted                                                                                                                                                                           | boot frame  | socket created by this process        | 1 (this process)                                             | —    |
+| 13  | Socket path present but not connectable for a reason other than refusal (e.g. mode 000 → `EACCES`)                                                                                                                                                       | boot frame  | socket + pid file unchanged           | not observable — assert the postcondition and exit only      | 0    |
+| 14  | Scripted listener replying `{ok:false, namespace_mismatch:true}`                                                                                                                                                                                         | boot frame  | socket + pid file unchanged           | 1 (scripted)                                                 | 0    |
 
 Row 12a is the `MayBind` branch and it is the only row where a live pid ends in
 binding. Its test asserts that the pid it matched is this process's own, not
@@ -773,24 +692,10 @@ the value the classification maps to rather than against a real process exit,
 and at least one end-to-end test per exit class asserts a real process exit code
 so the mapping itself is covered.
 
-Two further tests are required because their absence is what allowed the
-collapse:
+One further test is required because its absence is what allowed the collapse:
 
 - A test that starts a real live incumbent and drives each non-acknowledgement
   class against it, asserting that startup never leaves two live daemons.
-- A `--replace-incumbent` timeout test in which the incumbent ignores `SIGTERM`,
-  asserting refusal with the socket intact.
-- A `--replace-incumbent` test in which the acknowledgement carries a
-  `served_pid` that does not equal the recorded pid, asserting that **no signal
-  is sent** — the assertion is on the absence of the signal, not merely on the
-  refusal, because a sequence that signals and then reports refusal passes an
-  error-value check while doing the exact damage this step exists to prevent.
-  A sibling case with `served_pid` absent entirely, asserting the same.
-- A `--replace-incumbent` test on a platform exposing a kernel peer pid, in
-  which the kernel pid and a truthful `served_pid` agree and replacement
-  proceeds, paired with one in which they disagree and no signal is sent. The
-  disagreeing case is what proves the cross-check is read at all; without it the
-  agreeing case passes whether or not the kernel lookup is wired up.
 
 Each state's guard carries a mutation control: defeat the guard, confirm that
 exactly that state's test fails, and restore from a snapshot rather than by

--- a/docs/adr/ADR-049-khived-daemon.md
+++ b/docs/adr/ADR-049-khived-daemon.md
@@ -403,19 +403,22 @@ exactly what might succeed.
 end-to-end test both need to tell these apart, and "nonzero" is a class, not a
 value:
 
-| Exit | Meaning                                                            | States                    |
-| ---- | ------------------------------------------------------------------ | ------------------------- |
-| 0    | Refused; resolver is an operator or another process                | 1, 2, 3, 4, 6, 12, 13, 14 |
-| 1    | Reserved for unclassified failure; never emitted by classification | —                         |
-| 2    | Refused; connected but the peer did not answer                     | 7                         |
-| 3    | Refused; the peer's reply did not parse                            | 8                         |
-| 4    | Refused; connection refused while the recorded pid is running      | 9                         |
-| 5    | Reserved; formerly state 13, retired by this amendment             | —                         |
-| 6    | Refused; the peer answered but its identity could not be resolved  | 5                         |
+| Exit | Meaning                                                            | States                        |
+| ---- | ------------------------------------------------------------------ | ----------------------------- |
+| 0    | Refused; resolver is an operator or another process                | 1, 2, 3, 4, 6, 12, 13, 14, 15 |
+| 1    | Reserved for unclassified failure; never emitted by classification | —                             |
+| 2    | Refused; connected but the peer did not answer                     | 7                             |
+| 3    | Refused; the peer's reply did not parse                            | 8                             |
+| 4    | Refused; connection refused while the recorded pid is running      | 9                             |
+| 5    | Reserved; formerly state 13, retired by this amendment             | —                             |
+| 6    | Refused; the peer answered but its identity could not be resolved  | 5                             |
 
 Exit 1 is reserved so that an unclassified crash can never be mistaken for a
-classified refusal. States 10 and 11 have no exit code because they proceed to
-bind rather than refusing.
+classified refusal. States 10, 11, and 12s have no exit code because they
+proceed to bind rather than refusing. 12s is the only one of the three that
+binds with a live recorded pid, and it is licensed solely by that pid being
+this process: a harness must assert the pid identity, not merely that binding
+succeeded, or it cannot tell this branch from a collapse into cleanup.
 
 **State 13 moved from exit 5 to exit 0, and exit 5 is retired rather than
 reused.** An earlier draft gave state 13 a nonzero code on the reasoning that a
@@ -429,22 +432,24 @@ supervisor restarts ends it, so exit 0 is what the class rule requires. Exit 5
 is left defined and unemitted, like exit 1, so that a supervisor keyed on the
 old value reads a retired code rather than silently inheriting a reused one.
 
-| #  | State                                             | Observable                                                                                                                                                           | Disposition                                                                                                                                                                                            | Exit |
-| -- | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---- |
-| 1  | Exact acknowledgement                             | connect ok, probe ack, identity matches                                                                                                                              | Refuse to start; report the incumbent pid                                                                                                                                                              | 0    |
-| 2  | Protocol-version mismatch                         | connect ok, `version_mismatch`                                                                                                                                       | Refuse; name both versions and the remedy. Never unlink                                                                                                                                                | 0    |
-| 3  | Config mismatch                                   | connect ok, `config_mismatch` set — `served_config_id` may be absent, and is not part of this predicate                                                              | Refuse by default; name the first differing field without values when `served_config_id` is present, otherwise say identity was not echoed. Never unlink; replacing the incumbent is out of scope here | 0    |
-| 4  | Metrics-only reply                                | connect ok, reply carries metrics                                                                                                                                    | Refuse to start                                                                                                                                                                                        | 0    |
-| 5  | Identity unresolved                               | connect ok, reply HAS ack shape, no mismatch flag set, `served_config_id` absent or unequal                                                                          | Refuse to start; name the pid and that identity could not be established                                                                                                                               | 6    |
-| 6  | Parseable non-acknowledgement                     | connect ok, frame deserializes, reply does NOT have ack shape                                                                                                        | Refuse to start; name the observed shape                                                                                                                                                               | 0    |
-| 7  | Silent connect                                    | connect ok, no parseable response within the deadline                                                                                                                | Refuse; distinct error "connected but did not answer"                                                                                                                                                  | 2    |
-| 8  | Malformed reply                                   | connect ok, bytes returned, frame does not parse                                                                                                                     | Refuse to start                                                                                                                                                                                        | 3    |
-| 9  | Connection refused, pid live                      | `ECONNREFUSED`, pid running                                                                                                                                          | Refuse; name the pid                                                                                                                                                                                   | 4    |
-| 10 | Connection refused, no live listener              | `ECONNREFUSED`, and the recorded pid is not running OR no usable pid record exists (file absent, empty, or not parseable as a pid)                                   | Clean up and bind                                                                                                                                                                                      | —    |
-| 11 | No socket, no live pid                            | socket absent, and the recorded pid is not running OR no usable pid record exists (file absent, empty, or not parseable as a pid) — the same predicate state 10 uses | Clean up and bind                                                                                                                                                                                      | —    |
-| 12 | No socket, pid live                               | socket absent, pid running                                                                                                                                           | Refuse; name the pid AND its command line. If the pid is this process and same-process incumbency is permitted, the disposition is `MayBind` instead                                                   | 0    |
-| 13 | Other connect error (`EACCES`, `ENOTSOCK`, …)     | connect fails, not refused                                                                                                                                           | Refuse; name the errno. Never retry, kill, or spawn (Amendment 4)                                                                                                                                      | 0    |
-| 14 | Namespace mismatch (**defensive**, not reachable) | connect ok, `namespace_mismatch` — no conforming daemon sets this since ADR-096 Fork 1, and a peer old enough to set it fails the version check first                | Refuse; name both namespaces. Never unlink, never replace                                                                                                                                              | 0    |
+| #   | State                                             | Observable                                                                                                                                                           | Disposition                                                                                                                                                                                            | Exit |
+| --- | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---- |
+| 1   | Exact acknowledgement                             | connect ok, probe ack, identity matches                                                                                                                              | Refuse to start; report the incumbent pid                                                                                                                                                              | 0    |
+| 2   | Protocol-version mismatch                         | connect ok, `version_mismatch`                                                                                                                                       | Refuse; name both versions and the remedy. Never unlink                                                                                                                                                | 0    |
+| 3   | Config mismatch                                   | connect ok, `config_mismatch` set — `served_config_id` may be absent, and is not part of this predicate                                                              | Refuse by default; name the first differing field without values when `served_config_id` is present, otherwise say identity was not echoed. Never unlink; replacing the incumbent is out of scope here | 0    |
+| 4   | Metrics-only reply                                | connect ok, reply carries metrics                                                                                                                                    | Refuse to start                                                                                                                                                                                        | 0    |
+| 5   | Identity unresolved                               | connect ok, reply HAS ack shape, no mismatch flag set, `served_config_id` ABSENT                                                                                     | Refuse to start; name the pid and that identity could not be established                                                                                                                               | 6    |
+| 6   | Parseable non-acknowledgement                     | connect ok, frame deserializes, reply does NOT have ack shape                                                                                                        | Refuse to start; name the observed shape                                                                                                                                                               | 0    |
+| 7   | Silent connect                                    | connect ok, no parseable response within the deadline                                                                                                                | Refuse; distinct error "connected but did not answer"                                                                                                                                                  | 2    |
+| 8   | Malformed reply                                   | connect ok, bytes returned, frame does not parse                                                                                                                     | Refuse to start                                                                                                                                                                                        | 3    |
+| 9   | Connection refused, pid live                      | `ECONNREFUSED`, pid running                                                                                                                                          | Refuse; name the pid                                                                                                                                                                                   | 4    |
+| 10  | Connection refused, no live listener              | `ECONNREFUSED`, and the recorded pid is not running OR no usable pid record exists (file absent, empty, or not parseable as a pid)                                   | Clean up and bind                                                                                                                                                                                      | —    |
+| 11  | No socket, no live pid                            | socket absent, and the recorded pid is not running OR no usable pid record exists (file absent, empty, or not parseable as a pid) — the same predicate state 10 uses | Clean up and bind                                                                                                                                                                                      | —    |
+| 12  | No socket, pid live, FOREIGN pid                  | socket absent, pid running, and the pid is NOT this process                                                                                                          | Refuse; name the pid AND its command line                                                                                                                                                              | 0    |
+| 12s | No socket, pid live, THIS process                 | socket absent, pid running, the pid IS this process, and same-process incumbency is permitted                                                                        | `MayBind` — boot has not lost the fence to anyone, so it proceeds to bind                                                                                                                              | —    |
+| 13  | Other connect error (`EACCES`, `ENOTSOCK`, …)     | connect fails, not refused                                                                                                                                           | Refuse; name the errno. Never retry, kill, or spawn (Amendment 4)                                                                                                                                      | 0    |
+| 14  | Namespace mismatch (**defensive**, not reachable) | connect ok, `namespace_mismatch` — no conforming daemon sets this since ADR-096 Fork 1, and a peer old enough to set it fails the version check first                | Refuse; name both namespaces. Never unlink, never replace                                                                                                                                              | 0    |
+| 15  | Identity positively unequal                       | connect ok, reply HAS ack shape, no mismatch flag set, `served_config_id` PRESENT and unequal to this build's                                                        | Refuse to start; name the pid and both `config_id` values                                                                                                                                              | 0    |
 
 Only states 10 and 11 are genuinely stale. Collapsing any other state into
 "clean up and bind" is the defect this amendment forbids.
@@ -463,7 +468,9 @@ numbers in the table above are stable labels, not an order. A single observation
 can satisfy more than one row, so classification takes the FIRST match in this
 order:
 
-1. No socket → state 11 or 12, by whether the recorded pid is running.
+1. No socket → state 11 if there is no live recorded pid; otherwise state 12s
+   if that pid is this process and same-process incumbency is permitted, else
+   state 12.
 2. Connect fails → state 9, 10, or 13, by errno and pid record.
 3. Connect succeeds, nothing parseable within the deadline → state 7.
 4. Bytes returned that do not deserialize → state 8.
@@ -486,19 +493,25 @@ order:
    version.
 6. Frame deserializes, has ack shape, identity matches → state 1.
 7. Frame deserializes, carries metrics → state 4.
-8. Frame deserializes, has ack shape, no mismatch flag, identity absent or
-   unequal → state 5.
-9. Frame deserializes, does not have ack shape → state 6. This is the catch-all
-   and it is evaluated LAST among response rows. It must never fall through to
-   cleanup.
+8. Frame deserializes, has ack shape, no mismatch flag, `served_config_id`
+   ABSENT → state 5.
+9. Frame deserializes, has ack shape, no mismatch flag, `served_config_id`
+   PRESENT and unequal → state 15. This is the same distinction the protocol
+   version already draws two steps above: an identity the peer positively
+   published and that does not match is refuted, not unresolved, so no retry of
+   this process can change it and it exits 0.
+10. Frame deserializes, does not have ack shape → state 6. This is the catch-all
+    and it is evaluated LAST among response rows. It must never fall through to
+    cleanup.
 
-State 5 is evaluated before the state 6 catch-all deliberately. Under a naive
-first-match-by-row-number rule the catch-all would absorb every state-5 reply,
-because a reply with no `served_config_id` can be described as "not an
-acknowledgement" — and a conforming implementation could then never produce the
-state-5 diagnosis the table promises.
+States 5 and 15 are both evaluated before the state 6 catch-all deliberately.
+Under a naive first-match-by-row-number rule the catch-all would absorb every
+one of their replies, because a reply whose `served_config_id` is missing or
+wrong can be described as "not an acknowledgement" — and a conforming
+implementation could then never produce the identity diagnosis the table
+promises.
 
-**States 5 and 6 are the ones an enumeration drawn from a single build will
+**States 5, 6, and 15 are the ones an enumeration drawn from a single build will
 miss**, so they are stated explicitly, along with what actually produces them.
 
 State 6's motivating case is a live peer that answers with something well-formed
@@ -518,13 +531,25 @@ process, and is not an acknowledgement, so without state 6 a conforming
 implementation has no disposition for it and may classify it as stale.
 
 State 5 covers the same hazard on the identity axis: a reply that has ack shape
-but whose `served_config_id` is absent or does not match, while no mismatch flag
-is set. Identity that cannot be established is not identity that was refuted,
-and neither is death. It exits nonzero rather than 0 because a peer that has not
-yet published its identity may publish it before the next attempt, which makes a
-retry of this process the resolver.
+but carries NO `served_config_id`, while no mismatch flag is set. Identity that
+cannot be established is not identity that was refuted, and neither is death. It
+exits nonzero rather than 0 because a peer that has not yet published its
+identity may publish it before the next attempt, which makes a retry of this
+process the resolver.
 
-Every state above is reachable from the boot probe except **states 4 and 14**.
+State 15 is the other half of that observation and it exits 0, because the class
+rule turns on who resolves the condition. A peer that published a
+`served_config_id` and published a different one has refuted this build's
+identity positively. No number of restarts of this process changes what the
+incumbent echoes, so the resolver is an operator or the other process. An
+earlier draft folded both halves into state 5 and gave the pair exit 6, which
+told a supervisor to restart against a condition a restart cannot reach. The
+reasoning is exactly the one already applied to an unequal
+`daemon_protocol_version` two steps earlier in the precedence: a positively
+refuted identity is not an unresolved one.
+
+Every state above is reachable from the boot probe except **states 4, 14, and
+15**.
 The boot probe's request frame does not set the metrics flag, and the daemon's
 metrics reply is gated on that flag in the requesting frame, so a metrics-only
 reply cannot be elicited by boot. State 4 is retained as a defensive
@@ -544,6 +569,16 @@ exactly as state 4 is — because a frame that sets the flag is unambiguous proo
 of a live process whatever produced it, and reading it as absence would be the
 same defect — and its no-unlink, no-replace disposition stands unchanged, which
 is the whole reason retaining it costs nothing.
+
+**State 15 is defensive for a third reason: a conforming daemon that sees a
+different `config_id` sets `config_mismatch`, which is state 3.** So a peer that
+publishes an unequal `served_config_id` with no flag set is either
+non-conforming or a future variant that reports identity without judging it.
+The state exists because the observation is unambiguous — the peer answered, and
+it is not us — and because the alternative is to route it into state 5, which
+would attach a retryable exit to a condition no retry of this process can
+change. Retaining it costs nothing for the same reason states 4 and 14 do: its
+disposition refuses and touches nothing.
 
 Two consequences of the existing contract are worth stating because they are
 easy to invert:
@@ -580,13 +615,16 @@ easy to invert:
   recycled pid. A refusal that prints the bare number leaves them with nothing to
   act on and no signal that anything is wrong.
 
-  **The same-process case has its own disposition.** When the recorded pid is
-  this process and same-process incumbency is permitted, boot has not lost the
-  fence to anyone — it IS the incumbent — so the disposition is `MayBind` and
-  there is no exit at all. That is the only branch in the whole table where a
-  live pid yields `MayBind`, and it is licensed solely by the pid being this
-  process. A harness must assert the pid identity, not merely that binding
-  succeeded, or it cannot tell this branch from a collapse into cleanup.
+  **The same-process case is state 12s, not an exception buried in state 12.**
+  When the recorded pid is this process and same-process incumbency is
+  permitted, boot has not lost the fence to anyone — it IS the incumbent — so
+  the disposition is `MayBind` and there is no exit at all. An earlier draft
+  wrote that as a conditional clause inside state 12's disposition, which left
+  an implementer following the exit enumeration with no named outcome for it
+  while state 12's own exit 0 was correct only for the foreign-pid half. It is
+  its own row now, and the precedence names it. It remains the only state where
+  a live recorded pid yields `MayBind`, licensed solely by that pid being this
+  process.
 
 ### Replacing a live incumbent — out of scope
 
@@ -633,73 +671,32 @@ explicitly. Without all four, a test can be green while proving nothing:
 | **Rendezvous postcondition** | Whether the socket file and pid file still exist afterwards, asserted by stat, not inferred from the absence of an error.                                                                |
 | **Listener count**           | How many processes hold the socket after boot returns. This is the assertion that actually detects the double-bind, and no other element substitutes for it.                             |
 
-**The four elements, instantiated per state.** Stating the requirement without
-instantiating it leaves the test author to invent fixtures, and an invented
-fixture is exactly how a test ends up green against the wrong branch. Every row
-below is binding. `boot frame` means the standard probe: `probe_only` set, this
-build's `protocol_version`, this build's `config_id`. "scripted listener" means
-a socket bound by the test that replies with the frame given and nothing else.
+**The per-state fixture recipe is specified separately.** Instantiating the four
+elements for every state — the exact peer setup, the exact response frame, and
+the expected listener count per row — is a second normative surface with its own
+failure modes, and it is where the review of this amendment concentrated its
+findings. It belongs in a follow-up ADR rather than here, so that the
+classification contract above can be read and implemented on its own.
 
-**The frames below show only the fields that distinguish each case; they are not
-complete wire frames, and a harness must not transmit them literally.**
-`DaemonResponseFrame` declares `namespace_mismatch` with no `serde` default
-(`crates/khive-runtime/src/daemon.rs`), unlike its `config_mismatch`,
-`served_config_id`, `version_mismatch`, and `daemon_protocol_version` siblings.
-A row transmitted as written therefore fails to deserialize at the client, and
-rows 2, 3, 5, 6, and 14 would every one of them classify as state 8 — the exact
-state they exist to be distinguished from. Each fixture serializes a **complete**
-frame: the fields shown set as shown, every remaining field at its zero value.
+Two constraints that follow-up inherits, because both were established while
+writing this one and should not be rediscovered:
 
-| #   | Peer setup                                                                                                                                                                                                                                               | Probe input | Rendezvous postcondition              | Listeners after                                              | Exit |
-| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- | ------------------------------------- | ------------------------------------------------------------ | ---- |
-| 1   | Real daemon, same version, same `config_id`                                                                                                                                                                                                              | boot frame  | socket + pid file unchanged           | 1 (incumbent)                                                | 0    |
-| 2   | Scripted listener replying `{ok:false, version_mismatch:true, daemon_protocol_version:<other>}`                                                                                                                                                          | boot frame  | socket + pid file unchanged           | 1 (scripted)                                                 | 0    |
-| 3   | Scripted listener replying `{ok:false, config_mismatch:true, served_config_id:<other>}`                                                                                                                                                                  | boot frame  | socket + pid file unchanged           | 1 (scripted)                                                 | 0    |
-| 4   | Scripted listener replying with `metrics` populated. **Synthetic**: the real boot frame cannot elicit this                                                                                                                                               | boot frame  | socket + pid file unchanged           | 1 (scripted)                                                 | 0    |
-| 5   | Scripted listener replying `{ok:true}` with `served_config_id` ABSENT and no mismatch flag                                                                                                                                                               | boot frame  | socket + pid file unchanged           | 1 (scripted)                                                 | 6    |
-| 6   | Scripted listener replying `{ok:true, result:"legacy-result"}` — the value must be a JSON string, because the wire field is `Option<String>`; a non-string value fails to deserialize and lands in row 8. Ack-shape test fails on `result` being present | boot frame  | socket + pid file unchanged           | 1 (scripted)                                                 | 0    |
-| 7   | Scripted listener that accepts the connection and writes nothing until past the probe deadline                                                                                                                                                           | boot frame  | socket + pid file unchanged           | 1 (scripted)                                                 | 2    |
-| 8   | Scripted listener that writes bytes which are not a valid frame                                                                                                                                                                                          | boot frame  | socket + pid file unchanged           | 1 (scripted)                                                 | 3    |
-| 9   | Socket file present with nothing bound to it; pid file names a live process (a sleeper is fine)                                                                                                                                                          | boot frame  | socket + pid file unchanged           | 0                                                            | 4    |
-| 10  | Socket file present with nothing bound; pid file names a dead pid, **plus a case each for the pid file removed, empty, and not parseable as a pid** — the four cases of state 10's "no usable pid record" predicate                                      | boot frame  | socket + pid file REPLACED            | 1 (this process)                                             | —    |
-| 11  | No socket file; pid file names a dead pid, **plus a case each for the pid file removed, empty, and not parseable as a pid** — the same four cases as row 10                                                                                              | boot frame  | socket + pid file created             | 1 (this process)                                             | —    |
-| 12  | No socket file; pid file names a live process that is NOT this one                                                                                                                                                                                       | boot frame  | pid file unchanged, no socket created | 0 — the pid names a live process, not a listener (cf. row 9) | 0    |
-| 12a | No socket file; pid file names THIS process, same-process incumbency permitted                                                                                                                                                                           | boot frame  | socket created by this process        | 1 (this process)                                             | —    |
-| 13  | Socket path present but not connectable for a reason other than refusal (e.g. mode 000 → `EACCES`)                                                                                                                                                       | boot frame  | socket + pid file unchanged           | not observable — assert the postcondition and exit only      | 0    |
-| 14  | Scripted listener replying `{ok:false, namespace_mismatch:true}`                                                                                                                                                                                         | boot frame  | socket + pid file unchanged           | 1 (scripted)                                                 | 0    |
-
-Row 12a is the `MayBind` branch and it is the only row where a live pid ends in
-binding. Its test asserts that the pid it matched is this process's own, not
-merely that a bind succeeded: without that assertion the row is
-indistinguishable from a collapse into cleanup, which is the defect the whole
-table exists to prevent.
-
-Row 13's listener count is stated as not observable rather than given a number,
-because a socket that cannot be connected to also cannot be interrogated for who
-holds it. Writing a number there would be a fabricated assertion.
-
-Two states need their mechanism named because the general recipe does not reach
-them. **State 4** cannot be elicited by the real boot probe, so its test is
-explicitly synthetic: a scripted listener that returns a metrics-carrying reply.
-The test asserts the classification, and must be labelled synthetic so a later
-reader does not mistake it for evidence that boot can reach the state. **States
-10 and 11** are the two that bind, so their postcondition is inverted: the test
-asserts the rendezvous was replaced and that exactly one listener — this process
-— holds it afterwards.
-
-Where a state's test runs below process level, the exit code is asserted against
-the value the classification maps to rather than against a real process exit,
-and at least one end-to-end test per exit class asserts a real process exit code
-so the mapping itself is covered.
-
-One further test is required because its absence is what allowed the collapse:
-
-- A test that starts a real live incumbent and drives each non-acknowledgement
-  class against it, asserting that startup never leaves two live daemons.
-
-Each state's guard carries a mutation control: defeat the guard, confirm that
-exactly that state's test fails, and restore from a snapshot rather than by
-reapplying an inverse edit.
+- A fixture must serialize a frame that both deserializes at the client AND
+  passes the version check. `DaemonResponseFrame` declares `namespace_mismatch`
+  with no `serde` default (`crates/khive-runtime/src/daemon.rs`), unlike its
+  `config_mismatch`, `served_config_id`, `version_mismatch`, and
+  `daemon_protocol_version` siblings, so an abbreviated frame fails to
+  deserialize and lands in state 8. But "complete frame, every unspecified field
+  at its zero value" is equally wrong: `daemon_protocol_version` zero is unequal
+  to this build's, and precedence puts version mismatch ahead of the identity and
+  ack-shape rows, so such a frame lands in state 2 whatever else it sets. The
+  recipe therefore has to define an explicit valid baseline frame and override
+  only the distinguishing fields per row.
+- State 13 is not observable at the listener-count element: the socket path is
+  present but not connectable, so no fixture can count who holds it. Either give
+  13 a seam whose owner is known, or exempt it from the four-element rule and
+  name a testable substitute — never waive the element that detects the
+  double-bind while still calling it mandatory.
 
 ### What is unchanged
 


### PR DESCRIPTION
## What this amendment specifies

ADR-049 Amendment 6 gives `khived` boot a complete classification of what it can find
already holding the daemon's socket and pid file, and says what boot does in each case.

The distinction the amendment turns on is that **liveness and acceptability are different
questions**. A responsive incumbent whose configuration or protocol version does not match
this build is alive, and refusing to start is still the right answer. Conversely, a pid file
naming a dead process is not an incumbent at all. Conflating the two is what lets boot either
clean up a socket a live process is serving, or refuse to start against a stale file nobody
owns.

## Shape

Sixteen states, each with the observation that identifies it, boot's action, and the exit code
it produces. The states cover every combination the probe can reach: exact acknowledgement,
protocol-version mismatch, config mismatch, metrics-only reply, unresolved identity, a
parseable non-acknowledgement, a silent connect, a malformed reply, connection refused with
and without a live pid, and the socket-absent cases.

Two of those deserve calling out because they were the ones an earlier draft got wrong:

- **Identity unresolved (state 5) is separate from identity positively unequal (state 15).**
  A reply that has acknowledgement shape but carries no `served_config_id` establishes nothing
  about who is serving; a reply carrying a `served_config_id` that differs is a positive
  refutation. They warrant different messages, and the amendment keeps them apart rather than
  folding absence into mismatch.
- **A live pid with no socket splits on whether the pid is this process.** A foreign pid is an
  incumbent and boot refuses, naming the pid and its command line. This process's own pid means
  boot has not lost the fence to anyone, so it proceeds.

## Scope

Replacement of a live incumbent is **out of scope** and will be specified in its own ADR when
the capability is built. Nothing here authorises signalling a process. That section records the
three open items the replacement design inherits: what evidence establishes ownership (a
self-reported pid cannot on its own license signalling), the unlink race between the pid-file
recheck and the unlink, and platform reach, since the peer-credential lookup has a third arm
returning `Unsupported` for every Unix that is neither Apple nor Linux.

Test obligations accompany each state. The fixture recipe for building each observation is
deliberately left to the implementing change rather than fixed here.

## Relationship to the earlier PR

This supersedes an earlier PR carrying the same amendment. That one is closed with a pointer
here; the content is identical to its final state and review starts fresh against this one.
