### PR TITLE
docs(adr): ADR-182 Amendment 4

### DIFF
--- a/docs/adr/ADR-182-git-dev-loop-verbs.md
+++ b/docs/adr/ADR-182-git-dev-loop-verbs.md
@@ -226,3 +226,39 @@ Acceptance arms added: 27 two processes resolved as different actors get differe
 references for the same call, a process whose resolved actor has no row refuses `actor_unmapped`
 while the same call from a mapped actor proceeds (control), and the receipt's `actor` equals the
 resolved label in every case.
+
+## Amendment 4 (2026-09-08): symbolic refs, reconcile evidence, the tool pack at call time, gates on reads
+
+Adopted during the first implementation of the local slice, from findings the implementer read off
+the source before running anything. Each item records a ruling already given; nothing above is
+withdrawn.
+
+1. **Symbolic refs.** Every `update-ref` compare-and-swap runs with `--no-deref`, so the compare and
+   the move apply to the named ref itself; a branch ref observed as symbolic refuses before any move
+   with reason `ref_symbolic`. The expected-old semantics of Amendment 2 item 1 are unchanged.
+2. **Reconcile evidence.** Every ref move runs `update-ref --create-reflog -m
+   khive-receipt:<receipt-id>`. `git.reconcile` settles an `unknown` row to `committed` only when the
+   reflog of the moved ref carries the marker for that receipt together with the new sha. Equality of
+   the current head with the intended sha never settles anything, because a rival can install the
+   same sha (a deterministic commit, a concurrent create), and a pruned or absent reflog leaves
+   `unknown`.
+3. **The tool pack at call time.** The git pack keeps its kg dependency for the legacy verbs. The
+   verbs of this record require the tool pack when called and, when its tables are absent, fail
+   closed after the gate evaluated, with reason `policy_unavailable` and receipt
+   `policy: {decision: "deny", source: "policy_unavailable", id: null}`, so `policy` is null exactly
+   when the gate denied (Amendment 2 item 7). A boot-time dependency is a later decision.
+4. **Gates on reads, and `git.branch` without a credential.** `git.checkout`, `git.diff` and
+   `git.gates` gate on a repo-only match of the allow-list, and `gate.id` is the lowest matching entry
+   index; `git.reconcile` gates on the repo stored in the receipt; `git.receipts` is an audit read
+   scoped to the calling actor, is not filtered by the current allow-list (removing a row never hides
+   history) and writes no receipt of its own, as `git.gates` writes none. `git.branch` takes no
+   credential and no actor row; its receipt carries `credential: null`.
+5. **Daemon fingerprint.** The daemon's configuration fingerprint covers the whole `[git_write]`
+   section (allowed rows, actors, resolver, faults), so any change to it retires the running daemon.
+
+Acceptance arms added: 28 a branch ref made symbolic refuses `git.branch` and `git.commit` with
+`ref_symbolic` and nothing moves, while the same call on a plain ref proceeds (control); 29 a receipt
+left `unknown` after a rival installed the intended sha stays `unknown` under `git.reconcile`, and
+one whose reflog carries its marker settles to `committed`; 30 with the tool pack absent,
+`git.commit` with a tree refuses `policy_unavailable` with the gate decision recorded, while the
+legacy `git.commit` with `paths` still runs.


### PR DESCRIPTION
Amendment 4 to ADR-182, docs only, recording rulings given while the local slice of the git verbs is being implemented.

- Every `update-ref` compare-and-swap takes `--no-deref`; a symbolic branch ref refuses with `ref_symbolic`.
- Ref moves write a reflog entry carrying the receipt id; `git.reconcile` settles an `unknown` row only on that evidence, never on head equality.
- The new verbs require the tool pack at call time and fail closed as `policy_unavailable` when its tables are absent; the legacy verbs keep their kg-only dependency.
- Read verbs gate on a repo-only allow-list match; `git.receipts` is an actor-scoped audit read outside the allow-list; `git.branch` carries no credential.
- The daemon fingerprint covers the whole `[git_write]` section.

Acceptance arms 28 to 30 added.
