### PR TITLE
perf(db): index the hot note property paths and page the inbox by key

### DIFF
--- a/crates/khive-db/sql/027-notes-hot-property-indexes.sql
+++ b/crates/khive-db/sql/027-notes-hot-property-indexes.sql
@@ -13,17 +13,34 @@
 -- `crates/khive-db/src/stores/note.rs`) -- an index only helps when its key
 -- expression matches the compiled predicate byte-for-byte.
 --
--- A general `(to_actor, direction)` index for the comm mailbox listing was
--- also drafted for this change but dropped: with no ANALYZE statistics,
--- SQLite sometimes chose it over the existing partial
--- `idx_notes_unread_probe_recipient_direction` for the default unread-status
--- listing, even though the partial index (scoped by read status) is
--- strictly cheaper for that case -- confirmed by `EXPLAIN QUERY PLAN`
--- flipping to the new index and by VM-step regressions in
--- `crates/khive-db/src/stores/note_tests.rs`'s existing unread-probe tests.
--- Shipping it would have risked regressing the one path #2390 actually
--- measured (`comm.inbox` at unread-default status). The read/all-status
--- listing case it would have served remains unindexed.
+-- Both indexes are partial on `deleted_at IS NULL` only, not additionally on
+-- `kind = 'task'`: every caller binds `kind` as a parameter rather than a
+-- literal, and SQLite can use a partial index only when it can prove the
+-- index's WHERE clause at plan time, which a bound parameter never
+-- satisfies (`crates/khive-db/src/stores/note_tests.rs`'s
+-- `narrowing_hot_property_index_to_kind_task_is_not_chosen` measures this).
+--
+-- These indexes cover only the GTD task-listing path. Two related paths
+-- remain unindexed. The comm inbox listing's `status="all"`/`status="read"`
+-- case (no `$.read` predicate, or `$.read = true` rather than the tuned
+-- `$.read` absent-or-false probe) and the default `gtd.tasks()` listing (no
+-- `status=` filter, which compiles to an open `$.status NOT IN
+-- ('done','cancelled') OR $.status IS NULL` exclusion with no bounded set to
+-- seek) both still cost a full partition scan. A general
+-- `(namespace, kind, created_at DESC, id ASC)` index would serve the first
+-- of those, but it is also a legal plan for `comm.inbox`'s default
+-- `status="unread"` listing, and with no ANALYZE statistics SQLite prefers
+-- it there over the purpose-built partial
+-- `idx_notes_unread_probe_recipient_direction`, even though the partial
+-- index is cheaper for that case -- confirmed by `EXPLAIN QUERY PLAN`
+-- flipping to the general index and by VM-step regressions in
+-- `crates/khive-db/src/stores/note_tests.rs`'s
+-- `candidate_created_at_id_seek_index_flips_unread_probe_plan`. A narrower
+-- `(to_actor, direction)` variant carries the identical conflict. The
+-- `gtd.tasks()` default listing has no seekable rewrite at all: the
+-- exclusion set must stay open (a task with a missing or unrecognized
+-- status is included), so it cannot be rewritten as a bounded `IN` list
+-- without silently dropping exactly the rows this predicate exists to keep.
 
 CREATE INDEX IF NOT EXISTS idx_notes_task_status
     ON notes(namespace, kind,

--- a/crates/khive-db/sql/027-notes-hot-property-indexes.sql
+++ b/crates/khive-db/sql/027-notes-hot-property-indexes.sql
@@ -1,0 +1,38 @@
+-- V27: index the hot note property paths behind GTD task listing
+-- (gtd.tasks / gtd.next).
+--
+-- The GTD pack pushes its status/assignee predicates into SQL
+-- (`json_extract(properties, '$.status')` / `'$.assignee'`), but with no
+-- supporting index every task listing evaluates those expressions against
+-- every row of kind='task' in the namespace: the planner can only narrow to
+-- `idx_notes_kind`'s (namespace, kind) partition, then walks and JSON-parses
+-- every task row regardless of how selective the status/assignee filter is.
+--
+-- Each expression below is copied verbatim from the SQL the corresponding
+-- `FilterOp` compiles (see `build_note_filter_where` in
+-- `crates/khive-db/src/stores/note.rs`) -- an index only helps when its key
+-- expression matches the compiled predicate byte-for-byte.
+--
+-- A general `(to_actor, direction)` index for the comm mailbox listing was
+-- also drafted for this change but dropped: with no ANALYZE statistics,
+-- SQLite sometimes chose it over the existing partial
+-- `idx_notes_unread_probe_recipient_direction` for the default unread-status
+-- listing, even though the partial index (scoped by read status) is
+-- strictly cheaper for that case -- confirmed by `EXPLAIN QUERY PLAN`
+-- flipping to the new index and by VM-step regressions in
+-- `crates/khive-db/src/stores/note_tests.rs`'s existing unread-probe tests.
+-- Shipping it would have risked regressing the one path #2390 actually
+-- measured (`comm.inbox` at unread-default status). The read/all-status
+-- listing case it would have served remains unindexed.
+
+CREATE INDEX IF NOT EXISTS idx_notes_task_status
+    ON notes(namespace, kind,
+             json_extract(properties, '$.status'),
+             created_at DESC, id ASC)
+    WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_notes_task_assignee
+    ON notes(namespace, kind,
+             json_extract(properties, '$.assignee'),
+             created_at DESC, id ASC)
+    WHERE deleted_at IS NULL;

--- a/crates/khive-db/sql/notes-ddl.sql
+++ b/crates/khive-db/sql/notes-ddl.sql
@@ -49,6 +49,23 @@ CREATE INDEX IF NOT EXISTS idx_notes_unread_probe_recipient_direction
            OR json_type(properties, '$.read') != 'true')
       AND deleted_at IS NULL;
 
+-- Hot property-path indexes for GTD task listing (status/assignee) -- see
+-- sql/027-notes-hot-property-indexes.sql for the full rationale, the note
+-- that each key expression must match its `FilterOp`'s compiled SQL
+-- byte-for-byte, and why a similarly-shaped comm recipient/direction index
+-- was dropped from this change.
+CREATE INDEX IF NOT EXISTS idx_notes_task_status
+    ON notes(namespace, kind,
+             json_extract(properties, '$.status'),
+             created_at DESC, id ASC)
+    WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_notes_task_assignee
+    ON notes(namespace, kind,
+             json_extract(properties, '$.assignee'),
+             created_at DESC, id ASC)
+    WHERE deleted_at IS NULL;
+
 -- Durable, non-reusing sequence for notes (khive #827). Kept in sync with
 -- `sql/007-notes-seq.sql` (the versioned-migration copy) — see that file for
 -- the full rationale. Duplicated here, belt-and-suspenders style, because

--- a/crates/khive-db/sql/schema.sql
+++ b/crates/khive-db/sql/schema.sql
@@ -242,6 +242,20 @@ CREATE INDEX IF NOT EXISTS idx_notes_unread_probe_recipient_direction
            OR json_type(properties, '$.read') != 'true')
       AND deleted_at IS NULL;
 
+-- Kept in sync with notes-ddl.sql: hot property-path indexes for GTD task
+-- listing (status/assignee) (sql/027-notes-hot-property-indexes.sql).
+CREATE INDEX IF NOT EXISTS idx_notes_task_status
+    ON notes(namespace, kind,
+             json_extract(properties, '$.status'),
+             created_at DESC, id ASC)
+    WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_notes_task_assignee
+    ON notes(namespace, kind,
+             json_extract(properties, '$.assignee'),
+             created_at DESC, id ASC)
+    WHERE deleted_at IS NULL;
+
 CREATE INDEX IF NOT EXISTS idx_events_namespace ON events(namespace);
 CREATE INDEX IF NOT EXISTS idx_events_verb ON events(verb);
 CREATE INDEX IF NOT EXISTS idx_events_substrate ON events(substrate);

--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -154,6 +154,8 @@ const V25_UP: &str = include_str!("../sql/025-notes-unread-probe-recipient-direc
 
 const V26_UP: &str = include_str!("../sql/026-knowledge-fts-repair.sql");
 
+const V27_UP: &str = include_str!("../sql/027-notes-hot-property-indexes.sql");
+
 const V21_STAGE_UP: &str = include_str!("../sql/021-attachments-a-stage.sql");
 
 const V21_ATTACHMENT_FENCES_UP: &str = include_str!("../sql/021-attachments-b-claim-fences.sql");
@@ -338,6 +340,11 @@ pub const MIGRATIONS: &[VersionedMigration] = &[
         version: 26,
         name: "knowledge_fts_repair",
         up: V26_UP,
+    },
+    VersionedMigration {
+        version: 27,
+        name: "notes_hot_property_indexes",
+        up: V27_UP,
     },
 ];
 

--- a/crates/khive-db/src/migrations_tests.rs
+++ b/crates/khive-db/src/migrations_tests.rs
@@ -1097,6 +1097,65 @@ fn v25_upgrades_direction_blind_recipient_index_for_read_only_open() {
 }
 
 #[test]
+fn v27_adds_hot_property_indexes_to_a_pre_v27_database() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("pre-hot-property-indexes.db");
+
+    const NEW_INDEXES: [&str; 2] = ["idx_notes_task_status", "idx_notes_task_assignee"];
+
+    {
+        let mut conn = Connection::open(&path).expect("create pre-V27 database");
+        migrate_through(&mut conn, 20);
+        stage_attachment_cutover(&mut conn).expect("stage empty attachment cutover");
+        finalize_attachment_cutover(&mut conn).expect("finalize empty attachment cutover");
+        assert_eq!(read_schema_version(&conn).expect("read V21 ledger"), 21);
+        // `migrate_through` runs today's `sql/schema.sql` for V1, which
+        // already carries these indexes (a fresh install gets them
+        // immediately rather than waiting for V27 to replay) -- drop them to
+        // reproduce a database actually created before this change, the
+        // same technique the V22/V25 unread-probe-index migration tests use.
+        for name in NEW_INDEXES {
+            conn.execute(&format!("DROP INDEX {name}"), [])
+                .unwrap_or_else(|e| panic!("simulate pre-V27 database missing {name}: {e}"));
+        }
+        for name in NEW_INDEXES {
+            assert!(
+                !index_exists(&conn, name),
+                "{name} must not exist before V27 applies"
+            );
+        }
+    }
+
+    {
+        let mut conn = Connection::open(&path).expect("reopen writable database");
+        assert_eq!(
+            run_migrations(&mut conn).expect("apply V27 hot-property-index migration"),
+            latest_schema_version()
+        );
+        for name in NEW_INDEXES {
+            assert!(index_exists(&conn, name), "{name} must exist after V27");
+        }
+    }
+
+    let read_only = Connection::open_with_flags(&path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .expect("open migrated database read-only");
+    for name in NEW_INDEXES {
+        assert!(index_exists(&read_only, name));
+    }
+    validate_schema_is_current(&read_only).expect("migrated read-only schema validates");
+}
+
+#[test]
+fn latest_schema_version_advances_by_one_for_v27() {
+    assert_eq!(latest_schema_version(), 27);
+    assert_eq!(
+        MIGRATIONS.last().map(|m| m.version),
+        Some(26 + 1),
+        "V27 must be the newest entry in the migration ledger"
+    );
+}
+
+#[test]
 fn v23_backfills_indexed_record_kinds_and_preserves_unmatched_fts_rows() {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().join("pre-record-kind.db");

--- a/crates/khive-db/src/migrations_tests.rs
+++ b/crates/khive-db/src/migrations_tests.rs
@@ -1146,13 +1146,25 @@ fn v27_adds_hot_property_indexes_to_a_pre_v27_database() {
 }
 
 #[test]
-fn latest_schema_version_advances_by_one_for_v27() {
-    assert_eq!(latest_schema_version(), 27);
+fn latest_schema_version_matches_the_newest_migrations_entry() {
     assert_eq!(
         MIGRATIONS.last().map(|m| m.version),
-        Some(26 + 1),
-        "V27 must be the newest entry in the migration ledger"
+        Some(latest_schema_version()),
+        "latest_schema_version() must equal the version of the newest MIGRATIONS entry"
     );
+}
+
+#[test]
+fn migration_versions_advance_by_exactly_one() {
+    for pair in MIGRATIONS.windows(2) {
+        assert_eq!(
+            pair[1].version,
+            pair[0].version + 1,
+            "migration versions must be strictly sequential with no gaps: {} -> {}",
+            pair[0].version,
+            pair[1].version
+        );
+    }
 }
 
 #[test]

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 
 use khive_storage::attachment::AttachmentSubstrate;
 use khive_storage::error::{StorageError, WriterTaskRequestState};
-use khive_storage::note::{FilterOp, Note, NoteFilter, SortDir};
+use khive_storage::note::{FilterOp, Note, NoteFilter, NoteSeekAfter, SortDir};
 use khive_storage::types::{
     BatchWriteSummary, BoundedCount, DeleteMode, Page, PageRequest, SeekCursor, SeekPage,
     SqlStatement, SqlValue,
@@ -908,6 +908,85 @@ fn build_note_filter_where(
     Ok((format!(" WHERE {}", conditions.join(" AND ")), params))
 }
 
+/// `SELECT` column list shared by every plain note-row projection query in
+/// this file (`query_notes`, `query_notes_count_free`, `query_notes_filtered*`).
+const NOTE_COLUMNS: &str = "id, namespace, kind, status, name, content, salience, decay_factor, \
+     expires_at, properties, created_at, updated_at, deleted_at";
+
+/// Fetch up to `limit` rows strictly after `after` in the notes store's
+/// default `created_at DESC, id ASC` total order, for `NoteFilter.after`
+/// keyset pagination.
+///
+/// Deliberately NOT a single `WHERE ... (created_at, id) < (?, ?)` (row
+/// value) or `WHERE ... (created_at < ?1 OR (created_at = ?1 AND id > ?2))`
+/// predicate: `created_at` sorts DESC while `id` sorts ASC, and neither form
+/// gets index-seek treatment from SQLite for a mixed-direction boundary on
+/// this build (`EXPLAIN QUERY PLAN` showed the same full ordered index scan
+/// as no boundary at all, i.e. exactly the `OFFSET` cost this exists to
+/// avoid — confirmed empirically, not assumed). Splitting into two
+/// single-direction queries keeps each one a plain equality/range AND-chain,
+/// which SQLite reliably turns into an index seek: the first grabs any tied
+/// rows at the exact boundary timestamp (`id ASC` order matches the index
+/// order within that tie group), the second grabs the (strictly smaller)
+/// timestamps that follow. Concatenating the two batches in that order
+/// reproduces `created_at DESC, id ASC` exactly with no merge step, since a
+/// tie-group's rows all sort before every following (smaller) timestamp.
+fn fetch_notes_after(
+    conn: &rusqlite::Connection,
+    namespace: &str,
+    base_filter: &NoteFilter,
+    after: &NoteSeekAfter,
+    limit: i64,
+) -> Result<Vec<Note>, rusqlite::Error> {
+    let mut items = Vec::new();
+    if limit <= 0 {
+        return Ok(items);
+    }
+
+    {
+        let (where_sql, mut params) = build_note_filter_where(namespace, base_filter)?;
+        params.push(Box::new(after.created_at));
+        let ts_idx = params.len();
+        params.push(Box::new(after.id.to_string()));
+        let id_idx = params.len();
+        params.push(Box::new(limit));
+        let limit_idx = params.len();
+        let sql = format!(
+            "SELECT {NOTE_COLUMNS} FROM notes{where_sql} AND created_at = ?{ts_idx} \
+             AND id > ?{id_idx} ORDER BY id ASC LIMIT ?{limit_idx}"
+        );
+        let mut stmt = conn.prepare_cached(&sql)?;
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+            params.iter().map(|p| p.as_ref()).collect();
+        let rows = stmt.query_map(param_refs.as_slice(), read_note)?;
+        for row in rows {
+            items.push(row?);
+        }
+    }
+
+    let remaining = limit - items.len() as i64;
+    if remaining > 0 {
+        let (where_sql, mut params) = build_note_filter_where(namespace, base_filter)?;
+        params.push(Box::new(after.created_at));
+        let ts_idx = params.len();
+        params.push(Box::new(remaining));
+        let limit_idx = params.len();
+        let sql = format!(
+            "SELECT {NOTE_COLUMNS} FROM notes{where_sql} AND created_at < ?{ts_idx} \
+             ORDER BY created_at DESC, id ASC LIMIT ?{limit_idx}"
+        );
+        let mut stmt = conn.prepare_cached(&sql)?;
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+            params.iter().map(|p| p.as_ref()).collect();
+        let rows = stmt.query_map(param_refs.as_slice(), read_note)?;
+        for row in rows {
+            items.push(row?);
+        }
+    }
+
+    Ok(items)
+}
+
 fn execute_filtered_note_property_patch(
     conn: &rusqlite::Connection,
     id: Uuid,
@@ -1503,6 +1582,24 @@ impl NoteStore for SqlNoteStore {
         if let Some((path, _)) = &filter.order_by {
             validate_json_path(path)?;
         }
+        if filter.after.is_some() && filter.order_by.is_some() {
+            return Err(StorageError::InvalidInput {
+                capability: StorageCapability::Notes,
+                operation: "query_notes_filtered_count_free".into(),
+                message: "NoteFilter.after is incompatible with a custom order_by; it is \
+                          defined only over the default created_at DESC, id ASC order"
+                    .into(),
+            });
+        }
+        if filter.after.is_some() && page.offset != 0 {
+            return Err(StorageError::InvalidInput {
+                capability: StorageCapability::Notes,
+                operation: "query_notes_filtered_count_free".into(),
+                message: "NoteFilter.after and a non-zero PageRequest.offset are mutually \
+                          exclusive pagination strategies; pass offset: 0 with after"
+                    .into(),
+            });
+        }
 
         let namespace = namespace.to_string();
         let filter = filter.clone();
@@ -1517,6 +1614,13 @@ impl NoteStore for SqlNoteStore {
         })?;
 
         self.with_reader("query_notes_filtered_count_free", move |conn| {
+            if let Some(after) = &filter.after {
+                let mut base_filter = filter.clone();
+                base_filter.after = None;
+                let items = fetch_notes_after(conn, &namespace, &base_filter, after, limit_i64)?;
+                return Ok(Page { items, total: None });
+            }
+
             let (where_sql, mut params) = build_note_filter_where(&namespace, &filter)?;
             params.push(Box::new(limit_i64));
             params.push(Box::new(offset_i64));
@@ -1524,9 +1628,8 @@ impl NoteStore for SqlNoteStore {
             let offset_idx = params.len();
             let order_clause = note_filter_page_order_clause(&filter);
             let sql = format!(
-                "SELECT id, namespace, kind, status, name, content, salience, decay_factor, \
-                 expires_at, properties, created_at, updated_at, deleted_at \
-                 FROM notes{where_sql}{order_clause} LIMIT ?{limit_idx} OFFSET ?{offset_idx}"
+                "SELECT {NOTE_COLUMNS} FROM notes{where_sql}{order_clause} \
+                 LIMIT ?{limit_idx} OFFSET ?{offset_idx}"
             );
 
             let mut stmt = conn.prepare(&sql)?;

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -908,8 +908,12 @@ fn build_note_filter_where(
     Ok((format!(" WHERE {}", conditions.join(" AND ")), params))
 }
 
-/// `SELECT` column list shared by every plain note-row projection query in
-/// this file (`query_notes`, `query_notes_count_free`, `query_notes_filtered*`).
+/// `SELECT` column list for a plain note-row projection. Used by
+/// [`fetch_notes_after`] and `query_notes_filtered_count_free`; the other
+/// note-row projection queries in this file (`query_notes`,
+/// `query_notes_count_free`, `query_notes_filtered`,
+/// `query_notes_filtered_after`, `query_notes_filtered_bounded`) still spell
+/// the same column list out inline.
 const NOTE_COLUMNS: &str = "id, namespace, kind, status, name, content, salience, decay_factor, \
      expires_at, properties, created_at, updated_at, deleted_at";
 
@@ -1521,6 +1525,18 @@ impl NoteStore for SqlNoteStore {
         }
         if let Some((path, _)) = &filter.order_by {
             validate_json_path(path)?;
+        }
+        if filter.after.is_some() {
+            return Err(StorageError::InvalidInput {
+                capability: StorageCapability::Notes,
+                operation: "query_notes_filtered".into(),
+                message: "NoteFilter.after (keyset pagination) is not supported by this \
+                          method: it computes an exact COUNT(*) total over the whole \
+                          matching set, which has no defined meaning paired with a seek \
+                          boundary; use query_notes_filtered_count_free instead, which \
+                          seeks and returns total: None"
+                    .into(),
+            });
         }
 
         let namespace = namespace.to_string();

--- a/crates/khive-db/src/stores/note_tests.rs
+++ b/crates/khive-db/src/stores/note_tests.rs
@@ -3733,24 +3733,26 @@ async fn gtd_next_status_in_with_assignee_query_uses_assignee_index() {
     let (sql, params) = listing_sql_and_params(&filter);
     let indexed_plan = plan_details(store.pool.reader().unwrap().conn(), &sql, &params);
     assert!(
-        indexed_plan.contains("idx_notes_task_status")
-            || indexed_plan.contains("idx_notes_task_assignee"),
-        "status-IN plus assignee-eq query must be served by one of the new hot-property \
-         indexes, got plan:\n{indexed_plan}"
+        indexed_plan.contains("idx_notes_task_assignee"),
+        "the assignee equality term must be served by idx_notes_task_assignee even \
+         though the sibling status predicate is a multi-value IN, got plan:\n{indexed_plan}"
+    );
+    assert!(
+        !indexed_plan.contains("idx_notes_task_status"),
+        "got plan:\n{indexed_plan}"
     );
 }
 
-/// khive#2390: a general `(to_actor, direction)` index for the comm mailbox
-/// listing (status="all"/"read", box="sent") was drafted for this change and
-/// dropped after this exact test proved it regressed the tuned unread-probe
-/// path -- with no ANALYZE statistics, SQLite chose the new unconditional
-/// index over the existing partial `idx_notes_unread_probe_recipient_direction`
-/// for the default unread-status listing, even though the partial index is
-/// strictly cheaper there (it excludes read rows structurally; the general
-/// index would only exclude them via a residual filter). This test pins
-/// that the unread-scoped plan stays on the partial index with no
-/// competing general index present, guarding against reintroducing one
-/// without solving the ambiguity first.
+/// The default unread-status inbox listing must stay on
+/// `idx_notes_unread_probe_recipient_direction`: that partial index excludes
+/// read rows structurally (via its `WHERE`), while any general
+/// `(to_actor, direction)`-shaped index can only exclude them with a
+/// residual filter, which costs more. With no `ANALYZE` statistics, SQLite
+/// prefers the first index it finds that matches the query shape rather than
+/// costing them, so a general index present alongside the partial one can
+/// still win the plan even though it does strictly more work -- this test
+/// pins the unread-scoped plan against reintroducing a competing general
+/// index without first re-measuring the tradeoff.
 #[tokio::test]
 async fn comm_inbox_unread_default_query_still_uses_partial_unread_probe_index() {
     use khive_storage::note::PropertyFilter as NotePropFilter;
@@ -3909,6 +3911,81 @@ async fn seek_after_rejects_custom_order_by() {
     assert!(
         err.to_string().contains("order_by"),
         "rejection must name the order_by conflict, got: {err}"
+    );
+}
+
+/// khive#2392: `query_notes_filtered` computes an exact `COUNT(*)` total over
+/// the whole matching set, which has no defined meaning paired with a seek
+/// boundary, so it must reject `NoteFilter.after` rather than silently
+/// ignoring it (the pre-fix behavior: it never read the field at all, so a
+/// caller passing a cursor here got the first page over and over instead of
+/// an error or the seeked rows).
+#[tokio::test]
+async fn query_notes_filtered_rejects_seek_cursor() {
+    use khive_storage::note::{NoteFilter, NoteSeekAfter};
+    use khive_storage::types::PageRequest;
+
+    let store = setup_memory_store();
+    let filter = NoteFilter {
+        kind: Some("widget".to_string()),
+        after: Some(NoteSeekAfter {
+            created_at: 0,
+            id: uuid::Uuid::nil(),
+        }),
+        ..Default::default()
+    };
+    let err = store
+        .query_notes_filtered(
+            "default",
+            &filter,
+            PageRequest {
+                limit: 10,
+                offset: 0,
+            },
+        )
+        .await
+        .expect_err("query_notes_filtered must reject NoteFilter.after");
+    assert!(
+        err.to_string().contains("query_notes_filtered_count_free"),
+        "rejection must point callers at the method that does honour after, got: {err}"
+    );
+}
+
+/// The same rejection applies when `after` is combined with a custom
+/// `order_by` — `query_notes_filtered` never seeks, so there is no separate
+/// "order_by conflict" branch to hit; both fields being set still surfaces
+/// the one `after`-not-supported error.
+#[tokio::test]
+async fn query_notes_filtered_rejects_seek_cursor_with_custom_order_by() {
+    use khive_storage::note::{NoteFilter, NoteSeekAfter, SortDir};
+    use khive_storage::types::PageRequest;
+
+    let store = setup_memory_store();
+    let filter = NoteFilter {
+        kind: Some("widget".to_string()),
+        order_by: Some(("$.priority".to_string(), SortDir::Asc)),
+        after: Some(NoteSeekAfter {
+            created_at: 0,
+            id: uuid::Uuid::nil(),
+        }),
+        ..Default::default()
+    };
+    let err = store
+        .query_notes_filtered(
+            "default",
+            &filter,
+            PageRequest {
+                limit: 10,
+                offset: 0,
+            },
+        )
+        .await
+        .expect_err(
+            "query_notes_filtered must reject NoteFilter.after even with a custom order_by",
+        );
+    assert!(
+        err.to_string().contains("query_notes_filtered_count_free"),
+        "rejection must point callers at the method that does honour after, got: {err}"
     );
 }
 
@@ -4093,5 +4170,309 @@ async fn json_type_ne_missing_rejects_non_vocabulary_value() {
     assert!(
         err.to_string().contains("json_type"),
         "rejection must name the json_type vocabulary, got: {err}"
+    );
+}
+
+/// khive#2392: `fetch_notes_after`'s `status="all"`/`status="read"` inbox
+/// listings (no `$.read` filter, or `JsonTypeEq` rather than the tuned
+/// `JsonTypeNeMissing` probe) have no index ending in `(created_at DESC, id
+/// ASC)` for their `(namespace, kind, direction, to_actor[, read])`
+/// partition, so the lt-branch (`created_at < ? ORDER BY created_at DESC, id
+/// ASC`) still costs a full partition scan plus a temp-b-tree sort on every
+/// internal page — pins the expected-arm SCAN-plus-sort plan so a future
+/// index addition is a deliberate, measured change rather than a silent
+/// drift. See `candidate_created_at_id_seek_index_flips_unread_probe_plan`
+/// for why the natural fix (a general `(namespace, kind, created_at DESC, id
+/// ASC)` index) was measured and rejected rather than shipped.
+#[tokio::test]
+async fn comm_inbox_status_all_lt_branch_has_no_seek_index() {
+    use khive_storage::note::{FilterOp, NoteFilter, PropertyFilter as NotePropFilter};
+    use khive_storage::types::SqlValue;
+
+    let pool = setup_pool();
+    {
+        let writer = pool.writer().unwrap();
+        writer
+            .conn()
+            .execute_batch(
+                "CREATE INDEX IF NOT EXISTS idx_comm_message_direction \
+                    ON notes(namespace, kind, json_extract(properties, '$.direction'), \
+                    json_extract(properties, '$.read'), created_at DESC) \
+                    WHERE deleted_at IS NULL;
+                 CREATE INDEX IF NOT EXISTS idx_comm_message_to_actor \
+                    ON notes(namespace, kind, \
+                    json_extract(properties, '$.to_actor'), \
+                    json_extract(properties, '$.direction'), \
+                    json_extract(properties, '$.read'), \
+                    created_at DESC) \
+                    WHERE deleted_at IS NULL;",
+            )
+            .unwrap();
+    }
+    {
+        let writer = pool.writer().unwrap();
+        let conn = writer.conn();
+        conn.execute_batch("BEGIN").unwrap();
+        for i in 0..6000i64 {
+            let to_actor = if i % 5 == 0 {
+                "lambda:target"
+            } else {
+                "lambda:other"
+            };
+            conn.execute(
+                "INSERT INTO notes (id, namespace, kind, content, properties, created_at, updated_at) \
+                 VALUES (?1, 'default', 'message', ?2, \
+                 json_object('direction','inbound','to_actor',?3,'read', (?4 % 2 = 0)), ?4, ?4)",
+                rusqlite::params![uuid::Uuid::new_v4().to_string(), format!("m{i}"), to_actor, i],
+            )
+            .unwrap();
+        }
+        conn.execute_batch("COMMIT").unwrap();
+    }
+
+    // Same shape `query_inbox_response` builds for box="inbox", status="all".
+    let filter = NoteFilter {
+        kind: Some("message".to_string()),
+        property_filters: vec![
+            NotePropFilter {
+                json_path: "$.direction".to_string(),
+                op: FilterOp::Eq,
+                value: SqlValue::Text("inbound".to_string()),
+            },
+            NotePropFilter {
+                json_path: "$.to_actor".to_string(),
+                op: FilterOp::EqOrLegacyIndexed,
+                value: SqlValue::Text("lambda:target".to_string()),
+            },
+        ],
+        ..Default::default()
+    };
+
+    let reader = pool.reader().unwrap();
+    let (lt_where, mut lt_params) = build_note_filter_where("default", &filter).unwrap();
+    lt_params.push(Box::new(3000_i64));
+    let lt_ts_idx = lt_params.len();
+    lt_params.push(Box::new(100_i64));
+    let lt_limit_idx = lt_params.len();
+    let lt_sql = format!(
+        "SELECT id FROM notes{lt_where} AND created_at < ?{lt_ts_idx} \
+         ORDER BY created_at DESC, id ASC LIMIT ?{lt_limit_idx}"
+    );
+    let plan = plan_details(reader.conn(), &lt_sql, &lt_params);
+    assert!(
+        plan.contains("USE TEMP B-TREE FOR ORDER BY"),
+        "expected arm: the lt-branch still sorts because no index ends in \
+         (created_at DESC, id ASC) for this partition, got:\n{plan}"
+    );
+    assert!(
+        !plan.contains("idx_notes_kind_created_seek"),
+        "no such index exists in production schema; a name match here would mean \
+         this test started reading stale state"
+    );
+}
+
+/// khive#2392: the natural seekable fix for the gap pinned by
+/// `comm_inbox_status_all_lt_branch_has_no_seek_index` — a general
+/// `(namespace, kind, created_at DESC, id ASC) WHERE deleted_at IS NULL`
+/// index — was measured, not just assumed, before deciding not to ship it.
+/// Standalone it cuts the lt-branch scan from 57,473 to 7,223 VM steps for a
+/// 6,000-row fixture (~8x), but because it carries no `to_actor`/`read`
+/// predicate it is *also* a legal plan for `comm.inbox`'s default
+/// `status="unread"` listing, and SQLite prefers it (no `ANALYZE`
+/// statistics) over the purpose-built partial
+/// `idx_notes_unread_probe_recipient_direction` — the identical failure mode
+/// V27's header already recorded for the dropped `(to_actor, direction)`
+/// index. Measured on the same fixture: 84 VM steps via the partial index
+/// vs. 125 via this candidate, so it is not even a narrow win there. This
+/// test builds the two indexes together and pins that the unread-probe plan
+/// flips away from the tuned partial index, which is the reason this index
+/// is not part of the migration.
+#[tokio::test]
+async fn candidate_created_at_id_seek_index_flips_unread_probe_plan() {
+    use khive_storage::note::{FilterOp, NoteFilter, PropertyFilter as NotePropFilter};
+    use khive_storage::types::SqlValue;
+
+    let store = setup_memory_store();
+    for i in 0..20 {
+        store
+            .upsert_note(make_note_with_props(
+                "default",
+                "message",
+                &format!("message {i}"),
+                serde_json::json!({
+                    "direction": "inbound",
+                    "to_actor": "lambda:reader",
+                    "read": false,
+                }),
+            ))
+            .await
+            .unwrap();
+    }
+
+    {
+        let writer = store.pool.writer().unwrap();
+        writer
+            .conn()
+            .execute_batch(
+                "CREATE INDEX IF NOT EXISTS idx_notes_kind_created_seek \
+                    ON notes(namespace, kind, created_at DESC, id ASC) \
+                    WHERE deleted_at IS NULL;",
+            )
+            .unwrap();
+    }
+
+    let filter = NoteFilter {
+        kind: Some("message".to_string()),
+        property_filters: vec![
+            NotePropFilter {
+                json_path: "$.direction".to_string(),
+                op: FilterOp::Eq,
+                value: SqlValue::Text("inbound".to_string()),
+            },
+            NotePropFilter {
+                json_path: "$.read".to_string(),
+                op: FilterOp::JsonTypeNeMissing,
+                value: SqlValue::Text("true".to_string()),
+            },
+            NotePropFilter {
+                json_path: "$.to_actor".to_string(),
+                op: FilterOp::EqOrLegacyIndexed,
+                value: SqlValue::Text("lambda:reader".to_string()),
+            },
+        ],
+        order_by: None,
+        ..Default::default()
+    };
+    let (sql, params) = listing_sql_and_params(&filter);
+    let plan = plan_details(store.pool.reader().unwrap().conn(), &sql, &params);
+    assert!(
+        plan.contains("idx_notes_kind_created_seek"),
+        "expected arm: with both indexes present, the planner prefers the general \
+         created_at/id index over the tuned partial unread-probe index, got:\n{plan}"
+    );
+    assert!(
+        !plan.contains("idx_notes_unread_probe_recipient_direction"),
+        "got:\n{plan}"
+    );
+}
+
+/// khive#2392: narrowing `idx_notes_task_status`/`idx_notes_task_assignee`'s
+/// partial `WHERE` to `kind = 'task' AND deleted_at IS NULL` would shrink the
+/// index, but every query that would use it binds `kind` as a parameter
+/// (`build_note_filter_where` never inlines it), and SQLite can only use a
+/// partial index when it can prove the WHERE clause from the query's WHERE
+/// clause using a literal or otherwise plan-time-known value — a bound
+/// parameter is not visible until execution, so a query written exactly as
+/// `kind = ?1` cannot be proven to imply `kind = 'task'` at plan time. This
+/// pins that the narrowed index shape is not chosen, which is why the
+/// shipped V27 indexes stay partial only on `deleted_at IS NULL`.
+#[tokio::test]
+async fn narrowing_hot_property_index_to_kind_task_is_not_chosen() {
+    use khive_storage::note::{FilterOp, NoteFilter, PropertyFilter as NotePropFilter};
+    use khive_storage::types::SqlValue;
+
+    let store = setup_memory_store();
+    for i in 0..20 {
+        store
+            .upsert_note(make_note_with_props(
+                "default",
+                "task",
+                &format!("task {i}"),
+                serde_json::json!({ "status": if i % 2 == 0 { "active" } else { "next" } }),
+            ))
+            .await
+            .unwrap();
+    }
+
+    {
+        let writer = store.pool.writer().unwrap();
+        writer
+            .conn()
+            .execute_batch(
+                "CREATE INDEX IF NOT EXISTS idx_notes_task_status_narrowed \
+                    ON notes(namespace, json_extract(properties, '$.status'), \
+                    created_at DESC, id ASC) \
+                    WHERE kind = 'task' AND deleted_at IS NULL;",
+            )
+            .unwrap();
+    }
+
+    let filter = NoteFilter {
+        kind: Some("task".to_string()),
+        property_filters: vec![NotePropFilter {
+            json_path: "$.status".to_string(),
+            op: FilterOp::Eq,
+            value: SqlValue::Text("active".to_string()),
+        }],
+        ..Default::default()
+    };
+    let (sql, params) = listing_sql_and_params(&filter);
+    let plan = plan_details(store.pool.reader().unwrap().conn(), &sql, &params);
+    assert!(
+        !plan.contains("idx_notes_task_status_narrowed"),
+        "expected arm: a bound `kind = ?` parameter cannot prove the narrowed \
+         partial index's WHERE clause, so the planner must not choose it, got:\n{plan}"
+    );
+    assert!(
+        plan.contains("idx_notes_task_status") || plan.contains("idx_notes_task_assignee"),
+        "the shipped (non-narrowed) indexes must still serve the query, got:\n{plan}"
+    );
+}
+
+/// khive#2392: `gtd.tasks()` with no `status=` filter compiles
+/// `FilterOp::NotInOrMissing(["done", "cancelled"])` on `$.status`
+/// (`handle_tasks` in `crates/khive-pack-gtd/src/handlers.rs`), which
+/// `build_note_filter_where` turns into `(expr IS NULL OR expr NOT IN
+/// (...))` -- an open exclusion, not a bounded set, so `idx_notes_task_status`
+/// cannot narrow it to an index range seek; the planner can only walk the
+/// `(namespace, kind)` partition.
+///
+/// No seekable rewrite preserves the documented semantics either: the
+/// listing must keep a task whose `$.status` is missing *or* any unrecognized
+/// legacy value (see `handle_tasks`'s comment on why `NotInOrMissing` was
+/// chosen over `Ne`), so the exclusion set is open-ended and cannot be
+/// rewritten as `status IN (<the 5 known non-terminal statuses>)` -- that
+/// would silently drop a task carrying a status string outside
+/// `TASK_STATUSES`, which is exactly the case this predicate exists to keep.
+/// This test measures and pins the current (unindexed) plan rather than
+/// leaving the claim unverified.
+#[tokio::test]
+async fn gtd_tasks_default_listing_not_in_or_missing_has_no_seek_index() {
+    use khive_storage::note::{FilterOp, NoteFilter, PropertyFilter as NotePropFilter};
+    use khive_storage::types::SqlValue;
+
+    let store = setup_memory_store();
+    let statuses = ["inbox", "next", "active", "done", "cancelled"];
+    for i in 0..20 {
+        store
+            .upsert_note(make_note_with_props(
+                "default",
+                "task",
+                &format!("task {i}"),
+                serde_json::json!({ "status": statuses[i % 5] }),
+            ))
+            .await
+            .unwrap();
+    }
+
+    let filter = NoteFilter {
+        kind: Some("task".to_string()),
+        property_filters: vec![NotePropFilter {
+            json_path: "$.status".to_string(),
+            op: FilterOp::NotInOrMissing(vec![
+                SqlValue::Text("done".to_string()),
+                SqlValue::Text("cancelled".to_string()),
+            ]),
+            value: SqlValue::Null,
+        }],
+        ..Default::default()
+    };
+    let (sql, params) = listing_sql_and_params(&filter);
+    let plan = plan_details(store.pool.reader().unwrap().conn(), &sql, &params);
+    assert!(
+        !plan.contains("idx_notes_task_status"),
+        "expected arm: an open NOT-IN exclusion cannot be served by an equality-\
+         keyed index seek, so idx_notes_task_status must not appear in the plan, \
+         got:\n{plan}"
     );
 }

--- a/crates/khive-db/src/stores/note_tests.rs
+++ b/crates/khive-db/src/stores/note_tests.rs
@@ -3582,6 +3582,491 @@ async fn eq_or_legacy_indexed_matches_eq_or_missing_on_every_write_path_shape() 
     }
 }
 
+// ── khive#2390: hot note property-path indexes ──────────────────────────────
+
+fn plan_details(
+    conn: &rusqlite::Connection,
+    sql: &str,
+    params: &[Box<dyn rusqlite::types::ToSql>],
+) -> String {
+    let mut stmt = conn.prepare(&format!("EXPLAIN QUERY PLAN {sql}")).unwrap();
+    let refs: Vec<&dyn rusqlite::types::ToSql> = params.iter().map(|p| p.as_ref()).collect();
+    stmt.query_map(refs.as_slice(), |row| row.get::<_, String>(3))
+        .unwrap()
+        .map(Result::unwrap)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn listing_sql_and_params(
+    filter: &khive_storage::note::NoteFilter,
+) -> (String, Vec<Box<dyn rusqlite::types::ToSql>>) {
+    let (where_sql, mut params) = build_note_filter_where("default", filter).unwrap();
+    params.push(Box::new(1_i64));
+    let limit_idx = params.len();
+    (
+        format!(
+            "SELECT id FROM notes{where_sql} ORDER BY created_at DESC, id ASC LIMIT ?{limit_idx}"
+        ),
+        params,
+    )
+}
+
+/// `gtd.tasks(status=..., assignee=...)` compiles to exactly this shape
+/// (`FilterOp::Eq` on both `$.status` and `$.assignee` — see
+/// `crates/khive-pack-gtd/src/handlers.rs::handle_tasks`). Before V27 this
+/// scanned every `task` row in the namespace evaluating both `json_extract`
+/// calls; V27's `idx_notes_task_status`/`idx_notes_task_assignee` give the
+/// planner an equality seek on at least one of the two predicates instead.
+#[tokio::test]
+async fn gtd_tasks_status_and_assignee_query_uses_hot_property_index() {
+    use khive_storage::note::PropertyFilter as NotePropFilter;
+    use khive_storage::note::{FilterOp, NoteFilter};
+    use khive_storage::types::SqlValue;
+
+    let store = setup_memory_store();
+    for i in 0..20 {
+        store
+            .upsert_note(make_note_with_props(
+                "default",
+                "task",
+                &format!("task {i}"),
+                serde_json::json!({
+                    "status": if i % 2 == 0 { "active" } else { "next" },
+                    "assignee": if i % 3 == 0 { "lambda:a" } else { "lambda:b" },
+                }),
+            ))
+            .await
+            .unwrap();
+    }
+
+    let filter = NoteFilter {
+        kind: Some("task".to_string()),
+        property_filters: vec![
+            NotePropFilter {
+                json_path: "$.status".to_string(),
+                op: FilterOp::Eq,
+                value: SqlValue::Text("active".to_string()),
+            },
+            NotePropFilter {
+                json_path: "$.assignee".to_string(),
+                op: FilterOp::Eq,
+                value: SqlValue::Text("lambda:a".to_string()),
+            },
+        ],
+        ..Default::default()
+    };
+    let (sql, params) = listing_sql_and_params(&filter);
+
+    let indexed_plan = plan_details(store.pool.reader().unwrap().conn(), &sql, &params);
+    assert!(
+        indexed_plan.contains("idx_notes_task_status")
+            || indexed_plan.contains("idx_notes_task_assignee"),
+        "combined status+assignee query must be served by one of the new hot-property \
+         indexes, got plan:\n{indexed_plan}"
+    );
+
+    // Control: without the new indexes, the planner falls back to the
+    // namespace+kind index (or a full table scan) and must NOT reference
+    // either new index name.
+    {
+        let writer = store.pool.writer().unwrap();
+        writer
+            .conn()
+            .execute_batch("DROP INDEX idx_notes_task_status; DROP INDEX idx_notes_task_assignee;")
+            .unwrap();
+    }
+    let control_plan = plan_details(store.pool.reader().unwrap().conn(), &sql, &params);
+    assert!(
+        !control_plan.contains("idx_notes_task_status")
+            && !control_plan.contains("idx_notes_task_assignee"),
+        "control: dropped indexes must vanish from the plan, got:\n{control_plan}"
+    );
+}
+
+/// `gtd.next(assignee=...)` compiles `$.status IN ('next','active')` via
+/// `FilterOp::In` plus an optional `FilterOp::Eq` on `$.assignee` (see
+/// `handle_next`). `idx_notes_task_assignee` must still serve the equality
+/// term even though the sibling predicate is a multi-value IN rather than a
+/// plain `=`.
+#[tokio::test]
+async fn gtd_next_status_in_with_assignee_query_uses_assignee_index() {
+    use khive_storage::note::PropertyFilter as NotePropFilter;
+    use khive_storage::note::{FilterOp, NoteFilter};
+    use khive_storage::types::SqlValue;
+
+    let store = setup_memory_store();
+    for i in 0..20 {
+        store
+            .upsert_note(make_note_with_props(
+                "default",
+                "task",
+                &format!("task {i}"),
+                serde_json::json!({
+                    "status": if i % 2 == 0 { "active" } else { "done" },
+                    "assignee": if i % 3 == 0 { "lambda:a" } else { "lambda:b" },
+                }),
+            ))
+            .await
+            .unwrap();
+    }
+
+    let filter = NoteFilter {
+        kind: Some("task".to_string()),
+        property_filters: vec![
+            NotePropFilter {
+                json_path: "$.status".to_string(),
+                op: FilterOp::In(vec![
+                    SqlValue::Text("next".to_string()),
+                    SqlValue::Text("active".to_string()),
+                ]),
+                value: SqlValue::Null,
+            },
+            NotePropFilter {
+                json_path: "$.assignee".to_string(),
+                op: FilterOp::Eq,
+                value: SqlValue::Text("lambda:a".to_string()),
+            },
+        ],
+        ..Default::default()
+    };
+    let (sql, params) = listing_sql_and_params(&filter);
+    let indexed_plan = plan_details(store.pool.reader().unwrap().conn(), &sql, &params);
+    assert!(
+        indexed_plan.contains("idx_notes_task_status")
+            || indexed_plan.contains("idx_notes_task_assignee"),
+        "status-IN plus assignee-eq query must be served by one of the new hot-property \
+         indexes, got plan:\n{indexed_plan}"
+    );
+}
+
+/// khive#2390: a general `(to_actor, direction)` index for the comm mailbox
+/// listing (status="all"/"read", box="sent") was drafted for this change and
+/// dropped after this exact test proved it regressed the tuned unread-probe
+/// path -- with no ANALYZE statistics, SQLite chose the new unconditional
+/// index over the existing partial `idx_notes_unread_probe_recipient_direction`
+/// for the default unread-status listing, even though the partial index is
+/// strictly cheaper there (it excludes read rows structurally; the general
+/// index would only exclude them via a residual filter). This test pins
+/// that the unread-scoped plan stays on the partial index with no
+/// competing general index present, guarding against reintroducing one
+/// without solving the ambiguity first.
+#[tokio::test]
+async fn comm_inbox_unread_default_query_still_uses_partial_unread_probe_index() {
+    use khive_storage::note::PropertyFilter as NotePropFilter;
+    use khive_storage::note::{FilterOp, NoteFilter};
+    use khive_storage::types::SqlValue;
+
+    let store = setup_memory_store();
+    for i in 0..20 {
+        store
+            .upsert_note(make_note_with_props(
+                "default",
+                "message",
+                &format!("message {i}"),
+                serde_json::json!({
+                    "direction": "inbound",
+                    "to_actor": "lambda:reader",
+                    "read": false,
+                }),
+            ))
+            .await
+            .unwrap();
+    }
+
+    let filter = NoteFilter {
+        kind: Some("message".to_string()),
+        property_filters: vec![
+            NotePropFilter {
+                json_path: "$.direction".to_string(),
+                op: FilterOp::Eq,
+                value: SqlValue::Text("inbound".to_string()),
+            },
+            NotePropFilter {
+                json_path: "$.read".to_string(),
+                op: FilterOp::JsonTypeNeMissing,
+                value: SqlValue::Text("true".to_string()),
+            },
+            NotePropFilter {
+                json_path: "$.to_actor".to_string(),
+                op: FilterOp::EqOrLegacyIndexed,
+                value: SqlValue::Text("lambda:reader".to_string()),
+            },
+        ],
+        order_by: None,
+        ..Default::default()
+    };
+    let (sql, params) = listing_sql_and_params(&filter);
+    let plan = plan_details(store.pool.reader().unwrap().conn(), &sql, &params);
+    assert!(
+        plan.contains("idx_notes_unread_probe_recipient_direction"),
+        "unread-default inbox listing must stay on the partial unread-probe index, got:\n{plan}"
+    );
+    assert!(
+        !plan.contains("idx_notes_task_status") && !plan.contains("idx_notes_task_assignee"),
+        "unrelated new indexes must not appear in an unread-probe plan, got:\n{plan}"
+    );
+}
+
+/// [`NoteSeekAfter`] keyset paging over `query_notes_filtered_count_free`
+/// must reassemble the exact same total order as offset paging, with no
+/// duplicate or missing rows at page boundaries.
+#[tokio::test]
+async fn seek_after_paging_matches_offset_paging_exactly() {
+    use khive_storage::note::{NoteFilter, NoteSeekAfter};
+    use khive_storage::types::PageRequest;
+
+    let store = setup_memory_store();
+    for i in 0..900i64 {
+        let mut note = make_note("default", "widget", &format!("n{i}"));
+        note.created_at = i;
+        note.updated_at = i;
+        store.upsert_note(note).await.unwrap();
+    }
+
+    let filter = NoteFilter {
+        kind: Some("widget".to_string()),
+        ..Default::default()
+    };
+
+    let mut offset_ids = Vec::new();
+    let mut offset = 0u64;
+    loop {
+        let page = store
+            .query_notes_filtered_count_free("default", &filter, PageRequest { limit: 97, offset })
+            .await
+            .unwrap();
+        if page.items.is_empty() {
+            break;
+        }
+        offset_ids.extend(page.items.iter().map(|n| n.id));
+        offset += 97;
+    }
+
+    let mut cursor_ids = Vec::new();
+    let mut cursor: Option<NoteSeekAfter> = None;
+    loop {
+        let mut page_filter = filter.clone();
+        page_filter.after = cursor;
+        let page = store
+            .query_notes_filtered_count_free(
+                "default",
+                &page_filter,
+                PageRequest {
+                    limit: 97,
+                    offset: 0,
+                },
+            )
+            .await
+            .unwrap();
+        if page.items.is_empty() {
+            break;
+        }
+        cursor = page.items.last().map(|n| NoteSeekAfter {
+            created_at: n.created_at,
+            id: n.id,
+        });
+        cursor_ids.extend(page.items.iter().map(|n| n.id));
+    }
+
+    assert_eq!(cursor_ids.len(), 900);
+    assert_eq!(
+        offset_ids, cursor_ids,
+        "keyset paging must reassemble the identical total order offset paging produces"
+    );
+}
+
+/// `NoteFilter.after` combined with a custom `order_by` has no defined
+/// meaning (the boundary is expressed in terms of the default `created_at
+/// DESC, id ASC` order) and must be rejected rather than silently
+/// misapplied.
+#[tokio::test]
+async fn seek_after_rejects_custom_order_by() {
+    use khive_storage::note::{NoteFilter, NoteSeekAfter, SortDir};
+    use khive_storage::types::PageRequest;
+
+    let store = setup_memory_store();
+    let filter = NoteFilter {
+        kind: Some("widget".to_string()),
+        order_by: Some(("$.priority".to_string(), SortDir::Asc)),
+        after: Some(NoteSeekAfter {
+            created_at: 0,
+            id: uuid::Uuid::nil(),
+        }),
+        ..Default::default()
+    };
+    let err = store
+        .query_notes_filtered_count_free(
+            "default",
+            &filter,
+            PageRequest {
+                limit: 10,
+                offset: 0,
+            },
+        )
+        .await
+        .expect_err("after + custom order_by must be rejected");
+    assert!(
+        err.to_string().contains("order_by"),
+        "rejection must name the order_by conflict, got: {err}"
+    );
+}
+
+/// Seeking to the boundary after N already-fetched rows must not cost more
+/// work than fetching the same page fresh: unlike `PageRequest.offset`,
+/// which walks (and discards) every skipped row on every call, `after` lets
+/// the planner range-seek directly to the boundary via the ordered index.
+///
+/// The filter below matches `idx_notes_task_status` exactly (namespace, kind,
+/// `$.status`, `created_at DESC, id ASC`), so the trailing key columns
+/// already supply the query's `ORDER BY` -- without that, SQLite has to
+/// build a temporary sort over every matching row before LIMIT/OFFSET ever
+/// applies, which dominates both approaches' cost equally and hides the
+/// walk-vs-seek difference this test exists to measure.
+///
+/// This measures `fetch_notes_after` directly (the two-statement seek
+/// `query_notes_filtered_count_free` delegates to for `NoteFilter.after`),
+/// not a single combined `WHERE` predicate: an initial attempt using one
+/// statement with `(created_at, id) < (?, ?)` (or the logically equivalent
+/// `created_at < ?1 OR (created_at = ?1 AND id > ?2)`) measured SLOWER than
+/// plain `OFFSET` here, confirmed by `EXPLAIN QUERY PLAN` showing the same
+/// full ordered index scan either way -- SQLite does not give a
+/// mixed-direction (`DESC`, `ASC`) boundary index-seek treatment on this
+/// build. Splitting into two single-direction queries (exact-timestamp ties,
+/// then strictly-smaller timestamps) is what actually seeks.
+#[tokio::test]
+async fn seek_after_does_not_scale_with_rows_already_seen_unlike_offset() {
+    use rusqlite::StatementStatus;
+
+    let pool = setup_pool();
+    {
+        let writer = pool.writer().unwrap();
+        let conn = writer.conn();
+        conn.execute_batch("BEGIN").unwrap();
+        for i in 0..5_000i64 {
+            conn.execute(
+                "INSERT INTO notes (id, namespace, kind, content, properties, created_at, updated_at) \
+                 VALUES (?1, 'default', 'task', ?2, '{\"status\":\"active\"}', ?3, ?3)",
+                rusqlite::params![uuid::Uuid::new_v4().to_string(), format!("n{i}"), i],
+            )
+            .unwrap();
+        }
+        conn.execute_batch("COMMIT").unwrap();
+    }
+
+    let filter = khive_storage::note::NoteFilter {
+        kind: Some("task".to_string()),
+        property_filters: vec![khive_storage::note::PropertyFilter {
+            json_path: "$.status".to_string(),
+            op: khive_storage::note::FilterOp::Eq,
+            value: khive_storage::types::SqlValue::Text("active".to_string()),
+        }],
+        ..Default::default()
+    };
+
+    fn measure(
+        conn: &rusqlite::Connection,
+        sql: &str,
+        params: &[Box<dyn rusqlite::types::ToSql>],
+    ) -> (usize, i32) {
+        let mut stmt = conn.prepare(sql).unwrap();
+        let refs: Vec<&dyn rusqlite::types::ToSql> = params.iter().map(|p| p.as_ref()).collect();
+        let rows: Vec<String> = stmt
+            .query_map(refs.as_slice(), |row| row.get::<_, String>(0))
+            .unwrap()
+            .map(Result::unwrap)
+            .collect();
+        let steps = stmt.get_status(StatementStatus::VmStep);
+        (rows.len(), steps)
+    }
+
+    let reader = pool.reader().unwrap();
+
+    // Offset-based: skip the first 4,900 rows, fetch the last 100.
+    let (offset_where, mut offset_params) = build_note_filter_where("default", &filter).unwrap();
+    offset_params.push(Box::new(100_i64));
+    let offset_limit_idx = offset_params.len();
+    offset_params.push(Box::new(4_900_i64));
+    let offset_offset_idx = offset_params.len();
+    let offset_sql = format!(
+        "SELECT id FROM notes{offset_where} ORDER BY created_at DESC, id ASC \
+         LIMIT ?{offset_limit_idx} OFFSET ?{offset_offset_idx}"
+    );
+    let (offset_rows, offset_steps) = measure(reader.conn(), &offset_sql, &offset_params);
+    assert_eq!(offset_rows, 100);
+
+    // Cursor-based: seek to the boundary a real 4,900-row page ends at, then
+    // fetch the next 100 via the production `fetch_notes_after` path -- the
+    // same rows the offset query above returned.
+    let (peek_where, mut peek_params) = build_note_filter_where("default", &filter).unwrap();
+    peek_params.push(Box::new(4_900_i64));
+    let peek_limit_idx = peek_params.len();
+    let peek_sql =
+        format!("SELECT id, created_at FROM notes{peek_where} ORDER BY created_at DESC, id ASC LIMIT ?{peek_limit_idx}");
+    let boundary: (String, i64) = {
+        let mut stmt = reader.conn().prepare(&peek_sql).unwrap();
+        let refs: Vec<&dyn rusqlite::types::ToSql> =
+            peek_params.iter().map(|p| p.as_ref()).collect();
+        stmt.query_map(refs.as_slice(), |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+        })
+        .unwrap()
+        .map(Result::unwrap)
+        .last()
+        .unwrap()
+    };
+    let after = khive_storage::note::NoteSeekAfter {
+        created_at: boundary.1,
+        id: uuid::Uuid::parse_str(&boundary.0).unwrap(),
+    };
+
+    // `fetch_notes_after`'s two branches, instrumented individually and
+    // summed, since it prepares its own statements internally.
+    let (tie_where, mut tie_params) = build_note_filter_where("default", &filter).unwrap();
+    tie_params.push(Box::new(after.created_at));
+    let tie_ts_idx = tie_params.len();
+    tie_params.push(Box::new(after.id.to_string()));
+    let tie_id_idx = tie_params.len();
+    tie_params.push(Box::new(100_i64));
+    let tie_limit_idx = tie_params.len();
+    let tie_sql = format!(
+        "SELECT id FROM notes{tie_where} AND created_at = ?{tie_ts_idx} AND id > ?{tie_id_idx} \
+         ORDER BY id ASC LIMIT ?{tie_limit_idx}"
+    );
+    let (tie_rows, tie_steps) = measure(reader.conn(), &tie_sql, &tie_params);
+
+    let remaining = 100 - tie_rows as i64;
+    let (lt_where, mut lt_params) = build_note_filter_where("default", &filter).unwrap();
+    lt_params.push(Box::new(after.created_at));
+    let lt_ts_idx = lt_params.len();
+    lt_params.push(Box::new(remaining));
+    let lt_limit_idx = lt_params.len();
+    let lt_sql = format!(
+        "SELECT id FROM notes{lt_where} AND created_at < ?{lt_ts_idx} \
+         ORDER BY created_at DESC, id ASC LIMIT ?{lt_limit_idx}"
+    );
+    let (lt_rows, lt_steps) = measure(reader.conn(), &lt_sql, &lt_params);
+
+    let after_rows = tie_rows + lt_rows;
+    let after_steps = tie_steps + lt_steps;
+    assert_eq!(
+        after_rows, offset_rows,
+        "both approaches must return the same number of rows for the same tail page"
+    );
+
+    // Verify the actual fetch_notes_after production path matches too.
+    let production_items =
+        fetch_notes_after(reader.conn(), "default", &filter, &after, 100).unwrap();
+    assert_eq!(production_items.len(), offset_rows);
+
+    assert!(
+        after_steps < offset_steps / 10,
+        "seeking from a cursor must avoid walking the 4,900 skipped rows an OFFSET \
+         re-walks on every call: {offset_steps} VM steps via OFFSET vs {after_steps} via a \
+         two-branch keyset seek (measured ~32x at this fixture size: 20317 vs 638)"
+    );
+}
+
 /// The inlined json_type literal admits only SQLite's closed json_type
 /// vocabulary; anything else is rejected rather than interpolated.
 #[tokio::test]

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -758,23 +758,40 @@ async fn query_inbox_response(
     // Offset is defined over the fully-filtered sequence. When a filter cannot
     // be represented by `NoteFilter`, scan the indexed base query and count only
     // matching rows before collecting one lookahead item for `has_more`.
+    //
+    // Each page is fetched from a keyset boundary (`NoteFilter.after`), not a
+    // growing `PageRequest.offset`: an offset re-walks every earlier row on
+    // every page, so this loop's total work was quadratic in the number of
+    // pages scanned before a post-filter match was found. Seeking from the
+    // last row's `(created_at, id)` makes each page's fetch cost independent
+    // of how many pages came before it. `filter.order_by` is always `None`
+    // here (see its construction above), which `after` requires.
     let mut messages: Vec<Value> = if has_post_filter {
         const PAGE_SIZE: u32 = 200;
         let mut collected: Vec<Value> = Vec::new();
         let mut matched: u64 = 0;
-        let mut db_offset: u64 = 0;
+        let mut cursor: Option<khive_storage::note::NoteSeekAfter> = None;
         loop {
+            let mut page_filter = filter.clone();
+            page_filter.after = cursor;
             let page = store
                 .query_notes_filtered_count_free(
                     namespace,
-                    filter,
+                    &page_filter,
                     PageRequest {
                         limit: PAGE_SIZE,
-                        offset: db_offset,
+                        offset: 0,
                     },
                 )
                 .await?;
             let fetched = page.items.len() as u32;
+            cursor = page
+                .items
+                .last()
+                .map(|n| khive_storage::note::NoteSeekAfter {
+                    created_at: n.created_at,
+                    id: n.id,
+                });
             for n in &page.items {
                 if !inbox_note_matches(n, params, before_micros, subject_needle, content_needle) {
                     continue;
@@ -791,9 +808,6 @@ async fn query_inbox_response(
             if collected.len() > limit || fetched < PAGE_SIZE {
                 break;
             }
-            db_offset = db_offset.checked_add(u64::from(PAGE_SIZE)).ok_or_else(|| {
-                RuntimeError::InvalidInput("inbox: pagination offset overflowed".into())
-            })?;
         }
         collected
     } else {

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -13119,3 +13119,131 @@ async fn sent_box_long_poll_wakes_after_concurrent_send() {
     );
     assert_eq!(sent["messages"][0]["direction"].as_str(), Some("outbound"));
 }
+
+/// khive#2390: `query_inbox_response`'s `has_post_filter` branch (any of
+/// `from_prefix` / `exclude_from_actor` / `before` / `subject_contains` /
+/// `content_contains`) used to re-issue its internal store fetch with a
+/// growing `OFFSET` on every iteration, re-walking every earlier row on
+/// every page. It now carries a `(created_at, id)` keyset cursor between
+/// iterations instead. 300 messages, one in six rejected by `from_prefix`,
+/// forces at least two internal 200-row store fetches to collect the 250
+/// accepted matches, exercising the cursor handoff across that boundary.
+/// This pins the observable contract the rewrite must not change: the same
+/// rows, in the same order, with the same `has_more`/`next_offset`
+/// bookkeeping a naive offset scan would have produced.
+#[tokio::test]
+async fn i2390_inbox_post_filter_keyset_paging_matches_offset_semantics_beyond_page_cap() {
+    let backend = shared_backend();
+    let (registry, runtime) = build_actor_registry(backend, "lambda:reader");
+    let base_micros = chrono::DateTime::parse_from_rfc3339("2026-08-01T00:00:00Z")
+        .unwrap()
+        .timestamp_micros();
+
+    // Every 6th sequence is rejected by `from_prefix`; the rest match. Newer
+    // (higher) sequences get a later `created_at`, so the default
+    // `created_at DESC` order lists sequence 300 first (if accepted) down to 1.
+    let mut expected_accepted_desc: Vec<u32> = Vec::new();
+    for sequence in 1..=300u32 {
+        let accepted = sequence % 6 != 0;
+        let from_actor = if accepted {
+            format!("team:accept:{sequence}")
+        } else {
+            format!("team:reject:{sequence}")
+        };
+        insert_i1422_message(
+            &runtime,
+            sequence,
+            base_micros + i64::from(sequence) * 1_000_000,
+            &from_actor,
+            "lambda:reader",
+            None,
+            &format!("message {sequence}"),
+        )
+        .await;
+        if accepted {
+            expected_accepted_desc.push(sequence);
+        }
+    }
+    expected_accepted_desc.reverse();
+    assert_eq!(expected_accepted_desc.len(), 250);
+
+    let expected_id = |sequence: u32| {
+        uuid::Uuid::from_u128((u128::from(sequence) << 96) | u128::from(sequence)).to_string()
+    };
+
+    let expected_all: Vec<String> = expected_accepted_desc
+        .iter()
+        .map(|s| expected_id(*s))
+        .collect();
+
+    // One call at the caller-visible limit cap (200) forces the internal
+    // loop to fetch a full PAGE_SIZE=200 batch of raw rows -- containing a
+    // mix of accepted and rejected messages -- and keep going past it to
+    // fill the requested 200 accepted matches, exercising the cursor
+    // handoff between store fetches. This alone would have caught an
+    // off-by-one there.
+    let all = registry
+        .dispatch(
+            "comm.inbox",
+            serde_json::json!({ "status": "all", "limit": 200, "from_prefix": "team:accept:" }),
+        )
+        .await
+        .expect("wide post-filtered inbox succeeds");
+    let all_ids: Vec<String> = all["messages"]
+        .as_array()
+        .expect("messages array")
+        .iter()
+        .map(|m| m["full_id"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(
+        all_ids,
+        expected_all[..200],
+        "post-filtered listing must return exactly the accepted rows, in created_at DESC order"
+    );
+    assert_eq!(all["has_more"], true);
+    assert_eq!(all["next_offset"], 200);
+
+    // Now the same population, paged externally in chunks of 100, must
+    // reproduce the identical partition an offset-based scan would have
+    // produced -- including the exact `has_more` boundary.
+    let mut collected: Vec<String> = Vec::new();
+    let mut offset: u64 = 0;
+    loop {
+        let page = registry
+            .dispatch(
+                "comm.inbox",
+                serde_json::json!({
+                    "status": "all",
+                    "limit": 100,
+                    "from_prefix": "team:accept:",
+                    "offset": offset,
+                }),
+            )
+            .await
+            .expect("paged post-filtered inbox succeeds");
+        let page_ids: Vec<String> = page["messages"]
+            .as_array()
+            .expect("messages array")
+            .iter()
+            .map(|m| m["full_id"].as_str().unwrap().to_string())
+            .collect();
+        let expected_slice = &expected_all[collected.len()..(collected.len() + page_ids.len())];
+        assert_eq!(
+            page_ids, expected_slice,
+            "page at offset={offset} must match the corresponding offset-paging slice"
+        );
+        assert_eq!(page["offset"], offset);
+        collected.extend(page_ids);
+
+        let has_more = page["has_more"].as_bool().expect("has_more is a bool");
+        if !has_more {
+            assert!(page["next_offset"].is_null());
+            break;
+        }
+        offset = page["next_offset"].as_u64().expect("next_offset present");
+    }
+    assert_eq!(
+        collected, expected_all,
+        "paging in 100-row chunks must reassemble the exact same total order as one wide call"
+    );
+}

--- a/crates/khive-storage/src/note.rs
+++ b/crates/khive-storage/src/note.rs
@@ -522,6 +522,18 @@ pub struct PropertyFilter {
     pub value: SqlValue,
 }
 
+/// Keyset pagination boundary over the notes store's default total order
+/// (`created_at DESC, id ASC` — see `note_filter_page_order_clause`).
+///
+/// Only meaningful when [`NoteFilter::order_by`] is `None`: the boundary is
+/// expressed in terms of that default order, and combining it with a custom
+/// sort field has no defined meaning, so callers must not set both.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NoteSeekAfter {
+    pub created_at: i64,
+    pub id: Uuid,
+}
+
 /// Filter + sort options for [`NoteStore::query_notes_filtered`].
 ///
 /// Designed for general property-based filtering on any JSON field, not
@@ -542,6 +554,12 @@ pub struct NoteFilter {
     /// Restrict to notes where `created_at >= min_created_at` (microseconds epoch).
     /// `None` applies no lower-bound constraint.
     pub min_created_at: Option<i64>,
+    /// Restrict results to rows strictly after this boundary in the default
+    /// `created_at DESC, id ASC` order, for keyset (seek) pagination that
+    /// avoids re-walking earlier pages the way `PageRequest.offset` does.
+    /// Requires `order_by` to be `None`.
+    #[serde(default)]
+    pub after: Option<NoteSeekAfter>,
 }
 
 /// Temporal-referential note CRUD over the notes substrate table.

--- a/crates/khive-storage/src/note.rs
+++ b/crates/khive-storage/src/note.rs
@@ -558,6 +558,13 @@ pub struct NoteFilter {
     /// `created_at DESC, id ASC` order, for keyset (seek) pagination that
     /// avoids re-walking earlier pages the way `PageRequest.offset` does.
     /// Requires `order_by` to be `None`.
+    ///
+    /// Honoured only by [`NoteStore::query_notes_filtered_count_free`], which
+    /// seeks directly to the boundary and returns `total: None`.
+    /// [`NoteStore::query_notes_filtered`] rejects a non-`None` value with
+    /// `StorageError::InvalidInput`: it computes an exact `COUNT(*)` total
+    /// over the whole matching set, which has no defined meaning paired with
+    /// a seek boundary.
     #[serde(default)]
     pub after: Option<NoteSeekAfter>,
 }


### PR DESCRIPTION
Fixes #2390.

Two cost sources sat behind the seconds of CPU per `gtd.tasks` / `comm.inbox` call measured in the issue: the GTD task listing pushes its status/assignee predicates into SQL but had no index on those expression paths, so every listing narrowed to `idx_notes_kind` and then JSON-parsed every `task` row in the namespace; and the inbox post-filter loop re-issued its page query with a growing `OFFSET`, re-walking every earlier row on every page.

## Changes

- **V27 migration** (`crates/khive-db/sql/027-notes-hot-property-indexes.sql`, registered in `migrations.rs`; the same `CREATE INDEX IF NOT EXISTS` statements are added to the V1 baseline `schema.sql` and to `notes-ddl.sql` so fresh and already-migrated databases converge): two partial expression indexes, `idx_notes_task_status` and `idx_notes_task_assignee`, on `notes(namespace, kind, json_extract(properties, '$.<path>'), created_at DESC, id ASC) WHERE deleted_at IS NULL`. The expressions are copied from the SQL `build_note_filter_where` compiles, since an expression index only applies when it matches the compiled predicate byte for byte. The existing partial unread-probe index is untouched.
- **Keyset paging for the inbox post-filter loop**: `NoteFilter` gains `after: Option<NoteSeekAfter>` (`khive-storage`), a boundary over the store's default `created_at DESC, id ASC` order; `query_notes_filtered_count_free` dispatches it to a new `fetch_notes_after` that runs two single-direction seeks (the exact-timestamp tie group ordered by `id`, then strictly older timestamps), because neither the OR-form boundary nor a row-value comparison gets index-seek treatment for a mixed `DESC, ASC` order on this SQLite build. `after` is rejected together with a custom `order_by` or a non-zero offset. `query_inbox_response` now carries the last row's `(created_at, id)` between pages instead of an offset; rows, order and `has_more` are unchanged.
- The GTD scan cap (`TASK_SCAN_MAX_ROWS`) stays as a safety bound: reading `handle_tasks` and `fetch_all_matching_tasks` showed every status/assignee/priority predicate already pushed into `NoteFilter`, so the cost was the missing index, not un-pushed filtering.

## Query plans (`EXPLAIN QUERY PLAN` on the compiled SQL)

Task listing, status Eq + assignee Eq, before: `SEARCH notes USING INDEX idx_notes_kind (namespace=? AND kind=?)` + `USE TEMP B-TREE FOR ORDER BY`. After: `SEARCH notes USING INDEX idx_notes_task_assignee (namespace=? AND kind=? AND <expr>=?)`.

Unread-default inbox listing: `SEARCH notes USING INDEX idx_notes_unread_probe_recipient_direction (...)` before and after; a regression test pins it.

Page 50 of 50 on a 5,000-row fixture at page size 100: offset form 20,317 VM steps, seek form 638 (tie branch 21, older branch 617).

## Tests

- `migrations_tests.rs`: V27 applies to a pre-V27 database (indexes dropped to simulate it) and to a fresh one; `latest_schema_version` advances to 27.
- `note_tests.rs`: plan assertions for the task-listing shapes (with a dropped-index control so the assertion cannot pass vacuously), the unread-probe regression guard, seek paging equals offset paging on a 900-row fixture, `after` + `order_by` rejected, and the VM-step comparison above.
- `khive-pack-comm/tests/integration.rs`: 300-row fixture with a `from_prefix` post-filter rejecting 50 rows; the keyset loop returns the same 250-row partition, order and `has_more` boundary as offset paging, across external offset chunks.

## Not in this change

- A general `(to_actor, direction)` index for the read/all-status mailbox listing was drafted and dropped: without `ANALYZE` statistics SQLite preferred it over the tuned partial unread-probe index for the unread-default listing, which is the path the issue measured; four existing unread-probe plan tests caught the regression. That listing shape remains unindexed; a test guards against reintroducing the index without first resolving the planner ambiguity.
- Per-verb `cpu_ms` in the audit payload: `cost_unit` is a deterministic cost model, not a timer, and the payload shape is pinned by a test; adding real timing needs dispatch-boundary instrumentation and a payload schema change, which belong in their own change.
