### PR TITLE
fix(release): publish npm CLI alias

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,8 @@ name: Release
 # workflow today.
 #
 # Builds Rust binaries per-platform, publishes each khive-kernel-{platform}
-# npm subpackage, then publishes the umbrella khive package.
+# npm subpackage, publishes the umbrella khive package, then publishes its
+# exact-version @khive-ai/cli compatibility alias.
 #
 # Per ADR-026 §"Atomic release semantics": all subpackage publishes must
 # succeed before the umbrella publishes. This is enforced by separating the
@@ -21,8 +22,8 @@ name: Release
 #     artifact. No `npm publish` happens here.
 #
 #   Phase 2 (publish-all, single job): downloads all six platform artifacts,
-#     updates versions, publishes the six subpackages, then publishes the
-#     umbrella — in a single sequential job. If any subpackage publish fails,
+#     updates versions, publishes the six subpackages, the umbrella, then the
+#     dependent CLI alias — in a single sequential job. If any subpackage publish fails,
 #     the umbrella is never published. Because publishing is serialised in one
 #     job, partial failure cannot leave mismatched versions permanently on the
 #     registry (any already-published subpackage can be unpublished within 72h
@@ -181,7 +182,7 @@ jobs:
           exclude: ${{ steps.semver-excludes.outputs.list }}
 
   # ─────────────────────────────────────────────────────────────────────────
-  # Phase 2: Publish all subpackages + umbrella atomically in a single job.
+  # Phase 2: Publish all subpackages + umbrella + CLI alias in a single job.
   # Runs only after ALL Phase 1 jobs succeed (needs: build-platform with
   # fail-fast: true propagates any single failure here) and the release SemVer
   # gate passes.
@@ -225,13 +226,23 @@ jobs:
         run: |
           CARGO_VERSION=$(awk '/^\[workspace\.package\]/{f=1;next} /^\[/{f=0} f && /^version = /{gsub(/version = |"/,""); print; exit}' crates/Cargo.toml)
           NPM_VERSION=$(node -p "require('./npm/package.json').version")
-          echo "inputs.version=${VERSION} crates/Cargo.toml=${CARGO_VERSION} npm/package.json=${NPM_VERSION}"
+          ALIAS_VERSION=$(node -p "require('./npm/cli-alias/package.json').version")
+          ALIAS_KHIVE_VERSION=$(node -p "require('./npm/cli-alias/package.json').dependencies.khive")
+          echo "inputs.version=${VERSION} crates/Cargo.toml=${CARGO_VERSION} npm/package.json=${NPM_VERSION} npm/cli-alias=${ALIAS_VERSION} alias-khive=${ALIAS_KHIVE_VERSION}"
           if [ "$VERSION" != "$CARGO_VERSION" ]; then
             echo "::error::Dispatch version ${VERSION} does not match crates/Cargo.toml workspace version ${CARGO_VERSION}"
             exit 1
           fi
           if [ "$VERSION" != "$NPM_VERSION" ]; then
             echo "::error::Dispatch version ${VERSION} does not match npm/package.json version ${NPM_VERSION}"
+            exit 1
+          fi
+          if [ "$VERSION" != "$ALIAS_VERSION" ]; then
+            echo "::error::Dispatch version ${VERSION} does not match npm/cli-alias/package.json version ${ALIAS_VERSION}"
+            exit 1
+          fi
+          if [ "$VERSION" != "$ALIAS_KHIVE_VERSION" ]; then
+            echo "::error::@khive-ai/cli depends on khive ${ALIAS_KHIVE_VERSION}, expected ${VERSION}"
             exit 1
           fi
 
@@ -322,6 +333,26 @@ jobs:
 
       - name: Publish khive (umbrella)
         working-directory: npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # The alias carries an exact-version dependency on the umbrella, so it
+      # must be rewritten and published only after khive@VERSION is available.
+      - name: Set CLI alias version and khive dependency
+        env:
+          VERSION: ${{ env.VERSION }}
+        run: |
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('npm/cli-alias/package.json'));
+            pkg.version = process.env.VERSION;
+            pkg.dependencies.khive = process.env.VERSION;
+            fs.writeFileSync('npm/cli-alias/package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+
+      - name: Publish @khive-ai/cli (compatibility alias)
+        working-directory: npm/cli-alias
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/docs/adr/ADR-026-rust-binary-packaging.md
+++ b/docs/adr/ADR-026-rust-binary-packaging.md
@@ -132,7 +132,8 @@ unsigned Windows binaries work but trigger SmartScreen warnings on first run.
 
 ### Atomic release semantics
 
-Six platform publishes plus the umbrella publish = seven npm releases per khive version.
+Six platform publishes plus the umbrella publish = seven npm releases per khive version
+(eight with the `@khive-ai/cli` alias of Amendment 3).
 If any subpackage publish fails, the umbrella must not publish. The release pipeline
 enforces this: all subpackage jobs must succeed before the umbrella publish job runs.
 Partial failure leaves the user able to install the previous khive version unchanged.
@@ -252,7 +253,8 @@ users install once and run constantly, install size is a real friction point.
 
 - **Six native binaries built per release**, two per binary set (`kkernel` + `khive-mcp`)
   pre-convergence, dropping to one binary set post-convergence (ADR-003).
-- **Seven npm publishes per release** (six subpackages + umbrella). Releases must be
+- **Seven npm publishes per release** (six subpackages + umbrella; eight with the alias of
+  Amendment 3). Releases must be
   atomic — partial failure must not publish the umbrella.
 - **CI complexity** — a 6-job release matrix instead of 1. Mitigated by `cargo-zigbuild`
   handling musl/arm64 cross-compile.
@@ -378,3 +380,27 @@ the installed binary and stops the old daemon after verification so bridges can 
 new artifact under ADR-049. The ordering guarantee is narrower: no install or daemon
 interruption is reachable unless the exact artifact being staged has passed the pack/verb
 surface probe.
+
+## Amendment 3 (2026-09-02): the `@khive-ai/cli` compatibility alias
+
+`npm/cli-alias` publishes `@khive-ai/cli`, an alias whose only dependency is `khive` at the
+exact same version and whose `bin` entries point into that dependency. It is the eighth npm
+release per khive version: the six platform subpackages, the umbrella, then the alias.
+
+Ordering and gates. Both release paths (`.github/workflows/release.yml` and
+`scripts/npm-publish.sh`) refuse to publish anything when the alias version or its exact
+`khive` dependency differs from the release version, and both publish the alias last, after
+the umbrella it depends on is on the registry. The workflow rewrites the alias's version and
+dependency to the dispatch version before publishing it.
+
+Failure semantics. The atomic boundary of the accepted text is unchanged for the seven
+packages the umbrella covers: no subpackage failure lets the umbrella publish, and no
+umbrella failure lets the alias publish. The alias sits outside that boundary. If the
+umbrella publishes and the alias publish fails, `khive@VERSION` is installable and
+`@khive-ai/cli` stays at its previous version, which depends on the previous `khive`
+exactly, so alias installs keep resolving a consistent pair, one release behind. The
+workflow's publish job is not resumable; the repair path is `scripts/npm-publish.sh`, which
+skips every package already on the registry at the release version and publishes only what
+is missing. Its alias skip requires the published alias to carry the exact `khive`
+dependency; a published alias with a different dependency stops the script with an error
+instead of being reported as done.

--- a/scripts/npm-publish.sh
+++ b/scripts/npm-publish.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
-# Publish khive npm packages: platform binaries + main package.
+# Publish khive npm packages: platform binaries + main package + CLI alias.
 #
 # Usage:
-#   ./npm-publish.sh              # publish all (platform packages first, then main)
+#   ./npm-publish.sh              # publish all (platforms, main, then CLI alias)
 #   ./npm-publish.sh --dry-run    # show what would be published without uploading
 #
 # Prerequisites:
@@ -14,7 +14,8 @@ set -euo pipefail
 #
 # The script publishes platform packages BEFORE the main package because
 # the main package lists them as optionalDependencies — npm resolves them
-# at install time, so they must already exist on the registry.
+# at install time, so they must already exist on the registry. The CLI alias
+# publishes last because it depends on `khive` at the exact same version.
 
 DRY_RUN=false
 if [[ "${1:-}" == "--dry-run" ]]; then
@@ -25,6 +26,16 @@ fi
 cd "$(dirname "$0")/.."
 
 VERSION=$(jq -r .version npm/package.json)
+ALIAS_VERSION=$(jq -r .version npm/cli-alias/package.json)
+ALIAS_KHIVE_VERSION=$(jq -r .dependencies.khive npm/cli-alias/package.json)
+if [[ "$ALIAS_VERSION" != "$VERSION" ]]; then
+    echo "ERROR: npm/cli-alias version ${ALIAS_VERSION} does not match khive ${VERSION}" >&2
+    exit 1
+fi
+if [[ "$ALIAS_KHIVE_VERSION" != "$VERSION" ]]; then
+    echo "ERROR: @khive-ai/cli depends on khive ${ALIAS_KHIVE_VERSION}, expected ${VERSION}" >&2
+    exit 1
+fi
 echo "Publishing khive v${VERSION} to npm..."
 
 # Platform packages — publish each one that has binaries in bin/.
@@ -93,5 +104,20 @@ else
 fi
 
 echo ""
+echo "--- CLI alias ---"
+if npm view "@khive-ai/cli@${VERSION}" version 2>/dev/null | grep -q "${VERSION}"; then
+    echo "  @khive-ai/cli@${VERSION} already on npm — skipping"
+else
+    if $DRY_RUN; then
+        echo "  [dry-run] would publish @khive-ai/cli@${VERSION}"
+    else
+        echo "  Publishing @khive-ai/cli@${VERSION}..."
+        (cd npm/cli-alias && npm publish --access public)
+        echo "  Published @khive-ai/cli@${VERSION}"
+    fi
+fi
+
+echo ""
 echo "=== Done ==="
 echo "Verify: npm view khive@${VERSION}"
+echo "Verify: npm view @khive-ai/cli@${VERSION}"

--- a/scripts/npm-publish.sh
+++ b/scripts/npm-publish.sh
@@ -105,8 +105,14 @@ fi
 
 echo ""
 echo "--- CLI alias ---"
-if npm view "@khive-ai/cli@${VERSION}" version 2>/dev/null | grep -q "${VERSION}"; then
-    echo "  @khive-ai/cli@${VERSION} already on npm — skipping"
+# The skip requires the published alias to carry the exact khive dependency,
+# so a rerun repairs a missing alias and refuses a mismatched one.
+PUBLISHED_ALIAS_KHIVE=$(npm view "@khive-ai/cli@${VERSION}" dependencies.khive 2>/dev/null || true)
+if [[ "$PUBLISHED_ALIAS_KHIVE" == "$VERSION" ]]; then
+    echo "  @khive-ai/cli@${VERSION} already on npm with khive ${VERSION} — skipping"
+elif [[ -n "$PUBLISHED_ALIAS_KHIVE" ]]; then
+    echo "ERROR: @khive-ai/cli@${VERSION} on npm depends on khive ${PUBLISHED_ALIAS_KHIVE}, expected ${VERSION}" >&2
+    exit 1
 else
     if $DRY_RUN; then
         echo "  [dry-run] would publish @khive-ai/cli@${VERSION}"

--- a/scripts/npm-publish.sh
+++ b/scripts/npm-publish.sh
@@ -106,8 +106,17 @@ fi
 echo ""
 echo "--- CLI alias ---"
 # The skip requires the published alias to carry the exact khive dependency,
-# so a rerun repairs a missing alias and refuses a mismatched one.
-PUBLISHED_ALIAS_KHIVE=$(npm view "@khive-ai/cli@${VERSION}" dependencies.khive 2>/dev/null || true)
+# so a rerun repairs a missing alias and refuses a mismatched one. Only a
+# confirmed missing package or version counts as absent; any other lookup
+# failure stops the script rather than publishing blind.
+if ALIAS_LOOKUP=$(npm view "@khive-ai/cli@${VERSION}" dependencies.khive 2>&1); then
+    PUBLISHED_ALIAS_KHIVE="$ALIAS_LOOKUP"
+elif [[ "$ALIAS_LOOKUP" == *E404* ]]; then
+    PUBLISHED_ALIAS_KHIVE=""
+else
+    echo "ERROR: could not look up @khive-ai/cli@${VERSION} on npm: ${ALIAS_LOOKUP}" >&2
+    exit 1
+fi
 if [[ "$PUBLISHED_ALIAS_KHIVE" == "$VERSION" ]]; then
     echo "  @khive-ai/cli@${VERSION} already on npm with khive ${VERSION} — skipping"
 elif [[ -n "$PUBLISHED_ALIAS_KHIVE" ]]; then

--- a/scripts/tests/test_ci_workflows.py
+++ b/scripts/tests/test_ci_workflows.py
@@ -101,7 +101,7 @@ class NpmReleaseWorkflowTests(unittest.TestCase):
             npm_stub = pathlib.Path(temp_dir) / "npm"
             npm_stub.write_text(
                 "#!/bin/sh\n"
-                "if [ \"${1:-}\" = view ]; then exit 1; fi\n"
+                "if [ \"${1:-}\" = view ]; then echo 'npm ERR! code E404' >&2; exit 1; fi\n"
                 "echo \"unexpected npm command: $*\" >&2\n"
                 "exit 97\n"
             )
@@ -153,6 +153,36 @@ class NpmReleaseWorkflowTests(unittest.TestCase):
         version = json.loads((REPO_ROOT / "npm" / "package.json").read_text())["version"]
         self.assertEqual(completed.returncode, 1, completed.stdout)
         self.assertIn(f"depends on khive 0.0.1, expected {version}", completed.stderr)
+        self.assertNotIn("would publish @khive-ai/cli", completed.stdout)
+
+    def test_local_publish_stops_when_the_alias_lookup_fails_for_another_reason(self):
+        publish_script = REPO_ROOT / "scripts" / "npm-publish.sh"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            npm_stub = pathlib.Path(temp_dir) / "npm"
+            npm_stub.write_text(
+                "#!/bin/sh\n"
+                "if [ \"${1:-}\" = view ]; then\n"
+                "  case \"${2:-}\" in @khive-ai/cli@*) echo 'npm ERR! code ECONNREFUSED' >&2; exit 1;; esac\n"
+                "  echo 'npm ERR! code E404' >&2; exit 1\n"
+                "fi\n"
+                "echo \"unexpected npm command: $*\" >&2\n"
+                "exit 97\n"
+            )
+            npm_stub.chmod(0o755)
+            env = os.environ.copy()
+            env["PATH"] = f"{temp_dir}:{env['PATH']}"
+            completed = subprocess.run(
+                ["bash", str(publish_script), "--dry-run"],
+                cwd=REPO_ROOT,
+                env=env,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(completed.returncode, 1, completed.stdout)
+        self.assertIn("could not look up @khive-ai/cli@", completed.stderr)
+        self.assertIn("ECONNREFUSED", completed.stderr)
         self.assertNotIn("would publish @khive-ai/cli", completed.stdout)
 
 

--- a/scripts/tests/test_ci_workflows.py
+++ b/scripts/tests/test_ci_workflows.py
@@ -3,7 +3,11 @@
 
 from __future__ import annotations
 
+import json
+import os
 import pathlib
+import subprocess
+import tempfile
 import unittest
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
@@ -73,6 +77,53 @@ class BenchTrackWorkflowTests(unittest.TestCase):
         self.assertEqual(len(quick_commands), 1)
         self.assertIn("--benches", quick_commands[0])
         self.assertIn("--criterion-dir crates/target/criterion", workflow)
+
+
+class NpmReleaseWorkflowTests(unittest.TestCase):
+    def test_release_publishes_cli_alias_after_exact_version_umbrella(self):
+        workflow = workflow_text("release.yml")
+
+        self.assertIn("ALIAS_VERSION=$(node -p", workflow)
+        self.assertIn("ALIAS_KHIVE_VERSION=$(node -p", workflow)
+        self.assertIn('if [ "$VERSION" != "$ALIAS_VERSION" ]', workflow)
+        self.assertIn('if [ "$VERSION" != "$ALIAS_KHIVE_VERSION" ]', workflow)
+
+        umbrella_publish = workflow.index("- name: Publish khive (umbrella)")
+        alias_rewrite = workflow.index("- name: Set CLI alias version and khive dependency")
+        alias_publish = workflow.index("- name: Publish @khive-ai/cli (compatibility alias)")
+        self.assertLess(umbrella_publish, alias_rewrite)
+        self.assertLess(alias_rewrite, alias_publish)
+        self.assertIn("working-directory: npm/cli-alias", workflow[alias_publish:])
+
+    def test_local_publish_dry_run_includes_cli_alias_after_umbrella(self):
+        publish_script = REPO_ROOT / "scripts" / "npm-publish.sh"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            npm_stub = pathlib.Path(temp_dir) / "npm"
+            npm_stub.write_text(
+                "#!/bin/sh\n"
+                "if [ \"${1:-}\" = view ]; then exit 1; fi\n"
+                "echo \"unexpected npm command: $*\" >&2\n"
+                "exit 97\n"
+            )
+            npm_stub.chmod(0o755)
+            env = os.environ.copy()
+            env["PATH"] = f"{temp_dir}:{env['PATH']}"
+            completed = subprocess.run(
+                ["bash", str(publish_script), "--dry-run"],
+                cwd=REPO_ROOT,
+                env=env,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        version = json.loads((REPO_ROOT / "npm" / "package.json").read_text())["version"]
+        umbrella = f"[dry-run] would publish khive@{version}"
+        alias = f"[dry-run] would publish @khive-ai/cli@{version}"
+        self.assertIn(umbrella, completed.stdout)
+        self.assertIn(alias, completed.stdout)
+        self.assertLess(completed.stdout.index(umbrella), completed.stdout.index(alias))
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_ci_workflows.py
+++ b/scripts/tests/test_ci_workflows.py
@@ -125,6 +125,36 @@ class NpmReleaseWorkflowTests(unittest.TestCase):
         self.assertIn(alias, completed.stdout)
         self.assertLess(completed.stdout.index(umbrella), completed.stdout.index(alias))
 
+    def test_local_publish_refuses_published_alias_with_wrong_khive_dependency(self):
+        publish_script = REPO_ROOT / "scripts" / "npm-publish.sh"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            npm_stub = pathlib.Path(temp_dir) / "npm"
+            npm_stub.write_text(
+                "#!/bin/sh\n"
+                "if [ \"${1:-}\" = view ]; then\n"
+                "  case \"${2:-}\" in @khive-ai/cli@*) echo 0.0.1; exit 0;; esac\n"
+                "  exit 1\n"
+                "fi\n"
+                "echo \"unexpected npm command: $*\" >&2\n"
+                "exit 97\n"
+            )
+            npm_stub.chmod(0o755)
+            env = os.environ.copy()
+            env["PATH"] = f"{temp_dir}:{env['PATH']}"
+            completed = subprocess.run(
+                ["bash", str(publish_script), "--dry-run"],
+                cwd=REPO_ROOT,
+                env=env,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        version = json.loads((REPO_ROOT / "npm" / "package.json").read_text())["version"]
+        self.assertEqual(completed.returncode, 1, completed.stdout)
+        self.assertIn(f"depends on khive 0.0.1, expected {version}", completed.stderr)
+        self.assertNotIn("would publish @khive-ai/cli", completed.stdout)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- choose the ship-it resolution for the existing @khive-ai/cli compatibility package
- validate that alias package and exact khive dependency versions match the release version
- publish the alias after the umbrella in both GitHub Actions and the local release script
- add executable dry-run and workflow-ordering contract coverage

## Verification
- scripts/ci.sh lint: passed, including 5 CI workflow contract tests
- network-free npm-publish.sh dry-run fixture: passed
- bash syntax and git diff checks: passed
- npm pack --dry-run with an isolated cache: @khive-ai/cli@0.8.0 packaged successfully

Closes #2264