### PR TITLE
fix(runtime): keep the events daemon's SQLite locks across sidecar hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of a hard-coded identity with no meaning outside the deployment it
   was named for. Behaviour with the variable explicitly set is unchanged.
 
+### Fixed
+
+- The events daemon no longer releases SQLite's advisory locks on its own
+  database. Permission hardening of the `-wal`/`-shm` sidecars ran after the
+  database was opened and closed a descriptor on each file, which under POSIX
+  drops every lock the process holds on that inode; a backup or inspection
+  connection closing afterwards then took itself for the last connection,
+  checkpointed, and unlinked the sidecars while the daemon kept writing to the
+  unlinked files. Hardening now runs before the open, the post-open check uses
+  `lstat` only, and a cross-process test asserts the locks are held.
+
 ## [0.8.0] - 2026-08-27
 
 ### Added

--- a/crates/khive-runtime/src/events_split.rs
+++ b/crates/khive-runtime/src/events_split.rs
@@ -357,6 +357,8 @@ fn direct_backend(
             .create_new(true)
             .mode(0o600)
             .open(db_path);
+        // Before the open, and only before it: see the precondition on
+        // `harden_events_db_sidecars`.
         harden_events_db_sidecars(db_path)
             .map_err(|e| crate::error::RuntimeError::Internal(e.to_string()))?;
     }
@@ -674,6 +676,15 @@ fn ensure_events_db_owner_only(db_path: &Path) -> anyhow::Result<()> {
 /// Tighten the events database and its SQLite sidecars to owner-only.
 /// Fail closed, same contract as the socket chmod: a daemon that cannot
 /// keep its database owner-only must not serve it.
+///
+/// PRECONDITION: no SQLite connection to `db_path` may be open in this
+/// process. This function opens and closes a descriptor on the database and
+/// on each sidecar, and POSIX advisory locks are per process and per inode,
+/// released by the close of ANY descriptor for the inode (fcntl(2)): called
+/// on a live database it silently drops the SHARED lock SQLite keeps in WAL
+/// mode and the `-shm` DMS lock, while the connection believes it still
+/// holds them. Both callers run it before their open; keep it that way. The
+/// post-open check that opens nothing is `verify_events_db_owner_only_unopened`.
 #[cfg(unix)]
 fn harden_events_db_sidecars(db_path: &Path) -> anyhow::Result<()> {
     use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
@@ -713,6 +724,52 @@ fn harden_events_db_sidecars(db_path: &Path) -> anyhow::Result<()> {
                     path.display()
                 )
             })?;
+    }
+    Ok(())
+}
+
+/// Check, after SQLite has opened the database, that it and its sidecars are
+/// owner-only regular files WITHOUT opening any of them: `lstat` takes no
+/// descriptor, so it cannot release the advisory locks the open connections
+/// hold (see the precondition on `harden_events_db_sidecars`). Sidecars
+/// SQLite creates inherit the database file's mode, so a failure here means
+/// something else changed the file set; refuse to serve rather than tighten
+/// through a path-based chmod and its lookup race.
+#[cfg(unix)]
+fn verify_events_db_owner_only_unopened(db_path: &Path) -> anyhow::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut targets = vec![db_path.to_path_buf()];
+    for suffix in ["-wal", "-shm"] {
+        let mut name = db_path.as_os_str().to_os_string();
+        name.push(suffix);
+        targets.push(PathBuf::from(name));
+    }
+    for path in targets {
+        let metadata = match std::fs::symlink_metadata(&path) {
+            Ok(metadata) => metadata,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => {
+                anyhow::bail!(
+                    "refusing to serve events: cannot stat {}: {e}",
+                    path.display()
+                )
+            }
+        };
+        if !metadata.file_type().is_file() {
+            anyhow::bail!(
+                "refusing to serve events: {} is not a regular file. The events database \
+                 and its sidecars must be regular files.",
+                path.display()
+            );
+        }
+        let mode = metadata.permissions().mode() & 0o777;
+        if mode & 0o077 != 0 {
+            anyhow::bail!(
+                "refusing to serve events: {} is mode {mode:03o}, not owner-only. The events \
+                 database and its sidecars must be owner-only.",
+                path.display()
+            );
+        }
     }
     Ok(())
 }
@@ -858,12 +915,23 @@ pub async fn run_events_daemon(db_path: &Path, socket_path: &Path) -> anyhow::Re
         return Ok(());
     };
     ensure_events_db_owner_only(db_path)?;
+    // Tighten a pre-existing database and any `-wal`/`-shm` an earlier
+    // process left behind BEFORE SQLite opens the database. The order is
+    // load-bearing: hardening opens and closes its own descriptor on each of
+    // these files, and POSIX advisory locks are per process and per inode,
+    // released by the close of ANY descriptor for the inode (fcntl(2)). Run
+    // after the open, it silently dropped the SHARED lock SQLite keeps on the
+    // database in WAL mode and the shared lock on the `-shm` DMS byte, so the
+    // next external connection to close (a backup tool, an inspection shell)
+    // took itself for the last connection, checkpointed, and unlinked the
+    // sidecars underneath this daemon, which kept writing to the unlinked
+    // inodes. Sidecars SQLite creates from here on inherit the database
+    // file's mode; the check after the open below opens nothing.
+    harden_events_db_sidecars(db_path)?;
     let backend = Arc::new(StorageBackend::sqlite(db_path)?);
     // Ensure the schema once, loudly, before accepting traffic.
     backend.events()?;
-    // The `-wal`/`-shm` sidecars inherit the database file's mode at
-    // creation; tighten any that already exist from before the hardening.
-    harden_events_db_sidecars(db_path)?;
+    verify_events_db_owner_only_unopened(db_path)?;
 
     if socket_path.exists() {
         std::fs::remove_file(socket_path)?;
@@ -2234,6 +2302,51 @@ mod tests {
         assert!(
             !sidecar.exists(),
             "refusal must precede creation of the events database"
+        );
+    }
+
+    #[test]
+    fn unopened_check_refuses_a_loosened_or_replaced_sidecar() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        let db = dir.path().join("events.db");
+        let wal = PathBuf::from(format!("{}-wal", db.display()));
+        let shm = PathBuf::from(format!("{}-shm", db.display()));
+        for path in [&db, &wal] {
+            std::fs::write(path, b"").unwrap();
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        }
+        // Owner-only regular files, an absent `-shm`: nothing to refuse.
+        verify_events_db_owner_only_unopened(&db).unwrap();
+
+        std::fs::set_permissions(&wal, std::fs::Permissions::from_mode(0o644)).unwrap();
+        let err = verify_events_db_owner_only_unopened(&db)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("events.db-wal") && err.contains("644"),
+            "{err}"
+        );
+        std::fs::set_permissions(&wal, std::fs::Permissions::from_mode(0o600)).unwrap();
+        verify_events_db_owner_only_unopened(&db).unwrap();
+
+        // A link planted at the `-shm` name is refused as not a regular file,
+        // and the check never followed it: the target keeps its mode.
+        let victim = dir.path().join("victim");
+        std::fs::write(&victim, b"").unwrap();
+        std::fs::set_permissions(&victim, std::fs::Permissions::from_mode(0o644)).unwrap();
+        std::os::unix::fs::symlink(&victim, &shm).unwrap();
+        let err = verify_events_db_owner_only_unopened(&db)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("events.db-shm") && err.contains("regular file"),
+            "{err}"
+        );
+        assert_eq!(
+            std::fs::metadata(&victim).unwrap().permissions().mode() & 0o777,
+            0o644
         );
     }
 

--- a/crates/khive-runtime/src/events_split.rs
+++ b/crates/khive-runtime/src/events_split.rs
@@ -734,7 +734,10 @@ fn harden_events_db_sidecars(db_path: &Path) -> anyhow::Result<()> {
 /// hold (see the precondition on `harden_events_db_sidecars`). Sidecars
 /// SQLite creates inherit the database file's mode, so a failure here means
 /// something else changed the file set; refuse to serve rather than tighten
-/// through a path-based chmod and its lookup race.
+/// through a path-based chmod and its lookup race. What this attests is
+/// exactly that: each present path is a regular file with no group or other
+/// permission bits. It does not compare inode identity with the files SQLite
+/// opened, and an absent path is skipped, not refused.
 #[cfg(unix)]
 fn verify_events_db_owner_only_unopened(db_path: &Path) -> anyhow::Result<()> {
     use std::os::unix::fs::PermissionsExt;

--- a/crates/khive-runtime/src/events_split.rs
+++ b/crates/khive-runtime/src/events_split.rs
@@ -716,6 +716,15 @@ fn harden_events_db_sidecars(db_path: &Path) -> anyhow::Result<()> {
                 )
             }
         };
+        // The open succeeds on a directory too; fstat the handle (no path
+        // re-lookup) so a directory at the path is refused, never chmod'ed.
+        if !file.metadata()?.file_type().is_file() {
+            anyhow::bail!(
+                "refusing to serve events: {} is not a regular file. The events \
+                 database and its sidecars must be regular files.",
+                path.display()
+            );
+        }
         file.set_permissions(std::fs::Permissions::from_mode(0o600))
             .map_err(|e| {
                 anyhow::anyhow!(
@@ -2306,6 +2315,20 @@ mod tests {
             !sidecar.exists(),
             "refusal must precede creation of the events database"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn hardening_refuses_a_directory_at_the_database_path_without_touching_it() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("events.db");
+        std::fs::create_dir(&db).unwrap();
+        std::fs::set_permissions(&db, std::fs::Permissions::from_mode(0o700)).unwrap();
+        let err = harden_events_db_sidecars(&db).unwrap_err().to_string();
+        assert!(err.contains("not a regular file"), "{err}");
+        let mode = std::fs::metadata(&db).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o700, "the directory keeps its mode");
     }
 
     #[test]

--- a/crates/kkernel/tests/events_daemon_keeps_sqlite_locks.rs
+++ b/crates/kkernel/tests/events_daemon_keeps_sqlite_locks.rs
@@ -31,6 +31,12 @@ const SHARED_SIZE: i64 = 510;
 /// The `-shm` byte every connection with an open WAL index holds shared
 /// (`UNIX_SHM_DMS`).
 const SHM_DMS_BYTE: i64 = 128;
+/// The libc crate types `F_WRLCK`/`F_RDLCK` as `c_short` on macOS and as
+/// `c_int` on Linux, while `flock.l_type` is `c_short` on both.
+#[allow(clippy::unnecessary_cast)]
+const F_WRLCK: libc::c_short = libc::F_WRLCK as libc::c_short;
+#[allow(clippy::unnecessary_cast)]
+const F_RDLCK: libc::c_short = libc::F_RDLCK as libc::c_short;
 
 /// Ask the kernel, from this process, whether an exclusive lock over
 /// `[start, start + len)` of `path` would conflict with a lock held by another
@@ -43,7 +49,7 @@ fn conflicting_lock(path: &Path, start: i64, len: i64) -> libc::flock {
         .unwrap_or_else(|e| panic!("open {} for F_GETLK: {e}", path.display()));
     // SAFETY: `flock` is plain data; every field is set below or zero.
     let mut lock: libc::flock = unsafe { std::mem::zeroed() };
-    lock.l_type = libc::F_WRLCK;
+    lock.l_type = F_WRLCK;
     lock.l_whence = libc::SEEK_SET as libc::c_short;
     lock.l_start = start;
     lock.l_len = len;
@@ -126,7 +132,7 @@ fn events_daemon_keeps_shared_locks_on_its_database_while_idle() {
     let check = |label: &str, lock: libc::flock, path: &Path| {
         assert_eq!(
             lock.l_type,
-            libc::F_RDLCK,
+            F_RDLCK,
             "{label}: the idle events daemon must hold a shared lock on {} (F_GETLK type {})",
             path.display(),
             lock.l_type

--- a/crates/kkernel/tests/events_daemon_keeps_sqlite_locks.rs
+++ b/crates/kkernel/tests/events_daemon_keeps_sqlite_locks.rs
@@ -21,7 +21,7 @@
 
 use std::os::fd::AsRawFd;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
 /// SQLite's pending byte and the SHARED range above it (`os_unix.c`).
@@ -37,6 +37,15 @@ const SHM_DMS_BYTE: i64 = 128;
 const F_WRLCK: libc::c_short = libc::F_WRLCK as libc::c_short;
 #[allow(clippy::unnecessary_cast)]
 const F_RDLCK: libc::c_short = libc::F_RDLCK as libc::c_short;
+
+struct DaemonGuard(Child);
+
+impl Drop for DaemonGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
 
 /// Ask the kernel, from this process, whether an exclusive lock over
 /// `[start, start + len)` of `path` would conflict with a lock held by another
@@ -84,7 +93,7 @@ fn events_daemon_keeps_shared_locks_on_its_database_while_idle() {
     let stderr_path = dir.path().join("daemon.stderr");
     let stderr = std::fs::File::create(&stderr_path).unwrap();
 
-    let mut child = Command::new(env!("CARGO_BIN_EXE_kkernel"))
+    let child = Command::new(env!("CARGO_BIN_EXE_kkernel"))
         .arg("events-daemon")
         .arg("--db")
         .arg(&db)
@@ -97,6 +106,8 @@ fn events_daemon_keeps_shared_locks_on_its_database_while_idle() {
         .stderr(Stdio::from(stderr))
         .spawn()
         .expect("spawn events daemon");
+    let mut daemon = DaemonGuard(child);
+    let child = &mut daemon.0;
 
     // Readiness: the daemon binds the socket only after the schema is ensured,
     // which is after SQLite opened the database and its WAL. Cold builds and

--- a/crates/kkernel/tests/events_daemon_keeps_sqlite_locks.rs
+++ b/crates/kkernel/tests/events_daemon_keeps_sqlite_locks.rs
@@ -1,0 +1,158 @@
+//! The events daemon must hold SQLite's advisory locks on its database for as
+//! long as it serves it.
+//!
+//! In WAL mode every open connection keeps a SHARED lock on the database file
+//! and a shared lock on the `-shm` "DMS" byte; those locks are how any other
+//! connection learns, when it closes, that it is not the last one and must
+//! leave the `-wal`/`-shm` sidecars alone. POSIX advisory locks are per
+//! process and per inode and are released by the close of ANY descriptor for
+//! the inode, so a daemon that opens and closes a descriptor on its own
+//! database after SQLite did (a permission pass, an integrity peek) drops the
+//! locks without SQLite noticing. An external connection closing afterwards
+//! then checkpoints and unlinks the sidecars underneath the daemon, which keeps
+//! writing to the unlinked inodes.
+//!
+//! Locks are invisible to the process that holds them (`F_GETLK` never reports
+//! a conflict with one's own locks), so the check has to be cross-process: this
+//! test runs the real daemon subcommand as a child and probes both ranges from
+//! here with `F_GETLK`, which answers with the type and the pid of a
+//! conflicting holder.
+#![cfg(unix)]
+
+use std::os::fd::AsRawFd;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// SQLite's pending byte and the SHARED range above it (`os_unix.c`).
+const PENDING_BYTE: i64 = 0x4000_0000;
+const SHARED_FIRST: i64 = PENDING_BYTE + 2;
+const SHARED_SIZE: i64 = 510;
+/// The `-shm` byte every connection with an open WAL index holds shared
+/// (`UNIX_SHM_DMS`).
+const SHM_DMS_BYTE: i64 = 128;
+
+/// Ask the kernel, from this process, whether an exclusive lock over
+/// `[start, start + len)` of `path` would conflict with a lock held by another
+/// process. Returns the conflicting lock as the kernel describes it: `l_type`
+/// is `F_UNLCK` when nothing conflicts, else the holder's type and pid.
+fn conflicting_lock(path: &Path, start: i64, len: i64) -> libc::flock {
+    // Opening and closing this descriptor releases only THIS process's locks
+    // on the inode, of which there are none.
+    let file = std::fs::File::open(path)
+        .unwrap_or_else(|e| panic!("open {} for F_GETLK: {e}", path.display()));
+    // SAFETY: `flock` is plain data; every field is set below or zero.
+    let mut lock: libc::flock = unsafe { std::mem::zeroed() };
+    lock.l_type = libc::F_WRLCK;
+    lock.l_whence = libc::SEEK_SET as libc::c_short;
+    lock.l_start = start;
+    lock.l_len = len;
+    // SAFETY: `fd` is a live descriptor owned by `file` for the call; `lock`
+    // is a valid `flock` the kernel fills in.
+    let rc = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_GETLK, &mut lock) };
+    assert_eq!(
+        rc,
+        0,
+        "F_GETLK on {}: {}",
+        path.display(),
+        std::io::Error::last_os_error()
+    );
+    lock
+}
+
+fn sidecar(db: &Path, suffix: &str) -> PathBuf {
+    let mut name = db.as_os_str().to_os_string();
+    name.push(suffix);
+    PathBuf::from(name)
+}
+
+#[test]
+fn events_daemon_keeps_shared_locks_on_its_database_while_idle() {
+    use std::os::unix::fs::PermissionsExt;
+    let dir = tempfile::tempdir().unwrap();
+    // The daemon validates the socket directory's ownership and mode before
+    // binding; a private directory passes.
+    std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+    let db = dir.path().join("events.db");
+    let socket = dir.path().join("events.sock");
+    let stderr_path = dir.path().join("daemon.stderr");
+    let stderr = std::fs::File::create(&stderr_path).unwrap();
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_kkernel"))
+        .arg("events-daemon")
+        .arg("--db")
+        .arg(&db)
+        .arg("--socket")
+        .arg(&socket)
+        .current_dir(dir.path())
+        .env_remove("KHIVE_DB")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::from(stderr))
+        .spawn()
+        .expect("spawn events daemon");
+
+    // Readiness: the daemon binds the socket only after the schema is ensured,
+    // which is after SQLite opened the database and its WAL. Cold builds and
+    // loaded machines make this slow; the bound is generous and the failure
+    // message carries the child's stderr.
+    let deadline = Instant::now() + Duration::from_secs(60);
+    while !socket.exists() {
+        if let Some(status) = child.try_wait().unwrap() {
+            panic!(
+                "events daemon exited before binding: {status}\n{}",
+                std::fs::read_to_string(&stderr_path).unwrap_or_default()
+            );
+        }
+        assert!(
+            Instant::now() < deadline,
+            "events daemon did not bind {} in time\n{}",
+            socket.display(),
+            std::fs::read_to_string(&stderr_path).unwrap_or_default()
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    let wal = sidecar(&db, "-wal");
+    let shm = sidecar(&db, "-shm");
+    assert!(wal.exists(), "WAL mode leaves {} on disk", wal.display());
+    assert!(shm.exists(), "WAL mode leaves {} on disk", shm.display());
+
+    let probe = || {
+        let db_lock = conflicting_lock(&db, SHARED_FIRST, SHARED_SIZE);
+        let dms_lock = conflicting_lock(&shm, SHM_DMS_BYTE, 1);
+        (db_lock, dms_lock)
+    };
+    let daemon_pid = child.id() as libc::pid_t;
+    let check = |label: &str, lock: libc::flock, path: &Path| {
+        assert_eq!(
+            lock.l_type,
+            libc::F_RDLCK,
+            "{label}: the idle events daemon must hold a shared lock on {} (F_GETLK type {})",
+            path.display(),
+            lock.l_type
+        );
+        assert_eq!(
+            lock.l_pid,
+            daemon_pid,
+            "{label}: the shared lock on {} must be the daemon's",
+            path.display()
+        );
+    };
+
+    let (db_lock, dms_lock) = probe();
+    check("database SHARED range", db_lock, &db);
+    check("shm DMS byte", dms_lock, &shm);
+
+    // The locks are not a boot-time artifact: they are still held after the
+    // daemon has been idle for a while and after this process has opened and
+    // closed the files several more times.
+    std::thread::sleep(Duration::from_millis(500));
+    for _ in 0..3 {
+        let (db_lock, dms_lock) = probe();
+        check("database SHARED range, idle", db_lock, &db);
+        check("shm DMS byte, idle", dms_lock, &shm);
+    }
+
+    child.kill().unwrap();
+    let _ = child.wait();
+}


### PR DESCRIPTION
## Summary

The events daemon ran the owner-only hardening of its database and `-wal`/`-shm` sidecars after the pool had opened them. Hardening opens and closes a descriptor on each file, and POSIX advisory locks are per process and per inode, released by the close of any descriptor for the inode, so the SHARED lock SQLite keeps on the database in WAL mode and the shared lock on the `-shm` DMS byte were dropped while SQLite believed it still held them. An external connection closing later (a backup tool, an inspection shell) took itself for the last connection, checkpointed, and unlinked the sidecars underneath the daemon, which kept writing to the unlinked inodes; every other opener then read the database as malformed.

## Changes

- Hardening runs before the pool opens; a post-open check verifies the file set with `lstat` only and refuses to serve on a loosened or replaced entry; the hardening function documents its precondition.
- A cross-process test runs the real `events-daemon` subcommand and asserts with `F_GETLK` that the daemon holds both shared locks at bind and while idle; the lock constants are typed once so the test compiles on macOS and Linux.
- CHANGELOG entry.

Supersedes #2397, narrowed to the fix and its regression test. The broader sidecar-identity hardening explored on that branch (held databases resolved by inode, moved-away sidecars, read-only holders) is deferred to a follow-up.

Assessed and not changed: the read-only backend header probe in the database pool opens the header outside SQLite before that pool has connections; latent for a same-process live holder, outside this fix.
