### PR TITLE
fix(memory): cancellation-aware store acquisition, worker released on cancel or drop

### DIFF
--- a/crates/khive-db/src/backend.rs
+++ b/crates/khive-db/src/backend.rs
@@ -562,6 +562,20 @@ impl StorageBackend {
         )))
     }
 
+    fn constructor_writer(&self) -> Result<crate::pool::WriterGuard<'_>, SqliteError> {
+        let context = khive_storage::capture_request_read_context();
+        let Some(operation) = context.store_acquisition_operation() else {
+            return self.pool.try_writer();
+        };
+        self.pool
+            .writer_until(|| context.blocking_stop_reason().is_some())?
+            .ok_or_else(|| {
+                SqliteError::RequestReadStopped(khive_storage::StorageError::Timeout {
+                    operation: operation.into(),
+                })
+            })
+    }
+
     /// Get a NoteStore. Applies the notes DDL if not already present.
     ///
     /// Idempotent — safe to call multiple times.
@@ -582,7 +596,7 @@ impl StorageBackend {
             ));
         }
         if !self.is_read_only() {
-            let writer = self.pool.try_writer()?;
+            let writer = self.constructor_writer()?;
             note::ensure_notes_schema(writer.conn())?;
 
             // The anti-join repair is a full `notes` scan -- gate it to run at
@@ -630,7 +644,7 @@ impl StorageBackend {
             ));
         }
         if !self.is_read_only() {
-            let writer = self.pool.try_writer()?;
+            let writer = self.constructor_writer()?;
             event::ensure_events_schema(writer.conn())?;
         }
 
@@ -732,7 +746,7 @@ impl StorageBackend {
             )?));
         }
 
-        let writer = self.pool.try_writer()?;
+        let writer = self.constructor_writer()?;
 
         // Detect old-schema vec0 tables that predate the `field` column.
         // vec0 virtual tables do not support ALTER TABLE, so we must drop and recreate
@@ -1122,6 +1136,63 @@ mod tests {
     use super::*;
     use khive_storage::types::{EdgeFilter, SqlStatement, SqlValue};
     use khive_storage::{EntityFilter, EventFilter};
+
+    #[tokio::test]
+    async fn ordinary_store_accessors_ignore_request_read_cancellation() {
+        let backend = StorageBackend::memory().unwrap();
+        let (_sender, receiver) = tokio::sync::watch::channel(true);
+        khive_storage::scope_request_read_cancellation(receiver, async {
+            backend.notes().expect("ordinary notes accessor");
+            backend.events().expect("ordinary events accessor");
+            #[cfg(feature = "vectors")]
+            backend
+                .vectors("ordinary_store", "ordinary-store", 8)
+                .expect("ordinary vectors accessor");
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn admitted_store_constructor_finishes_ddl_after_cancellation() {
+        let backend = StorageBackend::memory().unwrap();
+        let (sender, receiver) = tokio::sync::watch::channel(false);
+        let fired = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        {
+            let writer = backend.pool.writer().unwrap();
+            let fired = fired.clone();
+            writer
+                .conn()
+                .authorizer(Some(move |_: rusqlite::hooks::AuthContext<'_>| {
+                    fired.store(true, Ordering::SeqCst);
+                    sender.send_replace(true);
+                    rusqlite::hooks::Authorization::Allow
+                }))
+                .unwrap();
+        }
+        let result = khive_storage::scope_request_read_cancellation(receiver, async {
+            khive_storage::capture_request_read_context()
+                .scope_store_acquisition("admitted_notes_store", || backend.notes())
+        })
+        .await;
+        let writer = backend.pool.writer().unwrap();
+        writer
+            .conn()
+            .authorizer(
+                None::<fn(rusqlite::hooks::AuthContext<'_>) -> rusqlite::hooks::Authorization>,
+            )
+            .unwrap();
+        result.expect("request cancellation must not interrupt admitted constructor DDL");
+        assert!(
+            fired.load(Ordering::SeqCst),
+            "cancellation must fire inside actual SQLite work"
+        );
+        assert_eq!(
+            backend.notes_seq_repair_run_count(),
+            1,
+            "constructor must finish schema repair"
+        );
+        assert!(sqlite_table_exists(writer.conn(), "notes_seq").unwrap());
+    }
 
     #[cfg(unix)]
     use khive_storage::test_support::freeze_snapshot_sidecars;

--- a/crates/khive-db/src/error.rs
+++ b/crates/khive-db/src/error.rs
@@ -7,6 +7,10 @@ use thiserror::Error;
 /// Errors produced by the SQLite storage backend.
 #[derive(Debug, Error)]
 pub enum SqliteError {
+    /// A request stopped before a store constructor acquired its writer.
+    #[error(transparent)]
+    RequestReadStopped(khive_storage::StorageError),
+
     /// Underlying rusqlite driver error.
     #[error("sqlite error: {0}")]
     Rusqlite(#[from] rusqlite::Error),

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -1458,6 +1458,67 @@ impl ConnectionPool {
         self.writer()
     }
 
+    pub(crate) fn writer_until<C>(
+        &self,
+        should_stop: C,
+    ) -> Result<Option<WriterGuard<'_>>, SqliteError>
+    where
+        C: Fn() -> bool,
+    {
+        self.ensure_pooled_writer_active()?;
+        let started = Instant::now();
+        loop {
+            if should_stop() {
+                return Ok(None);
+            }
+            let remaining = self
+                .config
+                .checkout_timeout
+                .saturating_sub(started.elapsed());
+            if let Some(guard) = self
+                .writer
+                .try_lock_for(remaining.min(Duration::from_millis(2)))
+            {
+                // Cancellation may have arrived during the final wait slice.
+                // Once this guard is returned, constructor DDL is not interrupted.
+                if should_stop() {
+                    return Ok(None);
+                }
+                self.ensure_pooled_writer_active()?;
+                self.writer_acquisition_counters
+                    .pooled_acquisitions
+                    .fetch_add(1, Ordering::Relaxed);
+                return Ok(Some(WriterGuard {
+                    guard,
+                    origin: self.origin(),
+                }));
+            }
+            if started.elapsed() >= self.config.checkout_timeout {
+                self.writer_acquisition_counters
+                    .pooled_timeouts
+                    .fetch_add(1, Ordering::Relaxed);
+                let message = format!(
+                    "timed out after {:?} waiting for sqlite writer connection",
+                    self.config.checkout_timeout
+                );
+                crate::timeout_sink::emit_timeout(
+                    &crate::timeout_sink::db_label(self),
+                    crate::timeout_sink::Site::PoolAdmission,
+                    &message,
+                    Some(
+                        self.config
+                            .checkout_timeout
+                            .as_millis()
+                            .min(u128::from(u64::MAX)) as u64,
+                    ),
+                );
+                return Err(SqliteError::WriterPoolCheckoutTimeout {
+                    timeout: self.config.checkout_timeout,
+                });
+            }
+        }
+    }
+
     /// Zero-wait writer checkout for background tasks.
     ///
     /// Uses `try_lock()` (no timeout, no spin) — returns `Err` immediately when
@@ -2709,6 +2770,79 @@ fn pool_exhausted_error(timeout: Duration, max_readers: usize) -> SqliteError {
 mod tests {
     use super::*;
     use serial_test::serial;
+
+    #[test]
+    fn constructor_writer_cancels_after_entering_the_wait_without_pool_timeout() {
+        let pool = ConnectionPool::new(PoolConfig {
+            path: None,
+            ..PoolConfig::default()
+        })
+        .unwrap();
+        let held = pool.writer().unwrap();
+        let before = pool.writer_acquisition_snapshot();
+        let checks = Cell::new(0);
+        let stopped = pool
+            .writer_until(|| {
+                checks.set(checks.get() + 1);
+                checks.get() == 2
+            })
+            .unwrap();
+        assert!(
+            stopped.is_none(),
+            "second predicate check must stop an in-flight wait"
+        );
+        assert_eq!(checks.get(), 2);
+        assert_eq!(pool.writer_acquisition_snapshot(), before);
+        drop(held);
+    }
+
+    #[tokio::test]
+    async fn constructor_writer_observes_absolute_blocking_deadline() {
+        let pool = ConnectionPool::new(PoolConfig {
+            path: None,
+            checkout_timeout: Duration::from_secs(5),
+            ..PoolConfig::default()
+        })
+        .unwrap();
+        let held = pool.writer().unwrap();
+        let context =
+            khive_storage::scope_request_read_deadline(Duration::from_millis(20), async {
+                khive_storage::capture_request_read_context()
+            })
+            .await;
+        let before = pool.writer_acquisition_snapshot();
+        let started = Instant::now();
+        let stopped = pool
+            .writer_until(|| context.blocking_stop_reason().is_some())
+            .unwrap();
+        assert!(stopped.is_none());
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "request deadline must beat pool timeout"
+        );
+        assert_eq!(pool.writer_acquisition_snapshot(), before);
+        drop(held);
+    }
+
+    #[test]
+    fn constructor_writer_preserves_uncancelled_checkout_timeout() {
+        let pool = ConnectionPool::new(PoolConfig {
+            path: None,
+            checkout_timeout: Duration::from_millis(5),
+            ..PoolConfig::default()
+        })
+        .unwrap();
+        let held = pool.writer().unwrap();
+        let before = pool.writer_acquisition_snapshot();
+        let result = pool.writer_until(|| false);
+        assert!(
+            matches!(result, Err(SqliteError::WriterPoolCheckoutTimeout { timeout }) if timeout == Duration::from_millis(5))
+        );
+        let after = pool.writer_acquisition_snapshot();
+        assert_eq!(after.timeouts, before.timeouts + 1);
+        assert_eq!(after.pooled_acquisitions, before.pooled_acquisitions);
+        drop(held);
+    }
 
     struct WarningCapture {
         messages: Arc<std::sync::Mutex<Vec<String>>>,

--- a/crates/khive-pack-memory/src/ann.rs
+++ b/crates/khive-pack-memory/src/ann.rs
@@ -1127,7 +1127,19 @@ pub(crate) async fn ensure_ann_for_model(
 
     let wall_us = phase_start.elapsed().as_micros() as i64;
     let cpu_us = khive_runtime::cpu_delta_us(cpu_start, khive_runtime::process_resource_usage());
-    match &result {
+    emit_ann_warm_terminal_phase(rt, token, model, &result, wall_us, cpu_us).await;
+    result
+}
+
+async fn emit_ann_warm_terminal_phase(
+    rt: &KhiveRuntime,
+    token: &NamespaceToken,
+    model: &str,
+    result: &Result<AnnEnsureStatus, RuntimeError>,
+    wall_us: i64,
+    cpu_us: Option<i64>,
+) {
+    match result {
         Err(e) if is_benign_shutdown_cancellation(e) => {
             emit_ann_warm_phase_event(
                 rt,
@@ -1159,7 +1171,6 @@ pub(crate) async fn ensure_ann_for_model(
             .await;
         }
     }
-    result
 }
 
 /// Append a best-effort ANN warm phase event without changing the warm result.
@@ -4170,6 +4181,40 @@ mod tests {
             }
             tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         }
+    }
+
+    #[test]
+    fn cancelled_store_join_emits_phase_cancelled() {
+        let executor = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .max_blocking_threads(1)
+            .build()
+            .expect("single-worker runtime");
+        executor.block_on(async {
+            let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+            let (release_tx, release_rx) = std::sync::mpsc::channel();
+            let blocker = tokio::task::spawn_blocking(move || {
+                started_tx.send(()).expect("worker started");
+                release_rx.recv().expect("release blocker");
+            });
+            started_rx.await.expect("blocking slot is occupied");
+            let queued = tokio::task::spawn_blocking(|| Ok(AnnEnsureStatus::EmptyCorpus));
+            queued.abort();
+            release_tx.send(()).expect("release blocking slot");
+            blocker.await.expect("blocker joined");
+            let result = crate::store_access::join_store_task("memory.ann.vector_store", queued).await;
+
+            let rt = KhiveRuntime::memory().expect("in-memory runtime");
+            let token = rt.authorize(Namespace::local()).expect("authorize local");
+            emit_ann_warm_terminal_phase(&rt, &token, "cancelled-store-join", &result, 1, None).await;
+            let page = rt.events(&token).expect("event store").query_events(
+                khive_storage::EventFilter::default(),
+                khive_storage::types::PageRequest { limit: 10, offset: 0 },
+            ).await.expect("terminal events");
+            assert_eq!(page.items.len(), 1, "exactly one terminal event: {page:?}");
+            assert_eq!(page.items[0].kind, khive_types::EventKind::PhaseCancelled,
+                "a cancelled acquisition join must emit PhaseCancelled, not PhaseCompleted: {result:?}");
+        });
     }
 
     #[tokio::test]

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -1727,9 +1727,10 @@ async fn collect_model_ann_hits_inner(
         }
 
         // Widen until enough visible hits survive or ANN reports corpus exhaustion.
+        let operation = "memory.recall.note_store";
         let note_result = khive_storage::await_request_read_phase(
-            "memory.recall.note_store",
-            crate::store_access::acquire_store("memory.recall.note_store", {
+            operation,
+            crate::store_access::acquire_store(operation, {
                 let runtime = runtime.clone();
                 let token = token.clone();
                 move || runtime.notes(&token)

--- a/crates/khive-pack-memory/src/store_access.rs
+++ b/crates/khive-pack-memory/src/store_access.rs
@@ -11,22 +11,34 @@ where
     // Store constructors may wait for SQLite's writer. An async snapshot
     // owner must be able to run and release that connection while they wait.
     khive_storage::ensure_request_read_active(operation)?;
-    let context = khive_storage::capture_request_read_context();
-    tokio::task::spawn_blocking(move || {
-        if context.stop_reason().is_some() {
-            return Err(khive_storage::StorageError::Timeout {
-                operation: operation.into(),
+    // Dropping the awaiting phase must also stop its pending constructor,
+    // even when no inherited cancellation source has fired.
+    let (lifetime, cancellation) = tokio::sync::watch::channel(false);
+    let result = khive_storage::scope_request_read_cancellation(cancellation, async {
+        let context = khive_storage::capture_request_read_context();
+        let task = tokio::task::spawn_blocking(move || {
+            if context.blocking_stop_reason().is_some() {
+                return Err(khive_storage::StorageError::Timeout {
+                    operation: operation.into(),
+                }
+                .into());
             }
-            .into());
-        }
-        // Once admitted, constructor schema work is not an interruptible read.
-        Ok(acquire())
+            // Once admitted, constructor schema work is not an interruptible read.
+            Ok(context.scope_store_acquisition(operation, acquire))
+        });
+        join_store_task(operation, task).await
     })
-    .await
-    .map_err(|error| {
-        RuntimeError::Internal(format!(
-            "{operation} store acquisition task failed: {error}"
-        ))
+    .await;
+    drop(lifetime);
+    result
+}
+
+pub(crate) async fn join_store_task<T>(
+    operation: &'static str,
+    task: tokio::task::JoinHandle<Result<T, RuntimeError>>,
+) -> Result<T, RuntimeError> {
+    task.await.map_err(|error| {
+        khive_storage::StorageError::driver(khive_storage::StorageCapability::Sql, operation, error)
     })?
 }
 

--- a/crates/khive-pack-memory/src/store_access/tests.rs
+++ b/crates/khive-pack-memory/src/store_access/tests.rs
@@ -68,3 +68,181 @@ async fn store_acquisition_yields_to_the_snapshot_owner_in_the_same_task() {
         );
     }
 }
+
+#[derive(Clone, Copy)]
+enum AcquisitionStop {
+    Cancel,
+    Drop,
+}
+
+fn stopped_acquisition_releases_the_blocking_worker(stop: AcquisitionStop, store: &'static str) {
+    use std::time::Duration;
+
+    use khive_runtime::RuntimeError;
+    use khive_storage::{scope_request_read_cancellation, StorageError};
+
+    // A marker queued behind acquisition can run only after the real worker
+    // returns; completing or dropping the async waiter alone is insufficient.
+    let executor = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .max_blocking_threads(1)
+        .build()
+        .expect("single-worker test runtime");
+    executor.block_on(async {
+        let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+        runtime.register_embedder(HashVecProvider {
+            model_name: "cancelled-store-model".to_owned(),
+            dims: 8,
+        });
+        let token = runtime
+            .authorize(Namespace::local())
+            .expect("authorize local");
+        runtime.notes(&token).expect("initialize notes store");
+        let pool = runtime.backend().pool();
+        let checkout_timeout = pool.config().checkout_timeout;
+        let release_bound = Duration::from_secs(1).min(checkout_timeout / 2);
+        assert!(
+            release_bound >= Duration::from_millis(100),
+            "fixture requires a checkout timeout long enough to distinguish cancellation"
+        );
+        let before = pool.writer_acquisition_snapshot();
+        let writer = pool.writer().expect("hold writer throughout cancellation");
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+        let (finished_tx, finished_rx) = tokio::sync::oneshot::channel();
+        let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+        let acquiring_runtime = runtime.clone();
+        let acquiring = tokio::spawn(scope_request_read_cancellation(
+            cancel_rx,
+            acquire_store("memory.recall.note_store", move || {
+                // This runs after acquire_store's initial context check, so
+                // cancellation cannot pass by preventing the closure's entry.
+                let _ = entered_tx.send(());
+                let result = match store {
+                    "notes" => acquiring_runtime.notes(&token).map(|_| ()),
+                    "events" => acquiring_runtime.events(&token).map(|_| ()),
+                    "vectors" => acquiring_runtime
+                        .vectors_for_model(&token, "cancelled-store-model")
+                        .map(|_| ()),
+                    _ => unreachable!("unknown constructor"),
+                };
+                let _ = finished_tx.send(());
+                result
+            }),
+        ));
+
+        let entered = tokio::time::timeout(release_bound, entered_rx).await;
+        if !matches!(entered, Ok(Ok(()))) {
+            drop(writer);
+            let _ = acquiring.await;
+            panic!("acquisition worker must enter before the stop signal");
+        }
+
+        match stop {
+            AcquisitionStop::Cancel => cancel_tx.send(true).expect("cancel acquisition"),
+            AcquisitionStop::Drop => acquiring.abort(),
+        }
+        let marker = tokio::task::spawn_blocking(|| ());
+        let released = tokio::time::timeout(release_bound, async {
+            finished_rx.await.expect("constructor returned");
+            marker.await.expect("blocking worker is available again");
+        })
+        .await;
+
+        // Always release the held writer before asserting a negative result,
+        // so a regressed worker can settle without delaying runtime teardown.
+        drop(writer);
+        let acquired = acquiring.await;
+        assert!(
+            released.is_ok(),
+            "worker must return while writer is held, within {release_bound:?}, before the {checkout_timeout:?} checkout timeout"
+        );
+        match stop {
+            AcquisitionStop::Cancel => {
+                let result = acquired
+                    .expect("acquisition task joins normally")
+                    .and_then(std::convert::identity);
+                assert!(
+                    matches!(
+                        result,
+                        Err(RuntimeError::Storage(StorageError::Timeout { .. }))
+                    ),
+                    "cancelled constructor must preserve the request timeout classification"
+                );
+            }
+            AcquisitionStop::Drop => assert!(
+                matches!(acquired, Err(error) if error.is_cancelled()),
+                "the async waiter must be dropped"
+            ),
+        }
+        assert_eq!(
+            pool.writer_acquisition_snapshot().timeouts,
+            before.timeouts,
+            "request cancellation must not exhaust the pool checkout budget"
+        );
+    });
+}
+
+#[test]
+fn cancelled_store_acquisition_releases_worker_while_writer_is_held() {
+    for store in ["notes", "events", "vectors"] {
+        stopped_acquisition_releases_the_blocking_worker(AcquisitionStop::Cancel, store);
+    }
+}
+
+#[test]
+fn dropped_store_acquisition_releases_worker_while_writer_is_held() {
+    for store in ["notes", "events", "vectors"] {
+        stopped_acquisition_releases_the_blocking_worker(AcquisitionStop::Drop, store);
+    }
+}
+
+#[test]
+fn uncancelled_store_acquisition_waits_for_writer_and_succeeds() {
+    use std::time::Duration;
+
+    let executor = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .max_blocking_threads(1)
+        .build()
+        .expect("single-worker test runtime");
+    executor.block_on(async {
+        let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+        let token = runtime
+            .authorize(Namespace::local())
+            .expect("authorize local");
+        runtime.notes(&token).expect("initialize notes store");
+        let pool = runtime.backend().pool();
+        let checkout_timeout = pool.config().checkout_timeout;
+        let release_bound = Duration::from_secs(1).min(checkout_timeout / 2);
+        assert!(release_bound >= Duration::from_millis(100));
+        let before = pool.writer_acquisition_snapshot();
+        let writer = pool
+            .writer()
+            .expect("hold writer before ordinary acquisition");
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+        let (finished_tx, mut finished_rx) = tokio::sync::oneshot::channel();
+        let acquiring_runtime = runtime.clone();
+        let acquiring = tokio::spawn(acquire_store("memory.recall.note_store", move || {
+            let _ = entered_tx.send(());
+            let result = acquiring_runtime.notes(&token);
+            let _ = finished_tx.send(());
+            result
+        }));
+        let entered = tokio::time::timeout(release_bound, entered_rx).await;
+        let waiting = tokio::time::timeout(Duration::from_millis(50), &mut finished_rx).await;
+        drop(writer);
+        let acquired = tokio::time::timeout(release_bound, acquiring).await;
+
+        assert!(matches!(entered, Ok(Ok(()))), "worker must enter");
+        assert!(
+            waiting.is_err(),
+            "uncancelled worker must wait for the held writer"
+        );
+        acquired
+            .expect("acquisition finishes after writer release")
+            .expect("acquisition task joins normally")
+            .and_then(std::convert::identity)
+            .expect("ordinary contention must still acquire its store");
+        assert_eq!(pool.writer_acquisition_snapshot().timeouts, before.timeouts);
+    });
+}

--- a/crates/khive-runtime/src/error.rs
+++ b/crates/khive-runtime/src/error.rs
@@ -295,7 +295,7 @@ pub enum RuntimeError {
     Storage(#[from] khive_storage::StorageError),
 
     #[error("sqlite: {0}")]
-    Sqlite(#[from] khive_db::SqliteError),
+    Sqlite(khive_db::SqliteError),
 
     #[error("query: {0}")]
     Query(#[from] khive_query::QueryError),
@@ -502,6 +502,15 @@ pub enum RuntimeError {
         budget_ms: u64,
         elapsed_ms: u64,
     },
+}
+
+impl From<khive_db::SqliteError> for RuntimeError {
+    fn from(error: khive_db::SqliteError) -> Self {
+        match error {
+            khive_db::SqliteError::RequestReadStopped(error) => Self::Storage(error),
+            error => Self::Sqlite(error),
+        }
+    }
 }
 
 impl RuntimeError {

--- a/crates/khive-storage/src/request_context.rs
+++ b/crates/khive-storage/src/request_context.rs
@@ -78,9 +78,41 @@ pub enum RequestReadStopReason {
 pub struct RequestReadContext {
     cancellations: Arc<[tokio::sync::watch::Receiver<bool>]>,
     deadline: Option<RequestReadDeadline>,
+    store_acquisition_operation: Option<&'static str>,
 }
 
 impl RequestReadContext {
+    /// Opt one blocking store-constructor call into request-aware admission.
+    /// Ordinary accessors under a read context remain outside this scope.
+    /// The previous context is restored even if the constructor panics.
+    pub fn scope_store_acquisition<T>(
+        mut self,
+        operation: &'static str,
+        work: impl FnOnce() -> T,
+    ) -> T {
+        self.store_acquisition_operation = Some(operation);
+        REQUEST_READ_CONTEXT.sync_scope(self, work)
+    }
+
+    /// The explicitly scoped constructor operation, absent for ordinary callers.
+    pub fn store_acquisition_operation(&self) -> Option<&'static str> {
+        self.store_acquisition_operation
+    }
+
+    /// Observe cancellation and the original wall-clock deadline in blocking work.
+    pub fn blocking_stop_reason(&self) -> Option<RequestReadStopReason> {
+        if self.cancellations.iter().any(receiver_cancelled) {
+            Some(RequestReadStopReason::Cancelled)
+        } else if self
+            .deadline
+            .is_some_and(|deadline| WallInstant::now() >= deadline.blocking_at)
+        {
+            Some(RequestReadStopReason::Deadline)
+        } else {
+            None
+        }
+    }
+
     /// Return the request's absolute deadline, when one is installed.
     pub fn deadline(&self) -> Option<RequestReadDeadline> {
         self.deadline


### PR DESCRIPTION
## Defect

`memory.recall` acquires its note, event and vector stores on a blocking worker. When the store constructor has to wait for the SQLite writer, that wait was a plain `try_lock_for(checkout_timeout)`: a cancelled or dropped recall left the worker parked for up to the full checkout timeout, and a cancelled `JoinError` from the acquisition task surfaced as `Internal` rather than the stored `PhaseCancelled` terminal event. Closes #2422.

## Change

- `ConnectionPool::writer_until(should_stop)`: the constructor path waits for the writer in slices of at most 2 ms, checks the stop predicate between slices, keeps the original absolute checkout deadline, and re-checks once more after acquiring so a cancellation that landed during the final slice still wins. Once admitted, constructor DDL is not interrupted.
- The memory store acquisition opts into that path through an explicit scope on the captured request context (`scope_store_acquisition`); ordinary accessors and ordinary writer admission are unchanged. Dropping the awaiting future closes a watch sender so the pending constructor stops even when no inherited cancellation fired.
- A stopped acquisition maps to the existing request-phase `StorageError::Timeout`; a cancelled join keeps its concrete `JoinError` inside `StorageError::Driver`, which the ANN shutdown classifier already reads as `PhaseCancelled`. The terminal-event emitter was extracted unchanged so a test can observe the stored event.

No storage trait, wire shape, schema or ADR changes.

## Tests

- Pool: an in-flight wait stops on the second predicate check without a pool timeout; a request deadline shorter than the checkout timeout stops the wait; an uncancelled wait still times out with the configured checkout timeout and the timeout counter moves.
- Backend: ordinary accessors ignore request cancellation; an admitted constructor finishes its DDL after a cancellation fired inside real SQLite work.
- Memory: cancelled and dropped acquisitions release the blocking worker while the writer is held (notes, events, vectors); an uncancelled acquisition waits and succeeds; a cancelled acquisition join emits exactly one `PhaseCancelled` event. The existing writer-contention regression test is unchanged and still passes.
- Mutation controls: with the stop predicate ignored inside the wait, the worker-release tests fail at their timing assertion; with the join error flattened as before, the terminal-event test fails on `PhaseCompleted`.

Gates run on Rust 1.95.0: fmt, clippy `--all-targets -D warnings` for the touched crates, and the `khive-pack-memory` and `khive-db` test suites pass. The full workspace test run stopped at a comm hold-time timing assertion while the host was under heavy unrelated load; that gate is re-run on a quiet host before merge and is recorded here rather than weakened.
