### PR TITLE
docs(adr): ADR-181 exec verb and ADR-182 git dev-loop verbs

### DIFF
--- a/docs/adr/ADR-181-exec-verb-sandboxed-run.md
+++ b/docs/adr/ADR-181-exec-verb-sandboxed-run.md
@@ -1,0 +1,83 @@
+# ADR-181: Exec Verb: One Declared Command in a Sandbox over a Materialized Tree
+
+- **Status**: Proposed
+- **Date**: 2026-09-08
+- **Extends**: [ADR-111](ADR-111-blob-store.md) (content-addressed objects; this record adds a tree
+  manifest over them), [ADR-180](ADR-180-tool-pack.md) (the policy vocabulary every run is checked
+  against)
+- **Relates to**: [ADR-108](ADR-108-git-write-surface.md) (git writes take the same tree),
+  [ADR-085](ADR-085-code-pack.md) (the code pack ingests and runs nothing; this record is where running
+  lives), [ADR-018](ADR-018-authorization-gate.md) (the Gate still runs on every dispatch)
+
+## Context
+
+An agent that develops on khive today still builds and tests through its own shell. Nothing in the
+verb set executes a command, so the one step of the loop that must touch a toolchain happens outside
+every policy, receipt and sandbox khive has. The blob store holds objects but has no notion of a tree,
+so a set of files cannot be named, moved or compared as one thing. The intended posture is an
+allow-list: the agent's whole tool set is khive verbs, a command that is not a registered tool does
+not exist for it, and the shell exists only inside one verb, over a tree khive materialized, with no
+network, no home directory and no credentials.
+
+## Decision
+
+A pack `exec`, requiring `blob` and `tool`. Verb names below are the proposal; the contract tests
+written for the loop driver finalize them.
+
+**Tree manifest.** A tree is a blob whose content is `{"schema": "khive-tree/v1", "entries": [{"path",
+"ref", "mode"}]}`: `path` is relative, normalized, contains no `..` or absolute component and names no
+symlink; `ref` is a blob reference; `mode` is `644` or `755`. `exec.tree(entries)` validates and stores
+one and returns its reference; `exec.tree_get(tree)` returns the entries; `exec.tree_diff(base, head)`
+lists `added`, `modified` and `deleted` paths with both references. The same manifest is what the git
+verbs read and write (ADR-182).
+
+**Run.** `exec.run(tree, tool, args, env, timeout_s, actor)`:
+
+1. Policy first. `tool` names a registry object of kind `tool` with `source` `exec:<absolute binary
+   path>`, registered by the operator; an unregistered name is refused before anything touches the
+   disk. `tool.check(actor, tool)` must answer `allow`; `ask` and `deny` are returned as the refusal
+   with the decision, so the agent's next call is `tool.request`, never a retry.
+2. Materialize. A fresh run directory under the daemon's exec root receives every entry from the blob
+   store with its mode; nothing else is present.
+3. Sandbox. The command runs under `sandbox-exec` with a seatbelt profile compiled from a fixed
+   template: default deny; read access to the run directory and to the toolchain roots listed in the
+   `[exec] read_roots` config; write access to the run directory and one run-scoped temporary
+   directory; no network; the environment is the allow-listed keys from `[exec] env` plus `HOME` set
+   to the run directory; no credential of the daemon or the operator reaches the process. The binary
+   is the registered absolute path, never a `PATH` lookup. The profile text is stored with the receipt
+   as a digest.
+4. Bound. `timeout_s` (default and maximum from config) kills the process group; stdout and stderr are
+   captured to blobs up to a configured size each and truncated with a marker beyond it.
+5. Capture. After exit the run directory is walked; every entry whose content changed, every new file
+   and every deleted entry is recorded, changed content stored as blobs, and a result tree manifest
+   written; the run directory is removed unless `keep` is set and permitted by config.
+6. Receipt. One row in the pack table `exec_runs`: id, namespace, actor, tool, argv, `tree_in`,
+   `tree_out`, exit code, `timed_out`, stdout and stderr references, started and finished times,
+   duration, the policy decision and its source id, the profile digest. The return value is the
+   receipt plus the change list. `exec.receipt(id)` and `exec.runs(actor, tool, limit)` read them.
+
+The run never reads or writes a repository; the git verbs (ADR-182) move trees in and out of git.
+
+## Acceptance
+
+1. An unregistered tool name is refused before materialization: no run directory is created.
+2. A registered tool with a `deny` policy is refused with `decision: deny` and the policy id; with
+   `ask`, refused with `ask`; after `tool.grant`, the same call runs.
+3. Materialization reproduces the tree: every entry's content and mode match; a manifest with `..`,
+   an absolute path or a symlink entry is refused by `exec.tree`.
+4. No network: a registered tool that opens a socket fails inside the run; the same binary outside the
+   sandbox succeeds (control).
+5. No writes outside the tree: a run that writes to the operator's home leaves no file there and
+   reports a non-zero exit; a write inside the tree appears in the change list.
+6. Timeout: a run exceeding `timeout_s` ends with `timed_out: true` and no process survives it.
+7. Capture classifies added, modified and deleted paths; every reference returned resolves through
+   `blob.get` to the content the run left.
+8. The receipt's `tree_in`, `tree_out`, output references and profile digest match the stored
+   objects; `exec.runs(actor)` lists it.
+
+## Known rough edges
+
+The sandbox is macOS seatbelt only; a Linux profile is a later slice. Toolchain read roots are operator
+configuration and a missing root reads as a tool failure, not a policy refusal. Every run materializes
+from scratch; build caches across runs are a later slice. Output caps and run retention are config,
+not policy.

--- a/docs/adr/ADR-182-git-dev-loop-verbs.md
+++ b/docs/adr/ADR-182-git-dev-loop-verbs.md
@@ -1,0 +1,83 @@
+# ADR-182: Git Verbs for the Dev Loop: Trees In and Out, Commit as Actor, Policy-Gated Push, Pull Requests
+
+- **Status**: Proposed
+- **Date**: 2026-09-08
+- **Extends**: [ADR-108](ADR-108-git-write-surface.md) and its Amendment 1 (write verbs over an
+  allow-listed repo set, force-push denied, hooks disabled; all of it stands),
+  [ADR-181](ADR-181-exec-verb-sandboxed-run.md) (the tree manifest)
+- **Relates to**: [ADR-180](ADR-180-tool-pack.md) (policy per actor), [ADR-088](ADR-088-git-lifecycle-pack.md)
+  (provenance ingest), [ADR-018](ADR-018-authorization-gate.md)
+
+## Context
+
+ADR-108 lets an actor commit, branch and push through khive against repositories an operator has
+allow-listed, with the hard rules that make that safe. Three things keep it from carrying a whole
+development loop. A repository's content cannot be read into khive as one object, so an agent
+without a filesystem cannot see what it is changing, and `git.commit` takes paths in a working tree
+the agent has no hands on. Identity is the daemon's: the author is whatever git config says, and the
+push uses whatever credential helper the daemon inherits, so "who asked" and "whose permission" are
+the same answer. Pull requests are outside khive entirely; the fleet's rule that a second account
+reviews is a memory, not a policy. The loop the presentation shows is one pull request end to end
+with a second actor approving under its own permissions, every step a receipt. Underlying git and the
+GitHub CLI stay underneath; khive adds no format.
+
+## Decision
+
+Verb names below are the proposal; the loop driver's contract tests finalize them.
+
+**Trees in and out.** `git.checkout(repo, ref)` reads the tree at `ref` (`git ls-tree -r` plus object
+reads, no working-tree checkout) into blobs and returns an ADR-181 tree manifest reference. `git.diff`
+takes either two refs of a repo or two tree references and returns a unified diff as a blob plus a
+summary (files, insertions, deletions). `git.commit` accepts `tree` in place of `paths`: the tree is
+materialized into a detached, hooks-disabled worktree of the repository at the branch head, the
+difference is staged and committed. `repo` remains subject to the ADR-108 allow-list.
+
+**Identity.** The commit author is derived from the calling actor through the `[git_write.actors]`
+table (actor label to name, email and credential reference); a caller-supplied `author` is accepted
+only when it equals the derived one. The credential reference is a keychain item name; no secret is
+stored. An actor without a row falls back to ADR-108 behaviour (the daemon's identity) and the receipt
+says `credential: daemon`.
+
+**Push as a policy-gated ref move.** `git.push(repo, branch)` now requires two allows: the ADR-108
+allow-list and `tool.check(actor, "git.push")`; the decision and its source id go into the receipt.
+Force-push stays denied unconditionally. The push runs with the actor's credential when a row exists.
+
+**Pull requests over the CLI.** `git.pr_open(repo, head, base, title, body)`, `git.pr_review(repo,
+number, verdict, body)` with `verdict` in `approve`, `request_changes`, `comment`, and
+`git.pr_merge(repo, number, method, subject, body)` with `method` in `squash`, `merge`. Each consults
+`tool.check(actor, <verb>)`, runs `gh` with `GH_TOKEN` resolved from the actor's credential reference
+and never from the daemon's session, and before any write asserts that the repository slug and
+visibility the CLI reports equal the configured expectation for `repo`. `approve` by the actor that
+opened the pull request is refused before the CLI runs; the reviewer's decision is what the platform
+records afterwards. `pr_merge` passes the administrator flag only when a policy row named
+`git.pr_merge.admin` allows it for the actor.
+
+**Receipts.** Every verb writes the ADR-108 audit event with a per-verb kind, carrying actor, repo,
+branch or pull request number, the tree references it consumed or produced, the resulting sha or URL,
+and the tool policy decision id. `git.receipts(repo, actor, limit)` reads them.
+
+## Acceptance
+
+1. `git.checkout` of a ref returns a tree whose entry count and per-file content match
+   `git ls-tree -r` and `git cat-file` at that ref.
+2. `git.commit(tree)` produces a commit whose tree equals the materialized manifest; author name and
+   email are the actor's row; a caller-supplied `author` that differs is refused; no hook runs
+   (ADR-108 Amendment 1 control stays green).
+3. `git.push` with a `deny` policy for the actor is refused before any network call; with the check
+   removed (mutation control) the push goes through; with `allow` it goes through and the receipt
+   names the policy id.
+4. `git.pr_open` against a repository whose reported slug differs from the configured one is refused.
+5. `git.pr_review(approve)` by the opening actor is refused; by a second actor with its own credential
+   row it succeeds and the platform's review state reads approved.
+6. `git.pr_merge` with `ask` policy is refused; after `tool.grant` it merges; the merge commit sha is
+   in the receipt.
+7. Every verb's receipt carries the decision id and the tree or sha it acted on; a refused call has a
+   receipt too.
+8. Force-push remains denied through every new parameter combination (ADR-108 rule 1 re-run).
+
+## Known rough edges
+
+The GitHub CLI is a runtime dependency of the pull request verbs. The actor credential table is
+pack-local until the provider pack owns profiles and credential references. Local merge, rebase and
+tags stay out of scope, as in ADR-108. Read-only checkout of a remote goes through the ADR-088 cache
+and inherits its bounds.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -195,6 +195,8 @@ The same head-binding governs review: a verdict authorizes only the exact commit
 | [ADR-178](ADR-178-plan-only-request.md)                                 | Plan-Only Request — Grammar Check Without Dispatch                                                         |
 | [ADR-179](ADR-179-operation-identity-memory-remember.md)                | Operation Identity on `memory.remember`: Keyed Create, Conflict Names the Holder                           |
 | [ADR-180](ADR-180-tool-pack.md)                                         | Tool Pack: Capability Registry, Ontological Discovery and Use Policy                                       |
+| [ADR-181](ADR-181-exec-verb-sandboxed-run.md)                           | Exec Verb: One Declared Command in a Sandbox over a Materialized Tree                                      |
+| [ADR-182](ADR-182-git-dev-loop-verbs.md)                                | Git Verbs for the Dev Loop: Trees In and Out, Commit as Actor, Policy-Gated Push, Pull Requests            |
 
 <!-- END GENERATED ADR CATALOG -->
 


### PR DESCRIPTION
## ADR-181 and ADR-182: the development loop on khive

Two proposed records. ADR-181 adds a tree manifest over the blob store and one exec verb: a registered tool runs in a seatbelt sandbox over a materialized tree, under the tool policy of ADR-180, with outputs and changed files captured back to blobs and a receipt. ADR-182 extends ADR-108: trees move in and out of a repository, commits carry the calling actor's identity, push is gated on tool policy in addition to the existing allow-list, and pull requests are opened, reviewed and merged over the GitHub CLI with actor-scoped credentials; self-approval is refused before the CLI runs.

Verb names are proposals until the loop's contract tests fix them; acceptance arms and known rough edges are in each record.
