### PR TITLE
ci(workflows): reject empty filtered test selections

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+scripts/assert-tests-ran.sh text eol=lf

--- a/.github/workflows/bench-pipeline.yml
+++ b/.github/workflows/bench-pipeline.yml
@@ -63,9 +63,12 @@ jobs:
       # if same-cluster vectors stop being more similar than cross-cluster ones,
       # the vector leg degenerates to noise and the per-leg floor is meaningless.
       - name: Test bench-embedder clustering invariant
+        shell: bash
         run: |
           set -euo pipefail
-          cargo test -p khive-mcp --features bench-embedder bench_embedder
+          # Floor 1 detects empty selection without pinning the suite size.
+          cargo test -p khive-mcp --features bench-embedder bench_embedder 2>&1 | tee "$RUNNER_TEMP/bench_embedder.log"
+          ../scripts/assert-tests-ran.sh "$RUNNER_TEMP/bench_embedder.log" 1
 
       # Build the bench binary (bench-embedder injects FNV-1a, no lattice model download)
       - name: Build kkernel (bench-embedder feature)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -756,12 +756,20 @@ jobs:
       # including tests outside the `walpin` module; it is not the full suite.
       # Keep this still-new lane fast; widen alongside the `cargo check` step above.
       - name: khive-db walpin Windows FFI tests
-        run: cargo test -p khive-db --lib walpin
+        shell: bash
+        run: |
+          # Floor 1 detects empty selection without pinning the suite size.
+          cargo test -p khive-db --lib walpin 2>&1 | tee "$RUNNER_TEMP/walpin.log"
+          ../scripts/assert-tests-ran.sh "$RUNNER_TEMP/walpin.log" 1
       # ADR-160 Phase 1: compile-only coverage cannot validate the Windows
       # no-reparse, handle-pinned bounded blob read. Keep this lane focused on
       # one normal-path test until the broader Windows suite is affordable.
       - name: khive-db bounded blob read Windows test
-        run: cargo test -p khive-db --lib bounded_verified_get_accepts_exact_and_portable_maximum_limits
+        shell: bash
+        run: |
+          # Floor 1 detects empty selection without pinning the suite size.
+          cargo test -p khive-db --lib bounded_verified_get_accepts_exact_and_portable_maximum_limits 2>&1 | tee "$RUNNER_TEMP/bounded_verified_get_accepts_exact_and_portable_maximum_limits.log"
+          ../scripts/assert-tests-ran.sh "$RUNNER_TEMP/bounded_verified_get_accepts_exact_and_portable_maximum_limits.log" 1
 
   coverage-measurement:
     name: Coverage measurement (advisory)

--- a/.github/workflows/tz-database-audit.yml
+++ b/.github/workflows/tz-database-audit.yml
@@ -86,9 +86,12 @@ jobs:
           grep -A1 '^name = "chrono-tz"' Cargo.lock
 
       - name: Run the all-zone sweep
+        shell: bash
         run: |
           set -euo pipefail
           # --ignored, not --include-ignored: this job exists to run exactly the
           # sweep, and including the ordinary tests here would let a failure in
           # one be reported as a failure of the other.
-          cargo test -p khive-runtime --lib --release tz_database_audit -- --ignored --nocapture
+          # Floor 1 detects empty selection without pinning the suite size.
+          cargo test -p khive-runtime --lib --release tz_database_audit -- --ignored --nocapture 2>&1 | tee "$RUNNER_TEMP/tz_database_audit.log"
+          ../scripts/assert-tests-ran.sh "$RUNNER_TEMP/tz_database_audit.log" 1

--- a/scripts/assert-tests-ran.sh
+++ b/scripts/assert-tests-ran.sh
@@ -27,7 +27,8 @@ count=$(LC_ALL=C awk '
         sub(/\r$/, "", line)
         # A Rust test path can begin with result::; it is not a summary.
         if (line !~ /^[[:space:]]*test result:([^:]|$)/) next
-        if (line !~ /^[[:space:]]*test result: (ok|FAILED)\. [0-9]+ passed; [0-9]+ failed;([[:space:]]|$)/) {
+        # The whole cargo summary grammar, so a truncated line or trailing text is malformed, not counted.
+        if (line !~ /^[[:space:]]*test result: (ok|FAILED)\. [0-9]+ passed; [0-9]+ failed; [0-9]+ ignored; [0-9]+ measured; [0-9]+ filtered out(; finished in [0-9]+(\.[0-9]+)?s)?[[:space:]]*$/) {
             printf "malformed test summary at line %d\n", NR > "/dev/stderr"
             invalid = 1
             next

--- a/scripts/assert-tests-ran.sh
+++ b/scripts/assert-tests-ran.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Cargo succeeds on an empty selection. This gate checks selection, not test success.
+set -uo pipefail
+set +e
+
+if [[ $# != 2 ]]; then
+    echo "usage: assert-tests-ran.sh <captured-log> <positive-floor>" >&2
+    exit 2
+fi
+
+log=$1
+floor=$2
+if [[ ! "$floor" =~ ^[1-9][0-9]*$ ]] || [[ ${#floor} -gt 10 ]] || [[ "$floor" -gt 2147483647 ]]; then
+    printf 'test selection: counted=unavailable floor=%s log=%s; floor must be 1..2147483647\n' "$floor" "$log" >&2
+    exit 2
+fi
+if [[ ! -f "$log" || ! -r "$log" ]]; then
+    printf 'test selection: counted=unavailable floor=%s log=%s; log is missing or unreadable\n' "$floor" "$log" >&2
+    exit 2
+fi
+
+count=$(LC_ALL=C awk '
+    BEGIN { total = 0; invalid = 0 }
+    {
+        line = $0
+        gsub(/\033\[[0-9;]*m/, "", line)
+        sub(/\r$/, "", line)
+        # A Rust test path can begin with result::; it is not a summary.
+        if (line !~ /^[[:space:]]*test result:([^:]|$)/) next
+        if (line !~ /^[[:space:]]*test result: (ok|FAILED)\. [0-9]+ passed; [0-9]+ failed;([[:space:]]|$)/) {
+            printf "malformed test summary at line %d\n", NR > "/dev/stderr"
+            invalid = 1
+            next
+        }
+        sub(/^[[:space:]]*test result: (ok|FAILED)\. /, "", line)
+        split(line, fields, ";")
+        passed = fields[1]
+        failed = fields[2]
+        sub(/ passed$/, "", passed)
+        sub(/^ /, "", failed)
+        sub(/ failed$/, "", failed)
+        passed += 0
+        failed += 0
+        # Keep accumulation exact on every supported awk implementation.
+        if (passed > 2147483647 || failed > 2147483647 || total + passed + failed > 2147483647) {
+            printf "test count exceeds supported range at line %d\n", NR > "/dev/stderr"
+            invalid = 1
+            next
+        }
+        total += passed + failed
+    }
+    END {
+        if (invalid) exit 2
+        printf "%.0f\n", total
+    }
+' < "$log")
+parse_status=$?
+if [[ $parse_status != 0 ]]; then
+    printf 'test selection: counted=unavailable floor=%s log=%s; parser exited %s\n' "$floor" "$log" "$parse_status" >&2
+    exit 2
+fi
+if [[ ! "$count" =~ ^(0|[1-9][0-9]*)$ ]] || [[ ${#count} -gt 10 ]] || [[ "$count" -gt 2147483647 ]]; then
+    printf 'test selection: counted=unavailable floor=%s log=%s; invalid parser output\n' "$floor" "$log" >&2
+    exit 2
+fi
+
+printf 'test selection: counted=%s floor=%s log=%s\n' "$count" "$floor" "$log"
+if [[ "$count" -lt "$floor" ]]; then
+    echo "test selection is below the required floor" >&2
+    exit 1
+fi

--- a/scripts/tests/test_ci_workflows.py
+++ b/scripts/tests/test_ci_workflows.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import json
 import os
 import pathlib
+import re
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -168,6 +170,484 @@ class BenchTrackWorkflowTests(unittest.TestCase):
         self.assertEqual(len(quick_commands), 1)
         self.assertIn("--benches", quick_commands[0])
         self.assertIn("--criterion-dir crates/target/criterion", workflow)
+
+
+class FilteredCargoTestWorkflowTests(unittest.TestCase):
+    ASSERT_SCRIPT = REPO_ROOT / "scripts" / "assert-tests-ran.sh"
+    SUMMARY = (
+        "test result: ok. 2 passed; 0 failed; 3 ignored; 0 measured; 9 filtered out\n"
+    )
+    ZERO_SUMMARY = (
+        "running 0 tests\ntest result: ok. 0 passed; 0 failed; 10 filtered out\n"
+    )
+
+    @staticmethod
+    def name_filter(command: str) -> str | None:
+        if "cargo" not in command:
+            return None
+        words = shlex.split(command, comments=True)
+        if "cargo" not in words:
+            return None
+        words = words[words.index("cargo") + 1 :]
+        if words and words[0].startswith("+"):
+            words = words[1:]
+        if not words or words.pop(0) != "test":
+            return None
+        value_options = {
+            "-p",
+            "--package",
+            "--exclude",
+            "--features",
+            "-F",
+            "--manifest-path",
+            "--target",
+            "--target-dir",
+            "--profile",
+            "--bin",
+            "--example",
+            "--test",
+            "--bench",
+            "--config",
+            "--message-format",
+            "--color",
+            "-j",
+            "--jobs",
+            "-Z",
+        }
+        while words:
+            word = words.pop(0)
+            if word in {"--", "|", "||", "&&", ";", "2>&1", ">", ">>"}:
+                break
+            if word in value_options:
+                if not words:
+                    raise AssertionError(f"missing value for {word}: {command}")
+                words.pop(0)
+            elif not word.startswith("-"):
+                return word
+        return None
+
+    @classmethod
+    def filtered_steps(cls, workflow: str):
+        # Match the repository's indented run scalars, then let shlex distinguish
+        # Cargo option values from test-name filters. No YAML dependency is needed
+        # by the stdlib-only lint entry point. Unsupported Cargo-bearing scalars
+        # fail loudly instead of disappearing from the discovered population.
+        lines = workflow.splitlines()
+        for index, line in enumerate(lines):
+            match = re.fullmatch(r"( *)(- )?run: (.*)", line)
+            if not match:
+                continue
+            indent = len(match[1]) + len(match[2] or "")
+            end = index + 1
+            while end < len(lines):
+                following = lines[end]
+                if (
+                    following.strip()
+                    and len(following) - len(following.lstrip()) <= indent
+                ):
+                    break
+                end += 1
+            scalar = match[3]
+            continuation = "\n".join(lines[index + 1 : end])
+            marker = scalar.split("#", 1)[0].strip()
+            if marker in {"|", "|-", "|+"}:
+                body = continuation
+            elif scalar.startswith(("'", '"', ">", "|")) or "cargo" in continuation:
+                if "cargo" in scalar or "cargo" in continuation:
+                    raise AssertionError(
+                        f"unsupported Cargo run scalar at line {index + 1}"
+                    )
+                continue
+            else:
+                body = scalar
+            commands = [
+                value.strip()
+                for value in body.replace("\\\n", " ").splitlines()
+                if value.strip() and not value.lstrip().startswith("#")
+            ]
+            for command_index, command in enumerate(commands):
+                name = cls.name_filter(command)
+                if name is None:
+                    continue
+                start = index
+                step_indent = indent - 2
+                while start > 0 and not lines[start].startswith(
+                    " " * step_indent + "- "
+                ):
+                    start -= 1
+                step_end = end
+                while step_end < len(lines):
+                    following = lines[step_end]
+                    if (
+                        following.strip()
+                        and len(following) - len(following.lstrip()) <= step_indent
+                    ):
+                        break
+                    step_end += 1
+                yield (
+                    index + 1,
+                    name,
+                    commands[command_index:],
+                    "\n".join(lines[start:step_end]),
+                )
+
+    def assert_guarded(self, site):
+        line, name, commands, step = site
+        label = f"line {line}, filter {name}"
+        words = shlex.split(commands[0], comments=True)
+        self.assertEqual(words[-4:-1], ["2>&1", "|", "tee"], label)
+        log = words[-1]
+        self.assertTrue(log.startswith("$RUNNER_TEMP/"), label)
+        self.assertGreaterEqual(len(commands), 2, label)
+        self.assertEqual(
+            shlex.split(commands[1], comments=True),
+            ["../scripts/assert-tests-ran.sh", log, "1"],
+            label,
+        )
+        self.assertRegex(step, r"(?m)^\s+shell: bash$", label)
+        self.assertNotRegex(step, r"continue-on-error:\s*(?:true|\$)", label)
+
+    def test_every_filtered_cargo_step_has_a_captured_floor(self):
+        sites = [
+            (path.name, site)
+            for path in sorted(WORKFLOWS.glob("*.y*ml"))
+            for site in self.filtered_steps(path.read_text())
+        ]
+        self.assertTrue(sites, "no filtered Cargo tests discovered")
+        print(
+            f"FilteredCargoTestWorkflowTests: {len(sites)} filtered steps discovered",
+            flush=True,
+        )
+        for path, site in sites:
+            with self.subTest(workflow=path, filter=site[1]):
+                self.assert_guarded(site)
+
+    def test_discovery_detects_a_new_unguarded_site(self):
+        workflow = (
+            "jobs:\n  new-job:\n    steps:\n      - name: New filtered suite\n"
+            "        run: cargo test -p example --features sample new_filter\n"
+        )
+        sites = list(self.filtered_steps(workflow))
+        self.assertEqual(len(sites), 1)
+        self.assertEqual(sites[0][1], "new_filter")
+        with self.assertRaises(AssertionError):
+            self.assert_guarded(sites[0])
+
+    def test_discovery_distinguishes_filters_from_option_values(self):
+        for command in (
+            "cargo test --workspace --all-features",
+            "cargo test -p sample --test integration -- --ignored",
+            "cargo test --target wasm32-wasip1 2>&1 | tee /tmp/result.log",
+            "cargo test --features 'one two' --bin example",
+        ):
+            with self.subTest(command=command):
+                self.assertIsNone(self.name_filter(command))
+        self.assertEqual(
+            self.name_filter(
+                "cargo +1.95.0 test --package=sample --lib 'module::test'"
+            ),
+            "module::test",
+        )
+
+    def test_discovery_cannot_skip_cargo_in_block_scalars(self):
+        prefix = "jobs:\n  example:\n    steps:\n      - name: Filtered suite\n"
+        for marker in ("|", "|-", "| # a comment"):
+            with self.subTest(marker=marker):
+                workflow = (
+                    prefix + f"        run: {marker}\n          cargo test new_filter\n"
+                )
+                sites = list(self.filtered_steps(workflow))
+                self.assertEqual(len(sites), 1)
+                self.assertEqual(sites[0][1], "new_filter")
+        for marker in (">", "|2", "&anchored |"):
+            with self.subTest(marker=marker):
+                workflow = (
+                    prefix + f"        run: {marker}\n          cargo test new_filter\n"
+                )
+                with self.assertRaisesRegex(
+                    AssertionError, "unsupported Cargo run scalar"
+                ):
+                    list(self.filtered_steps(workflow))
+
+    def test_removing_each_discovered_assertion_is_detected(self):
+        for path in sorted(WORKFLOWS.glob("*.y*ml")):
+            for site in self.filtered_steps(path.read_text()):
+                line, name, commands, step = site
+                with self.subTest(workflow=path.name, filter=name):
+                    self.assert_guarded(site)
+                    with self.assertRaises(AssertionError):
+                        self.assert_guarded((line, name, commands[:1], step))
+
+    def run_assertion(self, content: str | None, floor="1", *, fake_awk=None):
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            log = root / "selected_filter.log"
+            if content is not None:
+                log.write_text(content)
+            env = os.environ.copy()
+            if fake_awk is not None:
+                awk = root / "awk"
+                awk.write_text("#!/bin/sh\n" + fake_awk)
+                awk.chmod(0o755)
+                env["PATH"] = f"{root}:{env['PATH']}"
+            return subprocess.run(
+                ["bash", str(self.ASSERT_SCRIPT), str(log), floor],
+                capture_output=True,
+                text=True,
+                check=False,
+                env=env,
+            )
+
+    def test_nonzero_summary_passes_and_reports_count(self):
+        for count in (2, 82, 717):
+            with self.subTest(count=count):
+                result = self.run_assertion(
+                    self.SUMMARY.replace("2 passed", f"{count} passed")
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertIn(f"counted={count} floor=1", result.stdout)
+                self.assertIn("selected_filter", result.stdout)
+
+    def test_sums_passed_and_failed_across_harnesses(self):
+        result = self.run_assertion(
+            self.SUMMARY + "test result: FAILED. 0 passed; 1 failed; 0 ignored;\n", "3"
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("counted=3 floor=3", result.stdout)
+        self.assertNotEqual(self.run_assertion(self.SUMMARY, "3").returncode, 0)
+
+    def test_colored_crlf_summaries_are_counted_and_validated(self):
+        summary = self.SUMMARY.replace("ok.", "\x1b[32mok\x1b[0m.").replace(
+            "\n", "\r\n"
+        )
+        result = self.run_assertion(summary)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("counted=2 floor=1", result.stdout)
+        malformed = "\x1b[32mtest result: ok. 717junk passed; 0 failed;\x1b[0m\r\n"
+        self.assertNotEqual(self.run_assertion(summary + malformed).returncode, 0)
+
+    def test_zero_selection_and_no_summary_fail(self):
+        for content in (self.ZERO_SUMMARY, "", "running 1 test\n"):
+            with self.subTest(content=content):
+                result = self.run_assertion(content)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("counted=0 floor=1", result.stdout + result.stderr)
+
+    def test_result_module_test_names_are_not_summaries(self):
+        test_line = "test result::tests::default_is_zero_state_zero_count ... ok\n"
+        result = self.run_assertion(test_line + self.SUMMARY)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("counted=2 floor=1", result.stdout)
+        for malformed in (
+            "test result:ok. 1 passed; 0 failed;\n",
+            "test result:garbage\n",
+        ):
+            with self.subTest(malformed=malformed):
+                result = self.run_assertion(self.SUMMARY + malformed)
+                self.assertEqual(result.returncode, 2, result.stdout)
+                self.assertIn("malformed test summary", result.stderr)
+
+    def test_any_malformed_summary_fails_even_beside_a_valid_one(self):
+        for passed, failed in (
+            ("717junk", "0"),
+            ("unreadable", "unknown"),
+            ("1", "0junk"),
+            ("-1", "0"),
+            ("1.5", "0"),
+            ("", "0"),
+            ("1", ""),
+        ):
+            with self.subTest(passed=passed, failed=failed):
+                malformed = f"test result: ok. {passed} passed; {failed} failed;\n"
+                result = self.run_assertion(self.SUMMARY + malformed)
+                self.assertNotEqual(result.returncode, 0, result.stdout)
+                self.assertIn("floor=1", result.stdout + result.stderr)
+
+    def test_missing_log_and_invalid_floor_fail(self):
+        self.assertNotEqual(self.run_assertion(None).returncode, 0)
+        for floor in ("0", "-1", "", "1junk", "1.5", "99999999999999999999"):
+            with self.subTest(floor=floor):
+                self.assertNotEqual(
+                    self.run_assertion(self.SUMMARY, floor).returncode, 0
+                )
+
+    def test_parser_failure_cannot_pass_with_plausible_stdout(self):
+        result = self.run_assertion(self.SUMMARY, fake_awk="printf '100\\n'\nexit 7\n")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("parser exited 7", result.stderr)
+
+    def test_invalid_parser_output_and_count_overflow_fail(self):
+        for output in ("junk", "08", "99999999999999999999", "1\\n2"):
+            with self.subTest(output=output):
+                result = self.run_assertion(
+                    self.SUMMARY, fake_awk=f"printf '{output}\\n'\n"
+                )
+                self.assertNotEqual(result.returncode, 0, result.stdout)
+        result = self.run_assertion(
+            self.SUMMARY + "test result: ok. 2147483647 passed; 0 failed;\n"
+        )
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+
+    def test_unreadable_log_fails(self):
+        with tempfile.TemporaryDirectory() as directory:
+            log = pathlib.Path(directory) / "unreadable.log"
+            log.write_text(self.SUMMARY)
+            log.chmod(0)
+            try:
+                if os.access(log, os.R_OK):
+                    self.skipTest("this account can read mode-000 files")
+                result = subprocess.run(
+                    ["bash", str(self.ASSERT_SCRIPT), str(log), "1"],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+            finally:
+                log.chmod(0o600)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("unreadable", result.stderr)
+
+    def test_helper_keeps_lf_with_windows_checkout_conversion(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            repo = root / "repo"
+            checkout = root / "checkout"
+            repo.mkdir()
+            checkout.mkdir()
+            script = pathlib.Path("scripts/assert-tests-ran.sh")
+            source = repo / script
+            source.parent.mkdir()
+            source.write_bytes(self.ASSERT_SCRIPT.read_bytes())
+            source.chmod(self.ASSERT_SCRIPT.stat().st_mode & 0o777)
+            attributes = REPO_ROOT / ".gitattributes"
+            staged = [str(script)]
+            if attributes.is_file():
+                (repo / attributes.name).write_bytes(attributes.read_bytes())
+                staged.append(attributes.name)
+            env = os.environ.copy()
+            env.update(GIT_CONFIG_NOSYSTEM="1", GIT_CONFIG_GLOBAL=os.devnull)
+            for args in (
+                ["init", "--quiet"],
+                ["config", "core.autocrlf", "true"],
+                ["add", "--", *staged],
+                ["checkout-index", f"--prefix={checkout}{os.sep}", "--all"],
+            ):
+                result = subprocess.run(
+                    ["git", *args],
+                    cwd=repo,
+                    env=env,
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            exported = checkout / script
+            self.assertEqual(
+                exported.read_bytes().count(b"\r\n"),
+                0,
+                f"{script} was converted to CRLF under core.autocrlf=true",
+            )
+            log = root / "selected_filter.log"
+            log.write_text(self.SUMMARY)
+            result = subprocess.run(
+                [str(exported), str(log), "1"],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("counted=2 floor=1", result.stdout)
+
+    def test_each_discovered_step_runs_the_gate_and_preserves_pipeline_failures(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            cargo = root / "cargo"
+            cargo.write_text(
+                '#!/bin/sh\nprintf "%s\\n" "$TEST_SUMMARY"\nexit "$TEST_STATUS"\n'
+            )
+            cargo.chmod(0o755)
+            env = os.environ.copy()
+            env.update(PATH=f"{root}:{env['PATH']}", RUNNER_TEMP=str(root))
+            sites = [
+                site
+                for path in sorted(WORKFLOWS.glob("*.y*ml"))
+                for site in self.filtered_steps(path.read_text())
+            ]
+            self.assertTrue(sites)
+            for _, name, commands, _ in sites:
+                for summary, cargo_status, expected in (
+                    (self.SUMMARY, "0", 0),
+                    (self.ZERO_SUMMARY, "0", 1),
+                    (self.SUMMARY, "7", 7),
+                ):
+                    with self.subTest(
+                        filter=name, summary=summary, status=cargo_status
+                    ):
+                        env.update(TEST_SUMMARY=summary, TEST_STATUS=cargo_status)
+                        result = subprocess.run(
+                            [
+                                "bash",
+                                "--noprofile",
+                                "--norc",
+                                "-eo",
+                                "pipefail",
+                                "-c",
+                                "\n".join(commands),
+                            ],
+                            cwd=REPO_ROOT / "crates",
+                            env=env,
+                            capture_output=True,
+                            text=True,
+                            check=False,
+                        )
+                        self.assertEqual(
+                            result.returncode, expected, result.stdout + result.stderr
+                        )
+            tee = root / "tee"
+            tee.write_text("#!/bin/sh\ncat >/dev/null\nexit 9\n")
+            tee.chmod(0o755)
+            env.update(TEST_SUMMARY=self.SUMMARY, TEST_STATUS="0")
+            for _, name, commands, _ in sites:
+                with self.subTest(filter=name, failure="tee"):
+                    result = subprocess.run(
+                        [
+                            "bash",
+                            "--noprofile",
+                            "--norc",
+                            "-eo",
+                            "pipefail",
+                            "-c",
+                            "\n".join(commands),
+                        ],
+                        cwd=REPO_ROOT / "crates",
+                        env=env,
+                        capture_output=True,
+                        text=True,
+                        check=False,
+                    )
+                    self.assertEqual(
+                        result.returncode, 9, result.stdout + result.stderr
+                    )
+
+    def test_bare_success_check_cannot_distinguish_zero_selection(self):
+        with tempfile.TemporaryDirectory() as directory:
+            log = pathlib.Path(directory) / "selected_filter.log"
+            log.write_text(self.ZERO_SUMMARY)
+            bare = subprocess.run(
+                ["bash", "-c", 'cat "$1"; exit 0', "cargo-style", str(log)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            guarded = subprocess.run(
+                ["bash", str(self.ASSERT_SCRIPT), str(log), "1"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        self.assertEqual(bare.returncode, 0)
+        self.assertNotEqual(guarded.returncode, 0)
 
 
 class HarnessEnvironmentTests(unittest.TestCase):

--- a/scripts/tests/test_ci_workflows.py
+++ b/scripts/tests/test_ci_workflows.py
@@ -135,9 +135,7 @@ class WasmtimeParityWorkflowTests(unittest.TestCase):
             "${{ env.WASMTIME_VERSION }}",
             job,
         )
-        self.assertIn(
-            "if: steps.cache-wasmtime.outputs.cache-hit != 'true'", job
-        )
+        self.assertIn("if: steps.cache-wasmtime.outputs.cache-hit != 'true'", job)
         self.assertIn("set -euo pipefail", job)
         self.assertIn("--retry 5", job)
         self.assertIn("--retry-all-errors", job)
@@ -174,12 +172,8 @@ class BenchTrackWorkflowTests(unittest.TestCase):
 
 class FilteredCargoTestWorkflowTests(unittest.TestCase):
     ASSERT_SCRIPT = REPO_ROOT / "scripts" / "assert-tests-ran.sh"
-    SUMMARY = (
-        "test result: ok. 2 passed; 0 failed; 3 ignored; 0 measured; 9 filtered out\n"
-    )
-    ZERO_SUMMARY = (
-        "running 0 tests\ntest result: ok. 0 passed; 0 failed; 10 filtered out\n"
-    )
+    SUMMARY = "test result: ok. 2 passed; 0 failed; 3 ignored; 0 measured; 9 filtered out; finished in 0.01s\n"
+    ZERO_SUMMARY = "running 0 tests\ntest result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 10 filtered out; finished in 0.00s\n"
 
     @staticmethod
     def name_filter(command: str) -> str | None:
@@ -410,7 +404,9 @@ class FilteredCargoTestWorkflowTests(unittest.TestCase):
 
     def test_sums_passed_and_failed_across_harnesses(self):
         result = self.run_assertion(
-            self.SUMMARY + "test result: FAILED. 0 passed; 1 failed; 0 ignored;\n", "3"
+            self.SUMMARY
+            + "test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.20s\n",
+            "3",
         )
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("counted=3 floor=3", result.stdout)
@@ -425,6 +421,22 @@ class FilteredCargoTestWorkflowTests(unittest.TestCase):
         self.assertIn("counted=2 floor=1", result.stdout)
         malformed = "\x1b[32mtest result: ok. 717junk passed; 0 failed;\x1b[0m\r\n"
         self.assertNotEqual(self.run_assertion(summary + malformed).returncode, 0)
+
+    def test_truncated_and_trailing_text_summaries_are_malformed(self):
+        # A summary cut off after the failed count, or followed by anything after
+        # the cargo grammar, is not a summary; it must fail closed, not count.
+        for content in (
+            "test result: ok. 1 passed; 0 failed;\n",
+            "test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured;\n",
+            "test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s extra\n",
+            "test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s; more\n",
+        ):
+            with self.subTest(content=content):
+                result = self.run_assertion(self.SUMMARY + content)
+                self.assertNotEqual(result.returncode, 0, result.stdout)
+                self.assertIn("malformed test summary", result.stderr)
+        without_timing = self.SUMMARY.replace("; finished in 0.01s", "")
+        self.assertEqual(self.run_assertion(without_timing).returncode, 0)
 
     def test_zero_selection_and_no_summary_fail(self):
         for content in (self.ZERO_SUMMARY, "", "running 1 test\n"):
@@ -458,7 +470,7 @@ class FilteredCargoTestWorkflowTests(unittest.TestCase):
             ("1", ""),
         ):
             with self.subTest(passed=passed, failed=failed):
-                malformed = f"test result: ok. {passed} passed; {failed} failed;\n"
+                malformed = f"test result: ok. {passed} passed; {failed} failed; 0 ignored; 0 measured; 0 filtered out\n"
                 result = self.run_assertion(self.SUMMARY + malformed)
                 self.assertNotEqual(result.returncode, 0, result.stdout)
                 self.assertIn("floor=1", result.stdout + result.stderr)
@@ -484,7 +496,8 @@ class FilteredCargoTestWorkflowTests(unittest.TestCase):
                 )
                 self.assertNotEqual(result.returncode, 0, result.stdout)
         result = self.run_assertion(
-            self.SUMMARY + "test result: ok. 2147483647 passed; 0 failed;\n"
+            self.SUMMARY
+            + "test result: ok. 2147483647 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out\n"
         )
         self.assertNotEqual(result.returncode, 0, result.stdout)
 
@@ -771,8 +784,12 @@ class NpmReleaseWorkflowTests(unittest.TestCase):
         self.assertIn('if [ "$VERSION" != "$ALIAS_KHIVE_VERSION" ]', workflow)
 
         umbrella_publish = workflow.index("- name: Publish khive (umbrella)")
-        alias_rewrite = workflow.index("- name: Set CLI alias version and khive dependency")
-        alias_publish = workflow.index("- name: Publish @khive-ai/cli (compatibility alias)")
+        alias_rewrite = workflow.index(
+            "- name: Set CLI alias version and khive dependency"
+        )
+        alias_publish = workflow.index(
+            "- name: Publish @khive-ai/cli (compatibility alias)"
+        )
         self.assertLess(umbrella_publish, alias_rewrite)
         self.assertLess(alias_rewrite, alias_publish)
         self.assertIn("working-directory: npm/cli-alias", workflow[alias_publish:])
@@ -784,7 +801,7 @@ class NpmReleaseWorkflowTests(unittest.TestCase):
             npm_stub.write_text(
                 "#!/bin/sh\n"
                 "if [ \"${1:-}\" = view ]; then echo 'npm ERR! code E404' >&2; exit 1; fi\n"
-                "echo \"unexpected npm command: $*\" >&2\n"
+                'echo "unexpected npm command: $*" >&2\n'
                 "exit 97\n"
             )
             npm_stub.chmod(0o755)
@@ -800,7 +817,9 @@ class NpmReleaseWorkflowTests(unittest.TestCase):
             )
 
         self.assertEqual(completed.returncode, 0, completed.stderr)
-        version = json.loads((REPO_ROOT / "npm" / "package.json").read_text())["version"]
+        version = json.loads((REPO_ROOT / "npm" / "package.json").read_text())[
+            "version"
+        ]
         umbrella = f"[dry-run] would publish khive@{version}"
         alias = f"[dry-run] would publish @khive-ai/cli@{version}"
         self.assertIn(umbrella, completed.stdout)
@@ -813,11 +832,11 @@ class NpmReleaseWorkflowTests(unittest.TestCase):
             npm_stub = pathlib.Path(temp_dir) / "npm"
             npm_stub.write_text(
                 "#!/bin/sh\n"
-                "if [ \"${1:-}\" = view ]; then\n"
-                "  case \"${2:-}\" in @khive-ai/cli@*) echo 0.0.1; exit 0;; esac\n"
+                'if [ "${1:-}" = view ]; then\n'
+                '  case "${2:-}" in @khive-ai/cli@*) echo 0.0.1; exit 0;; esac\n'
                 "  exit 1\n"
                 "fi\n"
-                "echo \"unexpected npm command: $*\" >&2\n"
+                'echo "unexpected npm command: $*" >&2\n'
                 "exit 97\n"
             )
             npm_stub.chmod(0o755)
@@ -832,7 +851,9 @@ class NpmReleaseWorkflowTests(unittest.TestCase):
                 text=True,
             )
 
-        version = json.loads((REPO_ROOT / "npm" / "package.json").read_text())["version"]
+        version = json.loads((REPO_ROOT / "npm" / "package.json").read_text())[
+            "version"
+        ]
         self.assertEqual(completed.returncode, 1, completed.stdout)
         self.assertIn(f"depends on khive 0.0.1, expected {version}", completed.stderr)
         self.assertNotIn("would publish @khive-ai/cli", completed.stdout)
@@ -843,11 +864,11 @@ class NpmReleaseWorkflowTests(unittest.TestCase):
             npm_stub = pathlib.Path(temp_dir) / "npm"
             npm_stub.write_text(
                 "#!/bin/sh\n"
-                "if [ \"${1:-}\" = view ]; then\n"
+                'if [ "${1:-}" = view ]; then\n'
                 "  case \"${2:-}\" in @khive-ai/cli@*) echo 'npm ERR! code ECONNREFUSED' >&2; exit 1;; esac\n"
                 "  echo 'npm ERR! code E404' >&2; exit 1\n"
                 "fi\n"
-                "echo \"unexpected npm command: $*\" >&2\n"
+                'echo "unexpected npm command: $*" >&2\n'
                 "exit 97\n"
             )
             npm_stub.chmod(0o755)


### PR DESCRIPTION
`cargo test <filter>` exits 0 when the filter selects zero tests, so a workflow step that runs a filtered selection stays green forever once the filter stops matching (a renamed module, a removed `#[ignore]`). Four steps in this repository run such selections: the tz-database audit, the bench-embedder invariant in the bench pipeline, and the two Windows lanes in ci.yml.

This change adds `scripts/assert-tests-ran.sh`, which reads cargo's own `test result:` summary lines from a tee'd log and fails the step when the number of tests that reported a result is below the floor the step declares. All four steps declare a floor of 1: the guard detects an empty selection without pinning the suite size. `scripts/tests/test_ci_workflows.py` discovers every filtered `cargo test` step in the workflows and asserts each one is guarded, and exercises the guard's own arms (zero selection, malformed summary, a test path beginning with `result::`, CRLF and colored output).

No product code changes. The full workspace suite was run at this head on macOS with a newer stable toolchain than the CI pin, 0 failures.
