### PR TITLE
fix(python): preserve native pages and structured operation errors

### DIFF
--- a/python/docs/RESPONSE_WIRE_CONTRACT.md
+++ b/python/docs/RESPONSE_WIRE_CONTRACT.md
@@ -1,0 +1,201 @@
+# Response wire contract
+
+This document describes the native JSON shapes currently emitted for substrate
+`list` operations and per-operation failures. It records source behavior; it does
+not add server guarantees or describe every transport-level error. Examples omit
+record bodies and unrelated envelope fields. Message wording is diagnostic text,
+not a stable error discriminator.
+
+## Pages
+
+Offset-mode `list` results for entities, edges, and notes use `items` (R1):
+
+```json
+{
+  "items": [],
+  "requested_limit": 50,
+  "effective_limit": 50,
+  "limit_clamped": false
+}
+```
+
+This renderer does not emit `total` or `next_offset`. A client can preserve those
+fields when another response supplies them, but must not manufacture a count or
+an offset continuation and attribute it to this server response. An absent count
+means not counted, not zero.
+
+Supplying `after=""` selects cursor mode from the beginning. Subsequent calls
+supply the full UUID returned as `next_after`. The collection key is `entities`,
+`edges`, or `notes`, according to the substrate; the limit metadata is still
+present (R2). The Python facade exposes these rows as `Page.items`.
+
+```json
+{
+  "notes": [],
+  "next_after": "00000000-0000-0000-0000-000000000001",
+  "requested_limit": 1,
+  "effective_limit": 1,
+  "limit_clamped": false,
+  "scan_incomplete": true
+}
+```
+
+This is a possible filtered-note result after exhausting the bounded scan before
+finding enough matches. The cursor can refer to the last scanned row rather than
+a returned row. Continue using `next_after` even when `items` is empty or shorter
+than the effective limit. `next_after: null` is the normal cursor exhaustion
+marker; `scan_incomplete: true` explicitly prevents an exhaustion conclusion.
+Filtered offset-mode notes can also report `scan_incomplete: true`, without a
+cursor. That response reports incomplete scanning, not a resumable scan token
+(R3).
+
+The current requested limit caps are 500 entities, 200 notes, and 1,000 edges.
+For example, requesting 201 notes yields `requested_limit: 201`,
+`effective_limit: 200`, and `limit_clamped: true`. These are response metadata,
+not instructions to infer EOF from the caller's original requested limit (R4).
+
+## Per-operation results
+
+A request envelope carries `results` plus an aggregate `summary` with `total`,
+`succeeded`, `failed`, and `aborted`. Aggregate `status` is `success` when neither
+failed nor aborted operations exist, and `partial` otherwise. The result entries
+remain in input order even when execution is parallel. A batch failure does not
+roll back earlier or concurrent successes; callers must inspect individual
+entries (R5).
+
+```json
+{
+  "results": [
+    {"ok": true, "tool": "create", "result": {"id": "example-id"}},
+    {"ok": false, "tool": "get", "error": "not found: example-id"}
+  ],
+  "summary": {"total": 2, "succeeded": 1, "failed": 1, "aborted": 0},
+  "status": "partial"
+}
+```
+
+The `error` field can be a string or an object. `OpError` preserves an object's
+fields, including unfamiliar fields, while `OpResult.error` also accepts strings
+and absent/null errors. A string error is not upgraded to a fabricated structured
+error. In particular, today's missing-ID `get` returns `RuntimeError::NotFound`,
+which the server emits as a string (R6).
+
+Writer-task failures carry this object shape (R7):
+
+```json
+{
+  "kind": "storage",
+  "code": "writer_task_terminated",
+  "stage": "writer_task_terminated",
+  "message": "writer task terminated",
+  "retryable": false,
+  "request_state": "side_effects_unknown",
+  "task_terminated": true
+}
+```
+
+The exact current `request_state` strings are (R8):
+
+| Value | What the writer can establish |
+| --- | --- |
+| `not_started` | The operation closure was never invoked. |
+| `transaction_rolled_back` | The wrapping SQLite transaction was successfully rolled back. |
+| `side_effects_unknown` | The exact outcome cannot be established; side effects may exist. |
+
+Preserve these strings exactly. Preserve an unfamiliar value such as `unknown`
+exactly too, without converting it to a claim of failure or rollback.
+`task_terminated` describes writer-task liveness, separately from request finality.
+`retryable` describes the source failure's retry policy; rollback alone does not
+imply that policy is true. Do not infer known absence of writes from `ok: false`
+or replay an ambiguous write automatically.
+
+Retryable runtime failures use an `unavailable` object. The optional context
+values are emitted as JSON null when unavailable (R9):
+
+```json
+{
+  "kind": "unavailable",
+  "code": "writer_queue_saturated",
+  "stage": "writer_queue_saturated",
+  "message": "write queue full",
+  "retryable": true,
+  "timeout_ms": 100,
+  "capability": null,
+  "operation": null,
+  "scope": "writer_admission",
+  "retry_after_ms": 100
+}
+```
+
+`scope: "writer_admission"` identifies the queue-admission case. Other
+`unavailable` failures can have `scope: null`; do not infer that every retryable
+failure occurred before queue acceptance. The model preserves `kind`, `code`,
+`stage`, `message`, `retryable`, `timeout_ms`, `capability`, `operation`, `scope`,
+and `retry_after_ms` when present.
+
+The `RuntimeError::Khive` arm serializes `KhiveError` directly. It has `kind` and
+`message`, with nullable `code` and `details`. A populated code is a string such
+as `runtime:10`; populated details are a string-to-string map. Retry hints are
+not serialized as a field on this type (R10).
+
+```json
+{
+  "kind": "not_found",
+  "message": "entity not found: example-id",
+  "code": null,
+  "details": null
+}
+```
+
+These error families are not exhaustive. For example, depth refusal emits
+`kind: "result_too_deep"` and `message`, without `code` or `stage`. Preserving
+extra fields and admitting a message-only object avoids imposing a closed
+client-side taxonomy on evolving server responses (R11).
+
+## Aborted entries and correlation
+
+After a chain operation fails, later operations are not executed. The ordinary
+chain arm emits `ok: false`, `tool`, `aborted: true`, and a top-level `message`,
+without an `error` field. The strict-fallback arm omits that message as well (R12):
+
+```json
+{"ok": false, "tool": "get", "aborted": true}
+```
+
+The existing Python envelope compatibility rule also admits the older minimal
+shape `{"ok": false, "aborted": true}` and supplies an empty `tool` string.
+That admission does not mean the current ordinary server arm omits `tool`.
+An aborted entry must remain distinguishable from an attempted write whose
+effects are unknown.
+
+`request_id` correlates a request group with daemon responses and audit records.
+Every operation in a batch or chain shares it. It is neither an operation-unique
+identifier nor a cross-attempt idempotency key. Reusing it does not deduplicate a
+write. Correlate per-operation results by their response position and inspect
+their actual outcome; a partial batch is not permission to replay every operation
+(R13).
+
+## Source citations
+
+Each quoted fragment below is a verbatim substring of one source line. The test
+in `python/tests/test_response_wire_contract.py` checks citation presence in the
+named file, not semantics, branch identity, completeness, or a live deployment.
+A quote can recur at several sites. A passing presence check does not establish
+that the associated explanation remains correct after surrounding code changes;
+review those changes and use behavioral fixtures for the client obligations.
+
+| Rule | Source-line citations |
+| --- | --- |
+| R1 | crates/khive-pack-kg/src/handlers/list.rs -- "fn render_list_response(items: Value, requested: u32, effective: u32) -> Value {"; crates/khive-pack-kg/src/handlers/list.rs -- "\"items\": items,"; crates/khive-pack-kg/src/handlers/list.rs -- "\"requested_limit\": requested,"; crates/khive-pack-kg/src/handlers/list.rs -- "\"effective_limit\": effective,"; crates/khive-pack-kg/src/handlers/list.rs -- "\"limit_clamped\": requested > effective," |
+| R2 | crates/khive-pack-kg/src/handlers/list.rs -- "if raw.is_empty() {"; crates/khive-pack-kg/src/handlers/list.rs -- "uuid::Uuid::parse_str(raw).map(Some)"; crates/khive-pack-kg/src/handlers/list.rs -- "\"entities\": normalize_entity_timestamps_array(to_json(&entities)?),"; crates/khive-pack-kg/src/handlers/list.rs -- "\"edges\": to_json(&edges)?,"; crates/khive-pack-kg/src/handlers/list.rs -- "\"notes\": remapped,"; crates/khive-pack-kg/src/handlers/list.rs -- "\"next_after\": next_after,"; crates/khive-pack-kg/src/handlers/list.rs -- "add_list_limit_metadata(&mut response, requested, limit);" |
+| R3 | crates/khive-pack-kg/src/handlers/list.rs -- "} else if raw_more && scanned >= MAX_SCAN_TOTAL {"; crates/khive-pack-kg/src/handlers/list.rs -- "!has_more_match && raw_more && scanned >= MAX_SCAN_TOTAL,"; crates/khive-pack-kg/src/handlers/list.rs -- "response[\"scan_incomplete\"] = Value::Bool(true);"; crates/khive-pack-kg/src/handlers/list.rs -- "let mut response = render_list_response(to_json(&remapped)?, requested, limit);" |
+| R4 | crates/khive-pack-kg/src/handlers/list.rs -- "const ENTITY_LIST_CAP: u32 = 500;"; crates/khive-pack-kg/src/handlers/list.rs -- "const NOTE_LIST_CAP: u32 = 200;"; crates/khive-runtime/src/operations.rs -- "pub const EDGE_LIST_MAX_LIMIT: u32 = 1000;" |
+| R5 | crates/khive-mcp/src/server.rs -- "results[index] = Some(entry);"; crates/khive-mcp/src/server.rs -- "\"summary\": { \"total\": total, \"succeeded\": succeeded, \"failed\": failed, \"aborted\": 0 },"; crates/khive-mcp/src/server.rs -- "if failed == 0 && aborted == 0 {"; crates/khive-mcp/src/server.rs -- "ops (reported as {\"ok\": false, \"aborted\": true}). Committed ops are not rolled back." |
+| R6 | crates/khive-pack-kg/src/handlers/get.rs -- "Err(RuntimeError::NotFound(format!(\"not found: {}\", p.id)))"; crates/khive-mcp/src/server.rs -- "let Some(context) = other.retryable_failure_context() else {"; crates/khive-mcp/src/server.rs -- "return json!(other.to_string());" |
+| R7 | crates/khive-mcp/src/server.rs -- "if let Some(context) = other.writer_task_failure_context() {"; crates/khive-mcp/src/server.rs -- "\"kind\": \"storage\","; crates/khive-mcp/src/server.rs -- "\"code\": context.stage,"; crates/khive-mcp/src/server.rs -- "\"stage\": context.stage,"; crates/khive-mcp/src/server.rs -- "\"message\": other.to_string(),"; crates/khive-mcp/src/server.rs -- "\"retryable\": context.retryable,"; crates/khive-mcp/src/server.rs -- "\"request_state\": context.request_state.to_string(),"; crates/khive-mcp/src/server.rs -- "\"task_terminated\": context.task_terminated," |
+| R8 | crates/khive-storage/src/error.rs -- "Self::NotStarted => \"not_started\","; crates/khive-storage/src/error.rs -- "Self::TransactionRolledBack => \"transaction_rolled_back\","; crates/khive-storage/src/error.rs -- "Self::SideEffectsUnknown => \"side_effects_unknown\","; crates/khive-runtime/src/error.rs -- "/// not be inferred from rollback finality alone." |
+| R9 | crates/khive-mcp/src/server.rs -- "\"kind\": \"unavailable\","; crates/khive-mcp/src/server.rs -- "\"retryable\": true,"; crates/khive-mcp/src/server.rs -- "\"timeout_ms\": timeout_ms,"; crates/khive-mcp/src/server.rs -- "\"capability\": capability,"; crates/khive-mcp/src/server.rs -- "\"operation\": context.operation,"; crates/khive-mcp/src/server.rs -- "\"scope\": context.scope,"; crates/khive-mcp/src/server.rs -- "\"retry_after_ms\": context.retry_after_ms,"; crates/khive-runtime/src/error.rs -- "pub const WRITER_ADMISSION_SCOPE: &str = \"writer_admission\";" |
+| R10 | crates/khive-mcp/src/server.rs -- "RuntimeError::Khive(k) => serde_json::to_value(&k)"; crates/khive-types/src/khive_error.rs -- "pub struct KhiveError {"; crates/khive-types/src/khive_error.rs -- "code: Option<ErrorCode>,"; crates/khive-types/src/khive_error.rs -- "details: Option<Details>,"; crates/khive-types/src/khive_error.rs -- "s.serialize_str(&self.to_string())"; crates/khive-types/src/khive_error.rs -- "map.serialize_entry(k.as_ref(), v.as_ref())?;" |
+| R11 | crates/khive-mcp/src/server.rs -- "fn depth_error_payload(context: &str) -> Value {"; crates/khive-mcp/src/server.rs -- "\"kind\": \"result_too_deep\"," |
+| R12 | crates/khive-mcp/src/server.rs -- "\"aborted\": true,"; crates/khive-mcp/src/server.rs -- "\"message\": format!("; crates/khive-mcp/src/server.rs -- "json!({ \"ok\": false, \"tool\": op.tool, \"aborted\": true })" |
+| R13 | crates/khive-mcp/src/tools/request.rs -- "/// operation-unique id or a cross-attempt idempotency key."; crates/khive-mcp/src/tools/request.rs -- "pub request_id: Option<u64>," |

--- a/python/khive/__init__.py
+++ b/python/khive/__init__.py
@@ -16,7 +16,7 @@ from .errors import (
     RequestRejected,
     TransportError,
 )
-from .models import Edge, EdgeRelation, Entity, Incidence, Note, OpResult, Page
+from .models import Edge, EdgeRelation, Entity, Incidence, Note, OpError, OpResult, Page
 from .ops import encode, op
 from .transport import Session, SocketTransport, Transport
 
@@ -31,6 +31,7 @@ __all__ = [
     "Khive",
     "KhiveError",
     "Note",
+    "OpError",
     "OpResult",
     "OperationError",
     "Page",

--- a/python/khive/client.py
+++ b/python/khive/client.py
@@ -68,14 +68,20 @@ def _note_from_wire(row: dict[str, Any]) -> Note:
     return Note.model_validate(row)
 
 
-def _page(raw: Any, parse: Any) -> Page:
+def _page(raw: Any, parse: Any, *, cursor_key: str) -> Page:
     if isinstance(raw, dict):
-        items = raw.get("items", raw.get("results", []))
-        total = raw.get("total")
-        next_offset = raw.get("next_offset")
-    else:
-        items, total, next_offset = raw or [], None, None
-    return Page(items=[parse(x) for x in items], total=total, next_offset=next_offset)
+        items = raw.get("items", raw.get(cursor_key, raw.get("results", [])))
+        return Page(
+            items=[parse(x) for x in items],
+            total=raw.get("total"),
+            next_offset=raw.get("next_offset"),
+            next_after=raw.get("next_after"),
+            scan_incomplete=raw.get("scan_incomplete"),
+            requested_limit=raw.get("requested_limit"),
+            effective_limit=raw.get("effective_limit"),
+            limit_clamped=raw.get("limit_clamped"),
+        )
+    return Page(items=[parse(x) for x in raw or []])
 
 
 class Khive:
@@ -96,9 +102,7 @@ class Khive:
     ) -> None:
         if transport is None:
             transport = SocketTransport(socket_path)
-        self.session = Session(
-            transport, namespace=namespace, actor_id=actor_id, timeout=timeout
-        )
+        self.session = Session(transport, namespace=namespace, actor_id=actor_id, timeout=timeout)
         self.entities = _Entities(self)
         self.notes = _Notes(self)
         self.graph = _Graph(self)
@@ -112,14 +116,11 @@ class Khive:
     def batch(self, ops: list[dict[str, Any]]) -> list[OpResult]:
         """Like `raw`, but raises `BatchError` if any op failed."""
         results = self.session.request(encode(ops))
-        failures = [
-            (i, r.get("tool", "?"), str(r.get("error")))
-            for i, r in enumerate(results)
-            if not r.get("ok")
-        ]
+        parsed = [OpResult.model_validate(r) for r in results]
+        failures = [(i, r.tool, r.error) for i, r in enumerate(parsed) if not r.ok]
         if failures:
             raise BatchError(results, failures)
-        return [OpResult.model_validate(r) for r in results]
+        return parsed
 
     # -- database-wide reads ----------------------------------------------
 
@@ -152,7 +153,9 @@ class Khive:
         kind: str = "entity",
         limit: int | None = None,
     ) -> list[dict[str, Any]]:
-        raw = _one(self.session.request(encode([op("search", kind=kind, query=query, limit=limit)])))
+        raw = _one(
+            self.session.request(encode([op("search", kind=kind, query=query, limit=limit)]))
+        )
         if isinstance(raw, dict):
             return raw.get("items", raw.get("results", []))
         return raw or []
@@ -198,7 +201,7 @@ class _Entities:
                 encode([op("list", kind=kind, limit=limit, offset=offset, **filters)])
             )
         )
-        return _page(raw, Entity.model_validate)
+        return _page(raw, Entity.model_validate, cursor_key="entities")
 
     def update(self, id: str, **patch: Any) -> Entity:
         raw = _one(self._db.session.request(encode([op("update", id=id, **patch)])))
@@ -242,8 +245,10 @@ class _Notes:
         return _note_from_wire(_one(self._db.session.request(encode([op("get", id=id)]))))
 
     def list(self, *, kind: str = "note", limit: int | None = None, **filters: Any) -> Page:
-        raw = _one(self._db.session.request(encode([op("list", kind=kind, limit=limit, **filters)])))
-        return _page(raw, _note_from_wire)
+        raw = _one(
+            self._db.session.request(encode([op("list", kind=kind, limit=limit, **filters)]))
+        )
+        return _page(raw, _note_from_wire, cursor_key="notes")
 
 
 class _Graph:
@@ -315,9 +320,7 @@ class _Graph:
     ) -> Any:
         return _one(
             self._db.session.request(
-                encode(
-                    [op("neighbors", node_id=node_id, direction=direction, relations=relations)]
-                )
+                encode([op("neighbors", node_id=node_id, direction=direction, relations=relations)])
             )
         )
 
@@ -351,7 +354,7 @@ class _Graph:
         raw = _one(
             self._db.session.request(encode([op("list", kind="edge", limit=limit, **filters)]))
         )
-        return _page(raw, _edge_from_wire)
+        return _page(raw, _edge_from_wire, cursor_key="edges")
 
     # -- incidence-aware reads (client-side PROTOTYPE) ---------------------
     # The target engine computes these as an incidence join server-side:

--- a/python/khive/envelope.py
+++ b/python/khive/envelope.py
@@ -4,8 +4,7 @@ contract.
 
 This module provides the steps a transport needs to turn raw response
 bytes into validated `OpResult` entries: decode JSON, check the result is a
-request-envelope shape, flatten each per-op error object to the plain
-string `OpResult.error` expects, admit the daemon's minimal
+request-envelope shape, preserve validated per-op error objects, admit the daemon's minimal
 aborted-chain-entry shape, and validate every entry against `OpResult`. It
 is transport-agnostic and calls no transport itself — a transport that
 wants a malformed body, a malformed envelope, or a malformed per-op entry
@@ -20,7 +19,7 @@ from typing import Any
 from pydantic import ValidationError
 
 from .errors import TransportError
-from .models import OpResult
+from .models import OpError, OpResult
 
 
 def _decode_json_text(text: str, url: str) -> Any:
@@ -35,7 +34,7 @@ def _envelope_from_payload(payload: Any, url: str) -> dict[str, Any]:
     """Rejects a decoded JSON payload that is not a request envelope shape:
     a dict whose `results` member is a list. Shared by every transport so
     they all agree on this check, not just on the per-op normalization that
-    runs after it (`_stringify_op_errors`/`_validate_envelope_results`)."""
+    runs after it (`_validate_op_errors`/`_validate_envelope_results`)."""
     if not isinstance(payload, dict) or not isinstance(payload.get("results"), list):
         raise TransportError(f"response from {url} is not a request envelope: {str(payload)[:200]}")
     return payload
@@ -58,22 +57,17 @@ def _is_minimal_aborted_entry(entry: Any) -> bool:
 def _validate_envelope_results(envelope: dict[str, Any], url: str) -> dict[str, Any]:
     """Reject an envelope whose result entries do not match `OpResult`.
 
-    Runs after `_stringify_op_errors`, so a per-op error is already the
-    plain string `OpResult.error` expects, not a transport-native
-    `{"code","message"}` object — a top-level-only check would otherwise let
-    e.g. `{"results": [42]}` or an entry missing `ok`/`tool` reach the caller
-    as a successful response.
+    Error objects remain dictionaries in the returned envelope. Validation
+    never flattens or infers finality from their fields.
 
-    A minimal aborted entry (see `_is_minimal_aborted_entry`) is admitted
-    without going through `OpResult`, but normalized in place to carry
-    `tool: ""` first, keeping every entry (aborted or not) satisfying
+    A minimal aborted entry (see `_is_minimal_aborted_entry`) is normalized
+    in place to carry `tool: ""` before validation, keeping every entry satisfying
     `OpResult.tool: str` exactly, so every transport hands the caller the
     same object.
     """
     for index, entry in enumerate(envelope["results"]):
         if _is_minimal_aborted_entry(entry):
             entry["tool"] = ""
-            continue
         try:
             OpResult.model_validate(entry)
         except ValidationError as exc:
@@ -83,15 +77,8 @@ def _validate_envelope_results(envelope: dict[str, Any], url: str) -> dict[str, 
     return envelope
 
 
-def _stringify_op_errors(envelope: Any, url: str) -> Any:
-    """Flatten a transport's `{"code","message"}` per-op error objects to a
-    string, in place, so each entry still validates against
-    `OpResult.error: str | None`.
-
-    Validates the error object's shape first: `code`, when present, and
-    `message` must both be strings — anything else is a malformed entry,
-    not a value to flatten and pass along.
-    """
+def _validate_op_errors(envelope: Any, url: str) -> Any:
+    """Validate structured errors without replacing their original payloads."""
     if not isinstance(envelope, dict):
         return envelope
     for index, entry in enumerate(envelope.get("results", [])):
@@ -100,17 +87,10 @@ def _stringify_op_errors(envelope: Any, url: str) -> Any:
         err = entry.get("error")
         if not isinstance(err, dict):
             continue
-        code = err.get("code")
-        if code is not None and not isinstance(code, str):
+        try:
+            OpError.model_validate(err)
+        except ValidationError as exc:
             raise TransportError(
-                f"response from {url} has a malformed error object at index {index}: "
-                f"'code' must be a string, got {type(code).__name__}"
-            )
-        message = err.get("message")
-        if not isinstance(message, str):
-            raise TransportError(
-                f"response from {url} has a malformed error object at index {index}: "
-                f"'message' must be a string, got {type(message).__name__}"
-            )
-        entry["error"] = f"{code}: {message}" if code else message
+                f"response from {url} has a malformed error object at index {index}: {exc}"
+            ) from exc
     return envelope

--- a/python/khive/errors.py
+++ b/python/khive/errors.py
@@ -14,6 +14,8 @@ caller retries them differently:
 
 from __future__ import annotations
 
+from .models import OpError
+
 
 class KhiveError(Exception):
     """Base class for every error this package raises."""
@@ -50,8 +52,9 @@ class RequestRejected(KhiveError):
 class OperationError(KhiveError):
     """A single op inside a request failed server-side."""
 
-    def __init__(self, tool: str, message: str) -> None:
+    def __init__(self, tool: str, message: OpError | str) -> None:
         self.tool = tool
+        self.error = message
         super().__init__(f"{tool}: {message}")
 
 
@@ -62,7 +65,9 @@ class BatchError(KhiveError):
     `failures` is the failed subset as (index, tool, error) tuples.
     """
 
-    def __init__(self, results: list[dict], failures: list[tuple[int, str, str]]) -> None:
+    def __init__(
+        self, results: list[dict], failures: list[tuple[int, str, OpError | str | None]]
+    ) -> None:
         self.results = results
         self.failures = failures
         summary = "; ".join(f"[{i}] {tool}: {err}" for i, tool, err in failures[:3])

--- a/python/khive/models.py
+++ b/python/khive/models.py
@@ -69,12 +69,14 @@ class _Record(BaseModel):
     def _null_list(cls, v: Any) -> Any:
         return [] if v is None else v
 
+
 class Entity(_Record):
     """A named node in the graph. `kind` validates server-side against the
     pack-declared entity vocabulary (concept, document, project, ...)."""
 
     name: str
     description: str | None = None
+
 
 class Note(_Record):
     """Free-text annotation record. `kind` validates server-side against the
@@ -93,6 +95,7 @@ class Note(_Record):
         if not isinstance(v, str):
             raise TypeError(f"kind must be a string, got {type(v)}")
         return v
+
 
 class Incidence(BaseModel):
     """One node's participation in one edge (weighted incidence).
@@ -155,14 +158,47 @@ class Edge(_Record):
                 return m.weight
         raise KeyError(f"{node_id} is not a member of edge {self.id}")
 
+
 class Page(BaseModel, Generic[T]):
-    """One page of results. `total=None` means the server skipped the count."""
+    """One page; missing counts/continuations are not inferred from its length.
+
+    Cursor readers follow `next_after`. An empty or short page with a cursor
+    or `scan_incomplete=True` does not establish the end of the filtered scan.
+    """
 
     model_config = ConfigDict(extra="allow")
 
     items: list[T] = Field(default_factory=list)
     total: int | None = None
     next_offset: int | None = None
+    next_after: str | None = None
+    scan_incomplete: bool | None = None
+    requested_limit: int | None = None
+    effective_limit: int | None = None
+    limit_clamped: bool | None = None
+
+
+class OpError(BaseModel):
+    """A structured per-op error, including the server's unchanged write finality."""
+
+    model_config = ConfigDict(extra="allow", strict=True)
+
+    message: str
+    kind: str | None = None
+    code: str | None = None
+    stage: str | None = None
+    retryable: bool | None = None
+    request_state: str | None = None
+    task_terminated: bool | None = None
+    timeout_ms: int | None = None
+    capability: str | None = None
+    operation: str | None = None
+    scope: str | None = None
+    retry_after_ms: int | None = None
+    details: dict[str, str] | None = None
+
+    def __str__(self) -> str:
+        return f"{self.code}: {self.message}" if self.code else self.message
 
 
 class OpResult(BaseModel):
@@ -173,4 +209,4 @@ class OpResult(BaseModel):
     ok: bool
     tool: str
     result: Any = None
-    error: str | None = None
+    error: OpError | str | None = None

--- a/python/khive/transport.py
+++ b/python/khive/transport.py
@@ -30,6 +30,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any
 
+from .envelope import _decode_json_text, _envelope_from_payload, _validate_envelope_results
 from .errors import (
     ConfigMismatch,
     FrameTooLarge,
@@ -165,10 +166,9 @@ class Session:
         if not response.get("ok"):
             raise RequestRejected(str(response.get("error")))
         raw = response.get("result")
-        parsed = json.loads(raw) if isinstance(raw, str) else raw
-        if isinstance(parsed, dict) and "results" in parsed:
-            return parsed["results"]
-        raise TransportError(f"response result missing 'results': {str(parsed)[:200]}")
+        parsed = _decode_json_text(raw, "daemon") if isinstance(raw, str) else raw
+        envelope = _envelope_from_payload(parsed, "daemon")
+        return _validate_envelope_results(envelope, "daemon")["results"]
 
     def _base_frame(self) -> dict[str, Any]:
         return {

--- a/python/tests/test_client_response_contract.py
+++ b/python/tests/test_client_response_contract.py
@@ -1,0 +1,235 @@
+"""Source-shaped responses exercised through the native Session and facade."""
+
+from __future__ import annotations
+
+import copy
+import json
+
+import pytest
+
+from khive import BatchError, Khive, OperationError, Transport, op
+from khive.envelope import _validate_envelope_results
+from khive.errors import TransportError
+
+NOTE_ID = "00000000-0000-4000-8000-000000000001"
+NEXT_ID = "00000000-0000-4000-8000-000000000002"
+
+
+class ResponseTransport(Transport):
+    def __init__(self, results):
+        self.results = results
+
+    def round_trip(self, frame, timeout):
+        response = {"ok": True, "served_config_id": "test-config"}
+        if not frame.get("metrics_only"):
+            response["result"] = json.dumps({"results": self.results})
+        return response
+
+
+def client_for(results):
+    return Khive(transport=ResponseTransport(results), actor_id="test-client")
+
+
+ROWS = {
+    "entities": {"id": NOTE_ID, "kind": "concept", "name": "sample"},
+    "notes": {"id": NOTE_ID, "kind": "observation", "content": "sample"},
+    "edges": {
+        "id": NOTE_ID,
+        "relation": "extends",
+        "source_id": NOTE_ID,
+        "target_id": NEXT_ID,
+        "weight": 1.0,
+    },
+}
+
+
+def list_page(db, substrate, **kwargs):
+    if substrate == "edges":
+        return db.graph.edges(**kwargs)
+    return getattr(db, substrate).list(**kwargs)
+
+
+@pytest.mark.parametrize("substrate", ROWS)
+@pytest.mark.parametrize("cursor", [False, True])
+def test_native_pages_keep_records_and_metadata(substrate, cursor):
+    cap = {"entities": 500, "notes": 200, "edges": 1000}[substrate]
+    payload = {
+        substrate if cursor else "items": [ROWS[substrate]],
+        "requested_limit": 2000,
+        "effective_limit": cap,
+        "limit_clamped": True,
+    }
+    if cursor:
+        payload["next_after"] = NEXT_ID
+    db = client_for([{"ok": True, "tool": "list", "result": payload}])
+    page = list_page(db, substrate, limit=2000, **({"after": ""} if cursor else {}))
+    assert [item.id for item in page.items] == [NOTE_ID]
+    assert page.requested_limit == 2000
+    assert page.effective_limit == cap
+    assert page.limit_clamped is True
+    assert page.next_after == (NEXT_ID if cursor else None)
+    assert page.next_offset is None
+    assert page.total is None
+
+
+@pytest.mark.parametrize("cursor", [False, True])
+def test_empty_filtered_page_preserves_incomplete_scan(cursor):
+    payload = {
+        "notes" if cursor else "items": [],
+        "scan_incomplete": True,
+        "requested_limit": 1,
+        "effective_limit": 1,
+        "limit_clamped": False,
+    }
+    if cursor:
+        payload["next_after"] = NEXT_ID
+    db = client_for([{"ok": True, "tool": "list", "result": payload}])
+    page = db.notes.list(limit=1, tags=["cursor-test"], **({"after": ""} if cursor else {}))
+    assert page.items == []
+    assert page.scan_incomplete is True
+    assert page.next_after == (NEXT_ID if cursor else None)
+
+
+@pytest.mark.parametrize("container", ["items", "results"])
+def test_explicit_offset_metadata_is_preserved(container):
+    payload = {container: [ROWS["notes"]], "total": 10, "next_offset": 7}
+    page = client_for([{"ok": True, "tool": "list", "result": payload}]).notes.list()
+    assert page.total == 10 and page.next_offset == 7
+    assert [item.id for item in page.items] == [NOTE_ID]
+
+
+ERRORS = [
+    "entity not found",
+    {
+        "kind": "storage",
+        "code": "writer_task_terminated",
+        "stage": "writer_task_terminated",
+        "message": "writer task terminated",
+        "retryable": False,
+        "request_state": "side_effects_unknown",
+        "task_terminated": True,
+    },
+    {
+        "kind": "unavailable",
+        "code": "writer_queue_saturated",
+        "stage": "writer_queue_saturated",
+        "message": "write queue full",
+        "retryable": True,
+        "timeout_ms": 100,
+        "capability": None,
+        "operation": None,
+        "scope": "writer_admission",
+        "retry_after_ms": 100,
+    },
+    {"kind": "not_found", "message": "entity not found", "code": None, "details": None},
+    {
+        "kind": "conflict",
+        "message": "conflict",
+        "code": "version_conflict",
+        "details": {"current_version": "2"},
+        "request_state": "unknown",
+        "future_metadata": {"attempt": 2},
+    },
+]
+
+
+def error_payload(value):
+    return value.model_dump(exclude_unset=True) if hasattr(value, "model_dump") else value
+
+
+@pytest.mark.parametrize("error", ERRORS)
+@pytest.mark.parametrize("validate_envelope", [False, True])
+def test_error_objects_survive_raw_and_partial_batch(error, validate_envelope):
+    entries = [
+        {"ok": True, "tool": "stats", "result": {"count": 1}},
+        {"ok": False, "tool": "get", "error": copy.deepcopy(error)},
+    ]
+    if validate_envelope:
+        entries = _validate_envelope_results({"results": entries}, "fixture")["results"]
+    db = client_for(entries)
+    ops = [op("stats"), op("get", id=NOTE_ID)]
+    results = db.raw(ops)
+    assert results[0].result == {"count": 1}
+    assert error_payload(results[1].error) == error
+    with pytest.raises(BatchError) as raised:
+        db.batch(ops)
+    assert raised.value.results == entries
+    index, tool, failure = raised.value.failures[0]
+    assert (index, tool) == (1, "get")
+    assert error_payload(failure) == error
+    assert (error if isinstance(error, str) else error["message"]) in str(raised.value)
+
+
+def test_single_operation_preserves_unknown_write_error():
+    error = ERRORS[1]
+    db = client_for([{"ok": False, "tool": "get", "error": error}])
+    with pytest.raises(OperationError) as raised:
+        db.get(NOTE_ID)
+    assert error_payload(raised.value.error) == error
+    assert raised.value.error.request_state == "side_effects_unknown"
+
+
+@pytest.mark.parametrize(
+    "aborted",
+    [
+        {"ok": False, "aborted": True},
+        {"ok": False, "tool": "get", "aborted": True},
+        {"ok": False, "tool": "get", "aborted": True, "message": "prior operation failed"},
+    ],
+)
+def test_aborted_entries_remain_unexecuted_in_raw_and_batch(aborted):
+    entries = [{"ok": False, "tool": "get", "error": "not found"}, aborted]
+    db = client_for(entries)
+    ops = [op("get", id=NOTE_ID), op("get", id=NEXT_ID)]
+    results = db.raw(ops)
+    assert results[1].aborted is True
+    assert results[1].error is None
+    assert results[1].tool == aborted.get("tool", "")
+    with pytest.raises(BatchError) as raised:
+        db.batch(ops)
+    assert [failure[0] for failure in raised.value.failures] == [0, 1]
+    assert raised.value.results[1]["aborted"] is True
+
+
+@pytest.mark.parametrize(
+    "patch",
+    [{"message": 1}, {"code": 1}, {"retryable": "false"}, {"request_state": False}],
+)
+def test_malformed_error_fields_refused_by_session(patch):
+    error = {**ERRORS[1], **patch}
+    db = client_for([{"ok": False, "tool": "get", "error": error}])
+    with pytest.raises(TransportError, match="malformed"):
+        db.raw([op("get", id=NOTE_ID)])
+
+
+def test_live_three_note_cursor_walk(scratch_daemon):
+    db = Khive(socket_path=str(scratch_daemon["socket"]), actor_id="test-client")
+    # A tag identifies just this fixture in the shared scratch daemon.
+    created = [
+        db.notes.create(subject="cursor", content=f"cursor record {i}", tags=["cursor-test"])
+        for i in range(3)
+    ]
+    cursor = ""
+    seen = []
+    for index in range(3):
+        page = db.notes.list(limit=1, after=cursor, tags=["cursor-test"])
+        assert len(page.items) == 1
+        assert page.effective_limit == 1
+        assert page.scan_incomplete is not True
+        seen.append(page.items[0].id)
+        if index < 2:
+            assert page.next_after is not None
+            cursor = page.next_after
+        else:
+            assert page.next_after is None
+    assert len(set(seen)) == 3
+    assert set(seen) == {note.id for note in created}
+
+
+def test_live_missing_id_keeps_string_error_and_index(scratch_daemon):
+    db = Khive(socket_path=str(scratch_daemon["socket"]), actor_id="test-client")
+    with pytest.raises(BatchError) as raised:
+        db.batch([op("stats"), op("get", id="00000000-0000-0000-0000-000000000000")])
+    index, tool, error = raised.value.failures[0]
+    assert (index, tool) == (1, "get")
+    assert isinstance(error, str) and error

--- a/python/tests/test_envelope.py
+++ b/python/tests/test_envelope.py
@@ -1,6 +1,6 @@
 """Direct coverage for the transport-shared envelope normalization functions
 in `khive.envelope` — decoding, envelope-shape rejection, minimal aborted
-entries, per-entry `OpResult` validation, and per-op error flattening."""
+entries, per-entry `OpResult` validation, and per-op error preservation."""
 
 from __future__ import annotations
 
@@ -12,8 +12,8 @@ from khive.envelope import (
     _decode_json_text,
     _envelope_from_payload,
     _is_minimal_aborted_entry,
-    _stringify_op_errors,
     _validate_envelope_results,
+    _validate_op_errors,
 )
 from khive.errors import TransportError
 
@@ -103,50 +103,50 @@ def test_validate_envelope_results_rejects_entry_missing_tool():
         _validate_envelope_results({"results": [{"ok": True}]}, _SENTINEL_URL)
 
 
-def test_stringify_op_errors_code_and_message():
+def test_validate_op_errors_code_and_message():
     envelope = {"results": [{"ok": False, "tool": "v", "error": {"code": "x", "message": "m"}}]}
-    out = _stringify_op_errors(envelope, "url")
-    assert out["results"][0]["error"] == "x: m"
+    out = _validate_op_errors(envelope, "url")
+    assert out["results"][0]["error"] == {"code": "x", "message": "m"}
 
 
-def test_stringify_op_errors_message_only():
+def test_validate_op_errors_message_only():
     envelope = {"results": [{"ok": False, "tool": "v", "error": {"message": "m"}}]}
-    out = _stringify_op_errors(envelope, "url")
-    assert out["results"][0]["error"] == "m"
+    out = _validate_op_errors(envelope, "url")
+    assert out["results"][0]["error"] == {"message": "m"}
 
 
-def test_stringify_op_errors_non_string_code_raises():
+def test_validate_op_errors_non_string_code_raises():
     envelope = {"results": [{"ok": False, "tool": "v", "error": {"code": 1, "message": "m"}}]}
     with pytest.raises(TransportError, match=f"{re.escape(_SENTINEL_URL)}.*index 0"):
-        _stringify_op_errors(envelope, _SENTINEL_URL)
+        _validate_op_errors(envelope, _SENTINEL_URL)
 
 
-def test_stringify_op_errors_non_string_message_raises():
+def test_validate_op_errors_non_string_message_raises():
     envelope = {"results": [{"ok": False, "tool": "v", "error": {"code": "x", "message": 1}}]}
     with pytest.raises(TransportError, match=f"{re.escape(_SENTINEL_URL)}.*index 0"):
-        _stringify_op_errors(envelope, _SENTINEL_URL)
+        _validate_op_errors(envelope, _SENTINEL_URL)
 
 
-def test_stringify_op_errors_missing_message_raises():
+def test_validate_op_errors_missing_message_raises():
     envelope = {"results": [{"ok": False, "tool": "v", "error": {"code": "x"}}]}
     with pytest.raises(TransportError, match=f"{re.escape(_SENTINEL_URL)}.*index 0"):
-        _stringify_op_errors(envelope, _SENTINEL_URL)
+        _validate_op_errors(envelope, _SENTINEL_URL)
 
 
-def test_stringify_op_errors_non_dict_envelope_returned_unchanged():
-    assert _stringify_op_errors([1, 2, 3], "url") == [1, 2, 3]
-    assert _stringify_op_errors(None, "url") is None
+def test_validate_op_errors_non_dict_envelope_returned_unchanged():
+    assert _validate_op_errors([1, 2, 3], "url") == [1, 2, 3]
+    assert _validate_op_errors(None, "url") is None
 
 
-def test_stringify_op_errors_skips_non_dict_entry():
+def test_validate_op_errors_skips_non_dict_entry():
     envelope = {"results": [42, "also-not-a-dict"]}
-    out = _stringify_op_errors(envelope, "url")
+    out = _validate_op_errors(envelope, "url")
     assert out["results"] == [42, "also-not-a-dict"]
 
 
-def test_stringify_op_errors_leaves_string_error_alone():
+def test_validate_op_errors_leaves_string_error_alone():
     envelope = {"results": [{"ok": False, "tool": "v", "error": "already a string"}]}
-    out = _stringify_op_errors(envelope, "url")
+    out = _validate_op_errors(envelope, "url")
     assert out["results"][0]["error"] == "already a string"
 
 
@@ -161,7 +161,7 @@ def test_chain_abort_envelope_through_both_steps():
             {"ok": False, "aborted": True},
         ]
     }
-    stringified = _stringify_op_errors(envelope, "url")
-    validated = _validate_envelope_results(stringified, "url")
+    checked = _validate_op_errors(envelope, "url")
+    validated = _validate_envelope_results(checked, "url")
     assert validated["results"][1] == {"ok": False, "aborted": True, "tool": ""}
-    assert validated["results"][0]["error"] == "unknown_verb: no such verb"
+    assert validated["results"][0]["error"] == {"code": "unknown_verb", "message": "no such verb"}

--- a/python/tests/test_response_wire_contract.py
+++ b/python/tests/test_response_wire_contract.py
@@ -1,0 +1,66 @@
+"""Check source-line citation presence, not response behavior or semantics."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOC_PATH = Path(__file__).resolve().parents[1] / "docs" / "RESPONSE_WIRE_CONTRACT.md"
+DOC_TEXT = DOC_PATH.read_text()
+_CITE_RE = re.compile(r'([\w./-]+) -- ("(?:\\.|[^"\\])*")')
+
+
+def _citation_rows() -> dict[str, list[tuple[str, str]]]:
+    rows = {}
+    for line in DOC_TEXT.splitlines():
+        if not line.startswith("| R"):
+            continue
+        rule, separator, source_cell = line[2:].partition(" | ")
+        rule = rule.strip()
+        if not separator or not re.fullmatch(r"R\d+", rule):
+            continue
+        assert rule not in rows, f"duplicate citation rule: {rule}"
+        rows[rule] = [
+            (match.group(1), json.loads(match.group(2))) for match in _CITE_RE.finditer(source_cell)
+        ]
+    return rows
+
+
+def test_response_contract_citation_inventory():
+    rows = _citation_rows()
+    assert set(rows) == {f"R{index}" for index in range(1, 14)}
+    assert all(rows.values()), "every rule must cite at least one source line"
+    citation_lines = [line for line in DOC_TEXT.splitlines() if line.startswith("| R")]
+    # Detect an unparsed quote instead of silently reducing the audit surface.
+    assert sum(line.count(" -- ") for line in citation_lines) == sum(map(len, rows.values()))
+
+
+@pytest.mark.skipif(
+    not (REPO_ROOT / "crates" / "khive-mcp").exists(),
+    reason="server source is not present in this checkout",
+)
+def test_every_cited_response_line_exists_in_the_named_source():
+    """Presence alone cannot prove branch identity or the associated explanation.
+
+    Quotes may recur. Behavior is checked by separate client fixtures; this
+    check only detects removal or rewriting of the cited source fragments.
+    """
+    failures = []
+    file_cache: dict[str, list[str] | None] = {}
+    for rule, citations in _citation_rows().items():
+        for path, quoted in citations:
+            if path not in file_cache:
+                try:
+                    file_cache[path] = (REPO_ROOT / path).read_text().splitlines()
+                except FileNotFoundError:
+                    file_cache[path] = None
+            lines = file_cache[path]
+            if lines is None:
+                failures.append(f"{rule}: file not found: {path}")
+            elif not any(quoted in line for line in lines):
+                failures.append(f"{rule}: {path} has no line containing {quoted!r}")
+    assert not failures, "\n".join(failures)


### PR DESCRIPTION
Two contract defects in the Python client facade, both found by reading the daemon's wire shapes against the client's parsing.

- `list` results in cursor mode arrive under a collection key (`entities`, `notes`, `edges`) with `next_after` and `scan_incomplete`; the client read only `items`/`results`, so a cursor page parsed as empty. `Page` now carries the collection under its key plus `next_after`, `scan_incomplete` and the limit-clamping metadata, and does not invent `next_offset` or counts the server did not send.
- Per-op error objects (`kind`, `code`, `stage`, `retryable`, `request_state`, `task_terminated`, the unavailable-arm fields, `details`) were flattened to a string, which lost write finality. `OpResult.error` is now a validated `OpError` model preserving every field verbatim; string errors stay strings. `Session` now routes through the shared envelope validation instead of bypassing it.

Tests: offline fixtures derived from the server's error and page shapes, plus live controls against a scratch daemon (including a three-note cursor walk to a terminal page). Reverting either fix makes the corresponding tests fail.
