### PR TITLE
perf(events): opt into pages without totals

### DIFF
--- a/crates/khive-db/src/stores/event.rs
+++ b/crates/khive-db/src/stores/event.rs
@@ -165,6 +165,66 @@ impl SqlEventStore {
             .await
         }
     }
+
+    async fn query_events_page(
+        &self,
+        filter: EventFilter,
+        page: PageRequest,
+        include_total: bool,
+    ) -> Result<Page<Event>, StorageError> {
+        let namespace = self.namespace.clone();
+        let limit_i64 = i64::from(page.limit);
+        let offset_i64 = i64::try_from(page.offset).map_err(|_| StorageError::InvalidInput {
+            capability: StorageCapability::Events,
+            operation: "query_events".into(),
+            message: format!(
+                "PageRequest: offset must be <= i64::MAX, got {}",
+                page.offset
+            ),
+        })?;
+
+        self.with_reader("query_events", move |conn| {
+            let (where_clause, mut data_filter_params) =
+                build_event_filter_sql(conn, &namespace, &filter)?;
+
+            let total = if include_total {
+                let count_sql = format!("SELECT COUNT(*) FROM events{}", where_clause);
+                let mut stmt = conn.prepare(&count_sql)?;
+                let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+                    data_filter_params.iter().map(|p| p.as_ref()).collect();
+                Some(stmt.query_row(param_refs.as_slice(), |row| row.get::<_, i64>(0))? as u64)
+            } else {
+                None
+            };
+
+            data_filter_params.push(Box::new(limit_i64));
+            data_filter_params.push(Box::new(offset_i64));
+
+            let limit_idx = data_filter_params.len() - 1;
+            let offset_idx = data_filter_params.len();
+
+            let data_sql = format!(
+                "SELECT id, namespace, verb, substrate, actor, kind, outcome, payload, \
+                        payload_schema_version, profile_state_version, duration_us, target_id, \
+                        session_id, aggregate_kind, aggregate_id, created_at \
+                 FROM events{} ORDER BY created_at DESC, id DESC LIMIT ?{} OFFSET ?{}",
+                where_clause, limit_idx, offset_idx,
+            );
+
+            let mut stmt = conn.prepare(&data_sql)?;
+            let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+                data_filter_params.iter().map(|p| p.as_ref()).collect();
+            let rows = stmt.query_map(param_refs.as_slice(), read_event)?;
+
+            let mut items = Vec::new();
+            for row in rows {
+                items.push(row?);
+            }
+
+            Ok(Page { items, total })
+        })
+        .await
+    }
 }
 
 // =============================================================================
@@ -1264,60 +1324,15 @@ impl EventStore for SqlEventStore {
         filter: EventFilter,
         page: PageRequest,
     ) -> Result<Page<Event>, StorageError> {
-        let namespace = self.namespace.clone();
-        let limit_i64 = i64::from(page.limit);
-        let offset_i64 = i64::try_from(page.offset).map_err(|_| StorageError::InvalidInput {
-            capability: StorageCapability::Events,
-            operation: "query_events".into(),
-            message: format!(
-                "PageRequest: offset must be <= i64::MAX, got {}",
-                page.offset
-            ),
-        })?;
+        self.query_events_page(filter, page, true).await
+    }
 
-        self.with_reader("query_events", move |conn| {
-            let (where_clause, filter_params) = build_event_filter_sql(conn, &namespace, &filter)?;
-
-            let count_sql = format!("SELECT COUNT(*) FROM events{}", where_clause);
-            let total: i64 = {
-                let mut stmt = conn.prepare(&count_sql)?;
-                let param_refs: Vec<&dyn rusqlite::types::ToSql> =
-                    filter_params.iter().map(|p| p.as_ref()).collect();
-                stmt.query_row(param_refs.as_slice(), |row| row.get(0))?
-            };
-
-            let (_, data_filter_params) = build_event_filter_sql(conn, &namespace, &filter)?;
-            let mut all_params: Vec<Box<dyn rusqlite::types::ToSql>> = data_filter_params;
-            all_params.push(Box::new(limit_i64));
-            all_params.push(Box::new(offset_i64));
-
-            let limit_idx = all_params.len() - 1;
-            let offset_idx = all_params.len();
-
-            let data_sql = format!(
-                "SELECT id, namespace, verb, substrate, actor, kind, outcome, payload, \
-                        payload_schema_version, profile_state_version, duration_us, target_id, \
-                        session_id, aggregate_kind, aggregate_id, created_at \
-                 FROM events{} ORDER BY created_at DESC, id DESC LIMIT ?{} OFFSET ?{}",
-                where_clause, limit_idx, offset_idx,
-            );
-
-            let mut stmt = conn.prepare(&data_sql)?;
-            let param_refs: Vec<&dyn rusqlite::types::ToSql> =
-                all_params.iter().map(|p| p.as_ref()).collect();
-            let rows = stmt.query_map(param_refs.as_slice(), read_event)?;
-
-            let mut items = Vec::new();
-            for row in rows {
-                items.push(row?);
-            }
-
-            Ok(Page {
-                items,
-                total: Some(total as u64),
-            })
-        })
-        .await
+    async fn query_events_without_total(
+        &self,
+        filter: EventFilter,
+        page: PageRequest,
+    ) -> Result<Page<Event>, StorageError> {
+        self.query_events_page(filter, page, false).await
     }
 
     async fn count_events(&self, filter: EventFilter) -> Result<u64, StorageError> {

--- a/crates/khive-db/src/stores/event_tests.rs
+++ b/crates/khive-db/src/stores/event_tests.rs
@@ -71,6 +71,37 @@ async fn test_count_events() {
 }
 
 #[tokio::test]
+async fn query_events_without_total_matches_query_events_items_and_order() {
+    let store = setup_memory_store();
+
+    let mut older = make_event("default");
+    older.created_at = 100;
+    store.append_event(older).await.unwrap();
+
+    let mut newer = make_event("default");
+    newer.created_at = 200;
+    store.append_event(newer).await.unwrap();
+
+    let filter = EventFilter::default();
+    let page = PageRequest {
+        offset: 0,
+        limit: 10,
+    };
+    let with_total = store
+        .query_events(filter.clone(), page.clone())
+        .await
+        .unwrap();
+    let without_total = store
+        .query_events_without_total(filter, page)
+        .await
+        .unwrap();
+
+    assert_eq!(without_total.total, None);
+    assert_eq!(without_total.items, with_total.items);
+    assert_eq!(with_total.total, Some(2));
+}
+
+#[tokio::test]
 async fn test_query_events_filter_by_verb() {
     let store = setup_memory_store();
 

--- a/crates/khive-runtime/src/events_split.rs
+++ b/crates/khive-runtime/src/events_split.rs
@@ -1765,31 +1765,12 @@ impl SplitEventStore {
     pub fn new(legacy: Arc<dyn EventStore>, lane: Arc<dyn EventStore>) -> Self {
         Self { legacy, lane }
     }
-}
 
-#[async_trait]
-impl EventStore for SplitEventStore {
-    async fn append_event(&self, event: Event) -> StorageResult<()> {
-        self.legacy.append_event(event).await
-    }
-
-    async fn append_events(&self, events: Vec<Event>) -> StorageResult<BatchWriteSummary> {
-        self.legacy.append_events(events).await
-    }
-
-    async fn get_event(&self, id: Uuid) -> StorageResult<Option<Event>> {
-        // Domain events (legacy) are the likelier and cheaper hit; fall back
-        // to the lane for audit-batch rows.
-        if let Some(event) = self.legacy.get_event(id).await? {
-            return Ok(Some(event));
-        }
-        self.lane.get_event(id).await
-    }
-
-    async fn query_events(
+    async fn query_events_page(
         &self,
         filter: EventFilter,
         page: PageRequest,
+        include_total: bool,
     ) -> StorageResult<Page<Event>> {
         // Offset pagination cannot be split across two stores: fetch each
         // store's prefix covering the requested window, merge in the stores'
@@ -1821,14 +1802,27 @@ impl EventStore for SplitEventStore {
             offset: 0,
             limit: window.min(u64::from(u32::MAX)) as u32,
         };
-        let legacy = self
-            .legacy
-            .query_events(filter.clone(), prefix.clone())
-            .await?;
-        let lane = self.lane.query_events(filter, prefix).await?;
-        let total = match (legacy.total, lane.total) {
-            (Some(a), Some(b)) => Some(a + b),
-            _ => None,
+        let legacy = if include_total {
+            self.legacy
+                .query_events(filter.clone(), prefix.clone())
+                .await?
+        } else {
+            self.legacy
+                .query_events_without_total(filter.clone(), prefix.clone())
+                .await?
+        };
+        let lane = if include_total {
+            self.lane.query_events(filter, prefix).await?
+        } else {
+            self.lane.query_events_without_total(filter, prefix).await?
+        };
+        let total = if include_total {
+            match (legacy.total, lane.total) {
+                (Some(a), Some(b)) => Some(a + b),
+                _ => None,
+            }
+        } else {
+            None
         };
         let mut items = legacy.items;
         items.extend(lane.items);
@@ -1843,6 +1837,42 @@ impl EventStore for SplitEventStore {
             .take(page.limit as usize)
             .collect();
         Ok(Page { items, total })
+    }
+}
+
+#[async_trait]
+impl EventStore for SplitEventStore {
+    async fn append_event(&self, event: Event) -> StorageResult<()> {
+        self.legacy.append_event(event).await
+    }
+
+    async fn append_events(&self, events: Vec<Event>) -> StorageResult<BatchWriteSummary> {
+        self.legacy.append_events(events).await
+    }
+
+    async fn get_event(&self, id: Uuid) -> StorageResult<Option<Event>> {
+        // Domain events (legacy) are the likelier and cheaper hit; fall back
+        // to the lane for audit-batch rows.
+        if let Some(event) = self.legacy.get_event(id).await? {
+            return Ok(Some(event));
+        }
+        self.lane.get_event(id).await
+    }
+
+    async fn query_events(
+        &self,
+        filter: EventFilter,
+        page: PageRequest,
+    ) -> StorageResult<Page<Event>> {
+        self.query_events_page(filter, page, true).await
+    }
+
+    async fn query_events_without_total(
+        &self,
+        filter: EventFilter,
+        page: PageRequest,
+    ) -> StorageResult<Page<Event>> {
+        self.query_events_page(filter, page, false).await
     }
 
     async fn count_events(&self, filter: EventFilter) -> StorageResult<u64> {
@@ -1960,6 +1990,7 @@ impl EventStore for SplitEventStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::Ordering;
 
     // The full daemon/forwarding test suite for this module lands with the
     // final slice of this series; these tests cover the naming and
@@ -2348,6 +2379,66 @@ mod tests {
         (legacy, lane)
     }
 
+    struct QueryPathSpy {
+        inner: Arc<dyn EventStore>,
+        query_calls: Arc<std::sync::atomic::AtomicUsize>,
+        no_total_calls: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl EventStore for QueryPathSpy {
+        async fn append_event(&self, event: Event) -> StorageResult<()> {
+            self.inner.append_event(event).await
+        }
+
+        async fn append_events(&self, events: Vec<Event>) -> StorageResult<BatchWriteSummary> {
+            self.inner.append_events(events).await
+        }
+
+        async fn get_event(&self, id: Uuid) -> StorageResult<Option<Event>> {
+            self.inner.get_event(id).await
+        }
+
+        async fn query_events(
+            &self,
+            filter: EventFilter,
+            page: PageRequest,
+        ) -> StorageResult<Page<Event>> {
+            self.query_calls
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            self.inner.query_events(filter, page).await
+        }
+
+        async fn query_events_without_total(
+            &self,
+            filter: EventFilter,
+            page: PageRequest,
+        ) -> StorageResult<Page<Event>> {
+            self.no_total_calls
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            self.inner.query_events_without_total(filter, page).await
+        }
+
+        async fn count_events(&self, filter: EventFilter) -> StorageResult<u64> {
+            self.inner.count_events(filter).await
+        }
+
+        fn preflight_event(&self, event: &Event) -> StorageResult<()> {
+            self.inner.preflight_event(event)
+        }
+
+        async fn append_events_idempotent(
+            &self,
+            events: Vec<Event>,
+        ) -> StorageResult<IdempotentEventBatchResult> {
+            self.inner.append_events_idempotent(events).await
+        }
+
+        fn supports_idempotent_audit_batch(&self) -> bool {
+            self.inner.supports_idempotent_audit_batch()
+        }
+    }
+
     /// A retried audit batch whose first attempt landed on the legacy store
     /// before the cutover must be answered by the legacy store's comparison,
     /// never re-inserted into the lane — otherwise merged reads and counts
@@ -2443,6 +2534,100 @@ mod tests {
             .await
             .expect("a window at the bound is admitted");
         assert!(at_bound.items.is_empty());
+    }
+
+    #[tokio::test]
+    async fn merged_query_without_total_matches_interleaved_query_items() {
+        let dir = tempfile::tempdir().unwrap();
+        let (legacy, lane) = store_pair(dir.path());
+
+        let mut legacy_older = split_retry_event("legacy-older");
+        legacy_older.created_at = 100;
+        let mut lane_newer = split_retry_event("lane-newer");
+        lane_newer.created_at = 400;
+        let mut legacy_newer = split_retry_event("legacy-newer");
+        legacy_newer.created_at = 300;
+        let mut lane_older = split_retry_event("lane-older");
+        lane_older.created_at = 200;
+
+        legacy.append_event(legacy_older).await.unwrap();
+        lane.append_event(lane_newer).await.unwrap();
+        legacy.append_event(legacy_newer).await.unwrap();
+        lane.append_event(lane_older).await.unwrap();
+
+        let split = SplitEventStore::new(legacy, lane);
+        let filter = EventFilter::default();
+        let page = PageRequest {
+            offset: 0,
+            limit: 10,
+        };
+        let with_total = split
+            .query_events(filter.clone(), page.clone())
+            .await
+            .unwrap();
+        let without_total = split
+            .query_events_without_total(filter, page)
+            .await
+            .unwrap();
+
+        assert_eq!(without_total.total, None);
+        assert_eq!(without_total.items, with_total.items);
+        assert_eq!(
+            without_total
+                .items
+                .iter()
+                .map(|event| event.created_at)
+                .collect::<Vec<_>>(),
+            vec![400, 300, 200, 100]
+        );
+    }
+
+    #[tokio::test]
+    async fn merged_query_without_total_uses_no_total_path_for_both_stores() {
+        let dir = tempfile::tempdir().unwrap();
+        let (legacy_inner, lane_inner) = store_pair(dir.path());
+        legacy_inner
+            .append_event(split_retry_event("legacy"))
+            .await
+            .unwrap();
+        lane_inner
+            .append_event(split_retry_event("lane"))
+            .await
+            .unwrap();
+
+        let legacy_query_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let legacy_no_total_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let lane_query_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let lane_no_total_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let legacy: Arc<dyn EventStore> = Arc::new(QueryPathSpy {
+            inner: legacy_inner,
+            query_calls: Arc::clone(&legacy_query_calls),
+            no_total_calls: Arc::clone(&legacy_no_total_calls),
+        });
+        let lane: Arc<dyn EventStore> = Arc::new(QueryPathSpy {
+            inner: lane_inner,
+            query_calls: Arc::clone(&lane_query_calls),
+            no_total_calls: Arc::clone(&lane_no_total_calls),
+        });
+        let split = SplitEventStore::new(legacy, lane);
+
+        let page = split
+            .query_events_without_total(
+                EventFilter::default(),
+                PageRequest {
+                    offset: 0,
+                    limit: 10,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(page.total, None);
+        assert_eq!(page.items.len(), 2);
+        assert_eq!(legacy_query_calls.load(Ordering::Relaxed), 0);
+        assert_eq!(lane_query_calls.load(Ordering::Relaxed), 0);
+        assert_eq!(legacy_no_total_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(lane_no_total_calls.load(Ordering::Relaxed), 1);
     }
 
     #[cfg(unix)]

--- a/crates/khive-storage/src/event.rs
+++ b/crates/khive-storage/src/event.rs
@@ -224,6 +224,19 @@ pub trait EventStore: Send + Sync + 'static {
         filter: EventFilter,
         page: PageRequest,
     ) -> StorageResult<Page<Event>>;
+    /// Query events without requiring [`Page::total`].
+    ///
+    /// The default is correct, rather than merely tolerated: it returns a
+    /// total the caller said it did not need, which costs a count but is never
+    /// wrong. Backends can override this method when they can avoid that
+    /// count while returning the same page of events.
+    async fn query_events_without_total(
+        &self,
+        filter: EventFilter,
+        page: PageRequest,
+    ) -> StorageResult<Page<Event>> {
+        self.query_events(filter, page).await
+    }
     /// Count events matching a filter.
     async fn count_events(&self, filter: EventFilter) -> StorageResult<u64>;
 
@@ -278,5 +291,60 @@ pub trait EventStore: Send + Sync + 'static {
     /// build time instead of appearing healthy.
     fn supports_idempotent_audit_batch(&self) -> bool {
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct DefaultEventStore;
+
+    fn unsupported(operation: &'static str) -> StorageError {
+        StorageError::Unsupported {
+            capability: StorageCapability::Events,
+            operation: operation.into(),
+            message: "test store does not implement this operation".into(),
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl EventStore for DefaultEventStore {
+        async fn append_event(&self, _event: Event) -> StorageResult<()> {
+            Err(unsupported("append_event"))
+        }
+
+        async fn append_events(&self, _events: Vec<Event>) -> StorageResult<BatchWriteSummary> {
+            Err(unsupported("append_events"))
+        }
+
+        async fn get_event(&self, _id: Uuid) -> StorageResult<Option<Event>> {
+            Err(unsupported("get_event"))
+        }
+
+        async fn query_events(
+            &self,
+            _filter: EventFilter,
+            _page: PageRequest,
+        ) -> StorageResult<Page<Event>> {
+            Ok(Page {
+                items: Vec::new(),
+                total: Some(7),
+            })
+        }
+
+        async fn count_events(&self, _filter: EventFilter) -> StorageResult<u64> {
+            Err(unsupported("count_events"))
+        }
+    }
+
+    #[tokio::test]
+    async fn default_query_events_without_total_delegates_to_query_events() {
+        let page = DefaultEventStore
+            .query_events_without_total(EventFilter::default(), PageRequest::default())
+            .await
+            .expect("default method should delegate to query_events");
+
+        assert_eq!(page.total, Some(7));
     }
 }


### PR DESCRIPTION
## Summary

- Add a defaulted `EventStore::query_events_without_total` seam for callers that need event rows but not the page total.
- Make the SQLite implementation share its data query between total-aware and no-total reads, skipping `COUNT(*)` for the latter.
- Make the split implementation use the no-total path for both underlying stores while preserving merged ordering and the bounded prefix window.

## Design notes

The choice is expressed at the event read seam rather than by adding a field to `PageRequest`. The cursor remains unchanged, existing callers retain total-aware behavior through the default, and only the optimized paths opt out.

`ForwardingEventStore` remains on the default because the daemon `QueryEvents` frame has no separate no-total choice; changing that wire protocol is outside this change.

The merged offset refetch remains unchanged. It was observed as a separate cursor-paging concern and is left for a follow-up.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p khive-storage -p khive-db -p khive-runtime --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p khive-storage -p khive-db -p khive-runtime --no-deps`
- `cargo test -p khive-storage -p khive-db -p khive-runtime`
