### PR TITLE
ci: scope the secret scan to the change under review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,8 +381,67 @@ jobs:
         run: |
           curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.21.2/gitleaks_8.21.2_linux_x64.tar.gz \
             | tar -xz -C /usr/local/bin gitleaks
-      - name: Scan git history for credentials
-        run: gitleaks detect --source . --redact --no-banner
+      # Resolve which commits this run judges. A pull_request or push run must
+      # judge THE CHANGE, not the repository: with `fetch-depth: 0` and no range,
+      # `gitleaks detect` scans every ref in the checkout, so a finding on any
+      # branch pushed to the repo turns this job red on every other pull request,
+      # with no way to tell from the log which change is actually at fault.
+      #
+      # THE NARROWING IS ONLY SAFE BECAUSE THE WIDE POPULATION STAYS COVERED:
+      # the nightly `schedule` trigger takes no range and still scans every ref,
+      # so a credential reachable from any branch is still found within a day.
+      # If that scheduled run is ever removed, filtered, or given a range, this
+      # narrowing must be reverted in the same change.
+      - name: Resolve scan scope
+        id: scope
+        run: |
+          set -euo pipefail
+          range=""
+          case "${{ github.event_name }}" in
+            pull_request)
+              # actions/checkout resolves refs/pull/N/merge, whose first parent
+              # is the base and whose second parent is the pull request head.
+              if base=$(git rev-parse --verify -q 'HEAD^1') \
+                 && head=$(git rev-parse --verify -q 'HEAD^2'); then
+                range="${base}..${head}"
+              fi
+              ;;
+            push)
+              before="${{ github.event.before }}"
+              if [ -n "$before" ] \
+                 && [ "$before" != "0000000000000000000000000000000000000000" ] \
+                 && git cat-file -e "${before}^{commit}" 2>/dev/null; then
+                range="${before}..${{ github.sha }}"
+              fi
+              ;;
+          esac
+          # An unresolvable or empty range must widen the scan, never skip it:
+          # scanning nothing exits 0 and is indistinguishable from finding
+          # nothing, which would make this gate pass by being broken.
+          if [ -n "$range" ]; then
+            count=$(git rev-list --count "$range")
+            echo "commits in scope: $count ($range)"
+            if [ "$count" -eq 0 ]; then
+              echo "resolved range is empty — widening to every ref"
+              range=""
+            fi
+          else
+            echo "no range resolved for event '${{ github.event_name }}' — scanning every ref"
+          fi
+          echo "range=${range}" >> "$GITHUB_OUTPUT"
+      # `-v` prints each finding's file, line, commit and rule. Without it the
+      # job reports only `leaks found: N`, so every consumer of a red run has to
+      # reproduce locally before learning anything. `--redact` keeps the matched
+      # value out of the log.
+      - name: Scan for credentials
+        run: |
+          set -euo pipefail
+          range="${{ steps.scope.outputs.range }}"
+          if [ -n "$range" ]; then
+            gitleaks detect --source . --redact --no-banner -v --log-opts="$range"
+          else
+            gitleaks detect --source . --redact --no-banner -v
+          fi
 
   docs:
     name: Docs lint


### PR DESCRIPTION
The secret scan currently judges the repository rather than the change under test, which makes any pull request's result depend on every other branch in the repo.

## What happens today

`.github/workflows/ci.yml` checks out with `fetch-depth: 0` and runs:

```
gitleaks detect --source . --redact --no-banner
```

With no `--log-opts`, the scan population is every commit reachable from every ref in the checkout. A `fetch-depth: 0` checkout carries all branches, so a credential-shaped string pushed to *any* branch is scanned by every subsequent run on every pull request.

That is not theoretical. A test fixture on one open draft branch — a hex constant used to exercise the secret gate's own detector — put six unrelated pull requests into a red secret scan on 2026-08-30. The scans split cleanly on the moment that branch was pushed: the run that started before it was green, every run after it was red, across changes sharing no files with it. Runs on `main` stayed green only because `main`'s most recent commit happened to predate the push by two minutes; the same job runs on `push: [main]`, so the next merge would have inherited it.

The log gives a reader no way to reach that conclusion, because the invocation prints only `leaks found: 1` — no file, no line, no commit, no rule.

## What this changes

Pull request and push runs resolve a commit range and pass it to `--log-opts`:

- **pull_request** — `actions/checkout` resolves `refs/pull/N/merge`, whose first parent is the base and whose second is the pull request head, so `HEAD^1..HEAD^2` is exactly the commits the pull request contributes. Verified against a real merge ref: it resolves to the single commit that pull request adds.
- **push** — `github.event.before..github.sha`, when that predecessor exists in the checkout.
- **schedule / workflow_dispatch** — unchanged: no range, every ref.

An unresolvable or empty range **widens** the scan rather than skipping it. A scan of zero commits exits 0 and is indistinguishable in the log from a scan that found nothing, so the failure mode of this logic has to be "scan too much", never "scan nothing and pass".

## Why the narrowing is sound

Narrowing a credential scan's population is only legitimate if the wide population stays covered somewhere. It does: the nightly `schedule` run takes no range and still scans every ref, so a credential reachable from any branch is still found within a day. That pairing is written in a comment beside the code, together with the instruction that this narrowing must be reverted in the same change if the scheduled run is ever removed, filtered, or given a range.

The trade this accepts, stated plainly: a credential introduced on a branch is now surfaced by the nightly rather than instantly by that branch's own pull request run — except that it *is* surfaced instantly by that pull request's own run, since the branch's commits are in its own range. What is lost is the incidental cross-branch detection, which was never a designed property and could not be acted on anyway, because the log did not say what was found.

## Verification

- Scoped scan of an affected pull request's own commit: `1 commits scanned`, `no leaks found` — it goes green.
- Wide scan over every origin ref, same pinned binary: `4681 commits scanned`, `leaks found: 1` — the fixture is still found, which is what the nightly run will do.
- Range resolution checked against an actual `refs/pull/N/merge` checkout rather than reasoned about.
- Workflow YAML re-parsed after the edit; all four triggers and the job's step list intact.

`-v` is added at the same time so a red run names the file, line, commit and rule. `--redact` keeps the matched value out of the log, so findings stay reportable without publishing the string that matched.
