### PR TITLE
docs(adr): correct production graph site count

### DIFF
--- a/docs/adr/ADR-009-backend-architecture.md
+++ b/docs/adr/ADR-009-backend-architecture.md
@@ -406,5 +406,5 @@ read-to-replacement race without changing the ordinary upsert contract.
   still permits a stale document to overwrite concurrent changes.
 
 No open design question remains within this storage amendment: the conflict is a typed storage
-outcome, ordinary upserts retain their existing semantics, and the six-site boundary above is
+outcome, ordinary upserts retain their existing semantics, and the eight-site boundary above is
 explicit.

--- a/docs/adr/ADR-014-curation-operations.md
+++ b/docs/adr/ADR-014-curation-operations.md
@@ -621,7 +621,7 @@ relation validation, and index-maintenance behavior. The persistence failure mod
 caller whose patch was derived from a stale full-row snapshot: the caller receives a distinct
 optimistic-concurrency conflict instead of silently overwriting the newer row.
 
-For the six production-graph sites in scope, a full-row replacement carries the revision read
+For the eight production-graph sites in scope, a full-row replacement carries the revision read
 before patch application into the shared guarded store operation. The operation succeeds only if
 the row still has that revision and deletion state and the replacement revision strictly advances
 it. A conflict performs no curation update; the caller must fetch current state and explicitly


### PR DESCRIPTION
## Summary
- correct ADR-009s stale six-site boundary reference to eight sites
- correct ADR-014s Decision text to cover all eight enumerated production-graph sites
- preserve the separate accurate count of six finalization branches

## Verification
- repository search finds no remaining stale six-site or six production-graph-site phrase in the synchronized ADRs
- all three ADRs retain the eight-site control enumeration and six-branch wording
- git diff check passed
- deno formatting was not runnable locally because deno is not installed; the two edits only replace number words without changing layout

Closes #2257