### PR TITLE
Name moodboard in FULL_PACKS so the local verification gate can see its verbs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,15 @@
 # The full pack set the installed daemon must serve. `make local` verifies the
 # freshly built artifact before installation by running verbs() against that
-# exact binary. The floor is the current 90-verb production surface: additions
+# exact binary. The floor is the current 98-verb production surface: additions
 # pass without a Makefile change, while any loss remains fail-closed.
-FULL_PACKS := kg,gtd,memory,comm,schedule,session,workspace,blob,git,knowledge,brain,code,formal
-LOCAL_VERB_FLOOR := 90
+#
+# `moodboard` belongs in this list because `build-local` links pack-moodboard,
+# so the artifact serves the pack's seven verbs whether or not the list names
+# it. Omitting it did not make the gate lenient about a pack it never built; it
+# made the gate blind to seven verbs the artifact was already shipping, so
+# losing all of them still cleared a floor set below their count.
+FULL_PACKS := kg,gtd,memory,comm,schedule,session,workspace,blob,git,knowledge,brain,code,formal,moodboard
+LOCAL_VERB_FLOOR := 98
 CARGO ?= cargo
 LOCAL_BUILD_RECEIPT := crates/target/khive-local-build.json
 FLEET_ARTIFACT ?=
@@ -80,9 +86,10 @@ build:
 # binary an operator actually serves, and both packs are now optional crate
 # dependencies rather than unconditional ones. A default `cargo build` links
 # neither, which is the point of making them optional; a locally installed
-# kkernel still needs them, because FULL_PACKS above names `formal` and
-# verify-local-artifact runs the artifact with that list — a binary without the
-# pack answers `unknown pack name "formal"` and the verification gate fails.
+# kkernel still needs them, because FULL_PACKS above names both `formal` and
+# `moodboard` and verify-local-artifact runs the artifact with that list — a
+# binary without the pack answers `unknown pack name "formal"` and the
+# verification gate fails.
 # The same applies at runtime to any KHIVE_PACKS naming `formal` or `moodboard`.
 build-local:
 	@echo "==> Building kkernel (release, channel-email, channel-telegram, pack-formal, pack-moodboard)..."

--- a/scripts/tests/test_verify_local_artifact.py
+++ b/scripts/tests/test_verify_local_artifact.py
@@ -1172,7 +1172,7 @@ class MakefileGateContractTests(unittest.TestCase):
             "verify-local-artifact: validate-make-inputs build-local\n", self.makefile
         )
         self.assertIn("local: verify-local-artifact\n", self.makefile)
-        self.assertIn("LOCAL_VERB_FLOOR := 90", self.makefile)
+        self.assertIn("LOCAL_VERB_FLOOR := 98", self.makefile)
 
         local_recipe = self.makefile[self.makefile.index("local: verify-local-artifact") :]
         self.assertNotIn("cargo build", local_recipe)
@@ -1196,6 +1196,39 @@ class MakefileGateContractTests(unittest.TestCase):
         self.assertLess(copy, staged_check)
         self.assertLess(staged_check, install)
         self.assertLess(install, daemon_stop)
+
+    def test_full_packs_names_every_pack_build_local_links(self) -> None:
+        """The verification gate must probe every pack the artifact ships.
+
+        `build-local` selects optional pack features and `verify-local-artifact`
+        probes only the packs `FULL_PACKS` names. A pack that is linked but not
+        named is not merely unprobed: its verbs are in the artifact and absent
+        from the count the floor is compared against, so losing all of them can
+        still clear the floor. Deriving the expectation from the feature list
+        keeps the two from drifting apart again.
+        """
+        packs_line = re.search(r"^FULL_PACKS := (.+)$", self.makefile, re.MULTILINE)
+        self.assertIsNotNone(packs_line, "FULL_PACKS assignment not found in Makefile")
+        named = set(packs_line.group(1).split(","))
+        self.assertTrue(named, "FULL_PACKS parsed as empty")
+
+        features = re.search(r"^\s*--features (\S+) \\$", self.makefile, re.MULTILINE)
+        self.assertIsNotNone(features, "build-local --features line not found")
+        linked = {
+            feature.removeprefix("pack-")
+            for feature in features.group(1).split(",")
+            if feature.startswith("pack-")
+        }
+        self.assertTrue(
+            linked, "no pack-* features parsed from build-local; the regex is stale"
+        )
+
+        self.assertEqual(
+            set(),
+            linked - named,
+            "build-local links pack(s) that FULL_PACKS does not name, so the "
+            "verification gate cannot see their verbs",
+        )
 
     def test_fleet_targets_split_build_verification_from_verification_only(self) -> None:
         self.assertIn("fleet-build: verify-local-artifact\n", self.makefile)


### PR DESCRIPTION
Closes #2260.

## What was wrong

`build-local` links `pack-moodboard`, so the installed artifact serves the pack's
seven verbs. `FULL_PACKS` did not name it, and `verify-local-artifact` probes only
the packs that list names.

The gap was not that the gate was lenient about a pack it never built. The pack was
built and shipped; the gate simply could not see it. Seven verbs were present in the
binary and absent from the count compared against `LOCAL_VERB_FLOOR`, so a build that
lost every moodboard verb still cleared a floor of 90.

## Change

- `FULL_PACKS` gains `moodboard`.
- `LOCAL_VERB_FLOOR` moves from 90 to 98, the resulting surface, keeping the
  documented property that additions pass without a Makefile change while any loss
  fails closed.
- A test derives the expectation from `build-local`'s own `--features` line, so a
  pack that is linked but unnamed reddens rather than silently shrinking what the
  gate measures.

## Evidence

Verb count measured two independent ways, and they agree on seven:

- Probing the installed artifact with `verify_local_artifact.py`: 91 verbs across 13
  requested packs without `moodboard`, 98 across 14 with it.
- The pack's vocabulary declares exactly seven verbs: `moodboard.model`,
  `moodboard.ingest`, `moodboard.search`, `moodboard.serve`, `moodboard.judge`,
  `moodboard.train_preference`, `moodboard.preference`.

The gate itself, run end to end with the new values:

- `make fleet-check FLEET_ARTIFACT=~/.cargo/bin/kkernel` reports 98 verbs across 14
  requested packs, exit 0.
- Boundary control at `--min-verbs 99`: refuses with `artifact registered 98 verbs;
  expected at least 99`.
- Negative control with an unknown pack name in the list: the probe fails rather than
  passing, confirming the pack list is load-bearing.

New test verified by mutation, each arm isolating one conjunct:

- Removing `,moodboard` from `FULL_PACKS` reddens only the new test.
- Reverting the floor to 90 reddens only the existing dependency-chain test.
- The Makefile was restored byte-identical after both, checksum compared.

`scripts/tests/test_verify_local_artifact.py`: 35 passed, 50 subtests passed.

## Coverage note

CI does not run `verify-local-artifact`; it is a local and fleet gate. What CI does
cover is the constant and the new invariant, through
`scripts/tests/test_verify_local_artifact.py`, which parses the Makefile. The
end-to-end gate evidence above is a local run against the installed artifact.