### PR TITLE
test(mcp): guard outstanding tracker work

### DIFF
--- a/crates/khive-mcp/src/transport.rs
+++ b/crates/khive-mcp/src/transport.rs
@@ -24,6 +24,8 @@ mod counted_outstanding_entries {
 
     use super::{HashMap, OutstandingRequest, RequestId};
 
+    // Every method that reaches an element counts it; a traversal method,
+    // should one be added, must count each element it yields.
     #[derive(Default)]
     pub(super) struct OutstandingEntries {
         inner: HashMap<RequestId, OutstandingRequest>,
@@ -461,17 +463,19 @@ mod outstanding_request_tests {
         }
     }
 
-    fn assert_population_independent_work(
+    // Exact counts are the oracle: a counter that stops incrementing reads 0
+    // and a scan reads the population, so neither can pass as keyed work.
+    fn assert_keyed_work(
         operation: &str,
+        expected_touches: usize,
         small_touches: usize,
         large_touches: usize,
     ) {
-        let maximum_large_touches = small_touches.saturating_mul(2).max(1);
         assert!(
-            large_touches <= maximum_large_touches,
-            "{operation} element touches grew with outstanding-request population: \
-             {SMALL_POPULATION} entries required {small_touches}, {LARGE_POPULATION} entries \
-             required {large_touches}; maximum allowed is {maximum_large_touches}"
+            small_touches == expected_touches && large_touches == expected_touches,
+            "{operation} must touch exactly {expected_touches} element(s) at any population: \
+             {SMALL_POPULATION} entries touched {small_touches}, {LARGE_POPULATION} entries \
+             touched {large_touches}"
         );
     }
 
@@ -480,13 +484,16 @@ mod outstanding_request_tests {
         let small = measure_tracker_work(SMALL_POPULATION);
         let large = measure_tracker_work(LARGE_POPULATION);
 
-        for (operation, small_touches, large_touches) in [
-            ("contains", small.contains, large.contains),
-            ("admit", small.admit, large.admit),
-            ("retire", small.retire, large.retire),
-            ("non-stale sweep", small.sweep, large.sweep),
+        // contains: one lookup. admit: the duplicate check, the newest link
+        // update, the insert. retire (middle): the removal plus both neighbour
+        // links. sweep with nothing stale: one look at the oldest entry.
+        for (operation, expected_touches, small_touches, large_touches) in [
+            ("contains", 1, small.contains, large.contains),
+            ("admit", 3, small.admit, large.admit),
+            ("retire", 3, small.retire, large.retire),
+            ("non-stale sweep", 1, small.sweep, large.sweep),
         ] {
-            assert_population_independent_work(operation, small_touches, large_touches);
+            assert_keyed_work(operation, expected_touches, small_touches, large_touches);
         }
     }
 

--- a/crates/khive-mcp/src/transport.rs
+++ b/crates/khive-mcp/src/transport.rs
@@ -15,6 +15,72 @@ use crate::server::KhiveMcpServer;
 
 type RequestId = rmcp::model::RequestId;
 
+#[cfg(not(test))]
+type OutstandingEntries = HashMap<RequestId, OutstandingRequest>;
+
+#[cfg(test)]
+mod counted_outstanding_entries {
+    use std::cell::Cell;
+
+    use super::{HashMap, OutstandingRequest, RequestId};
+
+    #[derive(Default)]
+    pub(super) struct OutstandingEntries {
+        inner: HashMap<RequestId, OutstandingRequest>,
+        element_touches: Cell<usize>,
+    }
+
+    impl OutstandingEntries {
+        fn record_element_touch(&self) {
+            self.element_touches.set(self.element_touches.get() + 1);
+        }
+
+        pub(super) fn contains_key(&self, id: &RequestId) -> bool {
+            self.record_element_touch();
+            self.inner.contains_key(id)
+        }
+
+        pub(super) fn get(&self, id: &RequestId) -> Option<&OutstandingRequest> {
+            self.record_element_touch();
+            self.inner.get(id)
+        }
+
+        pub(super) fn get_mut(&mut self, id: &RequestId) -> Option<&mut OutstandingRequest> {
+            self.record_element_touch();
+            self.inner.get_mut(id)
+        }
+
+        pub(super) fn remove(&mut self, id: &RequestId) -> Option<OutstandingRequest> {
+            self.record_element_touch();
+            self.inner.remove(id)
+        }
+
+        pub(super) fn insert(
+            &mut self,
+            id: RequestId,
+            obligation: OutstandingRequest,
+        ) -> Option<OutstandingRequest> {
+            self.record_element_touch();
+            self.inner.insert(id, obligation)
+        }
+
+        pub(super) fn len(&self) -> usize {
+            self.inner.len()
+        }
+
+        pub(super) fn is_empty(&self) -> bool {
+            self.inner.is_empty()
+        }
+
+        pub(super) fn take_element_touches(&self) -> usize {
+            self.element_touches.replace(0)
+        }
+    }
+}
+
+#[cfg(test)]
+use counted_outstanding_entries::OutstandingEntries;
+
 /// Outstanding request obligations in admission order.
 ///
 /// The map makes duplicate detection and retirement O(1) on average. Each
@@ -23,7 +89,7 @@ type RequestId = rmcp::model::RequestId;
 /// a linear scan when a response retires a newer request.
 #[derive(Default)]
 pub(crate) struct OutstandingRequests {
-    entries: HashMap<RequestId, OutstandingRequest>,
+    entries: OutstandingEntries,
     oldest: Option<RequestId>,
     newest: Option<RequestId>,
 }
@@ -346,6 +412,83 @@ pub(crate) const DEFAULT_MAX_OUTSTANDING_REQUESTS: usize = 1024;
 #[cfg(test)]
 mod outstanding_request_tests {
     use super::*;
+
+    const SMALL_POPULATION: usize = 64;
+    const LARGE_POPULATION: usize = 1024;
+
+    #[derive(Clone, Copy)]
+    struct TrackerWork {
+        contains: usize,
+        admit: usize,
+        retire: usize,
+        sweep: usize,
+    }
+
+    fn request_id(value: usize) -> RequestId {
+        RequestId::Number(i64::try_from(value).expect("test request id must fit in i64"))
+    }
+
+    fn populated_tracker(population: usize) -> OutstandingRequests {
+        let mut outstanding = OutstandingRequests::default();
+        let admitted_at = Instant::now();
+        for value in 0..population {
+            assert!(outstanding.admit(request_id(value), admitted_at, population));
+        }
+        outstanding.entries.take_element_touches();
+        outstanding
+    }
+
+    fn measure_tracker_work(population: usize) -> TrackerWork {
+        let mut outstanding = populated_tracker(population);
+
+        assert!(!outstanding.contains(&request_id(population + 1)));
+        let contains = outstanding.entries.take_element_touches();
+
+        assert!(outstanding.admit(request_id(population), Instant::now(), population + 1));
+        let admit = outstanding.entries.take_element_touches();
+
+        outstanding.retire(&request_id(population / 2));
+        let retire = outstanding.entries.take_element_touches();
+
+        outstanding.drop_stale(Some(std::time::Duration::from_secs(60)));
+        let sweep = outstanding.entries.take_element_touches();
+
+        TrackerWork {
+            contains,
+            admit,
+            retire,
+            sweep,
+        }
+    }
+
+    fn assert_population_independent_work(
+        operation: &str,
+        small_touches: usize,
+        large_touches: usize,
+    ) {
+        let maximum_large_touches = small_touches.saturating_mul(2).max(1);
+        assert!(
+            large_touches <= maximum_large_touches,
+            "{operation} element touches grew with outstanding-request population: \
+             {SMALL_POPULATION} entries required {small_touches}, {LARGE_POPULATION} entries \
+             required {large_touches}; maximum allowed is {maximum_large_touches}"
+        );
+    }
+
+    #[test]
+    fn outstanding_request_tracker_work_is_population_independent() {
+        let small = measure_tracker_work(SMALL_POPULATION);
+        let large = measure_tracker_work(LARGE_POPULATION);
+
+        for (operation, small_touches, large_touches) in [
+            ("contains", small.contains, large.contains),
+            ("admit", small.admit, large.admit),
+            ("retire", small.retire, large.retire),
+            ("non-stale sweep", small.sweep, large.sweep),
+        ] {
+            assert_population_independent_work(operation, small_touches, large_touches);
+        }
+    }
 
     #[test]
     fn outstanding_request_tracker_rejects_admission_past_capacity() {


### PR DESCRIPTION
## Summary

- count logical map-element accesses in test builds without adding production instrumentation
- compare contains, admit, middle retirement, and non-stale sweep work at populations 64 and 1024
- keep new map traversal APIs from bypassing the counter by requiring the test-only facade to expose them

## Mutation proof

A deliberate full-map contains scan failed the guard with:

    64 entries required 64, 1024 entries required 1024; maximum allowed is 128

Restoring the keyed lookup makes the same guard pass.

## Test plan

- [x] focused population-independence regression
- [x] khive-mcp library suite: 450 passed
- [x] cargo fmt --all -- --check
- [x] cargo check --workspace
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] isolated kkernel code_ingest_cli integration suite: 7 passed
- [ ] full cargo test --workspace aggregate: every completed binary passed, but the run was cancelled after the unrelated code_ingest_cli binary made no log progress for 23 minutes under aggregate contention; that exact binary passed in isolation

Closes #2274