### PR TITLE
feat(request): inspect request plans without dispatch

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2018,6 +2018,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "sha2",
+ "syn",
  "tempfile",
  "tokio",
  "tokio-util",
@@ -2447,6 +2448,7 @@ dependencies = [
  "khive-types",
  "serde",
  "serde_json",
+ "syn",
 ]
 
 [[package]]
@@ -2494,6 +2496,7 @@ dependencies = [
  "khive-gate",
  "khive-gate-rego",
  "khive-query",
+ "khive-request",
  "khive-score",
  "khive-storage",
  "khive-types",

--- a/crates/khive-mcp/Cargo.toml
+++ b/crates/khive-mcp/Cargo.toml
@@ -10,6 +10,8 @@ homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
 description = "khive MCP server library — served via the kkernel binary"
+# The shared parser corpus is available only in a workspace checkout.
+exclude = ["tests/plan_conformance.rs"]
 
 [dependencies]
 khive-db = { version = "0.8.0", path = "../khive-db" }
@@ -81,6 +83,7 @@ pack-moodboard = ["khive-pack-moodboard"]
 test-forward-seam = []
 
 [dev-dependencies]
+syn = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 khive-runtime = { version = "0.8.0", path = "../khive-runtime", features = ["fault-injection"] }
 khive-storage = { version = "0.8.0", path = "../khive-storage", features = ["test-support"] }

--- a/crates/khive-mcp/src/coordinator.rs
+++ b/crates/khive-mcp/src/coordinator.rs
@@ -531,6 +531,7 @@ pub(crate) mod tests {
         );
         let _result = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops,
                 presentation: None,
                 presentation_per_op: None,
@@ -560,6 +561,7 @@ pub(crate) mod tests {
 
         let _result = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: r#"search(kind="entity", query="anything")"#.to_string(),
                 presentation: None,
                 presentation_per_op: None,
@@ -598,6 +600,7 @@ pub(crate) mod tests {
         ] {
             server
                 .dispatch_request_local(RequestParams {
+                    plan: None,
                     ops: ops.to_string(),
                     presentation: None,
                     presentation_per_op: None,
@@ -656,6 +659,7 @@ pub(crate) mod tests {
                 .with_coordinator(Arc::clone(&coord) as Arc<dyn CoordinatorService>);
             let raw = server
                 .dispatch_request_local(RequestParams {
+                    plan: None,
                     ops: ops.to_string(),
                     presentation: None,
                     presentation_per_op: None,
@@ -702,6 +706,7 @@ pub(crate) mod tests {
                 .with_coordinator(Arc::clone(&coord) as Arc<dyn CoordinatorService>);
             let raw = server
                 .dispatch_request_local(RequestParams {
+                    plan: None,
                     ops: ops.to_string(),
                     presentation: presentation.map(str::to_string),
                     presentation_per_op: None,
@@ -758,6 +763,7 @@ pub(crate) mod tests {
 
         let raw = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: r#"search(kind="entity", query="nothing matches")"#.to_string(),
                 presentation: None,
                 presentation_per_op: None,
@@ -800,6 +806,7 @@ pub(crate) mod tests {
 
         let raw = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: r#"search(kind="entity", query="LoRA")"#.to_string(),
                 presentation: None,
                 presentation_per_op: None,
@@ -859,6 +866,7 @@ pub(crate) mod tests {
 
         let raw = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: r#"search(kind="entity", query="degraded")"#.to_string(),
                 presentation: None,
                 presentation_per_op: None,
@@ -912,6 +920,7 @@ pub(crate) mod tests {
 
         let raw = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: r#"search(kind="entity", query="degraded", min_score=0.5)"#.to_string(),
                 presentation: None,
                 presentation_per_op: None,
@@ -949,6 +958,7 @@ pub(crate) mod tests {
 
             let raw = server
                 .dispatch_request_local(RequestParams {
+                    plan: None,
                     ops: format!(r#"search(kind="{kind}", query="anything")"#),
                     presentation: None,
                     presentation_per_op: None,
@@ -1009,6 +1019,7 @@ pub(crate) mod tests {
             for server in [&direct_server, &coordinator_server] {
                 server
                     .dispatch_request_local(RequestParams {
+                        plan: None,
                         ops: ops.clone(),
                         presentation: None,
                         presentation_per_op: None,
@@ -1071,6 +1082,7 @@ pub(crate) mod tests {
 
         let raw = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 // `note_kind` is invalid for an entity search. Denial must win
                 // before the intercepted handler validates that filter.
                 ops: r#"search(kind="entity", query="gate parity", note_kind="observation", namespace="tenant-a")"#.to_string(),
@@ -1121,6 +1133,7 @@ pub(crate) mod tests {
 
             let raw = server
                 .dispatch_request_local(RequestParams {
+                    plan: None,
                     ops: format!(r#"search(kind="{kind}", query="anything")"#),
                     presentation: None,
                     presentation_per_op: None,
@@ -1169,6 +1182,7 @@ pub(crate) mod tests {
         // Pass a non-string entry in the tags array; the strict parser must reject this.
         let raw = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: r#"search(kind="entity", query="anything", tags=[42])"#.to_string(),
                 presentation: None,
                 presentation_per_op: None,
@@ -1225,6 +1239,7 @@ pub(crate) mod tests {
             let ops = format!(r#"search(kind="entity", query="anything", namespace={ns_literal})"#);
             let raw = server
                 .dispatch_request_local(RequestParams {
+                    plan: None,
                     ops,
                     presentation: None,
                     presentation_per_op: None,
@@ -1288,6 +1303,7 @@ pub(crate) mod tests {
             );
             let raw = server
                 .dispatch_request_local(RequestParams {
+                    plan: None,
                     ops,
                     presentation: None,
                     presentation_per_op: None,
@@ -1345,6 +1361,7 @@ pub(crate) mod tests {
 
         let _result = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: r#"search(kind="entity", query="T6cEntity")"#.to_string(),
                 presentation: None,
                 presentation_per_op: None,
@@ -1381,6 +1398,7 @@ pub(crate) mod tests {
         let too_large: u64 = u64::from(u32::MAX) + 2;
         let raw = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: format!(r#"search(kind="entity", query="anything", limit={too_large})"#),
                 presentation: None,
                 presentation_per_op: None,
@@ -1427,6 +1445,7 @@ pub(crate) mod tests {
 
         let raw = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: format!(
                     r#"search(kind="entity", query="anything", limit={})"#,
                     u32::MAX

--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -428,6 +428,10 @@ fn fallback_or_reject(
 
 #[async_trait]
 impl daemon::DaemonDispatch for crate::server::KhiveMcpServer {
+    fn plan(&self, ops: &str) -> String {
+        self.plan_ops(ops)
+    }
+
     async fn dispatch(
         &self,
         ops: String,
@@ -439,6 +443,7 @@ impl daemon::DaemonDispatch for crate::server::KhiveMcpServer {
         identity: Option<khive_runtime::RequestIdentity>,
     ) -> Result<String, String> {
         let params = RequestParams {
+            plan: None,
             ops,
             presentation,
             presentation_per_op,
@@ -1196,6 +1201,7 @@ enum ProbeOutcome {
 ///   `Timeout` → do NOT kill (daemon may be healthy-but-busy; NEVER-KILL-SLOW)
 async fn probe_daemon_identity(config_id: &str, namespace: &str, timeout_ms: u64) -> ProbeOutcome {
     let probe = DaemonRequestFrame {
+        plan: false,
         ops: String::new(),
         presentation: None,
         presentation_per_op: None,
@@ -3275,6 +3281,7 @@ mod tests {
         std::env::set_var("KHIVE_NO_DAEMON", "1");
 
         let frame = DaemonRequestFrame {
+            plan: false,
             ops: "stats()".to_string(),
             presentation: None,
             presentation_per_op: None,
@@ -3319,6 +3326,7 @@ mod tests {
 
     fn unreachable_daemon_frame(config_id: &str) -> DaemonRequestFrame {
         DaemonRequestFrame {
+            plan: false,
             ops: "stats()".to_string(),
             presentation: None,
             presentation_per_op: None,
@@ -4272,6 +4280,7 @@ mod tests {
 
         // (a) valid same-namespace, same-config op
         let req = DaemonRequestFrame {
+            plan: false,
             ops: "stats()".to_string(),
             presentation: Some("verbose".to_string()),
             presentation_per_op: None,
@@ -4302,6 +4311,7 @@ mod tests {
 
         let reference_result = reference
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: "stats()".to_string(),
                 presentation: Some("verbose".to_string()),
                 presentation_per_op: None,
@@ -4344,6 +4354,7 @@ mod tests {
         // the frame's OWN namespace ("other") over the same shared warm
         // registry, instead of setting `namespace_mismatch`.
         let other = DaemonRequestFrame {
+            plan: false,
             ops: "stats()".to_string(),
             presentation: None,
             presentation_per_op: None,
@@ -4382,6 +4393,7 @@ mod tests {
         // config_id reject stays hard under ADR-096 Fork 1 — only the
         // namespace reject was softened.
         let mismatched_config = DaemonRequestFrame {
+            plan: false,
             ops: "stats()".to_string(),
             presentation: None,
             presentation_per_op: None,
@@ -4408,6 +4420,7 @@ mod tests {
 
         // (d) version mismatch → explicit error, NOT namespace/config mismatch
         let wrong_version = DaemonRequestFrame {
+            plan: false,
             ops: "stats()".to_string(),
             presentation: None,
             presentation_per_op: None,
@@ -4502,6 +4515,7 @@ mod tests {
         drop(ready);
 
         let request = DaemonRequestFrame {
+            plan: false,
             ops: "stats()".to_string(),
             presentation: None,
             presentation_per_op: None,
@@ -4571,6 +4585,7 @@ mod tests {
         drop(_ready);
 
         let alice_frame = DaemonRequestFrame {
+            plan: false,
             ops: "comm.send(to=\"bob\", content=\"hello from alice\") | comm.thread(id=$prev.full_id)"
                 .to_string(),
             presentation: None,
@@ -4589,6 +4604,7 @@ mod tests {
             request_id: None,
         };
         let bob_frame = DaemonRequestFrame {
+            plan: false,
             ops: "comm.send(to=\"alice\", content=\"hello from bob\") | comm.thread(id=$prev.full_id)"
                 .to_string(),
             presentation: None,
@@ -4607,6 +4623,7 @@ mod tests {
             request_id: None,
         };
         let charlie_frame = DaemonRequestFrame {
+            plan: false,
             ops: "comm.send(to=\"alice\", content=\"hello from charlie\") | comm.thread(id=$prev.full_id)"
                 .to_string(),
             presentation: None,
@@ -4753,6 +4770,7 @@ mod tests {
         drop(_ready);
 
         let frame = |ops: &str, actor: &str, visible: &[Namespace]| DaemonRequestFrame {
+            plan: false,
             ops: ops.to_string(),
             presentation: Some("verbose".to_string()),
             presentation_per_op: None,
@@ -4861,6 +4879,7 @@ mod tests {
         let server = make_comm_test_server(Some("baked-actor"));
         let result = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: "comm.send(to=\"someone\", content=\"hello\")".to_string(),
                 presentation: None,
                 presentation_per_op: None,
@@ -4911,6 +4930,7 @@ mod tests {
         drop(_ready);
 
         let frame = |from_wire: bool| DaemonRequestFrame {
+            plan: false,
             ops: "brain.state()".to_string(),
             presentation: None,
             presentation_per_op: None,
@@ -5073,6 +5093,7 @@ mod tests {
         let fake_handle = tokio::spawn(serve_one_response(listener, old_resp));
 
         let frame = DaemonRequestFrame {
+            plan: false,
             ops: "stats()".to_string(),
             presentation: None,
             presentation_per_op: None,
@@ -5174,6 +5195,7 @@ mod tests {
         let fake_handle = tokio::spawn(serve_crash_on_dispatch(listener));
 
         let frame = DaemonRequestFrame {
+            plan: false,
             ops: "stats()".to_string(),
             presentation: None,
             presentation_per_op: None,
@@ -5275,6 +5297,7 @@ mod tests {
              outright before the timeout can be observed"
         );
         let frame = DaemonRequestFrame {
+            plan: false,
             ops: big_ops,
             presentation: None,
             presentation_per_op: None,
@@ -5389,6 +5412,7 @@ mod tests {
         let fake_handle = tokio::spawn(serve_read_then_never_answer(listener));
 
         let frame = DaemonRequestFrame {
+            plan: false,
             ops: "stats()".to_string(),
             presentation: None,
             presentation_per_op: None,
@@ -5481,6 +5505,7 @@ mod tests {
         let fake_handle = tokio::spawn(serve_one_ok_response(listener, config_id.to_string()));
 
         let frame = DaemonRequestFrame {
+            plan: false,
             ops: "stats()".to_string(),
             presentation: None,
             presentation_per_op: None,
@@ -5910,6 +5935,10 @@ mod tests {
 
     #[async_trait]
     impl daemon::DaemonDispatch for BigDispatch {
+        fn plan(&self, ops: &str) -> String {
+            khive_request::plan_request(ops, &Default::default()).to_string()
+        }
+
         async fn dispatch(
             &self,
             _ops: String,
@@ -5974,6 +6003,7 @@ mod tests {
             .expect("daemon pid must be a u32");
 
         let frame = DaemonRequestFrame {
+            plan: false,
             ops: "stats()".to_string(),
             presentation: None,
             presentation_per_op: None,
@@ -6077,6 +6107,10 @@ mod tests {
 
     #[async_trait]
     impl daemon::DaemonDispatch for CountingDispatch {
+        fn plan(&self, ops: &str) -> String {
+            khive_request::plan_request(ops, &Default::default()).to_string()
+        }
+
         async fn dispatch(
             &self,
             _ops: String,
@@ -6185,6 +6219,7 @@ mod tests {
 
         // Now forward the real request exactly once — the call site's single forward.
         let real_frame = DaemonRequestFrame {
+            plan: false,
             ops: "stats()".to_string(),
             presentation: None,
             presentation_per_op: None,
@@ -6548,6 +6583,7 @@ mod tests {
 
         drop(connect_when_ready(&sock).await);
         let frame = DaemonRequestFrame {
+            plan: false,
             ops: "stats()".to_string(),
             presentation: None,
             presentation_per_op: None,
@@ -6699,6 +6735,7 @@ mod tests {
         });
 
         let frame = std::sync::Arc::new(DaemonRequestFrame {
+            plan: false,
             ops: "stats()".to_string(),
             presentation: None,
             presentation_per_op: None,
@@ -6881,6 +6918,10 @@ mod tests {
 
     #[async_trait]
     impl daemon::DaemonDispatch for FailDispatch {
+        fn plan(&self, ops: &str) -> String {
+            khive_request::plan_request(ops, &Default::default()).to_string()
+        }
+
         async fn dispatch(
             &self,
             _ops: String,
@@ -6933,6 +6974,7 @@ mod tests {
         drop(_ready);
 
         let frame = DaemonRequestFrame {
+            plan: false,
             ops: "stats()".to_string(),
             presentation: None,
             presentation_per_op: None,
@@ -7015,9 +7057,14 @@ mod tests {
 
     #[tokio::test]
     #[serial]
-    async fn v4_client_rejects_warm_v3_daemon_before_accepting_result() {
+    async fn current_client_rejects_warm_v3_daemon_before_accepting_result() {
         clear_daemon_env();
-        assert_eq!(PROTOCOL_VERSION, 4, "process_ref is the protocol-v4 change");
+        const {
+            assert!(
+                PROTOCOL_VERSION >= 4,
+                "process_ref requires protocol v4 or later"
+            )
+        };
         let dir = tempfile::tempdir().expect("tempdir");
         let sock = dir.path().join("khived.sock");
         let pid_file = dir.path().join("khived.pid");
@@ -7036,6 +7083,7 @@ mod tests {
         let fake_handle = tokio::spawn(serve_one_response(listener, mismatch_resp));
 
         let frame = DaemonRequestFrame {
+            plan: false,
             ops: "stats()".to_string(),
             presentation: None,
             presentation_per_op: None,
@@ -7119,6 +7167,7 @@ mod tests {
         let fake_handle = tokio::spawn(serve_one_response(listener, mismatch_resp));
 
         let frame = DaemonRequestFrame {
+            plan: false,
             ops: "stats()".to_string(),
             presentation: None,
             presentation_per_op: None,
@@ -7212,6 +7261,7 @@ mod tests {
         });
 
         let frame = DaemonRequestFrame {
+            plan: false,
             ops: "stats()".to_string(),
             presentation: None,
             presentation_per_op: None,
@@ -7317,6 +7367,7 @@ mod tests {
         });
 
         let frame = DaemonRequestFrame {
+            plan: false,
             ops: "stats()".to_string(),
             presentation: None,
             presentation_per_op: None,
@@ -7418,6 +7469,7 @@ mod tests {
         });
 
         let frame = DaemonRequestFrame {
+            plan: false,
             ops: "stats()".to_string(),
             presentation: None,
             presentation_per_op: None,
@@ -7548,6 +7600,7 @@ mod tests {
         });
 
         let frame = DaemonRequestFrame {
+            plan: false,
             ops: "stats()".to_string(),
             presentation: None,
             presentation_per_op: None,

--- a/crates/khive-mcp/src/daemon/test_harness.rs
+++ b/crates/khive-mcp/src/daemon/test_harness.rs
@@ -141,6 +141,10 @@ impl HarnessDispatch {
 
 #[async_trait]
 impl DaemonDispatch for HarnessDispatch {
+    fn plan(&self, ops: &str) -> String {
+        khive_request::plan_request(ops, &Default::default()).to_string()
+    }
+
     async fn dispatch(
         &self,
         _ops: String,

--- a/crates/khive-mcp/src/pending_events.rs
+++ b/crates/khive-mcp/src/pending_events.rs
@@ -3049,6 +3049,7 @@ async fn dispatch_action(
     let result = server
         .dispatch_request_replay_as(
             RequestParams {
+                plan: None,
                 ops: ops_str,
                 presentation: None,
                 presentation_per_op: None,
@@ -3604,6 +3605,7 @@ mod tests {
     async fn agenda_ticker_last_tick_at(server: &KhiveMcpServer) -> Option<DateTime<Utc>> {
         let response = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: "schedule.agenda()".to_string(),
                 presentation: Some("verbose".to_string()),
                 presentation_per_op: None,
@@ -6168,6 +6170,7 @@ mod tests {
         .expect("serialize cancel op");
         let cancel_result = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: cancel_ops,
                 presentation: None,
                 presentation_per_op: None,
@@ -7080,6 +7083,7 @@ mod tests {
         .expect("serialize cancel op");
         let cancel_result = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: cancel_ops,
                 presentation: None,
                 presentation_per_op: None,

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -5921,6 +5921,7 @@ id = "lambda:project-actor"
         // kg round-trip: create an entity on the main backend.
         let kg_resp = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: r#"create(kind="concept", name="MultiBackendTestEntity")"#.to_string(),
                 presentation: None,
                 presentation_per_op: None,
@@ -5945,6 +5946,7 @@ id = "lambda:project-actor"
         // comm round-trip: send a message on the secondary backend.
         let comm_resp = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: r#"comm.send(to="local", content="multi-backend-test")"#.to_string(),
                 presentation: None,
                 presentation_per_op: None,
@@ -6008,6 +6010,7 @@ id = "lambda:project-actor"
 
         let send_resp = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: r#"comm.send(to="local", content="adr-124 multi-backend boot probe")"#
                     .to_string(),
                 presentation: None,
@@ -6033,6 +6036,7 @@ id = "lambda:project-actor"
 
         let get_before_resp = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: format!(r#"get(id="{full_id}")"#),
                 presentation: None,
                 presentation_per_op: None,
@@ -6050,6 +6054,7 @@ id = "lambda:project-actor"
 
         let update_resp = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: format!(
                     r#"update(id="{full_id}", properties={{"from_actor": "forged-actor"}})"#
                 ),
@@ -6080,6 +6085,7 @@ id = "lambda:project-actor"
 
         let get_after_resp = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: format!(r#"get(id="{full_id}")"#),
                 presentation: None,
                 presentation_per_op: None,
@@ -6161,6 +6167,7 @@ id = "lambda:project-actor"
 
         let send_resp = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: r#"comm.send(to="local", content="adr-124 boot-occupancy actor probe")"#
                     .to_string(),
                 presentation: None,
@@ -6186,6 +6193,7 @@ id = "lambda:project-actor"
 
         let get_resp = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: format!(r#"get(id="{full_id}")"#),
                 presentation: None,
                 presentation_per_op: None,
@@ -6202,6 +6210,7 @@ id = "lambda:project-actor"
 
         let create_resp = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: r#"create(kind="message", content="adr-124 boot-occupancy create probe", properties={"from_actor": "forged-actor"})"#
                     .to_string(),
                 presentation: None,
@@ -7998,6 +8007,7 @@ region = "us-east-1"
             async move {
                 let resp = server
                     .dispatch_request_local(RequestParams {
+                        plan: None,
                         ops,
                         presentation: None,
                         presentation_per_op: None,
@@ -9213,6 +9223,7 @@ region = "us-east-1"
             async move {
                 server
                     .dispatch_request_local(RequestParams {
+                        plan: None,
                         ops,
                         presentation: None,
                         presentation_per_op: None,

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -3023,6 +3023,12 @@ where
 impl KhiveMcpServer {
     #[tool(description = r#"Run one or more khive verbs in a single MCP call.
 
+Set plan=true with ops alone to check syntax without execution. The result has
+parsed, mode, stage_count, stages (verb, pack, known, args, prev_refs), and parser
+limits. A syntax error returns parsed=false and error, with no stages. Planning
+does not check permission or resolve references. presentation, presentation_per_op,
+format, format_per_op, save_to, and request_id cannot accompany plan=true.
+
 ops syntax:
 
   Single op   : verb(name=value, name=value)
@@ -3135,7 +3141,28 @@ fn forward_or_spawn_boxed(
 }
 
 impl KhiveMcpServer {
+    pub(crate) fn plan_ops(&self, ops: &str) -> String {
+        let catalog = self
+            .registry
+            .all_verbs_with_names()
+            .into_iter()
+            .map(|(pack, handler)| (handler.name.to_string(), pack.to_string()))
+            .collect();
+        khive_request::plan_request(ops, &catalog).to_string()
+    }
+
+    fn plan_response(&self, p: &RequestParams) -> Result<Option<String>, McpError> {
+        if p.plan != Some(true) {
+            return Ok(None);
+        }
+        p.validate_plan_envelope()?;
+        Ok(Some(self.plan_ops(&p.ops)))
+    }
+
     async fn request_with_cancellation(&self, p: RequestParams) -> Result<String, McpError> {
+        if let Some(plan) = self.plan_response(&p)? {
+            return Ok(plan);
+        }
         let mut p = p;
         let request_id = ensure_bridge_request_id(&mut p);
         tracing::debug!(
@@ -3158,6 +3185,9 @@ impl KhiveMcpServer {
         p: RequestParams,
         #[cfg(unix)] forward_fn: ForwardFnPtr,
     ) -> Result<String, McpError> {
+        if let Some(plan) = self.plan_response(&p)? {
+            return Ok(plan);
+        }
         // Parse before the daemon decision. The daemon protocol's historical
         // error channel is string-only, so forwarding malformed DSL would turn
         // `invalid_params` plus its structured `parse-error` reason into an
@@ -3554,6 +3584,7 @@ impl KhiveMcpServer {
     #[cfg(unix)]
     pub(crate) fn wire_daemon_frame(&self, p: &RequestParams) -> khive_runtime::DaemonRequestFrame {
         khive_runtime::DaemonRequestFrame {
+            plan: false,
             ops: p.ops.clone(),
             presentation: p.presentation.clone(),
             presentation_per_op: p.presentation_per_op.clone(),
@@ -3676,6 +3707,7 @@ impl KhiveMcpServer {
         debug_assert!(policy.max_batch_concurrency > 0);
         let parsed = parse_typed_json_batch(ops).map_err(dsl_err_to_mcp)?;
         let p = RequestParams {
+            plan: None,
             ops: String::new(),
             presentation,
             presentation_per_op: None,
@@ -3772,6 +3804,9 @@ impl KhiveMcpServer {
         origin: DispatchOrigin,
         strict_refusals: bool,
     ) -> Result<String, McpError> {
+        if let Some(plan) = self.plan_response(&p)? {
+            return Ok(plan);
+        }
         // `dispatch_request_inner_scoped` is the complete parse/dispatch/render
         // pipeline. Keep that large generator behind one pointer before handing
         // it to the generic task-local scope: otherwise the scope embeds the
@@ -4505,6 +4540,31 @@ fn build_instructions(catalog: &str, builtins: &str) -> String {
 
 #[tool_handler]
 impl ServerHandler for KhiveMcpServer {
+    async fn call_tool(
+        &self,
+        request: rmcp::model::CallToolRequestParams,
+        context: rmcp::service::RequestContext<rmcp::RoleServer>,
+    ) -> Result<rmcp::model::CallToolResult, McpError> {
+        // The router turns parameter-deserialization failures into tool errors.
+        // Plan isolation requires the JSON-RPC invalid_params response instead.
+        if request.name == "request" {
+            if let Some(args) = request.arguments.as_ref() {
+                if args.get("plan") == Some(&Value::Bool(true)) {
+                    for field in crate::tools::request::PLAN_COMPANIONS {
+                        if args.contains_key(field) {
+                            return Err(McpError::invalid_params(
+                                format!("plan=true cannot be combined with {field}"),
+                                None,
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+        let context = rmcp::handler::server::tool::ToolCallContext::new(self, request, context);
+        Self::tool_router().call(context).await
+    }
+
     fn get_info(&self) -> ServerInfo {
         let catalog = self.verb_catalog();
         let builtins = builtin_pack_names().join(", ");
@@ -4547,6 +4607,7 @@ impl ServerHandler for KhiveMcpServer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    include!("server/plan_tests.rs");
     use khive_runtime::Namespace;
     use khive_storage::{EventFilter, PageRequest};
     use serial_test::serial;
@@ -4641,6 +4702,7 @@ mod tests {
         .expect("in-memory runtime");
         let server = KhiveMcpServer::new(runtime).expect("server builds with kg");
         let params = RequestParams {
+            plan: None,
             ops: json!({
                 "tool": "stats",
                 "args": {"payload": "x".repeat(khive_request::MAX_OPS_INPUT_LEN + 1)},
@@ -4721,6 +4783,7 @@ mod tests {
         SPY_CAPTURED_PACKS.with(|c| *c.borrow_mut() = None);
 
         let params = RequestParams {
+            plan: None,
             ops: "stats()".to_string(),
             presentation: None,
             presentation_per_op: None,
@@ -5378,6 +5441,7 @@ mod tests {
         crate::daemon::test_forward_seam::arm();
 
         let params = RequestParams {
+            plan: None,
             ops: "stats()".to_string(),
             presentation: None,
             presentation_per_op: None,
@@ -6395,6 +6459,7 @@ mod tests {
         let response = server
             .dispatch_request_inner(
                 RequestParams {
+                    plan: None,
                     ops: format!(
                         "[large_result(bytes={result_bytes}), large_result(bytes={result_bytes})]"
                     ),
@@ -6437,6 +6502,7 @@ mod tests {
         let result_bytes = khive_runtime::daemon::MAX_FRAME_BYTES + 1_024;
         let response = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: format!("large_result(bytes={result_bytes})"),
                 presentation: None,
                 presentation_per_op: None,
@@ -8778,6 +8844,7 @@ mod tests {
         let resp = server
             .request(
                 Parameters(RequestParams {
+                    plan: None,
                     ops: "stats()".to_string(),
                     presentation: None,
                     presentation_per_op: None,
@@ -8922,6 +8989,7 @@ mod tests {
 
         let baseline = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: "stats()".to_string(),
                 presentation: None,
                 presentation_per_op: None,
@@ -8936,6 +9004,7 @@ mod tests {
         let resp = server
             .request(
                 Parameters(RequestParams {
+                    plan: None,
                     ops: "comm.send(to=\"bob\", content=\"double-forward-probe\")".to_string(),
                     presentation: None,
                     presentation_per_op: None,
@@ -8966,6 +9035,7 @@ mod tests {
 
         let after = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: "stats()".to_string(),
                 presentation: None,
                 presentation_per_op: None,
@@ -9032,6 +9102,7 @@ mod tests {
 
         let baseline = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: "stats()".to_string(),
                 presentation: None,
                 presentation_per_op: None,
@@ -9065,6 +9136,7 @@ mod tests {
         let single_resp = server
             .request(
                 Parameters(RequestParams {
+                    plan: None,
                     ops: "comm.send(to=\"bob\", content=\"strict-single-probe\")".to_string(),
                     presentation: None,
                     presentation_per_op: None,
@@ -9093,6 +9165,7 @@ mod tests {
         let batch_resp = server
             .request(
                 Parameters(RequestParams {
+                    plan: None,
                     ops: "[comm.send(to=\"bob\", content=\"strict-batch-1\"), \
                        comm.send(to=\"bob\", content=\"strict-batch-2\")]"
                         .to_string(),
@@ -9123,6 +9196,7 @@ mod tests {
         let chain_resp = server
             .request(
                 Parameters(RequestParams {
+                    plan: None,
                     ops: "comm.send(to=\"bob\", content=\"strict-chain-1\") | \
                       comm.send(to=\"bob\", content=\"strict-chain-2\")"
                         .to_string(),
@@ -9154,6 +9228,7 @@ mod tests {
         // ── no local dispatch ever happened for any of the three calls ─────
         let after = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: "stats()".to_string(),
                 presentation: None,
                 presentation_per_op: None,
@@ -9201,6 +9276,7 @@ mod tests {
 
         let resp = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: r#"search(kind="entity", query="a deliberately long keyword dense query whose terms cannot all match any entity in this empty corpus")"#.to_string(),
                 presentation: None,
                 presentation_per_op: None,
@@ -9231,6 +9307,7 @@ mod tests {
         // guarantee (bounded-concurrency ops have no relative ordering).
         let resp = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: "create(kind=\"entity\", entity_kind=\"concept\", name=\"kg-search-status\") \
                        | search(kind=\"entity\", query=\"kg-search-status\")"
                     .to_string(),
@@ -9393,6 +9470,7 @@ mod tests {
         let server = in_memory_kg_server();
         let resp = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: "[create(kind=\"entity\", entity_kind=\"concept\", name=\"status-ok-1\"), \
                        create(kind=\"entity\", entity_kind=\"concept\", name=\"status-ok-2\")]"
                     .to_string(),
@@ -9420,6 +9498,7 @@ mod tests {
         // The second op targets an unknown kind and fails; the first succeeds.
         let resp = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops:
                     "[create(kind=\"entity\", entity_kind=\"concept\", name=\"status-partial-1\"), \
                        search(kind=\"not_a_real_kind\", query=\"x\")]"
@@ -9450,6 +9529,7 @@ mod tests {
         let server = in_memory_kg_server();
         let resp = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: "search(kind=\"not_a_real_kind\", query=\"x\") | \
                       create(kind=\"entity\", entity_kind=\"concept\", name=\"status-chain-aborted\")"
                     .to_string(),

--- a/crates/khive-mcp/src/server/plan_tests.rs
+++ b/crates/khive-mcp/src/server/plan_tests.rs
@@ -1,0 +1,193 @@
+#[tokio::test]
+#[serial_test::serial(config_ledger)]
+async fn plan_mcp_preserves_graph_events_and_request_identity() {
+    let server = make_daemon_save_to_test_server();
+    let store = server.event_store().unwrap();
+    let ops = r#"create(kind="entity", entity_kind="concept", name="first") | create(kind="entity", entity_kind="concept", name="second")"#;
+    let baseline = server
+        .dispatch_request_local(RequestParams {
+            ops: "stats()".into(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    let events = store.count_events(EventFilter::default()).await.unwrap();
+    let log = SearchCapturedLog::default();
+    let subscriber = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::DEBUG)
+        .without_time()
+        .with_ansi(false)
+        .with_writer(log.clone())
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
+    let params = serde_json::from_value(json!({"ops":ops,"plan":true})).unwrap();
+    let plan = server
+        .request(
+            Parameters(params),
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+    let plan: Value = serde_json::from_str(&plan).unwrap();
+    assert_eq!(plan["parsed"], true);
+    assert_eq!(plan["stage_count"], 2);
+    assert!(!log.contents().contains("bridge correlation id"));
+    assert!(!log.contents().contains("RequestIdentity"));
+    assert_eq!(
+        store.count_events(EventFilter::default()).await.unwrap(),
+        events
+    );
+    let after = server
+        .dispatch_request_local(RequestParams {
+            ops: "stats()".into(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        stats_without_request_local_usage(&after),
+        stats_without_request_local_usage(&baseline)
+    );
+    let before_control = store.count_events(EventFilter::default()).await.unwrap();
+    let result = server
+        .dispatch_request_local(RequestParams {
+            ops: ops.into(),
+            request_id: Some(8123),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    let result: Value = serde_json::from_str(&result).unwrap();
+    assert_eq!(result["summary"]["succeeded"], 2);
+    assert!(store.count_events(EventFilter::default()).await.unwrap() > before_control);
+    assert!(find_audit_event_with_request_id(&store, 8123)
+        .await
+        .is_some());
+    let final_stats = server
+        .dispatch_request_local(RequestParams {
+            ops: "stats()".into(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_ne!(
+        stats_without_request_local_usage(&final_stats),
+        stats_without_request_local_usage(&baseline)
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial(config_ledger)]
+async fn plan_mcp_uses_loaded_catalog_and_preserves_parser_errors() {
+    let server = make_daemon_save_to_test_server();
+    for ops in [
+        "stats() | missing_verb(id=$prev.id) | stats(x=$prev)",
+        "stats(",
+        "",
+    ] {
+        let params = serde_json::from_value(json!({"ops":ops,"plan":true})).unwrap();
+        let plan = server
+            .request(
+                Parameters(params),
+                tokio_util::sync::CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+        let plan: Value = serde_json::from_str(&plan).unwrap();
+        match parse_request(ops) {
+            Ok(_) => {
+                assert_eq!(plan["stage_count"], 3);
+                assert_eq!(plan["stages"][0]["pack"], "kg");
+                assert_eq!(plan["stages"][1]["known"], false);
+                assert_eq!(plan["stages"][1]["prev_refs"], json!(["id"]));
+                assert_eq!(plan["stages"][2]["prev_refs"], json!([""]));
+            }
+            Err(_) => {
+                let error = server
+                    .dispatch_request_local(RequestParams {
+                        ops: ops.into(),
+                        ..Default::default()
+                    })
+                    .await
+                    .unwrap_err();
+                assert_eq!(plan["parsed"], false);
+                assert_eq!(plan["error"], error.message.as_ref());
+                assert!(plan.get("stages").is_none());
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+#[tokio::test]
+#[serial_test::serial(config_ledger)]
+async fn plan_daemon_preserves_graph_events_and_identity_until_dispatch_control() {
+    use khive_runtime::daemon::{read_frame, write_frame, DaemonResponseFrame, PROTOCOL_VERSION};
+    let server = make_daemon_save_to_test_server();
+    let store = server.event_store().unwrap();
+    let ops = r#"create(kind="entity", entity_kind="concept", name="first") | create(kind="entity", entity_kind="concept", name="second")"#;
+    let baseline = server
+        .dispatch_request_local(RequestParams {
+            ops: "stats()".into(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    let events = store.count_events(EventFilter::default()).await.unwrap();
+    let log = SearchCapturedLog::default();
+    let subscriber = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::DEBUG)
+        .without_time()
+        .with_ansi(false)
+        .with_writer(log.clone())
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
+    for plan in [true, false] {
+        let (mut client, peer) = tokio::net::UnixStream::pair().unwrap();
+        let dispatch_server = server.clone();
+        let task = tokio::spawn(async move {
+            khive_runtime::daemon::handle_conn_for_test(peer, dispatch_server).await;
+        });
+        let payload = json!({"ops":ops,"plan":plan,"namespace":"test",
+            "config_id":server.config_id(),"protocol_version":PROTOCOL_VERSION});
+        write_frame(&mut client, &serde_json::to_vec(&payload).unwrap())
+            .await
+            .unwrap();
+        let response: DaemonResponseFrame =
+            serde_json::from_slice(&read_frame(&mut client).await.unwrap()).unwrap();
+        task.await.unwrap();
+        assert!(response.ok, "{:?}", response.error);
+        if plan {
+            let result: Value = serde_json::from_str(response.result.as_deref().unwrap()).unwrap();
+            assert_eq!(result["stage_count"], 2);
+            assert_eq!(
+                store.count_events(EventFilter::default()).await.unwrap(),
+                events
+            );
+            assert!(!log.contents().contains("RequestIdentity"));
+        } else {
+            let result: Value = serde_json::from_str(response.result.as_deref().unwrap()).unwrap();
+            assert_eq!(result["summary"]["succeeded"], 2);
+            assert!(store.count_events(EventFilter::default()).await.unwrap() > events);
+            assert!(log.contents().contains("RequestIdentity"));
+        }
+        let stats = server
+            .dispatch_request_local(RequestParams {
+                ops: "stats()".into(),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        if plan {
+            assert_eq!(
+                stats_without_request_local_usage(&stats),
+                stats_without_request_local_usage(&baseline)
+            );
+        } else {
+            assert_ne!(
+                stats_without_request_local_usage(&stats),
+                stats_without_request_local_usage(&baseline)
+            );
+        }
+    }
+}

--- a/crates/khive-mcp/src/tools/request.rs
+++ b/crates/khive-mcp/src/tools/request.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 /// Input for `request` — a DSL string (function-call or JSON form) plus
 /// optional presentation controls (`presentation` and `presentation_per_op`).
-#[derive(Debug, Default, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Default, Serialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct RequestParams {
     /// One or more operations as a function-call DSL or JSON-form string.
@@ -23,6 +23,11 @@ pub struct RequestParams {
     )]
     pub ops: String,
 
+    /// Parse and describe the request without dispatching any operation.
+    /// Only `ops` may accompany `plan=true`; syntax errors are plan results.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plan: Option<bool>,
+
     /// Presentation mode for the response.
     ///
     /// - `"agent"` (default): token-efficient — short UUIDs, compact timestamps,
@@ -31,7 +36,7 @@ pub struct RequestParams {
     /// - `"human"`: delegated to CLI layer (same as verbose at runtime level).
     ///
     /// When omitted, defaults to `"agent"`.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(description = "Presentation mode: \"agent\" (default), \"verbose\", or \"human\"")]
     pub presentation: Option<String>,
 
@@ -41,7 +46,7 @@ pub struct RequestParams {
     /// `null` entries fall back to the batch-level `presentation`.
     ///
     /// When omitted, all ops use `presentation`.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(description = "Per-op presentation mode override (optional)")]
     pub presentation_per_op: Option<Vec<Option<String>>>,
 
@@ -64,7 +69,7 @@ pub struct RequestParams {
     /// components and symlinked destinations are rejected.
     ///
     /// When omitted, results are returned inline (default behaviour).
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(
         description = "File path to sink results as JSONL (returns manifest, not raw results)"
     )]
@@ -79,7 +84,7 @@ pub struct RequestParams {
     ///
     /// Overrides `KHIVE_OUTPUT_FORMAT` and the TOML `default_output_format`.
     /// When omitted, the server's resolved default (env → toml → builtin `json`) is used.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(description = "Output format: \"json\" (default), \"auto\", or \"table\"")]
     pub format: Option<String>,
 
@@ -89,7 +94,7 @@ pub struct RequestParams {
     /// `null` entries fall back to the batch-level `format`.
     ///
     /// When omitted, all ops use `format`.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(description = "Per-op output format override (optional)")]
     pub format_per_op: Option<Vec<Option<String>>>,
 
@@ -101,17 +106,137 @@ pub struct RequestParams {
     /// Purely a correlation label — it never changes dispatch semantics. Every
     /// operation in a batch or chain shares the value; it is not an
     /// operation-unique id or a cross-attempt idempotency key.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(
         description = "Request-group correlation id echoed by the daemon and stamped into every operation's audit event; the MCP bridge generates one when omitted"
     )]
     pub request_id: Option<u64>,
 }
 
+pub(crate) const PLAN_COMPANIONS: [&str; 6] = [
+    "presentation",
+    "presentation_per_op",
+    "format",
+    "format_per_op",
+    "save_to",
+    "request_id",
+];
+
+impl<'de> Deserialize<'de> for RequestParams {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        if value.get("plan") == Some(&serde_json::Value::Bool(true)) {
+            if let Some(field) = PLAN_COMPANIONS
+                .iter()
+                .find(|field| value.get(**field).is_some())
+            {
+                return Err(serde::de::Error::custom(format!(
+                    "plan=true cannot be combined with {field}"
+                )));
+            }
+        }
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct Wire {
+            ops: String,
+            plan: Option<bool>,
+            presentation: Option<String>,
+            presentation_per_op: Option<Vec<Option<String>>>,
+            save_to: Option<String>,
+            format: Option<String>,
+            format_per_op: Option<Vec<Option<String>>>,
+            request_id: Option<u64>,
+        }
+        let wire: Wire = serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+        Ok(Self {
+            ops: wire.ops,
+            plan: wire.plan,
+            presentation: wire.presentation,
+            presentation_per_op: wire.presentation_per_op,
+            save_to: wire.save_to,
+            format: wire.format,
+            format_per_op: wire.format_per_op,
+            request_id: wire.request_id,
+        })
+    }
+}
+
+impl RequestParams {
+    pub(crate) fn validate_plan_envelope(&self) -> Result<(), rmcp::ErrorData> {
+        let present = [
+            self.presentation.is_some(),
+            self.presentation_per_op.is_some(),
+            self.format.is_some(),
+            self.format_per_op.is_some(),
+            self.save_to.is_some(),
+            self.request_id.is_some(),
+        ];
+        if let Some((field, _)) = PLAN_COMPANIONS
+            .iter()
+            .zip(present)
+            .find(|(_, present)| *present)
+        {
+            return Err(rmcp::ErrorData::invalid_params(
+                format!("plan=true cannot be combined with {field}"),
+                None,
+            ));
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::RequestParams;
     use serde_json::json;
+
+    #[test]
+    fn plan_envelope_accepts_ops_without_companions() {
+        for ops in ["stats()", "stats("] {
+            let params = serde_json::from_value::<RequestParams>(json!({
+                "ops": ops, "plan": true
+            }))
+            .expect("planning accepts valid and malformed DSL envelopes");
+            assert_eq!(params.ops, ops);
+        }
+        let schema = serde_json::to_value(rmcp::schemars::schema_for!(RequestParams)).unwrap();
+        assert!(schema["properties"].get("plan").is_some());
+    }
+
+    #[test]
+    fn plan_envelope_serialization_preserves_absent_companions() {
+        let params = RequestParams {
+            ops: "stats()".into(),
+            plan: Some(true),
+            ..Default::default()
+        };
+        let payload = serde_json::to_value(params).unwrap();
+        assert_eq!(payload, json!({"ops":"stats()", "plan":true}));
+        serde_json::from_value::<RequestParams>(payload).unwrap();
+    }
+
+    #[test]
+    fn plan_envelope_rejects_each_present_companion_including_null() {
+        for (field, value) in [
+            ("presentation", json!("verbose")),
+            ("presentation_per_op", json!([null])),
+            ("format", json!("json")),
+            ("format_per_op", json!([null])),
+            ("save_to", json!("unused.jsonl")),
+            ("request_id", json!(7)),
+        ] {
+            for value in [value, serde_json::Value::Null] {
+                let mut payload = json!({"ops":"stats()", "plan":true});
+                payload[field] = value;
+                let error = serde_json::from_value::<RequestParams>(payload).unwrap_err();
+                assert!(error.to_string().contains(field), "{field}: {error}");
+                assert!(
+                    !error.to_string().contains("unknown field `plan`"),
+                    "{error}"
+                );
+            }
+        }
+    }
 
     #[test]
     fn request_params_reject_unknown_envelope_fields() {

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -201,6 +201,7 @@ async fn seeded_read_only_snapshot_server() -> (tempfile::TempDir, KhiveMcpServe
         let server = KhiveMcpServer::new(runtime).expect("writable server");
         let seeded = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: r#"create(kind="concept", name="snapshot entity")"#.to_string(),
                 presentation: Some("verbose".to_string()),
                 presentation_per_op: None,
@@ -240,6 +241,7 @@ async fn chmod_read_only_snapshot_serves_stats_and_clamped_list_with_audit_advis
 
     let reads = server
         .dispatch_request_local(RequestParams {
+            plan: None,
             ops: r#"[stats(), list(kind="entity", limit=501)]"#.to_string(),
             presentation: Some("verbose".to_string()),
             presentation_per_op: None,
@@ -278,6 +280,7 @@ async fn chmod_read_only_snapshot_serves_stats_and_clamped_list_with_audit_advis
 
     let mutation = server
         .dispatch_request_local(RequestParams {
+            plan: None,
             ops: r#"create(kind="concept", name="must fail")"#.to_string(),
             presentation: Some("verbose".to_string()),
             presentation_per_op: None,
@@ -308,6 +311,7 @@ async fn chmod_read_only_snapshot_default_list_keeps_items_envelope_and_sibling_
     let (_dir, server) = seeded_read_only_snapshot_server().await;
     let response = server
         .dispatch_request_local(RequestParams {
+            plan: None,
             ops: r#"list(kind="entity")"#.to_string(),
             presentation: None,
             presentation_per_op: None,
@@ -3733,6 +3737,7 @@ async fn subhandler_verbs_are_allowed_on_operator_path() -> anyhow::Result<()> {
     for verb in &["brain.state", "brain.config", "brain.events"] {
         let raw = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: format!("{verb}()"),
                 presentation: None,
                 presentation_per_op: None,
@@ -5553,6 +5558,7 @@ async fn exec_output_valid_json_with_backslash_escape_content() -> anyhow::Resul
     // ── Step 1: create — output must be valid JSON ────────────────────────────
     let create_out = server
         .dispatch_request_local(RequestParams {
+            plan: None,
             ops: create_ops,
             presentation: Some("verbose".to_string()),
             presentation_per_op: None,
@@ -5573,6 +5579,7 @@ async fn exec_output_valid_json_with_backslash_escape_content() -> anyhow::Resul
     // ── Step 2: get — content round-trips byte-identical ─────────────────────
     let get_out = server
         .dispatch_request_local(RequestParams {
+            plan: None,
             ops: format!(r#"get(id="{note_id}")"#),
             presentation: Some("verbose".to_string()),
             presentation_per_op: None,
@@ -5612,6 +5619,7 @@ async fn exec_output_valid_json_with_backslash_escape_content() -> anyhow::Resul
     );
     let update_out = server
         .dispatch_request_local(RequestParams {
+            plan: None,
             ops: update_ops,
             presentation: Some("verbose".to_string()),
             presentation_per_op: None,
@@ -6174,6 +6182,7 @@ async fn dispatch_honors_explicit_namespace_else_local_adr007() {
     async fn dispatch_op(server: &KhiveMcpServer, ops: &str) -> Value {
         let out = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: ops.to_string(),
                 presentation: Some("verbose".to_string()),
                 presentation_per_op: None,
@@ -6293,6 +6302,7 @@ async fn format_auto_mixed_ok_error_batch_error_stays_compact() {
 
     // Batch: op0 succeeds (stats()), op1 fails (bad verb).
     let params = RequestParams {
+        plan: None,
         ops: r#"[stats(), no_such_verb()]"#.to_string(),
         presentation: None,
         presentation_per_op: None,
@@ -6356,6 +6366,7 @@ async fn format_per_op_override_selects_format_per_position() {
     // First build a state: two assign ops (both json), then one stats op (auto).
     // Simpler: two parallel stats() calls — one forced json, one forced auto.
     let params = RequestParams {
+        plan: None,
         ops: r#"[stats(), stats()]"#.to_string(),
         presentation: None,
         presentation_per_op: None,
@@ -6418,6 +6429,7 @@ async fn agent_json_deduplicates_gtd_and_preserves_chain_inputs() {
 
     let agent_raw = server
         .dispatch_request_local(RequestParams {
+            plan: None,
             ops: r#"gtd.assign(title="agent-json-dedup", priority="p1", assignee="lambda:test")"#
                 .to_string(),
             presentation: Some("agent".to_string()),
@@ -6441,6 +6453,7 @@ async fn agent_json_deduplicates_gtd_and_preserves_chain_inputs() {
 
     let verbose_raw = server
         .dispatch_request_local(RequestParams {
+            plan: None,
             ops:
                 r#"gtd.assign(title="verbose-json-control", priority="p1", assignee="lambda:test")"#
                     .to_string(),
@@ -6465,6 +6478,7 @@ async fn agent_json_deduplicates_gtd_and_preserves_chain_inputs() {
 
     let target_raw = server
         .dispatch_request_local(RequestParams {
+            plan: None,
             ops: r#"create(kind="entity", entity_kind="concept", name="AgentJsonChainTarget")"#
                 .to_string(),
             presentation: Some("verbose".to_string()),
@@ -6488,6 +6502,7 @@ async fn agent_json_deduplicates_gtd_and_preserves_chain_inputs() {
     ] {
         let chain_raw = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: format!(
                     r#"create(kind="entity", entity_kind="concept", name="{source_name}") | link(source_id=$prev.id, target_id="{target_id}", relation="extends")"#
                 ),
@@ -6524,6 +6539,7 @@ async fn presentation_per_op_verbose_preserves_full_id_namespace_and_props() {
     // Create a GTD task so we have a record with duplicated properties
     // (assignee/priority/status echoed in both top-level and `properties`).
     let create_params = RequestParams {
+        plan: None,
         ops: r#"gtd.assign(title="verbose-pin-task", priority="p1", assignee="lambda:test")"#
             .to_string(),
         presentation: Some("verbose".to_string()),
@@ -6548,6 +6564,7 @@ async fn presentation_per_op_verbose_preserves_full_id_namespace_and_props() {
     // We use gtd.tasks (which returns records with assignee/priority/status in both
     // top-level AND properties), then get the specific task in verbose mode.
     let batch_params = RequestParams {
+        plan: None,
         ops: format!(r#"[gtd.tasks(limit=10), get(id="{task_id}")]"#),
         // Batch default: agent (will apply redundancy drop).
         presentation: Some("agent".to_string()),
@@ -6644,6 +6661,7 @@ async fn format_auto_always_verbose_verb_skips_redundancy_drop_without_override(
     // Create a GTD task: assignee/priority/status are echoed in both top-level
     // and `properties`, and the record carries namespace="local".
     let create_params = RequestParams {
+        plan: None,
         ops: r#"gtd.assign(title="always-verbose-pin", priority="p1", assignee="lambda:test")"#
             .to_string(),
         presentation: Some("verbose".to_string()),
@@ -6667,6 +6685,7 @@ async fn format_auto_always_verbose_verb_skips_redundancy_drop_without_override(
     // AlwaysVerbose policy must force Verbose at the format seam, so the
     // redundancy-drop pre-pass is skipped and namespace/properties survive.
     let get_params = RequestParams {
+        plan: None,
         ops: format!(r#"get(id="{task_id}")"#),
         presentation: None,        // → default Agent
         presentation_per_op: None, // → no per-op override

--- a/crates/khive-mcp/tests/plan_conformance.rs
+++ b/crates/khive-mcp/tests/plan_conformance.rs
@@ -1,0 +1,145 @@
+//! Exercise parser conformance failures through the real MCP request tool.
+
+use std::sync::{Mutex, OnceLock};
+
+use khive_mcp::server::KhiveMcpServer;
+use khive_runtime::{KhiveRuntime, Namespace, RuntimeConfig};
+use rmcp::{
+    model::{CallToolRequestParams, ClientInfo, ErrorCode},
+    service::RunningService,
+    ClientHandler, RoleClient, ServiceError, ServiceExt,
+};
+use serde_json::{json, Value};
+
+#[allow(dead_code)]
+#[path = "../../khive-request/tests/parser.rs"]
+mod parser_conformance;
+
+#[derive(Clone, Default)]
+struct CorpusClient;
+
+impl ClientHandler for CorpusClient {
+    fn get_info(&self) -> ClientInfo {
+        ClientInfo::default()
+    }
+}
+
+struct CorpusHarness {
+    runtime: tokio::runtime::Runtime,
+    client: RunningService<RoleClient, CorpusClient>,
+}
+
+impl CorpusHarness {
+    fn new() -> Self {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .expect("corpus async runtime");
+        let client = runtime.block_on(async {
+            let config = RuntimeConfig {
+                db_path: None,
+                default_namespace: Namespace::parse("test").expect("test namespace"),
+                embedding_model: None,
+                additional_embedding_models: vec![],
+                packs: vec!["kg".to_string()],
+                ..RuntimeConfig::default()
+            };
+            let storage = KhiveRuntime::new(config).expect("in-memory corpus runtime");
+            let server = KhiveMcpServer::new(storage).expect("corpus server");
+            let (server_io, client_io) = tokio::io::duplex(65536);
+            tokio::spawn(async move {
+                let service = server.serve(server_io).await.expect("MCP server handshake");
+                let _ = service.waiting().await;
+            });
+            CorpusClient
+                .serve(client_io)
+                .await
+                .expect("MCP client handshake")
+        });
+        Self { runtime, client }
+    }
+}
+
+pub fn plan_for_parser_corpus(input: &str) -> Value {
+    // Ordinary requests parse before daemon forwarding. Only failing corpus
+    // inputs reach this callback, so neither call needs a production transport.
+    assert!(khive_request::parse_request(input).is_err());
+    static HARNESS: OnceLock<Mutex<CorpusHarness>> = OnceLock::new();
+    let harness = HARNESS
+        .get_or_init(|| Mutex::new(CorpusHarness::new()))
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    harness.runtime.block_on(async {
+        let planned = harness
+            .client
+            .call_tool(
+                CallToolRequestParams::new("request").with_arguments(
+                    json!({"ops": input, "plan": true})
+                        .as_object()
+                        .unwrap()
+                        .clone(),
+                ),
+            )
+            .await
+            .expect("malformed ops must return a successful plan result");
+        assert_ne!(planned.is_error, Some(true));
+        let text = planned
+            .content
+            .first()
+            .and_then(|content| content.raw.as_text())
+            .expect("plan response contains JSON text");
+        let plan: Value = serde_json::from_str(&text.text).expect("decoded plan object");
+        assert_eq!(plan["parsed"], false);
+        assert!(plan.get("stages").is_none());
+
+        let ordinary = harness
+            .client
+            .call_tool(
+                CallToolRequestParams::new("request")
+                    .with_arguments(json!({"ops": input}).as_object().unwrap().clone()),
+            )
+            .await
+            .expect_err("ordinary request must reject the same malformed ops");
+        let ServiceError::McpError(error) = ordinary else {
+            panic!("expected MCP invalid_params, got {ordinary:?}");
+        };
+        assert_eq!(error.code, ErrorCode::INVALID_PARAMS);
+        assert_eq!(plan["error"].as_str(), Some(error.message.as_ref()));
+        plan
+    })
+}
+
+#[test]
+fn plan_companions_return_mcp_invalid_params() {
+    let harness = CorpusHarness::new();
+    harness.runtime.block_on(async {
+        for (field, value) in [
+            ("presentation", json!("verbose")),
+            ("presentation_per_op", json!([null])),
+            ("format", json!("json")),
+            ("format_per_op", json!([null])),
+            ("save_to", json!("unused.jsonl")),
+            ("request_id", json!(9)),
+        ] {
+            for value in [value, Value::Null, json!({})] {
+                let mut args = json!({"ops":"stats()","plan":true});
+                args[field] = value;
+                let result = harness
+                    .client
+                    .call_tool(
+                        CallToolRequestParams::new("request")
+                            .with_arguments(args.as_object().unwrap().clone()),
+                    )
+                    .await;
+                let Err(ServiceError::McpError(error)) = result else {
+                    panic!("expected MCP invalid_params for {field}: {result:?}");
+                };
+                assert_eq!(error.code, ErrorCode::INVALID_PARAMS);
+                assert!(error
+                    .message
+                    .contains(&format!("cannot be combined with {field}")));
+            }
+        }
+    });
+}

--- a/crates/khive-mcp/tests/plan_dependencies.rs
+++ b/crates/khive-mcp/tests/plan_dependencies.rs
@@ -1,0 +1,224 @@
+fn format_expressions(mac: &syn::Macro) -> Vec<syn::Expr> {
+    use syn::parse::Parser;
+
+    syn::punctuated::Punctuated::<syn::Expr, syn::Token![,]>::parse_terminated
+        .parse2(mac.tokens.clone())
+        .expect("plan error formatting arguments must be inspectable Rust expressions")
+        .into_iter()
+        .collect()
+}
+
+fn adapter_method(source: &str, owner: &str, name: &str) -> syn::ImplItemFn {
+    let file = syn::parse_file(source).unwrap();
+    let mut methods = Vec::new();
+    for item in file.items {
+        let syn::Item::Impl(implementation) = item else {
+            continue;
+        };
+        let syn::Type::Path(ty) = *implementation.self_ty else {
+            continue;
+        };
+        if !ty.path.is_ident(owner) {
+            continue;
+        }
+        for item in implementation.items {
+            if let syn::ImplItem::Fn(method) = item {
+                if method.sig.ident == name {
+                    methods.push(method);
+                }
+            }
+        }
+    }
+    assert_eq!(methods.len(), 1, "expected one {owner}::{name} adapter");
+    methods.pop().unwrap()
+}
+
+fn assert_adapter_dependencies(method: &syn::ImplItemFn) {
+    use std::collections::BTreeSet;
+    use syn::visit::Visit;
+
+    struct Calls<'a> {
+        allowed_calls: &'a [&'a str],
+        allowed_methods: &'a [&'a str],
+        allowed_fields: &'a [&'a str],
+        calls: BTreeSet<String>,
+        methods: BTreeSet<String>,
+        order: Vec<String>,
+    }
+
+    fn path_name(path: &syn::Path) -> String {
+        path.segments
+            .iter()
+            .map(|segment| segment.ident.to_string())
+            .collect::<Vec<_>>()
+            .join("::")
+    }
+
+    impl<'ast> Visit<'ast> for Calls<'_> {
+        fn visit_expr_call(&mut self, call: &'ast syn::ExprCall) {
+            let syn::Expr::Path(function) = call.func.as_ref() else {
+                panic!("plan adapters must not invoke dynamic callbacks");
+            };
+            let name = path_name(&function.path);
+            assert!(
+                self.allowed_calls.contains(&name.as_str()),
+                "unexpected adapter call: {name}"
+            );
+            self.order.push(name.clone());
+            self.calls.insert(name);
+            syn::visit::visit_expr_call(self, call);
+        }
+
+        fn visit_expr_method_call(&mut self, call: &'ast syn::ExprMethodCall) {
+            let name = call.method.to_string();
+            assert!(
+                self.allowed_methods.contains(&name.as_str()),
+                "unexpected adapter method: {name}"
+            );
+            if matches!(name.as_str(), "map" | "find") {
+                assert!(
+                    matches!(call.args.first(), Some(syn::Expr::Closure(_))),
+                    "plan adapter callbacks must be inline and inspectable"
+                );
+            }
+            self.order.push(name.clone());
+            self.methods.insert(name);
+            syn::visit::visit_expr_method_call(self, call);
+        }
+
+        fn visit_expr_field(&mut self, field: &'ast syn::ExprField) {
+            let syn::Expr::Path(base) = field.base.as_ref() else {
+                panic!("plan adapters must not traverse unrelated state");
+            };
+            let syn::Member::Named(member) = &field.member else {
+                panic!("unexpected tuple field in plan adapter");
+            };
+            let name = format!("{}.{}", path_name(&base.path), member);
+            assert!(
+                self.allowed_fields.contains(&name.as_str()),
+                "unexpected adapter field: {name}"
+            );
+            syn::visit::visit_expr_field(self, field);
+        }
+
+        fn visit_macro(&mut self, mac: &'ast syn::Macro) {
+            assert!(
+                mac.path.is_ident("format"),
+                "plan adapter macros must only format error text"
+            );
+            for expression in format_expressions(mac) {
+                self.visit_expr(&expression);
+            }
+        }
+
+        fn visit_expr_struct(&mut self, _: &'ast syn::ExprStruct) {
+            panic!("plan adapters must not construct runtime objects");
+        }
+    }
+
+    let (calls, methods, fields): (&[&str], &[&str], &[&str]) =
+        match method.sig.ident.to_string().as_str() {
+            "plan_ops" => (
+                &["khive_request::plan_request"],
+                &[
+                    "all_verbs_with_names",
+                    "into_iter",
+                    "map",
+                    "collect",
+                    "to_string",
+                ],
+                &["self.registry", "handler.name"],
+            ),
+            "plan_response" => (
+                &["Some", "Ok"],
+                &["validate_plan_envelope", "plan_ops"],
+                &["p.plan", "p.ops"],
+            ),
+            "validate_plan_envelope" => (
+                &["Err", "Ok", "rmcp::ErrorData::invalid_params"],
+                &["is_some", "iter", "zip", "find"],
+                &[
+                    "self.presentation",
+                    "self.presentation_per_op",
+                    "self.format",
+                    "self.format_per_op",
+                    "self.save_to",
+                    "self.request_id",
+                ],
+            ),
+            name => panic!("unexpected plan adapter: {name}"),
+        };
+    let mut guard = Calls {
+        allowed_calls: calls,
+        allowed_methods: methods,
+        allowed_fields: fields,
+        calls: BTreeSet::new(),
+        methods: BTreeSet::new(),
+        order: Vec::new(),
+    };
+    guard.visit_block(&method.block);
+    assert_eq!(
+        guard.calls,
+        calls.iter().map(|name| (*name).to_owned()).collect()
+    );
+    assert_eq!(
+        guard.methods,
+        methods.iter().map(|name| (*name).to_owned()).collect()
+    );
+    let before = match method.sig.ident.to_string().as_str() {
+        "plan_ops" => Some(("all_verbs_with_names", "khive_request::plan_request")),
+        "plan_response" => Some(("validate_plan_envelope", "plan_ops")),
+        _ => None,
+    };
+    if let Some((first, second)) = before {
+        assert!(
+            guard.order.iter().position(|name| name == first).unwrap()
+                < guard.order.iter().position(|name| name == second).unwrap()
+        );
+    }
+}
+
+#[test]
+fn mcp_plan_adapters_only_validate_presence_read_catalog_and_plan() {
+    let server = include_str!("../src/server.rs");
+    for name in ["plan_ops", "plan_response"] {
+        assert_adapter_dependencies(&adapter_method(server, "KhiveMcpServer", name));
+    }
+    let request = include_str!("../src/tools/request.rs");
+    assert_adapter_dependencies(&adapter_method(
+        request,
+        "RequestParams",
+        "validate_plan_envelope",
+    ));
+}
+
+#[test]
+fn mcp_plan_adapter_guards_reject_effect_calls() {
+    for (source, owner, name) in [
+        (
+            include_str!("../src/server.rs"),
+            "KhiveMcpServer",
+            "plan_ops",
+        ),
+        (
+            include_str!("../src/server.rs"),
+            "KhiveMcpServer",
+            "plan_response",
+        ),
+        (
+            include_str!("../src/tools/request.rs"),
+            "RequestParams",
+            "validate_plan_envelope",
+        ),
+    ] {
+        let mut method = adapter_method(source, owner, name);
+        method
+            .block
+            .stmts
+            .insert(0, syn::parse_quote!(crate::gate::admit();));
+        assert!(
+            std::panic::catch_unwind(|| assert_adapter_dependencies(&method)).is_err(),
+            "{owner}::{name} accepted the mutation"
+        );
+    }
+}

--- a/crates/khive-request/Cargo.toml
+++ b/crates/khive-request/Cargo.toml
@@ -21,6 +21,7 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
+syn = { workspace = true }
 
 [[bench]]
 name = "request_bench"

--- a/crates/khive-request/src/lib.rs
+++ b/crates/khive-request/src/lib.rs
@@ -3,11 +3,13 @@
 pub mod atomic;
 mod conflict;
 mod parser;
+mod plan;
 mod types;
 
 pub use atomic::{check_atomic_admissible, AtomicRejection};
 pub use conflict::write_keys_for_op_pub;
 pub use parser::{parse_request, parse_typed_json_batch};
+pub use plan::plan_request;
 pub use types::{
     value_nesting_within_limit, ArgValue, DslError, ExecutionMode, ParsedOp, ParsedRequest,
     PrevFailure, TypedJsonOp, MAX_OPS, MAX_OPS_INPUT_LEN, NESTING_DEPTH_LIMIT,

--- a/crates/khive-request/src/plan.rs
+++ b/crates/khive-request/src/plan.rs
@@ -1,0 +1,86 @@
+//! Syntax and catalog inspection without dispatch or admission.
+
+use std::collections::BTreeMap;
+
+use serde_json::{json, Map, Value};
+
+use crate::parser::parse_request;
+use crate::types::{ArgValue, ExecutionMode, MAX_OPS, MAX_OPS_INPUT_LEN, NESTING_DEPTH_LIMIT};
+
+/// Parses a request and describes its stages using a verb-to-pack catalog.
+///
+/// Catalog membership does not grant permission to dispatch a verb. Previous
+/// result references remain literal strings and are never resolved.
+pub fn plan_request(ops: &str, catalog: &BTreeMap<String, String>) -> Value {
+    let limits = json!({
+        "max_ops": MAX_OPS,
+        "max_depth": NESTING_DEPTH_LIMIT,
+        "max_input_len": MAX_OPS_INPUT_LEN,
+    });
+    let request = match parse_request(ops) {
+        Ok(request) => request,
+        Err(error) => return json!({"parsed": false, "error": error.to_string(), "limits": limits}),
+    };
+    let mode = match request.mode {
+        ExecutionMode::Single => "single",
+        ExecutionMode::Parallel => "parallel",
+        ExecutionMode::Chain => "chain",
+    };
+    let stages: Vec<Value> = request
+        .ops
+        .into_iter()
+        .enumerate()
+        .map(|(index, op)| {
+            let mut prev_refs = Vec::new();
+            let args: Map<String, Value> = op
+                .args
+                .into_iter()
+                .map(|(name, arg)| (name, literal_arg(arg, &mut prev_refs)))
+                .collect();
+            let pack = catalog.get(&op.tool);
+            json!({
+                "index": index,
+                "verb": op.tool,
+                "pack": pack,
+                "known": pack.is_some(),
+                "args": args,
+                "prev_refs": prev_refs,
+            })
+        })
+        .collect();
+    json!({
+        "parsed": true,
+        "mode": mode,
+        "stage_count": stages.len(),
+        "stages": stages,
+        "limits": limits,
+    })
+}
+
+fn literal_arg(arg: ArgValue, prev_refs: &mut Vec<String>) -> Value {
+    match arg {
+        ArgValue::Value(value) => value,
+        ArgValue::PrevRef { path } => {
+            let literal_path = path.replace(".[", "[");
+            let literal = if path.is_empty() || path.starts_with('[') {
+                format!("$prev{literal_path}")
+            } else {
+                format!("$prev.{literal_path}")
+            };
+            prev_refs.push(path);
+            Value::String(literal)
+        }
+        ArgValue::Array(items) => Value::Array(
+            items
+                .into_iter()
+                .map(|item| literal_arg(item, prev_refs))
+                .collect(),
+        ),
+        ArgValue::Object(pairs) => Value::Object(
+            pairs
+                .into_iter()
+                .map(|(name, value)| (name, literal_arg(value, prev_refs)))
+                .collect(),
+        ),
+    }
+}

--- a/crates/khive-request/tests/parser.rs
+++ b/crates/khive-request/tests/parser.rs
@@ -5,10 +5,28 @@
 //! `src/conflict.rs` under `#[cfg(test)] mod tests`.
 
 use khive_request::{
-    parse_request, parse_typed_json_batch, ArgValue, DslError, ExecutionMode, TypedJsonOp, MAX_OPS,
-    MAX_OPS_INPUT_LEN, NESTING_DEPTH_LIMIT, RESERVED_ENVELOPE_ARGS,
+    parse_request as parse_request_unplanned, parse_typed_json_batch, plan_request, ArgValue,
+    DslError, ExecutionMode, TypedJsonOp, MAX_OPS, MAX_OPS_INPUT_LEN, NESTING_DEPTH_LIMIT,
+    RESERVED_ENVELOPE_ARGS,
 };
 use serde_json::json;
+
+/// Standalone default; including this corpus as a module lets a transport test
+/// supply its own crate-root callback over the same inputs.
+pub fn plan_for_parser_corpus(input: &str) -> serde_json::Value {
+    plan_request(input, &std::collections::BTreeMap::new())
+}
+
+fn parse_request(input: &str) -> Result<khive_request::ParsedRequest, DslError> {
+    let parsed = parse_request_unplanned(input);
+    if let Err(error) = &parsed {
+        let plan = crate::plan_for_parser_corpus(input);
+        assert_eq!(plan["parsed"], false);
+        assert_eq!(plan["error"], error.to_string());
+        assert!(plan.get("stages").is_none());
+    }
+    parsed
+}
 
 fn req(s: &str) -> khive_request::ParsedRequest {
     parse_request(s).unwrap_or_else(|e| panic!("parse({s:?}) failed: {e}"))

--- a/crates/khive-request/tests/plan.rs
+++ b/crates/khive-request/tests/plan.rs
@@ -1,0 +1,278 @@
+use std::collections::BTreeMap;
+
+use khive_request::{plan_request, MAX_OPS, MAX_OPS_INPUT_LEN, NESTING_DEPTH_LIMIT};
+use serde_json::json;
+
+fn catalog() -> BTreeMap<String, String> {
+    [
+        ("create", "kg"),
+        ("get", "kg"),
+        ("memory.remember", "memory"),
+    ]
+    .into_iter()
+    .map(|(verb, pack)| (verb.to_owned(), pack.to_owned()))
+    .collect()
+}
+
+#[test]
+fn chain_accounts_for_stages_and_preserves_nested_references() {
+    let plan = plan_request(
+        r#"create(content="line\n\"quoted\"", flags=[true, null, 3.5])
+        | memory.remember(z=$prev[0].id, a={"z":[$prev, $prev.id, {"nested":$prev.items[2].name}], "a":$prev.id}, literal="\\$prev.id")
+        | get(id=$prev.id)"#,
+        &catalog(),
+    );
+    assert_eq!(
+        plan,
+        json!({
+            "parsed": true,
+            "mode": "chain",
+            "stage_count": 3,
+            "stages": [
+                {
+                    "index": 0, "verb": "create", "pack": "kg", "known": true,
+                    "args": {"content": "line\n\"quoted\"", "flags": [true, null, 3.5]},
+                    "prev_refs": []
+                },
+                {
+                    "index": 1, "verb": "memory.remember", "pack": "memory", "known": true,
+                    "args": {
+                        "a": {"z": ["$prev", "$prev.id", {"nested": "$prev.items[2].name"}], "a": "$prev.id"},
+                        "literal": "$prev.id",
+                        "z": "$prev[0].id"
+                    },
+                    "prev_refs": ["", "id", "items.[2].name", "id", "[0].id"]
+                },
+                {
+                    "index": 2, "verb": "get", "pack": "kg", "known": true,
+                    "args": {"id": "$prev.id"}, "prev_refs": ["id"]
+                }
+            ],
+            "limits": {
+                "max_ops": MAX_OPS,
+                "max_depth": NESTING_DEPTH_LIMIT,
+                "max_input_len": MAX_OPS_INPUT_LEN
+            }
+        })
+    );
+}
+
+#[test]
+fn quoted_references_retain_parser_paths() {
+    let plan = plan_request(
+        r#"start() | finish(root="$prev[0].id", nested="$prev.items[2].name", all="$prev")"#,
+        &BTreeMap::new(),
+    );
+    assert_eq!(plan["parsed"], true);
+    assert_eq!(
+        plan["stages"][1]["prev_refs"],
+        json!(["", "items[2].name", "[0].id"])
+    );
+    assert_eq!(
+        plan["stages"][1]["args"],
+        json!({"all": "$prev", "nested": "$prev.items[2].name", "root": "$prev[0].id"})
+    );
+}
+
+#[test]
+fn unknown_verb_retains_requested_name_without_parse_error() {
+    let plan = plan_request("missing.action(value=4)", &catalog());
+    assert_eq!(plan["parsed"], true);
+    assert_eq!(plan["mode"], "single");
+    assert_eq!(plan["stage_count"], 1);
+    assert_eq!(
+        plan["stages"],
+        json!([{
+            "index": 0,
+            "verb": "missing.action",
+            "pack": null,
+            "known": false,
+            "args": {"value": 4},
+            "prev_refs": []
+        }])
+    );
+    assert!(plan.get("error").is_none());
+}
+
+#[test]
+fn plan_preserves_parser_modes_for_function_and_json_forms() {
+    for (input, mode, count) in [
+        ("create()", "single", 1),
+        (
+            r#"{"tool":"create","args":{"value":{"items":[1,2]}}}"#,
+            "single",
+            1,
+        ),
+        ("[create(), get(id=\"x\")]", "parallel", 2),
+        (
+            r#"[{"tool":"create"},{"tool":"get","args":{"id":"x"}}]"#,
+            "parallel",
+            2,
+        ),
+    ] {
+        let plan = plan_request(input, &catalog());
+        assert_eq!(plan["parsed"], true, "{input}");
+        assert_eq!(plan["mode"], mode, "{input}");
+        assert_eq!(plan["stage_count"], count, "{input}");
+    }
+}
+
+#[test]
+fn parse_failure_has_exact_error_and_limits_without_partial_stages() {
+    let input = "create() | get(id=";
+    let error = khive_request::parse_request(input).unwrap_err();
+    assert_eq!(
+        plan_request(input, &catalog()),
+        json!({
+            "parsed": false,
+            "error": error.to_string(),
+            "limits": {
+                "max_ops": MAX_OPS,
+                "max_depth": NESTING_DEPTH_LIMIT,
+                "max_input_len": MAX_OPS_INPUT_LEN
+            }
+        })
+    );
+}
+
+#[test]
+fn plan_module_dependencies_are_limited_to_parser_types_and_json() {
+    assert_planner_dependencies(include_str!("../src/plan.rs"));
+    let _: fn(&str, &BTreeMap<String, String>) -> serde_json::Value = plan_request;
+}
+
+fn assert_planner_dependencies(source: &str) {
+    use syn::visit::Visit;
+
+    struct Dependencies;
+
+    fn check_path(path: &[String]) {
+        let names: Vec<&str> = path.iter().map(String::as_str).collect();
+        let allowed = match names.as_slice() {
+            ["crate", "parser", "parse_request"] => true,
+            ["crate", "types", name] => matches!(
+                *name,
+                "ArgValue"
+                    | "ExecutionMode"
+                    | "MAX_OPS"
+                    | "MAX_OPS_INPUT_LEN"
+                    | "NESTING_DEPTH_LIMIT"
+            ),
+            ["std", "collections", "BTreeMap"] => true,
+            ["serde_json", name] => matches!(*name, "json" | "Map" | "Value"),
+            [root, ..] if names.len() > 1 => {
+                matches!(
+                    *root,
+                    "ArgValue" | "ExecutionMode" | "BTreeMap" | "Map" | "Value" | "Vec"
+                )
+            }
+            [_] => true,
+            _ => false,
+        };
+        assert!(
+            allowed,
+            "unexpected planner dependency: {}",
+            names.join("::")
+        );
+    }
+
+    fn check_use(tree: &syn::UseTree, prefix: &mut Vec<String>) {
+        match tree {
+            syn::UseTree::Path(path) => {
+                prefix.push(path.ident.to_string());
+                check_use(&path.tree, prefix);
+                prefix.pop();
+            }
+            syn::UseTree::Name(name) => {
+                prefix.push(name.ident.to_string());
+                check_path(prefix);
+                prefix.pop();
+            }
+            syn::UseTree::Group(group) => {
+                for item in &group.items {
+                    check_use(item, prefix);
+                }
+            }
+            _ => panic!("planner dependencies must use explicit, unaliased imports"),
+        }
+    }
+
+    impl<'ast> Visit<'ast> for Dependencies {
+        fn visit_item_use(&mut self, item: &'ast syn::ItemUse) {
+            check_use(&item.tree, &mut Vec::new());
+        }
+
+        fn visit_path(&mut self, path: &'ast syn::Path) {
+            check_path(
+                &path
+                    .segments
+                    .iter()
+                    .map(|part| part.ident.to_string())
+                    .collect::<Vec<_>>(),
+            );
+            syn::visit::visit_path(self, path);
+        }
+
+        fn visit_macro(&mut self, mac: &'ast syn::Macro) {
+            self.visit_path(&mac.path);
+            for expression in macro_expressions(mac) {
+                self.visit_expr(&expression);
+            }
+        }
+
+        fn visit_item_mod(&mut self, _: &'ast syn::ItemMod) {
+            panic!("the pure planner must not delegate to another module");
+        }
+
+        fn visit_item_extern_crate(&mut self, _: &'ast syn::ItemExternCrate) {
+            panic!("the pure planner must not import another crate");
+        }
+    }
+
+    let module = syn::parse_file(source).unwrap();
+    Dependencies.visit_file(&module);
+}
+
+fn macro_expressions(mac: &syn::Macro) -> Vec<syn::Expr> {
+    use syn::parse::Parser;
+
+    let name = mac.path.segments.last().unwrap().ident.to_string();
+    match name.as_str() {
+        "json" => {
+            let object = |input: syn::parse::ParseStream<'_>| {
+                let fields;
+                syn::braced!(fields in input);
+                let mut values = Vec::new();
+                while !fields.is_empty() {
+                    let _: syn::LitStr = fields.parse()?;
+                    let _: syn::Token![:] = fields.parse()?;
+                    values.push(fields.parse::<syn::Expr>()?);
+                    if !fields.is_empty() {
+                        let _: syn::Token![,] = fields.parse()?;
+                    }
+                }
+                Ok(values)
+            };
+            object
+                .parse2(mac.tokens.clone())
+                .expect("planner JSON values must be inspectable Rust expressions")
+        }
+        "format" => syn::punctuated::Punctuated::<syn::Expr, syn::Token![,]>::parse_terminated
+            .parse2(mac.tokens.clone())
+            .expect("planner formatting arguments must be inspectable Rust expressions")
+            .into_iter()
+            .collect(),
+        _ => panic!("unexpected planner macro: {name}"),
+    }
+}
+
+#[test]
+fn planner_dependency_guard_rejects_effect_calls_in_macros() {
+    let planner = include_str!("../src/plan.rs");
+    let mutated = planner.replace(
+        "\"parsed\": true,",
+        "\"parsed\": std::fs::metadata(\"unused\").is_ok(),",
+    );
+    assert_ne!(mutated, planner, "the mutation must change the planner");
+    assert!(std::panic::catch_unwind(|| assert_planner_dependencies(&mutated)).is_err());
+}

--- a/crates/khive-runtime/Cargo.toml
+++ b/crates/khive-runtime/Cargo.toml
@@ -46,6 +46,7 @@ unicode-general-category = { workspace = true }
 sha2 = { workspace = true }
 
 [dev-dependencies]
+khive-request = { version = "0.8.0", path = "../khive-request" }
 khive-gate-rego = { version = "0.8.0", path = "../khive-gate-rego" }
 khive-storage = { version = "0.8.0", path = "../khive-storage", features = ["test-support"] }
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/khive-runtime/docs/api/daemon.md
+++ b/crates/khive-runtime/docs/api/daemon.md
@@ -19,12 +19,21 @@ Version history for `PROTOCOL_VERSION`:
 - 4 — added request-origin `process_ref` attribution. Although optional, it can affect durable
   comm message properties, so v3/v4 peers reject each other before dispatch instead of allowing a
   v3 daemon to execute a write while silently ignoring the new field.
+- 5 — added `plan` (default false). A true value returns syntax and loaded-catalog information
+  before request identity construction or dispatch. Older daemons reject v5 frames before they
+  could ignore the flag and execute the operations. Restart a warm daemon when upgrading clients.
 
 `process_ref` carries the originating client's opaque `KHIVE_PROCESS_REF`; it is request
 attribution, not identity, and prevents a shared daemon from substituting its own process
 environment. Its `serde(default)` preserves the meaning of an omitted value within protocol v4;
 it does not make a v3 daemon safe to use. `request_id` is the independent additive numeric
 audit-correlation field and does not alter dispatch or persisted verb output.
+
+Plan frames retain the protocol and configuration checks. They reject the presence of
+`presentation`, `presentation_per_op`, `format`, `format_per_op`, or `request_id`, including null
+values, with an `invalid_params` error naming the field. The response `result` contains the same
+JSON object as `request(ops, plan=true)` and `Session.plan(ops)`. A grammar error is a successful
+response whose result has `parsed=false`; planning never grants permission or resolves `$prev`.
 
 ## try_acquire_flock_until
 

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -45,7 +45,7 @@ pub const MAX_FRAME_BYTES: usize = 8 * 1024 * 1024;
 /// that names both sides so the operator knows exactly what to do
 /// (`make local` rebuilds the client binary).
 /// See `docs/api/daemon.md#protocol_version` for the version-by-version history.
-pub const PROTOCOL_VERSION: u32 = 4;
+pub const PROTOCOL_VERSION: u32 = 5;
 
 const DEFAULT_DRAIN_TIMEOUT_SECS: u64 = 10;
 
@@ -406,7 +406,12 @@ pub(crate) fn uid_is_permitted(peer: u32, daemon_euid: u32) -> bool {
 #[derive(Serialize, Deserialize, Default)]
 pub struct DaemonRequestFrame {
     pub ops: String,
+    /// Parse and inspect the catalog without dispatch, identity, or storage access.
+    #[serde(default)]
+    pub plan: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub presentation: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub presentation_per_op: Option<Vec<Option<String>>>,
     /// The client's resolved storage/gate default namespace for this request.
     ///
@@ -468,9 +473,11 @@ pub struct DaemonRequestFrame {
     /// Output format for this request (ADR-078). Forwarded to the daemon's
     /// serialization seam. `None` means use the daemon's resolved default.
     #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub format: Option<String>,
     /// Per-operation output format overrides (ADR-078).
     #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub format_per_op: Option<Vec<Option<String>>>,
     /// Whether this request originated from the agent-facing MCP `request`
     /// tool (the wire surface). When `true`, the daemon rejects
@@ -494,6 +501,7 @@ pub struct DaemonRequestFrame {
     /// `#[serde(default)]` matches `metrics_only`/`format`/`format_per_op`
     /// precedent, with no `PROTOCOL_VERSION` bump.
     #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub request_id: Option<u64>,
 }
 
@@ -693,6 +701,9 @@ where
 #[cfg(unix)]
 #[async_trait]
 pub trait DaemonDispatch: Clone + Send + Sync + 'static {
+    /// Describe syntax and loaded catalog membership without dispatching.
+    fn plan(&self, ops: &str) -> String;
+
     /// Dispatch a verb-DSL request string and return the rendered result.
     ///
     /// `from_wire` carries the origin discriminator from
@@ -1051,6 +1062,34 @@ async fn handle_conn<D: DaemonDispatch>(stream: UnixStream, dispatcher: D) {
     handle_conn_with_shutdown(stream, dispatcher, None).await;
 }
 
+#[cfg(all(unix, feature = "fault-injection"))]
+#[doc(hidden)]
+pub async fn handle_conn_for_test<D: DaemonDispatch>(stream: UnixStream, dispatcher: D) {
+    handle_conn_with_shutdown(stream, dispatcher, None).await;
+}
+
+#[cfg(unix)]
+fn plan_frame_companion(raw: &[u8]) -> Option<&'static str> {
+    let value: serde_json::Value = serde_json::from_slice(raw).ok()?;
+    if value.get("plan").and_then(serde_json::Value::as_bool) != Some(true)
+        || value
+            .get("protocol_version")
+            .and_then(serde_json::Value::as_u64)
+            != Some(u64::from(PROTOCOL_VERSION))
+    {
+        return None;
+    }
+    [
+        "presentation",
+        "presentation_per_op",
+        "format",
+        "format_per_op",
+        "request_id",
+    ]
+    .into_iter()
+    .find(|field| value.get(*field).is_some())
+}
+
 #[cfg(unix)]
 async fn handle_conn_with_shutdown<D: DaemonDispatch>(
     mut stream: UnixStream,
@@ -1069,7 +1108,32 @@ async fn handle_conn_with_shutdown<D: DaemonDispatch>(
             return;
         }
     };
-    let frame: DaemonRequestFrame = match serde_json::from_slice(&raw) {
+    let decoded: Result<DaemonRequestFrame, _> = serde_json::from_slice(&raw);
+    if decoded.as_ref().ok().is_none_or(|frame| frame.plan) {
+        if let Some(field) = plan_frame_companion(&raw) {
+            let response = DaemonResponseFrame {
+                ok: false,
+                result: None,
+                error: Some(format!(
+                    "invalid_params: plan=true cannot be combined with {field}"
+                )),
+                namespace_mismatch: false,
+                config_mismatch: false,
+                served_config_id: Some(dispatcher.config_id().to_string()),
+                version_mismatch: false,
+                daemon_protocol_version: PROTOCOL_VERSION,
+                metrics: None,
+                request_id: None,
+            };
+            if let Ok(payload) = serde_json::to_vec(&response) {
+                if let Err(error) = write_frame(&mut stream, &payload).await {
+                    tracing::debug!(%error, "failed to write plan envelope refusal");
+                }
+            }
+            return;
+        }
+    }
+    let frame: DaemonRequestFrame = match decoded {
         Ok(f) => f,
         Err(e) => {
             tracing::debug!(error = %e, "failed to decode daemon request frame");
@@ -1102,7 +1166,7 @@ async fn handle_conn_with_shutdown<D: DaemonDispatch>(
             metrics: None,
             request_id: frame.request_id,
         }
-    } else if frame.metrics_only {
+    } else if frame.metrics_only && !frame.plan {
         // Process-global gauge read: namespace/config-agnostic, so this is
         // handled BEFORE the `config_id` equality reject below (unlike every
         // other arm) — a metrics probe must work regardless of which
@@ -1143,6 +1207,19 @@ async fn handle_conn_with_shutdown<D: DaemonDispatch>(
             metrics: None,
             request_id: frame.request_id,
         }
+    } else if frame.plan {
+        DaemonResponseFrame {
+            ok: true,
+            result: Some(dispatcher.plan(&frame.ops)),
+            error: None,
+            namespace_mismatch: false,
+            config_mismatch: false,
+            served_config_id,
+            version_mismatch: false,
+            daemon_protocol_version: PROTOCOL_VERSION,
+            metrics: None,
+            request_id: None,
+        }
     } else if frame.probe_only {
         // Probe-only request: identity checks passed; return immediately without
         // dispatching any verb. The client uses this to confirm the daemon is
@@ -1175,6 +1252,10 @@ async fn handle_conn_with_shutdown<D: DaemonDispatch>(
             process_ref: frame.process_ref.clone(),
             request_id: frame.request_id,
         };
+        tracing::debug!(
+            request_id = frame.request_id,
+            "daemon RequestIdentity constructed"
+        );
         let (read_cancel_tx, read_cancel_rx) = tokio::sync::watch::channel(false);
         let dispatch = khive_storage::scope_request_read_cancellation(
             shutdown,
@@ -2164,6 +2245,7 @@ mod khive_root_tests {
 
 #[cfg(all(test, unix))]
 mod tests {
+    include!("daemon/plan_tests.rs");
     use super::*;
     use serial_test::serial;
 
@@ -2870,6 +2952,10 @@ mod tests {
 
     #[async_trait]
     impl DaemonDispatch for CancellationAwareDispatch {
+        fn plan(&self, ops: &str) -> String {
+            khive_request::plan_request(ops, &Default::default()).to_string()
+        }
+
         async fn dispatch(
             &self,
             _ops: String,
@@ -2900,6 +2986,10 @@ mod tests {
 
     #[async_trait]
     impl DaemonDispatch for MockDispatch {
+        fn plan(&self, ops: &str) -> String {
+            khive_request::plan_request(ops, &Default::default()).to_string()
+        }
+
         async fn dispatch(
             &self,
             _ops: String,
@@ -2935,6 +3025,7 @@ mod tests {
 
     fn base_request_frame(config_id: &str) -> DaemonRequestFrame {
         DaemonRequestFrame {
+            plan: false,
             ops: String::new(),
             presentation: None,
             presentation_per_op: None,
@@ -3003,7 +3094,12 @@ mod tests {
     /// requested provenance, and leave the caller unable to retry safely.
     #[tokio::test]
     async fn protocol_v3_frame_is_rejected_before_process_ref_dispatch() {
-        assert_eq!(PROTOCOL_VERSION, 4, "process_ref is the protocol-v4 change");
+        const {
+            assert!(
+                PROTOCOL_VERSION >= 4,
+                "process_ref requires protocol v4 or later"
+            )
+        };
         let dispatch_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let dispatcher = MockDispatch {
             namespace: "local".to_string(),
@@ -3019,7 +3115,7 @@ mod tests {
         let response = round_trip(dispatcher, &request).await;
         assert!(!response.ok);
         assert!(response.version_mismatch);
-        assert_eq!(response.daemon_protocol_version, 4);
+        assert_eq!(response.daemon_protocol_version, PROTOCOL_VERSION);
         assert_eq!(
             dispatch_calls.load(std::sync::atomic::Ordering::SeqCst),
             0,
@@ -3027,7 +3123,7 @@ mod tests {
         );
         let error = response.error.expect("mismatch explains both versions");
         assert!(
-            error.contains("client=3") && error.contains("daemon=4"),
+            error.contains("client=3") && error.contains(&format!("daemon={PROTOCOL_VERSION}")),
             "mismatch must identify the exact rollout boundary; got {error:?}"
         );
     }

--- a/crates/khive-runtime/src/daemon/plan_tests.rs
+++ b/crates/khive-runtime/src/daemon/plan_tests.rs
@@ -1,0 +1,109 @@
+async fn plan_raw_round_trip(payload: serde_json::Value) -> (DaemonResponseFrame, usize) {
+    let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let dispatcher = MockDispatch {
+        namespace: "local".into(),
+        config_id: "plan-config".into(),
+        dispatch_calls: Arc::clone(&calls),
+        pool: None,
+        dispatch_err: None,
+    };
+    let (mut client, server) = UnixStream::pair().unwrap();
+    let handle = tokio::spawn(async move {
+        handle_conn(server, dispatcher).await;
+    });
+    write_frame(&mut client, &serde_json::to_vec(&payload).unwrap())
+        .await
+        .unwrap();
+    let raw = read_frame(&mut client).await.unwrap();
+    handle.await.unwrap();
+    (
+        serde_json::from_slice(&raw).unwrap(),
+        calls.load(std::sync::atomic::Ordering::SeqCst),
+    )
+}
+
+#[tokio::test]
+async fn plan_daemon_frame_returns_plan_without_dispatch() {
+    let payload = serde_json::json!({
+        "ops":"missing_verb()", "namespace":"", "plan":true,
+        "config_id":"plan-config", "protocol_version":PROTOCOL_VERSION
+    });
+    let (response, calls) = plan_raw_round_trip(payload).await;
+    assert!(response.ok);
+    assert_eq!(calls, 0);
+    let result: serde_json::Value =
+        serde_json::from_str(response.result.as_deref().unwrap()).unwrap();
+    assert_eq!(result["parsed"], true);
+    assert_eq!(result["stages"][0]["known"], false);
+    assert!(response.request_id.is_none());
+}
+
+#[tokio::test]
+async fn plan_daemon_refuses_each_present_companion_including_null() {
+    for (field, value) in [
+        ("presentation", serde_json::json!("verbose")),
+        ("presentation_per_op", serde_json::json!([null])),
+        ("format", serde_json::json!("json")),
+        ("format_per_op", serde_json::json!([null])),
+        ("request_id", serde_json::json!(7)),
+    ] {
+        for value in [
+            value,
+            serde_json::Value::Null,
+            serde_json::json!({"invalid":"type"}),
+        ] {
+            let mut payload = serde_json::json!({
+                "ops":"missing_verb()", "namespace":"", "plan":true,
+                "config_id":"plan-config", "protocol_version":PROTOCOL_VERSION
+            });
+            payload[field] = value;
+            let (response, calls) = plan_raw_round_trip(payload).await;
+            assert!(!response.ok, "{field}");
+            assert_eq!(calls, 0, "{field}");
+            let error = response.error.unwrap();
+            assert!(
+                error.contains("invalid_params") && error.contains(field),
+                "{error}"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn plan_daemon_protocol_rejects_previous_version_without_dispatch() {
+    assert_eq!(PROTOCOL_VERSION, 5);
+    let (response, calls) = plan_raw_round_trip(serde_json::json!({
+        "ops":"missing_verb()", "namespace":"", "plan":true,
+        "config_id":"plan-config", "protocol_version":4
+    }))
+    .await;
+    assert!(!response.ok);
+    assert!(response.version_mismatch);
+    assert_eq!(calls, 0);
+}
+
+#[tokio::test]
+async fn plan_daemon_duplicate_flags_do_not_reach_dispatch() {
+    let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let dispatcher = MockDispatch {
+        namespace: "local".into(),
+        config_id: "plan-config".into(),
+        dispatch_calls: Arc::clone(&calls),
+        pool: None,
+        dispatch_err: None,
+    };
+    let (mut client, peer) = UnixStream::pair().unwrap();
+    let task = tokio::spawn(async move {
+        handle_conn(peer, dispatcher).await;
+    });
+    let payload = format!(
+        r#"{{"ops":"missing_verb()","namespace":"","config_id":"plan-config","protocol_version":{PROTOCOL_VERSION},"plan":true,"plan":false}}"#
+    );
+    write_frame(&mut client, payload.as_bytes()).await.unwrap();
+    let response = tokio::time::timeout(std::time::Duration::from_secs(5), read_frame(&mut client))
+        .await
+        .unwrap();
+    assert!(response.is_err(), "duplicate fields must fail decoding");
+    task.await.unwrap();
+    assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 0);
+}

--- a/crates/khive-runtime/tests/component_teardown_on_setup_failure.rs
+++ b/crates/khive-runtime/tests/component_teardown_on_setup_failure.rs
@@ -22,6 +22,10 @@ struct NeverDispatch;
 
 #[async_trait]
 impl DaemonDispatch for NeverDispatch {
+    fn plan(&self, _ops: &str) -> String {
+        panic!("setup failure must not plan a request")
+    }
+
     async fn dispatch(
         &self,
         _ops: String,

--- a/crates/kkernel/docs/usage.md
+++ b/crates/kkernel/docs/usage.md
@@ -100,6 +100,32 @@ response. Without `--strict`, a _partially_ failed request (`status: "partial"` 
 one success) retains its compatibility behavior and exits zero; `--strict` converts any failed
 or aborted op into a nonzero process exit.
 
+### Check grammar without execution
+
+Use `kkernel exec --plan '<ops>'` to parse an operations string and inspect its stages without
+executing any verb:
+
+```bash
+kkernel exec --plan 'create(kind="note", content="example") | get(id=$prev.id)'
+```
+
+This requires an already-running daemon using the same configuration. Start it with
+`kkernel mcp --daemon` first, using matching `--db` and `--config` selections when needed.
+Planning connects to that daemon directly; it does not start a daemon or construct a local
+runtime. An unavailable daemon or a protocol/configuration mismatch is a terminal error.
+`KHIVE_NO_DAEMON` does not select local execution for a plan.
+
+The command prints the decoded plan object as JSON. Both `parsed=true` and `parsed=false`
+exit successfully: a grammar error appears in the result's `error` field. A plan lists
+normalized arguments, literal `$prev` references, stage count and whether each verb is in
+the daemon's loaded catalog. It does not establish permission or resolve references.
+
+`--plan` requires positional operations and rejects explicit presentation, output, save,
+bulk-file, execution-mode and identity options, including `--presentation verbose` and
+`--strict`. The ordinary command's default verbose presentation does not affect plans.
+`--db` and `--config` select the matching daemon configuration; no actor or request identity
+is sent. Invalid options and transport failures exit nonzero.
+
 ### Bulk JSONL execution
 
 `kkernel exec --ops-file batch.jsonl` accepts one independent JSON operation per

--- a/crates/kkernel/src/cli.rs
+++ b/crates/kkernel/src/cli.rs
@@ -2147,6 +2147,7 @@ mod tests {
                 // route around the coordinator's full-UUID-only interception.
                 let resp = server
                     .dispatch_request_local(RequestParams {
+                        plan: None,
                         ops,
                         presentation: Some("verbose".to_string()),
                         presentation_per_op: None,

--- a/crates/kkernel/src/coordinator/tests.rs
+++ b/crates/kkernel/src/coordinator/tests.rs
@@ -2429,6 +2429,7 @@ async fn t2c_cross_backend_link_authorize_gate_error_omits_backend_text_from_wir
     );
     let raw = server
         .dispatch_request_local(khive_mcp::tools::request::RequestParams {
+            plan: None,
             ops,
             presentation: None,
             presentation_per_op: None,
@@ -2546,6 +2547,7 @@ async fn t2d_rego_gate_evaluator_failure_omits_canary_from_wire_and_logs() {
     let ops = format!(r#"list(kind="entity", canary="{CANARY}")"#);
     let raw = server
         .dispatch_request_local(khive_mcp::tools::request::RequestParams {
+            plan: None,
             ops,
             presentation: None,
             presentation_per_op: None,
@@ -3303,6 +3305,7 @@ async fn t7a_multi_backend_search_populates_real_entity_kind() {
 
     let result_str = server
         .dispatch_request_local(khive_mcp::tools::request::RequestParams {
+            plan: None,
             ops: r#"search(kind="concept", query="T7aConcept")"#.to_string(),
             presentation: None,
             presentation_per_op: None,
@@ -3362,6 +3365,7 @@ async fn multi_backend_and_direct_search_rows_have_exact_key_set_parity() {
     ) -> BTreeSet<String> {
         let raw = server
             .dispatch_request_local(khive_mcp::tools::request::RequestParams {
+                plan: None,
                 ops: ops.to_string(),
                 presentation: None,
                 presentation_per_op: None,
@@ -3477,6 +3481,7 @@ async fn t7b_multi_backend_search_kind_filter_excludes_off_kind() {
 
     let result_str = server
         .dispatch_request_local(khive_mcp::tools::request::RequestParams {
+            plan: None,
             ops: r#"search(kind="concept", query="T7bTarget")"#.to_string(),
             presentation: None,
             presentation_per_op: None,
@@ -3540,6 +3545,7 @@ async fn coordinator_service_search_reports_vector_arm_error_in_json_envelope() 
 
     let result_str = server
         .dispatch_request_local(khive_mcp::tools::request::RequestParams {
+            plan: None,
             ops: r#"search(kind="concept", query="FlashAttention")"#.to_string(),
             presentation: None,
             presentation_per_op: None,
@@ -3614,6 +3620,7 @@ async fn t7c_multi_backend_search_min_score_applied() {
     // min_score=1.0 is always above any real RRF score → result must be empty.
     let result_str = server
         .dispatch_request_local(khive_mcp::tools::request::RequestParams {
+            plan: None,
             ops: r#"search(kind="concept", query="T7cMinScoreProbe", min_score=1.0)"#.to_string(),
             presentation: None,
             presentation_per_op: None,
@@ -3672,6 +3679,7 @@ async fn t7d_multi_backend_search_session_kind_routes_to_note_substrate() {
 
     let result_str = server
         .dispatch_request_local(khive_mcp::tools::request::RequestParams {
+            plan: None,
             ops: r#"search(kind="session", query="standup")"#.to_string(),
             presentation: None,
             presentation_per_op: None,

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -9,6 +9,8 @@
 //!
 //! - **DSL mode** (default): `kkernel exec '<dsl>'` — executes a single verb DSL
 //!   expression or batch against the configured database and namespace.
+//! - **Plan mode**: `kkernel exec --plan '<dsl>'` — parses through an already
+//!   running daemon and prints its plan without dispatch or local construction.
 //! - **Pending-events mode**: `kkernel exec --pending-events` — one-shot drain that
 //!   fires all due `scheduled_event` notes. Mutually exclusive with the positional
 //!   `ops` argument. Cron-friendly: run every minute for minute-granularity delivery.
@@ -61,6 +63,8 @@ use khive_runtime::KhiveRuntime;
 use khive_runtime::{daemon::PROTOCOL_VERSION, DaemonRequestFrame};
 use khive_runtime::{KhiveConfig, Namespace, RuntimeConfig};
 use khive_types::RefusalReason;
+
+mod plan;
 
 /// Stable stderr prefix for machine-classifiable exec refusals.
 const REFUSAL_PREFIX: &str = "kkernel-refusal: ";
@@ -397,6 +401,21 @@ pub struct ExecArgs {
     /// Mutually exclusive with `--pending-events` and `--ops-file`.
     pub ops: Option<String>,
 
+    /// Check grammar and list stages without executing operations.
+    ///
+    /// Requires an already-running daemon with matching configuration. Prints
+    /// the plan as JSON; a grammar error is a successful `parsed=false` result.
+    #[arg(
+        long,
+        requires = "ops",
+        conflicts_with_all = [
+            "presentation", "strict", "output_format", "save_file", "ops_file",
+            "pending_events", "dry_run", "serial", "atomic", "atomic_max_ops",
+            "verbose", "actor", "expect_actor", "namespace"
+        ]
+    )]
+    pub plan: bool,
+
     /// One-shot drain: fire all `scheduled_event` notes whose `trigger_at <= now`.
     ///
     /// Scans all namespaces, dispatches each event's action in its own namespace,
@@ -447,7 +466,11 @@ pub struct ExecArgs {
     /// canonical shape — unlike the MCP `request` tool, which defaults to
     /// `Agent` for token efficiency. Pass `--presentation agent` to opt into
     /// the trimmed shape, or `--presentation human` for pretty terminal output.
-    #[arg(long, default_value = "verbose")]
+    #[arg(
+        long,
+        default_value = "verbose",
+        default_value_if("plan", "true", None)
+    )]
     pub presentation: Option<String>,
 
     /// Output format for verb results (ADR-078 §2 precedence: this flag >
@@ -1682,6 +1705,12 @@ where
 /// skipped entirely, and all ops are dispatched through the in-process runtime
 /// in chunks (see module-level docs).
 pub async fn run_exec(args: ExecArgs) -> Result<()> {
+    if args.plan {
+        let result = plan::run(&args).await?;
+        writeln!(std::io::stdout().lock(), "{result}")?;
+        return Ok(());
+    }
+
     // Clap enforces these relations for normal CLI entry. Keep the same
     // boundary for library callers that construct `ExecArgs` directly.
     if args.serial && (args.ops_file.is_none() || args.ops.is_some() || args.atomic) {
@@ -2292,6 +2321,7 @@ async fn run_exec_inline_with_forward(
                 compute_config_id(&cfg, Some(&khive_cfg))
             },
             protocol_version: PROTOCOL_VERSION,
+            plan: false,
             probe_only: false,
             metrics_only: false,
             format: output_format.clone(),
@@ -2375,6 +2405,7 @@ async fn run_exec_inline_with_forward(
     .await?;
 
     let params = RequestParams {
+        plan: None,
         ops,
         presentation,
         presentation_per_op: None,
@@ -3237,6 +3268,7 @@ mod tests {
             .unwrap();
         let raw = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: r#"comm.send(to="local", content="actor pin attribution")"#.to_string(),
                 presentation: None,
                 presentation_per_op: None,
@@ -4059,6 +4091,7 @@ id = "lambda:fallback"
 
         let send = server
             .dispatch_request_local(RequestParams {
+                plan: None,
                 ops: r#"comm.send(to="actor-routing-test", content="routed-via-secondary", self_send=true)"#
                     .to_string(),
                 presentation: None,
@@ -4091,6 +4124,7 @@ id = "lambda:fallback"
             let probe = KhiveMcpServer::new(rt).expect("server on backend file");
             let raw = probe
                 .dispatch_request_local(RequestParams {
+                    plan: None,
                     ops: r#"list(kind="message")"#.to_string(),
                     presentation: None,
                     presentation_per_op: None,
@@ -4287,6 +4321,7 @@ id = "lambda:fallback"
 
             for i in 0..count {
                 let params = RequestParams {
+                    plan: None,
                     ops: format!(
                         r#"create(kind="observation", content="{writer_label} note {i} — boot race marker")"#
                     ),
@@ -4717,6 +4752,7 @@ id = "lambda:fallback"
 
         // Verify all 3 entities are present.
         let params = RequestParams {
+            plan: None,
             ops: r#"list(kind="concept")"#.to_string(),
             presentation: None,
             presentation_per_op: None,
@@ -5187,6 +5223,7 @@ id = "lambda:fallback"
         let db_path = db_file.path().to_str().expect("utf8").to_string();
         let server = isolated_server(&db_path);
         let params = RequestParams {
+            plan: None,
             ops: serde_json::json!({
                 "tool": "stats",
                 "args": {"payload": "x".repeat(khive_request::MAX_OPS_INPUT_LEN + 1)},
@@ -5347,6 +5384,7 @@ id = "lambda:fallback"
         // it describes. The stable list contract wraps rows in `items` whether or
         // not the requested limit reaches the entity cap.
         let params = RequestParams {
+            plan: None,
             ops: r#"list(kind="concept", limit=200)"#.to_string(),
             presentation: None,
             presentation_per_op: None,
@@ -5433,6 +5471,7 @@ id = "lambda:fallback"
             .contains("absent or an existing regular file"));
 
         let params = RequestParams {
+            plan: None,
             ops: r#"list(kind="concept")"#.to_string(),
             presentation: None,
             presentation_per_op: None,
@@ -5693,6 +5732,7 @@ id = "lambda:fallback"
 
         async fn dispatch(server: &KhiveMcpServer, ops: &str) -> serde_json::Value {
             let params = RequestParams {
+                plan: None,
                 ops: ops.to_string(),
                 presentation: None,
                 presentation_per_op: None,
@@ -5836,6 +5876,7 @@ id = "lambda:fallback"
         // Verify nothing was written by checking with a fresh server.
         let server = isolated_server(&db_path);
         let params = RequestParams {
+            plan: None,
             ops: r#"list(kind="concept")"#.to_string(),
             presentation: None,
             presentation_per_op: None,
@@ -7548,6 +7589,7 @@ backend = "sessions"
         // Because parse failed, no dispatch happened → DB is clean.
         let server = isolated_server(&db_path);
         let params = RequestParams {
+            plan: None,
             ops: r#"list(kind="concept")"#.to_string(),
             presentation: None,
             presentation_per_op: None,
@@ -7584,6 +7626,7 @@ backend = "sessions"
         // need the real id back out so it can feed straight into `update`/
         // `delete`/`link` args.
         let params = RequestParams {
+            plan: None,
             ops: ops.to_string(),
             presentation: Some("verbose".to_string()),
             presentation_per_op: None,

--- a/crates/kkernel/src/exec/plan.rs
+++ b/crates/kkernel/src/exec/plan.rs
@@ -1,0 +1,132 @@
+use anyhow::{Context, Result};
+use serde_json::Value;
+
+use super::ExecArgs;
+
+fn validate_args(args: &ExecArgs) -> Result<&str> {
+    for (present, flag) in [
+        (args.presentation.is_some(), "--presentation"),
+        (args.strict, "--strict"),
+        (args.output_format.is_some(), "--output-format"),
+        (args.save_file.is_some(), "--save-file"),
+        (args.ops_file.is_some(), "--ops-file"),
+        (args.pending_events, "--pending-events"),
+        (args.dry_run, "--dry-run"),
+        (args.serial, "--serial"),
+        (args.atomic, "--atomic"),
+        (args.atomic_max_ops.is_some(), "--atomic-max-ops"),
+        (args.verbose, "--verbose"),
+        (args.actor.is_some(), "--actor"),
+        (args.expect_actor.is_some(), "--expect-actor"),
+        (args.namespace != "local", "--namespace"),
+    ] {
+        anyhow::ensure!(!present, "--plan cannot be used with {flag}");
+    }
+    args.ops
+        .as_deref()
+        .context("--plan requires a positional operations string")
+}
+
+#[cfg(unix)]
+pub(super) async fn run(args: &ExecArgs) -> Result<Value> {
+    use khive_mcp::serve::{
+        normalize_redundant_db_override_with_source, resolve_runtime_config_with_db_anchor,
+        validate_declared_backend_access_modes, RuntimeConfigInputs,
+    };
+    use khive_mcp::server::{compute_config_id, compute_config_id_with_storage_mode};
+    use khive_runtime::daemon::{
+        read_frame, socket_path, write_frame, DaemonResponseFrame, PROTOCOL_VERSION,
+    };
+    use khive_runtime::Namespace;
+    use tokio::net::UnixStream;
+
+    // A pre-plan protocol can discard the flag and execute the operations.
+    const { assert!(PROTOCOL_VERSION >= 5) };
+
+    let ops = validate_args(args)?;
+    let (mut cfg, anchor) = resolve_runtime_config_with_db_anchor(RuntimeConfigInputs {
+        db: args.db.as_deref(),
+        config: args.config.as_deref(),
+        namespace: Namespace::local(),
+        namespace_explicit: false,
+        actor_explicit: false,
+        no_embed: false,
+        packs: None,
+        brain_profile: None,
+    })?;
+    let (khive_cfg, source) = super::load_exec_config(&super::ExecDbContext {
+        raw: args.db.clone(),
+        anchor,
+        config: args.config.clone(),
+    })?;
+    let force_memory = if khive_cfg.backends.is_empty() {
+        false
+    } else {
+        normalize_redundant_db_override_with_source(
+            &mut cfg,
+            args.db.as_deref(),
+            &khive_cfg.backends,
+            source.as_deref(),
+        )?
+    };
+    if !force_memory {
+        validate_declared_backend_access_modes(&khive_cfg.backends)?;
+    }
+    let config_id = if force_memory {
+        compute_config_id_with_storage_mode(&cfg, Some(&khive_cfg), false)
+    } else {
+        compute_config_id(&cfg, Some(&khive_cfg))
+    };
+    let frame = serde_json::json!({
+        "ops": ops,
+        "plan": true,
+        "config_id": config_id,
+        "protocol_version": PROTOCOL_VERSION,
+        "namespace": "",
+    });
+    let response = tokio::time::timeout(std::time::Duration::from_secs(30), async {
+        let mut stream = UnixStream::connect(socket_path()).await.context(
+            "--plan requires an already-running daemon; start one with matching configuration",
+        )?;
+        write_frame(&mut stream, &serde_json::to_vec(&frame)?)
+            .await
+            .context("send plan request to daemon")?;
+        let payload = read_frame(&mut stream)
+            .await
+            .context("read daemon plan response")?;
+        serde_json::from_slice::<DaemonResponseFrame>(&payload)
+            .context("decode daemon plan response")
+    })
+    .await
+    .context("timed out waiting for daemon plan response")??;
+
+    anyhow::ensure!(
+        !response.version_mismatch && response.daemon_protocol_version == PROTOCOL_VERSION,
+        "version_mismatch: plan client protocol {PROTOCOL_VERSION}, daemon protocol {}; restart the daemon with a matching version",
+        response.daemon_protocol_version
+    );
+    anyhow::ensure!(
+        !response.config_mismatch
+            && !response.namespace_mismatch
+            && response.served_config_id.as_deref() == Some(config_id.as_str()),
+        "plan daemon configuration mismatch; start a daemon with matching --db and --config settings"
+    );
+    anyhow::ensure!(
+        response.ok,
+        "{}",
+        response
+            .error
+            .as_deref()
+            .unwrap_or("daemon refused the plan request")
+    );
+    let result = response
+        .result
+        .context("daemon plan response is missing its result")?;
+    serde_json::from_str(&result).context("daemon returned invalid plan JSON")
+}
+
+#[cfg(not(unix))]
+pub(super) async fn run(args: &ExecArgs) -> Result<Value> {
+    validate_args(args)?;
+    anyhow::bail!("--plan requires a platform with Unix daemon sockets")
+}

--- a/crates/kkernel/src/repo.rs
+++ b/crates/kkernel/src/repo.rs
@@ -710,6 +710,7 @@ async fn dispatch_single(server: &KhiveMcpServer, tool: &str, args: Value) -> Re
         .context("serialize repository-showcase operation")?;
     let raw = server
         .dispatch_request_local(RequestParams {
+            plan: None,
             ops,
             presentation: Some("verbose".to_string()),
             presentation_per_op: None,

--- a/crates/kkernel/tests/actor_pin_default_read_scope.rs
+++ b/crates/kkernel/tests/actor_pin_default_read_scope.rs
@@ -48,6 +48,7 @@ impl Drop for EnvGuard {
 
 fn base_args(db: &str, actor: Option<&str>, ops: &str, save_file: &str) -> ExecArgs {
     ExecArgs {
+        plan: false,
         ops: Some(ops.to_string()),
         pending_events: false,
         db: Some(db.to_string()),

--- a/crates/kkernel/tests/config_discovery_reload_anchor.rs
+++ b/crates/kkernel/tests/config_discovery_reload_anchor.rs
@@ -107,6 +107,7 @@ path = "{}"
     std::env::set_current_dir(project_dir.path()).expect("chdir into isolated project dir");
 
     let args = ExecArgs {
+        plan: false,
         ops: Some("stats()".to_string()),
         pending_events: false,
         db: None, // the repro shape: --db left unset

--- a/crates/kkernel/tests/daemon_forward_frame_actor_pin.rs
+++ b/crates/kkernel/tests/daemon_forward_frame_actor_pin.rs
@@ -65,6 +65,7 @@ impl Drop for EnvGuard {
 
 fn base_args(db: &str, actor: Option<&str>) -> ExecArgs {
     ExecArgs {
+        plan: false,
         ops: Some("stats()".to_string()),
         pending_events: false,
         db: Some(db.to_string()),

--- a/crates/kkernel/tests/exec_plan.rs
+++ b/crates/kkernel/tests/exec_plan.rs
@@ -1,0 +1,295 @@
+use clap::{error::ErrorKind, Parser};
+use kkernel::exec::ExecArgs;
+
+#[test]
+fn plan_accepts_positional_ops_without_default_presentation() {
+    let args = ExecArgs::try_parse_from(["exec", "--plan", "create("])
+        .expect("plan accepts raw operations for the daemon parser");
+    assert_eq!(args.ops.as_deref(), Some("create("));
+    assert_eq!(args.presentation, None);
+}
+
+#[test]
+fn ordinary_exec_retains_verbose_presentation() {
+    let args =
+        ExecArgs::try_parse_from(["exec", "stats()"]).expect("ordinary operations remain accepted");
+    assert_eq!(args.presentation.as_deref(), Some("verbose"));
+}
+
+#[test]
+fn plan_requires_positional_ops() {
+    let error = ExecArgs::try_parse_from(["exec", "--plan"]).unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::MissingRequiredArgument);
+}
+
+#[test]
+fn plan_rejects_explicit_execution_controls() {
+    for option in [
+        vec!["--presentation", "verbose"],
+        vec!["--presentation", "agent"],
+        vec!["--strict"],
+        vec!["--output-format", "json"],
+        vec!["--save-file", "results.jsonl"],
+        vec!["--ops-file", "ops.jsonl"],
+        vec!["--pending-events"],
+        vec!["--dry-run"],
+        vec!["--serial"],
+        vec!["--atomic"],
+        vec!["--atomic-max-ops", "10"],
+        vec!["--verbose"],
+        vec!["--actor", "test"],
+        vec!["--expect-actor", "test"],
+        vec!["--namespace", "local"],
+    ] {
+        let mut argv = vec!["exec", "--plan", "stats()"];
+        argv.extend(option.iter().copied());
+        let error = ExecArgs::try_parse_from(argv).unwrap_err();
+        assert_eq!(
+            error.kind(),
+            ErrorKind::ArgumentConflict,
+            "{option:?}: {error}"
+        );
+        assert!(error.to_string().contains(option[0]), "{error}");
+    }
+}
+
+#[cfg(unix)]
+mod daemon {
+    use std::collections::BTreeMap;
+    use std::path::Path;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use khive_runtime::daemon::{read_frame, write_frame};
+    use serde_json::{json, Value};
+    use tempfile::TempDir;
+    use tokio::net::UnixListener;
+    use tokio::process::Command;
+
+    fn canonical_plan(ops: &str) -> Value {
+        let catalog = BTreeMap::from([
+            ("stats".to_string(), "kg".to_string()),
+            ("create".to_string(), "kg".to_string()),
+            ("get".to_string(), "kg".to_string()),
+            ("memory.remember".to_string(), "memory".to_string()),
+        ]);
+        khive_request::plan_request(ops, &catalog)
+    }
+
+    fn configured_command(temp: &TempDir, socket: &Path, ops: &str) -> Command {
+        let config = temp.path().join("config.toml");
+        std::fs::write(&config, "").unwrap();
+        let mut command = Command::new(env!("CARGO_BIN_EXE_kkernel"));
+        command
+            .args(["exec", "--plan", ops, "--config"])
+            .arg(config)
+            .arg("--db")
+            .arg(temp.path().join("must-stay-absent.db"))
+            .current_dir(temp.path())
+            .env("KHIVE_SOCKET", socket)
+            .env("KHIVE_PACKS", "kg,comm")
+            .env("KHIVE_REQUIRE_ATTRIBUTED_ACTOR", "1")
+            .env("KHIVE_OUTPUT_FORMAT", "table")
+            .env("KHIVE_PROCESS_REF", "ignored-plan-provenance")
+            .env("KHIVE_TEST_HARNESS", "1")
+            .env_remove("KHIVE_ACTOR")
+            .env_remove("KHIVE_CONFIG")
+            .env_remove("KHIVE_DB")
+            .env_remove("KHIVE_EMBEDDING_MODEL")
+            .env_remove("KHIVE_ADDITIONAL_EMBEDDING_MODELS")
+            .kill_on_drop(true);
+        command
+    }
+
+    fn response(frame: &Value, result: Value) -> Value {
+        json!({
+            "ok": true,
+            "result": serde_json::to_string(&result).unwrap(),
+            "error": null,
+            "namespace_mismatch": false,
+            "config_mismatch": false,
+            "served_config_id": frame["config_id"],
+            "version_mismatch": false,
+            "daemon_protocol_version": 5
+        })
+    }
+
+    async fn round_trip(ops: &str, result: Value) -> (std::process::Output, Value) {
+        let temp = tempfile::tempdir().unwrap();
+        let socket = temp.path().join("daemon.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let daemon_result = result.clone();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let frame: Value =
+                serde_json::from_slice(&read_frame(&mut stream).await.unwrap()).unwrap();
+            let reply = response(&frame, daemon_result);
+            write_frame(&mut stream, &serde_json::to_vec(&reply).unwrap())
+                .await
+                .unwrap();
+            frame
+        });
+        let output = tokio::time::timeout(
+            Duration::from_secs(10),
+            configured_command(&temp, &socket, ops).output(),
+        )
+        .await
+        .expect("plan must finish without fallback")
+        .unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let frame = tokio::time::timeout(Duration::from_secs(2), server)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(!temp.path().join("must-stay-absent.db").exists());
+        assert_eq!(
+            serde_json::from_slice::<Value>(&output.stdout).unwrap(),
+            result
+        );
+        (output, frame)
+    }
+
+    #[tokio::test]
+    async fn plan_returns_decoded_result_without_dispatch_rendering_or_identity() {
+        for ops in [
+            "stats()",
+            "unknown_verb(value=1)",
+            "[stats(), get(id=\"example\")]",
+            "create(kind=\"note\", content=\"example\") | get(id=$prev.id) | memory.remember(source_id=$prev.id)",
+            r#"{"tool":"get","args":{"id":"line\nbreak"}}"#,
+        ] {
+            let expected = canonical_plan(ops);
+            assert_eq!(expected["parsed"], true, "fixture must parse: {ops}");
+            let (_, frame) = round_trip(ops, expected).await;
+            assert_eq!(frame["plan"], true);
+            assert_eq!(frame["ops"], ops);
+            assert_eq!(frame["namespace"], "");
+            assert_eq!(frame["protocol_version"], 5);
+            assert!(frame["config_id"].as_str().is_some_and(|id| !id.is_empty()));
+            assert_eq!(frame.as_object().unwrap().len(), 5);
+        }
+    }
+
+    #[tokio::test]
+    async fn malformed_plan_is_a_successful_result() {
+        let ops = "create(";
+        let result = canonical_plan(ops);
+        assert_eq!(result["parsed"], false);
+        assert_eq!(
+            result["error"],
+            khive_request::parse_request(ops).unwrap_err().to_string()
+        );
+        round_trip(ops, result).await;
+    }
+
+    #[tokio::test]
+    async fn previous_daemon_version_refuses_plan_without_dispatch() {
+        let temp = tempfile::tempdir().unwrap();
+        let socket = temp.path().join("daemon.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let dispatched = Arc::new(AtomicUsize::new(0));
+        let daemon_dispatched = dispatched.clone();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let frame: Value =
+                serde_json::from_slice(&read_frame(&mut stream).await.unwrap()).unwrap();
+            let mismatch = frame["protocol_version"] != 4;
+            if !mismatch {
+                daemon_dispatched.fetch_add(1, Ordering::SeqCst);
+            }
+            let reply = json!({"ok":false,"result":null,"error":"version_mismatch",
+                "namespace_mismatch":false,"config_mismatch":false,"served_config_id":frame["config_id"],
+                "version_mismatch":mismatch,"daemon_protocol_version":4});
+            write_frame(&mut stream, &serde_json::to_vec(&reply).unwrap())
+                .await
+                .unwrap();
+        });
+        let output = tokio::time::timeout(
+            Duration::from_secs(10),
+            configured_command(
+                &temp,
+                &socket,
+                "create(kind=\"note\", content=\"must not execute\")",
+            )
+            .output(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        assert!(!output.status.success());
+        assert!(String::from_utf8_lossy(&output.stderr).contains("version_mismatch"));
+        tokio::time::timeout(Duration::from_secs(2), server)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(dispatched.load(Ordering::SeqCst), 0);
+        assert!(!temp.path().join("must-stay-absent.db").exists());
+    }
+
+    #[tokio::test]
+    async fn unavailable_daemon_fails_without_creating_a_database() {
+        let temp = tempfile::tempdir().unwrap();
+        let socket = temp.path().join("absent.sock");
+        let output = tokio::time::timeout(
+            Duration::from_secs(10),
+            configured_command(&temp, &socket, "stats()").output(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        assert!(!output.status.success());
+        assert!(String::from_utf8_lossy(&output.stderr).contains("already-running daemon"));
+        assert!(!socket.exists());
+        assert!(!temp.path().join("must-stay-absent.db").exists());
+    }
+
+    #[tokio::test]
+    async fn plan_rejects_unconfirmed_daemon_responses_without_fallback() {
+        for (field, replacement) in [
+            ("config_mismatch", json!(true)),
+            ("served_config_id", json!("different-config")),
+            ("served_config_id", Value::Null),
+            ("daemon_protocol_version", json!(4)),
+            ("namespace_mismatch", json!(true)),
+            ("result", Value::Null),
+            ("result", json!("not JSON")),
+        ] {
+            let temp = tempfile::tempdir().unwrap();
+            let socket = temp.path().join("daemon.sock");
+            let listener = UnixListener::bind(&socket).unwrap();
+            let server = tokio::spawn(async move {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let frame: Value =
+                    serde_json::from_slice(&read_frame(&mut stream).await.unwrap()).unwrap();
+                let mut reply = response(&frame, json!({"parsed":true}));
+                reply[field] = replacement;
+                write_frame(&mut stream, &serde_json::to_vec(&reply).unwrap())
+                    .await
+                    .unwrap();
+            });
+            let output = tokio::time::timeout(
+                Duration::from_secs(10),
+                configured_command(&temp, &socket, "stats()").output(),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+            assert!(!output.status.success(), "accepted {field}");
+            assert!(
+                output.stdout.is_empty(),
+                "{field}: {}",
+                String::from_utf8_lossy(&output.stdout)
+            );
+            tokio::time::timeout(Duration::from_secs(2), server)
+                .await
+                .unwrap()
+                .unwrap();
+            assert!(!temp.path().join("must-stay-absent.db").exists());
+        }
+    }
+}

--- a/docs/guide/request-and-dsl.md
+++ b/docs/guide/request-and-dsl.md
@@ -84,6 +84,47 @@ separate `request` calls or make that result the immediate predecessor.
 batches reject it. A failed chain operation prevents subsequent operations
 from running; completed operations are not rolled back.
 
+## Check syntax without executing
+
+Set `plan=true` on the MCP envelope to parse the same `ops` text and inspect
+the loaded verb catalog without dispatching any operation:
+
+```text
+request(ops="create(kind=\"note\", content=\"draft\") | get(id=$prev.id)", plan=true)
+```
+
+A successful parse returns `parsed: true`, `mode`, `stage_count`, and `stages`.
+Each stage reports its `index`, `verb`, `pack`, `known`, normalized `args`, and
+unresolved `prev_refs`. An unknown verb still parses, with `known: false` and
+`pack: null`. References stay as literal strings; paths in `prev_refs` retain
+the parser's representation. Both outcomes include `limits` with `max_ops`,
+`max_depth`, and `max_input_len` in bytes. A syntax error returns `parsed: false`
+and the ordinary parser error text, with no `stages`.
+
+Planning accepts `ops` alone. Supplying `presentation`, `presentation_per_op`,
+`format`, `format_per_op`, `save_to`, or `request_id` beside `plan=true`, even
+as `null`, produces `invalid_params` naming the field. A plan does not grant
+permission, check a lease, or guarantee that a reference will resolve.
+
+The CLI and Python client return the same object:
+
+```sh
+kkernel exec --plan 'create(kind="note", content="draft") | get(id=$prev.id)'
+```
+
+```python
+from khive import Session
+
+plan = Session().plan('create(kind="note", content="draft") | get(id=$prev.id)')
+```
+
+These two clients require an already-running daemon at protocol version 5 with
+matching configuration. The CLI accepts `--db` and `--config` to select that
+configuration. It exits successfully for either parse outcome; transport or
+envelope failures exit nonzero. It never starts a daemon or opens a local store
+for planning. Older daemons refuse the protocol version before dispatch, so a
+plan cannot silently execute as an ordinary request.
+
 ## Read the result envelope
 
 By default, `request` returns a `results` array and an aggregate `summary`
@@ -149,7 +190,7 @@ and its export-destination restriction.
 
 An invalid DSL string never reaches a verb handler. Lexing and parsing failures
 such as unterminated strings, malformed JSON, too many operations, or invalid
-use of `$prev` are reported by MCP as an `invalid_params` RPC error. Correct
+use of `$prev` are reported by ordinary MCP requests as an `invalid_params` RPC error. Correct
 the `ops` string and submit the request again.
 
 Once the DSL parses, validation or execution failures from an individual verb

--- a/python/README.md
+++ b/python/README.md
@@ -35,6 +35,37 @@ db.diagnostics()          # writer/WAL/checkpoint counters
 - A `batch()` is one request, not a transaction: ops succeed or fail
   individually and the per-op results say which.
 
+## Check request syntax
+
+`Session.plan(ops)` sends the original request text to the daemon's parser without
+executing any operations:
+
+```python
+from khive import Session
+
+session = Session()
+plan = session.plan('create(kind="note", content="sample") | get(id=$prev.id)')
+if plan["parsed"]:
+    print(plan["mode"], plan["stage_count"], plan["stages"])
+else:
+    print(plan["error"])
+```
+
+The returned dictionary preserves the daemon's plan: each stage includes its
+index, verb, pack, whether the verb is known, normalized arguments and unresolved
+`prev_refs`. `limits` contains `max_ops`, `max_depth` and `max_input_len`. An unknown
+verb has `known: false` and `pack: null`; it can still parse successfully.
+
+A syntax error returns `parsed: false` and an error string, with no `stages`.
+Transport failures and rejected frames still raise the usual client exceptions.
+A plan is not permission to execute or a check that references will resolve.
+
+Planning requires daemon protocol version 5. Older daemons raise
+`ProtocolMismatch`; the client never falls back to sending the operations as an
+ordinary request. Plan frames omit caller identity and rendering options; the
+required namespace field is sent empty. `session.request(...)` retains its
+ordinary dispatch behavior and returns per-operation results.
+
 ## Scratch database
 
 Experiments should run against a scratch daemon, not a production store:

--- a/python/khive/envelope.py
+++ b/python/khive/envelope.py
@@ -1,6 +1,4 @@
-"""Envelope-normalization functions for the request envelope's response
-shape (`{"results": [...]}`), each `OpResult`-shaped per the daemon's wire
-contract.
+"""Validation for request results and plan-only responses from the daemon.
 
 This module provides the steps a transport needs to turn raw response
 bytes into validated `OpResult` entries: decode JSON, check the result is a
@@ -37,6 +35,45 @@ def _envelope_from_payload(payload: Any, url: str) -> dict[str, Any]:
     runs after it (`_validate_op_errors`/`_validate_envelope_results`)."""
     if not isinstance(payload, dict) or not isinstance(payload.get("results"), list):
         raise TransportError(f"response from {url} is not a request envelope: {str(payload)[:200]}")
+    return payload
+
+
+def _plan_from_payload(payload: Any, url: str) -> dict[str, Any]:
+    """Validate a plan without normalizing its fields or interpreting admission."""
+    if not isinstance(payload, dict) or type(payload.get("parsed")) is not bool:
+        raise TransportError(f"response from {url} is not a plan: parsed must be a boolean")
+    limits = payload.get("limits")
+    if not isinstance(limits, dict) or any(
+        type(limits.get(key)) is not int or limits[key] < 0
+        for key in ("max_ops", "max_depth", "max_input_len")
+    ):
+        raise TransportError(f"response from {url} has malformed plan limits")
+    if payload["parsed"] is False:
+        if not isinstance(payload.get("error"), str) or "stages" in payload:
+            raise TransportError(f"response from {url} has a malformed plan parse error")
+        return payload
+    stages = payload.get("stages")
+    if (
+        payload.get("mode") not in ("single", "parallel", "chain")
+        or type(payload.get("stage_count")) is not int
+        or not isinstance(stages, list)
+        or payload["stage_count"] != len(stages)
+    ):
+        raise TransportError(f"response from {url} has malformed plan stages")
+    for index, stage in enumerate(stages):
+        if (
+            not isinstance(stage, dict)
+            or type(stage.get("index")) is not int
+            or stage["index"] != index
+            or not isinstance(stage.get("verb"), str)
+            or "pack" not in stage
+            or (stage["pack"] is not None and not isinstance(stage["pack"], str))
+            or type(stage.get("known")) is not bool
+            or not isinstance(stage.get("args"), dict)
+            or not isinstance(stage.get("prev_refs"), list)
+            or any(not isinstance(ref, str) for ref in stage["prev_refs"])
+        ):
+            raise TransportError(f"response from {url} has a malformed plan stage at index {index}")
     return payload
 
 

--- a/python/khive/transport.py
+++ b/python/khive/transport.py
@@ -30,7 +30,12 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any
 
-from .envelope import _decode_json_text, _envelope_from_payload, _validate_envelope_results
+from .envelope import (
+    _decode_json_text,
+    _envelope_from_payload,
+    _plan_from_payload,
+    _validate_envelope_results,
+)
 from .errors import (
     ConfigMismatch,
     FrameTooLarge,
@@ -39,7 +44,7 @@ from .errors import (
     TransportError,
 )
 
-PROTOCOL_VERSION = 4
+PROTOCOL_VERSION = 5
 MAX_FRAME_BYTES = 8 * 1024 * 1024
 
 
@@ -124,9 +129,10 @@ class Session:
     # -- handshake ---------------------------------------------------------
 
     def handshake(self) -> str:
-        response = self.transport.round_trip(
-            self._base_frame() | {"metrics_only": True}, self.timeout
-        )
+        return self._handshake(self._base_frame())
+
+    def _handshake(self, frame: dict[str, Any]) -> str:
+        response = self.transport.round_trip(frame | {"metrics_only": True}, self.timeout)
         self._check_version(response)
         served = response.get("served_config_id")
         if not served:
@@ -169,6 +175,39 @@ class Session:
         parsed = _decode_json_text(raw, "daemon") if isinstance(raw, str) else raw
         envelope = _envelope_from_payload(parsed, "daemon")
         return _validate_envelope_results(envelope, "daemon")["results"]
+
+    def plan(self, ops: str, *, timeout: float | None = None) -> dict[str, Any]:
+        """Parse ops without dispatch; return a plan, including parsed=false errors.
+
+        A successful parse reports syntax and catalog information, not permission
+        to execute the operations or evidence that their references will resolve.
+        """
+        if self._config_id is None:
+            self._handshake(self._plan_frame())
+        frame = self._plan_frame() | {"ops": ops, "plan": True}
+        response = self.transport.round_trip(frame, timeout or self.timeout)
+        self._check_version(response)
+        if response.get("config_mismatch"):
+            self._handshake(self._plan_frame())
+            frame["config_id"] = self._config_id
+            response = self.transport.round_trip(frame, timeout or self.timeout)
+            self._check_version(response)
+            if response.get("config_mismatch"):
+                raise ConfigMismatch(str(response.get("error")))
+        if not response.get("ok"):
+            raise RequestRejected(str(response.get("error")))
+        raw = response.get("result")
+        parsed = _decode_json_text(raw, "daemon") if isinstance(raw, str) else raw
+        return _plan_from_payload(parsed, "daemon")
+
+    def _plan_frame(self) -> dict[str, Any]:
+        return {
+            "ops": "",
+            # Required by the frame codec; the plan path never resolves identity.
+            "namespace": "",
+            "config_id": self._config_id or "",
+            "protocol_version": PROTOCOL_VERSION,
+        }
 
     def _base_frame(self) -> dict[str, Any]:
         return {

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -49,6 +49,8 @@ def scratch_daemon():
     env = os.environ.copy()
     env["KHIVE_SOCKET"] = str(sock)
     env["KHIVE_PID"] = str(root / "khived.pid")
+    env["KHIVE_LOCK"] = str(root / "khived.recovery.lock")
+    env["KHIVE_RECOVERER_LOCK"] = str(root / "khived.recoverer.lock")
     proc = subprocess.Popen(
         [
             binary,

--- a/python/tests/test_plan_surfaces.py
+++ b/python/tests/test_plan_surfaces.py
@@ -1,0 +1,199 @@
+"""The native session, CLI and MCP return the same complete plan object."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import selectors
+import subprocess
+import time
+
+import pytest
+
+from conftest import _kkernel
+from khive import Session, SocketTransport
+
+
+TIMEOUT_SECONDS = 30.0
+MAX_STDIO_BYTES = 8 * 1024 * 1024
+CHAIN = (
+    'create(kind="note", content="sample") | '
+    'update(id=$prev.id, properties={"nested": '
+    '[$prev.properties.owner, {"source": $prev.tags[0]}]}) | '
+    'get(id=$prev.id)'
+)
+
+
+def _scratch_environment(scratch):
+    root = scratch["root"]
+    env = os.environ.copy()
+    env.pop("KHIVE_NO_DAEMON", None)
+    env.update({
+        "KHIVE_SOCKET": str(scratch["socket"]),
+        "KHIVE_PID": str(root / "khived.pid"),
+        "KHIVE_LOCK": str(root / "khived.recovery.lock"),
+        "KHIVE_RECOVERER_LOCK": str(root / "khived.recoverer.lock"),
+        "KHIVE_DB": str(root / "scratch.db"),
+        "KHIVE_CONFIG": str(root / "khive.toml"),
+    })
+    return env
+
+
+def _cli_plan(binary, scratch, ops):
+    root = scratch["root"]
+    completed = subprocess.run(
+        [
+            binary, "exec", "--plan", "--db", str(root / "scratch.db"),
+            "--config", str(root / "khive.toml"), ops,
+        ],
+        env=_scratch_environment(scratch),
+        cwd=root,
+        capture_output=True,
+        text=True,
+        timeout=TIMEOUT_SECONDS,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    return json.loads(completed.stdout)
+
+
+class StdioMcp:
+    def __init__(self, process):
+        self.process = process
+        self.buffer = bytearray()
+        self.sequence = 0
+        self.selector = selectors.DefaultSelector()
+        self.selector.register(process.stdout, selectors.EVENT_READ)
+        os.set_blocking(process.stdout.fileno(), False)
+
+    def close(self):
+        self.selector.close()
+
+    def send(self, message):
+        self.process.stdin.write((json.dumps(message) + "\n").encode())
+        self.process.stdin.flush()
+
+    def notify(self, method):
+        self.send({"jsonrpc": "2.0", "method": method})
+
+    def request(self, method, params):
+        self.sequence += 1
+        request_id = self.sequence
+        self.send({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params})
+        deadline = time.monotonic() + TIMEOUT_SECONDS
+        while True:
+            while b"\n" in self.buffer:
+                line, _, remaining = self.buffer.partition(b"\n")
+                self.buffer = bytearray(remaining)
+                message = json.loads(line)
+                if message.get("id") == request_id:
+                    assert "error" not in message, message.get("error")
+                    return message["result"]
+            remaining_seconds = deadline - time.monotonic()
+            assert remaining_seconds > 0, f"MCP {method} timed out"
+            assert self.selector.select(remaining_seconds), f"MCP {method} timed out"
+            chunk = os.read(self.process.stdout.fileno(), 65536)
+            assert chunk, f"MCP closed stdout during {method}"
+            self.buffer.extend(chunk)
+            assert len(self.buffer) <= MAX_STDIO_BYTES, "MCP response exceeds the byte budget"
+
+
+def _stop_process(process):
+    try:
+        process.stdin.close()
+    except BrokenPipeError:
+        pass
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=5)
+    finally:
+        process.stdout.close()
+
+
+def _mcp_plan(binary, scratch, ops, case):
+    root: Path = scratch["root"]
+    stderr_path = root / f"plan-mcp-{case}.stderr"
+    with stderr_path.open("wb") as stderr:
+        process = subprocess.Popen(
+            [
+                binary, "mcp", "--db", str(root / "scratch.db"),
+                "--config", str(root / "khive.toml"),
+            ],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=stderr,
+            env=_scratch_environment(scratch),
+            cwd=root,
+        )
+        connection = None
+        try:
+            connection = StdioMcp(process)
+            connection.request("initialize", {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "plan-surface-test", "version": "1.0"},
+            })
+            connection.notify("notifications/initialized")
+            result = connection.request("tools/call", {
+                "name": "request",
+                "arguments": {"ops": ops, "plan": True},
+            })
+            assert result.get("isError") is not True, result
+            text = [entry["text"] for entry in result["content"] if entry["type"] == "text"]
+            assert len(text) == 1, result
+            return json.loads(text[0])
+        except Exception as error:
+            stderr.flush()
+            diagnostic = stderr_path.read_text(errors="replace")[-2000:]
+            raise AssertionError(
+                f"MCP plan exchange failed: {error}; stderr: {diagnostic}"
+            ) from error
+        finally:
+            if connection is not None:
+                connection.close()
+            _stop_process(process)
+
+
+@pytest.mark.parametrize(
+    ("case", "ops"),
+    [
+        ("nested-chain", CHAIN),
+        ("parse-error", "create("),
+        ("unknown-verb", "unregistered.plan_example()"),
+    ],
+    ids=["nested-chain", "parse-error", "unknown-verb"],
+)
+def test_plan_objects_match_across_all_three_surfaces(scratch_daemon, case, ops):
+    binary = _kkernel()
+    assert binary is not None, "scratch fixture already selected a kernel binary"
+    session = Session(SocketTransport(scratch_daemon["socket"]), timeout=TIMEOUT_SECONDS)
+    native = session.plan(ops)
+    cli = _cli_plan(binary, scratch_daemon, ops)
+    mcp = _mcp_plan(binary, scratch_daemon, ops, case)
+
+    assert native == cli == mcp
+    assert set(native["limits"]) >= {"max_ops", "max_depth", "max_input_len"}
+    if case == "nested-chain":
+        assert native["parsed"] is True
+        assert native["mode"] == "chain"
+        assert native["stage_count"] == 3
+        assert native["stages"][1]["args"]["properties"] == {
+            "nested": ["$prev.properties.owner", {"source": "$prev.tags[0]"}],
+        }
+        assert set(native["stages"][1]["prev_refs"]) == {"id", "properties.owner", "tags.[0]"}
+    elif case == "parse-error":
+        assert native["parsed"] is False
+        assert isinstance(native["error"], str)
+        assert "stages" not in native
+    else:
+        assert native["parsed"] is True
+        assert native["stage_count"] == 1
+        assert native["stages"][0]["known"] is False
+        assert native["stages"][0]["pack"] is None

--- a/python/tests/test_session_plan.py
+++ b/python/tests/test_session_plan.py
@@ -1,0 +1,277 @@
+"""Plan frames and decoded results through a daemon stub; no database or socket."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+
+import pytest
+
+from khive import envelope
+from khive.errors import ConfigMismatch, ProtocolMismatch, RequestRejected, TransportError
+from khive.transport import PROTOCOL_VERSION, Session, Transport
+
+
+LIMITS = {"max_ops": 100, "max_depth": 64, "max_input_len": 1048576}
+OPS = 'create(kind="note", content="sample") | get(id=$prev.id) | get(id=$prev.id)'
+PLAN = {
+    "parsed": True,
+    "mode": "chain",
+    "stage_count": 3,
+    "stages": [
+        {
+            "index": 0,
+            "verb": "create",
+            "pack": "kg",
+            "known": True,
+            "args": {"kind": "note", "content": "sample"},
+            "prev_refs": [],
+        },
+        {
+            "index": 1,
+            "verb": "get",
+            "pack": "kg",
+            "known": True,
+            "args": {"id": "$prev.id"},
+            "prev_refs": ["id"],
+        },
+        {
+            "index": 2,
+            "verb": "get",
+            "pack": "kg",
+            "known": True,
+            "args": {"id": "$prev.id"},
+            "prev_refs": ["id"],
+        },
+    ],
+    "limits": LIMITS,
+}
+PARSE_ERROR = {"parsed": False, "error": "unexpected end of input", "limits": LIMITS}
+
+
+class DaemonStub(Transport):
+    def __init__(self, payload=PLAN, *, encoded=True, version=5, mismatches=0, rejection=None):
+        self.payload = payload
+        self.encoded = encoded
+        self.version = version
+        self.mismatches = mismatches
+        self.rejection = rejection
+        self.frames = []
+        self.timeouts = []
+        self.dispatched_ops = []
+
+    def round_trip(self, frame, timeout):
+        self.frames.append(deepcopy(frame))
+        self.timeouts.append(timeout)
+        response = {"ok": True, "served_config_id": "catalog-config"}
+        if frame["protocol_version"] != self.version:
+            return {
+                "ok": False,
+                "version_mismatch": True,
+                "daemon_protocol_version": self.version,
+                "error": "protocol version mismatch",
+            }
+        if frame.get("metrics_only"):
+            return response
+        if self.mismatches:
+            self.mismatches -= 1
+            return {"ok": False, "config_mismatch": True, "error": "config changed"}
+        if self.rejection is not None:
+            return {"ok": False, "error": self.rejection}
+        if frame.get("plan"):
+            response["result"] = json.dumps(self.payload) if self.encoded else self.payload
+        else:
+            self.dispatched_ops.append(frame["ops"])
+            response["result"] = json.dumps({"results": [{"ok": True, "tool": "stats"}]})
+        return response
+
+
+def assert_no_identity_or_rendering(frames):
+    excluded = {
+        "actor_id", "process_ref", "visible_namespaces", "request_id",
+        "presentation", "presentation_per_op", "format", "format_per_op", "save_to",
+    }
+    for frame in frames:
+        assert excluded.isdisjoint(frame)
+        assert frame["namespace"] == ""
+
+
+def test_plan_protocol_version_refuses_daemons_that_cannot_plan():
+    assert PROTOCOL_VERSION == 5
+
+
+@pytest.mark.parametrize("encoded", [True, False])
+def test_plan_sends_isolated_frame_and_preserves_the_complete_result(encoded):
+    transport = DaemonStub(encoded=encoded)
+    session = Session(
+        transport, actor_id="test-client", namespace="project", visible_namespaces=["shared"]
+    )
+    assert session.plan(OPS) == PLAN
+    assert transport.frames == [
+        {
+            "ops": "", "namespace": "", "config_id": "", "protocol_version": 5,
+            "metrics_only": True,
+        },
+        {
+            "ops": OPS, "namespace": "", "config_id": "catalog-config",
+            "protocol_version": 5, "plan": True,
+        },
+    ]
+    assert_no_identity_or_rendering(transport.frames)
+    assert transport.dispatched_ops == []
+
+
+def test_plan_parse_failure_is_a_successful_decoded_result():
+    transport = DaemonStub(PARSE_ERROR)
+    result = Session(transport).plan("create(")
+    assert result == PARSE_ERROR
+    assert "stages" not in result
+    assert transport.dispatched_ops == []
+
+
+def test_plan_unknown_verb_and_null_pack_are_preserved():
+    payload = deepcopy(PLAN)
+    payload.update(mode="single", stage_count=1)
+    payload["stages"] = [{
+        "index": 0, "verb": "unknown.call", "pack": None,
+        "known": False, "args": {}, "prev_refs": [],
+    }]
+    assert Session(DaemonStub(payload)).plan("unknown.call()") == payload
+
+
+def test_plan_preserves_new_server_metadata_without_normalization():
+    payload = deepcopy(PLAN)
+    payload["future_metadata"] = {"catalog_revision": "example"}
+    payload["stages"][0]["future_metadata"] = [1, None, False]
+    assert Session(DaemonStub(payload, encoded=False)).plan(OPS) is payload
+
+
+def test_plan_timeout_override_applies_to_the_plan_exchange():
+    transport = DaemonStub()
+    session = Session(transport, timeout=12.0)
+    session.plan(OPS, timeout=3.0)
+    session.plan(OPS)
+    assert transport.timeouts == [12.0, 3.0, 12.0]
+    assert len([frame for frame in transport.frames if frame.get("metrics_only")]) == 1
+
+
+def test_plan_rehandshakes_once_on_config_change_without_identity():
+    transport = DaemonStub(mismatches=1)
+    session = Session(transport, actor_id="test-client")
+    session._config_id = "stale-config"
+    assert session.plan(OPS) == PLAN
+    assert [frame.get("metrics_only", False) for frame in transport.frames] == [False, True, False]
+    assert transport.frames[-1]["config_id"] == "catalog-config"
+    assert_no_identity_or_rendering(transport.frames)
+    assert transport.dispatched_ops == []
+
+
+def test_plan_persistent_config_mismatch_is_not_retried_again():
+    transport = DaemonStub(mismatches=2)
+    session = Session(transport)
+    session._config_id = "stale-config"
+    with pytest.raises(ConfigMismatch, match="config changed"):
+        session.plan(OPS)
+    assert len(transport.frames) == 3
+    assert_no_identity_or_rendering(transport.frames)
+    assert transport.dispatched_ops == []
+
+
+@pytest.mark.parametrize("handshaken", [True, False])
+def test_previous_protocol_rejects_plan_without_dispatch(handshaken):
+    transport = DaemonStub(version=4)
+    session = Session(transport)
+    if handshaken:
+        session._config_id = "catalog-config"
+    with pytest.raises(ProtocolMismatch) as raised:
+        session.plan(OPS)
+    assert raised.value.client_version == 5
+    assert raised.value.daemon_version == 4
+    assert len(transport.frames) == 1
+    assert transport.frames[0].get("plan", False) is handshaken
+    assert transport.dispatched_ops == []
+
+
+def test_plan_outer_rejection_remains_request_rejected():
+    transport = DaemonStub(rejection="invalid_params: presentation cannot be combined with plan")
+    with pytest.raises(RequestRejected, match="invalid_params: presentation"):
+        Session(transport).plan(OPS)
+
+
+def test_plan_malformed_json_is_a_transport_error():
+    with pytest.raises(TransportError, match="malformed JSON body from daemon"):
+        Session(DaemonStub("{not json", encoded=False)).plan(OPS)
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["presentation", "presentation_per_op", "format", "format_per_op", "save_to", "request_id"],
+)
+def test_plan_api_cannot_add_dispatch_envelope_fields(field):
+    transport = DaemonStub()
+    with pytest.raises(TypeError, match=field):
+        Session(transport).plan(OPS, **{field: "value"})
+    assert transport.frames == []
+
+
+def test_request_retains_dispatch_frame_and_per_operation_result_list():
+    transport = DaemonStub(version=PROTOCOL_VERSION)
+    session = Session(
+        transport, actor_id="test-client", namespace="project", visible_namespaces=["shared"]
+    )
+    assert session.request("stats()") == [{"ok": True, "tool": "stats"}]
+    assert transport.frames[-1] == {
+        "ops": "stats()", "presentation": "verbose", "format": "json",
+        "namespace": "project", "actor_id": "test-client", "visible_namespaces": ["shared"],
+        "config_id": "catalog-config", "protocol_version": PROTOCOL_VERSION, "from_wire": False,
+    }
+    assert transport.dispatched_ops == ["stats()"]
+
+
+@pytest.mark.parametrize("payload", [PLAN, PARSE_ERROR])
+def test_plan_envelope_validator_preserves_decoded_objects(payload):
+    assert envelope._plan_from_payload(payload, "test-daemon") is payload
+
+
+def malformed_plans():
+    yield None
+    yield []
+    yield {"results": []}
+    yield {"parsed": "false", "error": "bad syntax", "limits": LIMITS}
+    yield {"parsed": False, "limits": LIMITS}
+    yield {"parsed": False, "error": 42, "limits": LIMITS}
+    yield PARSE_ERROR | {"stages": []}
+    yield PLAN | {"parsed": 1}
+    yield PLAN | {"mode": "unknown"}
+    yield PLAN | {"stage_count": True}
+    yield PLAN | {"stage_count": 4}
+    yield PLAN | {"stages": None}
+    yield {key: value for key, value in PLAN.items() if key != "limits"}
+    yield PLAN | {"limits": {"max_ops": 100, "max_depth": 64}}
+    yield PLAN | {"limits": LIMITS | {"max_depth": "64"}}
+    yield PLAN | {"limits": LIMITS | {"max_input_len": False}}
+    yield PLAN | {"limits": LIMITS | {"max_ops": -1}}
+    for field, value in [
+        ("index", True), ("index", 2), ("verb", 1), ("pack", 1),
+        ("known", "true"), ("args", []), ("prev_refs", "id"), ("prev_refs", [1]),
+    ]:
+        payload = deepcopy(PLAN)
+        payload["stages"][0][field] = value
+        yield payload
+    payload = deepcopy(PLAN)
+    del payload["stages"][0]["pack"]
+    yield payload
+    payload = deepcopy(PLAN)
+    del payload["stages"][0]["verb"]
+    yield payload
+
+
+@pytest.mark.parametrize("payload", list(malformed_plans()))
+def test_malformed_plan_shapes_are_transport_errors(payload):
+    with pytest.raises(TransportError, match="daemon.*plan"):
+        Session(DaemonStub(payload)).plan(OPS)
+
+
+def test_plan_envelope_rejection_names_the_origin():
+    with pytest.raises(TransportError, match="test-daemon.*plan"):
+        envelope._plan_from_payload({"results": []}, "test-daemon")


### PR DESCRIPTION
`request(ops, plan=true)`, `kkernel exec --plan '<ops>'`, and `Session.plan(ops)` return the parsed plan of a request, its ops, verbs, parameters and dependencies as resolved against the grammar and the loaded verb catalog, without executing any operation. A malformed request reports its parse error in the same envelope shape; unknown verbs and unknown parameters are reported per op.

- `khive-request` gains a pure planner, `plan_request`, shared by every surface.
- The MCP `request` tool accepts `plan: bool` (default false) and returns the plan envelope.
- Daemon protocol moves to v5. Plan frames are a new request kind; a mismatched client or daemon refuses with `version_mismatch`, and the CLI plan path requires an already-running matching daemon.
- Python: `Session.plan(ops)` and transport support.
- Docs: request guide, daemon API reference, kkernel usage.

Validation: workspace fmt, clippy (all targets, `-D warnings`), check and tests; the Python suite; seven behavioral acceptance arms in which the MCP, CLI and Python surfaces produce identical plans for the same corpus.

Implements ADR-178.
