### PR TITLE
docs(mcp): define read acknowledgement ordering

### DIFF
--- a/crates/khive-mcp/docs/design.md
+++ b/crates/khive-mcp/docs/design.md
@@ -22,6 +22,11 @@ decisions and rationale.
   callers must not infer full success solely from the absence of an RPC-level error.
 - Per-op failures do not abort siblings in Parallel mode; they do abort remaining
   ops in Chain mode (reported as `{"ok": false, "aborted": true}`).
+- `comm.read` and `comm.mark_read` are state-mutating acknowledgements, not
+  dependencies on sibling delivery operations. In Parallel mode they may commit
+  even when a sibling `comm.send` or `comm.reply` fails. Callers that need the
+  acknowledgement conditioned on delivery must use a Chain, or use `comm.reply`
+  for the common deliver-first/read-mark-second flow.
 - Invalid DSL (parse/lex failure) is preflighted before warm-daemon forwarding
   and returns an RPC-level `invalid_params` error; its error data carries
   `reason: "parse-error"` on both local and daemon-available paths. Per-verb

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -2815,6 +2815,13 @@ or `"writer_task_begin_busy"`)
 never rolls back a sibling that already committed. Inspect each result
 entry's own `ok` field rather than assuming batch-level atomicity.
 
+`comm.read` and `comm.mark_read` mutate delivery state. In a parallel batch,
+either acknowledgement does not wait for or depend on comm.send/comm.reply, so
+a read mark can commit even when the sibling send fails. When the mark must
+depend on a send, use a chain so a failed send aborts the mark. For the common
+reply-and-read flow, prefer `comm.reply`: comm.reply delivers first, then attempts
+the original message's best-effort read mark.
+
 `search` carries its own per-op `status` ("complete" | "partial") inside that
 op's `result` entry, separate from the top-level batch `status` above. A
 degraded-but-answered search stays ok:true with status="partial" plus a

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -379,6 +379,32 @@ async fn request_tool_description_contains_dynamic_verb_catalog() -> anyhow::Res
     Ok(())
 }
 
+#[tokio::test]
+async fn request_tool_description_declares_comm_read_dependency_contract() -> anyhow::Result<()> {
+    let client = connect().await?;
+    let listed = client.list_tools(None).await?;
+    let request = listed
+        .tools
+        .iter()
+        .find(|t| t.name == "request")
+        .expect("request tool must be present");
+    let desc = request.description.as_deref().unwrap_or("");
+
+    assert!(
+        desc.contains("comm.read") && desc.contains("comm.mark_read"),
+        "the request surface must name state-mutating read acknowledgements: {desc}"
+    );
+    assert!(
+        desc.contains("does not wait for or depend on comm.send/comm.reply"),
+        "the parallel sibling-independence hazard must be explicit: {desc}"
+    );
+    assert!(
+        desc.contains("comm.reply delivers first") && desc.contains("use a chain"),
+        "the contract must give both safe sequencing alternatives: {desc}"
+    );
+    Ok(())
+}
+
 // ── KG verbs round-tripped through the DSL ──────────────────────────────────
 
 #[tokio::test]

--- a/crates/khive-pack-comm/README.md
+++ b/crates/khive-pack-comm/README.md
@@ -170,6 +170,14 @@ Use `comm.mark_read(ids=[...])` as the canonical bulk mutation. It reuses the
 same best-effort behavior by default. Pass `atomic=true` when every unique
 validated target must be marked inside one transaction or none may change.
 
+At the MCP request layer, a parallel batch makes every operation independent.
+Putting `comm.send` beside `comm.read` or `comm.mark_read` does not condition the
+read mark on delivery: the acknowledgement may commit even if the send fails.
+Use a `send | mark_read` chain when that dependency is required. For replying to
+one inbound message, prefer `comm.reply`; it commits delivery before attempting
+the original message's best-effort read mark, so a delivery failure cannot mark
+the original read.
+
 This is the residual scope of #1387 after the 0.7.0 release: #1572 already
 shipped bulk best-effort `comm.read(ids=[...])`, and ADR-057 superseded the
 issue's original namespace and legacy-recipient acceptance assumptions with

--- a/crates/khive-pack-comm/docs/api/message-lifecycle.md
+++ b/crates/khive-pack-comm/docs/api/message-lifecycle.md
@@ -312,6 +312,15 @@ sees the message still unread and can re-issue `comm.read` (self-healing).
 Every validation error that runs before the patch (not found, wrong kind,
 outbound, wrong addressee) is unaffected and stays a hard error.
 
+At the enclosing MCP request boundary, `comm.read` and `comm.mark_read` remain
+mutations even though their names are acknowledgement-shaped. Parallel batch
+entries are independent, so a read mark may commit when a sibling `comm.send`
+or `comm.reply` fails; result-array order is not execution or commit order. A
+caller that requires delivery before acknowledgement must use an abort-on-failure
+chain. The single-message reply path already provides the common safe ordering:
+`comm.reply` commits the delivery pair first and only then attempts its
+best-effort fold-in read mark.
+
 ## `handlers.rs::handle_mark_read`
 
 `comm.mark_read` is the canonical named bulk mutation; message bodies are retrieved through


### PR DESCRIPTION
Summary:
- declare comm.read and comm.mark_read as state-mutating acknowledgements at the MCP request boundary
- document that parallel siblings are independent and a failed send cannot roll back a committed read mark
- direct dependent callers to an abort-on-failure chain or the deliver-first comm.reply flow
- lock the caller-visible request-tool contract with an integration regression

Verification:
- cargo test --manifest-path crates/Cargo.toml --workspace
- cargo check --manifest-path crates/Cargo.toml --workspace
- cargo clippy --manifest-path crates/Cargo.toml --workspace --all-targets -- -D warnings
- cargo fmt --manifest-path crates/Cargo.toml --all -- --check
- git diff --check

Closes #1940