### PR TITLE
fix(brain): report zero-match unbind counts

### DIFF
--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -2495,7 +2495,12 @@ impl BrainPack {
                 });
 
                 let removed = before - state.bindings.len();
-                Ok(json!({ "unbound": removed }))
+                // `removed` is the canonical mutation count. Keep `unbound`
+                // as a compatibility alias for existing callers and smoke
+                // tests. In particular, both fields remain present at zero so
+                // a successful no-op cannot be mistaken for a confirmed
+                // removal.
+                Ok(json!({ "removed": removed, "unbound": removed }))
             },
         )
         .await

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -516,7 +516,28 @@ async fn dispatch_unbind_removes_binding() {
         )
         .await
         .unwrap();
+    assert_eq!(result["removed"], json!(1u64));
     assert_eq!(result["unbound"], json!(1u64));
+}
+
+#[tokio::test]
+async fn dispatch_unbind_reports_zero_when_selector_matches_nothing() {
+    let (pack, rt) = make_pack();
+    let registry = empty_registry();
+    let token = rt.authorize(Namespace::local()).unwrap();
+
+    let result = pack
+        .dispatch(
+            "brain.unbind",
+            json!({"profile_id": "well-formed-but-unbound"}),
+            &registry,
+            &token,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result["removed"], json!(0u64));
+    assert_eq!(result["unbound"], json!(0u64));
 }
 
 // ── UE5-H1: brain.profiles lifecycle filter public API ───────────────────

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -1308,6 +1308,10 @@ Remove rows from the profile resolution table. At least one filter is required.
 request(ops="brain.unbind(actor=\"role:implementer\")")
 ```
 
+The result includes `removed`, the number of matching bindings deleted. A successful
+request that matched nothing returns `removed: 0`. The legacy `unbound` field carries
+the same count for compatibility.
+
 ### `brain.bindings` — Assertive
 
 List rows in the profile resolution table, optionally filtered.


### PR DESCRIPTION
## Summary

- make zero-match `brain.unbind` responses report an explicit numeric removal count
- expose canonical `removed` while retaining the compatibility `unbound` field
- document and test the zero-removal response contract

## Tests

- focused brain unbind tests (3 passed)
- `cargo check -p khive-runtime`
- affected clippy and formatting checks
- `git diff --check`

Closes #2139

