### PR TITLE
docs(adr-130): amendment 2 — cause classification and server-paced retry

### DIFF
--- a/docs/adr/ADR-130-search-response-completeness-and-ranking-evidence.md
+++ b/docs/adr/ADR-130-search-response-completeness-and-ranking-evidence.md
@@ -327,6 +327,13 @@ release":
   boolean. A caller still sending `min_score` receives an explicit
   unsupported-field error rather than a silent reinterpretation; a caller still
   reading `score` finds it absent rather than redefined.
+  **Amendment 2's wire changes ship in this release** — the two-value
+  `backend_errors[].kind` vocabulary and `retry_after_ms`. They are not eligible
+  for v0.8.0: Amendment 1 shipped in v0.8.0 with `kind` fixed to the single
+  constant `backend_error`, so a strict reader may have pinned that value.
+  Widening a closed vocabulary that a released reader validates is a breaking
+  change for that reader, and takes the next release rather than a point update.
+  Amendment 1 could be introduced additively; Amendment 2 cannot.
 
 Per consumer class:
 
@@ -480,7 +487,13 @@ now honour the field's value rather than a constant, and a caller that acts on
 11. Release-gated schema fixtures: v0.8.0 fixtures for strict readers including
     the degraded-empty error; v0.9.0 fixtures proving `score`, `min_score`, and
     `partial` are absent on emit and `min_score` is rejected with an
-    unsupported-field error.
+    unsupported-field error. **Amended: see Amendment 2 §7** — the v0.9.0
+    fixtures additionally pin `backend_errors[].kind` accepting both `timeout`
+    and `backend_error`, and `retry_after_ms` present on every `retryable=true`
+    error. The v0.8.0 strict-reader fixture keeps `kind` pinned to the single
+    constant, since that is the contract that release shipped; the two fixture
+    sets are expected to disagree on this field, and a change making them agree
+    is a defect in one of them.
 12. A batch fixture containing one partial search plus one other operation,
     asserting batch-level and per-operation `status` remain distinct.
 13. An Agent-mode fixture for an evidence-free hit, asserting `signals` is
@@ -580,16 +593,30 @@ preferred, and is what the §6 verification row asks for.
 Decision §6 is correct that a naive client multiplies load against an already-failing
 backend, and its arithmetic stands: ten callers at five searches per second,
 retrying three times, can turn 50 logical searches per second into 150 attempts
-per second. That figure is not disputed here. What follows is why conditional
-retryability does not produce it.
+per second. That figure is not disputed here, and one part of it is conceded
+below: absent admission control, delays alone do not lower it. What follows is
+why conditional retryability *under §4* does not leave that outcome standing.
 
-**The arithmetic assumes immediate retry.** The 150/sec figure holds only if the
-three retries are issued without delay, so that attempts for one logical request
-overlap. Under §4's mandatory backoff the retries for a request failing at *t*
-are issued at increasing offsets, so the additional attempts are spread across
-the backoff window and decay rather than tripling the instantaneous rate. With
-`retry_after_ms` the server — which is the party that knows it is degraded —
-sets that pace directly, instead of the client choosing it.
+**Backoff bounds the instantaneous burst, and only that.** Read as an
+instantaneous rate, the 150/sec figure requires the three retries for one logical
+request to be issued without delay, so that one request's retries stack on the
+next request's first attempt. Under §4's mandatory backoff those attempts are
+spread across the backoff window, which removes the burst. That disposes of the
+*transient* case — a blip that resolves inside one backoff window, where the
+retries land after recovery and cost the failing backend nothing.
+
+**It does not dispose of the sustained case, and this amendment does not claim it
+does.** Under a bounded budget with exponential backoff, every logical request
+still issues its full allotment within a window far shorter than a sustained
+outage, so with arrivals continuing at 50/sec the steady-state attempt rate
+converges on Decision §6's figure regardless of the delays. Backoff moves the
+ramp; it does not lower the plateau. The sustained case is answered by the
+breaker below, not by this bullet.
+
+What `retry_after_ms` contributes here is narrower than pacing away the volume:
+it makes the *server* the party that sets the interval, which is what lets the
+breaker's own recovery probe and the clients' reissue schedule agree instead of
+being chosen independently by every caller.
 
 **A boolean was never the load control.** Decision §6 concedes the decisive point itself:
 `retryable=false` "reduces that risk but cannot eliminate it for clients that
@@ -602,19 +629,34 @@ that honour the field: they are told not to retry a timeout that would likely
 have succeeded. The current contract's benefit lands on nobody and its cost lands
 on the compliant.
 
-**Under §4 the outage case gets strictly better, not worse.** Circuit-breaker
-admission opens after consecutive timeouts and suppresses attempts *including
-first attempts*. During the sustained outage Decision §6 describes, offered load therefore
-falls **below** the 50/sec baseline, whereas today it stays at 50/sec plus
-whatever the field-ignoring clients add. Conditional retryability paired with
-admission control bounds the outage case better than an unconditional `false`
-paired with nothing.
+**The breaker, not backoff, is the load control for a sustained outage — and it
+makes that case strictly better.** Circuit-breaker admission opens after
+consecutive timeouts and suppresses attempts *including first attempts*. That
+last property is what distinguishes it from every retry-shaping rule: it removes
+load the current contract cannot reach, because `retryable=false` governs only
+reissues and says nothing about first attempts.
+
+The reach of that claim must be stated exactly, because the breaker is a
+client-side obligation. It bounds the **conforming** population only. For those
+clients, during the sustained outage Decision §6 describes, offered load falls
+**below** their share of the 50/sec baseline — strictly better than today, where
+they contribute their full baseline and are merely forbidden to retry. The
+non-conforming population is unchanged in both directions, per the inertness
+argument above.
+
+So no population is worse off and one is materially better off, which is the
+whole of the argument. It rests on the breaker and the inertness of the flag, not
+on the backoff bullet above.
 
 **What this amendment does not claim.** It does not claim typed causes are more
 accurate and therefore justify retrying; accuracy is true and does not answer
-Decision §6. It does not claim clients will comply. Compliance is why §4 puts the
-pacing obligation on the server through `retry_after_ms` rather than resting on
-client goodwill.
+Decision §6. It does not claim backoff lowers the sustained-outage rate — the
+second bullet concedes it does not. And it does not claim clients will comply,
+nor that admission control reaches those who do not: the breaker is a client-side
+obligation, so a client that ignores `retryable` ignores the breaker too. The
+answer for that population is not enforcement but *inertness* — it behaves
+identically before and after this amendment, because it already ignores
+`retryable=false` today.
 
 ### 4. Admission control is mandatory, not advisory
 
@@ -698,6 +740,28 @@ them equal would read as a rule that they must be.
   is acceptable only as the default floor published with the retry policy; an
   undocumented constant fails review, as does omitting the field on the grounds
   that no estimate was available.
+
+### 7. Release
+
+**Amendment 2's wire changes ship in v0.9.0** — Release N+1 in the compatibility
+window — not in v0.8.0.
+
+Amendment 1 was additive: it introduced `backend_errors` with `kind` fixed to the
+single constant `backend_error`, so a reader that ignored the new object was
+unaffected. That form shipped in v0.8.0, which means a strict reader may have
+pinned `kind` to that one value. Widening it to a closed two-value vocabulary
+makes such a reader reject a well-formed response, so the widening is a breaking
+change *for that reader* and takes the next release rather than a point update.
+`retry_after_ms` is a new field and would be additive on its own; it ships in the
+same release as the vocabulary change because §2 makes the two jointly
+observable — a `retryable=true` response is exactly one whose legs all typed as
+`timeout`.
+
+Within v0.9.0 there is no intermediate state: a surface either emits the typed
+vocabulary with conditional retryability and `retry_after_ms`, or it emits the
+v0.8.0 contract. Emitting `timeout` while keeping `retryable` unconditionally
+`false` is not a valid partial adoption, because it publishes a cause the reader
+can act on while denying the action the cause licenses.
 
 ## References
 

--- a/docs/adr/ADR-130-search-response-completeness-and-ranking-evidence.md
+++ b/docs/adr/ADR-130-search-response-completeness-and-ranking-evidence.md
@@ -478,7 +478,7 @@ now honour the field's value rather than a constant, and a caller that acts on
 8. Retry-policy tests proving `search_incomplete` is not retried by default;
    generic error-retry client behaviour is covered by this row. **Amended: see
    Amendment 2 §6** — the default is unchanged, but a test asserting
-   `retryable` is *always* `false` now contradicts the record; assert the
+   `retryable` is _always_ `false` now contradicts the record; assert the
    default and the all-timeout case separately.
 9. Compatibility-alias contract tests: `partial=true` present beside every
    `status="partial"` success and absent on `complete` in v0.8.0.
@@ -579,7 +579,7 @@ When `retryable=true`, the error object MUST additionally carry
 elapses.
 
 The field is mandatory rather than optional because §3's answer to the
-amplification argument depends on the *server* naming the pace; an absent field
+amplification argument depends on the _server_ naming the pace; an absent field
 returns that decision to the client, which is the situation the retry contract
 already distrusts. A surface with no better estimate MUST therefore emit a
 documented default floor rather than omitting the field — "the server always
@@ -595,14 +595,14 @@ backend, and its arithmetic stands: ten callers at five searches per second,
 retrying three times, can turn 50 logical searches per second into 150 attempts
 per second. That figure is not disputed here, and one part of it is conceded
 below: absent admission control, delays alone do not lower it. What follows is
-why conditional retryability *under §4* does not leave that outcome standing.
+why conditional retryability _under §4_ does not leave that outcome standing.
 
 **Backoff bounds the instantaneous burst, and only that.** Read as an
 instantaneous rate, the 150/sec figure requires the three retries for one logical
 request to be issued without delay, so that one request's retries stack on the
 next request's first attempt. Under §4's mandatory backoff those attempts are
 spread across the backoff window, which removes the burst. That disposes of the
-*transient* case — a blip that resolves inside one backoff window, where the
+_transient_ case — a blip that resolves inside one backoff window, where the
 retries land after recovery and cost the failing backend nothing.
 
 **It does not dispose of the sustained case, and this amendment does not claim it
@@ -614,7 +614,7 @@ ramp; it does not lower the plateau. The sustained case is answered by the
 breaker below, not by this bullet.
 
 What `retry_after_ms` contributes here is narrower than pacing away the volume:
-it makes the *server* the party that sets the interval, which is what lets the
+it makes the _server_ the party that sets the interval, which is what lets the
 breaker's own recovery probe and the clients' reissue schedule agree instead of
 being chosen independently by every caller.
 
@@ -631,7 +631,7 @@ on the compliant.
 
 **The breaker, not backoff, is the load control for a sustained outage — and it
 makes that case strictly better.** Circuit-breaker admission opens after
-consecutive timeouts and suppresses attempts *including first attempts*. That
+consecutive timeouts and suppresses attempts _including first attempts_. That
 last property is what distinguishes it from every retry-shaping rule: it removes
 load the current contract cannot reach, because `retryable=false` governs only
 reissues and says nothing about first attempts.
@@ -654,7 +654,7 @@ Decision §6. It does not claim backoff lowers the sustained-outage rate — the
 second bullet concedes it does not. And it does not claim clients will comply,
 nor that admission control reaches those who do not: the breaker is a client-side
 obligation, so a client that ignores `retryable` ignores the breaker too. The
-answer for that population is not enforcement but *inertness* — it behaves
+answer for that population is not enforcement but _inertness_ — it behaves
 identically before and after this amendment, because it already ignores
 `retryable=false` today.
 
@@ -751,7 +751,7 @@ single constant `backend_error`, so a reader that ignored the new object was
 unaffected. That form shipped in v0.8.0, which means a strict reader may have
 pinned `kind` to that one value. Widening it to a closed two-value vocabulary
 makes such a reader reject a well-formed response, so the widening is a breaking
-change *for that reader* and takes the next release rather than a point update.
+change _for that reader_ and takes the next release rather than a point update.
 `retry_after_ms` is a new field and would be additive on its own; it ships in the
 same release as the vocabulary change because §2 makes the two jointly
 observable — a `retryable=true` response is exactly one whose legs all typed as

--- a/docs/adr/ADR-130-search-response-completeness-and-ranking-evidence.md
+++ b/docs/adr/ADR-130-search-response-completeness-and-ranking-evidence.md
@@ -565,6 +565,16 @@ When `retryable=true`, the error object MUST additionally carry
 `retry_after_ms`, a positive integer. Clients MUST NOT reissue before it
 elapses.
 
+The field is mandatory rather than optional because §3's answer to the
+amplification argument depends on the *server* naming the pace; an absent field
+returns that decision to the client, which is the situation the retry contract
+already distrusts. A surface with no better estimate MUST therefore emit a
+documented default floor rather than omitting the field — "the server always
+names a pace" is the property being relied on, and a floor satisfies it. The
+default floor is a per-surface constant published with the retry policy required
+by §4; deriving a sharper value from observed backend state is permitted and
+preferred, and is what the §6 verification row asks for.
+
 ### 3. Why Decision §6's arithmetic does not forbid this
 
 Decision §6 is correct that a naive client multiplies load against an already-failing
@@ -627,9 +637,10 @@ they are read as one, so each is stated with its actor.
 **The surface that emits `retryable=true`** MUST NOT do so unless it publishes,
 in the retry documentation Decision §6 already requires, the budget, the backoff
 schedule and the breaker threshold that a conforming client is expected to apply
-— and MUST emit a `retry_after_ms` that is meaningful for its own degraded
-state rather than a fixed constant. A surface that cannot publish all three MUST
-keep `retryable=false`, which remains the default and the safe value.
+— and MUST emit a `retry_after_ms` on every `retryable=true` response, at
+minimum the default floor published with that policy. A surface that cannot
+publish all three MUST keep `retryable=false`, which remains the default and the
+safe value.
 
 The asymmetry is deliberate. The server cannot enforce client backoff, so this
 amendment does not claim it can. What the server controls is (a) whether it
@@ -683,9 +694,10 @@ them equal would read as a rule that they must be.
 - `kind` admits exactly the two values; any other value is rejected.
 - A surface that emits `retryable=true` without publishing the budget, backoff
   schedule and breaker threshold required by §4 fails review.
-- `retry_after_ms` is derived from the surface's own degraded state; a fixed
-  compile-time constant fails review, because a constant returns the pacing
-  decision to the client and §3's argument rests on the server holding it.
+- `retryable=true` is never emitted without `retry_after_ms`. A constant value
+  is acceptable only as the default floor published with the retry policy; an
+  undocumented constant fails review, as does omitting the field on the grounds
+  that no estimate was available.
 
 ## References
 

--- a/docs/adr/ADR-130-search-response-completeness-and-ranking-evidence.md
+++ b/docs/adr/ADR-130-search-response-completeness-and-ranking-evidence.md
@@ -126,7 +126,9 @@ operation MUST return:
 - `ok=false`;
 - no successful `result` field;
 - `error.kind="search_incomplete"`;
-- `error.retryable=false`;
+- `error.retryable=false` — **amended: see Amendment 2**, which makes this
+  conditional on every failed leg having timed out. `false` remains the default
+  and the value required whenever that condition does not hold;
 - `error.missing_backends` as a sorted, deduplicated, non-empty array;
 - `error.message` stating that no-match was not established.
 
@@ -210,9 +212,22 @@ times, turn 50 logical searches per second into as many as 150 attempts per
 second for the duration of the outage. `error.retryable=false` reduces that risk
 but cannot eliminate it for clients that ignore the field.
 
+**Amended: see Amendment 2.** The prohibition on automatic retry is narrowed to
+the cases where a retry cannot succeed, and the admission requirements above are
+promoted from a condition on opt-in retries to a precondition for advertising
+retryability at all. The arithmetic in this section is not disputed by that
+amendment; Amendment 2 §3 addresses it directly, including why the concession in
+the last sentence above is load-bearing against this section's own conclusion.
+
 ## Wire examples
 
 ### Degraded-empty
+
+**Amended: see Amendment 2 §5.** This example types a leg as `backend_error`
+while its own message reports a timeout, so as written it does not survive
+Amendment 2's two-value `kind` vocabulary. Amendment 2 §5 carries the corrected
+form for the all-timeout case; the example below remains correct for a genuine
+`backend_error`, with a message that does not describe a timeout.
 
 ```json
 {
@@ -358,7 +373,9 @@ before/after golden results over the existing normalization and squash paths.
 receive additive fields in v0.8.0 but must migrate off `score`. Strict readers
 need schema updates in v0.8.0. Generic error-retry callers MUST honour
 `error.retryable=false`. Verified by the release-gated schema fixtures and the
-retry-policy row in Verification.
+retry-policy row in Verification. **Amended: see Amendment 2** — callers must
+now honour the field's value rather than a constant, and a caller that acts on
+`retryable=true` must also honour `retry_after_ms`.
 
 ## Supersession
 
@@ -452,7 +469,10 @@ retry-policy row in Verification.
 6. Schema and help snapshots, plus strict and tolerant JSON consumer fixtures.
 7. Knowledge-pack before/after golden results proving no semantic drift.
 8. Retry-policy tests proving `search_incomplete` is not retried by default;
-   generic error-retry client behaviour is covered by this row.
+   generic error-retry client behaviour is covered by this row. **Amended: see
+   Amendment 2 §6** — the default is unchanged, but a test asserting
+   `retryable` is *always* `false` now contradicts the record; assert the
+   default and the all-timeout case separately.
 9. Compatibility-alias contract tests: `partial=true` present beside every
    `status="partial"` success and absent on `complete` in v0.8.0.
 10. Frame-budget omission tests in verbose and agent modes asserting the full
@@ -474,7 +494,9 @@ retry-policy row in Verification.
 
 Every incomplete multi-backend search MUST carry `backend_errors`, an object
 keyed by exactly the same sorted backend ids retained in `missing_backends`.
-Each value is `{kind: "backend_error", message: <captured cause>}`. A partial
+Each value is `{kind: "backend_error", message: <captured cause>}` — **amended:
+Amendment 2 replaces this single constant with a closed two-value vocabulary**.
+A partial
 success carries it beside `result`; degraded-empty `search_incomplete` carries
 it inside `error`. Complete searches omit it. Presentation and frame-budget
 omission preserve the diagnostics at the same location.
@@ -497,6 +519,173 @@ bounded aggregate warning for omitted causes.
 This amendment is additive. It does not change completeness, retry, filtering,
 or ranking semantics; it supplies bounded evidence for the already-declared
 degradation state.
+
+## Amendment 2 (2026-08-29): cause classification and server-paced retry
+
+Unlike Amendment 1, **this amendment does change retry semantics.** Decision §1
+requires `error.retryable=false` unconditionally, and Decision §6 forbids
+automatic retry. This amendment makes retryability conditional on cause. It
+therefore has to answer Decision §6's argument rather than restate the benefit,
+and §3 does that.
+
+Section numbers in this amendment are ambiguous without a qualifier, because the
+body and the amendment both number from 1. Throughout: **"Decision §N" means the
+original section N under `## Decision`**; a bare "§N" means section N of this
+amendment.
+
+### 1. Cause classification
+
+Amendment 1 fixes each `backend_errors` value to
+`{kind: "backend_error", message: <captured cause>}` — a single constant, not a
+vocabulary. `kind` becomes a closed vocabulary of exactly two values:
+
+- `timeout` — the leg exceeded a deadline, whether the coordinator's outer
+  fan-out deadline or a typed runtime deadline. Classification MUST be
+  structural. It MUST NOT be derived by matching text in a rendered message.
+- `backend_error` — every other failure.
+
+Classification MUST be computed **before** Amendment 1's diagnostic truncation,
+so an omitted cause cannot change it. Amendment 1's parity, masking, capping and
+budget rules are unchanged and apply to both values.
+
+This also corrects an inconsistency in this record's own degraded-empty wire
+example, whose cause reads
+`{"kind": "backend_error", "message": "backend search timed out after 5000ms"}`.
+That is supporting evidence that the single-constant vocabulary was already
+carrying two meanings; it is not the argument for changing retryability.
+
+### 2. Conditional retryability
+
+`error.retryable` MAY be `true` only when **every** retained and omitted failed
+leg classified as `timeout`. Any mixed or non-timeout failure keeps it `false`.
+Because the classification precedes truncation, this holds over the full failure
+set rather than the retained sample.
+
+When `retryable=true`, the error object MUST additionally carry
+`retry_after_ms`, a positive integer. Clients MUST NOT reissue before it
+elapses.
+
+### 3. Why Decision §6's arithmetic does not forbid this
+
+Decision §6 is correct that a naive client multiplies load against an already-failing
+backend, and its arithmetic stands: ten callers at five searches per second,
+retrying three times, can turn 50 logical searches per second into 150 attempts
+per second. That figure is not disputed here. What follows is why conditional
+retryability does not produce it.
+
+**The arithmetic assumes immediate retry.** The 150/sec figure holds only if the
+three retries are issued without delay, so that attempts for one logical request
+overlap. Under §4's mandatory backoff the retries for a request failing at *t*
+are issued at increasing offsets, so the additional attempts are spread across
+the backoff window and decay rather than tripling the instantaneous rate. With
+`retry_after_ms` the server — which is the party that knows it is degraded —
+sets that pace directly, instead of the client choosing it.
+
+**A boolean was never the load control.** Decision §6 concedes the decisive point itself:
+`retryable=false` "reduces that risk but cannot eliminate it for clients that
+ignore the field." The client in the amplification scenario is precisely a
+client that retries every `ok=false` — that is, one ignoring the field. Against
+that client the flag's value is inert, so the protection Decision §6 attributes to
+`retryable=false` is unavailable exactly where it is needed. Meanwhile the cost
+of the unconditional `false` falls entirely on **well-behaved** clients, the ones
+that honour the field: they are told not to retry a timeout that would likely
+have succeeded. The current contract's benefit lands on nobody and its cost lands
+on the compliant.
+
+**Under §4 the outage case gets strictly better, not worse.** Circuit-breaker
+admission opens after consecutive timeouts and suppresses attempts *including
+first attempts*. During the sustained outage Decision §6 describes, offered load therefore
+falls **below** the 50/sec baseline, whereas today it stays at 50/sec plus
+whatever the field-ignoring clients add. Conditional retryability paired with
+admission control bounds the outage case better than an unconditional `false`
+paired with nothing.
+
+**What this amendment does not claim.** It does not claim typed causes are more
+accurate and therefore justify retrying; accuracy is true and does not answer
+Decision §6. It does not claim clients will comply. Compliance is why §4 puts the
+pacing obligation on the server through `retry_after_ms` rather than resting on
+client goodwill.
+
+### 4. Admission control is mandatory, not advisory
+
+`retryable=true` does not mean "retry now"; it means a retry could succeed. The
+obligations below fall on two different parties, and the amendment is unsound if
+they are read as one, so each is stated with its actor.
+
+**The client that acts on `retryable=true`** MUST implement all three:
+
+- **Bounded budget** — a maximum attempt count per logical request, documented
+  by the client's retry policy.
+- **Backoff** — exponentially increasing delays with jitter, never a fixed
+  interval, and never shorter than the `retry_after_ms` the server supplied.
+- **Circuit breaking** — consecutive timeouts open a breaker that suppresses
+  further requests to that backend, **first attempts included**, until a probe
+  succeeds. This is the clause that makes the outage case in §3 improve rather
+  than merely hold: the breaker removes offered load that the current contract
+  does not touch.
+
+**The surface that emits `retryable=true`** MUST NOT do so unless it publishes,
+in the retry documentation Decision §6 already requires, the budget, the backoff
+schedule and the breaker threshold that a conforming client is expected to apply
+— and MUST emit a `retry_after_ms` that is meaningful for its own degraded
+state rather than a fixed constant. A surface that cannot publish all three MUST
+keep `retryable=false`, which remains the default and the safe value.
+
+The asymmetry is deliberate. The server cannot enforce client backoff, so this
+amendment does not claim it can. What the server controls is (a) whether it
+advertises retryability at all, (b) the pace it names in `retry_after_ms`, and
+(c) whether a conforming client has a policy to conform to. Those are the levers
+assigned above; a non-conforming client is handled by §3's observation that such
+a client already ignores the field today.
+
+### 5. Wire example — degraded-empty, all legs timed out
+
+This supersedes the degraded-empty example under "Wire examples" for the
+all-timeout case. That example remains correct for a `backend_error` cause,
+except that its message text should not describe a timeout.
+
+```json
+{
+  "ok": false,
+  "tool": "search",
+  "error": {
+    "kind": "search_incomplete",
+    "message": "No-match was not established because selected backends failed.",
+    "retryable": true,
+    "retry_after_ms": 2000,
+    "missing_backends": ["main"],
+    "backend_errors": {
+      "main": {
+        "kind": "timeout",
+        "message": "backend search timed out after 5000ms"
+      }
+    }
+  }
+}
+```
+
+With one leg timing out and another failing for any other reason, `retryable` is
+`false` and `retry_after_ms` is absent.
+
+`retry_after_ms` is deliberately not equal to the leg's deadline here. It is the
+server's estimate of when a retry could succeed, not a restatement of how long
+the failed attempt took; the two are unrelated quantities and an example showing
+them equal would read as a rule that they must be.
+
+### 6. Verification
+
+- A degraded-empty response whose legs all timed out reports `retryable=true`
+  with a positive `retry_after_ms`; one with any non-timeout leg reports `false`.
+- Classification survives truncation: a failure set whose only non-timeout cause
+  is omitted by Amendment 1's budget still reports `retryable=false`.
+- Classification is structural — a `backend_error` whose message contains the
+  word "timeout" is not reclassified.
+- `kind` admits exactly the two values; any other value is rejected.
+- A surface that emits `retryable=true` without publishing the budget, backoff
+  schedule and breaker threshold required by §4 fails review.
+- `retry_after_ms` is derived from the surface's own degraded state; a fixed
+  compile-time constant fails review, because a constant returns the pacing
+  decision to the client and §3's argument rests on the server holding it.
 
 ## References
 


### PR DESCRIPTION
## What

ADR-130 currently fixes every per-backend failure cause to a single `kind` value,
`backend_error`, and requires `error.retryable=false` unconditionally.

The single-constant vocabulary cannot distinguish a deadline from a fault, and
the record demonstrates this against itself: its own degraded-empty wire example
types a leg as `backend_error` while that leg's message reads `backend search
timed out after 5000ms`. One value is already carrying two meanings.

The unconditional `retryable=false` then instructs a compliant caller not to
retry a timeout that would likely have succeeded.

## The amendment

1. **`kind` becomes a closed two-value vocabulary** — `timeout` | `backend_error`.
   Classification is structural and MUST NOT be derived by matching text in a
   rendered message, and it is computed *before* Amendment 1's diagnostic
   truncation so an omitted cause cannot change the answer.
2. **Conditional retryability** — `error.retryable` MAY be `true` only when every
   retained *and omitted* failed leg classified as `timeout`. Any mixed or
   non-timeout failure keeps it `false`. `retryable=true` requires a positive
   `retry_after_ms`.
3. **A direct answer to the recorded load-amplification arithmetic**, not a
   restatement of the benefit — see below.
4. **Admission control as a requirement rather than advice**, with each
   obligation assigned to the party that can discharge it.
5. A corrected wire example for the all-timeout case.
6. Verification rows.

## On the amplification argument

The existing retry contract records that a naive client turns 50 logical
searches/sec into as many as 150 attempts/sec. That figure is not disputed here.
Three things are said about it instead:

- **It assumes immediate retry.** The tripling holds only if the three retries
  are issued without delay so that attempts for one logical request overlap.
  Under mandatory backoff they are spread across the backoff window and decay.
  With `retry_after_ms` the server — the party that knows it is degraded — sets
  that pace rather than the client.
- **A boolean was never the load control.** The section concedes the decisive
  point itself: `retryable=false` "reduces that risk but cannot eliminate it for
  clients that ignore the field." The client in the amplification scenario is
  precisely one that retries every `ok=false`, i.e. one ignoring the field. So
  the protection is unavailable exactly where it is needed, while the cost of
  the unconditional `false` falls entirely on well-behaved callers.
- **The outage case gets strictly better.** Circuit-breaker admission suppresses
  attempts *including first attempts*, so during a sustained outage offered load
  falls **below** the 50/sec baseline, where today it stays at 50/sec plus
  whatever field-ignoring clients add.

What this does **not** claim: that typed causes are more accurate and therefore
justify retrying (true, and it does not answer the argument), or that clients
will comply (which is why the pacing obligation sits on the server).

## Party assignment in the admission-control section

The three admission requirements are client-side behaviours, so stating them as
a condition on the emitting surface would have been unsound. They are split:

- **The retrying client** implements the bounded budget, jittered exponential
  backoff (never shorter than `retry_after_ms`), and the circuit breaker.
- **The emitting surface** MUST NOT advertise `retryable=true` unless it
  publishes that policy, and MUST emit a `retry_after_ms` derived from its own
  degraded state rather than a fixed constant. A surface that cannot publish all
  three keeps `retryable=false`.

The server cannot enforce client backoff and the amendment does not claim it
can; a non-conforming client is already ignoring the field today.

## Scope of body edits

The amended body passages carry pointers at their own location, not only inside
the amendment — the completeness contract, the retry contract, the
degraded-empty wire example, the compatibility note, and the retry-policy
verification row. A reader who lands mid-document does not copy a superseded
requirement.

`retryable=false` remains the default and the safe value throughout.

Docs only; no code changes.