### PR TITLE
fix(daemon): include forwarded actor in default read scope

### DIFF
--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -26,6 +26,9 @@ use tokio::net::UnixStream;
 use crate::tools::request::RequestParams;
 
 #[cfg(test)]
+mod memory_namespace_tests;
+
+#[cfg(test)]
 mod test_harness;
 
 #[cfg(test)]

--- a/crates/khive-mcp/src/daemon/memory_namespace_tests.rs
+++ b/crates/khive-mcp/src/daemon/memory_namespace_tests.rs
@@ -1,0 +1,335 @@
+use std::path::Path;
+use std::time::Duration;
+
+use futures::FutureExt;
+use khive_runtime::daemon::{run_daemon, DaemonRequestFrame, PROTOCOL_VERSION};
+use khive_runtime::{KhiveRuntime, RuntimeConfig};
+use serde_json::{json, Value};
+use serial_test::serial;
+use tokio::time::timeout;
+
+use super::test_harness::{clear_daemon_env, connect_when_ready, exchange, RecoveryTestGuard};
+use crate::server::KhiveMcpServer;
+
+const ACTOR: &str = "test:memory-writer";
+
+async fn request(
+    socket: &Path,
+    config_id: &str,
+    actor: Option<&str>,
+    visible: &[&str],
+    ops: String,
+) -> Vec<Value> {
+    let frame = DaemonRequestFrame {
+        ops,
+        presentation: Some("verbose".into()),
+        presentation_per_op: None,
+        namespace: "local".into(),
+        actor_id: actor.map(str::to_owned),
+        process_ref: None,
+        visible_namespaces: visible.iter().map(|ns| (*ns).to_owned()).collect(),
+        config_id: config_id.to_owned(),
+        protocol_version: PROTOCOL_VERSION,
+        probe_only: false,
+        metrics_only: false,
+        format: Some("json".into()),
+        format_per_op: None,
+        from_wire: true,
+        request_id: None,
+    };
+    let response = timeout(Duration::from_secs(10), exchange(socket, &frame))
+        .await
+        .expect("bounded daemon exchange");
+    assert!(response.ok, "frame failed: {:?}", response.error);
+    assert!(!response.namespace_mismatch);
+    assert!(!response.config_mismatch);
+    assert!(!response.version_mismatch);
+    let body: Value = serde_json::from_str(response.result.as_deref().expect("frame result"))
+        .expect("JSON response");
+    let operations = body["results"].as_array().expect("operation receipts");
+    assert!(!operations.is_empty(), "empty receipts: {body}");
+    operations
+        .iter()
+        .map(|operation| {
+            assert_eq!(operation["ok"], true, "inner operation failed: {body}");
+            operation["result"].clone()
+        })
+        .collect()
+}
+
+struct MemoryProbe {
+    memory_id: String,
+    observation_id: String,
+    created_before: String,
+}
+
+fn recall_items(result: &Value) -> &[Value] {
+    result
+        .as_array()
+        .or_else(|| result.get("results").and_then(Value::as_array))
+        .expect("recall array or result envelope")
+}
+
+async fn probe(
+    socket: &Path,
+    config_id: &str,
+    actor: Option<&str>,
+    visible: &[&str],
+    namespace: Option<&str>,
+    memory: &MemoryProbe,
+) -> [usize; 3] {
+    let mut operations = json!([
+        {"tool": "memory.recall", "args": {
+            "query": "settlementprobe", "tags": ["memory-namespace-probe"],
+            "created_before": memory.created_before, "fusion_strategy": "keyword_only",
+            "min_score": 0.0, "include_breakdown": true
+        }},
+        {"tool": "list", "args": {"kind": "memory", "tags": ["memory-namespace-probe"]}},
+        {"tool": "list", "args": {
+            "kind": "edge", "source_id": memory.memory_id, "relations": ["annotates"]
+        }}
+    ]);
+    if let Some(namespace) = namespace {
+        for operation in operations.as_array_mut().expect("operation array") {
+            operation["args"]["namespace"] = json!(namespace);
+        }
+    }
+    let results = request(socket, config_id, actor, visible, operations.to_string()).await;
+    assert_eq!(results.len(), 3);
+    let recall = recall_items(&results[0]);
+    let notes = results[1]["items"].as_array().expect("memory list");
+    let edges = results[2]["items"].as_array().expect("edge list");
+    [
+        recall
+            .iter()
+            .filter(|hit| hit["full_id"] == memory.memory_id)
+            .count(),
+        notes
+            .iter()
+            .filter(|note| note["id"] == memory.memory_id)
+            .count(),
+        edges
+            .iter()
+            .filter(|edge| {
+                edge["source_id"] == memory.memory_id
+                    && edge["target_id"] == memory.observation_id
+                    && edge["relation"] == "annotates"
+            })
+            .count(),
+    ]
+}
+
+async fn exercise(socket: &Path, config_id: &str) -> [bool; 3] {
+    drop(connect_when_ready(socket).await);
+    let chain = request(
+        socket,
+        config_id,
+        Some(ACTOR),
+        &[],
+        r#"create(kind="observation", content="settlementprobe source") | memory.remember(content="settlementprobe durable finding", memory_type="episodic", salience=1.0, decay_factor=0.0, tags=["memory-namespace-probe"], source_id=$prev.id)"#.into(),
+    )
+    .await;
+    assert_eq!(chain.len(), 2);
+    let created_at = chrono::DateTime::parse_from_rfc3339(
+        chain[1]["created_at"]
+            .as_str()
+            .expect("memory creation time"),
+    )
+    .expect("RFC3339 creation time");
+    let before = created_at + chrono::Duration::seconds(1);
+    assert!(
+        before > created_at,
+        "created_before must be exclusive and later"
+    );
+    let memory = MemoryProbe {
+        memory_id: chain[1]["id"].as_str().expect("memory UUID").into(),
+        observation_id: chain[0]["id"].as_str().expect("observation UUID").into(),
+        created_before: before.to_rfc3339(),
+    };
+    uuid::Uuid::parse_str(&memory.memory_id).expect("full memory UUID");
+    uuid::Uuid::parse_str(&memory.observation_id).expect("full observation UUID");
+
+    let positive = probe(socket, config_id, Some(ACTOR), &[ACTOR], None, &memory).await;
+    eprintln!("explicit actor visibility: {positive:?}; frame.ok and every inner ok verified");
+    assert_eq!(
+        positive,
+        [1, 1, 1],
+        "explicit visibility must find all three records"
+    );
+
+    let default = probe(socket, config_id, Some(ACTOR), &[], None, &memory).await;
+    let omissions = default.map(|count| count == 0);
+    eprintln!(
+        "empty-visibility actor omissions: recall={}, memory={}, annotates={}; frame.ok and every inner ok verified",
+        omissions[0], omissions[1], omissions[2]
+    );
+    assert!(
+        default.iter().all(|count| *count <= 1),
+        "duplicate default results"
+    );
+    assert_eq!(
+        probe(socket, config_id, None, &[], None, &memory).await,
+        [0, 0, 0],
+        "anonymous default reads must not include another actor's namespace"
+    );
+    assert_eq!(
+        probe(
+            socket,
+            config_id,
+            Some("test:other-reader"),
+            &[],
+            None,
+            &memory
+        )
+        .await,
+        [0, 0, 0],
+        "a different actor must not inherit the writer's default visibility"
+    );
+    assert_eq!(
+        probe(socket, config_id, Some(ACTOR), &[], Some(ACTOR), &memory).await,
+        [1, 1, 1],
+        "an explicit actor namespace must remain usable"
+    );
+    assert_eq!(
+        probe(
+            socket,
+            config_id,
+            Some(ACTOR),
+            &[ACTOR],
+            Some("local"),
+            &memory
+        )
+        .await,
+        [0, 0, 0],
+        "explicit local must not widen, even with actor visibility supplied"
+    );
+    assert_eq!(
+        probe(
+            socket,
+            config_id,
+            Some(ACTOR),
+            &[ACTOR, ACTOR],
+            None,
+            &memory
+        )
+        .await,
+        [1, 1, 1],
+        "repeated visibility entries must not duplicate results"
+    );
+
+    let writes = request(
+        socket,
+        config_id,
+        Some(ACTOR),
+        &[],
+        json!([
+            {"tool": "memory.remember", "args": {"content": "semantic location control", "memory_type": "semantic"}},
+            {"tool": "memory.remember", "args": {"content": "explicit location control", "memory_type": "episodic", "namespace": "local"}}
+        ]).to_string(),
+    ).await;
+    let anonymous = request(
+        socket, config_id, None, &[],
+        r#"memory.remember(content="anonymousprobe location control", memory_type="episodic", salience=1.0, decay_factor=0.0, tags=["anonymous-namespace-probe"])"#.into(),
+    ).await;
+    let destinations = request(
+        socket,
+        config_id,
+        Some(ACTOR),
+        &[],
+        json!([
+            {"tool": "list", "args": {"kind": "observation", "namespace": "local"}},
+            {"tool": "list", "args": {"kind": "observation", "namespace": ACTOR}},
+            {"tool": "list", "args": {"kind": "memory", "namespace": "local"}},
+            {"tool": "list", "args": {"kind": "memory", "namespace": ACTOR}}
+        ])
+        .to_string(),
+    )
+    .await;
+    let ids = |index: usize| -> Vec<&Value> {
+        destinations[index]["items"]
+            .as_array()
+            .expect("destination list")
+            .iter()
+            .map(|row| &row["id"])
+            .collect()
+    };
+    assert_eq!(
+        ids(0),
+        vec![&chain[0]["id"]],
+        "ordinary writes remain local"
+    );
+    assert!(
+        ids(1).is_empty(),
+        "actor visibility must not relocate observations"
+    );
+    let local_memories = ids(2);
+    assert_eq!(local_memories.len(), 3);
+    for id in [&writes[0]["id"], &writes[1]["id"], &anonymous[0]["id"]] {
+        assert!(
+            local_memories.contains(&id),
+            "semantic, explicit-local and anonymous writes remain local"
+        );
+    }
+    assert_eq!(
+        ids(3),
+        vec![&chain[1]["id"]],
+        "episodic default writes use the actor namespace"
+    );
+    let anonymous_recall = request(
+        socket, config_id, None, &[],
+        r#"memory.recall(query="anonymousprobe", tags=["anonymous-namespace-probe"], fusion_strategy="keyword_only", min_score=0.0, include_breakdown=true)"#.into(),
+    ).await;
+    let recalled_anonymous = recall_items(&anonymous_recall[0]);
+    assert_eq!(recalled_anonymous.len(), 1);
+    assert_eq!(recalled_anonymous[0]["full_id"], anonymous[0]["id"]);
+    eprintln!("anonymous, other actor, exact namespace, duplicate visibility and write destination controls passed");
+    omissions
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn bound_actor_memory_namespace_round_trip() {
+    let _environment = RecoveryTestGuard::new();
+    clear_daemon_env();
+    let directory = tempfile::tempdir().expect("isolated daemon storage");
+    let socket = directory.path().join("daemon.sock");
+    std::env::set_var("KHIVE_SOCKET", &socket);
+    std::env::set_var("KHIVE_PID", directory.path().join("daemon.pid"));
+    std::env::set_var("KHIVE_LOCK", directory.path().join("daemon.lock"));
+    std::env::set_var(
+        "KHIVE_RECOVERER_LOCK",
+        directory.path().join("recoverer.lock"),
+    );
+    let config = RuntimeConfig {
+        db_path: Some(directory.path().join("memory.db")),
+        packs: vec!["kg".into(), "memory".into()],
+        actor_id: None,
+        brain_profile: None,
+        ..RuntimeConfig::no_embeddings()
+    };
+    let runtime = KhiveRuntime::new(config).expect("file-backed runtime without embedders");
+    let server = KhiveMcpServer::new(runtime).expect("kg and memory server");
+    let config_id = server.config_id().to_owned();
+    let daemon = tokio::spawn(run_daemon(server));
+    // Catch control failures so even the intended RED result joins the daemon before unwinding.
+    let outcome = timeout(
+        Duration::from_secs(30),
+        std::panic::AssertUnwindSafe(exercise(&socket, &config_id)).catch_unwind(),
+    )
+    .await;
+    daemon.abort();
+    let stopped = timeout(Duration::from_secs(5), daemon)
+        .await
+        .expect("aborted daemon must join within five seconds");
+    assert!(
+        matches!(&stopped, Err(error) if error.is_cancelled()),
+        "daemon exited unexpectedly: {stopped:?}"
+    );
+    let omissions = outcome
+        .expect("bounded namespace scenario")
+        .unwrap_or_else(|panic| std::panic::resume_unwind(panic));
+    assert_eq!(
+        omissions, [false; 3],
+        "bound actor with empty wire visibility omitted [recall, memory, annotates]"
+    );
+}

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -9287,6 +9287,134 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    #[serial_test::serial(config_ledger)]
+    async fn issue_2427_scheduled_replay_does_not_gain_actor_visibility() {
+        let runtime = KhiveRuntime::new(RuntimeConfig {
+            db_path: None,
+            default_namespace: Namespace::local(),
+            actor_id: Some("lambda:daemon".to_string()),
+            visible_namespaces: vec![Namespace::parse("daemon-visible").unwrap()],
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            packs: vec!["kg".to_string()],
+            ..RuntimeConfig::default()
+        })
+        .expect("in-memory replay runtime");
+        let server = KhiveMcpServer::new(runtime).expect("replay server");
+
+        for actor_id in [Some("lambda:scheduled-replay"), None] {
+            let verified_actor = actor_id
+                .map(|actor| khive_runtime::VerifiedActor::new(actor).expect("verified creator"));
+            let raw = server
+                .dispatch_request_replay_as(
+                    RequestParams {
+                        ops: "whoami()".to_string(),
+                        presentation: Some("verbose".to_string()),
+                        format: Some("json".to_string()),
+                        ..Default::default()
+                    },
+                    "local",
+                    verified_actor,
+                )
+                .await
+                .expect("scheduled replay dispatch");
+            let envelope: Value = serde_json::from_str(&raw).expect("replay JSON envelope");
+            assert_eq!(envelope["results"][0]["ok"], true, "{envelope}");
+            let identity = &envelope["results"][0]["result"];
+            assert_eq!(identity["actor_id"], actor_id.unwrap_or("local"));
+            assert_eq!(
+                identity["actor_kind"],
+                if actor_id.is_some() {
+                    "actor"
+                } else {
+                    "anonymous"
+                }
+            );
+            assert_eq!(identity["unattributed"], actor_id.is_none());
+            assert_eq!(identity["namespace"], "local");
+            assert_eq!(
+                identity["visible_namespaces"],
+                json!(["local"]),
+                "replay must inherit neither actor-derived nor daemon visibility: {identity}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(config_ledger)]
+    async fn issue_2427_coordinator_search_consumes_normalized_identity_visibility() {
+        use crate::coordinator::tests::MockCoordinator;
+
+        let runtime = KhiveRuntime::new(RuntimeConfig {
+            db_path: None,
+            default_namespace: Namespace::local(),
+            actor_id: Some("lambda:daemon".to_string()),
+            visible_namespaces: vec![Namespace::parse("daemon-visible").unwrap()],
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            packs: vec!["kg".to_string()],
+            ..RuntimeConfig::default()
+        })
+        .expect("in-memory coordinator runtime");
+        let coordinator = MockCoordinator::multi_backend();
+        let server = KhiveMcpServer::new(runtime)
+            .expect("coordinator server")
+            .with_coordinator(Arc::clone(&coordinator) as Arc<dyn CoordinatorService>);
+
+        // Supply the boundary's normalized output directly; daemon-frame parsing
+        // and transport coverage belong to the daemon tests, not this fixture.
+        for (visible, explicit_namespace, mut expected) in [
+            (
+                vec!["lambda:request-actor", "client-visible"],
+                false,
+                vec!["lambda:request-actor", "client-visible", "local"],
+            ),
+            (vec![], false, vec!["local"]),
+            (vec!["lambda:request-actor", "client-visible"], true, vec![]),
+        ] {
+            let mut identity = request_identity_with_visible_namespaces(visible);
+            identity.actor_id = Some("lambda:request-actor".to_string());
+            let ops = if explicit_namespace {
+                r#"search(kind="entity", query="visibility", namespace="chosen")"#
+            } else {
+                r#"search(kind="entity", query="visibility")"#
+            };
+            coordinator.search_called.store(false, Ordering::SeqCst);
+            let raw = server
+                .dispatch_request_inner(
+                    RequestParams {
+                        ops: ops.to_string(),
+                        ..Default::default()
+                    },
+                    true,
+                    Some(identity),
+                    DispatchOrigin::Local,
+                )
+                .await
+                .expect("coordinator dispatch");
+            let envelope: Value = serde_json::from_str(&raw).expect("coordinator JSON envelope");
+            assert_eq!(envelope["results"][0]["ok"], true, "{envelope}");
+            assert!(
+                coordinator.search_called.load(Ordering::SeqCst),
+                "search must reach the coordinator, not the single-backend registry"
+            );
+            let mut actual: Vec<String> = coordinator
+                .last_extra_visible
+                .lock()
+                .expect("captured coordinator visibility")
+                .iter()
+                .map(|namespace| namespace.as_str().to_string())
+                .collect();
+            actual.sort();
+            expected.sort();
+            assert_eq!(
+                actual, expected,
+                "coordinator must consume supplied visibility without widening internal identities"
+            );
+        }
+    }
+
     /// No per-request identity: falls back to the registry's operator-baked
     /// `visible_namespaces`, widened with `local` — mirrors the normal
     /// registry dispatch path's default-case widening.

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -30,6 +30,8 @@ use tokio::net::{UnixListener, UnixStream};
 
 #[cfg(unix)]
 use khive_db::{run_checkpoint_task, CheckpointConfig, CheckpointLifecycleOwner, ConnectionPool};
+#[cfg(unix)]
+use khive_types::Namespace;
 
 #[cfg(unix)]
 use crate::pack::RequestIdentity;
@@ -430,8 +432,10 @@ pub struct DaemonRequestFrame {
     /// The client's resolved extra read-visibility namespaces (ADR-007 Rule
     /// 3b), carried on the frame so the warm daemon widens read scope to
     /// match the caller's own configuration rather than its own baked
-    /// `visible_namespaces` (ADR-096). Empty means no extra visibility beyond
-    /// `namespace` itself.
+    /// `visible_namespaces` (ADR-096). At ingress, a valid non-`local`
+    /// `actor_id` is included if absent, matching config loading; an empty
+    /// list therefore still includes that actor in default reads. Explicit
+    /// `namespace=` operations remain scoped to exactly that namespace.
     #[serde(default)]
     pub visible_namespaces: Vec<String>,
     /// Fingerprint of the client's engine-coherence config: packs, db target,
@@ -1168,10 +1172,18 @@ async fn handle_conn_with_shutdown<D: DaemonDispatch>(
         // `actor_id`/`visible_namespaces` the client resolved (defaulting to
         // `None`/`vec![]` for an older, field-absent payload, which is
         // exactly the prior anonymous/no-extra-visibility behavior).
+        let mut visible_namespaces = frame.visible_namespaces.clone();
+        if let Some(actor_id) = frame.actor_id.as_deref().filter(|actor_id| {
+            *actor_id != Namespace::LOCAL
+                && Namespace::parse(actor_id).is_ok()
+                && !visible_namespaces.iter().any(|ns| ns == *actor_id)
+        }) {
+            visible_namespaces.push(actor_id.to_string());
+        }
         let identity = RequestIdentity {
             namespace: frame.namespace.clone(),
             actor_id: frame.actor_id.clone(),
-            visible_namespaces: frame.visible_namespaces.clone(),
+            visible_namespaces,
             process_ref: frame.process_ref.clone(),
             request_id: frame.request_id,
         };

--- a/docs/adr/ADR-007-namespace.md
+++ b/docs/adr/ADR-007-namespace.md
@@ -452,6 +452,9 @@ appears in either source. When neither source contributes a non-`'local'` namesp
 default read scope is exactly `['local']`, identical to Rev 3. The widening is therefore
 opt-in: a deployment that configures neither `[actor] id` nor `[actor] visible_namespaces`
 keeps Rev 3 behavior verbatim.
+Daemon request ingress applies the same fold once to forwarded visibility, adding the
+unmodified actor id only when it parses as a non-`'local'` namespace and is not already
+present, without changing explicit `namespace=` scope or replayed token identities.
 
 The scope applies to all multi-record reads for all packs: list, search, recall, neighbors,
 traverse, query. The runtime supplies the set to the store as a `WHERE namespace IN (...)`


### PR DESCRIPTION
## Summary

A client that identifies with a non-`local` actor and forwards an empty visibility list to the warm daemon could write episodic memory into its actor namespace and then not read it back with a default-scope recall, because the daemon frame copied the forwarded visibility verbatim while direct configuration loading folds the actor id into default read scope. Closes #2427.

## Change

- `khive-runtime` daemon ingress applies the same fold once: a forwarded `actor_id` that parses as a non-`local` namespace is added to `visible_namespaces` when absent. Explicit `namespace=` operations and scheduled-replay token identities are unchanged.
- ADR-007 records the ingress fold in one sentence.

## Tests

- New wire regression against a file-backed scratch daemon (kg + memory packs): the three default-read omissions are red at the parent commit and green here; anonymous and other-actor default reads still do not see the actor's memory; explicit `local` does not widen; repeated actor visibility does not duplicate hits.
- Server controls: scheduled replay does not gain actor or daemon visibility; coordinator search consumes the normalized identity without widening internal identities.
