### PR TITLE
fix(marketplace): point the plugin manifest at the one plugin that exists

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,39 +7,9 @@
   },
   "plugins": [
     {
-      "name": "kg",
-      "source": "./marketplace/kg",
-      "description": "Persistent knowledge graph — typed entities, closed edge ontology, hybrid search, GQL/SPARQL queries"
-    },
-    {
-      "name": "gtd",
-      "source": "./marketplace/gtd",
-      "description": "GTD-style task lifecycle (assign/next/complete/transition) over the notes substrate"
-    },
-    {
-      "name": "memory",
-      "source": "./marketplace/memory",
-      "description": "Persistent agent memory with decay-weighted recall (remember/recall verbs)"
-    },
-    {
-      "name": "knowledge",
-      "source": "./marketplace/knowledge",
-      "description": "Structured knowledge atoms and domains — suggest, compose, search, fold, section-level hybrid scoring"
-    },
-    {
-      "name": "brain",
-      "source": "./marketplace/brain",
-      "description": "Bayesian adaptive profiles — posteriors over section types, feedback signals, profile lifecycle"
-    },
-    {
-      "name": "comm",
-      "source": "./marketplace/comm",
-      "description": "Inter-agent messaging — send, inbox, reply, threaded conversations with read tracking"
-    },
-    {
-      "name": "schedule",
-      "source": "./marketplace/schedule",
-      "description": "Time-based scheduling — reminders, future verb dispatch, recurring events"
+      "name": "khive",
+      "source": "./marketplace/khive",
+      "description": "khive for AI agents — knowledge graph, GTD, memory, inter-agent comm, scheduling, and domain knowledge over one MCP server. One pattern skill per pack, plus the kg stewardship agents."
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -325,12 +325,12 @@ For guided workflows, install the marketplace plugin:
 This adds one pattern skill per pack (`kg`, `gtd`, `memory`, `brain`, `comm`, `schedule`,
 `knowledge`), four kg workflow skills, and six kg stewardship agents:
 
-| Skill            | What it does                                                   |
-| ---------------- | -------------------------------------------------------------- |
-| `/khive:digest`  | Ingest material into the graph: extract entities, link, verify |
-| `/khive:gap`     | Survey the graph's structural gaps: read-only frontier ranking |
-| `/khive:expand`  | Grow the graph to close one strategic gap, with create caps    |
-| `/khive:polish`  | Audit and fix: orphans, low-degree nodes, duplicates           |
+| Skill           | What it does                                                   |
+| --------------- | -------------------------------------------------------------- |
+| `/khive:digest` | Ingest material into the graph: extract entities, link, verify |
+| `/khive:gap`    | Survey the graph's structural gaps: read-only frontier ranking |
+| `/khive:expand` | Grow the graph to close one strategic gap, with create caps    |
+| `/khive:polish` | Audit and fix: orphans, low-degree nodes, duplicates           |
 
 The agents (`khive:digester`, `khive:gap-analyst`, `khive:expander`, `khive:polisher`,
 `khive:librarian`, `khive:researcher`) and the pattern skills are described in

--- a/README.md
+++ b/README.md
@@ -313,23 +313,28 @@ Add the same server entry to `claude_desktop_config.json`:
 See [docs/guide/getting-started.md](docs/guide/getting-started.md) for the config file location
 on each platform.
 
-### Claude Code plugin (skills + agent)
+### Claude Code plugin (skills + agents)
 
-For guided research workflows, install the marketplace plugin:
+For guided workflows, install the marketplace plugin:
 
 ```
 /plugin marketplace add ohdearquant/khive
-/plugin install kg
+/plugin install khive
 ```
 
-This adds 4 workflow skills and a researcher agent:
+This adds one pattern skill per pack (`kg`, `gtd`, `memory`, `brain`, `comm`, `schedule`,
+`knowledge`), four kg workflow skills, and six kg stewardship agents:
 
-| Skill         | What it does                                                   |
-| ------------- | -------------------------------------------------------------- |
-| `/kg:digest`  | Ingest material into the graph: extract entities, link, verify |
-| `/kg:explore` | Discover what the graph knows: traverse, narrate, surface gaps |
-| `/kg:connect` | Wire a new concept into existing knowledge: find relations     |
-| `/kg:polish`  | Audit and fix: orphans, low-degree nodes, duplicates           |
+| Skill            | What it does                                                   |
+| ---------------- | -------------------------------------------------------------- |
+| `/khive:digest`  | Ingest material into the graph: extract entities, link, verify |
+| `/khive:gap`     | Survey the graph's structural gaps: read-only frontier ranking |
+| `/khive:expand`  | Grow the graph to close one strategic gap, with create caps    |
+| `/khive:polish`  | Audit and fix: orphans, low-degree nodes, duplicates           |
+
+The agents (`khive:digester`, `khive:gap-analyst`, `khive:expander`, `khive:polisher`,
+`khive:librarian`, `khive:researcher`) and the pattern skills are described in
+[marketplace/khive/README.md](marketplace/khive/README.md).
 
 ### Configuration
 

--- a/docs/adr/ADR-019-gtd-pack.md
+++ b/docs/adr/ADR-019-gtd-pack.md
@@ -717,3 +717,12 @@ minimal. Operators who want GTD configure it explicitly.
   `EDGE_RULES` — the mechanism GTD demonstrates.
 - ADR-018: Authorization Gate — gate enforcement applies to GTD verbs like any
   other.
+
+## Amendment 1 (2026-09-07): plugin packaging
+
+The per-pack plugin this ADR describes (`marketplace/gtd/`, a `plugin.json` pinning
+`KHIVE_PACKS=gtd`) no longer exists in the tree. The marketplace ships one umbrella plugin,
+`marketplace/khive/`, whose MCP server entry loads the default pack set; a task-only surface is
+still reachable by setting `KHIVE_PACKS=gtd` on that server's environment, which is the runtime
+selection §Configuration describes. The `marketplace/gtd/plugin.json` lines above are the design at
+acceptance and are kept as history; the shipping manifest is `.claude-plugin/marketplace.json`.


### PR DESCRIPTION
The plugin manifest listed seven plugin sources under `./marketplace/<pack>` that do not exist in the tree, so a marketplace client following it finds nothing. The only plugin is `./marketplace/khive`, whose `plugin.json` already covers every pack. The manifest now lists that one entry, taking its name and description from the plugin's own manifest.
