### PR TITLE
fix(db): preserve proven rollback finality

### DIFF
--- a/crates/khive-db/src/stores/blob.rs
+++ b/crates/khive-db/src/stores/blob.rs
@@ -5054,8 +5054,15 @@ mod tests {
         .await
         .expect_err("the probe must refuse when an id it would delete already names a row");
         assert!(
-            matches!(error, StorageError::Unsupported { .. }),
-            "expected StorageError::Unsupported, got {error:?}"
+            matches!(
+                &error,
+                StorageError::WriterTaskRequestFailed {
+                    request_state:
+                        khive_storage::WriterTaskRequestState::TransactionRolledBack,
+                    source,
+                } if matches!(source.as_ref(), StorageError::Unsupported { .. })
+            ),
+            "expected a proven-rollback wrapper retaining StorageError::Unsupported, got {error:?}"
         );
 
         let reader = backend.pool().reader().unwrap();

--- a/crates/khive-db/src/stores/note_tests.rs
+++ b/crates/khive-db/src/stores/note_tests.rs
@@ -965,8 +965,14 @@ async fn atomic_note_property_patch_rolls_back_when_one_target_is_ineligible() {
         .await
         .expect_err("an ineligible target must abort the atomic patch");
     assert!(
-        matches!(&error, StorageError::Conflict { message, .. }
-            if message.contains(&ineligible_id.to_string())),
+        matches!(
+            &error,
+            StorageError::WriterTaskRequestFailed {
+                request_state: WriterTaskRequestState::TransactionRolledBack,
+                source,
+            } if matches!(source.as_ref(), StorageError::Conflict { message, .. }
+                if message.contains(&ineligible_id.to_string()))
+        ),
         "the conflict must name the first failing id {ineligible_id}; got {error:?}"
     );
     assert!(!error.is_retryable(), "a precondition conflict is terminal");
@@ -1071,8 +1077,14 @@ async fn atomic_note_property_patch_writer_task_commits_and_rolls_back() {
         .await
         .expect_err("a later ineligible row must abort the writer-task transaction");
     assert!(
-        matches!(&error, StorageError::Conflict { message, .. }
-            if message.contains(&ineligible_id.to_string())),
+        matches!(
+            &error,
+            StorageError::WriterTaskRequestFailed {
+                request_state: WriterTaskRequestState::TransactionRolledBack,
+                source,
+            } if matches!(source.as_ref(), StorageError::Conflict { message, .. }
+                if message.contains(&ineligible_id.to_string()))
+        ),
         "the conflict must name the first failing id {ineligible_id}; got {error:?}"
     );
     assert_eq!(
@@ -1703,7 +1715,11 @@ async fn pooled_transaction_commit_failure_with_verified_rollback_keeps_writer_u
     assert!(
         matches!(
             &result,
-            Err(StorageError::Pool { operation, .. }) if operation == "test_pooled_commit"
+            Err(StorageError::WriterTaskRequestFailed {
+                request_state: WriterTaskRequestState::TransactionRolledBack,
+                source,
+            }) if matches!(source.as_ref(), StorageError::Pool { operation, .. }
+                if operation == "test_pooled_commit")
         ),
         "a denied COMMIT followed by a verified rollback must report the commit error: {result:?}"
     );

--- a/crates/khive-db/src/writer_task.rs
+++ b/crates/khive-db/src/writer_task.rs
@@ -375,9 +375,12 @@ where
                 }
                 Err(commit_error) => match rollback_after_failure(conn, "commit failure") {
                     RollbackDisposition::RolledBack => ProfiledWrappedTransaction {
-                        result: Err(StorageError::Pool {
-                            operation: commit_operation.into(),
-                            message: commit_error.to_string(),
+                        result: Err(StorageError::WriterTaskRequestFailed {
+                            request_state: WriterTaskRequestState::TransactionRolledBack,
+                            source: Box::new(StorageError::Pool {
+                                operation: commit_operation.into(),
+                                message: commit_error.to_string(),
+                            }),
                         }),
                         terminal_state: None,
                         body,
@@ -398,7 +401,10 @@ where
         Ok(Err(operation_error)) => {
             match rollback_after_failure(conn, "request operation failure") {
                 RollbackDisposition::RolledBack => ProfiledWrappedTransaction {
-                    result: Err(operation_error),
+                    result: Err(StorageError::WriterTaskRequestFailed {
+                        request_state: WriterTaskRequestState::TransactionRolledBack,
+                        source: Box::new(operation_error),
+                    }),
                     terminal_state: None,
                     body,
                     commit: Duration::ZERO,
@@ -1072,7 +1078,7 @@ mod tests {
     }
     use std::future::Future;
     use std::pin::Pin;
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::mpsc as std_mpsc;
     use std::sync::{Arc, Mutex};
     use std::task::{Context, Poll, Wake, Waker};
@@ -1810,7 +1816,7 @@ mod tests {
 
     #[tokio::test]
     #[serial(tx_registry)]
-    async fn operation_failure_with_successful_rollback_preserves_error_and_writer_continues() {
+    async fn operation_failure_with_successful_rollback_reports_finality_once_and_continues() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("writer_task_operation_rollback.db");
         let pool = file_pool(&path);
@@ -1823,8 +1829,11 @@ mod tests {
         }
         let handle = spawn(&pool, 8).expect("writer task spawn");
 
+        let executions = Arc::new(AtomicUsize::new(0));
+        let executions_in_op = Arc::clone(&executions);
         let original_error = handle
-            .send(|conn| -> Result<(), StorageError> {
+            .send(move |conn| -> Result<(), StorageError> {
+                executions_in_op.fetch_add(1, Ordering::SeqCst);
                 conn.execute("INSERT INTO t (id, v) VALUES (1, 'rolled-back')", [])
                     .map_err(|e| StorageError::Pool {
                         operation: "test_operation_error_insert".into(),
@@ -1835,13 +1844,23 @@ mod tests {
                 ))
             })
             .await;
-        assert!(
-            matches!(
-                &original_error,
-                Err(StorageError::Internal(message))
-                    if message == "intentional operation failure"
+        match &original_error {
+            Err(StorageError::WriterTaskRequestFailed {
+                request_state: WriterTaskRequestState::TransactionRolledBack,
+                source,
+            }) => assert!(
+                matches!(source.as_ref(), StorageError::Internal(message)
+                    if message == "intentional operation failure"),
+                "the proven-rollback wrapper must retain the typed operation error: {source:?}"
             ),
-            "a confirmed rollback must preserve the operation error, got {original_error:?}"
+            other => panic!(
+                "a confirmed rollback must carry TransactionRolledBack and preserve the operation error, got {other:?}"
+            ),
+        }
+        assert_eq!(
+            executions.load(Ordering::SeqCst),
+            1,
+            "finality propagation must not replay the request closure"
         );
 
         let affected = handle
@@ -1855,6 +1874,11 @@ mod tests {
             .await
             .expect("the writer must continue after a confirmed rollback");
         assert_eq!(affected, 1);
+        assert_eq!(
+            executions.load(Ordering::SeqCst),
+            1,
+            "serving a follow-up request must not replay the rolled-back closure"
+        );
 
         let reader = pool.reader().expect("reader");
         let rolled_back: i64 = reader
@@ -1871,7 +1895,7 @@ mod tests {
 
     #[tokio::test]
     #[serial(tx_registry)]
-    async fn commit_failure_with_successful_rollback_preserves_error_and_writer_continues() {
+    async fn commit_failure_with_successful_rollback_reports_finality_once_and_continues() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("writer_task_commit_rollback.db");
         let pool = file_pool(&path);
@@ -1884,8 +1908,11 @@ mod tests {
         }
         let handle = spawn(&pool, 8).expect("writer task spawn");
 
+        let executions = Arc::new(AtomicUsize::new(0));
+        let executions_in_op = Arc::clone(&executions);
         let commit_error = handle
-            .send(|conn| -> Result<usize, StorageError> {
+            .send(move |conn| -> Result<usize, StorageError> {
+                executions_in_op.fetch_add(1, Ordering::SeqCst);
                 let affected = conn
                     .execute("INSERT INTO t (id, v) VALUES (1, 'rolled-back')", [])
                     .map_err(|e| StorageError::Pool {
@@ -1900,14 +1927,19 @@ mod tests {
                 Ok(affected)
             })
             .await;
-        assert!(
-            matches!(
-                &commit_error,
-                Err(StorageError::Pool { operation, .. })
-                    if operation == "writer_task_commit"
+        match &commit_error {
+            Err(StorageError::WriterTaskRequestFailed {
+                request_state: WriterTaskRequestState::TransactionRolledBack,
+                source,
+            }) => assert!(
+                matches!(source.as_ref(), StorageError::Pool { operation, .. }
+                    if operation == "writer_task_commit"),
+                "the proven-rollback wrapper must retain the typed COMMIT error: {source:?}"
             ),
-            "a confirmed rollback must preserve the commit error, got {commit_error:?}"
-        );
+            other => panic!(
+                "a confirmed rollback must carry TransactionRolledBack and preserve the COMMIT error, got {other:?}"
+            ),
+        }
         assert!(
             commit_error
                 .as_ref()
@@ -1915,6 +1947,11 @@ mod tests {
                 .is_retryable(),
             "the existing retryable commit-error contract must remain unchanged after a \
              confirmed rollback"
+        );
+        assert_eq!(
+            executions.load(Ordering::SeqCst),
+            1,
+            "finality propagation must not replay the request closure"
         );
 
         let affected = handle
@@ -1933,6 +1970,11 @@ mod tests {
             .await
             .expect("the writer must continue after the failed COMMIT is rolled back");
         assert_eq!(affected, 1);
+        assert_eq!(
+            executions.load(Ordering::SeqCst),
+            1,
+            "serving a follow-up request must not replay the rolled-back closure"
+        );
 
         let reader = pool.reader().expect("reader");
         let rolled_back: i64 = reader
@@ -1995,9 +2037,12 @@ mod tests {
         let conn = Connection::open_in_memory().expect("in-memory connection");
         conn.execute_batch("CREATE TABLE t (id INTEGER PRIMARY KEY); BEGIN IMMEDIATE")
             .unwrap();
+        let executions = Arc::new(AtomicUsize::new(0));
+        let executions_in_op = Arc::clone(&executions);
         let (reply_tx, mut reply_rx) = oneshot::channel();
         let request = WriteRequest {
-            op: Box::new(|conn| -> Result<usize, StorageError> {
+            op: Box::new(move |conn| -> Result<usize, StorageError> {
+                executions_in_op.fetch_add(1, Ordering::SeqCst);
                 let affected = conn
                     .execute("INSERT INTO t (id) VALUES (1)", [])
                     .map_err(|e| StorageError::Pool {
@@ -2031,6 +2076,7 @@ mod tests {
             .try_recv()
             .expect("active request must receive a typed terminal reply");
         assert_writer_task_terminal_state(reply, WriterTaskRequestState::SideEffectsUnknown);
+        assert_eq!(executions.load(Ordering::SeqCst), 1);
         assert!(
             !conn.is_autocommit(),
             "the denied COMMIT and ROLLBACK must leave the test connection poisoned"
@@ -2137,9 +2183,12 @@ mod tests {
         let conn = Connection::open_in_memory().expect("in-memory connection");
         conn.execute_batch("CREATE TABLE t (id INTEGER PRIMARY KEY); BEGIN IMMEDIATE")
             .unwrap();
+        let executions = Arc::new(AtomicUsize::new(0));
+        let executions_in_op = Arc::clone(&executions);
         let (reply_tx, mut reply_rx) = oneshot::channel();
         let request = WriteRequest {
-            op: Box::new(|conn| -> Result<(), StorageError> {
+            op: Box::new(move |conn| -> Result<(), StorageError> {
+                executions_in_op.fetch_add(1, Ordering::SeqCst);
                 conn.authorizer(Some(deny_rollback))
                     .map_err(|e| StorageError::Pool {
                         operation: "test_install_authorizer".into(),
@@ -2169,6 +2218,7 @@ mod tests {
             .try_recv()
             .expect("active request must receive a typed terminal reply");
         assert_writer_task_terminal_state(reply, WriterTaskRequestState::SideEffectsUnknown);
+        assert_eq!(executions.load(Ordering::SeqCst), 1);
         assert!(
             !conn.is_autocommit(),
             "the denied ROLLBACK must leave the test connection poisoned"

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -2389,15 +2389,27 @@ fn coordinator_search_visibility(
 }
 
 /// Preserve the established flat-string payload for ordinary runtime errors,
-/// while carrying every typed safe-retry write failure structurally through
-/// every MCP execution mode. Pool checkout and queue saturation happen before
-/// admission; writer-task BEGIN contention happens after queue acceptance but
-/// before the operation closure runs. None can leave a partial side effect.
+/// while carrying typed write admission and writer-request finality through
+/// every MCP execution mode. Finality is independent of retryability: a proven
+/// rollback makes duplicate effects impossible but retains the source error's
+/// transient policy, while an unverified rollback remains terminal and
+/// ambiguous.
 fn runtime_error_value(error: RuntimeError) -> Value {
     match error {
         RuntimeError::Khive(k) => serde_json::to_value(&k)
             .unwrap_or_else(|_| json!({"kind": "internal", "message": k.to_string()})),
         other => {
+            if let Some(context) = other.writer_task_failure_context() {
+                return json!({
+                    "kind": "storage",
+                    "code": context.stage,
+                    "stage": context.stage,
+                    "message": other.to_string(),
+                    "retryable": context.retryable,
+                    "request_state": context.request_state.to_string(),
+                    "task_terminated": context.task_terminated,
+                });
+            }
             let Some(context) = other.retryable_failure_context() else {
                 return json!(other.to_string());
             };

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -1876,6 +1876,20 @@ impl khive_types::Pack for ErrorInjectPack {
             params: &[],
         },
         HandlerDef {
+            name: "writer_task_rolled_back",
+            description: "returns an ordinary writer request error after proven rollback",
+            visibility: Visibility::Verb,
+            category: VerbCategory::Assertive,
+            params: &[],
+        },
+        HandlerDef {
+            name: "writer_task_side_effects_unknown",
+            description: "returns a terminal writer error with ambiguous side effects",
+            visibility: Visibility::Verb,
+            category: VerbCategory::Assertive,
+            params: &[],
+        },
+        HandlerDef {
             name: "storage_admission_timeout",
             description: "returns a typed storage-admission timeout error",
             visibility: Visibility::Verb,
@@ -1943,6 +1957,24 @@ impl PackRuntime for ErrorInjectPack {
         if verb == "writer_task_busy" {
             return Err(RuntimeError::Storage(
                 khive_storage::StorageError::WriterTaskBusy { timeout_ms: 175 },
+            ));
+        }
+        if verb == "writer_task_rolled_back" {
+            return Err(RuntimeError::Storage(
+                khive_storage::StorageError::WriterTaskRequestFailed {
+                    request_state: khive_storage::WriterTaskRequestState::TransactionRolledBack,
+                    source: Box::new(khive_storage::StorageError::Pool {
+                        operation: "writer_task_commit".into(),
+                        message: "commit refused".into(),
+                    }),
+                },
+            ));
+        }
+        if verb == "writer_task_side_effects_unknown" {
+            return Err(RuntimeError::Storage(
+                khive_storage::StorageError::WriterTaskTerminated {
+                    request_state: khive_storage::WriterTaskRequestState::SideEffectsUnknown,
+                },
             ));
         }
         if verb == "storage_admission_timeout" {
@@ -2179,6 +2211,57 @@ async fn writer_task_busy_survives_storage_runtime_and_mcp_wire() -> anyhow::Res
             "retry_after_ms": serde_json::Value::Null,
         }),
         "BEGIN contention must remain distinguishable and safely retryable"
+    );
+
+    Ok(())
+}
+
+/// Request finality and writer-task liveness are independent. A COMMIT error
+/// followed by verified rollback is safe from duplicate effects and keeps the
+/// writer alive; a failed rollback is terminal and ambiguous. Preserve both
+/// facts as structured MCP fields rather than forcing clients to parse text.
+#[tokio::test]
+async fn writer_task_finality_survives_storage_runtime_and_mcp_wire() -> anyhow::Result<()> {
+    let client = connect_error_inject().await?;
+
+    let rolled_back = call(
+        &client,
+        "request",
+        serde_json::json!({"ops": "writer_task_rolled_back()"}),
+    )
+    .await?;
+    let rolled_back_body: serde_json::Value = serde_json::from_str(&first_text(&rolled_back))?;
+    assert_eq!(
+        rolled_back_body["results"][0]["error"],
+        serde_json::json!({
+            "kind": "storage",
+            "code": "writer_task_request_failed",
+            "stage": "writer_task_request_failed",
+            "message": "storage: writer task request failed (request_state=transaction_rolled_back): pool failure during writer_task_commit: commit refused",
+            "retryable": true,
+            "request_state": "transaction_rolled_back",
+            "task_terminated": false,
+        })
+    );
+
+    let unknown = call(
+        &client,
+        "request",
+        serde_json::json!({"ops": "writer_task_side_effects_unknown()"}),
+    )
+    .await?;
+    let unknown_body: serde_json::Value = serde_json::from_str(&first_text(&unknown))?;
+    assert_eq!(
+        unknown_body["results"][0]["error"],
+        serde_json::json!({
+            "kind": "storage",
+            "code": "writer_task_terminated",
+            "stage": "writer_task_terminated",
+            "message": "storage: writer task terminated (request_state=side_effects_unknown)",
+            "retryable": false,
+            "request_state": "side_effects_unknown",
+            "task_terminated": true,
+        })
     );
 
     Ok(())

--- a/crates/khive-runtime/docs/api/audit_batch.md
+++ b/crates/khive-runtime/docs/api/audit_batch.md
@@ -41,6 +41,7 @@ then joins the retained supervisor `JoinHandle`.
 Concurrent `submit()` calls that arrive while a driver iteration is draining the queue share the
 same generation and the same `append_events_idempotent()` call — this is the batching payoff.
 Each generation retries transient storage failures (`WriteQueueFull`, `WriterTaskBusy`,
+`WriterTaskRequestFailed{TransactionRolledBack}` and
 `WriterTaskTerminated{NotStarted | TransactionRolledBack | SideEffectsUnknown}`) up to
 `AuditBatchConfig::max_commit_attempts` with `retry_backoff` between attempts
 (`classify_store_error`). `Unsupported("append_events_idempotent")` and any other storage error

--- a/crates/khive-runtime/src/audit_batch.rs
+++ b/crates/khive-runtime/src/audit_batch.rs
@@ -394,7 +394,8 @@ fn classify_store_error(err: &StorageError) -> RetryDecision {
         // configured bounded retries exist for — treating them as terminal
         // would abandon a generation on the first blip of a daemon restart.
         StorageError::Pool { .. } | StorageError::Timeout { .. } => RetryDecision::Retry,
-        StorageError::WriterTaskTerminated { request_state } => match request_state {
+        StorageError::WriterTaskRequestFailed { request_state, .. }
+        | StorageError::WriterTaskTerminated { request_state } => match request_state {
             WriterTaskRequestState::NotStarted | WriterTaskRequestState::TransactionRolledBack => {
                 RetryDecision::Retry
             }

--- a/crates/khive-runtime/src/error.rs
+++ b/crates/khive-runtime/src/error.rs
@@ -21,6 +21,14 @@ pub const WRITER_QUEUE_SATURATED_STAGE: &str = "writer_queue_saturated";
 /// queue accepted a request but before its operation closure ran.
 pub const WRITER_TASK_BEGIN_BUSY_STAGE: &str = "writer_task_begin_busy";
 
+/// Stable wire code/stage for an ordinary writer request whose operation or
+/// COMMIT failed after the task proved its transaction was rolled back.
+pub const WRITER_TASK_REQUEST_FAILED_STAGE: &str = "writer_task_request_failed";
+
+/// Stable wire code/stage for a request reported by a permanently retired
+/// writer seam.
+pub const WRITER_TASK_TERMINATED_STAGE: &str = "writer_task_terminated";
+
 /// Stable wire code/stage for a bounded storage-admission wait (a
 /// reader/writer handle slot or a pooled reader checkout) that elapsed
 /// before anything was acquired. The operation never started, so the
@@ -100,6 +108,24 @@ pub struct RetryableFailureContext {
     pub scope: Option<&'static str>,
     /// Server backoff hint when a governing contract defines one.
     pub retry_after_ms: Option<u64>,
+}
+
+/// Structured writer-request finality recovered from a storage error.
+///
+/// `request_state` answers whether effects are known absent or ambiguous;
+/// `task_terminated` separately answers whether the writer seam remains
+/// usable. `retryable` retains the source error's transient policy and must
+/// not be inferred from rollback finality alone.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WriterTaskFailureContext {
+    /// Stable MCP code/stage for the error family.
+    pub stage: &'static str,
+    /// What the writer can prove about this request's effects.
+    pub request_state: khive_storage::WriterTaskRequestState,
+    /// Whether the writer seam was permanently retired.
+    pub task_terminated: bool,
+    /// Whether the source failure is transient independently of finality.
+    pub retryable: bool,
 }
 
 impl From<AdmissionFailureContext> for RetryableFailureContext {
@@ -612,6 +638,35 @@ impl RuntimeError {
         None
     }
 
+    /// Recover writer-request finality without parsing the rendered storage
+    /// error. Ordinary proven rollbacks and terminal writer failures are
+    /// deliberately distinct even when they carry the same request state.
+    pub fn writer_task_failure_context(&self) -> Option<WriterTaskFailureContext> {
+        let Self::Storage(error) = self else {
+            return None;
+        };
+        match error {
+            khive_storage::StorageError::WriterTaskRequestFailed {
+                request_state,
+                source,
+            } => Some(WriterTaskFailureContext {
+                stage: WRITER_TASK_REQUEST_FAILED_STAGE,
+                request_state: *request_state,
+                task_terminated: false,
+                retryable: source.is_retryable(),
+            }),
+            khive_storage::StorageError::WriterTaskTerminated { request_state } => {
+                Some(WriterTaskFailureContext {
+                    stage: WRITER_TASK_TERMINATED_STAGE,
+                    request_state: *request_state,
+                    task_terminated: true,
+                    retryable: false,
+                })
+            }
+            _ => None,
+        }
+    }
+
     /// Recover every typed failure for which this process can prove that
     /// retrying the one failed operation cannot duplicate a side effect.
     pub fn retryable_failure_context(&self) -> Option<RetryableFailureContext> {
@@ -781,6 +836,46 @@ mod channel_ingest_failure_class_tests {
             },
             "a rendered message resembling SecretDetected must remain Unknown unless its typed variant is SecretDetected"
         );
+    }
+
+    #[test]
+    fn writer_task_failure_context_separates_request_finality_from_task_liveness() {
+        use khive_storage::{StorageError, WriterTaskRequestState};
+
+        let rolled_back = RuntimeError::Storage(StorageError::WriterTaskRequestFailed {
+            request_state: WriterTaskRequestState::TransactionRolledBack,
+            source: Box::new(StorageError::Pool {
+                operation: "writer_task_commit".into(),
+                message: "commit refused".into(),
+            }),
+        });
+        let rolled_back_context = rolled_back
+            .writer_task_failure_context()
+            .expect("proven rollback must remain typed through RuntimeError");
+        assert_eq!(
+            rolled_back_context.request_state,
+            WriterTaskRequestState::TransactionRolledBack
+        );
+        assert_eq!(
+            rolled_back_context.stage,
+            super::WRITER_TASK_REQUEST_FAILED_STAGE
+        );
+        assert!(!rolled_back_context.task_terminated);
+        assert!(rolled_back_context.retryable);
+
+        let unknown = RuntimeError::Storage(StorageError::WriterTaskTerminated {
+            request_state: WriterTaskRequestState::SideEffectsUnknown,
+        });
+        let unknown_context = unknown
+            .writer_task_failure_context()
+            .expect("ambiguous finality must remain typed through RuntimeError");
+        assert_eq!(
+            unknown_context.request_state,
+            WriterTaskRequestState::SideEffectsUnknown
+        );
+        assert_eq!(unknown_context.stage, super::WRITER_TASK_TERMINATED_STAGE);
+        assert!(unknown_context.task_terminated);
+        assert!(!unknown_context.retryable);
     }
 
     #[test]

--- a/crates/khive-runtime/src/events_split.rs
+++ b/crates/khive-runtime/src/events_split.rs
@@ -64,14 +64,16 @@ use crate::daemon::{read_frame, write_frame};
 /// The server rejects frames whose version it does not speak, so a skewed
 /// client gets a typed refusal instead of a deserialization panic.
 ///
-/// Version 2 is the first version any release ships: version 1 carried a
+/// Version 2 was the first version any release shipped: version 1 carried a
 /// `side_effects_unknown` error field that was replaced by the
 /// `writer_task_state` carrier before this module reached any released ref,
 /// so v1 speakers existed only on unreleased development heads. The bump
 /// exists so that even such a process gets the version refusal above rather
 /// than having its retryable writer states silently mapped to terminal
-/// `InvalidInput`.
-pub const EVENTS_PROTOCOL_VERSION: u32 = 2;
+/// `InvalidInput`. Version 3 replaces that state-only carrier with a failure
+/// disposition so a proven rollback can cross the socket without falsely
+/// claiming the remote writer task terminated.
+pub const EVENTS_PROTOCOL_VERSION: u32 = 3;
 
 /// Default bound on the fire-and-forget append queue, in batches. The loss
 /// window on overflow is this depth times the batch size in flight; the value
@@ -470,30 +472,28 @@ pub enum EventsResponse {
     },
     /// Typed refusal. `retryable` distinguishes transient daemon-side
     /// conditions from contract errors (bad frame, version skew).
-    /// `writer_task_state` is the single carrier of the ADR-133 dispositions
-    /// the retryable bit cannot express: the daemon-side writer terminated
-    /// in a state the audit-batch retry classifier keys on per-variant —
-    /// `NotStarted` and `TransactionRolledBack` are safe replays,
-    /// `SideEffectsUnknown` gates double-send decisions. Flattening any of
-    /// them into a generic refusal turns a mandated retry into a terminal
-    /// failure on the client side. `None` means the error is not a
-    /// writer-task termination at all (parse errors, version refusals,
-    /// non-writer storage errors). No second spelling exists: within one
-    /// protocol version every storage-class Error frame carries this field,
-    /// and cross-version frames never reach this mapping because
-    /// `dispatch_events_request` refuses a mismatched version outright —
-    /// a refusal that happens BEFORE any write executes, so no retryable
-    /// writer state can exist to lose. That guarantee is why
-    /// [`EVENTS_PROTOCOL_VERSION`] must be bumped with any change to this
-    /// field's shape: two shapes sharing one version would make this exact
-    /// sentence false (v2 exists because v1 briefly had a second spelling
-    /// on unreleased development heads).
+    /// `writer_task_failure` carries both request finality and whether the
+    /// remote writer seam terminated. The retryable bit cannot express that
+    /// distinction: an ordinary operation or COMMIT error may be transient or
+    /// permanent while its transaction is independently proven rolled back.
+    /// `None` means the error is not from a writer request. Cross-version
+    /// frames never reach this mapping because `dispatch_events_request`
+    /// refuses a mismatched version before any write executes.
     Error {
         message: String,
         retryable: bool,
         #[serde(default)]
-        writer_task_state: Option<WireWriterTaskState>,
+        writer_task_failure: Option<WireWriterTaskFailure>,
     },
+}
+
+/// Whether a writer-state error belongs to one failed request on a still-live
+/// seam or to a permanently retired writer task.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum WireWriterTaskFailure {
+    RequestFailed { request_state: WireWriterTaskState },
+    TaskTerminated { request_state: WireWriterTaskState },
 }
 
 /// Wire mirror of [`khive_storage::WriterTaskRequestState`]. A separate type
@@ -1063,7 +1063,7 @@ async fn serve_events_conn(
             Err(error) => EventsResponse::Error {
                 message: format!("events daemon could not parse request frame: {error}"),
                 retryable: false,
-                writer_task_state: None,
+                writer_task_failure: None,
             },
         };
         let bytes = match serde_json::to_vec(&response) {
@@ -1100,7 +1100,7 @@ async fn dispatch_events_request(
                 request.protocol_version()
             ),
             retryable: false,
-            writer_task_state: None,
+            writer_task_failure: None,
         };
     }
     // The wire namespace is an unrestricted client-supplied String until this
@@ -1112,7 +1112,7 @@ async fn dispatch_events_request(
         return EventsResponse::Error {
             message: format!("events request namespace rejected: {error}"),
             retryable: false,
-            writer_task_state: None,
+            writer_task_failure: None,
         };
     }
     let store = match namespace_store(backend, stores, request.namespace()) {
@@ -1121,7 +1121,7 @@ async fn dispatch_events_request(
             return EventsResponse::Error {
                 message: format!("events store unavailable: {error}"),
                 retryable: true,
-                writer_task_state: None,
+                writer_task_failure: None,
             };
         }
     };
@@ -1149,7 +1149,7 @@ async fn dispatch_events_request(
                         page.limit, MAX_QUERY_EVENTS_PAGE_ROWS
                     ),
                     retryable: false,
-                    writer_task_state: None,
+                    writer_task_failure: None,
                 };
             }
             match store.query_events(filter, page).await {
@@ -1166,25 +1166,32 @@ async fn dispatch_events_request(
 
 #[cfg(unix)]
 fn storage_error_response(error: &StorageError) -> EventsResponse {
-    // Writer-task terminations carry their request state verbatim: the
-    // ADR-133 retry classifier decides per-variant (`NotStarted` and
-    // `TransactionRolledBack` are mandated retries), so the state must
-    // survive the socket even though `is_retryable()` reports the family
-    // non-transient.
-    let writer_task_state = match error {
-        StorageError::WriterTaskTerminated { request_state } => {
-            Some(WireWriterTaskState::from(*request_state))
-        }
-        _ => None,
+    let (message, writer_task_failure) = match error {
+        StorageError::WriterTaskRequestFailed {
+            request_state,
+            source,
+        } => (
+            source.to_string(),
+            Some(WireWriterTaskFailure::RequestFailed {
+                request_state: (*request_state).into(),
+            }),
+        ),
+        StorageError::WriterTaskTerminated { request_state } => (
+            error.to_string(),
+            Some(WireWriterTaskFailure::TaskTerminated {
+                request_state: (*request_state).into(),
+            }),
+        ),
+        _ => (error.to_string(), None),
     };
     EventsResponse::Error {
-        message: error.to_string(),
+        message,
         // Defer to the storage layer's own transience classifier rather than
         // re-enumerating variants here: a hand-rolled subset silently turns
         // transient writer contention (`WriterTaskBusy`, `Transaction`) into
         // a terminal error on the client side of the socket.
         retryable: error.is_retryable(),
-        writer_task_state,
+        writer_task_failure,
     }
 }
 
@@ -1599,23 +1606,33 @@ impl ForwardingEventStore {
             EventsResponse::Error {
                 message,
                 retryable,
-                writer_task_state,
+                writer_task_failure,
             } => {
-                if let Some(state) = writer_task_state {
-                    // Reconstruct the exact writer-task variant: the ADR-133
-                    // retry classifier decides per-state (`NotStarted` and
-                    // `TransactionRolledBack` are mandated retries,
-                    // `SideEffectsUnknown` gates double-send decisions), so
-                    // flattening any of them into a generic refusal breaks
-                    // the retry contract on the client side of the socket.
-                    // The field is the single carrier: cross-version frames
-                    // never reach this mapping (the daemon refuses a
-                    // mismatched protocol version before dispatch, and the
-                    // refusal precedes any write, so a version-skewed peer
-                    // has no writer state to lose — the guarantee that
-                    // obligates a version bump on any field-shape change).
-                    StorageError::WriterTaskTerminated {
-                        request_state: state.into(),
+                if let Some(failure) = writer_task_failure {
+                    match failure {
+                        WireWriterTaskFailure::RequestFailed { request_state } => {
+                            let source = if retryable {
+                                StorageError::Pool {
+                                    operation: op.into(),
+                                    message,
+                                }
+                            } else {
+                                StorageError::InvalidInput {
+                                    capability: khive_storage::StorageCapability::Events,
+                                    operation: op.into(),
+                                    message,
+                                }
+                            };
+                            StorageError::WriterTaskRequestFailed {
+                                request_state: request_state.into(),
+                                source: Box::new(source),
+                            }
+                        }
+                        WireWriterTaskFailure::TaskTerminated { request_state } => {
+                            StorageError::WriterTaskTerminated {
+                                request_state: request_state.into(),
+                            }
+                        }
                     }
                 } else if retryable {
                     StorageError::Pool {
@@ -2261,14 +2278,14 @@ mod tests {
             EventsResponse::Error {
                 message,
                 retryable,
-                writer_task_state,
+                writer_task_failure,
             } => {
                 assert!(
                     message.contains(&MAX_QUERY_EVENTS_PAGE_ROWS.to_string()),
                     "refusal must name the cap: {message}"
                 );
                 assert!(!retryable, "an over-cap page is not transient");
-                assert!(writer_task_state.is_none());
+                assert!(writer_task_failure.is_none());
             }
             other => panic!("over-cap query must be refused, got {other:?}"),
         }
@@ -2284,7 +2301,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn side_effects_unknown_state_crosses_the_wire_as_writer_task_state() {
+    fn side_effects_unknown_state_crosses_the_wire_as_terminal_failure() {
         let response = storage_error_response(&StorageError::WriterTaskTerminated {
             request_state: khive_storage::WriterTaskRequestState::SideEffectsUnknown,
         });
@@ -2292,7 +2309,9 @@ mod tests {
             matches!(
                 response,
                 EventsResponse::Error {
-                    writer_task_state: Some(WireWriterTaskState::SideEffectsUnknown),
+                    writer_task_failure: Some(WireWriterTaskFailure::TaskTerminated {
+                        request_state: WireWriterTaskState::SideEffectsUnknown,
+                    }),
                     ..
                 }
             ),
@@ -2303,15 +2322,36 @@ mod tests {
         assert!(matches!(
             busy,
             EventsResponse::Error {
-                writer_task_state: None,
+                writer_task_failure: None,
+                ..
+            }
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn proven_rollback_crosses_the_wire_without_claiming_task_termination() {
+        let response = storage_error_response(&StorageError::WriterTaskRequestFailed {
+            request_state: khive_storage::WriterTaskRequestState::TransactionRolledBack,
+            source: Box::new(StorageError::Pool {
+                operation: "writer_task_commit".into(),
+                message: "commit refused".into(),
+            }),
+        });
+        assert!(matches!(
+            response,
+            EventsResponse::Error {
+                writer_task_failure: Some(WireWriterTaskFailure::RequestFailed {
+                    request_state: WireWriterTaskState::TransactionRolledBack,
+                }),
                 ..
             }
         ));
     }
 
     #[test]
-    fn error_frames_without_writer_state_still_parse() {
-        // `writer_task_state` is `#[serde(default)]`: an Error frame for a
+    fn error_frames_without_writer_failure_still_parse() {
+        // `writer_task_failure` is `#[serde(default)]`: an Error frame for a
         // non-writer failure (parse error, version refusal) omits it and the
         // client must read `None`, not fail the parse.
         let bytes = br#"{"kind":"error","message":"boom","retryable":true}"#;
@@ -2320,7 +2360,7 @@ mod tests {
             parsed,
             EventsResponse::Error {
                 retryable: true,
-                writer_task_state: None,
+                writer_task_failure: None,
                 ..
             }
         ));
@@ -2449,7 +2489,7 @@ mod tests {
     #[tokio::test]
     async fn stateless_non_retryable_error_maps_terminal_not_writer_terminated() {
         // The terminal arm of the client mapping, pinned deliberately: an
-        // Error frame with `retryable: false` and NO `writer_task_state` is
+        // Error frame with `retryable: false` and NO `writer_task_failure` is
         // a non-writer failure (parse error, version refusal) and must map
         // to terminal `InvalidInput` — never to `WriterTaskTerminated`
         // (there is no state to reconstruct) and never to the retryable
@@ -2466,7 +2506,7 @@ mod tests {
         // Control: the same non-retryable frame WITH a writer state must
         // take the reconstruction arm instead — proving the terminal arm
         // above is selected by the field's absence, not by `retryable`.
-        let with_state = br#"{"kind":"error","message":"died","retryable":false,"writer_task_state":"side_effects_unknown"}"#;
+        let with_state = br#"{"kind":"error","message":"died","retryable":false,"writer_task_failure":{"kind":"task_terminated","request_state":"side_effects_unknown"}}"#;
         let parsed: EventsResponse =
             serde_json::from_slice(with_state).expect("stateful frame parses");
         assert!(matches!(
@@ -2513,10 +2553,41 @@ mod tests {
         assert!(matches!(
             busy,
             EventsResponse::Error {
-                writer_task_state: None,
+                writer_task_failure: None,
                 ..
             }
         ));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn proven_rollback_round_trips_as_non_terminal_request_failure() {
+        use khive_storage::WriterTaskRequestState as S;
+
+        let dir = tempfile::tempdir().unwrap();
+        let client =
+            EventsSplitClient::new(dir.path().join("never-bound.sock")).expect("client builds");
+        let store = ForwardingEventStore::new("test", client);
+        let response = storage_error_response(&StorageError::WriterTaskRequestFailed {
+            request_state: S::TransactionRolledBack,
+            source: Box::new(StorageError::Pool {
+                operation: "writer_task_commit".into(),
+                message: "commit refused".into(),
+            }),
+        });
+        let bytes = serde_json::to_vec(&response).unwrap();
+        let parsed: EventsResponse = serde_json::from_slice(&bytes).unwrap();
+        let err = store.unexpected("append_events_idempotent", parsed);
+        assert!(
+            matches!(
+                err,
+                StorageError::WriterTaskRequestFailed {
+                    request_state: S::TransactionRolledBack,
+                    ..
+                }
+            ),
+            "proven rollback must not reconstruct as a terminal writer: {err:?}"
+        );
     }
 
     #[cfg(unix)]
@@ -2638,7 +2709,7 @@ mod tests {
                 &response,
                 EventsResponse::Error {
                     retryable: false,
-                    writer_task_state: None,
+                    writer_task_failure: None,
                     ..
                 }
             ),

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -84,8 +84,9 @@ pub use engine_config::{
 };
 pub use error::{
     fts_text_leg_or_err, AdmissionFailureContext, ChannelIngestFailureClass, GuardedWriteFailure,
-    RuntimeError, RuntimeResult, WriterPoolCheckoutTimeoutContext, WRITER_ADMISSION_SCOPE,
-    WRITER_POOL_CHECKOUT_TIMEOUT_STAGE, WRITER_QUEUE_SATURATED_STAGE,
+    RuntimeError, RuntimeResult, WriterPoolCheckoutTimeoutContext, WriterTaskFailureContext,
+    WRITER_ADMISSION_SCOPE, WRITER_POOL_CHECKOUT_TIMEOUT_STAGE, WRITER_QUEUE_SATURATED_STAGE,
+    WRITER_TASK_REQUEST_FAILED_STAGE, WRITER_TASK_TERMINATED_STAGE,
 };
 pub use fusion::FusionStrategy;
 pub use graph_traversal::PathNode;

--- a/crates/khive-runtime/tests/adr133_audit_batch.rs
+++ b/crates/khive-runtime/tests/adr133_audit_batch.rs
@@ -102,7 +102,12 @@ impl EventStore for FakeStore {
         self.calls.fetch_add(1, Ordering::SeqCst);
         if self.fail_next.load(Ordering::SeqCst) > 0 {
             self.fail_next.fetch_sub(1, Ordering::SeqCst);
-            return Err(StorageError::WriterTaskBusy { timeout_ms: 1 });
+            return Err(StorageError::WriterTaskRequestFailed {
+                request_state: WriterTaskRequestState::TransactionRolledBack,
+                source: Box::new(StorageError::Internal(
+                    "simulated operation error after proven rollback".into(),
+                )),
+            });
         }
         if self.fail_pool_next.load(Ordering::SeqCst) > 0 {
             self.fail_pool_next.fetch_sub(1, Ordering::SeqCst);
@@ -312,7 +317,7 @@ async fn d1_retry_table_uses_typed_request_state() {
     assert_eq!(
         store.calls.load(Ordering::SeqCst),
         2,
-        "one failure then one successful retry"
+        "a proven rollback makes the idempotent batch replay effect-safe even when the source error is not independently transient"
     );
 }
 

--- a/crates/khive-storage/docs/api/error-taxonomy.md
+++ b/crates/khive-storage/docs/api/error-taxonomy.md
@@ -12,7 +12,7 @@ at first write rather than a `tokio::spawn`-outside-runtime panic. Flag-off
 callers never see this variant — `writer_task_handle` only attempts to spawn
 when `PoolConfig::write_queue_enabled` is set.
 
-## `WriterTaskTerminated` and `WriterTaskRequestState`
+## Writer-request finality
 
 `WriterTaskTerminated { request_state }` is the public error returned when a
 single-writer request cannot complete because its writer-task instance has terminated or the
@@ -22,7 +22,7 @@ what the execution seam can prove about the individual request:
 | State                   | Meaning                                                                                                                 |
 | ----------------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `NotStarted`            | The request was not accepted, or it was drained from the closed queue without invoking its operation closure            |
-| `TransactionRolledBack` | A transaction-wrapped operation panicked, and the writer task successfully rolled back its enclosing SQLite transaction |
+| `TransactionRolledBack` | The writer successfully rolled back the request's enclosing SQLite transaction; no wrapped database write committed       |
 | `SideEffectsUnknown`    | The operation may have started, and the task cannot prove its final transaction or side-effect state                    |
 
 A top-level operation has no enclosing transaction, so a panic is always
@@ -42,26 +42,35 @@ its rendered `writer task terminated` prefix retain their historical names for w
 compatibility.
 
 If rollback after a non-panic operation or commit failure succeeds and restores autocommit mode,
-no terminal error is introduced: the caller receives the original operation error or the existing
-retryable commit pool error, and the writer remains available. A caught operation panic remains
-terminal even when its transaction was provably rolled back.
+the caller receives
+`WriterTaskRequestFailed { request_state: TransactionRolledBack, source }`.
+This wrapper carries the proof that the request left no committed SQLite effect without claiming
+the writer task terminated. The writer remains available, and the request closure is never
+re-executed internally. `source` is the original operation error or the typed
+`writer_task_commit` pool error. `capability()`, `is_retryable()`, and the specialized FTS/UNIQUE
+classifiers delegate to that source: rollback finality makes replay effect-safe but does not make a
+deterministic error transient. A caught operation panic remains terminal even when its transaction
+was provably rolled back.
 
-This error has no storage capability attribution (`capability()` returns
+`WriterTaskTerminated` has no storage capability attribution (`capability()` returns
 `None`) and is not automatically retryable (`is_retryable()` returns `false`).
 In particular, callers must not blindly retry `SideEffectsUnknown`: the first
 attempt may have committed a side effect. Retry decisions belong to the
 operation's idempotency contract.
 
-Neither `WriterTaskTerminated` nor `WriterTaskRequestState` has a serialized
-wire representation. Runtime and MCP error envelopes continue to flatten this
-storage error through `Display`; the rendered form is
-`writer task terminated (request_state=<state>)`, where `<state>` is one of
-`not_started`, `transaction_rolled_back`, or `side_effects_unknown`. This adds
-typed in-process information without changing the enclosing runtime/MCP error
-schema. `StorageError` is a public enum without `#[non_exhaustive]`, so adding
-this variant is nevertheless a Rust source-compatibility change for downstream
-code that exhaustively matches every variant; those matches must add a
-`WriterTaskTerminated` arm.
+`RuntimeError::writer_task_failure_context()` preserves the request state, source retryability, and
+whether the writer seam terminated. MCP serializes that context with stable
+`writer_task_request_failed` / `writer_task_terminated` code and stage fields plus
+`request_state`, `task_terminated`, and `retryable`. The events socket protocol carries the same
+request-failed versus task-terminated disposition and reconstructs the matching storage variant.
+
+The rendered forms remain stable:
+
+- `writer task request failed (request_state=<state>): <source>`
+- `writer task terminated (request_state=<state>)`
+
+`StorageError` is a public enum without `#[non_exhaustive]`, so
+`WriterTaskRequestFailed` is a Rust source-compatibility change for downstream exhaustive matches.
 
 ## Bounded blob read failures
 

--- a/crates/khive-storage/src/error.rs
+++ b/crates/khive-storage/src/error.rs
@@ -20,8 +20,10 @@ use crate::capability::StorageCapability;
 pub enum WriterTaskRequestState {
     /// The request's operation closure was never invoked.
     NotStarted,
-    /// The request panicked inside `BEGIN IMMEDIATE`, and that transaction was
-    /// successfully rolled back on the connection that owned it.
+    /// The request ran inside `BEGIN IMMEDIATE`, and that transaction was
+    /// successfully rolled back on the connection that owned it. The request
+    /// may have returned an error, failed COMMIT, or panicked; none of its
+    /// wrapped SQLite writes committed.
     TransactionRolledBack,
     /// The request was accepted, but its exact outcome cannot be established;
     /// it may already have produced side effects and must not be blindly
@@ -212,6 +214,18 @@ pub enum StorageError {
     )]
     WriterTaskBusy { timeout_ms: u64 },
 
+    /// One transaction-wrapped writer request returned an error, and the
+    /// writer then proved that request's SQLite transaction was rolled back.
+    /// Unlike [`StorageError::WriterTaskTerminated`], this does not retire the
+    /// writer seam. `source` preserves the operation or COMMIT error so its
+    /// capability and retry policy remain independently inspectable.
+    #[error("writer task request failed (request_state={request_state}): {source}")]
+    WriterTaskRequestFailed {
+        request_state: WriterTaskRequestState,
+        #[source]
+        source: Box<StorageError>,
+    },
+
     /// A single-writer execution seam has terminated permanently. This is the
     /// historical writer-task variant and display name; the fail-closed
     /// pool-mutex fallback also uses it when transaction finalization becomes
@@ -281,6 +295,7 @@ impl StorageError {
             Self::BlobTooLarge { .. }
             | Self::BlobSizeMismatch { .. }
             | Self::BlobDigestMismatch { .. } => Some(StorageCapability::Blob),
+            Self::WriterTaskRequestFailed { source, .. } => source.capability(),
             Self::Pool { .. }
             | Self::Timeout { .. }
             | Self::AdmissionTimeout { .. }
@@ -297,6 +312,9 @@ impl StorageError {
 
     /// Whether this error is transient and the operation may succeed on retry.
     pub fn is_retryable(&self) -> bool {
+        if let Self::WriterTaskRequestFailed { source, .. } = self {
+            return source.is_retryable();
+        }
         matches!(
             self,
             Self::Pool { .. }
@@ -326,6 +344,9 @@ impl StorageError {
     /// "successful" search (issue #389).
     /// See `crates/khive-storage/docs/api/error-taxonomy.md#is_fts5_syntax_error`.
     pub fn is_fts5_syntax_error(&self) -> bool {
+        if let Self::WriterTaskRequestFailed { source, .. } = self {
+            return source.is_fts5_syntax_error();
+        }
         let Self::Driver {
             capability,
             operation,
@@ -358,6 +379,9 @@ impl StorageError {
     /// also hide genuine write failures (disk full, corruption).
     /// See `crates/khive-storage/docs/api/error-taxonomy.md#is_unique_constraint_violation`.
     pub fn is_unique_constraint_violation(&self) -> bool {
+        if let Self::WriterTaskRequestFailed { source, .. } = self {
+            return source.is_unique_constraint_violation();
+        }
         let Self::Driver {
             capability,
             operation,
@@ -428,6 +452,47 @@ mod tests {
             "writer task could not begin within 175ms because SQLite remained busy; request was not executed"
         );
         assert_eq!(error.capability(), None);
+    }
+
+    #[test]
+    fn writer_task_request_failure_preserves_source_policy_and_rollback_state() {
+        let error = StorageError::WriterTaskRequestFailed {
+            request_state: WriterTaskRequestState::TransactionRolledBack,
+            source: Box::new(StorageError::Pool {
+                operation: "writer_task_commit".into(),
+                message: "commit refused".into(),
+            }),
+        };
+
+        assert_eq!(error.capability(), None);
+        assert!(
+            error.is_retryable(),
+            "rollback finality must not discard the source error's retry policy"
+        );
+        assert_eq!(
+            error.to_string(),
+            "writer task request failed (request_state=transaction_rolled_back): pool failure during writer_task_commit: commit refused"
+        );
+        assert_eq!(
+            StdError::source(&error).map(ToString::to_string),
+            Some("pool failure during writer_task_commit: commit refused".to_string()),
+            "the original typed storage error must remain the public source"
+        );
+    }
+
+    #[test]
+    fn writer_task_request_failure_does_not_invent_retryability() {
+        let error = StorageError::WriterTaskRequestFailed {
+            request_state: WriterTaskRequestState::TransactionRolledBack,
+            source: Box::new(StorageError::InvalidInput {
+                capability: StorageCapability::Notes,
+                operation: "append_note".into(),
+                message: "deterministic refusal".into(),
+            }),
+        };
+
+        assert!(!error.is_retryable());
+        assert_eq!(error.capability(), Some(StorageCapability::Notes));
     }
 
     #[test]

--- a/docs/adr/ADR-067-write-owner-daemon.md
+++ b/docs/adr/ADR-067-write-owner-daemon.md
@@ -824,3 +824,30 @@ mean the queue never accepted the request. Non-busy/non-locked BEGIN failures
 remain generic pool errors. `comm.send` preserves this typed retryable result
 without adding an outbound delivery probe: `comm.delivered` remains reserved
 for `SideEffectsUnknown`, where a write may already have committed.
+
+## Amendment 5 (2026-08-30): Ordinary proven-rollback finality
+
+This amendment supersedes Amendment 3's statement that a verified rollback after an ordinary
+operation or COMMIT error returns the unwrapped source error, and Amendment 2's flat-MCP-envelope
+claim. The finalizer must retain both facts:
+the original error determines capability and retry policy, while the verified rollback determines
+effect finality.
+
+After an operation error or COMMIT error, `ROLLBACK` success counts only when the same connection is
+back in autocommit mode. That path returns
+`StorageError::WriterTaskRequestFailed { request_state: TransactionRolledBack, source }`, where
+`source` is the original operation error or the `writer_task_commit` pool error. The wrapper is
+non-terminal: the drain loop receives no terminal state, the writer serves the next request, and
+the failed request closure is invoked exactly once. Its classifiers delegate to `source`; a proven
+rollback makes replay safe from duplicate SQLite effects but does not declare every source error
+transient.
+
+An unverified rollback remains `WriterTaskTerminated { request_state: SideEffectsUnknown }`, retires
+the writer seam, and never exposes the original error as though finality were known. Panic handling
+is unchanged: a caught wrapped panic is terminal even when its transaction rolls back.
+
+Runtime exposes the state, source retryability, and task-liveness bit as typed context. MCP emits
+that context under `writer_task_request_failed` or `writer_task_terminated`, with
+`request_state`, `task_terminated`, and `retryable` fields. Events protocol v3 carries a tagged
+request-failed versus task-terminated disposition, so `TransactionRolledBack` cannot be
+reconstructed as a terminal writer error merely because it crossed the daemon socket.


### PR DESCRIPTION
## Summary
- carry verified rollback finality on ordinary writer operation and COMMIT errors while retaining the original source classifiers
- keep request closures exactly-once and the writer live after proven rollback; retain terminal SideEffectsUnknown when rollback cannot be verified
- propagate typed request finality through runtime, MCP, and events protocol v3, and document the public contract

## Validation
- cargo test -p khive-db --lib (838 passed)
- cargo test -p khive-storage -p khive-runtime -p khive-mcp (passed)
- cargo test -p khive-runtime --features fault-injection,test-internals --test adr133_audit_batch d1_retry_table_uses_typed_request_state (1 passed)
- cargo check -p khive-storage -p khive-db -p khive-runtime -p khive-mcp --all-targets
- cargo clippy -p khive-storage -p khive-db -p khive-runtime -p khive-mcp --all-targets -- -D warnings
- cargo fmt --all --manifest-path crates/Cargo.toml -- --check
- git diff --check

Closes #2213