### PR TITLE
fix(ci): ignore synthetic secret-gate test fixture in nightly all-ref scan

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -10,3 +10,7 @@ f245f9600e47ee5cb6740189b265b9ef71f7cb0f:crates/khive-pack-git/src/cache.rs:gene
 f245f9600e47ee5cb6740189b265b9ef71f7cb0f:crates/khive-pack-git/src/cache.rs:generic-api-key:1408
 4ce001460f67750796f533b1269c74c90c67eb5c:docs/adr/ADR-101-kg-changeset-model.md:generic-api-key:135
 39fb7052c29916e50f20083f5f6281861bb7ebd9:docs/adr/ADR-101-kg-changeset-model.md:generic-api-key:155
+# Synthetic 40-hex test constant in issue_1988_latex_exemption_does_not_hide_credential_runs
+# (secret_gate regression test on the open branch for #2056); flagged by the nightly
+# all-ref scan since 2026-08-30, confirmed non-credential.
+f1c8e732e61b9ec2516b794dbb37afd5152cee59:crates/khive-runtime/src/secret_gate.rs:generic-api-key:3338


### PR DESCRIPTION
## Summary

The nightly scheduled CI run (which scans every ref, per the documented design in ci.yml) has failed since 2026-08-30 on one gitleaks finding: a 40-hex synthetic test constant in `issue_1988_latex_exemption_does_not_hide_credential_runs` (crates/khive-runtime/src/secret_gate.rs), introduced on the open feature branch for #2056. Pull-request and push runs are range-scoped, so they stay green while every nightly is red.

This adds the exact reported fingerprint to `.gitleaksignore`, following the file's existing precedent for confirmed non-credential fixtures.

## Verification

- gitleaks 8.21.2 (the CI-pinned version), full no-range scan of a checkout with strictly more refs than CI fetches: the finding is reported without this entry and cleared with it.
- The only remaining local findings are attributed to a remote that CI does not fetch (already-ignored cache-lock fixtures re-attributed by unrelated history).
- The PR's own CI cannot exercise this path (range-scoped); the next scheduled run is the confirming artifact.