### PR TITLE
fix(mcp): a bridge behind a newer daemon re-execs instead of failing

### DIFF
--- a/crates/khive-mcp/docs/api/daemon-lifecycle.md
+++ b/crates/khive-mcp/docs/api/daemon-lifecycle.md
@@ -136,7 +136,12 @@ post-write outcome), which stay RPC-level errors.
 ## `trigger_bridge_self_heal` — concurrency accepted-risk note (#714)
 
 Called from both `forward_or_spawn`'s `ProtocolMismatch` arms (first-attempt
-and post-recovery-retry). If the bridge is mid-flight on more than one
+and post-recovery-retry). `ProtocolMismatch` covers both directions: a daemon
+behind this bridge and a daemon ahead of it. The second is the rebuilt-binary
+case the re-exec exists for (the on-disk binary was swapped and the daemon
+respawned from it while this process kept the old one); before it was routed
+here, that direction returned the hard error on every request and never
+re-exec'd. If the bridge is mid-flight on more than one
 outstanding client request when the mismatch fires, only the request that
 triggered this arm gets the ambiguous-error-then-resume treatment; any other
 in-flight request loses its response the same way it would if the process

--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -540,13 +540,17 @@ enum ForwardOutcome {
     /// daemon speaking a different wire format.
     ParseFailure,
     /// Connected and decoded a response, but the daemon's `daemon_protocol_version`
-    /// does not match [`PROTOCOL_VERSION`] even though `version_mismatch` is false.
-    /// This is the new-client + old-daemon (pre-versioning) scenario: the old daemon
-    /// ignores the unknown request field and returns a decodable response whose
-    /// protocol fields default to `false`/`0`. Since the real request was already
-    /// written, the client must treat this exactly like `ParseFailure`: return a
-    /// hard error without retrying, locally dispatching, killing, or respawning.
-    ProtocolMismatch,
+    /// does not match [`PROTOCOL_VERSION`], in either direction. Below: the
+    /// new-client + old-daemon scenario, implicit (a pre-versioning daemon ignores
+    /// the unknown request field and returns a decodable response whose protocol
+    /// fields default to `false`/`0`) or explicit (`version_mismatch=true` with the
+    /// daemon's lower number). Above: this bridge is the stale side, a rebuild
+    /// swapped the on-disk binary and respawned the daemon under a newer protocol
+    /// while this process kept running the old one. Since the real request was
+    /// already written, the client treats both exactly like `ParseFailure`: a hard
+    /// error without retrying, locally dispatching, killing, or respawning; the
+    /// consumer arms the #714 self-heal beside it.
+    ProtocolMismatch { daemon_protocol_version: u32 },
 }
 
 fn classify_socket_connect_error(error: std::io::Error) -> ForwardOutcome {
@@ -686,18 +690,24 @@ async fn try_forward_inner(frame: &DaemonRequestFrame) -> ForwardOutcome {
             // with `version_mismatch=true` and its own (lower) version number.
             // `daemon_protocol_version < PROTOCOL_VERSION` means the daemon is
             // stale — route through the same terminal error as the implicit case
-            // above. If `daemon_protocol_version > PROTOCOL_VERSION` the client
-            // binary is behind; let `map_response` return its hard error too.
-            let is_stale_daemon = frame.daemon_protocol_version != PROTOCOL_VERSION
-                && (!frame.version_mismatch || frame.daemon_protocol_version < PROTOCOL_VERSION);
-            if is_stale_daemon {
+            // above. `daemon_protocol_version > PROTOCOL_VERSION` means this bridge
+            // binary is behind: a rebuild swapped the on-disk binary and respawned
+            // the daemon under a newer protocol while this process kept running the
+            // old one. That is the scenario the #714 self-heal exists for, so it
+            // takes the same terminal path and the consumer arms the re-exec, which
+            // picks up the on-disk binary the daemon itself was spawned from.
+            // Leaving that direction to `map_response` returned the hard error on
+            // every request for the rest of the process's life and never re-exec'd.
+            if frame.daemon_protocol_version != PROTOCOL_VERSION {
                 tracing::warn!(
                     daemon_version = frame.daemon_protocol_version,
                     expected = PROTOCOL_VERSION,
                     explicit_mismatch = frame.version_mismatch,
                     "daemon protocol version mismatch after request write — rejecting without retry",
                 );
-                return ForwardOutcome::ProtocolMismatch;
+                return ForwardOutcome::ProtocolMismatch {
+                    daemon_protocol_version: frame.daemon_protocol_version,
+                };
             }
             ForwardOutcome::Response(Box::new(frame))
         }
@@ -716,6 +726,25 @@ async fn try_forward_inner(frame: &DaemonRequestFrame) -> ForwardOutcome {
 fn daemon_mcp_error(message: impl Into<String>, data: Option<serde_json::Value>) -> McpError {
     let error = daemon::DaemonDispatchError::new(message, data);
     McpError::internal_error(error.message, Some(error.error_detail))
+}
+
+/// The operator-facing text for a protocol mismatch, by direction. A daemon ahead
+/// of this bridge is the rebuilt-binary case: the bridge re-execs the on-disk binary
+/// once this response has flushed (#714), so the caller's next request reaches a
+/// bridge that matches.
+fn protocol_mismatch_message(daemon_protocol_version: u32) -> String {
+    if daemon_protocol_version > PROTOCOL_VERSION {
+        format!(
+            "daemon protocol mismatch: this bridge speaks version {PROTOCOL_VERSION}, the \
+             daemon speaks {daemon_protocol_version}; the bridge re-execs the current binary \
+             after this response, retry the request"
+        )
+    } else {
+        format!(
+            "daemon protocol mismatch: expected version {PROTOCOL_VERSION}; \
+             run `make local` to rebuild the daemon binary"
+        )
+    }
 }
 
 fn protocol_mismatch_error(message: String, data: Option<serde_json::Value>) -> McpError {
@@ -1314,7 +1343,7 @@ async fn probe_daemon_identity(config_id: &str, namespace: &str, timeout_ms: u64
         Ok(
             ForwardOutcome::NoSocket
             | ForwardOutcome::ParseFailure
-            | ForwardOutcome::ProtocolMismatch,
+            | ForwardOutcome::ProtocolMismatch { .. },
         ) => ProbeOutcome::Dead,
         Ok(ForwardOutcome::Unreachable {
             kind,
@@ -2380,7 +2409,9 @@ where
             );
             return Some(Err(ambiguous_forward_error()));
         }
-        ForwardOutcome::ProtocolMismatch => {
+        ForwardOutcome::ProtocolMismatch {
+            daemon_protocol_version,
+        } => {
             let config_id = opaque_config_id(&frame.config_id);
             tracing::warn!(
                 config_id = %config_id,
@@ -2394,10 +2425,7 @@ where
             // the hard error below, never in place of it.
             trigger_bridge_self_heal();
             return Some(Err(protocol_mismatch_error(
-                format!(
-                    "daemon protocol mismatch: expected version {PROTOCOL_VERSION}; \
-                     run `make local` to rebuild the daemon binary"
-                ),
+                protocol_mismatch_message(daemon_protocol_version),
                 None,
             )));
         }
@@ -2506,7 +2534,9 @@ where
                 );
                 return Some(Err(ambiguous_forward_error()));
             }
-            ForwardOutcome::ProtocolMismatch => {
+            ForwardOutcome::ProtocolMismatch {
+                daemon_protocol_version,
+            } => {
                 let config_id = opaque_config_id(&frame.config_id);
                 tracing::warn!(
                     config_id = %config_id,
@@ -2519,10 +2549,7 @@ where
                 // was the first probe or a retry after a kill/respawn.
                 trigger_bridge_self_heal();
                 return Some(Err(protocol_mismatch_error(
-                    format!(
-                        "daemon protocol mismatch: expected version {PROTOCOL_VERSION}; \
-                         run `make local` to rebuild the daemon binary"
-                    ),
+                    protocol_mismatch_message(daemon_protocol_version),
                     None,
                 )));
             }
@@ -5282,6 +5309,125 @@ mod tests {
         std::env::remove_var("KHIVE_LOCK");
     }
 
+    // ── bridge behind the daemon: the self-heal must arm ─────────────────────
+    //
+    // A binary swap that carries a protocol bump respawns the daemon under the
+    // new number while every running bridge keeps the old one. The daemon
+    // refuses each request with `version_mismatch=true` and its higher number.
+    // Before the fix `try_forward_inner` classified that as `Response` and
+    // `map_response` returned the hard error on every request for the rest of
+    // the bridge's life; the #714 re-exec, built for exactly this scenario, was
+    // armed only for the daemon-behind direction. Now both directions classify
+    // as `ProtocolMismatch`, the error names the direction, and the re-exec is
+    // armed so the next flush re-execs the on-disk binary the daemon came from.
+
+    fn newer_daemon_response(config_id: &str) -> DaemonResponseFrame {
+        DaemonResponseFrame {
+            ok: false,
+            result: None,
+            error: Some(format!(
+                "daemon protocol mismatch: client={} daemon={} — \
+                 rebuild/update the client binary (make local)",
+                PROTOCOL_VERSION,
+                PROTOCOL_VERSION + 1
+            )),
+            error_detail: None,
+            namespace_mismatch: false,
+            config_mismatch: false,
+            served_config_id: Some(config_id.to_string()),
+            version_mismatch: true,
+            daemon_protocol_version: PROTOCOL_VERSION + 1,
+            metrics: None,
+            request_id: None,
+        }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn forward_or_spawn_behind_a_newer_daemon_returns_the_error_and_arms_reexec() {
+        clear_daemon_env();
+        clear_pending_self_heal();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sock = dir.path().join("khived.sock");
+        let pid_file = dir.path().join("khived.pid");
+        let lock_file = dir.path().join("khived.recovery.lock");
+
+        std::env::set_var("KHIVE_SOCKET", &sock);
+        std::env::set_var("KHIVE_PID", &pid_file);
+        std::env::set_var("KHIVE_LOCK", &lock_file);
+        std::env::remove_var("KHIVE_NO_DAEMON");
+
+        let config_id = "packs=[kg];db=:memory:;embed=none;extra=[];backend=main";
+        let listener =
+            tokio::net::UnixListener::bind(&sock).expect("bind fake newer-daemon socket");
+        std::fs::write(&pid_file, std::process::id().to_string()).expect("write pid file");
+        let fake_handle = tokio::spawn(serve_one_response(
+            listener,
+            newer_daemon_response(config_id),
+        ));
+
+        let frame = DaemonRequestFrame {
+            plan: false,
+            ops: "stats()".to_string(),
+            presentation: None,
+            presentation_per_op: None,
+            namespace: "test".to_string(),
+            actor_id: None,
+            process_ref: None,
+            visible_namespaces: Vec::new(),
+            config_id: config_id.to_string(),
+            protocol_version: PROTOCOL_VERSION,
+            probe_only: false,
+            metrics_only: false,
+            format: None,
+            format_per_op: None,
+            from_wire: false,
+            request_id: None,
+        };
+
+        let result = forward_or_spawn(&frame).await;
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(2), fake_handle).await;
+
+        match result {
+            Some(Err(McpError { message, .. })) => {
+                assert!(
+                    message.contains("protocol mismatch"),
+                    "error must name 'protocol mismatch'; got: {message}"
+                );
+                assert!(
+                    message.contains("re-execs"),
+                    "error must say this bridge re-execs itself, not send the operator to \
+                     rebuild a daemon that is already current; got: {message}"
+                );
+            }
+            Some(Ok(v)) => {
+                panic!("forward_or_spawn must NOT accept a newer daemon's refusal; got Ok({v:?})")
+            }
+            None => panic!(
+                "forward_or_spawn must return Some(Err(..)) for protocol mismatch, \
+                 not None (which would cause silent fallback to local dispatch)"
+            ),
+        }
+
+        let armed = *PENDING_SELF_HEAL
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        assert_eq!(
+            armed,
+            Some(MismatchRecovery::ReexecScheduled),
+            "a bridge behind the daemon must arm the in-place re-exec"
+        );
+        // The pid file belongs to the live daemon; the terminal path leaves it alone.
+        assert!(
+            pid_file.exists(),
+            "the newer daemon's pid file must survive"
+        );
+
+        clear_pending_self_heal();
+        clear_daemon_env();
+        std::env::remove_var("KHIVE_LOCK");
+    }
+
     // ── daemon crash mid-dispatch regression (#91) ────────────────────────────
     //
     // When the daemon crashes (or panics) during dispatch it closes the
@@ -7265,7 +7411,7 @@ mod tests {
         let _ = tokio::time::timeout(std::time::Duration::from_secs(2), fake_handle).await;
 
         assert!(
-            matches!(outcome, ForwardOutcome::ProtocolMismatch),
+            matches!(outcome, ForwardOutcome::ProtocolMismatch { .. }),
             "explicit version_mismatch=true with daemon_protocol_version < PROTOCOL_VERSION \
              must classify as ProtocolMismatch (terminal no-retry path), not Response \
              (which would lose the stable stale-daemon classification)"


### PR DESCRIPTION
## What this fixes

A bridge process (`kkernel mcp`, one per MCP session) that is behind the daemon it forwards to returned a hard error on every request for the rest of its life and never recovered.

Measured on 2026-09-08 after a binary swap whose build had moved the daemon protocol from 4 to 5: the respawned daemon refused each request from a pre-swap bridge with `daemon protocol mismatch: client=4 daemon=5` and the instruction to rebuild the client binary, the bridge surfaced that verbatim, and none of the 22 running bridges re-executed. Every session that had opened its bridge before the swap lost the whole `request` surface until a person reconnected it.

## Why

`try_forward_inner` classified a decoded response as `ProtocolMismatch` only when the daemon was the older side (`daemon_protocol_version < PROTOCOL_VERSION`, or a pre-versioning daemon reporting 0). When the daemon was the newer side the response passed through as `Response` and `map_response` returned the hard error. The #714 self-heal, an in-place re-exec of the on-disk binary that fires once the mismatch response has flushed, was wired to the `ProtocolMismatch` arms only, so it never armed in the one scenario it was built for: the on-disk binary was rebuilt, the daemon came back from it, and this process kept running the old one.

## The change

- `try_forward_inner`: any `daemon_protocol_version` that differs from `PROTOCOL_VERSION` is `ProtocolMismatch`, in both directions. The variant now carries the daemon's number.
- Both `ProtocolMismatch` consumers keep the terminal no-retry path and the self-heal trigger; the error text names the direction. A daemon ahead of the bridge says the bridge re-execs the current binary after this response and the caller should retry; a daemon behind keeps the previous `make local` text.
- The stale-daemon classification and its tests are unchanged.

## Tests

- `forward_or_spawn_behind_a_newer_daemon_returns_the_error_and_arms_reexec`: a fake daemon on the socket answers with `version_mismatch=true` and `PROTOCOL_VERSION + 1`; the call returns the mismatch error naming the re-exec, the pending self-heal slot holds `ReexecScheduled`, and the daemon's pid file is untouched. Against the previous classification this test fails on the slot assertion (the slot stays empty) and on the message.
- `forward_or_spawn_rejects_old_daemon_and_returns_protocol_mismatch_error` and `try_forward_inner_returns_protocol_mismatch_for_explicit_version_mismatch` still pass.

## Measurement

Before: 22 of 22 bridges running when the swap landed stayed refused (0 re-exec lines in the daemon log, every bridge still on its old inode 20 minutes later). After: on the next protocol bump, every bridge built from this change re-execs on its first refused request, read the same way (inode per pid before and after, re-exec lines in the log).
