### PR TITLE
fix(runtime): refuse older clients in the shape their bridges heal on

### DIFF
--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -1322,7 +1322,19 @@ async fn handle_conn_with_shutdown<D: DaemonDispatch>(
             namespace_mismatch: false,
             config_mismatch: false,
             served_config_id,
-            version_mismatch: true,
+            // A client below this protocol is a bridge that predates the binary this
+            // daemon was spawned from. Through protocol 5 the bridge treats an
+            // explicit `version_mismatch` from a higher-numbered daemon as a terminal
+            // error it repeats on every request, and re-execs itself onto the on-disk
+            // binary only for the implicit shape: an unequal `daemon_protocol_version`
+            // with the flag clear. Answering older clients in that shape, still
+            // refused and still carrying the code in `error_detail`, lets every
+            // pre-swap bridge replace itself on its first request instead of staying
+            // refused until a person reconnects the session. A client above this
+            // protocol keeps the explicit flag. Remove at the next protocol bump:
+            // bridges built with the two-direction re-exec in khive-mcp no longer
+            // read the flag.
+            version_mismatch: frame.protocol_version > PROTOCOL_VERSION,
             daemon_protocol_version: PROTOCOL_VERSION,
             metrics: None,
             request_id: frame.request_id,
@@ -3521,7 +3533,14 @@ mod tests {
 
         let response = round_trip(dispatcher, &request).await;
         assert!(!response.ok);
-        assert!(response.version_mismatch);
+        assert!(
+            !response.version_mismatch,
+            "a client below this protocol is answered in the implicit shape its bridge re-execs on"
+        );
+        assert_eq!(
+            response.error_detail.as_ref().unwrap()["code"],
+            "version_mismatch"
+        );
         assert_eq!(
             response.error_detail.as_ref().unwrap()["domain_disposition"],
             "unknown"
@@ -3536,6 +3555,42 @@ mod tests {
         assert!(
             error.contains("client=3") && error.contains(&format!("daemon={PROTOCOL_VERSION}")),
             "mismatch must identify the exact rollout boundary; got {error:?}"
+        );
+    }
+
+    /// A client above this protocol is answered with the explicit flag: that
+    /// direction is the warm-old-daemon case, where the newer client's own
+    /// handling replaces the daemon, and the implicit shape reserved for older
+    /// bridges must not reach it. A matching client is served (the round-trip
+    /// tests above).
+    #[tokio::test]
+    async fn newer_client_frame_is_refused_with_the_explicit_flag() {
+        let dispatch_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let dispatcher = MockDispatch {
+            namespace: "local".to_string(),
+            config_id: "cfg-v4".to_string(),
+            dispatch_calls: Arc::clone(&dispatch_calls),
+            pool: None,
+            dispatch_err: None,
+        };
+        let mut request = base_request_frame("cfg-v4");
+        request.protocol_version = PROTOCOL_VERSION + 1;
+
+        let response = round_trip(dispatcher, &request).await;
+        assert!(!response.ok);
+        assert!(
+            response.version_mismatch,
+            "a client above this protocol keeps the explicit flag"
+        );
+        assert_eq!(response.daemon_protocol_version, PROTOCOL_VERSION);
+        assert_eq!(
+            response.error_detail.as_ref().unwrap()["code"],
+            "version_mismatch"
+        );
+        assert_eq!(
+            dispatch_calls.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "a newer client's frame must not dispatch"
         );
     }
 


### PR DESCRIPTION
## What this does

The daemon's refusal of a client whose protocol number is below its own now carries `version_mismatch: false` beside the daemon's number. The request is still refused before dispatch, the error text is unchanged, and `error_detail.code` is still `version_mismatch`. A client whose number is above the daemon's keeps the explicit flag; a matching client is served as before.

## Why

Every bridge (`kkernel mcp`) deployed through protocol 5 handles a daemon on another protocol in two ways. An explicit `version_mismatch` from a higher-numbered daemon is a terminal error it repeats on every request until its session is reconnected by hand. The implicit shape, an unequal `daemon_protocol_version` with the flag clear, is the one it re-execs itself on, onto the on-disk binary (#714). After the swap on 2026-09-08 that raised the protocol from 4 to 5, all 22 running bridges took the first path and none recovered. #2452 corrects the bridge for the future, but it reaches only bridges built from it. Answering older clients in the implicit shape reaches the bridges that exist now: on their first request each one refuses, re-execs onto the current binary, and serves from the next request on.

## Scope and removal

- Fires only for `protocol_version < PROTOCOL_VERSION`. The test `newer_client_frame_is_refused_with_the_explicit_flag` asserts a client above the daemon still receives `version_mismatch: true`; the matching case is covered by the existing round-trip tests.
- `protocol_v3_frame_is_rejected_before_process_ref_dispatch` now asserts the implicit shape for an older client, the `version_mismatch` code in `error_detail`, and that nothing dispatches.
- A pinned Python client below the daemon's protocol sees the plain refusal text rather than its typed `version_mismatch` error, because `python/khive/transport.py` keys the typed error on the flag; the error message names both versions either way.
- Remove at the next protocol bump: every bridge able to reach that daemon will have been built with the two-direction re-exec from #2452, and the line goes back to `version_mismatch: true`. The comment at the site says so.

## Measurement

Before: 22 of 22 bridges running at the 2026-09-08 swap stayed refused. After: on the swap carrying this change, the same bridges (same pids) move to the new binary's inode on their first request with no reconnect, and the count of `protocol version mismatch` lines in the daemon log stops rising.
