### PR TITLE
chore: bump workspace version to 0.8.0

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1785,7 +1785,7 @@ dependencies = [
 
 [[package]]
 name = "khive-bm25"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "criterion",
  "khive-score",
@@ -1799,7 +1799,7 @@ dependencies = [
 
 [[package]]
 name = "khive-brain-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -1814,7 +1814,7 @@ dependencies = [
 
 [[package]]
 name = "khive-changeset"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "khive-types",
  "proptest",
@@ -1825,7 +1825,7 @@ dependencies = [
 
 [[package]]
 name = "khive-channel"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1839,7 +1839,7 @@ dependencies = [
 
 [[package]]
 name = "khive-channel-email"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-imap",
  "async-native-tls",
@@ -1863,7 +1863,7 @@ dependencies = [
 
 [[package]]
 name = "khive-channel-telegram"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1878,7 +1878,7 @@ dependencies = [
 
 [[package]]
 name = "khive-db"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -1911,7 +1911,7 @@ dependencies = [
 
 [[package]]
 name = "khive-fold"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -1926,7 +1926,7 @@ dependencies = [
 
 [[package]]
 name = "khive-fusion"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "criterion",
  "khive-score",
@@ -1936,7 +1936,7 @@ dependencies = [
 
 [[package]]
 name = "khive-gate"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "khive-types",
@@ -1947,7 +1947,7 @@ dependencies = [
 
 [[package]]
 name = "khive-gate-rego"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "khive-gate",
  "khive-types",
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "khive-hnsw"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "criterion",
  "khive-fold",
@@ -1978,7 +1978,7 @@ dependencies = [
 
 [[package]]
 name = "khive-mcp"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2026,7 +2026,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-agent"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2041,7 +2041,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-blob"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2059,7 +2059,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-brain"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2086,7 +2086,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-code"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2110,7 +2110,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-comm"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2134,7 +2134,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-formal"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "inventory",
@@ -2146,7 +2146,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-git"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2170,7 +2170,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-gtd"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2190,7 +2190,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-kg"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2212,7 +2212,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-knowledge"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2242,7 +2242,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-memory"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -2274,7 +2274,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-moodboard"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2301,7 +2301,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-schedule"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2324,7 +2324,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-session"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2344,7 +2344,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-template"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "inventory",
@@ -2357,7 +2357,7 @@ dependencies = [
 
 [[package]]
 name = "khive-pack-workspace"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "inventory",
@@ -2374,7 +2374,7 @@ dependencies = [
 
 [[package]]
 name = "khive-quant"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "criterion",
  "rand 0.8.7",
@@ -2383,7 +2383,7 @@ dependencies = [
 
 [[package]]
 name = "khive-query"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "criterion",
  "khive-types",
@@ -2393,7 +2393,7 @@ dependencies = [
 
 [[package]]
 name = "khive-repo-showcase"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "hex",
@@ -2410,7 +2410,7 @@ dependencies = [
 
 [[package]]
 name = "khive-request"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "criterion",
  "khive-types",
@@ -2420,7 +2420,7 @@ dependencies = [
 
 [[package]]
 name = "khive-retrieval"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2449,7 +2449,7 @@ dependencies = [
 
 [[package]]
 name = "khive-runtime"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2487,7 +2487,7 @@ dependencies = [
 
 [[package]]
 name = "khive-score"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "criterion",
  "khive-types",
@@ -2497,7 +2497,7 @@ dependencies = [
 
 [[package]]
 name = "khive-storage"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "khive-text"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "criterion",
  "rust-stemmers",
@@ -2521,7 +2521,7 @@ dependencies = [
 
 [[package]]
 name = "khive-types"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "blake3",
  "serde",
@@ -2530,7 +2530,7 @@ dependencies = [
 
 [[package]]
 name = "khive-vamana"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "blake3",
  "bytemuck",
@@ -2551,7 +2551,7 @@ dependencies = [
 
 [[package]]
 name = "khive-vcs"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2572,7 +2572,7 @@ dependencies = [
 
 [[package]]
 name = "khive-vcs-adapters"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "khive-types",
@@ -2584,7 +2584,7 @@ dependencies = [
 
 [[package]]
 name = "khive-wire-protocol"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "kkernel"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -55,7 +55,7 @@ exclude = ["khive-merge"]
 # keep this exclusion from members.
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 # lattice-embed and lattice-fann require Rust 1.93, setting the workspace MSRV.
 # The previous 1.91 floor came from floor_char_boundary use (issue #398).

--- a/crates/khive-bm25/Cargo.toml
+++ b/crates/khive-bm25/Cargo.toml
@@ -15,8 +15,8 @@ description = "BM25 (Okapi BM25) keyword index with deterministic scoring"
 bench = false
 
 [dependencies]
-khive-score = { version = "0.7.0", path = "../khive-score" }
-khive-text = { version = "0.7.0", path = "../khive-text" }
+khive-score = { version = "0.8.0", path = "../khive-score" }
+khive-text = { version = "0.8.0", path = "../khive-text" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/khive-brain-core/Cargo.toml
+++ b/crates/khive-brain-core/Cargo.toml
@@ -15,7 +15,7 @@ description = "Brain primitives — Beta posteriors, section types, profile stat
 bench = false
 
 [dependencies]
-khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
+khive-runtime = { version = "0.8.0", path = "../khive-runtime" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }

--- a/crates/khive-changeset/Cargo.toml
+++ b/crates/khive-changeset/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 description = "Producer-agnostic KG change-set op-list model and NDJSON-delta serialization"
 
 [dependencies]
-khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
+khive-types = { version = "0.8.0", path = "../khive-types", features = ["serde"] }
 serde = { workspace = true }
 # float_roundtrip: the default float parser is a fast approximation that does
 # not always recover the exact f64 bits a prior serialize wrote (weight/

--- a/crates/khive-channel-email/Cargo.toml
+++ b/crates/khive-channel-email/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 description = "Email (SMTP/IMAP) channel adapter for khive (ADR-056)"
 
 [dependencies]
-khive-channel = { version = "0.7.0", path = "../khive-channel" }
+khive-channel = { version = "0.8.0", path = "../khive-channel" }
 async-trait = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }

--- a/crates/khive-channel-telegram/Cargo.toml
+++ b/crates/khive-channel-telegram/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 description = "Telegram Bot API channel adapter for khive (ADR-056)"
 
 [dependencies]
-khive-channel = { version = "0.7.0", path = "../khive-channel" }
+khive-channel = { version = "0.8.0", path = "../khive-channel" }
 async-trait = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }

--- a/crates/khive-db/Cargo.toml
+++ b/crates/khive-db/Cargo.toml
@@ -15,9 +15,9 @@ description = "SQLite storage backend: entities, edges, notes, events, FTS5, sql
 bench = false
 
 [dependencies]
-khive-storage = { version = "0.7.0", path = "../khive-storage" }
-khive-score = { version = "0.7.0", path = "../khive-score" }
-khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
+khive-storage = { version = "0.8.0", path = "../khive-storage" }
+khive-score = { version = "0.8.0", path = "../khive-score" }
+khive-types = { version = "0.8.0", path = "../khive-types", features = ["serde"] }
 tokio = { workspace = true }
 async-trait = { workspace = true }
 uuid = { workspace = true }
@@ -56,8 +56,8 @@ windows-sys = { version = "0.61", features = [
 tokio = { workspace = true, features = ["full", "test-util"] }
 rusqlite = { workspace = true, features = ["bundled", "column_decltype", "hooks", "limits", "functions"] }
 bytes = "1"
-khive-storage = { version = "0.7.0", path = "../khive-storage" }
-khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
+khive-storage = { version = "0.8.0", path = "../khive-storage" }
+khive-types = { version = "0.8.0", path = "../khive-types", features = ["serde"] }
 uuid = { workspace = true }
 criterion = { workspace = true }
 rand = { workspace = true }

--- a/crates/khive-fold/Cargo.toml
+++ b/crates/khive-fold/Cargo.toml
@@ -21,10 +21,10 @@ default = ["serde"]
 serde = ["dep:serde"]
 
 [dependencies]
-khive-score = { version = "0.7.0", path = "../khive-score" }
+khive-score = { version = "0.8.0", path = "../khive-score" }
 # ADR-024 boundary: khive-types + khive-score only.
 # blake3 feature enables Hash32::from_blake3 for checkpoint hashing.
-khive-types = { version = "0.7.0", path = "../khive-types", features = ["blake3", "serde"] }
+khive-types = { version = "0.8.0", path = "../khive-types", features = ["blake3", "serde"] }
 # serde: optional, gated by the `serde` feature above.
 serde = { workspace = true, optional = true }
 # serde_json: kept direct — serde_json::Value is used in FoldContext.extra,

--- a/crates/khive-fusion/Cargo.toml
+++ b/crates/khive-fusion/Cargo.toml
@@ -15,7 +15,7 @@ description = "Rank fusion strategies (RRF, Weighted, Union) with deterministic 
 bench = false
 
 [dependencies]
-khive-score = { version = "0.7.0", path = "../khive-score" }
+khive-score = { version = "0.8.0", path = "../khive-score" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/khive-gate-rego/Cargo.toml
+++ b/crates/khive-gate-rego/Cargo.toml
@@ -13,12 +13,12 @@ description = "Rego (Open Policy Agent) backend for khive-gate, powered by regor
 readme = "README.md"
 
 [dependencies]
-khive-gate = { version = "0.7.0", path = "../khive-gate" }
+khive-gate = { version = "0.8.0", path = "../khive-gate" }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 
 regorus = { workspace = true }
 
 [dev-dependencies]
-khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
+khive-types = { version = "0.8.0", path = "../khive-types", features = ["serde"] }
 tracing-subscriber = { workspace = true }

--- a/crates/khive-gate/Cargo.toml
+++ b/crates/khive-gate/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 description = "Pluggable authorization gate trait + default AllowAllGate impl for khive verb dispatch."
 
 [dependencies]
-khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
+khive-types = { version = "0.8.0", path = "../khive-types", features = ["serde"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/khive-hnsw/Cargo.toml
+++ b/crates/khive-hnsw/Cargo.toml
@@ -15,9 +15,9 @@ description = "HNSW (Hierarchical Navigable Small World) vector index with INT8 
 bench = false
 
 [dependencies]
-khive-score = { version = "0.7.0", path = "../khive-score" }
-khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
-khive-fold = { version = "0.7.0", path = "../khive-fold", optional = true }
+khive-score = { version = "0.8.0", path = "../khive-score" }
+khive-types = { version = "0.8.0", path = "../khive-types", features = ["serde"] }
+khive-fold = { version = "0.8.0", path = "../khive-fold", optional = true }
 lattice-embed = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/khive-mcp/Cargo.toml
+++ b/crates/khive-mcp/Cargo.toml
@@ -12,24 +12,24 @@ categories.workspace = true
 description = "khive MCP server library — served via the kkernel binary"
 
 [dependencies]
-khive-db = { version = "0.7.0", path = "../khive-db" }
-khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
-khive-storage = { version = "0.7.0", path = "../khive-storage" }
-khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
-khive-request = { version = "0.7.0", path = "../khive-request" }
-khive-pack-kg = { version = "0.7.0", path = "../khive-pack-kg" }
-khive-pack-gtd = { version = "0.7.0", path = "../khive-pack-gtd" }
-khive-pack-memory = { version = "0.7.0", path = "../khive-pack-memory" }
-khive-pack-brain = { version = "0.7.0", path = "../khive-pack-brain" }
-khive-pack-comm = { version = "0.7.0", path = "../khive-pack-comm" }
-khive-pack-schedule = { version = "0.7.0", path = "../khive-pack-schedule" }
-khive-pack-knowledge = { version = "0.7.0", path = "../khive-pack-knowledge" }
-khive-pack-session = { version = "0.7.0", path = "../khive-pack-session" }
-khive-pack-git = { version = "0.7.0", path = "../khive-pack-git" }
-khive-pack-code = { version = "0.7.0", path = "../khive-pack-code" }
-khive-pack-blob = { version = "0.7.0", path = "../khive-pack-blob" }
-khive-pack-moodboard = { version = "0.7.0", path = "../khive-pack-moodboard" }
-khive-pack-workspace = { version = "0.7.0", path = "../khive-pack-workspace" }
+khive-db = { version = "0.8.0", path = "../khive-db" }
+khive-runtime = { version = "0.8.0", path = "../khive-runtime" }
+khive-storage = { version = "0.8.0", path = "../khive-storage" }
+khive-types = { version = "0.8.0", path = "../khive-types", features = ["serde"] }
+khive-request = { version = "0.8.0", path = "../khive-request" }
+khive-pack-kg = { version = "0.8.0", path = "../khive-pack-kg" }
+khive-pack-gtd = { version = "0.8.0", path = "../khive-pack-gtd" }
+khive-pack-memory = { version = "0.8.0", path = "../khive-pack-memory" }
+khive-pack-brain = { version = "0.8.0", path = "../khive-pack-brain" }
+khive-pack-comm = { version = "0.8.0", path = "../khive-pack-comm" }
+khive-pack-schedule = { version = "0.8.0", path = "../khive-pack-schedule" }
+khive-pack-knowledge = { version = "0.8.0", path = "../khive-pack-knowledge" }
+khive-pack-session = { version = "0.8.0", path = "../khive-pack-session" }
+khive-pack-git = { version = "0.8.0", path = "../khive-pack-git" }
+khive-pack-code = { version = "0.8.0", path = "../khive-pack-code" }
+khive-pack-blob = { version = "0.8.0", path = "../khive-pack-blob" }
+khive-pack-moodboard = { version = "0.8.0", path = "../khive-pack-moodboard" }
+khive-pack-workspace = { version = "0.8.0", path = "../khive-pack-workspace" }
 uuid = { workspace = true }
 inventory = { workspace = true }
 rmcp = { workspace = true, features = ["server", "transport-io"] }
@@ -49,9 +49,9 @@ sha2 = { workspace = true }
 chrono = { workspace = true }
 tempfile = { workspace = true }
 lattice-embed = { workspace = true, optional = true }
-khive-channel = { version = "0.7.0", path = "../khive-channel", optional = true }
-khive-channel-email = { version = "0.7.0", path = "../khive-channel-email", optional = true }
-khive-channel-telegram = { version = "0.7.0", path = "../khive-channel-telegram", optional = true }
+khive-channel = { version = "0.8.0", path = "../khive-channel", optional = true }
+khive-channel-email = { version = "0.8.0", path = "../khive-channel-email", optional = true }
+khive-channel-telegram = { version = "0.8.0", path = "../khive-channel-telegram", optional = true }
 
 [features]
 # bench-embedder: inject deterministic FNV-1a hash embedder into the serve path.
@@ -73,9 +73,9 @@ test-forward-seam = []
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
-khive-runtime = { version = "0.7.0", path = "../khive-runtime", features = ["fault-injection"] }
+khive-runtime = { version = "0.8.0", path = "../khive-runtime", features = ["fault-injection"] }
 rmcp = { workspace = true, features = ["server", "transport-io", "client"] }
 async-trait = { workspace = true }
 serial_test = { workspace = true }
-khive-pack-knowledge = { version = "0.7.0", path = "../khive-pack-knowledge" }
+khive-pack-knowledge = { version = "0.8.0", path = "../khive-pack-knowledge" }
 rusqlite = { workspace = true, features = ["bundled"] }

--- a/crates/khive-merge/Cargo.lock
+++ b/crates/khive-merge/Cargo.lock
@@ -1175,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "khive-db"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -1204,7 +1204,7 @@ dependencies = [
 
 [[package]]
 name = "khive-fold"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -1218,7 +1218,7 @@ dependencies = [
 
 [[package]]
 name = "khive-fusion"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "khive-score",
  "serde",
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "khive-gate"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "khive-types",
@@ -1238,7 +1238,7 @@ dependencies = [
 
 [[package]]
 name = "khive-merge"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "khive-runtime",
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "khive-query"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "khive-types",
  "thiserror",
@@ -1260,7 +1260,7 @@ dependencies = [
 
 [[package]]
 name = "khive-runtime"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "khive-score"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "khive-types",
  "serde",
@@ -1302,7 +1302,7 @@ dependencies = [
 
 [[package]]
 name = "khive-storage"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1317,7 +1317,7 @@ dependencies = [
 
 [[package]]
 name = "khive-types"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "blake3",
  "serde",

--- a/crates/khive-merge/Cargo.toml
+++ b/crates/khive-merge/Cargo.toml
@@ -5,7 +5,7 @@
 # [workspace.package] below declares the shared version for this standalone workspace.
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 
 [package]
 name = "khive-merge"
@@ -18,8 +18,8 @@ homepage = "https://github.com/ohdearquant"
 description = "KG three-way merge with conflict detection (ADR-039)"
 
 [dependencies]
-khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
-khive-storage = { version = "0.7.0", path = "../khive-storage" }
+khive-runtime = { version = "0.8.0", path = "../khive-runtime" }
+khive-storage = { version = "0.8.0", path = "../khive-storage" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"

--- a/crates/khive-pack-agent/Cargo.toml
+++ b/crates/khive-pack-agent/Cargo.toml
@@ -12,9 +12,9 @@ categories.workspace = true
 description = "Agent verb pack — spawn/resume/kill/suspend/observe wire surface over the runtime-owned agent process table (ADR-142 §1)"
 
 [dependencies]
-khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde", "blake3"] }
-khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
-khive-storage = { version = "0.7.0", path = "../khive-storage" }
+khive-types = { version = "0.8.0", path = "../khive-types", features = ["serde", "blake3"] }
+khive-runtime = { version = "0.8.0", path = "../khive-runtime" }
+khive-storage = { version = "0.8.0", path = "../khive-storage" }
 async-trait = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }
@@ -22,4 +22,4 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-khive-pack-kg = { version = "0.7.0", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.8.0", path = "../khive-pack-kg" }

--- a/crates/khive-pack-blob/Cargo.toml
+++ b/crates/khive-pack-blob/Cargo.toml
@@ -12,9 +12,9 @@ categories.workspace = true
 description = "Blob verb pack — thin MCP verbs (put/get/stat) over the existing BlobStore CAS"
 
 [dependencies]
-khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
-khive-storage = { version = "0.7.0", path = "../khive-storage" }
+khive-types = { version = "0.8.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.8.0", path = "../khive-runtime" }
+khive-storage = { version = "0.8.0", path = "../khive-storage" }
 async-trait = { workspace = true }
 base64 = { workspace = true }
 inventory = { workspace = true }
@@ -23,7 +23,7 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 blake3 = { workspace = true }
-khive-db = { version = "0.7.0", path = "../khive-db" }
+khive-db = { version = "0.8.0", path = "../khive-db" }
 tempfile = { workspace = true }
 tokio = { workspace = true }
 

--- a/crates/khive-pack-brain/Cargo.toml
+++ b/crates/khive-pack-brain/Cargo.toml
@@ -15,18 +15,18 @@ description = "Brain pack — profile-oriented orchestration via Fold + Objectiv
 bench = false
 
 [dependencies]
-khive-brain-core = { version = "0.7.0", path = "../khive-brain-core" }
-khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
-khive-fold = { version = "0.7.0", path = "../khive-fold" }
-khive-storage = { version = "0.7.0", path = "../khive-storage" }
+khive-brain-core = { version = "0.8.0", path = "../khive-brain-core" }
+khive-types = { version = "0.8.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.8.0", path = "../khive-runtime" }
+khive-fold = { version = "0.8.0", path = "../khive-fold" }
+khive-storage = { version = "0.8.0", path = "../khive-storage" }
 # ADR-081 §2/§6 (findings 1+2): the fold gate needs the event
 # append on the SAME held `SqlWriter` transaction as the dedup claim + mass
 # fold, so it calls khive-db's transaction-enlisted `append_event_on_writer`
 # seam directly rather than going through the higher-level `EventStore`
 # trait (which always opens its own transaction). No cycle: khive-db does not
 # depend on this crate.
-khive-db = { version = "0.7.0", path = "../khive-db" }
+khive-db = { version = "0.8.0", path = "../khive-db" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 lattice-fann = { workspace = true, optional = true }
@@ -42,7 +42,7 @@ lattice-router = ["dep:lattice-fann"]
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
-khive-pack-kg = { version = "0.7.0", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.8.0", path = "../khive-pack-kg" }
 # Dev-only: exercises the real memory.recall -> BrainPack dispatch-hook path
 # (issue #459 regression). khive-pack-memory already carries khive-pack-brain
 # as a dev-dependency for its own tests; Cargo permits cyclic dev-dependencies

--- a/crates/khive-pack-code/Cargo.toml
+++ b/crates/khive-pack-code/Cargo.toml
@@ -12,9 +12,9 @@ categories.workspace = true
 description = "Code ontology pack - typed edge rules and audit findings vocabulary"
 
 [dependencies]
-khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
-khive-storage = { version = "0.7.0", path = "../khive-storage" }
+khive-types = { version = "0.8.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.8.0", path = "../khive-runtime" }
+khive-storage = { version = "0.8.0", path = "../khive-storage" }
 tokio = { workspace = true }
 inventory = { workspace = true }
 async-trait = { workspace = true }
@@ -30,6 +30,6 @@ syn = { workspace = true }
 quote = { workspace = true }
 
 [dev-dependencies]
-khive-pack-kg = { version = "0.7.0", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.8.0", path = "../khive-pack-kg" }
 tokio = { workspace = true, features = ["full"] }
 tempfile = { workspace = true }

--- a/crates/khive-pack-comm/Cargo.toml
+++ b/crates/khive-pack-comm/Cargo.toml
@@ -15,9 +15,9 @@ description = "Communication pack — inter-agent messaging (send, inbox, read, 
 bench = false
 
 [dependencies]
-khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
-khive-storage = { version = "0.7.0", path = "../khive-storage" }
+khive-types = { version = "0.8.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.8.0", path = "../khive-runtime" }
+khive-storage = { version = "0.8.0", path = "../khive-storage" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
@@ -29,11 +29,11 @@ tokio = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }
-khive-pack-kg = { version = "0.7.0", path = "../khive-pack-kg" }
-khive-db = { version = "0.7.0", path = "../khive-db" }
+khive-pack-kg = { version = "0.8.0", path = "../khive-pack-kg" }
+khive-db = { version = "0.8.0", path = "../khive-db" }
 criterion = { workspace = true }
 toml = { workspace = true }
-khive-runtime = { version = "0.7.0", path = "../khive-runtime", features = ["fault-injection"] }
+khive-runtime = { version = "0.8.0", path = "../khive-runtime", features = ["fault-injection"] }
 lattice-embed = { workspace = true }
 rusqlite = { workspace = true, features = ["bundled", "column_decltype"] }
 tempfile = { workspace = true }

--- a/crates/khive-pack-formal/Cargo.toml
+++ b/crates/khive-pack-formal/Cargo.toml
@@ -12,8 +12,8 @@ categories.workspace = true
 description = "Formal-math ontology pack — typed edge rules for theorem/definition/structure/instance/axiom/goal subtypes"
 
 [dependencies]
-khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
+khive-types = { version = "0.8.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.8.0", path = "../khive-runtime" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/khive-pack-git/Cargo.toml
+++ b/crates/khive-pack-git/Cargo.toml
@@ -12,10 +12,10 @@ categories.workspace = true
 description = "Git-lifecycle pack — commit/issue/pull_request provenance notes over the notes substrate (ADR-088)"
 
 [dependencies]
-khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
+khive-types = { version = "0.8.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.8.0", path = "../khive-runtime" }
 inventory = { workspace = true }
-khive-storage = { version = "0.7.0", path = "../khive-storage" }
+khive-storage = { version = "0.8.0", path = "../khive-storage" }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -30,7 +30,7 @@ libc = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-khive-pack-kg = { version = "0.7.0", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.8.0", path = "../khive-pack-kg" }
 tempfile = { workspace = true }
-khive-runtime = { version = "0.7.0", path = "../khive-runtime", features = ["fault-injection"] }
+khive-runtime = { version = "0.8.0", path = "../khive-runtime", features = ["fault-injection"] }
 lattice-embed = { workspace = true }

--- a/crates/khive-pack-gtd/Cargo.toml
+++ b/crates/khive-pack-gtd/Cargo.toml
@@ -15,10 +15,10 @@ description = "GTD verb pack — task lifecycle (assign/next/complete/transition
 bench = false
 
 [dependencies]
-khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
+khive-types = { version = "0.8.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.8.0", path = "../khive-runtime" }
 inventory = { workspace = true }
-khive-storage = { version = "0.7.0", path = "../khive-storage" }
+khive-storage = { version = "0.8.0", path = "../khive-storage" }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -29,7 +29,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-khive-pack-kg = { version = "0.7.0", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.8.0", path = "../khive-pack-kg" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/khive-pack-kg/Cargo.toml
+++ b/crates/khive-pack-kg/Cargo.toml
@@ -15,11 +15,11 @@ description = "KG verb pack — entity/note CRUD, graph traversal, hybrid search
 bench = false
 
 [dependencies]
-khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
-khive-query = { version = "0.7.0", path = "../khive-query" }
+khive-types = { version = "0.8.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.8.0", path = "../khive-runtime" }
+khive-query = { version = "0.8.0", path = "../khive-query" }
 inventory = { workspace = true }
-khive-storage = { version = "0.7.0", path = "../khive-storage" }
+khive-storage = { version = "0.8.0", path = "../khive-storage" }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 serde = { workspace = true }
@@ -32,7 +32,7 @@ tokio = { workspace = true, features = ["test-util"] }
 criterion = { workspace = true }
 serde_json = { workspace = true }
 khive-runtime = { path = "../khive-runtime", features = ["fault-injection", "test-internals"] }
-khive-pack-formal = { version = "0.7.0", path = "../khive-pack-formal" }
+khive-pack-formal = { version = "0.8.0", path = "../khive-pack-formal" }
 # Path-only: cyclic dev-dep pair with khive-pack-gtd; cargo strips it at publish.
 khive-pack-gtd = { path = "../khive-pack-gtd" }
 lattice-embed = { workspace = true }

--- a/crates/khive-pack-knowledge/Cargo.toml
+++ b/crates/khive-pack-knowledge/Cargo.toml
@@ -15,14 +15,14 @@ description = "Knowledge verb pack — lore corpus (atoms/domains), TF-IDF retri
 bench = false
 
 [dependencies]
-khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
-khive-brain-core = { version = "0.7.0", path = "../khive-brain-core" }
-khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
-khive-storage = { version = "0.7.0", path = "../khive-storage" }
-khive-fold = { version = "0.7.0", path = "../khive-fold" }
-khive-fusion = { version = "0.7.0", path = "../khive-fusion" }
-khive-score = { version = "0.7.0", path = "../khive-score" }
-khive-vamana = { version = "0.7.0", path = "../khive-vamana" }
+khive-types = { version = "0.8.0", path = "../khive-types", features = ["serde"] }
+khive-brain-core = { version = "0.8.0", path = "../khive-brain-core" }
+khive-runtime = { version = "0.8.0", path = "../khive-runtime" }
+khive-storage = { version = "0.8.0", path = "../khive-storage" }
+khive-fold = { version = "0.8.0", path = "../khive-fold" }
+khive-fusion = { version = "0.8.0", path = "../khive-fusion" }
+khive-score = { version = "0.8.0", path = "../khive-score" }
+khive-vamana = { version = "0.8.0", path = "../khive-vamana" }
 inventory = { workspace = true }
 tokio = { workspace = true }
 async-trait = { workspace = true }
@@ -36,9 +36,9 @@ toml = { workspace = true }
 libc = { workspace = true }
 
 [dev-dependencies]
-khive-pack-kg = { version = "0.7.0", path = "../khive-pack-kg" }
-khive-pack-brain = { version = "0.7.0", path = "../khive-pack-brain" }
-khive-storage = { version = "0.7.0", path = "../khive-storage" }
+khive-pack-kg = { version = "0.8.0", path = "../khive-pack-kg" }
+khive-pack-brain = { version = "0.8.0", path = "../khive-pack-brain" }
+khive-storage = { version = "0.8.0", path = "../khive-storage" }
 tokio = { workspace = true, features = ["test-util"] }
 lattice-embed = { workspace = true }
 criterion = { workspace = true }

--- a/crates/khive-pack-memory/Cargo.toml
+++ b/crates/khive-pack-memory/Cargo.toml
@@ -15,16 +15,16 @@ description = "Memory verb pack — remember/recall semantics with decay-aware r
 bench = false
 
 [dependencies]
-khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
-khive-fusion = { version = "0.7.0", path = "../khive-fusion" }
-khive-retrieval = { version = "0.7.0", path = "../khive-retrieval" }
-khive-score = { version = "0.7.0", path = "../khive-score" }
-khive-brain-core = { version = "0.7.0", path = "../khive-brain-core" }
-khive-vamana = { version = "0.7.0", path = "../khive-vamana" }
+khive-types = { version = "0.8.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.8.0", path = "../khive-runtime" }
+khive-fusion = { version = "0.8.0", path = "../khive-fusion" }
+khive-retrieval = { version = "0.8.0", path = "../khive-retrieval" }
+khive-score = { version = "0.8.0", path = "../khive-score" }
+khive-brain-core = { version = "0.8.0", path = "../khive-brain-core" }
+khive-vamana = { version = "0.8.0", path = "../khive-vamana" }
 blake3 = { workspace = true }
 inventory = { workspace = true }
-khive-storage = { version = "0.7.0", path = "../khive-storage" }
+khive-storage = { version = "0.8.0", path = "../khive-storage" }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -36,9 +36,9 @@ lru = { workspace = true }
 parking_lot = { workspace = true }
 
 [dev-dependencies]
-khive-db = { version = "0.7.0", path = "../khive-db" }
-khive-pack-kg = { version = "0.7.0", path = "../khive-pack-kg" }
-khive-pack-brain = { version = "0.7.0", path = "../khive-pack-brain" }
+khive-db = { version = "0.8.0", path = "../khive-db" }
+khive-pack-kg = { version = "0.8.0", path = "../khive-pack-kg" }
+khive-pack-brain = { version = "0.8.0", path = "../khive-pack-brain" }
 tokio = { workspace = true, features = ["test-util"] }
 lattice-embed = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/khive-pack-moodboard/Cargo.toml
+++ b/crates/khive-pack-moodboard/Cargo.toml
@@ -12,9 +12,9 @@ categories.workspace = true
 description = "Experimental Khive-native visual retrieval and pairwise preference learning"
 
 [dependencies]
-khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
-khive-storage = { version = "0.7.0", path = "../khive-storage" }
+khive-types = { version = "0.8.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.8.0", path = "../khive-runtime" }
+khive-storage = { version = "0.8.0", path = "../khive-storage" }
 async-trait = { workspace = true }
 base64 = { workspace = true }
 blake3 = { workspace = true }
@@ -40,8 +40,8 @@ windows-sys = { version = "0.61", features = [
 ] }
 
 [dev-dependencies]
-khive-db = { version = "0.7.0", path = "../khive-db" }
-khive-pack-kg = { version = "0.7.0", path = "../khive-pack-kg" }
+khive-db = { version = "0.8.0", path = "../khive-db" }
+khive-pack-kg = { version = "0.8.0", path = "../khive-pack-kg" }
 
 [[test]]
 name = "integration"

--- a/crates/khive-pack-schedule/Cargo.toml
+++ b/crates/khive-pack-schedule/Cargo.toml
@@ -15,10 +15,10 @@ description = "Schedule pack — time-triggered intent storage (remind, schedule
 bench = false
 
 [dependencies]
-khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
-khive-storage = { version = "0.7.0", path = "../khive-storage" }
-khive-request = { version = "0.7.0", path = "../khive-request" }
+khive-types = { version = "0.8.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.8.0", path = "../khive-runtime" }
+khive-storage = { version = "0.8.0", path = "../khive-storage" }
+khive-request = { version = "0.8.0", path = "../khive-request" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
@@ -29,10 +29,10 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-khive-pack-kg = { version = "0.7.0", path = "../khive-pack-kg" }
-khive-pack-comm = { version = "0.7.0", path = "../khive-pack-comm" }
-khive-pack-brain = { version = "0.7.0", path = "../khive-pack-brain" }
-khive-pack-git = { version = "0.7.0", path = "../khive-pack-git" }
+khive-pack-kg = { version = "0.8.0", path = "../khive-pack-kg" }
+khive-pack-comm = { version = "0.8.0", path = "../khive-pack-comm" }
+khive-pack-brain = { version = "0.8.0", path = "../khive-pack-brain" }
+khive-pack-git = { version = "0.8.0", path = "../khive-pack-git" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/khive-pack-session/Cargo.toml
+++ b/crates/khive-pack-session/Cargo.toml
@@ -12,10 +12,10 @@ categories.workspace = true
 description = "Session verb pack - store/list/resume/export over the notes substrate"
 
 [dependencies]
-khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
+khive-types = { version = "0.8.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.8.0", path = "../khive-runtime" }
 inventory = { workspace = true }
-khive-storage = { version = "0.7.0", path = "../khive-storage" }
+khive-storage = { version = "0.8.0", path = "../khive-storage" }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -26,7 +26,7 @@ tokio = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-khive-pack-kg = { version = "0.7.0", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.8.0", path = "../khive-pack-kg" }
 tempfile = { workspace = true }
 # Test-only: builds a bare `PoolConfig { write_queue_enabled: true, .. }` +
 # `SqlBridge` directly (no `KhiveRuntime`, no `KHIVE_WRITE_QUEUE` env var) for
@@ -34,4 +34,4 @@ tempfile = { workspace = true }
 # established pattern in khive-pack-brain's `fold_gate.rs` and `persist.rs`
 # (documented there: env-var mutation races other tests' `KhiveRuntime::new`
 # calls in the same binary; a literal `PoolConfig` sidesteps that).
-khive-db = { version = "0.7.0", path = "../khive-db" }
+khive-db = { version = "0.8.0", path = "../khive-db" }

--- a/crates/khive-pack-template/Cargo.toml
+++ b/crates/khive-pack-template/Cargo.toml
@@ -12,12 +12,12 @@ categories.workspace = true
 description = "Reference template for new khive packs (ADR-023 §8). Copy this crate to get a working pack scaffold."
 
 [dependencies]
-khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
+khive-types = { version = "0.8.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.8.0", path = "../khive-runtime" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
-khive-pack-kg = { version = "0.7.0", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.8.0", path = "../khive-pack-kg" }

--- a/crates/khive-pack-workspace/Cargo.toml
+++ b/crates/khive-pack-workspace/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "Workspace pack  -  pack-owned `workspace` entity kind with typed `contains` membership edges to issue/pull_request/commit/task/session records (issue #873)"
 
 [dependencies]
-khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
+khive-types = { version = "0.8.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.8.0", path = "../khive-runtime" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 serde_json = { workspace = true }
@@ -20,7 +20,7 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-khive-pack-kg = { version = "0.7.0", path = "../khive-pack-kg" }
-khive-pack-gtd = { version = "0.7.0", path = "../khive-pack-gtd" }
-khive-pack-git = { version = "0.7.0", path = "../khive-pack-git" }
-khive-pack-session = { version = "0.7.0", path = "../khive-pack-session" }
+khive-pack-kg = { version = "0.8.0", path = "../khive-pack-kg" }
+khive-pack-gtd = { version = "0.8.0", path = "../khive-pack-gtd" }
+khive-pack-git = { version = "0.8.0", path = "../khive-pack-git" }
+khive-pack-session = { version = "0.8.0", path = "../khive-pack-session" }

--- a/crates/khive-query/Cargo.toml
+++ b/crates/khive-query/Cargo.toml
@@ -15,7 +15,7 @@ description = "GQL and SPARQL parsers with SQL compiler for knowledge graph quer
 bench = false
 
 [dependencies]
-khive-types = { version = "0.7.0", path = "../khive-types" }
+khive-types = { version = "0.8.0", path = "../khive-types" }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/khive-request/Cargo.toml
+++ b/crates/khive-request/Cargo.toml
@@ -15,7 +15,7 @@ description = "Request DSL — parses verb-dispatch strings (function-call, JSON
 bench = false
 
 [dependencies]
-khive-types = { version = "0.7.0", path = "../khive-types" }
+khive-types = { version = "0.8.0", path = "../khive-types" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/khive-retrieval/Cargo.toml
+++ b/crates/khive-retrieval/Cargo.toml
@@ -15,15 +15,15 @@ description = "Hybrid retrieval composer (HNSW + BM25 + fusion + graph + cross-e
 bench = false
 
 [dependencies]
-khive-hnsw    = { version = "0.7.0", path = "../khive-hnsw" }
-khive-bm25    = { version = "0.7.0", path = "../khive-bm25" }
-khive-fusion  = { version = "0.7.0", path = "../khive-fusion" }
-khive-score   = { version = "0.7.0", path = "../khive-score" }
-khive-types   = { version = "0.7.0", path = "../khive-types" }
-khive-fold    = { version = "0.7.0", path = "../khive-fold", optional = true }
-khive-storage = { version = "0.7.0", path = "../khive-storage", optional = true }
-khive-db      = { version = "0.7.0", path = "../khive-db" }
-khive-gate    = { version = "0.7.0", path = "../khive-gate", optional = true }
+khive-hnsw    = { version = "0.8.0", path = "../khive-hnsw" }
+khive-bm25    = { version = "0.8.0", path = "../khive-bm25" }
+khive-fusion  = { version = "0.8.0", path = "../khive-fusion" }
+khive-score   = { version = "0.8.0", path = "../khive-score" }
+khive-types   = { version = "0.8.0", path = "../khive-types" }
+khive-fold    = { version = "0.8.0", path = "../khive-fold", optional = true }
+khive-storage = { version = "0.8.0", path = "../khive-storage", optional = true }
+khive-db      = { version = "0.8.0", path = "../khive-db" }
+khive-gate    = { version = "0.8.0", path = "../khive-gate", optional = true }
 lattice-embed = { workspace = true }
 
 serde = { workspace = true }
@@ -62,8 +62,8 @@ embed = []
 
 [dev-dependencies]
 criterion = { workspace = true }
-khive-score = { version = "0.7.0", path = "../khive-score" }
-khive-fusion = { version = "0.7.0", path = "../khive-fusion" }
+khive-score = { version = "0.8.0", path = "../khive-score" }
+khive-fusion = { version = "0.8.0", path = "../khive-fusion" }
 
 [[bench]]
 name = "fusion_bench"

--- a/crates/khive-runtime/Cargo.toml
+++ b/crates/khive-runtime/Cargo.toml
@@ -16,14 +16,14 @@ fault-injection = []
 test-internals = []
 
 [dependencies]
-khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde", "blake3"] }
-khive-storage = { version = "0.7.0", path = "../khive-storage" }
-khive-score = { version = "0.7.0", path = "../khive-score" }
-khive-fusion = { version = "0.7.0", path = "../khive-fusion" }
-khive-fold = { version = "0.7.0", path = "../khive-fold" }
-khive-db = { version = "0.7.0", path = "../khive-db", features = ["vectors"] }
-khive-query = { version = "0.7.0", path = "../khive-query" }
-khive-gate = { version = "0.7.0", path = "../khive-gate" }
+khive-types = { version = "0.8.0", path = "../khive-types", features = ["serde", "blake3"] }
+khive-storage = { version = "0.8.0", path = "../khive-storage" }
+khive-score = { version = "0.8.0", path = "../khive-score" }
+khive-fusion = { version = "0.8.0", path = "../khive-fusion" }
+khive-fold = { version = "0.8.0", path = "../khive-fold" }
+khive-db = { version = "0.8.0", path = "../khive-db", features = ["vectors"] }
+khive-query = { version = "0.8.0", path = "../khive-query" }
+khive-gate = { version = "0.8.0", path = "../khive-gate" }
 inventory = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
@@ -46,7 +46,7 @@ unicode-general-category = { workspace = true }
 sha2 = { workspace = true }
 
 [dev-dependencies]
-khive-gate-rego = { version = "0.7.0", path = "../khive-gate-rego" }
+khive-gate-rego = { version = "0.8.0", path = "../khive-gate-rego" }
 tokio = { workspace = true, features = ["test-util"] }
 tempfile = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/khive-score/Cargo.toml
+++ b/crates/khive-score/Cargo.toml
@@ -18,7 +18,7 @@ default = ["serde"]
 serde = ["dep:serde"]
 
 [dependencies]
-khive-types = { version = "0.7.0", path = "../khive-types" }
+khive-types = { version = "0.8.0", path = "../khive-types" }
 serde = { workspace = true, optional = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/crates/khive-storage/Cargo.toml
+++ b/crates/khive-storage/Cargo.toml
@@ -13,8 +13,8 @@ categories.workspace = true
 [dependencies]
 async-trait = { workspace = true }
 chrono = { workspace = true }
-khive-score = { version = "0.7.0", path = "../khive-score" }
-khive-types = { version = "0.7.0", path = "../khive-types", features = ["serde"] }
+khive-score = { version = "0.8.0", path = "../khive-score" }
+khive-types = { version = "0.8.0", path = "../khive-types", features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/khive-vamana/Cargo.toml
+++ b/crates/khive-vamana/Cargo.toml
@@ -27,7 +27,7 @@ serde = { workspace = true }
 thiserror = { workspace = true }
 blake3 = { workspace = true }
 uuid = { workspace = true, optional = true }
-khive-quant = { version = "0.7.0", path = "../khive-quant", default-features = false }
+khive-quant = { version = "0.8.0", path = "../khive-quant", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/khive-vcs-adapters/Cargo.toml
+++ b/crates/khive-vcs-adapters/Cargo.toml
@@ -11,7 +11,7 @@ description = "KG import/export format adapters — CSV, JSON, and future format
 
 [dependencies]
 chrono = { workspace = true }
-khive-types = { version = "0.7.0", path = "../khive-types" }
+khive-types = { version = "0.8.0", path = "../khive-types" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/khive-vcs/Cargo.toml
+++ b/crates/khive-vcs/Cargo.toml
@@ -10,9 +10,9 @@ homepage.workspace = true
 description = "KG versioning — git-native core types, canonical hash, and NDJSON-to-SQLite sync (ADR-010/ADR-020)"
 
 [dependencies]
-khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
-khive-storage = { version = "0.7.0", path = "../khive-storage" }
-khive-types = { version = "0.7.0", path = "../khive-types" }
+khive-runtime = { version = "0.8.0", path = "../khive-runtime" }
+khive-storage = { version = "0.8.0", path = "../khive-storage" }
+khive-types = { version = "0.8.0", path = "../khive-types" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
@@ -26,5 +26,5 @@ tempfile = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "macros"] }
-khive-vcs-adapters = { version = "0.7.0", path = "../khive-vcs-adapters" }
-khive-db = { version = "0.7.0", path = "../khive-db" }
+khive-vcs-adapters = { version = "0.8.0", path = "../khive-vcs-adapters" }
+khive-db = { version = "0.8.0", path = "../khive-db" }

--- a/crates/kkernel/Cargo.toml
+++ b/crates/kkernel/Cargo.toml
@@ -12,31 +12,31 @@ categories.workspace = true
 description = "khive kernel — stdio MCP server binary and admin CLI (sync, pack introspection, db ops)"
 
 [dependencies]
-khive-runtime = { version = "0.7.0", path = "../khive-runtime" }
-khive-mcp = { version = "0.7.0", path = "../khive-mcp" }
-khive-score = { version = "0.7.0", path = "../khive-score" }
-khive-db = { version = "0.7.0", path = "../khive-db" }
-khive-storage = { version = "0.7.0", path = "../khive-storage" }
-khive-types = { version = "0.7.0", path = "../khive-types" }
-khive-vcs = { version = "0.7.0", path = "../khive-vcs" }
-khive-vcs-adapters = { version = "0.7.0", path = "../khive-vcs-adapters" }
-khive-pack-kg = { version = "0.7.0", path = "../khive-pack-kg" }
-khive-pack-gtd = { version = "0.7.0", path = "../khive-pack-gtd" }
-khive-pack-memory = { version = "0.7.0", path = "../khive-pack-memory" }
-khive-pack-brain = { version = "0.7.0", path = "../khive-pack-brain" }
-khive-pack-comm = { version = "0.7.0", path = "../khive-pack-comm" }
-khive-pack-schedule = { version = "0.7.0", path = "../khive-pack-schedule" }
-khive-pack-formal = { version = "0.7.0", path = "../khive-pack-formal" }
-khive-pack-code = { version = "0.7.0", path = "../khive-pack-code" }
-khive-pack-knowledge = { version = "0.7.0", path = "../khive-pack-knowledge" }
-khive-pack-session = { version = "0.7.0", path = "../khive-pack-session" }
-khive-pack-git = { version = "0.7.0", path = "../khive-pack-git" }
-khive-pack-blob = { version = "0.7.0", path = "../khive-pack-blob" }
-khive-pack-moodboard = { version = "0.7.0", path = "../khive-pack-moodboard" }
-khive-pack-workspace = { version = "0.7.0", path = "../khive-pack-workspace" }
-khive-request = { version = "0.7.0", path = "../khive-request" }
-khive-changeset = { version = "0.7.0", path = "../khive-changeset" }
-khive-repo-showcase = { version = "0.7.0", path = "../khive-repo-showcase" }
+khive-runtime = { version = "0.8.0", path = "../khive-runtime" }
+khive-mcp = { version = "0.8.0", path = "../khive-mcp" }
+khive-score = { version = "0.8.0", path = "../khive-score" }
+khive-db = { version = "0.8.0", path = "../khive-db" }
+khive-storage = { version = "0.8.0", path = "../khive-storage" }
+khive-types = { version = "0.8.0", path = "../khive-types" }
+khive-vcs = { version = "0.8.0", path = "../khive-vcs" }
+khive-vcs-adapters = { version = "0.8.0", path = "../khive-vcs-adapters" }
+khive-pack-kg = { version = "0.8.0", path = "../khive-pack-kg" }
+khive-pack-gtd = { version = "0.8.0", path = "../khive-pack-gtd" }
+khive-pack-memory = { version = "0.8.0", path = "../khive-pack-memory" }
+khive-pack-brain = { version = "0.8.0", path = "../khive-pack-brain" }
+khive-pack-comm = { version = "0.8.0", path = "../khive-pack-comm" }
+khive-pack-schedule = { version = "0.8.0", path = "../khive-pack-schedule" }
+khive-pack-formal = { version = "0.8.0", path = "../khive-pack-formal" }
+khive-pack-code = { version = "0.8.0", path = "../khive-pack-code" }
+khive-pack-knowledge = { version = "0.8.0", path = "../khive-pack-knowledge" }
+khive-pack-session = { version = "0.8.0", path = "../khive-pack-session" }
+khive-pack-git = { version = "0.8.0", path = "../khive-pack-git" }
+khive-pack-blob = { version = "0.8.0", path = "../khive-pack-blob" }
+khive-pack-moodboard = { version = "0.8.0", path = "../khive-pack-moodboard" }
+khive-pack-workspace = { version = "0.8.0", path = "../khive-pack-workspace" }
+khive-request = { version = "0.8.0", path = "../khive-request" }
+khive-changeset = { version = "0.8.0", path = "../khive-changeset" }
+khive-repo-showcase = { version = "0.8.0", path = "../khive-repo-showcase" }
 lru = { workspace = true }
 tokio = { workspace = true }
 async-trait = { workspace = true }
@@ -64,8 +64,8 @@ rmcp = { workspace = true, features = ["client", "transport-child-process"] }
 # Re-declares the [dependencies] khive-mcp with test instrumentation enabled:
 # Cargo unifies features across the build graph, so test builds see the
 # armed-capture hook while the release dependency above stays untouched.
-khive-mcp = { version = "0.7.0", path = "../khive-mcp", features = ["test-forward-seam"] }
-khive-gate-rego = { version = "0.7.0", path = "../khive-gate-rego" }
+khive-mcp = { version = "0.8.0", path = "../khive-mcp", features = ["test-forward-seam"] }
+khive-gate-rego = { version = "0.8.0", path = "../khive-gate-rego" }
 
 [features]
 # Pass-through: enables the deterministic hash embedder in the serve path (bench use only).

--- a/npm/cli-alias/package.json
+++ b/npm/cli-alias/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@khive-ai/cli",
-  "version": "0.2.8",
+  "version": "0.8.0",
   "description": "Alias for the khive package — research knowledge graph runtime",
   "license": "Apache-2.0",
   "repository": {
@@ -8,7 +8,7 @@
     "url": "https://github.com/ohdearquant/khive"
   },
   "dependencies": {
-    "khive": "0.2.8"
+    "khive": "0.8.0"
   },
   "bin": {
     "khive": "./node_modules/khive/bin/khive",

--- a/npm/kernel-darwin-arm64/package.json
+++ b/npm/kernel-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@khive-ai/kernel-darwin-arm64",
-  "version": "0.2.8",
+  "version": "0.8.0",
   "description": "khive Rust binaries for macOS Apple Silicon (arm64)",
   "license": "Apache-2.0",
   "repository": {

--- a/npm/kernel-darwin-x64/package.json
+++ b/npm/kernel-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@khive-ai/kernel-darwin-x64",
-  "version": "0.2.8",
+  "version": "0.8.0",
   "description": "khive Rust binaries for macOS Intel (x64)",
   "license": "Apache-2.0",
   "repository": {

--- a/npm/kernel-linux-arm64/package.json
+++ b/npm/kernel-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@khive-ai/kernel-linux-arm64",
-  "version": "0.2.8",
+  "version": "0.8.0",
   "description": "khive Rust binaries for Linux ARM64 glibc",
   "license": "Apache-2.0",
   "repository": {

--- a/npm/kernel-linux-x64-gnu/package.json
+++ b/npm/kernel-linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@khive-ai/kernel-linux-x64-gnu",
-  "version": "0.2.8",
+  "version": "0.8.0",
   "description": "khive Rust binaries for Linux x86_64 glibc",
   "license": "Apache-2.0",
   "repository": {

--- a/npm/kernel-linux-x64-musl/package.json
+++ b/npm/kernel-linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@khive-ai/kernel-linux-x64-musl",
-  "version": "0.2.8",
+  "version": "0.8.0",
   "description": "khive Rust binaries for Linux x86_64 musl (Alpine etc.)",
   "license": "Apache-2.0",
   "repository": {

--- a/npm/kernel-win32-x64/package.json
+++ b/npm/kernel-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@khive-ai/kernel-win32-x64",
-  "version": "0.2.8",
+  "version": "0.8.0",
   "description": "khive Rust binaries for Windows x86_64",
   "license": "Apache-2.0",
   "repository": {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "khive",
-  "version": "0.5.0",
+  "version": "0.8.0",
   "description": "Research knowledge graph runtime over MCP stdio, with typed entities, closed ontology, and hybrid search for AI research agents.",
   "license": "Apache-2.0",
   "repository": {
@@ -35,11 +35,11 @@
     "node": ">=18"
   },
   "optionalDependencies": {
-    "@khive-ai/kernel-darwin-arm64": "0.5.0",
-    "@khive-ai/kernel-darwin-x64": "0.5.0",
-    "@khive-ai/kernel-linux-x64-gnu": "0.5.0",
-    "@khive-ai/kernel-linux-x64-musl": "0.5.0",
-    "@khive-ai/kernel-linux-arm64": "0.5.0",
-    "@khive-ai/kernel-win32-x64": "0.5.0"
+    "@khive-ai/kernel-darwin-arm64": "0.8.0",
+    "@khive-ai/kernel-darwin-x64": "0.8.0",
+    "@khive-ai/kernel-linux-x64-gnu": "0.8.0",
+    "@khive-ai/kernel-linux-x64-musl": "0.8.0",
+    "@khive-ai/kernel-linux-arm64": "0.8.0",
+    "@khive-ai/kernel-win32-x64": "0.8.0"
   }
 }


### PR DESCRIPTION
Bumps the release sources to the version they were released as.

The `v0.8.0` tag was cut on a tree whose `crates/Cargo.toml` still declares
`0.7.0`, so nothing in the sources carried the new version. `crates.io` serves
`khive-mcp` at 0.7.0 and the npm umbrella at 0.5.0.

## What moves

- `crates/Cargo.toml` workspace version `0.7.0` -> `0.8.0`, plus the 195
  in-workspace dependency pins naming it across 39 crate manifests.
- `crates/khive-merge`, which declares its own `[workspace.package]` so it stays
  standalone-compilable outside the members list, with its own lockfile.
- npm umbrella `0.5.0` -> `0.8.0` together with its `optionalDependencies` pins;
  the six platform subpackages and `@khive-ai/cli` `0.2.8` -> `0.8.0`.

Third-party dependencies are untouched. `cargo update --workspace` moved 54
lockfile entries and every one is an in-workspace crate; 107 external
dependencies were left as they were.

## Why both Cargo and npm had to move

`.github/workflows/release.yml` guards its `workflow_dispatch` by comparing the
version input against two checked-in sources, the workspace version and the
umbrella `npm/package.json`. With either still on the old value a `0.8.0`
dispatch is rejected before it reaches a publish step.

The platform subpackage versions and the umbrella's dependency pins are
rewritten by that workflow at publish time, so bumping them here is for
consistency in the tree rather than a requirement of the guard.

## Deliberately unchanged

`benches/retrieval/gold/A_fused_direct.json` still records
`kkernel 0.7.0 (revision 913790e6...)`. That field records which binary produced
a stored measurement; it is not a version pin, and rewriting it would misstate
the provenance of the fixture.

`CHANGELOG.md` is not touched here.
