### PR TITLE
docs(adr): ADR-181 and ADR-182 Amendment 1, run contract and credential rule

### DIFF
--- a/docs/adr/ADR-181-exec-verb-sandboxed-run.md
+++ b/docs/adr/ADR-181-exec-verb-sandboxed-run.md
@@ -81,3 +81,39 @@ The sandbox is macOS seatbelt only; a Linux profile is a later slice. Toolchain 
 configuration and a missing root reads as a tool failure, not a policy refusal. Every run materializes
 from scratch; build caches across runs are a later slice. Output caps and run retention are config,
 not policy.
+
+## Amendment 1 (2026-09-08): run parameters, capture, refusal receipts, sandbox identity
+
+Adopted on the first whole-file read against the loop driver's contract page. Each item is a
+contract the driver's tests bind to; the record above stands where not restated.
+
+1. **`cwd`.** `exec.run` takes `cwd`, a path relative to the tree, default `.`. An absolute path, a
+   `..` component or a symlink escape is refused before materialization.
+2. **Environment.** The caller supplies the environment values; the `[exec] env` config allow-lists
+   the keys that may pass; the server sets `HOME` to the run directory; nothing is inherited from the
+   host. The receipt records `env_keys`.
+3. **`declared_write_paths`** (optional). When given, a change outside the declared set makes the run
+   `success: false`, names the offending paths in `undeclared_changes`, and drops their bytes: they
+   are neither stored nor part of `tree_out`.
+4. **Capture over the cap keeps the tail.** For each stream the receipt carries `produced_bytes`,
+   `retained_bytes` and `capture: complete | incomplete`; a test runner's closing summary survives.
+5. **Every refusal writes a receipt.** An unregistered tool, a `deny` or `ask` decision, an invalid
+   tree and a `cwd` escape each write an `exec_runs` row with `decision` and `reason`, `tree_out`
+   null, and no run directory is created.
+6. **Session identity.** `exec.run` takes an optional `session_id`, echoed in the receipt with a
+   per-session `seq`; `exec.runs` filters on it. The driver's command identity is `session:seq`.
+7. **Sandbox object.** The receipt carries `sandbox: {profile_digest, tool_binary_digest,
+   read_roots_digest}` (the resolved read roots and the registered binary hashed at run time), not a
+   bare profile digest.
+8. **Version control never runs here.** A registered tool whose binary resolves, after
+   canonicalization, to `git` or `gh`, or to any path in the `[exec] never` config set, is refused;
+   repository operations go through ADR-182 only.
+9. **Driver mapping.** An `argv` from the driver binds `argv[0]` to a registered tool label and passes
+   `argv[1..]` as `args`; this lives in the driver's test file and changes nothing here.
+
+Acceptance arms added: 9 `cwd` escape refused with no run directory; 10 an env key outside the
+allow-list is absent inside the run and a caller value for an allowed key is present; 11 a write
+outside `declared_write_paths` yields `success: false` and the bytes are not retrievable; 12 output
+over the cap retains the tail and the receipt's counts match the bytes produced; 13 each refusal
+class has a receipt row; 14 two runs with one `session_id` carry `seq` 1 and 2; 15 the sandbox object
+changes when the read roots change (control); 16 a tool registered at the `git` binary is refused.

--- a/docs/adr/ADR-182-git-dev-loop-verbs.md
+++ b/docs/adr/ADR-182-git-dev-loop-verbs.md
@@ -81,3 +81,30 @@ The GitHub CLI is a runtime dependency of the pull request verbs. The actor cred
 pack-local until the provider pack owns profiles and credential references. Local merge, rebase and
 tags stay out of scope, as in ADR-108. Read-only checkout of a remote goes through the ADR-088 cache
 and inherits its bounds.
+
+## Amendment 1 (2026-09-08): credential rule, enforcement order, fork pull requests, checkout scope
+
+Adopted on the first whole-file read against ADR-108. The header's "all of it stands" reads as "all
+of it stands except hard rule 4, amended in item 1".
+
+1. **Credential rule (amends ADR-108 hard rule 4).** ADR-108 has khive never become a credential
+   broker: writes run on the daemon's own credentials. This record amends that for actor-bound
+   operations: a per-actor credential reference is resolved by the daemon at call time, is never
+   returned to any caller, is never stored (the table holds keychain reference names only), and the
+   receipt names `credential: actor | daemon`. No verb, receipt or error carries a secret value.
+2. **Enforcement order.** The Gate (ADR-018) decides first, as today; `tool.check` decides second;
+   both decisions are in the receipt; a refusal at either seam is the refusal, and the pack remains
+   not the policy author. Where a deployment wants one seam, the Gate consults `tool.check`.
+3. **Fork pull requests (ADR-108 fork (d)).** `git.pr_review(approve)` and `git.pr_merge` on a pull
+   request whose head repository differs from the base are refused unless a policy row named
+   `git.pr_review.fork` or `git.pr_merge.fork` allows the actor; the administrator flag is never
+   passed on a fork pull request.
+4. **Checkout scope.** `git.checkout` is a read-only object read (`ls-tree` and object reads into
+   blobs); it is not the working-tree checkout ADR-108 left out of scope, and it leaves the
+   repository's working tree untouched.
+
+Acceptance arms added: 9 no response, receipt or table row contains a credential value (a decoy
+value planted in the keychain item is absent from every output); 10 a Gate deny produces a receipt
+with the Gate decision and no `tool.check` call; 11 approving a fork pull request without the row is
+refused, and a fork merge never carries the administrator flag; 12 `git status` is identical before
+and after `git.checkout`.


### PR DESCRIPTION
## ADR-181 and ADR-182, Amendment 1

Adopted on the first whole-file reads of the two records. ADR-181 gains the run contract the loop driver binds to: `cwd` relative to the tree, caller-supplied environment filtered by allow-listed keys, `declared_write_paths`, tail-preserving capture with byte counts, a receipt for every refusal, session identity, a sandbox identity object, and a hard refusal of version-control binaries. ADR-182 states the credential rule as an explicit amendment of ADR-108 hard rule 4, fixes the enforcement order (Gate, then tool policy, both in the receipt), refuses approval and merge on fork pull requests without a named policy row, and scopes `git.checkout` to a read-only object read. Acceptance arms added to both.
