### PR TITLE
ci(wasm): cache and retry wasmtime setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -475,6 +475,8 @@ jobs:
     defaults:
       run:
         working-directory: crates
+    env:
+      WASMTIME_VERSION: v46.0.1
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@1.95.0
@@ -486,11 +488,36 @@ jobs:
           cache-on-failure: true
       # Pinned exact version (same rationale as the cargo-deny/gitleaks pins
       # above): a wasm-parity gate's tooling must not silently drift.
+      - name: Cache wasmtime
+        id: cache-wasmtime
+        uses: actions/cache@v4
+        with:
+          path: ~/.wasmtime
+          key: wasmtime-${{ runner.os }}-${{ runner.arch }}-${{ env.WASMTIME_VERSION }}
       - name: Install wasmtime (pinned)
+        if: steps.cache-wasmtime.outputs.cache-hit != 'true'
         run: |
-          set -o pipefail
-          curl https://wasmtime.dev/install.sh -sSf | bash -s -- --version v46.0.1
-          "$HOME/.wasmtime/bin/wasmtime" --version
+          set -euo pipefail
+          archive="$RUNNER_TEMP/wasmtime-${WASMTIME_VERSION}-x86_64-linux.tar.xz"
+          curl --fail --silent --show-error --location \
+            --retry 5 --retry-all-errors --retry-max-time 300 \
+            --output "$archive" \
+            "https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VERSION}/wasmtime-${WASMTIME_VERSION}-x86_64-linux.tar.xz"
+          mkdir -p "$HOME/.wasmtime/bin"
+          tar -xJf "$archive" \
+            -C "$HOME/.wasmtime/bin" \
+            --strip-components=1 \
+            "wasmtime-${WASMTIME_VERSION}-x86_64-linux/wasmtime"
+      - name: Verify wasmtime version
+        run: |
+          set -euo pipefail
+          expected_version="${WASMTIME_VERSION#v}"
+          actual_version="$("$HOME/.wasmtime/bin/wasmtime" --version)"
+          if [[ "$actual_version" != "wasmtime ${expected_version}"* ]]; then
+            echo "expected wasmtime ${expected_version}, got: ${actual_version}" >&2
+            exit 1
+          fi
+          echo "$actual_version"
           echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"
       - name: wasm32-unknown-unknown compile check (ADR-101 D5)
         run: cargo check -p khive-changeset --target wasm32-unknown-unknown

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -498,26 +498,37 @@ jobs:
         if: steps.cache-wasmtime.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
-          archive="$RUNNER_TEMP/wasmtime-${WASMTIME_VERSION}-x86_64-linux.tar.xz"
+          case "$RUNNER_ARCH" in
+            X64) wasmtime_arch="x86_64" ;;
+            ARM64) wasmtime_arch="aarch64" ;;
+            *)
+              echo "unsupported runner architecture for the wasmtime release asset: $RUNNER_ARCH" >&2
+              exit 1
+              ;;
+          esac
+          asset="wasmtime-${WASMTIME_VERSION}-${wasmtime_arch}-linux"
+          archive="$RUNNER_TEMP/${asset}.tar.xz"
           curl --fail --silent --show-error --location \
             --retry 5 --retry-all-errors --retry-max-time 300 \
             --output "$archive" \
-            "https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VERSION}/wasmtime-${WASMTIME_VERSION}-x86_64-linux.tar.xz"
+            "https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VERSION}/${asset}.tar.xz"
           mkdir -p "$HOME/.wasmtime/bin"
           tar -xJf "$archive" \
             -C "$HOME/.wasmtime/bin" \
             --strip-components=1 \
-            "wasmtime-${WASMTIME_VERSION}-x86_64-linux/wasmtime"
+            "${asset}/wasmtime"
       - name: Verify wasmtime version
         run: |
           set -euo pipefail
           expected_version="${WASMTIME_VERSION#v}"
-          actual_version="$("$HOME/.wasmtime/bin/wasmtime" --version)"
-          if [[ "$actual_version" != "wasmtime ${expected_version}"* ]]; then
-            echo "expected wasmtime ${expected_version}, got: ${actual_version}" >&2
+          actual_output="$("$HOME/.wasmtime/bin/wasmtime" --version)"
+          actual_version="${actual_output#wasmtime }"
+          actual_version="${actual_version%% *}"
+          if [[ "$actual_version" != "$expected_version" ]]; then
+            echo "expected wasmtime ${expected_version}, got: ${actual_output}" >&2
             exit 1
           fi
-          echo "$actual_version"
+          echo "$actual_output"
           echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"
       - name: wasm32-unknown-unknown compile check (ADR-101 D5)
         run: cargo check -p khive-changeset --target wasm32-unknown-unknown

--- a/scripts/tests/test_ci_workflows.py
+++ b/scripts/tests/test_ci_workflows.py
@@ -63,6 +63,32 @@ class AutoMergeGuardWorkflowTests(unittest.TestCase):
         self.assertEqual(permissions, {"contents: write", "pull-requests: write"})
 
 
+class WasmtimeParityWorkflowTests(unittest.TestCase):
+    def test_pinned_runtime_is_cached_retried_and_verified(self):
+        workflow = workflow_text("ci.yml")
+        job = indented_block(workflow, "wasm-parity", 2)
+
+        self.assertIn("WASMTIME_VERSION: v46.0.1", job)
+        self.assertIn("uses: actions/cache@v4", job)
+        self.assertIn("id: cache-wasmtime", job)
+        self.assertIn("path: ~/.wasmtime", job)
+        self.assertIn(
+            "key: wasmtime-${{ runner.os }}-${{ runner.arch }}-"
+            "${{ env.WASMTIME_VERSION }}",
+            job,
+        )
+        self.assertIn(
+            "if: steps.cache-wasmtime.outputs.cache-hit != 'true'", job
+        )
+        self.assertIn("set -euo pipefail", job)
+        self.assertIn("--retry 5", job)
+        self.assertIn("--retry-all-errors", job)
+        self.assertIn("releases/download/${WASMTIME_VERSION}", job)
+        self.assertNotIn("wasmtime.dev/install.sh", job)
+        self.assertIn('expected_version="${WASMTIME_VERSION#v}"', job)
+        self.assertIn('echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"', job)
+
+
 class BenchTrackWorkflowTests(unittest.TestCase):
     def test_component_runner_limits_quick_flag_to_bench_targets(self):
         workflow = workflow_text("bench-component.yml")

--- a/scripts/tests/test_ci_workflows.py
+++ b/scripts/tests/test_ci_workflows.py
@@ -85,8 +85,21 @@ class WasmtimeParityWorkflowTests(unittest.TestCase):
         self.assertIn("--retry-all-errors", job)
         self.assertIn("releases/download/${WASMTIME_VERSION}", job)
         self.assertNotIn("wasmtime.dev/install.sh", job)
-        self.assertIn('expected_version="${WASMTIME_VERSION#v}"', job)
-        self.assertIn('echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"', job)
+        self.assertIn('case "$RUNNER_ARCH" in', job)
+        self.assertIn('X64) wasmtime_arch="x86_64" ;;', job)
+        self.assertIn('ARM64) wasmtime_arch="aarch64" ;;', job)
+        self.assertNotIn("x86_64-linux.tar.xz", job)
+
+        verify_start = job.index("- name: Verify wasmtime version")
+        verify_step = job[verify_start : job.index("- name:", verify_start + 1)]
+        self.assertNotIn("if:", verify_step)
+        self.assertIn('expected_version="${WASMTIME_VERSION#v}"', verify_step)
+        self.assertIn('actual_version="${actual_version%% *}"', verify_step)
+        self.assertIn(
+            'if [[ "$actual_version" != "$expected_version" ]]; then', verify_step
+        )
+        self.assertNotIn('"wasmtime ${expected_version}"*', verify_step)
+        self.assertIn('echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"', verify_step)
 
 
 class BenchTrackWorkflowTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- cache the pinned Wasmtime toolchain by runner OS, architecture, and exact version
- retry the pinned release archive download and fail at the network error after bounded retries
- verify restored and newly installed binaries report v46.0.1 before exporting them to later parity steps

## Test plan

- `uv run --no-project --python 3.11 python scripts/tests/test_ci_workflows.py`
- `pre-commit run --files .github/workflows/ci.yml scripts/tests/test_ci_workflows.py`

Closes #2020