### PR TITLE
docs(adr): ADR-049 Amendment 7 — states 9 and 12 share one exit code

### DIFF
--- a/docs/adr/ADR-049-khived-daemon.md
+++ b/docs/adr/ADR-049-khived-daemon.md
@@ -423,9 +423,11 @@ to restart only on unsuccessful exit treats exit 0 as a deliberate stop.
 
 **The class rule is "who resolves it", not "how long it lasts".** A refusal
 exits 0 when the condition can only be resolved by something other than a later
-retry of this process — an operator changing configuration, or another process
-that already owns the rendezvous. A refusal exits nonzero when the resolver IS a
-later retry of this process, so that a supervisor restart is the remedy.
+retry of this process: an operator changing configuration, or another process
+resolving the rendezvous. Naming a possible resolver is not a finding that one
+exists. The code says only that the resolution lies outside this process. A
+refusal exits nonzero when the resolver IS a later retry of this process, so
+that a supervisor restart is the remedy.
 
 Transience is not the test. A rollout in which an older daemon answers the probe
 can last hours and still exits 0, because no number of restarts of this process
@@ -714,8 +716,10 @@ easy to invert:
   An earlier draft of this amendment classed refusals by transience, which put
   state 12 in the retryable class and exited nonzero. It was wrong, and working
   out why is what produced the rule now stated above: where the resolver is the
-  _other_ process, restarting this one cannot help, and a restart loop is the
-  likely result. Exit 0 encodes "someone else has this", not "nothing is wrong".
+  _other_ process, restarting this one cannot help, and under the
+  restart-on-nonzero policy Amendment 7 selects, a restart loop is the likely
+  result. Exit 0 encodes "the resolution lies outside this process", not
+  "nothing is wrong" and not "someone else has this".
   That same draft called state 12 transient, a peer between fork and bind. That
   description is withdrawn for the reason recorded in the note above, and the
   exit code rests on the asymmetry Amendment 7 states, not on that mechanism.
@@ -946,9 +950,11 @@ because retiring exit 4 created the need: a nonzero code was never a substitute
 for saying what the incumbent is.
 
 What the exit-code change does is raise the operational cost of omitting it.
-With exit 0 the refusal is terminal, so the message is the only channel the
-operator gets, and a refusal printing the bare number leaves them with nothing
-to act on.
+Under the restart-on-nonzero policy selected above, exit 0 makes the refusal
+terminal, so the message is the only channel the operator gets, and a refusal
+printing the bare number leaves them with nothing to act on. Under a policy that
+restarts on either status the message is no less necessary, because no restart
+of this process reaches the condition either way.
 
 ### Exit 4 is retired, not reused
 

--- a/docs/adr/ADR-049-khived-daemon.md
+++ b/docs/adr/ADR-049-khived-daemon.md
@@ -886,59 +886,87 @@ command line, as state 12's already does.**
 
 The class rule asks whether a later attempt of this process can observe a
 different classification. Amendment 6 established that the answer is the same in
-both states, so the rule does not separate them. Nothing else did either. A
-nonzero code asserts that a supervisor restart is the remedy; exit 0 asserts
-that someone else owns the rendezvous. State 9 can prove neither. `ECONNREFUSED`
-with a live recorded pid is consistent with a crashed daemon whose socket file
-outlived it and whose pid was recycled by an unrelated process, and that is
-exactly the reading Amendment 6 arrived at.
+both states, so the rule does not separate them. Nothing else did either.
+
+**What exit 0 means here, stated so it cannot be read as an ownership claim.** A
+nonzero code says a later attempt of this process is the remedy. Exit 0 says the
+opposite: this process must not retry, and whatever resolves the condition lies
+outside it. That is the exit table's own reading, "resolver is an operator or
+another process", and it is a statement about where the resolution lives, not a
+finding that some particular other process holds the rendezvous. Amendment 6's
+fact 3 forbids the stronger reading in both states, and nothing below relies on
+it.
+
+State 9 licenses neither code on evidence. `ECONNREFUSED` with a live recorded
+pid is consistent with a crashed daemon whose socket file outlived it and whose
+pid was recycled by an unrelated process, and that is exactly the reading
+Amendment 6 arrived at.
 
 So the split cannot be settled on evidence, and pretending otherwise is what
 produced the withdrawn trajectory argument. It is settled on the asymmetry of
 being wrong.
 
-### The asymmetry of harm
+### The asymmetry of harm, and the supervisor policy it assumes
 
-A wrong exit 0 wedges boot **visibly**. The refusal is terminal for a supervisor
-configured to restart only on unsuccessful exit, so it happens once, an operator
-sees one refusal naming a pid and a command line, and the command line is the
-evidence that tells them whether the incumbent is a khived at all.
+**The asymmetry is not deployment-independent, and this document chooses a
+policy rather than discovering a fact.** It optimises for a supervisor that
+restarts on nonzero exit and treats exit 0 as a deliberate stop. That is the
+shape `launchd` gives with `KeepAlive { SuccessfulExit: false }`, and it is what
+the deployments this ADR is written for run. A supervisor configured the other
+way — restarting on exit 0, or on both statuses, or alerting louder on nonzero —
+inverts the reasoning below, and an operator running one should read this
+section as stating which policy the codes were chosen against rather than as an
+argument that holds everywhere.
+
+Under that policy, a wrong exit 0 wedges boot **visibly**. The refusal is
+terminal, so it happens once, an operator sees one refusal naming a pid and a
+command line, and the command line is the evidence that tells them whether the
+incumbent is a khived at all.
 
 A wrong nonzero wedges boot **silently and repeatedly**. The supervisor restarts,
 the next probe reads the same stale socket and the same recycled pid, and the
 loop produces no information it did not have on the first attempt. This is the
 failure mode the class rule exists to prevent, stated in Amendment 6 for state
-12: exit 0 encodes "someone else has this", not "nothing is wrong".
+12: exit 0 encodes "do not retry this here", not "nothing is wrong".
 
-The two errors are not symmetric in cost, and only one of them is observable by
-the person who can fix it. That is the whole license for the code, and it is
-stated as such rather than dressed as a fact about what the daemon is doing.
+The two errors are not symmetric in cost under that policy, and only one of them
+is observable by the person who can fix it. That is the whole license for the
+code, and it is stated as such rather than dressed as a fact about what the
+daemon is doing.
 
-### The command line is now load-bearing for state 9
+### The command line requirement propagates to state 9
 
-Amendment 6 argued that state 12's refusal must print the pid **and** its
-command line, because the class rule has exactly one failure mode — a recycled
-pid that reads as a live incumbent forever — and the command line is the only
-evidence that distinguishes it from a genuine race. State 9 has the identical
-failure mode and did not have the identical remedy, because its nonzero code
-appeared to offer the supervisor a way out. Removing that code removes the
-excuse: with exit 0, the refusal message is the only channel left, so it carries
-the same two facts. A refusal that prints the bare number leaves an operator
-with nothing to act on and no signal that anything is wrong.
+Amendment 6 required state 12's refusal to print the pid **and** its command
+line, because the class rule has exactly one failure mode — a recycled pid that
+reads as a live incumbent forever — and the command line is the only evidence
+that distinguishes it from a genuine race. **That requirement follows from
+Amendment 6's fact 3, which applies to both states, so state 9 was always owed
+it.** It is added here because this is the amendment that revisits state 9, not
+because retiring exit 4 created the need: a nonzero code was never a substitute
+for saying what the incumbent is.
+
+What the exit-code change does is raise the operational cost of omitting it.
+With exit 0 the refusal is terminal, so the message is the only channel the
+operator gets, and a refusal printing the bare number leaves them with nothing
+to act on.
 
 ### Exit 4 is retired, not reused
 
-Like exit 1 and exit 5, exit 4 stays defined and unemitted. A supervisor keyed
-on the old value reads a retired code rather than silently inheriting a reused
-one, which is the same guarantee Amendment 6 gave when state 13 left exit 5.
+Like exit 1 and exit 5, exit 4 stays defined and unassigned. Nothing emits it
+now, so no supervisor reads a 4 for state 9. The point of reserving rather than
+recycling is the opposite one: an existing exit-4 rule somewhere must not start
+firing on a **new** meaning silently attached to that number. This is the same
+guarantee Amendment 6 gave when state 13 left exit 5.
 
 ### What this does not claim
 
 It does not claim that a state 9 observation means another process owns the
-rendezvous. It claims that a boot which cannot tell the difference should stop
-and say so, rather than ask a supervisor to try again at something no retry
-reaches. The three facts recorded in Amendment 6 are unchanged and remain the
-reason no trajectory reading is available here.
+rendezvous. Exit 0 here means this process must not retry and the resolution
+lies outside it, which is a disposition rather than a finding about who holds
+what. It claims that a boot which cannot tell the difference should stop and say
+so, rather than ask a supervisor to try again at something no retry reaches. The
+three facts recorded in Amendment 6 are unchanged and remain the reason no
+trajectory reading is available here.
 
 ### Test obligations
 

--- a/docs/adr/ADR-049-khived-daemon.md
+++ b/docs/adr/ADR-049-khived-daemon.md
@@ -427,7 +427,9 @@ retry of this process: an operator changing configuration, or another process
 resolving the rendezvous. Naming a possible resolver is not a finding that one
 exists. The code says only that the resolution lies outside this process. A
 refusal exits nonzero when the resolver IS a later retry of this process, so
-that a supervisor restart is the remedy.
+that under a supervisor configured to restart on nonzero a restart is the
+remedy. The codes are chosen for that policy; a supervisor configured otherwise
+reads them differently, and the choice is stated as a choice in Amendment 7.
 
 Transience is not the test. A rollout in which an older daemon answers the probe
 can last hours and still exits 0, because no number of restarts of this process
@@ -662,7 +664,8 @@ rule turns on who resolves the condition. A peer that published a
 identity positively. No number of restarts of this process changes what the
 incumbent echoes, so the resolver is an operator or the other process. An
 earlier draft folded both halves into state 5 and gave the pair exit 6, which
-told a supervisor to restart against a condition a restart cannot reach. The
+under the restart-on-nonzero policy tells a supervisor to restart against a
+condition a restart cannot reach. The
 reasoning is exactly the one already applied to an unequal
 `daemon_protocol_version` two steps earlier in the precedence: a positively
 refuted identity is not an unresolved one.
@@ -793,8 +796,8 @@ socket still exists, and no second listener was bound. A test that checks only
 the returned error passes while the socket is unlinked underneath a live
 process, which is precisely the failure being prevented. Each refuse state also
 asserts its exit code, since an otherwise-correct refusal carrying the wrong
-code either drives a supervisor restart loop or silently retires a retryable
-state.
+code either drives a restart loop under the restart-on-nonzero policy these
+codes are chosen for, or silently retires a retryable state.
 
 Where a state's test runs below process level, the exit code is asserted against
 the value the classification maps to rather than against a real process exit,
@@ -953,8 +956,12 @@ What the exit-code change does is raise the operational cost of omitting it.
 Under the restart-on-nonzero policy selected above, exit 0 makes the refusal
 terminal, so the message is the only channel the operator gets, and a refusal
 printing the bare number leaves them with nothing to act on. Under a policy that
-restarts on either status the message is no less necessary, because no restart
-of this process reaches the condition either way.
+restarts on either status the message is no less necessary: a restart may
+re-observe state 9, since the socket and the live pid can both be unchanged, but
+it cannot by itself establish who owns the rendezvous. That is Amendment 6's
+third fact and it is all that fact supports. Whether some restart eventually
+observes a different state depends on what happens outside this process, which
+is the point.
 
 ### Exit 4 is retired, not reused
 

--- a/docs/adr/ADR-049-khived-daemon.md
+++ b/docs/adr/ADR-049-khived-daemon.md
@@ -795,9 +795,9 @@ For every refuse state that must assert: the incumbent is still alive, the
 socket still exists, and no second listener was bound. A test that checks only
 the returned error passes while the socket is unlinked underneath a live
 process, which is precisely the failure being prevented. Each refuse state also
-asserts its exit code, since an otherwise-correct refusal carrying the wrong
-code either drives a restart loop under the restart-on-nonzero policy these
-codes are chosen for, or silently retires a retryable state.
+asserts its exit code, since under the restart-on-nonzero policy these codes are
+chosen for, an otherwise-correct refusal carrying the wrong code either drives a
+restart loop or silently retires a retryable state.
 
 Where a state's test runs below process level, the exit code is asserted against
 the value the classification maps to rather than against a real process exit,
@@ -977,7 +977,9 @@ It does not claim that a state 9 observation means another process owns the
 rendezvous. Exit 0 here means this process must not retry and the resolution
 lies outside it, which is a disposition rather than a finding about who holds
 what. It claims that a boot which cannot tell the difference should stop and say
-so, rather than ask a supervisor to try again at something no retry reaches. The
+so, rather than declare itself retryable at something a retry of this process
+does not resolve. What a supervisor then does with that is the supervisor's
+policy, which is why the code is chosen for a stated one. The
 three facts recorded in Amendment 6 are unchanged and remain the reason no
 trajectory reading is available here.
 

--- a/docs/adr/ADR-049-khived-daemon.md
+++ b/docs/adr/ADR-049-khived-daemon.md
@@ -450,12 +450,14 @@ published cannot be re-observed differently, so no retry reaches a different
 classification and it exits 0. State 7 is nonzero on the state 8 reading: a peer
 that did not answer within the deadline may answer within the next one.
 
-**OPEN: the split between exit 4 and exit 0 for states 9 and 12 is currently
-unlicensed.** Asking only whether a later attempt observes a different
-classification is necessary but not sufficient, because it is true of both
-states. They arise from the same instant of the same race and only the socket
-separates them, so the class rule alone does not say which of them gets a
-retryable code.
+**The split between exit 4 and exit 0 for states 9 and 12 was unlicensed. It is
+closed by Amendment 7, which gives both states exit 0 and retires exit 4.** The
+note below is kept as written because it is the evidence Amendment 7 rests on,
+and because the premise it withdrew must not be reopened. Asking only whether a
+later attempt observes a different classification is necessary but not
+sufficient, because it is true of both states. They arise from the same instant
+of the same race and only the socket separates them, so the class rule alone
+does not say which of them gets a retryable code.
 
 An earlier version of this section supplied that license with a trajectory
 argument: a socket present with a live refusing owner was said to be a daemon
@@ -506,26 +508,25 @@ in either state. Pid reuse is one explanation the observation admits and the one
 that no retry of this process ever resolves, but the facts do not establish that
 it is the explanation in any given case, and nothing here should be read as
 saying they do. Neither state licenses a trajectory reading, then, and these
-exit codes are normative for supervisors. **The codes in the table below are UNCHANGED and
-remain what implementations follow.** What is open is their justification, and
-it is tracked here rather than asserted. Resolving it is deliberately out of
-scope for this amendment: the classification is already the improvement over the
-code, and inventing a second mechanism to replace a refuted one, in the round
-that refuted it, is how the first one got here.
+exit codes are normative for supervisors. Resolving the split was deliberately
+out of scope for Amendment 6: the classification was already the improvement
+over the code, and inventing a second mechanism to replace a refuted one, in the
+round that refuted it, is how the first one got here. **Amendment 7 resolves it
+on the ground stated there, and the table below carries the resolved codes.**
 
 **Codes are numeric and distinct, not merely "nonzero".** A supervisor and an
 end-to-end test both need to tell these apart, and "nonzero" is a class, not a
 value:
 
-| Exit | Meaning                                                            | States                        |
-| ---- | ------------------------------------------------------------------ | ----------------------------- |
-| 0    | Refused; resolver is an operator or another process                | 1, 2, 3, 4, 6, 12, 13, 14, 15 |
-| 1    | Reserved for unclassified failure; never emitted by classification | —                             |
-| 2    | Refused; connected but the peer did not answer                     | 7                             |
-| 3    | Refused; the peer's reply did not parse                            | 8                             |
-| 4    | Refused; connection refused while the recorded pid is running      | 9                             |
-| 5    | Reserved; formerly state 13, retired by this amendment             | —                             |
-| 6    | Refused; the peer answered but its identity could not be resolved  | 5                             |
+| Exit | Meaning                                                            | States                           |
+| ---- | ------------------------------------------------------------------ | -------------------------------- |
+| 0    | Refused; resolver is an operator or another process                | 1, 2, 3, 4, 6, 9, 12, 13, 14, 15 |
+| 1    | Reserved for unclassified failure; never emitted by classification | —                                |
+| 2    | Refused; connected but the peer did not answer                     | 7                                |
+| 3    | Refused; the peer's reply did not parse                            | 8                                |
+| 4    | Reserved; formerly state 9, retired by Amendment 7                 | —                                |
+| 5    | Reserved; formerly state 13, retired by Amendment 6                | —                                |
+| 6    | Refused; the peer answered but its identity could not be resolved  | 5                                |
 
 Exit 1 is reserved so that an unclassified crash can never be mistaken for a
 classified refusal. States 10, 11, and 12s have no exit code because they
@@ -556,7 +557,7 @@ old value reads a retired code rather than silently inheriting a reused one.
 | 6   | Parseable non-acknowledgement                     | connect ok, frame deserializes, reply does NOT have ack shape                                                                                                        | Refuse to start; name the observed shape                                                                                                                                                               | 0    |
 | 7   | Silent connect                                    | connect ok, no parseable response within the deadline                                                                                                                | Refuse; distinct error "connected but did not answer"                                                                                                                                                  | 2    |
 | 8   | Malformed reply                                   | connect ok, bytes returned, frame does not parse                                                                                                                     | Refuse to start                                                                                                                                                                                        | 3    |
-| 9   | Connection refused, pid live                      | `ECONNREFUSED`, pid running                                                                                                                                          | Refuse; name the pid                                                                                                                                                                                   | 4    |
+| 9   | Connection refused, pid live                      | `ECONNREFUSED`, pid running                                                                                                                                          | Refuse; name the pid AND its command line                                                                                                                                                              | 0    |
 | 10  | Connection refused, no live listener              | `ECONNREFUSED`, and the recorded pid is not running OR no usable pid record exists (file absent, empty, or not parseable as a pid)                                   | Clean up and bind                                                                                                                                                                                      | —    |
 | 11  | No socket, no live pid                            | socket absent, and the recorded pid is not running OR no usable pid record exists (file absent, empty, or not parseable as a pid) — the same predicate state 10 uses | Clean up and bind                                                                                                                                                                                      | —    |
 | 12  | No socket, pid live, incumbency not permitted     | socket absent, pid running, and EITHER the pid is not this process OR same-process incumbency is not permitted                                                       | Refuse; name the pid AND its command line                                                                                                                                                              | 0    |
@@ -716,9 +717,8 @@ easy to invert:
   _other_ process, restarting this one cannot help, and a restart loop is the
   likely result. Exit 0 encodes "someone else has this", not "nothing is wrong".
   That same draft called state 12 transient, a peer between fork and bind. That
-  description is withdrawn for the reason recorded in the open note above, and
-  the exit code now rests on the class rule with its justification tracked as
-  open, not on that mechanism.
+  description is withdrawn for the reason recorded in the note above, and the
+  exit code rests on the asymmetry Amendment 7 states, not on that mechanism.
 
   **The refusal must name the pid AND its command line**, because the class rule
   has one failure mode and this is it. A pid file can outlive its writer and the
@@ -796,11 +796,12 @@ Where a state's test runs below process level, the exit code is asserted against
 the value the classification maps to rather than against a real process exit,
 and at least one end-to-end test per **emitted** exit class asserts a real
 process exit code so the mapping itself is covered. The emitted classes are 0,
-2, 3, 4, and 6. Codes 1 and 5 are reserved and unemitted by classification, so
+2, 3, and 6. Codes 1, 4, and 5 are reserved and unemitted by classification, so
 they are deliberately not exercised as classification outcomes; requiring an
 end-to-end test for them would require producing an outcome this document
-forbids. A test that asserts no classified refusal ever exits 1 or 5 is welcome
-but belongs to the reserved-code guarantee, not to this per-class obligation.
+forbids. A test that asserts no classified refusal ever exits 1, 4, or 5 is
+welcome but belongs to the reserved-code guarantee, not to this per-class
+obligation.
 
 "One test per state" is not by itself enough to tell a conforming test from one
 that checks an error value, so each state's test declares four things
@@ -872,3 +873,84 @@ boot fence, the exactly-once recovery boundary of Amendment 3, and the socket
 accessibility narrowing of Amendment 4 all stand as written. This amendment
 constrains only what boot may conclude from a probe result, and what it may do
 about it.
+
+## Amendment 7 (2026-08-27): states 9 and 12 share one exit code
+
+Amendment 6 classified the incumbent states and left one question open: why
+state 9 exits 4 and state 12 exits 0, when its own reading says ownership and
+trajectory are unproven in both. This amendment closes it. **State 9 exits 0.
+Exit 4 is retired and not reused. State 9's refusal names the pid and its
+command line, as state 12's already does.**
+
+### Why neither code was licensed by evidence
+
+The class rule asks whether a later attempt of this process can observe a
+different classification. Amendment 6 established that the answer is the same in
+both states, so the rule does not separate them. Nothing else did either. A
+nonzero code asserts that a supervisor restart is the remedy; exit 0 asserts
+that someone else owns the rendezvous. State 9 can prove neither. `ECONNREFUSED`
+with a live recorded pid is consistent with a crashed daemon whose socket file
+outlived it and whose pid was recycled by an unrelated process, and that is
+exactly the reading Amendment 6 arrived at.
+
+So the split cannot be settled on evidence, and pretending otherwise is what
+produced the withdrawn trajectory argument. It is settled on the asymmetry of
+being wrong.
+
+### The asymmetry of harm
+
+A wrong exit 0 wedges boot **visibly**. The refusal is terminal for a supervisor
+configured to restart only on unsuccessful exit, so it happens once, an operator
+sees one refusal naming a pid and a command line, and the command line is the
+evidence that tells them whether the incumbent is a khived at all.
+
+A wrong nonzero wedges boot **silently and repeatedly**. The supervisor restarts,
+the next probe reads the same stale socket and the same recycled pid, and the
+loop produces no information it did not have on the first attempt. This is the
+failure mode the class rule exists to prevent, stated in Amendment 6 for state
+12: exit 0 encodes "someone else has this", not "nothing is wrong".
+
+The two errors are not symmetric in cost, and only one of them is observable by
+the person who can fix it. That is the whole license for the code, and it is
+stated as such rather than dressed as a fact about what the daemon is doing.
+
+### The command line is now load-bearing for state 9
+
+Amendment 6 argued that state 12's refusal must print the pid **and** its
+command line, because the class rule has exactly one failure mode — a recycled
+pid that reads as a live incumbent forever — and the command line is the only
+evidence that distinguishes it from a genuine race. State 9 has the identical
+failure mode and did not have the identical remedy, because its nonzero code
+appeared to offer the supervisor a way out. Removing that code removes the
+excuse: with exit 0, the refusal message is the only channel left, so it carries
+the same two facts. A refusal that prints the bare number leaves an operator
+with nothing to act on and no signal that anything is wrong.
+
+### Exit 4 is retired, not reused
+
+Like exit 1 and exit 5, exit 4 stays defined and unemitted. A supervisor keyed
+on the old value reads a retired code rather than silently inheriting a reused
+one, which is the same guarantee Amendment 6 gave when state 13 left exit 5.
+
+### What this does not claim
+
+It does not claim that a state 9 observation means another process owns the
+rendezvous. It claims that a boot which cannot tell the difference should stop
+and say so, rather than ask a supervisor to try again at something no retry
+reaches. The three facts recorded in Amendment 6 are unchanged and remain the
+reason no trajectory reading is available here.
+
+### Test obligations
+
+The per-class end-to-end obligation now covers 0, 2, 3, and 6. State 9's test
+asserts exit 0 and asserts that the refusal message contains both the pid and
+the command line, since dropping either is the failure this amendment guards
+and neither is visible in an exit code. The reserved-code guarantee gains exit
+4: no classified refusal ever exits 1, 4, or 5.
+
+### What is unchanged
+
+Every other state's disposition and exit code, the class rule itself, the
+precedence order, the three withdrawn-premise facts, and all of Amendments 1
+through 5. This amendment changes one exit code, one disposition string, and the
+reserved set.


### PR DESCRIPTION
Closes the one question Amendment 6 left open.

Amendment 6 classified the states a booting daemon can find the rendezvous in, and recorded that ownership and trajectory are unproven in both state 9 (connection refused, recorded pid live) and state 12 (no socket, recorded pid live). It then left them on different exit codes, 4 and 0, with the split marked unlicensed rather than justified. This amendment gives state 9 exit 0, retires exit 4 without reusing it, and adds the command line to state 9's refusal.

**The split cannot be settled on evidence.** A nonzero code says a later attempt of this process is the remedy. Exit 0 says the opposite: this process must not retry, and whatever resolves the condition lies outside it. That is a disposition, not a finding that some particular other process holds the rendezvous — Amendment 6's fact 3 forbids the stronger reading in both states. State 9 licenses neither code on evidence: a connection refused beside a live recorded pid is equally consistent with a crashed daemon whose socket file outlived it and whose pid was recycled by an unrelated process.

**It is settled on the asymmetry of being wrong, under a stated supervisor policy.** The asymmetry is not deployment-independent, and the text says so: it optimises for a supervisor that restarts on nonzero and treats exit 0 as a deliberate stop, the `launchd KeepAlive { SuccessfulExit: false }` shape these deployments run. Under that policy a wrong exit 0 wedges boot once and visibly, with a refusal an operator reads; a wrong nonzero wedges it silently and repeatedly, because no retry reaches a peer refusing connections while its recorded pid belongs to a stranger. A supervisor configured the other way inverts that, and an operator running one should read the section as naming which policy the codes were chosen against.

**The command line requirement propagates rather than appears.** Amendment 6's fact 3 applies to both states, so state 9 was always owed the same diagnostic that state 12 got; this is simply the amendment that revisits state 9. Retiring exit 4 did not create the need. What it does is raise the cost of omitting it, since with exit 0 the refusal is terminal and its message is the only channel the operator gets.

**Exit 4 is reserved, not recycled.** Nothing emits it now. The reason to reserve is that an existing exit-4 rule somewhere must not start firing on a new meaning silently attached to that number, which is the same guarantee Amendment 6 gave when state 13 left exit 5.

Also updated: the per-class end-to-end test obligation now covers 0, 2, 3 and 6, and the reserved-code guarantee gains exit 4 alongside 1 and 5.

Nothing else moves. Every other state's disposition and code, the class rule, the precedence order, the three withdrawn-premise facts, and Amendments 1 through 5 stand as written. Documentation only; no code in this repository asserts exit 4 for this classification today.