### PR TITLE
fix(runtime): a committed write no longer fails on an enqueued audit row

### DIFF
--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -3968,8 +3968,10 @@ pub fn audit_admission_refused_obligation_count() -> u64 {
 
 /// Process-wide count of `DispatchObligation` rows that were **already
 /// enqueued but had not resolved by the time the caller's admission wait
-/// deadline elapsed** (`AuditTerminalReason::AdmissionDeadlineExpired`) for an
-/// [`VerbRegistry::admission_degrade_safe`] verb (#2147/#2217).
+/// deadline elapsed** (`AuditTerminalReason::AdmissionDeadlineExpired`) for a
+/// succeeded dispatch of any verb (#2147/#2217 introduced the count for
+/// [`VerbRegistry::admission_degrade_safe`] reads; writes joined it once a
+/// committed write stopped reporting failure over a row that still commits).
 /// Unlike [`AUDIT_ADMISSION_REFUSED_OBLIGATIONS`], a row counted here is not
 /// a confirmed loss: per `AuditTerminalReason::AdmissionDeadlineExpired`'s own
 /// doc, the row may still be committed (or terminally failed) by the
@@ -4216,8 +4218,13 @@ async fn persist_git_digest_receipt(
 /// derives eligibility from `producer` itself rather than trusting the
 /// caller's `degrade_allowlisted` answer in isolation, so a `DispatchFailed`
 /// row can never take the degrade path no matter what a caller passes: every
-/// failed dispatch, every write verb, every gate-denial/unknown-verb/git.digest
-/// row stays strictly obligation-bearing.
+/// failed dispatch and every gate-denial/unknown-verb/git.digest row stays
+/// strictly obligation-bearing. A succeeded write degrades on exactly one
+/// reason, `AdmissionDeadlineExpired`: its row is already enqueued and its
+/// generation commits it independently of the caller's wait, so failing the
+/// dispatch would report a committed domain write as failed while changing
+/// nothing about the row. `QueueAdmissionExhausted` (refused before enqueue,
+/// a confirmed loss) still fails a write's dispatch.
 ///
 /// When the registry has an audit-batch seam configured (it is whenever
 /// `store` is), the row routes through
@@ -4241,6 +4248,13 @@ async fn append_audit_event_best_effort(
     let is_obligation = classify(producer) == AuditProductionClass::DispatchObligation;
     let admission_degrade_eligible =
         degrade_allowlisted && producer == AuditProducer::DispatchSucceeded;
+    // A row that was enqueued before the caller's admission wait elapsed is
+    // committed by its generation independently of this response, so the
+    // only thing failing the dispatch would do is report a committed domain
+    // write as failed. That holds for every succeeded dispatch, allowlisted
+    // read or not; the refused-before-enqueue arm below stays strict for
+    // writes because that one is a confirmed audit loss.
+    let enqueued_row_outlives_deadline = producer == AuditProducer::DispatchSucceeded;
 
     if let Some(audit_batch) = audit_batch {
         if let Err(reason) = audit_batch
@@ -4263,35 +4277,35 @@ async fn append_audit_event_best_effort(
                 // `AdmissionDeadlineExpired` was already enqueued and may still
                 // commit later — see `AuditTerminalReason::AdmissionDeadlineExpired`'s
                 // own doc.
-                if admission_degrade_eligible {
-                    match reason {
-                        AuditTerminalReason::QueueAdmissionExhausted => {
-                            AUDIT_ADMISSION_REFUSED_OBLIGATIONS
-                                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                            tracing::warn!(
-                                verb,
-                                reason = ?reason,
-                                "read verb's audit obligation row was refused before \
-                                 enqueue under audit-lane admission pressure; dispatch \
-                                 still reports its own result (non-fatal)"
-                            );
-                            return Ok(());
-                        }
-                        AuditTerminalReason::AdmissionDeadlineExpired => {
-                            AUDIT_ADMISSION_UNRESOLVED_OBLIGATIONS
-                                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                            tracing::warn!(
-                                verb,
-                                reason = ?reason,
-                                "read verb's audit obligation row was still enqueued and \
-                                 unresolved when the caller's admission wait deadline \
-                                 elapsed; it may still commit. Dispatch still reports its \
-                                 own result (non-fatal)"
-                            );
-                            return Ok(());
-                        }
-                        _ => {}
-                    }
+                if enqueued_row_outlives_deadline
+                    && reason == AuditTerminalReason::AdmissionDeadlineExpired
+                {
+                    AUDIT_ADMISSION_UNRESOLVED_OBLIGATIONS
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    tracing::warn!(
+                        verb,
+                        reason = ?reason,
+                        degrade_allowlisted,
+                        "audit obligation row was still enqueued and unresolved when \
+                         the caller's admission wait deadline elapsed; its generation \
+                         commits it independently of this response. Dispatch reports \
+                         its own committed result (non-fatal)"
+                    );
+                    return Ok(());
+                }
+                if admission_degrade_eligible
+                    && reason == AuditTerminalReason::QueueAdmissionExhausted
+                {
+                    AUDIT_ADMISSION_REFUSED_OBLIGATIONS
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    tracing::warn!(
+                        verb,
+                        reason = ?reason,
+                        "read verb's audit obligation row was refused before \
+                         enqueue under audit-lane admission pressure; dispatch \
+                         still reports its own result (non-fatal)"
+                    );
+                    return Ok(());
                 }
                 AUDIT_OBLIGATION_APPEND_FAILURES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 tracing::error!(

--- a/crates/khive-runtime/src/pack_disposition_tests.rs
+++ b/crates/khive-runtime/src/pack_disposition_tests.rs
@@ -273,6 +273,7 @@ async fn disposition_audit_deadline_keeps_one_write_and_one_late_audit_row() {
         let registry = Arc::new(builder.build().unwrap());
         let handler_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let project_id = uuid::Uuid::new_v4();
+        let unresolved_before = crate::pack::audit_admission_unresolved_obligation_count();
         let mut dispatch = tokio::spawn({
             let registry = registry.clone();
             let notes = notes.clone();
@@ -320,29 +321,47 @@ async fn disposition_audit_deadline_keeps_one_write_and_one_late_audit_row() {
         .await
         .expect("released audit generation drains")
         .expect("late audit commit succeeds");
-        let error = response
+        let response = response
             .expect("audit deadline returns without waiting for the store release")
-            .expect("dispatch task joins")
-            .unwrap_err();
+            .expect("dispatch task joins");
         assert!(audit_was_uncommitted);
-        assert_eq!(error.disposition(), DomainDisposition::Committed);
-        assert!(error.source().retryable_failure_context().is_none());
-        let RuntimeError::AuditObligation {
-            failure,
-            domain_result,
-        } = error.into_source()
-        else {
-            panic!("expired post-write audit must retain the canonical domain result");
+        // The domain write committed and its audit row is enqueued; the
+        // generation commits that row on its own, so the dispatch reports the
+        // committed result. Only the git.digest receipt stays strict: there the
+        // audit row is the receipt the caller is promised.
+        let domain_result = if verb == "git.digest" {
+            let error = response.unwrap_err();
+            assert_eq!(error.disposition(), DomainDisposition::Committed);
+            assert!(error.source().retryable_failure_context().is_none());
+            let RuntimeError::AuditObligation {
+                failure,
+                domain_result,
+            } = error.into_source()
+            else {
+                panic!("expired receipt must retain the canonical domain result");
+            };
+            assert_eq!(failure.wire_code(), "admission_deadline_expired");
+            assert_eq!(
+                failure.reason,
+                crate::AuditObligationReason::Terminal(
+                    crate::audit_batch::AuditTerminalReason::AdmissionDeadlineExpired
+                )
+            );
+            domain_result
+        } else {
+            response
+                .expect("a committed write whose audit row is enqueued reports success")
+                .result
         };
-        assert_eq!(failure.wire_code(), "admission_deadline_expired");
-        assert_eq!(
-            failure.reason,
-            crate::AuditObligationReason::Terminal(
-                crate::audit_batch::AuditTerminalReason::AdmissionDeadlineExpired
-            )
-        );
         assert_eq!(domain_result["project_id"], serde_json::json!(project_id));
         assert_eq!(domain_result["count"], 1);
+        if verb != "git.digest" {
+            assert_eq!(
+                crate::pack::audit_admission_unresolved_obligation_count(),
+                unresolved_before + 1,
+                "a degraded write counts on the unresolved-obligation counter"
+            );
+        }
         let id = domain_result["id"].as_str().unwrap().parse().unwrap();
         assert!(notes.get_note(id).await.unwrap().is_some());
         assert_eq!(notes.count_notes("local", None).await.unwrap(), 1);


### PR DESCRIPTION
## What this fixes

A write verb whose domain transaction has already committed can report failure. On one host on 2026-09-08 the daemon log carried 516 dispatches that failed after their row existed, all with the same reason: `comm.cursor_get` 213, `comm.send` 43, `comm.heartbeat` 33, the rest spread over other verbs. The same day recorded 2,790 audit admission deadline expiries in total, against 385 the day before, and 0 queue admission refusals.

## Why

Dispatch order in `crates/khive-runtime/src/pack.rs`: the gate check runs, the handler runs and commits its transaction, then the DispatchSucceeded audit row is submitted to the audit batch and awaited under the caller's admission deadline. When that wait elapses on a row that is already enqueued, the generation driver still commits the row on its own; the caller's timeout changes nothing about it. For verbs on the admission-degrade allowlist this was already best-effort. For every other verb the dispatch failed, so a caller saw `audit obligation commit failed: AdmissionDeadlineExpired` for a write that had landed and an audit row that was going to land too.

`QueueAdmissionExhausted` is a different fact: the row was refused before enqueue and is a confirmed loss. That arm is unchanged and still fails a write's dispatch.

## The change

- `append_audit_event_best_effort`: an `AdmissionDeadlineExpired` on a succeeded dispatch degrades to success for every verb, counted on the existing unresolved-obligation counter (`writer_contention.audit_admission_unresolved_obligations` in `db_diagnostics`) and logged with the verb and whether it was allowlisted. The allowlist still decides the refused-before-enqueue arm for reads.
- The `git.digest` receipt path is separate and stays strict: there the audit row is the receipt the caller is promised.

## Tests

- `disposition_audit_deadline_keeps_one_write_and_one_late_audit_row`: the write arm now asserts the dispatch returns the committed domain result, the note exists once, the handler ran once, the late audit row drains exactly once, and the unresolved counter moved by one. The `git.digest` arm keeps its previous assertions.
- The read-verb deadline test in `tests/read_verb_admission_exhaustion.rs` is unchanged and still passes through the same arm.

## Measurement

Before: 516 failed-with-row-present dispatches in one day on one host, from `grep -c 'failing dispatch'` over the daemon log. After: the same count on the same host after the binary carrying this is serving; the expected value is 0, with the expiries themselves still visible on the unresolved counter.
