### PR TITLE
Make khive-pack-formal and khive-pack-moodboard optional dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,13 +76,21 @@ fmt-check:
 build:
 	cd crates && cargo build --workspace --release
 
+# pack-formal and pack-moodboard are listed here because this recipe builds the
+# binary an operator actually serves, and both packs are now optional crate
+# dependencies rather than unconditional ones. A default `cargo build` links
+# neither, which is the point of making them optional; a locally installed
+# kkernel still needs them, because FULL_PACKS above names `formal` and
+# verify-local-artifact runs the artifact with that list — a binary without the
+# pack answers `unknown pack name "formal"` and the verification gate fails.
+# The same applies at runtime to any KHIVE_PACKS naming `formal` or `moodboard`.
 build-local:
-	@echo "==> Building kkernel (release, channel-email, channel-telegram)..."
+	@echo "==> Building kkernel (release, channel-email, channel-telegram, pack-formal, pack-moodboard)..."
 	@python3 scripts/build_local_artifact.py \
 		--cargo "$$CARGO_VALUE" \
 		--manifest-path crates/Cargo.toml \
 		--package kkernel \
-		--features channel-email,channel-telegram \
+		--features channel-email,channel-telegram,pack-formal,pack-moodboard \
 		--receipt "$$LOCAL_BUILD_RECEIPT_VALUE"
 
 # Reject a FULL_PACKS/LOCAL_VERB_FLOOR value (from the Makefile default or a

--- a/crates/khive-mcp/Cargo.toml
+++ b/crates/khive-mcp/Cargo.toml
@@ -28,7 +28,7 @@ khive-pack-session = { version = "0.8.0", path = "../khive-pack-session" }
 khive-pack-git = { version = "0.8.0", path = "../khive-pack-git" }
 khive-pack-code = { version = "0.8.0", path = "../khive-pack-code" }
 khive-pack-blob = { version = "0.8.0", path = "../khive-pack-blob" }
-khive-pack-moodboard = { version = "0.8.0", path = "../khive-pack-moodboard" }
+khive-pack-moodboard = { version = "0.8.0", path = "../khive-pack-moodboard", optional = true }
 khive-pack-workspace = { version = "0.8.0", path = "../khive-pack-workspace" }
 uuid = { workspace = true }
 inventory = { workspace = true }
@@ -64,6 +64,14 @@ channel-email = ["khive-channel", "khive-channel-email"]
 # Requires KHIVE_TELEGRAM_* environment variables at runtime; does nothing when unset.
 # Coexists with channel-email (ChannelRegistry keys by (kind, slug), #606).
 channel-telegram = ["khive-channel", "khive-channel-telegram"]
+# pack-moodboard: link the opt-in, experimental khive-pack-moodboard crate
+# (visual-asset ingest, exact descriptor-space retrieval, and calibrated
+# pairwise preference learning). Off by default — the pack is not in
+# RuntimeConfig::built_in_packs() and must still be selected explicitly via
+# KHIVE_PACKS/--pack at runtime even when this feature is compiled in. With
+# this feature off, V21's attachment cutover fails closed instead of
+# migrating legacy moodboard preference models — see attachment_cutover.rs.
+pack-moodboard = ["khive-pack-moodboard"]
 # test-forward-seam: expose `daemon::test_forward_seam`, a one-shot capture
 # hook at the entry of `forward_or_spawn_with_config`, to crates outside this
 # one. Test-instrumentation only — unarmed, it has no runtime effect. Enabled

--- a/crates/khive-mcp/src/attachment_cutover.rs
+++ b/crates/khive-mcp/src/attachment_cutover.rs
@@ -4,11 +4,42 @@ use std::sync::Arc;
 
 use anyhow::Context as _;
 use khive_db::migrations::AttachmentCutoverStatus;
-use khive_runtime::{BlobHydrator, StorageBackend};
+use khive_runtime::{BlobHydrator, LegacyPreferenceVerifier, RuntimeError, StorageBackend};
 use khive_storage::types::{SqlStatement, SqlValue};
-use khive_storage::{Attachment, AttachmentSubstrate};
+use khive_storage::{Attachment, AttachmentSubstrate, SqlAccess};
 
 const FANN_NETWORK_ROLE: &str = "fann-network";
+
+/// Count legacy (pre-V21) moodboard preference-model artifact rows,
+/// including soft-deleted ones.
+///
+/// This is the core-side twin of `khive_pack_moodboard::legacy_preference_model_count`
+/// (same SQL, same label) — it lets V21 detect legacy moodboard rows without
+/// linking `khive-pack-moodboard`, which is an optional dependency. The
+/// query itself uses no moodboard types: it is a plain count over `entities`.
+/// `'moodboard_model'` is a value in the data, not a code dependency on the
+/// pack.
+pub(crate) async fn legacy_preference_model_count(
+    sql: &dyn SqlAccess,
+) -> Result<u64, RuntimeError> {
+    let mut reader = sql.reader().await?;
+    match reader
+        .query_scalar(SqlStatement {
+            sql: "SELECT COUNT(*) FROM entities \
+                  WHERE kind = 'artifact' AND entity_type = 'moodboard_model' \
+                    AND content_ref IS NOT NULL"
+                .to_string(),
+            params: vec![],
+            label: Some("moodboard_legacy_preference_model_count".to_string()),
+        })
+        .await?
+    {
+        Some(SqlValue::Integer(count)) if count >= 0 => Ok(count as u64),
+        other => Err(RuntimeError::Internal(format!(
+            "moodboard legacy preference model count returned invalid value {other:?}"
+        ))),
+    }
+}
 
 enum CutoverMode {
     Main,
@@ -90,6 +121,24 @@ async fn scalar_count(
     }
 }
 
+/// The V21 legacy-moodboard verifier for this build, or `None` when compiled
+/// without the `pack-moodboard` feature.
+///
+/// Boot call sites use this instead of naming `khive-pack-moodboard`
+/// directly, so the optional dependency stays confined to this one seam.
+#[cfg(feature = "pack-moodboard")]
+pub(crate) fn legacy_preference_verifier() -> Option<Arc<dyn LegacyPreferenceVerifier>> {
+    Some(Arc::new(
+        khive_pack_moodboard::MoodboardLegacyPreferenceVerifier,
+    ))
+}
+
+/// See the `pack-moodboard` variant above; this build ships no verifier.
+#[cfg(not(feature = "pack-moodboard"))]
+pub(crate) fn legacy_preference_verifier() -> Option<Arc<dyn LegacyPreferenceVerifier>> {
+    None
+}
+
 async fn cutover_status(backend: Arc<StorageBackend>) -> anyhow::Result<AttachmentCutoverStatus> {
     tokio::task::spawn_blocking(move || backend.attachment_cutover_status())
         .await
@@ -152,8 +201,9 @@ pub(crate) async fn require_secondary_attachment_empty(
 pub(crate) async fn coordinate_attachment_cutover(
     backend: Arc<StorageBackend>,
     hydrator: Option<Arc<BlobHydrator>>,
+    verifier: Option<Arc<dyn LegacyPreferenceVerifier>>,
 ) -> anyhow::Result<()> {
-    coordinate_attachment_cutover_inner(backend, hydrator, CutoverMode::Main).await
+    coordinate_attachment_cutover_inner(backend, hydrator, verifier, CutoverMode::Main).await
 }
 
 /// Finish an interrupted empty secondary without ever making it an
@@ -165,6 +215,7 @@ pub(crate) async fn coordinate_empty_secondary_attachment_cutover(
     coordinate_attachment_cutover_inner(
         backend,
         None,
+        None,
         CutoverMode::EmptySecondary {
             backend_name: backend_name.to_string(),
         },
@@ -175,6 +226,7 @@ pub(crate) async fn coordinate_empty_secondary_attachment_cutover(
 async fn coordinate_attachment_cutover_inner(
     backend: Arc<StorageBackend>,
     hydrator: Option<Arc<BlobHydrator>>,
+    verifier: Option<Arc<dyn LegacyPreferenceVerifier>>,
     mode: CutoverMode,
 ) -> anyhow::Result<()> {
     if cutover_status(Arc::clone(&backend)).await? == AttachmentCutoverStatus::Complete {
@@ -227,25 +279,30 @@ async fn coordinate_attachment_cutover_inner(
             Vec::new()
         } else {
             let sql = backend.sql();
-            let legacy_model_count =
-                khive_pack_moodboard::legacy_preference_model_count(sql.as_ref())
-                    .await
-                    .context("count legacy moodboard preference models")?;
+            let legacy_model_count = legacy_preference_model_count(sql.as_ref())
+                .await
+                .context("count legacy moodboard preference models")?;
             if legacy_model_count == 0 {
                 Vec::new()
             } else {
+                let verifier = verifier.as_ref().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "V21 found {legacy_model_count} legacy moodboard preference model(s), but \
+                         this build has no moodboard support (compiled without the \
+                         `pack-moodboard` feature); rebuild with that feature enabled to \
+                         migrate them, then retry boot"
+                    )
+                })?;
                 let hydrator = hydrator.as_ref().ok_or_else(|| {
                     anyhow::anyhow!(
                         "V21 found {legacy_model_count} legacy moodboard preference model(s), but \
                          no BlobHydrator is configured; configure [storage.blob] and retry boot"
                     )
                 })?;
-                let verified = khive_pack_moodboard::verify_legacy_preference_attachments(
-                    sql.as_ref(),
-                    hydrator.as_ref(),
-                )
-                .await
-                .context("verify legacy moodboard bundle/event/FANN evidence")?;
+                let verified = verifier
+                    .verify_legacy_preference_attachments(sql.as_ref(), hydrator.as_ref())
+                    .await
+                    .context("verify legacy moodboard bundle/event/FANN evidence")?;
                 if verified.len() as u64 != legacy_model_count {
                     anyhow::bail!(
                         "legacy moodboard verification returned {} attachment(s) for \
@@ -372,7 +429,7 @@ mod tests {
             ATTACHMENT_CUTOVER_VERSION - 1,
             "ordinary migration must stop before the coordinated legacy cutover"
         );
-        coordinate_attachment_cutover(Arc::clone(&backend), None)
+        coordinate_attachment_cutover(Arc::clone(&backend), None, None)
             .await
             .expect("non-model legacy content needs no BlobHydrator");
         assert_eq!(
@@ -400,8 +457,18 @@ mod tests {
         assert_eq!(legacy_columns, 0, "final V21 must drop the legacy column");
     }
 
+    /// Legacy count > 0 and no verifier installed (the default, feature-off
+    /// build) must fail closed rather than silently dropping the legacy
+    /// column with unmigrated models still on disk.
+    ///
+    /// Was: `legacy_model_without_hydrator_stays_incomplete_and_gc_refuses_to_run`,
+    /// which asserted the error contained "no BlobHydrator is configured".
+    /// Now: no verifier is ever passed in this test, so the *new* fail-closed
+    /// arm fires first — before hydrator configuration is even consulted —
+    /// and the assertion moves to the new message naming the legacy count
+    /// and the missing `pack-moodboard` feature.
     #[tokio::test]
-    async fn legacy_model_without_hydrator_stays_incomplete_and_gc_refuses_to_run() {
+    async fn legacy_model_without_verifier_fails_closed_and_gc_refuses_to_run() {
         let temp = tempfile::tempdir().unwrap();
         let db_path = temp.path().join("legacy-model.db");
         create_v20_database_fixture(&db_path, "moodboard_model", None);
@@ -411,7 +478,51 @@ mod tests {
             ATTACHMENT_CUTOVER_VERSION - 1
         );
 
-        let error = coordinate_attachment_cutover(Arc::clone(&backend), None)
+        let error = coordinate_attachment_cutover(Arc::clone(&backend), None, None)
+            .await
+            .expect_err("legacy model evidence requires an installed verifier");
+        let message = error.to_string();
+        assert!(
+            message.contains("1 legacy moodboard preference model"),
+            "error must name the legacy count: {message}"
+        );
+        assert!(
+            message.contains("pack-moodboard"),
+            "error must tell the operator which feature to rebuild with: {message}"
+        );
+        assert_eq!(
+            backend.attachment_cutover_status().unwrap(),
+            AttachmentCutoverStatus::Incomplete,
+            "a failed application stage must remain durably resumable"
+        );
+
+        let store = FsBlobStore::new(temp.path().join("blobs"), 0).unwrap();
+        let sweep_error = store
+            .transactional_orphan_sweep(backend.sql().as_ref(), false)
+            .await
+            .expect_err("GC must not run over an incomplete dual representation");
+        assert!(sweep_error.to_string().contains("fencing"));
+    }
+
+    /// With the `pack-moodboard` feature enabled, a verifier is installed but
+    /// no `BlobHydrator` is configured: the pre-existing hydrator-required
+    /// error must still fire, unchanged, for that case (only reachable past
+    /// the new fail-closed arm once a verifier exists).
+    #[cfg(feature = "pack-moodboard")]
+    #[tokio::test]
+    async fn legacy_model_with_verifier_but_no_hydrator_stays_incomplete_and_gc_refuses_to_run() {
+        let temp = tempfile::tempdir().unwrap();
+        let db_path = temp.path().join("legacy-model.db");
+        create_v20_database_fixture(&db_path, "moodboard_model", None);
+        let backend = Arc::new(StorageBackend::sqlite(&db_path).unwrap());
+        assert_eq!(
+            backend.prepare_core_schema().unwrap(),
+            ATTACHMENT_CUTOVER_VERSION - 1
+        );
+
+        let verifier: Arc<dyn LegacyPreferenceVerifier> =
+            Arc::new(khive_pack_moodboard::MoodboardLegacyPreferenceVerifier);
+        let error = coordinate_attachment_cutover(Arc::clone(&backend), None, Some(verifier))
             .await
             .expect_err("legacy model evidence requires configured blob hydration");
         assert!(error.to_string().contains("no BlobHydrator is configured"));
@@ -466,8 +577,16 @@ mod tests {
             std::fs::canonicalize(&db_path).expect("canonical fixture database"),
             Arc::clone(&barrier),
         );
-        let first = tokio::spawn(coordinate_attachment_cutover(Arc::clone(&backend), None));
-        let second = tokio::spawn(coordinate_attachment_cutover(Arc::clone(&backend), None));
+        let first = tokio::spawn(coordinate_attachment_cutover(
+            Arc::clone(&backend),
+            None,
+            None,
+        ));
+        let second = tokio::spawn(coordinate_attachment_cutover(
+            Arc::clone(&backend),
+            None,
+            None,
+        ));
 
         tokio::time::timeout(std::time::Duration::from_secs(5), barrier.wait())
             .await

--- a/crates/khive-mcp/src/pack.rs
+++ b/crates/khive-mcp/src/pack.rs
@@ -27,6 +27,7 @@ pub use khive_pack_kg::KgPack as _KgPack;
 pub use khive_pack_knowledge::KnowledgePack as _KnowledgePack;
 #[doc(hidden)]
 pub use khive_pack_memory::MemoryPack as _MemoryPack;
+#[cfg(feature = "pack-moodboard")]
 #[doc(hidden)]
 pub use khive_pack_moodboard::MoodboardPack as _MoodboardPack;
 #[doc(hidden)]

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -2516,7 +2516,7 @@ async fn schema_admin_requires_blob_hydrator(backend: Arc<StorageBackend>) -> an
     }
 
     Ok(
-        khive_pack_moodboard::legacy_preference_model_count(backend.sql().as_ref())
+        crate::attachment_cutover::legacy_preference_model_count(backend.sql().as_ref())
             .await
             .context("count legacy moodboard models before resolving blob storage")?
             != 0,
@@ -2693,6 +2693,7 @@ async fn prepare_configured_storage_topology(
     crate::attachment_cutover::coordinate_attachment_cutover(
         Arc::clone(&main_backend),
         shared_hydrator.clone(),
+        crate::attachment_cutover::legacy_preference_verifier(),
     )
     .await?;
 
@@ -3563,6 +3564,7 @@ pub async fn build_single_backend_runtime(
     crate::attachment_cutover::coordinate_attachment_cutover(
         Arc::clone(&backend),
         hydrator.clone(),
+        crate::attachment_cutover::legacy_preference_verifier(),
     )
     .await?;
 
@@ -3605,8 +3607,12 @@ async fn prepare_single_backend_for_schema_admin(
     } else {
         None
     };
-    crate::attachment_cutover::coordinate_attachment_cutover(Arc::clone(&backend), hydrator)
-        .await?;
+    crate::attachment_cutover::coordinate_attachment_cutover(
+        Arc::clone(&backend),
+        hydrator,
+        crate::attachment_cutover::legacy_preference_verifier(),
+    )
+    .await?;
     Ok(backend)
 }
 
@@ -6399,6 +6405,9 @@ region = "us-east-1"
         }
     }
 
+    // Requires the "moodboard" pack name to be registered, which only
+    // happens when the optional khive-pack-moodboard crate is linked in.
+    #[cfg(feature = "pack-moodboard")]
     #[tokio::test]
     async fn multi_backend_boot_shares_one_hydrator_across_default_core_blob_and_moodboard() {
         let blob_root = tempfile::tempdir().expect("blob root");

--- a/crates/khive-pack-moodboard/src/lib.rs
+++ b/crates/khive-pack-moodboard/src/lib.rs
@@ -24,7 +24,7 @@ use model::VisionModelState;
 
 pub use preference_artifact::{
     legacy_preference_model_count, verify_legacy_preference_attachments,
-    VerifiedModelNetworkAttachment,
+    MoodboardLegacyPreferenceVerifier, VerifiedModelNetworkAttachment,
 };
 
 pub(crate) const PACK_NAME: &str = "moodboard";

--- a/crates/khive-pack-moodboard/src/preference_artifact.rs
+++ b/crates/khive-pack-moodboard/src/preference_artifact.rs
@@ -466,6 +466,8 @@ pub async fn verify_legacy_preference_attachments(
 #[derive(Debug, Default)]
 pub struct MoodboardLegacyPreferenceVerifier;
 
+impl khive_runtime::preference_verification::sealed::Sealed for MoodboardLegacyPreferenceVerifier {}
+
 #[async_trait::async_trait]
 impl LegacyPreferenceVerifier for MoodboardLegacyPreferenceVerifier {
     async fn verify_legacy_preference_attachments(

--- a/crates/khive-pack-moodboard/src/preference_artifact.rs
+++ b/crates/khive-pack-moodboard/src/preference_artifact.rs
@@ -1,12 +1,14 @@
 //! Authenticated preference-model artifact verification shared by serving and boot cutover.
 
-use khive_runtime::{BlobHydrator, RuntimeError};
+use khive_runtime::{BlobHydrator, LegacyPreferenceVerifier, RuntimeError};
 use khive_storage::blob::ContentRef;
 use khive_storage::event::Event;
 use khive_storage::types::{PageRequest, SqlRow, SqlStatement, SqlValue};
 use khive_storage::SqlAccess;
 use khive_types::{EventKind, EventOutcome, SubstrateKind};
 use uuid::Uuid;
+
+pub use khive_runtime::VerifiedModelNetworkAttachment;
 
 use crate::preference::{
     deserialize_fann, sha256_hex, validate_loaded_bundle, ModelBundle, PreferenceScope,
@@ -134,14 +136,6 @@ pub(crate) fn verify_preference_network(
         ));
     }
     deserialize_fann(network_bytes)
-}
-
-/// One authenticated network role for the attachment cutover coordinator.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct VerifiedModelNetworkAttachment {
-    pub model_id: Uuid,
-    pub network_content_ref: ContentRef,
-    pub size_bytes: u64,
 }
 
 /// Count every legacy preference-model candidate, including soft-deleted rows.
@@ -463,6 +457,24 @@ pub async fn verify_legacy_preference_attachments(
         }
     }
     Ok(verified_rows)
+}
+
+/// [`LegacyPreferenceVerifier`] implementation delegating to
+/// [`verify_legacy_preference_attachments`], so `khive-mcp`'s V21 cutover can
+/// authenticate legacy moodboard evidence without depending on this crate
+/// directly.
+#[derive(Debug, Default)]
+pub struct MoodboardLegacyPreferenceVerifier;
+
+#[async_trait::async_trait]
+impl LegacyPreferenceVerifier for MoodboardLegacyPreferenceVerifier {
+    async fn verify_legacy_preference_attachments(
+        &self,
+        sql: &dyn SqlAccess,
+        hydrator: &BlobHydrator,
+    ) -> Result<Vec<VerifiedModelNetworkAttachment>, RuntimeError> {
+        verify_legacy_preference_attachments(sql, hydrator).await
+    }
 }
 
 #[cfg(test)]

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -29,6 +29,7 @@ pub mod operations;
 pub mod pack;
 pub mod phase_events;
 pub mod portability;
+pub mod preference_verification;
 pub mod presentation;
 pub mod reference_resolution;
 pub mod reference_ring;
@@ -125,6 +126,7 @@ pub use pack::{
 };
 pub use phase_events::{emit_phase_event, is_benign_shutdown_cancellation};
 pub use portability::{ImportSummary, KgArchive};
+pub use preference_verification::{LegacyPreferenceVerifier, VerifiedModelNetworkAttachment};
 pub use presentation::{
     apply_redundancy_drop, micros_to_iso, present, render_format, rfc3339_to_utc_micros,
     OutputFormat, PresentationMode,

--- a/crates/khive-runtime/src/preference_verification.rs
+++ b/crates/khive-runtime/src/preference_verification.rs
@@ -21,6 +21,24 @@ pub struct VerifiedModelNetworkAttachment {
     pub size_bytes: u64,
 }
 
+/// Restricts implementations of [`LegacyPreferenceVerifier`].
+///
+/// The verifier trait is `pub` because its one implementor lives in another
+/// crate, `khive-pack-moodboard`. It is not an extension point: the public
+/// commitment is the method shape the cutover calls, not open implementation.
+/// This supertrait is the marker that says so.
+///
+/// Note on what this does and does not enforce. Rust has no notion of
+/// "workspace-visible", so a marker a sibling crate can name is a marker any
+/// crate can name. This is the conventional sealing idiom — it prevents
+/// accidental implementation and documents intent — not a barrier a determined
+/// downstream cannot cross. Hard enforcement is unavailable while the
+/// implementor is a separate crate.
+#[doc(hidden)]
+pub mod sealed {
+    pub trait Sealed {}
+}
+
 /// Authenticates legacy moodboard preference-model bundle/event/FANN
 /// evidence for the V21 attachment cutover.
 ///
@@ -28,8 +46,10 @@ pub struct VerifiedModelNetworkAttachment {
 /// no implementation is installed and legacy rows exist, the cutover fails
 /// closed rather than silently dropping the legacy column with unmigrated
 /// models still on disk.
+///
+/// Sealed via [`sealed::Sealed`]; see that module for the scope of the seal.
 #[async_trait]
-pub trait LegacyPreferenceVerifier: Send + Sync {
+pub trait LegacyPreferenceVerifier: sealed::Sealed + Send + Sync {
     async fn verify_legacy_preference_attachments(
         &self,
         sql: &dyn SqlAccess,

--- a/crates/khive-runtime/src/preference_verification.rs
+++ b/crates/khive-runtime/src/preference_verification.rs
@@ -1,0 +1,38 @@
+//! Legacy moodboard preference-model verification, inverted behind a trait.
+//!
+//! `khive-mcp`'s V21 attachment cutover (ADR-121/ADR-160) must be able to
+//! authenticate legacy `khive-pack-moodboard` preference-model bundles
+//! without depending on that pack directly — the pack is opt-in and its
+//! crate dependency is feature-gated. `khive-runtime` already sits below
+//! both `khive-mcp` and `khive-pack-moodboard` in the dependency graph and
+//! already owns [`BlobHydrator`], so the trait lives here.
+
+use async_trait::async_trait;
+use khive_storage::{ContentRef, SqlAccess};
+use uuid::Uuid;
+
+use crate::{BlobHydrator, RuntimeError};
+
+/// One authenticated network role for the attachment cutover coordinator.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VerifiedModelNetworkAttachment {
+    pub model_id: Uuid,
+    pub network_content_ref: ContentRef,
+    pub size_bytes: u64,
+}
+
+/// Authenticates legacy moodboard preference-model bundle/event/FANN
+/// evidence for the V21 attachment cutover.
+///
+/// Implemented by `khive-pack-moodboard` when that pack is compiled in. When
+/// no implementation is installed and legacy rows exist, the cutover fails
+/// closed rather than silently dropping the legacy column with unmigrated
+/// models still on disk.
+#[async_trait]
+pub trait LegacyPreferenceVerifier: Send + Sync {
+    async fn verify_legacy_preference_attachments(
+        &self,
+        sql: &dyn SqlAccess,
+        hydrator: &BlobHydrator,
+    ) -> Result<Vec<VerifiedModelNetworkAttachment>, RuntimeError>;
+}

--- a/crates/kkernel/Cargo.toml
+++ b/crates/kkernel/Cargo.toml
@@ -26,13 +26,13 @@ khive-pack-memory = { version = "0.8.0", path = "../khive-pack-memory" }
 khive-pack-brain = { version = "0.8.0", path = "../khive-pack-brain" }
 khive-pack-comm = { version = "0.8.0", path = "../khive-pack-comm" }
 khive-pack-schedule = { version = "0.8.0", path = "../khive-pack-schedule" }
-khive-pack-formal = { version = "0.8.0", path = "../khive-pack-formal" }
+khive-pack-formal = { version = "0.8.0", path = "../khive-pack-formal", optional = true }
 khive-pack-code = { version = "0.8.0", path = "../khive-pack-code" }
 khive-pack-knowledge = { version = "0.8.0", path = "../khive-pack-knowledge" }
 khive-pack-session = { version = "0.8.0", path = "../khive-pack-session" }
 khive-pack-git = { version = "0.8.0", path = "../khive-pack-git" }
 khive-pack-blob = { version = "0.8.0", path = "../khive-pack-blob" }
-khive-pack-moodboard = { version = "0.8.0", path = "../khive-pack-moodboard" }
+khive-pack-moodboard = { version = "0.8.0", path = "../khive-pack-moodboard", optional = true }
 khive-pack-workspace = { version = "0.8.0", path = "../khive-pack-workspace" }
 khive-request = { version = "0.8.0", path = "../khive-request" }
 khive-changeset = { version = "0.8.0", path = "../khive-changeset" }
@@ -74,6 +74,15 @@ bench-embedder = ["khive-mcp/bench-embedder"]
 channel-email = ["khive-mcp/channel-email"]
 # Pass-through: enables the Telegram Bot API polling + outbox loop. Inert without KHIVE_TELEGRAM_* env vars.
 channel-telegram = ["khive-mcp/channel-telegram"]
+# Links the opt-in khive-pack-formal crate (typed edge endpoint rules for six
+# formal-math concept subtypes; pure ontology, no verbs). Not in the default
+# pack set — off by default.
+pack-formal = ["khive-pack-formal"]
+# Pass-through, plus links kkernel's own force-link reference: enables the
+# opt-in, experimental khive-pack-moodboard crate. Not in the default pack
+# set — off by default. See khive-mcp/Cargo.toml's pack-moodboard feature
+# for what leaving this off does to the V21 attachment cutover.
+pack-moodboard = ["khive-mcp/pack-moodboard", "khive-pack-moodboard"]
 
 [[bin]]
 name = "kkernel"

--- a/crates/kkernel/src/lib.rs
+++ b/crates/kkernel/src/lib.rs
@@ -39,12 +39,14 @@ mod _pack_links {
     use khive_pack_brain::BrainPack as _;
     use khive_pack_code::CodePack as _;
     use khive_pack_comm::CommPack as _;
+    #[cfg(feature = "pack-formal")]
     use khive_pack_formal::FormalPack as _;
     use khive_pack_git::GitPack as _;
     use khive_pack_gtd::GtdPack as _;
     use khive_pack_kg::KgPack as _;
     use khive_pack_knowledge::KnowledgePack as _;
     use khive_pack_memory::MemoryPack as _;
+    #[cfg(feature = "pack-moodboard")]
     use khive_pack_moodboard::MoodboardPack as _;
     use khive_pack_schedule::SchedulePack as _;
     use khive_pack_session::SessionPack as _;

--- a/crates/kkernel/tests/kg_commit_tier2.rs
+++ b/crates/kkernel/tests/kg_commit_tier2.rs
@@ -100,6 +100,9 @@ fn invalid_note_kind_op(id: &str) -> String {
 
 /// A `create` op for a `concept` entity carrying `entity_type` (the field
 /// H1's fix now projects into `entities.ndjson`).
+///
+/// Only used by the `pack-formal`-gated test below.
+#[cfg(feature = "pack-formal")]
 fn typed_concept_create_op(id: &str, name: &str, entity_type: &str) -> String {
     serde_json::json!({
         "op": "create",
@@ -136,6 +139,8 @@ fn described_concept_create_op(id: &str, name: &str, description: &str) -> Strin
     .to_string()
 }
 
+/// Only used by the `pack-formal`-gated test below.
+#[cfg(feature = "pack-formal")]
 fn link_op(id: &str, source: &str, target: &str, relation: &str) -> String {
     serde_json::json!({
         "op": "link",
@@ -373,6 +378,13 @@ fn kg_commit_fails_loud_on_malformed_changeset() {
 /// `entities.ndjson` the `edge-endpoint-types` rule reads. Before this fix
 /// both endpoints projected as plain `concept` with no `entity_type`, so the
 /// pack rule never matched and this change-set was wrongly rejected.
+///
+/// Requires `khive-pack-formal` to be linked into the `kkernel` binary this
+/// test shells out to: `edge_endpoint_types` reads pack-declared `EDGE_RULES`
+/// from every pack the binary links, independent of runtime pack selection,
+/// so the formal-only endpoint pairing only validates when the optional
+/// `pack-formal` feature is on.
+#[cfg(feature = "pack-formal")]
 #[test]
 fn kg_commit_lands_formal_typed_endpoint_with_edge_endpoint_types_enabled() {
     let repo = TempDir::new().expect("repo tmp");

--- a/docs/adr/ADR-160-shared-pack-infrastructure.md
+++ b/docs/adr/ADR-160-shared-pack-infrastructure.md
@@ -1014,6 +1014,26 @@ old path occurs in the same subphase that closes its last consumer.
 - Gate allow precedes the operation; Gate deny or infrastructure error never invokes the handler;
   visible scope does not become a by-ID namespace wall.
 
+##### Amendment 1 — the legacy preference verifier is inverted behind a trait
+
+`khive-pack-moodboard` is now an optional crate dependency rather than an unconditional one, so
+the cutover can no longer call into the pack directly. The legacy preference verification step
+moves behind `LegacyPreferenceVerifier` in `khive-runtime` (sealed; the moodboard pack is its one
+implementor), and the cutover holds it as `Option`, `Some` only when the build compiled the
+`pack-moodboard` feature. Detection is unaffected and stays in core: the legacy row count is a
+plain `SELECT COUNT(*)` over `entities` using no moodboard types.
+
+This splits the bullet above reading "an upgrade with moodboard disabled still migrates legacy
+models" into two cases, because "disabled" now has two meanings. A build that **compiled** the
+pack but does not **select** it at runtime through `KHIVE_PACKS`/`--pack` behaves exactly as that
+bullet states: the verifier is installed, and legacy models migrate. A build **compiled without**
+the feature has no verifier at all, and there the cutover **fails closed** — it refuses with an
+error naming the legacy count rather than completing V21 and dropping `entities.content_ref`
+while unmigrated models remain on disk. Silently proceeding would be data loss, so the operator
+is told to rebuild with the feature enabled, migrate, and retry boot. When the legacy count is
+zero, which is the overwhelmingly common case, the absent verifier is irrelevant and boot is
+unchanged.
+
 ### Embedding identity and migration
 
 - Moodboard canonical descriptor bytes, fingerprint, model key, response, and table selection are

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -295,7 +295,14 @@ phase_no_default_features() {
 
 phase_release() {
     echo "=== Build (release) ==="
-    cargo build --workspace --release
+    # pack-formal is an optional dependency, so a default build does not link it.
+    # smoke_test.py's formal section spawns the binary with `--pack formal` to
+    # cover the pack's additive EntityOfType endpoint rules, and an unlinked pack
+    # is UnknownPack at startup, not a skip. Link it here so that coverage
+    # survives. pack-moodboard is deliberately NOT linked: it registers verbs,
+    # and test_documented_verb_counts.py asserts the verb surface in this same
+    # phase.
+    cargo build --workspace --release --features kkernel/pack-formal
 }
 
 phase_contract_tests() {


### PR DESCRIPTION
Make the two non-default packs, `khive-pack-moodboard` and `khive-pack-formal`, optional dependencies, and stop a core migration path from depending on an experimental opt-in pack.

## The problem

Both packs are documented as not in the default set. `khive-pack-moodboard`'s crate doc says
"not in the default pack set; select it explicitly via `KHIVE_PACKS` or `--pack`", and neither
appears in `RuntimeConfig::built_in_packs()`, which returns exactly twelve: kg, gtd, memory,
brain, comm, schedule, knowledge, session, git, code, workspace, blob.

That opt-in was only one layer deep. At build and link time both packs were unconditional:

- `khive-pack-moodboard` was a plain `[dependencies]` entry of **both** `khive-mcp` and `kkernel`,
  and `khive-mcp/src/pack.rs` force-linked it so its `inventory::submit!` constructor reached the
  binary.
- `khive-pack-formal` was the same in `kkernel`, force-linked at `kkernel/src/lib.rs`.

So every build shipped both packs whether or not anyone wanted them, and the runtime-level
selection could not remove them.

The moodboard case was worse than a size question. The **V21 attachment cutover**, a core
migration, called directly into the pack (`attachment_cutover.rs`, `serve.rs`). A migration on
the boot path depended on an experimental, opt-in pack. That is the layering defect this PR
fixes; the feature flags are the consequence, not the point.

## What this does

**`khive-pack-formal`** is mechanical. The force-link was its only reference, so it becomes
`optional = true` behind a new `pack-formal` feature, off by default, following the
`channel-email` / `channel-telegram` convention already in that manifest.

**`khive-pack-moodboard`** needed the call sites untangled first. The two functions V21 used are
not the same kind of thing:

- `legacy_preference_model_count` uses **no moodboard types at all** — one `SELECT COUNT(*)` over
  `entities` through `SqlAccess`. It **moves into `khive-mcp`** beside the cutover code, SQL and
  statement label byte-identical. `'moodboard_model'` stays as a literal: it is a value in the
  data, not a code dependency. This is what lets V21 keep **detecting** legacy rows without
  linking the pack.
- `verify_legacy_preference_attachments` is genuinely moodboard-specific — it authenticates
  bundle evidence and deserializes a FANN network. Moving that into `khive-mcp` would drag the
  bundle format and FANN into the core, which is worse than the defect. Instead the dependency is
  **inverted behind a trait in `khive-runtime`**: `LegacyPreferenceVerifier`, alongside the
  `VerifiedModelNetworkAttachment` data struct it returns.

`khive-runtime` is the right home rather than a new crate or `khive-storage`: it already owns
`BlobHydrator` and `RuntimeError`, which the signature needs, and both `khive-mcp` and
`khive-pack-moodboard` already depend on it. No new dependency edge is created.

The trait is **sealed** by a private-supertrait marker. It has to be `pub`, because its one
implementor is in another crate, but it is not an extension point: the API commitment is the
method shape the cutover calls, not open implementation.

Worth stating plainly rather than leaving the word "sealed" to imply more than it delivers: this
is the conventional sealing idiom, not an enforced barrier. Rust has no notion of
"workspace-visible", so a marker a sibling crate can name is a marker any crate can name. It
prevents accidental implementation and documents intent. Hard enforcement is not available while
the implementor is a separate crate, and the module comment says so at the definition.

ADR-160 gains one amendment paragraph recording the inversion. The substantive part of it is a
disambiguation: that ADR's Phase 4b list says "an upgrade with moodboard disabled still migrates
legacy models", which was written when the pack was always compiled in, so "disabled" could only
mean deselected at runtime. It now has two meanings, and only one of them still matches that
sentence.

The optional dependency is then confined to a single `#[cfg]` seam that returns
`Option<Arc<dyn LegacyPreferenceVerifier>>` — `Some` with the feature on, `None` without — so no
boot call site names the pack.

## The cutover fails closed

This is the behavioural change worth reviewing carefully.

| legacy count | verifier | behaviour |
| --- | --- | --- |
| `0` | either | unchanged — the overwhelmingly common case, empty vector, proceeds |
| `> 0` | present | unchanged — verifies, keeps the existing length-mismatch check and the existing "no `BlobHydrator` is configured" error |
| `> 0` | **absent** | **hard error naming the count**, never proceeds |

The third row is new. Silently continuing would let V21 drop the legacy column while those models
stayed unmigrated, which is data loss. An operator hitting it needs a build with the feature
enabled to migrate, and the error says so.

## `formal` had a second call site the first survey missed — read this before approving

The initial survey for this change recorded that no core path calls into `khive-pack-formal`, on
the strength of a reference search for the crate name. That was wrong, and the way it was wrong is
worth stating because it generalises.

`kkernel/src/kg/validate.rs::build_pack_edge_rules()` calls `PackRegistry::discovered_names()`,
which enumerates every pack **linked into the binary** — not the packs selected at runtime through
`KHIVE_PACKS` or `--pack`. A name-based search cannot see that call, because the call site never
mentions the pack. `kg validate` and `kg commit --rules ... edge_endpoint_types` therefore depend
on which packs are compiled in, not on which are selected.

Confirmed by running the suite with the feature off:
`kkernel/tests/kg_commit_tier2.rs::kg_commit_lands_formal_typed_endpoint_with_edge_endpoint_types_enabled`
fails, because `theorem -[depends_on]-> definition` is a pairing only `khive-pack-formal`'s
`FORMAL_EDGE_RULES` permits and those rules are no longer in the binary.

**The user-visible consequence:** a repository that commits formal-math-typed KG entities
(`theorem` / `definition` / `structure` / `instance` / `axiom` / `goal`, per ADR-069) and relies on
`kg validate` or `kg commit` to accept those typed endpoint pairings needs a `kkernel` built with
`--features pack-formal`, even though it never touches the MCP `request` tool. That test is now
gated behind the feature rather than the pack being turned back on, since turning it back on would
defeat the change. This is called out here for explicit sign-off: it may be exactly the intended
behaviour, but it is a behaviour change beyond "the pack becomes an opt-in verb source".

## The locally installed binary keeps both packs

`make local` builds what an operator actually serves, and it must keep behaving as it does today.
Two things would otherwise break the moment this lands:

- `make local` fails **on its own gate**. `FULL_PACKS` in the Makefile names `formal`, and
  `verify-local-artifact` runs the freshly built artifact with that pack list. A binary without the
  pack answers `unknown pack name "formal"` and the verification refuses. That is the right failure
  direction — it declines rather than installing a binary that cannot serve its own configuration —
  but it is still a break.
- Any `KHIVE_PACKS` naming `formal` or `moodboard` fails at startup, not with a warning:
  `factory_for()` misses in `khive-runtime/src/pack.rs`, `PackLoadError::UnknownPack` propagates
  through `khive-mcp/src/server.rs`, `register_packs` returns `Err`, and the registry never builds.

So `build-local` now passes `--features channel-email,channel-telegram,pack-formal,pack-moodboard`.
A plain `cargo build` still links neither, which is the entire point of the change and what a
registry consumer gets.

**A gap this exposed, flagged rather than fixed here:** `FULL_PACKS` names `formal` but not
`moodboard`, so the build's verification gate is blind to `moodboard` being dropped. Widening that
list changes what the gate asserts on every local build, which is a separate decision from this
PR. Filed as #2260, including the question of whether `FULL_PACKS` should be derived from the
feature list `build-local` passes rather than kept as an independent literal that can drift.

## The non-default set is complete after this

There are 16 pack crates in the workspace. Reading the **dependency declarations** in
`kkernel/Cargo.toml` and `khive-mcp/Cargo.toml` — rather than searching for crate names, which
cannot see a call that reaches a pack through registry enumeration — the picture is:

- the 12 packs in `RuntimeConfig::built_in_packs()` are unconditional dependencies, which is
  correct: they are the default set;
- `khive-pack-formal` and `khive-pack-moodboard` are the two this PR makes optional;
- `khive-pack-agent` and `khive-pack-template` are declared **only as workspace members**, never
  as a dependency of either binary crate. `--workspace` compiles them; nothing links them.

So once this lands, every pack outside the default set is absent from a default build, and no
further manifest change is needed to get there.

## CI's smoke binary needed the pack too

The first CI run after this change failed, and the failure is worth recording because it is the
same shape as the `formal` discovery above: a consumer that reaches the pack without naming it in
a manifest.

`scripts/ci.sh` built the smoke binary with a plain `cargo build --workspace --release`, while
`tests/smoke_test.py` spawns that binary with `--pack kg --pack formal` to cover the pack's
additive `EntityOfType` endpoint rules. With the pack no longer linked, the name does not resolve
and the server exits at startup rather than the section skipping, so the run reported
`FAILED sections: formal` / `MCP server closed stdout`.

`phase_release` now passes `--features kkernel/pack-formal`, which keeps that coverage. Verified
without a full build: `cargo tree -p kkernel -e normal` shows no `khive-pack-formal` by default and
shows it as a direct dependency under the flag (rc 0). The startup behaviour was confirmed
separately against a binary that does link the pack — `KHIVE_PACKS=kg,formal` returns a normal
result, while a name that cannot resolve exits non-zero with empty stdout, which is exactly the
signature CI reported.

`pack-moodboard` is deliberately not linked there. It registers seven verbs, and
`tests/test_documented_verb_counts.py` asserts the verb surface in the same phase, so linking it
would change what that gate measures. Which pack set the gates should assert is the general
question already filed as #2260.

## Every runtime pack-selection site, enumerated

The claim that the non-default set is complete has now been wrong twice, both times because the
population I checked was "dependency declarations in the two binary crates". That is blind by
construction to anything selecting packs at runtime. Here is the actual enumeration, over tracked
files, of every site naming `formal` or `moodboard` in a selection context:

| site | what it does | status |
| --- | --- | --- |
| `kkernel/src/kg/validate.rs` | `PackRegistry::discovered_names()` enumerates LINKED packs; never names the pack | the typed-endpoint test is feature-gated, and the user-visible consequence is documented above |
| `tests/smoke_test.py:765` | spawns the release binary with `--pack kg --pack formal` | fixed: `phase_release` links `pack-formal` |
| `tests/khive-contract/khive_contract/client.py` + `conftest.py:75` | `khive_formal_session` spawns `packs=("kg", "formal")`; `_resolve_binary` falls back to `crates/target/release/kkernel` | same binary, so the same fix covers it. It runs after the smoke step in CI, so its outcome was latent behind the smoke failure rather than independently green |
| `crates/khive-pack-moodboard/tests/integration.rs:42` | sets `config.packs = ["kg", "moodboard"]` | self-contained: it is the pack's own integration test, so the crate is linked into that test binary by construction |
| `Makefile` `FULL_PACKS` | `verify-local-artifact` asserts `formal` | `build-local` links both packs; the missing `moodboard` assertion is #2260 |

`marketplace/INSTALL.md` and the README/docs mention `--pack` only for default-set packs, so they
are unaffected.

## What this does NOT do

It does not remove the crates.io publish requirement for either crate. An optional dependency
that carries a `version` requirement is still resolved against the registry even when its feature
is off, so both crates still have to be publishable. The justification here is layering alone.

## Evidence

Every command below was run from `crates/`, each against its own target directory.

```
$ cargo fmt --all -- --check                                              EXIT 0
$ cargo clippy --workspace --all-targets -- -D warnings                   EXIT 0   # default: both packs OFF

# compile matrix — all four feature states
$ cargo check --workspace                                                 EXIT 0   # both OFF
$ cargo check --workspace --features khive-mcp/pack-moodboard             EXIT 0
$ cargo check --workspace --features kkernel/pack-formal                  EXIT 0
$ cargo check --workspace \
    --features kkernel/pack-formal,kkernel/pack-moodboard,khive-mcp/pack-moodboard   EXIT 0

# test matrix
$ cargo test -p khive-mcp                                                 EXIT 0
    145 lib + 145 integration; attachment_cutover::tests 5/5 incl. the new fail-closed test
$ cargo test -p khive-mcp --features pack-moodboard                       EXIT 0
    435 lib + 145 integration; attachment_cutover::tests 6/6 — the cfg-gated
    verifier-present-no-hydrator test also runs and passes
$ env -u KHIVE_PACKS cargo test -p kkernel                                EXIT 0
    445 lib + 14 integration across 4 files; kg_commit_tier2's formal test correctly
    does NOT run, being cfg'd off
$ env -u KHIVE_PACKS cargo test -p kkernel --features pack-formal         EXIT 0
    all green incl. kg_commit_tier2 8/8
$ env -u KHIVE_PACKS cargo test --workspace                               EXIT 0
```

The single-feature states are what catch a feature that only compiles when its sibling is also
enabled. The combined state is covered by `cargo check` above and by the clippy/test pair
recorded in the following section.

**`env -u KHIVE_PACKS` is required and is not incidental.** The `kkernel` suite reads the
ambient `KHIVE_PACKS` environment variable. In a shell that exports a list naming `formal`,
`cargo test -p kkernel` fails with `unknown pack name "formal"` at
`exec::tests::build_local_fallback_server_installs_blob_store_single_backend` once the pack is
gated off — a property of the environment, not of this diff. Anyone running these tests with a
populated `KHIVE_PACKS` will hit it.

The behaviour change that most needs a reviewer's eye is the third row of the fail-closed table
above; it is asserted by a test whose name states the outcome rather than the mechanism,
`legacy_model_without_verifier_fails_closed_and_gc_refuses_to_run`.

### That test was checked for being load-bearing, not just present

A passing test proves nothing about a guard unless removing the guard makes it fail. The
verifier-absent arm was no-opped by widening the early return to
`if legacy_model_count == 0 || verifier.is_none()`, which restores exactly the pre-guard
behaviour and still compiles:

```
mutant:   test result: FAILED. 4 passed; 1 failed
          legacy_model_without_verifier_fails_closed_and_gc_refuses_to_run ... FAILED
          panicked: "error must name the legacy count"
restored: test result: ok. 5 passed; 0 failed
```

One test reddened and only one, which was the predicted set: the hydrator sibling is gated
behind `pack-moodboard` and passes a verifier, and the other three exercise zero-count paths.
The file was restored from a byte-identical snapshot (sha256 verified, working tree matches
`HEAD`), and the suite re-run green afterwards so the restoration is confirmed functionally and
not only textually.



