### PR TITLE
docs(git): record the typed remote fetch failure contract for git.digest

### DIFF
--- a/docs/adr/ADR-088-amendment-1-git-digest.md
+++ b/docs/adr/ADR-088-amendment-1-git-digest.md
@@ -175,6 +175,15 @@ frozen `until`; temporary absence is not evidence that the pass failed or commit
 4. Cleanup on eviction uses directory removal of the scratch path only (never touches
    user-owned paths).
 
+5. Failure contract (2026-09-02). A remote source whose clone or fetch setup fails
+   returns the typed `RemoteFetchError { remote, message }` rather than a generic error:
+   `remote` is the canonical URL with any embedded credentials and query string redacted,
+   and `message` is the underlying git failure. A source that cannot be parsed as a local
+   path or a remote URL stays `InvalidInput`, and storage failures keep their existing
+   error types, so callers can tell a network or authentication failure apart from a
+   malformed request without inspecting message text. The rendered error never contains
+   the credential or query material stripped from `remote`.
+
 ### Accepted cache crash-residue rider (2026-08-09)
 
 The staging-then-rename design can clean every ordinary error return, but no

--- a/docs/adr/ADR-088-amendment-1-git-digest.md
+++ b/docs/adr/ADR-088-amendment-1-git-digest.md
@@ -188,10 +188,13 @@ frozen `until`; temporary absence is not evidence that the pass failed or commit
    the rendered message, in-process or on the wire, never contains the credential or
    query material stripped from it. A clone/fetch failure hit later, while repairing a
    missing object during commit walking against an already-cached clone (a bounded
-   refetch-then-reclone attempt), is not raised as `RemoteFetchError`; it is wrapped as a
-   plain error and reaches the caller as `InvalidInput` instead. A source that cannot be
-   parsed as a local path or a remote URL also stays `InvalidInput`, and storage failures
-   keep their existing error types.
+   refetch-then-reclone attempt), is not raised as `RemoteFetchError`. A git-level refetch
+   failure is followed by the one guarded reclone, and a reclone that succeeds lets the
+   ingest complete normally; only when that bounded repair ultimately fails (a non-git
+   refetch failure, or a failed reclone) is the failure wrapped as a plain error that
+   reaches the caller as `InvalidInput`. A source that cannot be parsed as a local path or
+   a remote URL also stays `InvalidInput`, and storage failures keep their existing error
+   types.
 
 ### Accepted cache crash-residue rider (2026-08-09)
 

--- a/docs/adr/ADR-088-amendment-1-git-digest.md
+++ b/docs/adr/ADR-088-amendment-1-git-digest.md
@@ -189,12 +189,13 @@ frozen `until`; temporary absence is not evidence that the pass failed or commit
    query material stripped from it. A clone/fetch failure hit later, while repairing a
    missing object during commit walking against an already-cached clone (a bounded
    refetch-then-reclone attempt), is not raised as `RemoteFetchError`. A git-level refetch
-   failure is followed by the one guarded reclone, and a reclone that succeeds lets the
-   ingest complete normally; only when that bounded repair ultimately fails (a non-git
-   refetch failure, or a failed reclone) is the failure wrapped as a plain error that
-   reaches the caller as `InvalidInput`. A source that cannot be parsed as a local path or
-   a remote URL also stays `InvalidInput`, and storage failures keep their existing error
-   types.
+   failure is followed by the one guarded reclone, and each successful repair earns exactly
+   one more snapshot attempt: the ingest completes normally only when that attempt
+   succeeds. When the bounded repair ultimately fails (a non-git refetch failure, a failed
+   reclone, or a snapshot that still fails after the reclone) the failure is wrapped as a
+   plain error that reaches the caller as `InvalidInput`; no third repair is attempted. A
+   source that cannot be parsed as a local path or a remote URL also stays `InvalidInput`,
+   and storage failures keep their existing error types.
 
 ### Accepted cache crash-residue rider (2026-08-09)
 

--- a/docs/adr/ADR-088-amendment-1-git-digest.md
+++ b/docs/adr/ADR-088-amendment-1-git-digest.md
@@ -175,14 +175,23 @@ frozen `until`; temporary absence is not evidence that the pass failed or commit
 4. Cleanup on eviction uses directory removal of the scratch path only (never touches
    user-owned paths).
 
-5. Failure contract (2026-09-02). A remote source whose clone or fetch setup fails
-   returns the typed `RemoteFetchError { remote, message }` rather than a generic error:
-   `remote` is the canonical URL with any embedded credentials and query string redacted,
-   and `message` is the underlying git failure. A source that cannot be parsed as a local
-   path or a remote URL stays `InvalidInput`, and storage failures keep their existing
-   error types, so callers can tell a network or authentication failure apart from a
-   malformed request without inspecting message text. The rendered error never contains
-   the credential or query material stripped from `remote`.
+5. Failure contract (2026-09-02). When the initial clone or fetch that establishes a
+   cache entry (step 1) fails, it returns the typed `RemoteFetchError { remote, message }`
+   in-process rather than a generic error: `remote` is the canonical URL with any embedded
+   credentials and query string redacted, and `message` is the cache/setup error text: a
+   synthesized exit-status summary for a failed git invocation, or the I/O, size-cap, or
+   unsafe-replace guard message for a non-git cache failure; none of these retain git's
+   own stderr. This typed variant reaches in-process `VerbRegistry::dispatch` callers; the
+   MCP `request` envelope has no dedicated wire encoding for it and falls back to
+   rendering the plain error message, so an MCP caller still has to read that text to tell
+   it apart from `InvalidInput`. Because `remote` is redacted before the error is built,
+   the rendered message, in-process or on the wire, never contains the credential or
+   query material stripped from it. A clone/fetch failure hit later, while repairing a
+   missing object during commit walking against an already-cached clone (a bounded
+   refetch-then-reclone attempt), is not raised as `RemoteFetchError`; it is wrapped as a
+   plain error and reaches the caller as `InvalidInput` instead. A source that cannot be
+   parsed as a local path or a remote URL also stays `InvalidInput`, and storage failures
+   keep their existing error types.
 
 ### Accepted cache crash-residue rider (2026-08-09)
 

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -42,8 +42,9 @@ to in-process callers; the MCP `request` envelope renders it as a plain error me
 rather than structured fields (ADR-088 Amendment 1, Remote-URL mode, point 5). A
 clone/fetch failure hit later while repairing an already-cached clone surfaces as
 `InvalidInput` only when the bounded refetch-then-reclone repair ultimately fails (a
-successful reclone lets the digest complete); a source that parses as neither a local
-path nor a remote URL is `InvalidInput` as well.
+successful repair earns one more snapshot attempt, and the digest completes only when
+that attempt succeeds); a source that parses as neither a local path nor a remote URL
+is `InvalidInput` as well.
 
 `workspace` requires `kg`, `git`, `gtd`, and `session` to be loaded alongside it (the runtime rejects a pack set that omits a declared dependency), so its minimal example lists all four.
 

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -40,8 +40,10 @@ with hardened, allowlisted argv construction. A remote `git.digest` source whose
 clone or fetch setup fails returns a typed `RemoteFetchError` naming the redacted remote
 to in-process callers; the MCP `request` envelope renders it as a plain error message
 rather than structured fields (ADR-088 Amendment 1, Remote-URL mode, point 5). A
-clone/fetch failure hit later while repairing an already-cached clone, or a source that
-parses as neither a local path nor a remote URL, is `InvalidInput` instead.
+clone/fetch failure hit later while repairing an already-cached clone surfaces as
+`InvalidInput` only when the bounded refetch-then-reclone repair ultimately fails (a
+successful reclone lets the digest complete); a source that parses as neither a local
+path nor a remote URL is `InvalidInput` as well.
 
 `workspace` requires `kg`, `git`, `gtd`, and `session` to be loaded alongside it (the runtime rejects a pack set that omits a declared dependency), so its minimal example lists all four.
 

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -36,10 +36,12 @@ An always-machine-readable copy of this page is at
 `run_ingest` core (`crates/khive-pack-git/src/ingest.rs`) that both `git.digest` and the
 `kkernel git-ingest` CLI drive. Its four verbs are `git.digest` (read/ingest) plus three
 write verbs, `git.commit` / `git.branch` / `git.push` (ADR-108), that shell to system git
-with hardened, allowlisted argv construction. A remote `git.digest` source whose clone or
-fetch fails returns a typed `RemoteFetchError` naming the redacted remote (ADR-088
-Amendment 1, Remote-URL mode, point 5); a source that parses as neither a local path nor a
-remote URL is `InvalidInput`.
+with hardened, allowlisted argv construction. A remote `git.digest` source whose initial
+clone or fetch setup fails returns a typed `RemoteFetchError` naming the redacted remote
+to in-process callers; the MCP `request` envelope renders it as a plain error message
+rather than structured fields (ADR-088 Amendment 1, Remote-URL mode, point 5). A
+clone/fetch failure hit later while repairing an already-cached clone, or a source that
+parses as neither a local path nor a remote URL, is `InvalidInput` instead.
 
 `workspace` requires `kg`, `git`, `gtd`, and `session` to be loaded alongside it (the runtime rejects a pack set that omits a declared dependency), so its minimal example lists all four.
 

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -36,7 +36,10 @@ An always-machine-readable copy of this page is at
 `run_ingest` core (`crates/khive-pack-git/src/ingest.rs`) that both `git.digest` and the
 `kkernel git-ingest` CLI drive. Its four verbs are `git.digest` (read/ingest) plus three
 write verbs, `git.commit` / `git.branch` / `git.push` (ADR-108), that shell to system git
-with hardened, allowlisted argv construction.
+with hardened, allowlisted argv construction. A remote `git.digest` source whose clone or
+fetch fails returns a typed `RemoteFetchError` naming the redacted remote (ADR-088
+Amendment 1, Remote-URL mode, point 5); a source that parses as neither a local path nor a
+remote URL is `InvalidInput`.
 
 `workspace` requires `kg`, `git`, `gtd`, and `session` to be loaded alongside it (the runtime rejects a pack set that omits a declared dependency), so its minimal example lists all four.
 


### PR DESCRIPTION
Documentation follow-up to #2290.

Since #2290, `git.digest` returns `RemoteFetchError { remote, message }` when a remote source's clone or fetch setup fails, with credentials and query strings redacted from `remote`; a source that parses as neither a local path nor a remote URL stays `InvalidInput`, and storage failures keep their existing types. Neither ADR-088 Amendment 1 nor the API reference stated that contract.

- `docs/adr/ADR-088-amendment-1-git-digest.md`: point 5 under Remote-URL mode records the failure contract and the redaction guarantee.
- `docs/guide/api-reference.md`: the git pack overview names the typed failure.

No code changes.
