### PR TITLE
fix(mcp): default inbound email actor to "local"

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,8 +42,8 @@ KHIVE_EMAIL_PASSWORD=your-app-password-here
 # KHIVE_EMAIL_INGEST_NAMESPACE=local
 
 # Actor that receives fresh inbound email (no In-Reply-To correlation match).
-# Default: lambda:leo
-# KHIVE_EMAIL_DEFAULT_ACTOR=lambda:leo
+# Default: local
+# KHIVE_EMAIL_DEFAULT_ACTOR=local
 
 # Comma-separated allowlist of recipient addresses the outbox loop may deliver
 # to. Defaults to KHIVE_EMAIL_MAINTAINER_ADDRESS when unset or empty.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `KHIVE_EMAIL_DEFAULT_ACTOR` now falls back to `local` when unset or blank,
+  matching `KHIVE_EMAIL_INGEST_NAMESPACE` and the adjacent startup resolver,
+  instead of a hard-coded identity with no meaning outside the deployment it
+  was named for. Behaviour with the variable explicitly set is unchanged.
+
 ## [0.8.0] - 2026-08-27
 
 ### Added

--- a/crates/khive-channel-email/src/lib.rs
+++ b/crates/khive-channel-email/src/lib.rs
@@ -30,7 +30,7 @@
 //!
 //! | Variable | Default | Description |
 //! |---|---|---|
-//! | `KHIVE_EMAIL_DEFAULT_ACTOR` | `lambda:leo` | Actor that receives fresh inbound email (no In-Reply-To match) |
+//! | `KHIVE_EMAIL_DEFAULT_ACTOR` | `local` | Actor that receives fresh inbound email (no In-Reply-To match) |
 //! | `KHIVE_EMAIL_SEND_ALLOWED_RECIPIENTS` | maintainer address | Comma-separated allowlist of recipient addresses the outbox loop may deliver to; defaults to the single maintainer address |
 //! | `KHIVE_EMAIL_INGEST_NAMESPACE` | `local` | Namespace used when persisting inbound and outbound messages |
 

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -537,15 +537,15 @@ fn ingest_namespace_from_env() -> String {
 
 /// Resolve the default inbound actor for fresh (uncorrelated) email messages.
 ///
-/// Reads `KHIVE_EMAIL_DEFAULT_ACTOR`; falls back to `"lambda:leo"` when the
+/// Reads `KHIVE_EMAIL_DEFAULT_ACTOR`; falls back to `"local"` when the
 /// variable is unset or blank. Called once at server startup alongside
-/// `ingest_namespace_from_env`.
+/// `ingest_namespace_from_env`, and defaults to the same neutral value.
 #[cfg(feature = "channel-email")]
 fn default_inbound_actor_from_env() -> String {
     std::env::var("KHIVE_EMAIL_DEFAULT_ACTOR")
         .ok()
         .filter(|s| !s.trim().is_empty())
-        .unwrap_or_else(|| "lambda:leo".to_string())
+        .unwrap_or_else(|| "local".to_string())
 }
 
 /// Parse the outbox allowlist from `KHIVE_EMAIL_SEND_ALLOWED_RECIPIENTS`.
@@ -8999,6 +8999,43 @@ region = "us-east-1"
         outcome.expect("test body panicked");
     }
 
+    // --- default_inbound_actor_from_env ---
+
+    #[cfg(feature = "channel-email")]
+    mod default_inbound_actor_tests {
+        use super::*;
+
+        #[test]
+        #[serial]
+        fn default_inbound_actor_defaults_to_local() {
+            std::env::remove_var("KHIVE_EMAIL_DEFAULT_ACTOR");
+            assert_eq!(
+                default_inbound_actor_from_env(),
+                "local",
+                "an unset actor must resolve to the neutral namespace, not to any particular \
+                 deployment's identity"
+            );
+        }
+
+        #[test]
+        #[serial]
+        fn default_inbound_actor_reads_env_var() {
+            std::env::set_var("KHIVE_EMAIL_DEFAULT_ACTOR", "lambda:mybot");
+            let actor = default_inbound_actor_from_env();
+            std::env::remove_var("KHIVE_EMAIL_DEFAULT_ACTOR");
+            assert_eq!(actor, "lambda:mybot");
+        }
+
+        #[test]
+        #[serial]
+        fn default_inbound_actor_ignores_blank_env_var() {
+            std::env::set_var("KHIVE_EMAIL_DEFAULT_ACTOR", "  ");
+            let actor = default_inbound_actor_from_env();
+            std::env::remove_var("KHIVE_EMAIL_DEFAULT_ACTOR");
+            assert_eq!(actor, "local", "blank env var must fall back to default");
+        }
+    }
+
     // --- ingest_namespace_from_env (Fix 4: namespace env var) ---
 
     #[cfg(feature = "channel-email")]
@@ -10416,7 +10453,7 @@ backend = "kg-backend"
                 "content": "hello",
                 "channel_kind": "email",
                 "external_id": "test-msg-1",
-                "default_inbound_actor": "lambda:leo",
+                "default_inbound_actor": "lambda:mybot",
             });
             registry
                 .dispatch("comm.ingest", ingest_params)

--- a/docs/guide/communication.md
+++ b/docs/guide/communication.md
@@ -348,7 +348,7 @@ Optional, with defaults:
   quarantine record instead of dropping it)
 - `KHIVE_EMAIL_INGEST_NAMESPACE` (default `local`; target namespace for
   ingested messages)
-- `KHIVE_EMAIL_DEFAULT_ACTOR` (default `lambda:leo`; inbound actor assigned to
+- `KHIVE_EMAIL_DEFAULT_ACTOR` (default `local`; inbound actor assigned to
   fresh, uncorrelated email messages)
 - `KHIVE_EMAIL_SEND_ALLOWED_RECIPIENTS` (comma-separated outbound allowlist;
   falls back to the maintainer address when unset)

--- a/docs/khive-config-example.toml
+++ b/docs/khive-config-example.toml
@@ -41,24 +41,24 @@
 # optional — the defaults apply when the section is absent.
 
 [actor]
-# Attribution identity. Must be a valid namespace string ("local", "lambda:khive",
+# Attribution identity. Must be a valid namespace string ("local", "lambda:mybot",
 # …). Validated at load — an invalid value is a startup error, not a silent
 # fallback. Absent → `local`. Overridden by --actor / KHIVE_ACTOR. A non-`local` id
 # does NOT route writes; it only widens the default read scope (see below).
-# id = "lambda:khive"
+# id = "lambda:mybot"
 
 # Human-readable label. Surfaced in introspection and logs only; never used for
 # routing.
-# display_name = "khive lambda"
+# display_name = "my bot"
 
 # Widen the DEFAULT multi-record READ scope to {local} ∪ these namespaces
 # (ADR-007 Rev 4 Rule 3b). Writes stay pinned to `local`. An explicit `namespace=`
 # request parameter is a precise escape and is not widened by this list.
-# visible_namespaces = ["lambda:khive", "local"]
+# visible_namespaces = ["lambda:mybot", "local"]
 
 # Namespaces this actor's comm.send / comm.reply may deliver INTO. Empty (default)
 # denies all cross-namespace delivery. Each entry must be a valid namespace.
-# allowed_outbound_namespaces = ["lambda:leo"]
+# allowed_outbound_namespaces = ["lambda:otherbot"]
 
 # ── [runtime] — runtime knobs ────────────────────────────────────────────────────
 
@@ -280,7 +280,7 @@ fusion_weight = 0.5
 #   KHIVE_EMAIL_MAINTAINER_ADDRESS=you@example.com
 #                                Required. Comma-separated allowlist of senders whose inbound mail
 #                                is accepted; the first entry is primary.
-#   KHIVE_EMAIL_DEFAULT_ACTOR=lambda:leo      Actor for new inbound mail with no thread match.
+#   KHIVE_EMAIL_DEFAULT_ACTOR=local           Actor for new inbound mail with no thread match.
 #   KHIVE_EMAIL_INGEST_NAMESPACE=local        Namespace stamped on channel messages.
 #   KHIVE_EMAIL_SEND_ALLOWED_RECIPIENTS=you@example.com
 #                                Comma-separated outbound allowlist. Default: the maintainer address.


### PR DESCRIPTION
## What

`default_inbound_actor_from_env()` resolves the actor that fresh, uncorrelated inbound email is
attributed to at server startup. When `KHIVE_EMAIL_DEFAULT_ACTOR` was unset or blank it fell back
to a hard-coded identity string rather than a neutral one. This changes that fallback to `"local"`.

Behaviour when the variable **is** set is unchanged.

## Why

The sibling resolver immediately above it in the same file, `ingest_namespace_from_env()`, already
falls back to `"local"`. Two adjacent startup resolvers, same shape, both reading an optional env
var, disagreeing about what "unset" means — and the one naming a specific identity is the odd one
out. `"local"` is the value the rest of the codebase already uses for "no attribution was
specified" (ADR-007: namespace is attribution, not isolation).

The practical effect of the old default: a deployment built with `--features channel-email` that
does not set `KHIVE_EMAIL_DEFAULT_ACTOR` attributes inbound mail to an identity that does not
exist in that deployment, and nothing surfaces the mismatch — the messages simply land under a
name their operator never chose.

This is a behaviour change for anyone depending on the old fallback, but depending on it would
mean depending on an identity string that was never theirs.

## Scope

- `crates/khive-mcp/src/serve.rs` — the fallback, its doc comment, and three regression tests
  (unset / set / blank-string).
- `.env.example`, `docs/khive-config-example.toml` — these *document* this default, so they move
  with it. The sample identities in the config example also become obvious placeholders, so they
  read as values to replace rather than values to copy.

## Verification

```
cargo test -p khive-mcp --features channel-email default_inbound_actor
test result: ok. 3 passed; 0 failed
```

The tests are load-bearing rather than decorative, checked by reverting the one-line fallback and
re-running: `default_inbound_actor_defaults_to_local` and `default_inbound_actor_ignores_blank_env_var`
fail on the assertion (`left: "<old default>", right: "local"`) while `default_inbound_actor_reads_env_var`
stays green, since an explicitly set variable never reaches the fallback.


- `crates/khive-channel-email/src/lib.rs`, `docs/guide/communication.md` — two further sites
  that stated the old value as the documented default. Found by grepping the variable across
  the tree at this ref rather than by code search, which under-reported.

## Trade-off: what `local` means

`local` is not an inert bucket. Actor resolution falls back to `local` for any caller that is
not running with an explicit identity, so `local` is also the pool that identity-less readers
see by default. This change therefore moves fresh, uncorrelated inbound mail — text the
operator did not author — out of one named identity's mailbox and into that shared pool.

That is a trade rather than a free win, and it is worth stating plainly:

- the old behaviour attributed external mail to a specific identity, which is wrong in any
  deployment that has no such identity and misleading in one that does;
- the new behaviour attributes it to nothing in particular, which is honest, but puts it where
  an unconfigured reader will see it.

`local` is chosen here because it matches `ingest_namespace_from_env`, the sibling resolver
immediately above it, and because inventing a new actor convention is out of scope for a change
whose whole point is that two adjacent resolvers disagreed about the same question. A dedicated
non-identity actor such as `channel:email` would give operator honesty *without* routing external
mail into the default-read pool. That is the better end state and it needs its own change, since
it introduces a convention rather than correcting a default.

Deployments that want inbound mail kept out of the default pool should set
`KHIVE_EMAIL_DEFAULT_ACTOR` explicitly. Behaviour with the variable set is unchanged.
