### PR TITLE
fix(release): report semver gate work honestly

### DIFF
--- a/scripts/lib/semver_gate.py
+++ b/scripts/lib/semver_gate.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Validate and summarize the local cargo-semver-checks release gate."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+# v0.50.0 adds rustdoc JSON v60/v61 support, covering the repository's
+# current Rust 1.98 toolchain. Future format changes must raise this floor.
+MIN_CHECKER_VERSION = (0, 50, 0)
+_VERSION_RE = re.compile(r"\bcargo-semver-checks\s+v?(\d+)\.(\d+)\.(\d+)\b")
+_ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+_CHECKED_RE = re.compile(r"\bChecked\s+\[[^\]]+\]\s+(\d+)\s+checks:")
+
+
+def parse_checker_version(output: str) -> tuple[int, int, int]:
+    match = _VERSION_RE.search(output)
+    if match is None:
+        raise ValueError(
+            "could not parse `cargo-semver-checks --version` output: "
+            f"{output.strip()!r}"
+        )
+    return tuple(int(part) for part in match.groups())
+
+
+def validate_checker_version(output: str) -> tuple[int, int, int]:
+    version = parse_checker_version(output)
+    if version < MIN_CHECKER_VERSION:
+        required = ".".join(str(part) for part in MIN_CHECKER_VERSION)
+        actual = ".".join(str(part) for part in version)
+        raise ValueError(
+            f"cargo-semver-checks {actual} is too old; khive requires >= {required} "
+            "for the current rustdoc JSON generation"
+        )
+    return version
+
+
+def summarize_log(text: str) -> tuple[int, int]:
+    clean = _ANSI_RE.sub("", text)
+    selected_checks = [int(match.group(1)) for match in _CHECKED_RE.finditer(clean)]
+    if not selected_checks:
+        raise ValueError(
+            "cargo-semver-checks completed without any recognizable per-crate "
+            "`Checked ... N checks:` records"
+        )
+    return len(selected_checks), sum(selected_checks)
+
+
+def _check_version(raw_version: str) -> int:
+    try:
+        version = validate_checker_version(raw_version)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    actual = ".".join(str(part) for part in version)
+    print(f"    cargo-semver-checks {actual} compatibility floor OK")
+    return 0
+
+
+def _summarize(path: Path) -> int:
+    try:
+        crates, evaluated = summarize_log(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        print(f"ERROR: cannot summarize SemVer gate: {exc}", file=sys.stderr)
+        return 1
+
+    if evaluated == 0:
+        print(
+            f"    SemVer gate completed: {crates} crates checked, 0 lints "
+            "evaluated — VACUOUS PASS for this version delta"
+        )
+    else:
+        print(
+            f"    SemVer gate completed: {crates} crates checked, "
+            f"{evaluated} lints evaluated"
+        )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    version_parser = subparsers.add_parser("check-version")
+    version_parser.add_argument("version_output")
+
+    summary_parser = subparsers.add_parser("summarize")
+    summary_parser.add_argument("log", type=Path)
+
+    args = parser.parse_args(argv)
+    if args.command == "check-version":
+        return _check_version(args.version_output)
+    return _summarize(args.log)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -104,7 +104,14 @@ DELAY=10  # seconds to wait for crates.io index between publishes
 echo ""
 echo "--- Publish ladder guard (CRATES membership vs cargo metadata) ---"
 METADATA_JSON=$(mktemp)
-trap 'rm -f "$METADATA_JSON"' EXIT
+SEMVER_LOG=""
+cleanup_publish_temp() {
+    rm -f "$METADATA_JSON"
+    if [[ -n "$SEMVER_LOG" ]]; then
+        rm -f "$SEMVER_LOG"
+    fi
+}
+trap cleanup_publish_temp EXIT
 cargo metadata --no-deps --format-version=1 >"$METADATA_JSON"
 if ! check_crates_ladder "$METADATA_JSON" "${CRATES[@]}"; then
     exit 1
@@ -117,10 +124,11 @@ echo "    CRATES ladder OK (${#CRATES[@]} publishable workspace members all pres
 # version bump. This runs at the publish boundary — where the version actually
 # bumps — because mid-cycle on a fixed dev version the check is permanently red
 # (which is why it is NOT a per-PR CI gate). Runs in preflight and live alike so
-# `make publish-dry` validates SemVer before any real publish. The exclude list
-# (crates with no crates.io baseline yet) lives in scripts/lib/semver_excludes.txt
-# (#568) — also consumed by .github/workflows/release.yml's semver-gate job, so
-# the two gates cannot drift out of sync with each other.
+# `make publish-dry` validates SemVer before any real publish. The shared exclude
+# list covers pre-1.0 surfaces still moving under active development, including
+# some crates that already have a crates.io baseline. Its full policy lives in
+# scripts/lib/semver_excludes.txt (#568), also consumed by release.yml so the two
+# gates cannot drift out of sync with each other.
 echo ""
 echo "--- SemVer gate (cargo-semver-checks vs crates.io baseline) ---"
 if ! command -v cargo-semver-checks >/dev/null 2>&1; then
@@ -128,13 +136,42 @@ if ! command -v cargo-semver-checks >/dev/null 2>&1; then
     echo "       Install it:  cargo install cargo-semver-checks --locked" >&2
     exit 1
 fi
+SEMVER_CHECKER_VERSION=$(cargo-semver-checks --version 2>&1)
+RUSTC_VERSION=$(rustc --version)
+if ! python3 "$SCRIPT_DIR/lib/semver_gate.py" check-version "$SEMVER_CHECKER_VERSION"; then
+    echo "       Upgrade with: cargo install cargo-semver-checks --locked --force" >&2
+    exit 1
+fi
+echo "    Toolchain: $SEMVER_CHECKER_VERSION; $RUSTC_VERSION"
 SEMVER_EXCLUDE_ARGS=()
 while IFS= read -r crate; do
     [[ "$crate" =~ ^[[:space:]]*(#|$) ]] && continue
     SEMVER_EXCLUDE_ARGS+=(--exclude "$crate")
 done <"$SCRIPT_DIR/lib/semver_excludes.txt"
-cargo semver-checks check-release --workspace "${SEMVER_EXCLUDE_ARGS[@]}"
-echo "    SemVer gate OK"
+SEMVER_LOG=$(mktemp)
+set +e
+set -o pipefail
+CARGO_TERM_COLOR=never cargo semver-checks check-release --workspace "${SEMVER_EXCLUDE_ARGS[@]}" 2>&1 | tee "$SEMVER_LOG"
+SEMVER_STATUS=${PIPESTATUS[0]}
+set +o pipefail
+set -e
+if ((SEMVER_STATUS != 0)); then
+    case "$SEMVER_STATUS" in
+        100)
+            echo "ERROR: SemVer API violations reported (checker exit 100)." >&2
+            ;;
+        101)
+            echo "ERROR: cargo-semver-checks could not complete (checker exit 101)." >&2
+            echo "       This is a checker/toolchain/build/network failure, not a clean API result." >&2
+            echo "       Toolchain: $SEMVER_CHECKER_VERSION; $RUSTC_VERSION" >&2
+            ;;
+        *)
+            echo "ERROR: cargo-semver-checks failed with unexpected exit $SEMVER_STATUS." >&2
+            ;;
+    esac
+    exit "$SEMVER_STATUS"
+fi
+python3 "$SCRIPT_DIR/lib/semver_gate.py" summarize "$SEMVER_LOG"
 
 for crate in "${CRATES[@]}"; do
     echo ""

--- a/scripts/tests/publish-guard-test.sh
+++ b/scripts/tests/publish-guard-test.sh
@@ -44,7 +44,7 @@ else
 fi
 
 echo "--- case 3: publish=false crate never appears as missing, even from an empty ladder ---"
-if check_crates_ladder "$FIXTURE" 2>"$STDERR_CAPTURE"; then
+if check_crates_ladder "$FIXTURE" __empty_ladder_sentinel__ 2>"$STDERR_CAPTURE"; then
     echo "FAIL: guard passed with an empty ladder (should have flagged crate-a, crate-b)" >&2
     exit 1
 fi
@@ -98,6 +98,19 @@ while IFS= read -r crate; do
         exit 1
     fi
 done < <(grep -v '^[[:space:]]*#' "$SEMVER_EXCLUDES_FILE" | grep -v '^[[:space:]]*$')
+echo "PASS"
+
+echo "--- case 6: local SemVer gate reports tool compatibility and evaluated work ---"
+SEMVER_HELPER="$SCRIPT_DIR/lib/semver_gate.py"
+if [[ ! -f "$SEMVER_HELPER" ]] ||
+    ! grep -q 'semver_gate.py.*check-version' "$PUBLISH_SCRIPT" ||
+    ! grep -q 'semver_gate.py.*summarize' "$PUBLISH_SCRIPT" ||
+    ! grep -q 'CARGO_TERM_COLOR=never cargo semver-checks' "$PUBLISH_SCRIPT" ||
+    ! grep -q 'set -o pipefail' "$PUBLISH_SCRIPT" ||
+    ! grep -q 'SEMVER_STATUS=${PIPESTATUS\[0\]}' "$PUBLISH_SCRIPT"; then
+    echo "FAIL: publish.sh must validate, capture, preserve, and summarize the SemVer gate" >&2
+    exit 1
+fi
 echo "PASS"
 
 echo ""

--- a/scripts/tests/test_semver_gate.py
+++ b/scripts/tests/test_semver_gate.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Regression tests for the local release SemVer gate helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import unittest
+
+
+SCRIPT = pathlib.Path(__file__).resolve().parents[1] / "lib" / "semver_gate.py"
+SPEC = importlib.util.spec_from_file_location("semver_gate", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+semver_gate = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(semver_gate)
+
+
+class CheckerVersionTests(unittest.TestCase):
+    def test_rejects_checker_without_current_rustdoc_support(self):
+        with self.assertRaisesRegex(ValueError, r"0\.48\.0.*>= 0\.50\.0"):
+            semver_gate.validate_checker_version("cargo-semver-checks 0.48.0")
+
+    def test_accepts_current_checker(self):
+        self.assertEqual(
+            semver_gate.validate_checker_version("cargo-semver-checks 0.50.0"),
+            (0, 50, 0),
+        )
+
+    def test_rejects_unrecognized_version_output(self):
+        with self.assertRaisesRegex(ValueError, "could not parse"):
+            semver_gate.validate_checker_version("semver checker unknown")
+
+
+class SemverSummaryTests(unittest.TestCase):
+    def test_sums_evaluated_lints_across_success_and_finding_formats(self):
+        log = """
+        Checked [   0.100s] 3 checks: 3 pass, 251 skip
+        Checked [   0.200s] 5 checks: 3 pass, 1 fail, 1 warn, 249 skip
+        """
+        self.assertEqual(semver_gate.summarize_log(log), (2, 8))
+
+    def test_identifies_vacuous_pass_with_ansi_output(self):
+        log = (
+            "\x1b[32m     Checked\x1b[0m [   0.123s] 0 checks: 0 pass, 254 skip\n"
+            "\x1b[32m     Checked\x1b[0m [   0.456s] 0 checks: 0 pass, 254 skip\n"
+        )
+        self.assertEqual(semver_gate.summarize_log(log), (2, 0))
+
+    def test_fails_closed_when_checker_output_shape_is_unknown(self):
+        with self.assertRaisesRegex(ValueError, "without any recognizable"):
+            semver_gate.summarize_log("Summary no semver update required\n")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #2254
Closes #2255
Closes #2265

## Summary
- reject cargo-semver-checks versions older than the current rustdoc-compatible floor
- preserve checker exit classes and label incomplete tool/runtime runs separately from API findings
- aggregate per-crate evaluated lint counts and call out a zero-lint vacuous pass
- align the publish-script comment with the shared pre-1.0 exclusion policy

## Validation
- 6 SemVer helper unit tests
- publish-guard fixture suite, all 6 cases passed
- bash syntax checks for publish and guard scripts
- Python compile checks
- git diff --check

Draft for Claude review and merge.