### PR TITLE
perf(memory): scope FTS gather to memory corpus

### DIFF
--- a/crates/khive-db/benches/db_hot_path.rs
+++ b/crates/khive-db/benches/db_hot_path.rs
@@ -85,6 +85,7 @@ fn build_text_corpus() -> Vec<TextDocument> {
         .map(|i| TextDocument {
             subject_id: Uuid::new_v4(),
             kind: SubstrateKind::Note,
+            record_kind: None,
             namespace: NAMESPACE.to_string(),
             title: Some(gen_title(i)),
             body: gen_body(&mut rng, i),
@@ -449,6 +450,7 @@ fn bench_fts_upsert_batch(c: &mut Criterion) {
                             .map(|i| TextDocument {
                                 subject_id: Uuid::new_v4(),
                                 kind: SubstrateKind::Note,
+                                record_kind: None,
                                 namespace: NAMESPACE.to_string(),
                                 title: Some(gen_title(i)),
                                 body: gen_body(&mut rng, i),

--- a/crates/khive-db/sql/023-fts-record-kind.sql
+++ b/crates/khive-db/sql/023-fts-record-kind.sql
@@ -1,0 +1,88 @@
+-- V23: index the granular source-record kind inside the shared FTS tables.
+-- The copy preserves every indexed row, including stale rows whose base record
+-- no longer exists; those rows receive an empty classifier and remain visible
+-- to unscoped text searches exactly as before.
+
+CREATE VIRTUAL TABLE fts_entities_v23 USING fts5(
+    subject_id UNINDEXED,
+    kind UNINDEXED,
+    title,
+    body,
+    tags UNINDEXED,
+    namespace UNINDEXED,
+    metadata UNINDEXED,
+    updated_at UNINDEXED,
+    record_kind,
+    tokenize = 'trigram'
+);
+
+INSERT INTO fts_entities_v23(
+    subject_id,
+    kind,
+    title,
+    body,
+    tags,
+    namespace,
+    metadata,
+    updated_at,
+    record_kind
+)
+SELECT
+    f.subject_id,
+    f.kind,
+    f.title,
+    f.body,
+    f.tags,
+    f.namespace,
+    f.metadata,
+    f.updated_at,
+    coalesce(e.kind, '')
+FROM fts_entities AS f
+LEFT JOIN entities AS e
+    ON e.id = f.subject_id
+   AND e.deleted_at IS NULL;
+
+DROP TABLE fts_entities;
+ALTER TABLE fts_entities_v23 RENAME TO fts_entities;
+
+CREATE VIRTUAL TABLE fts_notes_v23 USING fts5(
+    subject_id UNINDEXED,
+    kind UNINDEXED,
+    title,
+    body,
+    tags UNINDEXED,
+    namespace UNINDEXED,
+    metadata UNINDEXED,
+    updated_at UNINDEXED,
+    record_kind,
+    tokenize = 'trigram'
+);
+
+INSERT INTO fts_notes_v23(
+    subject_id,
+    kind,
+    title,
+    body,
+    tags,
+    namespace,
+    metadata,
+    updated_at,
+    record_kind
+)
+SELECT
+    f.subject_id,
+    f.kind,
+    f.title,
+    f.body,
+    f.tags,
+    f.namespace,
+    f.metadata,
+    f.updated_at,
+    coalesce(n.kind, '')
+FROM fts_notes AS f
+LEFT JOIN notes AS n
+    ON n.id = f.subject_id
+   AND n.deleted_at IS NULL;
+
+DROP TABLE fts_notes;
+ALTER TABLE fts_notes_v23 RENAME TO fts_notes;

--- a/crates/khive-db/src/backend.rs
+++ b/crates/khive-db/src/backend.rs
@@ -802,6 +802,7 @@ impl StorageBackend {
              namespace UNINDEXED, \
              metadata UNINDEXED, \
              updated_at UNINDEXED, \
+             record_kind, \
              tokenize = '{}'\
              )",
             table_key, tokenizer
@@ -1356,6 +1357,7 @@ mod tests {
         let doc = khive_storage::types::TextDocument {
             subject_id: id,
             kind: khive_types::SubstrateKind::Entity,
+            record_kind: None,
             title: Some("Test Title".to_string()),
             body: "This is a searchable document about Rust.".to_string(),
             tags: vec!["rust".to_string()],
@@ -1395,6 +1397,7 @@ mod tests {
         let doc = khive_storage::types::TextDocument {
             subject_id: id,
             kind: khive_types::SubstrateKind::Note,
+            record_kind: None,
             title: None,
             body: "Hello world.".to_string(),
             tags: vec![],
@@ -1534,6 +1537,7 @@ mod tests {
         let doc = TextDocument {
             subject_id: uuid::Uuid::new_v4(),
             kind: SubstrateKind::Entity,
+            record_kind: None,
             title: Some("Title".to_string()),
             body: "Body text.".to_string(),
             tags: vec![],
@@ -1727,6 +1731,7 @@ mod tests {
         let doc = khive_storage::types::TextDocument {
             subject_id: entity_id,
             kind: khive_types::SubstrateKind::Entity,
+            record_kind: None,
             title: Some("Issue1029Repro".to_string()),
             body: "issue 1029 repro body".to_string(),
             tags: vec![],
@@ -1820,6 +1825,7 @@ mod tests {
         let doc = khive_storage::types::TextDocument {
             subject_id: entity_id,
             kind: khive_types::SubstrateKind::Entity,
+            record_kind: None,
             title: Some("Issue1029TwoPools".to_string()),
             body: "issue 1029 two-pool repro body".to_string(),
             tags: vec![],
@@ -1914,6 +1920,7 @@ mod tests {
         let doc = khive_storage::types::TextDocument {
             subject_id: uuid::Uuid::new_v4(),
             kind: khive_types::SubstrateKind::Entity,
+            record_kind: None,
             title: Some("Issue1029Starved".to_string()),
             body: "issue 1029 starvation diagnostic body".to_string(),
             tags: vec![],

--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -146,6 +146,8 @@ const V20_UP: &str = include_str!("../sql/020-blob-gc-claims.sql");
 
 const V22_UP: &str = include_str!("../sql/022-notes-unread-probe-recipient.sql");
 
+const V23_UP: &str = include_str!("../sql/023-fts-record-kind.sql");
+
 const V21_STAGE_UP: &str = include_str!("../sql/021-attachments-a-stage.sql");
 
 const V21_ATTACHMENT_FENCES_UP: &str = include_str!("../sql/021-attachments-b-claim-fences.sql");
@@ -310,6 +312,11 @@ pub const MIGRATIONS: &[VersionedMigration] = &[
         version: 22,
         name: "notes_unread_probe_recipient",
         up: V22_UP,
+    },
+    VersionedMigration {
+        version: 23,
+        name: "fts_record_kind",
+        up: V23_UP,
     },
 ];
 

--- a/crates/khive-db/src/migrations_tests.rs
+++ b/crates/khive-db/src/migrations_tests.rs
@@ -1035,6 +1035,153 @@ fn v22_upgrades_pre_index_database_for_read_only_open() {
     validate_schema_is_current(&read_only).expect("migrated read-only schema validates");
 }
 
+#[test]
+fn v23_backfills_indexed_record_kinds_and_preserves_unmatched_fts_rows() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("pre-record-kind.db");
+
+    {
+        let mut conn = Connection::open(&path).expect("create pre-V23 database");
+        migrate_through(&mut conn, 20);
+        stage_attachment_cutover(&mut conn).expect("stage empty attachment cutover");
+        finalize_attachment_cutover(&mut conn).expect("finalize empty attachment cutover");
+
+        let v22 = MIGRATIONS
+            .iter()
+            .find(|migration| migration.version == 22)
+            .expect("V22 migration");
+        let tx = conn.transaction().expect("begin V22 migration");
+        tx.execute_batch(v22.up).expect("apply V22 migration");
+        tx.execute(
+            "INSERT INTO _schema_migrations (version, name, applied_at) VALUES (?1, ?2, 0)",
+            rusqlite::params![v22.version, v22.name],
+        )
+        .expect("record V22 migration");
+        tx.commit().expect("commit V22 migration");
+        assert_eq!(read_schema_version(&conn).expect("read V22 ledger"), 22);
+        assert!(!column_exists(&conn, "fts_notes", "record_kind"));
+
+        conn.execute(
+            "INSERT INTO notes \
+             (id, namespace, kind, status, content, created_at, updated_at) \
+             VALUES ('memory-id', 'local', 'memory', 'active', 'common recall token', 1, 1)",
+            [],
+        )
+        .expect("insert memory note");
+        conn.execute(
+            "INSERT INTO notes \
+             (id, namespace, kind, status, content, created_at, updated_at) \
+             VALUES ('message-id', 'local', 'message', 'active', 'common recall token', 1, 1)",
+            [],
+        )
+        .expect("insert message note");
+        conn.execute(
+            "INSERT INTO notes \
+             (id, namespace, kind, status, content, created_at, updated_at, deleted_at) \
+             VALUES ('deleted-memory-id', 'local', 'memory', 'deleted', \
+                     'common recall token', 1, 2, 2)",
+            [],
+        )
+        .expect("insert soft-deleted memory note");
+        conn.execute(
+            "INSERT INTO entities \
+             (id, namespace, kind, name, tags, created_at, updated_at) \
+             VALUES ('concept-id', 'local', 'concept', 'Common concept', '[]', 1, 1)",
+            [],
+        )
+        .expect("insert concept entity");
+
+        let insert_legacy_fts = |table: &str, id: &str, body: &str| {
+            conn.execute(
+                &format!(
+                    "INSERT INTO {table} \
+                     (subject_id, kind, title, body, tags, namespace, metadata, updated_at) \
+                     VALUES (?1, ?2, '', ?3, '[]', 'local', NULL, 1)"
+                ),
+                rusqlite::params![
+                    id,
+                    if table == "fts_notes" {
+                        "note"
+                    } else {
+                        "entity"
+                    },
+                    body
+                ],
+            )
+            .expect("insert legacy FTS row");
+        };
+        insert_legacy_fts("fts_notes", "memory-id", "common recall token");
+        insert_legacy_fts("fts_notes", "message-id", "common recall token");
+        insert_legacy_fts("fts_notes", "deleted-memory-id", "common recall token");
+        insert_legacy_fts("fts_notes", "stale-id", "common recall token");
+        insert_legacy_fts("fts_entities", "concept-id", "common concept token");
+
+        assert_eq!(
+            run_migrations(&mut conn).expect("apply V23 record-kind migration"),
+            23
+        );
+        assert!(column_exists(&conn, "fts_notes", "record_kind"));
+        assert!(column_exists(&conn, "fts_entities", "record_kind"));
+
+        let table_sql: String = conn
+            .query_row(
+                "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'fts_notes'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read rebuilt FTS DDL");
+        assert!(table_sql.contains("record_kind"), "{table_sql}");
+        assert!(
+            !table_sql.contains("record_kind UNINDEXED"),
+            "record_kind must participate in the FTS index: {table_sql}"
+        );
+
+        let rows = conn
+            .prepare(
+                "SELECT subject_id, record_kind FROM fts_notes \
+                 ORDER BY subject_id",
+            )
+            .expect("prepare backfill read")
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .expect("query backfilled rows")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("collect backfilled rows");
+        assert_eq!(
+            rows,
+            vec![
+                ("deleted-memory-id".to_string(), String::new()),
+                ("memory-id".to_string(), "memory".to_string()),
+                ("message-id".to_string(), "message".to_string()),
+                ("stale-id".to_string(), String::new()),
+            ],
+            "V23 must preserve every prior FTS row while classifying live records"
+        );
+        let memory_matches: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM fts_notes \
+                 WHERE fts_notes MATCH 'record_kind : \"memory\" AND common'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("query indexed memory classifier");
+        assert_eq!(memory_matches, 1);
+        let entity_kind: String = conn
+            .query_row(
+                "SELECT record_kind FROM fts_entities WHERE subject_id = 'concept-id'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read entity classifier");
+        assert_eq!(entity_kind, "concept");
+    }
+
+    let read_only = Connection::open_with_flags(&path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .expect("open V23 database read-only");
+    validate_schema_is_current(&read_only).expect("V23 read-only schema validates");
+}
+
 // ── V5: external_id unique index tests ──────────────────────────────────────
 
 fn index_exists(conn: &Connection, name: &str) -> bool {

--- a/crates/khive-db/src/stores/text.rs
+++ b/crates/khive-db/src/stores/text.rs
@@ -50,8 +50,8 @@ pub fn insert_document_statement(table: &str, document: &TextDocument) -> SqlSta
     SqlStatement {
         sql: format!(
             "INSERT INTO {table} \
-             (subject_id, kind, title, body, tags, namespace, metadata, updated_at) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)"
+             (subject_id, kind, title, body, tags, namespace, metadata, updated_at, record_kind) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)"
         ),
         params: vec![
             SqlValue::Text(document.subject_id.to_string()),
@@ -65,6 +65,10 @@ pub fn insert_document_statement(table: &str, document: &TextDocument) -> SqlSta
                 None => SqlValue::Null,
             },
             SqlValue::Integer(dt_to_micros(&document.updated_at)),
+            match &document.record_kind {
+                Some(kind) => SqlValue::Text(kind.clone()),
+                None => SqlValue::Null,
+            },
         ],
         label: Some(format!("fts-insert-{table}")),
     }
@@ -88,7 +92,8 @@ pub(crate) fn ensure_fts5_schema(
          tags UNINDEXED, \
          namespace UNINDEXED, \
          metadata UNINDEXED, \
-         updated_at UNINDEXED\
+         updated_at UNINDEXED, \
+         record_kind\
          )",
         table_name
     );
@@ -112,8 +117,9 @@ fn count_fts_pass(context: Option<&UsageContext>) {
 /// A TextSearch backed by SQLite FTS5 virtual tables.
 ///
 /// Each instance manages one table: `fts_{table_key}`. Documents are stored
-/// with their metadata in UNINDEXED columns; only `title` and `body` are
-/// full-text indexed.
+/// with their metadata in UNINDEXED columns. `title`, `body`, and the optional
+/// granular `record_kind` classifier are indexed; corpus filters use the
+/// classifier inside MATCH and retain exact row predicates.
 pub struct Fts5TextSearch {
     pool: Arc<ConnectionPool>,
     is_file_backed: bool,
@@ -594,6 +600,56 @@ fn build_match_expr(query: &str, mode: TextQueryMode) -> Option<String> {
     }
 }
 
+fn quote_fts5_phrase(value: &str) -> String {
+    format!("\"{}\"", value.replace('"', "\"\""))
+}
+
+/// Build an indexed classifier predicate for FTS5's MATCH expression.
+///
+/// The production tokenizer is trigram, so values shorter than three
+/// characters have no postings. In that uncommon case the caller keeps only
+/// the exact row predicate from `build_filter_clause`; correctness is
+/// preserved while the indexed optimization deliberately declines.
+fn record_kind_match_expr(filter: Option<&TextFilter>) -> Option<String> {
+    let record_kinds = &filter?.record_kinds;
+    if record_kinds.is_empty() || record_kinds.iter().any(|kind| kind.chars().count() < 3) {
+        return None;
+    }
+
+    let clauses: Vec<String> = record_kinds
+        .iter()
+        .map(|kind| format!("record_kind : {}", quote_fts5_phrase(kind)))
+        .collect();
+    if clauses.len() == 1 {
+        clauses.into_iter().next()
+    } else {
+        Some(format!("({})", clauses.join(" OR ")))
+    }
+}
+
+fn build_filtered_match_expr(
+    query: &str,
+    mode: TextQueryMode,
+    filter: Option<&TextFilter>,
+) -> Option<String> {
+    // Keep lexical terms confined to the two historically indexed text
+    // columns. Once record_kind became indexed, an unqualified query would
+    // otherwise make `memory` match every memory row solely via its classifier.
+    let query = format!("{{title body}} : ({})", build_match_expr(query, mode)?);
+    match record_kind_match_expr(filter) {
+        Some(classifier) => Some(format!("{classifier} AND ({query})")),
+        None => Some(query),
+    }
+}
+
+/// Custom FTS5 rank configuration that keeps the classifier out of lexical
+/// relevance while retaining the optimized hidden-`rank` ORDER BY path.
+///
+/// `record_kind` participates in MATCH for candidate pruning, but its weight is
+/// zero so the classifier cannot become a relevance signal. Subject metadata
+/// columns were already UNINDEXED; title/body retain their default unit weight.
+const LEXICAL_BM25_RANK: &str = "bm25(0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0)";
+
 /// Build a WHERE clause fragment and params for a `TextFilter`.
 ///
 /// Returns `(clause, params)` where clause is empty if no filters are active.
@@ -640,6 +696,26 @@ fn build_filter_clause(
         conditions.push(format!("{}.kind IN ({})", table, placeholders.join(", ")));
         for kind in &filter.kinds {
             params.push(Box::new(kind.to_string()));
+        }
+    }
+
+    if !filter.record_kinds.is_empty() {
+        let placeholders: Vec<String> = filter
+            .record_kinds
+            .iter()
+            .map(|_| {
+                let p = format!("?{}", idx);
+                idx += 1;
+                p
+            })
+            .collect();
+        conditions.push(format!(
+            "{}.record_kind IN ({})",
+            table,
+            placeholders.join(", ")
+        ));
+        for kind in &filter.record_kinds {
+            params.push(Box::new(kind.clone()));
         }
     }
 
@@ -712,8 +788,8 @@ fn batch_upsert_documents_dml(
     );
     let ins_sql = format!(
         "INSERT INTO {} \
-         (subject_id, kind, title, body, tags, namespace, metadata, updated_at) \
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+         (subject_id, kind, title, body, tags, namespace, metadata, updated_at, record_kind) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
         table
     );
 
@@ -742,6 +818,7 @@ fn batch_upsert_documents_dml(
                     namespace,
                     &metadata_json,
                     dt_to_micros(&doc.updated_at),
+                    &doc.record_kind,
                 ],
             )?;
             Ok::<(), rusqlite::Error>(())
@@ -885,7 +962,7 @@ impl TextSearch for Fts5TextSearch {
 
         self.with_reader("fts_get", move |conn| {
             let sql = format!(
-                "SELECT subject_id, kind, title, body, tags, namespace, metadata, updated_at \
+                "SELECT subject_id, kind, title, body, tags, namespace, metadata, updated_at, record_kind \
                  FROM {} WHERE namespace = ?1 AND subject_id = ?2",
                 table
             );
@@ -902,6 +979,7 @@ impl TextSearch for Fts5TextSearch {
                     let ns: String = row.get(5)?;
                     let metadata_json: Option<String> = row.get(6)?;
                     let updated_at_micros: i64 = row.get(7)?;
+                    let record_kind: Option<String> = row.get(8)?;
 
                     let sid = Uuid::parse_str(&id_str).map_err(|e| {
                         rusqlite::Error::FromSqlConversionFailure(
@@ -922,6 +1000,7 @@ impl TextSearch for Fts5TextSearch {
                     Ok(Some(TextDocument {
                         subject_id: sid,
                         kind,
+                        record_kind,
                         title: if title.is_empty() { None } else { Some(title) },
                         body,
                         tags: tags_from_json(&tags_json),
@@ -942,7 +1021,11 @@ impl TextSearch for Fts5TextSearch {
 
         let result = self
             .with_reader("fts_search", move |conn| {
-                let match_expr = match build_match_expr(&request.query, request.mode) {
+                let match_expr = match build_filtered_match_expr(
+                    &request.query,
+                    request.mode,
+                    request.filter.as_ref(),
+                ) {
                     Some(expr) => expr,
                     None => return Ok(Vec::new()),
                 };
@@ -968,7 +1051,8 @@ impl TextSearch for Fts5TextSearch {
 
                 let sql = format!(
                     "SELECT subject_id, rank, title, {snippet_expr} \
-                     FROM {table} WHERE {table} MATCH ?1{filter_clause} \
+                     FROM {table} WHERE {table} MATCH ?1 \
+                     AND rank MATCH '{LEXICAL_BM25_RANK}'{filter_clause} \
                      ORDER BY rank LIMIT ?2",
                 );
 
@@ -1042,21 +1126,29 @@ impl TextSearch for Fts5TextSearch {
         let table = self.table_name.clone();
 
         self.with_reader("fts_count", move |conn| {
-            let (filter_clause, filter_params) = build_filter_clause(&filter, &table, 1);
+            let indexed_classifier = record_kind_match_expr(Some(&filter));
+            let filter_start = if indexed_classifier.is_some() { 2 } else { 1 };
+            let (filter_clause, filter_params) = build_filter_clause(&filter, &table, filter_start);
 
-            let sql = if filter_clause.is_empty() {
-                format!("SELECT COUNT(*) FROM {}", table)
+            let sql = if indexed_classifier.is_some() {
+                format!("SELECT COUNT(*) FROM {table} WHERE {table} MATCH ?1{filter_clause}")
+            } else if filter_clause.is_empty() {
+                format!("SELECT COUNT(*) FROM {table}")
             } else {
                 let where_part = filter_clause.trim_start_matches(" AND ");
-                format!("SELECT COUNT(*) FROM {} WHERE {}", table, where_part)
+                format!("SELECT COUNT(*) FROM {table} WHERE {where_part}")
             };
 
             let mut stmt = conn.prepare(&sql)?;
 
+            if let Some(classifier) = indexed_classifier {
+                stmt.raw_bind_parameter(1, classifier)?;
+            }
+
             for (i, param) in filter_params.iter().enumerate() {
                 param
                     .to_sql()
-                    .map(|val| stmt.raw_bind_parameter(1 + i, val))
+                    .map(|val| stmt.raw_bind_parameter(filter_start + i, val))
                     .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))??;
             }
 
@@ -1114,26 +1206,35 @@ impl TextSearch for Fts5TextSearch {
 
         self.with_reader("fts_term_stats", move |conn| {
             let filter = request.filter.as_ref();
+            let indexed_classifier = record_kind_match_expr(filter);
 
-            // Document count uses params starting at ?1 (no MATCH expression).
+            let count_filter_start = if indexed_classifier.is_some() { 2 } else { 1 };
             let (count_filter_clause, count_filter_params) = if let Some(f) = filter {
-                build_filter_clause(f, &table, 1)
+                build_filter_clause(f, &table, count_filter_start)
             } else {
                 (String::new(), Vec::new())
             };
 
             let document_count: u64 = {
-                let count_sql = if count_filter_clause.is_empty() {
+                let count_sql = if indexed_classifier.is_some() {
+                    format!(
+                        "SELECT COUNT(*) FROM {table} \
+                         WHERE {table} MATCH ?1{count_filter_clause}"
+                    )
+                } else if count_filter_clause.is_empty() {
                     format!("SELECT COUNT(*) FROM {table}")
                 } else {
                     let where_part = count_filter_clause.trim_start_matches(" AND ");
                     format!("SELECT COUNT(*) FROM {table} WHERE {where_part}")
                 };
                 let mut stmt = conn.prepare(&count_sql)?;
+                if let Some(ref classifier) = indexed_classifier {
+                    stmt.raw_bind_parameter(1, classifier)?;
+                }
                 for (i, param) in count_filter_params.iter().enumerate() {
                     param
                         .to_sql()
-                        .map(|val| stmt.raw_bind_parameter(1 + i, val))
+                        .map(|val| stmt.raw_bind_parameter(count_filter_start + i, val))
                         .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))??;
                 }
                 let mut rows = stmt.raw_query();
@@ -1168,11 +1269,16 @@ impl TextSearch for Fts5TextSearch {
                     (String::new(), Vec::new())
                 };
 
+                let text_term = format!("{{title body}} : ({sanitized})");
+                let term_match = match &indexed_classifier {
+                    Some(classifier) => format!("{classifier} AND ({text_term})"),
+                    None => text_term,
+                };
                 let count_sql = format!(
                     "SELECT COUNT(*) FROM {table} WHERE {table} MATCH ?1{term_filter_clause}"
                 );
                 let mut stmt = conn.prepare(&count_sql)?;
-                stmt.raw_bind_parameter(1, &sanitized)?;
+                stmt.raw_bind_parameter(1, &term_match)?;
                 for (i, param) in term_filter_params.iter().enumerate() {
                     param
                         .to_sql()
@@ -1244,7 +1350,11 @@ impl Fts5TextSearch {
         let usage = khive_storage::usage::current();
 
         self.with_reader("fts_search_unranked", move |conn| {
-            let match_expr = match build_match_expr(&request.query, request.mode) {
+            let match_expr = match build_filtered_match_expr(
+                &request.query,
+                request.mode,
+                request.filter.as_ref(),
+            ) {
                 Some(expr) => expr,
                 None => return Ok(Vec::new()),
             };
@@ -1315,7 +1425,11 @@ impl Fts5TextSearch {
         let usage = khive_storage::usage::current();
 
         self.with_reader("fts_search_rank_within_cap", move |conn| {
-            let match_expr = match build_match_expr(&request.query, request.mode) {
+            let match_expr = match build_filtered_match_expr(
+                &request.query,
+                request.mode,
+                request.filter.as_ref(),
+            ) {
                 Some(expr) => expr,
                 None => return Ok(Vec::new()),
             };
@@ -1370,8 +1484,10 @@ impl Fts5TextSearch {
 
             let rank_sql = format!(
                 "SELECT subject_id, rank, title, {snippet_expr} \
-                 FROM {table} WHERE {table} MATCH ?1 AND subject_id IN ({in_clause}) \
-                 ORDER BY rank LIMIT ?2"
+                 FROM {table} WHERE {table} MATCH ?1 \
+                 AND rank MATCH '{LEXICAL_BM25_RANK}' \
+                 AND subject_id IN ({in_clause}) \
+                 ORDER BY rank LIMIT ?2",
             );
 
             let mut stmt2 = conn.prepare(&rank_sql)?;
@@ -1509,6 +1625,7 @@ struct FtsRenameRow {
     tags: String,
     metadata: Option<String>,
     updated_at: i64,
+    record_kind: Option<String>,
 }
 
 /// Move every FTS5 document row from `old_ns` to `new_ns` in `table`.
@@ -1525,7 +1642,7 @@ fn rename_namespace_dml(
     new_ns: &str,
 ) -> Result<u64, rusqlite::Error> {
     let sel_sql = format!(
-        "SELECT subject_id, kind, title, body, tags, metadata, updated_at \
+        "SELECT subject_id, kind, title, body, tags, metadata, updated_at, record_kind \
          FROM {} WHERE namespace = ?1",
         table
     );
@@ -1540,6 +1657,7 @@ fn rename_namespace_dml(
                 tags: row.get(4)?,
                 metadata: row.get(5)?,
                 updated_at: row.get(6)?,
+                record_kind: row.get(7)?,
             })
         })?;
         iter.collect::<Result<Vec<_>, _>>()?
@@ -1554,8 +1672,8 @@ fn rename_namespace_dml(
 
     let ins_sql = format!(
         "INSERT INTO {} \
-         (subject_id, kind, title, body, tags, namespace, metadata, updated_at) \
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+         (subject_id, kind, title, body, tags, namespace, metadata, updated_at, record_kind) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
         table
     );
     for row in &rows {
@@ -1570,6 +1688,7 @@ fn rename_namespace_dml(
                 new_ns,
                 row.metadata,
                 row.updated_at,
+                row.record_kind,
             ],
         )?;
     }

--- a/crates/khive-db/src/stores/text_tests.rs
+++ b/crates/khive-db/src/stores/text_tests.rs
@@ -44,6 +44,7 @@ fn setup_trigram_store(table_key: &str) -> Fts5TextSearch {
              namespace UNINDEXED, \
              metadata UNINDEXED, \
              updated_at UNINDEXED, \
+             record_kind, \
              tokenize = 'trigram'\
              )",
             table_name
@@ -58,6 +59,7 @@ fn make_document(subject_id: Uuid, title: &str, body: &str) -> TextDocument {
     TextDocument {
         subject_id,
         kind: SubstrateKind::Note,
+        record_kind: None,
         title: if title.is_empty() {
             None
         } else {
@@ -68,6 +70,18 @@ fn make_document(subject_id: Uuid, title: &str, body: &str) -> TextDocument {
         namespace: "test_ns".to_string(),
         metadata: None,
         updated_at: Utc::now(),
+    }
+}
+
+fn make_record_kind_document(
+    subject_id: Uuid,
+    record_kind: &str,
+    title: &str,
+    body: &str,
+) -> TextDocument {
+    TextDocument {
+        record_kind: Some(record_kind.to_string()),
+        ..make_document(subject_id, title, body)
     }
 }
 
@@ -86,6 +100,7 @@ async fn test_upsert_and_search() {
     let doc = TextDocument {
         subject_id: id,
         kind: SubstrateKind::Entity,
+        record_kind: None,
         title: Some("Rust Programming".to_string()),
         body: "Rust is a systems programming language focused on safety and performance."
             .to_string(),
@@ -217,6 +232,7 @@ async fn test_count_with_filter() {
         let doc = TextDocument {
             subject_id: Uuid::new_v4(),
             kind,
+            record_kind: None,
             title: Some(format!("Doc {}", i)),
             body: format!("Content for document number {}", i),
             tags: vec![],
@@ -265,6 +281,7 @@ async fn test_get_document_roundtrip() {
     let original = TextDocument {
         subject_id: id,
         kind: SubstrateKind::Note,
+        record_kind: Some("memory".to_string()),
         title: Some("Important Memo".to_string()),
         body: "This memo contains critical information.".to_string(),
         tags: vec!["important".to_string(), "memo".to_string()],
@@ -278,6 +295,7 @@ async fn test_get_document_roundtrip() {
     let retrieved = store.get_document("work", id).await.unwrap().unwrap();
     assert_eq!(retrieved.subject_id, id);
     assert_eq!(retrieved.kind, SubstrateKind::Note);
+    assert_eq!(retrieved.record_kind.as_deref(), Some("memory"));
     assert_eq!(retrieved.title, Some("Important Memo".to_string()));
     assert_eq!(retrieved.body, "This memo contains critical information.");
     assert_eq!(retrieved.tags, vec!["important", "memo"]);
@@ -315,6 +333,7 @@ async fn test_batch_upsert() {
         .map(|i| TextDocument {
             subject_id: Uuid::new_v4(),
             kind: SubstrateKind::Entity,
+            record_kind: None,
             title: Some(format!("Item {}", i)),
             body: format!("This is the body content for item number {}", i),
             tags: vec![format!("tag_{}", i % 5)],
@@ -381,6 +400,7 @@ async fn test_search_with_kind_filter() {
         .upsert_document(TextDocument {
             subject_id: id_entity,
             kind: SubstrateKind::Entity,
+            record_kind: None,
             title: Some("Rust Guide".to_string()),
             body: "A comprehensive guide to Rust programming.".to_string(),
             tags: vec![],
@@ -395,6 +415,7 @@ async fn test_search_with_kind_filter() {
         .upsert_document(TextDocument {
             subject_id: id_note,
             kind: SubstrateKind::Note,
+            record_kind: None,
             title: Some("Rust Notes".to_string()),
             body: "Quick notes about Rust concepts.".to_string(),
             tags: vec![],
@@ -422,6 +443,154 @@ async fn test_search_with_kind_filter() {
 
     assert_eq!(hits.len(), 1);
     assert_eq!(hits[0].subject_id, id_entity);
+}
+
+#[tokio::test]
+async fn record_kind_filter_preserves_results_and_scopes_every_gather_mode() {
+    let store = setup_trigram_store("record_kind_gather_modes");
+    let memory_ids = [Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4()];
+    for id in memory_ids {
+        store
+            .upsert_document(make_record_kind_document(
+                id,
+                "memory",
+                "recall fixture",
+                "zircon recall evidence",
+            ))
+            .await
+            .unwrap();
+    }
+
+    let request = |record_kinds: Vec<String>| TextSearchRequest {
+        query: "zircon".to_string(),
+        mode: TextQueryMode::Plain,
+        filter: Some(TextFilter {
+            namespaces: vec!["test_ns".to_string()],
+            record_kinds,
+            ..TextFilter::default()
+        }),
+        top_k: 10,
+        snippet_chars: 0,
+    };
+    let before_noise = store.search(request(Vec::new())).await.unwrap();
+    assert_eq!(before_noise.len(), memory_ids.len());
+    let mut classifier_only_query = request(Vec::new());
+    classifier_only_query.query = "memory".to_string();
+    assert!(
+        store
+            .search(classifier_only_query)
+            .await
+            .unwrap()
+            .is_empty(),
+        "an unscoped lexical query must not match indexed classifier text"
+    );
+
+    for i in 0..100 {
+        store
+            .upsert_document(make_record_kind_document(
+                Uuid::new_v4(),
+                "message",
+                &format!("unrelated {i}"),
+                "zircon recall evidence",
+            ))
+            .await
+            .unwrap();
+    }
+
+    let ranked = store
+        .search(request(vec!["memory".to_string()]))
+        .await
+        .unwrap();
+    assert_eq!(
+        ranked.iter().map(|hit| hit.subject_id).collect::<Vec<_>>(),
+        before_noise
+            .iter()
+            .map(|hit| hit.subject_id)
+            .collect::<Vec<_>>(),
+        "indexed corpus scoping must preserve the memory-only result set and order"
+    );
+
+    for options in [
+        TextSearchOptions {
+            gather_mode: khive_storage::types::TextGatherMode::Unranked,
+            gather_limit: None,
+        },
+        TextSearchOptions {
+            gather_mode: khive_storage::types::TextGatherMode::RankWithinCap,
+            gather_limit: Some(20),
+        },
+    ] {
+        let hits = store
+            .search_with_options(request(vec!["memory".to_string()]), options)
+            .await
+            .unwrap();
+        assert_eq!(hits.len(), memory_ids.len());
+        assert!(
+            hits.iter().all(|hit| memory_ids.contains(&hit.subject_id)),
+            "every gather mode must honor the indexed record-kind corpus"
+        );
+    }
+}
+
+#[tokio::test]
+async fn record_kind_filter_scopes_count_term_stats_and_short_kind_fallback() {
+    let store = setup_trigram_store("record_kind_counts");
+    for (record_kind, body) in [
+        ("memory", "common rare recall"),
+        ("memory", "common recall"),
+        ("message", "common rare message"),
+        ("message", "common rare message"),
+        ("ai", "common rare short classifier"),
+    ] {
+        store
+            .upsert_document(make_record_kind_document(
+                Uuid::new_v4(),
+                record_kind,
+                "fixture",
+                body,
+            ))
+            .await
+            .unwrap();
+    }
+
+    let memory_filter = TextFilter {
+        namespaces: vec!["test_ns".to_string()],
+        record_kinds: vec!["memory".to_string()],
+        ..TextFilter::default()
+    };
+    assert_eq!(store.count(memory_filter.clone()).await.unwrap(), 2);
+    let stats = store
+        .term_stats(TextTermStatsRequest {
+            terms: vec!["common".to_string(), "rare".to_string()],
+            filter: Some(memory_filter),
+        })
+        .await
+        .unwrap();
+    let common = stats.iter().find(|stat| stat.term == "common").unwrap();
+    let rare = stats.iter().find(|stat| stat.term == "rare").unwrap();
+    assert_eq!(common.document_count, 2);
+    assert_eq!(common.document_frequency, 2);
+    assert_eq!(rare.document_frequency, 1);
+
+    let short_kind_hits = store
+        .search(TextSearchRequest {
+            query: "common".to_string(),
+            mode: TextQueryMode::Plain,
+            filter: Some(TextFilter {
+                namespaces: vec!["test_ns".to_string()],
+                record_kinds: vec!["ai".to_string()],
+                ..TextFilter::default()
+            }),
+            top_k: 10,
+            snippet_chars: 0,
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        short_kind_hits.len(),
+        1,
+        "a classifier too short for trigram postings must retain exact-filter correctness"
+    );
 }
 
 #[tokio::test]
@@ -1570,6 +1739,7 @@ async fn test_rename_namespace() {
     let doc = TextDocument {
         subject_id: id,
         kind: SubstrateKind::Note,
+        record_kind: None,
         title: Some("Rename test".to_string()),
         body: "keyword_unique_xyz".to_string(),
         tags: vec![],
@@ -1626,6 +1796,7 @@ async fn test_metadata_none_roundtrip() {
     let doc = TextDocument {
         subject_id: id,
         kind: SubstrateKind::Note,
+        record_kind: None,
         namespace: "test_ns".to_string(),
         title: None,
         body: "no metadata".to_string(),
@@ -1646,6 +1817,7 @@ async fn test_rename_namespace_noop() {
     let doc = TextDocument {
         subject_id: id,
         kind: SubstrateKind::Note,
+        record_kind: None,
         title: None,
         body: "noop_test_content".to_string(),
         tags: vec![],
@@ -2774,4 +2946,120 @@ fn general_write_routes_through_writer_task_when_store_built_outside_runtime() {
             .expect("write task must not panic")
             .expect("upsert_document must succeed once unblocked");
     });
+}
+
+/// #1907: memory recall's lexical work must scale with the memory corpus, not
+/// with unrelated notes that happen to match the same common query term.
+#[test]
+fn memory_kind_match_work_is_bounded_by_memory_corpus() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use rusqlite::functions::FunctionFlags;
+
+    fn measure(noise_rows: usize) -> (usize, usize, String) {
+        let conn = rusqlite::Connection::open_in_memory().expect("in-memory SQLite");
+        conn.execute_batch(
+            "CREATE VIRTUAL TABLE fts_notes USING fts5(\
+             subject_id UNINDEXED, \
+             kind UNINDEXED, \
+             title, \
+             body, \
+             tags UNINDEXED, \
+             namespace UNINDEXED, \
+             metadata UNINDEXED, \
+             updated_at UNINDEXED, \
+             record_kind, \
+             tokenize = 'trigram'\
+             )",
+        )
+        .expect("production-shaped trigram table");
+
+        conn.execute_batch("BEGIN").expect("begin seed");
+        {
+            let mut insert = conn
+                .prepare(
+                    "INSERT INTO fts_notes \
+                    (subject_id, kind, title, body, tags, namespace, metadata, updated_at, record_kind) \
+                     VALUES (?1, 'note', '', 'common recall token', '[]', 'local', NULL, 0, ?2)",
+                )
+                .expect("prepare seed insert");
+            for i in 0..noise_rows {
+                insert
+                    .execute(rusqlite::params![format!("noise-{i}"), "message"])
+                    .expect("insert non-memory note");
+            }
+            for i in 0..50 {
+                insert
+                    .execute(rusqlite::params![format!("memory-{i}"), "memory"])
+                    .expect("insert memory note");
+            }
+        }
+        conn.execute_batch("COMMIT").expect("commit seed");
+
+        let visits = std::sync::Arc::new(AtomicUsize::new(0));
+        let visits_for_fn = std::sync::Arc::clone(&visits);
+        conn.create_scalar_function(
+            "visit_memory_kind",
+            1,
+            FunctionFlags::SQLITE_UTF8,
+            move |ctx| {
+                visits_for_fn.fetch_add(1, Ordering::Relaxed);
+                Ok(i64::from(ctx.get::<String>(0)? == "memory"))
+            },
+        )
+        .expect("register visit counter");
+
+        let filter = TextFilter {
+            record_kinds: vec!["memory".to_string()],
+            ..TextFilter::default()
+        };
+        let match_expr = build_filtered_match_expr("common", TextQueryMode::Plain, Some(&filter))
+            .expect("filtered MATCH expression");
+        assert!(
+            match_expr.contains("record_kind : \"memory\""),
+            "granular kind must be part of MATCH, got {match_expr:?}"
+        );
+        let sql = format!(
+            "SELECT subject_id FROM fts_notes \
+             WHERE fts_notes MATCH ?1 \
+             AND rank MATCH '{LEXICAL_BM25_RANK}' \
+             AND visit_memory_kind(record_kind) = 1 \
+             ORDER BY rank LIMIT 20"
+        );
+        let plan = conn
+            .prepare(&format!("EXPLAIN QUERY PLAN {sql}"))
+            .expect("prepare explain")
+            .query_map([&match_expr], |row| row.get::<_, String>(3))
+            .expect("query explain")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("collect explain")
+            .join("\n");
+        let hits = conn
+            .prepare(&sql)
+            .expect("prepare measured query")
+            .query_map([&match_expr], |row| row.get::<_, String>(0))
+            .expect("run measured query")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("collect measured hits");
+
+        (hits.len(), visits.load(Ordering::Relaxed), plan)
+    }
+
+    let (small_hits, small_visits, small_plan) = measure(200);
+    let (large_hits, large_visits, large_plan) = measure(2_000);
+    assert_eq!(small_hits, 20);
+    assert_eq!(large_hits, 20);
+    assert_eq!(
+        small_visits, 20,
+        "only the requested memory top-K is visited"
+    );
+    assert_eq!(large_visits, 20, "unrelated notes must add no visits");
+    assert!(small_plan.contains("VIRTUAL TABLE"), "{small_plan}");
+    assert!(large_plan.contains("VIRTUAL TABLE"), "{large_plan}");
+    assert!(
+        large_visits < small_visits.saturating_mul(3),
+        "memory query scanned the unrelated note corpus: {small_visits} candidate visits \
+         with 200 noise rows versus {large_visits} with 2,000 noise rows\n\
+         small plan:\n{small_plan}\nlarge plan:\n{large_plan}"
+    );
 }

--- a/crates/khive-db/tests/contract/backend.rs
+++ b/crates/khive-db/tests/contract/backend.rs
@@ -308,6 +308,7 @@ async fn test_text_search(backend: &StorageBackend) {
     let doc = TextDocument {
         subject_id: id,
         kind: SubstrateKind::Entity,
+        record_kind: None,
         title: Some("Rust Programming".to_string()),
         body: "The Rust language provides memory safety without GC.".to_string(),
         tags: vec!["rust".to_string()],

--- a/crates/khive-db/tests/writer_timeout_sink.rs
+++ b/crates/khive-db/tests/writer_timeout_sink.rs
@@ -524,6 +524,7 @@ async fn text_busy_standalone_writer_emits_ndjson_row() {
     let doc = TextDocument {
         subject_id: Uuid::new_v4(),
         kind: SubstrateKind::Entity,
+        record_kind: None,
         title: Some("t".to_string()),
         body: "body".to_string(),
         tags: vec![],

--- a/crates/khive-pack-memory/benches/fts_gather.rs
+++ b/crates/khive-pack-memory/benches/fts_gather.rs
@@ -190,6 +190,7 @@ fn note_filter() -> TextFilter {
     TextFilter {
         namespaces: vec![NS.to_string()],
         kinds: vec![SubstrateKind::Note],
+        record_kinds: vec!["memory".to_string()],
         ..TextFilter::default()
     }
 }
@@ -358,6 +359,7 @@ async fn main() {
         docs.push(TextDocument {
             subject_id: id,
             kind: SubstrateKind::Note,
+            record_kind: Some(row.kind.clone()),
             title: (!row.title.is_empty()).then_some(row.title),
             body: row.body,
             tags: vec![],

--- a/crates/khive-pack-memory/docs/api/text-retrieval.md
+++ b/crates/khive-pack-memory/docs/api/text-retrieval.md
@@ -28,6 +28,14 @@ Missing statistics remain eligible but sort behind measured selective terms. The
 
 CJK queries can bypass statistical selection because whitespace term boundaries are not a reliable segmentation mechanism. The storage query always retains the memory kind and namespace constraints. `Ranked` returns the legacy top-ranked rows; rank-within-cap mode first bounds the match set, then ranks within that cap.
 
+The memory-kind constraint is part of candidate retrieval, not a filter after
+the shared note MATCH. SQLite FTS stores the granular note kind in its indexed
+`record_kind` column and intersects `record_kind : "memory"` with the query
+postings before ranking. It also retains an exact `record_kind = "memory"` row
+predicate as a trigram-tokenizer correctness backstop. The same corpus scope is
+used for term statistics, so document frequency and IDF describe memories
+rather than all notes.
+
 ## Query embedding cache
 
 `QueryEmbeddingCache` is a thread-safe LRU local to the pack. The key is the model name plus exact query text, so embeddings cannot cross model spaces. Capacity is non-zero and defaults to 512 entries. Reads update recency; insertion replaces an existing key and evicts the least-recently-used entry when necessary.

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -821,6 +821,7 @@ impl MemoryPack {
                     filter: Some(TextFilter {
                         namespaces: namespaces.to_vec(),
                         kinds: vec![SubstrateKind::Note],
+                        record_kinds: vec!["memory".to_string()],
                         ..TextFilter::default()
                     }),
                     top_k: candidate_limit,

--- a/crates/khive-pack-memory/src/text_gather.rs
+++ b/crates/khive-pack-memory/src/text_gather.rs
@@ -89,6 +89,7 @@ pub async fn collect_text_hits(
     let filter = Some(TextFilter {
         namespaces: namespaces.to_vec(),
         kinds: vec![SubstrateKind::Note],
+        record_kinds: vec!["memory".to_string()],
         ..TextFilter::default()
     });
 
@@ -128,6 +129,7 @@ pub async fn collect_text_hits(
                 filter: Some(TextFilter {
                     namespaces: namespaces.to_vec(),
                     kinds: vec![SubstrateKind::Note],
+                    record_kinds: vec!["memory".to_string()],
                     ..TextFilter::default()
                 }),
             })
@@ -289,6 +291,7 @@ mod collect_text_hits_tests {
         let doc = TextDocument {
             subject_id: id,
             kind: SubstrateKind::Note,
+            record_kind: Some("memory".to_string()),
             title: None,
             body: body.to_string(),
             tags: vec![],
@@ -317,6 +320,7 @@ mod collect_text_hits_tests {
             .upsert_document(TextDocument {
                 subject_id: fixture_id,
                 kind: SubstrateKind::Note,
+                record_kind: Some("memory".to_string()),
                 title: None,
                 body: "quantum_xqzzy_unique signal_phrase_fixture relevant_term".to_string(),
                 tags: vec![],
@@ -432,6 +436,7 @@ mod collect_text_hits_tests {
             .upsert_document(TextDocument {
                 subject_id: rare_id,
                 kind: SubstrateKind::Note,
+                record_kind: Some("memory".to_string()),
                 title: None,
                 body: "rare_xqzzy_token common_word_term context".to_string(),
                 tags: vec![],
@@ -539,6 +544,7 @@ mod collect_text_hits_tests {
             .upsert_document(TextDocument {
                 subject_id: cjk_id,
                 kind: SubstrateKind::Note,
+                record_kind: Some("memory".to_string()),
                 title: None,
                 body: "这是一个中文注释关于机器学习的内容".to_string(),
                 tags: vec![],
@@ -593,6 +599,7 @@ mod collect_text_hits_tests {
             .upsert_document(TextDocument {
                 subject_id: id1,
                 kind: SubstrateKind::Note,
+                record_kind: Some("memory".to_string()),
                 title: None,
                 body: "alpha_tok beta_tok primary content".to_string(),
                 tags: vec![],
@@ -606,6 +613,7 @@ mod collect_text_hits_tests {
             .upsert_document(TextDocument {
                 subject_id: id2,
                 kind: SubstrateKind::Note,
+                record_kind: Some("memory".to_string()),
                 title: None,
                 body: "alpha_tok secondary content".to_string(),
                 tags: vec![],

--- a/crates/khive-retrieval/src/adapters/storage.rs
+++ b/crates/khive-retrieval/src/adapters/storage.rs
@@ -300,6 +300,7 @@ mod tests {
             .upsert_document(TextDocument {
                 subject_id: id1,
                 kind: SubstrateKind::Entity,
+                record_kind: None,
                 namespace: "test".to_string(),
                 title: Some("Rust Programming".to_string()),
                 body: "Rust is a systems programming language.".to_string(),
@@ -314,6 +315,7 @@ mod tests {
             .upsert_document(TextDocument {
                 subject_id: id2,
                 kind: SubstrateKind::Entity,
+                record_kind: None,
                 namespace: "test".to_string(),
                 title: Some("Python Guide".to_string()),
                 body: "Python is a high-level programming language.".to_string(),
@@ -345,6 +347,7 @@ mod tests {
                 .upsert_document(TextDocument {
                     subject_id: Uuid::new_v4(),
                     kind: SubstrateKind::Note,
+                    record_kind: None,
                     namespace: "test".to_string(),
                     title: Some(format!("Doc {}", i)),
                     body: format!("Programming topic number {}.", i),
@@ -382,6 +385,7 @@ mod tests {
             .upsert_document(TextDocument {
                 subject_id: Uuid::new_v4(),
                 kind: SubstrateKind::Entity,
+                record_kind: None,
                 namespace: "test".to_string(),
                 title: Some("Alpha".to_string()),
                 body: "Alpha article content.".to_string(),
@@ -518,6 +522,7 @@ mod tests {
             .upsert_document(TextDocument {
                 subject_id: id,
                 kind: SubstrateKind::Note,
+                record_kind: None,
                 namespace: "test".to_string(),
                 title: Some("Test".to_string()),
                 body: "Test document for fusion.".to_string(),

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -2219,6 +2219,7 @@ pub fn entity_fts_document(entity: &Entity) -> TextDocument {
     TextDocument {
         subject_id: entity.id,
         kind: SubstrateKind::Entity,
+        record_kind: Some(entity.kind.clone()),
         title: Some(entity.name.clone()),
         body: entity_embedding_text(entity),
         tags: entity.tags.clone(),
@@ -2250,6 +2251,7 @@ pub fn note_fts_document(note: &Note) -> TextDocument {
     TextDocument {
         subject_id: note.id,
         kind: SubstrateKind::Note,
+        record_kind: Some(note.kind.clone()),
         title: note.name.clone(),
         body,
         tags: vec![],
@@ -2265,6 +2267,8 @@ pub fn note_fts_document(note: &Note) -> TextDocument {
 /// exactly what [`Fts5TextSearch::upsert_document`] would write, preventing
 /// null/empty-string divergence on the `title` column for nameless notes.
 pub(crate) struct NoteFtsScalars {
+    /// Granular note kind used by the indexed corpus classifier.
+    pub record_kind: String,
     /// Empty string when `note.name` is `None` — matches the `unwrap_or("")` in
     /// `Fts5TextSearch::upsert_document`.
     pub title: String,
@@ -2284,6 +2288,7 @@ pub(crate) struct NoteFtsScalars {
 pub(crate) fn note_fts_scalars(note: &Note) -> NoteFtsScalars {
     let doc = note_fts_document(note);
     NoteFtsScalars {
+        record_kind: doc.record_kind.unwrap_or_default(),
         title: doc.title.unwrap_or_default(),
         body: doc.body,
         tags: "[]".to_string(),
@@ -2818,8 +2823,8 @@ fn merge_entity_sql(
         conn.execute(
             &format!(
                 "INSERT INTO {} \
-                 (subject_id, kind, title, body, tags, namespace, metadata, updated_at) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                (subject_id, kind, title, body, tags, namespace, metadata, updated_at, record_kind) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
                 fts_table
             ),
             rusqlite::params![
@@ -2831,6 +2836,7 @@ fn merge_entity_sql(
                 &namespace,
                 &props_str,
                 now,
+                &into_entity.kind,
             ],
         )?;
 
@@ -3432,8 +3438,8 @@ fn merge_note_sql(
         conn.execute(
             &format!(
                 "INSERT INTO {} \
-                 (subject_id, kind, title, body, tags, namespace, metadata, updated_at) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                (subject_id, kind, title, body, tags, namespace, metadata, updated_at, record_kind) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
                 fts_table
             ),
             rusqlite::params![
@@ -3445,6 +3451,7 @@ fn merge_note_sql(
                 &namespace,
                 &fts_merged.metadata,
                 fts_merged.updated_at_micros,
+                &fts_merged.record_kind,
             ],
         )?;
 

--- a/crates/khive-runtime/src/fusion.rs
+++ b/crates/khive-runtime/src/fusion.rs
@@ -391,6 +391,7 @@ mod tests {
         let document = |subject_id, repetitions: usize| TextDocument {
             subject_id,
             kind: SubstrateKind::Entity,
+            record_kind: None,
             namespace: "local".to_string(),
             title: None,
             body: std::iter::repeat_n(query_text, repetitions)

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -13409,6 +13409,7 @@ mod tests {
             .count(TextFilter {
                 ids: vec![],
                 kinds: vec![],
+                record_kinds: vec![],
                 namespaces: vec![ns.clone()],
             })
             .await
@@ -13522,6 +13523,7 @@ mod tests {
             .count(TextFilter {
                 ids: vec![],
                 kinds: vec![],
+                record_kinds: vec![],
                 namespaces: vec![ns.clone()],
             })
             .await

--- a/crates/khive-storage/src/types/text.rs
+++ b/crates/khive-storage/src/types/text.rs
@@ -61,6 +61,13 @@ pub struct TextTermStats {
 pub struct TextDocument {
     pub subject_id: Uuid,
     pub kind: SubstrateKind,
+    /// Granular kind of the indexed record (`memory`, `task`, `concept`, ...).
+    ///
+    /// This is distinct from [`Self::kind`], which identifies only the
+    /// substrate. Backends may index this classifier so corpus-scoped searches
+    /// can prune before ranking instead of filtering a shared posting list.
+    #[serde(default)]
+    pub record_kind: Option<String>,
     pub namespace: String,
     pub title: Option<String>,
     pub body: String,
@@ -74,6 +81,11 @@ pub struct TextDocument {
 pub struct TextFilter {
     pub ids: Vec<Uuid>,
     pub kinds: Vec<SubstrateKind>,
+    /// Exact granular record kinds. Backends with an indexed classifier push
+    /// this restriction into candidate retrieval and retain an exact row
+    /// predicate as the correctness backstop.
+    #[serde(default)]
+    pub record_kinds: Vec<String>,
     pub namespaces: Vec<String>,
 }
 

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -2317,6 +2317,7 @@ mod tests {
         let before = fts
             .count(TextFilter {
                 kinds: vec![SubstrateKind::Note],
+                record_kinds: vec![],
                 namespaces: vec!["local".to_string()],
                 ids: vec![],
             })
@@ -2332,6 +2333,7 @@ mod tests {
         let after = fts
             .count(TextFilter {
                 kinds: vec![SubstrateKind::Note],
+                record_kinds: vec![],
                 namespaces: vec!["local".to_string()],
                 ids: vec![],
             })
@@ -2491,6 +2493,7 @@ mod tests {
         let count = fts
             .count(TextFilter {
                 kinds: vec![SubstrateKind::Note],
+                record_kinds: vec![],
                 namespaces: vec!["local".to_string()],
                 ids: vec![],
             })
@@ -2541,6 +2544,7 @@ mod tests {
         let count = fts
             .count(TextFilter {
                 kinds: vec![SubstrateKind::Note],
+                record_kinds: vec![],
                 namespaces: vec!["local".to_string()],
                 ids: vec![],
             })
@@ -2583,6 +2587,7 @@ mod tests {
         let count = fts
             .count(TextFilter {
                 kinds: vec![SubstrateKind::Note],
+                record_kinds: vec![],
                 namespaces: vec!["local".to_string()],
                 ids: vec![],
             })
@@ -2646,6 +2651,7 @@ mod tests {
         let before = fts
             .count(TextFilter {
                 kinds: vec![SubstrateKind::Entity],
+                record_kinds: vec![],
                 namespaces: vec!["local".to_string()],
                 ids: vec![],
             })
@@ -2661,6 +2667,7 @@ mod tests {
         let after = fts
             .count(TextFilter {
                 kinds: vec![SubstrateKind::Entity],
+                record_kinds: vec![],
                 namespaces: vec!["local".to_string()],
                 ids: vec![],
             })
@@ -2763,6 +2770,7 @@ mod tests {
         let count = fts
             .count(TextFilter {
                 kinds: vec![SubstrateKind::Entity],
+                record_kinds: vec![],
                 namespaces: vec!["local".to_string()],
                 ids: vec![],
             })
@@ -2805,6 +2813,7 @@ mod tests {
         let count = fts
             .count(TextFilter {
                 kinds: vec![SubstrateKind::Entity],
+                record_kinds: vec![],
                 namespaces: vec!["local".to_string()],
                 ids: vec![],
             })

--- a/docs/adr/ADR-015-schema-migrations.md
+++ b/docs/adr/ADR-015-schema-migrations.md
@@ -3,7 +3,8 @@
 **Status**: accepted\
 **Date**: 2026-05-23\
 **Authors**: khive maintainers
-**Amended by**: [ADR-062](ADR-062-fts-ann-consolidation.md), which adds schema version 4.
+**Amended by**: [ADR-062](ADR-062-fts-ann-consolidation.md), which adds schema version 4
+and records the indexed FTS record-kind classifier added by schema version 23.
 
 ## Context
 
@@ -149,6 +150,8 @@ above remains the historical pre-consolidation record.
 |     V19 | #1649              | list_cursor_backfill_repair        | shipped |
 |     V20 | ADR-091 / #1850    | blob_gc_claims                     | shipped |
 |     V21 | ADR-121 / ADR-160  | attachments_first_class            | shipped |
+|     V22 | #2166              | notes_unread_probe_recipient       | shipped |
+|     V23 | ADR-062 / #1907    | fts_record_kind                    | shipped |
 
 > **V9 record (2026-07-18)**: `entities_name_ci_index` (ADR-104) ships in the `MIGRATIONS`
 > array as `009-entities-name-ci-index.sql`; its status here was `claimed`, stale from ADR-104,
@@ -199,6 +202,18 @@ above remains the historical pre-consolidation record.
 > is derived from the marker row's absence, never stored. The V21 ledger row is
 > inserted only in the final transaction that swaps claim fences and drops
 > `entities.content_ref`.
+
+> **V22 record (2026-08-30, #2166)**:
+> `notes_unread_probe_recipient` replaces the recipient-blind unread partial
+> index with a recipient-leading shape used by comm inbox projections.
+
+> **V23 record (2026-08-30, ADR-062 / #1907)**:
+> `fts_record_kind` rebuilds the two shared FTS5 tables with an indexed
+> granular `record_kind` classifier. Existing entity and note rows backfill the
+> classifier from their base-table `kind`; unmatched legacy FTS rows are
+> retained with an empty classifier. Memory recall can therefore intersect
+> `record_kind : "memory"` inside MATCH before ranking while an exact SQL
+> predicate remains the correctness backstop.
 
 > **Phase 4a compatibility record (2026-08-16, ADR-111 / ADR-160)**: the
 > separately deployed GC compatibility epoch gate does not add attachments,

--- a/docs/adr/ADR-021-memory-pack.md
+++ b/docs/adr/ADR-021-memory-pack.md
@@ -7,6 +7,8 @@
 [ADR-007](ADR-007-namespace.md) Rev 6 carve-out: episodic memory writes stamp the caller's actor
 id by default, semantic memory writes stamp the shared pool, and an explicit `namespace=`
 overrides both.
+**Amended**: 2026-08-30, schema V23 makes the `memory` candidate filter an
+indexed FTS classifier rather than a post-MATCH row filter (#1907).
 
 ## Context
 
@@ -148,7 +150,10 @@ distinguish it from generic note search:
    pushed into FTS5 and vector-search retrieval (not as a post-filter). In a mixed
    `kg,gtd,memory` namespace with thousands of non-memory notes, this prevents
    high-ranking non-memory notes from filling the candidate pool before any memory note
-   is considered. If the underlying `search_notes` operation applies kind only as a
+   is considered. The SQLite backend stores granular note kind in the indexed
+   `record_kind` FTS column and intersects `record_kind : "memory"` with the lexical
+   query inside MATCH; an exact row predicate remains the equality backstop for the
+   trigram tokenizer. If the underlying `search_notes` operation applies kind only as a
    post-filter, the handler implements bounded over-fetch (ceiling `limit * 20` raw
    candidates) until `limit` memory hits are collected.
 2. **Decay-weighted scoring.** Each candidate's `salience` is decayed by age:

--- a/docs/adr/ADR-062-fts-ann-consolidation.md
+++ b/docs/adr/ADR-062-fts-ann-consolidation.md
@@ -5,6 +5,8 @@
 **PR**: #171
 **Amends**: [ADR-015](ADR-015-schema-migrations.md) -- adds schema version 4
 **Depends on**: [ADR-031](ADR-031-multi-engine-retrieval.md), [ADR-044](ADR-044-vector-store-extensions.md), [ADR-052](ADR-052-ann-production-lifecycle.md)
+**Amended**: 2026-08-30, schema V23 adds an indexed granular record-kind
+classifier to the shared entity and note FTS tables (#1907).
 
 ---
 
@@ -195,6 +197,33 @@ Both sweeps are no-ops on databases that have no stale partitions.
   where the global index is heavily dominated by foreign-namespace vectors, additional retry rounds
   may increase recall latency.
 
+## 2026-08-30 Amendment: Indexed Record-Kind Classifier (Schema V23)
+
+The shared tables remain the canonical FTS topology, but substrate `kind`
+(`entity` or `note`) is not selective enough for pack-owned corpora. In
+particular, memory recall previously ran its text MATCH over every note posting
+and applied note kind `memory` only after candidate retrieval.
+
+Schema V23 appends an indexed `record_kind` column to `fts_entities` and
+`fts_notes`. The runtime stamps the base entity or note kind on every FTS write.
+The migration rebuilds both virtual tables in one versioned transaction,
+backfills the classifier by joining base records, and preserves unmatched FTS
+rows with an empty classifier so unscoped search semantics do not change.
+
+`TextFilter.record_kinds` has a two-part contract:
+
+1. Backends push supported granular kinds into the MATCH expression so FTS5
+   intersects classifier and query postings before ranking.
+2. Backends retain an exact `record_kind IN (...)` row predicate because the
+   production trigram tokenizer provides substring rather than equality
+   semantics. Classifiers shorter than one trigram skip only the MATCH
+   optimization and still use the exact predicate.
+
+Memory recall supplies `record_kind="memory"` to ranked, unranked,
+rank-within-cap, count, and term-statistics paths. Candidate work is therefore
+proportional to the matching memory corpus rather than matching notes of every
+pack.
+
 ---
 
 ## Alternatives Considered
@@ -217,5 +246,6 @@ is the canonical pattern for FTS5 multi-tenant tables in SQLite.
 - [ADR-044](ADR-044-vector-store-extensions.md) -- vector store extensions; ANN lifecycle
 - [ADR-052](ADR-052-ann-production-lifecycle.md) -- ANN production lifecycle; snapshot management
 - `crates/khive-db/sql/004-fts-consolidation.sql` -- the V4 migration SQL
+- `crates/khive-db/sql/023-fts-record-kind.sql` -- the V23 classifier rebuild
 - `crates/khive-db/src/migrations.rs` -- V4 registered as `fts_consolidation` at version 4
 - `crates/kkernel/src/reindex.rs` -- stale partition sweep implementation


### PR DESCRIPTION
## Summary

- add schema V23 with an indexed granular `record_kind` classifier on the two shared FTS5 tables; backfill live base-record kinds while preserving unmatched/stale FTS rows unscoped
- stamp the classifier on normal, batch, merge, namespace-rename, and reindex writes, and scope every memory ranked/unranked/rank-within-cap/count/term-statistics path to `memory`
- keep user lexical terms title/body-only, retain an exact SQL equality predicate for trigram correctness, and use a zero-weight custom hidden-rank configuration so classifier text cannot affect relevance or defeat FTS5's optimized top-K path
- document the storage, migration, and memory-recall contract in ADR-015, ADR-021, ADR-062, and the memory text-retrieval API notes

## Production-shaped evidence

Read-only source snapshot (the live database was never mutated):

- 212,801 `fts_notes` rows
- 93,695 live notes
- 27,832 live memory notes; 27,829 corresponding FTS rows

Five fixed AnyTerm queries were run before and after against copies of the same snapshot: `memory|recall`, `agent|task`, `khive|runtime`, `database|query`, and `performance|issue`, each at top-K 150.

- post-MATCH baseline candidate visits: 368-1,171
- indexed memory MATCH candidate visits: exactly 150 for every query
- median query latency: 85.52-360.09 ms before, 37.61-109.29 ms after (about 1.65x-3.29x faster)
- plan changed from shared lexical scan plus note lookup (`SCAN f VIRTUAL TABLE INDEX 32:M8`) to the classifier/rank-constrained FTS scan (`SCAN fts_notes VIRTUAL TABLE INDEX 32:rM9`)

The focused RED fixture held 50 memories constant and increased matching non-memory notes from 200 to 2,000. Before pushdown, visits rose from 220 to 2,020; after pushdown, both runs visit only the requested 20 memory rows.

## Verification

- `cargo test -p khive-db memory_kind_match_work_is_bounded_by_memory_corpus`
- `cargo test -p khive-db record_kind_`
- `cargo test -p khive-db v23_backfills_indexed_record_kinds_and_preserves_unmatched_fts_rows`
- `cargo test -p khive-db --lib`: all 841 non-flaking tests passed; unrelated concurrent note-page seam test flaked once and passed immediately in isolation (the same full suite passed all 842 on the prior run)
- `cargo test -p khive-pack-memory`: 324 unit + 89 integration passed; 1 documented model-loading test ignored
- `cargo test -p khive-runtime --lib`: 1,415 passed; 7 documented heavyweight/audit tests ignored
- `cargo test -p khive-storage -p khive-retrieval`: 310 passed
- `cargo check --workspace --all-targets`
- `cargo clippy -p khive-storage -p khive-db -p khive-runtime -p khive-retrieval -p khive-pack-memory -p kkernel --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `scripts/lint-sql.sh`: 32 SQL files OK
- `git diff --check`

## Related scope

This does not close #1906. V23 performs a one-time FTS rebuild, but #1906 still requires periodic optimize/merge maintenance, segment-count diagnostics, and per-stage recall timings.

Closes #1907
