### PR TITLE
test(knowledge): wait for the rotation watcher by paused time, not a yield budget

### DIFF
--- a/crates/khive-db/src/writer_task.rs
+++ b/crates/khive-db/src/writer_task.rs
@@ -2851,9 +2851,12 @@ mod tests {
         }
         let handle = spawn(&pool, 8).unwrap();
 
+        // The delay must dwarf a COMMIT on a slow disk (an fsync of a few
+        // hundred milliseconds has been observed on shared runners), or the
+        // commit-stage comparison below reads the disk instead of the body.
         handle
             .send(|conn| {
-                std::thread::sleep(Duration::from_millis(60));
+                std::thread::sleep(Duration::from_millis(400));
                 conn.execute("INSERT INTO t VALUES (1)", [])
                     .map_err(|error| StorageError::Pool {
                         operation: "writer_stage_sample".into(),
@@ -2865,7 +2868,7 @@ mod tests {
 
         let sample = last_writer_stage_observation(&pool).expect("writer stage sample");
         assert!(
-            sample.body_micros >= 50_000,
+            sample.body_micros >= 350_000,
             "the synthetic delay must land in the body stage: {sample:?}"
         );
         assert!(

--- a/crates/khive-pack-knowledge/src/pack.rs
+++ b/crates/khive-pack-knowledge/src/pack.rs
@@ -732,12 +732,18 @@ mod tests {
             "dropping the pack must drop its last strong ANN reference"
         );
 
+        // The watcher builds its interval on its first poll, which can land
+        // after this advance; under paused time `sleep` auto-advances the
+        // clock once every task is idle, so the tick is reached by virtual
+        // time rather than by a fixed yield budget.
         tokio::time::advance(std::time::Duration::from_secs(6)).await;
-        for _ in 0..100 {
-            if khive_runtime::background_task_count() == before {
-                break;
-            }
-            tokio::task::yield_now().await;
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(60);
+        while khive_runtime::background_task_count() != before {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "the watcher must exit once its ANN state is dropped"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         }
         assert_eq!(
             khive_runtime::background_task_count(),


### PR DESCRIPTION
The drop test in the knowledge pack advanced the paused clock and then gave the rotation watcher at most 100 yields to exit. The watcher builds its interval on its first poll, which can land after that advance, so the tick is never reached inside the budget and the test fails on a loaded runner; it failed on two unrelated changes in CI today.

The wait now runs under paused time with a 60-second virtual deadline. Under a paused runtime, sleep auto-advances the clock once every task is idle, so the tick is reached by virtual time rather than by a fixed yield budget. Twenty consecutive local runs pass before and after the change, so the failure is runner-load dependent and the change is justified by the mechanism rather than by a local reproduction.


### Second flaky test: `writer_stage_sample_attributes_a_slow_body`

The test slept 60 ms in the writer body and asserted the body dominated the stage sample; a commit fsync on a slow runner takes close to 200 ms and outweighed it. The body now sleeps 400 ms with a 350 ms floor, so the slow arm is the one measured on every runner. Twenty consecutive local runs pass; the whole `writer_task` suite passes.
