### PR TITLE
fix(runtime): assert the served protocol version in the legacy decode test

### DIFF
--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -3340,7 +3340,7 @@ mod tests {
         let legacy: LegacyV4Response = serde_json::from_slice(&encoded).expect("legacy v4 decode");
         assert!(!legacy.ok);
         assert_eq!(legacy.error.as_deref(), Some("audit failed"));
-        assert_eq!(legacy.daemon_protocol_version, 4);
+        assert_eq!(legacy.daemon_protocol_version, PROTOCOL_VERSION);
     }
 
     #[tokio::test]


### PR DESCRIPTION
The legacy-decoder test in the daemon module pinned the response's version
field to the literal `4`. The served constant is now `5`, so the assertion
failed against a frame that was otherwise correct, and because the suite runs
fail-fast the failure also stopped roughly 1400 later tests from running.

What the test exists to show is that a response struct shaped for the older
protocol still decodes a current frame, including the version field it carries.
Asserting the constant preserves that subject and does not go stale on the next
bump. The neighbouring fixtures that carry literal mismatched versions (`0`,
`3`, `99`) are untouched: there the literal is the input under test, not an
expectation about what the daemon serves.
