### PR TITLE
fix(mcp): finalize a dispatched event from a fresh read, not the page snapshot

### DIFF
--- a/crates/khive-mcp/src/pending_events.rs
+++ b/crates/khive-mcp/src/pending_events.rs
@@ -1309,6 +1309,32 @@ async fn run_pending_events_on_with_lease(
                         continue;
                     }
                 };
+                // The receipt persisted at claim time names an occurrence
+                // derived from the trigger the page query saw. If the row is
+                // now scheduled for a different instant, writing a terminal row
+                // would pair that receipt with a trigger it does not describe —
+                // and terminal rows are past the reach of recovery, whose scan
+                // fences on `status = 'firing'`, so nothing would ever
+                // re-examine it. Refuse for the same reason and in the same
+                // shape as the unparseable-trigger branch above: the dispatch
+                // has happened, so the honest outcome is a failed finalization
+                // that leaves the row `firing` for the receipt validator to
+                // adjudicate once the lease expires.
+                let fresh_occurrence_id = dispatch_occurrence_id(id, trigger_at);
+                if fresh_occurrence_id != claim.occurrence_id {
+                    tracing::error!(
+                        scheduled_event_id = %id,
+                        trigger_at = %trigger_at_fresh_str,
+                        claimed_occurrence_id = %claim.occurrence_id,
+                        fresh_occurrence_id = %fresh_occurrence_id,
+                        "pending-events: the event was rescheduled after its dispatch was \
+                         claimed; refusing to finalize a terminal row whose receipt names a \
+                         different occurrence"
+                    );
+                    summary.failed += 1;
+                    continue;
+                }
+
                 let repeat = expected_value
                     .get("repeat")
                     .and_then(Value::as_str)
@@ -6864,6 +6890,109 @@ mod tests {
         assert!(
             stored.get("dispatch_receipt").is_none() || stored["dispatch_receipt"].is_null(),
             "no receipt may be persisted for a claim that never succeeded: {stored:?}"
+        );
+    }
+
+    /// The post-claim half of the same invariant, and the one that cannot be
+    /// left to recovery.
+    ///
+    /// A reschedule landing after the claim but before the finalizer's fresh
+    /// read is INSIDE that read, so every finalization CAS predicate passes:
+    /// status, `firing_at`, invocation id, lease, and the exact-properties
+    /// fence all match. Committing there would write a terminal `fired` row
+    /// whose `dispatch_receipt.occurrence_id` names the old instant while
+    /// `trigger_at` names the new one — and the receipt validator that would
+    /// catch that pairing is only ever reached through the recovery scan, which
+    /// fences on `status = 'firing'`. A terminal row is past it forever, so the
+    /// mismatch would never be adjudicated at all.
+    ///
+    /// So the drain must refuse instead, leaving the row `firing` for recovery.
+    /// This differs from
+    /// `production_drain_refuses_to_claim_an_event_rescheduled_in_the_claim_window`
+    /// only in WHICH seam the write lands at, which is what makes the two
+    /// windows separately load-bearing.
+    #[tokio::test]
+    async fn production_drain_refuses_to_finalize_an_event_rescheduled_after_the_claim() {
+        let (_tmp, db_path) = tmp_db();
+        let rt = make_rt(&db_path).await;
+        let id = create_scheduled_event(
+            &rt,
+            "local",
+            &due_rfc3339(),
+            Some("stats()"),
+            None,
+            "schedule",
+        )
+        .await;
+
+        let gate = race_seam::PauseGate {
+            at: race_seam::PausePoint::BeforeFinalizeRead,
+            reached: std::sync::Arc::new(tokio::sync::Barrier::new(2)),
+            release: std::sync::Arc::new(tokio::sync::Barrier::new(2)),
+        };
+
+        let drain_task = {
+            let rt = rt.clone();
+            let gate = gate.clone();
+            tokio::spawn(race_seam::PAUSE_GATE.scope(gate, async move {
+                let server = KhiveMcpServer::new(rt.clone()).map_err(|e| anyhow::anyhow!("{e}"))?;
+                run_pending_events_on(&rt, &server, false).await
+            }))
+        };
+
+        // Parked AFTER claim and dispatch, so the claim's trigger_at fence has
+        // already passed and this write cannot be caught by it. Still a valid
+        // parseable instant, so the refusal cannot be confused with the
+        // unparseable-trigger branch.
+        gate.reached.wait().await;
+        let rescheduled_trigger = "2002-01-01T00:00:00Z";
+        let mut writer = rt.sql().writer().await.expect("writer");
+        let rows = writer
+            .execute(SqlStatement {
+                sql: "UPDATE notes SET properties = json_set(properties, '$.trigger_at', ?2) \
+                      WHERE id = ?1"
+                    .to_string(),
+                params: vec![
+                    SqlValue::Text(id.to_string()),
+                    SqlValue::Text(rescheduled_trigger.to_string()),
+                ],
+                label: Some("test_reschedule_after_claim".into()),
+            })
+            .await
+            .expect("concurrent write");
+        assert_eq!(rows, 1);
+        drop(writer);
+
+        gate.release.wait().await;
+        let summary = drain_task
+            .await
+            .expect("drain task")
+            .expect("drain must not error");
+        assert_eq!(
+            summary.fired, 0,
+            "no terminal row may be written for an occurrence the row no longer names: {summary:?}"
+        );
+        assert_eq!(
+            summary.failed, 1,
+            "the refusal must be recorded as a failed finalization, which is what leaves the row \
+             for recovery: {summary:?}"
+        );
+
+        let stored = get_note_props(&rt, id).await;
+        assert_eq!(
+            stored["status"].as_str(),
+            Some("firing"),
+            "the row must stay firing so the recovery scan, which fences on status='firing', can \
+             still reach it; a terminal row would be past that scan forever: {stored:?}"
+        );
+        assert_eq!(
+            stored["trigger_at"].as_str(),
+            Some(rescheduled_trigger),
+            "the writer's reschedule must survive: {stored:?}"
+        );
+        assert!(
+            stored.get("dispatch_receipt").is_some(),
+            "the claim receipt stays on the row for the validator to adjudicate: {stored:?}"
         );
     }
 

--- a/crates/khive-mcp/src/pending_events.rs
+++ b/crates/khive-mcp/src/pending_events.rs
@@ -689,6 +689,10 @@ async fn run_pending_events_on_with_lease(
                 };
                 let trigger_at = trigger_at_fixed.with_timezone(&Utc);
                 let trigger_offset = *trigger_at_fixed.offset();
+                // Owned copy of the exact bytes this page snapshot saw, so the
+                // claim below can fence on them however `properties` is
+                // borrowed or moved in between.
+                let snapshot_trigger_at = trigger_at_str.to_string();
 
                 if trigger_at > now {
                     summary.skipped_not_due += 1;
@@ -791,7 +795,11 @@ async fn run_pending_events_on_with_lease(
                 // pending -> firing now so a concurrent `schedule.cancel`
                 // cannot land between the read and this point (whichever
                 // side wins the CAS proceeds; the loser skips). The same
-                // claim gates the missed path too.
+                // claim gates the missed path too. The claim also fences on
+                // the snapshot's `trigger_at`, so a writer that reschedules
+                // the event in that same window makes the claim a no-op
+                // instead of stamping this occurrence id onto a row that is
+                // now scheduled for a different instant.
                 let occurrence_id = dispatch_occurrence_id(id, trigger_at);
                 let receipt_actor = creator
                     .as_ref()
@@ -807,19 +815,28 @@ async fn run_pending_events_on_with_lease(
                             "anonymous:local".to_string()
                         }
                     });
-                let claim =
-                    match claim_pending_event(rt, ns_str, id, occurrence_id, &receipt_actor, lease)
-                        .await
-                    {
-                        Ok(c) => c,
-                        Err(e) => {
-                            if verbose {
-                                eprintln!("[pending-events] claim failed for note {id}: {e}");
-                            }
-                            summary.failed += 1;
-                            continue;
+                #[cfg(test)]
+                race_seam::pause_before_claim().await;
+                let claim = match claim_pending_event(
+                    rt,
+                    ns_str,
+                    id,
+                    occurrence_id,
+                    &snapshot_trigger_at,
+                    &receipt_actor,
+                    lease,
+                )
+                .await
+                {
+                    Ok(c) => c,
+                    Err(e) => {
+                        if verbose {
+                            eprintln!("[pending-events] claim failed for note {id}: {e}");
                         }
-                    };
+                        summary.failed += 1;
+                        continue;
+                    }
+                };
                 let Some(claim) = claim else {
                     if verbose {
                         eprintln!(
@@ -1505,11 +1522,26 @@ fn validate_dispatch_receipt(
 
 /// CAS-claim a pending scheduled event and atomically persist the occurrence
 /// and invocation identity before any action future can be polled.
+///
+/// `expected_trigger_at` is the raw `trigger_at` string the caller's page
+/// snapshot saw, and the claim refuses unless the row still carries those exact
+/// bytes. That is what keeps the persisted receipt's `occurrence_id` — derived
+/// from the snapshot's instant — describing the same occurrence the row is
+/// scheduled for. Without it a writer landing between the page query and this
+/// claim reschedules the event while the claim stamps the old occurrence onto
+/// it, and the resulting terminal row fails receipt validation and is
+/// quarantined as indeterminate rather than read as the dispatch it was.
+/// A refusal costs nothing: the row stays `pending` and the next drain picks it
+/// up from the value the writer actually left. The comparison is on bytes, not
+/// on the parsed instant, so a rewrite to a different spelling of the same
+/// instant also refuses; that is stricter than the invariant strictly needs and
+/// the extra refusals cost one drain interval each.
 async fn claim_pending_event(
     rt: &KhiveRuntime,
     namespace: &str,
     id: uuid::Uuid,
     occurrence_id: uuid::Uuid,
+    expected_trigger_at: &str,
     actor: &str,
     lease: DispatchLeaseConfig,
 ) -> Result<Option<DispatchClaim>> {
@@ -1544,7 +1576,8 @@ async fn claim_pending_event(
                     AND namespace = ?5 \
                     AND kind = 'scheduled_event' \
                     AND deleted_at IS NULL \
-                    AND json_extract(properties, '$.status') = 'pending'"
+                    AND json_extract(properties, '$.status') = 'pending' \
+                    AND json_extract(properties, '$.trigger_at') = ?6"
                 .to_string(),
             params: vec![
                 SqlValue::Integer(updated_at),
@@ -1552,6 +1585,7 @@ async fn claim_pending_event(
                 SqlValue::Text(receipt_json),
                 SqlValue::Text(id.to_string()),
                 SqlValue::Text(namespace.to_string()),
+                SqlValue::Text(expected_trigger_at.to_string()),
             ],
             label: Some("pending_events_claim_firing".into()),
         })
@@ -3194,11 +3228,13 @@ pub async fn schedule_tick_loop(
     }
 }
 
-/// Test-only pause point right after a drain iteration's page-query
-/// snapshot (`properties`) and before claim/dispatch/finalization, so a
-/// concurrent property write landing between that snapshot and the
-/// finalizer's later fresh current-properties read can be reproduced
-/// deterministically instead of relying on scheduler luck or sleeps. A
+/// Test-only pause points inside a drain iteration, so a concurrent property
+/// write landing in one of its races can be reproduced deterministically
+/// instead of relying on scheduler luck or sleeps. There are two, and they
+/// bracket different windows: `pause_before_claim` parks between the page-query
+/// snapshot (`properties`) and the CAS claim, and `pause_before_finalize_read`
+/// parks after claim and dispatch and immediately before the finalizer's fresh
+/// current-properties read. Each is a
 /// no-op unless the calling task runs inside `PAUSE_GATE.scope(...)`;
 /// production code never establishes that scope, so this costs nothing
 /// outside these regression tests, and it does not exist at all in
@@ -3208,6 +3244,20 @@ pub(crate) mod race_seam {
     use std::sync::Arc;
     use tokio::sync::Barrier;
 
+    /// Which of the drain's windows a gate is armed for. A gate trips at the
+    /// point it names and nowhere else, so a drain that passes through both
+    /// seams parks once, at the one the test asked for. Without this a test
+    /// arming the earlier window would also be caught by the later one and
+    /// hang waiting for a second handshake it never planned to perform.
+    #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+    pub(crate) enum PausePoint {
+        /// Between the page-query snapshot and the CAS claim.
+        BeforeClaim,
+        /// After claim and dispatch, immediately before the finalizer's fresh
+        /// current-properties read.
+        BeforeFinalizeRead,
+    }
+
     /// Two-phase handshake: `reached` lets the driving test learn the drain
     /// task has arrived at the pause point (i.e. genuinely parked, not just
     /// scheduled) before it performs a concurrent write; `release` then lets
@@ -3216,6 +3266,7 @@ pub(crate) mod race_seam {
     /// would resume together with no window for the test to act in between.
     #[derive(Clone)]
     pub(crate) struct PauseGate {
+        pub(crate) at: PausePoint,
         pub(crate) reached: Arc<Barrier>,
         pub(crate) release: Arc<Barrier>,
     }
@@ -3224,11 +3275,21 @@ pub(crate) mod race_seam {
         pub(crate) static PAUSE_GATE: PauseGate;
     }
 
-    pub(crate) async fn pause_before_finalize_read() {
+    async fn pause_at(point: PausePoint) {
         if let Ok(gate) = PAUSE_GATE.try_with(Clone::clone) {
-            gate.reached.wait().await;
-            gate.release.wait().await;
+            if gate.at == point {
+                gate.reached.wait().await;
+                gate.release.wait().await;
+            }
         }
+    }
+
+    pub(crate) async fn pause_before_claim() {
+        pause_at(PausePoint::BeforeClaim).await;
+    }
+
+    pub(crate) async fn pause_before_finalize_read() {
+        pause_at(PausePoint::BeforeFinalizeRead).await;
     }
 }
 
@@ -3796,14 +3857,15 @@ mod tests {
     }
 
     async fn claim_for_test(rt: &KhiveRuntime, id: uuid::Uuid, trigger_at: &str) -> DispatchClaim {
-        let trigger_at = trigger_at
+        let parsed = trigger_at
             .parse::<DateTime<Utc>>()
             .expect("trigger timestamp");
         claim_pending_event(
             rt,
             "local",
             id,
-            dispatch_occurrence_id(id, trigger_at),
+            dispatch_occurrence_id(id, parsed),
+            trigger_at,
             "anonymous:local",
             DispatchLeaseConfig::from_env(),
         )
@@ -6487,6 +6549,7 @@ mod tests {
         .await;
 
         let gate = race_seam::PauseGate {
+            at: race_seam::PausePoint::BeforeFinalizeRead,
             reached: std::sync::Arc::new(tokio::sync::Barrier::new(2)),
             release: std::sync::Arc::new(tokio::sync::Barrier::new(2)),
         };
@@ -6569,6 +6632,7 @@ mod tests {
         .await;
 
         let gate = race_seam::PauseGate {
+            at: race_seam::PausePoint::BeforeFinalizeRead,
             reached: std::sync::Arc::new(tokio::sync::Barrier::new(2)),
             release: std::sync::Arc::new(tokio::sync::Barrier::new(2)),
         };
@@ -6617,6 +6681,189 @@ mod tests {
             "finalization must schedule from the repeat it read fresh (cleared, so terminal), \
              not from the pre-claim page snapshot (\"daily\", which would reschedule to \
              pending): got {stored:?}"
+        );
+    }
+
+    /// The claim's `trigger_at` fence, isolated. The receipt's `occurrence_id`
+    /// is derived from the caller's page snapshot, so a claim that lands on a
+    /// row whose `trigger_at` has since moved would persist an occurrence id
+    /// describing an instant the row is no longer scheduled for. Receipt
+    /// validation rejects exactly that pairing, so such a row can only ever be
+    /// quarantined as indeterminate; refusing the claim is what keeps it out of
+    /// the durable record in the first place.
+    #[tokio::test]
+    async fn claim_refuses_when_a_concurrent_writer_rescheduled_since_the_page_read() {
+        let (_tmp, db_path) = tmp_db();
+        let rt = make_rt(&db_path).await;
+        let snapshot_trigger = "2000-01-01T00:00:00Z";
+        let id = create_scheduled_event(
+            &rt,
+            "local",
+            snapshot_trigger,
+            Some("stats()"),
+            None,
+            "schedule",
+        )
+        .await;
+
+        // Positive control in the same test: the fence admits the claim when
+        // the row still carries the snapshot's bytes. Without this arm a
+        // refusal below would be consistent with a fence that refuses
+        // everything, which proves nothing about the race.
+        let admitted = claim_pending_event(
+            &rt,
+            "local",
+            id,
+            dispatch_occurrence_id(id, snapshot_trigger.parse::<DateTime<Utc>>().unwrap()),
+            snapshot_trigger,
+            "actor:test",
+            short_test_lease(),
+        )
+        .await
+        .expect("claim query must not error");
+        assert!(
+            admitted.is_some(),
+            "the claim must be admitted when the row still holds the snapshot's trigger_at"
+        );
+
+        // Put the row back to pending so the refusal arm is testing the
+        // trigger_at predicate and not the status one.
+        let rescheduled_trigger = "2000-06-01T00:00:00Z";
+        force_set_properties(
+            &rt,
+            id,
+            &json!({
+                "trigger_at": rescheduled_trigger,
+                "status": "pending",
+                "action": "stats()",
+                "event_type": "schedule",
+            }),
+        )
+        .await;
+
+        let refused = claim_pending_event(
+            &rt,
+            "local",
+            id,
+            dispatch_occurrence_id(id, snapshot_trigger.parse::<DateTime<Utc>>().unwrap()),
+            snapshot_trigger,
+            "actor:test",
+            short_test_lease(),
+        )
+        .await
+        .expect("claim query must not error");
+        assert!(
+            refused.is_none(),
+            "the claim must refuse once the row's trigger_at has moved away from the snapshot"
+        );
+
+        let stored = get_note_props(&rt, id).await;
+        assert_eq!(
+            stored["status"].as_str(),
+            Some("pending"),
+            "a refused claim must leave the row claimable by the next drain: {stored:?}"
+        );
+        assert_eq!(
+            stored["trigger_at"].as_str(),
+            Some(rescheduled_trigger),
+            "a refused claim must leave the writer's reschedule intact: {stored:?}"
+        );
+        assert!(
+            stored.get("dispatch_receipt").is_none() || stored["dispatch_receipt"].is_null(),
+            "a refused claim must persist no receipt: {stored:?}"
+        );
+    }
+
+    /// The same refusal, driven through the production drain rather than the
+    /// claim primitive, so it would fail if the drain's call site stopped
+    /// passing the page snapshot's `trigger_at` down. Parks at
+    /// `PausePoint::BeforeClaim` so the concurrent reschedule lands strictly
+    /// between the candidate-page query and the claim: that is the window in
+    /// which the occurrence id is already derived but not yet persisted.
+    #[tokio::test]
+    async fn production_drain_refuses_to_claim_an_event_rescheduled_in_the_claim_window() {
+        let (_tmp, db_path) = tmp_db();
+        let rt = make_rt(&db_path).await;
+        let id = create_scheduled_event(
+            &rt,
+            "local",
+            &due_rfc3339(),
+            Some("stats()"),
+            None,
+            "schedule",
+        )
+        .await;
+
+        let gate = race_seam::PauseGate {
+            at: race_seam::PausePoint::BeforeClaim,
+            reached: std::sync::Arc::new(tokio::sync::Barrier::new(2)),
+            release: std::sync::Arc::new(tokio::sync::Barrier::new(2)),
+        };
+
+        let drain_task = {
+            let rt = rt.clone();
+            let gate = gate.clone();
+            tokio::spawn(race_seam::PAUSE_GATE.scope(gate, async move {
+                let server = KhiveMcpServer::new(rt.clone()).map_err(|e| anyhow::anyhow!("{e}"))?;
+                run_pending_events_on(&rt, &server, false).await
+            }))
+        };
+
+        gate.reached.wait().await;
+
+        // Still due, so the row stays a drain candidate and the refusal cannot
+        // be confused with the event simply not being ready.
+        let rescheduled_trigger = "2001-01-01T00:00:00Z";
+        let mut writer = rt.sql().writer().await.expect("writer");
+        let rows = writer
+            .execute(SqlStatement {
+                sql: "UPDATE notes SET properties = json_set(properties, '$.trigger_at', ?2) \
+                      WHERE id = ?1"
+                    .to_string(),
+                params: vec![
+                    SqlValue::Text(id.to_string()),
+                    SqlValue::Text(rescheduled_trigger.to_string()),
+                ],
+                label: Some("test_concurrent_reschedule".into()),
+            })
+            .await
+            .expect("concurrent write");
+        assert_eq!(rows, 1);
+        drop(writer);
+
+        gate.release.wait().await;
+        let summary = drain_task
+            .await
+            .expect("drain task")
+            .expect("drain must not error");
+        assert_eq!(
+            summary.fired, 0,
+            "an event rescheduled inside the claim window must not fire on this pass: {summary:?}"
+        );
+        assert_eq!(
+            summary.skipped_race, 1,
+            "the pass must record the refusal as a lost race, not as a failure or a silent \
+             no-candidate pass: {summary:?}"
+        );
+        assert_eq!(
+            summary.failed, 0,
+            "a refused claim is not an error: {summary:?}"
+        );
+
+        let stored = get_note_props(&rt, id).await;
+        assert_eq!(
+            stored["status"].as_str(),
+            Some("pending"),
+            "the refused row must stay pending for the next drain: {stored:?}"
+        );
+        assert_eq!(
+            stored["trigger_at"].as_str(),
+            Some(rescheduled_trigger),
+            "the writer's reschedule must survive: {stored:?}"
+        );
+        assert!(
+            stored.get("dispatch_receipt").is_none() || stored["dispatch_receipt"].is_null(),
+            "no receipt may be persisted for a claim that never succeeded: {stored:?}"
         );
     }
 

--- a/crates/khive-mcp/src/pending_events.rs
+++ b/crates/khive-mcp/src/pending_events.rs
@@ -775,8 +775,12 @@ async fn run_pending_events_on_with_lease(
                         .map(|actor| reminder_delivery_action(actor, &content))
                 };
 
-                // ── Determine repeat (read before claim; only informs which
-                // finalize branch runs below, never mutates the row read) ──
+                // ── Determine repeat (read before claim) ──
+                // This value gates ADMISSION only — which finalize branch is
+                // eligible. It must never reach anything WRITTEN: the value the
+                // finalizer schedules from is re-derived at the write, from the
+                // same fresh read the CAS is guarded on. See the re-derivation
+                // just before `final_properties_after_dispatch`.
                 let repeat = properties
                     .as_ref()
                     .and_then(|p| p.get("repeat"))
@@ -832,7 +836,16 @@ async fn run_pending_events_on_with_lease(
                     .is_some_and(|repeat| !matches!(repeat, "daily" | "weekly" | "monthly"))
                 {
                     let error = "scheduled event uses an unsupported repeat expression; only daily, weekly, and monthly are executable";
-                    let mut props = properties.clone().unwrap_or_else(|| json!({}));
+                    summary.failed += 1;
+                    let Some(expected_properties) =
+                        current_properties_for_finalize(rt, ns_str, id, "unsupported-repeat").await
+                    else {
+                        continue;
+                    };
+                    let Some(mut props) = expected_properties_value(&expected_properties, id)
+                    else {
+                        continue;
+                    };
                     props["status"] = json!("failed");
                     let (error_key, error_at_key) = dispatch_error_property_keys(&props);
                     props[error_key] = json!(error);
@@ -843,8 +856,17 @@ async fn run_pending_events_on_with_lease(
                         completed_at,
                         Some(error),
                     );
-                    summary.failed += 1;
-                    match finalize_fired_event(rt, ns_str, id, &props, completed_at, &claim).await {
+                    match finalize_fired_event(
+                        rt,
+                        ns_str,
+                        id,
+                        &props,
+                        completed_at,
+                        &claim,
+                        &expected_properties,
+                    )
+                    .await
+                    {
                         Ok(true) => summary.finalized += 1,
                         Ok(false) => summary.skipped_race += 1,
                         Err(error) => tracing::error!(
@@ -870,7 +892,15 @@ async fn run_pending_events_on_with_lease(
                         eprintln!("[pending-events] dispatch refused for note {id}: {error}");
                     }
                     summary.failed += 1;
-                    let mut props = properties.clone().unwrap_or_else(|| json!({}));
+                    let Some(expected_properties) =
+                        current_properties_for_finalize(rt, ns_str, id, "failed-identity").await
+                    else {
+                        continue;
+                    };
+                    let Some(mut props) = expected_properties_value(&expected_properties, id)
+                    else {
+                        continue;
+                    };
                     props["status"] = json!("failed");
                     props["dispatch_error"] = json!(error);
                     props["dispatch_failed_at"] = json!(Utc::now().to_rfc3339());
@@ -880,7 +910,17 @@ async fn run_pending_events_on_with_lease(
                         updated_at,
                         Some(error),
                     );
-                    match finalize_fired_event(rt, ns_str, id, &props, updated_at, &claim).await {
+                    match finalize_fired_event(
+                        rt,
+                        ns_str,
+                        id,
+                        &props,
+                        updated_at,
+                        &claim,
+                        &expected_properties,
+                    )
+                    .await
+                    {
                         Ok(true) => summary.finalized += 1,
                         Ok(false) => tracing::error!(
                             scheduled_event_id = %id,
@@ -908,7 +948,17 @@ async fn run_pending_events_on_with_lease(
                             grace.num_seconds()
                         );
                     }
-                    let mut props = properties.clone().unwrap_or_else(|| json!({}));
+                    let Some(expected_properties) =
+                        current_properties_for_finalize(rt, ns_str, id, "missed").await
+                    else {
+                        summary.failed += 1;
+                        continue;
+                    };
+                    let Some(mut props) = expected_properties_value(&expected_properties, id)
+                    else {
+                        summary.failed += 1;
+                        continue;
+                    };
                     props["missed_at"] = json!(now.timestamp_micros());
                     match advance_repeat_past_missed(&repeat, trigger_at, now) {
                         Some(next_at) => {
@@ -933,7 +983,17 @@ async fn run_pending_events_on_with_lease(
                         None,
                     );
 
-                    match finalize_fired_event(rt, ns_str, id, &props, updated_at, &claim).await {
+                    match finalize_fired_event(
+                        rt,
+                        ns_str,
+                        id,
+                        &props,
+                        updated_at,
+                        &claim,
+                        &expected_properties,
+                    )
+                    .await
+                    {
                         Ok(true) => {
                             summary.missed.push(id);
                             summary.finalized += 1;
@@ -978,7 +1038,16 @@ async fn run_pending_events_on_with_lease(
                         event_type,
                         "pending-events: refusing empty scheduled-event dispatch"
                     );
-                    let mut props = properties.clone().unwrap_or_else(|| json!({}));
+                    summary.failed += 1;
+                    let Some(expected_properties) =
+                        current_properties_for_finalize(rt, ns_str, id, "empty-payload").await
+                    else {
+                        continue;
+                    };
+                    let Some(mut props) = expected_properties_value(&expected_properties, id)
+                    else {
+                        continue;
+                    };
                     let (error_key, error_at_key) = dispatch_error_property_keys(&props);
                     props[error_key] = json!(error);
                     props[error_at_key] = json!(Utc::now().to_rfc3339());
@@ -989,8 +1058,17 @@ async fn run_pending_events_on_with_lease(
                         completed_at,
                         Some(error),
                     );
-                    summary.failed += 1;
-                    match finalize_fired_event(rt, ns_str, id, &props, completed_at, &claim).await {
+                    match finalize_fired_event(
+                        rt,
+                        ns_str,
+                        id,
+                        &props,
+                        completed_at,
+                        &claim,
+                        &expected_properties,
+                    )
+                    .await
+                    {
                         Ok(true) => summary.finalized += 1,
                         Ok(false) => summary.skipped_race += 1,
                         Err(error) => tracing::error!(
@@ -1007,7 +1085,16 @@ async fn run_pending_events_on_with_lease(
                         scheduled_event_id = %id,
                         "pending-events: refusing non-single scheduled action"
                     );
-                    let mut props = properties.clone().unwrap_or_else(|| json!({}));
+                    summary.failed += 1;
+                    let Some(expected_properties) =
+                        current_properties_for_finalize(rt, ns_str, id, "non-single-action").await
+                    else {
+                        continue;
+                    };
+                    let Some(mut props) = expected_properties_value(&expected_properties, id)
+                    else {
+                        continue;
+                    };
                     props["dispatch_error"] = json!(error);
                     props["dispatch_failed_at"] = json!(Utc::now().to_rfc3339());
                     props["status"] = json!("failed");
@@ -1017,8 +1104,17 @@ async fn run_pending_events_on_with_lease(
                         completed_at,
                         Some(error),
                     );
-                    summary.failed += 1;
-                    match finalize_fired_event(rt, ns_str, id, &props, completed_at, &claim).await {
+                    match finalize_fired_event(
+                        rt,
+                        ns_str,
+                        id,
+                        &props,
+                        completed_at,
+                        &claim,
+                        &expected_properties,
+                    )
+                    .await
+                    {
                         Ok(true) => summary.finalized += 1,
                         Ok(false) => summary.skipped_race += 1,
                         Err(error) => tracing::error!(
@@ -1110,8 +1206,99 @@ async fn run_pending_events_on_with_lease(
                         .await;
                     }
                 }
+                // Re-read the row's CURRENT properties immediately before
+                // finalizing, and guard the terminal write on exact equality
+                // to that read (mirroring `finalize_corrupt_receipt`'s
+                // `selected_properties` guard, #7 in the RMW census). Dispatch
+                // may have run for an arbitrary duration and this same process
+                // may have renewed the lease meanwhile, so the pre-dispatch
+                // `properties` snapshot captured at claim time is expected to
+                // have moved; only a read taken right here — after this
+                // process's own intervening writes have already landed —
+                // can distinguish "nothing else touched this row since I last
+                // looked" from a genuine concurrent writer.
+                //
+                // The race seam parks HERE, not before the claim: a test that
+                // pauses earlier lands its concurrent write before the
+                // candidate-page snapshot is taken, so the page already carries
+                // that write and the test passes whether finalization rebuilds
+                // from the stale page or from this fresh read. Parked here, the
+                // write is genuinely between the claim and this read, which is
+                // the only window that separates the two behaviours.
+                #[cfg(test)]
+                race_seam::pause_before_finalize_read().await;
+                let expected_properties = match current_note_properties_text(rt, ns_str, id).await {
+                    Ok(Some(text)) => text,
+                    Ok(None) => {
+                        summary.failed += 1;
+                        continue;
+                    }
+                    Err(error) => {
+                        tracing::error!(
+                            scheduled_event_id = %id,
+                            error = %error,
+                            "pending-events: could not read current properties before finalization"
+                        );
+                        summary.failed += 1;
+                        continue;
+                    }
+                };
+                let Some(expected_value) = expected_properties_value(&expected_properties, id)
+                else {
+                    summary.failed += 1;
+                    continue;
+                };
+                // Re-derive the SCHEDULING inputs from the fresh read too, not
+                // just the properties blob. `trigger_at`, `trigger_offset` and
+                // `repeat` above came from the pre-claim page snapshot, and
+                // guarding the write on the fresh properties text protects the
+                // blob while still letting a stale scheduling decision be
+                // computed from it: `final_properties_after_dispatch` uses
+                // these three to write the next `trigger_at` and the terminal
+                // `status`. A writer that changed `repeat` or `trigger_at`
+                // between the page snapshot and the fresh read would have its
+                // value retained as the CAS base and then immediately
+                // contradicted by a next-occurrence computed from the value it
+                // replaced.
+                //
+                // The earlier values keep their job: they gate ADMISSION (is
+                // this due, is it inside the grace window), which is a decision
+                // about whether to dispatch at all and is correctly made from
+                // what was observed before the claim. What must not come from
+                // them is anything WRITTEN.
+                let trigger_at_fresh_str = expected_value
+                    .get("trigger_at")
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                let (trigger_at, trigger_offset) = match trigger_at_fresh_str
+                    .parse::<DateTime<FixedOffset>>()
+                {
+                    Ok(fixed) => (fixed.with_timezone(&Utc), *fixed.offset()),
+                    Err(_) => {
+                        // The row's own `trigger_at` stopped being parseable
+                        // between the page read and here. Refuse rather than
+                        // fall back to the stale pair: falling back is
+                        // exactly the silent-overwrite this guard exists to
+                        // prevent, and the dispatch has already happened, so
+                        // the honest outcome is a failed finalization that
+                        // recovery will re-examine.
+                        tracing::error!(
+                            scheduled_event_id = %id,
+                            trigger_at = %trigger_at_fresh_str,
+                            "pending-events: trigger_at not parseable at finalization; refusing \
+                             to finalize from the pre-claim snapshot"
+                        );
+                        summary.failed += 1;
+                        continue;
+                    }
+                };
+                let repeat = expected_value
+                    .get("repeat")
+                    .and_then(Value::as_str)
+                    .map(str::to_string);
+
                 let (final_props, disposition) = final_properties_after_dispatch(
-                    properties.clone().unwrap_or_else(|| json!({})),
+                    expected_value,
                     receipt,
                     &completion,
                     trigger_at,
@@ -1125,6 +1312,7 @@ async fn run_pending_events_on_with_lease(
                     &final_props,
                     Utc::now().timestamp_micros(),
                     &claim,
+                    &expected_properties,
                 )
                 .await
                 {
@@ -2102,6 +2290,103 @@ async fn reclaim_stale_firing_events(rt: &KhiveRuntime, now_micros: i64) -> Resu
     Ok(summary)
 }
 
+/// Read a `scheduled_event` note's CURRENT `properties` column, verbatim as
+/// stored (no round-trip through `serde_json` re-serialization), so a caller
+/// can use the exact byte string as an exact-equality CAS guard on a later
+/// write. Returns `Ok(None)` when the row is absent, soft-deleted, or no
+/// longer a `scheduled_event` note.
+async fn current_note_properties_text(
+    rt: &KhiveRuntime,
+    namespace: &str,
+    id: uuid::Uuid,
+) -> Result<Option<String>> {
+    let mut reader = rt
+        .sql()
+        .reader()
+        .await
+        .map_err(|e| anyhow::anyhow!("pending-events: open SQL reader: {e}"))?;
+    let rows = reader
+        .query_all(SqlStatement {
+            sql: "SELECT properties FROM notes \
+                  WHERE id = ?1 AND namespace = ?2 AND kind = 'scheduled_event' \
+                    AND deleted_at IS NULL"
+                .to_string(),
+            params: vec![
+                SqlValue::Text(id.to_string()),
+                SqlValue::Text(namespace.to_string()),
+            ],
+            label: Some("pending_events_current_properties".into()),
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("pending-events: read current properties: {e}"))?;
+    match rows.as_slice() {
+        [] => Ok(None),
+        [row] => match row.get("properties") {
+            Some(SqlValue::Text(value)) => Ok(Some(value.clone())),
+            Some(SqlValue::Null) | None => Ok(None),
+            other => Err(anyhow::anyhow!(
+                "pending-events: unexpected properties column shape: {other:?}"
+            )),
+        },
+        _ => Err(anyhow::anyhow!(
+            "pending-events: multiple rows for scheduled_event {id}"
+        )),
+    }
+}
+
+/// Parses a finalizer's freshly read current-properties CAS snapshot into the
+/// `Value` base a terminal write's field mutations are applied to. Callers
+/// must build their write on this value, not on the page-query snapshot taken
+/// before the claim — a property written between that snapshot and this read
+/// still passes the CAS fence (it is part of what "current" means by the time
+/// this is called) but would otherwise be silently discarded by a write whose
+/// base predates it. Returns `None` (and logs) if the stored text is not
+/// valid JSON; the caller must treat that as a failed finalization.
+fn expected_properties_value(expected_properties: &str, id: uuid::Uuid) -> Option<Value> {
+    match serde_json::from_str(expected_properties) {
+        Ok(value) => Some(value),
+        Err(error) => {
+            tracing::error!(
+                scheduled_event_id = %id,
+                error = %error,
+                "pending-events: could not parse current properties for finalization"
+            );
+            None
+        }
+    }
+}
+
+/// Read the row's raw current properties at the same read boundary as a
+/// pending-action finalization decision, for use as `finalize_fired_event`'s
+/// mandatory exact-properties CAS fence. Returns `None` (and logs) on a read
+/// error or a vanished row; the caller must treat that as a failed
+/// finalization rather than retry with a stale or synthetic snapshot.
+async fn current_properties_for_finalize(
+    rt: &KhiveRuntime,
+    namespace: &str,
+    id: uuid::Uuid,
+    context: &'static str,
+) -> Option<String> {
+    match current_note_properties_text(rt, namespace, id).await {
+        Ok(Some(text)) => Some(text),
+        Ok(None) => {
+            tracing::error!(
+                scheduled_event_id = %id,
+                "pending-events: row vanished before {context} finalization"
+            );
+            None
+        }
+        Err(error) => {
+            tracing::error!(
+                scheduled_event_id = %id,
+                error = %error,
+                "pending-events: could not read current properties before {context} finalization"
+            );
+            None
+        }
+    }
+}
+
 /// CAS-persist the post-drain state of a claimed event: `firing -> {fired |
 /// pending | missed | failed}` (`pending` is an advanced repeat; `failed` is
 /// the unattributed-generic-action policy state). `claimed_firing_at` is
@@ -2110,6 +2395,25 @@ async fn reclaim_stale_firing_events(rt: &KhiveRuntime, now_micros: i64) -> Resu
 /// Clears `firing_at` on the terminal write. Returns
 /// `Ok(true)` iff exactly one row was updated. See
 /// `crates/khive-mcp/docs/api/pending-events.md`.
+/// Bundles `finalize_firing_event`'s two independent CAS guard inputs — the
+/// recovery-only legacy-stale timing predicate and the exact-properties
+/// equality predicate any caller may supply — into one parameter so the
+/// function stays under clippy's argument-count lint.
+#[derive(Clone, Copy, Default)]
+struct FinalizeGuard<'a> {
+    expired_at: Option<i64>,
+    expected_properties: Option<&'a str>,
+}
+
+/// Finalize a row this process's own claim is dispatching, guarded on the
+/// row's exact current properties as well as claim identity. `expected_properties`
+/// is mandatory — not `Option` — so a future branch cannot silently drop the
+/// content fence by passing `None`: the claim token alone is an ownership
+/// fence, not a substitute for detecting a concurrent property writer that
+/// landed between claim and finalization (ADR-106). Callers must read the
+/// row's raw current properties at the same read boundary as their
+/// finalization decision — see `current_note_properties_text` — and pass
+/// that snapshot here.
 async fn finalize_fired_event(
     rt: &KhiveRuntime,
     namespace: &str,
@@ -2117,8 +2421,21 @@ async fn finalize_fired_event(
     properties: &Value,
     updated_at: i64,
     claim: &DispatchClaim,
+    expected_properties: &str,
 ) -> Result<bool> {
-    finalize_firing_event(rt, namespace, id, properties, updated_at, claim, None).await
+    finalize_firing_event(
+        rt,
+        namespace,
+        id,
+        properties,
+        updated_at,
+        claim,
+        FinalizeGuard {
+            expired_at: None,
+            expected_properties: Some(expected_properties),
+        },
+    )
+    .await
 }
 
 /// Finalize a row selected by the expired-lease recovery pass, but only while
@@ -2141,7 +2458,10 @@ async fn finalize_expired_firing_event(
         properties,
         updated_at,
         claim,
-        Some(snapshot),
+        FinalizeGuard {
+            expired_at: Some(snapshot.expired_at),
+            expected_properties: Some(snapshot.properties),
+        },
     )
     .await
 }
@@ -2153,9 +2473,12 @@ async fn finalize_firing_event(
     properties: &Value,
     updated_at: i64,
     claim: &DispatchClaim,
-    snapshot: Option<RecoverySnapshot<'_>>,
+    guard: FinalizeGuard<'_>,
 ) -> Result<bool> {
-    let expired_at = snapshot.map(|value| value.expired_at);
+    let FinalizeGuard {
+        expired_at,
+        expected_properties,
+    } = guard;
     let legacy_stale_before =
         expired_at.map(|value| value.saturating_sub(LEGACY_STALE_FIRING_TIMEOUT_MICROS));
     let mut properties = properties.clone();
@@ -2202,9 +2525,7 @@ async fn finalize_firing_event(
                 SqlValue::Text(claim.invocation_id.to_string()),
                 expired_at.map_or(SqlValue::Null, SqlValue::Integer),
                 legacy_stale_before.map_or(SqlValue::Null, SqlValue::Integer),
-                snapshot.map_or(SqlValue::Null, |value| {
-                    SqlValue::Text(value.properties.to_string())
-                }),
+                expected_properties.map_or(SqlValue::Null, |value| SqlValue::Text(value.to_string())),
             ],
             label: Some("pending_events_finalize_fired".into()),
         })
@@ -2869,6 +3190,44 @@ pub async fn schedule_tick_loop(
                     "schedule drain pass failed: {e}"
                 )));
             }
+        }
+    }
+}
+
+/// Test-only pause point right after a drain iteration's page-query
+/// snapshot (`properties`) and before claim/dispatch/finalization, so a
+/// concurrent property write landing between that snapshot and the
+/// finalizer's later fresh current-properties read can be reproduced
+/// deterministically instead of relying on scheduler luck or sleeps. A
+/// no-op unless the calling task runs inside `PAUSE_GATE.scope(...)`;
+/// production code never establishes that scope, so this costs nothing
+/// outside these regression tests, and it does not exist at all in
+/// non-test builds. Mirrors `khive-runtime::curation::race_seam`.
+#[cfg(test)]
+pub(crate) mod race_seam {
+    use std::sync::Arc;
+    use tokio::sync::Barrier;
+
+    /// Two-phase handshake: `reached` lets the driving test learn the drain
+    /// task has arrived at the pause point (i.e. genuinely parked, not just
+    /// scheduled) before it performs a concurrent write; `release` then lets
+    /// the driving test resume the drain task only once that write has
+    /// landed. A single shared `Barrier` cannot express this — both parties
+    /// would resume together with no window for the test to act in between.
+    #[derive(Clone)]
+    pub(crate) struct PauseGate {
+        pub(crate) reached: Arc<Barrier>,
+        pub(crate) release: Arc<Barrier>,
+    }
+
+    tokio::task_local! {
+        pub(crate) static PAUSE_GATE: PauseGate;
+    }
+
+    pub(crate) async fn pause_before_finalize_read() {
+        if let Ok(gate) = PAUSE_GATE.try_with(Clone::clone) {
+            gate.reached.wait().await;
+            gate.release.wait().await;
         }
     }
 }
@@ -5068,6 +5427,7 @@ mod tests {
             *trigger_fixed.offset(),
             &None,
         );
+        let expected_properties = get_raw_note_properties(&rt, id).await;
         assert!(finalize_fired_event(
             &rt,
             "local",
@@ -5075,6 +5435,7 @@ mod tests {
             &final_properties,
             Utc::now().timestamp_micros(),
             &claim,
+            &expected_properties,
         )
         .await
         .expect("live owner finalizes"));
@@ -5703,6 +6064,7 @@ mod tests {
 
         // Finalize the fire as the drain would, then confirm the terminal
         // state is "fired" — the cancel never got a chance to overwrite it.
+        let expected_properties = get_raw_note_properties(&rt, id).await;
         let finalized = finalize_fired_event(
             &rt,
             "local",
@@ -5718,6 +6080,7 @@ mod tests {
             }),
             Utc::now().timestamp_micros(),
             &claim,
+            &expected_properties,
         )
         .await
         .expect("finalize query");
@@ -5910,6 +6273,7 @@ mod tests {
         // A resumes (unaware it was reclaimed) and attempts to finalize using
         // its own stale claim token. This must be a no-op: it must NOT match
         // B's current firing_at, and must NOT clobber B's live claim.
+        let expected_properties_for_a = get_raw_note_properties(&rt, id).await;
         let a_finalize_result = finalize_fired_event(
             &rt,
             "local",
@@ -5925,6 +6289,7 @@ mod tests {
             }),
             Utc::now().timestamp_micros(),
             &a_claim,
+            &expected_properties_for_a,
         )
         .await
         .expect("finalize query must not error");
@@ -5949,6 +6314,7 @@ mod tests {
 
         // B now finalizes with its own (correct) claim token — this must
         // succeed, proving the fix doesn't wedge legitimate finalization.
+        let expected_properties_for_b = get_raw_note_properties(&rt, id).await;
         let b_finalize_result = finalize_fired_event(
             &rt,
             "local",
@@ -5964,6 +6330,7 @@ mod tests {
             }),
             Utc::now().timestamp_micros(),
             &b_claim,
+            &expected_properties_for_b,
         )
         .await
         .expect("finalize query must not error");
@@ -5981,6 +6348,275 @@ mod tests {
         assert!(
             final_props.get("firing_at").is_none() || final_props["firing_at"].is_null(),
             "firing_at must be cleared on terminal finalize, got {final_props:?}"
+        );
+    }
+
+    /// Regression for the normal-finalization lost-update race (khive #1753).
+    /// `finalize_fired_event` reads the row's CURRENT properties immediately
+    /// before finalizing (see the call site above `final_properties_after_dispatch`
+    /// in the main drain loop) and must refuse the terminal write if a
+    /// concurrent writer changed properties since that read, even though the
+    /// claim tokens (`firing_at`/`invocation_id`/lease) are still valid —
+    /// those predicates alone do not detect an out-of-band property change.
+    /// This deterministically reproduces "two reads from one revision": the
+    /// snapshot captured here (`expected_properties`) is used for the stale
+    /// finalize attempt AFTER a concurrent write has already landed, so the
+    /// exact-equality predicate must fail. Before threading a real snapshot
+    /// through, normal finalization always called with `snapshot=None`,
+    /// which makes `AND (?9 IS NULL OR properties = ?9)` unconditionally
+    /// true — this test reddens if that call reverts to `None`: the stale
+    /// finalize would then succeed and the concurrent writer's
+    /// `concurrent_marker` field would be silently discarded.
+    #[tokio::test]
+    async fn normal_finalize_refuses_when_a_concurrent_writer_changed_properties_since_the_read() {
+        let (_tmp, db_path) = tmp_db();
+        let rt = make_rt(&db_path).await;
+
+        let past = "2000-01-01T00:00:00Z";
+        let id =
+            create_scheduled_event(&rt, "local", past, Some("stats()"), None, "schedule").await;
+        let claim = claim_for_test(&rt, id, past).await;
+
+        // The finalizer's fresh pre-write read (what `current_note_properties_text`
+        // returns right before finalizing in production).
+        let expected_properties = get_raw_note_properties(&rt, id).await;
+
+        // A concurrent writer mutates the row AFTER that read while leaving
+        // every claim predicate (status/firing_at/invocation_id/lease)
+        // valid — e.g. an external property patch racing the finalizer.
+        let mut writer = rt.sql().writer().await.expect("writer");
+        let rows = writer
+            .execute(SqlStatement {
+                sql: "UPDATE notes SET properties = json_set(properties, \
+                      '$.concurrent_marker', 'yes') WHERE id = ?1"
+                    .to_string(),
+                params: vec![SqlValue::Text(id.to_string())],
+                label: Some("test_concurrent_property_write".into()),
+            })
+            .await
+            .expect("concurrent write");
+        assert_eq!(rows, 1);
+        drop(writer);
+
+        let final_props = json!({
+            "trigger_at": past,
+            "repeat": null,
+            "status": "fired",
+            "event_type": "schedule",
+            "payload": "stats()",
+            "fired_at": Utc::now().to_rfc3339(),
+            "cancelled_at": null,
+        });
+        let finalized = finalize_fired_event(
+            &rt,
+            "local",
+            id,
+            &final_props,
+            Utc::now().timestamp_micros(),
+            &claim,
+            &expected_properties,
+        )
+        .await
+        .expect("finalize query must not error");
+        assert!(
+            !finalized,
+            "finalize must refuse a terminal write when properties changed since the read it guards on"
+        );
+
+        let props_after = get_note_props(&rt, id).await;
+        assert_eq!(
+            props_after["status"].as_str(),
+            Some("firing"),
+            "the row must remain firing, not silently finalized over the concurrent writer's \
+             change: {props_after:?}"
+        );
+        assert_eq!(
+            props_after["concurrent_marker"].as_str(),
+            Some("yes"),
+            "the concurrent writer's field must survive the refused finalize: {props_after:?}"
+        );
+
+        // A finalize guarded on the CURRENT properties (as the real drain
+        // loop does, re-reading right before this call) must still succeed.
+        let fresh_properties = get_raw_note_properties(&rt, id).await;
+        let finalized_fresh = finalize_fired_event(
+            &rt,
+            "local",
+            id,
+            &final_props,
+            Utc::now().timestamp_micros(),
+            &claim,
+            &fresh_properties,
+        )
+        .await
+        .expect("finalize query must not error");
+        assert!(
+            finalized_fresh,
+            "finalize with a fresh snapshot must succeed"
+        );
+        assert_eq!(
+            get_note_props(&rt, id).await["status"].as_str(),
+            Some("fired")
+        );
+    }
+
+    /// Regression test driven through the PRODUCTION
+    /// drain entry point (`run_pending_events_on`) rather than calling
+    /// `final_properties_after_dispatch` directly — this closes a gap a
+    /// primitive-level test cannot: it would still pass unchanged if the
+    /// drain loop's call site reverted to building `final_props` from the
+    /// stale pre-claim `properties` snapshot instead of the freshly read
+    /// `expected_properties`, since it would never invoke that call site at
+    /// all. Uses `race_seam::pause_before_finalize_read` (test-only,
+    /// compiled out of non-test builds) to force the concurrent property
+    /// write to land deterministically between claim/dispatch and the
+    /// finalizer's fresh current-properties read — no sleeps, no reliance on
+    /// scheduler ordering.
+    #[tokio::test]
+    async fn production_drain_preserves_a_property_written_between_claim_and_current_read() {
+        let (_tmp, db_path) = tmp_db();
+        let rt = make_rt(&db_path).await;
+        let id = create_scheduled_event(
+            &rt,
+            "local",
+            &due_rfc3339(),
+            Some("stats()"),
+            None,
+            "schedule",
+        )
+        .await;
+
+        let gate = race_seam::PauseGate {
+            reached: std::sync::Arc::new(tokio::sync::Barrier::new(2)),
+            release: std::sync::Arc::new(tokio::sync::Barrier::new(2)),
+        };
+
+        let drain_task = {
+            let rt = rt.clone();
+            let gate = gate.clone();
+            tokio::spawn(race_seam::PAUSE_GATE.scope(gate, async move {
+                let server = KhiveMcpServer::new(rt.clone()).map_err(|e| anyhow::anyhow!("{e}"))?;
+                run_pending_events_on(&rt, &server, false).await
+            }))
+        };
+
+        // Block until the drain task has genuinely parked at the seam — which
+        // sits AFTER the candidate-page query and the claim, immediately
+        // before the fresh pre-finalize read — THEN write, THEN release it.
+        // That placement is what makes the write land strictly between the
+        // page-query snapshot and the fresh read: parked any earlier, the
+        // write would already be inside the page snapshot and the test would
+        // pass whether finalization used the stale page or the fresh read.
+        gate.reached.wait().await;
+
+        let mut writer = rt.sql().writer().await.expect("writer");
+        let rows = writer
+            .execute(SqlStatement {
+                sql: "UPDATE notes SET properties = json_set(properties, \
+                      '$.custom', 'added-concurrently') WHERE id = ?1"
+                    .to_string(),
+                params: vec![SqlValue::Text(id.to_string())],
+                label: Some("test_concurrent_property_add".into()),
+            })
+            .await
+            .expect("concurrent write");
+        assert_eq!(rows, 1);
+        drop(writer);
+
+        gate.release.wait().await;
+        let summary = drain_task
+            .await
+            .expect("drain task")
+            .expect("drain must not error");
+        assert_eq!(summary.fired, 1, "the event must have fired: {summary:?}");
+
+        let stored = get_note_props(&rt, id).await;
+        assert_eq!(
+            stored["custom"].as_str(),
+            Some("added-concurrently"),
+            "a property written between claim and the finalizer's current-properties read \
+             must survive finalization, got {stored:?}"
+        );
+        assert_eq!(stored["status"].as_str(), Some("fired"));
+    }
+
+    /// Guarding the finalizer's write on the freshly-read properties protects
+    /// the properties BLOB while still allowing a stale SCHEDULING decision to
+    /// be computed over it. `repeat` and `trigger_at` are parsed from the
+    /// pre-claim candidate page; if the finalizer keeps using those, a writer
+    /// who cancels the repeat in the claim window has their edit retained as
+    /// the CAS base and then immediately contradicted by a next occurrence
+    /// scheduled from the value they replaced.
+    ///
+    /// This fixture makes the two behaviours produce different terminal states
+    /// rather than different timestamps, so the assertion cannot pass by
+    /// rounding: the event is seeded `repeat: "daily"`, and the concurrent
+    /// write clears `repeat` while the drain is parked at the seam. Scheduling
+    /// from the fresh read yields a terminal `fired`; scheduling from the stale
+    /// page yields a rescheduled `pending` with an advanced `trigger_at`.
+    #[tokio::test]
+    async fn production_drain_schedules_from_the_fresh_read_not_the_page_snapshot() {
+        let (_tmp, db_path) = tmp_db();
+        let rt = make_rt(&db_path).await;
+        let id = create_scheduled_event(
+            &rt,
+            "local",
+            &due_rfc3339(),
+            Some("stats()"),
+            Some("daily"),
+            "schedule",
+        )
+        .await;
+
+        let gate = race_seam::PauseGate {
+            reached: std::sync::Arc::new(tokio::sync::Barrier::new(2)),
+            release: std::sync::Arc::new(tokio::sync::Barrier::new(2)),
+        };
+
+        let drain_task = {
+            let rt = rt.clone();
+            let gate = gate.clone();
+            tokio::spawn(race_seam::PAUSE_GATE.scope(gate, async move {
+                let server = KhiveMcpServer::new(rt.clone()).map_err(|e| anyhow::anyhow!("{e}"))?;
+                run_pending_events_on(&rt, &server, false).await
+            }))
+        };
+
+        gate.reached.wait().await;
+
+        let mut writer = rt.sql().writer().await.expect("writer");
+        let rows = writer
+            .execute(SqlStatement {
+                sql:
+                    "UPDATE notes SET properties = json_set(properties, '$.repeat', json('null')) \
+                      WHERE id = ?1"
+                        .to_string(),
+                params: vec![SqlValue::Text(id.to_string())],
+                label: Some("test_concurrent_repeat_clear".into()),
+            })
+            .await
+            .expect("concurrent write");
+        assert_eq!(rows, 1);
+        drop(writer);
+
+        gate.release.wait().await;
+        let summary = drain_task
+            .await
+            .expect("drain task")
+            .expect("drain must not error");
+        assert_eq!(summary.fired, 1, "the event must have fired: {summary:?}");
+
+        let stored = get_note_props(&rt, id).await;
+        assert!(
+            stored.get("repeat").is_none() || stored["repeat"].is_null(),
+            "the concurrent clear of `repeat` must survive finalization, got {stored:?}"
+        );
+        assert_eq!(
+            stored["status"].as_str(),
+            Some("fired"),
+            "finalization must schedule from the repeat it read fresh (cleared, so terminal), \
+             not from the pre-claim page snapshot (\"daily\", which would reschedule to \
+             pending): got {stored:?}"
         );
     }
 


### PR DESCRIPTION
## Problem

The scheduled-event drain reads a page of candidate rows, claims one, dispatches
it, then writes the row back. The properties it wrote back came from the page
snapshot, taken before the claim. A writer that changed a property between the
page read and the finalize had that change silently overwritten: the finalize
succeeded, the row looked normal, and nothing recorded that anything was lost.

This is the sixth site from #2233. The other five landed in #2238.

## What this changes

Three things were wrong here, and they are fixed separately because they fail
separately. Each of the three windows is described in its own section below, in
the order they were found; each later one was opened, or made reachable, by
closing the one before it.

The properties written back are re-read at the same read boundary as the
finalization decision, so both the decision and the write proceed from the row as
it actually is. That is what preserves a concurrent writer's change.

The finalize is then fenced on that fresh snapshot: the conditional update
requires the row's current properties to still equal it, and reports zero
affected rows as a refusal rather than as success. `expected_properties` is a
`&str` and not an `Option`, so a later branch cannot drop the fence by passing
`None`. The claim token is an ownership fence; it is not a substitute for
detecting a content writer that landed inside the claim.

## Tests

Three regressions, each arranging the concurrent write in the window that
separates the two behaviours. A test-only seam parks the drain between the claim
and the fresh read, because a write that lands before the page snapshot is
already carried by the page and would pass either way.

## Mutation

Arms predicted before running and reconciled after.

Dropping the content fence on the normal path reddens exactly one test, the one
asserting the finalize is refused when properties moved; 430 green. It does not
redden the property-preservation test, which is carried by the fresh read rather
than by the fence. Recording that rather than smoothing it over: exactly one test
stands between this fence and its removal.

Feeding the finalization decision the page snapshot while leaving the fence on the
fresh read reddens exactly the two drain tests; 429 green.

A third mutation, replacing the fresh read with the page snapshot outright, was
run and discarded as an instrument rather than reported as evidence. It reddens
more than twenty tests, because the page snapshot predates the claim and lacks the
claim's own fields, so the fence refuses every row. A mutation that breaks
everything distinguishes nothing.

## Verification

```
cargo fmt --all -- --check
cargo clippy -p khive-mcp --all-targets -- -D warnings
RUSTDOCFLAGS="-D warnings" cargo doc -p khive-mcp --no-deps
cargo test -p khive-mcp
```

All pass. 431 unit tests. The three new tests were additionally run by name, so
the count is a reading and not a filter artefact.


---

## Second commit: the claim seam

Review of the first commit found that closing the finalize window opens a smaller
one at the claim.

The dispatch receipt's `occurrence_id` is derived from the `trigger_at` the
candidate-page query saw, while the claim required only `status = 'pending'`. A
writer rescheduling the event between that page read and the claim therefore got a
receipt stamped for an instant the row is no longer scheduled for. Receipt
validation rejects exactly that pairing, so the terminal row could only ever be
quarantined as indeterminate rather than read as the dispatch it recorded.

Finalizing from the row's current properties is what makes that reachable. Before
this branch, the finalizer wrote the whole page-snapshot document back, silently
restoring the old `trigger_at` and leaving the receipt self-consistent by
destroying the writer's edit. Preserving that edit is the point of the first
commit, and it is also what exposes the mismatch, so the same invariant is needed
one seam earlier.

The claim now refuses unless the row still carries the snapshot's exact
`trigger_at` bytes. A refusal costs nothing: the row stays pending and the next
drain reads the value the writer left. The comparison is on bytes rather than the
parsed instant, so a rewrite to a different spelling of the same instant also
refuses. That is stricter than the invariant needs and each such refusal costs one
drain interval.

The post-claim window is a separate matter and is addressed in the third commit
below. An earlier version of this description said that window ends in the
recovery quarantine, which is the safe outcome. That was wrong, and the
correction is the third commit: the finalizer terminalizes the row, and the
recovery scan only reaches rows still marked `firing`, so a terminal row carrying
a mismatched receipt is past recovery permanently.

The test seam gained a second pause point and a `PausePoint` discriminant so a gate
trips only at the window a test armed. Without it a drain crossing both seams would
park at the later one too and wait on a handshake the test never planned.

### Coverage and mutation

Two tests added: one on the claim primitive, carrying its own positive-control arm
so a refusal cannot be confused with a fence that refuses everything, and one
through the production drain parked before the claim.

Replacing the new predicate with a tautology that keeps the parameter bound reddens
exactly those two and leaves the other 431 green. That was the prediction stated
before the run.

### Verification at this head

`cargo fmt --all -- --check`, `cargo clippy -p khive-mcp --all-targets -- -D warnings`,
`RUSTDOCFLAGS="-D warnings" cargo doc -p khive-mcp --no-deps` all clean;
`cargo test -p khive-mcp` gives 433 unit and 145 integration passing. The two new
tests were also run by name.


---

## Third commit: the post-claim occurrence fence

Fencing the claim closes the window before the dispatch. It leaves the window
after it, and that one is worse, because it ends in a terminal row rather than a
retry.

Between the claim and the finalize the drain re-reads the row, by design, so that
a concurrent writer's edit survives. If that writer moved `trigger_at`, the fresh
read carries the new instant while the receipt already persisted carries the
occurrence derived from the old one. Every finalization predicate still passes:
the status, the firing timestamp, the invocation id, the lease and the properties
text all match what the finalizer expects. The row is committed as terminal
`fired`, with a receipt naming an occurrence the event is no longer scheduled for.

Nothing downstream catches it. The stale-row recovery scan selects on
`status = 'firing'`, so it does not consider a row that has already reached a
terminal state. The receipt validator that would reject this exact pairing runs
only inside that scan. A terminal row with a mismatched receipt is therefore past
every check the system has.

The finalize now derives the occurrence from the fresh trigger and compares it to
the claimed one. On mismatch it logs both, counts the event as failed, and
declines to write the terminal row. The row stays `firing`, which is what puts it
back in reach of recovery: the lease expires, the scan selects it, receipt
validation finds the mismatch it was written to find, and the event is recorded
as indeterminate rather than as a dispatch that did not happen the way the row
claims. The action is not replayed.

`failed` is the right counter rather than `skipped_race`. The dispatch was
attempted and its outcome is durable; what failed is the finalization. The
pre-claim refusal keeps `skipped_race`, where nothing was attempted at all.

### Coverage and mutation

One test added, parking the drain between the dispatch and the fresh read and
rescheduling the event there. It asserts the whole disposition rather than the
branch: no event fired, one failed, the row still `firing`, the writer's trigger
preserved, and the receipt still present.

Short-circuiting the new comparison while keeping its operands bound reddens
exactly that test and leaves 433 green. The arm was stated before the run.

One reconciliation worth recording rather than smoothing over: the first mutation
run reported 432 green and 2 red. The second, on the same mutant, reported the
predicted 433 and 1. The extra failure did not reproduce across two subsequent
clean runs and is an intermittent unrelated to this change; it is called out here
rather than left as a discrepancy between a prediction and a result.

### Verification at this head

`cargo fmt --all -- --check`, `cargo clippy -p khive-mcp --all-targets -- -D warnings`,
`RUSTDOCFLAGS="-D warnings" cargo doc -p khive-mcp --no-deps` all clean;
`cargo test -p khive-mcp` gives 434 unit and 145 integration passing.
