### PR TITLE
docs(vamana): plain reference to the private build_thread_count

### DIFF
--- a/crates/khive-vamana/src/index.rs
+++ b/crates/khive-vamana/src/index.rs
@@ -576,7 +576,7 @@ impl VamanaIndex {
     /// Uses `GsSq8Codec` for the acquisition-tier distance during graph construction
     /// (ADR-052 §1, Step 2: default-on for Vamana, algebraically exact in code space).
     ///
-    /// Runs inside the bounded build pool (see [`build_thread_count`]), so every
+    /// Runs inside the bounded build pool (see `build_thread_count`), so every
     /// nested `par_iter` in graph construction inherits that bound instead of the
     /// global pool's one-thread-per-core.
     pub fn build(vectors: &[f32], config: VamanaConfig) -> Result<Self> {


### PR DESCRIPTION
The public docs of `VamanaIndex::build` linked the private `build_thread_count`, which the doc build rejects under `-D warnings` (`rustdoc::private_intra_doc_links`). A code span says the same thing without a link. `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace` passes locally on this head.
