### PR TITLE
test(timing): derive latency bounds from fixtures

### DIFF
--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -4458,9 +4458,9 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("high_water_test.db");
 
-        // busy_timeout = 2000ms: a TRUNCATE regression blocks ~2s (clearly caught by
-        // the <500ms assertion below), but PASSIVE returns well within 500ms even on
-        // a heavily loaded CI runner. 4x margin on both sides vs. the old 200ms/50ms.
+        // busy_timeout = 2000ms: a TRUNCATE regression blocks ~2s, while the
+        // assertion below uses the midpoint of that gap instead of a noise-floor
+        // threshold. The checkpoint config carries the same 2000ms default.
         let pool = Arc::new(
             ConnectionPool::new(PoolConfig {
                 path: Some(path.clone()),
@@ -4500,12 +4500,13 @@ mod tests {
                 .unwrap();
         }
 
+        let checkpoint_config = CheckpointConfig::default();
         let conn = checkpoint_conn(&pool);
         let start = std::time::Instant::now();
         checkpoint_once(
             &pool,
             &conn,
-            &CheckpointConfig::default(),
+            &checkpoint_config,
             &mut TruncateState::default(),
         )
         .expect("checkpoint_once must succeed against a healthy dedicated connection");
@@ -4515,15 +4516,18 @@ mod tests {
         reader.execute_batch("COMMIT;").ok();
         drop(reader);
 
-        // PASSIVE returns in <1ms even with an open reader snapshot.
-        // A TRUNCATE regression would block ~busy_timeout (2000ms) and fail here.
-        // 500ms threshold is generous for CI jitter while staying well below 2000ms.
+        // PASSIVE returns without waiting for the reader snapshot. A TRUNCATE
+        // regression would block for the configured busy timeout (2000ms), so
+        // use the midpoint of that gap rather than a noise-floor threshold.
+        let max_elapsed = checkpoint_config.truncate_busy_timeout / 2;
         assert!(
-            elapsed < std::time::Duration::from_millis(500),
-            "checkpoint_once with active reader snapshot took {:?}; \
-             expected <500ms (PASSIVE must not block on readers; \
-             a TRUNCATE regression would block ~2000ms)",
-            elapsed
+            elapsed < max_elapsed,
+            "checkpoint_once with active reader snapshot took {:?}; expected <{:?} \
+             (PASSIVE must not block on readers; a TRUNCATE regression would block \
+             for the configured {:?})",
+            elapsed,
+            max_elapsed,
+            checkpoint_config.truncate_busy_timeout
         );
     }
 

--- a/crates/khive-db/tests/writer_timeout_sink_stalled.rs
+++ b/crates/khive-db/tests/writer_timeout_sink_stalled.rs
@@ -116,20 +116,17 @@ fn sink_never_adds_measurable_latency_when_its_directory_is_unwritable() {
     // write anywhere in this test.
     let held = pool.writer().expect("first checkout should succeed");
     let pool_for_thread = Arc::clone(&pool);
-    let start = Instant::now();
-    let timed_out = std::thread::spawn(move || pool_for_thread.writer().is_err())
-        .join()
-        .unwrap();
-    let elapsed = start.elapsed();
+    let (timed_out_tx, timed_out_rx) = std::sync::mpsc::sync_channel(1);
+    std::thread::spawn(move || {
+        let _ = timed_out_tx.send(pool_for_thread.writer().is_err());
+    });
+    let timed_out = timed_out_rx
+        .recv_timeout(HANG_GUARD_TIMEOUT)
+        .expect("writer admission blocked on the unwritable sink directory");
     drop(held);
 
     assert!(
         timed_out,
         "a second writer checkout while the first is held must time out"
-    );
-    assert!(
-        elapsed < Duration::from_millis(250),
-        "checkout_timeout was 50ms but writer() took {elapsed:?} against an unwritable sink \
-         directory — emit_timeout must be a non-blocking enqueue, never blocking I/O"
     );
 }

--- a/crates/khive-db/tests/writer_timeout_sink_stalled_fifo.rs
+++ b/crates/khive-db/tests/writer_timeout_sink_stalled_fifo.rs
@@ -18,7 +18,7 @@
 use std::process::Command;
 use std::sync::mpsc;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use khive_db::{ConnectionPool, PoolConfig};
 
@@ -75,32 +75,17 @@ fn sink_never_adds_measurable_latency_when_its_file_is_a_blocked_fifo() {
         ..PoolConfig::default()
     };
 
-    let construct_start = Instant::now();
     let pool =
         bounded(move || Arc::new(ConnectionPool::new(cfg).expect("file-backed pool should open")));
-    let construct_elapsed = construct_start.elapsed();
-    assert!(
-        construct_elapsed < Duration::from_millis(500),
-        "pool construction took {construct_elapsed:?} against a sink file that is a FIFO with \
-         no reader — the sink must never add filesystem-bound latency to pool boot"
-    );
 
     let held = pool.writer().expect("first checkout should succeed");
     let pool_for_thread = Arc::clone(&pool);
-    let start = Instant::now();
     let timed_out = bounded(move || pool_for_thread.writer().is_err());
-    let elapsed = start.elapsed();
     drop(held);
 
     assert!(
         timed_out,
         "a second writer checkout while the first is held must time out"
-    );
-    assert!(
-        elapsed < Duration::from_millis(250),
-        "checkout_timeout was 50ms but writer() took {elapsed:?} against a sink file that is a \
-         FIFO with no reader — emit_timeout must be a non-blocking enqueue, never blocking on \
-         the writer thread's own (stuck) I/O"
     );
 
     // Interaction with the rotate-on-open fix: a FIFO is not a regular

--- a/crates/khive-db/tests/writer_timeout_sink_stalled_writer.rs
+++ b/crates/khive-db/tests/writer_timeout_sink_stalled_writer.rs
@@ -56,7 +56,7 @@ fn sink_never_adds_measurable_latency_when_its_writer_is_genuinely_slow() {
     let pool = Arc::new(ConnectionPool::new(cfg).expect("file-backed pool should open"));
     let construct_elapsed = construct_start.elapsed();
     assert!(
-        construct_elapsed < Duration::from_millis(500),
+        construct_elapsed < Duration::from_millis(WRITE_DELAY_MS / 2),
         "pool construction took {construct_elapsed:?} against a {WRITE_DELAY_MS}ms-per-write \
          sink — the sink must never add filesystem-bound latency to pool boot"
     );
@@ -79,7 +79,7 @@ fn sink_never_adds_measurable_latency_when_its_writer_is_genuinely_slow() {
         "a second writer checkout while the first is held must time out"
     );
     assert!(
-        elapsed < Duration::from_millis(250),
+        elapsed < Duration::from_millis(WRITE_DELAY_MS / 2),
         "checkout_timeout was 50ms but writer() took {elapsed:?} against a \
          {WRITE_DELAY_MS}ms-per-write sink — emit_timeout must be a non-blocking enqueue, \
          never blocking on the writer thread's own I/O latency"

--- a/crates/khive-pack-knowledge/src/knowledge/vamana.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/vamana.rs
@@ -3784,9 +3784,9 @@ mod tests {
         mark_unavailable(&ann, &key, current_generation(&ann, "local"));
 
         let start = std::time::Instant::now();
-        // Timeout is generous (5s, matching production ANN_WARM_WAIT_TIMEOUT_MS)
+        // Timeout is generous (matching production ANN_WARM_WAIT_TIMEOUT_MS)
         // to prove the short-circuit fires rather than the deadline.
-        let ready = wait_ready(&ann, &key, 5_000, 50).await;
+        let ready = wait_ready(&ann, &key, ANN_WARM_WAIT_TIMEOUT_MS, 50).await;
         let elapsed = start.elapsed();
 
         assert!(
@@ -3794,7 +3794,7 @@ mod tests {
             "must return false for a key marked unavailable at the current generation"
         );
         assert!(
-            elapsed < std::time::Duration::from_millis(200),
+            elapsed < std::time::Duration::from_millis(ANN_WARM_WAIT_TIMEOUT_MS / 2),
             "terminal unavailable outcome must short-circuit, not poll out the timeout: {elapsed:?}"
         );
     }
@@ -5757,13 +5757,13 @@ mod tests {
         );
 
         let start = std::time::Instant::now();
-        let ready = wait_ready(&ann, &key, 5_000, 50).await;
+        let ready = wait_ready(&ann, &key, ANN_WARM_WAIT_TIMEOUT_MS, 50).await;
         let elapsed = start.elapsed();
 
         assert!(!ready, "empty corpus must never become ready");
         assert!(
-            elapsed < std::time::Duration::from_millis(200),
-            "the terminal unavailable outcome must short-circuit the 5s warm-wait: {elapsed:?}"
+            elapsed < std::time::Duration::from_millis(ANN_WARM_WAIT_TIMEOUT_MS / 2),
+            "the terminal unavailable outcome must short-circuit the warm-wait: {elapsed:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

Several test assertions bounded latency with a wall-clock literal that had no derivation from the
fixture it was meant to discriminate. A bound like `elapsed < 500ms` guarding a claim about a
5,000ms-per-write sink has ten times more headroom than the hypothesis needs, and its failure margin
is host scheduling noise rather than the behaviour under test — so it reddens changes that never
touched the code path.

That happened: pool construction measured 511.665366ms against the 500ms bound while the claim it
protects concerns a 5,000ms write, on a change that touched only documentation. Because the suite
runs sharded with fail-fast, one such failure cancelled its siblings and left most of the suite
unrun, so the cost is much larger than one red test.

## Changes

Each bound is now derived from the fixture constant that makes it discriminating:

- `crates/khive-db/tests/writer_timeout_sink_stalled_writer.rs:59,82` — both bounds become
  `Duration::from_millis(WRITE_DELAY_MS / 2)`. The 2,500ms midpoint sits far below the 5,000ms write
  the assertion exists to rule out, while leaving scheduler noise no way to reach it.
- `crates/khive-db/src/checkpoint.rs:4524` — bound becomes half of
  `checkpoint_config.truncate_busy_timeout`, the midpoint between normal PASSIVE completion and the
  TRUNCATE regression it separates.
- `crates/khive-pack-knowledge/src/knowledge/vamana.rs:3797,5765` — terminal-unavailable
  short-circuit bounds become `ANN_WARM_WAIT_TIMEOUT_MS / 2`, with the same constant passed as the
  wait timeout so the two cannot drift apart.

Two assertions are removed rather than rebased, because they duplicated a guard already present:

- `crates/khive-db/tests/writer_timeout_sink_stalled_fifo.rs:78,85` — these calls already run through
  `bounded()`, which waits on a channel with `recv_timeout(BOUND_TIMEOUT)` and fails the test if the
  operation does not complete. A blocked caller path therefore still fails; the wall-clock ceilings
  added a second, noisier way to say the same thing. The `timed_out` assertions remain.
- `crates/khive-db/tests/writer_timeout_sink_stalled.rs:124` — the elapsed ceiling is replaced by a
  `sync_channel` plus `recv_timeout(HANG_GUARD_TIMEOUT)`. This fixture models a path with no finite
  write duration, so completion is the discriminating observation and a duration ceiling was never
  measuring the right thing.

Four sites are deliberately left alone: two recall paths and one runtime operation whose ceilings are
broad secondary guards around assertions that already state the real condition, and the coordinator
test, which runs under `start_paused = true` and therefore measures deterministic virtual time rather
than host latency. Its lower `>= 5s` bound is load-bearing and unchanged.

## Verification

The two rewritten bounds were shown to still fail when they should. Temporarily making `emit_timeout`
fill the bounded queue synchronously forces the caller to wait behind the delayed writer:

```text
pool construction took 5.016870167s against a 5000ms-per-write sink — the sink must never add
filesystem-bound latency to pool boot

checkout_timeout was 50ms but writer() took 5.015753834s against a 5000ms-per-write sink —
emit_timeout must be a non-blocking enqueue, never blocking on the writer thread's own I/O latency
```

Both exit 101. With the mutation reverted the test passes in 0.07s. A bound that cannot be shown to
fail is not evidence that it still guards anything, which is the whole point of widening these.

Closes #2310
