### PR TITLE
refactor(storage): extract the shared WAL sidecar freeze helper

### DIFF
--- a/crates/khive-db/Cargo.toml
+++ b/crates/khive-db/Cargo.toml
@@ -56,7 +56,7 @@ windows-sys = { version = "0.61", features = [
 tokio = { workspace = true, features = ["full", "test-util"] }
 rusqlite = { workspace = true, features = ["bundled", "column_decltype", "hooks", "limits", "functions"] }
 bytes = "1"
-khive-storage = { version = "0.8.0", path = "../khive-storage" }
+khive-storage = { version = "0.8.0", path = "../khive-storage", features = ["test-support"] }
 khive-types = { version = "0.8.0", path = "../khive-types", features = ["serde"] }
 uuid = { workspace = true }
 criterion = { workspace = true }

--- a/crates/khive-db/src/backend.rs
+++ b/crates/khive-db/src/backend.rs
@@ -912,27 +912,8 @@ mod tests {
     use super::*;
     use khive_storage::types::{SqlStatement, SqlValue};
 
-    /// A writable fixture backend can leave `-wal`/`-shm` sidecars behind at
-    /// scope drop (their owning connection closes asynchronously), and
-    /// read-only admission rejects a writable `-shm` as potentially live.
-    /// Freeze any lingering sidecars so the reopened path is the documented
-    /// frozen-snapshot form: read-only `-wal` plus read-only `-shm`.
     #[cfg(unix)]
-    fn freeze_snapshot_sidecars(path: &std::path::Path) {
-        use std::os::unix::fs::PermissionsExt;
-        for suffix in ["-wal", "-shm"] {
-            let mut name = path.file_name().expect("db file name").to_os_string();
-            name.push(suffix);
-            let sidecar = path.parent().expect("db parent dir").join(name);
-            if sidecar.exists() {
-                let mut permissions = std::fs::metadata(&sidecar)
-                    .expect("sidecar metadata")
-                    .permissions();
-                permissions.set_mode(0o444);
-                std::fs::set_permissions(&sidecar, permissions).expect("freeze sidecar");
-            }
-        }
-    }
+    use khive_storage::test_support::freeze_snapshot_sidecars;
 
     #[cfg(unix)]
     #[tokio::test]

--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -6605,19 +6605,7 @@ mod tests {
 
         #[cfg(unix)]
         {
-            use std::os::unix::fs::PermissionsExt;
-            for suffix in ["-wal", "-shm"] {
-                let mut name = path.file_name().expect("db file name").to_os_string();
-                name.push(suffix);
-                let sidecar = path.parent().expect("db parent dir").join(name);
-                if sidecar.exists() {
-                    let mut permissions = std::fs::metadata(&sidecar)
-                        .expect("sidecar metadata")
-                        .permissions();
-                    permissions.set_mode(0o444);
-                    std::fs::set_permissions(&sidecar, permissions).expect("freeze sidecar");
-                }
-            }
+            khive_storage::test_support::freeze_snapshot_sidecars(&path);
         }
 
         let pool = Arc::new(

--- a/crates/khive-mcp/Cargo.toml
+++ b/crates/khive-mcp/Cargo.toml
@@ -82,6 +82,7 @@ test-forward-seam = []
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
 khive-runtime = { version = "0.8.0", path = "../khive-runtime", features = ["fault-injection"] }
+khive-storage = { version = "0.8.0", path = "../khive-storage", features = ["test-support"] }
 rmcp = { workspace = true, features = ["server", "transport-io", "client"] }
 async-trait = { workspace = true }
 serial_test = { workspace = true }

--- a/crates/khive-mcp/src/components.rs
+++ b/crates/khive-mcp/src/components.rs
@@ -633,21 +633,7 @@ mod tests {
     }
 
     #[cfg(unix)]
-    fn freeze_snapshot_sidecars(path: &std::path::Path) {
-        use std::os::unix::fs::PermissionsExt;
-        for suffix in ["-wal", "-shm"] {
-            let mut name = path.file_name().expect("db file name").to_os_string();
-            name.push(suffix);
-            let sidecar = path.parent().expect("db parent dir").join(name);
-            if sidecar.exists() {
-                let mut permissions = std::fs::metadata(&sidecar)
-                    .expect("sidecar metadata")
-                    .permissions();
-                permissions.set_mode(0o444);
-                std::fs::set_permissions(&sidecar, permissions).expect("freeze sidecar");
-            }
-        }
-    }
+    use khive_storage::test_support::freeze_snapshot_sidecars;
 
     async fn make_server(db_path: &str) -> KhiveMcpServer {
         let cfg = RuntimeConfig {

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -4206,25 +4206,8 @@ mod tests {
         );
     }
 
-    // Freeze lingering `-wal`/`-shm` sidecars left by a writable fixture whose
-    // connections close asynchronously; read-only admission rejects a writable
-    // `-shm` as potentially live.
     #[cfg(unix)]
-    fn freeze_snapshot_sidecars(path: &std::path::Path) {
-        use std::os::unix::fs::PermissionsExt;
-        for suffix in ["-wal", "-shm"] {
-            let mut name = path.file_name().expect("db file name").to_os_string();
-            name.push(suffix);
-            let sidecar = path.parent().expect("db parent dir").join(name);
-            if sidecar.exists() {
-                let mut permissions = std::fs::metadata(&sidecar)
-                    .expect("sidecar metadata")
-                    .permissions();
-                permissions.set_mode(0o444);
-                std::fs::set_permissions(&sidecar, permissions).expect("freeze sidecar");
-            }
-        }
-    }
+    use khive_storage::test_support::freeze_snapshot_sidecars;
     use serial_test::serial;
     use std::io::Write;
 

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -3870,25 +3870,8 @@ mod tests {
         }
     }
 
-    // Freeze lingering `-wal`/`-shm` sidecars left by a writable fixture whose
-    // connections close asynchronously; read-only admission rejects a writable
-    // `-shm` as potentially live.
     #[cfg(unix)]
-    fn freeze_snapshot_sidecars(path: &std::path::Path) {
-        use std::os::unix::fs::PermissionsExt;
-        for suffix in ["-wal", "-shm"] {
-            let mut name = path.file_name().expect("db file name").to_os_string();
-            name.push(suffix);
-            let sidecar = path.parent().expect("db parent dir").join(name);
-            if sidecar.exists() {
-                let mut permissions = std::fs::metadata(&sidecar)
-                    .expect("sidecar metadata")
-                    .permissions();
-                permissions.set_mode(0o444);
-                std::fs::set_permissions(&sidecar, permissions).expect("freeze sidecar");
-            }
-        }
-    }
+    use khive_storage::test_support::freeze_snapshot_sidecars;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
 

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -197,21 +197,7 @@ async fn seeded_read_only_snapshot_server() -> (tempfile::TempDir, KhiveMcpServe
     let mut permissions = std::fs::metadata(&path).unwrap().permissions();
     permissions.set_mode(0o444);
     std::fs::set_permissions(&path, permissions).unwrap();
-    // Freeze lingering `-wal`/`-shm` sidecars left by the writable fixture's
-    // asynchronously closing connections; read-only admission rejects a
-    // writable `-shm` as potentially live.
-    for suffix in ["-wal", "-shm"] {
-        let mut name = path.file_name().expect("db file name").to_os_string();
-        name.push(suffix);
-        let sidecar = path.parent().expect("db parent dir").join(name);
-        if sidecar.exists() {
-            let mut sidecar_permissions = std::fs::metadata(&sidecar)
-                .expect("sidecar metadata")
-                .permissions();
-            sidecar_permissions.set_mode(0o444);
-            std::fs::set_permissions(&sidecar, sidecar_permissions).expect("freeze sidecar");
-        }
-    }
+    khive_storage::test_support::freeze_snapshot_sidecars(&path);
 
     let runtime = KhiveRuntime::new(config)
         .expect("normal boot must detect and validate the read-only snapshot");

--- a/crates/khive-pack-knowledge/Cargo.toml
+++ b/crates/khive-pack-knowledge/Cargo.toml
@@ -38,7 +38,7 @@ libc = { workspace = true }
 [dev-dependencies]
 khive-pack-kg = { version = "0.8.0", path = "../khive-pack-kg" }
 khive-pack-brain = { version = "0.8.0", path = "../khive-pack-brain" }
-khive-storage = { version = "0.8.0", path = "../khive-storage" }
+khive-storage = { version = "0.8.0", path = "../khive-storage", features = ["test-support"] }
 tokio = { workspace = true, features = ["test-util"] }
 lattice-embed = { workspace = true }
 criterion = { workspace = true }

--- a/crates/khive-pack-knowledge/src/knowledge/vamana.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/vamana.rs
@@ -3161,20 +3161,8 @@ mod tests {
         drop(KhiveRuntime::new(config.clone()).expect("migrate snapshot source"));
         #[cfg(unix)]
         {
-            use std::os::unix::fs::PermissionsExt;
             let db_path = config.db_path.as_ref().expect("db path");
-            for suffix in ["-wal", "-shm"] {
-                let mut name = db_path.file_name().expect("db file name").to_os_string();
-                name.push(suffix);
-                let sidecar = db_path.parent().expect("db parent dir").join(name);
-                if sidecar.exists() {
-                    let mut permissions = std::fs::metadata(&sidecar)
-                        .expect("sidecar metadata")
-                        .permissions();
-                    permissions.set_mode(0o444);
-                    std::fs::set_permissions(&sidecar, permissions).expect("freeze sidecar");
-                }
-            }
+            khive_storage::test_support::freeze_snapshot_sidecars(db_path);
         }
         let rt = KhiveRuntime::new_readonly(config).expect("open snapshot read-only");
         let ann = new_shared();

--- a/crates/khive-pack-knowledge/src/pack.rs
+++ b/crates/khive-pack-knowledge/src/pack.rs
@@ -654,20 +654,8 @@ mod tests {
 
         #[cfg(unix)]
         {
-            use std::os::unix::fs::PermissionsExt;
             let db_path = config.db_path.as_ref().expect("db path");
-            for suffix in ["-wal", "-shm"] {
-                let mut name = db_path.file_name().expect("db file name").to_os_string();
-                name.push(suffix);
-                let sidecar = db_path.parent().expect("db parent dir").join(name);
-                if sidecar.exists() {
-                    let mut permissions = std::fs::metadata(&sidecar)
-                        .expect("sidecar metadata")
-                        .permissions();
-                    permissions.set_mode(0o444);
-                    std::fs::set_permissions(&sidecar, permissions).expect("freeze sidecar");
-                }
-            }
+            khive_storage::test_support::freeze_snapshot_sidecars(db_path);
         }
 
         let read_only = KhiveRuntime::new_readonly(config).expect("open snapshot read-only");

--- a/crates/khive-runtime/Cargo.toml
+++ b/crates/khive-runtime/Cargo.toml
@@ -47,6 +47,7 @@ sha2 = { workspace = true }
 
 [dev-dependencies]
 khive-gate-rego = { version = "0.8.0", path = "../khive-gate-rego" }
+khive-storage = { version = "0.8.0", path = "../khive-storage", features = ["test-support"] }
 tokio = { workspace = true, features = ["test-util"] }
 tempfile = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/khive-runtime/src/events_split.rs
+++ b/crates/khive-runtime/src/events_split.rs
@@ -3322,21 +3322,7 @@ mod tests {
 
         // Freeze the WAL sidecars the writable runtime left behind — the
         // read-only opener refuses a snapshot with a writable -shm.
-        {
-            use std::os::unix::fs::PermissionsExt;
-            for suffix in ["-wal", "-shm"] {
-                let mut name = main_db.file_name().expect("db file name").to_os_string();
-                name.push(suffix);
-                let sidecar = main_db.parent().expect("db parent dir").join(name);
-                if sidecar.exists() {
-                    let mut permissions = std::fs::metadata(&sidecar)
-                        .expect("sidecar metadata")
-                        .permissions();
-                    permissions.set_mode(0o444);
-                    std::fs::set_permissions(&sidecar, permissions).expect("freeze sidecar");
-                }
-            }
-        }
+        khive_storage::test_support::freeze_snapshot_sidecars(&main_db);
 
         let split_config = |db: PathBuf| RuntimeConfig {
             db_path: Some(main_db.clone()),
@@ -3378,21 +3364,7 @@ mod tests {
                 .await
                 .expect("seed lane row");
         }
-        {
-            use std::os::unix::fs::PermissionsExt;
-            for suffix in ["-wal", "-shm"] {
-                let mut name = events_db.file_name().expect("db file name").to_os_string();
-                name.push(suffix);
-                let sidecar = events_db.parent().expect("db parent dir").join(name);
-                if sidecar.exists() {
-                    let mut permissions = std::fs::metadata(&sidecar)
-                        .expect("sidecar metadata")
-                        .permissions();
-                    permissions.set_mode(0o444);
-                    std::fs::set_permissions(&sidecar, permissions).expect("freeze sidecar");
-                }
-            }
-        }
+        khive_storage::test_support::freeze_snapshot_sidecars(&events_db);
         let store = ro.events(&token).expect("events store with lane present");
         let count = store
             .count_events(EventFilter::default())

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -10539,21 +10539,7 @@ mod help_tests {
             writable.prepare_core_schema().expect("current schema");
         }
         #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            for suffix in ["-wal", "-shm"] {
-                let mut name = path.file_name().expect("db file name").to_os_string();
-                name.push(suffix);
-                let sidecar = path.parent().expect("db parent dir").join(name);
-                if sidecar.exists() {
-                    let mut permissions = std::fs::metadata(&sidecar)
-                        .expect("sidecar metadata")
-                        .permissions();
-                    permissions.set_mode(0o444);
-                    std::fs::set_permissions(&sidecar, permissions).expect("freeze sidecar");
-                }
-            }
-        }
+        khive_storage::test_support::freeze_snapshot_sidecars(&path);
         let backend = khive_db::StorageBackend::sqlite_read_only(&path).expect("read-only backend");
         let empty_map: HashMap<&str, &khive_db::StorageBackend> = HashMap::new();
 

--- a/crates/khive-runtime/src/phase_events.rs
+++ b/crates/khive-runtime/src/phase_events.rs
@@ -121,20 +121,8 @@ mod tests {
         drop(KhiveRuntime::new(config.clone()).expect("migrate snapshot source"));
         #[cfg(unix)]
         {
-            use std::os::unix::fs::PermissionsExt;
             let db_path = config.db_path.as_ref().expect("db path");
-            for suffix in ["-wal", "-shm"] {
-                let mut name = db_path.file_name().expect("db file name").to_os_string();
-                name.push(suffix);
-                let sidecar = db_path.parent().expect("db parent dir").join(name);
-                if sidecar.exists() {
-                    let mut permissions = std::fs::metadata(&sidecar)
-                        .expect("sidecar metadata")
-                        .permissions();
-                    permissions.set_mode(0o444);
-                    std::fs::set_permissions(&sidecar, permissions).expect("freeze sidecar");
-                }
-            }
+            khive_storage::test_support::freeze_snapshot_sidecars(db_path);
         }
         let runtime = KhiveRuntime::new_readonly(config).expect("open snapshot read-only");
         let token = runtime

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -2197,18 +2197,7 @@ mod tests {
         // A lingering writable `-shm` from the writable fixture's asynchronous
         // connection close is rejected by read-only admission as potentially
         // live; freeze any sidecars into the documented frozen-snapshot form.
-        for suffix in ["-wal", "-shm"] {
-            let mut name = path.file_name().expect("db file name").to_os_string();
-            name.push(suffix);
-            let sidecar = path.parent().expect("db parent dir").join(name);
-            if sidecar.exists() {
-                let mut sidecar_permissions = std::fs::metadata(&sidecar)
-                    .expect("sidecar metadata")
-                    .permissions();
-                sidecar_permissions.set_mode(0o444);
-                std::fs::set_permissions(&sidecar, sidecar_permissions).expect("freeze sidecar");
-            }
-        }
+        khive_storage::test_support::freeze_snapshot_sidecars(&path);
 
         let read_only_config = RuntimeConfig {
             embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
@@ -2255,21 +2244,7 @@ mod tests {
         };
         KhiveRuntime::new(config.clone()).expect("create migrated database");
         #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            for suffix in ["-wal", "-shm"] {
-                let mut name = path.file_name().expect("db file name").to_os_string();
-                name.push(suffix);
-                let sidecar = path.parent().expect("db parent dir").join(name);
-                if sidecar.exists() {
-                    let mut permissions = std::fs::metadata(&sidecar)
-                        .expect("sidecar metadata")
-                        .permissions();
-                    permissions.set_mode(0o444);
-                    std::fs::set_permissions(&sidecar, permissions).expect("freeze sidecar");
-                }
-            }
-        }
+        khive_storage::test_support::freeze_snapshot_sidecars(&path);
 
         let runtime = KhiveRuntime::new_readonly(config).expect("explicit read-only boot");
         assert!(runtime.is_read_only());
@@ -2360,21 +2335,7 @@ mod tests {
         };
         KhiveRuntime::new(config.clone()).expect("create migrated database");
         #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            for suffix in ["-wal", "-shm"] {
-                let mut name = path.file_name().expect("db file name").to_os_string();
-                name.push(suffix);
-                let sidecar = path.parent().expect("db parent dir").join(name);
-                if sidecar.exists() {
-                    let mut permissions = std::fs::metadata(&sidecar)
-                        .expect("sidecar metadata")
-                        .permissions();
-                    permissions.set_mode(0o444);
-                    std::fs::set_permissions(&sidecar, permissions).expect("freeze sidecar");
-                }
-            }
-        }
+        khive_storage::test_support::freeze_snapshot_sidecars(&path);
         let runtime = KhiveRuntime::new_readonly(config).expect("read-only boot");
         assert!(runtime.is_read_only());
         (dir, runtime)

--- a/crates/khive-storage/Cargo.toml
+++ b/crates/khive-storage/Cargo.toml
@@ -23,3 +23,6 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }
+
+[features]
+test-support = []

--- a/crates/khive-storage/src/lib.rs
+++ b/crates/khive-storage/src/lib.rs
@@ -15,6 +15,8 @@ pub mod request_context;
 pub mod sparse;
 pub mod sql;
 pub mod telemetry;
+#[cfg(feature = "test-support")]
+pub mod test_support;
 pub mod text;
 pub mod tx_registry;
 pub mod types;

--- a/crates/khive-storage/src/test_support.rs
+++ b/crates/khive-storage/src/test_support.rs
@@ -1,0 +1,26 @@
+//! Shared test-only fixtures for storage-adjacent crates.
+//!
+//! Gated behind the `test-support` feature so it never ships in a default
+//! build; consumers pull it in as a dev-dependency.
+
+/// Freeze any lingering `-wal`/`-shm` sidecars for `path` by making them
+/// read-only. Fixtures that close their SQLite connection asynchronously can
+/// leave a writable sidecar behind; read-only admission rejects a writable
+/// `-shm` as potentially live, so tests that reopen the file read-only freeze
+/// the sidecars first to land on the documented frozen-snapshot form.
+#[cfg(unix)]
+pub fn freeze_snapshot_sidecars(path: &std::path::Path) {
+    use std::os::unix::fs::PermissionsExt;
+    for suffix in ["-wal", "-shm"] {
+        let mut name = path.file_name().expect("db file name").to_os_string();
+        name.push(suffix);
+        let sidecar = path.parent().expect("db parent dir").join(name);
+        if sidecar.exists() {
+            let mut permissions = std::fs::metadata(&sidecar)
+                .expect("sidecar metadata")
+                .permissions();
+            permissions.set_mode(0o444);
+            std::fs::set_permissions(&sidecar, permissions).expect("freeze sidecar");
+        }
+    }
+}

--- a/crates/kkernel/Cargo.toml
+++ b/crates/kkernel/Cargo.toml
@@ -66,6 +66,7 @@ rmcp = { workspace = true, features = ["client", "transport-child-process"] }
 # armed-capture hook while the release dependency above stays untouched.
 khive-mcp = { version = "0.8.0", path = "../khive-mcp", features = ["test-forward-seam"] }
 khive-gate-rego = { version = "0.8.0", path = "../khive-gate-rego" }
+khive-storage = { version = "0.8.0", path = "../khive-storage", features = ["test-support"] }
 
 [features]
 # Pass-through: enables the deterministic hash embedder in the serve path (bench use only).

--- a/crates/kkernel/src/cli.rs
+++ b/crates/kkernel/src/cli.rs
@@ -1272,19 +1272,7 @@ mod tests {
         // inspection below accepts only the frozen snapshot form.
         #[cfg(unix)]
         {
-            use std::os::unix::fs::PermissionsExt;
-            for suffix in ["-wal", "-shm"] {
-                let mut name = path.file_name().expect("db file name").to_os_string();
-                name.push(suffix);
-                let sidecar = path.parent().expect("db parent dir").join(name);
-                if sidecar.exists() {
-                    let mut permissions = std::fs::metadata(&sidecar)
-                        .expect("sidecar metadata")
-                        .permissions();
-                    permissions.set_mode(0o444);
-                    std::fs::set_permissions(&sidecar, permissions).expect("freeze sidecar");
-                }
-            }
+            khive_storage::test_support::freeze_snapshot_sidecars(&path);
         }
         let before = std::fs::read(&path).expect("read db before check");
         // strict passes only when the db is already current — proves the read sees V1.

--- a/crates/kkernel/src/code_audit.rs
+++ b/crates/kkernel/src/code_audit.rs
@@ -1696,21 +1696,7 @@ crate-b = 1
     }
 
     #[cfg(unix)]
-    fn freeze_snapshot_sidecars(path: &Path) {
-        use std::os::unix::fs::PermissionsExt;
-        for suffix in ["-wal", "-shm"] {
-            let mut name = path.file_name().expect("db file name").to_os_string();
-            name.push(suffix);
-            let sidecar = path.parent().expect("db parent dir").join(name);
-            if sidecar.exists() {
-                let mut permissions = std::fs::metadata(&sidecar)
-                    .expect("sidecar metadata")
-                    .permissions();
-                permissions.set_mode(0o444);
-                std::fs::set_permissions(&sidecar, permissions).expect("freeze sidecar");
-            }
-        }
-    }
+    use khive_storage::test_support::freeze_snapshot_sidecars;
 
     /// `generate_report` behind the frozen-snapshot form its read-only open
     /// accepts. SQLite connection close is deferred, so a fixture seeded and

--- a/crates/kkernel/src/engine.rs
+++ b/crates/kkernel/src/engine.rs
@@ -288,21 +288,7 @@ mod tests {
         // open this database read-only, which accepts only the frozen
         // snapshot form. No engine test writes after this point.
         #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            for suffix in ["-wal", "-shm"] {
-                let mut name = path.file_name().expect("db file name").to_os_string();
-                name.push(suffix);
-                let sidecar = path.parent().expect("db parent dir").join(name);
-                if sidecar.exists() {
-                    let mut permissions = std::fs::metadata(&sidecar)
-                        .expect("sidecar metadata")
-                        .permissions();
-                    permissions.set_mode(0o444);
-                    std::fs::set_permissions(&sidecar, permissions).expect("freeze sidecar");
-                }
-            }
-        }
+        khive_storage::test_support::freeze_snapshot_sidecars(&path);
         (tmp, Some(path))
     }
 


### PR DESCRIPTION
Addresses item 3 of #2204.

## What

Five crates each carried a byte-identical copy of the fixture that makes a SQLite database's `-wal`/`-shm` sidecars read-only, and thirteen further call sites wrote the same sequence inline. This moves the helper into a single `test_support` module in `khive-storage`, behind an off-by-default `test-support` feature, and updates every caller.

Definitions removed (5): `khive-db/src/backend.rs`, `khive-mcp/src/components.rs`, `khive-mcp/src/serve.rs`, `khive-mcp/src/server.rs`, `kkernel/src/code_audit.rs`.
Inline sites converted (13): across `khive-runtime`, `khive-pack-knowledge`, `khive-mcp`, `khive-db`, `kkernel`.

## Why khive-storage

It is the only crate every consumer depends on. `khive-db` reads as the more natural home given the helper's subject, but `khive-pack-knowledge` does not depend on `khive-db`, so a helper there could not reach two of the inline sites. A `#[cfg(test)]` module cannot cross crate boundaries at all, which is why this is a feature rather than a test-cfg. Consumers take it as a dev-dependency with `features = ["test-support"]`.

## Behaviour

Unchanged. The helper body is the existing one; four of the five copies were byte-identical under whitespace normalisation and the fifth differed only in `&Path` versus `&std::path::Path`.

23 files changed, 54 insertions, 270 deletions.