### PR TITLE
perf(db): stop computing a discarded COUNT(*) on every paged event read

### DIFF
--- a/crates/khive-db/src/stores/event.rs
+++ b/crates/khive-db/src/stores/event.rs
@@ -1280,14 +1280,11 @@ impl EventStore for SqlEventStore {
             // carried no `LIMIT`, so it scanned the whole filtered set on every
             // paged read while the data query below fetches only
             // `offset + limit` rows — and on the merged event plane a single
-            // read paid it twice, once per underlying store. No caller reads
-            // `Page.total` on this path: both production callers
-            // (`khive-mcp::coordinator` and `khive-mcp::pending_events`) take
-            // `.items`, and the merged fold in `khive-runtime::events_split`
-            // propagates `None` rather than inventing a number. `Page.total`
-            // is `Option<u64>` precisely so a store may decline to compute it;
-            // `count_events` below remains for callers that genuinely want a
-            // cardinality.
+            // read paid it twice, once per underlying store. `Page.total` is
+            // `Option<u64>` precisely so a store may decline to compute it, and
+            // the merged fold in `khive-runtime::events_split` propagates `None`
+            // rather than inventing a number. `count_events` below remains for
+            // callers that genuinely want a cardinality.
             let (where_clause, filter_params) = build_event_filter_sql(conn, &namespace, &filter)?;
 
             let mut all_params: Vec<Box<dyn rusqlite::types::ToSql>> = filter_params;

--- a/crates/khive-db/src/stores/event.rs
+++ b/crates/khive-db/src/stores/event.rs
@@ -1276,18 +1276,21 @@ impl EventStore for SqlEventStore {
         })?;
 
         self.with_reader("query_events", move |conn| {
+            // No `COUNT(*)` here, and `total` is therefore `None`. The count
+            // carried no `LIMIT`, so it scanned the whole filtered set on every
+            // paged read while the data query below fetches only
+            // `offset + limit` rows — and on the merged event plane a single
+            // read paid it twice, once per underlying store. No caller reads
+            // `Page.total` on this path: both production callers
+            // (`khive-mcp::coordinator` and `khive-mcp::pending_events`) take
+            // `.items`, and the merged fold in `khive-runtime::events_split`
+            // propagates `None` rather than inventing a number. `Page.total`
+            // is `Option<u64>` precisely so a store may decline to compute it;
+            // `count_events` below remains for callers that genuinely want a
+            // cardinality.
             let (where_clause, filter_params) = build_event_filter_sql(conn, &namespace, &filter)?;
 
-            let count_sql = format!("SELECT COUNT(*) FROM events{}", where_clause);
-            let total: i64 = {
-                let mut stmt = conn.prepare(&count_sql)?;
-                let param_refs: Vec<&dyn rusqlite::types::ToSql> =
-                    filter_params.iter().map(|p| p.as_ref()).collect();
-                stmt.query_row(param_refs.as_slice(), |row| row.get(0))?
-            };
-
-            let (_, data_filter_params) = build_event_filter_sql(conn, &namespace, &filter)?;
-            let mut all_params: Vec<Box<dyn rusqlite::types::ToSql>> = data_filter_params;
+            let mut all_params: Vec<Box<dyn rusqlite::types::ToSql>> = filter_params;
             all_params.push(Box::new(limit_i64));
             all_params.push(Box::new(offset_i64));
 
@@ -1312,10 +1315,7 @@ impl EventStore for SqlEventStore {
                 items.push(row?);
             }
 
-            Ok(Page {
-                items,
-                total: Some(total as u64),
-            })
+            Ok(Page { items, total: None })
         })
         .await
     }

--- a/crates/khive-db/src/stores/event_tests.rs
+++ b/crates/khive-db/src/stores/event_tests.rs
@@ -1191,3 +1191,40 @@ async fn reply_loss_after_commit_retries_exactly_once() {
     );
     assert!(store.get_event(id).await.unwrap().is_some());
 }
+
+#[tokio::test]
+async fn query_events_declines_to_compute_a_total() {
+    let store = setup_memory_store();
+
+    for _ in 0..3 {
+        store.append_event(make_event("default")).await.unwrap();
+    }
+
+    // The paged read returns no total: the unconditional `COUNT(*)` it used to
+    // run carried no `LIMIT`, so it scanned the whole filtered set on every
+    // page while the data query fetched only `offset + limit` rows. `total` is
+    // `Option<u64>` so a store may decline it, and no caller of this path reads
+    // it.
+    let page = store
+        .query_events(
+            EventFilter::default(),
+            PageRequest {
+                limit: 2,
+                offset: 0,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(page.total, None);
+
+    // The page itself is unaffected: the limit still applies and the rows are
+    // still returned. This is the arm that fails if the change removed more
+    // than the count.
+    assert_eq!(page.items.len(), 2);
+
+    // A caller that genuinely wants a cardinality still has one, and it sees
+    // all three rows rather than the page's two — so `None` above is a
+    // declined count, not a broken query.
+    let counted = store.count_events(EventFilter::default()).await.unwrap();
+    assert_eq!(counted, 3);
+}


### PR DESCRIPTION
Addresses item 1 of #2204, scoped to the event path.

## The change

`query_events` ran a `COUNT(*)` with no `LIMIT` before its data query, so it scanned the whole filtered set on every paged read while the data query fetched only `offset + limit` rows. On the merged event plane a single read paid it twice, once per underlying store. This stops computing it and returns `total: None`. It also drops the second `build_event_filter_sql` call, which existed only because the count had consumed the first call's parameters.

## The question the issue raised, and how it is decided here

The issue says the skip "has to be decided where the caller's intent is known and applied to both sides together", because the merged fold folds `(Some(a), Some(b)) => Some(a + b), _ => None` (`khive-runtime/src/events_split.rs:1829-1832`) and a `None` from either store erases the total.

**Decided: no caller-intent mechanism is needed, because on this path there is no intent to erase.** No caller reads `Page.total` on the event path, at any layer. `None` is then the accurate answer rather than a lost one, and the fold needs no change.

### The two-arm control for that claim

A "nothing reads it" claim is only worth as much as the instrument's ability to find a reader, so both arms were run with the same instrument.

**Must-match arm.** The instrument does find a real `Page.total` consumer when one exists: `khive-runtime/src/reference_resolution.rs:381`, `let total = page.total.unwrap_or(page.items.len() as u64)`, in `async fn exact_name_match`, production code. It reads the total from `query_entities` and makes a zero/one/many decision from it. So an existing reader is detectable.

**Must-not-match arm.** Applied to the event path, the same instrument returns nothing:

| caller of `query_events` | takes |
| --- | --- |
| `khive-mcp/src/coordinator.rs:437` | `.items` |
| `khive-mcp/src/pending_events.rs:4209` | `.items` |
| `khive-mcp/src/server.rs:4619`, `:6474` | `.items` (tests) |
| `khive-runtime/src/events_split.rs:1789` (merged) | folds the totals, and its own callers are the two above |

The arms disagree, which is what makes the negative readable. Had both come back empty, the right conclusion would have been that the instrument was broken rather than that nothing reads the field.

Two instrument defects were caught by controls while deriving this and are worth naming so the numbers are not taken on trust: `git grep -E` silently returns zero for `\b`, and an unqualified `.total` search sweeps `total_weight` / `total_count` / `total_micros` on unrelated structs. A third, a population restricted to files literally containing `Page<`, hid the `reference_resolution.rs` reader because type inference means a consumer need never name the type; that one was caught late and only by a differently-scoped search.

## Why the other four sites are not in this PR

- **`note.rs:1310` and `:1367`** compute their count inside a transaction (`note.rs:527 query_note_page_snapshot`, `Transaction::new_unchecked` at `:536`) so the count and the data read share one snapshot, and `note_page_count_and_items_share_one_snapshot_during_concurrent_insert` pins it by asserting `page.total == Some(1)` while a concurrent writer commits between the two reads. Removing the count there deletes the invariant's only observable. That is a design decision, not a perf cleanup.
- **`graph.rs:2085` and `:2214`** have no production callers at all, so skipping their count buys nothing measurable while costing three test updates.

`Transaction::new_unchecked` count per store: `event.rs` 0, `graph.rs` 0, `note.rs` 1.

## Contract

`Page.total` is `Option<u64>`, and `entity.rs:897` already returns `None` on its skip path, so every correct caller must already handle `None`. Callers wanting a cardinality still have `count_events`.

## Gates

Run from `crates/` (the workspace root; a bare `cargo` at the repo root finds no manifest).

- `cargo fmt --all -- --check` — pass
- `cargo clippy -p khive-db --all-targets -- -D warnings` — pass
- `cargo test -p khive-db` — 831 passed, 0 failed, including the new `query_events_declines_to_compute_a_total`
- Blast radius, `cargo test -p khive-runtime -p khive-mcp -p khive-storage` — 2232 passed, 0 failed across 18 test binaries

The new test has three arms: the declined total, the page contents still correct under a limit (fails if the change removed more than the count), and `count_events` still returning the full count (so `None` reads as declined, not broken).
