### PR TITLE
fix(kg-editor): skip unauthenticated showcase probe

### DIFF
--- a/apps/kg-editor/src/lib/adapters/preferred-showcase-source.test.ts
+++ b/apps/kg-editor/src/lib/adapters/preferred-showcase-source.test.ts
@@ -52,6 +52,7 @@ describe("preferred showcase source", () => {
     const result = await loadPreferredShowcaseBundle(
       configuredStaticEntry,
       fetchBundle,
+      { accessToken: "operator-secret" },
     );
 
     expect(result.source).toBe("khive-db-snapshot");
@@ -62,6 +63,7 @@ describe("preferred showcase source", () => {
       credentials: "same-origin",
       redirect: "error",
       signal: expect.any(AbortSignal),
+      headers: { authorization: "Bearer operator-secret" },
     });
   });
 
@@ -89,24 +91,25 @@ describe("preferred showcase source", () => {
     });
   });
 
-  it("sends no Authorization header when the operator token is blank", async () => {
-    const fetchBundle = vi.fn(async () =>
-      response(golden, 200, {
-        "x-khive-analysis-id": "khive",
-        "x-khive-analysis-source": "khive-db-snapshot",
-      })
+  it("loads the curated asset directly when the operator token is blank", async () => {
+    const fetchBundle = vi.fn(async () => response(golden, 200));
+
+    const result = await loadPreferredShowcaseBundle(
+      configuredStaticEntry,
+      fetchBundle,
+      { accessToken: "   " },
     );
 
-    await loadPreferredShowcaseBundle(configuredStaticEntry, fetchBundle, {
-      accessToken: "   ",
-    });
-
-    expect(fetchBundle).toHaveBeenCalledWith("/api/showcase/analyses/khive", {
-      cache: "no-store",
-      credentials: "same-origin",
-      redirect: "error",
-      signal: expect.any(AbortSignal),
-    });
+    expect(result.source).toBe("curated-static-fallback");
+    expect(fetchBundle).toHaveBeenCalledOnce();
+    expect(fetchBundle).toHaveBeenCalledWith(
+      "/showcase/khive-repo-v1-khive.json",
+      {
+        cache: "force-cache",
+        credentials: "same-origin",
+        redirect: "error",
+      },
+    );
   });
 
   it("reads the operator token from browser session storage", () => {
@@ -122,7 +125,23 @@ describe("preferred showcase source", () => {
     expect(readOperatorShowcaseAccessToken()).toBeNull();
   });
 
-  it("uses the curated asset only when the DB snapshot route is not configured", async () => {
+  it("does not probe the protected DB route when no token is configured", async () => {
+    const fetchBundle = vi.fn(async () => response(golden, 200));
+
+    const result = await loadPreferredShowcaseBundle(
+      configuredStaticEntry,
+      fetchBundle,
+    );
+
+    expect(result.source).toBe("curated-static-fallback");
+    expect(fetchBundle).toHaveBeenCalledOnce();
+    expect(fetchBundle).toHaveBeenCalledWith(
+      "/showcase/khive-repo-v1-khive.json",
+      expect.any(Object),
+    );
+  });
+
+  it("falls back to the curated asset when an authenticated snapshot is absent", async () => {
     const fetchBundle = vi.fn(async (input: string) =>
       input.startsWith("/api/")
         ? response(new Uint8Array(), 404)
@@ -132,6 +151,7 @@ describe("preferred showcase source", () => {
     const result = await loadPreferredShowcaseBundle(
       configuredStaticEntry,
       fetchBundle,
+      { accessToken: "operator-secret" },
     );
 
     expect(result.source).toBe("curated-static-fallback");
@@ -145,7 +165,9 @@ describe("preferred showcase source", () => {
     const fetchBundle = vi.fn(async () => response(new Uint8Array(), 503));
 
     await expect(
-      loadPreferredShowcaseBundle(configuredStaticEntry, fetchBundle),
+      loadPreferredShowcaseBundle(configuredStaticEntry, fetchBundle, {
+        accessToken: "operator-secret",
+      }),
     ).rejects.toThrow(/database snapshot.*503/i);
     expect(fetchBundle).toHaveBeenCalledOnce();
   });
@@ -159,7 +181,9 @@ describe("preferred showcase source", () => {
     );
 
     await expect(
-      loadPreferredShowcaseBundle(configuredStaticEntry, fetchBundle),
+      loadPreferredShowcaseBundle(configuredStaticEntry, fetchBundle, {
+        accessToken: "operator-secret",
+      }),
     ).rejects.toThrow(/provenance/i);
   });
 
@@ -175,7 +199,9 @@ describe("preferred showcase source", () => {
     );
 
     await expect(
-      loadPreferredShowcaseBundle(configuredStaticEntry, fetchBundle),
+      loadPreferredShowcaseBundle(configuredStaticEntry, fetchBundle, {
+        accessToken: "operator-secret",
+      }),
     ).rejects.toThrow(/repository identity/i);
     expect(fetchBundle).toHaveBeenCalledOnce();
   });
@@ -225,6 +251,7 @@ describe("preferred showcase source", () => {
       const resultPromise = loadPreferredShowcaseBundle(
         configuredStaticEntry,
         fetchBundle,
+        { accessToken: "operator-secret" },
       );
       const assertion = expect(resultPromise).rejects.toThrow(
         /did not settle/i,
@@ -254,6 +281,7 @@ describe("preferred showcase source", () => {
       const resultPromise = loadPreferredShowcaseBundle(
         configuredStaticEntry,
         fetchBundle,
+        { accessToken: "operator-secret" },
       );
       const assertion = expect(resultPromise).rejects.toThrow(
         /did not settle/i,
@@ -284,7 +312,9 @@ describe("preferred showcase source", () => {
       );
 
       await expect(
-        loadPreferredShowcaseBundle(configuredStaticEntry, fetchBundle),
+        loadPreferredShowcaseBundle(configuredStaticEntry, fetchBundle, {
+          accessToken: "operator-secret",
+        }),
       ).rejects.toThrow();
       expect(fetchBundle).toHaveBeenCalledOnce();
     }

--- a/apps/kg-editor/src/lib/adapters/preferred-showcase-source.ts
+++ b/apps/kg-editor/src/lib/adapters/preferred-showcase-source.ts
@@ -22,8 +22,8 @@ export type LoadedShowcaseBundle = Readonly<{
 export type PreferredShowcaseOptions = Readonly<{
   /**
    * Operator-supplied bearer token for the protected DB-snapshot routes.
-   * When absent, the request is sent without credentials and the protected
-   * route fails closed to 404, which selects the curated static fallback.
+   * When absent and a curated asset exists, the asset is loaded directly so
+   * the browser does not probe a protected route it cannot authenticate to.
    */
   accessToken?: string | null;
 }>;
@@ -71,6 +71,17 @@ export async function loadPreferredShowcaseBundle(
     if (!entry.assetPath) {
       throw new ShowcaseAnalysisNotFoundError(entry.canonicalUrl);
     }
+    return {
+      bundle: await loadStaticShowcaseBundle(entry, fetchBundle),
+      source: "curated-static-fallback",
+    };
+  }
+
+  // The snapshot route intentionally hides from unauthenticated callers with
+  // a 404. Avoid that guaranteed failed request when the curated fallback can
+  // satisfy the load immediately. Dynamic-only entries still probe the route
+  // so public deployments and an explicit not-found result keep working.
+  if (!options.accessToken?.trim() && entry.assetPath) {
     return {
       bundle: await loadStaticShowcaseBundle(entry, fetchBundle),
       source: "curated-static-fallback",


### PR DESCRIPTION
## Summary

- load the curated static showcase bundle directly when no nonblank operator token is available
- preserve authenticated DB-snapshot reads and their 404-only static fallback
- preserve API probing for dynamic-only entries that have no curated asset

## Tests

- `npx vitest run src/lib/adapters/preferred-showcase-source.test.ts`
- `npm run typecheck`
- `npx eslint src/lib/adapters/preferred-showcase-source.ts src/lib/adapters/preferred-showcase-source.test.ts`
- `git diff --check`

Closes #2036
