### PR TITLE
fix(memory): avoid blocking recall on store acquisition

### DIFF
--- a/crates/khive-pack-memory/src/ann.rs
+++ b/crates/khive-pack-memory/src/ann.rs
@@ -1171,7 +1171,13 @@ async fn emit_ann_warm_phase_event<P: serde::Serialize>(
     payload: P,
 ) {
     // A missing event store means auditing is unconfigured, not that warming failed.
-    let Ok(store) = rt.events(token) else {
+    let result = crate::store_access::acquire_store("memory.ann.event_store", {
+        let runtime = rt.clone();
+        let token = token.clone();
+        move || runtime.events(&token)
+    })
+    .await;
+    let Ok(Ok(store)) = result else {
         return;
     };
     let payload_value = match serde_json::to_value(&payload) {
@@ -1311,7 +1317,14 @@ async fn compute_memory_fingerprint(
     token: &NamespaceToken,
     model: &str,
 ) -> Option<CorpusFingerprint> {
-    let store = rt.vectors_for_model(token, model).ok()?;
+    let result = crate::store_access::acquire_store("memory.ann.fingerprint_store", {
+        let runtime = rt.clone();
+        let token = token.clone();
+        let model = model.to_owned();
+        move || runtime.vectors_for_model(&token, &model)
+    })
+    .await;
+    let store = result.ok()?.ok()?;
     let info = store.info().await.ok()?;
     let table_name = format!("vec_{}", sanitize_model_key(model));
     let sql = rt.sql();
@@ -1349,7 +1362,14 @@ async fn load_and_build_from_vector_store(
     token: &NamespaceToken,
     model: &str,
 ) -> Result<Option<AnnBridge>, RuntimeError> {
-    let store = match rt.vectors_for_model(token, model) {
+    let result = crate::store_access::acquire_store("memory.ann.vector_store", {
+        let runtime = rt.clone();
+        let token = token.clone();
+        let model = model.to_owned();
+        move || runtime.vectors_for_model(&token, &model)
+    })
+    .await?;
+    let store = match result {
         Ok(s) => s,
         Err(_) => return Ok(None),
     };

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -1727,7 +1727,16 @@ async fn collect_model_ann_hits_inner(
         }
 
         // Widen until enough visible hits survive or ANN reports corpus exhaustion.
-        let note_store = runtime.notes(token)?;
+        let note_result = khive_storage::await_request_read_phase(
+            "memory.recall.note_store",
+            crate::store_access::acquire_store("memory.recall.note_store", {
+                let runtime = runtime.clone();
+                let token = token.clone();
+                move || runtime.notes(&token)
+            }),
+        )
+        .await??;
+        let note_store = note_result?;
         let visible_set: HashSet<&str> = visible_namespaces.iter().map(String::as_str).collect();
 
         // Empty namespace metadata is conservative; a visible-only set skips retry.

--- a/crates/khive-pack-memory/src/lib.rs
+++ b/crates/khive-pack-memory/src/lib.rs
@@ -8,6 +8,7 @@ pub(crate) mod query_cache;
 pub mod recall_feedback;
 pub mod rerank;
 pub mod scoring;
+mod store_access;
 #[doc(hidden)]
 pub mod text_gather;
 pub mod tunable;

--- a/crates/khive-pack-memory/src/store_access.rs
+++ b/crates/khive-pack-memory/src/store_access.rs
@@ -1,0 +1,34 @@
+use khive_runtime::RuntimeError;
+
+pub(crate) async fn acquire_store<T, F>(
+    operation: &'static str,
+    acquire: F,
+) -> Result<T, RuntimeError>
+where
+    T: Send + 'static,
+    F: FnOnce() -> T + Send + 'static,
+{
+    // Store constructors may wait for SQLite's writer. An async snapshot
+    // owner must be able to run and release that connection while they wait.
+    khive_storage::ensure_request_read_active(operation)?;
+    let context = khive_storage::capture_request_read_context();
+    tokio::task::spawn_blocking(move || {
+        if context.stop_reason().is_some() {
+            return Err(khive_storage::StorageError::Timeout {
+                operation: operation.into(),
+            }
+            .into());
+        }
+        // Once admitted, constructor schema work is not an interruptible read.
+        Ok(acquire())
+    })
+    .await
+    .map_err(|error| {
+        RuntimeError::Internal(format!(
+            "{operation} store acquisition task failed: {error}"
+        ))
+    })?
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/khive-pack-memory/src/store_access/tests.rs
+++ b/crates/khive-pack-memory/src/store_access/tests.rs
@@ -1,0 +1,70 @@
+use khive_runtime::{KhiveRuntime, Namespace};
+use khive_storage::types::SqlStatement;
+
+use super::acquire_store;
+use crate::test_support::HashVecProvider;
+
+#[tokio::test(flavor = "current_thread")]
+async fn store_acquisition_yields_to_the_snapshot_owner_in_the_same_task() {
+    const MODEL: &str = "store-access-snapshot-model";
+
+    let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+    runtime.register_embedder(HashVecProvider {
+        model_name: MODEL.to_owned(),
+        dims: 8,
+    });
+    let token = runtime
+        .authorize(Namespace::local())
+        .expect("authorize local");
+    runtime.notes(&token).expect("initialize notes store");
+    runtime.events(&token).expect("initialize event store");
+    runtime
+        .vectors_for_model(&token, MODEL)
+        .expect("initialize vector store");
+
+    for store in ["notes", "events", "vectors"] {
+        let before = runtime.backend().pool().writer_acquisition_snapshot();
+        let mut reader = runtime.sql().reader().await.expect("snapshot reader");
+        reader
+            .query_all(SqlStatement {
+                sql: "BEGIN DEFERRED".into(),
+                params: vec![],
+                label: Some("store_access_snapshot_begin".into()),
+            })
+            .await
+            .expect("admit snapshot before acquiring store");
+
+        let acquiring_runtime = runtime.clone();
+        let acquiring_token = token.clone();
+        // Poll acquisition first so a blocking checkout prevents its own
+        // snapshot-release sibling from running, even on a larger executor.
+        let (acquired, committed) = tokio::join!(
+            biased;
+            acquire_store("memory.recall.store", move || match store {
+                "notes" => acquiring_runtime.notes(&acquiring_token).map(|_| ()),
+                "events" => acquiring_runtime.events(&acquiring_token).map(|_| ()),
+                "vectors" => acquiring_runtime
+                    .vectors_for_model(&acquiring_token, MODEL)
+                    .map(|_| ()),
+                _ => unreachable!("unknown store constructor"),
+            }),
+            reader.query_all(SqlStatement {
+                sql: "COMMIT".into(),
+                params: vec![],
+                label: Some("store_access_snapshot_commit".into()),
+            }),
+        );
+
+        committed.unwrap_or_else(|error| panic!("{store}: release snapshot: {error}"));
+        acquired
+            .and_then(std::convert::identity)
+            .unwrap_or_else(|error| {
+                panic!("{store}: acquisition must yield to its snapshot-release sibling: {error}")
+            });
+        assert_eq!(
+            runtime.backend().pool().writer_acquisition_snapshot().timeouts,
+            before.timeouts,
+            "{store}: acquisition must not exhaust writer checkout while its snapshot owner can run"
+        );
+    }
+}


### PR DESCRIPTION
`memory.recall` could exceed its request deadline on a loaded machine: the memory pack called synchronous store constructors (`notes`, `events`, `vectors_for_model`) from async code, and each may wait for SQLite's writer connection. When the same task also owned an open read snapshot, the constructor's wait blocked the executor that had to run the snapshot's release, so the wait ran to the writer checkout timeout, once per model and per site. Under test-suite parallelism this surfaced as one CI shard failing `ns733b_recall_verbose_multi_model_breakdown_excludes_off_namespace_candidates` with `memory.recall exceeded its 30000ms deadline`; the same call sites are reachable from the daemon's dispatch path, where it is a latency defect.

Fix: `store_access::acquire_store` runs a store constructor on a blocking worker after the request read phase is confirmed active, carrying the request context so a stopped request is refused instead of admitted; the four call sites (recall note store, ANN event store, ANN fingerprint store, ANN vector store) use it. Request deadlines and the detached ANN build lifecycle are unchanged; no deadline, readiness timeout or poll count was altered; `recall.rs` is untouched.

Regression control: a current-thread test opens a deferred snapshot, then polls store acquisition ahead of the snapshot's release in a biased join, for each of the three stores. On the previous code it fails with a writer checkout timeout; with the fix all three acquisitions complete while the sibling releases the snapshot, and the writer timeout counter does not move.

Measured under matched load (64 fresh test processes, 32 concurrent, 32 CPU hogs, 12 logical CPUs): before, 1 of 64 hit the deadline with first-dispatch median/max 301 ms / 35.2 s; after, 0 of 64 with 467 ms / 769 ms.

Gates on the CI-pinned toolchain: fmt, clippy (workspace, all targets, deny warnings), memory pack tests (331 + 89), full workspace tests.
