### PR TITLE
ci: report a coverage timeout as unavailable instead of cancelling the job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -766,7 +766,12 @@ jobs:
   coverage-measurement:
     name: Coverage measurement (advisory)
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # The measuring step carries its own budget below. A job-level timeout
+    # cancels the job, and a cancelled job is neither success nor skipped, so
+    # the gate would read an advisory measurement's timeout as a failure while
+    # the unavailable-measurement step never ran. This job-level value only
+    # bounds setup around the step.
+    timeout-minutes: 40
     outputs:
       available: ${{ steps.compute_coverage.outcome == 'success' }}
       current: ${{ steps.compute_coverage.outputs.current }}
@@ -800,6 +805,10 @@ jobs:
       - name: Compute coverage
         id: compute_coverage
         continue-on-error: true
+        # A step timeout is a step failure, which the unavailable-measurement
+        # path below already handles; the job stays green and the ratchet is
+        # skipped, as for any other measurement failure.
+        timeout-minutes: 28
         working-directory: crates
         # #705: this job runs every workspace test binary alongside instrumented
         # (and therefore slower) execution, which widens the writer-checkout


### PR DESCRIPTION
## Summary

The advisory coverage measurement carried its time budget at the job level. When `cargo llvm-cov` exceeded it, GitHub cancelled the job, and a cancelled job is neither `success` nor `skipped`, so the CI gate read it as a failed job and blocked the merge. The step that reports an unavailable measurement never ran either, because cancellation is not a step outcome it could see.

This moves the budget onto the measuring step (28 minutes) and raises the job-level limit to 40 minutes so it only bounds setup. A step timeout is a step failure, which the existing unavailable-measurement path already handles: the job stays green, `available` is false, and the coverage ratchet is skipped exactly as for any other measurement failure.

## Verification

- `.github/workflows/ci.yml` is the only file touched; the gate predicate and the ratchet wiring are unchanged.
- This PR's own CI run exercises the edited workflow.
