### PR TITLE
fix(knowledge): report lexical/ANN score provenance instead of fixed score bands

### DIFF
--- a/crates/khive-pack-knowledge/README.md
+++ b/crates/khive-pack-knowledge/README.md
@@ -7,9 +7,10 @@ rerank, and composed into markdown briefings under a token budget.
 ## Features
 
 - **TF-IDF corpus search** (`knowledge.search`) over atom name/tags/content, with
-  score bands (`>=0.46` reliable, `0.42-0.46` mixed, `<0.42` mostly off-target),
-  query decomposition, and RRF fusion against an ANN pass when an embedder is
-  configured
+  request-relative scores, explicit lexical/ANN score provenance, query
+  decomposition, and RRF fusion against an ANN pass when an embedder is configured.
+  Scores are not calibrated probabilities or absolute presence signals; interpret
+  rank together with the reported candidate and score provenance
 - **Section-level records** (`knowledge.edit`) — a closed 10-value `section_type`
   enum (`overview`, `core_model`, `formalism`, `failure_modes`, ... `other`) per
   atom, each independently disputable and adjudicable (ADR-051)

--- a/crates/khive-pack-knowledge/src/knowledge/search.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/search.rs
@@ -43,6 +43,71 @@ struct ScoredHit {
     is_domain: bool,
     status: Option<String>,
     score: f32,
+    provenance: ScoreProvenance,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ScoreProvenance {
+    lexical: bool,
+    ann: bool,
+    embedding_rerank: bool,
+}
+
+impl ScoreProvenance {
+    const fn lexical() -> Self {
+        Self {
+            lexical: true,
+            ann: false,
+            embedding_rerank: false,
+        }
+    }
+
+    const fn ann() -> Self {
+        Self {
+            lexical: false,
+            ann: true,
+            embedding_rerank: false,
+        }
+    }
+
+    fn merge_sources(&mut self, other: Self) {
+        self.lexical |= other.lexical;
+        self.ann |= other.ann;
+        self.embedding_rerank |= other.embedding_rerank;
+    }
+
+    fn sources(self) -> Vec<&'static str> {
+        let mut sources = Vec::with_capacity(2);
+        if self.lexical {
+            sources.push("lexical");
+        }
+        if self.ann {
+            sources.push("ann");
+        }
+        sources
+    }
+
+    fn to_json(self) -> Value {
+        json!({
+            "sources": self.sources(),
+            "embedding_rerank": self.embedding_rerank,
+            "normalization": "s_over_s_plus_1",
+            "calibrated": false,
+        })
+    }
+}
+
+/// `ann` only when the returned set carries ANN evidence and no returned hit
+/// carries lexical evidence — i.e. the response is entirely ANN-sourced, not
+/// merely ANN-assisted.
+fn candidate_fallback(hits: &[ScoredHit]) -> &'static str {
+    let has_lexical = hits.iter().any(|hit| hit.provenance.lexical);
+    let has_ann = hits.iter().any(|hit| hit.provenance.ann);
+    if has_ann && !has_lexical {
+        "ann"
+    } else {
+        "none"
+    }
 }
 
 enum AnnAvailability {
@@ -188,7 +253,14 @@ fn fuse_ann_hits(fts_hits: &mut Vec<ScoredHit>, ann_hits: &[ScoredHit], min_scor
         .map(|hit| (hit.id.clone(), DeterministicScore::from_f32(hit.score)))
         .collect();
     for hit in ann_hits {
-        by_id.entry(hit.id.clone()).or_insert_with(|| hit.clone());
+        match by_id.entry(hit.id.clone()) {
+            std::collections::hash_map::Entry::Occupied(mut entry) => {
+                entry.get_mut().provenance.merge_sources(hit.provenance);
+            }
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(hit.clone());
+            }
+        }
     }
 
     let source_count = usize::from(!fts_source.is_empty()) + usize::from(!ann_source.is_empty());
@@ -255,7 +327,7 @@ fn deprecated_allowed_by_status_policy(statuses: &[String], exclude_statuses: &[
 
 /// Remove hits that do not match `type_filter` after hydration.
 ///
-/// Mirrors the FTS/SQL path in `fetch_fts_candidates` (the full-scan fallback):
+/// Mirrors the FTS/SQL path in `fetch_fts_candidates`:
 ///
 /// - `Some("domain")` keeps only domain hits (`hit.is_domain == true`).
 /// - `Some(other)` where other is non-empty keeps only non-domain hits.
@@ -357,7 +429,7 @@ fn fts5_candidate_expression(raw_query: &str) -> String {
 /// SQL eligibility predicate for the public atom/domain kind filter.
 ///
 /// Domain mirrors are atoms carrying the exact `type:domain` tag. Applying
-/// this predicate in the FTS/full-scan query is load-bearing: filtering after
+/// this predicate in the bounded FTS query is load-bearing: filtering after
 /// `LIMIT` lets the wrong kind consume every candidate slot.
 fn type_eligibility_sql(type_filter: Option<&str>, atom_alias: &str) -> String {
     match type_filter {
@@ -380,13 +452,62 @@ const FTS_TERM_LIMIT: usize = 500;
 
 /// Outcome of the bounded lexical candidate fetch.
 ///
-/// `timed_out` is set only for [`khive_storage::StorageError::Timeout`] — the
-/// request-scoped read deadline elapsing mid-fetch. Any other storage error
-/// (including a genuine FTS5 syntax/parser error) still surfaces as an `Err`;
-/// fail-open applies to a timeout only.
+/// `state` distinguishes a real lexical miss from a match removed by public
+/// eligibility and from the fail-open timeout outcome. Any non-timeout
+/// storage error (including a genuine FTS5 syntax/parser error) still
+/// surfaces as an `Err`.
 struct FtsFetchOutcome {
     atoms: Vec<Atom>,
-    timed_out: bool,
+    state: LexicalCandidateState,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LexicalCandidateState {
+    Matched,
+    NoMatch,
+    Filtered,
+    PartialTimeout,
+    TimedOut,
+}
+
+impl LexicalCandidateState {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Matched => "matched",
+            Self::NoMatch => "no_match",
+            Self::Filtered => "filtered",
+            Self::PartialTimeout => "partial_timeout",
+            Self::TimedOut => "timed_out",
+        }
+    }
+
+    const fn timed_out(self) -> bool {
+        matches!(self, Self::PartialTimeout | Self::TimedOut)
+    }
+
+    fn merge(states: &[Self]) -> Self {
+        if states.contains(&Self::PartialTimeout) {
+            return Self::PartialTimeout;
+        }
+
+        let timeout_count = states
+            .iter()
+            .filter(|state| **state == Self::TimedOut)
+            .count();
+        if timeout_count == states.len() {
+            return Self::TimedOut;
+        }
+        if timeout_count > 0 {
+            return Self::PartialTimeout;
+        }
+        if states.contains(&Self::Matched) {
+            return Self::Matched;
+        }
+        if states.contains(&Self::Filtered) {
+            return Self::Filtered;
+        }
+        Self::NoMatch
+    }
 }
 
 #[cfg(test)]
@@ -450,7 +571,7 @@ async fn fetch_fts_candidates(
         Err(e) if is_timeout(&e) => {
             return Ok(FtsFetchOutcome {
                 atoms: Vec::new(),
-                timed_out: true,
+                state: LexicalCandidateState::TimedOut,
             });
         }
         Err(e) => return Err(sql_err("search fts reader", e)),
@@ -535,25 +656,29 @@ async fn fetch_fts_candidates(
     }
 
     if term_query_timed_out {
+        let state = if combined.is_empty() {
+            LexicalCandidateState::TimedOut
+        } else {
+            LexicalCandidateState::PartialTimeout
+        };
         return Ok(FtsFetchOutcome {
             atoms: combined,
-            timed_out: true,
+            state,
         });
     }
 
     if !combined.is_empty() {
         return Ok(FtsFetchOutcome {
             atoms: combined,
-            timed_out: false,
+            state: LexicalCandidateState::Matched,
         });
     }
 
-    // No term produced an eligible row. Preserve the fallback's established
-    // meaning: it is for a lexical miss, not for a lexical match whose rows
-    // were all ineligible. In the latter case an empty result is correct; a
-    // full scan could otherwise admit unrelated zero-score rows when
-    // min_score is the default 0. This probe has no ORDER BY and LIMIT 1, so
-    // it stays cheap even over the OR-joined expression.
+    // No term produced an eligible row. Distinguish a true lexical miss from
+    // a lexical match whose rows were all ineligible. In either case an empty
+    // lexical result is correct; the distinction is response provenance.
+    // This probe has no ORDER BY and LIMIT 1, so it stays cheap even over the
+    // OR-joined expression.
     let match_expr = fts5_candidate_expression(raw_query);
     let raw_fts_match = match reader
         .query_row(SqlStatement {
@@ -569,7 +694,7 @@ async fn fetch_fts_candidates(
         Err(e) if is_timeout(&e) => {
             return Ok(FtsFetchOutcome {
                 atoms: Vec::new(),
-                timed_out: true,
+                state: LexicalCandidateState::TimedOut,
             });
         }
         Err(e) => return Err(sql_err("search fts eligibility probe", e)),
@@ -577,46 +702,16 @@ async fn fetch_fts_candidates(
     if raw_fts_match.is_some() {
         return Ok(FtsFetchOutcome {
             atoms: Vec::new(),
-            timed_out: false,
+            state: LexicalCandidateState::Filtered,
         });
     }
 
-    // FTS returned nothing — fall back to a bounded full scan. Eligibility
-    // remains inside SQL so the cap is filled from rows the caller can
-    // actually receive.
-    let (status_clause, status_params) = status_sql_clause(statuses, exclude_statuses, 3);
-    let sql_str = format!(
-        "SELECT a.* FROM knowledge_atoms AS a \
-         WHERE a.namespace = ?1 AND a.deleted_at IS NULL{status_clause}{type_clause} \
-         ORDER BY a.created_at DESC, a.slug LIMIT ?2"
-    );
-    let mut params = vec![
-        SqlValue::Text(ns.to_owned()),
-        SqlValue::Integer(fetch_limit as i64),
-    ];
-    params.extend(status_params);
-
-    let rows = match reader
-        .query_all(SqlStatement {
-            sql: sql_str,
-            params,
-            label: None,
-        })
-        .await
-    {
-        Ok(rows) => rows,
-        Err(e) if is_timeout(&e) => {
-            return Ok(FtsFetchOutcome {
-                atoms: Vec::new(),
-                timed_out: true,
-            });
-        }
-        Err(e) => return Err(sql_err("search full scan", e)),
-    };
-
+    // A genuine FTS miss is an empty lexical candidate set. Corpus recency is
+    // not query evidence; feeding newest rows into rank fusion creates an
+    // artificial lexical source and can make off-topic results look topical.
     Ok(FtsFetchOutcome {
-        atoms: rows.iter().filter_map(atom_from_row).collect(),
-        timed_out: false,
+        atoms: Vec::new(),
+        state: LexicalCandidateState::NoMatch,
     })
 }
 
@@ -636,13 +731,12 @@ struct SearchCtx<'a> {
 
 // ─── core single-pass search ──────────────────────────────────────────────────
 
-/// `search_core`'s result plus whether the lexical/FTS candidate fetch hit the
-/// request read deadline (issue #1930's fail-open signal). A caller sees
-/// `hits` possibly empty/partial and `lexical_timed_out = true` instead of an
-/// `Err` — never a verb-level error for a genuine timeout.
+/// `search_core`'s result plus the lexical/FTS candidate-stage outcome. A
+/// caller sees `hits` possibly empty/partial and an explicit timeout state
+/// instead of an `Err` for a genuine request read-deadline expiry.
 struct SearchCoreOutcome {
     hits: Vec<ScoredHit>,
-    lexical_timed_out: bool,
+    lexical_state: LexicalCandidateState,
 }
 
 async fn search_core(ctx: &SearchCtx<'_>, query: &str) -> Result<SearchCoreOutcome, RuntimeError> {
@@ -657,7 +751,7 @@ async fn search_core(ctx: &SearchCtx<'_>, query: &str) -> Result<SearchCoreOutco
     if raw_query.is_empty() {
         return Ok(SearchCoreOutcome {
             hits: Vec::new(),
-            lexical_timed_out: false,
+            lexical_state: LexicalCandidateState::NoMatch,
         });
     }
 
@@ -688,7 +782,7 @@ async fn search_core(ctx: &SearchCtx<'_>, query: &str) -> Result<SearchCoreOutco
     // fall through to exact-name-bonus-only scoring rather than returning early.
     let terms_only_exact = terms.is_empty();
 
-    let FtsFetchOutcome { atoms, timed_out } = fetch_fts_candidates(
+    let FtsFetchOutcome { atoms, state } = fetch_fts_candidates(
         runtime,
         ns,
         &raw_query,
@@ -701,7 +795,7 @@ async fn search_core(ctx: &SearchCtx<'_>, query: &str) -> Result<SearchCoreOutco
     if atoms.is_empty() {
         return Ok(SearchCoreOutcome {
             hits: Vec::new(),
-            lexical_timed_out: timed_out,
+            lexical_state: state,
         });
     }
 
@@ -709,7 +803,7 @@ async fn search_core(ctx: &SearchCtx<'_>, query: &str) -> Result<SearchCoreOutco
     if candidates.is_empty() {
         return Ok(SearchCoreOutcome {
             hits: Vec::new(),
-            lexical_timed_out: timed_out,
+            lexical_state: state,
         });
     }
 
@@ -758,9 +852,10 @@ async fn search_core(ctx: &SearchCtx<'_>, query: &str) -> Result<SearchCoreOutco
                 finalized: cand.finalized,
                 is_domain: cand.is_domain,
                 score,
+                provenance: ScoreProvenance::lexical(),
             })
             .collect(),
-        lexical_timed_out: timed_out,
+        lexical_state: state,
     })
 }
 
@@ -783,7 +878,7 @@ async fn search_decomposed(
 
     let SearchCoreOutcome {
         hits: full,
-        lexical_timed_out: full_timed_out,
+        lexical_state: full_state,
     } = search_core(ctx, query).await?;
     let sub_ctx1 = SearchCtx {
         runtime: ctx.runtime,
@@ -798,13 +893,13 @@ async fn search_decomposed(
     };
     let SearchCoreOutcome {
         hits: s1,
-        lexical_timed_out: s1_timed_out,
+        lexical_state: s1_state,
     } = search_core(&sub_ctx1, &sub_q1).await?;
     let SearchCoreOutcome {
         hits: s2,
-        lexical_timed_out: s2_timed_out,
+        lexical_state: s2_state,
     } = search_core(&sub_ctx1, &sub_q2).await?;
-    let lexical_timed_out = full_timed_out || s1_timed_out || s2_timed_out;
+    let lexical_state = LexicalCandidateState::merge(&[full_state, s1_state, s2_state]);
 
     let mut scores: HashMap<String, f32> = HashMap::new();
     let mut data: HashMap<String, ScoredHit> = HashMap::new();
@@ -855,7 +950,7 @@ async fn search_decomposed(
     ranked.truncate(ctx.fetch_limit);
     Ok(SearchCoreOutcome {
         hits: ranked,
-        lexical_timed_out,
+        lexical_state,
     })
 }
 
@@ -915,6 +1010,7 @@ async fn rerank_with_embeddings(
         for (hit, cos) in hits.iter_mut().zip(cosines.iter()) {
             let norm_tfidf = hit.score / max_tfidf;
             hit.score = alpha * norm_tfidf + (1.0 - alpha) * cos.max(0.0);
+            hit.provenance.embedding_rerank = true;
         }
         hits.sort_by(|a, b| {
             b.score
@@ -1227,6 +1323,7 @@ async fn search_eligible_ann_with_refill(
                 is_domain: false,
                 status: None,
                 score,
+                provenance: ScoreProvenance::ann(),
             })
             .collect();
 
@@ -1985,12 +2082,13 @@ impl KnowledgeHandlers {
 
         let SearchCoreOutcome {
             mut hits,
-            lexical_timed_out,
+            lexical_state,
         } = if do_decompose && non_stop_count >= decompose_threshold {
             search_decomposed(&ctx, &raw_query, intersection_bonus).await?
         } else {
             search_core(&ctx, &raw_query).await?
         };
+        let lexical_timed_out = lexical_state.timed_out();
 
         let mut ann_unavailable = false;
         if !ann_hits.is_empty() {
@@ -2023,6 +2121,7 @@ impl KnowledgeHandlers {
         apply_status_multipliers(&mut hits, allow_deprecated);
         enforce_min_score_floor(&mut hits, min_score);
         hits.truncate(limit);
+        let fallback = candidate_fallback(&hits);
 
         let atom_ids: Vec<String> = hits
             .iter()
@@ -2063,12 +2162,20 @@ impl KnowledgeHandlers {
                     "finalized": h.finalized,
                     "kind": if h.is_domain { "domain" } else { "atom" },
                     "score": h.score,
+                    "score_provenance": h.provenance.to_json(),
                 })
             })
             .collect();
         let count = results.len();
 
-        let mut out = json!({ "results": results, "total": count });
+        let mut out = json!({
+            "results": results,
+            "total": count,
+            "candidate_provenance": {
+                "lexical": lexical_state.as_str(),
+                "fallback": fallback,
+            },
+        });
         if ann_unavailable {
             out["ann_unavailable"] = json!(true);
         }
@@ -2180,8 +2287,9 @@ impl KnowledgeHandlers {
 
         let SearchCoreOutcome {
             mut hits,
-            lexical_timed_out,
+            lexical_state,
         } = search_core(&ctx, &raw_query).await?;
+        let lexical_timed_out = lexical_state.timed_out();
 
         let mut ann_unavailable = false;
         if !ann_hits.is_empty() {
@@ -2943,10 +3051,7 @@ mod tests {
             "the per-term fetch must return partial degradation when the controlled deadline \
              expires between term queries",
         );
-        assert!(
-            outcome.timed_out,
-            "the controlled deadline must be observed"
-        );
+        assert_eq!(outcome.state, LexicalCandidateState::PartialTimeout);
         assert!(
             !outcome.atoms.is_empty(),
             "candidates from the completed term must survive degradation"
@@ -3069,7 +3174,7 @@ mod tests {
             fetch_fts_candidates(&runtime, "local", "alpha beta", None, &[], &[], fetch_limit)
                 .await
                 .expect("fetch must not error");
-        assert!(!outcome.timed_out);
+        assert_eq!(outcome.state, LexicalCandidateState::Matched);
         assert_eq!(outcome.atoms.len(), fetch_limit);
 
         let beta_present = outcome
@@ -3089,6 +3194,134 @@ mod tests {
         );
     }
 
+    /// Issue #1982: a genuine FTS miss is not a request to browse the newest
+    /// corpus rows. The former bounded full-scan fallback returned this atom
+    /// despite there being no lexical overlap, and rank fusion could then
+    /// turn that arbitrary recency order into a topical-looking score.
+    #[tokio::test]
+    async fn true_lexical_miss_does_not_return_newest_rows() {
+        let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+        {
+            let access = runtime.sql();
+            let mut writer = access.writer().await.expect("writer");
+            writer
+                .execute(SqlStatement {
+                    sql: "INSERT INTO knowledge_atoms ( \
+                              id, namespace, slug, name, content, tags, properties, finalized, \
+                              status, source_uri, source_type, created_at, updated_at, deleted_at \
+                          ) VALUES ( \
+                              '92000000-0000-0000-0000-000000000001', 'local', \
+                              'newest-unrelated', 'Newest Unrelated', \
+                              'content about retrieval systems and vector indexes', '[]', NULL, \
+                              1, 'reviewed', NULL, NULL, 999, 999, NULL \
+                          )"
+                    .to_string(),
+                    params: Vec::new(),
+                    label: None,
+                })
+                .await
+                .expect("seed unrelated atom");
+        }
+
+        let outcome = fetch_fts_candidates(
+            &runtime,
+            "local",
+            "zzzxqvnonexistent",
+            None,
+            &[],
+            &[],
+            CANDIDATE_POOL,
+        )
+        .await
+        .expect("lexical miss must not error");
+
+        assert_eq!(outcome.state, LexicalCandidateState::NoMatch);
+        assert!(
+            outcome.atoms.is_empty(),
+            "a true lexical miss must stay empty, not return newest rows: {:?}",
+            outcome
+                .atoms
+                .iter()
+                .map(|atom| atom.slug.as_str())
+                .collect::<Vec<_>>()
+        );
+
+        let token = runtime.authorize(Namespace::local()).expect("local token");
+        let ann = vamana::new_shared();
+        let off_topic = KnowledgeHandlers::search(
+            &runtime,
+            &token,
+            json!({"query": "zzzxqvnonexistent", "rerank": false}),
+            &ann,
+        )
+        .await
+        .expect("off-topic search must not error");
+        assert_eq!(off_topic["total"], 0);
+        assert_eq!(off_topic["candidate_provenance"]["lexical"], "no_match");
+        assert_eq!(off_topic["candidate_provenance"]["fallback"], "none");
+
+        let lexical = KnowledgeHandlers::search(
+            &runtime,
+            &token,
+            json!({"query": "retrieval", "rerank": false}),
+            &ann,
+        )
+        .await
+        .expect("lexical search must not error");
+        assert_eq!(lexical["candidate_provenance"]["lexical"], "matched");
+        assert_eq!(lexical["candidate_provenance"]["fallback"], "none");
+        let first = &lexical["results"][0];
+        assert_eq!(first["slug"], "newest-unrelated");
+        assert_eq!(first["score_provenance"]["sources"], json!(["lexical"]));
+        assert_eq!(first["score_provenance"]["embedding_rerank"], false);
+        assert_eq!(
+            first["score_provenance"]["normalization"],
+            "s_over_s_plus_1"
+        );
+        assert_eq!(first["score_provenance"]["calibrated"], false);
+    }
+
+    #[tokio::test]
+    async fn lexical_candidate_state_distinguishes_filtered_match() {
+        let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+        {
+            let access = runtime.sql();
+            let mut writer = access.writer().await.expect("writer");
+            writer
+                .execute(SqlStatement {
+                    sql: "INSERT INTO knowledge_atoms ( \
+                              id, namespace, slug, name, content, tags, properties, finalized, \
+                              status, source_uri, source_type, created_at, updated_at, deleted_at \
+                          ) VALUES ( \
+                              '92000000-0000-0000-0000-000000000002', 'local', \
+                              'filtered-draft', 'Filtered Draft', \
+                              'uniquefilteredtoken content', '[]', NULL, 0, 'draft', \
+                              NULL, NULL, 1, 1, NULL \
+                          )"
+                    .to_string(),
+                    params: Vec::new(),
+                    label: None,
+                })
+                .await
+                .expect("seed filtered atom");
+        }
+
+        let outcome = fetch_fts_candidates(
+            &runtime,
+            "local",
+            "uniquefilteredtoken",
+            None,
+            &[],
+            &["draft", "deprecated"],
+            CANDIDATE_POOL,
+        )
+        .await
+        .expect("filtered lexical match must not error");
+
+        assert!(outcome.atoms.is_empty());
+        assert_eq!(outcome.state, LexicalCandidateState::Filtered);
+    }
+
     #[tokio::test]
     async fn missing_ann_hydration_is_dropped_and_reported() {
         let runtime = KhiveRuntime::memory().expect("in-memory runtime");
@@ -3102,6 +3335,7 @@ mod tests {
             is_domain: false,
             status: None,
             score: 0.8,
+            provenance: ScoreProvenance::ann(),
         }];
 
         let failures = hydrate_empty_hits(&runtime, "local", &mut hits).await;
@@ -3179,6 +3413,7 @@ mod tests {
                 is_domain: false,
                 status: None,
                 score: 1.0,
+                provenance: ScoreProvenance::ann(),
             })
             .collect();
 
@@ -3314,6 +3549,7 @@ mod tests {
             is_domain: false,
             status: None,
             score: 1.0,
+            provenance: ScoreProvenance::ann(),
         })
         .collect();
 
@@ -3383,7 +3619,47 @@ mod tests {
             is_domain: false,
             status: status.map(str::to_string),
             score,
+            provenance: ScoreProvenance::lexical(),
         }
+    }
+
+    fn make_ann_hit(id: &str, status: Option<&str>, score: f32) -> ScoredHit {
+        let mut hit = make_hit(id, status, score);
+        hit.provenance = ScoreProvenance::ann();
+        hit
+    }
+
+    #[test]
+    fn rrf_fusion_preserves_per_hit_score_sources_and_ann_fallback() {
+        let mut hybrid = vec![make_hit("shared", Some("reviewed"), 0.8)];
+        let ann = vec![make_ann_hit("shared", Some("reviewed"), 0.9)];
+        fuse_ann_hits(&mut hybrid, &ann, 0.0);
+        assert_eq!(hybrid.len(), 1);
+        assert_eq!(hybrid[0].provenance.sources(), ["lexical", "ann"]);
+        assert_eq!(candidate_fallback(&hybrid), "none");
+
+        let mut ann_only = Vec::new();
+        fuse_ann_hits(
+            &mut ann_only,
+            &[make_ann_hit("semantic", Some("reviewed"), 0.9)],
+            0.0,
+        );
+        assert_eq!(ann_only.len(), 1);
+        assert_eq!(ann_only[0].provenance.sources(), ["ann"]);
+        assert_eq!(candidate_fallback(&ann_only), "ann");
+        assert_eq!(
+            ann_only[0].provenance.to_json(),
+            json!({
+                "sources": ["ann"],
+                "embedding_rerank": false,
+                "normalization": "s_over_s_plus_1",
+                "calibrated": false,
+            })
+        );
+
+        let lexical_only = vec![make_hit("lexical", Some("reviewed"), 0.7)];
+        assert_eq!(lexical_only[0].provenance.sources(), ["lexical"]);
+        assert_eq!(candidate_fallback(&lexical_only), "none");
     }
 
     #[test]
@@ -3619,6 +3895,133 @@ mod tests {
             healthy.and_then(|counts| counts.get(&atom_ids[0]).copied()),
             Some(0),
             "control: without a deadline the lookup returns real counts"
+        );
+    }
+
+    // ── deterministic embedder for the rerank-provenance test ────────────
+
+    const RERANK_TEST_MODEL_KEY: &str = "all-minilm-l6-v2";
+    const RERANK_TEST_DIM: usize = 384;
+
+    struct RerankTestEmbedService;
+
+    #[async_trait::async_trait]
+    impl lattice_embed::EmbeddingService for RerankTestEmbedService {
+        async fn embed(
+            &self,
+            texts: &[String],
+            _model: lattice_embed::EmbeddingModel,
+        ) -> Result<Vec<Vec<f32>>, lattice_embed::EmbedError> {
+            // Distinct, non-degenerate unit vectors per text position so
+            // cosine similarity is well-defined and never uniform, the same
+            // shape `ann_degrade_tests::FakeDimService` uses.
+            Ok(texts
+                .iter()
+                .enumerate()
+                .map(|(i, _)| {
+                    let v = (i + 1) as f32;
+                    let norm = (RERANK_TEST_DIM as f32 * v * v).sqrt();
+                    vec![v / norm; RERANK_TEST_DIM]
+                })
+                .collect())
+        }
+
+        fn supports_model(&self, _model: lattice_embed::EmbeddingModel) -> bool {
+            true
+        }
+
+        fn name(&self) -> &'static str {
+            "rerank-test-embed"
+        }
+    }
+
+    struct RerankTestEmbedProvider;
+
+    #[async_trait::async_trait]
+    impl khive_runtime::EmbedderProvider for RerankTestEmbedProvider {
+        fn name(&self) -> &str {
+            RERANK_TEST_MODEL_KEY
+        }
+
+        fn dimensions(&self) -> usize {
+            RERANK_TEST_DIM
+        }
+
+        async fn build(
+            &self,
+        ) -> Result<std::sync::Arc<dyn lattice_embed::EmbeddingService>, RuntimeError> {
+            Ok(std::sync::Arc::new(RerankTestEmbedService))
+        }
+    }
+
+    fn runtime_with_deterministic_embedder() -> KhiveRuntime {
+        let rt = KhiveRuntime::new(khive_runtime::RuntimeConfig {
+            git_write: Default::default(),
+            display_timezone: khive_runtime::config::resolve_default_display_timezone(),
+            events_split: None,
+            db_path: None,
+            blob_hydration_bytes: khive_runtime::DEFAULT_BLOB_HYDRATION_BYTES,
+            default_namespace: Namespace::local(),
+            embedding_model: Some(lattice_embed::EmbeddingModel::AllMiniLmL6V2),
+            additional_embedding_models: vec![],
+            gate: std::sync::Arc::new(khive_runtime::AllowAllGate),
+            packs: vec!["kg".to_string(), "knowledge".to_string()],
+            backend_id: khive_runtime::BackendId::main(),
+            brain_profile: None,
+            visible_namespaces: vec![],
+            allowed_outbound_namespaces: vec![],
+            actor_id: None,
+        })
+        .expect("in-memory runtime with embedder config");
+        rt.register_embedder(RerankTestEmbedProvider);
+        rt
+    }
+
+    /// Existing coverage only asserts `score_provenance.embedding_rerank ==
+    /// false` (no embedder configured); the mutation at
+    /// `rerank_with_embeddings` that sets it `true` on a successful rerank
+    /// had no test that would fail if it were deleted. This pins the `true`
+    /// case under a deterministic embedder.
+    #[tokio::test]
+    async fn embedding_rerank_provenance_is_true_when_rerank_runs() {
+        let runtime = runtime_with_deterministic_embedder();
+        {
+            let access = runtime.sql();
+            let mut writer = access.writer().await.expect("writer");
+            writer
+                .execute(SqlStatement {
+                    sql: "INSERT INTO knowledge_atoms ( \
+                              id, namespace, slug, name, content, tags, properties, finalized, \
+                              status, source_uri, source_type, created_at, updated_at, deleted_at \
+                          ) VALUES ( \
+                              '94000000-0000-0000-0000-000000000001', 'local', \
+                              'rerank-target', 'Rerank Target', \
+                              'content that the lexical stage must match for the rerank pass', \
+                              '[]', NULL, 1, 'reviewed', NULL, NULL, 1000, 1000, NULL \
+                          )"
+                    .to_string(),
+                    params: Vec::new(),
+                    label: None,
+                })
+                .await
+                .expect("seed rerank target atom");
+        }
+
+        let token = runtime.authorize(Namespace::local()).expect("local token");
+        let ann = vamana::new_shared();
+        let out = KnowledgeHandlers::search(
+            &runtime,
+            &token,
+            json!({"query": "rerank target content", "rerank": true}),
+            &ann,
+        )
+        .await
+        .expect("rerank-enabled search must not error");
+
+        assert_eq!(out["total"], 1);
+        assert_eq!(
+            out["results"][0]["score_provenance"]["embedding_rerank"], true,
+            "a successful embedding rerank must record embedding_rerank: true; got {out:?}"
         );
     }
 }

--- a/crates/khive-pack-knowledge/src/knowledge/search.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/search.rs
@@ -702,18 +702,108 @@ async fn fetch_fts_candidates(
         });
     }
 
-    if !combined.is_empty() {
+    // Whether FTS itself produced any eligible row, captured before the
+    // recovery step below folds more rows into `combined`. A query that
+    // lexically matches something else in the trigram index must not
+    // suppress a name/tag match FTS cannot see — so recovery runs whenever
+    // the query could plausibly hit either recoverable class, independent of
+    // whether FTS already matched, matched only ineligible rows, or missed
+    // entirely; its rows are unioned in below rather than gated behind an
+    // early return on any of those three outcomes.
+    let fts_had_rows = !combined.is_empty();
+
+    // Two candidate classes the scorer still promises can never reach the
+    // trigram index at all, regardless of the query: `exact_name_bonus`
+    // scores a name that contains the raw query as a substring, and a query
+    // shorter than the trigram minimum span (e.g. "RAG", "ML") never matches
+    // any trigram; and `w_tags` scores atom tags, which `fts_knowledge` does
+    // not index. Recover both with a bounded direct-predicate lookup — not a
+    // recency scan — so only rows that actually overlap the query by name
+    // substring or literal tag come back.
+    let name_needle = raw_query.trim().to_lowercase();
+    let tag_terms = tag_match_terms(raw_query);
+    if !name_needle.is_empty() || !tag_terms.is_empty() {
+        let mut exact_params: Vec<SqlValue> = vec![SqlValue::Text(ns.to_owned())];
+        let mut predicates: Vec<String> = Vec::new();
+        let mut next_param = 2;
+        if !name_needle.is_empty() {
+            predicates.push(format!("a.name LIKE ?{next_param} ESCAPE '\\'"));
+            exact_params.push(SqlValue::Text(format!("%{}%", escape_like(&name_needle))));
+            next_param += 1;
+        }
+        for term in &tag_terms {
+            predicates.push(format!("a.tags LIKE ?{next_param} ESCAPE '\\'"));
+            exact_params.push(SqlValue::Text(format!("%\"{}\"%", escape_like(term))));
+            next_param += 1;
+        }
+
+        let (status_clause, status_params) =
+            status_sql_clause(statuses, exclude_statuses, next_param);
+        next_param += status_params.len();
+        exact_params.extend(status_params);
+        let limit_param = next_param;
+        exact_params.push(SqlValue::Integer(fetch_limit as i64));
+
+        let exact_sql = format!(
+            "SELECT a.* FROM knowledge_atoms AS a \
+             WHERE a.namespace = ?1 AND a.deleted_at IS NULL{status_clause}{type_clause} \
+               AND ({predicate_or}) \
+             ORDER BY a.slug LIMIT ?{limit_param}",
+            predicate_or = predicates.join(" OR ")
+        );
+
+        let exact_rows = match reader
+            .query_all(SqlStatement {
+                sql: exact_sql,
+                params: exact_params,
+                label: None,
+            })
+            .await
+        {
+            Ok(rows) => rows,
+            // FTS already found eligible rows — report those rather than
+            // discarding them over a timed-out recovery lookup. Only a
+            // recovery timeout on an otherwise-empty pool is a real timeout.
+            Err(e) if is_timeout(&e) => {
+                return Ok(FtsFetchOutcome {
+                    atoms: combined,
+                    state: if fts_had_rows {
+                        LexicalCandidateState::Matched
+                    } else {
+                        LexicalCandidateState::TimedOut
+                    },
+                });
+            }
+            Err(e) => return Err(sql_err("search exact-match candidates", e)),
+        };
+
+        for atom in exact_rows.iter().filter_map(atom_from_row) {
+            if seen_ids.insert(atom.id) {
+                combined.push(atom);
+            }
+        }
+    }
+
+    if fts_had_rows {
         return Ok(FtsFetchOutcome {
             atoms: combined,
             state: LexicalCandidateState::Matched,
         });
     }
 
-    // No term produced an eligible row. Distinguish a true lexical miss from
-    // a lexical match whose rows were all ineligible. In either case an empty
-    // lexical result is correct; the distinction is response provenance.
-    // This probe has no ORDER BY and LIMIT 1, so it stays cheap even over the
-    // OR-joined expression.
+    if !combined.is_empty() {
+        return Ok(FtsFetchOutcome {
+            atoms: combined,
+            state: LexicalCandidateState::ExactMatch,
+        });
+    }
+
+    // No term produced an eligible row and neither name nor tag recovery
+    // matched. Distinguish a true lexical miss from a lexical match whose
+    // rows were all ineligible. In either case an empty lexical result is
+    // correct; the distinction is response provenance. This probe has no
+    // ORDER BY and LIMIT 1, so it stays cheap even over the OR-joined
+    // expression.
     let match_expr = fts5_candidate_expression(raw_query);
     let raw_fts_match = match reader
         .query_row(SqlStatement {
@@ -741,81 +831,9 @@ async fn fetch_fts_candidates(
         });
     }
 
-    // A genuine FTS miss. Corpus recency is still not query evidence — that
-    // fallback stays removed — but two candidate classes the scorer still
-    // promises can never reach the trigram index at all, regardless of the
-    // query: `exact_name_bonus` scores a name that contains the raw query as
-    // a substring, and a query shorter than the trigram minimum span (e.g.
-    // "RAG", "ML") never matches any trigram; and `w_tags` scores atom tags,
-    // which `fts_knowledge` does not index. Recover both with a bounded
-    // direct-predicate lookup — not a recency scan — so only rows that
-    // actually overlap the query by name substring or literal tag come back.
-    let name_needle = raw_query.trim().to_lowercase();
-    let tag_terms = tag_match_terms(raw_query);
-    if name_needle.is_empty() && tag_terms.is_empty() {
-        return Ok(FtsFetchOutcome {
-            atoms: Vec::new(),
-            state: LexicalCandidateState::NoMatch,
-        });
-    }
-
-    let mut exact_params: Vec<SqlValue> = vec![SqlValue::Text(ns.to_owned())];
-    let mut predicates: Vec<String> = Vec::new();
-    let mut next_param = 2;
-    if !name_needle.is_empty() {
-        predicates.push(format!("a.name LIKE ?{next_param} ESCAPE '\\'"));
-        exact_params.push(SqlValue::Text(format!("%{}%", escape_like(&name_needle))));
-        next_param += 1;
-    }
-    for term in &tag_terms {
-        predicates.push(format!("a.tags LIKE ?{next_param} ESCAPE '\\'"));
-        exact_params.push(SqlValue::Text(format!("%\"{}\"%", escape_like(term))));
-        next_param += 1;
-    }
-
-    let (status_clause, status_params) = status_sql_clause(statuses, exclude_statuses, next_param);
-    next_param += status_params.len();
-    exact_params.extend(status_params);
-    let limit_param = next_param;
-    exact_params.push(SqlValue::Integer(fetch_limit as i64));
-
-    let exact_sql = format!(
-        "SELECT a.* FROM knowledge_atoms AS a \
-         WHERE a.namespace = ?1 AND a.deleted_at IS NULL{status_clause}{type_clause} \
-           AND ({predicate_or}) \
-         ORDER BY a.slug LIMIT ?{limit_param}",
-        predicate_or = predicates.join(" OR ")
-    );
-
-    let exact_rows = match reader
-        .query_all(SqlStatement {
-            sql: exact_sql,
-            params: exact_params,
-            label: None,
-        })
-        .await
-    {
-        Ok(rows) => rows,
-        Err(e) if is_timeout(&e) => {
-            return Ok(FtsFetchOutcome {
-                atoms: Vec::new(),
-                state: LexicalCandidateState::TimedOut,
-            });
-        }
-        Err(e) => return Err(sql_err("search exact-match candidates", e)),
-    };
-
-    let exact_atoms: Vec<Atom> = exact_rows.iter().filter_map(atom_from_row).collect();
-    if exact_atoms.is_empty() {
-        return Ok(FtsFetchOutcome {
-            atoms: Vec::new(),
-            state: LexicalCandidateState::NoMatch,
-        });
-    }
-
     Ok(FtsFetchOutcome {
-        atoms: exact_atoms,
-        state: LexicalCandidateState::ExactMatch,
+        atoms: Vec::new(),
+        state: LexicalCandidateState::NoMatch,
     })
 }
 
@@ -3424,6 +3442,193 @@ mod tests {
 
         assert!(outcome.atoms.is_empty());
         assert_eq!(outcome.state, LexicalCandidateState::Filtered);
+    }
+
+    /// Issue #2381 follow-up: FTS finding *something* for the query must not
+    /// suppress a sibling atom that FTS structurally cannot reach at all
+    /// (here, a tag-only match — `fts_knowledge` never indexes `tags`). The
+    /// old code returned as soon as `combined` was non-empty, before the
+    /// name/tag recovery query ever ran, so the tag-only atom was silently
+    /// dropped whenever anything else in the corpus happened to share a
+    /// lexical term with the query. Recovery must run and union its rows in
+    /// even on a full FTS match.
+    #[tokio::test]
+    async fn matched_fts_result_still_recovers_tag_only_sibling() {
+        let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+        {
+            let access = runtime.sql();
+            let mut writer = access.writer().await.expect("writer");
+            writer
+                .execute(SqlStatement {
+                    sql: "INSERT INTO knowledge_atoms ( \
+                              id, namespace, slug, name, content, tags, properties, finalized, \
+                              status, source_uri, source_type, created_at, updated_at, deleted_at \
+                          ) VALUES ( \
+                              '94000000-0000-0000-0000-000000000001', 'local', \
+                              'content-match', 'Content Match', \
+                              'this atom mentions throttle explicitly in its content', \
+                              '[]', NULL, 1, 'reviewed', NULL, NULL, 1000, 1000, NULL \
+                          ), ( \
+                              '94000000-0000-0000-0000-000000000002', 'local', \
+                              'tag-only-sibling', 'Something Else Entirely', \
+                              'content with no lexical overlap with the query at all', \
+                              '[\"throttle\"]', NULL, 1, 'reviewed', NULL, NULL, 2000, 2000, NULL \
+                          )"
+                    .to_string(),
+                    params: Vec::new(),
+                    label: None,
+                })
+                .await
+                .expect("seed content-match atom and tag-only sibling");
+        }
+
+        let outcome = fetch_fts_candidates(
+            &runtime,
+            "local",
+            "throttle",
+            None,
+            &[],
+            &[],
+            CANDIDATE_POOL,
+        )
+        .await
+        .expect("union recovery must not error");
+
+        assert_eq!(
+            outcome.state,
+            LexicalCandidateState::Matched,
+            "FTS rows exist, so provenance stays matched even though recovery added a row"
+        );
+        let mut slugs: Vec<&str> = outcome.atoms.iter().map(|a| a.slug.as_str()).collect();
+        slugs.sort_unstable();
+        assert_eq!(
+            slugs,
+            ["content-match", "tag-only-sibling"],
+            "the tag-only sibling must survive alongside the FTS-matched atom: {slugs:?}"
+        );
+    }
+
+    /// Companion to the match case above, on the `Filtered` branch: FTS
+    /// matches only an ineligible row (excluded by status), and a *separate*
+    /// eligible atom is reachable exclusively by tag. The old code returned
+    /// `Filtered` as soon as the raw-match probe found the ineligible row,
+    /// before ever attempting name/tag recovery, so the eligible tag-only
+    /// atom was dropped even though nothing about its own eligibility ruled
+    /// it out.
+    ///
+    /// (Note: an equivalent name-substring construction is not possible here
+    /// — the trigram tokenizer indexes `name` as raw substrings, so any
+    /// eligible atom whose name contains the query would already be found by
+    /// the FTS probe itself, making the outcome `Matched` rather than
+    /// `Filtered`. Verified empirically: a `trigram` FTS5 table matches a
+    /// query phrase against any substring occurrence, mid-word included.
+    /// Tags are the only recoverable class genuinely invisible to FTS
+    /// regardless of eligibility, so this test exercises the `Filtered`
+    /// branch through tags instead.)
+    #[tokio::test]
+    async fn filtered_fts_result_still_recovers_tag_only_sibling() {
+        let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+        {
+            let access = runtime.sql();
+            let mut writer = access.writer().await.expect("writer");
+            writer
+                .execute(SqlStatement {
+                    sql: "INSERT INTO knowledge_atoms ( \
+                              id, namespace, slug, name, content, tags, properties, finalized, \
+                              status, source_uri, source_type, created_at, updated_at, deleted_at \
+                          ) VALUES ( \
+                              '94000000-0000-0000-0000-000000000003', 'local', \
+                              'ineligible-draft', 'Ineligible Draft', \
+                              'gizmocraft content mentioned only in a draft', \
+                              '[]', NULL, 0, 'draft', NULL, NULL, 1000, 1000, NULL \
+                          ), ( \
+                              '94000000-0000-0000-0000-000000000004', 'local', \
+                              'eligible-tag-sibling', 'Eligible Tag Sibling', \
+                              'unrelated content with no lexical overlap at all', \
+                              '[\"gizmocraft\"]', NULL, 1, 'reviewed', NULL, NULL, 2000, 2000, NULL \
+                          )"
+                    .to_string(),
+                    params: Vec::new(),
+                    label: None,
+                })
+                .await
+                .expect("seed ineligible-draft atom and eligible tag sibling");
+        }
+
+        let outcome = fetch_fts_candidates(
+            &runtime,
+            "local",
+            "gizmocraft",
+            None,
+            &[],
+            &["draft", "deprecated"],
+            CANDIDATE_POOL,
+        )
+        .await
+        .expect("filtered-branch recovery must not error");
+
+        assert_eq!(
+            outcome.state,
+            LexicalCandidateState::ExactMatch,
+            "FTS produced no eligible row, so a non-empty recovery reports the recovered-rows state"
+        );
+        let slugs: Vec<&str> = outcome.atoms.iter().map(|a| a.slug.as_str()).collect();
+        assert_eq!(
+            slugs,
+            ["eligible-tag-sibling"],
+            "the eligible tag sibling must be recovered even though the raw FTS probe only found \
+             the ineligible draft row: {slugs:?}"
+        );
+    }
+
+    /// The union must dedup by id: an atom reachable both through FTS content
+    /// and through the recovery predicate (here, a tag literally equal to
+    /// the query) must appear exactly once in the returned pool.
+    #[tokio::test]
+    async fn union_dedupes_atom_reachable_by_both_fts_and_tag() {
+        let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+        {
+            let access = runtime.sql();
+            let mut writer = access.writer().await.expect("writer");
+            writer
+                .execute(SqlStatement {
+                    sql: "INSERT INTO knowledge_atoms ( \
+                              id, namespace, slug, name, content, tags, properties, finalized, \
+                              status, source_uri, source_type, created_at, updated_at, deleted_at \
+                          ) VALUES ( \
+                              '94000000-0000-0000-0000-000000000005', 'local', \
+                              'both-paths', 'Both Paths', \
+                              'this content explicitly mentions duplicatecheck', \
+                              '[\"duplicatecheck\"]', NULL, 1, 'reviewed', NULL, NULL, 1000, 1000, \
+                              NULL \
+                          )"
+                    .to_string(),
+                    params: Vec::new(),
+                    label: None,
+                })
+                .await
+                .expect("seed atom reachable by both content and tag");
+        }
+
+        let outcome = fetch_fts_candidates(
+            &runtime,
+            "local",
+            "duplicatecheck",
+            None,
+            &[],
+            &[],
+            CANDIDATE_POOL,
+        )
+        .await
+        .expect("dedup union must not error");
+
+        assert_eq!(outcome.state, LexicalCandidateState::Matched);
+        let slugs: Vec<&str> = outcome.atoms.iter().map(|a| a.slug.as_str()).collect();
+        assert_eq!(
+            slugs,
+            ["both-paths"],
+            "an atom reachable both ways must appear exactly once: {slugs:?}"
+        );
     }
 
     /// A query shorter than the trigram tokenizer's minimum span (schema.sql:

--- a/crates/khive-pack-knowledge/src/knowledge/search.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/search.rs
@@ -426,6 +426,36 @@ fn fts5_candidate_expression(raw_query: &str) -> String {
     fts5_candidate_terms(raw_query).join(" OR ")
 }
 
+/// De-duplicated, non-stop, length-eligible query tokens, expanded the same
+/// way `search_core` expands scoring terms. Used only by the exact-match
+/// recovery path's tag predicate below — `fts_knowledge` does not index
+/// `tags` at all (schema.sql), so a tag-only query can never surface through
+/// FTS regardless of term length.
+fn tag_match_terms(raw_query: &str) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut terms: Vec<String> = matching::tokenize_field(raw_query)
+        .into_iter()
+        .filter(|term| term.len() >= MIN_TERM_LEN && !is_stop(term))
+        .filter(|term| seen.insert(term.clone()))
+        .collect();
+    let _ = expand_terms(&mut terms);
+    terms
+}
+
+/// Escape SQLite `LIKE` wildcard characters (`%`, `_`) and the escape
+/// character itself (`\`) so a query token is matched literally under
+/// `LIKE ... ESCAPE '\'` rather than as a pattern.
+fn escape_like(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for c in input.chars() {
+        if matches!(c, '\\' | '%' | '_') {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out
+}
+
 /// SQL eligibility predicate for the public atom/domain kind filter.
 ///
 /// Domain mirrors are atoms carrying the exact `type:domain` tag. Applying
@@ -464,6 +494,7 @@ struct FtsFetchOutcome {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum LexicalCandidateState {
     Matched,
+    ExactMatch,
     NoMatch,
     Filtered,
     PartialTimeout,
@@ -474,6 +505,7 @@ impl LexicalCandidateState {
     const fn as_str(self) -> &'static str {
         match self {
             Self::Matched => "matched",
+            Self::ExactMatch => "exact_match",
             Self::NoMatch => "no_match",
             Self::Filtered => "filtered",
             Self::PartialTimeout => "partial_timeout",
@@ -502,6 +534,9 @@ impl LexicalCandidateState {
         }
         if states.contains(&Self::Matched) {
             return Self::Matched;
+        }
+        if states.contains(&Self::ExactMatch) {
+            return Self::ExactMatch;
         }
         if states.contains(&Self::Filtered) {
             return Self::Filtered;
@@ -706,12 +741,81 @@ async fn fetch_fts_candidates(
         });
     }
 
-    // A genuine FTS miss is an empty lexical candidate set. Corpus recency is
-    // not query evidence; feeding newest rows into rank fusion creates an
-    // artificial lexical source and can make off-topic results look topical.
+    // A genuine FTS miss. Corpus recency is still not query evidence — that
+    // fallback stays removed — but two candidate classes the scorer still
+    // promises can never reach the trigram index at all, regardless of the
+    // query: `exact_name_bonus` scores a name that contains the raw query as
+    // a substring, and a query shorter than the trigram minimum span (e.g.
+    // "RAG", "ML") never matches any trigram; and `w_tags` scores atom tags,
+    // which `fts_knowledge` does not index. Recover both with a bounded
+    // direct-predicate lookup — not a recency scan — so only rows that
+    // actually overlap the query by name substring or literal tag come back.
+    let name_needle = raw_query.trim().to_lowercase();
+    let tag_terms = tag_match_terms(raw_query);
+    if name_needle.is_empty() && tag_terms.is_empty() {
+        return Ok(FtsFetchOutcome {
+            atoms: Vec::new(),
+            state: LexicalCandidateState::NoMatch,
+        });
+    }
+
+    let mut exact_params: Vec<SqlValue> = vec![SqlValue::Text(ns.to_owned())];
+    let mut predicates: Vec<String> = Vec::new();
+    let mut next_param = 2;
+    if !name_needle.is_empty() {
+        predicates.push(format!("a.name LIKE ?{next_param} ESCAPE '\\'"));
+        exact_params.push(SqlValue::Text(format!("%{}%", escape_like(&name_needle))));
+        next_param += 1;
+    }
+    for term in &tag_terms {
+        predicates.push(format!("a.tags LIKE ?{next_param} ESCAPE '\\'"));
+        exact_params.push(SqlValue::Text(format!("%\"{}\"%", escape_like(term))));
+        next_param += 1;
+    }
+
+    let (status_clause, status_params) = status_sql_clause(statuses, exclude_statuses, next_param);
+    next_param += status_params.len();
+    exact_params.extend(status_params);
+    let limit_param = next_param;
+    exact_params.push(SqlValue::Integer(fetch_limit as i64));
+
+    let exact_sql = format!(
+        "SELECT a.* FROM knowledge_atoms AS a \
+         WHERE a.namespace = ?1 AND a.deleted_at IS NULL{status_clause}{type_clause} \
+           AND ({predicate_or}) \
+         ORDER BY a.slug LIMIT ?{limit_param}",
+        predicate_or = predicates.join(" OR ")
+    );
+
+    let exact_rows = match reader
+        .query_all(SqlStatement {
+            sql: exact_sql,
+            params: exact_params,
+            label: None,
+        })
+        .await
+    {
+        Ok(rows) => rows,
+        Err(e) if is_timeout(&e) => {
+            return Ok(FtsFetchOutcome {
+                atoms: Vec::new(),
+                state: LexicalCandidateState::TimedOut,
+            });
+        }
+        Err(e) => return Err(sql_err("search exact-match candidates", e)),
+    };
+
+    let exact_atoms: Vec<Atom> = exact_rows.iter().filter_map(atom_from_row).collect();
+    if exact_atoms.is_empty() {
+        return Ok(FtsFetchOutcome {
+            atoms: Vec::new(),
+            state: LexicalCandidateState::NoMatch,
+        });
+    }
+
     Ok(FtsFetchOutcome {
-        atoms: Vec::new(),
-        state: LexicalCandidateState::NoMatch,
+        atoms: exact_atoms,
+        state: LexicalCandidateState::ExactMatch,
     })
 }
 
@@ -3322,6 +3426,127 @@ mod tests {
         assert_eq!(outcome.state, LexicalCandidateState::Filtered);
     }
 
+    /// A query shorter than the trigram tokenizer's minimum span (schema.sql:
+    /// `tokenize='trigram case_sensitive 0'`) can never MATCH `fts_knowledge`,
+    /// regardless of corpus content — so an atom findable only by exact name
+    /// (e.g. "ML", "RAG") was unreachable once the recency fallback was
+    /// removed. Recovered via the bounded exact-name predicate.
+    #[tokio::test]
+    async fn exact_name_match_recovers_query_below_trigram_minimum() {
+        let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+        {
+            let access = runtime.sql();
+            let mut writer = access.writer().await.expect("writer");
+            writer
+                .execute(SqlStatement {
+                    sql: "INSERT INTO knowledge_atoms ( \
+                              id, namespace, slug, name, content, tags, properties, finalized, \
+                              status, source_uri, source_type, created_at, updated_at, deleted_at \
+                          ) VALUES ( \
+                              '93000000-0000-0000-0000-000000000001', 'local', \
+                              'ml-abbrev', 'ML', 'filler content unrelated to the query', \
+                              '[]', NULL, 1, 'reviewed', NULL, NULL, 1000, 1000, NULL \
+                          ), ( \
+                              '93000000-0000-0000-0000-000000000002', 'local', \
+                              'zzz-control', 'Zzz Control', \
+                              'this atom shares nothing with the query', \
+                              '[]', NULL, 1, 'reviewed', NULL, NULL, 2000, 2000, NULL \
+                          )"
+                    .to_string(),
+                    params: Vec::new(),
+                    label: None,
+                })
+                .await
+                .expect("seed ML atom and unrelated control");
+        }
+
+        let outcome = fetch_fts_candidates(&runtime, "local", "ML", None, &[], &[], CANDIDATE_POOL)
+            .await
+            .expect("exact-name recovery must not error");
+
+        assert_eq!(outcome.state, LexicalCandidateState::ExactMatch);
+        let slugs: Vec<&str> = outcome.atoms.iter().map(|a| a.slug.as_str()).collect();
+        assert_eq!(
+            slugs, ["ml-abbrev"],
+            "only the exact-name match returns, never the unrelated control (no recency leakage): {slugs:?}"
+        );
+
+        let token = runtime.authorize(Namespace::local()).expect("local token");
+        let ann = vamana::new_shared();
+        let out = KnowledgeHandlers::search(
+            &runtime,
+            &token,
+            json!({"query": "ML", "rerank": false}),
+            &ann,
+        )
+        .await
+        .expect("exact-name search must not error");
+        assert_eq!(out["candidate_provenance"]["lexical"], "exact_match");
+        assert_eq!(out["total"], 1);
+        assert_eq!(out["results"][0]["slug"], "ml-abbrev");
+    }
+
+    /// `fts_knowledge` indexes only `slug`, `name`, `content` (schema.sql) —
+    /// `tags` is never part of the FTS index, so a query matching an atom
+    /// only through its tags was unreachable once the recency fallback was
+    /// removed. Recovered via the bounded exact-tag predicate.
+    #[tokio::test]
+    async fn tag_only_match_recovers_without_recency_fallback() {
+        let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+        {
+            let access = runtime.sql();
+            let mut writer = access.writer().await.expect("writer");
+            writer
+                .execute(SqlStatement {
+                    sql: "INSERT INTO knowledge_atoms ( \
+                              id, namespace, slug, name, content, tags, properties, finalized, \
+                              status, source_uri, source_type, created_at, updated_at, deleted_at \
+                          ) VALUES ( \
+                              '93000000-0000-0000-0000-000000000003', 'local', \
+                              'tag-only-hit', 'Something Else Entirely', \
+                              'content with no lexical overlap either', \
+                              '[\"lora\"]', NULL, 1, 'reviewed', NULL, NULL, 1000, 1000, NULL \
+                          ), ( \
+                              '93000000-0000-0000-0000-000000000004', 'local', \
+                              'zzz-control-2', 'Zzz Control Two', \
+                              'unrelated content and unrelated tags', \
+                              '[\"other\"]', NULL, 1, 'reviewed', NULL, NULL, 2000, 2000, NULL \
+                          )"
+                    .to_string(),
+                    params: Vec::new(),
+                    label: None,
+                })
+                .await
+                .expect("seed tag-only atom and unrelated control");
+        }
+
+        let outcome =
+            fetch_fts_candidates(&runtime, "local", "lora", None, &[], &[], CANDIDATE_POOL)
+                .await
+                .expect("tag-only recovery must not error");
+
+        assert_eq!(outcome.state, LexicalCandidateState::ExactMatch);
+        let slugs: Vec<&str> = outcome.atoms.iter().map(|a| a.slug.as_str()).collect();
+        assert_eq!(
+            slugs, ["tag-only-hit"],
+            "only the tag match returns, never the unrelated control (no recency leakage): {slugs:?}"
+        );
+
+        let token = runtime.authorize(Namespace::local()).expect("local token");
+        let ann = vamana::new_shared();
+        let out = KnowledgeHandlers::search(
+            &runtime,
+            &token,
+            json!({"query": "lora", "rerank": false}),
+            &ann,
+        )
+        .await
+        .expect("tag-only search must not error");
+        assert_eq!(out["candidate_provenance"]["lexical"], "exact_match");
+        assert_eq!(out["total"], 1);
+        assert_eq!(out["results"][0]["slug"], "tag-only-hit");
+    }
+
     #[tokio::test]
     async fn missing_ann_hydration_is_dropped_and_reported() {
         let runtime = KhiveRuntime::memory().expect("in-memory runtime");
@@ -3912,16 +4137,20 @@ mod tests {
             texts: &[String],
             _model: lattice_embed::EmbeddingModel,
         ) -> Result<Vec<Vec<f32>>, lattice_embed::EmbedError> {
-            // Distinct, non-degenerate unit vectors per text position so
-            // cosine similarity is well-defined and never uniform, the same
-            // shape `ann_degrade_tests::FakeDimService` uses.
+            // One unit basis vector per text position (dominant coordinate
+            // `i % RERANK_TEST_DIM`, everything else zero) so distinct
+            // positions are genuinely distinct directions with a
+            // well-defined, non-uniform cosine similarity between them.
+            // The uniform-scaling `vec![v / norm; DIM]` shape this replaced
+            // collapsed to the same vector for every positive `v` — `norm`
+            // is `v * sqrt(DIM)`, so `v / norm` cancels `v` out entirely.
             Ok(texts
                 .iter()
                 .enumerate()
                 .map(|(i, _)| {
-                    let v = (i + 1) as f32;
-                    let norm = (RERANK_TEST_DIM as f32 * v * v).sqrt();
-                    vec![v / norm; RERANK_TEST_DIM]
+                    let mut v = vec![0.0f32; RERANK_TEST_DIM];
+                    v[i % RERANK_TEST_DIM] = 1.0;
+                    v
                 })
                 .collect())
         }

--- a/crates/khive-pack-knowledge/src/vocab.rs
+++ b/crates/khive-pack-knowledge/src/vocab.rs
@@ -255,7 +255,7 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 20] = [
     },
     HandlerDef {
         name: "knowledge.search",
-        description: "TF-IDF ranked search over the atom teaching corpus ONLY — knowledge graph entities and notes are a disjoint corpus and are never returned here; use the kg pack's `search` verb for those. Embedding rerank applies by default when an embedder is configured. Draft and deprecated atoms are excluded by default; pass include_drafts=true to include drafts (deprecated remain excluded). Scores are squash-normalized to [0,1); absolute score is not a presence signal — use result rank for presence/coverage checks. Atom results include `body_lines`, the aggregate line count of their stored sections (str::lines() semantics: a terminal newline adds no line, blank interior lines count; 0 for a sectionless atom); domain results and deadline-degraded rows report null, the latter alongside a `degraded` flag.",
+        description: "TF-IDF ranked search over the atom teaching corpus ONLY — knowledge graph entities and notes are a disjoint corpus and are never returned here; use the kg pack's `search` verb for those. Embedding rerank applies by default when an embedder is configured. A genuine FTS miss returns no lexical candidates instead of scanning newest corpus rows; a healthy ANN leg may still return explicitly labeled ANN-only results. Draft and deprecated atoms are excluded by default; pass include_drafts=true to include drafts (deprecated remain excluded). The top-level `candidate_provenance` reports lexical state (`matched`, `no_match`, `filtered`, `partial_timeout`, or `timed_out`) and whether the returned set is an ANN fallback. Every result carries `score_provenance` with lexical/ANN sources, embedding-rerank use, `s_over_s_plus_1` normalization, and `calibrated:false`. Scores are request-relative and squash-normalized to [0,1); absolute score is not a presence signal — use result rank together with provenance for presence/coverage checks. Atom results include `body_lines`, the aggregate line count of their stored sections (str::lines() semantics: a terminal newline adds no line, blank interior lines count; 0 for a sectionless atom); domain results and deadline-degraded rows report null, the latter alongside a `degraded` flag.",
         visibility: Visibility::Verb,
         category: VerbCategory::Assertive,
         params: &[
@@ -312,7 +312,7 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 20] = [
                 name: "min_score",
                 param_type: "number",
                 required: false,
-                description: "Minimum score threshold (default 0.0). Scores are squash-normalized to [0,1); absolute score is not a presence signal — use result rank for presence/coverage checks.",
+                description: "Minimum final-score threshold (default 0.0). Scores are request-relative and squash-normalized to [0,1), not calibrated presence signals; use rank together with candidate_provenance and score_provenance.",
                 resolution_mode: IdResolutionMode::NotApplicable,
             },
             ParamDef {

--- a/docs/adr/ADR-047-knowledge-pack.md
+++ b/docs/adr/ADR-047-knowledge-pack.md
@@ -1,11 +1,27 @@
 # ADR-047: Knowledge Pack
 
-**Status**: accepted (amended 2026-06-07, 2026-06-10, 2026-06-10b, 2026-08-01, 2026-08-06, 2026-08-29, 2026-08-30)
+**Status**: accepted (amended 2026-06-07, 2026-06-10, 2026-06-10b, 2026-08-01, 2026-08-06, 2026-08-29, 2026-08-30, 2026-09-03)
 **Date**: 2026-05-25
 **Authors**: khive maintainers
 **Amended by**: proposed [ADR-160](ADR-160-shared-pack-infrastructure.md), which adds a bounded,
 operator-opt-in intent-rephrase retrieval path while preserving original-only behavior by default
 on acceptance.
+
+## Amendment (2026-09-03): exact-name/tag recovery for a genuine FTS miss
+
+Removing the recency fallback (below) made two scorable candidate classes unreachable, because
+`fts_knowledge` cannot surface them regardless of corpus content: a query shorter than the
+trigram tokenizer's minimum span (e.g. "RAG", "ML") never forms a trigram, so `exact_name_bonus`
+scoring — which only needs the raw query as a substring of the name — never got a candidate to
+score; and `tags` is not one of the FTS-indexed columns at all, so a query that only overlaps an
+atom's tags (`w_tags` scoring) never got one either.
+
+A genuine FTS miss now runs one further bounded, direct-predicate lookup — not a recency scan —
+before reporting empty: atoms whose `name` contains the raw query (case-insensitive) or whose
+`tags` JSON array contains a query token, capped at the same candidate-pool limit and still
+scoped by namespace/status/kind eligibility inside the SQL. `candidate_provenance.lexical` reports
+this outcome as `exact_match`, distinct from `matched` (a real FTS/bm25 hit) so a caller can still
+tell which lexical mechanism produced the candidates.
 
 ## Amendment (2026-08-30): honest lexical fallback and score provenance
 
@@ -18,8 +34,8 @@ an embedder and index can supply it.
 
 `knowledge.search` adds backward-compatible provenance fields:
 
-- Top-level `candidate_provenance.lexical` is `matched`, `no_match`, `filtered`, `partial_timeout`,
-  or `timed_out`.
+- Top-level `candidate_provenance.lexical` is `matched`, `exact_match`, `no_match`, `filtered`,
+  `partial_timeout`, or `timed_out` (`exact_match` added 2026-09-03, see amendment above).
 - Top-level `candidate_provenance.fallback` is `ann` only when the returned set has ANN
   evidence and no returned result has lexical evidence; otherwise it is `none`.
 - Each result adds `score_provenance` with a stable-order `sources` subset of `lexical` and

--- a/docs/adr/ADR-047-knowledge-pack.md
+++ b/docs/adr/ADR-047-knowledge-pack.md
@@ -1,11 +1,27 @@
 # ADR-047: Knowledge Pack
 
-**Status**: accepted (amended 2026-06-07, 2026-06-10, 2026-06-10b, 2026-08-01, 2026-08-06, 2026-08-29, 2026-08-30, 2026-09-03)
+**Status**: accepted (amended 2026-06-07, 2026-06-10, 2026-06-10b, 2026-08-01, 2026-08-06, 2026-08-29, 2026-08-30, 2026-09-03, 2026-09-04)
 **Date**: 2026-05-25
 **Authors**: khive maintainers
 **Amended by**: proposed [ADR-160](ADR-160-shared-pack-infrastructure.md), which adds a bounded,
 operator-opt-in intent-rephrase retrieval path while preserving original-only behavior by default
 on acceptance.
+
+## Amendment (2026-09-04): union the exact-name/tag recovery with every lexical outcome
+
+The 2026-09-03 recovery below only ran once FTS had already reported a genuine miss — but FTS
+reports a miss only when _every_ term the query decomposes into failed to match anything eligible.
+A name- or tag-only atom was therefore still dropped whenever the query happened to also match
+some unrelated, eligible atom (FTS non-empty) or match only an ineligible atom (the `filtered`
+case): both outcomes returned before the recovery lookup ever ran.
+
+The recovery lookup now runs whenever the query yields a name needle or tag terms, independent of
+what FTS found, and its rows are unioned with FTS's rows (deduplicated by id, FTS rows ordered
+first). Provenance: `matched` stays `matched` whenever FTS contributed at least one eligible row,
+even if recovery added more; a `filtered` or genuine-miss outcome that recovery turns non-empty
+now reports `exact_match` — the same state the 2026-09-03 amendment already used for
+recovery-sourced rows, so no new provenance value was needed. `filtered` and `no_match` are
+unchanged for the case where recovery also finds nothing.
 
 ## Amendment (2026-09-03): exact-name/tag recovery for a genuine FTS miss
 

--- a/docs/adr/ADR-047-knowledge-pack.md
+++ b/docs/adr/ADR-047-knowledge-pack.md
@@ -1,11 +1,37 @@
 # ADR-047: Knowledge Pack
 
-**Status**: accepted (amended 2026-06-07, 2026-06-10, 2026-06-10b, 2026-08-01, 2026-08-06, 2026-08-29)
+**Status**: accepted (amended 2026-06-07, 2026-06-10, 2026-06-10b, 2026-08-01, 2026-08-06, 2026-08-29, 2026-08-30)
 **Date**: 2026-05-25
 **Authors**: khive maintainers
 **Amended by**: proposed [ADR-160](ADR-160-shared-pack-infrastructure.md), which adds a bounded,
 operator-opt-in intent-rephrase retrieval path while preserving original-only behavior by default
 on acceptance.
+
+## Amendment (2026-08-30): honest lexical fallback and score provenance
+
+A genuine FTS miss yields an empty lexical candidate set. It no longer falls back to a
+bounded scan ordered by atom creation time: corpus recency is not query evidence, and treating
+those newest rows as a lexical rank source lets reciprocal-rank fusion manufacture relevance
+for zero-overlap queries. The cheap raw-FTS existence probe remains so a miss can be distinguished
+from a lexical match removed by kind/status eligibility. ANN-only retrieval remains available when
+an embedder and index can supply it.
+
+`knowledge.search` adds backward-compatible provenance fields:
+
+- Top-level `candidate_provenance.lexical` is `matched`, `no_match`, `filtered`, `partial_timeout`,
+  or `timed_out`.
+- Top-level `candidate_provenance.fallback` is `ann` only when the returned set has ANN
+  evidence and no returned result has lexical evidence; otherwise it is `none`.
+- Each result adds `score_provenance` with a stable-order `sources` subset of `lexical` and
+  `ann`, `embedding_rerank` (whether a successful dense rerank transformed the score),
+  `normalization: "s_over_s_plus_1"`, and `calibrated: false`.
+
+Search scores are request-relative ranking values. After lexical/ANN fusion and optional
+embedding rerank, the score is monotonically squashed with `s / (s + 1)` and receives the
+existing status multiplier. It is not a probability, a cross-query comparable measure, or an
+absolute presence signal. The former `0.46`/`0.42` bands predated the squash and are retired;
+callers use response-local rank together with candidate and per-hit provenance. `min_score`
+continues to apply to the final returned score.
 
 ## Amendment (2026-08-29): tri-state atom upsert patches
 
@@ -287,7 +313,7 @@ exhausted. Pure computation — no database access.
 #### `knowledge.search` — TF-IDF ranked search
 
 ```
-search(query, type?, status?, exclude_status?, include_drafts?: false, role?, limit?: 10, min_score?: 0.0, weights?: {}, decompose?: false, decompose_threshold?: 4, intersection_bonus?: 0.25, rerank?: true, rerank_alpha?: 0.7) → {results: [...], total: N}
+search(query, type?, status?, exclude_status?, include_drafts?: false, role?, limit?: 10, min_score?: 0.0, weights?: {}, decompose?: false, decompose_threshold?: 4, intersection_bonus?: 0.25, rerank?: true, rerank_alpha?: 0.7) → {results: [...], total: N, candidate_provenance: {lexical, fallback}}
 ```
 
 FTS5 recall → in-memory TF-IDF scoring across name, tags, and content
@@ -326,8 +352,12 @@ retrieval path goes through the same status gate.
 same default exclusion. There is no `include_drafts` override on `suggest` — domain atoms in
 draft state should not drive agent composition.
 
-**Score bands** (observed in production): `score >= 0.46` reliably on-target,
-`0.42 <= score < 0.46` mixed quality, `score < 0.42` mostly off-target.
+**Score interpretation (amended 2026-08-30)**: scores are request-relative hybrid ranking
+values, not calibrated relevance probabilities or absolute presence signals. Use result rank
+together with `candidate_provenance` and each result's `score_provenance`; do not apply fixed
+numeric bands across queries. A true lexical miss returns no lexical candidates instead of
+ranking the newest corpus rows, though a healthy ANN leg may still return explicitly labeled
+ANN-only results.
 
 #### `knowledge.compose` — namespace-consistent briefing composition
 

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -1844,9 +1844,10 @@ request(ops="[{\"tool\":\"knowledge.fold\",\"args\":{\"candidates\":[{\"id\":\"a
 ### `knowledge.search` — Assertive
 
 TF-IDF ranked search over the knowledge corpus with embedding rerank (default when an
-embedder is configured). Draft and deprecated atoms are excluded by default. Score
-bands: `score>=0.46` reliably on-target, `0.42<=score<0.46` mixed quality, `score<0.42`
-mostly off-target.
+embedder is configured). Draft and deprecated atoms are excluded by default. Scores are
+request-relative hybrid ranking values, not calibrated probabilities or absolute presence
+signals. Compare rank within the response and inspect provenance instead of applying fixed
+score bands.
 
 | Param                 | Type    | Required | Notes                                                                                   |
 | --------------------- | ------- | -------- | --------------------------------------------------------------------------------------- |
@@ -1864,6 +1865,35 @@ mostly off-target.
 | `intersection_bonus`  | number  | no       | Default 0.25; score multiplier for multi-sub-query hits.                                |
 | `rerank`              | bool    | no       | Default true; embedding rerank; no-op with no embedder configured.                      |
 | `rerank_alpha`        | number  | no       | Default 0.7 (TF-IDF-dominant blend).                                                    |
+
+The response is `{results, total, candidate_provenance, ...}`. A genuine FTS miss does
+not scan or rank the newest corpus rows. `candidate_provenance.lexical` reports one of:
+
+- `matched`: eligible lexical candidates were found.
+- `no_match`: FTS found no lexical match.
+- `filtered`: FTS matched, but kind/status eligibility removed every lexical candidate.
+- `partial_timeout`: part of a lexical/decomposed candidate stage completed before the
+  request read deadline.
+- `timed_out`: the lexical candidate stage timed out without a completed candidate leg.
+
+`candidate_provenance.fallback` is `ann` only when the returned set has ANN evidence and
+no returned result has lexical evidence; it is otherwise `none`, including for an empty
+result. Each result includes `score_provenance`:
+
+```json
+{
+  "sources": ["lexical", "ann"],
+  "embedding_rerank": true,
+  "normalization": "s_over_s_plus_1",
+  "calibrated": false
+}
+```
+
+`sources` is a stable-order subset of `lexical` and `ann`. `embedding_rerank` records
+whether a successful embedding rerank transformed that result's score. The raw
+request-local score is monotonically squashed with `s / (s + 1)` and then receives the
+existing status multiplier; therefore a score remains useful for ordering and
+`min_score` within a call, but no fixed numeric band establishes corpus presence.
 
 ```
 request(ops="knowledge.search(query=\"FastAPI JWT middleware\", rerank=true, limit=10)")

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -1889,8 +1889,12 @@ score bands.
 The response is `{results, total, candidate_provenance, ...}`. A genuine FTS miss does
 not scan or rank the newest corpus rows. `candidate_provenance.lexical` reports one of:
 
-- `matched`: eligible lexical candidates were found.
-- `no_match`: FTS found no lexical match.
+- `matched`: eligible lexical candidates were found via FTS.
+- `exact_match`: FTS found no match, but a bounded direct-predicate lookup found candidates
+  by exact name substring or literal tag — the only way to reach a query too short for the
+  trigram index (e.g. "RAG", "ML") or a query that only overlaps an atom's tags (tags are not
+  FTS-indexed).
+- `no_match`: neither FTS nor the exact-match lookup found a lexical candidate.
 - `filtered`: FTS matched, but kind/status eligibility removed every lexical candidate.
 - `partial_timeout`: part of a lexical/decomposed candidate stage completed before the
   request read deadline.

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -1932,15 +1932,24 @@ score bands.
 | `rerank_alpha`        | number  | no       | Default 0.7 (TF-IDF-dominant blend).                                                    |
 
 The response is `{results, total, candidate_provenance, ...}`. A genuine FTS miss does
-not scan or rank the newest corpus rows. `candidate_provenance.lexical` reports one of:
+not scan or rank the newest corpus rows. Alongside FTS, a bounded direct-predicate lookup
+always runs for a query that yields a name needle or literal tag terms, and its rows are
+unioned (deduplicated by id) with whatever FTS produced — the lookup is not gated behind an
+FTS miss, so an atom reachable only by exact name substring or literal tag is not dropped
+just because the query happens to also match something else in the trigram index.
+`candidate_provenance.lexical` reports one of:
 
-- `matched`: eligible lexical candidates were found via FTS.
-- `exact_match`: FTS found no match, but a bounded direct-predicate lookup found candidates
-  by exact name substring or literal tag — the only way to reach a query too short for the
+- `matched`: FTS found eligible candidates. The direct-predicate lookup still ran and its
+  rows (if any) are unioned in, but provenance stays `matched` whenever FTS contributed at
+  least one row.
+- `exact_match`: FTS found no eligible row (whether a genuine trigram miss or a trigram
+  match whose rows were all ineligible), but the direct-predicate lookup found candidates by
+  exact name substring or literal tag — the only way to reach a query too short for the
   trigram index (e.g. "RAG", "ML") or a query that only overlaps an atom's tags (tags are not
   FTS-indexed).
-- `no_match`: neither FTS nor the exact-match lookup found a lexical candidate.
-- `filtered`: FTS matched, but kind/status eligibility removed every lexical candidate.
+- `no_match`: neither FTS nor the direct-predicate lookup found a lexical candidate.
+- `filtered`: FTS matched, but kind/status eligibility removed every lexical candidate, and
+  the direct-predicate lookup found nothing to recover either.
 - `partial_timeout`: part of a lexical/decomposed candidate stage completed before the
   request read deadline.
 - `timed_out`: the lexical candidate stage timed out without a completed candidate leg.


### PR DESCRIPTION
Replaces the fixed score bands (0.46 / 0.42) with per-hit score provenance and a request-level candidate provenance on `knowledge.search`.

- `ScoreProvenance` on every scored hit (lexical, ann, embedding_rerank), merged on RRF fusion overlap.
- `LexicalCandidateState` (matched, no_match, filtered, partial_timeout, timed_out) replaces the bounded full-scan fallback: a genuine FTS miss returns nothing instead of the newest corpus rows.
- `candidate_provenance` on the response reports the lexical state and whether a fallback ran.
- Docs (pack README, ADR-047, api-reference) drop the score bands in favor of provenance-based interpretation.
- Test fixture fix: the rerank embed stub now yields distinct unit vectors per text; the rerank-runs case is pinned.

First of three stacked changes; the next two build on the `LexicalCandidateState` vocabulary introduced here.
