### PR TITLE
docs(kg-editor): describe the direct static load for sessions without an operator token

### DIFF
--- a/apps/kg-editor/DEMO.md
+++ b/apps/kg-editor/DEMO.md
@@ -20,9 +20,10 @@ npm run dev
 ```
 
 Place the report at `$KHIVE_SHOWCASE_ANALYSIS_ROOT/khive/khive.repo.v1.json`.
-The protected route requires the bearer token on every request and fails closed
-to 404 without it, which silently selects the static fallback. Unlock the UI in
-the browser console before opening the repository:
+The protected route requires the bearer token on every request and fails closed to 404
+without it. Without a token the UI skips that request for an entry that has a curated
+asset and loads the static fallback directly. Unlock the UI in the browser console
+before opening the repository:
 
 ```js
 sessionStorage.setItem("khive.showcase.accessToken", "a-long-random-operator-secret");

--- a/apps/kg-editor/README.md
+++ b/apps/kg-editor/README.md
@@ -172,7 +172,7 @@ containment and file identity after opening and reads at most 8 MiB plus one sen
 byte.
 
 This is a pinned DB-backed snapshot, not a live mutable query and not arbitrary URL
-ingest. See ADR-147 Amendments 1–4 and the repository-showcase CLI guide.
+ingest. See ADR-147 Amendments 1–5 and the repository-showcase CLI guide.
 
 ## Adapter boundary
 

--- a/apps/kg-editor/README.md
+++ b/apps/kg-editor/README.md
@@ -146,7 +146,9 @@ With a token present, the UI sends it as the bearer credential on snapshot reque
 only a 404 from the protected route falls back to the curated static bundle. Without a
 token the UI does not request the protected route for an entry that has a curated asset;
 it loads that asset directly, so the token never ships in the client build. Entries that
-exist only in the configured catalog still probe the route so an honest miss is reported.
+exist only in the configured catalog are known to the browser only after a successful
+catalog discovery, which itself carries the token, or when supplied explicitly; those still
+probe the route so an honest miss is reported.
 An absent or mismatched token is indistinguishable from an unconfigured catalog: both
 routes fail closed to the same sanitized 404. Without `KHIVE_SHOWCASE_ACCESS_TOKEN` set,
 no request can be authorized, regardless of what credentials it presents.

--- a/apps/kg-editor/README.md
+++ b/apps/kg-editor/README.md
@@ -142,12 +142,14 @@ supply the same token to your own browser session before loading a repository:
 sessionStorage.setItem("khive.showcase.accessToken", "a-long-random-operator-secret");
 ```
 
-The UI sends it as the bearer credential on snapshot requests. Without it the protected
-route answers 404 and the UI falls back to the curated static bundle, so the token never
-ships in the client build. An absent or mismatched token is indistinguishable
-from an unconfigured catalog: both routes fail closed to the same sanitized 404. Without
-`KHIVE_SHOWCASE_ACCESS_TOKEN` set, no request can be authorized, regardless of what
-credentials it presents.
+With a token present, the UI sends it as the bearer credential on snapshot requests, and
+only a 404 from the protected route falls back to the curated static bundle. Without a
+token the UI does not request the protected route for an entry that has a curated asset;
+it loads that asset directly, so the token never ships in the client build. Entries that
+exist only in the configured catalog still probe the route so an honest miss is reported.
+An absent or mismatched token is indistinguishable from an unconfigured catalog: both
+routes fail closed to the same sanitized 404. Without `KHIVE_SHOWCASE_ACCESS_TOKEN` set,
+no request can be authorized, regardless of what credentials it presents.
 
 ```bash
 curl -H "Authorization: Bearer $KHIVE_SHOWCASE_ACCESS_TOKEN" \

--- a/docs/adr/ADR-147-repo-showcase-bundle.md
+++ b/docs/adr/ADR-147-repo-showcase-bundle.md
@@ -439,8 +439,11 @@ in the session:
   that asset directly and makes no snapshot request; the reported source is the curated
   static fallback, exactly as it would have been after the `404`;
 - an entry that exists only in the configured catalog, with no curated asset, still probes
-  the route regardless of the token, so an unauthenticated session receives an honest
-  repository miss rather than a silent empty state.
+  the route regardless of the token. The browser knows such an entry only after a
+  successful catalog discovery, which itself carries the token, or when the entry is
+  supplied explicitly; so a session without a token reaches this arm only for an
+  explicitly supplied entry, and then receives an honest repository miss rather than a
+  silent empty state.
 
 The fallback boundary is unchanged: server errors, malformed or oversized reports, missing
 or mismatched provenance headers, repository-identity mismatches, and an elapsed request

--- a/docs/adr/ADR-147-repo-showcase-bundle.md
+++ b/docs/adr/ADR-147-repo-showcase-bundle.md
@@ -420,3 +420,28 @@ constant-time digest comparison. An absent, malformed, or mismatched credential,
 unset or blank `KHIVE_SHOWCASE_ACCESS_TOKEN`, all return the same sanitized 404 used for
 an unconfigured catalog — the failure mode stays indistinguishable from "not
 configured," consistent with the sanitized-error posture in Amendments 1 and 2.
+
+## Amendment 5 — Direct static load when no operator token is present (2026-09-02)
+
+Amendment 3 states that the browser requests the opaque ID route first for a configured
+entry and falls back to the curated asset only on a `404`. Since Amendment 4 that route
+answers every unauthenticated request with the same sanitized `404`, so a browser session
+without an operator token was guaranteed one failed request per load before reaching the
+asset it was always going to use.
+
+The browser now distinguishes the two cases by the presence of a non-blank operator token
+in the session:
+
+- with a non-blank token, the order in Amendment 3 stands unchanged: the opaque ID route is
+  requested first, only a `404` may fall back, and only to the approved curated asset owned
+  by the same merged entry;
+- with no token, or a blank one, a merged entry that owns an approved curated asset loads
+  that asset directly and makes no snapshot request; the reported source is the curated
+  static fallback, exactly as it would have been after the `404`;
+- an entry that exists only in the configured catalog, with no curated asset, still probes
+  the route regardless of the token, so an unauthenticated session receives an honest
+  repository miss rather than a silent empty state.
+
+The fallback boundary is unchanged: server errors, malformed or oversized reports, missing
+or mismatched provenance headers, repository-identity mismatches, and an elapsed request
+deadline remain hard failures on the authenticated path and never fall back.


### PR DESCRIPTION
Documentation follow-up to #2298.

Since #2298 the showcase browser loads the approved curated asset directly when the session holds no operator token and the entry owns one, instead of first requesting the protected snapshot route that is guaranteed to answer 404 for unauthenticated callers. With a non-blank token the route-first order and the 404-only fallback of ADR-147 Amendment 3 are unchanged, and entries that exist only in the configured catalog still probe the route.

- `docs/adr/ADR-147-repo-showcase-bundle.md`: Amendment 5 records that order and restates the fallback boundary for authenticated requests.
- `apps/kg-editor/README.md`, `apps/kg-editor/DEMO.md`: the operator-token paragraphs no longer describe a snapshot request that is not made without a token.

No code changes.
