### PR TITLE
fix(knowledge): support explicit-null atom patches

### DIFF
--- a/crates/khive-pack-knowledge/src/knowledge/crud.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/crud.rs
@@ -114,10 +114,10 @@ impl KnowledgeHandlers {
             khive_runtime::secret_gate::reject_reserved_secret_gate_property(
                 atom_in.properties.as_ref(),
             )?;
-            if let Some(ref uri) = atom_in.source_uri {
+            if let Some(Some(uri)) = &atom_in.source_uri {
                 khive_runtime::secret_gate::check(uri)?;
             }
-            if let Some(ref st) = atom_in.source_type {
+            if let Some(Some(st)) = &atom_in.source_type {
                 khive_runtime::secret_gate::check(st)?;
             }
         }
@@ -199,13 +199,23 @@ impl KnowledgeHandlers {
             let source_uri = atom_in
                 .source_uri
                 .as_ref()
+                .and_then(Option::as_ref)
                 .map(|s| s.trim())
                 .filter(|s| !s.is_empty());
+            // Blank strings keep their established update behavior (preserve),
+            // while JSON null is now an explicit clear.
+            let source_uri_present =
+                matches!(&atom_in.source_uri, Some(None)) || source_uri.is_some();
             let source_type = atom_in
                 .source_type
                 .as_ref()
+                .and_then(Option::as_ref)
                 .map(|s| s.trim())
                 .filter(|s| !s.is_empty());
+            let source_type_present =
+                matches!(&atom_in.source_type, Some(None)) || source_type.is_some();
+            let finalized_present = atom_in.finalized.is_some();
+            let finalized = atom_in.finalized.flatten().unwrap_or(false);
 
             if insert {
                 statements.push(SqlStatement {
@@ -222,8 +232,8 @@ impl KnowledgeHandlers {
                             source_type.map_or(SqlValue::Null, |s| SqlValue::Text(s.to_string())),
                             // status mirrors the lifecycle backfill (finalized => reviewed) so a
                             // freshly-finalized atom is never left at the 'draft' default.
-                            SqlValue::Text(if atom_in.finalized.unwrap_or(false) { "reviewed" } else { "draft" }.to_string()),
-                            SqlValue::Integer(atom_in.finalized.unwrap_or(false) as i64),
+                            SqlValue::Text(if finalized { "reviewed" } else { "draft" }.to_string()),
+                            SqlValue::Integer(finalized as i64),
                             SqlValue::Integer(now),
                             SqlValue::Integer(now),
                         ],
@@ -232,25 +242,22 @@ impl KnowledgeHandlers {
                 created += 1;
             } else {
                 statements.push(SqlStatement {
-                    // Promote draft -> reviewed when this upsert finalizes the atom.
-                    // Never demote an already reviewed row, and leave status
-                    // untouched when not finalizing. finalized=COALESCE(?7, finalized)
-                    // preserves the existing flag when the caller omits it; SQLite's
-                    // `NULL = 1` evaluates to NULL (falsy), so an omitted field also
-                    // leaves the status CASE on its ELSE branch. source_uri/source_type
-                    // use the same COALESCE shape so an omitted field preserves the
-                    // existing attribution instead of clobbering it with NULL.
-                    sql: "UPDATE knowledge_atoms SET name=?1, content=?2, tags=?3, properties=?4, source_uri=COALESCE(?5, source_uri), source_type=COALESCE(?6, source_type), finalized=COALESCE(?7, finalized), status = CASE WHEN ?7 = 1 AND status = 'draft' THEN 'reviewed' ELSE status END, updated_at=?8 WHERE id=?9 AND namespace=?10".into(),
+                    // Presence/value pairs distinguish omission from explicit JSON
+                    // null. Finalized is non-nullable, so its null value is bound as
+                    // false. Only true promotes draft -> reviewed; clearing the flag
+                    // does not demote an independent lifecycle status.
+                    sql: "UPDATE knowledge_atoms SET name=?1, content=?2, tags=?3, properties=?4, source_uri=CASE WHEN ?5 = 1 THEN ?6 ELSE source_uri END, source_type=CASE WHEN ?7 = 1 THEN ?8 ELSE source_type END, finalized=CASE WHEN ?9 = 1 THEN ?10 ELSE finalized END, status=CASE WHEN ?9 = 1 AND ?10 = 1 AND status = 'draft' THEN 'reviewed' ELSE status END, updated_at=?11 WHERE id=?12 AND namespace=?13".into(),
                     params: vec![
                         SqlValue::Text(atom_in.name.clone()),
                         SqlValue::Text(content),
                         SqlValue::Text(tags_json),
                         props_json.map_or(SqlValue::Null, SqlValue::Text),
+                        SqlValue::Integer(source_uri_present as i64),
                         source_uri.map_or(SqlValue::Null, |s| SqlValue::Text(s.to_string())),
+                        SqlValue::Integer(source_type_present as i64),
                         source_type.map_or(SqlValue::Null, |s| SqlValue::Text(s.to_string())),
-                        atom_in
-                            .finalized
-                            .map_or(SqlValue::Null, |f| SqlValue::Integer(f as i64)),
+                        SqlValue::Integer(finalized_present as i64),
+                        SqlValue::Integer(finalized as i64),
                         SqlValue::Integer(now),
                         SqlValue::Text(id),
                         SqlValue::Text(ns.clone()),

--- a/crates/khive-pack-knowledge/src/knowledge/schema.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/schema.rs
@@ -1,6 +1,6 @@
 //! Param/option types for the knowledge pack verbs.
 
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 use serde_json::Value;
 use uuid::Uuid;
 
@@ -93,12 +93,29 @@ pub(crate) struct AtomInput {
     pub tags: Option<Vec<String>>,
     #[serde(default)]
     pub properties: Option<Value>,
-    #[serde(default)]
-    pub finalized: Option<bool>,
-    #[serde(default)]
-    pub source_uri: Option<String>,
-    #[serde(default)]
-    pub source_type: Option<String>,
+    /// Patch semantics: omitted preserves an existing flag, `null` resets it
+    /// to false, and a boolean sets it explicitly.
+    #[serde(default, deserialize_with = "tri_state")]
+    pub finalized: Option<Option<bool>>,
+    /// Patch semantics: omitted preserves an existing URI, `null` clears it,
+    /// and a string replaces it.
+    #[serde(default, deserialize_with = "tri_state")]
+    pub source_uri: Option<Option<String>>,
+    /// Patch semantics: omitted preserves an existing type, `null` clears it,
+    /// and a string replaces it.
+    #[serde(default, deserialize_with = "tri_state")]
+    pub source_type: Option<Option<String>>,
+}
+
+/// Preserve the distinction Serde's ordinary `Option<T>` collapses: an absent
+/// key uses the field default (`None`), while a present null/value becomes
+/// `Some(None)` / `Some(Some(value))`.
+fn tri_state<'de, T, D>(deserializer: D) -> Result<Option<Option<T>>, D::Error>
+where
+    T: Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    Ok(Some(Option::deserialize(deserializer)?))
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/khive-pack-knowledge/src/vocab.rs
+++ b/crates/khive-pack-knowledge/src/vocab.rs
@@ -35,7 +35,7 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 20] = [
                 name: "atoms",
                 param_type: "array<object>",
                 required: true,
-                description: "List of atoms: {slug, name, content, tags?, properties?, finalized?}",
+                description: "List of atoms: {slug, name, content, tags?, properties?, source_uri?, source_type?, finalized?}. On update, omitted source/finalized fields are preserved; null clears a source or resets finalized to false without demoting lifecycle status.",
                 resolution_mode: IdResolutionMode::NotApplicable,
             },
             ParamDef {

--- a/crates/khive-pack-knowledge/tests/fixes.rs
+++ b/crates/khive-pack-knowledge/tests/fixes.rs
@@ -1528,6 +1528,112 @@ async fn upsert_explicit_source_fields_replace_existing_values() {
     );
 }
 
+// #1999: nullable atom fields distinguish omission from explicit null.
+
+#[tokio::test]
+async fn upsert_explicit_nulls_clear_sources_and_reset_finalized_without_demoting_status() {
+    let f = pack(rt());
+
+    f.dispatch(
+        "knowledge.upsert_atoms",
+        json!({ "atoms": [{
+            "slug": "clear-nullable-atom",
+            "name": "Clear Nullable Atom",
+            "content": "body dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity",
+            "source_uri": "https://example.com/original",
+            "source_type": "manual",
+            "finalized": true
+        }] }),
+    )
+    .await
+    .expect("insert attributed finalized atom");
+
+    f.dispatch(
+        "knowledge.upsert_atoms",
+        json!({ "atoms": [{
+            "slug": "clear-nullable-atom",
+            "name": "Clear Nullable Atom V2",
+            "content": "body updated dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity",
+            "source_uri": null,
+            "source_type": null,
+            "finalized": null
+        }] }),
+    )
+    .await
+    .expect("clear nullable fields");
+
+    let atom = f
+        .dispatch("knowledge.get", json!({ "id": "clear-nullable-atom" }))
+        .await
+        .expect("read cleared atom");
+    assert!(
+        atom["source_uri"].is_null(),
+        "explicit source_uri=null must clear the stored URI: {atom}"
+    );
+    assert!(
+        atom["source_type"].is_null(),
+        "explicit source_type=null must clear the stored type: {atom}"
+    );
+    assert_eq!(
+        atom["finalized"],
+        json!(false),
+        "finalized=null resets the non-null flag to false"
+    );
+    assert_eq!(
+        atom["status"],
+        json!("reviewed"),
+        "clearing finalization must not demote an independent lifecycle status"
+    );
+
+    // A later patch that omits the nullable fields must preserve the explicit clears.
+    f.dispatch(
+        "knowledge.upsert_atoms",
+        json!({ "atoms": [{
+            "slug": "clear-nullable-atom",
+            "name": "Clear Nullable Atom V3",
+            "content": "body updated again dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity"
+        }] }),
+    )
+    .await
+    .expect("re-upsert with nullable fields omitted");
+    let atom = f
+        .dispatch("knowledge.get", json!({ "id": "clear-nullable-atom" }))
+        .await
+        .expect("read atom after omitted patch");
+    assert!(atom["source_uri"].is_null());
+    assert!(atom["source_type"].is_null());
+    assert_eq!(atom["finalized"], json!(false));
+    assert_eq!(atom["status"], json!("reviewed"));
+}
+
+#[tokio::test]
+async fn upsert_explicit_nulls_on_insert_use_storage_defaults() {
+    let f = pack(rt());
+
+    f.dispatch(
+        "knowledge.upsert_atoms",
+        json!({ "atoms": [{
+            "slug": "null-default-atom",
+            "name": "Null Default Atom",
+            "content": "body dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity",
+            "source_uri": null,
+            "source_type": null,
+            "finalized": null
+        }] }),
+    )
+    .await
+    .expect("insert atom with explicit nulls");
+
+    let atom = f
+        .dispatch("knowledge.get", json!({ "id": "null-default-atom" }))
+        .await
+        .expect("read inserted atom");
+    assert!(atom["source_uri"].is_null());
+    assert!(atom["source_type"].is_null());
+    assert_eq!(atom["finalized"], json!(false));
+    assert_eq!(atom["status"], json!("draft"));
+}
+
 // ── FTS5 MATCH escaping regression ───────────────────────────────────────────
 
 #[tokio::test]

--- a/docs/adr/ADR-047-knowledge-pack.md
+++ b/docs/adr/ADR-047-knowledge-pack.md
@@ -1,11 +1,26 @@
 # ADR-047: Knowledge Pack
 
-**Status**: accepted (amended 2026-06-07, 2026-06-10, 2026-06-10b, 2026-08-01, 2026-08-06)
+**Status**: accepted (amended 2026-06-07, 2026-06-10, 2026-06-10b, 2026-08-01, 2026-08-06, 2026-08-29)
 **Date**: 2026-05-25
 **Authors**: khive maintainers
 **Amended by**: proposed [ADR-160](ADR-160-shared-pack-infrastructure.md), which adds a bounded,
 operator-opt-in intent-rephrase retrieval path while preserving original-only behavior by default
 on acceptance.
+
+## Amendment (2026-08-29): tri-state atom upsert patches
+
+On an existing atom, `knowledge.upsert_atoms` treats `source_uri`, `source_type`, and `finalized`
+as patch fields with three wire states. An omitted key preserves the stored value. JSON `null`
+clears a source field, while a non-blank string replaces it. A boolean sets `finalized`
+explicitly. Because the `finalized` column is non-nullable, `finalized: null` resets it to the
+schema default (`false`), the same persisted flag as explicit `false`.
+
+The atom lifecycle `status` remains independent from the legacy finalization flag. Setting
+`finalized: true` promotes `draft` to `reviewed`; `false` or `null` does not demote `reviewed`,
+`deprecated`, or any future non-draft lifecycle state. On insert, omitted or null source fields
+store SQL NULL, and omitted or null `finalized` creates a non-finalized `draft` atom. Blank source
+strings retain their prior compatibility behavior: they store NULL on insert and leave an
+existing source unchanged on update.
 
 ## Amendment (2026-08-06): identifier parity for `knowledge.get`
 
@@ -184,13 +199,13 @@ does **not** introduce new note kinds, entity kinds, or edge relations:
 #### `knowledge.upsert_atoms` — bulk atom insert/update
 
 ```
-upsert_atoms(atoms: [{slug, name, content, tags?, properties?, finalized?}, ...], chunk_size?) → {upserted: N}
+upsert_atoms(atoms: [{slug, name, content, tags?, properties?, source_uri?, source_type?, finalized?}, ...], chunk_size?) → {upserted: N}
 ```
 
 Inserts or updates atoms by `(namespace, slug)` key. On conflict, updates name,
-content, tags, properties, finalized, and `updated_at`. Empty `atoms`
-array is rejected. Tags are stored as a JSON array string; properties as a JSON
-object string.
+content, tags, properties, source attribution, finalized, and `updated_at` according to the
+tri-state amendment above. Empty `atoms` array is rejected. Tags are stored as a JSON array
+string; properties as a JSON object string.
 
 #### `knowledge.upsert_domains` — bulk domain insert/update
 


### PR DESCRIPTION
## Summary

- distinguish omitted, explicit-null, and concrete values for atom source/finalization patches
- clear `source_uri` / `source_type` on null and define `finalized: null` as resetting the flag to false without demoting lifecycle status
- document the accepted tri-state contract in ADR-047 and live verb help

## Tests

- `cargo test -p khive-pack-knowledge`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #1999
