### PR TITLE
docs(adr): admission-degrade allowlist extension to operational read verbs (ADR-103 Am.4, ADR-133 Am.2 — Proposed)

### DIFF
--- a/docs/adr/ADR-103-resource-attribution-model.md
+++ b/docs/adr/ADR-103-resource-attribution-model.md
@@ -995,16 +995,16 @@ each brace-scoped and found write-free — are `wait_for_inbox_response`
 transitive callees below these named helpers are covered by the criterion's enforcement point
 (the census test and review of the handlers' own code), not by this table.
 
-| Verb | Category | Handler extent scanned | Dispatch-path writes | Eligible |
-|---|---|---|---|---|
-| `gtd.tasks` | Assertive | `crates/khive-pack-gtd/src/handlers.rs:1434-1618` | none | yes |
-| `gtd.next` | Assertive | `crates/khive-pack-gtd/src/handlers.rs:1291-1358` | none | yes |
-| `comm.inbox` | Assertive | `crates/khive-pack-comm/src/handlers.rs:462-681` | none | yes |
-| `comm.unread` | Assertive | `crates/khive-pack-comm/src/handlers.rs:841-853` | none | yes |
-| `comm.thread` | Assertive | `crates/khive-pack-comm/src/handlers.rs:1511-1834` | none (comment mentions only) | yes |
-| `comm.delivered` | Assertive | `crates/khive-pack-comm/src/handlers.rs:401-460` | none | yes |
-| `comm.probe` | Assertive | `crates/khive-pack-comm/src/handlers.rs:2838-2869` | none (doc-comment mention only) | yes |
-| `comm.health` | Assertive | `crates/khive-pack-comm/src/handlers.rs:2645-2836` | none | yes |
+| Verb             | Category  | Handler extent scanned                             | Dispatch-path writes            | Eligible |
+| ---------------- | --------- | -------------------------------------------------- | ------------------------------- | -------- |
+| `gtd.tasks`      | Assertive | `crates/khive-pack-gtd/src/handlers.rs:1434-1618`  | none                            | yes      |
+| `gtd.next`       | Assertive | `crates/khive-pack-gtd/src/handlers.rs:1291-1358`  | none                            | yes      |
+| `comm.inbox`     | Assertive | `crates/khive-pack-comm/src/handlers.rs:462-681`   | none                            | yes      |
+| `comm.unread`    | Assertive | `crates/khive-pack-comm/src/handlers.rs:841-853`   | none                            | yes      |
+| `comm.thread`    | Assertive | `crates/khive-pack-comm/src/handlers.rs:1511-1834` | none (comment mentions only)    | yes      |
+| `comm.delivered` | Assertive | `crates/khive-pack-comm/src/handlers.rs:401-460`   | none                            | yes      |
+| `comm.probe`     | Assertive | `crates/khive-pack-comm/src/handlers.rs:2838-2869` | none (doc-comment mention only) | yes      |
+| `comm.health`    | Assertive | `crates/khive-pack-comm/src/handlers.rs:2645-2836` | none                            | yes      |
 
 ### Named exclusions, with reasons
 

--- a/docs/adr/ADR-103-resource-attribution-model.md
+++ b/docs/adr/ADR-103-resource-attribution-model.md
@@ -983,20 +983,28 @@ amplified the outage: clients retried failed reads into an already-saturated adm
 
 Extend `VerbRegistry::ADMISSION_DEGRADE_SAFE_VERBS` with eight operational read verbs, each
 individually reviewed under Amendment 3's criterion (declared `VerbCategory::Assertive` AND no
-write-shaped call on the dispatch path). The review evidence is a lexical scan of each handler's
-full extent for `INSERT|UPDATE|DELETE|writer()|write_|upsert|persist|execute_script|mark_`
-(comment-only mentions excluded), at the revision this amendment was drafted against:
+write-shaped call on the dispatch path). The review evidence is a lexical scan for
+`INSERT|UPDATE|DELETE|writer()|write_|upsert|persist|execute_script|mark_`
+(comment-only mentions excluded), at the revision this amendment was drafted against.
+
+**Evidence depth, stated precisely:** the scan covers each handler's full brace-scoped extent
+PLUS each helper the handler calls that could carry a write off-extent. The helpers so scanned —
+each brace-scoped and found write-free — are `wait_for_inbox_response`
+(`crates/khive-pack-comm/src/handlers.rs:683-731`), `count_unread_messages` (`:855-905`), and
+`notes_seq_high_water_mark` (`:2871-2887`). A lexical scan answers the question it encodes:
+transitive callees below these named helpers are covered by the criterion's enforcement point
+(the census test and review of the handlers' own code), not by this table.
 
 | Verb | Category | Handler extent scanned | Dispatch-path writes | Eligible |
 |---|---|---|---|---|
-| `gtd.tasks` | Assertive | `khive-pack-gtd/src/handlers.rs:1434-1618` | none | yes |
-| `gtd.next` | Assertive | `khive-pack-gtd/src/handlers.rs:1291-1358` | none | yes |
-| `comm.inbox` | Assertive | `khive-pack-comm/src/handlers.rs:462-681` | none | yes |
-| `comm.unread` | Assertive | `khive-pack-comm/src/handlers.rs:841-853` | none | yes |
-| `comm.thread` | Assertive | `khive-pack-comm/src/handlers.rs:1511-1834` | none (comment mentions only) | yes |
-| `comm.delivered` | Assertive | `khive-pack-comm/src/handlers.rs:401-460` | none | yes |
-| `comm.probe` | Assertive | `khive-pack-comm/src/handlers.rs:2838-2869` | none (doc-comment mention only) | yes |
-| `comm.health` | Assertive | `khive-pack-comm/src/handlers.rs:2645-2836` | none | yes |
+| `gtd.tasks` | Assertive | `crates/khive-pack-gtd/src/handlers.rs:1434-1618` | none | yes |
+| `gtd.next` | Assertive | `crates/khive-pack-gtd/src/handlers.rs:1291-1358` | none | yes |
+| `comm.inbox` | Assertive | `crates/khive-pack-comm/src/handlers.rs:462-681` | none | yes |
+| `comm.unread` | Assertive | `crates/khive-pack-comm/src/handlers.rs:841-853` | none | yes |
+| `comm.thread` | Assertive | `crates/khive-pack-comm/src/handlers.rs:1511-1834` | none (comment mentions only) | yes |
+| `comm.delivered` | Assertive | `crates/khive-pack-comm/src/handlers.rs:401-460` | none | yes |
+| `comm.probe` | Assertive | `crates/khive-pack-comm/src/handlers.rs:2838-2869` | none (doc-comment mention only) | yes |
+| `comm.health` | Assertive | `crates/khive-pack-comm/src/handlers.rs:2645-2836` | none | yes |
 
 ### Named exclusions, with reasons
 
@@ -1006,7 +1014,7 @@ full extent for `INSERT|UPDATE|DELETE|writer()|write_|upsert|persist|execute_scr
   failures during the incident were the mechanism working as specified.
 - **`comm.cursor_get` — excluded as-is, with a named precondition.** Although declared Assertive,
   its dispatch path checks out the writer connection and runs a schema-ensure
-  `execute_script` (`khive-pack-comm/src/handlers.rs:3009-3011`) before its SELECT. Two
+  `execute_script` (`crates/khive-pack-comm/src/handlers.rs:3009-3011`) before its SELECT. Two
   consequences: it performs a write-shaped operation per dispatch, and under writer contention its
   body stalls on the writer checkout — so degrading its audit row would not have made it
   incident-safe anyway. Precondition for a future amendment: move the schema-ensure to
@@ -1025,16 +1033,36 @@ reads.
 
 ### Mechanical requirements
 
-1. The eight verbs join `ADMISSION_DEGRADE_SAFE_VERBS` under their full namespaced names —
-   `admission_degrade_safe` matches on the dispatch verb string and cross-checks the category by
-   walking every registered pack's handlers, so cross-pack membership needs no lookup change.
+1. **Canonical entry form**: an allowlist entry is the handler's registered `name` — the exact
+   dispatch verb string — which is BARE for the KG base pack (`"get"`, `"list"`, ...) and
+   NAMESPACED for every other pack (`"gtd.tasks"`, `"comm.inbox"`, ...). The eight additions use
+   their namespaced names. `admission_degrade_safe` matches on the dispatch verb string and
+   cross-checks the category by walking every registered pack's handlers, so cross-pack
+   membership needs no lookup change — but a mis-spelled or dead entry silently never matches,
+   which is why requirement 2 makes resolution an asserted property rather than an assumption.
 2. The census test (`admission_degrade_safe_verbs_are_registered_assertive`) currently re-derives
-   classifications from `khive-pack-kg/src/handler_defs.rs` alone; per its own documentation,
+   classifications from `crates/khive-pack-kg/src/handler_defs.rs` alone; per its own documentation,
    adding verbs from other packs REQUIRES extending its source scan to
-   `khive-pack-comm/src/vocab.rs` and `khive-pack-gtd/src/vocab.rs`. The extension must also
-   assert the two named exclusions cannot be silently re-added, exactly as the existing test does
-   for `memory.recall` and `db_diagnostics`.
+   `crates/khive-pack-comm/src/vocab.rs` and `crates/khive-pack-gtd/src/vocab.rs`. The extended
+   census must additionally assert (a) that EVERY allowlist entry resolves to exactly one
+   registered handler — so a dead entry fails loud instead of silently never matching; (b) that
+   the allowlist equals THIS amendment's enumeration exactly (the eleven Amendment 3 verbs plus
+   the eight named here) — so an unreviewed addition on any branch fails the census rather than
+   widening the D4/INV-1 exception silently; and (c) that the two named exclusions cannot be
+   silently re-added, exactly as the existing test does for `memory.recall` and `db_diagnostics`.
 3. The Amendment 3 undercount consequence now covers nineteen verbs; the two disjoint diagnostics
    counters are unchanged and already verb-agnostic.
+
+### Enumeration authority and in-flight coordination
+
+The authoritative enumeration of the exception's verb set is this document, not the constant in
+`crates/khive-runtime/src/pack.rs`; requirement 2(b) is what keeps the two mechanically equal. At
+drafting time at least one in-flight branch carries a WIDER allowlist (namespaced comm and gtd
+entries plus `agent.observe`, `blob.get`, `blob.stat`, and five `brain.*` verbs) with no per-verb
+review of the additions. Sequencing: such a branch must either trim its allowlist to this
+amendment's enumeration before landing, or its additional verbs must first receive the same
+per-verb review (category + brace-scoped dispatch-path scan + named helpers) in a stacked
+amendment signed before that branch lands. The census equality assertion enforces this
+mechanically: a wider list fails the test until its amendment exists.
 
 ADR-133 Amendment 2 carries the corresponding qualification of D4/INV-1 scope.

--- a/docs/adr/ADR-103-resource-attribution-model.md
+++ b/docs/adr/ADR-103-resource-attribution-model.md
@@ -988,12 +988,18 @@ write-shaped call on the dispatch path). The review evidence is a lexical scan f
 (comment-only mentions excluded), at the revision this amendment was drafted against.
 
 **Evidence depth, stated precisely:** the scan covers each handler's full brace-scoped extent
-PLUS each helper the handler calls that could carry a write off-extent. The helpers so scanned —
-each brace-scoped and found write-free — are `wait_for_inbox_response`
-(`crates/khive-pack-comm/src/handlers.rs:683-731`), `count_unread_messages` (`:855-905`), and
-`notes_seq_high_water_mark` (`:2871-2887`). A lexical scan answers the question it encodes:
-transitive callees below these named helpers are covered by the criterion's enforcement point
-(the census test and review of the handlers' own code), not by this table.
+PLUS each direct helper the handlers call that could carry a write off-extent. The helpers so
+scanned — each brace-scoped and found write-free — are `wait_for_inbox_response`
+(`crates/khive-pack-comm/src/handlers.rs:683-731`), `query_inbox_response` (`:734-837`),
+`count_unread_messages` (`:855-905`), `load_quarantine_counts` (`:2544-2609`),
+`notes_seq_high_water_mark` (`:2871-2887`), `query_probe` (`:2889-2986`),
+`fetch_all_matching_tasks` (`crates/khive-pack-gtd/src/handlers.rs:802-839`), and
+`diagnose_tasks` (`crates/khive-pack-gtd/src/dependency.rs:46-88`). An earlier draft named only
+three of these; review found the enumeration incomplete against its own claim, and the other
+five were scanned with the same instrument before this text was corrected — all clean, table
+unchanged. A lexical scan answers the question it encodes: transitive callees below these named
+helpers are covered by the criterion's enforcement point (the census test and review of the
+handlers' own code), not by this table.
 
 | Verb             | Category  | Handler extent scanned                             | Dispatch-path writes            | Eligible |
 | ---------------- | --------- | -------------------------------------------------- | ------------------------------- | -------- |

--- a/docs/adr/ADR-103-resource-attribution-model.md
+++ b/docs/adr/ADR-103-resource-attribution-model.md
@@ -965,3 +965,76 @@ considered and rejected for this PR as new storage-and-plumbing machinery. See t
 amendment in `docs/adr/ADR-133-incidental-writes-off-the-request-hot-path.md` ("Amendment 1") for
 the corresponding narrowing of that record's D4/INV-1 language, which this same PR's change
 requires.
+
+## Amendment 4 (2026-09-01): Extending the Admission-Degrade Allowlist to Operational Read Verbs
+
+**Status**: Proposed.
+
+Amendment 3 scoped the admission-pressure read-cost undercount to eleven KG-base verbs. A
+store-pressure incident measured on 2026-08-31 showed the cost of that scoping: during a
+sustained admission-pressure window (32 `AdmissionDeadlineExpired` dispatch failures in one
+process's stderr over ~3 minutes), the dispatches that failed were `comm.heartbeat`,
+`comm.cursor_get`, and `gtd.tasks` — the polling, cursor, and task-listing verbs operational
+clients depend on precisely when the store is under pressure. The verbs most needed during an
+incident were exactly the ones outside the allowlist, so they kept hard-fail semantics and
+amplified the outage: clients retried failed reads into an already-saturated admission lane.
+
+### Decision
+
+Extend `VerbRegistry::ADMISSION_DEGRADE_SAFE_VERBS` with eight operational read verbs, each
+individually reviewed under Amendment 3's criterion (declared `VerbCategory::Assertive` AND no
+write-shaped call on the dispatch path). The review evidence is a lexical scan of each handler's
+full extent for `INSERT|UPDATE|DELETE|writer()|write_|upsert|persist|execute_script|mark_`
+(comment-only mentions excluded), at the revision this amendment was drafted against:
+
+| Verb | Category | Handler extent scanned | Dispatch-path writes | Eligible |
+|---|---|---|---|---|
+| `gtd.tasks` | Assertive | `khive-pack-gtd/src/handlers.rs:1434-1618` | none | yes |
+| `gtd.next` | Assertive | `khive-pack-gtd/src/handlers.rs:1291-1358` | none | yes |
+| `comm.inbox` | Assertive | `khive-pack-comm/src/handlers.rs:462-681` | none | yes |
+| `comm.unread` | Assertive | `khive-pack-comm/src/handlers.rs:841-853` | none | yes |
+| `comm.thread` | Assertive | `khive-pack-comm/src/handlers.rs:1511-1834` | none (comment mentions only) | yes |
+| `comm.delivered` | Assertive | `khive-pack-comm/src/handlers.rs:401-460` | none | yes |
+| `comm.probe` | Assertive | `khive-pack-comm/src/handlers.rs:2838-2869` | none (doc-comment mention only) | yes |
+| `comm.health` | Assertive | `khive-pack-comm/src/handlers.rs:2645-2836` | none | yes |
+
+### Named exclusions, with reasons
+
+- **`comm.heartbeat` — excluded by design.** It is `VerbCategory::Declaration` and its primary
+  effect is a persist ("Persist a per-channel-credential heartbeat row"). Its audit row is
+  obligation-bearing exactly as Amendment 3's "What does not change" requires for writes. Its
+  failures during the incident were the mechanism working as specified.
+- **`comm.cursor_get` — excluded as-is, with a named precondition.** Although declared Assertive,
+  its dispatch path checks out the writer connection and runs a schema-ensure
+  `execute_script` (`khive-pack-comm/src/handlers.rs:3009-3011`) before its SELECT. Two
+  consequences: it performs a write-shaped operation per dispatch, and under writer contention its
+  body stalls on the writer checkout — so degrading its audit row would not have made it
+  incident-safe anyway. Precondition for a future amendment: move the schema-ensure to
+  pack initialization and read through a reader connection; only then does it meet the criterion.
+- **`memory.recall` and `db_diagnostics`** remain excluded for the reasons Amendment 3's
+  implementation records (background accounting write; physical checkpoint I/O).
+
+### What the extension does and does not buy
+
+The exception still covers only the dispatch's OWN audit row under the two transient admission
+terminal reasons. It does not make any verb's body immune to store pressure: a read whose body
+times out on its own query still fails. The incident evidence supports exactly this scope — the
+three failing dispatches named above failed at audit admission (`AdmissionDeadlineExpired`
+surfaced as the dispatch error), which is the failure class this mechanism removes for eligible
+reads.
+
+### Mechanical requirements
+
+1. The eight verbs join `ADMISSION_DEGRADE_SAFE_VERBS` under their full namespaced names —
+   `admission_degrade_safe` matches on the dispatch verb string and cross-checks the category by
+   walking every registered pack's handlers, so cross-pack membership needs no lookup change.
+2. The census test (`admission_degrade_safe_verbs_are_registered_assertive`) currently re-derives
+   classifications from `khive-pack-kg/src/handler_defs.rs` alone; per its own documentation,
+   adding verbs from other packs REQUIRES extending its source scan to
+   `khive-pack-comm/src/vocab.rs` and `khive-pack-gtd/src/vocab.rs`. The extension must also
+   assert the two named exclusions cannot be silently re-added, exactly as the existing test does
+   for `memory.recall` and `db_diagnostics`.
+3. The Amendment 3 undercount consequence now covers nineteen verbs; the two disjoint diagnostics
+   counters are unchanged and already verb-agnostic.
+
+ADR-133 Amendment 2 carries the corresponding qualification of D4/INV-1 scope.

--- a/docs/adr/ADR-133-incidental-writes-off-the-request-hot-path.md
+++ b/docs/adr/ADR-133-incidental-writes-off-the-request-hot-path.md
@@ -678,3 +678,28 @@ This amendment does not revisit "Split the audit row so accounting lives in its 
 Alternatives considered above — that remains rejected for the reasons stated there (a migration,
 and it breaks the response/audit-payload identity property). The accepted trade here is a bounded,
 measured undercount over that redesign.
+
+## Amendment 2 (2026-09-01): Extending Amendment 1's Verb Set to Operational Reads
+
+**Status**: Proposed.
+
+Amendment 1's exception to D2 and D4/INV-1 was scoped to the eleven verbs on
+`VerbRegistry::ADMISSION_DEGRADE_SAFE_VERBS`. ADR-103 Amendment 4 extends that list with eight
+operational read verbs (`gtd.tasks`, `gtd.next`, `comm.inbox`, `comm.unread`, `comm.thread`,
+`comm.delivered`, `comm.probe`, `comm.health`), each individually reviewed against the same
+criterion: declared `VerbCategory::Assertive` and no write-shaped operation on the dispatch path.
+The per-verb evidence table, the two named exclusions (`comm.heartbeat`, whose primary effect is
+a persist; `comm.cursor_get`, whose dispatch path checks out the writer and runs a schema-ensure
+script), and the incident measurement motivating the extension live in ADR-103 Amendment 4.
+
+Nothing else in Amendment 1 changes. The exception remains:
+
+- reads only, for the two transient admission terminal reasons only, never persistent store
+  failure;
+- opt-in per verb and fail-closed by default (`admission_degrade_safe`), so the eight additions
+  are deliberate review products, not a loosening of the default posture;
+- counted on the same two disjoint diagnostics counters, so the undercount stays measurable.
+
+D4/INV-1 continues to hold without qualification for every write, every non-allowlisted Assertive
+handler, gate-denial rows, unknown-verb rows, and `git.digest` receipts — the sentence is
+unchanged; only the enumerated verb set it excepts has grown, by review.

--- a/docs/adr/ADR-133-incidental-writes-off-the-request-hot-path.md
+++ b/docs/adr/ADR-133-incidental-writes-off-the-request-hot-path.md
@@ -703,3 +703,8 @@ Nothing else in Amendment 1 changes. The exception remains:
 D4/INV-1 continues to hold without qualification for every write, every non-allowlisted Assertive
 handler, gate-denial rows, unknown-verb rows, and `git.digest` receipts — the sentence is
 unchanged; only the enumerated verb set it excepts has grown, by review.
+
+The exception's enumerated verb set is authoritative in ADR-103 Amendment 4, which also requires
+the extended census test to assert list-to-enumeration equality and per-entry handler resolution —
+so a branch widening the constant without a signed amendment fails the census rather than widening
+this exception silently.


### PR DESCRIPTION
## Summary

Proposes extending `ADMISSION_DEGRADE_SAFE_VERBS` (ADR-103 Amendment 3 / ADR-133 Amendment 1, PR #2228) with eight operational read verbs: `gtd.tasks`, `gtd.next`, `comm.inbox`, `comm.unread`, `comm.thread`, `comm.delivered`, `comm.probe`, `comm.health`.

Motivation: during a measured admission-pressure window (2026-08-31, 32 `AdmissionDeadlineExpired` dispatch failures in ~3 minutes in one process's stderr), the dispatches that failed were exactly the polling/cursor/task-listing reads operational clients need during an incident — all outside the current 11-verb allowlist, so they kept hard-fail semantics and amplified the outage with retries into the saturated admission lane.

## Contents

- **ADR-103 Amendment 4** (Proposed): the extension decision, a per-verb evidence table (category + handler extent + dispatch-path write scan), named exclusions with reasons — `comm.heartbeat` (primary effect is a persist; its incident failures were the mechanism working as specified) and `comm.cursor_get` (writer checkout + schema-ensure `execute_script` on the dispatch path; precondition for future eligibility stated) — and the mechanical requirements, including the mandatory census-test source-scan extension to the comm/gtd vocab files.
- **ADR-133 Amendment 2** (Proposed): the corresponding scope note on the D2/D4/INV-1 exception; nothing else in Amendment 1 changes.

## Scope

Docs only — no implementation in this PR. Both amendments are marked **Proposed**; implementation is gated on acceptance. The exception's shape is unchanged: reads only, the two transient admission terminal reasons only, opt-in fail-closed, loss counted on the existing disjoint diagnostics counters.