### PR TITLE
fix(vamana): readers take the publication lock; only the warm daemon builds a corpus index

### DIFF
--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -151,6 +151,9 @@ pub async fn run(args: Args, registry: &TransportRegistry) -> anyhow::Result<()>
     // before `build_server` runs migrations/FTS DDL unguarded — see
     // `acquire_daemon_boot_guard`. Non-daemon callers keep the best-effort
     // lock (dropped right after construction below).
+    if args.daemon {
+        khive_runtime::daemon::mark_warm_index_host();
+    }
     #[cfg(unix)]
     let boot_guard = if args.daemon {
         Some(khive_runtime::daemon::acquire_daemon_boot_guard()?)

--- a/crates/khive-pack-knowledge/src/knowledge/vamana.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/vamana.rs
@@ -68,6 +68,8 @@ enum AnnWarmFailure {
     EmptyCorpus,
     Operational,
     Interrupted,
+    /// Not the warm index host; the build belongs to the daemon.
+    NotWarmHost,
 }
 
 /// Result of one load/rebuild worker. Kept separate from `AnnWarmState` so a
@@ -78,6 +80,10 @@ pub(crate) enum AnnWarmOutcome {
     Ready,
     Empty,
     Failed,
+    /// This process is not the warm index host and the only way forward was a
+    /// corpus-scale build. Retryable exactly like `Failed`: the caller serves
+    /// its degraded path for this request and the daemon builds.
+    Declined,
 }
 
 /// Lifecycle for one per-{namespace, model} warm slot.
@@ -156,6 +162,15 @@ pub(crate) struct AnnState {
     checkpoint_locks: std::sync::Mutex<HashMap<AnnKey, std::sync::Weak<tokio::sync::Mutex<()>>>>,
     /// Idempotence guard for the pack-lifetime file-generation watcher.
     rotation_watch_started: AtomicBool,
+    /// Whether this process may build an ANN index from the full corpus and
+    /// publish the result. A corpus build is minutes of CPU and a segment
+    /// rewrite every other reader on the index root must then absorb, and it
+    /// pays for itself only in a process that outlives the request. Serving
+    /// processes set this from the daemon role at construction; the admin
+    /// reindex path sets it unconditionally, because building is what it was
+    /// invoked to do. A process without it serves what is already persisted,
+    /// or serves degraded and leaves the build to the daemon.
+    builds_corpus_indexes: bool,
     /// Test-only rendezvous for `finish_warm`'s Ready publish (issue #2340
     /// regression coverage) — see `run_finish_warm_ready_test_hook`.
     #[cfg(test)]
@@ -174,8 +189,17 @@ pub(crate) struct FinishWarmReadyTestHook {
 
 pub(crate) type SharedAnn = Arc<AnnState>;
 
+/// Shared ANN state for a process that builds corpus indexes: the warm daemon
+/// and the admin reindex path.
 pub(crate) fn new_shared() -> SharedAnn {
+    new_shared_for_role(true)
+}
+
+/// Shared ANN state whose corpus-build authority is stated explicitly. Serving
+/// packs pass the daemon role; see `AnnState::builds_corpus_indexes`.
+pub(crate) fn new_shared_for_role(builds_corpus_indexes: bool) -> SharedAnn {
     Arc::new(AnnState {
+        builds_corpus_indexes,
         indexes: RwLock::new(HashMap::new()),
         warm_states: std::sync::Mutex::new(HashMap::new()),
         next_warm_attempt_id: AtomicU64::new(1),
@@ -469,6 +493,13 @@ async fn finish_warm(mut permit: AnnWarmPermit, outcome: AnnWarmOutcome) {
             let next = AnnWarmState::Failed {
                 generation: permit.generation,
                 error: AnnWarmFailure::Operational,
+            };
+            finish_warm_state(&mut permit, next);
+        }
+        AnnWarmOutcome::Declined => {
+            let next = AnnWarmState::Failed {
+                generation: permit.generation,
+                error: AnnWarmFailure::NotWarmHost,
             };
             finish_warm_state(&mut permit, next);
         }
@@ -3139,6 +3170,14 @@ async fn classify_and_adopt_segment(
             return SegmentOutcome::Cold;
         }
         bridge.set_applied_seq(new_s);
+        // Replay is cheap and in memory; the checkpoint that follows it is a full
+        // segment publication. A process that is not the warm index host serves the
+        // replayed bridge and publishes nothing — same answers, no rewrite for every
+        // other reader on the root to absorb.
+        if !ann.builds_corpus_indexes {
+            install_if_fresher(ann, key, bridge.with_generation(target_generation)).await;
+            return SegmentOutcome::Installed;
+        }
         let checkpointed = checkpoint_raise_compact_readopt(
             rt,
             ann,
@@ -3162,6 +3201,12 @@ async fn classify_and_adopt_segment(
             tracing::info!(namespace = %ns, model = %model, tail, live,
                 "tail above rebuild threshold; serving stale segment during rebuild");
             install_if_fresher(ann, key, bridge.with_generation(target_generation)).await;
+            // Rule 8 serves stale and lets the caller rebuild. Only the warm index
+            // host has a rebuild to fall through to; for anyone else the stale
+            // segment IS the answer for this request.
+            if !ann.builds_corpus_indexes {
+                return SegmentOutcome::Installed;
+            }
         }
         Err(e) => {
             tracing::warn!(error = %e, dir = %seg_dir.display(),
@@ -3191,6 +3236,15 @@ pub(crate) async fn ensure_ann_for_model(
     let ns = token.namespace().as_str().to_owned();
     let key = AnnKey::new(&ns, model);
 
+    // A corpus-scale build is minutes of CPU and a segment rewrite every other
+    // reader on the root must then take. It pays for itself only in a process
+    // that outlives the request, so only the warm daemon does it; everyone else
+    // serves what is already persisted, or serves degraded and lets the daemon
+    // build. The same answer gates the registry writes below: publishing a
+    // rebuild sentinel is an authority act, and a process that will not do the
+    // rebuild must not claim it.
+    let warm_host = ann.builds_corpus_indexes;
+
     // Registration precedes every scan or legacy serve. Local absence of a
     // bridge cannot prove global first use: a peer may still hold stale v1 or
     // Owned state after this row was administratively removed. Every absent
@@ -3199,11 +3253,23 @@ pub(crate) async fn ensure_ann_for_model(
     let mut force_rebuild = force_rebuild_required(ann, &key);
     match read_own_watermark(rt, &ns, model).await {
         Ok(Some(watermark)) if watermark < 0 => {
+            if !warm_host {
+                tracing::debug!(namespace = %ns, model = %model,
+                    "ANN rebuild is pending and this process is not the warm index host; \
+                     declining");
+                return AnnWarmOutcome::Declined;
+            }
             mark_force_rebuild(ann, &key);
             force_rebuild = true;
         }
         Ok(Some(_)) => {}
         Ok(None) => {
+            if !warm_host {
+                tracing::debug!(namespace = %ns, model = %model,
+                    "ANN registry row absent and this process is not the warm index host; \
+                     declining rather than claiming the rebuild");
+                return AnnWarmOutcome::Declined;
+            }
             if let Err(error) = prepare_authoritative_rebuild(rt, ann, &key).await {
                 tracing::warn!(error = %error, "failed to fence ANN registry loss");
                 return AnnWarmOutcome::Failed;
@@ -3307,6 +3373,12 @@ pub(crate) async fn ensure_ann_for_model(
 
     // 4. Rebuild fallthrough — build from vector store, persist and re-adopt
     // the v2 segment, then raise the registry watermark and compact the log.
+    if !warm_host {
+        tracing::info!(namespace = %ns, model = %model,
+            "no adoptable ANN segment and this process is not the warm index host; \
+             serving degraded and leaving the corpus build to the daemon");
+        return AnnWarmOutcome::Declined;
+    }
     let scan_authority = match prepare_full_corpus_scan(rt, ann, &key).await {
         Ok(authority) => authority,
         Err(error) => {
@@ -6370,6 +6442,42 @@ mod tests {
             ready,
             "after a rebuild error the wait must keep polling and observe the \
              retry's install, not short-circuit false"
+        );
+    }
+
+    /// A process that is not the warm index host must not build the corpus, and —
+    /// the part that matters on a shared index root — must not publish a segment or
+    /// claim the rebuild in the registry on its way to declining. Claiming without
+    /// building would fence every other consumer behind a rebuild nobody is doing.
+    #[tokio::test]
+    async fn a_non_warm_host_declines_the_corpus_build_and_writes_nothing() {
+        let dir = TempDir::new().expect("tempdir");
+        let rt = file_rt_with_embedder(dir.path().join("test.db"));
+        let token = rt.authorize(Namespace::local()).expect("authorize");
+        seed_warm_corpus(&rt, &token, 3).await;
+
+        let ann = new_shared_for_role(false);
+        let outcome = ensure_ann_for_model(&rt, &token, &ann, WARM_TEST_MODEL).await;
+        assert_eq!(outcome, AnnWarmOutcome::Declined);
+
+        let key = AnnKey::new("local", WARM_TEST_MODEL);
+        assert!(
+            !ann.indexes.read().await.contains_key(&key),
+            "a declined warm must not install an index"
+        );
+        if let Some(seg_dir) = ann_segment_dir(&rt, "local", WARM_TEST_MODEL) {
+            assert!(
+                !seg_dir.join("metadata.bin").exists(),
+                "a declined warm must not publish a segment"
+            );
+        }
+        assert!(
+            matches!(
+                read_own_watermark(&rt, "local", WARM_TEST_MODEL).await,
+                Ok(None)
+            ),
+            "a declined warm must leave the registry untouched: no row, and in \
+             particular no rebuild sentinel this process will never satisfy"
         );
     }
 

--- a/crates/khive-pack-knowledge/src/pack.rs
+++ b/crates/khive-pack-knowledge/src/pack.rs
@@ -60,7 +60,9 @@ impl KnowledgePack {
         let brain_profile = runtime.config().brain_profile.clone();
         Self {
             runtime,
-            ann: vamana::new_shared(),
+            // Serving processes build corpus indexes only when they are the warm
+            // daemon: see `AnnState::builds_corpus_indexes`.
+            ann: vamana::new_shared_for_role(khive_runtime::daemon::is_warm_index_host()),
             section_posteriors: Mutex::new(HashMap::new()),
             brain_profile,
         }

--- a/crates/khive-pack-knowledge/src/pack.rs
+++ b/crates/khive-pack-knowledge/src/pack.rs
@@ -57,12 +57,18 @@ impl Pack for KnowledgePack {
 impl KnowledgePack {
     /// Create a new pack bound to the given runtime, initializing a shared ANN index.
     pub fn new(runtime: KhiveRuntime) -> Self {
+        Self::new_with_index_role(runtime, true)
+    }
+
+    /// As [`Self::new`], but states whether this process may build the atom
+    /// index from the full corpus. See `MemoryPack::new_with_index_role` for the
+    /// reasoning; the two packs share one index root per model family and the
+    /// same cost.
+    pub fn new_with_index_role(runtime: KhiveRuntime, builds_corpus_indexes: bool) -> Self {
         let brain_profile = runtime.config().brain_profile.clone();
         Self {
             runtime,
-            // Serving processes build corpus indexes only when they are the warm
-            // daemon: see `AnnState::builds_corpus_indexes`.
-            ann: vamana::new_shared_for_role(khive_runtime::daemon::is_warm_index_host()),
+            ann: vamana::new_shared_for_role(builds_corpus_indexes),
             section_posteriors: Mutex::new(HashMap::new()),
             brain_profile,
         }
@@ -81,7 +87,10 @@ impl khive_runtime::PackFactory for KnowledgePackFactory {
     }
 
     fn create(&self, runtime: KhiveRuntime) -> Box<dyn khive_runtime::PackRuntime> {
-        Box::new(KnowledgePack::new(runtime))
+        Box::new(KnowledgePack::new_with_index_role(
+            runtime,
+            khive_runtime::daemon::is_warm_index_host(),
+        ))
     }
 
     fn create_resolver(

--- a/crates/khive-pack-memory/src/ann.rs
+++ b/crates/khive-pack-memory/src/ann.rs
@@ -66,6 +66,14 @@ pub(crate) struct AnnBridge {
 
 /// Shared model-index cache with single-flight and freshness coordination.
 pub(crate) struct AnnState {
+    /// Whether this process may build the memory index from the full corpus and
+    /// publish the result. A corpus build is minutes of CPU and a segment
+    /// rewrite every other reader on the index root must then absorb, and it
+    /// pays for itself only in a process that outlives the request. Serving
+    /// processes set this from the daemon role at construction; the admin
+    /// reindex path sets it unconditionally, because building is what it was
+    /// invoked to do.
+    pub(crate) builds_corpus_indexes: bool,
     indexes: RwLock<HashMap<AnnKey, AnnBridge>>,
     /// Synchronous so `WarmingGuard::drop` can release it on every exit path.
     warming: std::sync::Mutex<HashSet<AnnKey>>,
@@ -110,8 +118,17 @@ pub(crate) struct AnnState {
 
 pub(crate) type SharedAnn = Arc<AnnState>;
 
+/// Shared ANN state for a process that builds corpus indexes: the warm daemon
+/// and the admin reindex path.
 pub(crate) fn new_shared() -> SharedAnn {
+    new_shared_for_role(true)
+}
+
+/// Shared ANN state whose corpus-build authority is stated explicitly. The
+/// serving pack passes the daemon role; see `AnnState::builds_corpus_indexes`.
+pub(crate) fn new_shared_for_role(builds_corpus_indexes: bool) -> SharedAnn {
     Arc::new(AnnState {
+        builds_corpus_indexes,
         indexes: RwLock::new(HashMap::new()),
         warming: std::sync::Mutex::new(HashSet::new()),
         model_locks: Mutex::new(HashMap::new()),
@@ -183,10 +200,38 @@ const DURABLE_EPOCH_CHECK_INTERVAL: std::time::Duration = std::time::Duration::f
 const DURABLE_EPOCH_CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_secs(0);
 
 /// Delay between chained rebuild tasks so continuous writes coalesce.
+///
+/// One second coalesces nothing against a fleet that writes continuously: the
+/// chain re-enqueues before the next write arrives, so it never idles and the
+/// index is rebuilt and republished on a cadence set by nothing in particular.
+/// The chain exists so a write converges without a reader, not to keep readers
+/// fresh — a recall warms on demand at request time — so the window it should
+/// use is the one that batches a burst of writes into one build. Override with
+/// `KHIVE_ANN_REBUILD_DEBOUNCE_MS`; a malformed value falls back to the default.
 #[cfg(not(test))]
-const REBUILD_CHAIN_DEBOUNCE: std::time::Duration = std::time::Duration::from_secs(1);
+const REBUILD_CHAIN_DEBOUNCE_DEFAULT: std::time::Duration = std::time::Duration::from_secs(30);
 #[cfg(test)]
-const REBUILD_CHAIN_DEBOUNCE: std::time::Duration = std::time::Duration::from_millis(5);
+const REBUILD_CHAIN_DEBOUNCE_DEFAULT: std::time::Duration = std::time::Duration::from_millis(5);
+
+fn rebuild_chain_debounce() -> std::time::Duration {
+    resolve_rebuild_chain_debounce(
+        std::env::var("KHIVE_ANN_REBUILD_DEBOUNCE_MS").ok().as_deref(),
+        REBUILD_CHAIN_DEBOUNCE_DEFAULT,
+    )
+}
+
+/// Pure half of [`rebuild_chain_debounce`], so the policy is testable without
+/// mutating process environment. Zero is a legal override: it means the caller
+/// asked for no coalescing at all.
+fn resolve_rebuild_chain_debounce(
+    override_value: Option<&str>,
+    default: std::time::Duration,
+) -> std::time::Duration {
+    match override_value.and_then(|raw| raw.trim().parse::<u64>().ok()) {
+        Some(ms) => std::time::Duration::from_millis(ms),
+        None => default,
+    }
+}
 
 /// File-generation polling cadence for mmap bridges. Only the tiny commit
 /// record is read on an unchanged tick; vector/graph files are reopened only
@@ -582,6 +627,10 @@ pub(crate) enum AnnEnsureStatus {
     Built { vectors: usize },
     EmptyCorpus,
     DiscardedStaleBuild,
+    /// Nothing on disk was adoptable and this process does not build corpus
+    /// indexes. The caller serves its exact/lexical path for this request; the
+    /// daemon builds and publishes, and the next attempt adopts that segment.
+    DeclinedNotWarmHost,
 }
 
 // ── state operations ──────────────────────────────────────────────────────────
@@ -747,7 +796,7 @@ fn spawn_rebuild_task_inner(
     };
     khive_runtime::track_background_task(async move {
         if chained {
-            tokio::time::sleep(REBUILD_CHAIN_DEBOUNCE).await;
+            tokio::time::sleep(rebuild_chain_debounce()).await;
         }
         // Recheck after each build because writes that found this guard occupied were not queued.
         // Bound attempts so continuous writes cannot retain the guard indefinitely; daemon drain
@@ -1265,6 +1314,13 @@ async fn ensure_ann_for_model_inner(
                 SegmentOutcome::Cold => {}
             }
         }
+    }
+
+    if !ann.builds_corpus_indexes {
+        tracing::info!(namespace = %ns, model = %model,
+            "no adoptable memory ANN segment and this process does not build corpus \
+             indexes; serving degraded and leaving the build to the daemon");
+        return Ok(AnnEnsureStatus::DeclinedNotWarmHost);
     }
 
     // The fingerprint sandwich bounds scan races; generation ordering closes the
@@ -3349,6 +3405,83 @@ mod tests {
              empty set to keep over-fetching for eligible visible memories",
             bridge.namespace_set
         );
+    }
+
+    /// A process without corpus-build authority declines instead of scanning and
+    /// publishing. The second half is the control: the same corpus, the same
+    /// runtime, with the authority, builds — so the decline is caused by the role
+    /// and not by a fixture that could not have built anyway.
+    #[tokio::test]
+    async fn a_process_that_does_not_build_declines_instead_of_scanning_the_corpus() {
+        const MODEL: &str = "memory-non-building-process-declines-test-model";
+        const DIMS: usize = 4;
+        let rt = test_runtime_with_hash_embedder(MODEL, DIMS);
+        let token = rt.authorize(Namespace::local()).expect("authorize local");
+        rt.create_note_with_decay_for_embedding_model(
+            &token,
+            "memory",
+            None,
+            "a note the daemon will index",
+            Some(0.7),
+            0.01,
+            None,
+            vec![],
+            None,
+        )
+        .await
+        .expect("create note");
+
+        let key = AnnKey::new(MODEL);
+        let client = new_shared_for_role(false);
+        let declined = ensure_ann_for_model(&rt, &token, &client, MODEL)
+            .await
+            .expect("ensure must not error, it must decline");
+        assert!(
+            matches!(declined, AnnEnsureStatus::DeclinedNotWarmHost),
+            "a process without corpus-build authority must decline, got {declined:?}"
+        );
+        assert!(
+            !client.indexes.read().await.contains_key(&key),
+            "a decline must install nothing"
+        );
+        if let Some(seg_dir) = ann_segment_dir(&rt, MODEL) {
+            assert!(
+                !seg_dir.join("metadata.bin").exists(),
+                "a decline must publish no segment"
+            );
+        }
+
+        let host = new_shared();
+        let built = ensure_ann_for_model(&rt, &token, &host, MODEL)
+            .await
+            .expect("control build");
+        assert!(
+            matches!(built, AnnEnsureStatus::Built { vectors: 1 }),
+            "control: with the authority the same corpus builds, got {built:?}"
+        );
+    }
+
+    /// The chain debounce is what decides how many writes one rebuild absorbs.
+    /// One second absorbed nothing against a fleet writing continuously, which is
+    /// how a coalescing window became a rebuild cadence.
+    #[test]
+    fn rebuild_chain_debounce_policy() {
+        let default = std::time::Duration::from_secs(30);
+        assert_eq!(resolve_rebuild_chain_debounce(None, default), default);
+        assert_eq!(
+            resolve_rebuild_chain_debounce(Some(" 2500 "), default),
+            std::time::Duration::from_millis(2500)
+        );
+        // Zero is a real answer: it means no coalescing was asked for.
+        assert_eq!(
+            resolve_rebuild_chain_debounce(Some("0"), default),
+            std::time::Duration::ZERO
+        );
+        // A malformed value must not silently become zero, which would restore
+        // the behaviour this default exists to fix.
+        assert_eq!(resolve_rebuild_chain_debounce(Some("soon"), default), default);
+        assert_eq!(resolve_rebuild_chain_debounce(Some("-1"), default), default);
+        assert_eq!(resolve_rebuild_chain_debounce(Some(""), default), default);
     }
 
     /// Mirrors the knowledge-pack invalid-rotation tests (issue #2340): a

--- a/crates/khive-pack-memory/src/ann.rs
+++ b/crates/khive-pack-memory/src/ann.rs
@@ -118,8 +118,10 @@ pub(crate) struct AnnState {
 
 pub(crate) type SharedAnn = Arc<AnnState>;
 
-/// Shared ANN state for a process that builds corpus indexes: the warm daemon
-/// and the admin reindex path.
+/// Shared ANN state for a process that builds corpus indexes. Test-only here:
+/// production reaches this through `MemoryPack::new_with_index_role`, which
+/// states the role rather than assuming it.
+#[cfg(test)]
 pub(crate) fn new_shared() -> SharedAnn {
     new_shared_for_role(true)
 }
@@ -215,7 +217,9 @@ const REBUILD_CHAIN_DEBOUNCE_DEFAULT: std::time::Duration = std::time::Duration:
 
 fn rebuild_chain_debounce() -> std::time::Duration {
     resolve_rebuild_chain_debounce(
-        std::env::var("KHIVE_ANN_REBUILD_DEBOUNCE_MS").ok().as_deref(),
+        std::env::var("KHIVE_ANN_REBUILD_DEBOUNCE_MS")
+            .ok()
+            .as_deref(),
         REBUILD_CHAIN_DEBOUNCE_DEFAULT,
     )
 }
@@ -624,7 +628,9 @@ pub(crate) fn snapshot_key(_namespace: &str, model: &str) -> String {
 pub(crate) enum AnnEnsureStatus {
     AlreadyLoaded,
     LoadedSnapshot,
-    Built { vectors: usize },
+    Built {
+        vectors: usize,
+    },
     EmptyCorpus,
     DiscardedStaleBuild,
     /// Nothing on disk was adoptable and this process does not build corpus
@@ -3479,7 +3485,10 @@ mod tests {
         );
         // A malformed value must not silently become zero, which would restore
         // the behaviour this default exists to fix.
-        assert_eq!(resolve_rebuild_chain_debounce(Some("soon"), default), default);
+        assert_eq!(
+            resolve_rebuild_chain_debounce(Some("soon"), default),
+            default
+        );
         assert_eq!(resolve_rebuild_chain_debounce(Some("-1"), default), default);
         assert_eq!(resolve_rebuild_chain_debounce(Some(""), default), default);
     }

--- a/crates/khive-pack-memory/src/ann.rs
+++ b/crates/khive-pack-memory/src/ann.rs
@@ -2879,6 +2879,23 @@ async fn classify_and_adopt_segment(
             tracing::warn!(error = %e, "memory tail replay failed; Cold rebuild");
             return SegmentOutcome::Cold;
         }
+        // Replay is cheap and in memory; the checkpoint that follows it is a full
+        // segment publication. A process that is not the warm index host serves the
+        // replayed bridge and publishes nothing, so a client warming after a write
+        // does not rewrite the segment for every other reader on the root.
+        if !ann.builds_corpus_indexes {
+            install_replacing(
+                ann,
+                key,
+                bridge
+                    .with_generation(target_generation)
+                    .with_epoch_baseline(target_epoch),
+            )
+            .await;
+            tracing::debug!(model = %model, tail,
+                "memory ANN served from Stale-tail replay without checkpoint; not the warm index host");
+            return SegmentOutcome::Installed(AnnEnsureStatus::LoadedSnapshot);
+        }
         let installed = checkpoint_raise_compact_readopt(
             rt,
             ann,
@@ -3464,6 +3481,109 @@ mod tests {
         assert!(
             matches!(built, AnnEnsureStatus::Built { vectors: 1 }),
             "control: with the authority the same corpus builds, got {built:?}"
+        );
+    }
+
+    /// The Stale-tail path replays in memory and then checkpoints, and the
+    /// checkpoint is a full segment publication. A process without corpus-build
+    /// authority must serve the replayed bridge and publish nothing, or every
+    /// client warming after any write republishes the segment. The search for
+    /// the tail note is the witness that the replay path ran rather than a Hot
+    /// load of the seeded segment. The control is the same state warmed with
+    /// the authority, which does checkpoint.
+    #[tokio::test]
+    async fn a_process_that_does_not_build_replays_the_tail_without_publishing() {
+        const MODEL: &str = "memory-non-building-process-stale-tail-test-model";
+        const DIMS: usize = 4;
+        let rt = test_runtime_with_hash_embedder(MODEL, DIMS);
+        let token = rt.authorize(Namespace::local()).expect("authorize local");
+        for i in 0..4 {
+            rt.create_note_with_decay_for_embedding_model(
+                &token,
+                "memory",
+                None,
+                &format!("seeded note {i}"),
+                Some(0.7),
+                0.01,
+                None,
+                vec![],
+                None,
+            )
+            .await
+            .expect("create seeded note");
+        }
+        let seed = new_shared();
+        let built = ensure_ann_for_model(&rt, &token, &seed, MODEL)
+            .await
+            .expect("seed build");
+        assert!(
+            matches!(built, AnnEnsureStatus::Built { vectors: 4 }),
+            "seed: expected a build over 4 vectors, got {built:?}"
+        );
+        let seg_dir = ann_segment_dir(&rt, MODEL).expect("segment dir");
+        let metadata = seg_dir.join("metadata.bin");
+        let vectors = seg_dir.join("vectors.bin");
+        let before_metadata = std::fs::read(&metadata).expect("seeded metadata.bin");
+        let before_vectors = std::fs::read(&vectors).expect("seeded vectors.bin");
+
+        // One more note: live = 5, tail = 1 ≤ ceil(0.20 × 5) → Stale-tail.
+        let tail_note = rt
+            .create_note_with_decay_for_embedding_model(
+                &token,
+                "memory",
+                None,
+                "the note only a tail replay can find",
+                Some(0.7),
+                0.01,
+                None,
+                vec![],
+                None,
+            )
+            .await
+            .expect("create tail note");
+
+        let key = AnnKey::new(MODEL);
+        let client = new_shared_for_role(false);
+        let status = ensure_ann_for_model(&rt, &token, &client, MODEL)
+            .await
+            .expect("client warm");
+        assert!(
+            matches!(status, AnnEnsureStatus::LoadedSnapshot),
+            "a client must adopt the segment through Stale-tail replay, got {status:?}"
+        );
+        let query = fnv_to_vec("the note only a tail replay can find", DIMS);
+        let hits = search_loaded(&client, &key, &query, 5)
+            .await
+            .expect("search must succeed")
+            .expect("the replayed bridge must be installed");
+        assert!(
+            hits.iter()
+                .any(|(id, score)| *id == tail_note.id && *score > 0.99),
+            "the tail note must be served from the replayed bridge, got {hits:?}"
+        );
+        assert_eq!(
+            std::fs::read(&metadata).expect("metadata.bin after client warm"),
+            before_metadata,
+            "a client must not checkpoint: metadata.bin changed"
+        );
+        assert_eq!(
+            std::fs::read(&vectors).expect("vectors.bin after client warm"),
+            before_vectors,
+            "a client must not checkpoint: vectors.bin changed"
+        );
+
+        let host = new_shared();
+        let status = ensure_ann_for_model(&rt, &token, &host, MODEL)
+            .await
+            .expect("host warm");
+        assert!(
+            matches!(status, AnnEnsureStatus::LoadedSnapshot),
+            "control: the host adopts the same segment, got {status:?}"
+        );
+        assert_ne!(
+            std::fs::read(&metadata).expect("metadata.bin after host warm"),
+            before_metadata,
+            "control: the host checkpoints after replay, so metadata.bin must change"
         );
     }
 

--- a/crates/khive-pack-memory/src/pack.rs
+++ b/crates/khive-pack-memory/src/pack.rs
@@ -14,7 +14,7 @@ use khive_types::{HandlerDef, IdResolutionMode, Pack, ParamDef, VerbCategory, Vi
 
 use khive_brain_core::BalancedRecallState;
 
-use crate::ann::{new_shared, SharedAnn, MEMORY_SCHEMA_PLAN_STMTS};
+use crate::ann::{new_shared_for_role, SharedAnn, MEMORY_SCHEMA_PLAN_STMTS};
 use crate::config::RecallConfig;
 use crate::query_cache::QueryEmbeddingCache;
 
@@ -43,11 +43,22 @@ impl MemoryPack {
     ///
     /// See `crates/khive-pack-memory/docs/api/pack-integration.md`.
     pub fn new(runtime: KhiveRuntime) -> Self {
+        Self::new_with_index_role(runtime, true)
+    }
+
+    /// As [`Self::new`], but states whether this process may build the memory
+    /// index from the full corpus. The serving factory passes the daemon role:
+    /// a corpus build is minutes of CPU and a segment rewrite every other reader
+    /// on the index root must absorb, so a short-lived client serves what is
+    /// persisted and leaves the build to the daemon. Direct constructions —
+    /// admin reindex, benches, tests — build, because building is what they are
+    /// for.
+    pub fn new_with_index_role(runtime: KhiveRuntime, builds_corpus_indexes: bool) -> Self {
         let brain_profile = runtime.config().brain_profile.clone();
         Self {
             runtime,
             config: Mutex::new(RecallConfig::default()),
-            ann: new_shared(),
+            ann: new_shared_for_role(builds_corpus_indexes),
             query_cache: QueryEmbeddingCache::with_default_capacity(),
             recall_state: Mutex::new(BalancedRecallState::new(10_000)),
             brain_profile,
@@ -405,7 +416,10 @@ impl khive_runtime::PackFactory for MemoryPackFactory {
     }
 
     fn create(&self, runtime: KhiveRuntime) -> Box<dyn khive_runtime::PackRuntime> {
-        Box::new(MemoryPack::new(runtime))
+        Box::new(MemoryPack::new_with_index_role(
+            runtime,
+            khive_runtime::daemon::is_warm_index_host(),
+        ))
     }
 }
 

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -957,6 +957,29 @@ fn checkpoint_task_specs(
 // presence that `drain()` waits on, exactly like the `active` counter does
 // for in-flight connections: the caller still only pays for the spawn +
 // counter increment, never the task's own work.
+/// Set once by the boot path that takes the daemon role, and never cleared: a
+/// process that is not the warm daemon has no path to becoming one except exec.
+static WARM_INDEX_HOST: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Declare this process the warm index host. Called by the serve path as soon as
+/// the daemon role is decided, before any runtime is built, so nothing warms
+/// under the wrong answer.
+pub fn mark_warm_index_host() {
+    WARM_INDEX_HOST.store(true, std::sync::atomic::Ordering::Release);
+}
+
+/// Whether this process is the warm index host.
+///
+/// Building an ANN index from the full corpus is minutes of CPU and hundreds of
+/// megabytes of segment rewrite, and it pays for itself only across a process
+/// that outlives the request. A short-lived client that does it pays the whole
+/// cost, discards the result at exit, and publishes a checkpoint that every
+/// other reader on the root must then re-read. Consumers use this to decide
+/// whether to build or to serve degraded and let the daemon build.
+pub fn is_warm_index_host() -> bool {
+    WARM_INDEX_HOST.load(std::sync::atomic::Ordering::Acquire)
+}
+
 static BACKGROUND_TASKS: std::sync::OnceLock<Arc<std::sync::atomic::AtomicUsize>> =
     std::sync::OnceLock::new();
 

--- a/crates/khive-runtime/tests/warm_index_host_role.rs
+++ b/crates/khive-runtime/tests/warm_index_host_role.rs
@@ -1,0 +1,16 @@
+//! The warm-index-host marker in its own test binary: it is a process-global that
+//! is never cleared, so a test that flips it cannot share a binary with one that
+//! asserts the default.
+
+/// Order matters and is why this is one test rather than two: the default must be
+/// observed before anything marks the process. A client that inherits the host role
+/// by accident is exactly the failure this flag exists to prevent.
+#[test]
+fn the_role_defaults_to_client_and_is_set_only_by_an_explicit_mark() {
+    assert!(
+        !khive_runtime::daemon::is_warm_index_host(),
+        "a process is a client until its boot path says otherwise"
+    );
+    khive_runtime::daemon::mark_warm_index_host();
+    assert!(khive_runtime::daemon::is_warm_index_host());
+}

--- a/crates/khive-vamana/src/index.rs
+++ b/crates/khive-vamana/src/index.rs
@@ -808,6 +808,61 @@ impl VamanaIndex {
     /// [`Self::load_or_build`] and crates/khive-vamana/docs/api/persistence.md#v2-crash-safe-save-load).
     #[cfg(feature = "mmap")]
     pub fn load(path: &Path) -> Result<Self> {
+        Self::load_with_lock_hook(path, |lock| lock.lock_shared().map_err(Into::into))
+    }
+
+    /// Reader half of the publication protocol, and the seam the concurrency tests
+    /// drive. `acquire_lock` receives the open (but unlocked) `.checkpoint.lock` and
+    /// must return only once this reader holds a shared lock on it; production passes
+    /// the blocking `lock_shared()` call.
+    ///
+    /// [`Self::save_atomic_with_lock_hook`] renames `metadata.bin` into place as the
+    /// commit record and only then renames the four segment files, so a reader that
+    /// opens the directory between those renames sees a new commit record against stale
+    /// segments and fails the checksum gate. That window is deliberate for crash
+    /// recovery, where it is reached once and the caller rebuilds. Under concurrent
+    /// processes it is reached on *every* publication, and the rebuild each reader
+    /// performs to recover from it publishes again — so the recovery path is also the
+    /// amplifier. Taking a shared lock on the same file the writer holds exclusively
+    /// puts the whole rename sequence outside anything a reader can observe.
+    ///
+    /// A directory with no lock file — a v1 layout, or a segment no `save_atomic` has
+    /// ever written — loads unlocked, because there is no writer using this protocol to
+    /// exclude. The lock releases when the guard drops at the end of the load; an mmap
+    /// taken during the load holds its own inode open, so a rename landing afterwards
+    /// cannot change what was loaded.
+    #[cfg(feature = "mmap")]
+    fn load_with_lock_hook(
+        path: &Path,
+        acquire_lock: impl FnOnce(&File) -> Result<()>,
+    ) -> Result<Self> {
+        let _publication_guard = Self::open_publication_lock(path, acquire_lock)?;
+        Self::load_unlocked(path)
+    }
+
+    /// Open `path`'s `.checkpoint.lock` and hand it to `acquire_lock`. `None` means the
+    /// directory has no lock file, which is not a failure: a v1 layout, or a segment no
+    /// `save_atomic` has ever written, has no writer using this protocol to exclude.
+    #[cfg(feature = "mmap")]
+    fn open_publication_lock(
+        path: &Path,
+        acquire_lock: impl FnOnce(&File) -> Result<()>,
+    ) -> Result<Option<File>> {
+        match OpenOptions::new()
+            .read(true)
+            .open(path.join(".checkpoint.lock"))
+        {
+            Ok(lock) => {
+                acquire_lock(&lock)?;
+                Ok(Some(lock))
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    #[cfg(feature = "mmap")]
+    fn load_unlocked(path: &Path) -> Result<Self> {
         let metadata_path = path.join("metadata.bin");
         let head = fs::read(&metadata_path)?;
         if head.len() >= 8 && &head[..8] == V2_COMMIT_MAGIC {
@@ -1029,7 +1084,21 @@ impl VamanaIndex {
         rebuild_last_applied_seq: Option<u64>,
     ) -> Result<Self> {
         let metadata_path = path.join("metadata.bin");
-        let rebuild_and_persist = |config| {
+
+        // Every read below — the commit record and all four segments — happens under a
+        // shared publication lock, so it cannot observe `save_atomic`'s rename sequence
+        // half-applied. Without it a concurrent publication is seen as a new commit
+        // record against stale segments, the checksum gate rejects it, and the recovery
+        // is `rebuild_and_persist` — which publishes, tearing the next reader. See
+        // `load_with_lock_hook`.
+        let mut publication_guard =
+            Self::open_publication_lock(path, |lock| lock.lock_shared().map_err(Into::into))?;
+
+        // Takes the guard because `save_atomic` acquires the same file exclusively and
+        // file locks are not reentrant across descriptors: the read lock is released
+        // before anything publishes.
+        let rebuild_and_persist = |guard: &mut Option<File>, config| {
+            guard.take();
             let mut index = Self::rebuild_from_corpus(corpus_vectors, config)?;
             index.set_last_applied_seq(rebuild_last_applied_seq);
             index.save_atomic(path)?;
@@ -1047,20 +1116,20 @@ impl VamanaIndex {
                 ] {
                     let _ = fs::remove_file(path.join(suffix));
                 }
-                return rebuild_and_persist(fallback_config);
+                return rebuild_and_persist(&mut publication_guard, fallback_config);
             }
             Err(e) => return Err(e.into()),
         };
 
         if metadata_bytes.len() < 8 {
-            return rebuild_and_persist(fallback_config);
+            return rebuild_and_persist(&mut publication_guard, fallback_config);
         }
 
         if &metadata_bytes[..8] == V2_COMMIT_MAGIC {
             let commit = match parse_v2_commit(&metadata_bytes) {
                 Ok(c) => c,
                 Err(_) => {
-                    return rebuild_and_persist(fallback_config);
+                    return rebuild_and_persist(&mut publication_guard, fallback_config);
                 }
             };
 
@@ -1074,7 +1143,7 @@ impl VamanaIndex {
                         search_list_size: commit.index_meta.search_list_size,
                         alpha: commit.index_meta.alpha,
                     };
-                    return rebuild_and_persist(config);
+                    return rebuild_and_persist(&mut publication_guard, config);
                 }
                 Err(e) => return Err(e.into()),
             };
@@ -1087,7 +1156,7 @@ impl VamanaIndex {
                         search_list_size: commit.index_meta.search_list_size,
                         alpha: commit.index_meta.alpha,
                     };
-                    return rebuild_and_persist(config);
+                    return rebuild_and_persist(&mut publication_guard, config);
                 }
                 Err(e) => return Err(e.into()),
             };
@@ -1100,7 +1169,7 @@ impl VamanaIndex {
                         search_list_size: commit.index_meta.search_list_size,
                         alpha: commit.index_meta.alpha,
                     };
-                    return rebuild_and_persist(config);
+                    return rebuild_and_persist(&mut publication_guard, config);
                 }
                 Err(e) => return Err(e.into()),
             };
@@ -1119,7 +1188,7 @@ impl VamanaIndex {
                     search_list_size: commit.index_meta.search_list_size,
                     alpha: commit.index_meta.alpha,
                 };
-                return rebuild_and_persist(config);
+                return rebuild_and_persist(&mut publication_guard, config);
             }
 
             // codes.bin is checksum-gated exactly like the other segments whenever the
@@ -1136,7 +1205,7 @@ impl VamanaIndex {
                         search_list_size: commit.index_meta.search_list_size,
                         alpha: commit.index_meta.alpha,
                     };
-                    return rebuild_and_persist(config);
+                    return rebuild_and_persist(&mut publication_guard, config);
                 }
             }
 
@@ -1149,7 +1218,7 @@ impl VamanaIndex {
                     search_list_size: commit.index_meta.search_list_size,
                     alpha: commit.index_meta.alpha,
                 };
-                return rebuild_and_persist(config);
+                return rebuild_and_persist(&mut publication_guard, config);
             }
             let live_count = corpus_vectors.len() / dim;
             let live_content_hash = *blake3::hash(cast_slice(corpus_vectors)).as_bytes();
@@ -1165,7 +1234,7 @@ impl VamanaIndex {
                     search_list_size: commit.index_meta.search_list_size,
                     alpha: commit.index_meta.alpha,
                 };
-                return rebuild_and_persist(config);
+                return rebuild_and_persist(&mut publication_guard, config);
             }
 
             // Fast path: load all segments, restore lifecycle state.
@@ -1182,7 +1251,7 @@ impl VamanaIndex {
                         search_list_size: commit.index_meta.search_list_size,
                         alpha: commit.index_meta.alpha,
                     };
-                    rebuild_and_persist(config)
+                    rebuild_and_persist(&mut publication_guard, config)
                 }
                 Err(e) => Err(e),
             }
@@ -1199,13 +1268,16 @@ impl VamanaIndex {
             // Release the mmap before save_atomic overwrites the same files.
             index.ensure_owned()?;
             index.set_last_applied_seq(rebuild_last_applied_seq);
+            // Same reason as in `rebuild_and_persist`: this branch publishes, so the
+            // shared read lock must be gone before `save_atomic` asks for it exclusively.
+            publication_guard.take();
             index.save_atomic(path)?;
             Ok(index)
         } else {
             // Unknown or garbage magic: treat as corrupt snapshot and rebuild.
             // VamanaIndex::load (direct v1 callers) remains strict; load_or_build always
             // recovers because the caller supplies a corpus and fallback config.
-            rebuild_and_persist(fallback_config)
+            rebuild_and_persist(&mut publication_guard, fallback_config)
         }
     }
 
@@ -5423,6 +5495,164 @@ mod tests {
         let persisted = VamanaIndex::load(dir.path()).unwrap();
         assert_eq!(persisted.last_applied_seq(), Some(200));
         assert_eq!(persisted.vectors().unwrap(), vectors);
+    }
+
+    /// A reader must not be admitted into `save_atomic`'s critical section, because
+    /// every rename that publishes a checkpoint happens inside it: `metadata.bin` as the
+    /// commit record first, then the four segment files. A reader admitted between those
+    /// renames reads a new commit record against stale segments — the state seen in
+    /// production as `lifecycle.bin rev_num_nodes N != num_vectors M` and `v2 codes
+    /// segment checksum mismatch` — and every caller's recovery from it is a rebuild,
+    /// which publishes, which tears the next reader.
+    ///
+    /// The probe uses `try_lock_shared` while the writer holds the lock, so `WouldBlock`
+    /// is evidence of real exclusion rather than a timing guess.
+    #[cfg(feature = "mmap")]
+    #[test]
+    fn a_reader_cannot_enter_the_publication_critical_section() {
+        let vectors = rand_unit_vectors(30, 8, 0x1138_0300);
+        let config = VamanaConfig::with_dimensions(8)
+            .with_max_degree(8)
+            .with_search_list_size(16);
+        let mut index = VamanaIndex::build(&vectors, config).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        index.set_last_applied_seq(Some(1));
+        index.save_atomic(dir.path()).unwrap();
+        index.set_last_applied_seq(Some(2));
+
+        let writer_path = dir.path().to_path_buf();
+        let (locked_tx, locked_rx) = std::sync::mpsc::sync_channel(0);
+        let (release_tx, release_rx) = std::sync::mpsc::sync_channel(0);
+        let writer_handle = std::thread::spawn(move || {
+            index.save_atomic_with_lock_hook(&writer_path, |lock| {
+                lock.lock()?;
+                locked_tx.send(()).unwrap();
+                release_rx.recv().unwrap();
+                Ok(())
+            })
+        });
+        locked_rx.recv().unwrap();
+
+        enum ProbeOutcome {
+            Contended,
+            Uncontended,
+            ProbeFailed(String),
+        }
+        let reader_path = dir.path().to_path_buf();
+        let (probe_tx, probe_rx) = std::sync::mpsc::sync_channel(0);
+        let reader_handle = std::thread::spawn(move || {
+            VamanaIndex::load_with_lock_hook(&reader_path, |lock| {
+                match lock.try_lock_shared() {
+                    Ok(()) => {
+                        probe_tx.send(ProbeOutcome::Uncontended).unwrap();
+                        Ok(())
+                    }
+                    Err(std::fs::TryLockError::WouldBlock) => {
+                        probe_tx.send(ProbeOutcome::Contended).unwrap();
+                        lock.lock_shared()?;
+                        Ok(())
+                    }
+                    Err(std::fs::TryLockError::Error(err)) => {
+                        probe_tx
+                            .send(ProbeOutcome::ProbeFailed(err.to_string()))
+                            .unwrap();
+                        Err(err.into())
+                    }
+                }
+            })
+        });
+        match probe_rx
+            .recv_timeout(std::time::Duration::from_secs(60))
+            .expect("reader probe never signaled within 60s")
+        {
+            ProbeOutcome::Contended => {}
+            ProbeOutcome::Uncontended => {
+                panic!("a reader entered the publication critical section")
+            }
+            ProbeOutcome::ProbeFailed(err) => panic!("reader lock probe failed: {err}"),
+        }
+
+        release_tx.send(()).unwrap();
+        writer_handle.join().unwrap().unwrap();
+        // The reader was delayed, not failed: it completes once publication ends, and
+        // what it gets is the finished checkpoint rather than a torn one.
+        let loaded = reader_handle.join().unwrap().unwrap();
+        assert_eq!(loaded.last_applied_seq(), Some(2));
+        assert_eq!(loaded.vectors().unwrap(), vectors);
+    }
+
+    /// The reader lock is shared, so it excludes publication and nothing else. Without
+    /// this the fix would trade a rebuild storm for a read convoy across every process
+    /// on the index root.
+    #[cfg(feature = "mmap")]
+    #[test]
+    fn concurrent_readers_do_not_exclude_each_other() {
+        let vectors = rand_unit_vectors(24, 8, 0x1138_0400);
+        let config = VamanaConfig::with_dimensions(8)
+            .with_max_degree(8)
+            .with_search_list_size(16);
+        let index = VamanaIndex::build(&vectors, config).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        index.save_atomic(dir.path()).unwrap();
+
+        let first_path = dir.path().to_path_buf();
+        let (holding_tx, holding_rx) = std::sync::mpsc::sync_channel(0);
+        let (release_tx, release_rx) = std::sync::mpsc::sync_channel(0);
+        let first = std::thread::spawn(move || {
+            VamanaIndex::load_with_lock_hook(&first_path, |lock| {
+                lock.lock_shared()?;
+                holding_tx.send(()).unwrap();
+                release_rx.recv().unwrap();
+                Ok(())
+            })
+        });
+        holding_rx.recv().unwrap();
+
+        let second_path = dir.path().to_path_buf();
+        let (probe_tx, probe_rx) = std::sync::mpsc::sync_channel(0);
+        let second = std::thread::spawn(move || {
+            VamanaIndex::load_with_lock_hook(&second_path, |lock| {
+                let acquired = lock.try_lock_shared().is_ok();
+                probe_tx.send(acquired).unwrap();
+                if acquired {
+                    Ok(())
+                } else {
+                    lock.lock_shared().map_err(Into::into)
+                }
+            })
+        });
+        assert!(
+            probe_rx
+                .recv_timeout(std::time::Duration::from_secs(60))
+                .expect("second reader never probed within 60s"),
+            "a shared publication lock must not exclude another reader"
+        );
+
+        release_tx.send(()).unwrap();
+        assert_eq!(first.join().unwrap().unwrap().vectors().unwrap(), vectors);
+        assert_eq!(second.join().unwrap().unwrap().vectors().unwrap(), vectors);
+    }
+
+    /// A directory with no `.checkpoint.lock` has no writer using this protocol, so the
+    /// load proceeds unlocked rather than failing. Covers v1 layouts and any segment
+    /// directory `save_atomic` has never written.
+    #[cfg(feature = "mmap")]
+    #[test]
+    fn load_succeeds_when_no_publication_lock_file_exists() {
+        let vectors = rand_unit_vectors(16, 8, 0x1138_0500);
+        let config = VamanaConfig::with_dimensions(8)
+            .with_max_degree(8)
+            .with_search_list_size(16);
+        let index = VamanaIndex::build(&vectors, config).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        index.save_atomic(dir.path()).unwrap();
+
+        let lock_path = dir.path().join(".checkpoint.lock");
+        assert!(lock_path.exists(), "save_atomic must create the lock file");
+        fs::remove_file(&lock_path).unwrap();
+
+        let loaded = VamanaIndex::load(dir.path()).unwrap();
+        assert_eq!(loaded.vectors().unwrap(), vectors);
     }
 
     #[cfg(feature = "mmap")]

--- a/crates/khive-vamana/src/index.rs
+++ b/crates/khive-vamana/src/index.rs
@@ -520,12 +520,80 @@ fn require_finite(values: &[f32], location: &str) -> Result<()> {
     Ok(())
 }
 
+/// Threads an index build may use. Half the machine's parallelism by default,
+/// at least one, overridable with `KHIVE_ANN_BUILD_THREADS`.
+///
+/// A build is not the only thing the machine is doing. On the default rayon pool
+/// it takes every core, so a build triggered while requests are in flight
+/// competes with the process serving them — and on a host where several
+/// processes share one index root, with the other builds too. Half leaves the
+/// machine responsive and costs build wall-clock, which is the right trade for
+/// work that is supposed to happen rarely.
+#[cfg(feature = "parallel")]
+fn build_thread_count() -> usize {
+    resolve_build_threads(
+        std::env::var("KHIVE_ANN_BUILD_THREADS").ok().as_deref(),
+        std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(1),
+    )
+}
+
+/// Pure half of [`build_thread_count`], so the policy is testable without
+/// mutating process environment. A malformed or zero override falls back to the
+/// default rather than failing: this knob bounds a cost, it does not gate
+/// correctness, and a typo in it must not stop an index from building.
+#[cfg(feature = "parallel")]
+fn resolve_build_threads(override_value: Option<&str>, available: usize) -> usize {
+    if let Some(threads) = override_value
+        .and_then(|raw| raw.trim().parse::<usize>().ok())
+        .filter(|threads| *threads > 0)
+    {
+        return threads;
+    }
+    available.div_ceil(2).max(1)
+}
+
+/// The bounded pool index builds run in. `None` if the pool could not be built,
+/// in which case the build runs on the caller's thread pool as it did before —
+/// a failure to bound parallelism is not a reason to fail the build.
+#[cfg(feature = "parallel")]
+fn build_pool() -> Option<&'static rayon::ThreadPool> {
+    static POOL: std::sync::OnceLock<Option<rayon::ThreadPool>> = std::sync::OnceLock::new();
+    POOL.get_or_init(|| {
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(build_thread_count())
+            .thread_name(|i| format!("khive-ann-build-{i}"))
+            .build()
+            .ok()
+    })
+    .as_ref()
+}
+
 impl VamanaIndex {
     /// Build from row-major flat slice. Errors if config invalid, empty, wrong length, non-finite, or N > u32::MAX.
     ///
     /// Uses `GsSq8Codec` for the acquisition-tier distance during graph construction
     /// (ADR-052 §1, Step 2: default-on for Vamana, algebraically exact in code space).
+    ///
+    /// Runs inside the bounded build pool (see [`build_thread_count`]), so every
+    /// nested `par_iter` in graph construction inherits that bound instead of the
+    /// global pool's one-thread-per-core.
     pub fn build(vectors: &[f32], config: VamanaConfig) -> Result<Self> {
+        #[cfg(feature = "parallel")]
+        {
+            match build_pool() {
+                Some(pool) => pool.install(|| Self::build_on_current_pool(vectors, config)),
+                None => Self::build_on_current_pool(vectors, config),
+            }
+        }
+        #[cfg(not(feature = "parallel"))]
+        {
+            Self::build_on_current_pool(vectors, config)
+        }
+    }
+
+    fn build_on_current_pool(vectors: &[f32], config: VamanaConfig) -> Result<Self> {
         config.validate()?;
         if vectors.is_empty() {
             return Err(VamanaError::EmptyInput);
@@ -5495,6 +5563,45 @@ mod tests {
         let persisted = VamanaIndex::load(dir.path()).unwrap();
         assert_eq!(persisted.last_applied_seq(), Some(200));
         assert_eq!(persisted.vectors().unwrap(), vectors);
+    }
+
+    /// The build pool bound: half the machine, at least one, and an override that
+    /// cannot break a build by being wrong.
+    #[cfg(feature = "parallel")]
+    #[test]
+    fn build_threads_default_to_half_the_machine_and_survive_a_bad_override() {
+        assert_eq!(resolve_build_threads(None, 10), 5);
+        // Odd counts round up: on a 1-core machine the answer must still be 1.
+        assert_eq!(resolve_build_threads(None, 9), 5);
+        assert_eq!(resolve_build_threads(None, 1), 1);
+        assert_eq!(resolve_build_threads(None, 0), 1);
+        assert_eq!(resolve_build_threads(Some(" 3 "), 10), 3);
+        // A build is not gated on the knob parsing: zero, negative and garbage
+        // all fall back to the default rather than to zero threads or an error.
+        assert_eq!(resolve_build_threads(Some("0"), 10), 5);
+        assert_eq!(resolve_build_threads(Some("-2"), 10), 5);
+        assert_eq!(resolve_build_threads(Some("half"), 10), 5);
+        assert_eq!(resolve_build_threads(Some(""), 10), 5);
+    }
+
+    /// The pool builds are installed into is actually bounded to that number, so
+    /// every nested `par_iter` in graph construction inherits the bound rather
+    /// than the global one-thread-per-core pool.
+    #[cfg(feature = "parallel")]
+    #[test]
+    fn the_build_pool_is_bounded_to_the_resolved_thread_count() {
+        let pool = build_pool().expect("build pool");
+        assert_eq!(pool.current_num_threads(), build_thread_count());
+        assert!(
+            pool.current_num_threads()
+                <= std::thread::available_parallelism()
+                    .map(|n| n.get())
+                    .unwrap_or(1),
+            "the build pool must never exceed the machine"
+        );
+        // Observed from inside the pool, which is what a build sees.
+        let observed = pool.install(rayon::current_num_threads);
+        assert_eq!(observed, build_thread_count());
     }
 
     /// A reader must not be admitted into `save_atomic`'s critical section, because

--- a/crates/khive-vamana/src/index.rs
+++ b/crates/khive-vamana/src/index.rs
@@ -5648,23 +5648,21 @@ mod tests {
         let reader_path = dir.path().to_path_buf();
         let (probe_tx, probe_rx) = std::sync::mpsc::sync_channel(0);
         let reader_handle = std::thread::spawn(move || {
-            VamanaIndex::load_with_lock_hook(&reader_path, |lock| {
-                match lock.try_lock_shared() {
-                    Ok(()) => {
-                        probe_tx.send(ProbeOutcome::Uncontended).unwrap();
-                        Ok(())
-                    }
-                    Err(std::fs::TryLockError::WouldBlock) => {
-                        probe_tx.send(ProbeOutcome::Contended).unwrap();
-                        lock.lock_shared()?;
-                        Ok(())
-                    }
-                    Err(std::fs::TryLockError::Error(err)) => {
-                        probe_tx
-                            .send(ProbeOutcome::ProbeFailed(err.to_string()))
-                            .unwrap();
-                        Err(err.into())
-                    }
+            VamanaIndex::load_with_lock_hook(&reader_path, |lock| match lock.try_lock_shared() {
+                Ok(()) => {
+                    probe_tx.send(ProbeOutcome::Uncontended).unwrap();
+                    Ok(())
+                }
+                Err(std::fs::TryLockError::WouldBlock) => {
+                    probe_tx.send(ProbeOutcome::Contended).unwrap();
+                    lock.lock_shared()?;
+                    Ok(())
+                }
+                Err(std::fs::TryLockError::Error(err)) => {
+                    probe_tx
+                        .send(ProbeOutcome::ProbeFailed(err.to_string()))
+                        .unwrap();
+                    Err(err.into())
                 }
             })
         });

--- a/crates/khive-vamana/tests/publication_concurrency.rs
+++ b/crates/khive-vamana/tests/publication_concurrency.rs
@@ -39,7 +39,9 @@ fn corpus(round: u64) -> Vec<f32> {
     let mut state = 0x2545_F491_4F6C_DD1Du64 ^ round.wrapping_mul(0x9E37_79B9_7F4A_7C15);
     (0..VECTORS * DIMS)
         .map(|_| {
-            state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
             ((state >> 33) as f32 / (1u64 << 31) as f32) - 0.5
         })
         .collect()

--- a/crates/khive-vamana/tests/publication_concurrency.rs
+++ b/crates/khive-vamana/tests/publication_concurrency.rs
@@ -1,0 +1,125 @@
+//! Two processes on one segment directory: one publishing, one loading.
+//!
+//! `save_atomic` renames `metadata.bin` into place as the commit record and only
+//! then renames the four segment files. A reader admitted between those renames
+//! reads a new commit record against stale segments and fails the checksum gate —
+//! observed in production as `lifecycle.bin rev_num_nodes N != num_vectors M` and
+//! `v2 codes segment checksum mismatch`, with the recovery from it being a full
+//! rebuild that publishes again.
+//!
+//! Threads in one process would not reproduce the shape that matters: the file
+//! lock this relies on is a cross-process primitive, and the deployment that
+//! showed the defect is forty processes on one index root. So the writer is a
+//! real child process.
+//!
+//! The window is wide enough to land in without any help, because the commit
+//! record is fsynced between its rename and the segment renames and an fsync is
+//! milliseconds. Measured with the reader lock reverted: 32 torn reads across
+//! 234 loads.
+
+#![cfg(all(feature = "mmap", feature = "parallel"))]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use khive_vamana::{VamanaConfig, VamanaIndex};
+
+const DIMS: usize = 16;
+const VECTORS: usize = 400;
+const PUBLICATIONS: u64 = 6;
+const DIR_ENV: &str = "KHIVE_VAMANA_PUBLICATION_DIR";
+
+/// A different corpus per publication. This matters: if every publication wrote
+/// byte-identical segments, the stale segments left in the window would still
+/// match the new commit record's hashes and the torn state would be
+/// indistinguishable from a healthy one — the test would pass whether or not the
+/// reader held the lock.
+fn corpus(round: u64) -> Vec<f32> {
+    // Deterministic and non-degenerate: a fixed LCG, unit-ish spread.
+    let mut state = 0x2545_F491_4F6C_DD1Du64 ^ round.wrapping_mul(0x9E37_79B9_7F4A_7C15);
+    (0..VECTORS * DIMS)
+        .map(|_| {
+            state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            ((state >> 33) as f32 / (1u64 << 31) as f32) - 0.5
+        })
+        .collect()
+}
+
+fn config() -> VamanaConfig {
+    VamanaConfig::with_dimensions(DIMS)
+        .with_max_degree(16)
+        .with_search_list_size(32)
+}
+
+fn build(seq: u64) -> VamanaIndex {
+    let mut index = VamanaIndex::build(&corpus(seq), config()).expect("build");
+    index.set_last_applied_seq(Some(seq));
+    index
+}
+
+/// The publishing half, run as a child process. Ignored so a normal test run
+/// never picks it up; the reader test invokes it by name.
+#[test]
+#[ignore = "child process of publication_never_exposes_a_torn_segment_set"]
+fn publication_child() {
+    let dir = PathBuf::from(std::env::var(DIR_ENV).expect("child needs the segment directory"));
+    for seq in 2..=PUBLICATIONS + 1 {
+        build(seq).save_atomic(&dir).expect("child publication");
+    }
+}
+
+fn spawn_child(dir: &Path) -> std::process::Child {
+    Command::new(std::env::current_exe().expect("current exe"))
+        .args(["--exact", "publication_child", "--ignored", "--nocapture"])
+        .env(DIR_ENV, dir)
+        .spawn()
+        .expect("spawn publishing child")
+}
+
+/// A reader must never observe a new commit record over stale segments while
+/// another process publishes.
+///
+/// The second assertion is the control: a reader that never spanned a
+/// publication boundary would pass the first assertion without testing anything,
+/// so the test also requires that it observed the sequence advance.
+#[test]
+fn publication_never_exposes_a_torn_segment_set() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    build(1).save_atomic(dir.path()).expect("seed publication");
+
+    let mut child = spawn_child(dir.path());
+
+    let mut observed_sequences = std::collections::BTreeSet::new();
+    let mut failures: Vec<String> = Vec::new();
+    let mut loads = 0u64;
+    loop {
+        match VamanaIndex::load(dir.path()) {
+            Ok(index) => {
+                observed_sequences.insert(index.last_applied_seq());
+            }
+            Err(error) => failures.push(error.to_string()),
+        }
+        loads += 1;
+        if let Some(status) = child.try_wait().expect("child status") {
+            assert!(status.success(), "publishing child failed: {status}");
+            break;
+        }
+        assert!(
+            loads < 200_000,
+            "child never exited; loads={loads}, failures={}",
+            failures.len()
+        );
+    }
+
+    assert!(
+        failures.is_empty(),
+        "a reader observed {} torn segment set(s) across {loads} loads; first: {}",
+        failures.len(),
+        failures.first().map(String::as_str).unwrap_or("<none>")
+    );
+    assert!(
+        observed_sequences.len() >= 2,
+        "control: the reader never spanned a publication, so this proved nothing \
+         (loads={loads}, sequences observed={observed_sequences:?})"
+    );
+}

--- a/crates/kkernel/src/cli.rs
+++ b/crates/kkernel/src/cli.rs
@@ -438,6 +438,9 @@ pub async fn cli_main() -> Result<()> {
                 // failing to acquire the lock here must abort before that
                 // unguarded construction runs, rather than silently
                 // proceeding with `boot_guard = None`.
+                if a.daemon {
+                    khive_runtime::daemon::mark_warm_index_host();
+                }
                 #[cfg(unix)]
                 let boot_guard = if a.daemon {
                     Some(khive_runtime::daemon::acquire_daemon_boot_guard()?)


### PR DESCRIPTION
## What this fixes

Two ANN segments on this machine were republished 21 times in 19.6 minutes: 223.55 MiB and 215.26 MiB, about 64 publications an hour, roughly 14 GiB of segment rewrite an hour. A third segment on the same root that nothing writes did not move once, which is the control. The numbers are a lower bound, because two of the observed publications were 19 seconds apart and the sampler ran at 30-second intervals.

The daemon's own log recorded two failed segment loads inside that window:

```
invalid index file: lifecycle.bin rev_num_nodes 94419 != num_vectors 94421
invalid index file: v2 codes segment checksum mismatch
```

Both fall between two observed publications.

## Root cause

`save_atomic` renames `metadata.bin` into place as the commit record, fsyncs the directory, and only then renames `vectors.bin`, `graph.bin`, `lifecycle.bin` and `codes.bin`. A reader that opens the directory in between sees a new commit record against stale segments and fails the checksum gate.

That window was reasoned about as a crash property, where it is reached once and the caller recovers by rebuilding. Under concurrent processes it is reached on every publication, and the recovery from it is a full rebuild, which publishes again, which tears the next reader. The recovery path is also the amplifier.

A publication lock already existed. `save_atomic` takes `.checkpoint.lock` exclusively, but readers never took it, so it ordered writers against writers and did nothing for readers.

## The four changes

1. **Readers take a shared publication lock.** `VamanaIndex::load` and the read phase of `load_or_build_with_sequence` take the same file with a shared lock, which puts the whole rename sequence outside anything a reader can observe. The read lock is released before either path publishes, because file locks are not reentrant across descriptors. A directory with no lock file loads unlocked: a v1 layout has no writer using this protocol to exclude.

2. **Only a warm daemon builds a corpus index.** A corpus build is minutes of CPU and a segment rewrite every other reader on the root must absorb, and it pays for itself only in a process that outlives the request. Serving packs take the authority from the daemon role at the pack factory; a process without it declines and serves degraded rather than building, claiming a rebuild sentinel it will never satisfy, or checkpointing after a stale-tail replay. Direct construction still builds, because the admin reindex path, the benches and the tests exist to build.

3. **Index builds run in a bounded pool.** Half the machine's parallelism rather than the global rayon pool's one thread per core, so a build does not take every core from the process serving requests. `KHIVE_ANN_BUILD_THREADS` overrides; a malformed value falls back to the default rather than failing.

4. **A debounce that coalesces.** The memory pack's chained rebuild debounced for one second so continuous writes would coalesce. Against continuous writes one second coalesces nothing: the chain re-enqueues before the next write lands, so it never idles. The chain exists so a write converges without a reader, not to keep readers fresh, because a recall warms on demand. Default is now 30 seconds, `KHIVE_ANN_REBUILD_DEBOUNCE_MS` overrides.

## Tests

- Two processes, one publishing and one loading, asserting the reader never observes a torn segment set. Each publication writes different bytes: republishing an identical index leaves the stale segments matching the new commit record's hashes, and the first version of this test passed with the fix reverted for exactly that reason. With the fix, zero failed loads across three consecutive runs; with the reader lock reverted, 32 torn reads across 234 loads with the production error string.
- A reader probing `try_lock_shared` while a writer holds the lock observes `WouldBlock`, then loads the finished checkpoint.
- Two readers do not exclude each other, so this does not trade a rebuild storm for a read convoy.
- A directory whose lock file has been removed still loads.
- The role defaults to client and is set only by an explicit mark, in its own test binary because the flag is a process-global that is never cleared.
- A process without build authority declines, installs nothing, publishes nothing and claims no registry row, with a control that builds the same corpus in the same runtime once the authority is there, so the decline is attributable to the role.
- Thread-count and debounce policy including every malformed-override arm.

## What this does not do

The fix reaches the running fleet only when the serving binary is replaced; readers are the client processes. The acceptance measurement is the same sampler script for 20 minutes after that, and the number to watch is publications per hour falling to a write-driven rate rather than a tear-driven one.


Addresses #2446 and #2447.
