### PR TITLE
feat(knowledge): expose bounded lexical timeout diagnostics

### DIFF
--- a/crates/khive-pack-knowledge/docs/design.md
+++ b/crates/khive-pack-knowledge/docs/design.md
@@ -132,7 +132,11 @@
   lexical-only degradation with request time left to spare still gets a full rerank pass; the
   `lexical_timeout` degradation flag is still attached to the response whenever the stage itself
   timed out, independent of whether the rest of the request completed normally.
-- `degraded.lexical_timeout` remains a boolean. When a timed-out read's phase can be disclosed
+- `degraded.lexical_timeout` remains a boolean. On instrumented builds, every response with
+  `degraded.lexical_timeout=true` also carries `degraded.lexical_timeout_instrumented=true`,
+  regardless of whether any phase is withheld. This marker identifies build capability, not
+  hidden execution details; healthy lexical responses omit it entirely, never emitting false.
+  When a timed-out read's phase can be disclosed
   without exposing global-index match presence, `degraded.lexical_timeout_details` adds at most
   one record per lexical pass (`full`, `subquery_1`, `subquery_2`), at most three records total.
   Each record contains `pass`, `phase`, `stage_elapsed_ms`, `operation_elapsed_ms`,
@@ -146,7 +150,8 @@
   entry does not depend on corpus contents. The later `phase_a_rowids`, `phase_b_hydration`,
   `eligibility_fallback`, `namespace_membership`, and `recent_fallback` records are operator-only:
   their reachability can change with foreign-index matches even when local results do not.
-  Responses with only operator-only records retain the boolean and omit the details list.
+  Responses with only operator-only records retain both booleans and omit the details list.
+  The public list can omit records and is not a complete execution ledger, even when non-empty.
   All seven phases emit the same structured timing fields through tracing, with no SQL, query
   text, row identifiers, namespace names, row counts, or byte counts. A phase identifies where
   the timeout was observed, not why the allowance was exhausted. Pooled-reader waiting occurs

--- a/crates/khive-pack-knowledge/docs/design.md
+++ b/crates/khive-pack-knowledge/docs/design.md
@@ -132,6 +132,25 @@
   lexical-only degradation with request time left to spare still gets a full rerank pass; the
   `lexical_timeout` degradation flag is still attached to the response whenever the stage itself
   timed out, independent of whether the rest of the request completed normally.
+- `degraded.lexical_timeout` remains a boolean. When a timed-out read's phase can be disclosed
+  without exposing global-index match presence, `degraded.lexical_timeout_details` adds at most
+  one record per lexical pass (`full`, `subquery_1`, `subquery_2`), at most three records total.
+  Each record contains `pass`, `phase`, `stage_elapsed_ms`, `operation_elapsed_ms`,
+  `configured_budget_ms`, and `effective_budget_ms`. Milliseconds are monotonic durations,
+  truncated to integers and captured when the failed read returns. The effective budget is the
+  remaining deadline allowance at stage entry, including an earlier parent deadline; it is not
+  reset after cancellation or sampled after leaving the scope. Stage elapsed includes earlier
+  work in the pass, while operation elapsed covers just the failed read attempt, including
+  waiting and cleanup. Neither is an attribution of deadline expiry versus cancellation.
+  Healthy responses omit the list. Public phases are `reader_open` and `term_frequency`, whose
+  entry does not depend on corpus contents. The later `phase_a_rowids`, `phase_b_hydration`,
+  `eligibility_fallback`, `namespace_membership`, and `recent_fallback` records are operator-only:
+  their reachability can change with foreign-index matches even when local results do not.
+  Responses with only operator-only records retain the boolean and omit the details list.
+  All seven phases emit the same structured timing fields through tracing, with no SQL, query
+  text, row identifiers, namespace names, row counts, or byte counts. A phase identifies where
+  the timeout was observed, not why the allowance was exhausted. Pooled-reader waiting occurs
+  inside query calls and cannot be separated from execution without separate backend timing.
 - `load_domain_member_token_sizes` (member-token pricing for `suggest`'s `results[].size`) returns
   a `(HashMap<String, usize>, bool)` — the `bool` marks whether the whole batch timed out before
   any domain could be measured. A single `query_all` call has no partial-completion state, so one

--- a/crates/khive-pack-knowledge/src/knowledge/lexical_timeout.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/lexical_timeout.rs
@@ -105,7 +105,7 @@ impl LexicalStage {
     ) -> Result<T, StorageError> {
         let operation_started = Instant::now();
         #[cfg(test)]
-        if let Some(error) = tests::inject_timeout(phase).await {
+        if let Some(error) = tests::inject_timeout(self.pass, phase).await {
             self.capture_timeout(phase, operation_started);
             return Err(error);
         }
@@ -144,7 +144,7 @@ pub(super) mod tests {
     use super::*;
 
     tokio::task_local! {
-        static INJECT: (Vec<LexicalPhase>, Duration);
+        static INJECT: (Vec<(LexicalPass, LexicalPhase)>, Duration);
     }
 
     pub(in crate::knowledge) async fn with_timeout<F: Future>(
@@ -152,12 +152,34 @@ pub(super) mod tests {
         elapsed: Duration,
         future: F,
     ) -> F::Output {
-        INJECT.scope((phases, elapsed), future).await
+        let targets = phases
+            .into_iter()
+            .flat_map(|phase| {
+                [
+                    LexicalPass::Full,
+                    LexicalPass::Subquery1,
+                    LexicalPass::Subquery2,
+                ]
+                .map(|pass| (pass, phase))
+            })
+            .collect();
+        with_pass_timeouts(targets, elapsed, future).await
     }
 
-    pub(super) async fn inject_timeout(phase: LexicalPhase) -> Option<StorageError> {
+    pub(in crate::knowledge) async fn with_pass_timeouts<F: Future>(
+        targets: Vec<(LexicalPass, LexicalPhase)>,
+        elapsed: Duration,
+        future: F,
+    ) -> F::Output {
+        INJECT.scope((targets, elapsed), future).await
+    }
+
+    pub(super) async fn inject_timeout(
+        pass: LexicalPass,
+        phase: LexicalPhase,
+    ) -> Option<StorageError> {
         let elapsed = INJECT
-            .try_with(|(phases, elapsed)| phases.contains(&phase).then_some(*elapsed))
+            .try_with(|(targets, elapsed)| targets.contains(&(pass, phase)).then_some(*elapsed))
             .ok()
             .flatten()?;
         tokio::time::advance(elapsed).await;

--- a/crates/khive-pack-knowledge/src/knowledge/lexical_timeout.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/lexical_timeout.rs
@@ -1,0 +1,289 @@
+use std::{future::Future, time::Duration};
+
+use khive_storage::{capture_request_read_context, StorageError};
+use serde::Serialize;
+use tokio::time::Instant;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum LexicalPass {
+    Full,
+    #[serde(rename = "subquery_1")]
+    Subquery1,
+    #[serde(rename = "subquery_2")]
+    Subquery2,
+}
+
+impl LexicalPass {
+    pub(super) fn label(self) -> &'static str {
+        match self {
+            Self::Full => "full",
+            Self::Subquery1 => "subquery_1",
+            Self::Subquery2 => "subquery_2",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum LexicalPhase {
+    ReaderOpen,
+    TermFrequency,
+    PhaseARowids,
+    PhaseBHydration,
+    EligibilityFallback,
+    NamespaceMembership,
+    RecentFallback,
+}
+
+impl LexicalPhase {
+    pub(super) fn label(self) -> &'static str {
+        match self {
+            Self::ReaderOpen => "reader_open",
+            Self::TermFrequency => "term_frequency",
+            Self::PhaseARowids => "phase_a_rowids",
+            Self::PhaseBHydration => "phase_b_hydration",
+            Self::EligibilityFallback => "eligibility_fallback",
+            Self::NamespaceMembership => "namespace_membership",
+            Self::RecentFallback => "recent_fallback",
+        }
+    }
+
+    pub(super) fn public(self) -> bool {
+        // Later phases depend on global-index matches before namespace filtering.
+        // Even their presence, without row counts, can reveal foreign matches.
+        matches!(self, Self::ReaderOpen | Self::TermFrequency)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+pub(super) struct LexicalTimeout {
+    pub(super) pass: LexicalPass,
+    pub(super) phase: LexicalPhase,
+    pub(super) stage_elapsed_ms: u64,
+    pub(super) operation_elapsed_ms: u64,
+    pub(super) configured_budget_ms: u64,
+    pub(super) effective_budget_ms: u64,
+}
+
+fn millis(duration: Duration) -> u64 {
+    duration.as_millis().min(u64::MAX as u128) as u64
+}
+
+pub(super) struct LexicalStage {
+    pass: LexicalPass,
+    started: Instant,
+    configured_budget_ms: u64,
+    effective_budget_ms: u64,
+    pub(super) timeout: Option<LexicalTimeout>,
+}
+
+impl LexicalStage {
+    pub(super) fn new(pass: LexicalPass, started: Instant, configured: Duration) -> Self {
+        let effective = capture_request_read_context()
+            .deadline()
+            .map(|deadline| {
+                deadline
+                    .async_at()
+                    .saturating_duration_since(Instant::now())
+            })
+            .unwrap_or(configured)
+            .min(configured);
+        Self {
+            pass,
+            started,
+            configured_budget_ms: millis(configured),
+            effective_budget_ms: millis(effective),
+            timeout: None,
+        }
+    }
+
+    pub(super) async fn read<T>(
+        &mut self,
+        phase: LexicalPhase,
+        read: impl Future<Output = Result<T, StorageError>>,
+    ) -> Result<T, StorageError> {
+        let operation_started = Instant::now();
+        #[cfg(test)]
+        if let Some(error) = tests::inject_timeout(phase).await {
+            self.capture_timeout(phase, operation_started);
+            return Err(error);
+        }
+        let result = read.await;
+        if matches!(&result, Err(StorageError::Timeout { .. })) {
+            self.capture_timeout(phase, operation_started);
+        }
+        result
+    }
+
+    fn capture_timeout(&mut self, phase: LexicalPhase, operation_started: Instant) {
+        let now = Instant::now();
+        let detail = LexicalTimeout {
+            pass: self.pass,
+            phase,
+            stage_elapsed_ms: millis(now.saturating_duration_since(self.started)),
+            operation_elapsed_ms: millis(now.saturating_duration_since(operation_started)),
+            configured_budget_ms: self.configured_budget_ms,
+            effective_budget_ms: self.effective_budget_ms,
+        };
+        tracing::warn!(
+            pass = detail.pass.label(),
+            phase = detail.phase.label(),
+            stage_elapsed_ms = detail.stage_elapsed_ms,
+            operation_elapsed_ms = detail.operation_elapsed_ms,
+            configured_budget_ms = detail.configured_budget_ms,
+            effective_budget_ms = detail.effective_budget_ms,
+            "lexical read timed out"
+        );
+        self.timeout = Some(detail);
+    }
+}
+
+#[cfg(test)]
+pub(super) mod tests {
+    use super::*;
+
+    tokio::task_local! {
+        static INJECT: (Vec<LexicalPhase>, Duration);
+    }
+
+    pub(in crate::knowledge) async fn with_timeout<F: Future>(
+        phases: Vec<LexicalPhase>,
+        elapsed: Duration,
+        future: F,
+    ) -> F::Output {
+        INJECT.scope((phases, elapsed), future).await
+    }
+
+    pub(super) async fn inject_timeout(phase: LexicalPhase) -> Option<StorageError> {
+        let elapsed = INJECT
+            .try_with(|(phases, elapsed)| phases.contains(&phase).then_some(*elapsed))
+            .ok()
+            .flatten()?;
+        tokio::time::advance(elapsed).await;
+        Some(StorageError::Timeout {
+            operation: "test.lexical_read".into(),
+        })
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn earlier_deadline_and_cancellation_keep_the_entry_allowance() {
+        for cancel in [false, true] {
+            let (tx, rx) = tokio::sync::watch::channel(false);
+            khive_storage::scope_request_read_cancellation(
+                rx,
+                khive_storage::scope_request_read_deadline(Duration::from_millis(100), async {
+                    tokio::time::advance(Duration::from_millis(30)).await;
+                    let started = Instant::now();
+                    khive_storage::scope_request_read_deadline(
+                        Duration::from_millis(2000),
+                        async {
+                            let mut stage = LexicalStage::new(
+                                LexicalPass::Full,
+                                started,
+                                Duration::from_millis(2000),
+                            );
+                            let elapsed = if cancel { 11 } else { 70 };
+                            let result = stage
+                                .read(LexicalPhase::TermFrequency, async {
+                                    tokio::time::advance(Duration::from_millis(elapsed)).await;
+                                    if cancel {
+                                        tx.send(true).expect("cancel receiver alive");
+                                    }
+                                    khive_storage::ensure_request_read_active("test.read")
+                                })
+                                .await;
+                            assert!(matches!(result, Err(StorageError::Timeout { .. })));
+                            let detail = stage.timeout.expect("missing timeout detail");
+                            assert_eq!(detail.effective_budget_ms, 70);
+                            assert_eq!(detail.configured_budget_ms, 2000);
+                            assert_eq!(detail.operation_elapsed_ms, elapsed);
+                            assert_eq!(detail.stage_elapsed_ms, elapsed);
+                            assert!(serde_json::to_value(detail).unwrap().get("cause").is_none());
+                        },
+                    )
+                    .await;
+                }),
+            )
+            .await;
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn timings_are_per_operation_and_frozen_before_downstream_work() {
+        let started = Instant::now();
+        khive_storage::scope_request_read_deadline(Duration::from_millis(2000), async {
+            let mut stage =
+                LexicalStage::new(LexicalPass::Full, started, Duration::from_millis(2000));
+            stage
+                .read(LexicalPhase::TermFrequency, async {
+                    tokio::time::advance(Duration::from_millis(25)).await;
+                    Ok(())
+                })
+                .await
+                .unwrap();
+            let result: Result<(), StorageError> = stage
+                .read(LexicalPhase::TermFrequency, async {
+                    tokio::time::advance(Duration::from_millis(7)).await;
+                    Err(StorageError::Timeout {
+                        operation: "test.read".into(),
+                    })
+                })
+                .await;
+            assert!(result.is_err());
+            tokio::time::advance(Duration::from_millis(4000)).await;
+            let detail = stage.timeout.expect("missing timeout detail");
+            assert_eq!(detail.stage_elapsed_ms, 32);
+            assert_eq!(detail.operation_elapsed_ms, 7);
+            assert_eq!(detail.effective_budget_ms, 2000);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn non_timeout_errors_do_not_create_diagnostics() {
+        let mut stage = LexicalStage::new(
+            LexicalPass::Full,
+            Instant::now(),
+            Duration::from_millis(2000),
+        );
+        let result: Result<(), StorageError> = stage
+            .read(LexicalPhase::ReaderOpen, async {
+                Err(StorageError::AdmissionTimeout {
+                    operation: "test.admission".into(),
+                    timeout_ms: 5,
+                })
+            })
+            .await;
+        assert!(matches!(
+            result,
+            Err(StorageError::AdmissionTimeout { timeout_ms: 5, .. })
+        ));
+        assert!(stage.timeout.is_none());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn expired_parent_has_zero_allowance() {
+        khive_storage::scope_request_read_deadline(Duration::from_millis(5), async {
+            tokio::time::advance(Duration::from_millis(8)).await;
+            let started = Instant::now();
+            khive_storage::scope_request_read_deadline(Duration::from_millis(2000), async {
+                let mut stage =
+                    LexicalStage::new(LexicalPass::Full, started, Duration::from_millis(2000));
+                assert!(stage
+                    .read(LexicalPhase::ReaderOpen, async {
+                        khive_storage::ensure_request_read_active("test.expired")
+                    })
+                    .await
+                    .is_err());
+                let detail = stage.timeout.expect("missing expired timeout detail");
+                assert_eq!(detail.effective_budget_ms, 0);
+                assert_eq!(detail.configured_budget_ms, 2000);
+                assert_eq!(detail.stage_elapsed_ms, 0);
+                assert_eq!(detail.operation_elapsed_ms, 0);
+            })
+            .await;
+        })
+        .await;
+    }
+}

--- a/crates/khive-pack-knowledge/src/knowledge/lexical_timeout_tests.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/lexical_timeout_tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::knowledge::lexical_timeout::tests::with_timeout;
+use crate::knowledge::lexical_timeout::tests::{with_pass_timeouts, with_timeout};
 use khive_pack_kg::KgPack;
 use khive_runtime::{VerbRegistry, VerbRegistryBuilder};
 use std::{
@@ -213,6 +213,13 @@ async fn public_dispatch_preserves_boolean_and_all_three_pass_tags() {
             .unwrap()
             .remove("lexical_timeout_details");
         assert_eq!(
+            response["degraded"]
+                .as_object_mut()
+                .unwrap()
+                .remove("lexical_timeout_instrumented"),
+            Some(json!(true))
+        );
+        assert_eq!(
             response,
             json!({"results": [], "total": 0, "degraded": {"lexical_timeout": true}}),
             "legacy empty-timeout response must be unchanged: {verb}"
@@ -239,6 +246,10 @@ async fn healthy_dispatch_omits_timeout_details() {
         assert!(response
             .get("degraded")
             .and_then(|d| d.get("lexical_timeout"))
+            .is_none());
+        assert!(response
+            .get("degraded")
+            .and_then(|d| d.get("lexical_timeout_instrumented"))
             .is_none());
         assert_eq!(
             response["total"],
@@ -294,7 +305,8 @@ async fn public_details_do_not_reveal_foreign_matches_or_data_dependent_phases()
             assert_eq!(
                 response,
                 json!({"results": [], "total": 0, "degraded": {
-                    "lexical_timeout": true, "lexical_timeout_details": [{
+                    "lexical_timeout": true, "lexical_timeout_instrumented": true,
+                    "lexical_timeout_details": [{
                         "pass": "full", "phase": phase.label(), "stage_elapsed_ms": 11,
                         "operation_elapsed_ms": 11, "configured_budget_ms": 2000, "effective_budget_ms": 2000,
                     }]
@@ -314,7 +326,85 @@ async fn public_details_do_not_reveal_foreign_matches_or_data_dependent_phases()
     );
     assert_eq!(
         responses[0],
-        json!({"results": [], "total": 0, "degraded": {"lexical_timeout": true}})
+        json!({"results": [], "total": 0, "degraded": {
+            "lexical_timeout": true, "lexical_timeout_instrumented": true
+        }})
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn mixed_pass_capability_marker_does_not_reveal_foreign_matches() {
+    let mut responses = Vec::new();
+    for foreign in [false, true] {
+        let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+        if foreign {
+            let sql = runtime.sql();
+            let mut writer = sql.writer().await.expect("writer");
+            writer.execute(SqlStatement {
+                sql: "INSERT INTO knowledge_atoms (id, namespace, slug, name, content, tags, finalized, status, created_at, updated_at) VALUES (?1, ?2, ?3, ?3, ?4, '[]', 1, 'reviewed', 0, 0)".into(),
+                params: [
+                    "10000000-0000-0000-0000-000000000002", "tenant-b",
+                    "foreign-control", "zzoraclezz",
+                ].into_iter().map(|value| SqlValue::Text(value.into())).collect(),
+                label: None,
+            }).await.expect("seed foreign row with no local rows");
+        }
+        let registry = registry(&runtime);
+        let events = TimeoutEvents::default();
+        // The full pass is identical; only the foreign match enables the hidden read.
+        let response = with_pass_timeouts(
+            vec![
+                (LexicalPass::Full, LexicalPhase::TermFrequency),
+                (LexicalPass::Subquery1, LexicalPhase::PhaseARowids),
+            ],
+            Duration::from_millis(11),
+            registry.dispatch(
+                "knowledge.search",
+                json!({
+                    "query": "zzoraclezz alphazz betazz gammazz",
+                    "decompose": true, "rerank": false,
+                }),
+            ),
+        )
+        .with_subscriber(events.clone())
+        .await
+        .expect("mixed-pass public dispatch");
+        let observed: Vec<_> = events
+            .0
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|detail| (detail["pass"].clone(), detail["phase"].clone()))
+            .collect();
+        let mut expected = vec![(json!("full"), json!("term_frequency"))];
+        if foreign {
+            expected.push((json!("subquery_1"), json!("phase_a_rowids")));
+        }
+        assert_eq!(
+            observed, expected,
+            "positive control: only the foreign corpus enables the hidden timeout"
+        );
+        assert_eq!(
+            response["degraded"]["lexical_timeout_instrumented"], true,
+            "capability marker must be true regardless of hidden records: foreign={foreign}"
+        );
+        assert_eq!(
+            response,
+            json!({"results": [], "total": 0, "degraded": {
+                "lexical_timeout": true, "lexical_timeout_instrumented": true,
+                "lexical_timeout_details": [{
+                    "pass": "full", "phase": "term_frequency",
+                    "stage_elapsed_ms": 11, "operation_elapsed_ms": 11,
+                    "configured_budget_ms": 2000, "effective_budget_ms": 2000,
+                }]
+            }}),
+            "both corpora must disclose exactly the same public record"
+        );
+        responses.push(serde_json::to_vec(&response).expect("serialize public JSON"));
+    }
+    assert_eq!(
+        responses[0], responses[1],
+        "public JSON must be byte-identical despite different hidden timeout records"
     );
 }
 
@@ -343,6 +433,13 @@ fn attachment_preserves_other_degradation_fields_and_hides_operator_only_phases(
                 effective_budget_ms: 70,
             }],
         );
+        assert_eq!(
+            response["degraded"]
+                .as_object_mut()
+                .unwrap()
+                .remove("lexical_timeout_instrumented"),
+            Some(json!(true))
+        );
         assert_eq!(response, base);
     }
     let mut public = base.clone();
@@ -356,6 +453,13 @@ fn attachment_preserves_other_degradation_fields_and_hides_operator_only_phases(
             configured_budget_ms: 2000,
             effective_budget_ms: 70,
         }],
+    );
+    assert_eq!(
+        public["degraded"]
+            .as_object_mut()
+            .unwrap()
+            .remove("lexical_timeout_instrumented"),
+        Some(json!(true))
     );
     let detail = public["degraded"]
         .as_object_mut()
@@ -488,6 +592,13 @@ async fn partial_scored_candidates_match_the_base_rare_term_fixture() {
         );
         let mut legacy = json!({});
         attach_lexical_timeout_degradation(&mut legacy, &outcome.lexical_timeouts);
+        assert_eq!(
+            legacy["degraded"]
+                .as_object_mut()
+                .unwrap()
+                .remove("lexical_timeout_instrumented"),
+            Some(json!(true))
+        );
         assert_eq!(legacy, json!({"degraded": {"lexical_timeout": true}}));
     }
 }

--- a/crates/khive-pack-knowledge/src/knowledge/lexical_timeout_tests.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/lexical_timeout_tests.rs
@@ -1,0 +1,520 @@
+use super::*;
+use crate::knowledge::lexical_timeout::tests::with_timeout;
+use khive_pack_kg::KgPack;
+use khive_runtime::{VerbRegistry, VerbRegistryBuilder};
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+use tracing::{field::Visit, instrument::WithSubscriber, span, Event, Metadata, Subscriber};
+
+fn registry(runtime: &KhiveRuntime) -> VerbRegistry {
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(runtime.clone()));
+    builder.register(crate::KnowledgePack::new(runtime.clone()));
+    let registry = builder.build().expect("registry");
+    runtime.install_edge_rules(registry.all_edge_rules());
+    registry
+}
+
+async fn fixture(foreign: bool) -> KhiveRuntime {
+    let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+    let sql = runtime.sql();
+    let mut writer = sql.writer().await.expect("writer");
+    for (id, ns, slug, content) in [
+        (
+            "10000000-0000-0000-0000-000000000001",
+            "local",
+            "local-control",
+            "unrelated background",
+        ),
+        (
+            "10000000-0000-0000-0000-000000000002",
+            "tenant-b",
+            "foreign-control",
+            "zzoraclezz",
+        ),
+    ]
+    .into_iter()
+    .take(if foreign { 2 } else { 1 })
+    {
+        writer.execute(SqlStatement {
+            sql: "INSERT INTO knowledge_atoms (id, namespace, slug, name, content, tags, finalized, status, created_at, updated_at) VALUES (?1, ?2, ?3, ?3, ?4, '[]', 1, 'reviewed', 0, 0)".into(),
+            params: [id, ns, slug, content].into_iter().map(|value| SqlValue::Text(value.into())).collect(),
+            label: None,
+        }).await.expect("seed fixture");
+    }
+    drop(writer);
+    runtime
+}
+
+async fn fetch(runtime: &KhiveRuntime, query: &str) -> FtsFetchOutcome {
+    let configured = lexical_stage_budget();
+    let started = tokio::time::Instant::now();
+    khive_storage::scope_request_read_deadline(configured, async {
+        fetch_fts_candidates(
+            runtime,
+            "local",
+            query,
+            None,
+            &[],
+            &[],
+            5,
+            LexicalStage::new(LexicalPass::Full, started, configured),
+        )
+        .await
+    })
+    .await
+    .expect("lexical fetch")
+}
+
+#[derive(Clone, Default)]
+struct TimeoutEvents(Arc<Mutex<Vec<Value>>>);
+
+#[derive(Default)]
+struct Fields(serde_json::Map<String, Value>);
+
+impl Visit for Fields {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        self.0
+            .insert(field.name().into(), json!(format!("{value:?}")));
+    }
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        self.0.insert(field.name().into(), json!(value));
+    }
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        self.0.insert(field.name().into(), json!(value));
+    }
+}
+
+impl Subscriber for TimeoutEvents {
+    fn enabled(&self, _: &Metadata<'_>) -> bool {
+        true
+    }
+    fn new_span(&self, _: &span::Attributes<'_>) -> span::Id {
+        span::Id::from_u64(1)
+    }
+    fn record(&self, _: &span::Id, _: &span::Record<'_>) {}
+    fn record_follows_from(&self, _: &span::Id, _: &span::Id) {}
+    fn enter(&self, _: &span::Id) {}
+    fn exit(&self, _: &span::Id) {}
+    fn event(&self, event: &Event<'_>) {
+        let mut fields = Fields::default();
+        event.record(&mut fields);
+        if fields.0.contains_key("stage_elapsed_ms") {
+            fields.0.remove("message");
+            self.0
+                .lock()
+                .expect("events lock")
+                .push(Value::Object(fields.0));
+        }
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn each_catch_site_captures_its_phase_and_identical_structured_event() {
+    let runtime = fixture(true).await;
+    for (phase, label, query) in [
+        (LexicalPhase::ReaderOpen, "reader_open", "zzoraclezz"),
+        (LexicalPhase::TermFrequency, "term_frequency", "zzoraclezz"),
+        (LexicalPhase::PhaseARowids, "phase_a_rowids", "zzoraclezz"),
+        (
+            LexicalPhase::PhaseBHydration,
+            "phase_b_hydration",
+            "zzoraclezz",
+        ),
+        (
+            LexicalPhase::EligibilityFallback,
+            "eligibility_fallback",
+            "zzoraclezz",
+        ),
+        (
+            LexicalPhase::NamespaceMembership,
+            "namespace_membership",
+            "zzoraclezz",
+        ),
+        (
+            LexicalPhase::RecentFallback,
+            "recent_fallback",
+            "zzabsentzz",
+        ),
+    ] {
+        let events = TimeoutEvents::default();
+        let outcome = with_timeout(
+            vec![phase],
+            Duration::from_millis(7),
+            with_phase_a_widen_ceiling_override(1, fetch(&runtime, query)),
+        )
+        .with_subscriber(events.clone())
+        .await;
+        let detail = outcome
+            .timeout
+            .unwrap_or_else(|| panic!("missing timeout detail for {label}"));
+        let expected = json!({
+            "pass": "full", "phase": label,
+            "stage_elapsed_ms": 7, "operation_elapsed_ms": 7,
+            "configured_budget_ms": 2000, "effective_budget_ms": 2000,
+        });
+        assert_eq!(serde_json::to_value(detail).unwrap(), expected, "{label}");
+        assert_eq!(*events.0.lock().unwrap(), vec![expected], "{label}");
+        assert!(
+            outcome.atoms.is_empty(),
+            "base drops the unfinished term: {label}"
+        );
+        tokio::time::advance(Duration::from_millis(123)).await;
+        assert_eq!(
+            detail.stage_elapsed_ms, 7,
+            "elapsed must be frozen at capture"
+        );
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn public_dispatch_preserves_boolean_and_all_three_pass_tags() {
+    let runtime = fixture(false).await;
+    let registry = registry(&runtime);
+    for (verb, decompose, passes) in [
+        ("knowledge.search", false, vec!["full"]),
+        (
+            "knowledge.search",
+            true,
+            vec!["full", "subquery_1", "subquery_2"],
+        ),
+        ("knowledge.suggest", false, vec!["full"]),
+    ] {
+        let mut args = json!({"query": "alpha beta gamma delta epsilon zeta"});
+        if verb == "knowledge.search" {
+            args["decompose"] = json!(decompose);
+            args["rerank"] = json!(false);
+        }
+        let mut response = with_timeout(
+            vec![LexicalPhase::TermFrequency],
+            Duration::from_millis(9),
+            registry.dispatch(verb, args),
+        )
+        .await
+        .expect("public dispatch");
+        let details = response["degraded"]["lexical_timeout_details"]
+            .as_array()
+            .expect("missing public lexical_timeout_details");
+        assert_eq!(details.len(), passes.len(), "one record per executed pass");
+        for (detail, pass) in details.iter().zip(passes) {
+            assert_eq!(
+                *detail,
+                json!({
+                    "pass": pass, "phase": "term_frequency",
+                    "stage_elapsed_ms": 9, "operation_elapsed_ms": 9,
+                    "configured_budget_ms": 2000, "effective_budget_ms": 2000,
+                })
+            );
+        }
+        response["degraded"]
+            .as_object_mut()
+            .unwrap()
+            .remove("lexical_timeout_details");
+        assert_eq!(
+            response,
+            json!({"results": [], "total": 0, "degraded": {"lexical_timeout": true}}),
+            "legacy empty-timeout response must be unchanged: {verb}"
+        );
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn healthy_dispatch_omits_timeout_details() {
+    let runtime = fixture(false).await;
+    let registry = registry(&runtime);
+    for verb in ["knowledge.search", "knowledge.suggest"] {
+        let response = registry
+            .dispatch(
+                verb,
+                json!({"query": "unrelated background alpha beta gamma"}),
+            )
+            .await
+            .expect("healthy public dispatch");
+        assert!(response
+            .get("degraded")
+            .and_then(|d| d.get("lexical_timeout_details"))
+            .is_none());
+        assert!(response
+            .get("degraded")
+            .and_then(|d| d.get("lexical_timeout"))
+            .is_none());
+        assert_eq!(
+            response["total"],
+            if verb == "knowledge.search" { 1 } else { 0 }
+        );
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn public_details_do_not_reveal_foreign_matches_or_data_dependent_phases() {
+    let mut responses = Vec::new();
+    let mut observed = Vec::new();
+    for foreign in [false, true] {
+        let runtime = fixture(foreign).await;
+        let registry = registry(&runtime);
+        let healthy = fetch(&runtime, "zzoraclezz").await;
+        assert_eq!(
+            healthy
+                .atoms
+                .iter()
+                .map(|atom| atom.slug.as_str())
+                .collect::<Vec<_>>(),
+            ["local-control"]
+        );
+        assert!(healthy.timeout.is_none());
+        let events = TimeoutEvents::default();
+        // At the first corpus-dependent read, both arms fail at the same fake time.
+        // The foreign row changes the phase, not the local results or elapsed time.
+        let response = with_timeout(
+            vec![LexicalPhase::PhaseARowids, LexicalPhase::RecentFallback],
+            Duration::from_millis(11),
+            registry.dispatch(
+                "knowledge.search",
+                json!({"query": "zzoraclezz", "rerank": false}),
+            ),
+        )
+        .with_subscriber(events.clone())
+        .await
+        .expect("public dispatch");
+        observed.push(events.0.lock().unwrap()[0]["phase"].clone());
+        responses.push(response);
+        for phase in [LexicalPhase::ReaderOpen, LexicalPhase::TermFrequency] {
+            let response = with_timeout(
+                vec![phase],
+                Duration::from_millis(11),
+                registry.dispatch(
+                    "knowledge.search",
+                    json!({"query": "zzoraclezz", "rerank": false}),
+                ),
+            )
+            .await
+            .expect("public timing-only phase");
+            assert_eq!(
+                response,
+                json!({"results": [], "total": 0, "degraded": {
+                    "lexical_timeout": true, "lexical_timeout_details": [{
+                        "pass": "full", "phase": phase.label(), "stage_elapsed_ms": 11,
+                        "operation_elapsed_ms": 11, "configured_budget_ms": 2000, "effective_budget_ms": 2000,
+                    }]
+                }}),
+                "public diagnostic must not vary with foreign corpus: {foreign}"
+            );
+        }
+    }
+    assert_eq!(
+        observed,
+        vec![json!("recent_fallback"), json!("phase_a_rowids")],
+        "positive control: foreign corpus actually changed the internal phase"
+    );
+    assert_eq!(
+        responses[0], responses[1],
+        "the public response must not disclose that difference"
+    );
+    assert_eq!(
+        responses[0],
+        json!({"results": [], "total": 0, "degraded": {"lexical_timeout": true}})
+    );
+}
+
+#[test]
+fn attachment_preserves_other_degradation_fields_and_hides_operator_only_phases() {
+    let base = json!({"results": [], "degraded": {
+        "lexical_timeout": true, "reason": "ann_unavailable", "mode": "no_match", "cache_safe": false,
+        "body_lines_timeout": true, "hydration_failures": 2, "member_sizing_timeout": ["domain"]
+    }});
+    for phase in [
+        LexicalPhase::PhaseARowids,
+        LexicalPhase::PhaseBHydration,
+        LexicalPhase::EligibilityFallback,
+        LexicalPhase::NamespaceMembership,
+        LexicalPhase::RecentFallback,
+    ] {
+        let mut response = base.clone();
+        attach_lexical_timeout_degradation(
+            &mut response,
+            &[LexicalTimeout {
+                pass: LexicalPass::Full,
+                phase,
+                stage_elapsed_ms: 4,
+                operation_elapsed_ms: 3,
+                configured_budget_ms: 2000,
+                effective_budget_ms: 70,
+            }],
+        );
+        assert_eq!(response, base);
+    }
+    let mut public = base.clone();
+    attach_lexical_timeout_degradation(
+        &mut public,
+        &[LexicalTimeout {
+            pass: LexicalPass::Full,
+            phase: LexicalPhase::TermFrequency,
+            stage_elapsed_ms: 4,
+            operation_elapsed_ms: 3,
+            configured_budget_ms: 2000,
+            effective_budget_ms: 70,
+        }],
+    );
+    let detail = public["degraded"]
+        .as_object_mut()
+        .unwrap()
+        .remove("lexical_timeout_details")
+        .expect("missing public timeout detail");
+    assert_eq!(detail.as_array().unwrap().len(), 1);
+    assert_eq!(
+        public, base,
+        "adding details must preserve every pre-existing field"
+    );
+    attach_lexical_timeout_degradation(&mut public, &[]);
+    assert_eq!(public, base, "healthy attachment must be a no-op");
+}
+
+struct TimedFrequencyReader(usize);
+
+#[async_trait::async_trait]
+impl khive_storage::SqlReader for TimedFrequencyReader {
+    async fn query_row(
+        &mut self,
+        _: SqlStatement,
+    ) -> khive_storage::types::StorageResult<Option<khive_storage::types::SqlRow>> {
+        panic!("frequency probes must use query_all")
+    }
+    async fn query_all(
+        &mut self,
+        _: SqlStatement,
+    ) -> khive_storage::types::StorageResult<Vec<khive_storage::types::SqlRow>> {
+        self.0 += 1;
+        if self.0 == 1 {
+            tokio::time::advance(Duration::from_millis(25)).await;
+            Ok(Vec::new())
+        } else {
+            tokio::time::advance(Duration::from_millis(7)).await;
+            Err(khive_storage::StorageError::Timeout {
+                operation: "test.probe".into(),
+            })
+        }
+    }
+    async fn query_scalar(
+        &mut self,
+        _: SqlStatement,
+    ) -> khive_storage::types::StorageResult<Option<SqlValue>> {
+        panic!("frequency probes must use query_all")
+    }
+    async fn explain(
+        &mut self,
+        _: SqlStatement,
+    ) -> khive_storage::types::StorageResult<Vec<khive_storage::types::SqlRow>> {
+        panic!("diagnostics must not issue explain queries")
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn frequency_capture_times_the_failed_probe_not_the_whole_term_loop() {
+    let configured = Duration::from_millis(2000);
+    let started = tokio::time::Instant::now();
+    khive_storage::scope_request_read_deadline(configured, async {
+        let mut stage = LexicalStage::new(LexicalPass::Full, started, configured);
+        let mut reader = TimedFrequencyReader(0);
+        let result = rarest_fts_terms_first(
+            &mut reader,
+            vec!["first".into(), "second".into()],
+            &mut stage,
+        )
+        .await;
+        assert!(matches!(
+            result,
+            Err(khive_storage::StorageError::Timeout { .. })
+        ));
+        assert_eq!(reader.0, 2);
+        let detail = stage
+            .timeout
+            .expect("missing term_frequency timeout detail");
+        assert_eq!(detail.phase, LexicalPhase::TermFrequency);
+        assert_eq!(detail.stage_elapsed_ms, 32);
+        assert_eq!(
+            detail.operation_elapsed_ms, 7,
+            "operation elapsed must exclude the successful first probe"
+        );
+    })
+    .await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn partial_scored_candidates_match_the_base_rare_term_fixture() {
+    let runtime = KhiveRuntime::memory().expect("runtime");
+    seed_low_overlap_corpus(&runtime, 1_000, 20).await;
+    let weights = Weights::default();
+    let ctx = SearchCtx {
+        runtime: &runtime,
+        ns: "local",
+        role: None,
+        type_filter: None,
+        min_score: 0.0,
+        w: &weights,
+        fetch_limit: 100,
+        statuses: &[],
+        exclude_statuses: &[],
+    };
+    for query in ["term1 term18", "term18 term1"] {
+        let outcome = with_fts_deadline_advance_after_term(
+            1,
+            Duration::from_millis(2000),
+            search_core(&ctx, query, LexicalPass::Full),
+        )
+        .await
+        .expect("partial scored results");
+        assert_eq!(
+            outcome.lexical_timeouts.len(),
+            1,
+            "scored return must retain timeout detail"
+        );
+        assert_eq!(
+            outcome.lexical_timeouts[0].phase,
+            LexicalPhase::PhaseARowids
+        );
+        // The base fixture completes exactly the 50 term18 rows before the common term.
+        let expected: Vec<_> = (0..50)
+            .map(|i| format!("lowoverlap-{:06}", 18 + i * 20))
+            .collect();
+        assert_eq!(
+            outcome
+                .hits
+                .iter()
+                .map(|hit| hit.slug.clone())
+                .collect::<Vec<_>>(),
+            expected
+        );
+        let mut legacy = json!({});
+        attach_lexical_timeout_degradation(&mut legacy, &outcome.lexical_timeouts);
+        assert_eq!(legacy, json!({"degraded": {"lexical_timeout": true}}));
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn configured_budget_uses_the_stage_override() {
+    let runtime = fixture(false).await;
+    let registry = registry(&runtime);
+    let response = with_lexical_stage_budget_override_ms(
+        137,
+        with_timeout(
+            vec![LexicalPhase::TermFrequency],
+            Duration::from_millis(9),
+            registry.dispatch(
+                "knowledge.search",
+                json!({"query": "zzoraclezz", "rerank": false}),
+            ),
+        ),
+    )
+    .await
+    .expect("public dispatch");
+    assert_eq!(
+        response["degraded"]["lexical_timeout_details"][0]["configured_budget_ms"],
+        137
+    );
+    assert_eq!(
+        response["degraded"]["lexical_timeout_details"][0]["effective_budget_ms"],
+        137
+    );
+}

--- a/crates/khive-pack-knowledge/src/knowledge/mod.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/mod.rs
@@ -11,6 +11,7 @@ mod crud;
 mod eval;
 mod fold_handler;
 pub(crate) mod index_handler;
+mod lexical_timeout;
 mod search;
 mod sections;
 pub(crate) mod sections_index;

--- a/crates/khive-pack-knowledge/src/knowledge/search.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/search.rs
@@ -15,6 +15,7 @@ use khive_score::DeterministicScore;
 use khive_storage::types::{PageRequest, SqlStatement, SqlValue};
 use khive_storage::EntityFilter;
 
+use super::lexical_timeout::{LexicalPass, LexicalPhase, LexicalStage, LexicalTimeout};
 use super::matching;
 use super::schema::{Atom, ComposeParams, Domain, SearchParams, SuggestParams};
 use super::scoring::{
@@ -378,13 +379,17 @@ fn phase_a_rowids_statement(term: &str, limit: usize) -> SqlStatement {
 async fn rarest_fts_terms_first(
     reader: &mut dyn khive_storage::SqlReader,
     terms: Vec<String>,
+    stage: &mut LexicalStage,
 ) -> Result<Vec<String>, khive_storage::StorageError> {
     let mut frequencies = Vec::with_capacity(terms.len());
     for term in terms {
         // Count only a bounded index prefix. Rare counts are exact; terms
         // above the cap tie by spelling, without scanning their whole lists.
-        let rows = reader
-            .query_all(phase_a_rowids_statement(&term, FTS_TERM_LIMIT + 1))
+        let rows = stage
+            .read(
+                LexicalPhase::TermFrequency,
+                reader.query_all(phase_a_rowids_statement(&term, FTS_TERM_LIMIT + 1)),
+            )
             .await?;
         if !rows.is_empty() {
             frequencies.push((term, rows.len()));
@@ -473,13 +478,12 @@ where
 
 /// Outcome of the bounded lexical candidate fetch.
 ///
-/// `timed_out` is set only for [`khive_storage::StorageError::Timeout`] — the
-/// request-scoped read deadline elapsing mid-fetch. Any other storage error
+/// `timeout` is set only for [`khive_storage::StorageError::Timeout`]. Any other storage error
 /// (including a genuine FTS5 syntax/parser error) still surfaces as an `Err`;
 /// fail-open applies to a timeout only.
 struct FtsFetchOutcome {
     atoms: Vec<Atom>,
-    timed_out: bool,
+    timeout: Option<LexicalTimeout>,
 }
 
 #[cfg(test)]
@@ -570,6 +574,7 @@ fn is_read_timeout(e: &RuntimeError) -> bool {
 /// term, unioned and deduplicated in application code. FTS remains only the
 /// candidate generator; TF-IDF in `search_core` remains the ranker, so the
 /// per-term merge order does not need to be a globally correct bm25 rank.
+#[allow(clippy::too_many_arguments)]
 async fn fetch_fts_candidates(
     runtime: &KhiveRuntime,
     ns: &str,
@@ -578,14 +583,15 @@ async fn fetch_fts_candidates(
     statuses: &[String],
     exclude_statuses: &[&str],
     fetch_limit: usize,
+    mut stage: LexicalStage,
 ) -> Result<FtsFetchOutcome, RuntimeError> {
     let sql = runtime.sql();
-    let mut reader = match sql.reader().await {
+    let mut reader = match stage.read(LexicalPhase::ReaderOpen, sql.reader()).await {
         Ok(reader) => reader,
         Err(e) if is_timeout(&e) => {
             return Ok(FtsFetchOutcome {
                 atoms: Vec::new(),
-                timed_out: true,
+                timeout: stage.timeout,
             });
         }
         Err(e) => return Err(sql_err("search fts reader", e)),
@@ -616,12 +622,12 @@ async fn fetch_fts_candidates(
     };
 
     if terms.len() > 1 {
-        terms = match rarest_fts_terms_first(reader.as_mut(), terms).await {
+        terms = match rarest_fts_terms_first(reader.as_mut(), terms, &mut stage).await {
             Ok(terms) => terms,
             Err(e) if is_timeout(&e) => {
                 return Ok(FtsFetchOutcome {
                     atoms: Vec::new(),
-                    timed_out: true,
+                    timeout: stage.timeout,
                 });
             }
             Err(e) => return Err(sql_err("search fts term frequency probe", e)),
@@ -646,8 +652,11 @@ async fn fetch_fts_candidates(
         let mut probe_limit = base_probe_limit;
 
         let (mut eligible, probed_rowids): (Vec<Atom>, Vec<i64>) = loop {
-            let phase_a_rows = match reader
-                .query_all(phase_a_rowids_statement(term, probe_limit))
+            let phase_a_rows = match stage
+                .read(
+                    LexicalPhase::PhaseARowids,
+                    reader.query_all(phase_a_rowids_statement(term, probe_limit)),
+                )
                 .await
             {
                 Ok(rows) => rows,
@@ -675,7 +684,10 @@ async fn fetch_fts_candidates(
                     exclude_statuses,
                     type_clause.as_str(),
                 );
-                let rows = match reader.query_all(statement).await {
+                let rows = match stage
+                    .read(LexicalPhase::PhaseBHydration, reader.query_all(statement))
+                    .await
+                {
                     Ok(rows) => rows,
                     Err(e) if is_timeout(&e) => {
                         term_query_timed_out = true;
@@ -735,12 +747,15 @@ async fn fetch_fts_candidates(
                     SqlValue::Integer(per_term_limit as i64),
                 ];
                 scoped_params.extend(scoped_status_params);
-                let scoped_rows = match reader
-                    .query_all(SqlStatement {
-                        sql: scoped_sql,
-                        params: scoped_params,
-                        label: None,
-                    })
+                let scoped_rows = match stage
+                    .read(
+                        LexicalPhase::EligibilityFallback,
+                        reader.query_all(SqlStatement {
+                            sql: scoped_sql,
+                            params: scoped_params,
+                            label: None,
+                        }),
+                    )
                     .await
                 {
                     Ok(rows) => rows,
@@ -786,14 +801,14 @@ async fn fetch_fts_candidates(
     if term_query_timed_out {
         return Ok(FtsFetchOutcome {
             atoms: combined,
-            timed_out: true,
+            timeout: stage.timeout,
         });
     }
 
     if !combined.is_empty() {
         return Ok(FtsFetchOutcome {
             atoms: combined,
-            timed_out: false,
+            timeout: None,
         });
     }
 
@@ -836,19 +851,22 @@ async fn fetch_fts_candidates(
             "SELECT 1 AS present FROM knowledge_atoms \
              WHERE rowid IN ({placeholders}) AND namespace = ?1 LIMIT 1"
         );
-        let row = match reader
-            .query_row(SqlStatement {
-                sql: membership_sql,
-                params,
-                label: None,
-            })
+        let row = match stage
+            .read(
+                LexicalPhase::NamespaceMembership,
+                reader.query_row(SqlStatement {
+                    sql: membership_sql,
+                    params,
+                    label: None,
+                }),
+            )
             .await
         {
             Ok(row) => row,
             Err(e) if is_timeout(&e) => {
                 return Ok(FtsFetchOutcome {
                     atoms: Vec::new(),
-                    timed_out: true,
+                    timeout: stage.timeout,
                 });
             }
             Err(e) => return Err(sql_err("search fts namespace membership probe", e)),
@@ -861,7 +879,7 @@ async fn fetch_fts_candidates(
     if namespace_has_match {
         return Ok(FtsFetchOutcome {
             atoms: Vec::new(),
-            timed_out: false,
+            timeout: None,
         });
     }
 
@@ -880,19 +898,22 @@ async fn fetch_fts_candidates(
     ];
     params.extend(status_params);
 
-    let rows = match reader
-        .query_all(SqlStatement {
-            sql: sql_str,
-            params,
-            label: None,
-        })
+    let rows = match stage
+        .read(
+            LexicalPhase::RecentFallback,
+            reader.query_all(SqlStatement {
+                sql: sql_str,
+                params,
+                label: None,
+            }),
+        )
         .await
     {
         Ok(rows) => rows,
         Err(e) if is_timeout(&e) => {
             return Ok(FtsFetchOutcome {
                 atoms: Vec::new(),
-                timed_out: true,
+                timeout: stage.timeout,
             });
         }
         Err(e) => return Err(sql_err("search full scan", e)),
@@ -900,7 +921,7 @@ async fn fetch_fts_candidates(
 
     Ok(FtsFetchOutcome {
         atoms: rows.iter().filter_map(atom_from_row).collect(),
-        timed_out: false,
+        timeout: None,
     })
 }
 
@@ -920,16 +941,19 @@ struct SearchCtx<'a> {
 
 // ─── core single-pass search ──────────────────────────────────────────────────
 
-/// `search_core`'s result plus whether the lexical/FTS candidate fetch hit the
-/// request read deadline (issue #1930's fail-open signal). A caller sees
-/// `hits` possibly empty/partial and `lexical_timed_out = true` instead of an
+/// `search_core`'s result plus any lexical/FTS read timeout diagnostics.
+/// A caller sees `hits` possibly empty/partial and timeout details instead of an
 /// `Err` — never a verb-level error for a genuine timeout.
 struct SearchCoreOutcome {
     hits: Vec<ScoredHit>,
-    lexical_timed_out: bool,
+    lexical_timeouts: Vec<LexicalTimeout>,
 }
 
-async fn search_core(ctx: &SearchCtx<'_>, query: &str) -> Result<SearchCoreOutcome, RuntimeError> {
+async fn search_core(
+    ctx: &SearchCtx<'_>,
+    query: &str,
+    pass: LexicalPass,
+) -> Result<SearchCoreOutcome, RuntimeError> {
     let runtime = ctx.runtime;
     let ns = ctx.ns;
     let role = ctx.role;
@@ -941,7 +965,7 @@ async fn search_core(ctx: &SearchCtx<'_>, query: &str) -> Result<SearchCoreOutco
     if raw_query.is_empty() {
         return Ok(SearchCoreOutcome {
             hits: Vec::new(),
-            lexical_timed_out: false,
+            lexical_timeouts: Vec::new(),
         });
     }
 
@@ -979,23 +1003,29 @@ async fn search_core(ctx: &SearchCtx<'_>, query: &str) -> Result<SearchCoreOutco
     // deadline governs everything that runs after it (rerank, body-line
     // counts, member sizing) — a lexical-stage timeout no longer spends the
     // whole request.
-    let FtsFetchOutcome { atoms, timed_out } = khive_storage::scope_request_read_deadline(
-        lexical_stage_budget(),
-        fetch_fts_candidates(
-            runtime,
-            ns,
-            &raw_query,
-            type_filter,
-            ctx.statuses,
-            ctx.exclude_statuses,
-            CANDIDATE_POOL,
-        ),
-    )
-    .await?;
+    let configured_budget = lexical_stage_budget();
+    let stage_started = tokio::time::Instant::now();
+    let FtsFetchOutcome { atoms, timeout } =
+        khive_storage::scope_request_read_deadline(configured_budget, async {
+            let stage = LexicalStage::new(pass, stage_started, configured_budget);
+            fetch_fts_candidates(
+                runtime,
+                ns,
+                &raw_query,
+                type_filter,
+                ctx.statuses,
+                ctx.exclude_statuses,
+                CANDIDATE_POOL,
+                stage,
+            )
+            .await
+        })
+        .await?;
+    let lexical_timeouts: Vec<_> = timeout.into_iter().collect();
     if atoms.is_empty() {
         return Ok(SearchCoreOutcome {
             hits: Vec::new(),
-            lexical_timed_out: timed_out,
+            lexical_timeouts,
         });
     }
 
@@ -1003,7 +1033,7 @@ async fn search_core(ctx: &SearchCtx<'_>, query: &str) -> Result<SearchCoreOutco
     if candidates.is_empty() {
         return Ok(SearchCoreOutcome {
             hits: Vec::new(),
-            lexical_timed_out: timed_out,
+            lexical_timeouts,
         });
     }
 
@@ -1054,7 +1084,7 @@ async fn search_core(ctx: &SearchCtx<'_>, query: &str) -> Result<SearchCoreOutco
                 score,
             })
             .collect(),
-        lexical_timed_out: timed_out,
+        lexical_timeouts,
     })
 }
 
@@ -1077,8 +1107,8 @@ async fn search_decomposed(
 
     let SearchCoreOutcome {
         hits: full,
-        lexical_timed_out: full_timed_out,
-    } = search_core(ctx, query).await?;
+        mut lexical_timeouts,
+    } = search_core(ctx, query, LexicalPass::Full).await?;
     let sub_ctx1 = SearchCtx {
         runtime: ctx.runtime,
         ns: ctx.ns,
@@ -1092,13 +1122,14 @@ async fn search_decomposed(
     };
     let SearchCoreOutcome {
         hits: s1,
-        lexical_timed_out: s1_timed_out,
-    } = search_core(&sub_ctx1, &sub_q1).await?;
+        lexical_timeouts: s1_timeouts,
+    } = search_core(&sub_ctx1, &sub_q1, LexicalPass::Subquery1).await?;
     let SearchCoreOutcome {
         hits: s2,
-        lexical_timed_out: s2_timed_out,
-    } = search_core(&sub_ctx1, &sub_q2).await?;
-    let lexical_timed_out = full_timed_out || s1_timed_out || s2_timed_out;
+        lexical_timeouts: s2_timeouts,
+    } = search_core(&sub_ctx1, &sub_q2, LexicalPass::Subquery2).await?;
+    lexical_timeouts.extend(s1_timeouts);
+    lexical_timeouts.extend(s2_timeouts);
 
     let mut scores: HashMap<String, f32> = HashMap::new();
     let mut data: HashMap<String, ScoredHit> = HashMap::new();
@@ -1149,7 +1180,7 @@ async fn search_decomposed(
     ranked.truncate(ctx.fetch_limit);
     Ok(SearchCoreOutcome {
         hits: ranked,
-        lexical_timed_out,
+        lexical_timeouts,
     })
 }
 
@@ -1586,7 +1617,10 @@ fn attach_hydration_degradation(out: &mut Value, hydration_failures: usize) {
 /// (issue #1930). Set alongside whatever ANN-backed results (if any) still
 /// made it into the response — a timed-out lexical stage degrades the
 /// response, it never fails the verb outright.
-fn attach_lexical_timeout_degradation(out: &mut Value) {
+fn attach_lexical_timeout_degradation(out: &mut Value, timeouts: &[LexicalTimeout]) {
+    if timeouts.is_empty() {
+        return;
+    }
     if !out
         .get("degraded")
         .is_some_and(serde_json::Value::is_object)
@@ -1594,6 +1628,14 @@ fn attach_lexical_timeout_degradation(out: &mut Value) {
         out["degraded"] = json!({});
     }
     out["degraded"]["lexical_timeout"] = json!(true);
+    let details: Vec<_> = timeouts
+        .iter()
+        .filter(|detail| detail.phase.public())
+        .take(3)
+        .collect();
+    if !details.is_empty() {
+        out["degraded"]["lexical_timeout_details"] = json!(details);
+    }
 }
 
 /// Flag that the best-effort body-line aggregate hit the request read
@@ -2505,11 +2547,11 @@ impl KnowledgeHandlers {
 
         let SearchCoreOutcome {
             mut hits,
-            lexical_timed_out,
+            lexical_timeouts,
         } = if do_decompose && non_stop_count >= decompose_threshold {
             search_decomposed(&ctx, &raw_query, intersection_bonus).await?
         } else {
-            search_core(&ctx, &raw_query).await?
+            search_core(&ctx, &raw_query, LexicalPass::Full).await?
         };
 
         let mut ann_unavailable = false;
@@ -2533,7 +2575,7 @@ impl KnowledgeHandlers {
         filter_hits_by_type(&mut hits, type_filter);
 
         // The lexical stage now owns its own budget (issue #1930 Amendment
-        // 2), so `lexical_timed_out` no longer implies the request read
+        // 2), so `lexical_timeout` no longer implies the request read
         // deadline is spent — only that stage's narrower budget is. Gate on
         // the live ambient deadline instead: a lexical-only degradation
         // with request time left to spare still gets its embedding rerank.
@@ -2600,9 +2642,7 @@ impl KnowledgeHandlers {
         if ann_unavailable {
             out["ann_unavailable"] = json!(true);
         }
-        if lexical_timed_out {
-            attach_lexical_timeout_degradation(&mut out);
-        }
+        attach_lexical_timeout_degradation(&mut out, &lexical_timeouts);
         if body_lines_timed_out {
             attach_body_lines_timeout_degradation(&mut out);
         }
@@ -2742,8 +2782,8 @@ impl KnowledgeHandlers {
 
         let SearchCoreOutcome {
             mut hits,
-            lexical_timed_out,
-        } = search_core(&ctx, &raw_query).await?;
+            lexical_timeouts,
+        } = search_core(&ctx, &raw_query, LexicalPass::Full).await?;
 
         let mut ann_unavailable = false;
         if !ann_hits.is_empty() {
@@ -2759,7 +2799,7 @@ impl KnowledgeHandlers {
         filter_hits_by_type(&mut hits, Some("domain"));
 
         // The lexical stage now owns its own budget (issue #1930 Amendment
-        // 2), so `lexical_timed_out` no longer implies the request read
+        // 2), so `lexical_timeout` no longer implies the request read
         // deadline is spent — only that stage's narrower budget is. Gate on
         // the live ambient deadline instead: a lexical-only degradation
         // with request time left to spare still gets its embedding rerank.
@@ -2883,9 +2923,7 @@ impl KnowledgeHandlers {
                 "note": note,
             });
         }
-        if lexical_timed_out {
-            attach_lexical_timeout_degradation(&mut out);
-        }
+        attach_lexical_timeout_degradation(&mut out, &lexical_timeouts);
         attach_hydration_degradation(&mut out, hydration_failures);
         attach_member_sizing_timeout_degradation(&mut out, &excluded);
         // The lexical stage's own budget no longer implies the request
@@ -3495,9 +3533,39 @@ pub(crate) async fn seed_low_overlap_corpus(runtime: &KhiveRuntime, n: u32, voca
 }
 
 #[cfg(test)]
+#[path = "lexical_timeout_tests.rs"]
+mod lexical_timeout_tests;
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use khive_storage::types::{SqlRow, StorageResult};
+
+    async fn fetch_fts_candidates(
+        runtime: &KhiveRuntime,
+        ns: &str,
+        raw_query: &str,
+        type_filter: Option<&str>,
+        statuses: &[String],
+        exclude_statuses: &[&str],
+        fetch_limit: usize,
+    ) -> Result<FtsFetchOutcome, RuntimeError> {
+        super::fetch_fts_candidates(
+            runtime,
+            ns,
+            raw_query,
+            type_filter,
+            statuses,
+            exclude_statuses,
+            fetch_limit,
+            LexicalStage::new(
+                LexicalPass::Full,
+                tokio::time::Instant::now(),
+                lexical_stage_budget(),
+            ),
+        )
+        .await
+    }
 
     struct ProbeRecordingReader {
         inner: Box<dyn khive_storage::SqlReader>,
@@ -3582,6 +3650,11 @@ mod tests {
         let ordered = rarest_fts_terms_first(
             &mut reader,
             terms.iter().map(|term| (*term).to_string()).collect(),
+            &mut LexicalStage::new(
+                LexicalPass::Full,
+                tokio::time::Instant::now(),
+                lexical_stage_budget(),
+            ),
         )
         .await
         .expect("frequency probes");
@@ -3678,7 +3751,7 @@ mod tests {
             )
             .await
             .expect("bounded candidate fetch");
-            assert!(!outcome.timed_out);
+            assert!(outcome.timeout.is_none());
             assert_eq!(outcome.atoms.len(), FTS_TERM_LIMIT);
             assert_eq!(
                 outcome.atoms.iter().any(|atom| atom.slug == "zzprefix-best"),
@@ -3745,7 +3818,7 @@ mod tests {
             )
             .await
             .expect("partial fetch");
-            assert!(outcome.timed_out);
+            assert!(outcome.timeout.is_some());
             assert_eq!(
                 outcome.atoms.len(),
                 50,
@@ -3800,7 +3873,7 @@ mod tests {
              expires between term queries",
         );
         assert!(
-            outcome.timed_out,
+            outcome.timeout.is_some(),
             "the controlled deadline must be observed"
         );
         assert!(
@@ -3925,7 +3998,7 @@ mod tests {
             fetch_fts_candidates(&runtime, "local", "alpha beta", None, &[], &[], fetch_limit)
                 .await
                 .expect("fetch must not error");
-        assert!(!outcome.timed_out);
+        assert!(outcome.timeout.is_none());
         assert_eq!(outcome.atoms.len(), fetch_limit);
 
         let beta_present = outcome
@@ -4008,7 +4081,7 @@ mod tests {
             .await;
 
         assert!(
-            fetch.timed_out,
+            fetch.timeout.is_some(),
             "the lexical stage's own narrower budget must be observed"
         );
         assert!(
@@ -4086,7 +4159,7 @@ mod tests {
             .await
             .expect("fetch must not error");
 
-        assert!(!outcome.timed_out);
+        assert!(outcome.timeout.is_none());
         assert_eq!(
             outcome.atoms.len(),
             3,
@@ -4148,7 +4221,7 @@ mod tests {
             .await
             .expect("fetch must not error");
 
-        assert!(!outcome.timed_out);
+        assert!(outcome.timeout.is_none());
         assert_eq!(
             outcome.atoms.len(),
             2,
@@ -4196,7 +4269,7 @@ mod tests {
             .await
             .expect("fetch must not error");
 
-        assert!(!outcome.timed_out);
+        assert!(outcome.timeout.is_none());
         assert_eq!(
             outcome.atoms.len(),
             1,
@@ -4300,7 +4373,7 @@ mod tests {
                     println!(
                         "LEXICAL_NAMESPACE mode={mode} foreign_present={foreign_present} local_matches={local_matches} rows={} lexical_elapsed_ms={elapsed_ms:.3} lexical_timeout={}",
                         outcome.atoms.len(),
-                        outcome.timed_out,
+                        outcome.timeout.is_some(),
                     );
                 }
             }
@@ -4356,8 +4429,8 @@ mod tests {
                 .await
                 .expect("fetch must not error");
 
-        assert!(!foreign_match.timed_out);
-        assert!(!no_match.timed_out);
+        assert!(foreign_match.timeout.is_none());
+        assert!(no_match.timeout.is_none());
         let foreign_slugs: Vec<&str> = foreign_match
             .atoms
             .iter()
@@ -4416,7 +4489,7 @@ mod tests {
             .await
             .expect("fetch must not error");
 
-        assert!(!outcome.timed_out);
+        assert!(outcome.timeout.is_none());
         assert_eq!(
             outcome.atoms.len(),
             1,
@@ -4499,7 +4572,7 @@ mod tests {
         .await
         .expect("fetch must not error");
 
-        assert!(!outcome.timed_out);
+        assert!(outcome.timeout.is_none());
         assert_eq!(
             outcome.atoms.len(),
             2,

--- a/crates/khive-pack-knowledge/src/knowledge/search.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/search.rs
@@ -1628,6 +1628,7 @@ fn attach_lexical_timeout_degradation(out: &mut Value, timeouts: &[LexicalTimeou
         out["degraded"] = json!({});
     }
     out["degraded"]["lexical_timeout"] = json!(true);
+    out["degraded"]["lexical_timeout_instrumented"] = json!(true);
     let details: Vec<_> = timeouts
         .iter()
         .filter(|detail| detail.phase.public())


### PR DESCRIPTION
## Summary

Add `degraded.lexical_timeout_details` to `knowledge.search` and
`knowledge.suggest` when a lexical read times out in a publicly disclosable phase.
The list contains at most one record per pass and at most three records total.

Every response with `degraded.lexical_timeout=true` also carries
`degraded.lexical_timeout_instrumented=true`, regardless of whether any phase is
withheld. This marker identifies build instrumentation capability, not hidden
execution details. Healthy lexical responses omit it entirely; it is never false.

| Field | Meaning |
| --- | --- |
| `pass` | `full`, `subquery_1`, or `subquery_2` |
| `phase` | `reader_open` or `term_frequency` in public responses |
| `stage_elapsed_ms` | Time since the lexical read stage began, captured at the failed read |
| `operation_elapsed_ms` | Time spent in that failed read attempt, including waiting and cleanup |
| `configured_budget_ms` | The configured lexical-stage budget |
| `effective_budget_ms` | The remaining deadline allowance at stage entry, respecting an earlier parent deadline |

Durations use a monotonic clock and are truncated to whole milliseconds. They
are captured before subsequent reranking or metadata work, not at serialization.
Healthy responses omit the details list. A timed-out response also omits the list
when all of its timeout records are operator-only.

## Compatibility

`degraded.lexical_timeout` remains the same boolean with the same meaning.
Consumers reading that boolean see no change, including when no public details
are available. Existing candidate selection, partial-result retention, stage
budgets, timeout predicates, and other degradation fields are unchanged. Other
storage errors still propagate as before.

## Disclosure Design

Public phase labels are limited to `reader_open` and `term_frequency`: whether
these phases are entered does not depend on matches returned by the corpus.

The remaining labels are operator-only: `phase_a_rowids`, `phase_b_hydration`,
`eligibility_fallback`, `namespace_membership`, and `recent_fallback`. Their
reachability depends on global-index matches before namespace filtering.
Changing only foreign-namespace matches can select a different failure phase
while leaving local results unchanged. Exposing those labels would therefore
reveal match presence even without returning a foreign row or a match count.
These omissions are intentional, not missing instrumentation.
The public list can omit records and is not a complete execution ledger, even
when it is non-empty. The capability marker does not disclose whether a hidden
pass timed out or completed normally.

All seven phases emit the same structured timing fields as warning-level tracing
events. The diagnostic records contain no SQL, raw errors, query text, row
identifiers, namespace names, match counts, touched-row counts, or byte counts.
This change does not eliminate pre-existing wall-clock timing side channels.

## Interpretation Limits

A phase identifies where the timeout was observed, not why the allowance was
exhausted or where the entire budget was spent. Earlier work may have consumed
the budget before an almost-immediate failed read. Pooled-reader waiting occurs
inside query calls, so operation elapsed cannot separate waiting from execution.
Elapsed time also cannot distinguish deadline expiry from explicit cancellation.
This change adds diagnostics; it does not fix or establish the underlying timeout
cause.

## Validation

Required package validation is `cargo test -p khive-pack-knowledge`, and it passes at
this revision, including the capability marker and its mixed-pass test.

- Deterministic failures at every read site check the phase label and matching structured tracing fields.
- Clock controls distinguish individual-probe time from whole-stage time, preserve earlier parent deadlines, cover cancellation and expired deadlines, and verify that downstream work cannot alter captured values.
- Public dispatch checks healthy omission, the configured budget, all three decomposed pass identities, and preservation of the existing boolean and other response fields.
- Partial-result fixtures check the exact retained candidates under both query orders; existing candidate-selection regressions remain covered.
- A foreign-match fixture changes the withheld failure phase at equal elapsed time while requiring identical public output and unchanged local fallback results.
- A decomposed-query fixture toggles a real foreign match to add an operator-only timeout while retaining the same public timeout record. Both responses must serialize to identical bytes with the capability marker present and true in both.
- Two mutation controls were run against this revision. Disabling timeout-record propagation fails at the missing-record assertion, and making the capability marker depend on withholding fails at the mixed-pass marker assertion. Both sources were restored byte for byte afterwards and the package suite, the workspace check, the formatter and the linter all pass again.
