### PR TITLE
fix(mcp): bound the lifetime of an abandoned stdio bridge session

### DIFF
--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -995,6 +995,129 @@ fn stdio_serve_mode_for(resumed_generation: Option<u32>) -> StdioServeMode {
     }
 }
 
+/// Optional idle timeout for a stdio bridge session: when configured, no
+/// request for this long and the session closes (see
+/// [`crate::transport::CancelOnEofTransport`]), releasing its reader-pool
+/// admission and DB connection — a client that comes back simply respawns the
+/// bridge, seamlessly from its perspective.
+/// This closes only a genuinely idle session: an admitted request with a
+/// response still being written — running long, or delivered slowly to a
+/// backpressured reader — defers the close rather than being cancelled out
+/// from under it, up to the separate response-delivery bound documented on
+/// [`stdio_bridge_response_deadline_from_env`].
+///
+/// **Off unless configured, and that is a deliberate reading of existing
+/// repository law rather than caution.** ADR-091 enumerates "kill long-lived
+/// reader sessions" among its rejected alternatives, on the ground that
+/// long-lived stdio sessions are live Claude Code instances and closing them
+/// by age is a worse user experience than bounding what they hold underneath
+/// them. Closing a session after an hour of quiet is that rejected policy
+/// whatever the mechanism, because this transport has no signal that
+/// separates an abandoned pipe from a live client that simply has not been
+/// asked anything. Defaulting it on would reverse an accepted decision from
+/// inside an unrelated change, so the default is off and turning it on is an
+/// operator's explicit act — a supervised deployment, a CI harness, or any
+/// context where session churn is cheap and a pinned WAL connection is not.
+/// Making it the default requires amending ADR-091, not a different number
+/// here.
+///
+/// Set `KHIVE_BRIDGE_IDLE_TIMEOUT_SECS` to a positive number of seconds to
+/// enable it. `0`, absent, and unparsable all leave it disabled; unparsable
+/// falls back rather than panicking, matching this codebase's other
+/// `_from_env` helpers, and it falls back to *disabled* because a typo must
+/// never silently start closing live sessions. 3600 is the suggested value
+/// where it is wanted: long enough that ordinary gaps in a live session never
+/// trip it.
+fn stdio_bridge_idle_timeout_from_env() -> Option<std::time::Duration> {
+    let secs = std::env::var("KHIVE_BRIDGE_IDLE_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(0);
+    if secs == 0 {
+        None
+    } else {
+        Some(std::time::Duration::from_secs(secs))
+    }
+}
+
+/// How long an admitted request whose response has not been written keeps
+/// deferring the idle close.
+///
+/// The idle check must not treat a session with work outstanding as idle, or
+/// it cancels a running handler out from under itself. But rmcp spawns each
+/// request handler and drops the join handle, so a handler that panics never
+/// reaches the response construction that would clear its obligation. Deferring
+/// on an outstanding obligation with no bound therefore hands any panicking
+/// handler the power to disable idle reaping for the life of the session — the
+/// exact unbounded lifetime the idle timeout exists to close, reintroduced
+/// through the guard that protects it.
+///
+/// This bound is separate from the idle window on purpose. Reusing the idle
+/// window would mean a handler that runs longer than one quiet window stops
+/// protecting its own session, which is the guarantee the obligation exists to
+/// provide. It is set far above any real handler and answers a different
+/// question: not "has this session been quiet" but "has this request been
+/// outstanding so long that its handler must be gone".
+///
+/// Overridable via `KHIVE_BRIDGE_REQUEST_OBLIGATION_SECS`; `0` disables the
+/// bound, restoring the unbounded defer. An unparsable value falls back to the
+/// default. Default: 3600s.
+fn stdio_bridge_request_obligation_ttl_from_env() -> Option<std::time::Duration> {
+    const DEFAULT_SECS: u64 = 3600;
+    let secs = std::env::var("KHIVE_BRIDGE_REQUEST_OBLIGATION_SECS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_SECS);
+    if secs == 0 {
+        None
+    } else {
+        Some(std::time::Duration::from_secs(secs))
+    }
+}
+
+/// Response-delivery deadline for a stdio bridge session: the longest a
+/// single response write may stay pending before it is abandoned (see
+/// [`crate::transport::CancelOnEofTransport::send`]) and this session is
+/// closed. Independent of the idle timeout above — it bounds an admitted
+/// request's response write directly, rather than the gap between
+/// requests. Without this bound, a peer that admits a request and then
+/// stops reading its response — while leaving the pipe itself open — keeps
+/// that write pending forever, so the idle timeout would defer indefinitely
+/// (an in-flight response always defers idle-close) and the session would
+/// never be reaped.
+///
+/// Overridable via `KHIVE_BRIDGE_RESPONSE_DEADLINE_SECS`, accepted range
+/// 1..=u64::MAX seconds. Unlike `KHIVE_BRIDGE_IDLE_TIMEOUT_SECS`, this bound
+/// cannot be disabled: `0` is a startup error naming the variable, the
+/// rejected value, and the accepted range, rather than a silent opt-out — a
+/// configuration that restores an unbounded pending write restores the
+/// defect this deadline exists to close (see the type doc above). An
+/// unparsable value falls back to the default rather than erroring, matching
+/// this codebase's other `_from_env` helpers. Default: 300s (5 minutes) —
+/// long enough that legitimately slow verbs and ordinary reader backpressure
+/// never trip it, short enough that a peer that has genuinely stopped
+/// reading does not pin the session's reader-pool admission / DB connection
+/// indefinitely.
+fn stdio_bridge_response_deadline_from_env() -> anyhow::Result<std::time::Duration> {
+    const DEFAULT_SECS: u64 = 300;
+    let secs = match std::env::var("KHIVE_BRIDGE_RESPONSE_DEADLINE_SECS") {
+        Ok(raw) => match raw.trim().parse::<u64>() {
+            Ok(secs) => secs,
+            Err(_) => DEFAULT_SECS,
+        },
+        Err(_) => DEFAULT_SECS,
+    };
+    if secs == 0 {
+        anyhow::bail!(
+            "KHIVE_BRIDGE_RESPONSE_DEADLINE_SECS=0 is not accepted: the response-delivery \
+             deadline cannot be disabled (a disabled deadline lets a peer that stops reading \
+             pin the bridge's response write forever). Set it to a positive number of seconds \
+             (accepted range: 1..=u64::MAX, default {DEFAULT_SECS})."
+        );
+    }
+    Ok(std::time::Duration::from_secs(secs))
+}
+
 impl KhiveMcpServer {
     /// Build a server from `runtime.config().packs`. Errors if any pack is unknown or missing deps.
     ///
@@ -1409,13 +1532,18 @@ impl KhiveMcpServer {
         use rmcp::transport::{async_rw::AsyncRwTransport, stdio};
 
         let root = tokio_util::sync::CancellationToken::new();
+        let idle_timeout = stdio_bridge_idle_timeout_from_env();
+        let response_deadline = stdio_bridge_response_deadline_from_env()?;
         let build_transport = |root: tokio_util::sync::CancellationToken| {
             let (read, write) = stdio();
-            crate::transport::CancelOnEofTransport::new(
+            crate::transport::CancelOnEofTransport::with_idle_timeout(
                 crate::daemon::SelfHealOnFlushTransport::new(AsyncRwTransport::new_server(
                     read, write,
                 )),
                 root,
+                idle_timeout,
+                Some(response_deadline),
+                stdio_bridge_request_obligation_ttl_from_env(),
             )
         };
 
@@ -1454,9 +1582,13 @@ impl KhiveMcpServer {
 
         let root = tokio_util::sync::CancellationToken::new();
         let (read, write) = stdio();
-        let transport = crate::transport::CancelOnEofTransport::new(
+        let response_deadline = stdio_bridge_response_deadline_from_env()?;
+        let transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
             AsyncRwTransport::new_server(read, write),
             root.clone(),
+            stdio_bridge_idle_timeout_from_env(),
+            Some(response_deadline),
+            stdio_bridge_request_obligation_ttl_from_env(),
         );
         let service = self.serve_with_ct(transport, root).await?;
         service.waiting().await?;
@@ -7330,9 +7462,12 @@ mod request_read_cancellation_tests {
         let root = tokio_util::sync::CancellationToken::new();
         let (server_io, mut client_io) = tokio::io::duplex(16 * 1024);
         let (read, write) = tokio::io::split(server_io);
-        let transport = crate::transport::CancelOnEofTransport::new(
+        let transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
             AsyncRwTransport::new_server(read, write),
             root.clone(),
+            None,
+            None,
+            Some(Duration::from_secs(3600)),
         );
         let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
 
@@ -7368,6 +7503,374 @@ mod request_read_cancellation_tests {
         );
     }
 
+    /// An idle stdio bridge — pipe still open, no request sent — must
+    /// be reaped the same way a real EOF is, not held open indefinitely.
+    #[tokio::test]
+    async fn stdio_idle_timeout_cancels_root_without_eof() {
+        use rmcp::transport::async_rw::AsyncRwTransport;
+
+        let started = Arc::new(tokio::sync::Notify::new());
+        let cancelled = Arc::new(tokio::sync::Notify::new());
+        let probe = EofProbeServer {
+            started: started.clone(),
+            cancelled: cancelled.clone(),
+        };
+        let root = tokio_util::sync::CancellationToken::new();
+        let (server_io, client_io) = tokio::io::duplex(16 * 1024);
+        let (read, write) = tokio::io::split(server_io);
+        let transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
+            AsyncRwTransport::new_server(read, write),
+            root.clone(),
+            Some(Duration::from_millis(50)),
+            None,
+            Some(Duration::from_secs(3600)),
+        );
+        let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
+
+        // Deliberately never write anything and never drop `client_io`: the
+        // pipe stays open exactly like an abandoned bridge's client — this
+        // must still be reaped once the idle timeout elapses.
+        let reason = tokio::time::timeout(Duration::from_secs(2), running.waiting())
+            .await
+            .expect("idle timeout never closed the session")
+            .expect("rmcp service task panicked");
+        assert!(
+            root.is_cancelled(),
+            "idle timeout must cancel the exact root token passed into rmcp"
+        );
+        assert!(
+            matches!(
+                reason,
+                rmcp::service::QuitReason::Closed | rmcp::service::QuitReason::Cancelled
+            ),
+            "unexpected rmcp quit reason after idle timeout: {reason:?}"
+        );
+        drop(client_io);
+    }
+
+    #[derive(Clone)]
+    struct SlowProbeServer {
+        started: Arc<tokio::sync::Notify>,
+        delay: Duration,
+    }
+
+    impl rmcp::ServerHandler for SlowProbeServer {
+        fn call_tool(
+            &self,
+            _request: rmcp::model::CallToolRequestParams,
+            _context: rmcp::service::RequestContext<rmcp::RoleServer>,
+        ) -> impl Future<Output = Result<rmcp::model::CallToolResult, McpError>> + Send + '_
+        {
+            let started = self.started.clone();
+            let delay = self.delay;
+            async move {
+                started.notify_one();
+                tokio::time::sleep(delay).await;
+                Ok(rmcp::model::CallToolResult::success(Vec::new()))
+            }
+        }
+    }
+
+    /// Regression: two outstanding obligations under one request id are
+    /// refused, not resolved by guessing.
+    ///
+    /// Retirement matches on request id, so two live entries sharing an id
+    /// make it ambiguous which one a completing response discharges — and both
+    /// resolutions are wrong in opposite directions. Removing the first match
+    /// can leave a *completed* request's instant as the newest entry, so the
+    /// freshness check defers past the older obligation's TTL: the unbounded
+    /// session this whole mechanism exists to close. Removing the last match
+    /// can leave the older instant, so the session closes out from under a
+    /// live handler. The transport cannot tell the two apart, so it refuses
+    /// the second admission instead.
+    ///
+    /// Idle reaping is off and the pipe is deliberately never closed, so the
+    /// refusal is the only thing that can end this session. A build that
+    /// admitted the duplicate would leave `root` uncancelled and this test
+    /// would exhaust its bound.
+    #[tokio::test]
+    async fn stdio_refuses_a_second_outstanding_obligation_under_one_request_id() {
+        use rmcp::transport::async_rw::AsyncRwTransport;
+        use tokio::io::AsyncWriteExt;
+
+        let first_admitted = Arc::new(tokio::sync::Notify::new());
+        let probe = OutOfOrderProbeServer {
+            first_admitted: first_admitted.clone(),
+            calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+        };
+        let root = tokio_util::sync::CancellationToken::new();
+        let (server_io, client_io) = tokio::io::duplex(16 * 1024);
+        let (server_read, server_write) = tokio::io::split(server_io);
+        let transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
+            AsyncRwTransport::new_server(server_read, server_write),
+            root.clone(),
+            // No idle timer: only the duplicate-id refusal can close this.
+            None,
+            None,
+            Some(Duration::from_secs(3600)),
+        );
+        let obligations = transport.in_flight_handle();
+        let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
+        let (_client_read, mut client_write) = tokio::io::split(client_io);
+
+        let request = b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\
+                        \"params\":{\"name\":\"probe\",\"arguments\":{}}}\n";
+        client_write
+            .write_all(request)
+            .await
+            .expect("write the first request");
+        tokio::time::timeout(Duration::from_secs(2), first_admitted.notified())
+            .await
+            .expect("rmcp never admitted the first request");
+
+        // Premise: id 1 is genuinely still outstanding. Without this the second
+        // request would just be a reuse after retirement, which is legitimate
+        // and not what this test is about.
+        assert_eq!(
+            obligations.lock().expect("obligation queue poisoned").len(),
+            1,
+            "fixture premise: the first request must still be outstanding when the duplicate \
+             arrives, otherwise nothing is ambiguous"
+        );
+        assert!(
+            !root.is_cancelled(),
+            "fixture premise: a single outstanding request must not have closed the session"
+        );
+
+        client_write
+            .write_all(request)
+            .await
+            .expect("write the duplicate-id request");
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while !root.is_cancelled() && std::time::Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(
+            root.is_cancelled(),
+            "a second outstanding obligation under an id that already has one must close the \
+             session; admitting it leaves retirement to pick an entry arbitrarily, which \
+             corrupts the freshness check in one direction or the other"
+        );
+
+        drop(client_write);
+        let _ = tokio::time::timeout(Duration::from_secs(2), running.waiting()).await;
+    }
+
+    /// Regression: an id whose obligation has gone STALE is still a duplicate.
+    ///
+    /// Staleness is a statement about the freshness check, not about the
+    /// handler: rmcp keeps a spawned handler alive independently of this
+    /// receive loop, so an entry past its TTL routinely names a request that
+    /// is still running and has simply not answered yet. If the staleness drop
+    /// runs before the duplicate scan, that entry is gone by the time the scan
+    /// looks, the reused id is admitted as a fresh obligation, and the first of
+    /// the two eventual responses retires the NEW entry by id match — leaving
+    /// the older live handler untracked and the idle branch free to close out
+    /// from under it. Scanning before pruning refuses the reuse instead.
+    ///
+    /// This is the arm the earlier ordering passed: the plain duplicate test
+    /// above uses an hour-long TTL, so its entry is never stale and the two
+    /// orderings are indistinguishable there.
+    ///
+    /// Idle reaping is off and the pipe is never closed, so the refusal is the
+    /// only thing that can end this session.
+    #[tokio::test]
+    async fn stdio_refuses_a_reused_id_whose_obligation_is_already_stale() {
+        use rmcp::transport::async_rw::AsyncRwTransport;
+        use tokio::io::AsyncWriteExt;
+
+        const OBLIGATION_TTL: Duration = Duration::from_millis(100);
+
+        let first_admitted = Arc::new(tokio::sync::Notify::new());
+        let probe = OutOfOrderProbeServer {
+            first_admitted: first_admitted.clone(),
+            // Parks forever on the first call: the handler outlives its TTL.
+            calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+        };
+        let root = tokio_util::sync::CancellationToken::new();
+        let (server_io, client_io) = tokio::io::duplex(16 * 1024);
+        let (server_read, server_write) = tokio::io::split(server_io);
+        let transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
+            AsyncRwTransport::new_server(server_read, server_write),
+            root.clone(),
+            // No idle timer: only the duplicate-id refusal can close this.
+            None,
+            None,
+            Some(OBLIGATION_TTL),
+        );
+        let obligations = transport.in_flight_handle();
+        let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
+        let (_client_read, mut client_write) = tokio::io::split(client_io);
+
+        let request = b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\
+                        \"params\":{\"name\":\"probe\",\"arguments\":{}}}\n";
+        client_write
+            .write_all(request)
+            .await
+            .expect("write the first request");
+        tokio::time::timeout(Duration::from_secs(2), first_admitted.notified())
+            .await
+            .expect("rmcp never admitted the first request");
+
+        tokio::time::sleep(OBLIGATION_TTL * 3).await;
+
+        // Premise, asserted rather than assumed: the entry is still in the
+        // queue AND the transport's own freshness rule already calls it stale.
+        // Both halves matter — a test that only slept would pass against a
+        // build that pruned the entry, since an empty queue also admits the
+        // reuse without closing, which is the very defect under test.
+        {
+            let queue = obligations.lock().expect("obligation queue poisoned");
+            let (id, admitted_at) = queue
+                .front()
+                .expect(
+                    "fixture premise: the unanswered obligation must still be queued when the \
+                     reused id arrives; an empty queue means something pruned it and this test \
+                     can no longer distinguish the orderings",
+                )
+                .clone();
+            assert_eq!(
+                id,
+                rmcp::model::NumberOrString::Number(1),
+                "fixture premise: the queued entry must be the request under test"
+            );
+            assert!(
+                admitted_at.elapsed() >= OBLIGATION_TTL,
+                "fixture premise: the entry must already be STALE by the transport's own rule, \
+                 otherwise this is just the plain duplicate case"
+            );
+        }
+        assert!(
+            !root.is_cancelled(),
+            "fixture premise: a single outstanding request must not have closed the session"
+        );
+
+        client_write
+            .write_all(request)
+            .await
+            .expect("write the request reusing the stale id");
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while !root.is_cancelled() && std::time::Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(
+            root.is_cancelled(),
+            "reusing an id whose obligation is stale but whose handler is still alive must close \
+             the session. Admitting it lets the first response retire the wrong entry, which \
+             leaves a live handler untracked and the idle close free to fire under it."
+        );
+
+        drop(client_write);
+        let _ = tokio::time::timeout(Duration::from_secs(2), running.waiting()).await;
+    }
+
+    /// Regression: the obligation queue must not grow without bound.
+    ///
+    /// Retirement is keyed by request id, so it only ever removes the entry
+    /// whose response was actually written. A request that never produces one
+    /// — a handler that panics, a request the peer cancels — leaves its entry
+    /// behind. Under the earlier oldest-first retirement any completion
+    /// removed *some* entry, so the queue tracked admissions minus
+    /// completions; keying by id means an unanswered request now holds its
+    /// slot for the life of the session unless something drops it.
+    ///
+    /// Nothing here waits on the idle timer: it is disabled, so the only thing
+    /// that can bound this queue is the staleness drop.
+    #[tokio::test]
+    async fn stdio_obligation_queue_drops_entries_past_their_ttl() {
+        use rmcp::transport::async_rw::AsyncRwTransport;
+        use tokio::io::AsyncWriteExt;
+
+        const OBLIGATION_TTL: Duration = Duration::from_millis(100);
+        // Longer than the TTL, so every earlier admission is already stale by
+        // the time the next one arrives and the queue can never hold two.
+        const ADMISSION_GAP: Duration = Duration::from_millis(150);
+        const ADMISSIONS: u32 = 4;
+
+        let probe = SlowProbeServer {
+            started: Arc::new(tokio::sync::Notify::new()),
+            // Never answers, so nothing is ever retired by id.
+            delay: Duration::from_secs(3600),
+        };
+        let root = tokio_util::sync::CancellationToken::new();
+        let (server_io, mut client_io) = tokio::io::duplex(16 * 1024);
+        let (server_read, server_write) = tokio::io::split(server_io);
+        let transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
+            AsyncRwTransport::new_server(server_read, server_write),
+            root.clone(),
+            // Idle reaping off: this test is about the queue, not the timer.
+            None,
+            None,
+            Some(OBLIGATION_TTL),
+        );
+        let obligations = transport.in_flight_handle();
+        let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
+
+        for id in 1..=ADMISSIONS {
+            client_io
+                .write_all(
+                    format!(
+                        "{{\"jsonrpc\":\"2.0\",\"id\":{id},\"method\":\"tools/call\",\
+                         \"params\":{{\"name\":\"probe\",\"arguments\":{{}}}}}}\n"
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .expect("write request");
+            tokio::time::sleep(ADMISSION_GAP).await;
+        }
+
+        let outstanding = obligations.lock().expect("obligation queue poisoned").len();
+        assert!(
+            outstanding <= 1,
+            "an unanswered request must not hold its obligation slot past the TTL: after \
+             {ADMISSIONS} admissions spaced {}ms apart against a {}ms TTL the queue holds \
+             {outstanding} entries. Without the staleness drop it would hold {ADMISSIONS}, one \
+             per admission, and would keep growing for as long as the session lives.",
+            ADMISSION_GAP.as_millis(),
+            OBLIGATION_TTL.as_millis(),
+        );
+
+        drop(client_io);
+        let _ = tokio::time::timeout(Duration::from_secs(2), running.waiting()).await;
+    }
+
+    /// Parks forever on the first call and answers every later one promptly,
+    /// so a test can produce out-of-order response completion: the request
+    /// admitted first stays outstanding while a later one completes.
+    #[derive(Clone)]
+    struct OutOfOrderProbeServer {
+        first_admitted: Arc<tokio::sync::Notify>,
+        calls: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    impl rmcp::ServerHandler for OutOfOrderProbeServer {
+        fn call_tool(
+            &self,
+            _request: rmcp::model::CallToolRequestParams,
+            _context: rmcp::service::RequestContext<rmcp::RoleServer>,
+        ) -> impl Future<Output = Result<rmcp::model::CallToolResult, McpError>> + Send + '_
+        {
+            let first_admitted = self.first_admitted.clone();
+            let calls = self.calls.clone();
+            async move {
+                if calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst) == 0 {
+                    first_admitted.notify_one();
+                    // Never answers. This is the older obligation, and it is
+                    // the one whose TTL must govern when the session closes.
+                    tokio::time::sleep(Duration::from_secs(3600)).await;
+                }
+                Ok(rmcp::model::CallToolResult::success(Vec::new()))
+            }
+        }
+    }
+
+    /// Distinguishes handler behavior by tool name: `"slow"` blocks for
+    /// `slow_delay` (keeping `in_flight` above zero across several idle
+    /// windows), `"quick"` (or anything else) completes immediately — used
+    /// to admit a second request while the first is still running.
     #[tokio::test]
     async fn rmcp_cancellation_token_reaches_request_read_scope() {
         let token = tokio_util::sync::CancellationToken::new();
@@ -7449,5 +7952,39 @@ mod request_read_cancellation_tests {
                 );
             }
         }
+    }
+
+    // ── KHIVE_BRIDGE_RESPONSE_DEADLINE_SECS=0 must not disable the bound ──
+
+    /// The response-delivery deadline used to treat `0` as "disable
+    /// the bound", mirroring `KHIVE_BRIDGE_IDLE_TIMEOUT_SECS=0`. Unlike the
+    /// idle timeout, an unbounded response-delivery deadline restores the
+    /// exact defect this deadline exists to close (a peer that admits a
+    /// request and stops reading pins the bridge's response write forever)
+    /// — so `0` is now a hard startup error instead of a supported opt-out.
+    #[test]
+    #[serial_test::serial]
+    fn response_deadline_from_env_rejects_zero() {
+        std::env::set_var("KHIVE_BRIDGE_RESPONSE_DEADLINE_SECS", "0");
+        let result = stdio_bridge_response_deadline_from_env();
+        std::env::remove_var("KHIVE_BRIDGE_RESPONSE_DEADLINE_SECS");
+
+        let error = result.expect_err(
+            "KHIVE_BRIDGE_RESPONSE_DEADLINE_SECS=0 must be rejected, not silently accepted \
+             as \"disable the bound\"",
+        );
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("KHIVE_BRIDGE_RESPONSE_DEADLINE_SECS"),
+            "error must name the offending variable: {rendered}"
+        );
+        assert!(
+            rendered.contains("=0"),
+            "error must name the rejected value: {rendered}"
+        );
+        assert!(
+            rendered.contains("1..=u64::MAX"),
+            "error must state the accepted range: {rendered}"
+        );
     }
 }

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -8150,12 +8150,23 @@ mod request_read_cancellation_tests {
         );
     }
 
-    /// Discriminating arm: the rule is scoped to responses on purpose, so a
-    /// failed NOTIFICATION write must leave the session alone. Without this,
-    /// the test above would also pass against a blanket cancel-on-any-write-
-    /// error, which is a wider change than the one being made.
+    /// A failed NOTIFICATION write closes the session too, and this test used
+    /// to assert the opposite. The rule was scoped to responses on the ground
+    /// that rmcp carried its own accounting for server-initiated messages. It
+    /// does carry accounting and the accounting does not close anything: a
+    /// failed notification send delivers `ServiceError::TransportSend` to the
+    /// notification's own responder (`rmcp-1.8.0` `src/service.rs:1074-1093`)
+    /// and a failed request send does the same to the caller's responder
+    /// (`:1066-1073`), while the serve loop's only exits are receive EOF, token
+    /// cancellation, and a send-task join error (`:1028-1062`). So the same
+    /// broken writer strands the session whatever class of message hit it.
+    ///
+    /// The discriminating arm is now
+    /// `notification_write_to_a_reading_peer_leaves_the_session_open`: without
+    /// it, this test would pass against a transport that cancelled on every
+    /// write, successful ones included.
     #[tokio::test]
-    async fn notification_write_that_fails_fast_leaves_the_session_open() {
+    async fn notification_write_that_fails_fast_also_closes_the_session() {
         use rmcp::transport::async_rw::AsyncRwTransport;
         use rmcp::transport::Transport;
 
@@ -8186,13 +8197,73 @@ mod request_read_cancellation_tests {
             ),
         });
 
-        let _ = tokio::time::timeout(Duration::from_secs(2), transport.send(message))
+        let error = tokio::time::timeout(Duration::from_secs(2), transport.send(message))
             .await
-            .expect("a write to a closed pipe must fail fast, not wait out its deadline");
+            .expect("a write to a closed pipe must fail fast, not wait out its deadline")
+            .expect_err("a write to a closed pipe must not report success");
+
+        assert!(
+            !error.to_string().contains("deadline"),
+            "this must exercise the error path, not the deadline path: {error}"
+        );
+        assert!(
+            root.is_cancelled(),
+            "a notification that could not be written must close the session; rmcp hands the \
+             error to the notification's own responder and never breaks the serve loop"
+        );
+    }
+
+    /// Discriminating arm for the two fail-fast tests above. Without it, both
+    /// would pass against a transport that cancelled on every write rather than
+    /// on every FAILED write, which is a far worse rule than either.
+    #[tokio::test]
+    async fn notification_write_to_a_reading_peer_leaves_the_session_open() {
+        use rmcp::transport::async_rw::AsyncRwTransport;
+        use rmcp::transport::Transport;
+        use tokio::io::AsyncReadExt;
+
+        let (server_read, _peer_write_side) = tokio::io::duplex(1024);
+        let (server_write, mut peer_read_side) = tokio::io::duplex(16 * 1024);
+
+        let root = tokio_util::sync::CancellationToken::new();
+        let mut transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
+            AsyncRwTransport::new_server(server_read, server_write),
+            root.clone(),
+            None,
+            Some(Duration::from_secs(30)),
+            None,
+        );
+
+        // This peer reads.
+        let reader = tokio::spawn(async move {
+            let mut buf = vec![0u8; 8192];
+            let _ = peer_read_side.read(&mut buf).await;
+            buf
+        });
+
+        let message = rmcp::model::JsonRpcMessage::Notification(rmcp::model::JsonRpcNotification {
+            jsonrpc: rmcp::model::JsonRpcVersion2_0,
+            notification: rmcp::model::ServerNotification::ProgressNotification(
+                rmcp::model::Notification::new(rmcp::model::ProgressNotificationParam {
+                    progress_token: rmcp::model::ProgressToken(
+                        rmcp::model::NumberOrString::Number(1),
+                    ),
+                    progress: 1.0,
+                    total: None,
+                    message: None,
+                }),
+            ),
+        });
+
+        tokio::time::timeout(Duration::from_secs(2), transport.send(message))
+            .await
+            .expect("a write to a reading peer must not hit the 2s test bound")
+            .expect("a write to a reading peer must succeed");
 
         assert!(
             !root.is_cancelled(),
-            "the cancel is scoped to responses; a failed notification must not close the session"
+            "a delivered notification must not close the session"
         );
+        let _ = reader.await;
     }
 }

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -7530,14 +7530,23 @@ mod request_read_cancellation_tests {
         // Deliberately never write anything and never drop `client_io`: the
         // pipe stays open exactly like an abandoned bridge's client — this
         // must still be reaped once the idle timeout elapses.
+        // Observe the cancellation BEFORE consuming the service, and it has to
+        // be in this order. `RunningService` holds a `dg: DropGuard`
+        // (rmcp 1.8.0, `src/service.rs:712`) and `waiting(mut self)` consumes
+        // `self`, so the guard cancels this very token as `waiting` returns
+        // whatever the transport did. Asserting `root.is_cancelled()` after
+        // that await therefore passes even with the adapter's cancel deleted:
+        // it measures rmcp's drop guard, not the idle path. Awaiting
+        // `root.cancelled()` while the service is still alive is the only
+        // ordering that can tell the two apart.
+        tokio::time::timeout(Duration::from_secs(2), root.cancelled())
+            .await
+            .expect("idle timeout must cancel the exact root token passed into rmcp");
+
         let reason = tokio::time::timeout(Duration::from_secs(2), running.waiting())
             .await
             .expect("idle timeout never closed the session")
             .expect("rmcp service task panicked");
-        assert!(
-            root.is_cancelled(),
-            "idle timeout must cancel the exact root token passed into rmcp"
-        );
         assert!(
             matches!(
                 reason,

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -1087,6 +1087,23 @@ fn stdio_bridge_request_obligation_ttl_from_env() -> Option<std::time::Duration>
     }
 }
 
+/// Maximum number of requests a stdio bridge admits to rmcp while their
+/// responses are still outstanding. A full session is closed before another
+/// handler is spawned, bounding the per-session handler and obligation state.
+///
+/// Overridable via `KHIVE_BRIDGE_MAX_OUTSTANDING_REQUESTS`. Values must be
+/// positive; `0`, an unparsable value, or a value too large for this platform
+/// falls back to the default. Default: 1024, enough for ordinary concurrent
+/// MCP traffic while keeping a peer that stops reading from growing the
+/// session without limit.
+fn stdio_bridge_max_outstanding_requests_from_env() -> usize {
+    std::env::var("KHIVE_BRIDGE_MAX_OUTSTANDING_REQUESTS")
+        .ok()
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .filter(|&value| value > 0)
+        .unwrap_or(crate::transport::DEFAULT_MAX_OUTSTANDING_REQUESTS)
+}
+
 /// Response-delivery deadline for a stdio bridge session: the longest a
 /// single response write may stay pending before it is abandoned (see
 /// [`crate::transport::CancelOnEofTransport::send`]) and this session is
@@ -1546,9 +1563,10 @@ impl KhiveMcpServer {
         let root = tokio_util::sync::CancellationToken::new();
         let idle_timeout = stdio_bridge_idle_timeout_from_env();
         let response_deadline = stdio_bridge_response_deadline_from_env()?;
+        let max_outstanding_requests = stdio_bridge_max_outstanding_requests_from_env();
         let build_transport = |root: tokio_util::sync::CancellationToken| {
             let (read, write) = stdio();
-            crate::transport::CancelOnEofTransport::with_idle_timeout(
+            crate::transport::CancelOnEofTransport::with_idle_timeout_and_max_outstanding(
                 crate::daemon::SelfHealOnFlushTransport::new(AsyncRwTransport::new_server(
                     read, write,
                 )),
@@ -1556,6 +1574,7 @@ impl KhiveMcpServer {
                 idle_timeout,
                 Some(response_deadline),
                 stdio_bridge_request_obligation_ttl_from_env(),
+                max_outstanding_requests,
             )
         };
 
@@ -1595,13 +1614,15 @@ impl KhiveMcpServer {
         let root = tokio_util::sync::CancellationToken::new();
         let (read, write) = stdio();
         let response_deadline = stdio_bridge_response_deadline_from_env()?;
-        let transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
-            AsyncRwTransport::new_server(read, write),
-            root.clone(),
-            stdio_bridge_idle_timeout_from_env(),
-            Some(response_deadline),
-            stdio_bridge_request_obligation_ttl_from_env(),
-        );
+        let transport =
+            crate::transport::CancelOnEofTransport::with_idle_timeout_and_max_outstanding(
+                AsyncRwTransport::new_server(read, write),
+                root.clone(),
+                stdio_bridge_idle_timeout_from_env(),
+                Some(response_deadline),
+                stdio_bridge_request_obligation_ttl_from_env(),
+                stdio_bridge_max_outstanding_requests_from_env(),
+            );
         let service = self.serve_with_ct(transport, root).await?;
         service.waiting().await?;
         Ok(())
@@ -7889,6 +7910,63 @@ mod request_read_cancellation_tests {
              per admission, and would keep growing for as long as the session lives.",
             ADMISSION_GAP.as_millis(),
             OBLIGATION_TTL.as_millis(),
+        );
+
+        drop(client_io);
+        let _ = tokio::time::timeout(Duration::from_secs(2), running.waiting()).await;
+    }
+
+    /// Regression: a peer that keeps sending requests without consuming
+    /// responses cannot make the transport's outstanding state grow without
+    /// limit. The third request is rejected before rmcp can spawn its handler.
+    #[tokio::test]
+    async fn stdio_closes_when_outstanding_request_limit_is_reached() {
+        use rmcp::transport::async_rw::AsyncRwTransport;
+        use tokio::io::AsyncWriteExt;
+
+        const MAX_OUTSTANDING: usize = 2;
+        let probe = SlowProbeServer {
+            started: Arc::new(tokio::sync::Notify::new()),
+            delay: Duration::from_secs(3600),
+        };
+        let root = tokio_util::sync::CancellationToken::new();
+        let (server_io, mut client_io) = tokio::io::duplex(16 * 1024);
+        let (server_read, server_write) = tokio::io::split(server_io);
+        let transport =
+            crate::transport::CancelOnEofTransport::with_idle_timeout_and_max_outstanding(
+                AsyncRwTransport::new_server(server_read, server_write),
+                root.clone(),
+                None,
+                None,
+                Some(Duration::from_secs(3600)),
+                MAX_OUTSTANDING,
+            );
+        let obligations = transport.in_flight_handle();
+        let running = rmcp::service::serve_directly_with_ct(probe, transport, None, root.clone());
+
+        for id in 1..=MAX_OUTSTANDING + 1 {
+            let request = format!(
+                "{}\n",
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "method": "tools/call",
+                    "params": {"name": "probe", "arguments": {}}
+                })
+            );
+            client_io
+                .write_all(request.as_bytes())
+                .await
+                .expect("write request");
+        }
+
+        tokio::time::timeout(Duration::from_secs(2), root.cancelled())
+            .await
+            .expect("the transport must close after reaching its admission limit");
+        assert_eq!(
+            obligations.lock().expect("obligation queue poisoned").len(),
+            MAX_OUTSTANDING,
+            "the rejected request must not enter the outstanding tracker"
         );
 
         drop(client_io);

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -8310,12 +8310,19 @@ mod request_read_cancellation_tests {
         }
     }
 
-    /// The exception to "every failed outbound write closes the session".
+    /// The exception to "every failed outbound write closes the session", and
+    /// it is narrower than the writer's health alone.
     ///
     /// An interrupted flush leaves the writer usable, so closing on it would
     /// trade a lost message for a lost session. The second send is what makes
     /// that claim rather than assuming it: if the transport were dead the
     /// assertion could not distinguish a correct decision from a lucky one.
+    ///
+    /// This arm uses a NOTIFICATION because the exception is scoped to the
+    /// classes whose loss someone can observe. See
+    /// `an_interrupted_response_still_closes_the_session` for the other side of
+    /// that boundary, which is the arm that would go red if the scope were
+    /// dropped.
     #[tokio::test]
     async fn an_interrupted_write_leaves_the_session_open_and_the_writer_usable() {
         use rmcp::transport::async_rw::AsyncRwTransport;
@@ -8372,6 +8379,63 @@ mod request_read_cancellation_tests {
         assert!(
             !root.is_cancelled(),
             "a successful write after an interrupted one must leave the session open"
+        );
+    }
+
+    /// The boundary of that exception: a usable writer is not enough when the
+    /// message was a RESPONSE.
+    ///
+    /// The interrupted flush leaves the writer able to carry the next message,
+    /// exactly as in the notification arm, so this test differs from that one
+    /// in the message class and nothing else. The outcome differs because rmcp
+    /// treats the classes differently. A failed notification or server-initiated
+    /// request send reaches a local responder (`rmcp-1.8.0`
+    /// `src/service.rs:1074-1093` and `:1066-1073`), so something in the process
+    /// learns the message was lost. A failed response send is only logged
+    /// (`:1095-1112`): nothing goes to the peer, no local caller is waiting, and
+    /// the serve loop keeps running. The client that asked the question would
+    /// wait on an answer that is not coming and could not tell that from a slow
+    /// one. Closing is what turns that into an EOF it can act on.
+    #[tokio::test]
+    async fn an_interrupted_response_still_closes_the_session() {
+        use rmcp::transport::async_rw::AsyncRwTransport;
+        use rmcp::transport::Transport;
+
+        let (server_read, _peer_write_side) = tokio::io::duplex(1024);
+        let writer = InterruptOnceWriter {
+            interrupted_yet: false,
+        };
+
+        let root = tokio_util::sync::CancellationToken::new();
+        let mut transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
+            AsyncRwTransport::new_server(server_read, writer),
+            root.clone(),
+            None,
+            // Long enough that the deadline cannot be what resolves this write,
+            // so a pass here cannot come from the timeout path.
+            Some(Duration::from_secs(30)),
+            None,
+        );
+
+        let response = rmcp::model::JsonRpcMessage::Error(rmcp::model::JsonRpcError {
+            jsonrpc: rmcp::model::JsonRpcVersion2_0,
+            id: Some(rmcp::model::RequestId::Number(1)),
+            error: rmcp::model::ErrorData::internal_error("answering a request", None),
+        });
+
+        let error = tokio::time::timeout(Duration::from_secs(2), transport.send(response))
+            .await
+            .expect("an interrupted flush must resolve, not hang")
+            .expect_err("an interrupted flush must be reported as an error");
+        assert_eq!(
+            error.kind(),
+            std::io::ErrorKind::Interrupted,
+            "this arm must exercise the interrupted class, not some other failure: {error}"
+        );
+        assert!(
+            root.is_cancelled(),
+            "an interrupted RESPONSE must still close the session: the writer's health does not \
+             help a peer that is waiting on an answer rmcp will only log the loss of"
         );
     }
 }

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -8266,4 +8266,112 @@ mod request_read_cancellation_tests {
         );
         let _ = reader.await;
     }
+
+    /// A writer whose first flush is interrupted and which works from then on.
+    ///
+    /// This is the shape Tokio's blocking stdout adapter presents on EINTR: it
+    /// restores its idle state and puts the writer back before returning the
+    /// flush error (`tokio-1.52.4/src/io/blocking.rs:146-176`), and its
+    /// `uninterruptibly!` retry macro (`:183-192`) is not applied to that
+    /// branch. Writes are accepted and discarded, because what this arm asserts
+    /// is the session's fate, not the bytes.
+    struct InterruptOnceWriter {
+        interrupted_yet: bool,
+    }
+
+    impl tokio::io::AsyncWrite for InterruptOnceWriter {
+        fn poll_write(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+            buf: &[u8],
+        ) -> std::task::Poll<std::io::Result<usize>> {
+            std::task::Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(
+            mut self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            if self.interrupted_yet {
+                return std::task::Poll::Ready(Ok(()));
+            }
+            self.interrupted_yet = true;
+            std::task::Poll::Ready(Err(std::io::Error::new(
+                std::io::ErrorKind::Interrupted,
+                "flush interrupted by a signal",
+            )))
+        }
+
+        fn poll_shutdown(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            std::task::Poll::Ready(Ok(()))
+        }
+    }
+
+    /// The exception to "every failed outbound write closes the session".
+    ///
+    /// An interrupted flush leaves the writer usable, so closing on it would
+    /// trade a lost message for a lost session. The second send is what makes
+    /// that claim rather than assuming it: if the transport were dead the
+    /// assertion could not distinguish a correct decision from a lucky one.
+    #[tokio::test]
+    async fn an_interrupted_write_leaves_the_session_open_and_the_writer_usable() {
+        use rmcp::transport::async_rw::AsyncRwTransport;
+        use rmcp::transport::Transport;
+
+        let (server_read, _peer_write_side) = tokio::io::duplex(1024);
+        let writer = InterruptOnceWriter {
+            interrupted_yet: false,
+        };
+
+        let root = tokio_util::sync::CancellationToken::new();
+        let mut transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
+            AsyncRwTransport::new_server(server_read, writer),
+            root.clone(),
+            None,
+            Some(Duration::from_secs(30)),
+            None,
+        );
+
+        let notification = || {
+            rmcp::model::JsonRpcMessage::Notification(rmcp::model::JsonRpcNotification {
+                jsonrpc: rmcp::model::JsonRpcVersion2_0,
+                notification: rmcp::model::ServerNotification::ProgressNotification(
+                    rmcp::model::Notification::new(rmcp::model::ProgressNotificationParam {
+                        progress_token: rmcp::model::ProgressToken(
+                            rmcp::model::NumberOrString::Number(1),
+                        ),
+                        progress: 1.0,
+                        total: None,
+                        message: None,
+                    }),
+                ),
+            })
+        };
+
+        let error = tokio::time::timeout(Duration::from_secs(2), transport.send(notification()))
+            .await
+            .expect("an interrupted flush must resolve, not hang")
+            .expect_err("an interrupted flush must be reported as an error");
+        assert_eq!(
+            error.kind(),
+            std::io::ErrorKind::Interrupted,
+            "this arm must exercise the interrupted class, not some other failure: {error}"
+        );
+        assert!(
+            !root.is_cancelled(),
+            "an interrupted write must not close the session; the writer is still usable"
+        );
+
+        tokio::time::timeout(Duration::from_secs(2), transport.send(notification()))
+            .await
+            .expect("the second write must resolve, not hang")
+            .expect("the writer is usable after an interrupted flush, so the next write succeeds");
+        assert!(
+            !root.is_cancelled(),
+            "a successful write after an interrupted one must leave the session open"
+        );
+    }
 }

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -7996,4 +7996,97 @@ mod request_read_cancellation_tests {
             "error must state the accepted range: {rendered}"
         );
     }
+
+    /// The response-delivery deadline had no test that ever let it elapse:
+    /// the only coverage rejected `0` at startup, which exercises the parser
+    /// and not the bound. A bound whose expiry is never observed is a claim,
+    /// so this drives a real write against a peer that has stopped reading.
+    #[tokio::test]
+    async fn response_write_past_its_deadline_is_abandoned_and_closes_the_session() {
+        use rmcp::transport::async_rw::AsyncRwTransport;
+        use rmcp::transport::Transport;
+
+        // A 16-byte pipe that nobody reads. `_client_io` is held, not dropped,
+        // so this is a peer that is present and simply not reading — the case
+        // the deadline exists for. Dropping it would produce a broken pipe
+        // instead, which is a different failure and already handled.
+        let (server_io, _client_io) = tokio::io::duplex(16);
+        let (read, write) = tokio::io::split(server_io);
+        let root = tokio_util::sync::CancellationToken::new();
+        let mut transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
+            AsyncRwTransport::new_server(read, write),
+            root.clone(),
+            None,
+            Some(Duration::from_millis(50)),
+            None,
+        );
+
+        // An error response is a response for this purpose: `send` bounds
+        // `Response` and `Error` alike, because either one can leave the write
+        // pinned.
+        let message = rmcp::model::JsonRpcMessage::Error(rmcp::model::JsonRpcError {
+            jsonrpc: rmcp::model::JsonRpcVersion2_0,
+            id: Some(rmcp::model::RequestId::Number(1)),
+            error: rmcp::model::ErrorData::internal_error("x".repeat(4096), None),
+        });
+
+        let error = tokio::time::timeout(Duration::from_secs(2), transport.send(message))
+            .await
+            .expect("the deadline must resolve the write; it hung instead")
+            .expect_err("a write that outlived its deadline must not report success");
+
+        assert!(
+            error.to_string().contains("deadline"),
+            "the error must name the deadline that abandoned the write: {error}"
+        );
+        assert!(
+            root.is_cancelled(),
+            "a peer that stops reading must close the session, not just fail one write"
+        );
+    }
+
+    /// Discriminating arm for the test above. Without this, that test would
+    /// also pass against a deadline that fired on every response regardless of
+    /// whether the peer was reading.
+    #[tokio::test]
+    async fn response_write_inside_its_deadline_succeeds_and_leaves_the_session_open() {
+        use rmcp::transport::async_rw::AsyncRwTransport;
+        use rmcp::transport::Transport;
+        use tokio::io::AsyncReadExt;
+
+        let (server_io, mut client_io) = tokio::io::duplex(16 * 1024);
+        let (read, write) = tokio::io::split(server_io);
+        let root = tokio_util::sync::CancellationToken::new();
+        let mut transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
+            AsyncRwTransport::new_server(read, write),
+            root.clone(),
+            None,
+            Some(Duration::from_secs(30)),
+            None,
+        );
+
+        // This peer reads.
+        let reader = tokio::spawn(async move {
+            let mut buf = vec![0u8; 8192];
+            let _ = client_io.read(&mut buf).await;
+            buf
+        });
+
+        let message = rmcp::model::JsonRpcMessage::Error(rmcp::model::JsonRpcError {
+            jsonrpc: rmcp::model::JsonRpcVersion2_0,
+            id: Some(rmcp::model::RequestId::Number(1)),
+            error: rmcp::model::ErrorData::internal_error("read by the peer", None),
+        });
+
+        tokio::time::timeout(Duration::from_secs(2), transport.send(message))
+            .await
+            .expect("a write to a reading peer must not hit the 2s test bound")
+            .expect("a write to a reading peer must succeed");
+
+        assert!(
+            !root.is_cancelled(),
+            "a response delivered inside its deadline must not close the session"
+        );
+        let _ = reader.await;
+    }
 }

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -8089,4 +8089,110 @@ mod request_read_cancellation_tests {
         );
         let _ = reader.await;
     }
+
+    /// The deadline bounds a write left PENDING. It says nothing about a write
+    /// that fails immediately, which is what a half-closed peer produces: one
+    /// that closes the side it reads from while keeping the side it writes to
+    /// open. rmcp does not close the session for us there — the response-send
+    /// task logs the error and returns (`rmcp-1.8.0` `src/service.rs:1105-1112`)
+    /// — the receive loop stays pending on the still-open read side, and idle
+    /// reaping is off by default, so before this the session outlived the
+    /// peer's ability to receive anything from it.
+    ///
+    /// Two independent pipes, because a single `duplex` cannot be half-closed:
+    /// dropping either end closes both directions, and `tokio::io::split`
+    /// keeps the stream alive until both halves drop. Separate pipes for the
+    /// read source and the write sink are what let the peer close exactly one.
+    #[tokio::test]
+    async fn response_write_that_fails_fast_closes_the_session() {
+        use rmcp::transport::async_rw::AsyncRwTransport;
+        use rmcp::transport::Transport;
+
+        // peer -> server: held open and silent, so the receive side would stay
+        // pending forever. This is what makes the missing cancel a leak rather
+        // than a race with EOF.
+        let (server_read, _peer_write_side) = tokio::io::duplex(1024);
+        // server -> peer: the peer has closed the side it reads from, so every
+        // write fails with BrokenPipe.
+        let (server_write, peer_read_side) = tokio::io::duplex(1024);
+        drop(peer_read_side);
+
+        let root = tokio_util::sync::CancellationToken::new();
+        let mut transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
+            AsyncRwTransport::new_server(server_read, server_write),
+            root.clone(),
+            None,
+            // Long enough that the deadline cannot be what resolves this
+            // write. If the fix were the deadline rather than the error path,
+            // the 2s bound below would trip instead of the assertion.
+            Some(Duration::from_secs(30)),
+            None,
+        );
+
+        let message = rmcp::model::JsonRpcMessage::Error(rmcp::model::JsonRpcError {
+            jsonrpc: rmcp::model::JsonRpcVersion2_0,
+            id: Some(rmcp::model::RequestId::Number(1)),
+            error: rmcp::model::ErrorData::internal_error("peer closed its read side", None),
+        });
+
+        let error = tokio::time::timeout(Duration::from_secs(2), transport.send(message))
+            .await
+            .expect("a write to a closed pipe must fail fast, not wait out its deadline")
+            .expect_err("a write to a closed pipe must not report success");
+
+        assert!(
+            !error.to_string().contains("deadline"),
+            "this must exercise the error path, not the deadline path: {error}"
+        );
+        assert!(
+            root.is_cancelled(),
+            "a response that could not be written must close the session; rmcp only logs it"
+        );
+    }
+
+    /// Discriminating arm: the rule is scoped to responses on purpose, so a
+    /// failed NOTIFICATION write must leave the session alone. Without this,
+    /// the test above would also pass against a blanket cancel-on-any-write-
+    /// error, which is a wider change than the one being made.
+    #[tokio::test]
+    async fn notification_write_that_fails_fast_leaves_the_session_open() {
+        use rmcp::transport::async_rw::AsyncRwTransport;
+        use rmcp::transport::Transport;
+
+        let (server_read, _peer_write_side) = tokio::io::duplex(1024);
+        let (server_write, peer_read_side) = tokio::io::duplex(1024);
+        drop(peer_read_side);
+
+        let root = tokio_util::sync::CancellationToken::new();
+        let mut transport = crate::transport::CancelOnEofTransport::with_idle_timeout(
+            AsyncRwTransport::new_server(server_read, server_write),
+            root.clone(),
+            None,
+            Some(Duration::from_secs(30)),
+            None,
+        );
+
+        let message = rmcp::model::JsonRpcMessage::Notification(rmcp::model::JsonRpcNotification {
+            jsonrpc: rmcp::model::JsonRpcVersion2_0,
+            notification: rmcp::model::ServerNotification::ProgressNotification(
+                rmcp::model::Notification::new(rmcp::model::ProgressNotificationParam {
+                    progress_token: rmcp::model::ProgressToken(
+                        rmcp::model::NumberOrString::Number(1),
+                    ),
+                    progress: 1.0,
+                    total: None,
+                    message: None,
+                }),
+            ),
+        });
+
+        let _ = tokio::time::timeout(Duration::from_secs(2), transport.send(message))
+            .await
+            .expect("a write to a closed pipe must fail fast, not wait out its deadline");
+
+        assert!(
+            !root.is_cancelled(),
+            "the cancel is scoped to responses; a failed notification must not close the session"
+        );
+    }
 }

--- a/crates/khive-mcp/src/transport.rs
+++ b/crates/khive-mcp/src/transport.rs
@@ -5,13 +5,156 @@
 //! transports (e.g. Streamable HTTP) register with [`TransportRegistry::register`]
 //! before serving, so the serve path never hard-codes a transport enum.
 
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use async_trait::async_trait;
 
 use crate::server::KhiveMcpServer;
+
+type RequestId = rmcp::model::RequestId;
+
+/// Outstanding request obligations in admission order.
+///
+/// The map makes duplicate detection and retirement O(1) on average. Each
+/// entry also links its predecessor and successor, so the linked ordering
+/// structure makes stale-obligation expiry deadline-ordered without requiring
+/// a linear scan when a response retires a newer request.
+#[derive(Default)]
+pub(crate) struct OutstandingRequests {
+    entries: HashMap<RequestId, OutstandingRequest>,
+    oldest: Option<RequestId>,
+    newest: Option<RequestId>,
+}
+
+struct OutstandingRequest {
+    admitted_at: Instant,
+    previous: Option<RequestId>,
+    next: Option<RequestId>,
+}
+
+impl OutstandingRequests {
+    fn admit(&mut self, id: RequestId, admitted_at: Instant, capacity: usize) -> bool {
+        if self.entries.contains_key(&id) || self.entries.len() >= capacity {
+            return false;
+        }
+
+        let previous = self.newest.clone();
+        if let Some(previous_id) = previous.as_ref() {
+            self.entries
+                .get_mut(previous_id)
+                .expect("newest obligation must remain in the map")
+                .next = Some(id.clone());
+        } else {
+            self.oldest = Some(id.clone());
+        }
+        self.newest = Some(id.clone());
+        self.entries.insert(
+            id,
+            OutstandingRequest {
+                admitted_at,
+                previous,
+                next: None,
+            },
+        );
+        true
+    }
+
+    fn contains(&self, id: &RequestId) -> bool {
+        self.entries.contains_key(id)
+    }
+
+    fn retire(&mut self, id: &RequestId) {
+        let Some(obligation) = self.entries.remove(id) else {
+            return;
+        };
+
+        if let Some(previous_id) = obligation.previous.as_ref() {
+            self.entries
+                .get_mut(previous_id)
+                .expect("previous obligation must remain in the map")
+                .next = obligation.next.clone();
+        } else {
+            self.oldest = obligation.next.clone();
+        }
+
+        if let Some(next_id) = obligation.next.as_ref() {
+            self.entries
+                .get_mut(next_id)
+                .expect("next obligation must remain in the map")
+                .previous = obligation.previous.clone();
+        } else {
+            self.newest = obligation.previous;
+        }
+    }
+
+    fn drop_stale(&mut self, obligation_ttl: Option<std::time::Duration>) {
+        let Some(ttl) = obligation_ttl else {
+            return;
+        };
+
+        while let Some(oldest_id) = self.oldest.clone() {
+            let stale = self
+                .entries
+                .get(&oldest_id)
+                .is_some_and(|obligation| obligation.admitted_at.elapsed() >= ttl);
+            if !stale {
+                break;
+            }
+            self.retire(&oldest_id);
+        }
+    }
+
+    fn newest_admitted_at(&self) -> Option<Instant> {
+        self.newest
+            .as_ref()
+            .and_then(|id| self.entries.get(id))
+            .map(|obligation| obligation.admitted_at)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn front(&self) -> Option<(RequestId, Instant)> {
+        self.oldest.as_ref().and_then(|id| {
+            self.entries
+                .get(id)
+                .map(|obligation| (id.clone(), obligation.admitted_at))
+        })
+    }
+}
+
+struct ObligationRetirementGuard {
+    in_flight: Arc<Mutex<OutstandingRequests>>,
+    id: Option<RequestId>,
+    obligation_ttl: Option<std::time::Duration>,
+}
+
+impl ObligationRetirementGuard {
+    fn retire(&mut self) {
+        let Some(id) = self.id.take() else {
+            return;
+        };
+        if let Ok(mut outstanding) = self.in_flight.lock() {
+            outstanding.retire(&id);
+            outstanding.drop_stale(self.obligation_ttl);
+        }
+    }
+}
+
+impl Drop for ObligationRetirementGuard {
+    fn drop(&mut self) {
+        self.retire();
+    }
+}
 
 /// Cancels rmcp's root service token before reporting transport EOF — and,
 /// with an idle timeout configured, before reporting a synthetic EOF when no
@@ -104,14 +247,18 @@ pub(crate) struct CancelOnEofTransport<T> {
     /// request's admission and leave a *completed* one as the newest entry —
     /// making the freshness test below read the completed request's timestamp
     /// and defer past the older obligation's TTL. Removing the entry whose id
-    /// matches keeps `back()` the genuinely newest outstanding admission,
+    /// matches keeps the linked list's newest entry genuinely outstanding,
     /// which is what the freshness rule assumes.
     ///
     /// Because retirement is keyed, a request that never produces a response
     /// would hold its entry for the life of the session. Entries past
-    /// `obligation_ttl` are therefore dropped whenever this queue is touched;
-    /// see [`drop_stale_obligations`].
-    in_flight: Arc<Mutex<VecDeque<(rmcp::model::RequestId, Instant)>>>,
+    /// `obligation_ttl` are therefore dropped whenever this tracker is
+    /// touched.
+    in_flight: Arc<Mutex<OutstandingRequests>>,
+    /// Maximum number of requests admitted to rmcp without a completed
+    /// response. Reaching this bound closes the session before another
+    /// handler can be spawned.
+    max_outstanding_requests: usize,
     /// How long an outstanding request keeps deferring the idle close. `None`
     /// defers without bound. See the type doc.
     obligation_ttl: Option<std::time::Duration>,
@@ -133,6 +280,7 @@ impl<T> CancelOnEofTransport<T> {
     /// bound, which is only safe where `idle_timeout` is also `None`, because
     /// a handler that panics never produces the response that would clear the
     /// obligation (see the type doc).
+    #[cfg(test)]
     pub(crate) fn with_idle_timeout(
         inner: T,
         root: tokio_util::sync::CancellationToken,
@@ -140,51 +288,63 @@ impl<T> CancelOnEofTransport<T> {
         response_deadline: Option<std::time::Duration>,
         obligation_ttl: Option<std::time::Duration>,
     ) -> Self {
+        Self::with_idle_timeout_and_max_outstanding(
+            inner,
+            root,
+            idle_timeout,
+            response_deadline,
+            obligation_ttl,
+            DEFAULT_MAX_OUTSTANDING_REQUESTS,
+        )
+    }
+
+    pub(crate) fn with_idle_timeout_and_max_outstanding(
+        inner: T,
+        root: tokio_util::sync::CancellationToken,
+        idle_timeout: Option<std::time::Duration>,
+        response_deadline: Option<std::time::Duration>,
+        obligation_ttl: Option<std::time::Duration>,
+        max_outstanding_requests: usize,
+    ) -> Self {
+        assert!(
+            max_outstanding_requests > 0,
+            "maximum outstanding requests must be positive"
+        );
         Self {
             inner,
             root,
             idle_timeout,
             response_deadline,
-            in_flight: Arc::new(Mutex::new(VecDeque::new())),
+            in_flight: Arc::new(Mutex::new(OutstandingRequests::default())),
+            max_outstanding_requests,
             obligation_ttl,
         }
     }
 
-    /// The obligation queue, for tests that need to observe its size.
+    /// The outstanding-obligation tracker, for tests that need to observe it.
     #[cfg(test)]
-    pub(crate) fn in_flight_handle(
-        &self,
-    ) -> Arc<Mutex<VecDeque<(rmcp::model::RequestId, Instant)>>> {
+    pub(crate) fn in_flight_handle(&self) -> Arc<Mutex<OutstandingRequests>> {
         self.in_flight.clone()
     }
 }
 
-/// Drops obligations that are already past their TTL.
-///
-/// An entry older than `obligation_ttl` is, by this transport's own rule, no
-/// longer evidence of life: the freshness check will not defer on it. Keeping
-/// it buys nothing, and keeping it *forever* is a real cost, because
-/// retirement is keyed by request id and so only ever removes the entry whose
-/// response was actually written. A request that never produces one — a
-/// handler that panics, a request the peer cancels — would otherwise hold its
-/// entry for the life of the session, and a long-lived session accumulates one
-/// per such request without bound.
-///
-/// Entries are pushed in admission order, so the stale ones are a prefix.
-///
-/// With no TTL configured there is no notion of staleness and nothing is
-/// dropped. That is the configuration which already restores the unbounded
-/// defer (see the type doc), so it is unbounded in the same way for the same
-/// reason.
-fn drop_stale_obligations(
-    queue: &mut VecDeque<(rmcp::model::RequestId, Instant)>,
-    obligation_ttl: Option<std::time::Duration>,
-) {
-    let Some(ttl) = obligation_ttl else {
-        return;
-    };
-    while queue.front().is_some_and(|(_, at)| at.elapsed() >= ttl) {
-        queue.pop_front();
+/// Default per-session cap for requests whose responses have not finished
+/// writing. The server can raise or lower it through its environment setting.
+pub(crate) const DEFAULT_MAX_OUTSTANDING_REQUESTS: usize = 1024;
+
+#[cfg(test)]
+mod outstanding_request_tests {
+    use super::*;
+
+    #[test]
+    fn outstanding_request_tracker_rejects_admission_past_capacity() {
+        let mut outstanding = OutstandingRequests::default();
+        let admitted_at = Instant::now();
+
+        assert!(outstanding.admit(rmcp::model::RequestId::Number(1), admitted_at, 2,));
+        assert!(outstanding.admit(rmcp::model::RequestId::Number(2), admitted_at, 2,));
+        assert!(!outstanding.admit(rmcp::model::RequestId::Number(3), admitted_at, 2,));
+        assert_eq!(outstanding.len(), 2);
     }
 }
 
@@ -300,8 +460,16 @@ where
         let root = self.root.clone();
         let response_deadline = self.response_deadline;
         let obligation_ttl = self.obligation_ttl;
+        let retirement = retire_id.map(|id| ObligationRetirementGuard {
+            in_flight,
+            id: Some(id),
+            obligation_ttl,
+        });
         let send = self.inner.send(item);
         async move {
+            // The guard retires the matching id both after a resolved write and
+            // if rmcp cancels/drops this send future before it resolves.
+            let _retirement = retirement;
             let result = match (is_response, response_deadline) {
                 (true, Some(deadline)) => match tokio::time::timeout(deadline, send).await {
                     Ok(result) => result,
@@ -349,19 +517,6 @@ where
                     root.cancel();
                 }
             }
-            // Clear THIS request's obligation once the write is resolved
-            // either way — see the `in_flight` field doc for why a failed
-            // write must not be left permanently counted as pending, and why
-            // the entry removed has to be the matching one rather than the
-            // oldest. An id-less error matches nothing and removes nothing.
-            if let Ok(mut q) = in_flight.lock() {
-                if let Some(id) = retire_id {
-                    if let Some(position) = q.iter().position(|(entry, _)| *entry == id) {
-                        q.remove(position);
-                    }
-                }
-                drop_stale_obligations(&mut q, obligation_ttl);
-            }
             result
         }
     }
@@ -374,6 +529,7 @@ where
         let idle_timeout = self.idle_timeout;
         let in_flight = self.in_flight.clone();
         let obligation_ttl = self.obligation_ttl;
+        let max_outstanding_requests = self.max_outstanding_requests;
         async move {
             // Created once and reused across every retry below: `select!`ing
             // a *fresh* `self.inner.receive()` each time the idle sleep wins
@@ -420,7 +576,7 @@ where
                                 let fresh = in_flight
                                     .lock()
                                     .ok()
-                                    .and_then(|q| q.back().map(|(_, at)| *at))
+                                    .and_then(|q| q.newest_admitted_at())
                                     .is_some_and(|newest| match obligation_ttl {
                                         Some(ttl) => newest.elapsed() < ttl,
                                         None => true,
@@ -487,13 +643,18 @@ where
                 // nothing a conforming peer can notice, because an id whose
                 // response WAS written is not in the queue at all.
                 let mut duplicate_id = None;
+                let mut capacity_exceeded = false;
                 if let Some(rmcp::model::JsonRpcMessage::Request(request)) = &message {
                     if let Ok(mut q) = in_flight.lock() {
-                        if q.iter().any(|(entry, _)| *entry == request.id) {
+                        if q.contains(&request.id) {
                             duplicate_id = Some(request.id.clone());
                         } else {
-                            drop_stale_obligations(&mut q, obligation_ttl);
-                            q.push_back((request.id.clone(), Instant::now()));
+                            q.drop_stale(obligation_ttl);
+                            capacity_exceeded = !q.admit(
+                                request.id.clone(),
+                                Instant::now(),
+                                max_outstanding_requests,
+                            );
                         }
                     }
                 }
@@ -503,6 +664,14 @@ where
                         "stdio bridge received a request whose id already has an outstanding \
                          obligation; the response could not be attributed to either, so this \
                          session is closed rather than left with corrupt lifetime accounting"
+                    );
+                    root.cancel();
+                    return None;
+                }
+                if capacity_exceeded {
+                    tracing::warn!(
+                        max_outstanding_requests,
+                        "stdio bridge reached its outstanding request limit; closing the session"
                     );
                     root.cancel();
                     return None;

--- a/crates/khive-mcp/src/transport.rs
+++ b/crates/khive-mcp/src/transport.rs
@@ -6,8 +6,6 @@
 //! before serving, so the serve path never hard-codes a transport enum.
 
 use std::collections::{BTreeMap, HashMap};
-#[cfg(test)]
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
@@ -28,8 +26,6 @@ pub(crate) struct OutstandingRequests {
     entries: HashMap<RequestId, OutstandingRequest>,
     oldest: Option<RequestId>,
     newest: Option<RequestId>,
-    #[cfg(test)]
-    operation_count: AtomicUsize,
 }
 
 struct OutstandingRequest {
@@ -46,8 +42,6 @@ impl OutstandingRequests {
 
         let previous = self.newest.clone();
         if let Some(previous_id) = previous.as_ref() {
-            #[cfg(test)]
-            self.record_operation();
             self.entries
                 .get_mut(previous_id)
                 .expect("newest obligation must remain in the map")
@@ -68,21 +62,15 @@ impl OutstandingRequests {
     }
 
     fn contains(&self, id: &RequestId) -> bool {
-        #[cfg(test)]
-        self.record_operation();
         self.entries.contains_key(id)
     }
 
     fn retire(&mut self, id: &RequestId) {
-        #[cfg(test)]
-        self.record_operation();
         let Some(obligation) = self.entries.remove(id) else {
             return;
         };
 
         if let Some(previous_id) = obligation.previous.as_ref() {
-            #[cfg(test)]
-            self.record_operation();
             self.entries
                 .get_mut(previous_id)
                 .expect("previous obligation must remain in the map")
@@ -92,8 +80,6 @@ impl OutstandingRequests {
         }
 
         if let Some(next_id) = obligation.next.as_ref() {
-            #[cfg(test)]
-            self.record_operation();
             self.entries
                 .get_mut(next_id)
                 .expect("next obligation must remain in the map")
@@ -109,8 +95,6 @@ impl OutstandingRequests {
         };
 
         while let Some(oldest_id) = self.oldest.clone() {
-            #[cfg(test)]
-            self.record_operation();
             let stale = self
                 .entries
                 .get(&oldest_id)
@@ -125,11 +109,7 @@ impl OutstandingRequests {
     fn newest_admitted_at(&self) -> Option<Instant> {
         self.newest
             .as_ref()
-            .and_then(|id| {
-                #[cfg(test)]
-                self.record_operation();
-                self.entries.get(id)
-            })
+            .and_then(|id| self.entries.get(id))
             .map(|obligation| obligation.admitted_at)
     }
 
@@ -145,21 +125,10 @@ impl OutstandingRequests {
     #[cfg(test)]
     pub(crate) fn front(&self) -> Option<(RequestId, Instant)> {
         self.oldest.as_ref().and_then(|id| {
-            self.record_operation();
             self.entries
                 .get(id)
                 .map(|obligation| (id.clone(), obligation.admitted_at))
         })
-    }
-
-    #[cfg(test)]
-    fn record_operation(&self) {
-        self.operation_count.fetch_add(1, Ordering::Relaxed);
-    }
-
-    #[cfg(test)]
-    fn operation_count(&self) -> usize {
-        self.operation_count.load(Ordering::Relaxed)
     }
 }
 
@@ -387,68 +356,6 @@ mod outstanding_request_tests {
         assert!(outstanding.admit(rmcp::model::RequestId::Number(2), admitted_at, 2,));
         assert!(!outstanding.admit(rmcp::model::RequestId::Number(3), admitted_at, 2,));
         assert_eq!(outstanding.len(), 2);
-    }
-
-    fn tracker_operations_for(n: usize) -> (usize, usize) {
-        let mut outstanding = OutstandingRequests::default();
-        let admitted_at = Instant::now();
-
-        for id in 0..n {
-            let id = rmcp::model::RequestId::Number(id as i64);
-            assert!(!outstanding.contains(&id));
-            assert!(outstanding.admit(id, admitted_at, n + 1));
-        }
-        let admission_operations = outstanding.operation_count();
-
-        for id in (0..n).rev() {
-            outstanding.retire(&rmcp::model::RequestId::Number(id as i64));
-        }
-        let retirement_operations = outstanding.operation_count() - admission_operations;
-
-        assert!(outstanding.is_empty());
-        (admission_operations, retirement_operations)
-    }
-
-    fn assert_constant_work(
-        operation: &str,
-        small_n: usize,
-        small_work: usize,
-        large_n: usize,
-        large_work: usize,
-    ) {
-        const MAX_OPERATIONS_PER_REQUEST: usize = 8;
-
-        assert!(
-            small_work <= small_n * MAX_OPERATIONS_PER_REQUEST,
-            "{operation} work exceeded the constant bound at n={small_n}: {small_work}"
-        );
-        assert!(
-            large_work <= large_n * MAX_OPERATIONS_PER_REQUEST,
-            "{operation} work exceeded the constant bound at n={large_n}: {large_work}"
-        );
-        assert!(
-            large_work * small_n <= small_work * large_n * 2,
-            "{operation} work grew with the number of outstanding requests: n={small_n} -> \
-             {small_work}, n={large_n} -> {large_work}"
-        );
-    }
-
-    #[test]
-    fn outstanding_request_tracker_work_stays_constant_as_load_grows() {
-        const SMALL: usize = 64;
-        const LARGE: usize = 512;
-
-        let (small_admission, small_retirement) = tracker_operations_for(SMALL);
-        let (large_admission, large_retirement) = tracker_operations_for(LARGE);
-
-        assert_constant_work("admission", SMALL, small_admission, LARGE, large_admission);
-        assert_constant_work(
-            "retirement",
-            SMALL,
-            small_retirement,
-            LARGE,
-            large_retirement,
-        );
     }
 
     fn poison_tracker(tracker: &Arc<Mutex<OutstandingRequests>>) {

--- a/crates/khive-mcp/src/transport.rs
+++ b/crates/khive-mcp/src/transport.rs
@@ -6,6 +6,8 @@
 //! before serving, so the serve path never hard-codes a transport enum.
 
 use std::collections::{BTreeMap, HashMap};
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
@@ -26,6 +28,8 @@ pub(crate) struct OutstandingRequests {
     entries: HashMap<RequestId, OutstandingRequest>,
     oldest: Option<RequestId>,
     newest: Option<RequestId>,
+    #[cfg(test)]
+    operation_count: AtomicUsize,
 }
 
 struct OutstandingRequest {
@@ -36,12 +40,16 @@ struct OutstandingRequest {
 
 impl OutstandingRequests {
     fn admit(&mut self, id: RequestId, admitted_at: Instant, capacity: usize) -> bool {
+        #[cfg(test)]
+        self.record_operation();
         if self.entries.contains_key(&id) || self.entries.len() >= capacity {
             return false;
         }
 
         let previous = self.newest.clone();
         if let Some(previous_id) = previous.as_ref() {
+            #[cfg(test)]
+            self.record_operation();
             self.entries
                 .get_mut(previous_id)
                 .expect("newest obligation must remain in the map")
@@ -62,15 +70,21 @@ impl OutstandingRequests {
     }
 
     fn contains(&self, id: &RequestId) -> bool {
+        #[cfg(test)]
+        self.record_operation();
         self.entries.contains_key(id)
     }
 
     fn retire(&mut self, id: &RequestId) {
+        #[cfg(test)]
+        self.record_operation();
         let Some(obligation) = self.entries.remove(id) else {
             return;
         };
 
         if let Some(previous_id) = obligation.previous.as_ref() {
+            #[cfg(test)]
+            self.record_operation();
             self.entries
                 .get_mut(previous_id)
                 .expect("previous obligation must remain in the map")
@@ -80,6 +94,8 @@ impl OutstandingRequests {
         }
 
         if let Some(next_id) = obligation.next.as_ref() {
+            #[cfg(test)]
+            self.record_operation();
             self.entries
                 .get_mut(next_id)
                 .expect("next obligation must remain in the map")
@@ -95,6 +111,8 @@ impl OutstandingRequests {
         };
 
         while let Some(oldest_id) = self.oldest.clone() {
+            #[cfg(test)]
+            self.record_operation();
             let stale = self
                 .entries
                 .get(&oldest_id)
@@ -109,7 +127,11 @@ impl OutstandingRequests {
     fn newest_admitted_at(&self) -> Option<Instant> {
         self.newest
             .as_ref()
-            .and_then(|id| self.entries.get(id))
+            .and_then(|id| {
+                #[cfg(test)]
+                self.record_operation();
+                self.entries.get(id)
+            })
             .map(|obligation| obligation.admitted_at)
     }
 
@@ -125,10 +147,21 @@ impl OutstandingRequests {
     #[cfg(test)]
     pub(crate) fn front(&self) -> Option<(RequestId, Instant)> {
         self.oldest.as_ref().and_then(|id| {
+            self.record_operation();
             self.entries
                 .get(id)
                 .map(|obligation| (id.clone(), obligation.admitted_at))
         })
+    }
+
+    #[cfg(test)]
+    fn record_operation(&self) {
+        self.operation_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    #[cfg(test)]
+    fn operation_count(&self) -> usize {
+        self.operation_count.load(Ordering::Relaxed)
     }
 }
 
@@ -345,6 +378,68 @@ mod outstanding_request_tests {
         assert!(outstanding.admit(rmcp::model::RequestId::Number(2), admitted_at, 2,));
         assert!(!outstanding.admit(rmcp::model::RequestId::Number(3), admitted_at, 2,));
         assert_eq!(outstanding.len(), 2);
+    }
+
+    fn tracker_operations_for(n: usize) -> (usize, usize) {
+        let mut outstanding = OutstandingRequests::default();
+        let admitted_at = Instant::now();
+
+        for id in 0..n {
+            let id = rmcp::model::RequestId::Number(id as i64);
+            assert!(!outstanding.contains(&id));
+            assert!(outstanding.admit(id, admitted_at, n + 1));
+        }
+        let admission_operations = outstanding.operation_count();
+
+        for id in (0..n).rev() {
+            outstanding.retire(&rmcp::model::RequestId::Number(id as i64));
+        }
+        let retirement_operations = outstanding.operation_count() - admission_operations;
+
+        assert!(outstanding.is_empty());
+        (admission_operations, retirement_operations)
+    }
+
+    fn assert_constant_work(
+        operation: &str,
+        small_n: usize,
+        small_work: usize,
+        large_n: usize,
+        large_work: usize,
+    ) {
+        const MAX_OPERATIONS_PER_REQUEST: usize = 8;
+
+        assert!(
+            small_work <= small_n * MAX_OPERATIONS_PER_REQUEST,
+            "{operation} work exceeded the constant bound at n={small_n}: {small_work}"
+        );
+        assert!(
+            large_work <= large_n * MAX_OPERATIONS_PER_REQUEST,
+            "{operation} work exceeded the constant bound at n={large_n}: {large_work}"
+        );
+        assert!(
+            large_work * small_n <= small_work * large_n * 2,
+            "{operation} work grew with the number of outstanding requests: n={small_n} -> \
+             {small_work}, n={large_n} -> {large_work}"
+        );
+    }
+
+    #[test]
+    fn outstanding_request_tracker_work_stays_constant_as_load_grows() {
+        const SMALL: usize = 64;
+        const LARGE: usize = 512;
+
+        let (small_admission, small_retirement) = tracker_operations_for(SMALL);
+        let (large_admission, large_retirement) = tracker_operations_for(LARGE);
+
+        assert_constant_work("admission", SMALL, small_admission, LARGE, large_admission);
+        assert_constant_work(
+            "retirement",
+            SMALL,
+            small_retirement,
+            LARGE,
+            large_retirement,
+        );
     }
 }
 

--- a/crates/khive-mcp/src/transport.rs
+++ b/crates/khive-mcp/src/transport.rs
@@ -188,10 +188,36 @@ fn drop_stale_obligations(
     }
 }
 
+/// Whether a failed outbound write names an operation that may simply be
+/// repeated, leaving the writer usable.
+///
+/// `ErrorKind::Interrupted` is the one such class the stdio path can reach, and
+/// it reaches it through flush rather than through write. Tokio's blocking
+/// stdout adapter restores `State::Idle` and puts its writer back before it
+/// returns the flush result (`tokio-1.52.4/src/io/blocking.rs:146-176`), and
+/// the `uninterruptibly!` macro that repeats interrupted operations
+/// (`:183-192`) is not applied to that branch. `FramedWrite` propagates the
+/// error up unchanged (`tokio-util-0.7.18/src/codec/framed_impl.rs:277-303`).
+/// So an EINTR during flush arrives here as `Err` from a writer that is still
+/// able to carry the next message, and cancelling on it would lose a healthy
+/// session to a signal.
+///
+/// The message that hit it is still lost; rmcp handles that the same way it
+/// handles any other transport-send error. What is preserved is the session.
+pub(crate) trait RepeatableWriteError {
+    fn is_repeatable(&self) -> bool;
+}
+
+impl RepeatableWriteError for std::io::Error {
+    fn is_repeatable(&self) -> bool {
+        self.kind() == std::io::ErrorKind::Interrupted
+    }
+}
+
 impl<T> rmcp::transport::Transport<rmcp::RoleServer> for CancelOnEofTransport<T>
 where
     T: rmcp::transport::Transport<rmcp::RoleServer>,
-    T::Error: From<std::io::Error>,
+    T::Error: From<std::io::Error> + RepeatableWriteError,
 {
     type Error = T::Error;
 
@@ -230,6 +256,12 @@ where
     /// failed request or notification write strands the session exactly as a
     /// failed response did — the argument for the narrower rule pointed at a
     /// mechanism without reading what it does, and is withdrawn.
+    ///
+    /// One class of failure is excepted, and it is excepted on read evidence
+    /// rather than on the same kind of argument: an error saying the operation
+    /// may simply be repeated leaves the writer usable, so cancelling on it
+    /// would lose a healthy session. See `RepeatableWriteError` for which class
+    /// that is and how it reaches this transport.
     ///
     /// A failed write is reported once, here, whichever way it failed: the
     /// deadline arm's error names its own cause, so a second log line at the
@@ -276,15 +308,29 @@ where
             // one write and carry on; see the method doc for why this covers
             // requests and notifications too, and why the error case needs
             // saying separately from the timeout case.
+            //
+            // The exception is a write error that says the operation may simply
+            // be repeated. There the writer is still usable, so cancelling
+            // would trade a lost message for a lost session. See
+            // `RepeatableWriteError`.
             if let Err(error) = &result {
-                tracing::warn!(
-                    %error,
-                    is_response,
-                    response_deadline_secs = response_deadline.map(|d| d.as_secs()),
-                    "stdio bridge could not deliver an outbound message to its peer; closing \
-                     this session rather than leaving it alive unable to answer"
-                );
-                root.cancel();
+                if error.is_repeatable() {
+                    tracing::warn!(
+                        %error,
+                        is_response,
+                        "stdio bridge write was interrupted; the writer is still usable, so \
+                         the session stays open and the error is reported unchanged"
+                    );
+                } else {
+                    tracing::warn!(
+                        %error,
+                        is_response,
+                        response_deadline_secs = response_deadline.map(|d| d.as_secs()),
+                        "stdio bridge could not deliver an outbound message to its peer; closing \
+                         this session rather than leaving it alive unable to answer"
+                    );
+                    root.cancel();
+                }
             }
             // Clear THIS request's obligation once the write is resolved
             // either way — see the `in_flight` field doc for why a failed

--- a/crates/khive-mcp/src/transport.rs
+++ b/crates/khive-mcp/src/transport.rs
@@ -202,8 +202,20 @@ fn drop_stale_obligations(
 /// able to carry the next message, and cancelling on it would lose a healthy
 /// session to a signal.
 ///
-/// The message that hit it is still lost; rmcp handles that the same way it
-/// handles any other transport-send error. What is preserved is the session.
+/// The message that hit it is still lost, and what happens next depends on
+/// which class it belonged to. For a server-initiated request rmcp hands the
+/// error to the local responder that was awaiting it
+/// (`rmcp-1.8.0/src/service.rs:1066-1073`), and it does the same for a
+/// notification (`:1074-1093`), so in both cases a local caller learns. For a
+/// response it only logs (`:1095-1112`): nothing is sent to the peer, no local
+/// caller is waiting, and the serve loop stays alive, so the client that asked
+/// the question waits for an answer that will never arrive and cannot tell that
+/// from a slow one.
+///
+/// That asymmetry is why this predicate is not the whole condition. Keeping the
+/// session is the better trade only when losing the message leaves someone able
+/// to observe the loss. It never does for a response, so the caller pairs this
+/// with the message class rather than using it alone.
 pub(crate) trait RepeatableWriteError {
     fn is_repeatable(&self) -> bool;
 }
@@ -310,16 +322,21 @@ where
             // saying separately from the timeout case.
             //
             // The exception is a write error that says the operation may simply
-            // be repeated. There the writer is still usable, so cancelling
-            // would trade a lost message for a lost session. See
+            // be repeated, on a message that is not a response. There the writer
+            // is still usable and the loss is observable by someone, so
+            // cancelling would trade a lost message for a lost session. A
+            // response gets no such exception: rmcp only logs a failed response
+            // send, so the peer is left waiting on an answer that is not coming
+            // and closing is the only way it finds out. See
             // `RepeatableWriteError`.
             if let Err(error) = &result {
-                if error.is_repeatable() {
+                if error.is_repeatable() && !is_response {
                     tracing::warn!(
                         %error,
                         is_response,
-                        "stdio bridge write was interrupted; the writer is still usable, so \
-                         the session stays open and the error is reported unchanged"
+                        "stdio bridge write was interrupted; the writer is still usable and this \
+                         is not a response, so the session stays open and the error is reported \
+                         unchanged"
                     );
                 } else {
                     tracing::warn!(

--- a/crates/khive-mcp/src/transport.rs
+++ b/crates/khive-mcp/src/transport.rs
@@ -199,10 +199,32 @@ where
     /// straight through, untimed — only a response can leave `in_flight`
     /// permanently pinned). On timeout the write future is dropped —
     /// releasing whatever lock the inner transport held across it, see the
-    /// type doc — `in_flight` is decremented the same as any other resolved
-    /// write, and `root` is cancelled directly: the peer has demonstrated it
-    /// is not going to read this response, so there is no reason to wait for
-    /// the next idle tick to notice.
+    /// type doc — and `in_flight` is decremented the same as any other
+    /// resolved write.
+    ///
+    /// A response write that RESOLVES AS AN ERROR cancels `root` for the same
+    /// reason a timed-out one does, and the two together are what actually
+    /// bound the write side. The deadline only covers a write left *pending*:
+    /// a peer that has stopped reading while its pipe stays open. A peer that
+    /// closes the side it reads from fails the write immediately instead, well
+    /// inside any deadline, so nothing here would fire — and rmcp does not
+    /// close the session on its own behalf: the response-send task logs the
+    /// error and returns (`rmcp-1.8.0`, `src/service.rs:1105-1112`), while the
+    /// inner transport reports writer errors independently of the reader
+    /// (`src/transport/async_rw.rs:107-122`). With the read side still open
+    /// and silent, the receive loop stays pending, and with idle reaping
+    /// disabled by default there is no later tick to notice. So the session
+    /// would outlive the peer's ability to receive anything from it.
+    ///
+    /// Gated on `is_response` deliberately. A response is the discharge of an
+    /// admitted obligation, so failing to write one means an admitted request
+    /// can never be answered on this session. Server-initiated requests carry
+    /// their own send accounting inside rmcp (`SendTaskResult::Request`), and
+    /// bringing them under this rule is a separate change.
+    ///
+    /// A failed write is reported once, here, whichever way it failed: the
+    /// deadline arm's error names its own cause, so a second log line at the
+    /// timeout would only repeat it.
     fn send(
         &mut self,
         item: rmcp::service::TxJsonRpcMessage<rmcp::RoleServer>,
@@ -230,23 +252,30 @@ where
             let result = match (is_response, response_deadline) {
                 (true, Some(deadline)) => match tokio::time::timeout(deadline, send).await {
                     Ok(result) => result,
-                    Err(_) => {
-                        tracing::warn!(
-                            deadline_secs = deadline.as_secs(),
-                            "stdio bridge response-delivery deadline elapsed while a response \
-                             write was still pending (peer stopped reading); abandoning the \
-                             write and closing this session"
-                        );
-                        root.cancel();
-                        Err(std::io::Error::new(
-                            std::io::ErrorKind::TimedOut,
-                            "response-delivery deadline elapsed before the write completed",
-                        )
-                        .into())
-                    }
+                    Err(_) => Err(std::io::Error::new(
+                        std::io::ErrorKind::TimedOut,
+                        "response-delivery deadline elapsed before the write completed",
+                    )
+                    .into()),
                 },
                 _ => send.await,
             };
+            // Either failure — the write outlived its deadline, or it resolved
+            // as an error — means this peer will not be receiving the answer to
+            // a request it was admitted to make. Close the session rather than
+            // fail one write and carry on; see the method doc for why the error
+            // case needs saying separately from the timeout case.
+            if is_response {
+                if let Err(error) = &result {
+                    tracing::warn!(
+                        %error,
+                        response_deadline_secs = response_deadline.map(|d| d.as_secs()),
+                        "stdio bridge could not deliver a response to its peer; closing this \
+                         session rather than leaving it alive with an unanswerable request"
+                    );
+                    root.cancel();
+                }
+            }
             // Clear THIS request's obligation once the write is resolved
             // either way — see the `in_flight` field doc for why a failed
             // write must not be left permanently counted as pending, and why

--- a/crates/khive-mcp/src/transport.rs
+++ b/crates/khive-mcp/src/transport.rs
@@ -5,13 +5,18 @@
 //! transports (e.g. Streamable HTTP) register with [`TransportRegistry::register`]
 //! before serving, so the serve path never hard-codes a transport enum.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 use async_trait::async_trait;
 
 use crate::server::KhiveMcpServer;
 
-/// Cancels rmcp's root service token before reporting transport EOF.
+/// Cancels rmcp's root service token before reporting transport EOF — and,
+/// with an idle timeout configured, before reporting a synthetic EOF when no
+/// message has arrived within that window even though the pipe itself stays
+/// open.
 ///
 /// rmcp otherwise classifies EOF as a graceful close and drains in-flight
 /// handlers for five seconds without cancelling their per-request child
@@ -20,42 +25,391 @@ use crate::server::KhiveMcpServer;
 /// begins. Send and close remain transparent, allowing this wrapper to sit
 /// outside the Unix post-flush self-heal transport without changing its flush
 /// ordering.
+///
+/// An abandoned stdio bridge — a client whose pipe never closes but which
+/// has stopped sending requests — is otherwise indistinguishable from a live
+/// one: nothing reaps it, so it holds its reader-pool admission and DB
+/// connection for as long as the parent process happens to stay alive
+/// (observed up to tens of hours in production). Idle timeout treats "no
+/// request for `idle_timeout`" the same as real EOF: `receive()` yields
+/// `None`, which cancels `root` and lets rmcp's normal graceful-close path
+/// tear the session down — the same clean-exit path that already releases
+/// pooled resources on a real disconnect.
+///
+/// Wire-idle is not session-idle: rmcp keeps racing `transport.receive()`
+/// while each admitted request runs in its own task, so a handler that
+/// outlasts `idle_timeout` (slow verb, large batch) must not have its
+/// session torn down out from under it. `in_flight` counts JSON-RPC
+/// `Request` messages this transport has handed to rmcp minus the
+/// `Response`/`Error` messages it has *finished writing* back for them —
+/// not merely handed to `inner.send`, since rmcp spawns the response send
+/// and the underlying framed write awaits the transport writer, so a slow
+/// or stalled reader leaves the write pending well after `send` is called.
+/// The idle branch only treats a quiet window as EOF when that count is
+/// zero, i.e. nothing admitted has an undelivered response. A response
+/// write that fails also decrements the counter (once resolved, one way or
+/// another, it is no longer pending) — the broken transport will surface
+/// through `receive()` returning `None` on its own, so this counter must
+/// not be the thing that gets stuck open forever on a write error.
+///
+/// **An obligation is evidence of life only while it is fresh.** rmcp spawns
+/// each request handler with `spawn_service_task` and drops the join handle
+/// (`rmcp::service`), so a handler that panics never reaches the response
+/// construction that would let this transport decrement. A bare counter would
+/// then stay positive for the life of the process and the idle branch would
+/// defer forever — the precise unbounded lifetime this type exists to close,
+/// reintroduced through its own guard. `in_flight` therefore records the
+/// *instant* each request was admitted, and the idle branch defers only while
+/// the newest outstanding obligation is younger than `obligation_ttl`. An
+/// obligation older than that is not distinguishable, by any signal available
+/// at the transport, from a handler that died without answering.
+///
+/// `obligation_ttl` is deliberately NOT the idle window. Tying the two
+/// together would make a long-running handler stop protecting its own session
+/// after a single quiet window, which is the guarantee this counter exists to
+/// provide. It is its own bound, set well above any real handler, and it
+/// answers a different question: not "has this session been quiet" but "has
+/// this request been outstanding so long that the handler must be gone".
+/// `None` restores the unbounded defer, and with it the leak — it exists for
+/// callers that do not enable idle reaping at all, where the defer decision is
+/// never reached.
+///
+/// A response write that never resolves — a peer that admits a request,
+/// then stops reading its response while keeping the pipe open — would
+/// otherwise pin this session (and its reader-pool admission / DB
+/// connection) forever: the obligation would never clear, so the idle
+/// check above would defer for as long as the freshness rule allows. `response_deadline` bounds the
+/// write itself (see [`Self::send`]) rather than the idle check: rmcp's
+/// underlying `AsyncRwTransport` serializes writes through a
+/// `tokio::sync::Mutex` held across the pending write's `.await`, so a
+/// write that never resolves also blocks any later `close()` on the same
+/// transport — merely cancelling the root token would not free that lock.
+/// Timing out the write future instead *drops* it, which releases the
+/// mutex guard the same way any other future cancellation would, so a
+/// subsequent `close()` (part of rmcp's normal post-cancellation drain)
+/// can still proceed.
 pub(crate) struct CancelOnEofTransport<T> {
     inner: T,
     root: tokio_util::sync::CancellationToken,
+    idle_timeout: Option<std::time::Duration>,
+    response_deadline: Option<std::time::Duration>,
+    /// Requests handed to rmcp whose response has not finished writing, each
+    /// paired with the instant it was admitted. Ordered oldest-first; see the
+    /// type doc for why the instants matter and not just the count.
+    ///
+    /// Entries are keyed by request id because they are **not**
+    /// interchangeable. rmcp spawns each handler and each response send
+    /// independently, so a newer request's response can finish first. Retiring
+    /// the oldest entry on any completion would then drop a still-outstanding
+    /// request's admission and leave a *completed* one as the newest entry —
+    /// making the freshness test below read the completed request's timestamp
+    /// and defer past the older obligation's TTL. Removing the entry whose id
+    /// matches keeps `back()` the genuinely newest outstanding admission,
+    /// which is what the freshness rule assumes.
+    ///
+    /// Because retirement is keyed, a request that never produces a response
+    /// would hold its entry for the life of the session. Entries past
+    /// `obligation_ttl` are therefore dropped whenever this queue is touched;
+    /// see [`drop_stale_obligations`].
+    in_flight: Arc<Mutex<VecDeque<(rmcp::model::RequestId, Instant)>>>,
+    /// How long an outstanding request keeps deferring the idle close. `None`
+    /// defers without bound. See the type doc.
+    obligation_ttl: Option<std::time::Duration>,
 }
 
 impl<T> CancelOnEofTransport<T> {
-    pub(crate) fn new(inner: T, root: tokio_util::sync::CancellationToken) -> Self {
-        Self { inner, root }
+    /// `idle_timeout`: a `receive()` call that yields no message within this
+    /// window is treated as EOF (see the type doc), but only when no
+    /// admitted request is still awaiting its response. `None` disables it.
+    ///
+    /// `response_deadline`: the longest a single response write may stay
+    /// pending before it is abandoned (see [`Self::send`]) — independent of
+    /// `idle_timeout`, and meaningful whether or not an idle timeout is
+    /// configured. `None` disables the bound (a response write waits
+    /// unbounded, matching this transport's pre-existing behavior).
+    ///
+    /// `obligation_ttl`: how long an admitted request whose response has not
+    /// been written keeps deferring the idle close. `None` defers without
+    /// bound, which is only safe where `idle_timeout` is also `None`, because
+    /// a handler that panics never produces the response that would clear the
+    /// obligation (see the type doc).
+    pub(crate) fn with_idle_timeout(
+        inner: T,
+        root: tokio_util::sync::CancellationToken,
+        idle_timeout: Option<std::time::Duration>,
+        response_deadline: Option<std::time::Duration>,
+        obligation_ttl: Option<std::time::Duration>,
+    ) -> Self {
+        Self {
+            inner,
+            root,
+            idle_timeout,
+            response_deadline,
+            in_flight: Arc::new(Mutex::new(VecDeque::new())),
+            obligation_ttl,
+        }
+    }
+
+    /// The obligation queue, for tests that need to observe its size.
+    #[cfg(test)]
+    pub(crate) fn in_flight_handle(
+        &self,
+    ) -> Arc<Mutex<VecDeque<(rmcp::model::RequestId, Instant)>>> {
+        self.in_flight.clone()
+    }
+}
+
+/// Drops obligations that are already past their TTL.
+///
+/// An entry older than `obligation_ttl` is, by this transport's own rule, no
+/// longer evidence of life: the freshness check will not defer on it. Keeping
+/// it buys nothing, and keeping it *forever* is a real cost, because
+/// retirement is keyed by request id and so only ever removes the entry whose
+/// response was actually written. A request that never produces one — a
+/// handler that panics, a request the peer cancels — would otherwise hold its
+/// entry for the life of the session, and a long-lived session accumulates one
+/// per such request without bound.
+///
+/// Entries are pushed in admission order, so the stale ones are a prefix.
+///
+/// With no TTL configured there is no notion of staleness and nothing is
+/// dropped. That is the configuration which already restores the unbounded
+/// defer (see the type doc), so it is unbounded in the same way for the same
+/// reason.
+fn drop_stale_obligations(
+    queue: &mut VecDeque<(rmcp::model::RequestId, Instant)>,
+    obligation_ttl: Option<std::time::Duration>,
+) {
+    let Some(ttl) = obligation_ttl else {
+        return;
+    };
+    while queue.front().is_some_and(|(_, at)| at.elapsed() >= ttl) {
+        queue.pop_front();
     }
 }
 
 impl<T> rmcp::transport::Transport<rmcp::RoleServer> for CancelOnEofTransport<T>
 where
     T: rmcp::transport::Transport<rmcp::RoleServer>,
+    T::Error: From<std::io::Error>,
 {
     type Error = T::Error;
 
+    /// Bounds a response/error write by `response_deadline` (requests pass
+    /// straight through, untimed — only a response can leave `in_flight`
+    /// permanently pinned). On timeout the write future is dropped —
+    /// releasing whatever lock the inner transport held across it, see the
+    /// type doc — `in_flight` is decremented the same as any other resolved
+    /// write, and `root` is cancelled directly: the peer has demonstrated it
+    /// is not going to read this response, so there is no reason to wait for
+    /// the next idle tick to notice.
     fn send(
         &mut self,
         item: rmcp::service::TxJsonRpcMessage<rmcp::RoleServer>,
     ) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send + 'static {
-        self.inner.send(item)
+        let is_response = matches!(
+            item,
+            rmcp::model::JsonRpcMessage::Response(_) | rmcp::model::JsonRpcMessage::Error(_)
+        );
+        // Which obligation this write discharges. A `Response` always names
+        // its request. A `JsonRpcError` carries `Option<RequestId>`: the MCP
+        // spec omits the id when the server could not read it (parse error,
+        // invalid request), and such an error answers no admitted request, so
+        // it must retire nothing rather than retire an arbitrary one.
+        let retire_id: Option<rmcp::model::RequestId> = match &item {
+            rmcp::model::JsonRpcMessage::Response(response) => Some(response.id.clone()),
+            rmcp::model::JsonRpcMessage::Error(error) => error.id.clone(),
+            _ => None,
+        };
+        let in_flight = self.in_flight.clone();
+        let root = self.root.clone();
+        let response_deadline = self.response_deadline;
+        let obligation_ttl = self.obligation_ttl;
+        let send = self.inner.send(item);
+        async move {
+            let result = match (is_response, response_deadline) {
+                (true, Some(deadline)) => match tokio::time::timeout(deadline, send).await {
+                    Ok(result) => result,
+                    Err(_) => {
+                        tracing::warn!(
+                            deadline_secs = deadline.as_secs(),
+                            "stdio bridge response-delivery deadline elapsed while a response \
+                             write was still pending (peer stopped reading); abandoning the \
+                             write and closing this session"
+                        );
+                        root.cancel();
+                        Err(std::io::Error::new(
+                            std::io::ErrorKind::TimedOut,
+                            "response-delivery deadline elapsed before the write completed",
+                        )
+                        .into())
+                    }
+                },
+                _ => send.await,
+            };
+            // Clear THIS request's obligation once the write is resolved
+            // either way — see the `in_flight` field doc for why a failed
+            // write must not be left permanently counted as pending, and why
+            // the entry removed has to be the matching one rather than the
+            // oldest. An id-less error matches nothing and removes nothing.
+            if let Ok(mut q) = in_flight.lock() {
+                if let Some(id) = retire_id {
+                    if let Some(position) = q.iter().position(|(entry, _)| *entry == id) {
+                        q.remove(position);
+                    }
+                }
+                drop_stale_obligations(&mut q, obligation_ttl);
+            }
+            result
+        }
     }
 
     fn receive(
         &mut self,
     ) -> impl std::future::Future<Output = Option<rmcp::service::RxJsonRpcMessage<rmcp::RoleServer>>>
            + Send {
-        let receive = self.inner.receive();
         let root = self.root.clone();
+        let idle_timeout = self.idle_timeout;
+        let in_flight = self.in_flight.clone();
+        let obligation_ttl = self.obligation_ttl;
         async move {
-            let message = receive.await;
-            if message.is_none() {
-                root.cancel();
+            // Created once and reused across every retry below: `select!`ing
+            // a *fresh* `self.inner.receive()` each time the idle sleep wins
+            // would drop the in-progress read and restart it next iteration.
+            // rmcp's line-buffered receive clears its buffer at the start of
+            // each call, so restarting mid-read silently discards whatever
+            // prefix of the next request had already arrived before the
+            // deferred timeout — the remainder then parses as garbage.
+            // Racing the sleep against `&mut` this same pinned future keeps
+            // the partial read alive across as many deferrals as it takes.
+            let recv_fut = self.inner.receive();
+            tokio::pin!(recv_fut);
+            loop {
+                let message = match idle_timeout {
+                    Some(timeout) => {
+                        tokio::select! {
+                            // The read branch MUST win a tie, so it is first and
+                            // the arms are polled in order. Without `biased`,
+                            // `select!` picks a starting branch at random for
+                            // fairness (tokio 1.52.4, `src/macros/select.rs`
+                            // lines 61-68), which here means that a request
+                            // already sitting in the buffer loses a coin flip to
+                            // an idle timer that has just elapsed. The session is
+                            // then closed on a peer that did answer inside the
+                            // window, and it happens only under the scheduling
+                            // delay that makes both branches ready at once, so it
+                            // is load-dependent rather than reproducible.
+                            //
+                            // Starving the timer is the usual cost of `biased`
+                            // and is not a cost here: a read that is continuously
+                            // ready means the session is not idle, which is
+                            // exactly when the timer must not fire. The sleep is
+                            // also rebuilt on every iteration, so deferring never
+                            // accumulates elapsed time against the next window.
+                            biased;
+                            message = &mut recv_fut => message,
+                            () = tokio::time::sleep(timeout) => {
+                                // Defer only on a FRESH obligation. The newest
+                                // entry is the test: if even that one predates a
+                                // full idle window, everything outstanding is
+                                // stale and none of it is evidence of life. See
+                                // the type doc for why a bare count cannot be
+                                // trusted here.
+                                let fresh = in_flight
+                                    .lock()
+                                    .ok()
+                                    .and_then(|q| q.back().map(|(_, at)| *at))
+                                    .is_some_and(|newest| match obligation_ttl {
+                                        Some(ttl) => newest.elapsed() < ttl,
+                                        None => true,
+                                    });
+                                if fresh {
+                                    tracing::debug!(
+                                        idle_timeout_secs = timeout.as_secs(),
+                                        "stdio bridge idle timeout elapsed but an admitted \
+                                         request is still awaiting its response; deferring \
+                                         session close"
+                                    );
+                                    continue;
+                                }
+                                if in_flight.lock().is_ok_and(|q| !q.is_empty()) {
+                                    tracing::warn!(
+                                        idle_timeout_secs = timeout.as_secs(),
+                                        obligation_ttl_secs =
+                                            obligation_ttl.map(|d| d.as_secs()),
+                                        "stdio bridge closing with admitted requests whose \
+                                         responses never arrived and whose admission is older \
+                                         than the request-obligation TTL; treating them as \
+                                         dead rather than deferring indefinitely"
+                                    );
+                                }
+                                tracing::info!(
+                                    idle_timeout_secs = timeout.as_secs(),
+                                    "stdio bridge idle timeout elapsed with no request; \
+                                     closing this session to release its pooled resources"
+                                );
+                                None
+                            }
+                        }
+                    }
+                    None => recv_fut.await,
+                };
+                // A second outstanding obligation under an id that already has
+                // one is refused rather than admitted. Two entries sharing an
+                // id make retirement ambiguous, and BOTH ways of resolving it
+                // are wrong: retiring the first match can leave a completed
+                // request's instant as the newest entry and defer past the
+                // older obligation's TTL (the leak), while retiring the last
+                // match can leave the older instant and close the session out
+                // from under a live handler (the opposite failure). There is
+                // no third choice, because the transport cannot tell the two
+                // apart — the ambiguity has to be refused where it enters.
+                //
+                // MCP requires a request id to be unused within a session
+                // (2025-11-25, "Requests"), so a conforming peer never reaches
+                // this. A non-conforming one must not be able to corrupt the
+                // session's lifetime accounting from the wire, which is what
+                // makes this the transport's problem rather than the peer's.
+                //
+                // The duplicate scan runs BEFORE the staleness drop, and that
+                // order is load-bearing. A stale entry is an id whose response
+                // was never observed — the handler may still be running, since
+                // rmcp keeps it alive independently of this receive loop until
+                // it constructs its response. Dropping it first would convert
+                // exactly the ambiguous case into a silent re-admission: the
+                // id passes the check, is pushed as a fresh entry, and the
+                // first of the two eventual responses retires the NEW entry by
+                // id match, leaving the older live handler untracked and the
+                // idle branch free to close out from under it. Scanning the
+                // full queue first refuses that reuse instead. It costs
+                // nothing a conforming peer can notice, because an id whose
+                // response WAS written is not in the queue at all.
+                let mut duplicate_id = None;
+                if let Some(rmcp::model::JsonRpcMessage::Request(request)) = &message {
+                    if let Ok(mut q) = in_flight.lock() {
+                        if q.iter().any(|(entry, _)| *entry == request.id) {
+                            duplicate_id = Some(request.id.clone());
+                        } else {
+                            drop_stale_obligations(&mut q, obligation_ttl);
+                            q.push_back((request.id.clone(), Instant::now()));
+                        }
+                    }
+                }
+                if let Some(id) = duplicate_id {
+                    tracing::warn!(
+                        duplicate_request_id = ?id,
+                        "stdio bridge received a request whose id already has an outstanding \
+                         obligation; the response could not be attributed to either, so this \
+                         session is closed rather than left with corrupt lifetime accounting"
+                    );
+                    root.cancel();
+                    return None;
+                }
+                if message.is_none() {
+                    root.cancel();
+                }
+                return message;
             }
-            message
         }
     }
 

--- a/crates/khive-mcp/src/transport.rs
+++ b/crates/khive-mcp/src/transport.rs
@@ -40,9 +40,7 @@ struct OutstandingRequest {
 
 impl OutstandingRequests {
     fn admit(&mut self, id: RequestId, admitted_at: Instant, capacity: usize) -> bool {
-        #[cfg(test)]
-        self.record_operation();
-        if self.entries.contains_key(&id) || self.entries.len() >= capacity {
+        if self.contains(&id) || self.entries.len() >= capacity {
             return false;
         }
 
@@ -169,6 +167,7 @@ struct ObligationRetirementGuard {
     in_flight: Arc<Mutex<OutstandingRequests>>,
     id: Option<RequestId>,
     obligation_ttl: Option<std::time::Duration>,
+    root: tokio_util::sync::CancellationToken,
 }
 
 impl ObligationRetirementGuard {
@@ -176,9 +175,19 @@ impl ObligationRetirementGuard {
         let Some(id) = self.id.take() else {
             return;
         };
-        if let Ok(mut outstanding) = self.in_flight.lock() {
-            outstanding.retire(&id);
-            outstanding.drop_stale(self.obligation_ttl);
+        match self.in_flight.lock() {
+            Ok(mut outstanding) => {
+                outstanding.retire(&id);
+                outstanding.drop_stale(self.obligation_ttl);
+            }
+            Err(_) => {
+                tracing::error!(
+                    request_id = ?id,
+                    "stdio bridge outstanding-request tracker is poisoned during retirement; \
+                     cancelling the session rather than losing the obligation"
+                );
+                self.root.cancel();
+            }
         }
     }
 }
@@ -441,6 +450,69 @@ mod outstanding_request_tests {
             large_retirement,
         );
     }
+
+    fn poison_tracker(tracker: &Arc<Mutex<OutstandingRequests>>) {
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = tracker
+                .lock()
+                .expect("tracker mutex must initially be healthy");
+            panic!("deliberately poison the tracker mutex");
+        }));
+        assert!(
+            result.is_err(),
+            "the poisoning fixture must panic while holding the mutex"
+        );
+    }
+
+    #[tokio::test]
+    async fn poisoned_tracker_fails_closed_on_admission_and_retirement() {
+        use rmcp::transport::async_rw::AsyncRwTransport;
+        use rmcp::transport::Transport as _;
+        use tokio::io::AsyncWriteExt;
+
+        let root = tokio_util::sync::CancellationToken::new();
+        let (server_io, mut client_io) = tokio::io::duplex(4096);
+        let (server_read, server_write) = tokio::io::split(server_io);
+        let mut transport = CancelOnEofTransport::with_idle_timeout(
+            AsyncRwTransport::new_server(server_read, server_write),
+            root.clone(),
+            None,
+            None,
+            None,
+        );
+        let tracker = transport.in_flight_handle();
+        poison_tracker(&tracker);
+
+        client_io
+            .write_all(
+                br#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"probe","arguments":{}}}
+"#,
+            )
+            .await
+            .expect("write the request used to exercise poisoned admission");
+
+        assert!(
+            transport.receive().await.is_none(),
+            "poisoned admission must return transport EOF instead of handing the request to rmcp"
+        );
+        assert!(
+            root.is_cancelled(),
+            "poisoned admission must cancel the rmcp root token"
+        );
+
+        let retirement_root = tokio_util::sync::CancellationToken::new();
+        let mut retirement = ObligationRetirementGuard {
+            in_flight: tracker,
+            id: Some(rmcp::model::RequestId::Number(1)),
+            obligation_ttl: None,
+            root: retirement_root.clone(),
+        };
+        retirement.retire();
+        assert!(
+            retirement_root.is_cancelled(),
+            "poisoned retirement must cancel the session instead of consuming the id silently"
+        );
+    }
 }
 
 /// Whether a failed outbound write names an operation that may simply be
@@ -559,6 +631,7 @@ where
             in_flight,
             id: Some(id),
             obligation_ttl,
+            root: root.clone(),
         });
         let send = self.inner.send(item);
         async move {
@@ -668,14 +741,26 @@ where
                                 // stale and none of it is evidence of life. See
                                 // the type doc for why a bare count cannot be
                                 // trusted here.
-                                let fresh = in_flight
-                                    .lock()
-                                    .ok()
-                                    .and_then(|q| q.newest_admitted_at())
-                                    .is_some_and(|newest| match obligation_ttl {
-                                        Some(ttl) => newest.elapsed() < ttl,
-                                        None => true,
-                                    });
+                                let (fresh, has_outstanding) = match in_flight.lock() {
+                                    Ok(q) => {
+                                        let fresh = q
+                                            .newest_admitted_at()
+                                            .is_some_and(|newest| match obligation_ttl {
+                                                Some(ttl) => newest.elapsed() < ttl,
+                                                None => true,
+                                            });
+                                        (fresh, !q.is_empty())
+                                    }
+                                    Err(_) => {
+                                        tracing::error!(
+                                            "stdio bridge outstanding-request tracker is \
+                                             poisoned during idle handling; cancelling the \
+                                             session"
+                                        );
+                                        root.cancel();
+                                        return None;
+                                    }
+                                };
                                 if fresh {
                                     tracing::debug!(
                                         idle_timeout_secs = timeout.as_secs(),
@@ -685,7 +770,7 @@ where
                                     );
                                     continue;
                                 }
-                                if in_flight.lock().is_ok_and(|q| !q.is_empty()) {
+                                if has_outstanding {
                                     tracing::warn!(
                                         idle_timeout_secs = timeout.as_secs(),
                                         obligation_ttl_secs =
@@ -740,16 +825,28 @@ where
                 let mut duplicate_id = None;
                 let mut capacity_exceeded = false;
                 if let Some(rmcp::model::JsonRpcMessage::Request(request)) = &message {
-                    if let Ok(mut q) = in_flight.lock() {
-                        if q.contains(&request.id) {
-                            duplicate_id = Some(request.id.clone());
-                        } else {
-                            q.drop_stale(obligation_ttl);
-                            capacity_exceeded = !q.admit(
-                                request.id.clone(),
-                                Instant::now(),
-                                max_outstanding_requests,
+                    match in_flight.lock() {
+                        Ok(mut q) => {
+                            if q.contains(&request.id) {
+                                duplicate_id = Some(request.id.clone());
+                            } else {
+                                q.drop_stale(obligation_ttl);
+                                capacity_exceeded = !q.admit(
+                                    request.id.clone(),
+                                    Instant::now(),
+                                    max_outstanding_requests,
+                                );
+                            }
+                        }
+                        Err(_) => {
+                            tracing::error!(
+                                request_id = ?request.id,
+                                "stdio bridge outstanding-request tracker is poisoned during \
+                                 admission; cancelling the session rather than admitting \
+                                 untracked work"
                             );
+                            root.cancel();
+                            return None;
                         }
                     }
                 }

--- a/crates/khive-mcp/src/transport.rs
+++ b/crates/khive-mcp/src/transport.rs
@@ -216,11 +216,20 @@ where
     /// disabled by default there is no later tick to notice. So the session
     /// would outlive the peer's ability to receive anything from it.
     ///
-    /// Gated on `is_response` deliberately. A response is the discharge of an
-    /// admitted obligation, so failing to write one means an admitted request
-    /// can never be answered on this session. Server-initiated requests carry
-    /// their own send accounting inside rmcp (`SendTaskResult::Request`), and
-    /// bringing them under this rule is a separate change.
+    /// **Every** failed outbound write cancels, not only a response. An
+    /// earlier version of this scoped the cancel to responses, on the ground
+    /// that a response discharges an admitted obligation while server-initiated
+    /// requests and notifications "carry their own send accounting inside rmcp
+    /// (`SendTaskResult::Request`)". That accounting exists and does not do
+    /// this job: on a failed request send, rmcp removes the caller's responder
+    /// and hands it `ServiceError::TransportSend`
+    /// (`rmcp-1.8.0`, `src/service.rs:1066-1073`); on a failed notification
+    /// send it does the same to the notification's responder (`:1074-1093`).
+    /// Neither branch breaks the serve loop, whose only exits are receive EOF,
+    /// token cancellation, and a send-task join error (`:1028-1062`). So a
+    /// failed request or notification write strands the session exactly as a
+    /// failed response did — the argument for the narrower rule pointed at a
+    /// mechanism without reading what it does, and is withdrawn.
     ///
     /// A failed write is reported once, here, whichever way it failed: the
     /// deadline arm's error names its own cause, so a second log line at the
@@ -261,20 +270,21 @@ where
                 _ => send.await,
             };
             // Either failure — the write outlived its deadline, or it resolved
-            // as an error — means this peer will not be receiving the answer to
-            // a request it was admitted to make. Close the session rather than
-            // fail one write and carry on; see the method doc for why the error
-            // case needs saying separately from the timeout case.
-            if is_response {
-                if let Err(error) = &result {
-                    tracing::warn!(
-                        %error,
-                        response_deadline_secs = response_deadline.map(|d| d.as_secs()),
-                        "stdio bridge could not deliver a response to its peer; closing this \
-                         session rather than leaving it alive with an unanswerable request"
-                    );
-                    root.cancel();
-                }
+            // as an error — means this peer is not receiving what the session
+            // just tried to send it, and rmcp will not close on its own behalf
+            // for any of the three message classes. Close here rather than fail
+            // one write and carry on; see the method doc for why this covers
+            // requests and notifications too, and why the error case needs
+            // saying separately from the timeout case.
+            if let Err(error) = &result {
+                tracing::warn!(
+                    %error,
+                    is_response,
+                    response_deadline_secs = response_deadline.map(|d| d.as_secs()),
+                    "stdio bridge could not deliver an outbound message to its peer; closing \
+                     this session rather than leaving it alive unable to answer"
+                );
+                root.cancel();
             }
             // Clear THIS request's obligation once the write is resolved
             // either way — see the `in_flight` field doc for why a failed

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -301,7 +301,7 @@ are read once at serve time.
 | `KHIVE_BRIDGE_IDLE_TIMEOUT_SECS`        | **disabled** | When set to a positive number, a session that receives no request for this many seconds closes, releasing its reader-pool admission and DB connection. `0`, absent, or unparsable leaves it disabled. |
 | `KHIVE_BRIDGE_RESPONSE_DEADLINE_SECS`   | `300`        | The longest a single response write may stay pending before it is abandoned and the session closes. `0` is rejected at startup rather than treated as an opt-out.                                     |
 | `KHIVE_BRIDGE_REQUEST_OBLIGATION_SECS`  | `3600`       | How long an admitted request whose response has not been written keeps deferring the idle close. Only reached when the idle timeout is enabled. `0` restores an unbounded defer.                      |
-| `KHIVE_BRIDGE_MAX_OUTSTANDING_REQUESTS` | `1024`       | Maximum requests admitted to rmcp while their responses remain outstanding. A full session closes before another handler is spawned. `0` or an unparsable value uses the default.                 |
+| `KHIVE_BRIDGE_MAX_OUTSTANDING_REQUESTS` | `1024`       | Maximum requests admitted to rmcp while their responses remain outstanding. A full session closes before another handler is spawned. `0` or an unparsable value uses the default.                     |
 
 **Idle reaping is off by default, and that is deliberate.**
 [ADR-091](adr/ADR-091-wal-snapshot-lifetime.md) rejects closing long-lived

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -324,14 +324,20 @@ including after it has passed the obligation TTL. Ageing past that TTL means the
 request no longer defers the idle close; it does not mean the request finished,
 and the handler may well still be running. Reuse is refused in that state too.
 
-**A session also closes when a response cannot be written at all.** A response
-write that fails is the same fact as one that outlives its deadline: the peer
-will not be receiving the answer to a request it was admitted to make. It is
-worth stating separately because the deadline does not cover it. The deadline
-bounds a write left _pending_, which is what a peer that stops reading with its
-pipe still open produces; a peer that closes the side it reads from fails the
-write immediately instead, well inside any deadline. The rule is scoped to
-responses, so a failed notification write does not close the session.
+**A session also closes when an outbound message cannot be written at all.** A
+write that fails is the same fact as one that outlives its deadline: the peer is
+not receiving what the session tried to send it. It is worth stating separately
+because the deadline does not cover it. The deadline bounds a write left
+_pending_, which is what a peer that stops reading with its pipe still open
+produces; a peer that closes the side it reads from fails the write immediately
+instead, well inside any deadline.
+
+This applies to responses, server-initiated requests and notifications alike.
+The underlying library does not close the session for any of them: a failed send
+is reported to whoever was awaiting that particular message, and its serve loop
+exits only on receive EOF, cancellation, or a task join error. A session left
+running against a writer that cannot write is one that will never answer
+anything, so the transport ends it here. A write that succeeds changes nothing.
 
 **Known gap.** The response-delivery deadline covers responses this transport
 writes. It does not cover parse-error responses, which the underlying line

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -296,12 +296,12 @@ Four environment variables bound how long a stdio bridge session and its
 individual writes may live, or how many requests it can admit at once. They
 are read once at serve time.
 
-| Variable                               | Default      | Effect                                                                                                                                                                                                |
-| -------------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `KHIVE_BRIDGE_IDLE_TIMEOUT_SECS`       | **disabled** | When set to a positive number, a session that receives no request for this many seconds closes, releasing its reader-pool admission and DB connection. `0`, absent, or unparsable leaves it disabled. |
-| `KHIVE_BRIDGE_RESPONSE_DEADLINE_SECS`  | `300`        | The longest a single response write may stay pending before it is abandoned and the session closes. `0` is rejected at startup rather than treated as an opt-out.                                     |
-| `KHIVE_BRIDGE_REQUEST_OBLIGATION_SECS` | `3600`       | How long an admitted request whose response has not been written keeps deferring the idle close. Only reached when the idle timeout is enabled. `0` restores an unbounded defer.                      |
-| `KHIVE_BRIDGE_MAX_OUTSTANDING_REQUESTS`| `1024`       | Maximum requests admitted to rmcp while their responses remain outstanding. A full session closes before another handler is spawned. `0` or an unparsable value uses the default.                 |
+| Variable                                | Default      | Effect                                                                                                                                                                                                |
+| --------------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `KHIVE_BRIDGE_IDLE_TIMEOUT_SECS`        | **disabled** | When set to a positive number, a session that receives no request for this many seconds closes, releasing its reader-pool admission and DB connection. `0`, absent, or unparsable leaves it disabled. |
+| `KHIVE_BRIDGE_RESPONSE_DEADLINE_SECS`   | `300`        | The longest a single response write may stay pending before it is abandoned and the session closes. `0` is rejected at startup rather than treated as an opt-out.                                     |
+| `KHIVE_BRIDGE_REQUEST_OBLIGATION_SECS`  | `3600`       | How long an admitted request whose response has not been written keeps deferring the idle close. Only reached when the idle timeout is enabled. `0` restores an unbounded defer.                      |
+| `KHIVE_BRIDGE_MAX_OUTSTANDING_REQUESTS` | `1024`       | Maximum requests admitted to rmcp while their responses remain outstanding. A full session closes before another handler is spawned. `0` or an unparsable value uses the default.                 |
 
 **Idle reaping is off by default, and that is deliberate.**
 [ADR-091](adr/ADR-091-wal-snapshot-lifetime.md) rejects closing long-lived

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -290,6 +290,59 @@ partial-override mode.
 
 ---
 
+## Stdio bridge session lifetime
+
+Three environment variables bound how long a stdio bridge session and its
+individual writes may live. They are read once at serve time.
+
+| Variable                               | Default      | Effect                                                                                                                                                                                                |
+| -------------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `KHIVE_BRIDGE_IDLE_TIMEOUT_SECS`       | **disabled** | When set to a positive number, a session that receives no request for this many seconds closes, releasing its reader-pool admission and DB connection. `0`, absent, or unparsable leaves it disabled. |
+| `KHIVE_BRIDGE_RESPONSE_DEADLINE_SECS`  | `300`        | The longest a single response write may stay pending before it is abandoned and the session closes. `0` is rejected at startup rather than treated as an opt-out.                                     |
+| `KHIVE_BRIDGE_REQUEST_OBLIGATION_SECS` | `3600`       | How long an admitted request whose response has not been written keeps deferring the idle close. Only reached when the idle timeout is enabled. `0` restores an unbounded defer.                      |
+
+**Idle reaping is off by default, and that is deliberate.**
+[ADR-091](adr/ADR-091-wal-snapshot-lifetime.md) rejects closing long-lived
+reader sessions by age, on the ground that they are live clients and that
+bounding what they hold underneath them is the better fix. This transport has
+no signal separating an abandoned pipe from a live client that has simply not
+been asked anything, so enabling the idle timeout by default would reverse that
+decision. Turn it on where session churn is cheap and a pinned WAL connection
+is not: a supervised deployment, a CI harness, a batch runner.
+
+**A session also closes on a duplicate outstanding request id.** MCP requires a
+request id to be unused within a session, and this transport tracks outstanding
+requests by id in order to decide whether a quiet session still has work
+running. Two live requests sharing an id make that undecidable: a completing
+response could discharge either, and picking wrong either keeps a finished
+session alive indefinitely or closes a live one. The second such request is
+therefore refused and the session closes, with the id logged at `WARN`. A
+conforming client never reaches this.
+
+An id counts as outstanding for this purpose while its entry is still tracked,
+including after it has passed the obligation TTL. Ageing past that TTL means the
+request no longer defers the idle close; it does not mean the request finished,
+and the handler may well still be running. Reuse is refused in that state too.
+
+**Known gap.** The response-delivery deadline covers responses this transport
+writes. It does not cover parse-error responses, which the underlying line
+transport writes directly through its own framed writer without passing through
+the deadline. A peer that sends malformed input and then stops reading can leave
+that one write pending.
+
+What bounds that pending write depends on what else the session has
+outstanding, and the idle window alone is not the answer:
+
+- Idle timeout disabled: nothing bounds it.
+- Idle timeout enabled, nothing else outstanding: the idle window bounds it.
+- Idle timeout enabled with a request still awaiting its response: the idle
+  close defers while that obligation is fresh, so the bound is the request
+  obligation TTL rather than the idle window. A peer can reach this deliberately
+  by admitting a request and then sending malformed input.
+
+Closing the gap requires replacing or adapting the line transport and is tracked
+separately.
+
 ## Troubleshooting a connect failure
 
 **Symptom:** an MCP client (Claude Code, Claude Desktop, Codex, Gemini) reports

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -339,6 +339,12 @@ exits only on receive EOF, cancellation, or a task join error. A session left
 running against a writer that cannot write is one that will never answer
 anything, so the transport ends it here. A write that succeeds changes nothing.
 
+One class of write error is excepted: an error saying the operation was
+interrupted and may simply be repeated. The writer behind such an error is still
+usable, so ending the session would trade one lost message for a session that
+could have gone on serving. That message is still lost, and the error still
+reaches whoever was awaiting it. Only the session survives.
+
 **Known gap.** The response-delivery deadline covers responses this transport
 writes. It does not cover parse-error responses, which the underlying line
 transport writes directly through its own framed writer without passing through

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -339,11 +339,19 @@ exits only on receive EOF, cancellation, or a task join error. A session left
 running against a writer that cannot write is one that will never answer
 anything, so the transport ends it here. A write that succeeds changes nothing.
 
-One class of write error is excepted: an error saying the operation was
-interrupted and may simply be repeated. The writer behind such an error is still
-usable, so ending the session would trade one lost message for a session that
-could have gone on serving. That message is still lost, and the error still
-reaches whoever was awaiting it. Only the session survives.
+One narrow class of write error is excepted: an error saying the operation was
+interrupted and may simply be repeated, on a message that is not a response. The
+writer behind such an error is still usable, so ending the session would trade
+one lost message for a session that could have gone on serving. The message is
+still lost, and for these classes the error still reaches whoever was awaiting
+it. Only the session survives.
+
+A response gets no such exception, however healthy the writer is. When a
+response cannot be written, the failure is recorded on the server side and
+nothing is sent to the client, which is left waiting on an answer that will not
+arrive and has no way to tell that from a slow one. Ending the session is what
+turns that into an end-of-input the client can act on, so an interrupted
+response closes the session exactly as any other failed response does.
 
 **Known gap.** The response-delivery deadline covers responses this transport
 writes. It does not cover parse-error responses, which the underlying line

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -292,14 +292,16 @@ partial-override mode.
 
 ## Stdio bridge session lifetime
 
-Three environment variables bound how long a stdio bridge session and its
-individual writes may live. They are read once at serve time.
+Four environment variables bound how long a stdio bridge session and its
+individual writes may live, or how many requests it can admit at once. They
+are read once at serve time.
 
 | Variable                               | Default      | Effect                                                                                                                                                                                                |
 | -------------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `KHIVE_BRIDGE_IDLE_TIMEOUT_SECS`       | **disabled** | When set to a positive number, a session that receives no request for this many seconds closes, releasing its reader-pool admission and DB connection. `0`, absent, or unparsable leaves it disabled. |
 | `KHIVE_BRIDGE_RESPONSE_DEADLINE_SECS`  | `300`        | The longest a single response write may stay pending before it is abandoned and the session closes. `0` is rejected at startup rather than treated as an opt-out.                                     |
 | `KHIVE_BRIDGE_REQUEST_OBLIGATION_SECS` | `3600`       | How long an admitted request whose response has not been written keeps deferring the idle close. Only reached when the idle timeout is enabled. `0` restores an unbounded defer.                      |
+| `KHIVE_BRIDGE_MAX_OUTSTANDING_REQUESTS`| `1024`       | Maximum requests admitted to rmcp while their responses remain outstanding. A full session closes before another handler is spawned. `0` or an unparsable value uses the default.                 |
 
 **Idle reaping is off by default, and that is deliberate.**
 [ADR-091](adr/ADR-091-wal-snapshot-lifetime.md) rejects closing long-lived
@@ -309,6 +311,13 @@ no signal separating an abandoned pipe from a live client that has simply not
 been asked anything, so enabling the idle timeout by default would reverse that
 decision. Turn it on where session churn is cheap and a pinned WAL connection
 is not: a supervised deployment, a CI harness, a batch runner.
+
+The outstanding-request limit applies per stdio session and is independent of
+the idle and response deadlines. The default of 1024 allows ordinary
+concurrent MCP traffic while ensuring that a peer that stops reading cannot
+make the session's handler and request-obligation state grow without bound.
+Raise or lower it with `KHIVE_BRIDGE_MAX_OUTSTANDING_REQUESTS` when the
+deployment's concurrency and memory budget require a different bound.
 
 **A session also closes on a duplicate outstanding request id.** MCP requires a
 request id to be unused within a session, and this transport tracks outstanding

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -324,6 +324,15 @@ including after it has passed the obligation TTL. Ageing past that TTL means the
 request no longer defers the idle close; it does not mean the request finished,
 and the handler may well still be running. Reuse is refused in that state too.
 
+**A session also closes when a response cannot be written at all.** A response
+write that fails is the same fact as one that outlives its deadline: the peer
+will not be receiving the answer to a request it was admitted to make. It is
+worth stating separately because the deadline does not cover it. The deadline
+bounds a write left _pending_, which is what a peer that stops reading with its
+pipe still open produces; a peer that closes the side it reads from fails the
+write immediately instead, well inside any deadline. The rule is scoped to
+responses, so a failed notification write does not close the session.
+
 **Known gap.** The response-delivery deadline covers responses this transport
 writes. It does not cover parse-error responses, which the underlying line
 transport writes directly through its own framed writer without passing through


### PR DESCRIPTION
An abandoned stdio bridge session — a client whose pipe never closes but which has
stopped sending — is otherwise indistinguishable from a live one, so nothing reaps
it and it holds its reader-pool admission and DB connection for as long as the
parent process happens to survive. This bounds that lifetime, and it bounds the
symmetric case where a session stays alive but can no longer answer.

## The rule

**A failed outbound write closes the session, unless the writer is still healthy
AND the loss is observable by someone.** Both halves are load-bearing and the
second one is the correction that this branch exists to carry.

A write error saying the operation may simply be repeated leaves the writer
usable. Tokio's blocking stdout restores its idle state and puts the writer back
before returning the flush result, and the retry macro that repeats interrupted
operations is not applied to that branch, so an interrupted flush arrives as an
error from a writer that can still carry the next message. Cancelling there would
trade a lost message for a healthy session.

That is not sufficient on its own, because the three outbound message classes are
not handled alike:

- a failed server-initiated **request** send is handed back to the local responder
  awaiting it (`rmcp-1.8.0` `src/service.rs:1066-1073`)
- a failed **notification** send does the same (`:1074-1093`)
- a failed **response** send is only logged (`:1095-1112`)

For the first two, something in the process learns the message was lost. For a
response, nothing does: no bytes reach the peer, no local caller is waiting, and
the serve loop keeps running, so the client that asked the question waits on an
answer that is never coming and cannot distinguish that from a slow one. A healthy
writer does not help it. Closing is what turns the loss into an end-of-input it
can act on.

So the exception is scoped to non-response writes.

## Also here

A response write that never resolves pins the session, because the underlying
transport serializes writes through a mutex held across the pending write, which
also blocks any later close. A response deadline bounds the write and drops the
future rather than merely cancelling a token, which releases that guard.

Idle reaping treats a quiet window as end-of-input only when no admitted request
is still awaiting its response, and an outstanding request counts as evidence of
life only while it is fresh — a handler that dies without answering would
otherwise defer the close forever, reintroducing the exact unbounded lifetime this
change exists to remove.

## Verification

The interrupted-response test differs from the interrupted-notification test in
the message class and nothing else, so the pair is what makes the scope
load-bearing rather than incidental. Short-circuiting the class check reddens
exactly that one test and leaves the other 439 green, which was the prediction
stated before the run.

`cargo fmt --all -- --check`, `cargo clippy -p khive-mcp --all-targets -D warnings`,
`RUSTDOCFLAGS="-D warnings" cargo doc -p khive-mcp --no-deps` and `deno fmt --check`
all clean; `cargo test -p khive-mcp` gives 440 unit and 145 integration passing.

## Known gap, stated

The response deadline covers responses this transport writes. It does not cover
parse-error responses, which the underlying line transport writes directly through
its own framed writer without passing through here.
