### PR TITLE
docs(kg,mcp): state the envelope contract of get and neighbors in help

### DIFF
--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -4710,7 +4710,10 @@ fn build_instructions(catalog: &str, builtins: &str) -> String {
     format!(
         "khive — request-only MCP surface. One tool, `request`, \
          dispatches verbs through the loaded pack registry. Configure packs via \
-         KHIVE_PACKS or --pack (built-ins: {builtins}). Verbs registered on this \
+         KHIVE_PACKS or --pack (built-ins: {builtins}). The kg pack's verbs are \
+         unprefixed (create, get, list, search, link, neighbors, ...); every other pack's \
+         verbs are written pack.verb. Read verbs return their record or hits directly \
+         unless the verb's help says it wraps them in an envelope. Verbs registered on this \
          server:\n{catalog}\nFor detailed usage of each verb, see the corresponding \
          plugin's SKILL.md files.\n\
          Docs: https://ohdearquant.github.io/khive/ (hosted) or docs/*.md in the repo \

--- a/crates/khive-pack-kg/src/handler_defs.rs
+++ b/crates/khive-pack-kg/src/handler_defs.rs
@@ -136,7 +136,10 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 20] = [
     // Assertive: retrieves and presents a record
     HandlerDef {
         name: "get",
-        description: "Fetch any record by UUID",
+        description: "Fetch any record by UUID. Returns the bare record, no envelope: `kind` is \
+                      the granular kind (concept, task, observation, ...), `entity_type` is the \
+                      governed subtype when one is set, and an entity's vocabulary type lives \
+                      at `properties.type`.",
         visibility: Visibility::Verb,
         category: VerbCategory::Assertive,
         params: &[
@@ -784,7 +787,10 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 20] = [
     // Assertive: retrieves immediate graph neighbors
     HandlerDef {
         name: "neighbors",
-        description: "Immediate graph neighbors; each hit includes origin_id for the queried node",
+        description: "Immediate graph neighbors, returned as a bare array of hits rather than the \
+                      {\"items\": [...]} envelope `list` uses. Each hit carries origin_id for the \
+                      queried node, edge_id, relation, weight, and the neighbor's id, kind and \
+                      name; include_entity_type=true adds entity_type when the neighbor has one.",
         visibility: Visibility::Verb,
         category: VerbCategory::Assertive,
         params: &[

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -231,7 +231,7 @@ request(ops="create(kind=\"concept\", name=\"RoPE\", description=\"Rotary positi
 
 ### `get` — Assertive
 
-Fetch any record by UUID (auto-detects entity/note/edge/event/proposal).
+Fetch any record by UUID (auto-detects entity/note/edge/event/proposal). Returns the bare record with no envelope: `kind` is the granular kind (`concept`, `task`, `observation`, ...), `entity_type` is the governed subtype when one is set, and an entity's vocabulary type lives at `properties.type`.
 
 | Param             | Type | Required | Notes                                                                  |
 | ----------------- | ---- | -------- | ---------------------------------------------------------------------- |
@@ -575,7 +575,7 @@ request(ops="link(source_id=\"<uuid-a>\", target_id=\"<uuid-b>\", relation=\"ext
 
 ### `neighbors` — Assertive
 
-Immediate graph neighbors.
+Immediate graph neighbors, returned as a bare array of hits rather than the `{"items": [...]}` envelope that `list` uses. Each hit carries `origin_id` for the queried node, `edge_id`, `relation`, `weight`, and the neighbor's `id`, `kind` and `name`; `include_entity_type=true` adds `entity_type` when the neighbor has one.
 
 Each returned hit includes `origin_id`, the resolved queried node. This lets
 batch callers verify that every result is associated with the submitted root.


### PR DESCRIPTION
## What this states

Callers read the verb help through `verbs()` and the MCP instructions, and three shapes were not written down anywhere a caller reads:

- `get` returns the bare record with no envelope. `kind` is the granular kind (`concept`, `task`, `observation`, ...), `entity_type` is the governed subtype when one is set, and an entity's vocabulary type lives at `properties.type`.
- `neighbors` returns a bare array of hits, while `list` returns the `{"items": [...]}` envelope. Each hit carries `origin_id` for the queried node, `edge_id`, `relation`, `weight`, and the neighbor's `id`, `kind` and `name`; `include_entity_type=true` adds `entity_type` when the neighbor has one.
- The kg pack's verbs are unprefixed; every other pack's verbs are written `pack.verb`.

Measured against the serving binary before writing: `list(kind="entity", limit=1) | get(id=...) | neighbors(node_id=..., include_entity_type=true, limit=2)` returned an envelope, a bare record with `kind: concept`, `entity_type: null` and `properties.type` set, and a bare array of two hits with exactly the keys listed.

## Where

`crates/khive-pack-kg/src/handler_defs.rs` for the two verb descriptions, `crates/khive-mcp/src/server.rs` for the instructions sentence, `docs/guide/api-reference.md` for the same two statements. No behaviour changes.
