### PR TITLE
fix(mcp): route pack-scoped rows through the pack's assigned backend

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2219,6 +2219,7 @@ dependencies = [
  "criterion",
  "inventory",
  "khive-brain-core",
+ "khive-db",
  "khive-fold",
  "khive-fusion",
  "khive-pack-brain",

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -3735,10 +3735,12 @@ fn build_pack_runtime(
     main_backend: &Arc<StorageBackend>,
     main_runtime: &KhiveRuntime,
 ) -> KhiveRuntime {
-    let rt = KhiveRuntime::from_backend(backend, rt_config);
+    // Every pack runtime carries main's embedder wiring for core(): a
+    // main-assigned pack has no core pointer, but with `no_embed` its own
+    // registry is empty and core-routed concept writes must still embed.
+    let rt = KhiveRuntime::from_backend(backend, rt_config).with_core_embedders_from(main_runtime);
     if backend_name != BackendId::MAIN {
         rt.with_core_backend(main_backend.clone())
-            .with_core_embedders_from(main_runtime)
     } else {
         rt
     }
@@ -10817,20 +10819,32 @@ backend = "kg-backend"
                         read_only: false,
                     },
                 ],
-                packs: HashMap::from([(
-                    "comm".to_string(),
-                    PackConfig {
-                        backend: "comm-store".to_string(),
-                        no_embed: true,
-                    },
-                )]),
+                packs: HashMap::from([
+                    (
+                        "comm".to_string(),
+                        PackConfig {
+                            backend: "comm-store".to_string(),
+                            no_embed: true,
+                        },
+                    ),
+                    // A MAIN-assigned no_embed pack: no core pointer, but its
+                    // core() must still carry main's embedders (a main
+                    // assignment used to skip the core-embedder wiring).
+                    (
+                        "gtd".to_string(),
+                        PackConfig {
+                            backend: BackendId::MAIN.to_string(),
+                            no_embed: true,
+                        },
+                    ),
+                ]),
                 ..KhiveConfig::default()
             };
 
             // Unlike the other fixtures, keep the default embedding model so
             // the control arm has something to retain.
             let base = RuntimeConfig {
-                packs: vec!["kg".to_string(), "comm".to_string()],
+                packs: vec!["kg".to_string(), "comm".to_string(), "gtd".to_string()],
                 ..base_runtime_config_for_multi_backend()
             };
             let base = RuntimeConfig {
@@ -10867,6 +10881,21 @@ backend = "kg-backend"
                     .registered_embedding_model_names(),
                 main_models,
                 "no_embed pack's core() must carry the main runtime's embedders"
+            );
+            // Same contract for a MAIN-assigned no_embed pack, whose runtime
+            // has no core pointer at all.
+            assert!(
+                multi.per_pack_runtimes["gtd"]
+                    .registered_embedding_model_names()
+                    .is_empty(),
+                "main-assigned no_embed pack runtime must register zero embedders"
+            );
+            assert_eq!(
+                multi.per_pack_runtimes["gtd"]
+                    .core()
+                    .registered_embedding_model_names(),
+                main_models,
+                "main-assigned no_embed pack's core() must carry the main runtime's embedders"
             );
         }
 

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -457,7 +457,6 @@ fn spawn_email_channel_loops(
             let ingest_ns_clone = ingest_ns.clone();
             let default_actor_clone = default_actor.clone();
             let verb_reg_poll = verb_reg.clone();
-            let verb_reg_outbox = verb_reg.clone();
             let ingest_ns_outbox = ingest_ns.clone();
             let allowlist_clone = allowlist.clone();
             let mailbox_clone = mailbox.clone();
@@ -490,7 +489,6 @@ fn spawn_email_channel_loops(
                         Some(rt) => {
                             tokio::task::spawn(channel_outbox_loop(
                                 email_ch_clone,
-                                verb_reg_outbox,
                                 rt,
                                 ingest_ns_outbox,
                                 mailbox_clone,
@@ -500,8 +498,8 @@ fn spawn_email_channel_loops(
                         }
                         None => {
                             tracing::error!(
-                                "email outbox loop was NOT started: server has no KG-routed \
-                                 runtime handle, which the loop needs to claim external_id on \
+                                "email outbox loop was NOT started: server has no comm-routed \
+                                 runtime handle, which the loop needs to scan, claim, and mark \
                                  outbound notes; outbound mail will not be sent"
                             );
                         }
@@ -1381,18 +1379,18 @@ fn note_already_delivered(props: &serde_json::Map<String, serde_json::Value>) ->
 /// `delivered_at` write causes a duplicate send on restart; the duplicate carries
 /// the same Message-ID so receiving MTAs typically collapse it.
 ///
-/// The `external_id` claim goes through `runtime`'s non-wire
-/// `claim_outbound_message_external_id` rather than a `registry.dispatch("update",
-/// ...)` call: `external_id` is one of the owner-established properties the
-/// generic `update` verb refuses to patch on a pack-owned note kind, so a caller
-/// patch through `dispatch` is rejected by design and would leave every note
-/// stuck retrying forever.
+/// Every storage touch (scan, `external_id` claim, `delivered_at` mark) goes
+/// through `runtime`'s non-wire owner-side APIs rather than
+/// `registry.dispatch(...)`: the generic wire verbs run on the kg pack's
+/// runtime, which under a `[packs.comm]` backend assignment is a different
+/// backend than the one holding comm's notes, and `external_id` is
+/// additionally one of the owner-established properties the generic `update`
+/// verb refuses to patch on a pack-owned note kind.
 ///
 /// Only compiled when the `channel-email` feature is enabled.
 #[cfg(feature = "channel-email")]
 async fn channel_outbox_loop(
     email_channel: std::sync::Arc<khive_channel_email::EmailChannel>,
-    registry: khive_runtime::VerbRegistry,
     runtime: khive_runtime::KhiveRuntime,
     ingest_namespace: String,
     mailbox: String,
@@ -1415,10 +1413,8 @@ async fn channel_outbox_loop(
         tokio::time::sleep(std::time::Duration::from_secs(5)).await;
         channel_outbox_once(
             email_channel.as_ref(),
-            &registry,
             &runtime,
             &namespace,
-            &ingest_namespace,
             &mailbox,
             &domain,
             &allowlist,
@@ -1434,45 +1430,44 @@ async fn channel_outbox_loop(
 #[allow(clippy::too_many_arguments)]
 async fn channel_outbox_once(
     email_channel: &dyn khive_channel::Channel,
-    registry: &khive_runtime::VerbRegistry,
     runtime: &khive_runtime::KhiveRuntime,
     namespace: &khive_runtime::Namespace,
-    ingest_namespace: &str,
     mailbox: &str,
     domain: &str,
     allowlist: &[String],
 ) {
     use chrono::Utc;
     use khive_channel::ChannelEnvelope;
-    use serde_json::json;
 
-    // Query outbound messages via the registry. The note `list` handler applies
-    // the `direction` filter server-side (scanning up to its internal cap) and
-    // returns an `items` envelope of full note objects. There is no `delivered_at`
-    // or recipient-prefix filter, so the `email:` prefix and the
-    // already-delivered check are applied per-note below.
-    let list_params = json!({
-        "namespace": ingest_namespace,
-        "kind": "message",
-        "direction": "outbound",
-        "delivered": false,
-        "limit": 200,
-    });
-    let list_result = match registry.dispatch("list", list_params).await {
-        Ok(result) => result,
+    // Query outbound messages through the runtime's non-wire outbox scan.
+    // The generic wire `list` verb runs on the kg pack's runtime, which under
+    // a `[packs.comm]` backend assignment is not the backend holding comm's
+    // notes — the scan must use the comm-routed handle this loop was given.
+    // There is no recipient-prefix filter in the scan, so the `email:` prefix
+    // check (and a defensive re-check of direction/delivered) is applied
+    // per-note below.
+    let token = match runtime.authorize(namespace.clone()) {
+        Ok(token) => token,
         Err(error) => {
-            tracing::warn!(error = %error, "outbox loop: list failed");
+            tracing::warn!(error = %error, "outbox loop: namespace authorization failed");
             return;
         }
     };
-
-    let Some(notes) = list_result
-        .get("items")
-        .and_then(serde_json::Value::as_array)
-    else {
-        return;
+    let notes = match runtime
+        .list_undelivered_outbound_messages(&token, 200)
+        .await
+    {
+        Ok(notes) => notes,
+        Err(error) => {
+            tracing::warn!(error = %error, "outbox loop: outbox scan failed");
+            return;
+        }
     };
-    for note_val in notes {
+    let notes: Vec<serde_json::Value> = notes
+        .iter()
+        .filter_map(|note| serde_json::to_value(note).ok())
+        .collect();
+    for note_val in &notes {
         let props = match note_val.get("properties") {
             Some(serde_json::Value::Object(properties)) => properties.clone(),
             _ => continue,
@@ -1534,18 +1529,11 @@ async fn channel_outbox_once(
             _ => {
                 let message_id = format!("<{note_id}@{domain}>");
                 let claim_result = match uuid::Uuid::parse_str(&note_id) {
-                    Ok(uuid) => match runtime.authorize(namespace.clone()) {
-                        Ok(token) => {
-                            runtime
-                                .claim_outbound_message_external_id(
-                                    &token,
-                                    uuid,
-                                    message_id.clone(),
-                                )
-                                .await
-                        }
-                        Err(error) => Err(error),
-                    },
+                    Ok(uuid) => {
+                        runtime
+                            .claim_outbound_message_external_id(&token, uuid, message_id.clone())
+                            .await
+                    }
                     Err(error) => Err(khive_runtime::RuntimeError::InvalidInput(format!(
                         "note id {note_id} is not a valid UUID: {error}"
                     ))),
@@ -1582,17 +1570,16 @@ async fn channel_outbox_once(
         match email_channel.send(envelope).await {
             Ok(()) => {
                 let delivered_at = Utc::now().to_rfc3339();
-                match registry
-                    .dispatch(
-                        "update",
-                        json!({
-                            "namespace": ingest_namespace,
-                            "id": note_id,
-                            "properties": { "delivered_at": delivered_at },
-                        }),
-                    )
-                    .await
-                {
+                let delivered_result = match uuid::Uuid::parse_str(&note_id) {
+                    Ok(uuid) => runtime
+                        .mark_outbound_message_delivered(&token, uuid, delivered_at)
+                        .await
+                        .map(|_| ()),
+                    Err(error) => Err(khive_runtime::RuntimeError::InvalidInput(format!(
+                        "note id {note_id} is not a valid UUID: {error}"
+                    ))),
+                };
+                match delivered_result {
                     Ok(_) => tracing::info!(
                         note_id = %note_id,
                         recipient = %recipient,
@@ -1668,7 +1655,7 @@ fn spawn_telegram_channel_loops(
             let ingest_ns = telegram_ingest_namespace_from_env();
 
             let verb_reg_poll = verb_reg.clone();
-            let verb_reg_outbox = verb_reg.clone();
+            let outbox_runtime = server.channel_outbox_runtime_clone();
             let ingest_ns_poll = ingest_ns.clone();
             let ingest_ns_outbox = ingest_ns.clone();
             let tg_ch_poll = Arc::clone(&tg_ch);
@@ -1690,12 +1677,23 @@ fn spawn_telegram_channel_loops(
                     tracing::info!("telegram channel polling loop started");
                 }
                 if admission.outbound_delivery {
-                    tokio::task::spawn(telegram_outbox_loop(
-                        tg_ch_outbox,
-                        verb_reg_outbox,
-                        ingest_ns_outbox,
-                    ));
-                    tracing::info!("telegram channel outbox loop started");
+                    match outbox_runtime {
+                        Some(rt) => {
+                            tokio::task::spawn(telegram_outbox_loop(
+                                tg_ch_outbox,
+                                rt,
+                                ingest_ns_outbox,
+                            ));
+                            tracing::info!("telegram channel outbox loop started");
+                        }
+                        None => {
+                            tracing::error!(
+                                "telegram outbox loop was NOT started: server has no \
+                                 comm-routed runtime handle, which the loop needs to scan and \
+                                 mark outbound notes; outbound telegram will not be sent"
+                            );
+                        }
+                    }
                 }
             });
             if !spawned {
@@ -1825,38 +1823,50 @@ async fn telegram_poll_loop(
 #[cfg(feature = "channel-telegram")]
 async fn telegram_outbox_loop(
     telegram_channel: std::sync::Arc<khive_channel_telegram::TelegramChannel>,
-    registry: khive_runtime::VerbRegistry,
+    runtime: khive_runtime::KhiveRuntime,
     ingest_namespace: String,
 ) {
     use chrono::Utc;
     use khive_channel::{Channel, ChannelEnvelope};
-    use serde_json::json;
+
+    let namespace = match khive_runtime::Namespace::parse(&ingest_namespace) {
+        Ok(ns) => ns,
+        Err(e) => {
+            tracing::error!(
+                namespace = %ingest_namespace,
+                error = %e,
+                "telegram outbox loop: ingest namespace does not parse; loop will not run"
+            );
+            return;
+        }
+    };
 
     loop {
         tokio::time::sleep(std::time::Duration::from_secs(5)).await;
 
-        let list_params = json!({
-            "namespace": ingest_namespace,
-            "kind": "message",
-            "direction": "outbound",
-            "delivered": false,
-            "limit": 200,
-        });
-        let list_result = match registry.dispatch("list", list_params).await {
-            Ok(r) => r,
+        // Scan through the comm-routed runtime handle, not the wire `list`
+        // verb — see `channel_outbox_once` for the backend-routing rationale.
+        let token = match runtime.authorize(namespace.clone()) {
+            Ok(token) => token,
             Err(e) => {
-                tracing::warn!(error = %e, "telegram outbox loop: list failed");
+                tracing::warn!(error = %e, "telegram outbox loop: namespace authorization failed");
                 continue;
             }
         };
-
-        let notes = match list_result
-            .get("items")
-            .and_then(serde_json::Value::as_array)
+        let notes = match runtime
+            .list_undelivered_outbound_messages(&token, 200)
+            .await
         {
-            Some(arr) => arr.clone(),
-            None => continue,
+            Ok(notes) => notes,
+            Err(e) => {
+                tracing::warn!(error = %e, "telegram outbox loop: outbox scan failed");
+                continue;
+            }
         };
+        let notes: Vec<serde_json::Value> = notes
+            .iter()
+            .filter_map(|note| serde_json::to_value(note).ok())
+            .collect();
 
         for note_val in notes {
             let props = match note_val.get("properties") {
@@ -1892,16 +1902,15 @@ async fn telegram_outbox_loop(
             match telegram_channel.send(env).await {
                 Ok(()) => {
                     let delivered_at = Utc::now().to_rfc3339();
-                    let mark_result = registry
-                        .dispatch(
-                            "update",
-                            json!({
-                                "namespace": ingest_namespace,
-                                "id": note_id,
-                                "properties": { "delivered_at": delivered_at },
-                            }),
-                        )
-                        .await;
+                    let mark_result = match uuid::Uuid::parse_str(&note_id) {
+                        Ok(uuid) => runtime
+                            .mark_outbound_message_delivered(&token, uuid, delivered_at)
+                            .await
+                            .map(|_| ()),
+                        Err(e) => Err(khive_runtime::RuntimeError::InvalidInput(format!(
+                            "note id {note_id} is not a valid UUID: {e}"
+                        ))),
+                    };
                     match mark_result {
                         Ok(_) => {
                             tracing::info!(note_id = %note_id, "telegram outbox loop: delivered");
@@ -2726,8 +2735,8 @@ async fn build_registry_for_multi_backend_inner(
     let pack_names = &base_config.packs;
     let mut per_pack_runtimes_local: HashMap<String, KhiveRuntime> = HashMap::new();
     for pack_name in pack_names {
-        let (backend_name, backend) = match khive_cfg.packs.get(pack_name.as_str()) {
-            None => (BackendId::MAIN, main_backend.clone()),
+        let (backend_name, backend, no_embed) = match khive_cfg.packs.get(pack_name.as_str()) {
+            None => (BackendId::MAIN, main_backend.clone(), false),
             Some(pack_cfg) => {
                 let backend_name = pack_cfg.backend.as_str();
                 let backend = backends.get(backend_name).cloned().ok_or_else(|| {
@@ -2736,11 +2745,20 @@ async fn build_registry_for_multi_backend_inner(
                         "[packs.{pack_name}].backend = {backend_name:?} references an unknown backend; defined backends: {defined}"
                     )
                 })?;
-                (backend_name, backend)
+                (backend_name, backend, pack_cfg.no_embed)
             }
         };
         let mut rt_config = base_config.clone();
         rt_config.backend_id = BackendId::new(backend_name);
+        if no_embed {
+            // `[packs.<name>] no_embed = true`: this pack's runtime gets zero
+            // embedders — its writes are FTS + metadata only, including
+            // core()-routed ones (core() inherits the runtime's embedder
+            // set). Clear both model fields together, same contract as
+            // `RuntimeConfig::no_embeddings`.
+            rt_config.embedding_model = None;
+            rt_config.additional_embedding_models = Vec::new();
+        }
         per_pack_runtimes_local.insert(
             pack_name.clone(),
             build_pack_runtime(backend, backend_name, rt_config, &main_backend),
@@ -3356,13 +3374,16 @@ pub fn build_server_from_multi_backend_registry(
 ) -> KhiveMcpServer {
     #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
     let channel_loop_admission = crate::server::ChannelLoopAdmission::for_pack_runtimes(
-        multi.per_pack_runtimes.get("kg").map(Arc::as_ref),
         multi.per_pack_runtimes.get("comm").map(Arc::as_ref),
     );
+    // The delivery loops scan, claim, and mark outbound `message` notes, so
+    // they must hold the runtime that owns comm's rows — under a
+    // `[packs.comm]` backend assignment that is the comm pack's runtime, not
+    // the kg/main one (which would list an empty outbox forever).
     #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
     let channel_outbox_runtime = multi
         .per_pack_runtimes
-        .get("kg")
+        .get("comm")
         .map(|runtime| runtime.as_ref().clone());
     // Wire the main backend's pool for background WAL checkpointing. The pool is
     // only present for file-backed databases; in-memory backends return None here
@@ -5553,6 +5574,7 @@ id = "lambda:project-actor"
                     "comm".to_string(),
                     PackConfig {
                         backend: "secondary".to_string(),
+                        no_embed: false,
                     },
                 );
                 m
@@ -6743,6 +6765,7 @@ region = "us-east-1"
                 "blob".to_string(),
                 PackConfig {
                     backend: "blob-snapshot".to_string(),
+                    no_embed: false,
                 },
             )]),
             ..KhiveConfig::default()
@@ -6804,6 +6827,7 @@ region = "us-east-1"
                 "blob".to_string(),
                 PackConfig {
                     backend: "blob-writable".to_string(),
+                    no_embed: false,
                 },
             )]),
             storage: StorageSectionConfig {
@@ -6869,6 +6893,7 @@ region = "us-east-1"
                     "comm".to_string(),
                     PackConfig {
                         backend: "secondary".to_string(),
+                        no_embed: false,
                     },
                 );
                 m
@@ -6958,12 +6983,14 @@ region = "us-east-1"
                     "kg".to_string(),
                     PackConfig {
                         backend: "direct".to_string(),
+                        no_embed: false,
                     },
                 );
                 m.insert(
                     "comm".to_string(),
                     PackConfig {
                         backend: "alias".to_string(),
+                        no_embed: false,
                     },
                 );
                 m
@@ -7046,6 +7073,7 @@ region = "us-east-1"
                     "comm".to_string(),
                     PackConfig {
                         backend: "secondary".to_string(),
+                        no_embed: false,
                     },
                 );
                 m
@@ -7103,6 +7131,7 @@ region = "us-east-1"
                     "comm".to_string(),
                     PackConfig {
                         backend: "secondary".to_string(),
+                        no_embed: false,
                     },
                 );
                 packs
@@ -7487,6 +7516,7 @@ region = "us-east-1"
                     "comm".to_string(),
                     PackConfig {
                         backend: "secondary".to_string(),
+                        no_embed: false,
                     },
                 );
                 m
@@ -7567,6 +7597,7 @@ region = "us-east-1"
                     "comm".to_string(),
                     PackConfig {
                         backend: "secondary".to_string(),
+                        no_embed: false,
                     },
                 );
                 m
@@ -7694,6 +7725,7 @@ region = "us-east-1"
                     "comm".to_string(),
                     PackConfig {
                         backend: "archive".to_string(),
+                        no_embed: false,
                     },
                 );
                 m
@@ -7752,6 +7784,7 @@ region = "us-east-1"
                     "comm".to_string(),
                     PackConfig {
                         backend: "archive".to_string(),
+                        no_embed: false,
                     },
                 );
                 m
@@ -7915,6 +7948,7 @@ region = "us-east-1"
                 "comm".to_string(),
                 PackConfig {
                     backend: "comm-store".to_string(),
+                    no_embed: false,
                 },
             )]),
             ..KhiveConfig::default()
@@ -8027,6 +8061,7 @@ region = "us-east-1"
                 "comm".to_string(),
                 PackConfig {
                     backend: "comm-store".to_string(),
+                    no_embed: false,
                 },
             )]),
             ..KhiveConfig::default()
@@ -8059,8 +8094,9 @@ region = "us-east-1"
             "comm.ingest/cursor/heartbeat are backed by the read-only comm runtime"
         );
         assert!(
-            admission.outbound_delivery,
-            "list/update are backed by the writable kg runtime"
+            !admission.outbound_delivery,
+            "the outbox scan/claim/mark also run on the read-only comm runtime, so no \
+             external send task may start"
         );
         drop(server);
         #[cfg(unix)]
@@ -8097,9 +8133,9 @@ region = "us-east-1"
             "comm.ingest/cursor/heartbeat are backed by the writable comm runtime"
         );
         assert!(
-            !admission.outbound_delivery,
-            "a read-only kg runtime cannot durably claim or mark delivery, so no external send \
-             task may start"
+            admission.outbound_delivery,
+            "the outbox scan/claim/mark run on the writable comm runtime — a read-only kg/main \
+             no longer gates external sends"
         );
     }
 
@@ -8153,6 +8189,7 @@ region = "us-east-1"
                     "comm".to_string(),
                     PackConfig {
                         backend: "alias".to_string(),
+                        no_embed: false,
                     },
                 );
                 packs
@@ -8497,6 +8534,7 @@ region = "us-east-1"
                     "comm".to_string(),
                     PackConfig {
                         backend: "secondary".to_string(),
+                        no_embed: false,
                     },
                 );
                 m
@@ -8562,6 +8600,7 @@ region = "us-east-1"
                     "comm".to_string(),
                     PackConfig {
                         backend: "secondary".to_string(),
+                        no_embed: false,
                     },
                 );
                 m
@@ -8639,6 +8678,7 @@ region = "us-east-1"
             "comm".to_string(),
             PackConfig {
                 backend: "secondary".to_string(),
+                no_embed: false,
             },
         );
 
@@ -8735,6 +8775,7 @@ region = "us-east-1"
                     "comm".to_string(),
                     PackConfig {
                         backend: "second".to_string(),
+                        no_embed: false,
                     },
                 );
                 m
@@ -10598,12 +10639,14 @@ backend = "kg-backend"
                         "kg".to_string(),
                         PackConfig {
                             backend: "kg-store".to_string(),
+                            no_embed: false,
                         },
                     ),
                     (
                         "comm".to_string(),
                         PackConfig {
                             backend: "kg-store".to_string(),
+                            no_embed: false,
                         },
                     ),
                 ]),
@@ -10625,7 +10668,7 @@ backend = "kg-backend"
             let registry = server.verb_registry_clone();
             let owner_runtime = server
                 .channel_outbox_runtime_clone()
-                .expect("email outbox must retain the KG-routed runtime");
+                .expect("email outbox must retain the comm-routed runtime");
             assert_eq!(owner_runtime.backend_id().as_str(), "kg-store");
 
             let send = registry
@@ -10648,10 +10691,8 @@ backend = "kg-backend"
             let namespace = Namespace::parse("local").unwrap();
             channel_outbox_once(
                 &channel,
-                &registry,
                 &owner_runtime,
                 &namespace,
-                "local",
                 "maintainer@example.com",
                 "example.com",
                 &["recipient@example.com".to_string()],
@@ -10694,6 +10735,213 @@ backend = "kg-backend"
                      FROM notes WHERE content = 'kg-secondary-outbox-probe' \
                        AND json_extract(properties, '$.direction') = 'outbound'",
                     [],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )
+                .unwrap();
+            assert!(!external_id.is_empty());
+            assert!(!delivered_at.is_empty());
+        }
+
+        /// `[packs.<name>] no_embed = true` must strip the embedder set from
+        /// exactly that pack's runtime. Registration is config-driven and
+        /// lazy-loading, so the registered-name lists are observable without
+        /// any model files present. The kg runtime doubles as the must-match
+        /// control: same base config, embedders retained.
+        #[tokio::test]
+        #[serial]
+        async fn pack_no_embed_strips_embedders_from_that_runtime_only() {
+            let dir = tempfile::tempdir().unwrap();
+            let khive_cfg = KhiveConfig {
+                backends: vec![
+                    BackendConfig {
+                        name: BackendId::MAIN.to_string(),
+                        kind: BackendKind::Sqlite,
+                        path: Some(dir.path().join("main.db")),
+                        cache_mb: None,
+                        journal_mode: None,
+                        read_only: false,
+                    },
+                    BackendConfig {
+                        name: "comm-store".to_string(),
+                        kind: BackendKind::Sqlite,
+                        path: Some(dir.path().join("comm.db")),
+                        cache_mb: None,
+                        journal_mode: None,
+                        read_only: false,
+                    },
+                ],
+                packs: HashMap::from([(
+                    "comm".to_string(),
+                    PackConfig {
+                        backend: "comm-store".to_string(),
+                        no_embed: true,
+                    },
+                )]),
+                ..KhiveConfig::default()
+            };
+
+            // Unlike the other fixtures, keep the default embedding model so
+            // the control arm has something to retain.
+            let base = RuntimeConfig {
+                packs: vec!["kg".to_string(), "comm".to_string()],
+                ..base_runtime_config_for_multi_backend()
+            };
+            let base = RuntimeConfig {
+                embedding_model: RuntimeConfig::default().embedding_model,
+                ..base
+            };
+            assert!(
+                base.embedding_model.is_some(),
+                "control arm needs a configured embedder"
+            );
+
+            let multi = build_registry_for_multi_backend_inner(base, &khive_cfg, None)
+                .await
+                .expect("no_embed topology must build");
+
+            assert!(
+                multi.per_pack_runtimes["comm"]
+                    .registered_embedding_model_names()
+                    .is_empty(),
+                "no_embed pack runtime must register zero embedders"
+            );
+            assert!(
+                !multi.per_pack_runtimes["kg"]
+                    .registered_embedding_model_names()
+                    .is_empty(),
+                "packs without no_embed must keep the configured embedders"
+            );
+        }
+
+        /// Two-backend regression for the comm split topology: comm assigned
+        /// its own backend while kg stays on main. The delivery loop's
+        /// non-wire scan/claim/mark must all land on the comm backend; the
+        /// generic wire `list` (kg/main-routed) cannot see the outbox at all,
+        /// which is exactly why the loop must not use it.
+        #[tokio::test]
+        #[serial]
+        async fn comm_secondary_runtime_owns_outbox_scan_claim_and_delivery_mark() {
+            let dir = tempfile::tempdir().unwrap();
+            let main_path = dir.path().join("main.db");
+            let comm_path = dir.path().join("comm-secondary.db");
+            let khive_cfg = KhiveConfig {
+                backends: vec![
+                    BackendConfig {
+                        name: BackendId::MAIN.to_string(),
+                        kind: BackendKind::Sqlite,
+                        path: Some(main_path.clone()),
+                        cache_mb: None,
+                        journal_mode: None,
+                        read_only: false,
+                    },
+                    BackendConfig {
+                        name: "comm-store".to_string(),
+                        kind: BackendKind::Sqlite,
+                        path: Some(comm_path.clone()),
+                        cache_mb: None,
+                        journal_mode: None,
+                        read_only: false,
+                    },
+                ],
+                packs: HashMap::from([(
+                    "comm".to_string(),
+                    PackConfig {
+                        backend: "comm-store".to_string(),
+                        no_embed: false,
+                    },
+                )]),
+                ..KhiveConfig::default()
+            };
+
+            let multi = build_registry_for_multi_backend_inner(
+                base_runtime_config_for_multi_backend(),
+                &khive_cfg,
+                None,
+            )
+            .await
+            .expect("comm-secondary registry must build");
+            let server = build_server_from_multi_backend_registry(multi, &khive_cfg, None);
+            let registry = server.verb_registry_clone();
+            let owner_runtime = server
+                .channel_outbox_runtime_clone()
+                .expect("email outbox must retain the comm-routed runtime");
+            assert_eq!(owner_runtime.backend_id().as_str(), "comm-store");
+
+            let send = registry
+                .dispatch(
+                    "comm.send",
+                    serde_json::json!({
+                        "to": "email:recipient@example.com",
+                        "subject": "comm split outbox",
+                        "content": "comm-secondary-outbox-probe",
+                    }),
+                )
+                .await
+                .expect("comm.send must create the outbound row on the comm backend");
+            let note_id = send["full_id"]
+                .as_str()
+                .expect("comm.send returns full_id")
+                .to_string();
+
+            // The generic wire `list` runs on kg/main and must NOT see the
+            // outbox row — pinning the routing gap the non-wire scan closes.
+            let wire_list = registry
+                .dispatch(
+                    "list",
+                    serde_json::json!({
+                        "kind": "message",
+                        "direction": "outbound",
+                        "delivered": false,
+                        "limit": 200,
+                    }),
+                )
+                .await
+                .expect("generic list must succeed on main");
+            let wire_items = wire_list
+                .get("items")
+                .and_then(serde_json::Value::as_array)
+                .cloned()
+                .unwrap_or_default();
+            assert!(
+                wire_items.is_empty(),
+                "main-routed wire list must not see comm's outbox: {wire_list}"
+            );
+
+            let channel = RecordingChannel::default();
+            let namespace = Namespace::parse("local").unwrap();
+            channel_outbox_once(
+                &channel,
+                &owner_runtime,
+                &namespace,
+                "maintainer@example.com",
+                "example.com",
+                &["recipient@example.com".to_string()],
+            )
+            .await;
+            assert_eq!(
+                channel.sent.lock().unwrap().len(),
+                1,
+                "non-wire scan must find and deliver the comm-backend outbox row"
+            );
+
+            let main = rusqlite::Connection::open(&main_path).unwrap();
+            let main_count: i64 = main
+                .query_row(
+                    "SELECT COUNT(*) FROM notes WHERE content = 'comm-secondary-outbox-probe'",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(main_count, 0, "main backend must not own the message");
+
+            let comm = rusqlite::Connection::open(&comm_path).unwrap();
+            let (external_id, delivered_at): (String, String) = comm
+                .query_row(
+                    "SELECT json_extract(properties, '$.external_id'), \
+                            json_extract(properties, '$.delivered_at') \
+                     FROM notes WHERE id = ?1 \
+                       AND json_extract(properties, '$.direction') = 'outbound'",
+                    [&note_id],
                     |row| Ok((row.get(0)?, row.get(1)?)),
                 )
                 .unwrap();

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -363,7 +363,7 @@ fn spawn_email_channel_loops_if_daemon(server: &KhiveMcpServer, args: &Args) {
     }
     if !admission.inbound_poll && !admission.outbound_delivery {
         tracing::info!(
-            "email channel loops: skipped (assigned comm and kg runtimes do not admit writes)"
+            "email channel loops: skipped (assigned comm runtime does not admit writes)"
         );
         return;
     }
@@ -1360,16 +1360,24 @@ fn log_eligible_poll_failure(
 
 /// True if a note's `delivered_at` property marks it as already delivered.
 ///
-/// Must match the `list` query predicate's null handling (`list.rs`): a
-/// present-but-null `delivered_at` is undelivered, not delivered. Checking
-/// `.is_some()` alone would treat an explicit null (e.g. left by a curation
-/// `update`) as delivered and strand the note in the outbox forever.
+/// Must match the outbox-scan pending predicate
+/// (`list_undelivered_outbound_messages`): a present-but-null `delivered_at`
+/// is undelivered, not delivered (checking `.is_some()` alone would treat an
+/// explicit null — e.g. left by a curation `update` — as delivered and strand
+/// the note in the outbox forever), and a terminal `properties.delivery`
+/// state (`"delivered"` / `"failed"`, ADR-122 §1) is not pending even when
+/// `delivered_at` is absent.
 #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
 fn note_already_delivered(props: &serde_json::Map<String, serde_json::Value>) -> bool {
-    props
+    let delivered_at_set = props
         .get("delivered_at")
         .map(|v| !v.is_null())
-        .unwrap_or(false)
+        .unwrap_or(false);
+    let terminal_delivery = props
+        .get("delivery")
+        .and_then(|v| v.as_str())
+        .is_some_and(|state| state == "delivered" || state == "failed");
+    delivered_at_set || terminal_delivery
 }
 
 /// Background task that delivers undelivered outbound email notes every 5 seconds.
@@ -1443,9 +1451,9 @@ async fn channel_outbox_once(
     // The generic wire `list` verb runs on the kg pack's runtime, which under
     // a `[packs.comm]` backend assignment is not the backend holding comm's
     // notes — the scan must use the comm-routed handle this loop was given.
-    // There is no recipient-prefix filter in the scan, so the `email:` prefix
-    // check (and a defensive re-check of direction/delivered) is applied
-    // per-note below.
+    // The `email:` prefix is applied INSIDE the scan (before its limit), so a
+    // backlog of another channel's pending rows cannot starve this one; the
+    // per-note checks below are defensive re-checks only.
     let token = match runtime.authorize(namespace.clone()) {
         Ok(token) => token,
         Err(error) => {
@@ -1454,7 +1462,7 @@ async fn channel_outbox_once(
         }
     };
     let notes = match runtime
-        .list_undelivered_outbound_messages(&token, 200)
+        .list_undelivered_outbound_messages(&token, Some("email:"), 200)
         .await
     {
         Ok(notes) => notes,
@@ -1492,11 +1500,33 @@ async fn channel_outbox_once(
             .unwrap_or(to_actor.as_str())
             .to_string();
         if !allowlist.is_empty() && !allowlist.contains(&recipient) {
-            tracing::warn!(
-                note_id = %note_id,
-                recipient = %recipient,
-                "outbox loop: recipient not in allowlist; skipping"
-            );
+            // ADR-122 §2: an allowlist rejection is a PERMANENT failure and
+            // must be recorded — skipping with only a log line leaves the row
+            // pending forever while the sender saw `ok: true`.
+            let failed_at = Utc::now().to_rfc3339();
+            let last_error = format!("recipient {recipient} not in outbound allowlist");
+            let mark_result = match uuid::Uuid::parse_str(&note_id) {
+                Ok(uuid) => runtime
+                    .mark_outbound_message_failed(&token, uuid, failed_at, last_error.clone())
+                    .await
+                    .map(|_| ()),
+                Err(error) => Err(khive_runtime::RuntimeError::InvalidInput(format!(
+                    "note id {note_id} is not a valid UUID: {error}"
+                ))),
+            };
+            match mark_result {
+                Ok(_) => tracing::warn!(
+                    note_id = %note_id,
+                    recipient = %recipient,
+                    "outbox loop: recipient not in allowlist; recorded permanent failure"
+                ),
+                Err(error) => tracing::warn!(
+                    note_id = %note_id,
+                    recipient = %recipient,
+                    error = %error,
+                    "outbox loop: recipient not in allowlist; failed to record failure (will re-encounter)"
+                ),
+            }
             continue;
         }
 
@@ -1522,8 +1552,8 @@ async fn channel_outbox_once(
             .and_then(|value| value.as_str())
             .map(str::to_string);
 
-        // Mint-before-send through the KG runtime's owner-only path. Generic
-        // `update` correctly refuses caller patches to `external_id`.
+        // Mint-before-send through the comm-routed runtime's owner-only path.
+        // Generic `update` correctly refuses caller patches to `external_id`.
         let message_id = match props.get("external_id").and_then(|value| value.as_str()) {
             Some(external_id) if !external_id.is_empty() => external_id.to_string(),
             _ => {
@@ -1572,7 +1602,12 @@ async fn channel_outbox_once(
                 let delivered_at = Utc::now().to_rfc3339();
                 let delivered_result = match uuid::Uuid::parse_str(&note_id) {
                     Ok(uuid) => runtime
-                        .mark_outbound_message_delivered(&token, uuid, delivered_at)
+                        .mark_outbound_message_delivered(
+                            &token,
+                            uuid,
+                            delivered_at,
+                            Some(message_id.clone()),
+                        )
                         .await
                         .map(|_| ()),
                     Err(error) => Err(khive_runtime::RuntimeError::InvalidInput(format!(
@@ -1604,8 +1639,8 @@ async fn channel_outbox_once(
 }
 
 /// Apply the same independent daemon/runtime admission as the email adapter:
-/// Telegram polling follows the comm runtime, while outbound delivery follows
-/// the kg runtime that must durably mark `delivered_at`.
+/// both Telegram polling and outbound delivery follow the comm runtime, which
+/// holds the message notes and durably marks delivery outcomes.
 #[cfg(feature = "channel-telegram")]
 fn spawn_telegram_channel_loops_if_daemon(server: &KhiveMcpServer, args: &Args) {
     let admission = channel_loop_plan(server, args);
@@ -1615,7 +1650,7 @@ fn spawn_telegram_channel_loops_if_daemon(server: &KhiveMcpServer, args: &Args) 
     }
     if !admission.inbound_poll && !admission.outbound_delivery {
         tracing::info!(
-            "telegram channel loops: skipped (assigned comm and kg runtimes do not admit writes)"
+            "telegram channel loops: skipped (assigned comm runtime does not admit writes)"
         );
         return;
     }
@@ -1854,7 +1889,7 @@ async fn telegram_outbox_loop(
             }
         };
         let notes = match runtime
-            .list_undelivered_outbound_messages(&token, 200)
+            .list_undelivered_outbound_messages(&token, Some("telegram:"), 200)
             .await
         {
             Ok(notes) => notes,
@@ -1904,7 +1939,7 @@ async fn telegram_outbox_loop(
                     let delivered_at = Utc::now().to_rfc3339();
                     let mark_result = match uuid::Uuid::parse_str(&note_id) {
                         Ok(uuid) => runtime
-                            .mark_outbound_message_delivered(&token, uuid, delivered_at)
+                            .mark_outbound_message_delivered(&token, uuid, delivered_at, None)
                             .await
                             .map(|_| ()),
                         Err(e) => Err(khive_runtime::RuntimeError::InvalidInput(format!(
@@ -2732,6 +2767,15 @@ async fn build_registry_for_multi_backend_inner(
     )
     .await?;
 
+    // Built before the pack loop: secondary-pack runtimes capture the main
+    // runtime's embedder wiring so their `core()`-routed writes embed with
+    // main's models even when the pack itself is `no_embed`.
+    let default_runtime = KhiveRuntime::from_backend(main_backend.clone(), {
+        let mut cfg = base_config.clone();
+        cfg.backend_id = BackendId::main();
+        cfg
+    });
+
     let pack_names = &base_config.packs;
     let mut per_pack_runtimes_local: HashMap<String, KhiveRuntime> = HashMap::new();
     for pack_name in pack_names {
@@ -2752,24 +2796,25 @@ async fn build_registry_for_multi_backend_inner(
         rt_config.backend_id = BackendId::new(backend_name);
         if no_embed {
             // `[packs.<name>] no_embed = true`: this pack's runtime gets zero
-            // embedders — its writes are FTS + metadata only, including
-            // core()-routed ones (core() inherits the runtime's embedder
-            // set). Clear both model fields together, same contract as
-            // `RuntimeConfig::no_embeddings`.
+            // embedders — pack-owned writes are FTS + metadata only. Clear
+            // both model fields together, same contract as
+            // `RuntimeConfig::no_embeddings`. `core()`-routed concept writes
+            // are NOT affected: `build_pack_runtime` hands every secondary
+            // pack the main runtime's embedder wiring for core().
             rt_config.embedding_model = None;
             rt_config.additional_embedding_models = Vec::new();
         }
         per_pack_runtimes_local.insert(
             pack_name.clone(),
-            build_pack_runtime(backend, backend_name, rt_config, &main_backend),
+            build_pack_runtime(
+                backend,
+                backend_name,
+                rt_config,
+                &main_backend,
+                &default_runtime,
+            ),
         );
     }
-
-    let default_runtime = KhiveRuntime::from_backend(main_backend.clone(), {
-        let mut cfg = base_config.clone();
-        cfg.backend_id = BackendId::main();
-        cfg
-    });
 
     // ADR-160 D3: resolve the config-selected `BlobStore` once, pair it with
     // exactly one aggregate hydration budget, and install the same immutable
@@ -3688,10 +3733,12 @@ fn build_pack_runtime(
     backend_name: &str,
     rt_config: RuntimeConfig,
     main_backend: &Arc<StorageBackend>,
+    main_runtime: &KhiveRuntime,
 ) -> KhiveRuntime {
     let rt = KhiveRuntime::from_backend(backend, rt_config);
     if backend_name != BackendId::MAIN {
         rt.with_core_backend(main_backend.clone())
+            .with_core_embedders_from(main_runtime)
     } else {
         rt
     }
@@ -10805,11 +10852,21 @@ backend = "kg-backend"
                     .is_empty(),
                 "no_embed pack runtime must register zero embedders"
             );
+            let main_models = multi.per_pack_runtimes["kg"].registered_embedding_model_names();
             assert!(
-                !multi.per_pack_runtimes["kg"]
-                    .registered_embedding_model_names()
-                    .is_empty(),
+                !main_models.is_empty(),
                 "packs without no_embed must keep the configured embedders"
+            );
+            // The routing contract: no_embed strips the PACK's own writes
+            // only. core()-routed concept writes must embed with the main
+            // runtime's wiring, or a no_embed secondary pack would silently
+            // write unembedded entities into the shared graph.
+            assert_eq!(
+                multi.per_pack_runtimes["comm"]
+                    .core()
+                    .registered_embedding_model_names(),
+                main_models,
+                "no_embed pack's core() must carry the main runtime's embedders"
             );
         }
 

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -697,13 +697,17 @@ fn encode_backend_topology(cfg: &khive_runtime::KhiveConfig) -> String {
         .collect();
     backend_rows.sort();
 
-    let mut pack_rows: Vec<(String, String)> = cfg
+    let mut pack_rows: Vec<(String, String, bool)> = cfg
         .packs
         .iter()
         .map(|(pack, pack_config)| {
             legacy_safe &= legacy_topology_component_is_safe(pack)
                 && legacy_topology_component_is_safe(&pack_config.backend);
-            (pack.clone(), pack_config.backend.clone())
+            (
+                pack.clone(),
+                pack_config.backend.clone(),
+                pack_config.no_embed,
+            )
         })
         .collect();
     pack_rows.sort();
@@ -719,7 +723,13 @@ fn encode_backend_topology(cfg: &khive_runtime::KhiveConfig) -> String {
             .join(",");
         let pack_backends = pack_rows
             .iter()
-            .map(|(pack, backend)| format!("{pack}={backend}"))
+            .map(|(pack, backend, no_embed)| {
+                // `no_embed` changes runtime behavior (that pack's runtime
+                // carries zero embedders), so it must move the fingerprint;
+                // emitted only when set so pre-existing configs keep their id.
+                let no_embed = if *no_embed { ":no_embed" } else { "" };
+                format!("{pack}={backend}{no_embed}")
+            })
             .collect::<Vec<_>>()
             .join(",");
         (backends, pack_backends)
@@ -739,9 +749,10 @@ fn encode_backend_topology(cfg: &khive_runtime::KhiveConfig) -> String {
             .join(",");
         let pack_backends = pack_rows
             .iter()
-            .map(|(pack, backend)| {
+            .map(|(pack, backend, no_embed)| {
+                let no_embed = if *no_embed { ":no_embed" } else { "" };
                 format!(
-                    "{}={}",
+                    "{}={}{no_embed}",
                     escape_topology_component(pack),
                     escape_topology_component(backend),
                 )
@@ -5844,6 +5855,58 @@ mod tests {
         assert!(
             config_id.ends_with(&expected_suffix),
             "delimiter-free topologies must retain their legacy fingerprint spelling; got {config_id}"
+        );
+    }
+
+    /// `no_embed` changes runtime behavior (that pack's runtime carries zero
+    /// embedders), so two configs differing only in it must not share a
+    /// `config_id` — a shared id would let a daemon serve a client whose
+    /// embedding policy it does not implement. Absent/false keeps the
+    /// pre-existing spelling so already-deployed configs keep their id.
+    #[test]
+    fn config_id_differs_when_pack_no_embed_differs() {
+        use khive_runtime::{BackendConfig, BackendId, BackendKind, KhiveConfig, PackConfig};
+
+        let dir = tempfile::tempdir().expect("no_embed topology tempdir");
+        let main_path = dir.path().join("main.db");
+        let runtime = RuntimeConfig {
+            db_path: Some(main_path.clone()),
+            packs: vec!["comm".to_string()],
+            backend_id: BackendId::main(),
+            ..RuntimeConfig::no_embeddings()
+        };
+        let topology_for = |no_embed: bool| KhiveConfig {
+            backends: vec![BackendConfig {
+                name: "main".to_string(),
+                kind: BackendKind::Sqlite,
+                path: Some(main_path.clone()),
+                cache_mb: None,
+                journal_mode: None,
+                read_only: false,
+            }],
+            packs: std::collections::HashMap::from([(
+                "comm".to_string(),
+                PackConfig {
+                    backend: "main".to_string(),
+                    no_embed,
+                },
+            )]),
+            ..KhiveConfig::default()
+        };
+
+        let with_flag = compute_config_id(&runtime, Some(&topology_for(true)));
+        let without_flag = compute_config_id(&runtime, Some(&topology_for(false)));
+        assert_ne!(
+            with_flag, without_flag,
+            "configs differing only in no_embed must not share a config_id"
+        );
+        assert!(
+            with_flag.contains("comm=main:no_embed"),
+            "no_embed must appear in the pack fingerprint; got {with_flag}"
+        );
+        assert!(
+            without_flag.contains("comm=main]"),
+            "absent no_embed keeps the legacy pack spelling; got {without_flag}"
         );
     }
 

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -1193,7 +1193,7 @@ impl KhiveMcpServer {
         self
     }
 
-    /// Attach the exact KG-routed runtime that owns outbox note properties.
+    /// Attach the exact comm-routed runtime that owns outbox note properties.
     /// Multi-backend boot overrides the default-runtime fallback installed by
     /// [`Self::with_runtime`]; single-backend construction already points both
     /// handles at the same runtime.

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -820,11 +820,13 @@ fn build_verb_catalog(verbs: impl IntoIterator<Item = (String, String, String)>)
 /// Runtime-mode admission for transport background work.
 ///
 /// The inbound tasks dispatch only `comm.*` verbs (`comm.ingest`, heartbeat,
-/// and cursor operations), so their write authority is the comm pack's actual
-/// assigned runtime. The outbound tasks scan and mutate notes through the kg
-/// pack's generic `list`/`update` verbs, so they must not perform an external
-/// send unless that runtime can durably record the claim and `delivered_at`.
-/// Keeping the two decisions separate preserves mixed-backend topologies.
+/// and cursor operations), and the outbound tasks scan, claim, and mark
+/// outbound `message` notes through the runtime's non-wire owner-side APIs —
+/// both against the comm pack's actual assigned runtime, since under a
+/// `[packs.comm]` backend assignment that is the backend holding comm's
+/// rows. Neither loop may run unless that runtime can durably record its
+/// writes. The two decisions stay separate so a future topology can admit
+/// one direction without the other.
 #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(crate) struct ChannelLoopAdmission {
@@ -836,21 +838,18 @@ pub(crate) struct ChannelLoopAdmission {
 impl ChannelLoopAdmission {
     fn for_single_runtime(runtime: &KhiveRuntime, packs: &[String]) -> Self {
         let comm_loaded = packs.iter().any(|pack| pack == "comm");
-        let kg_loaded = packs.iter().any(|pack| pack == "kg");
         let writable = !runtime.is_read_only();
         Self {
             inbound_poll: comm_loaded && writable,
-            outbound_delivery: comm_loaded && kg_loaded && writable,
+            outbound_delivery: comm_loaded && writable,
         }
     }
 
-    pub(crate) fn for_pack_runtimes(
-        kg: Option<&KhiveRuntime>,
-        comm: Option<&KhiveRuntime>,
-    ) -> Self {
+    pub(crate) fn for_pack_runtimes(comm: Option<&KhiveRuntime>) -> Self {
+        let admitted = comm.is_some_and(|runtime| !runtime.is_read_only());
         Self {
-            inbound_poll: comm.is_some_and(|runtime| !runtime.is_read_only()),
-            outbound_delivery: comm.is_some() && kg.is_some_and(|runtime| !runtime.is_read_only()),
+            inbound_poll: admitted,
+            outbound_delivery: admitted,
         }
     }
 }
@@ -878,11 +877,13 @@ pub struct KhiveMcpServer {
     /// [`Self::from_registry`]/[`Self::from_registry_with_meta`] without an
     /// explicit [`Self::with_runtime`] call (test-only construction paths).
     runtime: Option<KhiveRuntime>,
-    /// Runtime that owns KG-routed outbox notes. The email loop's
-    /// `external_id` claim is deliberately non-wire, so it cannot rely on the
-    /// registry to route that one mutation. In a multi-backend topology this
-    /// may differ from `runtime` (the default backend); retaining the exact KG
-    /// runtime keeps list, owner claim, and delivered-at update on one store.
+    /// Runtime that owns the outbound `message` notes the delivery loops
+    /// scan, claim, and mark — the comm pack's assigned runtime. Every one of
+    /// those touches is deliberately non-wire (the generic verbs run on the
+    /// kg/main runtime, which under a `[packs.comm]` backend assignment does
+    /// not hold comm's rows). In a multi-backend topology this may differ
+    /// from `runtime` (the default backend); retaining the exact comm
+    /// runtime keeps scan, owner claim, and delivered-at update on one store.
     #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
     channel_outbox_runtime: Option<KhiveRuntime>,
     /// Pool arc for the WAL checkpoint background task. `None` for in-memory
@@ -5784,6 +5785,7 @@ mod tests {
                 "knowledge".to_string(),
                 PackConfig {
                     backend: "archive".to_string(),
+                    no_embed: false,
                 },
             )]),
             ..KhiveConfig::default()
@@ -5828,6 +5830,7 @@ mod tests {
                 "kg".to_string(),
                 PackConfig {
                     backend: "main".to_string(),
+                    no_embed: false,
                 },
             )]),
             ..KhiveConfig::default()

--- a/crates/khive-pack-knowledge/Cargo.toml
+++ b/crates/khive-pack-knowledge/Cargo.toml
@@ -37,6 +37,9 @@ libc = { workspace = true }
 
 [dev-dependencies]
 khive-pack-kg = { version = "0.8.0", path = "../khive-pack-kg" }
+# Test-only: builds the two-backend (secondary + core main) runtime for the
+# ADR-073 concept-tier routing regression tests.
+khive-db = { version = "0.8.0", path = "../khive-db" }
 khive-pack-brain = { version = "0.8.0", path = "../khive-pack-brain" }
 khive-storage = { version = "0.8.0", path = "../khive-storage", features = ["test-support"] }
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/khive-pack-knowledge/src/handlers.rs
+++ b/crates/khive-pack-knowledge/src/handlers.rs
@@ -159,8 +159,12 @@ impl KnowledgePack {
             }
         }
 
+        // Concept entities are linkable graph rows and must live on the core
+        // (main) backend even when the pack is assigned a secondary backend
+        // (ADR-073; same seam as the session pack's ADR-083 §4 fix).
         let entity = self
             .runtime
+            .core()
             .create_entity(
                 token,
                 "concept",
@@ -191,12 +195,14 @@ impl KnowledgePack {
         params: Value,
     ) -> Result<Value, RuntimeError> {
         let p: CiteParams = deser(params)?;
-        let concept_id = resolve_uuid(&p.concept_id, &self.runtime, token).await?;
-        let source_id = resolve_uuid(&p.source_id, &self.runtime, token).await?;
+        // Concepts and their sources live on the core graph, so both prefix
+        // resolution and the edge write must target the core backend (ADR-073).
+        let core = self.runtime.core();
+        let concept_id = resolve_uuid(&p.concept_id, &core, token).await?;
+        let source_id = resolve_uuid(&p.source_id, &core, token).await?;
         let weight = p.weight.unwrap_or(1.0).clamp(0.0, 1.0);
 
-        let edge = self
-            .runtime
+        let edge = core
             .link(
                 token,
                 concept_id,
@@ -224,6 +230,10 @@ impl KnowledgePack {
         params: Value,
     ) -> Result<Value, RuntimeError> {
         let p: TopicParams = deser(params)?;
+        // Concept entities live on the core graph (see handle_learn); every
+        // read in this handler must go through the core backend or a
+        // secondary-assigned pack would list/search an empty graph (ADR-073).
+        let core = self.runtime.core();
         let limit = p.limit.unwrap_or(20).min(100);
         // Normalise domain filter to lowercase for case-insensitive matching.
         let domain_filter = p
@@ -237,8 +247,7 @@ impl KnowledgePack {
             // We fetch limit*4 candidates to give the domain filter enough to work with.
             // `total` = post-filter count of the candidate window (bounded by limit*4),
             // NOT a true corpus count — see doc comment above.
-            let hits = self
-                .runtime
+            let hits = core
                 .hybrid_search(
                     token,
                     query,
@@ -255,8 +264,7 @@ impl KnowledgePack {
             // unified item shape (K-2) and apply the domain filter reliably.
             let hit_ids: Vec<Uuid> = hits.iter().map(|h| h.entity_id).collect();
             let entity_map: std::collections::HashMap<Uuid, _> = if !hit_ids.is_empty() {
-                self.runtime
-                    .get_entities_by_ids(token, &hit_ids)
+                core.get_entities_by_ids(token, &hit_ids)
                     .await?
                     .into_iter()
                     .map(|e| (e.id, e))
@@ -307,13 +315,11 @@ impl KnowledgePack {
             // Listing path: DB-level domain filter via tags_any avoids silent
             // truncation (K-3).  `count_entities_tagged` gives the pre-limit
             // match count for `total` (K-6).
-            let total = self
-                .runtime
+            let total = core
                 .count_entities_tagged(token, Some("concept"), domain_filter.as_deref())
                 .await?;
 
-            let entities = self
-                .runtime
+            let entities = core
                 .list_entities_tagged(token, Some("concept"), domain_filter.as_deref(), limit, 0)
                 .await?;
 
@@ -559,6 +565,125 @@ mod tests {
 
     use crate::knowledge::section_feedback::on_section_feedback;
     use crate::KnowledgePack;
+
+    /// A runtime shaped like a `[packs.knowledge]` backend assignment: bound
+    /// to a secondary `knowledge` backend with the shared-graph main backend
+    /// reachable only through `core()`. Both backends are fresh in-memory
+    /// databases with migrations applied (same construction as the session
+    /// pack's ADR-083 §4 regression tests).
+    fn secondary_backend_runtime() -> KhiveRuntime {
+        use std::sync::Arc;
+
+        let make_backend = || {
+            let backend = khive_db::StorageBackend::memory().expect("in-memory backend");
+            {
+                let mut writer = backend.pool().try_writer().expect("writer");
+                khive_db::run_migrations(writer.conn_mut()).expect("migrations");
+            }
+            Arc::new(backend)
+        };
+        let main_backend = make_backend();
+        let knowledge_backend = make_backend();
+
+        let mut config = khive_runtime::RuntimeConfig::no_embeddings();
+        config.packs = vec!["kg".to_string()];
+        config.backend_id = khive_runtime::BackendId::new("knowledge");
+
+        KhiveRuntime::from_backend(knowledge_backend, config).with_core_backend(main_backend)
+    }
+
+    /// ADR-073 regression: the concept tier (`learn`/`cite`/`topic`) must
+    /// read and write the core graph. On a secondary-assigned runtime,
+    /// pre-fix behavior wrote the concept entity into the pack's own backend
+    /// — self-consistent from inside the pack, but invisible to kg and lost
+    /// to every core-graph consumer.
+    #[tokio::test]
+    async fn concept_tier_routes_through_core_on_secondary_backend() {
+        let rt = secondary_backend_runtime();
+        let pack = KnowledgePack::new(rt.clone());
+        let registry = VerbRegistryBuilder::new()
+            .build()
+            .expect("empty registry builds");
+        let token = rt.authorize(Namespace::local()).expect("authorize local");
+
+        let learned = pack
+            .dispatch(
+                "knowledge.learn",
+                json!({ "name": "core-routing probe", "content": "concept body", "domain": "retrieval" }),
+                &registry,
+                &token,
+            )
+            .await
+            .expect("learn succeeds");
+        let concept_id: Uuid = learned["full_id"]
+            .as_str()
+            .expect("full_id")
+            .parse()
+            .expect("uuid");
+
+        // The entity must exist on the core graph...
+        let on_core = rt
+            .core()
+            .get_entities_by_ids(&token, &[concept_id])
+            .await
+            .expect("core read succeeds");
+        assert_eq!(
+            on_core.len(),
+            1,
+            "learn must write the concept entity to the core (main) backend"
+        );
+        // ...and must NOT have been written into the pack's secondary backend.
+        let on_secondary = rt
+            .get_entities_by_ids(&token, &[concept_id])
+            .await
+            .expect("secondary read succeeds");
+        assert!(
+            on_secondary.is_empty(),
+            "concept entity must not land on the knowledge backend"
+        );
+
+        // cite: prefix resolution and the edge write share the core seam.
+        // The source is a document entity on the core graph (the shape cite
+        // links against in production).
+        let source = rt
+            .core()
+            .create_entity(
+                &token,
+                "document",
+                None,
+                "source paper",
+                Some("source body"),
+                None,
+                vec![],
+            )
+            .await
+            .expect("source document entity");
+        let source_id = source.id.to_string();
+        pack.dispatch(
+            "knowledge.cite",
+            json!({ "concept_id": concept_id.to_string(), "source_id": source_id }),
+            &registry,
+            &token,
+        )
+        .await
+        .expect("cite must resolve both core-side entities and write the edge");
+
+        // topic (listing mode) reads through core and must see the concepts.
+        let topics = pack
+            .dispatch(
+                "knowledge.topic",
+                json!({ "domain": "retrieval" }),
+                &registry,
+                &token,
+            )
+            .await
+            .expect("topic succeeds");
+        assert_eq!(
+            topics["total"].as_u64(),
+            Some(1),
+            "topic must list the core-side concept: {topics}"
+        );
+    }
 
     /// Regression: handle_topic's entity lookup must never panic when an entity_id
     /// is absent from the map.

--- a/crates/khive-pack-knowledge/src/knowledge/search.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/search.rs
@@ -2576,7 +2576,18 @@ impl KnowledgeHandlers {
                 // response instead of aborting the whole compose — the
                 // finalized atom/section body above is still a valid,
                 // useful briefing even without the supplementary KG section.
-                match search_kg_entities(runtime, token, &ns, &raw_query, KG_BLEND_CAP, floor).await
+                // KG entities live on the core (main) backend; on a
+                // secondary-assigned pack runtime this search would silently
+                // blend against an empty graph (ADR-073).
+                match search_kg_entities(
+                    &runtime.core(),
+                    token,
+                    &ns,
+                    &raw_query,
+                    KG_BLEND_CAP,
+                    floor,
+                )
+                .await
                 {
                     Ok(kg_hits) => {
                         let remaining_budget = char_budget.saturating_sub(body_used);

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -1855,11 +1855,7 @@ impl KhiveRuntime {
     /// markers: they take caller-supplied UUIDs, and the generic
     /// `update_note` they patch through would happily stamp delivery
     /// properties onto any note kind.
-    async fn assert_outbound_message(
-        &self,
-        token: &NamespaceToken,
-        id: Uuid,
-    ) -> RuntimeResult<()> {
+    async fn assert_outbound_message(&self, token: &NamespaceToken, id: Uuid) -> RuntimeResult<()> {
         let note = self
             .notes(token)?
             .get_note(id)
@@ -4027,7 +4023,10 @@ mod tests {
             store.upsert_note(note).await.expect("seed note");
         }
         store.upsert_note(inbound).await.expect("seed inbound");
-        store.upsert_note(wrong_kind).await.expect("seed non-message");
+        store
+            .upsert_note(wrong_kind)
+            .await
+            .expect("seed non-message");
 
         let marked = rt
             .mark_outbound_message_delivered(
@@ -4038,8 +4037,15 @@ mod tests {
             )
             .await
             .expect("mark delivered succeeds");
-        let props = marked.properties.as_ref().and_then(|v| v.as_object()).unwrap();
-        assert_eq!(props.get("delivery").and_then(|v| v.as_str()), Some("delivered"));
+        let props = marked
+            .properties
+            .as_ref()
+            .and_then(|v| v.as_object())
+            .unwrap();
+        assert_eq!(
+            props.get("delivery").and_then(|v| v.as_str()),
+            Some("delivered")
+        );
         assert_eq!(
             props.get("delivered_at").and_then(|v| v.as_str()),
             Some("2026-08-28T00:00:00Z")
@@ -4058,8 +4064,15 @@ mod tests {
             )
             .await
             .expect("mark failed succeeds");
-        let props = failed.properties.as_ref().and_then(|v| v.as_object()).unwrap();
-        assert_eq!(props.get("delivery").and_then(|v| v.as_str()), Some("failed"));
+        let props = failed
+            .properties
+            .as_ref()
+            .and_then(|v| v.as_object())
+            .unwrap();
+        assert_eq!(
+            props.get("delivery").and_then(|v| v.as_str()),
+            Some("failed")
+        );
         assert_eq!(
             props.get("failed_at").and_then(|v| v.as_str()),
             Some("2026-08-28T00:00:01Z")

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -3782,6 +3782,65 @@ mod tests {
         note
     }
 
+    /// Predicate + ordering contract of the non-wire outbox scan: outbound
+    /// with absent OR explicitly-null `delivered_at` is undelivered; a
+    /// non-null `delivered_at`, an inbound row, and a soft-deleted row are
+    /// all excluded; results come newest-first and respect `limit`.
+    #[tokio::test]
+    async fn list_undelivered_outbound_messages_predicate_and_order() {
+        let rt = rt();
+        rt.install_pack_owned_note_kinds(vec!["message".to_string()]);
+        let tok = NamespaceToken::local();
+        let store = rt.notes(&tok).expect("note store");
+
+        let mut undelivered_old = outbound_message_note();
+        undelivered_old.created_at -= 10;
+        let mut undelivered_null = outbound_message_note();
+        undelivered_null.properties =
+            Some(serde_json::json!({"direction": "outbound", "delivered_at": null}));
+        let mut delivered = outbound_message_note();
+        delivered.properties = Some(
+            serde_json::json!({"direction": "outbound", "delivered_at": "2026-08-28T00:00:00Z"}),
+        );
+        let mut inbound = Note::new("local", "message", "inbound row");
+        inbound.properties = Some(serde_json::json!({"direction": "inbound"}));
+        let mut soft_deleted = outbound_message_note();
+        soft_deleted.deleted_at = Some(chrono::Utc::now().timestamp_micros());
+
+        let old_id = undelivered_old.id;
+        let null_id = undelivered_null.id;
+        for note in [
+            undelivered_old,
+            undelivered_null,
+            delivered,
+            inbound,
+            soft_deleted,
+        ] {
+            store.upsert_note(note).await.expect("seed note");
+        }
+
+        let hits = rt
+            .list_undelivered_outbound_messages(&tok, 200)
+            .await
+            .expect("scan succeeds");
+        let ids: Vec<_> = hits.iter().map(|n| n.id).collect();
+        assert_eq!(
+            ids,
+            vec![null_id, old_id],
+            "only the two undelivered outbound rows, newest-first"
+        );
+
+        let capped = rt
+            .list_undelivered_outbound_messages(&tok, 1)
+            .await
+            .expect("capped scan succeeds");
+        assert_eq!(
+            capped.iter().map(|n| n.id).collect::<Vec<_>>(),
+            vec![null_id],
+            "limit truncates after the newest undelivered row"
+        );
+    }
+
     #[tokio::test]
     async fn claim_outbound_message_external_id_sets_value_and_survives_readback() {
         let rt = rt();

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -1760,6 +1760,92 @@ impl KhiveRuntime {
             .ok_or_else(|| RuntimeError::NotFound(format!("note {id}")))
     }
 
+    /// Non-wire outbox scan for the channel delivery loops.
+    ///
+    /// Pages newest-first through live `message` notes (the same order and
+    /// 10k scan cap as the generic `list` verb's filtered offset path) and
+    /// returns those with `properties.direction == "outbound"` whose
+    /// `delivered_at` is absent or null, capped at `limit`. This lives on the
+    /// runtime rather than going through the wire registry for the same
+    /// reason as [`Self::claim_outbound_message_external_id`]: the delivery
+    /// loop must scan the backend that actually holds comm's notes, and under
+    /// a `[packs.comm]` backend assignment that is not the backend serving
+    /// the generic kg verbs.
+    pub async fn list_undelivered_outbound_messages(
+        &self,
+        token: &NamespaceToken,
+        limit: u32,
+    ) -> RuntimeResult<Vec<khive_storage::note::Note>> {
+        const PAGE_SIZE: u32 = 200;
+        const MAX_SCAN_TOTAL: u32 = 10_000;
+        let mut collected: Vec<khive_storage::note::Note> = Vec::new();
+        let mut db_offset: u32 = 0;
+        loop {
+            let remaining_scan = MAX_SCAN_TOTAL.saturating_sub(db_offset).min(PAGE_SIZE);
+            if remaining_scan == 0 {
+                break;
+            }
+            let page = self
+                .list_notes(token, Some("message"), remaining_scan, db_offset)
+                .await?;
+            let fetched = page.len() as u32;
+            for note in page {
+                if note.deleted_at.is_some() {
+                    continue;
+                }
+                let props = note.properties.as_ref().and_then(|v| v.as_object());
+                let outbound = props
+                    .and_then(|p| p.get("direction"))
+                    .and_then(|v| v.as_str())
+                    == Some("outbound");
+                if !outbound {
+                    continue;
+                }
+                // Must match `note_already_delivered` in the delivery loop: a
+                // present-but-null `delivered_at` is undelivered.
+                let delivered = props
+                    .and_then(|p| p.get("delivered_at"))
+                    .is_some_and(|v| !v.is_null());
+                if delivered {
+                    continue;
+                }
+                collected.push(note);
+                if collected.len() >= limit as usize {
+                    return Ok(collected);
+                }
+            }
+            if fetched < PAGE_SIZE {
+                break;
+            }
+            db_offset += fetched;
+        }
+        Ok(collected)
+    }
+
+    /// Mark an outbound `message` note delivered by merging
+    /// `properties.delivered_at`, through the same patch path the generic
+    /// `update` verb uses (`delivered_at` is deliberately not
+    /// owner-established, pinned by
+    /// `generic_update_can_still_patch_delivered_at_on_message_note`).
+    /// Non-wire companion to [`Self::list_undelivered_outbound_messages`] so
+    /// the delivery loop writes the backend that holds the note.
+    pub async fn mark_outbound_message_delivered(
+        &self,
+        token: &NamespaceToken,
+        id: Uuid,
+        delivered_at: String,
+    ) -> RuntimeResult<khive_storage::note::Note> {
+        self.update_note(
+            token,
+            id,
+            NotePatch {
+                properties: Some(serde_json::json!({ "delivered_at": delivered_at })),
+                ..NotePatch::default()
+            },
+        )
+        .await
+    }
+
     /// Merge `from_id` note into `into_id` note.
     ///
     /// Both notes must exist in the namespace and have the same `kind`. Content is merged

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -1764,20 +1764,30 @@ impl KhiveRuntime {
     ///
     /// Pages newest-first through live `message` notes (the same order and
     /// 10k scan cap as the generic `list` verb's filtered offset path) and
-    /// returns those with `properties.direction == "outbound"` whose
-    /// `delivered_at` is absent or null, capped at `limit`. This lives on the
-    /// runtime rather than going through the wire registry for the same
-    /// reason as [`Self::claim_outbound_message_external_id`]: the delivery
-    /// loop must scan the backend that actually holds comm's notes, and under
-    /// a `[packs.comm]` backend assignment that is not the backend serving
-    /// the generic kg verbs.
+    /// returns those with `properties.direction == "outbound"` that are still
+    /// pending delivery, capped at `limit`. Pending means `delivered_at` is
+    /// absent or null AND `properties.delivery` carries no terminal state
+    /// (`"delivered"` / `"failed"`, ADR-122 §1). When `to_prefix` is given,
+    /// only rows whose `properties.to_actor` starts with it are counted —
+    /// the channel predicate must run BEFORE the limit, otherwise a backlog
+    /// of another channel's pending rows starves this channel indefinitely.
+    /// This lives on the runtime rather than going through the wire registry
+    /// for the same reason as
+    /// [`Self::claim_outbound_message_external_id`]: the delivery loop must
+    /// scan the backend that actually holds comm's notes, and under a
+    /// `[packs.comm]` backend assignment that is not the backend serving the
+    /// generic kg verbs.
     pub async fn list_undelivered_outbound_messages(
         &self,
         token: &NamespaceToken,
+        to_prefix: Option<&str>,
         limit: u32,
     ) -> RuntimeResult<Vec<khive_storage::note::Note>> {
         const PAGE_SIZE: u32 = 200;
         const MAX_SCAN_TOTAL: u32 = 10_000;
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
         let mut collected: Vec<khive_storage::note::Note> = Vec::new();
         let mut db_offset: u32 = 0;
         loop {
@@ -1801,12 +1811,30 @@ impl KhiveRuntime {
                 if !outbound {
                     continue;
                 }
+                if let Some(prefix) = to_prefix {
+                    let to_matches = props
+                        .and_then(|p| p.get("to_actor"))
+                        .and_then(|v| v.as_str())
+                        .is_some_and(|actor| actor.starts_with(prefix));
+                    if !to_matches {
+                        continue;
+                    }
+                }
                 // Must match `note_already_delivered` in the delivery loop: a
-                // present-but-null `delivered_at` is undelivered.
+                // present-but-null `delivered_at` is undelivered, and a
+                // terminal `delivery` state ("delivered"/"failed") is not
+                // pending even without `delivered_at` (ADR-122 §1).
                 let delivered = props
                     .and_then(|p| p.get("delivered_at"))
                     .is_some_and(|v| !v.is_null());
                 if delivered {
+                    continue;
+                }
+                let terminal = props
+                    .and_then(|p| p.get("delivery"))
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|state| state == "delivered" || state == "failed");
+                if terminal {
                     continue;
                 }
                 collected.push(note);
@@ -1822,24 +1850,102 @@ impl KhiveRuntime {
         Ok(collected)
     }
 
-    /// Mark an outbound `message` note delivered by merging
-    /// `properties.delivered_at`, through the same patch path the generic
-    /// `update` verb uses (`delivered_at` is deliberately not
-    /// owner-established, pinned by
+    /// Assert that `id` names a live outbound `message` note, returning
+    /// `InvalidInput` otherwise. Guard shared by the delivery-outcome
+    /// markers: they take caller-supplied UUIDs, and the generic
+    /// `update_note` they patch through would happily stamp delivery
+    /// properties onto any note kind.
+    async fn assert_outbound_message(
+        &self,
+        token: &NamespaceToken,
+        id: Uuid,
+    ) -> RuntimeResult<()> {
+        let note = self
+            .notes(token)?
+            .get_note(id)
+            .await?
+            .ok_or_else(|| RuntimeError::NotFound(format!("note {id}")))?;
+        if note.kind != "message" || note.deleted_at.is_some() {
+            return Err(RuntimeError::InvalidInput(format!(
+                "note {id} is not a live message note (kind {})",
+                note.kind
+            )));
+        }
+        let outbound = note
+            .properties
+            .as_ref()
+            .and_then(|v| v.as_object())
+            .and_then(|p| p.get("direction"))
+            .and_then(|v| v.as_str())
+            == Some("outbound");
+        if !outbound {
+            return Err(RuntimeError::InvalidInput(format!(
+                "note {id} is not an outbound message"
+            )));
+        }
+        Ok(())
+    }
+
+    /// Mark an outbound `message` note delivered by merging the ADR-122 §1
+    /// terminal-outcome properties (`delivery = "delivered"`, `delivered_at`,
+    /// and `transport_message_id` when the transport minted one), through the
+    /// same patch path the generic `update` verb uses (`delivered_at` is
+    /// deliberately not owner-established, pinned by
     /// `generic_update_can_still_patch_delivered_at_on_message_note`).
-    /// Non-wire companion to [`Self::list_undelivered_outbound_messages`] so
-    /// the delivery loop writes the backend that holds the note.
+    /// Refuses (`InvalidInput`) unless `id` names a live outbound `message`
+    /// note. Non-wire companion to
+    /// [`Self::list_undelivered_outbound_messages`] so the delivery loop
+    /// writes the backend that holds the note.
     pub async fn mark_outbound_message_delivered(
         &self,
         token: &NamespaceToken,
         id: Uuid,
         delivered_at: String,
+        transport_message_id: Option<String>,
     ) -> RuntimeResult<khive_storage::note::Note> {
+        self.assert_outbound_message(token, id).await?;
+        let mut props = serde_json::Map::new();
+        props.insert("delivery".into(), Value::String("delivered".into()));
+        props.insert("delivered_at".into(), Value::String(delivered_at));
+        if let Some(transport_message_id) = transport_message_id {
+            props.insert(
+                "transport_message_id".into(),
+                Value::String(transport_message_id),
+            );
+        }
         self.update_note(
             token,
             id,
             NotePatch {
-                properties: Some(serde_json::json!({ "delivered_at": delivered_at })),
+                properties: Some(Value::Object(props)),
+                ..NotePatch::default()
+            },
+        )
+        .await
+    }
+
+    /// Record a permanent delivery failure on an outbound `message` note:
+    /// `delivery = "failed"`, `failed_at`, `last_error` (ADR-122 §2 — an
+    /// allowlist rejection must be recorded, not skipped, or the row stays
+    /// pending forever while the caller saw `ok: true`). Refuses
+    /// (`InvalidInput`) unless `id` names a live outbound `message` note.
+    pub async fn mark_outbound_message_failed(
+        &self,
+        token: &NamespaceToken,
+        id: Uuid,
+        failed_at: String,
+        last_error: String,
+    ) -> RuntimeResult<khive_storage::note::Note> {
+        self.assert_outbound_message(token, id).await?;
+        self.update_note(
+            token,
+            id,
+            NotePatch {
+                properties: Some(serde_json::json!({
+                    "delivery": "failed",
+                    "failed_at": failed_at,
+                    "last_error": last_error,
+                })),
                 ..NotePatch::default()
             },
         )
@@ -3784,8 +3890,9 @@ mod tests {
 
     /// Predicate + ordering contract of the non-wire outbox scan: outbound
     /// with absent OR explicitly-null `delivered_at` is undelivered; a
-    /// non-null `delivered_at`, an inbound row, and a soft-deleted row are
-    /// all excluded; results come newest-first and respect `limit`.
+    /// non-null `delivered_at`, a terminal `delivery` state, an inbound row,
+    /// and a soft-deleted row are all excluded; results come newest-first
+    /// and respect `limit`; `limit=0` returns nothing.
     #[tokio::test]
     async fn list_undelivered_outbound_messages_predicate_and_order() {
         let rt = rt();
@@ -3802,6 +3909,11 @@ mod tests {
         delivered.properties = Some(
             serde_json::json!({"direction": "outbound", "delivered_at": "2026-08-28T00:00:00Z"}),
         );
+        // ADR-122 terminal states without `delivered_at` are not pending.
+        let mut terminal_failed = outbound_message_note();
+        terminal_failed.properties = Some(
+            serde_json::json!({"direction": "outbound", "delivery": "failed", "last_error": "x"}),
+        );
         let mut inbound = Note::new("local", "message", "inbound row");
         inbound.properties = Some(serde_json::json!({"direction": "inbound"}));
         let mut soft_deleted = outbound_message_note();
@@ -3813,6 +3925,7 @@ mod tests {
             undelivered_old,
             undelivered_null,
             delivered,
+            terminal_failed,
             inbound,
             soft_deleted,
         ] {
@@ -3820,7 +3933,7 @@ mod tests {
         }
 
         let hits = rt
-            .list_undelivered_outbound_messages(&tok, 200)
+            .list_undelivered_outbound_messages(&tok, None, 200)
             .await
             .expect("scan succeeds");
         let ids: Vec<_> = hits.iter().map(|n| n.id).collect();
@@ -3831,7 +3944,7 @@ mod tests {
         );
 
         let capped = rt
-            .list_undelivered_outbound_messages(&tok, 1)
+            .list_undelivered_outbound_messages(&tok, None, 1)
             .await
             .expect("capped scan succeeds");
         assert_eq!(
@@ -3839,6 +3952,153 @@ mod tests {
             vec![null_id],
             "limit truncates after the newest undelivered row"
         );
+
+        let zero = rt
+            .list_undelivered_outbound_messages(&tok, None, 0)
+            .await
+            .expect("zero-limit scan succeeds");
+        assert!(zero.is_empty(), "limit=0 returns no rows, not one");
+    }
+
+    /// The channel prefix runs BEFORE the limit: a backlog of another
+    /// channel's pending rows must not consume the scan budget and starve
+    /// the requested channel (the pre-fix defect: filter-after-limit).
+    #[tokio::test]
+    async fn list_undelivered_outbound_messages_prefix_filters_before_limit() {
+        let rt = rt();
+        rt.install_pack_owned_note_kinds(vec!["message".to_string()]);
+        let tok = NamespaceToken::local();
+        let store = rt.notes(&tok).expect("note store");
+
+        // Older email row behind three newer telegram rows.
+        let mut email = outbound_message_note();
+        email.created_at -= 100;
+        email.properties =
+            Some(serde_json::json!({"direction": "outbound", "to_actor": "email:a@b.c"}));
+        let email_id = email.id;
+        store.upsert_note(email).await.expect("seed email");
+        for _ in 0..3 {
+            let mut tg = outbound_message_note();
+            tg.properties =
+                Some(serde_json::json!({"direction": "outbound", "to_actor": "telegram:42"}));
+            store.upsert_note(tg).await.expect("seed telegram");
+        }
+
+        // With filter-after-limit this would return a telegram row (newest
+        // first) and the email loop would see nothing deliverable.
+        let hits = rt
+            .list_undelivered_outbound_messages(&tok, Some("email:"), 1)
+            .await
+            .expect("scan succeeds");
+        assert_eq!(
+            hits.iter().map(|n| n.id).collect::<Vec<_>>(),
+            vec![email_id],
+            "prefix predicate applies before the limit"
+        );
+
+        let telegram_hits = rt
+            .list_undelivered_outbound_messages(&tok, Some("telegram:"), 200)
+            .await
+            .expect("scan succeeds");
+        assert_eq!(telegram_hits.len(), 3, "telegram prefix sees its own rows");
+    }
+
+    /// Terminal-outcome markers: `delivered` stamps the ADR-122 §1 property
+    /// set (with `transport_message_id` only when given), `failed` stamps
+    /// §2's permanent-failure set, and both refuse targets that are not live
+    /// outbound message notes.
+    #[tokio::test]
+    async fn outbound_delivery_markers_stamp_adr122_properties_and_validate_target() {
+        let rt = rt();
+        rt.install_pack_owned_note_kinds(vec!["message".to_string()]);
+        let tok = NamespaceToken::local();
+        let store = rt.notes(&tok).expect("note store");
+
+        let delivered_note = outbound_message_note();
+        let delivered_id = delivered_note.id;
+        let failed_note = outbound_message_note();
+        let failed_id = failed_note.id;
+        let mut inbound = Note::new("local", "message", "inbound row");
+        inbound.properties = Some(serde_json::json!({"direction": "inbound"}));
+        let inbound_id = inbound.id;
+        let wrong_kind = Note::new("local", "observation", "not a message");
+        let wrong_kind_id = wrong_kind.id;
+        for note in [delivered_note, failed_note] {
+            store.upsert_note(note).await.expect("seed note");
+        }
+        store.upsert_note(inbound).await.expect("seed inbound");
+        store.upsert_note(wrong_kind).await.expect("seed non-message");
+
+        let marked = rt
+            .mark_outbound_message_delivered(
+                &tok,
+                delivered_id,
+                "2026-08-28T00:00:00Z".to_string(),
+                Some("<mid@example>".to_string()),
+            )
+            .await
+            .expect("mark delivered succeeds");
+        let props = marked.properties.as_ref().and_then(|v| v.as_object()).unwrap();
+        assert_eq!(props.get("delivery").and_then(|v| v.as_str()), Some("delivered"));
+        assert_eq!(
+            props.get("delivered_at").and_then(|v| v.as_str()),
+            Some("2026-08-28T00:00:00Z")
+        );
+        assert_eq!(
+            props.get("transport_message_id").and_then(|v| v.as_str()),
+            Some("<mid@example>")
+        );
+
+        let failed = rt
+            .mark_outbound_message_failed(
+                &tok,
+                failed_id,
+                "2026-08-28T00:00:01Z".to_string(),
+                "recipient not in allowlist".to_string(),
+            )
+            .await
+            .expect("mark failed succeeds");
+        let props = failed.properties.as_ref().and_then(|v| v.as_object()).unwrap();
+        assert_eq!(props.get("delivery").and_then(|v| v.as_str()), Some("failed"));
+        assert_eq!(
+            props.get("failed_at").and_then(|v| v.as_str()),
+            Some("2026-08-28T00:00:01Z")
+        );
+        assert_eq!(
+            props.get("last_error").and_then(|v| v.as_str()),
+            Some("recipient not in allowlist")
+        );
+
+        // Both marked rows are now terminal: the scan must not return them.
+        let pending = rt
+            .list_undelivered_outbound_messages(&tok, None, 200)
+            .await
+            .expect("scan succeeds");
+        assert!(
+            pending.is_empty(),
+            "terminal rows left in scan: {:?}",
+            pending.iter().map(|n| n.id).collect::<Vec<_>>()
+        );
+
+        // Validation arms: inbound message and non-message kind both refuse.
+        for (id, label) in [(inbound_id, "inbound"), (wrong_kind_id, "non-message")] {
+            let err = rt
+                .mark_outbound_message_delivered(&tok, id, "t".to_string(), None)
+                .await
+                .expect_err(label);
+            assert!(
+                matches!(err, RuntimeError::InvalidInput(_)),
+                "{label}: expected InvalidInput, got {err:?}"
+            );
+            let err = rt
+                .mark_outbound_message_failed(&tok, id, "t".to_string(), "e".to_string())
+                .await
+                .expect_err(label);
+            assert!(
+                matches!(err, RuntimeError::InvalidInput(_)),
+                "{label}: expected InvalidInput, got {err:?}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/khive-runtime/src/engine_config.rs
+++ b/crates/khive-runtime/src/engine_config.rs
@@ -276,11 +276,24 @@ pub struct BackendConfig {
 /// ```toml
 /// [packs.knowledge]
 /// backend = "knowledge"
+///
+/// [packs.comm]
+/// backend = "comm"
+/// no_embed = true
 /// ```
 #[derive(Debug, Clone, Deserialize)]
 pub struct PackConfig {
     /// Backend name this pack is assigned to. Must match a `[[backends]].name`.
     pub backend: String,
+    /// Disable vector embedding for this pack's runtime: rows it writes get
+    /// FTS and metadata only, no `vec_*` rows and no ANN participation. The
+    /// opt-out covers every write made through this pack's runtime, including
+    /// its `core()`-routed ones (`core()` inherits the runtime's embedder
+    /// set), so it fits packs whose rows are structural rather than
+    /// retrieval targets (e.g. comm). Effective in multi-backend boot, where
+    /// each pack gets its own runtime. Defaults to `false`.
+    #[serde(default)]
+    pub no_embed: bool,
 }
 
 // ---- Blob store config (ADR-111 Amendment 2) ----

--- a/crates/khive-runtime/src/engine_config.rs
+++ b/crates/khive-runtime/src/engine_config.rs
@@ -287,9 +287,11 @@ pub struct PackConfig {
     pub backend: String,
     /// Disable vector embedding for this pack's runtime: rows it writes get
     /// FTS and metadata only, no `vec_*` rows and no ANN participation. The
-    /// opt-out covers every write made through this pack's runtime, including
-    /// its `core()`-routed ones (`core()` inherits the runtime's embedder
-    /// set), so it fits packs whose rows are structural rather than
+    /// opt-out covers pack-owned writes on the pack's own backend; it does
+    /// NOT cover `core()`-routed concept writes, which embed with the MAIN
+    /// runtime's embedders (the boot path wires them in via
+    /// `with_core_embedders_from`) so the shared graph stays uniformly
+    /// searchable. Fits packs whose own rows are structural rather than
     /// retrieval targets (e.g. comm). Effective in multi-backend boot, where
     /// each pack gets its own runtime. Defaults to `false`.
     #[serde(default)]

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -433,7 +433,23 @@ impl KhiveRuntime {
     /// `RuntimeConfig` (a heap-allocated struct containing `Vec<String>` fields).
     pub fn core(&self) -> KhiveRuntime {
         match &self.core_backend {
-            None => self.clone(),
+            // A main-assigned pack runtime has no core pointer, but may still
+            // carry main's embedder wiring: with `no_embed` its OWN registry
+            // is empty, and core-routed concept writes must embed regardless
+            // of which backend the pack was assigned to.
+            None => match &self.core_embedders {
+                None => self.clone(),
+                Some(core_embedders) => {
+                    let mut core = self.clone();
+                    core.config.embedding_model = core_embedders.embedding_model;
+                    core.config.additional_embedding_models =
+                        core_embedders.additional_embedding_models.clone();
+                    core.embedder_registry = core_embedders.registry.clone();
+                    core.default_embedder_name = core_embedders.default_embedder_name.clone();
+                    core.core_embedders = None;
+                    core
+                }
+            },
             Some(main_arc) => {
                 let mut core_config = self.config.clone();
                 core_config.backend_id = BackendId::main();

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -145,6 +145,17 @@ pub use crate::config::{
 /// Composable runtime handle used by the MCP server.
 ///
 /// Wraps a `StorageBackend` and provides namespace-scoped accessor methods
+/// Snapshot of the main runtime's embedder wiring (registry handle, default
+/// name, and the config model fields the default-resolution path reads).
+/// Carried by secondary-pack runtimes; consumed by [`KhiveRuntime::core`].
+#[derive(Clone)]
+struct CoreEmbedderState {
+    registry: Arc<std::sync::RwLock<crate::embedder_registry::EmbedderRegistry>>,
+    default_embedder_name: Arc<str>,
+    embedding_model: Option<EmbeddingModel>,
+    additional_embedding_models: Vec<EmbeddingModel>,
+}
+
 /// for each storage capability, plus a lazily-loaded embedder.
 #[derive(Clone)]
 pub struct KhiveRuntime {
@@ -166,6 +177,13 @@ pub struct KhiveRuntime {
     /// construction; packs may add more via [`PackRuntime::register_embedders`].
     embedder_registry: Arc<std::sync::RwLock<crate::embedder_registry::EmbedderRegistry>>,
     default_embedder_name: Arc<str>,
+    /// The MAIN runtime's embedder wiring, carried by secondary-backend
+    /// runtimes so that `core()`-routed writes embed with the main runtime's
+    /// models even when this pack's own registry is empty (`no_embed`).
+    /// `None` on the main runtime, and on secondaries wired before the boot
+    /// path calls [`with_core_embedders_from`](Self::with_core_embedders_from)
+    /// — `core()` then falls back to this runtime's own embedder state.
+    core_embedders: Option<CoreEmbedderState>,
     /// Pack-extensible edge endpoint rules. Shared across clones
     /// via `Arc<RwLock<_>>`; installed once by the transport after the
     /// `VerbRegistry` is built. Empty until installed
@@ -343,6 +361,7 @@ impl KhiveRuntime {
             ann_fresh_tail_enabled,
             embedder_registry: Arc::new(std::sync::RwLock::new(registry)),
             default_embedder_name,
+            core_embedders: None,
             edge_rules: Arc::new(RwLock::new(Vec::new())),
             valid_entity_kinds: Arc::new(RwLock::new(Vec::new())),
             valid_note_kinds: Arc::new(RwLock::new(Vec::new())),
@@ -373,6 +392,26 @@ impl KhiveRuntime {
         self
     }
 
+    /// Carry the main runtime's embedder wiring for `core()`-routed writes.
+    ///
+    /// Boot-path companion to [`with_core_backend`](Self::with_core_backend).
+    /// Without it, `core()` shares this pack runtime's own embedder registry —
+    /// which under `[packs.<name>] no_embed = true` is empty, so core-routed
+    /// concept writes would silently skip embedding on the shared graph.
+    pub fn with_core_embedders_from(mut self, main: &KhiveRuntime) -> Self {
+        debug_assert!(
+            main.core_backend.is_none(),
+            "with_core_embedders_from takes the MAIN runtime"
+        );
+        self.core_embedders = Some(CoreEmbedderState {
+            registry: main.embedder_registry.clone(),
+            default_embedder_name: main.default_embedder_name.clone(),
+            embedding_model: main.config.embedding_model,
+            additional_embedding_models: main.config.additional_embedding_models.clone(),
+        });
+        self
+    }
+
     /// Return a runtime handle bound to the main (shared-graph) backend.
     ///
     /// When `self` is already the main runtime (`core_backend` is `None`),
@@ -398,13 +437,34 @@ impl KhiveRuntime {
             Some(main_arc) => {
                 let mut core_config = self.config.clone();
                 core_config.backend_id = BackendId::main();
+                // Core-routed writes embed with the MAIN runtime's wiring when
+                // the boot path supplied it (see `with_core_embedders_from`);
+                // both the registry handle and the config model fields must
+                // come from main, since default-model resolution reads
+                // `config.embedding_model` (`resolve_embedding_model`).
+                let (embedder_registry, default_embedder_name) = match &self.core_embedders {
+                    Some(core_embedders) => {
+                        core_config.embedding_model = core_embedders.embedding_model;
+                        core_config.additional_embedding_models =
+                            core_embedders.additional_embedding_models.clone();
+                        (
+                            core_embedders.registry.clone(),
+                            core_embedders.default_embedder_name.clone(),
+                        )
+                    }
+                    None => (
+                        self.embedder_registry.clone(),
+                        self.default_embedder_name.clone(),
+                    ),
+                };
                 KhiveRuntime {
                     backend: main_arc.clone(),
                     core_backend: None,
                     config: core_config,
                     ann_fresh_tail_enabled: self.ann_fresh_tail_enabled,
-                    embedder_registry: self.embedder_registry.clone(),
-                    default_embedder_name: self.default_embedder_name.clone(),
+                    embedder_registry,
+                    default_embedder_name,
+                    core_embedders: None,
                     edge_rules: self.edge_rules.clone(),
                     valid_entity_kinds: self.valid_entity_kinds.clone(),
                     valid_note_kinds: self.valid_note_kinds.clone(),

--- a/crates/kkernel/src/cli.rs
+++ b/crates/kkernel/src/cli.rs
@@ -2095,6 +2095,7 @@ mod tests {
                     "session".to_string(),
                     PackConfig {
                         backend: "sessions".to_string(),
+                        no_embed: false,
                     },
                 );
                 m

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -3857,6 +3857,7 @@ id = "lambda:fallback"
                     "session".to_string(),
                     PackConfig {
                         backend: "sessions".to_string(),
+                        no_embed: false,
                     },
                 );
                 m
@@ -3969,6 +3970,7 @@ id = "lambda:fallback"
                     "comm".to_string(),
                     PackConfig {
                         backend: "secondary".to_string(),
+                        no_embed: false,
                     },
                 );
                 m

--- a/docs/khive-config-example.toml
+++ b/docs/khive-config-example.toml
@@ -203,9 +203,15 @@ fusion_weight = 0.5
 # Route an individual pack to a declared backend. Packs not listed here fall back to
 # `main`. The referenced backend must appear in [[backends]] above. Loadable packs:
 # kg, gtd, memory, brain, comm, schedule, knowledge, session, git, code.
+# Optional `no_embed = true` gives that pack's runtime zero embedders: its rows
+# get FTS + metadata only (no vec_* rows, no ANN).
 
 # [packs.knowledge]
 # backend = "knowledge"
+
+# [packs.comm]
+# backend = "comm"
+# no_embed = true
 
 # ═════════════════════════════════════════════════════════════════════════════════
 # Environment variables

--- a/docs/khive-config-example.toml
+++ b/docs/khive-config-example.toml
@@ -203,8 +203,10 @@ fusion_weight = 0.5
 # Route an individual pack to a declared backend. Packs not listed here fall back to
 # `main`. The referenced backend must appear in [[backends]] above. Loadable packs:
 # kg, gtd, memory, brain, comm, schedule, knowledge, session, git, code.
-# Optional `no_embed = true` gives that pack's runtime zero embedders: its rows
-# get FTS + metadata only (no vec_* rows, no ANN).
+# Optional `no_embed = true` gives that pack's runtime zero embedders: its own
+# rows get FTS + metadata only (no vec_* rows, no ANN). Writes the pack routes
+# through core() still embed with the main runtime's embedders. Flipping the
+# flag changes the config_id (daemon restart required).
 
 # [packs.knowledge]
 # backend = "knowledge"

--- a/docs/multi-backend.md
+++ b/docs/multi-backend.md
@@ -123,6 +123,10 @@ path   = "~/.khive/records.db"
 # ── Per-pack routing ───────────────────────────────────────────────────────────
 # Packs not listed here fall back to "main".
 # The value of `backend` must match a [[backends]].name above.
+# `no_embed = true` additionally strips the embedder set from that pack's
+# runtime: its rows get FTS and metadata only — no vec_* rows, no ANN
+# participation. Use it for packs whose rows are structural rather than
+# retrieval targets (e.g. comm).
 
 [packs.records]           # hypothetical operator-supplied records pack
 backend = "records"
@@ -412,14 +416,14 @@ a writable main; conversely, a writable blob secondary beside a read-only main
 retains normal puts.
 
 Feature-enabled email and Telegram background work is also admitted by the
-runtime that serves each loop's verbs, not by `--daemon` alone. Inbound polling
-requires the assigned `comm` runtime to be writable because it dispatches
-`comm.ingest`, heartbeat, and cursor writes. Outbound delivery requires the
-assigned `kg` runtime to be writable because it uses generic `list`/`update` to
-claim and mark a message; otherwise no external send task starts, avoiding a
-send followed by an inevitably failed `delivered_at` write. These gates are
-independent, so a mixed topology can admit one direction without admitting the
-other.
+runtime that serves each loop's verbs, not by `--daemon` alone. Both
+directions key on the assigned `comm` runtime being writable: inbound polling
+dispatches `comm.ingest`, heartbeat, and cursor writes, and outbound delivery
+scans, claims, and marks outbound `message` notes through that runtime's
+non-wire owner-side APIs (the notes live on whatever backend `[packs.comm]`
+assigns, so the generic kg-routed `list`/`update` verbs cannot reach them).
+If the comm runtime is not writable, no external send task starts, avoiding a
+send followed by an inevitably failed `delivered_at` write.
 
 The explicit `read_only` value participates in the backend-topology portion of
 the warm-daemon `config_id`. In multi-backend configuration it must agree with

--- a/docs/multi-backend.md
+++ b/docs/multi-backend.md
@@ -124,9 +124,13 @@ path   = "~/.khive/records.db"
 # Packs not listed here fall back to "main".
 # The value of `backend` must match a [[backends]].name above.
 # `no_embed = true` additionally strips the embedder set from that pack's
-# runtime: its rows get FTS and metadata only — no vec_* rows, no ANN
-# participation. Use it for packs whose rows are structural rather than
-# retrieval targets (e.g. comm).
+# runtime: its own rows get FTS and metadata only — no vec_* rows, no ANN
+# participation. Concept-tier writes the pack routes through core() are NOT
+# stripped: they embed with the main runtime's embedders, so the shared graph
+# stays uniformly searchable. Use it for packs whose own rows are structural
+# rather than retrieval targets (e.g. comm). The flag participates in the
+# warm-daemon config_id: flipping it requires a daemon restart like any other
+# topology change.
 
 [packs.records]           # hypothetical operator-supplied records pack
 backend = "records"
@@ -422,8 +426,13 @@ dispatches `comm.ingest`, heartbeat, and cursor writes, and outbound delivery
 scans, claims, and marks outbound `message` notes through that runtime's
 non-wire owner-side APIs (the notes live on whatever backend `[packs.comm]`
 assigns, so the generic kg-routed `list`/`update` verbs cannot reach them).
-If the comm runtime is not writable, no external send task starts, avoiding a
-send followed by an inevitably failed `delivered_at` write.
+The scan applies each channel's recipient prefix before its row limit, so one
+channel's backlog cannot starve another's, and delivery outcomes are recorded
+as terminal `properties.delivery` states (`delivered` with `delivered_at` and
+the transport message id, or `failed` with `failed_at`/`last_error` for
+permanent rejections such as a recipient outside the allowlist). If the comm
+runtime is not writable, no external send task starts, avoiding a send
+followed by an inevitably failed delivery mark.
 
 The explicit `read_only` value participates in the backend-topology portion of
 the warm-daemon `config_id`. In multi-backend configuration it must agree with


### PR DESCRIPTION
Assigning the comm or knowledge pack its own backend via `[packs.<name>]` exposed three gaps:

## Knowledge concept tier wrote to the wrong backend

`learn`/`cite`/`topic` (and compose's KG-entity blend in `search.rs`) called entity read/write APIs on the pack runtime directly. On a secondary-assigned backend those concept entities and `introduced_by` edges landed in the pack's own file — self-consistent from inside the pack, but invisible to the shared graph. This is the same seam ADR-083 closed for the session pack; all concept-tier sites now route through `core()`.

## Outbox delivery loops were blind to a comm-assigned backend

The email/telegram outbox loops scanned and marked outbound `message` notes through the generic wire `list`/`update` verbs (kg-routed) and held the kg runtime for the `external_id` claim. With `[packs.comm]` assigned, `comm.send` writes the outbox row into the comm backend while the wire scan lists the main one — outbound delivery goes permanently silent. The loops now use non-wire owner-side runtime APIs (`list_undelivered_outbound_messages`, `mark_outbound_message_delivered`, plus the existing claim) on the comm pack's runtime, and delivery admission for both directions keys on that runtime's writability. The scan preserves the wire predicate exactly: outbound, absent-or-null `delivered_at`, newest-first, 200-row result cap, 10k scan cap.

## No way to exclude a pack's rows from embedding

New optional `[packs.<name>] no_embed = true` strips the embedder set from that pack's runtime: its rows get FTS and metadata only — no `vec_*` rows, no ANN participation. Intended for packs whose rows are structural rather than retrieval targets. The opt-out covers the runtime's `core()`-routed writes too (documented), since `core()` inherits the runtime's embedder set.

## Tests

- Two-backend concept-tier regression: entity must land on main and not the pack backend; listing/citing resolve through `core()`.
- Comm-secondary outbox end to end: the wire list is provably blind to the outbox row while the non-wire scan finds, claims, sends, and marks it — all in the comm file, zero rows on main.
- Scan predicate/ordering/limit unit test (null `delivered_at`, inbound, soft-deleted exclusions).
- Per-pack `no_embed` with a must-match control (kg runtime keeps its embedders).
- Mixed read-only topology admission updated to the comm-keyed contract.

Single-backend mode is zero-change: every pack runtime is the same runtime there, and `core()` is a self-clone.