### PR TITLE
docs(adr): ADR-182 Amendment 5

### DIFF
--- a/docs/adr/ADR-182-git-dev-loop-verbs.md
+++ b/docs/adr/ADR-182-git-dev-loop-verbs.md
@@ -262,3 +262,28 @@ left `unknown` after a rival installed the intended sha stays `unknown` under `g
 one whose reflog carries its marker settles to `committed`; 30 with the tool pack absent,
 `git.commit` with a tree refuses `policy_unavailable` with the gate decision recorded, while the
 legacy `git.commit` with `paths` still runs.
+
+## Amendment 5 (2026-09-08): reconcile needs the marker and the ref, policy through the registry
+
+Adopted the same day as Amendment 4, from two further source readings by the implementer. Item 1
+tightens Amendment 4 item 2; item 2 fixes the mechanism behind Amendment 4 item 3.
+
+1. **The marker is necessary, not sufficient.** Git's files backend appends the reflog entry before
+   it installs the ref, and a failed install does not remove the entry, so a process lost between the
+   two leaves the marker with no ref move. `git.reconcile` settles an `unknown` row to `committed`
+   only when both hold: the reflog of the ref carries `khive-receipt:<receipt-id>` with the new sha,
+   and that sha is the current head of the ref or an ancestor of it. A marker without the ref
+   installed, and a head equal to the sha without the marker, both leave `unknown`. No claim of
+   crash atomicity is made anywhere in help or receipts.
+2. **Policy through the registry.** Pack backends may differ (ADR-028), so a decision read through
+   the git pack's own backend handle could see stale tool rows. The verbs of this record obtain their
+   policy decision through the registry dispatch of `tool.check`, carrying the caller's identity and
+   namespace, never by reading the tool tables directly; the decision is taken before any write
+   begins and no writer or lock is held across the dispatch. A failed or absent dispatch is the
+   receipted `policy_unavailable` of Amendment 4 item 3.
+
+Acceptance arms added: 31 a hand-appended reflog entry carrying a receipt's marker while the ref
+still points elsewhere leaves that receipt `unknown` under `git.reconcile`, and the same marker with
+the ref advanced past the sha settles to `committed`; 32 with the git and tool packs on different
+backends and a stale allow row planted in the git backend beside a deny row in the tool backend, the
+verb refuses with the tool pack's decision and id.


### PR DESCRIPTION
Amendment 5 to ADR-182, docs only, two tightenings found by reading Git and the runtime source.

- Reconcile: Git's files backend appends the reflog entry before installing the ref and a failed install keeps the entry, so the receipt marker is necessary, not sufficient. An `unknown` row settles to `committed` only with the marker present and the sha at or below the current head. No crash-atomicity claim anywhere.
- Policy: pack backends may differ, so the decision comes through the registry dispatch of `tool.check` with the caller's identity, never by reading the tool tables through the git pack's own backend handle; taken before any write, no lock held across it.

Acceptance arms 31 and 32 added.
