### PR TITLE
docs(adr): ADR-181 and ADR-182 Amendment 3

### DIFF
--- a/docs/adr/ADR-181-exec-verb-sandboxed-run.md
+++ b/docs/adr/ADR-181-exec-verb-sandboxed-run.md
@@ -142,3 +142,39 @@ the named limit; 18 a run over `cpu_seconds` ends by signal 24 and one over `fil
 signal 25 or a failed write, with the receipt's `enforced` limits equal to the configuration; 19
 `exec.identity` and the receipt's `sandbox` agree on the read-roots digest, and the digest changes
 when a read root is added (control).
+
+## Amendment 3 (2026-09-08): declared write paths, sequence allocation, version control at the kernel boundary
+
+Adopted after the review that followed the first exec implementation. Each item makes exact a rule
+the implementation already followed loosely; nothing above is withdrawn.
+
+1. **Declared write paths are a prefix set at path boundaries.** Each entry of `declared_write_paths`
+   is a tree-relative path under the same validation as a tree entry (no leading `/`, no empty, `.`
+   or `..` segment). An entry covers exactly itself and every path below it separated by `/`: `src`
+   covers `src` and `src/main.rs`, never `src.bak`. A change is any path whose bytes or mode differ
+   from `tree_in`, any path added, and any path missing at the end of the run, and every change is
+   tested against the set. An undeclared change goes to the receipt's `undeclared_changes`, its bytes
+   are not stored, `tree_out` carries the `tree_in` entry for that path (a deleted file reappears
+   with its old content, an added file is absent), and `success` is false even when the exit status
+   is zero. An absent `declared_write_paths` declares every path.
+2. **Sequence numbers are allocated by the insert.** The per-session `seq` is computed inside the
+   statement that inserts the receipt row (`MAX(seq) + 1` over the namespace and session), and a
+   unique index over `(namespace, session_id, seq)` for session rows turns any duplicate into a
+   constraint failure instead of an overlap. The column is authoritative: `exec.run`, `exec.receipt`
+   and `exec.runs` all report it, a refusal consumes a number like a run, and a run without a session
+   carries `null`.
+3. **Version control is denied at the kernel boundary.** Beside the registered-binary refusal of
+   Amendment 1 item 8, the seatbelt profile denies `process-exec` for any executable whose file name
+   is `git` or `gh` or starts with `git-`, and for every canonical path in the `[exec] never` set. A
+   run whose registered binary is allowed but which reaches git from inside (a shell, a build script,
+   a package manager hook) gets an operation-not-permitted failure from the kernel, visible in the
+   child's exit status and captured stderr, and the receipt records it like any other failed run. The
+   profile template digest changes with this rule; `exec.identity` reports the `never` set beside it.
+
+Acceptance arms added: 20 with `declared_write_paths = ["a", "b"]` a write to `a/x`, a new `a/y`
+and a deletion of `b` are listed in `changed`, a write to `a.bak` is listed in `undeclared_changes`
+with its input entry kept in `tree_out`, and `success` is false with exit status zero; 21 two runs
+started concurrently in one session receive `seq` 1 and 2, `exec.runs` for the session lists both,
+and `exec.receipt` reports the same number as the run reply; 22 a shell run that invokes
+`git --version` and one that invokes a `never` path both end with a non-zero status and the kernel's
+refusal in stderr, while the same shell invoking `/bin/echo` exits zero (control).

--- a/docs/adr/ADR-182-git-dev-loop-verbs.md
+++ b/docs/adr/ADR-182-git-dev-loop-verbs.md
@@ -200,3 +200,29 @@ exactly one native call, and `git.reconcile` settles it to `committed`; 24 recei
 every reply, receipt, table row and raw record; 25 the resolver is read exactly once per mutation
 and returns the rotated value; 26 a gate deny records no `tool.check` call and a null policy, while a
 gate allow records exactly one call with the policy id.
+
+## Amendment 3 (2026-09-08): credential selection bound to the resolved caller, fork merges recorded
+
+Adopted after the review that followed the first exec implementation, which read this record beside
+it. Item 1 makes Amendment 2 item 3 exact; item 2 records an argument rather than a change.
+
+1. **The actor is the identity the runtime resolved, never a value the call carries.** The
+   `[git_write.actors]` row that selects a credential is looked up by the actor label the runtime
+   resolved for the request before the handler ran (ADR-096: the peer's declared identity on the
+   daemon socket, or the configured actor of an in-process dispatch), which is the label the receipt
+   records as `actor`. No request parameter, no environment variable read by the handler and no
+   repository configuration takes part in that lookup; the `actor`, `author` and `credential` params
+   refuse (Amendment 2 item 3) so that a caller cannot name a row. A contract fixture therefore binds
+   an identity by running a process as that actor, not by passing a field. Two processes with the
+   same resolved label share the row, which is a trust decision the deployment takes in
+   configuration.
+2. **Fork merges (recorded argument).** The review asked that a merge of a cross-repository pull
+   request require a human decision. The policy row `git.pr_merge.fork` is that decision: a person
+   writes it, it names the actor, and without it every fork merge refuses (Amendment 1 item 3). A
+   per-call prompt is not available to a daemon with no console, and the row leaves the person in
+   the loop and the decision in the audit. No rule changes.
+
+Acceptance arms added: 27 two processes resolved as different actors get different credential
+references for the same call, a process whose resolved actor has no row refuses `actor_unmapped`
+while the same call from a mapped actor proceeds (control), and the receipt's `actor` equals the
+resolved label in every case.


### PR DESCRIPTION
Amendment 3 to two accepted records, docs only.

ADR-181 (exec):
- `declared_write_paths` entries cover themselves and every path below them at a `/` boundary; a change is any byte, mode, addition or deletion difference against `tree_in`; undeclared changes keep the input entry in `tree_out` and make `success` false.
- The per-session `seq` is allocated inside the receipt insert and backed by a unique index over `(namespace, session_id, seq)`; the column is what every reader reports.
- The sandbox profile denies `process-exec` for `git`, `gh`, `git-*` and every path in the `[exec] never` set, beside the existing registered-binary refusal.

ADR-182 (git):
- The `[git_write.actors]` row is selected by the actor the runtime resolved for the request, never by a request field.
- The fork-merge decision is the `git.pr_merge.fork` policy row; recorded as an argument, no rule change.

Acceptance arms 20-22 (ADR-181) and 27 (ADR-182) added. The matching exec code lands in the exec pack PR.
