### PR TITLE
docs(adr): ADR-174 Amendment 2

### DIFF
--- a/docs/adr/ADR-174-ordered-streams-append.md
+++ b/docs/adr/ADR-174-ordered-streams-append.md
@@ -417,3 +417,36 @@ serial execution under the writer lock.
    refusals promoted to whole-batch refusals, arm 4 goes red; with per-stream numbering assigned
    outside the transaction, arm 6 goes red; with per-member mode run as one transaction, arm 7's
    interleaving control goes red.
+
+## Amendment 2 (2026-09-08): the ledger refuses updates, an isolating fixture for the check constraint
+
+Adopted on the source audit that preceded the first implementation of Amendment 1. Nothing above is
+withdrawn; item 1 adds a guard the Decision claimed by implication, item 2 corrects an acceptance
+arm that could not fail.
+
+1. **No update on the ledger.** The schema guards `note_streams` against inserts that break order or
+   membership and against deletes, and says nothing about updates, so a direct `UPDATE note_streams`
+   could move a `seq` or rebind a `note_id` past every invariant claimed above. A sixth trigger
+   closes it, in the same migration as the rest of the streams schema:
+
+```sql
+CREATE TRIGGER IF NOT EXISTS refuse_stream_ledger_update
+BEFORE UPDATE ON note_streams
+BEGIN
+    SELECT RAISE(ABORT, 'stream_member');
+END;
+```
+
+A ledger row is immutable once written; the only write to `note_streams` is an append. Acceptance
+7 gains, in its direct-statement list, an `UPDATE note_streams` that changes `seq` or `note_id`,
+and acceptance 8 counts six triggers.
+2. **The check constraint is overdetermined for `seq = 0`.** `refuse_stream_gap` refuses `seq = 0`
+on its own, because zero is never one more than the head, so dropping `CHECK (seq > 0)` alone
+leaves acceptance 7's `seq = 0` arm green and proves nothing about the check. The mutation arm for
+the check drops `refuse_stream_gap` as well: with both removed the `seq = 0` insert succeeds
+(red); with only the trigger removed it still refuses through the check (control). Acceptance 8
+reads accordingly. The check stays in the schema as the one guard that does not depend on a head
+read.
+3. **Count and head are read from one snapshot.** `stream.stat` reads `COUNT(*)` and `MAX(seq)` in
+one statement over the same rows, so the equality acceptance 7 asserts compares two readings of
+one snapshot, and a divergence between them is a ledger defect, never a race between two reads.

--- a/docs/adr/ADR-174-ordered-streams-append.md
+++ b/docs/adr/ADR-174-ordered-streams-append.md
@@ -437,9 +437,14 @@ BEGIN
 END;
 ```
 
-A ledger row is immutable once written; the only write to `note_streams` is an append. Acceptance
-7 gains, in its direct-statement list, an `UPDATE note_streams` that changes `seq` or `note_id`,
-and acceptance 8 counts six triggers.
+A ledger row is immutable once written; the only write to `note_streams` is an append. The
+membership trigger `refuse_stream_foreign_note` also refuses an insert naming a `note_id` already in
+the ledger (`OR EXISTS (SELECT 1 FROM note_streams WHERE note_id = NEW.note_id)` in its `WHEN`),
+because `INSERT OR REPLACE` resolves the `UNIQUE (note_id)` conflict by deleting the old row without
+firing the delete trigger while recursive triggers are off, which would re-seat an entry at a new
+`seq` past every guard above. Acceptance 7 gains, in its direct-statement list, an
+`UPDATE note_streams` that changes `seq` or `note_id` and an `INSERT OR REPLACE` naming a member's
+`note_id` at the next `seq`, each leaving count and head unchanged; acceptance 8 counts six triggers.
 2. **The check constraint is overdetermined for `seq = 0`.** `refuse_stream_gap` refuses `seq = 0`
 on its own, because zero is never one more than the head, so dropping `CHECK (seq > 0)` alone
 leaves acceptance 7's `seq = 0` arm green and proves nothing about the check. The mutation arm for


### PR DESCRIPTION
Amendment 2 to ADR-174, docs only, found on the source audit before the streams schema lands.

- The stream ledger gains a sixth trigger refusing any `UPDATE` on `note_streams`; a ledger row is append-only once written. Acceptance 7 adds the direct-statement arm, acceptance 8 counts six triggers.
- `CHECK (seq > 0)` is overdetermined by the gap trigger for `seq = 0`, so its mutation arm now strips the gap trigger as well, with the trigger-only removal as the control.
- `stream.stat` reads count and head from one statement over the same rows.
