### PR TITLE
test(kkernel): serialize the config-ledger seam in the served-kind fan-out test

### DIFF
--- a/crates/kkernel/src/coordinator/tests.rs
+++ b/crates/kkernel/src/coordinator/tests.rs
@@ -220,6 +220,7 @@ fn registry_without_a_served_kind_declaration_is_conservatively_included() {
 }
 
 #[tokio::test]
+#[serial_test::serial(config_ledger)]
 async fn fan_out_search_uses_served_kind_metadata_before_dispatch() {
     let mut registry = BackendRegistry::new();
     registry


### PR DESCRIPTION
The workspace census test in khive-runtime (`event_store_test_fixtures_are_config_ledger_serialized`, added by #2287) requires every test that reaches the config-ledger seam to carry `#[serial_test::serial(config_ledger)]`. The served-kind fan-out test added by #2292 reaches the seam through `fan_out_search` and lacked the attribute, so workspace tests shard 2/2 fails on main and on every open PR's merge ref.

This adds the attribute to `fan_out_search_uses_served_kind_metadata_before_dispatch`, matching the neighbouring fan-out tests in the same module. No behaviour change.

Verified locally: the census test passes and `cargo test -p kkernel fan_out_search` passes.
