### PR TITLE
Move chacha20 off the yanked 0.10.1

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -472,9 +472,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",


### PR DESCRIPTION
`chacha20` 0.10.1 was yanked upstream today at 18:33Z, together with 0.10.0. The supply-chain
gate runs `cargo deny --manifest-path crates/Cargo.toml --all-features check bans licenses
sources advisories`, and its yanked-crate class reads the live registry index rather than
anything in the tree. So a lockfile entry that passed every job all day started failing every
job scheduled after the yank, with no change to the repository:

```
error[yanked]: detected yanked crate (try `cargo update -p chacha20`)
advisories FAILED, bans ok, licenses ok, sources ok
```

0.10.2 was published at 17:51Z the same day and is not yanked.

## Scope

Lockfile only. `cargo update -p chacha20` reported `Locking 1 package to latest compatible
version`, leaving the other 108 dependencies untouched. The whole diff is one version and one
checksum.

## Why this is a separate PR

The failure is not specific to any branch — it is a property of the registry plus the committed
lockfile, so it lands on `main` and on every open PR at its next CI run. At the time of writing,
the other open PRs still display a green supply-chain check, but each of those runs completed
hours before the yank (12:03Z, 12:25Z, and 00:13Z the previous day) and is a stale conclusion
rather than evidence that they would pass now. Keeping the fix on its own branch lets it merge
without waiting on unrelated review.

## Verification

Run with the CI-pinned cargo-deny 0.19.9 and the gate's own command, against a refreshed
advisory database:

```
before:  advisories FAILED, bans ok, licenses ok, sources ok    (error[yanked]: chacha20)
after:   advisories ok, bans ok, licenses ok, sources ok        exit 0
```
