### PR TITLE
fix(runtime): keep the events daemon's SQLite locks across sidecar hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of a hard-coded identity with no meaning outside the deployment it
   was named for. Behaviour with the variable explicitly set is unchanged.
 
+### Fixed
+
+- The events daemon no longer releases SQLite's advisory locks on its own
+  database. Permission hardening of the `-wal`/`-shm` sidecars ran after the
+  database was opened and closed a descriptor on each file, which under POSIX
+  drops every lock the process holds on that inode; a backup or inspection
+  connection closing afterwards then took itself for the last connection,
+  checkpointed, and unlinked the sidecars while the daemon kept writing to the
+  unlinked files. Hardening now runs before the open, the post-open check uses
+  `lstat` only, and a cross-process test asserts the locks are held.
+
 ## [0.8.0] - 2026-08-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   moved away, a writable open there is refused while its sidecars remain,
   whatever file has since appeared at the spelling, a database this process
   holds read-only included, and however the path is written: the directory is
-  resolved before the spellings are compared.
+  resolved before the spellings are compared, and the sidecars are known by
+  the identity the holder pinned at its open, so the same files reached under
+  another name, a hard link or a spelling the filesystem folds onto theirs,
+  are refused the same way.
 
 ## [0.8.0] - 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   open, so a held database is found under any spelling and after a rename: a
   second spelling reuses the open backend, a read-only open of a database the
   process holds writable is refused, and a writable open beside a read-only
-  holder goes through SQLite alone, with no hardening of the held files.
+  holder goes through SQLite alone, with no hardening of the held files. A
+  writable open at a spelling where `-wal`/`-shm` sidecars remain beside no
+  database is refused rather than creating a database over them: they belong
+  to a database moved or removed from that spelling, possibly one still open.
 
 ## [0.8.0] - 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   checkpointed, and unlinked the sidecars while the daemon kept writing to the
   unlinked files. Hardening now runs before the open, the post-open check uses
   `lstat` only, and a cross-process test asserts the locks are held. The
-  embedded backend registry resolves a database by file identity before it
-  hardens anything, so a second spelling of a held database reuses the open
-  backend and the other access mode is refused instead of touching held files.
+  embedded backend registry resolves a database by the inode it pinned at
+  open, so a held database is found under any spelling and after a rename: a
+  second spelling reuses the open backend, a read-only open of a database the
+  process holds writable is refused, and a writable open beside a read-only
+  holder goes through SQLite alone, with no hardening of the held files.
 
 ## [0.8.0] - 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   removed from that spelling, possibly one still open. Where this process
   holds the database that was at a spelling, since moved away, a writable
   open there is refused while its sidecars remain, whatever file has since
-  appeared at the spelling.
+  appeared at the spelling and however the path is written: the directory is
+  resolved before the spellings are compared.
 
 ## [0.8.0] - 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   removed from that spelling, possibly one still open. Where this process
   holds the database that was at a spelling, writable or read-only, since
   moved away, a writable open there is refused while its sidecars remain,
-  whatever file has since appeared at the spelling and however the path is
-  written: the directory is
+  whatever file has since appeared at the spelling, a database this process
+  holds read-only included, and however the path is written: the directory is
   resolved before the spellings are compared.
 
 ## [0.8.0] - 2026-08-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   database is refused rather than creating a database over them, on the
   embedded and the daemon arm alike: they belong to a database moved or
   removed from that spelling, possibly one still open. Where this process
-  holds the database that was at a spelling, since moved away, a writable
-  open there is refused while its sidecars remain, whatever file has since
-  appeared at the spelling and however the path is written: the directory is
+  holds the database that was at a spelling, writable or read-only, since
+  moved away, a writable open there is refused while its sidecars remain,
+  whatever file has since appeared at the spelling and however the path is
+  written: the directory is
   resolved before the spellings are compared.
 
 ## [0.8.0] - 2026-08-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   process holds writable is refused, and a writable open beside a read-only
   holder goes through SQLite alone, with no hardening of the held files. A
   writable open at a spelling where `-wal`/`-shm` sidecars remain beside no
-  database is refused rather than creating a database over them: they belong
-  to a database moved or removed from that spelling, possibly one still open.
+  database is refused rather than creating a database over them, on the
+  embedded and the daemon arm alike: they belong to a database moved or
+  removed from that spelling, possibly one still open. Where this process
+  holds the database that was at a spelling, since moved away, a writable
+  open there is refused while its sidecars remain, whatever file has since
+  appeared at the spelling.
 
 ## [0.8.0] - 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   open, so a held database is found under any spelling and after a rename: a
   second spelling reuses the open backend, a read-only open of a database the
   process holds writable is refused, and a writable open beside a read-only
-  holder goes through SQLite alone, with no hardening of the held files. A
+  holder goes through SQLite alone, with no hardening of the held files, and
+  is refused when that file set is no longer owner-only, read by metadata
+  alone rather than tightened. A
   writable open at a spelling where `-wal`/`-shm` sidecars remain beside no
   database is refused rather than creating a database over them, on the
   embedded and the daemon arm alike: they belong to a database moved or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   connection closing afterwards then took itself for the last connection,
   checkpointed, and unlinked the sidecars while the daemon kept writing to the
   unlinked files. Hardening now runs before the open, the post-open check uses
-  `lstat` only, and a cross-process test asserts the locks are held.
+  `lstat` only, and a cross-process test asserts the locks are held. The
+  embedded backend registry resolves a database by file identity before it
+  hardens anything, so a second spelling of a held database reuses the open
+  backend and the other access mode is refused instead of touching held files.
 
 ## [0.8.0] - 2026-08-27
 

--- a/crates/khive-runtime/src/events_split.rs
+++ b/crates/khive-runtime/src/events_split.rs
@@ -357,10 +357,42 @@ fn direct_backend(
             .create_new(true)
             .mode(0o600)
             .open(db_path);
-        // Before the open, and only before it: see the precondition on
-        // `harden_events_db_sidecars`.
-        harden_events_db_sidecars(db_path)
-            .map_err(|e| crate::error::RuntimeError::Internal(e.to_string()))?;
+    }
+    // The registry is keyed by spelling and mode, so a second key can name a
+    // file this process already holds: another spelling of the path, or the
+    // other `read_only` flag. No open outside SQLite may touch that file
+    // then: the hardening below, and the header read a read-only pool makes
+    // before its own open, each close a descriptor, and that close would
+    // release the locks of the pool already holding the file (the
+    // precondition on `harden_events_db_sidecars`). Physical identity by
+    // `stat`, which takes no descriptor, is the test. Same mode: the existing
+    // backend is the backend for this file. Other mode: refused; one process
+    // holds one physical events database in one mode.
+    #[cfg(unix)]
+    match held_backend_for_file(&registry, db_path) {
+        Some((mode, existing)) if mode == read_only => {
+            registry.insert(key, Arc::clone(&existing));
+            return Ok(existing);
+        }
+        Some((mode, _)) => {
+            let name = |read_only: bool| if read_only { "read-only" } else { "writable" };
+            return Err(crate::error::RuntimeError::Internal(format!(
+                "refusing to open the events database {} {}: this process already holds it \
+                 {}, and a second open in the other mode would release the held pool's \
+                 SQLite locks",
+                db_path.display(),
+                name(read_only),
+                name(mode)
+            )));
+        }
+        None => {
+            // Before the open, and only before it: see the precondition on
+            // `harden_events_db_sidecars`.
+            if !read_only {
+                harden_events_db_sidecars(db_path)
+                    .map_err(|e| crate::error::RuntimeError::Internal(e.to_string()))?;
+            }
+        }
     }
     let backend = Arc::new(if read_only {
         StorageBackend::sqlite_read_only(db_path)?
@@ -369,6 +401,30 @@ fn direct_backend(
     });
     registry.insert(key, Arc::clone(&backend));
     Ok(backend)
+}
+
+/// The physical identity of an existing file, device and inode, read with
+/// `stat`: no descriptor is opened, so it can be asked about a live database.
+#[cfg(unix)]
+fn file_identity(path: &Path) -> Option<(u64, u64)> {
+    use std::os::unix::fs::MetadataExt;
+    std::fs::metadata(path)
+        .ok()
+        .map(|metadata| (metadata.dev(), metadata.ino()))
+}
+
+/// The backend this process already holds for the file at `db_path`, under
+/// any spelling and either mode, with that entry's `read_only` flag.
+#[cfg(unix)]
+fn held_backend_for_file(
+    registry: &BackendMap,
+    db_path: &Path,
+) -> Option<(bool, Arc<StorageBackend>)> {
+    let identity = file_identity(db_path)?;
+    registry
+        .iter()
+        .find(|((path, _), _)| file_identity(path) == Some(identity))
+        .map(|((_, read_only), backend)| (*read_only, Arc::clone(backend)))
 }
 
 /// Forwarding metrics for the process-wide client at `socket_path`, if one
@@ -2728,6 +2784,74 @@ mod tests {
                 path.display()
             );
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn second_spelling_of_a_held_database_reuses_the_backend_and_never_reopens_its_files() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        let real = dir.path().join("real");
+        std::fs::create_dir(&real).unwrap();
+        // A directory link owned by this user is an accepted path component,
+        // and `real/events.db` and `alias/events.db` are two registry keys
+        // for one file.
+        let alias = dir.path().join("alias");
+        std::os::unix::fs::symlink(&real, &alias).unwrap();
+        let db = real.join("events.db");
+        let first = direct_backend_for(&db).expect("first open");
+        let wal = PathBuf::from(format!("{}-wal", db.display()));
+        assert!(wal.exists(), "the open leaves {} on disk", wal.display());
+        // Loosened by path while the file is held: the hardening, had it run
+        // on the second key, would have opened and tightened it.
+        std::fs::set_permissions(&wal, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let second = direct_backend_for(&alias.join("events.db")).expect("second spelling");
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "one physical file must resolve to one backend"
+        );
+        assert_eq!(
+            std::fs::metadata(&wal).unwrap().permissions().mode() & 0o777,
+            0o644,
+            "a held file set is never touched by a later key"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn the_other_mode_on_a_held_database_is_refused_and_never_runs_the_hardening() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        let db = dir.path().join("events.db");
+        // An existing database for the read-only arm, created outside the
+        // registry and closed again.
+        drop(StorageBackend::sqlite(&db).expect("create the database"));
+        // A pool closes asynchronously and can leave a writable -shm behind;
+        // a read-only open admits only a frozen sidecar set.
+        khive_storage::test_support::freeze_snapshot_sidecars(&db);
+        std::fs::set_permissions(&db, std::fs::Permissions::from_mode(0o600)).unwrap();
+        let _read_only = direct_backend_read_only_for(&db).expect("read-only open");
+        // Loosened by path while the read-only pool holds the file.
+        std::fs::set_permissions(&db, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        // The writable key must not tighten it (that would open and close the
+        // held file); the other mode is refused outright.
+        let err = direct_backend_for(&db)
+            .err()
+            .expect("the other mode on a held database is refused")
+            .to_string();
+        assert!(
+            err.contains("events.db") && err.contains("already holds it read-only"),
+            "{err}"
+        );
+        assert_eq!(
+            std::fs::metadata(&db).unwrap().permissions().mode() & 0o777,
+            0o644,
+            "the held file was not touched"
+        );
     }
 
     #[cfg(unix)]

--- a/crates/khive-runtime/src/events_split.rs
+++ b/crates/khive-runtime/src/events_split.rs
@@ -402,7 +402,10 @@ fn direct_backend(
     // file set is never touched and keeps the modes the holder admitted. A
     // set no longer owner-only is refused, read by `lstat` alone, never
     // tightened here: tightening opens descriptors, and a close would
-    // release the holder's locks.
+    // release the holder's locks. The moved-away check runs on that arm as
+    // well, first: the holder's database may have come to this spelling by
+    // a rename, over the sidecars a database this process holds writable
+    // left when it was moved away from here.
     #[cfg(unix)]
     match held_backend_for_file(&registry, db_path, read_only)? {
         Some(held) if held.read_only == read_only => return Ok(Arc::clone(&held.backend)),
@@ -414,6 +417,7 @@ fn direct_backend(
             )));
         }
         Some(_) => {
+            refuse_held_spellings_sidecars(&registry, db_path)?;
             verify_events_db_owner_only_unopened(db_path)
                 .map_err(|e| crate::error::RuntimeError::Internal(e.to_string()))?;
         }
@@ -537,7 +541,9 @@ fn held_backend_for_file<'a>(
 /// `harden_events_db_sidecars`), whatever file has since appeared at the
 /// spelling, so it is refused while any of them remains. Move them with the
 /// database or remove them first. A holder whose file is still here was
-/// found by `held_backend_for_file` before this runs.
+/// found by `held_backend_for_file` before this runs; when that file is a
+/// read-only holder's own, come here by a rename, the writable open beside
+/// it runs this check too, for the sidecars another holder left.
 #[cfg(unix)]
 fn refuse_held_spellings_sidecars(
     registry: &BackendMap,
@@ -3304,6 +3310,73 @@ mod tests {
         }
         let fresh = direct_backend_for(&db).expect("a new database once the sidecars went with it");
         assert!(!Arc::ptr_eq(&read_only, &fresh));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_read_only_holders_database_renamed_over_a_moved_holders_spelling_is_refused() {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        let db = dir.path().join("events.db");
+        let writable = direct_backend_for(&db).expect("writable open");
+        let sidecars = sidecar_paths(&db);
+        let identity = |sidecars: &[PathBuf; 2]| -> Vec<(u64, u32, u64)> {
+            sidecars
+                .iter()
+                .map(|s| {
+                    let m = std::fs::metadata(s).expect("the holder's sidecar is there");
+                    (m.ino(), m.permissions().mode() & 0o777, m.len())
+                })
+                .collect()
+        };
+        let live = identity(&sidecars);
+        // The writable holder's main file renamed away; its live sidecars
+        // stay at the old spelling, as a rename leaves them.
+        let moved = dir.path().join("moved.db");
+        std::fs::rename(&db, &moved).expect("rename the held database");
+        // A database this process holds read-only, renamed over that
+        // spelling: the writable open finds the read-only holder by inode
+        // and would go through SQLite alone, onto the other holder's live
+        // sidecars. Refused, with nothing touched.
+        let other = dir.path().join("other.db");
+        drop(StorageBackend::sqlite(&other).expect("create the other database"));
+        khive_storage::test_support::freeze_snapshot_sidecars(&other);
+        std::fs::set_permissions(&other, std::fs::Permissions::from_mode(0o600)).unwrap();
+        let read_only = direct_backend_read_only_for(&other).expect("read-only open");
+        std::fs::rename(&other, &db).expect("rename the read-only holder's database");
+        let err = direct_backend_for(&db)
+            .err()
+            .expect("a writable holder's live sidecars are not opened under another database")
+            .to_string();
+        assert!(
+            err.contains("since moved away") && err.contains("events.db-wal"),
+            "{err}"
+        );
+        assert_eq!(
+            identity(&sidecars),
+            live,
+            "the writable holder's sidecars were never touched"
+        );
+        let still = direct_backend_for(&moved).expect("the writable holder is still served");
+        assert!(
+            Arc::ptr_eq(&writable, &still),
+            "found by its inode under its new name"
+        );
+        let snapshot =
+            direct_backend_read_only_for(&db).expect("the read-only holder is still served");
+        assert!(
+            Arc::ptr_eq(&read_only, &snapshot),
+            "found by its inode under its new name"
+        );
+        // The sidecars moved with their database: the writable open beside
+        // the read-only holder lands.
+        for (from, suffix) in sidecars.iter().zip(["-wal", "-shm"]) {
+            std::fs::rename(from, PathBuf::from(format!("{}{suffix}", moved.display()))).unwrap();
+        }
+        let beside = direct_backend_for(&db).expect("a writable open beside the read-only holder");
+        assert!(!Arc::ptr_eq(&read_only, &beside));
+        assert!(!Arc::ptr_eq(&writable, &beside));
     }
 
     #[cfg(unix)]

--- a/crates/khive-runtime/src/events_split.rs
+++ b/crates/khive-runtime/src/events_split.rs
@@ -357,6 +357,8 @@ fn direct_backend(
             .create_new(true)
             .mode(0o600)
             .open(db_path);
+        // Before the open, and only before it: see the precondition on
+        // `harden_events_db_sidecars`.
         harden_events_db_sidecars(db_path)
             .map_err(|e| crate::error::RuntimeError::Internal(e.to_string()))?;
     }
@@ -674,6 +676,15 @@ fn ensure_events_db_owner_only(db_path: &Path) -> anyhow::Result<()> {
 /// Tighten the events database and its SQLite sidecars to owner-only.
 /// Fail closed, same contract as the socket chmod: a daemon that cannot
 /// keep its database owner-only must not serve it.
+///
+/// PRECONDITION: no SQLite connection to `db_path` may be open in this
+/// process. This function opens and closes a descriptor on the database and
+/// on each sidecar, and POSIX advisory locks are per process and per inode,
+/// released by the close of ANY descriptor for the inode (fcntl(2)): called
+/// on a live database it silently drops the SHARED lock SQLite keeps in WAL
+/// mode and the `-shm` DMS lock, while the connection believes it still
+/// holds them. Both callers run it before their open; keep it that way. The
+/// post-open check that opens nothing is `verify_events_db_owner_only_unopened`.
 #[cfg(unix)]
 fn harden_events_db_sidecars(db_path: &Path) -> anyhow::Result<()> {
     use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
@@ -713,6 +724,52 @@ fn harden_events_db_sidecars(db_path: &Path) -> anyhow::Result<()> {
                     path.display()
                 )
             })?;
+    }
+    Ok(())
+}
+
+/// Check, after SQLite has opened the database, that it and its sidecars are
+/// owner-only regular files WITHOUT opening any of them: `lstat` takes no
+/// descriptor, so it cannot release the advisory locks the open connections
+/// hold (see the precondition on `harden_events_db_sidecars`). Sidecars
+/// SQLite creates inherit the database file's mode, so a failure here means
+/// something else changed the file set; refuse to serve rather than tighten
+/// through a path-based chmod and its lookup race.
+#[cfg(unix)]
+fn verify_events_db_owner_only_unopened(db_path: &Path) -> anyhow::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut targets = vec![db_path.to_path_buf()];
+    for suffix in ["-wal", "-shm"] {
+        let mut name = db_path.as_os_str().to_os_string();
+        name.push(suffix);
+        targets.push(PathBuf::from(name));
+    }
+    for path in targets {
+        let metadata = match std::fs::symlink_metadata(&path) {
+            Ok(metadata) => metadata,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => {
+                anyhow::bail!(
+                    "refusing to serve events: cannot stat {}: {e}",
+                    path.display()
+                )
+            }
+        };
+        if !metadata.file_type().is_file() {
+            anyhow::bail!(
+                "refusing to serve events: {} is not a regular file. The events database \
+                 and its sidecars must be regular files.",
+                path.display()
+            );
+        }
+        let mode = metadata.permissions().mode() & 0o777;
+        if mode & 0o077 != 0 {
+            anyhow::bail!(
+                "refusing to serve events: {} is mode {mode:03o}, not owner-only. The events \
+                 database and its sidecars must be owner-only.",
+                path.display()
+            );
+        }
     }
     Ok(())
 }
@@ -858,12 +915,23 @@ pub async fn run_events_daemon(db_path: &Path, socket_path: &Path) -> anyhow::Re
         return Ok(());
     };
     ensure_events_db_owner_only(db_path)?;
+    // Tighten a pre-existing database and any `-wal`/`-shm` an earlier
+    // process left behind BEFORE SQLite opens the database. The order is
+    // load-bearing: hardening opens and closes its own descriptor on each of
+    // these files, and POSIX advisory locks are per process and per inode,
+    // released by the close of ANY descriptor for the inode (fcntl(2)). Run
+    // after the open, it silently dropped the SHARED lock SQLite keeps on the
+    // database in WAL mode and the shared lock on the `-shm` DMS byte, so the
+    // next external connection to close (a backup tool, an inspection shell)
+    // took itself for the last connection, checkpointed, and unlinked the
+    // sidecars underneath this daemon, which kept writing to the unlinked
+    // inodes. Sidecars SQLite creates from here on inherit the database
+    // file's mode; the check after the open below opens nothing.
+    harden_events_db_sidecars(db_path)?;
     let backend = Arc::new(StorageBackend::sqlite(db_path)?);
     // Ensure the schema once, loudly, before accepting traffic.
     backend.events()?;
-    // The `-wal`/`-shm` sidecars inherit the database file's mode at
-    // creation; tighten any that already exist from before the hardening.
-    harden_events_db_sidecars(db_path)?;
+    verify_events_db_owner_only_unopened(db_path)?;
 
     if socket_path.exists() {
         std::fs::remove_file(socket_path)?;
@@ -2234,6 +2302,51 @@ mod tests {
         assert!(
             !sidecar.exists(),
             "refusal must precede creation of the events database"
+        );
+    }
+
+    #[test]
+    fn unopened_check_refuses_a_loosened_or_replaced_sidecar() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        let db = dir.path().join("events.db");
+        let wal = PathBuf::from(format!("{}-wal", db.display()));
+        let shm = PathBuf::from(format!("{}-shm", db.display()));
+        for path in [&db, &wal] {
+            std::fs::write(path, b"").unwrap();
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        }
+        // Owner-only regular files, an absent `-shm`: nothing to refuse.
+        verify_events_db_owner_only_unopened(&db).unwrap();
+
+        std::fs::set_permissions(&wal, std::fs::Permissions::from_mode(0o644)).unwrap();
+        let err = verify_events_db_owner_only_unopened(&db)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("events.db-wal") && err.contains("644"),
+            "{err}"
+        );
+        std::fs::set_permissions(&wal, std::fs::Permissions::from_mode(0o600)).unwrap();
+        verify_events_db_owner_only_unopened(&db).unwrap();
+
+        // A link planted at the `-shm` name is refused as not a regular file,
+        // and the check never followed it: the target keeps its mode.
+        let victim = dir.path().join("victim");
+        std::fs::write(&victim, b"").unwrap();
+        std::fs::set_permissions(&victim, std::fs::Permissions::from_mode(0o644)).unwrap();
+        std::os::unix::fs::symlink(&victim, &shm).unwrap();
+        let err = verify_events_db_owner_only_unopened(&db)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("events.db-shm") && err.contains("regular file"),
+            "{err}"
+        );
+        assert_eq!(
+            std::fs::metadata(&victim).unwrap().permissions().mode() & 0o777,
+            0o644
         );
     }
 

--- a/crates/khive-runtime/src/events_split.rs
+++ b/crates/khive-runtime/src/events_split.rs
@@ -370,9 +370,13 @@ fn direct_backend(
     // and — because event rows carry the same audit payloads either way — a
     // pre-existing database or -wal/-shm sidecar is tightened to 0600 too,
     // fail-closed. A create race just means SQLite finds the file present.
+    // Sidecars beside no database belong to a database that left; nothing
+    // is created over them (see `refuse_orphaned_sidecars`).
     #[cfg(unix)]
     if !read_only {
         use std::os::unix::fs::OpenOptionsExt;
+        refuse_orphaned_sidecars(db_path)
+            .map_err(|e| crate::error::RuntimeError::Internal(e.to_string()))?;
         let _ = std::fs::OpenOptions::new()
             .write(true)
             .create_new(true)
@@ -715,18 +719,59 @@ pub fn try_acquire_events_daemon_guard(socket_path: &Path) -> Option<EventsDaemo
 /// sidecar path — is a pre-existing symlink. These paths are derived, never
 /// user-chosen (`events_db_path_beside` canonicalizes the main database
 /// spelling first), so a link here is a planted redirect, not an alias:
+/// The `-wal` and `-shm` names SQLite derives from a database's path.
+fn sidecar_paths(db_path: &Path) -> [PathBuf; 2] {
+    ["-wal", "-shm"].map(|suffix| {
+        let mut name = db_path.as_os_str().to_os_string();
+        name.push(suffix);
+        PathBuf::from(name)
+    })
+}
+
+/// The database and its two sidecars, the file set every check here covers.
+fn database_and_sidecars(db_path: &Path) -> Vec<PathBuf> {
+    let mut targets = vec![db_path.to_path_buf()];
+    targets.extend(sidecar_paths(db_path));
+    targets
+}
+
+/// A `-wal` or `-shm` file beside a database that does not exist is a live
+/// sidecar set left behind: a rename moves the main file alone, so a
+/// database moved away from this spelling, held in this process or another,
+/// still has its SQLite locks on these files, and creating a database here
+/// would open them (the precondition on `harden_events_db_sidecars`) and hand
+/// the new pool another database's WAL. Refused before anything is created;
+/// stale sidecars of a removed database are the operator's to remove.
+#[cfg(unix)]
+fn refuse_orphaned_sidecars(db_path: &Path) -> anyhow::Result<()> {
+    if std::fs::symlink_metadata(db_path).is_ok() {
+        return Ok(());
+    }
+    let orphaned: Vec<String> = sidecar_paths(db_path)
+        .iter()
+        .filter(|path| std::fs::symlink_metadata(path).is_ok())
+        .map(|path| path.display().to_string())
+        .collect();
+    if orphaned.is_empty() {
+        return Ok(());
+    }
+    anyhow::bail!(
+        "refusing to create the events database {}: {} exist beside no database. They are \
+         the sidecars of a database moved or removed from this spelling, possibly one still \
+         open, and a new database here would strip its SQLite locks; move them with it or \
+         remove them first.",
+        db_path.display(),
+        orphaned.join(" and ")
+    )
+}
+
 /// permission hardening and SQLite would otherwise follow it and tighten or
 /// write event rows through to whatever file the link's author chose
 /// (CWE-59). Runs before any open on both the embedded and daemon arms; a
 /// link planted after admission is bounded by the daemon's trusted-directory
 /// contract on the socket parent.
 fn refuse_events_db_symlinks(db_path: &Path) -> anyhow::Result<()> {
-    let mut targets = vec![db_path.to_path_buf()];
-    for suffix in ["-wal", "-shm"] {
-        let mut name = db_path.as_os_str().to_os_string();
-        name.push(suffix);
-        targets.push(PathBuf::from(name));
-    }
+    let targets = database_and_sidecars(db_path);
     for path in targets {
         match std::fs::symlink_metadata(&path) {
             Ok(meta) if meta.file_type().is_symlink() => anyhow::bail!(
@@ -811,12 +856,7 @@ fn ensure_events_db_owner_only(db_path: &Path) -> anyhow::Result<()> {
 #[cfg(unix)]
 fn harden_events_db_sidecars(db_path: &Path) -> anyhow::Result<()> {
     use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
-    let mut targets = vec![db_path.to_path_buf()];
-    for suffix in ["-wal", "-shm"] {
-        let mut name = db_path.as_os_str().to_os_string();
-        name.push(suffix);
-        targets.push(PathBuf::from(name));
-    }
+    let targets = database_and_sidecars(db_path);
     for path in targets {
         // Pin the inode before touching it: `O_NOFOLLOW` makes the open
         // itself refuse a symlink at the final component, and the chmod is
@@ -861,12 +901,7 @@ fn harden_events_db_sidecars(db_path: &Path) -> anyhow::Result<()> {
 #[cfg(unix)]
 fn verify_events_db_owner_only_unopened(db_path: &Path) -> anyhow::Result<()> {
     use std::os::unix::fs::PermissionsExt;
-    let mut targets = vec![db_path.to_path_buf()];
-    for suffix in ["-wal", "-shm"] {
-        let mut name = db_path.as_os_str().to_os_string();
-        name.push(suffix);
-        targets.push(PathBuf::from(name));
-    }
+    let targets = database_and_sidecars(db_path);
     for path in targets {
         let metadata = match std::fs::symlink_metadata(&path) {
             Ok(metadata) => metadata,
@@ -2990,7 +3025,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn a_file_created_at_a_held_spelling_after_a_rename_is_another_database() {
+    fn a_database_at_a_held_spelling_after_a_rename_waits_for_the_sidecars_to_go_with_it() {
         use std::os::unix::fs::PermissionsExt;
         let dir = tempfile::tempdir().unwrap();
         std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
@@ -2998,9 +3033,42 @@ mod tests {
         let first = direct_backend_for(&db).expect("first open");
         let moved = dir.path().join("moved.db");
         std::fs::rename(&db, &moved).expect("rename the held database");
+        let sidecars = sidecar_paths(&db);
+        assert!(
+            sidecars.iter().all(|s| s.exists()),
+            "a writable open leaves -wal and -shm, which a rename of the main file leaves behind"
+        );
+        // Loosened by path while the holder uses them: the hardening a new
+        // database here would run opens and tightens them, releasing the
+        // holder's locks with the close.
+        for sidecar in &sidecars {
+            std::fs::set_permissions(sidecar, std::fs::Permissions::from_mode(0o644)).unwrap();
+        }
 
-        // The old spelling now names a new file: its own pool, hardened and
-        // opened afresh, while the moved file keeps its holder.
+        let err = direct_backend_for(&db)
+            .err()
+            .expect("no database is created over another database's sidecars")
+            .to_string();
+        assert!(
+            err.contains("events.db-wal") && err.contains("beside no database"),
+            "{err}"
+        );
+        assert!(!db.exists(), "the refusal created nothing");
+        for sidecar in &sidecars {
+            assert_eq!(
+                std::fs::metadata(sidecar).unwrap().permissions().mode() & 0o777,
+                0o644,
+                "{}: the holder's sidecar was never touched",
+                sidecar.display()
+            );
+        }
+
+        // The sidecars moved with the main file: the old spelling now names a
+        // new file, its own pool, hardened and opened afresh, while the moved
+        // file keeps its holder.
+        for (from, to) in sidecars.iter().zip(sidecar_paths(&moved)) {
+            std::fs::rename(from, to).unwrap();
+        }
         let second = direct_backend_for(&db).expect("a new database at the old spelling");
         assert!(
             !Arc::ptr_eq(&first, &second),

--- a/crates/khive-runtime/src/events_split.rs
+++ b/crates/khive-runtime/src/events_split.rs
@@ -270,10 +270,24 @@ pub struct EventsSplitConfig {
 
 #[cfg(unix)]
 type ClientMap = std::collections::HashMap<PathBuf, Arc<EventsSplitClient>>;
-/// Keyed by (path, read_only): a read-only open and a writable open of the
-/// same file are different pools with different guarantees and must never be
-/// handed out interchangeably.
-type BackendMap = std::collections::HashMap<(PathBuf, bool), Arc<StorageBackend>>;
+/// One events database this process holds open through the embedded
+/// registry: one pool, in one mode, under the spelling it was opened as.
+struct HeldBackend {
+    path: PathBuf,
+    read_only: bool,
+    /// The held file's inode, pinned: a descriptor on the database, opened
+    /// after the pool and never closed, so `fstat` on it names the file the
+    /// pool holds whatever its path is now, and the inode number cannot be
+    /// reused by another file while the entry lives. See `identity_probe`.
+    #[cfg(unix)]
+    probe: std::fs::File,
+    backend: Arc<StorageBackend>,
+}
+
+/// A read-only open and a writable open of one file are different pools with
+/// different guarantees and are never handed out interchangeably; entries
+/// are found by spelling and mode first, then by the pinned identity.
+type BackendMap = Vec<HeldBackend>;
 
 #[cfg(unix)]
 fn client_registry() -> &'static std::sync::Mutex<ClientMap> {
@@ -283,7 +297,7 @@ fn client_registry() -> &'static std::sync::Mutex<ClientMap> {
 
 fn direct_backend_registry() -> &'static std::sync::Mutex<BackendMap> {
     static REGISTRY: std::sync::OnceLock<std::sync::Mutex<BackendMap>> = std::sync::OnceLock::new();
-    REGISTRY.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+    REGISTRY.get_or_init(|| std::sync::Mutex::new(Vec::new()))
 }
 
 /// The process-wide client for `socket_path`, created (and its forwarder
@@ -324,9 +338,11 @@ fn direct_backend(
     let mut registry = direct_backend_registry()
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    let key = (db_path.to_path_buf(), read_only);
-    if let Some(existing) = registry.get(&key) {
-        return Ok(Arc::clone(existing));
+    if let Some(held) = registry
+        .iter()
+        .find(|held| held.read_only == read_only && held.path.as_path() == db_path)
+    {
+        return Ok(Arc::clone(&held.backend));
     }
     refuse_events_db_symlinks(db_path)
         .map_err(|e| crate::error::RuntimeError::Internal(e.to_string()))?;
@@ -358,33 +374,34 @@ fn direct_backend(
             .mode(0o600)
             .open(db_path);
     }
-    // The registry is keyed by spelling and mode, so a second key can name a
-    // file this process already holds: another spelling of the path, or the
-    // other `read_only` flag. No open outside SQLite may touch that file
-    // then: the hardening below, and the header read a read-only pool makes
-    // before its own open, each close a descriptor, and that close would
-    // release the locks of the pool already holding the file (the
-    // precondition on `harden_events_db_sidecars`). Physical identity by
-    // `stat`, which takes no descriptor, is the test. Same mode: the existing
-    // backend is the backend for this file. Other mode: refused; one process
-    // holds one physical events database in one mode.
+    // The registry holds files, not spellings. A second spelling of a held
+    // path, or the other mode on it, names a file this process already
+    // holds, and no open outside SQLite may touch that file then: the
+    // hardening below, and the header read a read-only pool makes before
+    // its own open, each close a descriptor, and that close would release
+    // the held pool's locks (the precondition on
+    // `harden_events_db_sidecars`). The test is physical identity: `stat`
+    // of the requested path, which takes no descriptor, against the inode
+    // each holder pinned at its open, so a holder is found under any
+    // spelling and after a rename. Same mode: the holder is the backend for
+    // this file. Held writable, read-only asked: refused, since the
+    // read-only open reads the header through a descriptor of its own, and
+    // a read-only pool admits no live sidecar set anyway. Held read-only,
+    // writable asked: the holder is a snapshot reader, and the writable
+    // pool opens beside it through SQLite alone, which coordinates its own
+    // descriptors on one inode; the hardening is skipped, so the holder's
+    // file set is never touched and keeps the modes the holder admitted.
     #[cfg(unix)]
-    match held_backend_for_file(&registry, db_path) {
-        Some((mode, existing)) if mode == read_only => {
-            registry.insert(key, Arc::clone(&existing));
-            return Ok(existing);
-        }
-        Some((mode, _)) => {
-            let name = |read_only: bool| if read_only { "read-only" } else { "writable" };
+    match held_backend_for_file(&registry, db_path, read_only)? {
+        Some(held) if held.read_only == read_only => return Ok(Arc::clone(&held.backend)),
+        Some(_) if read_only => {
             return Err(crate::error::RuntimeError::Internal(format!(
-                "refusing to open the events database {} {}: this process already holds it \
-                 {}, and a second open in the other mode would release the held pool's \
-                 SQLite locks",
-                db_path.display(),
-                name(read_only),
-                name(mode)
+                "refusing to open the events database {} read-only: this process already holds \
+                 it writable, and a read-only open would release the held pool's SQLite locks",
+                db_path.display()
             )));
         }
+        Some(_) => {}
         None => {
             // Before the open, and only before it: see the precondition on
             // `harden_events_db_sidecars`.
@@ -399,32 +416,77 @@ fn direct_backend(
     } else {
         StorageBackend::sqlite(db_path)?
     });
-    registry.insert(key, Arc::clone(&backend));
+    #[cfg(unix)]
+    let probe = identity_probe(db_path)?;
+    registry.push(HeldBackend {
+        path: db_path.to_path_buf(),
+        read_only,
+        #[cfg(unix)]
+        probe,
+        backend: Arc::clone(&backend),
+    });
     Ok(backend)
 }
 
-/// The physical identity of an existing file, device and inode, read with
-/// `stat`: no descriptor is opened, so it can be asked about a live database.
+/// A descriptor on the database a pool just opened, never closed while its
+/// registry entry lives, which is the life of the process. Opened read-only
+/// and `O_NOFOLLOW`, after the pool: an open takes no lock and this one reads
+/// nothing, and only a close releases locks (the precondition on
+/// `harden_events_db_sidecars`), which this descriptor never does.
 #[cfg(unix)]
-fn file_identity(path: &Path) -> Option<(u64, u64)> {
+fn identity_probe(db_path: &Path) -> crate::error::RuntimeResult<std::fs::File> {
+    use std::os::unix::fs::OpenOptionsExt;
+    std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(db_path)
+        .map_err(|e| {
+            crate::error::RuntimeError::Internal(format!(
+                "cannot pin the identity of the events database {}: {e}",
+                db_path.display()
+            ))
+        })
+}
+
+/// Device and inode from metadata, whether read by `stat` or `fstat`.
+#[cfg(unix)]
+fn file_identity(metadata: &std::fs::Metadata) -> (u64, u64) {
     use std::os::unix::fs::MetadataExt;
-    std::fs::metadata(path)
-        .ok()
-        .map(|metadata| (metadata.dev(), metadata.ino()))
+    (metadata.dev(), metadata.ino())
 }
 
 /// The backend this process already holds for the file at `db_path`, under
-/// any spelling and either mode, with that entry's `read_only` flag.
+/// any spelling and after a rename: the holder in the asked mode when there
+/// is one, else the holder in the other mode. `None` when no file exists at
+/// the path or no holder pinned its inode. A holder whose pinned descriptor
+/// cannot be read fails the lookup closed rather than passing as absent.
 #[cfg(unix)]
-fn held_backend_for_file(
-    registry: &BackendMap,
+fn held_backend_for_file<'a>(
+    registry: &'a BackendMap,
     db_path: &Path,
-) -> Option<(bool, Arc<StorageBackend>)> {
-    let identity = file_identity(db_path)?;
-    registry
-        .iter()
-        .find(|((path, _), _)| file_identity(path) == Some(identity))
-        .map(|((_, read_only), backend)| (*read_only, Arc::clone(backend)))
+    read_only: bool,
+) -> crate::error::RuntimeResult<Option<&'a HeldBackend>> {
+    let Ok(requested) = std::fs::metadata(db_path) else {
+        return Ok(None);
+    };
+    let identity = file_identity(&requested);
+    let mut other_mode = None;
+    for held in registry {
+        let pinned = held.probe.metadata().map_err(|e| {
+            crate::error::RuntimeError::Internal(format!(
+                "cannot read the pinned identity of the held events database {}: {e}",
+                held.path.display()
+            ))
+        })?;
+        if file_identity(&pinned) != identity {
+            continue;
+        }
+        if held.read_only == read_only {
+            return Ok(Some(held));
+        }
+        other_mode = Some(held);
+    }
+    Ok(other_mode)
 }
 
 /// Forwarding metrics for the process-wide client at `socket_path`, if one
@@ -2821,36 +2883,103 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn the_other_mode_on_a_held_database_is_refused_and_never_runs_the_hardening() {
+    fn read_only_on_a_writable_holder_is_refused() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        let db = dir.path().join("events.db");
+        let writable = direct_backend_for(&db).expect("writable open");
+
+        // A read-only pool would read the header through a descriptor of its
+        // own before its open; the refusal comes first.
+        let err = direct_backend_read_only_for(&db)
+            .err()
+            .expect("read-only on a writable holder is refused")
+            .to_string();
+        assert!(
+            err.contains("events.db") && err.contains("already holds it writable"),
+            "{err}"
+        );
+        let again = direct_backend_for(&db).expect("the writable holder is still served");
+        assert!(Arc::ptr_eq(&writable, &again));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn writable_beside_a_read_only_holder_opens_through_sqlite_alone() {
         use std::os::unix::fs::PermissionsExt;
         let dir = tempfile::tempdir().unwrap();
         std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
         let db = dir.path().join("events.db");
         // An existing database for the read-only arm, created outside the
-        // registry and closed again.
+        // registry and closed again. A pool closes asynchronously and can
+        // leave a writable -shm behind; a read-only open admits only a frozen
+        // sidecar set.
         drop(StorageBackend::sqlite(&db).expect("create the database"));
-        // A pool closes asynchronously and can leave a writable -shm behind;
-        // a read-only open admits only a frozen sidecar set.
         khive_storage::test_support::freeze_snapshot_sidecars(&db);
         std::fs::set_permissions(&db, std::fs::Permissions::from_mode(0o600)).unwrap();
-        let _read_only = direct_backend_read_only_for(&db).expect("read-only open");
-        // Loosened by path while the read-only pool holds the file.
+        let read_only = direct_backend_read_only_for(&db).expect("read-only open");
+        // Loosened by path while the read-only pool holds the file: the
+        // hardening, had it run for the writable key, would have opened and
+        // tightened it. The sidecars go back to writable by path, as a writer
+        // elsewhere leaves them, so the writable pool can use them.
         std::fs::set_permissions(&db, std::fs::Permissions::from_mode(0o644)).unwrap();
+        for suffix in ["-wal", "-shm"] {
+            let sidecar = PathBuf::from(format!("{}{suffix}", db.display()));
+            if sidecar.exists() {
+                std::fs::set_permissions(&sidecar, std::fs::Permissions::from_mode(0o600)).unwrap();
+            }
+        }
 
-        // The writable key must not tighten it (that would open and close the
-        // held file); the other mode is refused outright.
-        let err = direct_backend_for(&db)
-            .err()
-            .expect("the other mode on a held database is refused")
-            .to_string();
+        let writable =
+            direct_backend_for(&db).expect("a writable pool opens beside a read-only holder");
         assert!(
-            err.contains("events.db") && err.contains("already holds it read-only"),
-            "{err}"
+            !Arc::ptr_eq(&read_only, &writable),
+            "the two modes are two pools"
         );
         assert_eq!(
             std::fs::metadata(&db).unwrap().permissions().mode() & 0o777,
             0o644,
             "the held file was not touched"
+        );
+        // Each mode keeps its own holder from here on.
+        let ro_again = direct_backend_read_only_for(&db).expect("read-only again");
+        let rw_again = direct_backend_for(&db).expect("writable again");
+        assert!(Arc::ptr_eq(&read_only, &ro_again));
+        assert!(Arc::ptr_eq(&writable, &rw_again));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_held_database_is_found_after_a_rename_and_never_touched() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        let db = dir.path().join("events.db");
+        let first = direct_backend_for(&db).expect("first open");
+        let moved = dir.path().join("moved.db");
+        std::fs::rename(&db, &moved).expect("rename the held database");
+        // Loosened by path under its new name while held: the hardening, had
+        // it run for the new spelling, would have opened and tightened it.
+        std::fs::set_permissions(&moved, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let second = direct_backend_for(&moved).expect("the moved spelling");
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "one physical file must resolve to one backend across a rename"
+        );
+        assert_eq!(
+            std::fs::metadata(&moved).unwrap().permissions().mode() & 0o777,
+            0o644,
+            "a held file is never touched under a new name"
+        );
+        let err = direct_backend_read_only_for(&moved)
+            .err()
+            .expect("the other mode on the moved file is refused")
+            .to_string();
+        assert!(
+            err.contains("moved.db") && err.contains("already holds it writable"),
+            "{err}"
         );
     }
 

--- a/crates/khive-runtime/src/events_split.rs
+++ b/crates/khive-runtime/src/events_split.rs
@@ -413,8 +413,10 @@ fn direct_backend(
         Some(_) => {}
         None => {
             // Before the open, and only before it: see the precondition on
-            // `harden_events_db_sidecars`.
+            // `harden_events_db_sidecars`. Never on a held database's
+            // sidecars left at this spelling by a rename.
             if !read_only {
+                refuse_held_spellings_sidecars(&registry, db_path)?;
                 harden_events_db_sidecars(db_path)
                     .map_err(|e| crate::error::RuntimeError::Internal(e.to_string()))?;
             }
@@ -496,6 +498,55 @@ fn held_backend_for_file<'a>(
         other_mode = Some(held);
     }
     Ok(other_mode)
+}
+
+/// A database this process holds writable, opened under this very spelling
+/// and since moved away (its pinned inode is no longer the file here, or no
+/// file is here), keeps its live `-wal`/`-shm` at this spelling: a rename
+/// moves the main file alone. A writable open here would open them for the
+/// hardening and release the holder's locks with the close (the precondition
+/// on `harden_events_db_sidecars`), whatever file has since appeared at the
+/// spelling, so it is refused while any of them remains. Move them with the
+/// database or remove them first. Read-only holders admit no live sidecar
+/// set and are not consulted; a holder whose file is still here was found by
+/// `held_backend_for_file` before this runs.
+#[cfg(unix)]
+fn refuse_held_spellings_sidecars(
+    registry: &BackendMap,
+    db_path: &Path,
+) -> crate::error::RuntimeResult<()> {
+    let present: Vec<String> = sidecar_paths(db_path)
+        .iter()
+        .filter(|path| std::fs::symlink_metadata(path).is_ok())
+        .map(|path| path.display().to_string())
+        .collect();
+    if present.is_empty() {
+        return Ok(());
+    }
+    let here = std::fs::metadata(db_path).ok().map(|m| file_identity(&m));
+    for held in registry {
+        if held.read_only || held.path != db_path {
+            continue;
+        }
+        let pinned = held.probe.metadata().map_err(|e| {
+            crate::error::RuntimeError::Internal(format!(
+                "cannot read the pinned identity of the held events database {}: {e}",
+                held.path.display()
+            ))
+        })?;
+        if Some(file_identity(&pinned)) == here {
+            continue;
+        }
+        return Err(crate::error::RuntimeError::Internal(format!(
+            "refusing to open the events database {}: this process holds the database that \
+             was at this spelling, since moved away, and {} are its sidecars; a new database \
+             here would open them and release its SQLite locks. Move them with it or remove \
+             them first.",
+            db_path.display(),
+            present.join(" and ")
+        )));
+    }
+    Ok(())
 }
 
 /// Forwarding metrics for the process-wide client at `socket_path`, if one
@@ -715,10 +766,6 @@ pub fn try_acquire_events_daemon_guard(socket_path: &Path) -> Option<EventsDaemo
     }
 }
 
-/// Refuse to serve an events database whose path — or whose `-wal`/`-shm`
-/// sidecar path — is a pre-existing symlink. These paths are derived, never
-/// user-chosen (`events_db_path_beside` canonicalizes the main database
-/// spelling first), so a link here is a planted redirect, not an alias:
 /// The `-wal` and `-shm` names SQLite derives from a database's path.
 fn sidecar_paths(db_path: &Path) -> [PathBuf; 2] {
     ["-wal", "-shm"].map(|suffix| {
@@ -740,8 +787,11 @@ fn database_and_sidecars(db_path: &Path) -> Vec<PathBuf> {
 /// database moved away from this spelling, held in this process or another,
 /// still has its SQLite locks on these files, and creating a database here
 /// would open them (the precondition on `harden_events_db_sidecars`) and hand
-/// the new pool another database's WAL. Refused before anything is created;
-/// stale sidecars of a removed database are the operator's to remove.
+/// the new pool another database's WAL. Refused before anything is created,
+/// on the embedded and the daemon arm alike; stale sidecars of a removed
+/// database are the operator's to remove. A database already at the spelling
+/// is taken with the sidecars beside it as its own, as SQLite takes it, except
+/// where this process knows better: `refuse_held_spellings_sidecars`.
 #[cfg(unix)]
 fn refuse_orphaned_sidecars(db_path: &Path) -> anyhow::Result<()> {
     if std::fs::symlink_metadata(db_path).is_ok() {
@@ -765,6 +815,10 @@ fn refuse_orphaned_sidecars(db_path: &Path) -> anyhow::Result<()> {
     )
 }
 
+/// Refuse to serve an events database whose path — or whose `-wal`/`-shm`
+/// sidecar path — is a pre-existing symlink. These paths are derived, never
+/// user-chosen (`events_db_path_beside` canonicalizes the main database
+/// spelling first), so a link here is a planted redirect, not an alias:
 /// permission hardening and SQLite would otherwise follow it and tighten or
 /// write event rows through to whatever file the link's author chose
 /// (CWE-59). Runs before any open on both the embedded and daemon arms; a
@@ -825,6 +879,10 @@ fn ensure_events_db_owner_only(db_path: &Path) -> anyhow::Result<()> {
     // After creation so a fresh parent can be validated; a directory this
     // process just created in a trusted ancestor passes by construction.
     ensure_events_db_parent_trusted(db_path)?;
+    // Nothing is created over the sidecars of a database that left this
+    // spelling (see `refuse_orphaned_sidecars`); the embedded arm refuses
+    // the same before its own create.
+    refuse_orphaned_sidecars(db_path)?;
     match std::fs::OpenOptions::new()
         .write(true)
         .create_new(true)
@@ -3054,14 +3112,39 @@ mod tests {
             "{err}"
         );
         assert!(!db.exists(), "the refusal created nothing");
-        for sidecar in &sidecars {
-            assert_eq!(
-                std::fs::metadata(sidecar).unwrap().permissions().mode() & 0o777,
-                0o644,
-                "{}: the holder's sidecar was never touched",
-                sidecar.display()
-            );
-        }
+        let untouched = |sidecars: &[PathBuf; 2]| {
+            for sidecar in sidecars {
+                assert_eq!(
+                    std::fs::metadata(sidecar).unwrap().permissions().mode() & 0o777,
+                    0o644,
+                    "{}: the holder's sidecar was never touched",
+                    sidecar.display()
+                );
+            }
+        };
+        untouched(&sidecars);
+
+        // The daemon's own create refuses the same topology, before it.
+        let err = ensure_events_db_owner_only(&db)
+            .expect_err("the daemon creates nothing over another database's sidecars")
+            .to_string();
+        assert!(err.contains("beside no database"), "{err}");
+        assert!(!db.exists(), "the daemon's refusal created nothing");
+        untouched(&sidecars);
+
+        // A file someone else put at the old spelling does not make the
+        // holder's sidecars its own: this process knows whose they are.
+        std::fs::write(&db, b"").unwrap();
+        let err = direct_backend_for(&db)
+            .err()
+            .expect("the holder's sidecars are not opened under a foreign file")
+            .to_string();
+        assert!(
+            err.contains("since moved away") && err.contains("events.db-wal"),
+            "{err}"
+        );
+        untouched(&sidecars);
+        std::fs::remove_file(&db).unwrap();
 
         // The sidecars moved with the main file: the old spelling now names a
         // new file, its own pool, hardened and opened afresh, while the moved

--- a/crates/khive-runtime/src/events_split.rs
+++ b/crates/khive-runtime/src/events_split.rs
@@ -281,6 +281,12 @@ struct HeldBackend {
     /// reused by another file while the entry lives. See `identity_probe`.
     #[cfg(unix)]
     probe: std::fs::File,
+    /// Its `-wal`/`-shm` as they stood beside it at the open, pinned the same
+    /// way (`sidecar_probes`): reached under another name, a hard link or a
+    /// spelling the filesystem folds onto theirs, they are still its
+    /// sidecars, and a close would still release its locks.
+    #[cfg(unix)]
+    sidecars: Vec<std::fs::File>,
     backend: Arc<StorageBackend>,
 }
 
@@ -439,11 +445,15 @@ fn direct_backend(
     });
     #[cfg(unix)]
     let probe = identity_probe(db_path)?;
+    #[cfg(unix)]
+    let sidecars = sidecar_probes(db_path)?;
     registry.push(HeldBackend {
         path: db_path.to_path_buf(),
         read_only,
         #[cfg(unix)]
         probe,
+        #[cfg(unix)]
+        sidecars,
         backend: Arc::clone(&backend),
     });
     Ok(backend)
@@ -467,6 +477,35 @@ fn identity_probe(db_path: &Path) -> crate::error::RuntimeResult<std::fs::File> 
                 db_path.display()
             ))
         })
+}
+
+/// Descriptors on the sidecars beside the database a pool just opened, one
+/// per sidecar present, never closed while the entry lives, as
+/// `identity_probe`: a sidecar reached later under another name is known by
+/// what they pin. A sidecar SQLite has not created by the open pins nothing,
+/// and the spelling check stands for it; a present one that cannot be pinned
+/// fails the open closed.
+#[cfg(unix)]
+fn sidecar_probes(db_path: &Path) -> crate::error::RuntimeResult<Vec<std::fs::File>> {
+    use std::os::unix::fs::OpenOptionsExt;
+    let mut probes = Vec::new();
+    for path in sidecar_paths(db_path) {
+        match std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NOFOLLOW)
+            .open(&path)
+        {
+            Ok(file) => probes.push(file),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                return Err(crate::error::RuntimeError::Internal(format!(
+                    "cannot pin the identity of the events database sidecar {}: {e}",
+                    path.display()
+                )))
+            }
+        }
+    }
+    Ok(probes)
 }
 
 /// Device and inode from metadata, whether read by `stat` or `fstat`.
@@ -539,27 +578,44 @@ fn held_backend_for_file<'a>(
 /// as real. A writable open here would open them for the hardening and
 /// release the holder's locks with the close (the precondition on
 /// `harden_events_db_sidecars`), whatever file has since appeared at the
-/// spelling, so it is refused while any of them remains. Move them with the
-/// database or remove them first. A holder whose file is still here was
-/// found by `held_backend_for_file` before this runs; when that file is a
-/// read-only holder's own, come here by a rename, the writable open beside
-/// it runs this check too, for the sidecars another holder left.
+/// spelling, so it is refused while any of them remains. The same sidecars
+/// reached under another name, a hard link or a spelling the filesystem
+/// folds onto theirs (case, on a volume that folds it), are known by the
+/// identity the holder pinned at its open (`sidecar_probes`) and refused the
+/// same way. Move them with the database or remove them first. A holder
+/// whose file is still here was found by `held_backend_for_file` before this
+/// runs; when that file is a read-only holder's own, come here by a rename,
+/// the writable open beside it runs this check too, for the sidecars another
+/// holder left.
 #[cfg(unix)]
 fn refuse_held_spellings_sidecars(
     registry: &BackendMap,
     db_path: &Path,
 ) -> crate::error::RuntimeResult<()> {
-    let present: Vec<String> = sidecar_paths(db_path)
-        .iter()
-        .filter(|path| std::fs::symlink_metadata(path).is_ok())
-        .map(|path| path.display().to_string())
+    let present: Vec<(PathBuf, (u64, u64))> = sidecar_paths(db_path)
+        .into_iter()
+        .filter_map(|path| {
+            let identity = file_identity(&std::fs::symlink_metadata(&path).ok()?);
+            Some((path, identity))
+        })
         .collect();
     if present.is_empty() {
         return Ok(());
     }
     let here = std::fs::metadata(db_path).ok().map(|m| file_identity(&m));
     for held in registry {
-        if !same_spelling(&held.path, db_path) {
+        let mut theirs = same_spelling(&held.path, db_path);
+        for probe in &held.sidecars {
+            let pinned = probe.metadata().map_err(|e| {
+                crate::error::RuntimeError::Internal(format!(
+                    "cannot read the pinned identity of a sidecar of the held events database \
+                     {}: {e}",
+                    held.path.display()
+                ))
+            })?;
+            theirs |= present.iter().any(|(_, id)| *id == file_identity(&pinned));
+        }
+        if !theirs {
             continue;
         }
         let pinned = held.probe.metadata().map_err(|e| {
@@ -571,13 +627,17 @@ fn refuse_held_spellings_sidecars(
         if Some(file_identity(&pinned)) == here {
             continue;
         }
+        let names: Vec<String> = present
+            .iter()
+            .map(|(p, _)| p.display().to_string())
+            .collect();
         return Err(crate::error::RuntimeError::Internal(format!(
-            "refusing to open the events database {}: this process holds the database that \
-             was at this spelling, since moved away, and {} are its sidecars; a new database \
-             here would open them and release its SQLite locks. Move them with it or remove \
-             them first.",
+            "refusing to open the events database {}: {} are the sidecars of a database this \
+             process holds, at this spelling since moved away or reached here under another \
+             name; a new database here would open them and release its SQLite locks. Move \
+             them with it or remove them first.",
             db_path.display(),
-            present.join(" and ")
+            names.join(" and ")
         )));
     }
     Ok(())
@@ -3377,6 +3437,97 @@ mod tests {
         let beside = direct_backend_for(&db).expect("a writable open beside the read-only holder");
         assert!(!Arc::ptr_eq(&read_only, &beside));
         assert!(!Arc::ptr_eq(&writable, &beside));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_held_sidecar_reached_under_another_name_is_refused_before_the_hardening() {
+        use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        let db = dir.path().join("events.db");
+        let writable = direct_backend_for(&db).expect("writable open");
+        let sidecars = sidecar_paths(&db);
+        let identity = |sidecars: &[PathBuf; 2]| -> Vec<(u64, u32, u64)> {
+            sidecars
+                .iter()
+                .map(|s| {
+                    let m = std::fs::metadata(s).expect("the holder's sidecar is there");
+                    (m.ino(), m.permissions().mode() & 0o777, m.len())
+                })
+                .collect()
+        };
+        let fresh_file = |path: &Path| {
+            std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .mode(0o600)
+                .open(path)
+                .expect("a fresh database file");
+        };
+        let live = identity(&sidecars);
+        let moved = dir.path().join("moved.db");
+        std::fs::rename(&db, &moved).expect("rename the held database");
+        // The holder's live sidecars under another name: hard links beside a
+        // fresh database file, no spelling of the holder's among them.
+        let other = dir.path().join("other.db");
+        let linked = sidecar_paths(&other);
+        for (from, to) in sidecars.iter().zip(&linked) {
+            std::fs::hard_link(from, to).expect("link the holder's sidecar under another name");
+        }
+        fresh_file(&other);
+        let err = direct_backend_for(&other)
+            .err()
+            .expect("the holder's sidecars are not opened under another name")
+            .to_string();
+        assert!(
+            err.contains("since moved away") && err.contains("other.db-wal"),
+            "{err}"
+        );
+        assert_eq!(
+            identity(&sidecars),
+            live,
+            "the holder's sidecars were never touched"
+        );
+        let still = direct_backend_for(&moved).expect("the holder is still served");
+        assert!(
+            Arc::ptr_eq(&writable, &still),
+            "found by its inode under its new name"
+        );
+        // The links gone, the other spelling is a database of its own.
+        for path in &linked {
+            std::fs::remove_file(path).unwrap();
+        }
+        let own = direct_backend_for(&other).expect("a database of its own once the links went");
+        assert!(!Arc::ptr_eq(&writable, &own));
+        // A spelling the filesystem folds onto the holder's reaches the same
+        // sidecars and is refused the same way; where nothing folds, it is a
+        // name of its own and the open lands.
+        let folded = dir.path().join("Events.db");
+        fresh_file(&folded);
+        let folds = std::fs::symlink_metadata(dir.path().join("Events.db-wal")).is_ok();
+        match direct_backend_for(&folded) {
+            Err(e) => {
+                assert!(folds, "refused where nothing folds: {e}");
+                let e = e.to_string();
+                assert!(
+                    e.contains("since moved away") && e.contains("Events.db-wal"),
+                    "{e}"
+                );
+                assert_eq!(
+                    identity(&sidecars),
+                    live,
+                    "never touched through the folded name"
+                );
+            }
+            Ok(own) => {
+                assert!(
+                    !folds,
+                    "landed where the name folds onto the holder's sidecars"
+                );
+                assert!(!Arc::ptr_eq(&writable, &own));
+            }
+        }
     }
 
     #[cfg(unix)]

--- a/crates/khive-runtime/src/events_split.rs
+++ b/crates/khive-runtime/src/events_split.rs
@@ -286,7 +286,7 @@ struct HeldBackend {
 
 /// A read-only open and a writable open of one file are different pools with
 /// different guarantees and are never handed out interchangeably; entries
-/// are found by spelling and mode first, then by the pinned identity.
+/// are found by the pinned identity and the mode, never by spelling.
 type BackendMap = Vec<HeldBackend>;
 
 #[cfg(unix)]
@@ -338,6 +338,11 @@ fn direct_backend(
     let mut registry = direct_backend_registry()
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
+    // Without the inode probe the registry can only go by spelling and mode.
+    // With it, the spelling is never consulted: a file created at a held
+    // path after a rename is another inode and gets its own pool, and a link
+    // planted there is refused below like any other.
+    #[cfg(not(unix))]
     if let Some(held) = registry
         .iter()
         .find(|held| held.read_only == read_only && held.path.as_path() == db_path)
@@ -2981,6 +2986,45 @@ mod tests {
             err.contains("moved.db") && err.contains("already holds it writable"),
             "{err}"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_file_created_at_a_held_spelling_after_a_rename_is_another_database() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        let db = dir.path().join("events.db");
+        let first = direct_backend_for(&db).expect("first open");
+        let moved = dir.path().join("moved.db");
+        std::fs::rename(&db, &moved).expect("rename the held database");
+
+        // The old spelling now names a new file: its own pool, hardened and
+        // opened afresh, while the moved file keeps its holder.
+        let second = direct_backend_for(&db).expect("a new database at the old spelling");
+        assert!(
+            !Arc::ptr_eq(&first, &second),
+            "a spelling is not a file: the new file at the old path is another database"
+        );
+        assert_eq!(
+            std::fs::metadata(&db).unwrap().permissions().mode() & 0o777,
+            0o600,
+            "the new file was created owner-only"
+        );
+        let held = direct_backend_for(&moved).expect("the moved file is still held");
+        assert!(Arc::ptr_eq(&first, &held));
+
+        // A link planted at the old spelling is refused, held holder or not.
+        let linked = dir.path().join("linked.db");
+        let third = direct_backend_for(&linked).expect("a third database");
+        std::fs::rename(&linked, dir.path().join("linked-moved.db")).unwrap();
+        std::os::unix::fs::symlink(&moved, &linked).unwrap();
+        let err = direct_backend_for(&linked)
+            .err()
+            .expect("a symlink at a held spelling is refused")
+            .to_string();
+        assert!(err.contains("linked.db"), "{err}");
+        drop(third);
     }
 
     #[cfg(unix)]

--- a/crates/khive-runtime/src/events_split.rs
+++ b/crates/khive-runtime/src/events_split.rs
@@ -399,7 +399,10 @@ fn direct_backend(
     // writable asked: the holder is a snapshot reader, and the writable
     // pool opens beside it through SQLite alone, which coordinates its own
     // descriptors on one inode; the hardening is skipped, so the holder's
-    // file set is never touched and keeps the modes the holder admitted.
+    // file set is never touched and keeps the modes the holder admitted. A
+    // set no longer owner-only is refused, read by `lstat` alone, never
+    // tightened here: tightening opens descriptors, and a close would
+    // release the holder's locks.
     #[cfg(unix)]
     match held_backend_for_file(&registry, db_path, read_only)? {
         Some(held) if held.read_only == read_only => return Ok(Arc::clone(&held.backend)),
@@ -410,7 +413,10 @@ fn direct_backend(
                 db_path.display()
             )));
         }
-        Some(_) => {}
+        Some(_) => {
+            verify_events_db_owner_only_unopened(db_path)
+                .map_err(|e| crate::error::RuntimeError::Internal(e.to_string()))?;
+        }
         None => {
             // Before the open, and only before it: see the precondition on
             // `harden_events_db_sidecars`. Never on a held database's
@@ -2542,6 +2548,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn unopened_check_refuses_a_loosened_or_replaced_sidecar() {
         use std::os::unix::fs::PermissionsExt;
@@ -3040,8 +3047,10 @@ mod tests {
         let read_only = direct_backend_read_only_for(&db).expect("read-only open");
         // Loosened by path while the read-only pool holds the file: the
         // hardening, had it run for the writable key, would have opened and
-        // tightened it. The sidecars go back to writable by path, as a writer
-        // elsewhere leaves them, so the writable pool can use them.
+        // tightened it. The loosened set is refused instead, read by `lstat`
+        // alone, and the file keeps the mode it was given. The sidecars go
+        // back to writable by path, as a writer elsewhere leaves them, so
+        // the writable pool can use them once the database is owner-only.
         std::fs::set_permissions(&db, std::fs::Permissions::from_mode(0o644)).unwrap();
         for suffix in ["-wal", "-shm"] {
             let sidecar = PathBuf::from(format!("{}{suffix}", db.display()));
@@ -3049,7 +3058,22 @@ mod tests {
                 std::fs::set_permissions(&sidecar, std::fs::Permissions::from_mode(0o600)).unwrap();
             }
         }
+        let err = direct_backend_for(&db)
+            .err()
+            .expect("a loosened database beside a read-only holder is refused")
+            .to_string();
+        assert!(err.contains("not owner-only"), "{err}");
+        assert_eq!(
+            std::fs::metadata(&db).unwrap().permissions().mode() & 0o777,
+            0o644,
+            "refused by metadata alone: the held file was not touched"
+        );
+        let ro_still = direct_backend_read_only_for(&db).expect("the holder is still served");
+        assert!(Arc::ptr_eq(&read_only, &ro_still));
 
+        // Owner-only again, by path as an operator would: the writable pool
+        // opens beside the holder, and still touches nothing.
+        std::fs::set_permissions(&db, std::fs::Permissions::from_mode(0o600)).unwrap();
         let writable =
             direct_backend_for(&db).expect("a writable pool opens beside a read-only holder");
         assert!(
@@ -3058,7 +3082,7 @@ mod tests {
         );
         assert_eq!(
             std::fs::metadata(&db).unwrap().permissions().mode() & 0o777,
-            0o644,
+            0o600,
             "the held file was not touched"
         );
         // Each mode keeps its own holder from here on.

--- a/crates/khive-runtime/src/events_split.rs
+++ b/crates/khive-runtime/src/events_split.rs
@@ -526,17 +526,18 @@ fn held_backend_for_file<'a>(
     Ok(other_mode)
 }
 
-/// A database this process holds writable, opened at this spelling (the
-/// same directory however it was written, the same name) and since moved
-/// away (its pinned inode is no longer the file here, or no file is here),
-/// keeps its live `-wal`/`-shm` at this spelling: a rename
-/// moves the main file alone. A writable open here would open them for the
-/// hardening and release the holder's locks with the close (the precondition
-/// on `harden_events_db_sidecars`), whatever file has since appeared at the
+/// A database this process holds, writable or read-only, opened at this
+/// spelling (the same directory however it was written, the same name) and
+/// since moved away (its pinned inode is no longer the file here, or no file
+/// is here), keeps its `-wal`/`-shm` at this spelling: a rename moves the
+/// main file alone. A writable holder's are its live sidecars; a read-only
+/// holder's are the frozen snapshot it reads through, its locks on them just
+/// as real. A writable open here would open them for the hardening and
+/// release the holder's locks with the close (the precondition on
+/// `harden_events_db_sidecars`), whatever file has since appeared at the
 /// spelling, so it is refused while any of them remains. Move them with the
-/// database or remove them first. Read-only holders admit no live sidecar
-/// set and are not consulted; a holder whose file is still here was found by
-/// `held_backend_for_file` before this runs.
+/// database or remove them first. A holder whose file is still here was
+/// found by `held_backend_for_file` before this runs.
 #[cfg(unix)]
 fn refuse_held_spellings_sidecars(
     registry: &BackendMap,
@@ -552,7 +553,7 @@ fn refuse_held_spellings_sidecars(
     }
     let here = std::fs::metadata(db_path).ok().map(|m| file_identity(&m));
     for held in registry {
-        if held.read_only || !same_spelling(&held.path, db_path) {
+        if !same_spelling(&held.path, db_path) {
             continue;
         }
         let pinned = held.probe.metadata().map_err(|e| {
@@ -3242,6 +3243,67 @@ mod tests {
             .to_string();
         assert!(err.contains("linked.db"), "{err}");
         drop(third);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_replacement_beside_a_read_only_holders_frozen_sidecars_is_refused() {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        let db = dir.path().join("events.db");
+        drop(StorageBackend::sqlite(&db).expect("create the database"));
+        khive_storage::test_support::freeze_snapshot_sidecars(&db);
+        std::fs::set_permissions(&db, std::fs::Permissions::from_mode(0o600)).unwrap();
+        let read_only = direct_backend_read_only_for(&db).expect("read-only open");
+        // The set the holder admitted and reads through, as its open left
+        // it: SQLite gives an empty WAL the database's mode at open, the
+        // frozen -shm keeps its own.
+        let sidecars = sidecar_paths(&db);
+        let identity = |sidecars: &[PathBuf; 2]| -> Vec<(u64, u32, u64)> {
+            sidecars
+                .iter()
+                .map(|s| {
+                    let m = std::fs::metadata(s).expect("the holder's sidecar is there");
+                    (m.ino(), m.permissions().mode() & 0o777, m.len())
+                })
+                .collect()
+        };
+        let held = identity(&sidecars);
+        assert_eq!(held[1].1, 0o444, "the frozen -shm: {held:?}");
+        // The main file renamed away under the holder; the frozen snapshot
+        // it reads through stays at the old spelling, as a rename leaves it.
+        let moved = dir.path().join("moved.db");
+        std::fs::rename(&db, &moved).expect("rename the held database");
+        // A replacement at the old spelling: hardening would open and close
+        // the holder's sidecars and drop its locks, then SQLite would treat
+        // that snapshot as the replacement's own. Refused, with nothing touched.
+        std::fs::write(&db, b"").unwrap();
+        let err = direct_backend_for(&db)
+            .err()
+            .expect("a read-only holder's frozen sidecars are not opened under a replacement")
+            .to_string();
+        assert!(
+            err.contains("since moved away") && err.contains("events.db-wal"),
+            "{err}"
+        );
+        assert_eq!(
+            identity(&sidecars),
+            held,
+            "the holder's sidecars were never touched"
+        );
+        let still = direct_backend_read_only_for(&moved).expect("the holder is still served");
+        assert!(
+            Arc::ptr_eq(&read_only, &still),
+            "found by its inode under its new name"
+        );
+        // The sidecars moved with the database: the old spelling is free.
+        std::fs::remove_file(&db).unwrap();
+        for (from, suffix) in sidecars.iter().zip(["-wal", "-shm"]) {
+            std::fs::rename(from, PathBuf::from(format!("{}{suffix}", moved.display()))).unwrap();
+        }
+        let fresh = direct_backend_for(&db).expect("a new database once the sidecars went with it");
+        assert!(!Arc::ptr_eq(&read_only, &fresh));
     }
 
     #[cfg(unix)]

--- a/crates/khive-runtime/src/events_split.rs
+++ b/crates/khive-runtime/src/events_split.rs
@@ -466,6 +466,26 @@ fn file_identity(metadata: &std::fs::Metadata) -> (u64, u64) {
     (metadata.dev(), metadata.ino())
 }
 
+/// Whether two paths spell the same file: the same directory once `.`,
+/// `..` and symlinks are resolved, and the same name. A path whose
+/// directory cannot be resolved spells nothing and equals no other.
+#[cfg(unix)]
+fn same_spelling(a: &Path, b: &Path) -> bool {
+    match (physical_spelling(a), physical_spelling(b)) {
+        (Some(a), Some(b)) => a == b,
+        _ => false,
+    }
+}
+
+#[cfg(unix)]
+fn physical_spelling(path: &Path) -> Option<PathBuf> {
+    let dir = match path.parent() {
+        Some(dir) if !dir.as_os_str().is_empty() => dir,
+        _ => Path::new("."),
+    };
+    Some(dir.canonicalize().ok()?.join(path.file_name()?))
+}
+
 /// The backend this process already holds for the file at `db_path`, under
 /// any spelling and after a rename: the holder in the asked mode when there
 /// is one, else the holder in the other mode. `None` when no file exists at
@@ -500,9 +520,10 @@ fn held_backend_for_file<'a>(
     Ok(other_mode)
 }
 
-/// A database this process holds writable, opened under this very spelling
-/// and since moved away (its pinned inode is no longer the file here, or no
-/// file is here), keeps its live `-wal`/`-shm` at this spelling: a rename
+/// A database this process holds writable, opened at this spelling (the
+/// same directory however it was written, the same name) and since moved
+/// away (its pinned inode is no longer the file here, or no file is here),
+/// keeps its live `-wal`/`-shm` at this spelling: a rename
 /// moves the main file alone. A writable open here would open them for the
 /// hardening and release the holder's locks with the close (the precondition
 /// on `harden_events_db_sidecars`), whatever file has since appeared at the
@@ -525,7 +546,7 @@ fn refuse_held_spellings_sidecars(
     }
     let here = std::fs::metadata(db_path).ok().map(|m| file_identity(&m));
     for held in registry {
-        if held.read_only || held.path != db_path {
+        if held.read_only || !same_spelling(&held.path, db_path) {
             continue;
         }
         let pinned = held.probe.metadata().map_err(|e| {
@@ -3144,6 +3165,27 @@ mod tests {
             "{err}"
         );
         untouched(&sidecars);
+
+        // Nor under another spelling of the same directory: through `.`, or
+        // through a symlink to it. The spelling is compared resolved.
+        let elsewhere = tempfile::tempdir().unwrap();
+        let linked = elsewhere.path().join("linked");
+        std::os::unix::fs::symlink(dir.path(), &linked).unwrap();
+        for spelled in [
+            dir.path().join(".").join("events.db"),
+            linked.join("events.db"),
+        ] {
+            let err = direct_backend_for(&spelled)
+                .err()
+                .expect("a spelling is refused however it is written")
+                .to_string();
+            assert!(
+                err.contains("since moved away") && err.contains("events.db-wal"),
+                "{}: {err}",
+                spelled.display()
+            );
+            untouched(&sidecars);
+        }
         std::fs::remove_file(&db).unwrap();
 
         // The sidecars moved with the main file: the old spelling now names a

--- a/crates/kkernel/tests/events_daemon_keeps_sqlite_locks.rs
+++ b/crates/kkernel/tests/events_daemon_keeps_sqlite_locks.rs
@@ -31,6 +31,12 @@ const SHARED_SIZE: i64 = 510;
 /// The `-shm` byte every connection with an open WAL index holds shared
 /// (`UNIX_SHM_DMS`).
 const SHM_DMS_BYTE: i64 = 128;
+/// The libc crate types `F_WRLCK`/`F_RDLCK` as `c_short` on macOS and as
+/// `c_int` on Linux, while `flock.l_type` is `c_short` on both.
+#[allow(clippy::unnecessary_cast)]
+const F_WRLCK: libc::c_short = libc::F_WRLCK as libc::c_short;
+#[allow(clippy::unnecessary_cast)]
+const F_RDLCK: libc::c_short = libc::F_RDLCK as libc::c_short;
 
 /// Ask the kernel, from this process, whether an exclusive lock over
 /// `[start, start + len)` of `path` would conflict with a lock held by another
@@ -43,7 +49,7 @@ fn conflicting_lock(path: &Path, start: i64, len: i64) -> libc::flock {
         .unwrap_or_else(|e| panic!("open {} for F_GETLK: {e}", path.display()));
     // SAFETY: `flock` is plain data; every field is set below or zero.
     let mut lock: libc::flock = unsafe { std::mem::zeroed() };
-    lock.l_type = libc::F_WRLCK;
+    lock.l_type = F_WRLCK;
     lock.l_whence = libc::SEEK_SET as libc::c_short;
     lock.l_start = start;
     lock.l_len = len;
@@ -126,7 +132,7 @@ fn events_daemon_keeps_shared_locks_on_its_database_while_idle() {
     let check = |label: &str, lock: libc::flock, path: &Path| {
         assert_eq!(
             lock.l_type,
-            libc::F_RDLCK,
+            F_RDLCK,
             "{label}: the idle events daemon must hold a shared lock on {} (F_GETLK type {})",
             path.display(),
             lock.l_type

--- a/crates/kkernel/tests/events_daemon_keeps_sqlite_locks.rs
+++ b/crates/kkernel/tests/events_daemon_keeps_sqlite_locks.rs
@@ -66,6 +66,17 @@ fn conflicting_lock(path: &Path, start: i64, len: i64) -> libc::flock {
     lock
 }
 
+/// The daemon under test, killed when the test unwinds: a failed assertion
+/// must not leave a child holding descriptors against a removed directory.
+struct KillOnDrop(std::process::Child);
+
+impl Drop for KillOnDrop {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
 fn sidecar(db: &Path, suffix: &str) -> PathBuf {
     let mut name = db.as_os_str().to_os_string();
     name.push(suffix);
@@ -84,19 +95,21 @@ fn events_daemon_keeps_shared_locks_on_its_database_while_idle() {
     let stderr_path = dir.path().join("daemon.stderr");
     let stderr = std::fs::File::create(&stderr_path).unwrap();
 
-    let mut child = Command::new(env!("CARGO_BIN_EXE_kkernel"))
-        .arg("events-daemon")
-        .arg("--db")
-        .arg(&db)
-        .arg("--socket")
-        .arg(&socket)
-        .current_dir(dir.path())
-        .env_remove("KHIVE_DB")
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::from(stderr))
-        .spawn()
-        .expect("spawn events daemon");
+    let mut child = KillOnDrop(
+        Command::new(env!("CARGO_BIN_EXE_kkernel"))
+            .arg("events-daemon")
+            .arg("--db")
+            .arg(&db)
+            .arg("--socket")
+            .arg(&socket)
+            .current_dir(dir.path())
+            .env_remove("KHIVE_DB")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::from(stderr))
+            .spawn()
+            .expect("spawn events daemon"),
+    );
 
     // Readiness: the daemon binds the socket only after the schema is ensured,
     // which is after SQLite opened the database and its WAL. Cold builds and
@@ -104,7 +117,7 @@ fn events_daemon_keeps_shared_locks_on_its_database_while_idle() {
     // message carries the child's stderr.
     let deadline = Instant::now() + Duration::from_secs(60);
     while !socket.exists() {
-        if let Some(status) = child.try_wait().unwrap() {
+        if let Some(status) = child.0.try_wait().unwrap() {
             panic!(
                 "events daemon exited before binding: {status}\n{}",
                 std::fs::read_to_string(&stderr_path).unwrap_or_default()
@@ -128,7 +141,7 @@ fn events_daemon_keeps_shared_locks_on_its_database_while_idle() {
         let dms_lock = conflicting_lock(&shm, SHM_DMS_BYTE, 1);
         (db_lock, dms_lock)
     };
-    let daemon_pid = child.id() as libc::pid_t;
+    let daemon_pid = child.0.id() as libc::pid_t;
     let check = |label: &str, lock: libc::flock, path: &Path| {
         assert_eq!(
             lock.l_type,
@@ -159,6 +172,5 @@ fn events_daemon_keeps_shared_locks_on_its_database_while_idle() {
         check("shm DMS byte, idle", dms_lock, &shm);
     }
 
-    child.kill().unwrap();
-    let _ = child.wait();
+    drop(child);
 }

--- a/crates/kkernel/tests/events_daemon_keeps_sqlite_locks.rs
+++ b/crates/kkernel/tests/events_daemon_keeps_sqlite_locks.rs
@@ -1,0 +1,158 @@
+//! The events daemon must hold SQLite's advisory locks on its database for as
+//! long as it serves it.
+//!
+//! In WAL mode every open connection keeps a SHARED lock on the database file
+//! and a shared lock on the `-shm` "DMS" byte; those locks are how any other
+//! connection learns, when it closes, that it is not the last one and must
+//! leave the `-wal`/`-shm` sidecars alone. POSIX advisory locks are per
+//! process and per inode and are released by the close of ANY descriptor for
+//! the inode, so a daemon that opens and closes a descriptor on its own
+//! database after SQLite did (a permission pass, an integrity peek) drops the
+//! locks without SQLite noticing. An external connection closing afterwards
+//! then checkpoints and unlinks the sidecars underneath the daemon, which keeps
+//! writing to the unlinked inodes.
+//!
+//! Locks are invisible to the process that holds them (`F_GETLK` never reports
+//! a conflict with one's own locks), so the check has to be cross-process: this
+//! test runs the real daemon subcommand as a child and probes both ranges from
+//! here with `F_GETLK`, which answers with the type and the pid of a
+//! conflicting holder.
+#![cfg(unix)]
+
+use std::os::fd::AsRawFd;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// SQLite's pending byte and the SHARED range above it (`os_unix.c`).
+const PENDING_BYTE: i64 = 0x4000_0000;
+const SHARED_FIRST: i64 = PENDING_BYTE + 2;
+const SHARED_SIZE: i64 = 510;
+/// The `-shm` byte every connection with an open WAL index holds shared
+/// (`UNIX_SHM_DMS`).
+const SHM_DMS_BYTE: i64 = 128;
+
+/// Ask the kernel, from this process, whether an exclusive lock over
+/// `[start, start + len)` of `path` would conflict with a lock held by another
+/// process. Returns the conflicting lock as the kernel describes it: `l_type`
+/// is `F_UNLCK` when nothing conflicts, else the holder's type and pid.
+fn conflicting_lock(path: &Path, start: i64, len: i64) -> libc::flock {
+    // Opening and closing this descriptor releases only THIS process's locks
+    // on the inode, of which there are none.
+    let file = std::fs::File::open(path)
+        .unwrap_or_else(|e| panic!("open {} for F_GETLK: {e}", path.display()));
+    // SAFETY: `flock` is plain data; every field is set below or zero.
+    let mut lock: libc::flock = unsafe { std::mem::zeroed() };
+    lock.l_type = libc::F_WRLCK;
+    lock.l_whence = libc::SEEK_SET as libc::c_short;
+    lock.l_start = start;
+    lock.l_len = len;
+    // SAFETY: `fd` is a live descriptor owned by `file` for the call; `lock`
+    // is a valid `flock` the kernel fills in.
+    let rc = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_GETLK, &mut lock) };
+    assert_eq!(
+        rc,
+        0,
+        "F_GETLK on {}: {}",
+        path.display(),
+        std::io::Error::last_os_error()
+    );
+    lock
+}
+
+fn sidecar(db: &Path, suffix: &str) -> PathBuf {
+    let mut name = db.as_os_str().to_os_string();
+    name.push(suffix);
+    PathBuf::from(name)
+}
+
+#[test]
+fn events_daemon_keeps_shared_locks_on_its_database_while_idle() {
+    use std::os::unix::fs::PermissionsExt;
+    let dir = tempfile::tempdir().unwrap();
+    // The daemon validates the socket directory's ownership and mode before
+    // binding; a private directory passes.
+    std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+    let db = dir.path().join("events.db");
+    let socket = dir.path().join("events.sock");
+    let stderr_path = dir.path().join("daemon.stderr");
+    let stderr = std::fs::File::create(&stderr_path).unwrap();
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_kkernel"))
+        .arg("events-daemon")
+        .arg("--db")
+        .arg(&db)
+        .arg("--socket")
+        .arg(&socket)
+        .current_dir(dir.path())
+        .env_remove("KHIVE_DB")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::from(stderr))
+        .spawn()
+        .expect("spawn events daemon");
+
+    // Readiness: the daemon binds the socket only after the schema is ensured,
+    // which is after SQLite opened the database and its WAL. Cold builds and
+    // loaded machines make this slow; the bound is generous and the failure
+    // message carries the child's stderr.
+    let deadline = Instant::now() + Duration::from_secs(60);
+    while !socket.exists() {
+        if let Some(status) = child.try_wait().unwrap() {
+            panic!(
+                "events daemon exited before binding: {status}\n{}",
+                std::fs::read_to_string(&stderr_path).unwrap_or_default()
+            );
+        }
+        assert!(
+            Instant::now() < deadline,
+            "events daemon did not bind {} in time\n{}",
+            socket.display(),
+            std::fs::read_to_string(&stderr_path).unwrap_or_default()
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    let wal = sidecar(&db, "-wal");
+    let shm = sidecar(&db, "-shm");
+    assert!(wal.exists(), "WAL mode leaves {} on disk", wal.display());
+    assert!(shm.exists(), "WAL mode leaves {} on disk", shm.display());
+
+    let probe = || {
+        let db_lock = conflicting_lock(&db, SHARED_FIRST, SHARED_SIZE);
+        let dms_lock = conflicting_lock(&shm, SHM_DMS_BYTE, 1);
+        (db_lock, dms_lock)
+    };
+    let daemon_pid = child.id() as libc::pid_t;
+    let check = |label: &str, lock: libc::flock, path: &Path| {
+        assert_eq!(
+            lock.l_type,
+            libc::F_RDLCK,
+            "{label}: the idle events daemon must hold a shared lock on {} (F_GETLK type {})",
+            path.display(),
+            lock.l_type
+        );
+        assert_eq!(
+            lock.l_pid,
+            daemon_pid,
+            "{label}: the shared lock on {} must be the daemon's",
+            path.display()
+        );
+    };
+
+    let (db_lock, dms_lock) = probe();
+    check("database SHARED range", db_lock, &db);
+    check("shm DMS byte", dms_lock, &shm);
+
+    // The locks are not a boot-time artifact: they are still held after the
+    // daemon has been idle for a while and after this process has opened and
+    // closed the files several more times.
+    std::thread::sleep(Duration::from_millis(500));
+    for _ in 0..3 {
+        let (db_lock, dms_lock) = probe();
+        check("database SHARED range, idle", db_lock, &db);
+        check("shm DMS byte, idle", dms_lock, &shm);
+    }
+
+    child.kill().unwrap();
+    let _ = child.wait();
+}


### PR DESCRIPTION
## Summary

The events daemon released SQLite's advisory locks on its own database at boot. An external connection that closed later (a backup tool, an inspection shell) then took itself for the last connection, checkpointed, and unlinked the `-wal`/`-shm` sidecars while the daemon kept writing to the unlinked inodes. Every other opener saw a stale sidecar pair over a newer main file and read the database as malformed, while writes through the daemon socket kept landing.

Mechanism: `run_events_daemon` opened the pool, ensured the schema, and only then ran the owner-only hardening of the database and its sidecars. The hardening opens and closes a descriptor on each file (`O_NOFOLLOW` open, `fchmod`). POSIX advisory locks are per process and per inode and are released by the close of any descriptor for the inode, so that close dropped the SHARED lock SQLite keeps on the database in WAL mode and the shared lock on the `-shm` DMS byte, while SQLite still believed it held both.

## Change

- `run_events_daemon`: hardening runs before the pool opens. A pre-existing database and any sidecars an earlier process left behind are tightened first; sidecars SQLite creates afterwards inherit the database file's mode. After the open, the new `verify_events_db_owner_only_unopened` checks the file set with `lstat` only and refuses to serve on a loosened or replaced entry, so nothing opens a live store file outside SQLite.
- `harden_events_db_sidecars` documents its precondition (no open connection to the database in this process). The embedded arm already ran it before the open; the comment now says the order is load-bearing.
- Cross-process regression test `crates/kkernel/tests/events_daemon_keeps_sqlite_locks.rs`: runs the real `events-daemon` subcommand as a child process and probes the database SHARED range and the `-shm` DMS byte from the test process with `F_GETLK`, asserting a shared lock held by the daemon's pid at bind and after an idle period. A process cannot see its own locks through `F_GETLK`, so the check has to be cross-process. The test kills the daemon on unwind (an RAII guard), so a failed assertion leaves no child holding descriptors against a removed directory.
- Unit test for the unopened check: a loosened `-wal` is refused naming the file and its mode; a symlink planted at `-shm` is refused without being followed.
- Embedded (direct) backend registry: the registry was keyed by path spelling and mode, so a second key could name a file this process already holds (another spelling, the other `read_only` flag, or the path after a rename) and run the hardening, or a read-only pool's header read, on it. Each registry entry now pins the held file's inode with a read-only descriptor opened after the pool and never closed (a close is the only descriptor operation that releases the process's locks), and `direct_backend` resolves the requested path by `stat` against those pinned identities before anything else. The same mode reuses the existing backend under any spelling and after a rename. A read-only open of a database this process holds writable is refused: its header read would close a descriptor on the held file, and a read-only pool admits no live sidecar set anyway. A writable open beside a read-only holder proceeds through SQLite alone, with no hardening of the held files: a read-only main beside a writable secondary is a supported topology, and in direct mode the read-only handle may reach the shared events database first. The spelling itself is never a key: a file created at a held path after a rename is another database with its own pool. Only a file nobody in the process holds is hardened. Five regression tests: a second spelling through a directory link resolves to the same backend and leaves a loosened sidecar untouched; a renamed held database resolves to the same backend and is not touched under its new name; a writable open beside a read-only holder succeeds and leaves the file's mode alone; a read-only open of a writable-held database is refused; a new file at a held spelling after a rename gets its own pool and a link planted there is refused.
- CHANGELOG entry under Unreleased.

## Verification

- `cargo test -p khive-runtime --lib events_split::tests::`: 45 passed.
- `cargo test -p kkernel --test events_daemon_keeps_sqlite_locks`: passes on this branch. With the old order restored (hardening after the open) the same test fails with `F_GETLK type 2` (`F_UNLCK`) on the database range, and passes again after the restore.
- Scratch reproduction: an events daemon built from this branch holding a scratch database, then `sqlite3_rsync origin replica` (the local-replica backup form). Shared locks held by the daemon on both ranges before and after; sidecars still on the path with the same inodes. The released 0.8.0 binary under the same procedure: no lock before, sidecars unlinked after.
- Two runs of the local-replica backup script against a scratch registry and backup root, with the daemon from this branch holding the origin: both `success`, `wal_after_bytes` equal to `wal_before_bytes`, sidecars on the path with the same inodes, shared locks still held, replica and origin `quick_check` ok.
- `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean; `cargo test -p khive-runtime` green (1457 passed).

## Not changed

`khive-db`'s read-only open path reads the database header through a plain file open before any connection of that pool exists; it serves read-only backends and snapshot inspection and holds no live connection of its own, so it is outside this fix. The embedded registry keeps that path off any database this process holds writable by refusing the read-only open first; the same rule applies to any other caller that reaches it from a process holding a connection to the same file.
