### PR TITLE
docs(adr): ADR-181 and ADR-182 Amendment 2

### DIFF
--- a/docs/adr/ADR-181-exec-verb-sandboxed-run.md
+++ b/docs/adr/ADR-181-exec-verb-sandboxed-run.md
@@ -117,3 +117,28 @@ outside `declared_write_paths` yields `success: false` and the bytes are not ret
 over the cap retains the tail and the receipt's counts match the bytes produced; 13 each refusal
 class has a receipt row; 14 two runs with one `session_id` carry `seq` 1 and 2; 15 the sandbox object
 changes when the read roots change (control); 16 a tool registered at the `git` binary is refused.
+
+## Amendment 2 (2026-09-08): limits per platform, file-size semantics, profile identity
+
+Adopted on the first native run of the loop driver's exec contract on macOS.
+
+1. **Limits the platform cannot enforce per run are refused at load.** `[exec] limits` accepts
+   `cpu_seconds`, `address_space`, `file_size` and `nproc`. On macOS the address-space limit is not
+   settable and the process limit counts every process of the user, so a configuration naming either
+   is refused at config load with `[exec] limits.<name>: unsupported_on_platform`; the daemon does not
+   start and the reason is in the startup log. The receipt's `limits` carries `requested` (the config)
+   and `enforced` (the child's own report of the limits it received).
+2. **File-size semantics.** A write that crosses the file-size limit is truncated to the limit with no
+   signal; the signal fires on a write attempted at the limit. A run over the limit therefore ends by
+   signal 25 or, for a runtime that ignores that signal, by a failed write reported in its own stream.
+   The receipt's `exit_signal` and captured streams are the evidence, never the exit status alone.
+3. **Profile identity.** The seatbelt profile allows reads of the root directory, the system read
+   roots, the configured read roots and the run directory, and writes only under the run directory.
+   `exec.identity` reports the read roots, their digest, the profile template digest and the digest
+   algorithm, so a client can check its expectation of the sandbox before it runs anything.
+
+Acceptance arms added: 17 a configuration naming `address_space` or `nproc` refuses at startup with
+the named limit; 18 a run over `cpu_seconds` ends by signal 24 and one over `file_size` ends by
+signal 25 or a failed write, with the receipt's `enforced` limits equal to the configuration; 19
+`exec.identity` and the receipt's `sandbox` agree on the read-roots digest, and the digest changes
+when a read root is added (control).

--- a/docs/adr/ADR-182-git-dev-loop-verbs.md
+++ b/docs/adr/ADR-182-git-dev-loop-verbs.md
@@ -108,3 +108,95 @@ value planted in the keychain item is absent from every output); 10 a Gate deny 
 with the Gate decision and no `tool.check` call; 11 approving a fork pull request without the row is
 refused, and a fork merge never carries the administrator flag; 12 `git status` is identical before
 and after `git.checkout`.
+
+## Amendment 2 (2026-09-08): exact compares, actor-only credentials, dispositions, receipts
+
+Adopted on the second whole-file read against the loop driver's contract page. Each item is a
+contract the driver's tests bind to; the record above stands where not restated, and Amendment 1
+item 1 is amended again in item 3.
+
+1. **Exact compares on every ref move.** `git.branch(repo, name, from, expected?)`: `from` is a sha
+   or a ref name; when `expected` is given, `from` must resolve to it at call time. The ref is created
+   with `git update-ref refs/heads/<name> <sha> <zero-oid>`, a create-only compare-and-swap, so an
+   existing ref refuses and nothing is written. `git.commit(repo, branch, tree, message,
+   expected_head, session_id?)`: the new commit's parent is `expected_head` and the ref move is
+   `update-ref refs/heads/<branch> <new> <expected_head>`; a tip elsewhere refuses before any ref
+   moves. `git.push(repo, branch, expected_local, expected_remote, session_id?)`: `expected_local`
+   must equal the local tip at call time; `expected_remote` is required, a sha or an explicit `null`
+   meaning the remote branch must not exist, and omission refuses as `invalid_params`; the push is
+   `git push <remote> <expected_local>:refs/heads/<branch>
+   --force-with-lease=refs/heads/<branch>:<expected_remote>` after a fast-forward check, so a remote
+   that moves between the check and the push refuses at the server. `git.pr_review` submits its
+   review with `commit_id = expected_head` after reading the head from the platform; `git.pr_merge`
+   merges with the platform's match-head option, so a head that moves after the pre-check is refused
+   by the platform itself. Every other `expected_*` value is a 40-hex sha; absent or `null` refuses.
+   `git.branch.expected` stays optional.
+2. **Commits by plumbing.** `git.commit` builds the commit from the khive tree with
+   `hash-object -w --no-filters`, `mktree`, `commit-tree` and `update-ref`; no checkout, index or
+   working tree is touched; a path the manifest omits is a deletion; `100644` and `100755` are the
+   only modes. This replaces the Decision's detached-worktree materialization.
+3. **Actor-only credentials (amends Amendment 1 item 1).** `git.commit`, `git.push`, `git.pr_open`,
+   `git.pr_review` and `git.pr_merge` resolve the caller's `[git_write.actors]` row at every call; an
+   actor without a row refuses with reason `actor_unmapped`; these verbs have no daemon fallback and
+   `credential.source` takes only the value `actor`. Author name and email come only from that row;
+   the params `author`, `actor` and `credential` refuse as `invalid_params`. The credential value is
+   read through `[git_write] credential_resolver`, an argv template with an absolute program, no
+   shell and `{ref}` as its only template argument (default: the platform keychain lookup by
+   reference name), validated at startup; a resolver failure is `actor_unmapped`. The receipt carries
+   `credential: {source: "actor", ref, platform_identity}`.
+4. **No hooks, filters or configuration.** Every git invocation runs with
+   `-c core.hooksPath=/dev/null -c core.fsmonitor=false -c commit.gpgsign=false
+   -c credential.helper= -c core.sshCommand=/usr/bin/false`, `GIT_CONFIG_NOSYSTEM=1` and
+   `GIT_CONFIG_GLOBAL=/dev/null`; object writes use `--no-filters` and reads use `cat-file`, so clean
+   and smudge filters never run. Only `https` remotes are supported in this slice; another scheme
+   refuses with reason `remote_scheme`.
+5. **Repository and reviewer identity.** Before any platform write the CLI's reported slug and
+   visibility must both equal the configured expectation for `repo`. Self-approval is refused at the
+   platform login: the reviewer's login, read through its own credential, must differ from the pull
+   request author's login, so two actors on one platform account refuse, and two actor rows naming
+   the same credential reference refuse likewise. `git.pr_merge` requires an approved review on
+   `expected_head` from a login other than the author, read from the platform before the merge call.
+   The administrator flag needs the `git.pr_merge.admin` row and is never passed for a fork.
+6. **Dispositions.** Every receipt carries `disposition: not_committed | committed | unknown`. A
+   mutation writes its receipt row as `unknown` before the effect and updates it to `committed` or
+   `not_committed` afterwards; a lost reply or a failed audit append leaves `unknown` or `committed`
+   in the durable row, never a refusal, and a caller never retries a mutation. `git.reconcile(receipt)`
+   is read-only: it re-reads the ref or the pull request and settles an `unknown` row to what the
+   platform holds.
+7. **Receipts.** `git.receipts(repo?, session_id?, limit, offset)` returns `{receipts, next_offset}`
+   scoped to the calling actor; an `actor` filter naming another actor refuses. A receipt carries
+   `id`, `namespace`, `actor`, `session_id`, `verb`, `repo`, `inputs`, `gate: {decision, source:
+   "git_write.allowed", id}` (the allow-list entry index, or `deny:<reason>`), `policy: {decision,
+   source, id}` (null when the gate denied, because `tool.check` was never called), `fork_policy` on a
+   cross-repository pull request, `credential`, `timing: {started_at, finished_at}`, `disposition`,
+   `result` and `reason`. `git.gates(repo)` lists the effective allow-list rows with those ids. No
+   receipt, error or table row carries a credential value.
+8. **Trees and diffs.** `git.checkout(repo, ref)` returns `{commit, tree}` from `rev-parse`,
+   `ls-tree -r` and `cat-file blob`; symlink and submodule entries refuse. `git.diff(repo,
+   input_kind, base, head)` with `input_kind` `commits` or `trees` runs `git diff-tree -p
+   --no-ext-diff --no-textconv --no-color --no-renames <base> <head>` and `--numstat` for
+   `summary: {files, additions, deletions}`; tree inputs are written to a scratch repository with
+   `mktree` first. The receipt's `inputs` are exactly `{input_kind, base, head}`.
+9. **Test-only faults.** `[git_write] contract_faults = true` refuses at startup unless the binary was
+   built with the `contract-faults` feature, and the refusal is named in the startup log.
+10. **Operator read (Proposed).** A policy-gated `git.receipts.all` for an operator actor enters as
+    Proposed so the audit ledger has a verb; the driver's tests do not require it.
+
+Acceptance arms added: 13 an existing ref refuses `git.branch` with nothing written; 14 a moved
+parent refuses `git.commit` before any ref moves, and a committed tree equals its manifest with the
+index and working tree unchanged; 15 `author`, `actor` and `credential` params refuse, and an
+unmapped actor refuses with no daemon credential read; 16 hostile hooks, filters and configuration
+leave no marker and the committed bytes are exact; 17 a moved local tip, a moved remote tip, and a
+remote moved at the ref-move seam each refuse with both ref sets unchanged; 18 `force`,
+`force_with_lease` and `refspec` in every form refuse; 19 an omitted `expected_remote` refuses with
+no effect, an explicit `null` creates only an absent remote branch, and an explicit `null` against an
+existing rival head preserves the rival; 20 a slug or visibility mismatch refuses `git.pr_open`; 21
+approval by the author's login or by a second actor on the same platform account refuses, and a
+review binds `commit_id` to `expected_head`; 22 a head moved before or after the check refuses the
+merge, and `ask`, `deny`, an expired grant, a foreign grant, a wrong scope and a missing review each
+refuse; 23 a lost reply after a committed push or merge leaves a `committed` or `unknown` row with
+exactly one native call, and `git.reconcile` settles it to `committed`; 24 receipts page by
+`session_id`, a foreign `actor` filter refuses, and a planted decoy credential value is absent from
+every reply, receipt, table row and raw record; 25 the resolver is read exactly once per mutation
+and returns the rotated value; 26 a gate deny records no `tool.check` call and a null policy, while a
+gate allow records exactly one call with the policy id.


### PR DESCRIPTION
Two amendments adopted from the loop driver's contract tests.

ADR-181 Amendment 2: limits the platform cannot enforce per run are refused at config load with `unsupported_on_platform`; the file-size limit's truncate-then-signal semantics; `exec.identity` as the sandbox identity a client checks before running.

ADR-182 Amendment 2: exact compare on every ref move (`expected`, `expected_head`, `expected_local`, `expected_remote` with explicit `null` for an absent remote branch), commits by plumbing, actor-only credentials through a validated resolver, no hooks or filters or configuration, repository and reviewer identity at the platform login, `disposition` with a read-only `git.reconcile`, caller-scoped receipts with `gate` and `policy`, tree and diff reads, and the test-only `contract-faults` feature.
