### PR TITLE
test: clean up temporary database fixtures

### DIFF
--- a/crates/khive-db/tests/writer_timeout_sink_stalled_writer.rs
+++ b/crates/khive-db/tests/writer_timeout_sink_stalled_writer.rs
@@ -23,22 +23,19 @@ use khive_db::{ConnectionPool, PoolConfig};
 
 const WRITE_DELAY_MS: u64 = 5_000;
 
-fn point_sink_at_slow_writer() {
+fn point_sink_at_slow_writer() -> tempfile::TempDir {
     let dir = tempfile::tempdir().expect("tempdir");
     std::env::set_var("KHIVE_WRITER_TIMEOUT_SINK_DIR", dir.path());
     std::env::set_var(
         "KHIVE_WRITER_TIMEOUT_SINK_WRITE_DELAY_MS",
         WRITE_DELAY_MS.to_string(),
     );
-    // Leak the tempdir so it stays alive for the rest of the process — the
-    // writer thread keeps writing (slowly) into it for as long as the
-    // process runs.
-    std::mem::forget(dir);
+    dir
 }
 
 #[test]
 fn sink_never_adds_measurable_latency_when_its_writer_is_genuinely_slow() {
-    point_sink_at_slow_writer();
+    let _sink_dir = point_sink_at_slow_writer();
 
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("stalled_writer_sink_test.db");

--- a/crates/khive-mcp/src/components.rs
+++ b/crates/khive-mcp/src/components.rs
@@ -624,12 +624,13 @@ mod tests {
     use super::*;
     use khive_runtime::{KhiveRuntime, Namespace, RuntimeConfig};
     use std::sync::atomic::{AtomicU32, Ordering};
-    use tempfile::NamedTempFile;
+    use tempfile::TempDir;
 
-    fn tmp_db() -> (NamedTempFile, String) {
-        let f = NamedTempFile::new().expect("tempfile");
-        let path = f.path().to_str().expect("utf8 path").to_string();
-        (f, path)
+    fn tmp_db() -> (TempDir, String) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("khive-test.db");
+        let path = path.to_str().expect("utf8 path").to_string();
+        (dir, path)
     }
 
     #[cfg(unix)]
@@ -708,6 +709,22 @@ mod tests {
             restart_delay_ms(u64::MAX, u64::MAX),
             u64::MAX,
             "saturating jitter arithmetic must remain overflow-safe"
+        );
+    }
+
+    #[test]
+    fn tmp_db_guard_removes_database_and_all_sidecars() {
+        let (dir, db_path) = tmp_db();
+        let dir_path = dir.path().to_path_buf();
+        for suffix in ["", "-wal", "-shm", ".khive-blob-gc.lock"] {
+            std::fs::write(format!("{db_path}{suffix}"), b"fixture").expect("write fixture");
+        }
+
+        drop(dir);
+
+        assert!(
+            !dir_path.exists(),
+            "dropping the directory guard must remove the database and every sibling sidecar"
         );
     }
 

--- a/crates/khive-mcp/src/pending_events.rs
+++ b/crates/khive-mcp/src/pending_events.rs
@@ -3328,7 +3328,7 @@ mod tests {
     use khive_storage::event::EventFilter;
     use khive_storage::types::PageRequest;
     use khive_types::{Details, HandlerDef, KhiveError, VerbCategory, Visibility};
-    use tempfile::NamedTempFile;
+    use tempfile::TempDir;
     use tokio_util::sync::CancellationToken;
 
     #[derive(Debug)]
@@ -3550,10 +3550,11 @@ mod tests {
         }
     }
 
-    fn tmp_db() -> (NamedTempFile, String) {
-        let f = NamedTempFile::new().expect("tempfile");
-        let path = f.path().to_str().expect("utf8 path").to_string();
-        (f, path)
+    fn tmp_db() -> (TempDir, String) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("khive-test.db");
+        let path = path.to_str().expect("utf8 path").to_string();
+        (dir, path)
     }
 
     /// Due, but inside the default missed-event grace window, so callers land

--- a/crates/khive-pack-memory/src/ann.rs
+++ b/crates/khive-pack-memory/src/ann.rs
@@ -2628,6 +2628,20 @@ mod tests {
     use super::*;
     use serial_test::serial;
 
+    /// Owns a file-backed runtime and removes its database directory after shutdown.
+    struct TestRuntime {
+        runtime: KhiveRuntime,
+        _temp_dir: tempfile::TempDir,
+    }
+
+    impl std::ops::Deref for TestRuntime {
+        type Target = KhiveRuntime;
+
+        fn deref(&self) -> &Self::Target {
+            &self.runtime
+        }
+    }
+
     struct InterleavingTailReader {
         subject: Uuid,
         calls: Vec<String>,
@@ -3906,14 +3920,12 @@ mod tests {
         );
     }
 
-    fn test_runtime_with_hash_embedder(model: &str, dims: usize) -> KhiveRuntime {
+    fn test_runtime_with_hash_embedder(model: &str, dims: usize) -> TestRuntime {
         let tmp = tempfile::Builder::new()
             .prefix("khive-memory-ann-test-")
             .tempdir_in(std::env::temp_dir())
             .expect("temp db dir");
-        // Leak the guard so the returned runtime's database directory remains alive.
         let db_path = tmp.path().join("khive-graph.db");
-        std::mem::forget(tmp);
         let rt = KhiveRuntime::new(khive_runtime::RuntimeConfig {
             db_path: Some(db_path),
             embedding_model: None,
@@ -3925,7 +3937,10 @@ mod tests {
             model_name: model.to_owned(),
             dims,
         });
-        rt
+        TestRuntime {
+            runtime: rt,
+            _temp_dir: tmp,
+        }
     }
 
     /// A completed warm releases its guard so a later write can trigger another rebuild.
@@ -4381,7 +4396,6 @@ mod tests {
             .tempdir_in(std::env::temp_dir())
             .expect("temp db dir");
         let db_path = tmp.path().join("khive-graph.db");
-        std::mem::forget(tmp);
 
         // "Daemon": first runtime, warms the ANN index and stays resident —
         // exactly like a long-lived `kkernel mcp --daemon` process.

--- a/crates/khive-pack-memory/src/handlers/feedback.rs
+++ b/crates/khive-pack-memory/src/handlers/feedback.rs
@@ -115,15 +115,28 @@ mod tests {
     use khive_pack_kg::KgPack;
     use khive_runtime::{Namespace, RuntimeConfig, RuntimeError, VerbRegistryBuilder};
 
-    fn build_memory_rt(brain_profile: Option<String>) -> khive_runtime::KhiveRuntime {
+    /// Owns a file-backed runtime and removes its database directory after shutdown.
+    struct TestRuntime {
+        runtime: khive_runtime::KhiveRuntime,
+        _temp_dir: tempfile::TempDir,
+    }
+
+    impl std::ops::Deref for TestRuntime {
+        type Target = khive_runtime::KhiveRuntime;
+
+        fn deref(&self) -> &Self::Target {
+            &self.runtime
+        }
+    }
+
+    fn build_memory_rt(brain_profile: Option<String>) -> TestRuntime {
         let tmp = tempfile::Builder::new()
             .prefix("khive-mem-feedback-")
             .tempdir_in(std::env::temp_dir())
             .expect("temp dir");
         let db_path = tmp.path().join("khive.db");
-        std::mem::forget(tmp);
 
-        khive_runtime::KhiveRuntime::new(RuntimeConfig {
+        let runtime = khive_runtime::KhiveRuntime::new(RuntimeConfig {
             db_path: Some(db_path),
             embedding_model: None,
             additional_embedding_models: vec![],
@@ -131,7 +144,11 @@ mod tests {
             brain_profile,
             ..RuntimeConfig::default()
         })
-        .expect("runtime")
+        .expect("runtime");
+        TestRuntime {
+            runtime,
+            _temp_dir: tmp,
+        }
     }
 
     #[tokio::test]
@@ -139,7 +156,7 @@ mod tests {
         let rt = build_memory_rt(None);
         let mut builder = VerbRegistryBuilder::new();
         builder.register(KgPack::new(rt.clone()));
-        builder.register(crate::MemoryPack::new(rt));
+        builder.register(crate::MemoryPack::new(rt.clone()));
         let registry = builder.build().expect("registry");
 
         let error = registry
@@ -226,7 +243,7 @@ mod tests {
 
         let mut builder = VerbRegistryBuilder::new();
         builder.register(KgPack::new(rt.clone()));
-        builder.register(crate::MemoryPack::new(rt));
+        builder.register(crate::MemoryPack::new(rt.clone()));
         let registry = builder.build().expect("registry");
 
         let result = registry
@@ -395,15 +412,14 @@ mod tests {
     // Each test builds a registry with ALL THREE packs registered and inspects
     // `brain.profile` (total_events) to confirm which profile received credit.
 
-    fn build_full_rt(brain_profile: Option<String>) -> khive_runtime::KhiveRuntime {
+    fn build_full_rt(brain_profile: Option<String>) -> TestRuntime {
         let tmp = tempfile::Builder::new()
             .prefix("khive-mem-3tier-")
             .tempdir_in(std::env::temp_dir())
             .expect("temp dir");
         let db_path = tmp.path().join("khive.db");
-        std::mem::forget(tmp);
 
-        khive_runtime::KhiveRuntime::new(RuntimeConfig {
+        let runtime = khive_runtime::KhiveRuntime::new(RuntimeConfig {
             db_path: Some(db_path),
             embedding_model: None,
             additional_embedding_models: vec![],
@@ -411,7 +427,11 @@ mod tests {
             brain_profile,
             ..RuntimeConfig::default()
         })
-        .expect("runtime")
+        .expect("runtime");
+        TestRuntime {
+            runtime,
+            _temp_dir: tmp,
+        }
     }
 
     /// Tier-1 wins over tier-2: when an explicit profile is configured AND a

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -1236,6 +1236,30 @@ mod tests {
 
     use crate::MemoryPack;
 
+    /// Keeps a file-backed test runtime alive before removing its database directory.
+    /// Fields are declared in drop order: the runtime closes before the guard cleans up.
+    struct TestRuntime {
+        runtime: KhiveRuntime,
+        _temp_dir: Option<tempfile::TempDir>,
+    }
+
+    impl TestRuntime {
+        fn in_memory(runtime: KhiveRuntime) -> Self {
+            Self {
+                runtime,
+                _temp_dir: None,
+            }
+        }
+    }
+
+    impl std::ops::Deref for TestRuntime {
+        type Target = KhiveRuntime;
+
+        fn deref(&self) -> &Self::Target {
+            &self.runtime
+        }
+    }
+
     fn memory_runtime_with_fresh_tail(ann_fresh_tail_enabled: bool) -> KhiveRuntime {
         KhiveRuntime::memory()
             .expect("in-memory runtime")
@@ -2003,22 +2027,25 @@ mod tests {
 
     // ── ADR-081 §5 (#394): recall serve-time attribution + ledger append ──────
 
-    fn build_full_rt_with_brain() -> khive_runtime::KhiveRuntime {
+    fn build_full_rt_with_brain() -> TestRuntime {
         let tmp = tempfile::Builder::new()
             .prefix("khive-mem-recall-adr081-")
             .tempdir_in(std::env::temp_dir())
             .expect("temp dir");
         let db_path = tmp.path().join("khive.db");
-        std::mem::forget(tmp);
 
-        khive_runtime::KhiveRuntime::new(khive_runtime::RuntimeConfig {
+        let runtime = khive_runtime::KhiveRuntime::new(khive_runtime::RuntimeConfig {
             db_path: Some(db_path),
             embedding_model: None,
             additional_embedding_models: vec![],
             packs: vec!["kg".to_string(), "memory".to_string(), "brain".to_string()],
             ..khive_runtime::RuntimeConfig::default()
         })
-        .expect("runtime")
+        .expect("runtime");
+        TestRuntime {
+            runtime,
+            _temp_dir: Some(tmp),
+        }
     }
 
     // `#[serial(background_tasks)]`: see the note on
@@ -2160,7 +2187,6 @@ mod tests {
             .tempdir_in(std::env::temp_dir())
             .expect("temp dir");
         let db_path = tmp.path().join("khive.db");
-        std::mem::forget(tmp);
 
         let rt = khive_runtime::KhiveRuntime::new(khive_runtime::RuntimeConfig {
             db_path: Some(db_path),
@@ -2616,7 +2642,6 @@ mod tests {
             .tempdir_in(std::env::temp_dir())
             .expect("temp dir");
         let db_path = tmp.path().join("khive.db");
-        std::mem::forget(tmp);
 
         let rt = khive_runtime::KhiveRuntime::new(khive_runtime::RuntimeConfig {
             db_path: Some(db_path),
@@ -2761,7 +2786,6 @@ mod tests {
             .tempdir_in(std::env::temp_dir())
             .expect("temp dir");
         let db_path = tmp.path().join("khive.db");
-        std::mem::forget(tmp);
 
         let rt = khive_runtime::KhiveRuntime::new(khive_runtime::RuntimeConfig {
             db_path: Some(db_path),
@@ -3161,7 +3185,7 @@ mod tests {
             let rt = if with_brain {
                 build_full_rt_with_brain()
             } else {
-                KhiveRuntime::memory().expect("in-memory runtime")
+                TestRuntime::in_memory(KhiveRuntime::memory().expect("in-memory runtime"))
             };
             let ns = Namespace::parse("local").expect("ns");
             let token = rt.authorize(ns.clone()).expect("token");
@@ -3333,7 +3357,7 @@ mod tests {
 
     /// Build a controlled four-note corpus whose profile salience projection flips H/L order.
     async fn adr104_build_ranking_corpus() -> (
-        khive_runtime::KhiveRuntime,
+        TestRuntime,
         khive_runtime::VerbRegistry,
         Namespace,
         Uuid,
@@ -3500,7 +3524,7 @@ mod tests {
             let rt = if with_brain {
                 build_full_rt_with_brain()
             } else {
-                KhiveRuntime::memory().expect("in-memory runtime")
+                TestRuntime::in_memory(KhiveRuntime::memory().expect("in-memory runtime"))
             };
             let ns = Namespace::parse("local").expect("ns");
             let token = rt.authorize(ns.clone()).expect("token");

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -1766,6 +1766,20 @@ mod tests {
     use crate::embedder_registry::EmbedderProvider;
     use crate::runtime::RuntimeConfig;
 
+    /// Owns a file-backed runtime and removes its database directory after shutdown.
+    struct TestRuntime {
+        runtime: KhiveRuntime,
+        _temp_dir: tempfile::TempDir,
+    }
+
+    impl std::ops::Deref for TestRuntime {
+        type Target = KhiveRuntime;
+
+        fn deref(&self) -> &Self::Target {
+            &self.runtime
+        }
+    }
+
     const STUB_MODEL: &str = "stub-adr099-b3";
     const STUB_DIMS: usize = 4;
 
@@ -1807,18 +1821,20 @@ mod tests {
         }
     }
 
-    fn scratch_runtime() -> KhiveRuntime {
+    fn scratch_runtime() -> TestRuntime {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("atomic_prepare_reindex.db");
-        let rt = KhiveRuntime::new(RuntimeConfig {
+        let runtime = KhiveRuntime::new(RuntimeConfig {
             db_path: Some(path),
             embedding_model: None,
             additional_embedding_models: vec![],
             ..RuntimeConfig::default()
         })
         .expect("runtime");
-        std::mem::forget(dir);
-        rt
+        TestRuntime {
+            runtime,
+            _temp_dir: dir,
+        }
     }
 
     /// Atomic `update` must reject a field that does not apply to the

--- a/crates/khive-runtime/src/atomic_runner.rs
+++ b/crates/khive-runtime/src/atomic_runner.rs
@@ -401,13 +401,27 @@ mod tests {
     use khive_storage::types::{SqlValue, StorageResult as StorageResultAlias};
     use uuid::Uuid;
 
+    /// Owns a file-backed pool and removes its database directory after shutdown.
+    struct TestPool {
+        pool: StdArc<ConnectionPool>,
+        _temp_dir: tempfile::TempDir,
+    }
+
+    impl std::ops::Deref for TestPool {
+        type Target = StdArc<ConnectionPool>;
+
+        fn deref(&self) -> &Self::Target {
+            &self.pool
+        }
+    }
+
     /// A scratch pool wired exactly like the daemon.rs / sql_bridge.rs
     /// tests above it: file-backed (atomic_unit's single-writer path is
     /// only reachable file-backed), `write_queue_enabled: Some(true)` so
     /// `atomic_unit` routes through the real `WriterTask` + `block_on_sync`
     /// seam rather than the flag-off manual-transaction fallback — the
     /// suspend-trap contract only fires on this path.
-    fn scratch_pool(name: &str) -> StdArc<ConnectionPool> {
+    fn scratch_pool(name: &str) -> TestPool {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join(format!("{name}.db"));
         let pool = StdArc::new(
@@ -418,10 +432,10 @@ mod tests {
             })
             .expect("pool open"),
         );
-        // Leak the tempdir so the file lives for the pool's lifetime within
-        // one test function — every test here is single-scoped and short.
-        std::mem::forget(dir);
-        pool
+        TestPool {
+            pool,
+            _temp_dir: dir,
+        }
     }
 
     /// Minimal real schema slice (`entities`, `graph_edges`) — copied from

--- a/crates/kkernel/src/atomic_apply.rs
+++ b/crates/kkernel/src/atomic_apply.rs
@@ -1517,18 +1517,34 @@ mod tests {
 
     use khive_types::Namespace;
 
-    fn scratch_runtime() -> KhiveRuntime {
+    /// Owns a file-backed runtime and removes its database directory after shutdown.
+    struct TestRuntime {
+        runtime: KhiveRuntime,
+        _temp_dir: tempfile::TempDir,
+    }
+
+    impl std::ops::Deref for TestRuntime {
+        type Target = KhiveRuntime;
+
+        fn deref(&self) -> &Self::Target {
+            &self.runtime
+        }
+    }
+
+    fn scratch_runtime() -> TestRuntime {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("atomic_apply_gtd.db");
-        let rt = KhiveRuntime::new(RuntimeConfig {
+        let runtime = KhiveRuntime::new(RuntimeConfig {
             db_path: Some(path),
             embedding_model: None,
             additional_embedding_models: vec![],
             ..RuntimeConfig::default()
         })
         .expect("runtime");
-        std::mem::forget(dir);
-        rt
+        TestRuntime {
+            runtime,
+            _temp_dir: dir,
+        }
     }
 
     /// Seed a live GTD task note directly (bypassing `gtd.assign`'s handler,


### PR DESCRIPTION
## Summary

- place both khive-mcp scratch databases inside owned TempDir directories so SQLite WAL/SHM and blob-GC lock sidecars are removed together
- replace all 12 deliberately forgotten test TempDir guards with owned runtime, pool, or test-scope guards
- add focused coverage for recursive database-and-sidecar cleanup

## Verification

- cargo test --manifest-path crates/Cargo.toml -p khive-mcp -p khive-runtime -p khive-pack-memory -p kkernel -p khive-db --no-run
- focused tests: MCP cleanup (1), stalled writer (1), atomic runner (10), atomic prepare (40), atomic apply (18), memory feedback (10), recall lifetime cases (4), ANN lifetime cases (2)
- cargo check --manifest-path crates/Cargo.toml --workspace --all-targets --all-features
- cargo clippy --manifest-path crates/Cargo.toml --workspace --all-targets --all-features -- -D warnings
- cargo fmt --manifest-path crates/Cargo.toml --all -- --check
- git diff --check

Closes #2263