### PR TITLE
docs(adr): ADR-174 Amendment 1, stream.batch as one fenced transaction with per-op errors as values

### DIFF
--- a/docs/adr/ADR-174-ordered-streams-append.md
+++ b/docs/adr/ADR-174-ordered-streams-append.md
@@ -336,8 +336,11 @@ keyed document write of ADR-172 §2 and §3). Common to both modes:
   as `existing_id` (ADR-179 D5), so the consumer rule of ADR-133 Amendment 3 reads it without a
   special case.
 - Authority is checked once for the batch, on the caller's namespace, before the first write.
-- Appends to one stream take consecutive numbers in list order; appends to different streams are
-  independent.
+- Appends to one stream are numbered in list order, so a batch's numbers on one stream increase
+  with list position; appends to different streams are independent. Adjacency is a property of
+  the mode: an atomic batch's appends to one stream take consecutive numbers, because they are one
+  transaction; a per-member batch's appends may have another process's append between them, and
+  only the union is dense (§3).
 - Reads (`get`, `stream.read`, `stream.head`) are not members: a batch is a write primitive. The
   consumer's case reads an unknown object inside its batch; on khive that read is issued beside
   the batch by the adapter, and the assertion on its value is unchanged.
@@ -355,12 +358,13 @@ present, is a list of `{"key": K, "version": V}` the caller read before composin
 entry is checked inside the transaction before the first write, and a mismatch refuses the batch
 with `version_conflict` naming the key. A member's own refusal (`unknown_op`, `seq_conflict`,
 `version_conflict`, `key_conflict`) refuses the whole batch: the transaction rolls back, nothing
-is written, and the error carries that member's refusal plus `member` (the list index) and
-`committed: false`. The caller may
-ignore the result list on success, because success means every member committed.
+is written, and the error carries that member's refusal plus `member` (the list index); the
+disposition is the `domain_disposition: not_committed` every member refusal already carries, and
+no parallel boolean rides beside it. The caller may ignore the result list on success, because
+success means every member committed.
 
-**Per-member (unfenced) mode.** Each member runs in its own writer transaction, in list order, and
-the numbering guarantee follows from that order. A member's own refusal (`unknown_op`, `seq_conflict`,
+**Per-member (unfenced) mode.** Each member runs in its own writer transaction, in list order, so
+one stream's numbers increase with list position but need not be adjacent. A member's own refusal (`unknown_op`, `seq_conflict`,
 `version_conflict`, `key_conflict`) is returned as that member's value and its siblings stand; the result is still
 `{"results": [...], "committed": true}`, where `committed` says the request as a whole ran to the
 end, and each member's outcome is its own entry. `observed` is refused in this mode
@@ -399,11 +403,17 @@ serial execution under the writer lock.
 5. **Authority once.** A batch whose caller lacks write authority on the namespace is refused as a
    whole before any member runs, in both modes; a control with authority and the same members
    commits.
-6. **Two processes.** Two processes issue atomic batches to one stream concurrently; each batch's
-   appends are consecutive within the batch, and the union of numbers is dense.
-7. **Mode arguments.** `atomic=false` with a `fence`, and `observed` without atomic mode, are each
+6. **Two processes, atomic.** Two processes issue atomic batches to one stream concurrently; each
+   batch's appends are consecutive within the batch, and the union of numbers is dense.
+7. **Two processes, per-member.** Two processes issue per-member batches to one stream concurrently
+   across repeats; the union is dense and each batch's numbers increase in list order, and the test
+   does not assert adjacency. A control counts the repeats in which another process's number fell
+   between two members of one batch and requires at least one, so the arm is known to exercise the
+   interleaving it permits.
+8. **Mode arguments.** `atomic=false` with a `fence`, and `observed` without atomic mode, are each
    refused as `invalid_input` and write nothing; `atomic=true` without a fence behaves as arm 2.
-8. **Mutation.** With atomic refusals demoted to member values, arm 2 goes red; with `observed`
+9. **Mutation.** With atomic refusals demoted to member values, arm 2 goes red; with `observed`
    checked after the first write, arm 3's unchanged-count assertion goes red; with per-member
    refusals promoted to whole-batch refusals, arm 4 goes red; with per-stream numbering assigned
-   outside the transaction, arm 6 goes red.
+   outside the transaction, arm 6 goes red; with per-member mode run as one transaction, arm 7's
+   interleaving control goes red.

--- a/docs/adr/ADR-174-ordered-streams-append.md
+++ b/docs/adr/ADR-174-ordered-streams-append.md
@@ -278,7 +278,7 @@ Stated before implementation, checked at the PR that lands the code; every arm n
 - ADR-007 (namespaces), ADR-088 (note kinds), ADR-172 (`version`, `key`, `fence`, durability), migration
   V7 (`notes_seq`) and V13 (list cursor ledgers).
 
-## Amendment 1 (2026-09-08): a fenced batch is one request, one transaction, per-op errors as values
+## Amendment 1 (2026-09-08): `stream.batch`, one request over several streams, all-or-nothing under a fence
 
 **Status**: Proposed.
 
@@ -287,14 +287,22 @@ Stated before implementation, checked at the PR that lands the code; every arm n
 §5 says a request array of appends is dense but unordered, and that a caller wanting order on one
 stream sends a chain or carries `expected_seq`. A state layer built on streams needs a third shape
 that neither the array nor the chain gives: one request that appends to several streams in the
-order written, writes a document beside them, checks the caller's authority once, and reports a
-failing member as a value while every sibling still commits. A chain aborts the remainder after a
-failure; an array commits siblings but assigns numbers in admission order and returns nothing about
-a member's place in the caller's list. Neither form can be composed into the third by the caller,
-because the fence is per transaction and checking authority once is the point.
+order written, writes a keyed document beside them, checks the caller's authority once, and either
+commits every member or writes nothing. A chain aborts the remainder after a failure but keeps what
+already committed; an array commits siblings but assigns numbers in admission order and returns
+nothing about a member's place in the caller's list. Neither form can be composed into the third by
+the caller, because the fence is per transaction and checking authority once is the point.
 
-The conformance case that decides it, from the consumer's own suite (a batch of two appends to one
-stream, a read of an unknown object, an unknown verb and a head write):
+The consumer's own state layer carries two batch forms, and its suite proves both. Its fenced form
+takes an allow-listed member set, opens one transaction, checks every version the caller observed
+before the first write, and rolls the whole batch back on any member's failure, raising to the
+caller; its executed tests assert that after a foreign or stale fence neither the head nor the
+stream record landed, and that every observation check precedes every insert. Its production caller
+issues an expiry batch and ignores the return list, which is only sound because a conflict cannot
+leave a partial commit. Its unfenced form is the opposite: each member owns its connection, a
+failing member returns as that member's value, and its siblings stand. The conformance case for the
+unfenced form (two appends to one stream, a read of an unknown object, an unknown verb and a head
+write):
 
 ```text
 res = store.batch([
@@ -309,54 +317,84 @@ assert isinstance(res[2], NotFound) and isinstance(res[3], Refused) and res[4].v
 assert [e.record["n"] for e in store.read("b")] == [1, 2]
 ```
 
+Both forms are load-bearing, so the verb carries both and names which one it is running.
+
 ### A1.1 `stream.batch`
 
-`stream.batch(ops, fence=None, namespace=None)` takes a list of member operations, each
-`{"op": "append", "stream": S, "record": R, "expected_seq": N | null}` or
+`stream.batch(ops, fence=None, observed=None, atomic=None, namespace=None)` takes a list of member
+operations, each `{"op": "append", "stream": S, "record": R, "expected_seq": N | null}` or
 `{"op": "write", "key": K, "kind": <note kind>, "doc": D, "expected_version": V | null}` (the
-keyed document write of ADR-172 §2 and §3), and runs the whole list inside one writer transaction:
+keyed document write of ADR-172 §2 and §3). Common to both modes:
 
 - Members are validated before anything is written: an unknown `op`, a malformed member, or a
   record over the note content limit refuses the whole batch with `KhiveError::invalid_input` and
   writes nothing.
-- Authority is checked once for the batch, on the caller's namespace, before the first write; the
-  optional `fence` is ADR-172 §2b, evaluated once inside the same transaction; `fence_conflict`
-  refuses the whole batch and writes nothing.
+- Authority is checked once for the batch, on the caller's namespace, before the first write.
 - Appends to one stream take consecutive numbers in list order; appends to different streams are
-  independent. Every member commits in the transaction unless the batch is refused as a whole.
-- A member's own refusal (`seq_conflict`, `version_conflict`, `key_conflict`) is returned as that
-  member's value, with the ADR-172 §2 error shape, and does not abort its siblings; the transaction
-  still commits the members that succeeded. This is the one place in khive where a per-op error is
-  a value inside a committed transaction, and the record says so here so no one reads it as the
-  request array's semantics.
-- The result is `{"results": [<member result or member error>...], "committed": true}` in list
-  order; a member result is the append's `{"seq", "id", "created_at"}` or the write's
-  `{"id", "version"}`.
-- Reads (`get`, `stream.read`) are not members: a batch is a write primitive. The consumer's case
-  above reads an unknown object inside its batch; on khive that read is issued beside the batch,
-  not inside it, and the consumer's adapter places it there.
+  independent.
+- Reads (`get`, `stream.read`, `stream.head`) are not members: a batch is a write primitive. The
+  consumer's case reads an unknown object inside its batch; on khive that read is issued beside
+  the batch by the adapter, and the assertion on its value is unchanged.
+- The result is `{"results": [<member result>...], "committed": true}` in list order; a member
+  result is the append's `{"seq", "id", "created_at"}` or the write's `{"id", "version"}`.
+
+`atomic` selects the mode. It defaults to whether `fence` is present, so a fenced batch is atomic
+unless the caller says otherwise, and the caller may not say otherwise: `atomic=false` with a
+`fence` is refused as `invalid_input`, because a fence that admits partial commits is the failure
+the consumer's production caller cannot detect. `atomic=true` without a fence is allowed.
+
+**Atomic (fenced) mode.** The whole list runs inside one writer transaction. The `fence` is
+ADR-172 §2b, evaluated once inside that transaction before the first write. `observed`, when
+present, is a list of `{"key": K, "version": V}` the caller read before composing the batch; every
+entry is checked inside the transaction before the first write, and a mismatch refuses the batch
+with `version_conflict` naming the key. A member's own refusal (`seq_conflict`, `version_conflict`,
+`key_conflict`) refuses the whole batch: the transaction rolls back, nothing is written, and the
+error carries the member's ADR-172 §2 error shape plus `member` (the list index) and
+`committed: false`. Under ADR-133 Amendment 3 the disposition is `not_committed`. The caller may
+ignore the result list on success, because success means every member committed.
+
+**Per-member (unfenced) mode.** Each member runs in its own writer transaction, in list order, and
+the numbering guarantee follows from that order. A member's own refusal is returned as that
+member's value, with the ADR-172 §2 error shape, and its siblings stand; the result is still
+`{"results": [...], "committed": true}`, where `committed` says the request as a whole ran to the
+end, and each member's outcome is its own entry. `observed` is refused in this mode
+(`invalid_input`): an observation set is a precondition for a transaction, and there is none here.
+
+The consumer's allow-list admits reads inside its fenced form. khive does not, and the two
+observation needs it serves are covered without them: a version precondition is `observed`, and a
+read-your-write inside one fence has no consumer today. If one appears, the members widen by a
+further amendment; the adapter carries the divergence until then.
 
 ### A1.2 What does not change
 
 §5 stands for the request array and the chain. `stream.append` alone is unchanged. The density
-invariant (§3) holds inside the batch by construction: numbers are assigned by the same ledger
-insert, in one transaction.
+invariant (§3) holds inside an atomic batch by construction and across a per-member batch by
+serial execution under the writer lock.
 
 ### Acceptance
 
-1. **Order and values.** The conformance case above, with the read issued beside the batch:
-   `results[0].seq == 1`, `results[1].seq == 2`, the unknown-op member refused as a value, the
-   document write at version 1, and `stream.read("b")` returning records 1 then 2.
-2. **Whole-batch refusal writes nothing.** A malformed member, a stale fence and a missing fence
-   row each refuse the batch; the note count, the ledger count and every named stream's head are
-   unchanged; the audit population is read as domain events only.
-3. **Member refusal commits siblings.** A batch of three appends where the second carries a stale
-   `expected_seq` returns `seq_conflict` for it as a value and commits the first and the third with
-   consecutive numbers; the stream reads two records.
-4. **Authority once.** A batch whose caller lacks write authority on the namespace is refused as a
-   whole before any member runs; a control with authority and the same members commits.
-5. **Two processes.** Two processes issue batches to one stream concurrently; each batch's appends
-   are consecutive within the batch, and the union of numbers is dense.
-6. **Mutation.** With member refusals promoted to whole-batch refusals, arm 3 goes red; with the
-   fence evaluated after the first write, arm 2's unchanged-count assertion goes red; with per-stream
-   numbering assigned outside the transaction, arm 5 goes red.
+1. **Per-member order and values.** The conformance case above, unfenced, with the read issued
+   beside the batch: `results[0].seq == 1`, `results[1].seq == 2`, the unknown-op member refused
+   as a value, the document write at version 1, and `stream.read("b")` returning records 1 then 2.
+2. **Atomic refusal writes nothing.** Under a fence, a batch of three appends where the second
+   carries a stale `expected_seq` is refused as a whole with `seq_conflict` and `member: 1`; the
+   note count, the ledger count and every named stream's head are unchanged; the audit population
+   is read as domain events only. The same for a stale fence and for a missing fence row.
+3. **Observed before the first write.** A fenced batch carrying `observed` with one stale version
+   is refused with `version_conflict` naming that key and writes nothing; a control with current
+   versions commits every member. The statement trace shows every observation check before the
+   first insert.
+4. **Per-member refusal keeps siblings.** Unfenced, the same three appends return `seq_conflict`
+   as the second member's value and commit the first and the third with consecutive numbers; the
+   stream reads two records.
+5. **Authority once.** A batch whose caller lacks write authority on the namespace is refused as a
+   whole before any member runs, in both modes; a control with authority and the same members
+   commits.
+6. **Two processes.** Two processes issue atomic batches to one stream concurrently; each batch's
+   appends are consecutive within the batch, and the union of numbers is dense.
+7. **Mode arguments.** `atomic=false` with a `fence`, and `observed` without atomic mode, are each
+   refused as `invalid_input` and write nothing; `atomic=true` without a fence behaves as arm 2.
+8. **Mutation.** With atomic refusals demoted to member values, arm 2 goes red; with `observed`
+   checked after the first write, arm 3's unchanged-count assertion goes red; with per-member
+   refusals promoted to whole-batch refusals, arm 4 goes red; with per-stream numbering assigned
+   outside the transaction, arm 6 goes red.

--- a/docs/adr/ADR-174-ordered-streams-append.md
+++ b/docs/adr/ADR-174-ordered-streams-append.md
@@ -277,3 +277,86 @@ Stated before implementation, checked at the PR that lands the code; every arm n
 
 - ADR-007 (namespaces), ADR-088 (note kinds), ADR-172 (`version`, `key`, `fence`, durability), migration
   V7 (`notes_seq`) and V13 (list cursor ledgers).
+
+## Amendment 1 (2026-09-08): a fenced batch is one request, one transaction, per-op errors as values
+
+**Status**: Proposed.
+
+### The gap
+
+§5 says a request array of appends is dense but unordered, and that a caller wanting order on one
+stream sends a chain or carries `expected_seq`. A state layer built on streams needs a third shape
+that neither the array nor the chain gives: one request that appends to several streams in the
+order written, writes a document beside them, checks the caller's authority once, and reports a
+failing member as a value while every sibling still commits. A chain aborts the remainder after a
+failure; an array commits siblings but assigns numbers in admission order and returns nothing about
+a member's place in the caller's list. Neither form can be composed into the third by the caller,
+because the fence is per transaction and checking authority once is the point.
+
+The conformance case that decides it, from the consumer's own suite (a batch of two appends to one
+stream, a read of an unknown object, an unknown verb and a head write):
+
+```text
+res = store.batch([
+  ("append", {"stream": "b", "record": {"n": 1}}),
+  ("append", {"stream": "b", "record": {"n": 2}}),
+  ("get", {"ref": "0" * 64}),
+  ("nope", {}),
+  ("write_head", {"key": "h", "kind": "job", "doc": {}}),
+])
+assert [r.seq for r in res[:2]] == [1, 2]
+assert isinstance(res[2], NotFound) and isinstance(res[3], Refused) and res[4].version == 1
+assert [e.record["n"] for e in store.read("b")] == [1, 2]
+```
+
+### A1.1 `stream.batch`
+
+`stream.batch(ops, fence=None, namespace=None)` takes a list of member operations, each
+`{"op": "append", "stream": S, "record": R, "expected_seq": N | null}` or
+`{"op": "write", "key": K, "kind": <note kind>, "doc": D, "expected_version": V | null}` (the
+keyed document write of ADR-172 §2 and §3), and runs the whole list inside one writer transaction:
+
+- Members are validated before anything is written: an unknown `op`, a malformed member, or a
+  record over the note content limit refuses the whole batch with `KhiveError::invalid_input` and
+  writes nothing.
+- Authority is checked once for the batch, on the caller's namespace, before the first write; the
+  optional `fence` is ADR-172 §2b, evaluated once inside the same transaction; `fence_conflict`
+  refuses the whole batch and writes nothing.
+- Appends to one stream take consecutive numbers in list order; appends to different streams are
+  independent. Every member commits in the transaction unless the batch is refused as a whole.
+- A member's own refusal (`seq_conflict`, `version_conflict`, `key_conflict`) is returned as that
+  member's value, with the ADR-172 §2 error shape, and does not abort its siblings; the transaction
+  still commits the members that succeeded. This is the one place in khive where a per-op error is
+  a value inside a committed transaction, and the record says so here so no one reads it as the
+  request array's semantics.
+- The result is `{"results": [<member result or member error>...], "committed": true}` in list
+  order; a member result is the append's `{"seq", "id", "created_at"}` or the write's
+  `{"id", "version"}`.
+- Reads (`get`, `stream.read`) are not members: a batch is a write primitive. The consumer's case
+  above reads an unknown object inside its batch; on khive that read is issued beside the batch,
+  not inside it, and the consumer's adapter places it there.
+
+### A1.2 What does not change
+
+§5 stands for the request array and the chain. `stream.append` alone is unchanged. The density
+invariant (§3) holds inside the batch by construction: numbers are assigned by the same ledger
+insert, in one transaction.
+
+### Acceptance
+
+1. **Order and values.** The conformance case above, with the read issued beside the batch:
+   `results[0].seq == 1`, `results[1].seq == 2`, the unknown-op member refused as a value, the
+   document write at version 1, and `stream.read("b")` returning records 1 then 2.
+2. **Whole-batch refusal writes nothing.** A malformed member, a stale fence and a missing fence
+   row each refuse the batch; the note count, the ledger count and every named stream's head are
+   unchanged; the audit population is read as domain events only.
+3. **Member refusal commits siblings.** A batch of three appends where the second carries a stale
+   `expected_seq` returns `seq_conflict` for it as a value and commits the first and the third with
+   consecutive numbers; the stream reads two records.
+4. **Authority once.** A batch whose caller lacks write authority on the namespace is refused as a
+   whole before any member runs; a control with authority and the same members commits.
+5. **Two processes.** Two processes issue batches to one stream concurrently; each batch's appends
+   are consecutive within the batch, and the union of numbers is dense.
+6. **Mutation.** With member refusals promoted to whole-batch refusals, arm 3 goes red; with the
+   fence evaluated after the first write, arm 2's unchanged-count assertion goes red; with per-stream
+   numbering assigned outside the transaction, arm 5 goes red.

--- a/docs/adr/ADR-174-ordered-streams-append.md
+++ b/docs/adr/ADR-174-ordered-streams-append.md
@@ -326,9 +326,15 @@ operations, each `{"op": "append", "stream": S, "record": R, "expected_seq": N |
 `{"op": "write", "key": K, "kind": <note kind>, "doc": D, "expected_version": V | null}` (the
 keyed document write of ADR-172 §2 and §3). Common to both modes:
 
-- Members are validated before anything is written: an unknown `op`, a malformed member, or a
-  record over the note content limit refuses the whole batch with `KhiveError::invalid_input` and
-  writes nothing.
+- Members are validated for shape before anything is written: a member that is not an object, a
+  member without an `op` string, or a record over the note content limit refuses the whole batch
+  with `KhiveError::invalid_input` and writes nothing. An op string that names no member operation
+  is not a shape error: it is that member's refusal, `unknown_op`, and the mode below decides
+  whether it stops the batch or returns as the member's value.
+- A member refusal, wherever it surfaces, carries the ADR-172 §2 error shape plus
+  `domain_disposition: not_committed` (ADR-133 Amendment 3), and a `key_conflict` names the holder
+  as `existing_id` (ADR-179 D5), so the consumer rule of ADR-133 Amendment 3 reads it without a
+  special case.
 - Authority is checked once for the batch, on the caller's namespace, before the first write.
 - Appends to one stream take consecutive numbers in list order; appends to different streams are
   independent.
@@ -347,15 +353,15 @@ the consumer's production caller cannot detect. `atomic=true` without a fence is
 ADR-172 §2b, evaluated once inside that transaction before the first write. `observed`, when
 present, is a list of `{"key": K, "version": V}` the caller read before composing the batch; every
 entry is checked inside the transaction before the first write, and a mismatch refuses the batch
-with `version_conflict` naming the key. A member's own refusal (`seq_conflict`, `version_conflict`,
-`key_conflict`) refuses the whole batch: the transaction rolls back, nothing is written, and the
-error carries the member's ADR-172 §2 error shape plus `member` (the list index) and
-`committed: false`. Under ADR-133 Amendment 3 the disposition is `not_committed`. The caller may
+with `version_conflict` naming the key. A member's own refusal (`unknown_op`, `seq_conflict`,
+`version_conflict`, `key_conflict`) refuses the whole batch: the transaction rolls back, nothing
+is written, and the error carries that member's refusal plus `member` (the list index) and
+`committed: false`. The caller may
 ignore the result list on success, because success means every member committed.
 
 **Per-member (unfenced) mode.** Each member runs in its own writer transaction, in list order, and
-the numbering guarantee follows from that order. A member's own refusal is returned as that
-member's value, with the ADR-172 §2 error shape, and its siblings stand; the result is still
+the numbering guarantee follows from that order. A member's own refusal (`unknown_op`, `seq_conflict`,
+`version_conflict`, `key_conflict`) is returned as that member's value and its siblings stand; the result is still
 `{"results": [...], "committed": true}`, where `committed` says the request as a whole ran to the
 end, and each member's outcome is its own entry. `observed` is refused in this mode
 (`invalid_input`): an observation set is a precondition for a transaction, and there is none here.
@@ -367,7 +373,10 @@ further amendment; the adapter carries the divergence until then.
 
 ### A1.2 What does not change
 
-§5 stands for the request array and the chain. `stream.append` alone is unchanged. The density
+§5 stands for the request array and the chain. `stream.append` alone is unchanged. The `write`
+member depends on ADR-172's keyed create and versioned write (§2, §3) landing; the append-only
+form of the batch does not, and implementation lands appends first and the `write` member with the
+keyed write. The density
 invariant (§3) holds inside an atomic batch by construction and across a per-member batch by
 serial execution under the writer lock.
 
@@ -375,7 +384,7 @@ serial execution under the writer lock.
 
 1. **Per-member order and values.** The conformance case above, unfenced, with the read issued
    beside the batch: `results[0].seq == 1`, `results[1].seq == 2`, the unknown-op member refused
-   as a value, the document write at version 1, and `stream.read("b")` returning records 1 then 2.
+   as a value (`unknown_op`, `domain_disposition: not_committed`), the document write at version 1, and `stream.read("b")` returning records 1 then 2.
 2. **Atomic refusal writes nothing.** Under a fence, a batch of three appends where the second
    carries a stale `expected_seq` is refused as a whole with `seq_conflict` and `member: 1`; the
    note count, the ledger count and every named stream's head are unchanged; the audit population


### PR DESCRIPTION
## Summary

ADR-174 Amendment 1 (Proposed): `stream.batch`, one request that runs a list of appends and keyed document writes with authority checked once and per-stream numbering in list order, in one of two named modes. Atomic mode (the default under a fence) runs the list in one writer transaction, checks a caller-supplied `observed` version set before the first write, and refuses the whole batch on any member's conflict, writing nothing. Per-member mode (no fence) runs each member in its own transaction in list order and returns a member's refusal as that member's value while its siblings stand.

## Why

§5 leaves a caller two shapes: the request array (siblings commit, numbers in admission order, nothing about list position) and the chain (ordered, but the remainder aborts after a failure and keeps what committed). A state layer built on streams needs both an all-or-nothing form under a fence and a best-effort form without one, and neither can be composed from the array or the chain on the caller's side because the fence is per transaction and checking authority once is the point. The consumer's suite proves both forms; its unfenced conformance case is quoted in the amendment as arm 1, and its fenced tests (nothing lands after a stale fence; every observation check precedes every insert) shape arms 2 and 3.

## What does not change

The request array and the chain keep §5's semantics; `stream.append` is unchanged; the density invariant holds inside an atomic batch by construction and across a per-member batch by serial execution. Reads are not batch members in either mode.

## Acceptance

Nine arms in the amendment: per-member order and values, atomic refusal writes nothing, observed checked before the first write, per-member refusal keeps siblings, authority once, two processes atomic (adjacent numbers), two processes per-member (dense union, list order, no adjacency, interleaving control), mode-argument refusals, and five mutation controls.
