### PR TITLE
fix(scripts): data guard reads staged blobs from the index

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,6 +399,8 @@ jobs:
       - uses: actions/checkout@v7
       - name: Scan whole tree for corpus files
         run: bash scripts/check-json-data.sh --all
+      - name: Guard fixture test (staged blobs judged from the index)
+        run: bash scripts/tests/check-json-data-test.sh
 
   secret-scan:
     name: Secret scan (gitleaks)

--- a/scripts/check-json-data.sh
+++ b/scripts/check-json-data.sh
@@ -5,7 +5,10 @@
 # an entire memory corpus as JSONL onto a public PR.
 #
 # Modes:
-#   default (no args)    — inspect staged files (git diff --cached); use in pre-commit
+#   default (no args)    — inspect staged files (git diff --cached); use in pre-commit.
+#                          Reads the staged blobs from the index, never the working
+#                          tree: a staged file that was since deleted or rewritten on
+#                          disk is judged by what the commit will contain.
 #   --all                — scan entire working tree; use in CI
 #
 # Rules:
@@ -27,12 +30,23 @@ BENCH_RE='(^|/)(bench|benches|benchmark|benchmarks|criterion)(/|$)|bench.*result
 SHOWCASE_GOLDEN_RE='^(docs/schemas/examples/khive-repo-v1-khive\.json|apps/kg-editor/public/showcase/khive-repo-v1-khive\.json)$'
 SHOWCASE_MAX_JSON_KB=8192
 
+MODE=tree
 fail=0
+
+# Byte size of the object the mode judges: the staged blob in pre-commit mode, the
+# working-tree file in --all mode. Prints nothing and returns non-zero when unreadable.
+object_bytes() {
+  if [ "$MODE" = staged ]; then
+    git cat-file -s ":$1" 2>/dev/null
+  else
+    wc -c < "$1"
+  fi
+}
 
 check_file() {
   local f="$1"
-  [ -f "$f" ] || return 0
-  local base lower size_kb
+  [ "$MODE" = staged ] || [ -f "$f" ] || return 0
+  local base lower bytes size_kb
   base="$(basename "$f")"
   lower="$(printf '%s' "$f" | tr '[:upper:]' '[:lower:]')"
 
@@ -46,7 +60,12 @@ check_file() {
     *.json)
       printf '%s' "$base" | grep -qE "^(${LOCKFILES})$" && return 0
       printf '%s' "$lower" | grep -qE "$BENCH_RE" && return 0
-      size_kb=$(( ($(wc -c < "$f") + 1023) / 1024 ))
+      if ! bytes=$(object_bytes "$f") || [ -z "$bytes" ]; then
+        echo "BLOCKED: $f — staged JSON could not be read from the index." >&2
+        fail=1
+        return 0
+      fi
+      size_kb=$(( (bytes + 1023) / 1024 ))
       # ADR-147 requires one canonical public golden and its byte-identical browser
       # asset. Keep this exception exact and below the renderer's closed 8 MiB cap;
       # the KG Studio contract job validates both JSON shape and byte parity.
@@ -71,7 +90,8 @@ if [ "${1:-}" = "--all" ]; then
     check_file "$f"
   done < <(git ls-files && git ls-files --others --exclude-standard)
 else
-  # Pre-commit mode: staged files only
+  # Pre-commit mode: staged files only, judged from the index
+  MODE=staged
   while IFS= read -r f; do
     check_file "$f"
   done < <(git diff --cached --name-only --diff-filter=ACMR)

--- a/scripts/tests/check-json-data-test.sh
+++ b/scripts/tests/check-json-data-test.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Fixture test for scripts/check-json-data.sh.
+# Builds a scratch repository per case; nothing is committed and no hook runs. Run with:
+#   bash scripts/tests/check-json-data-test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+GUARD="${CJD_SCRIPT:-$SCRIPT_DIR/check-json-data.sh}"
+[ -f "$GUARD" ] || { echo "guard not found at $GUARD" >&2; exit 2; }
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+fresh_repo() {
+  local d="$WORK/$1"
+  rm -rf "$d"
+  mkdir -p "$d"
+  git -C "$d" init -q
+  printf '%s\n' "$d"
+}
+
+# run_guard <repo> [--all] -> prints rc, captures stderr in $ERR
+ERR="$WORK/stderr"
+run_guard() {
+  local repo="$1"; shift
+  local rc=0
+  (cd "$repo" && KHIVE_ALLOW_DATA=0 bash "$GUARD" "$@") 2>"$ERR" || rc=$?
+  printf '%s' "$rc"
+}
+
+pass() { echo "PASS"; }
+fail() { echo "FAIL: $1" >&2; cat "$ERR" >&2 || true; exit 1; }
+
+echo "--- case 1: staged JSONL present in the working tree is refused (control) ---"
+R=$(fresh_repo c1)
+printf '{"a":1}\n' >"$R/data.jsonl"; git -C "$R" add data.jsonl
+[ "$(run_guard "$R")" = 1 ] && grep -q 'data.jsonl' "$ERR" && pass || fail "staged data.jsonl was not refused"
+
+echo "--- case 2: staged JSONL whose working-tree file was removed is still refused ---"
+R=$(fresh_repo c2)
+printf '{"a":1}\n' >"$R/data.jsonl"; git -C "$R" add data.jsonl; rm "$R/data.jsonl"
+[ "$(run_guard "$R")" = 1 ] && grep -q 'data.jsonl' "$ERR" && pass || fail "staged data.jsonl with no working-tree file passed"
+
+echo "--- case 3: staged oversize JSON is measured from the index, not the working tree ---"
+R=$(fresh_repo c3)
+head -c 307200 /dev/zero | tr '\0' 'x' >"$R/big.json"; git -C "$R" add big.json
+printf 'x' >"$R/big.json"
+[ "$(run_guard "$R")" = 1 ] && grep -q '300KB' "$ERR" && pass || fail "staged 300KB big.json passed after the working-tree copy was truncated"
+
+echo "--- case 4: staged small JSON commits (must-pass control) ---"
+R=$(fresh_repo c4)
+printf '{"ok":true}\n' >"$R/config.json"; git -C "$R" add config.json
+[ "$(run_guard "$R")" = 0 ] && pass || fail "small config.json was refused"
+
+echo "--- case 5: staged JSONL with no working-tree file, deliberate bypass still works ---"
+R=$(fresh_repo c5)
+printf '{"a":1}\n' >"$R/data.jsonl"; git -C "$R" add data.jsonl; rm "$R/data.jsonl"
+rc=0; (cd "$R" && KHIVE_ALLOW_DATA=1 bash "$GUARD") 2>"$ERR" || rc=$?
+[ "$rc" = 0 ] && pass || fail "KHIVE_ALLOW_DATA=1 did not bypass"
+
+echo "--- case 6: --all scans the working tree (untracked JSONL refused; index not consulted) ---"
+R=$(fresh_repo c6)
+printf '{"a":1}\n' >"$R/loose.jsonl"
+[ "$(run_guard "$R" --all)" = 1 ] && grep -q 'loose.jsonl' "$ERR" && pass || fail "--all did not refuse an untracked loose.jsonl"
+
+echo "--- case 7: benchmark-path JSONL staged with no working-tree file still passes ---"
+R=$(fresh_repo c7)
+mkdir -p "$R/bench"; printf '{"t":1}\n' >"$R/bench/run.jsonl"; git -C "$R" add bench/run.jsonl; rm "$R/bench/run.jsonl"
+[ "$(run_guard "$R")" = 0 ] && pass || fail "bench/run.jsonl was refused"
+
+echo "all cases passed"


### PR DESCRIPTION
## Defect

`scripts/check-json-data.sh` in pre-commit mode listed the staged paths from the index but judged each one by its working-tree file: `check_file` returned early when the path had no file on disk, and the size check read `wc -c` on the working-tree copy. Two staged states therefore passed the guard and reached the commit:

- a staged `.jsonl` whose working-tree file was removed after `git add` (the guard exits 0, the commit contains the JSONL);
- a staged JSON above the size ceiling whose working-tree copy was truncated after `git add` (the guard measures the 1-byte file, the commit contains the 300 KB one).

Reproduced in a scratch repository; the fixture test below carries both arms.

## Change

Pre-commit mode now reads the staged blob: existence is the index listing itself (`--diff-filter=ACMR`), and the size is `git cat-file -s :<path>`. A staged JSON whose object cannot be read is refused rather than skipped. `--all` mode is unchanged: it scans the working tree, which is what a CI checkout has.

## Test

`scripts/tests/check-json-data-test.sh`, seven cases in scratch repositories with nothing committed: staged JSONL present (refused), staged JSONL with the working-tree file removed (refused), staged oversize JSON with the working-tree copy truncated (refused, message names the staged size), small JSON (passes), `KHIVE_ALLOW_DATA=1` bypass (passes), `--all` on an untracked JSONL (refused), benchmark-path JSONL with the file removed (passes). Against the previous script the same test fails at case 2. The test runs in the existing data-leak-guard CI job after the tree scan.
