### PR TITLE
fix(runtime): a failed audit flush sets the lifetime degraded flag

### DIFF
--- a/crates/khive-db/src/diagnostics.rs
+++ b/crates/khive-db/src/diagnostics.rs
@@ -774,9 +774,11 @@ pub struct WriterContentionDiagnostics {
     pub audit_degraded_rows: Option<u64>,
     /// Why `audit_degraded_rows` is unavailable to this caller.
     pub audit_degraded_rows_unavailable_reason: Option<String>,
-    /// Monotonic process-lifetime flag set once any row has been released
-    /// degraded. `None` under the same conditions as
-    /// `audit_batch_flush_failures`.
+    /// Monotonic process-lifetime flag set once any accepted row has been
+    /// released without a commit: a pure-observability row released degraded,
+    /// or a generation that failed to flush, whose rows are absent from the
+    /// audit trail whether or not their callers were told. `None` under the
+    /// same conditions as `audit_batch_flush_failures`.
     pub audit_degraded: Option<bool>,
     /// Why `audit_degraded` is unavailable to this caller.
     pub audit_degraded_unavailable_reason: Option<String>,

--- a/crates/khive-runtime/src/audit_batch.rs
+++ b/crates/khive-runtime/src/audit_batch.rs
@@ -298,6 +298,7 @@ impl Inner {
         let drained: Vec<Waiting> = std::mem::take(&mut state.pending);
         if !already_failed {
             state.flush_failures += 1;
+            state.degraded = true;
             let generation_id = state.next_generation_id;
             state.generations.push(AuditGenerationSnapshot {
                 generation_id,
@@ -583,6 +584,7 @@ async fn supervisor_loop(
                     state.in_flight_generation = None;
                     state.store_batch_calls += 1;
                     state.flush_failures += 1;
+                    state.degraded = true;
                     let generation_id = state.next_generation_id.saturating_sub(1);
                     state.generations.push(AuditGenerationSnapshot {
                         generation_id,

--- a/crates/khive-runtime/tests/adr133_audit_batch.rs
+++ b/crates/khive-runtime/tests/adr133_audit_batch.rs
@@ -449,6 +449,36 @@ async fn d1_supervisor_panic_fails_waiters_before_background_baseline() {
     assert_eq!(result, Err(AuditTerminalReason::DriverPanicked));
     let metrics = batch.metrics_snapshot();
     assert_eq!(metrics.flush_failures, 1);
+    assert!(
+        metrics.degraded,
+        "a flush failure leaves rows out of the audit trail, so the lifetime flag must read true"
+    );
+    assert_eq!(metrics.degraded_rows, 0);
+}
+
+#[serial]
+#[tokio::test]
+async fn d8_exhausted_commit_retries_set_the_lifetime_degraded_flag() {
+    let store = FakeStore::new();
+    store.fail_next.store(8, Ordering::SeqCst);
+    let batch = AuditBatch::new(store.clone(), AuditBatchConfig::default());
+    let result = batch
+        .submit(PreparedAuditRow {
+            event: mk_event("kg.create"),
+            producer: AuditProducer::DispatchSucceeded,
+        })
+        .await;
+    assert_eq!(result, Err(AuditTerminalReason::StoreFailure));
+    let metrics = batch.metrics_snapshot();
+    assert_eq!(metrics.flush_failures, 1);
+    assert!(
+        metrics.degraded,
+        "a generation that failed to flush leaves its rows out of the audit trail"
+    );
+    assert_eq!(
+        metrics.degraded_rows, 0,
+        "an obligation row released with an error is not a degraded pure-observability row"
+    );
 }
 
 #[serial]

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -897,7 +897,8 @@ neither is ever `null`.
 `audit_batch_flush_failures`, `audit_degraded_rows`, and `audit_degraded` are additive fields
 supplied by the runtime's audit-batch control once one is registered: accepted batch generations
 that reached a terminal non-commit outcome after retry, pure-observability rows released without a
-commit, and a monotonic process-lifetime degradation flag, respectively. Each carries a matching
+commit, and a monotonic process-lifetime degradation flag that either of the first two sets,
+respectively. Each carries a matching
 `_unavailable_reason` field and reports `null` — never a fabricated `0`/`false` — for a direct
 `khive-db` caller or a runtime with no audit-batch control registered.
 


### PR DESCRIPTION
## What this fixes

`db_diagnostics` could report `writer_contention.audit_batch_flush_failures: 1` beside `audit_degraded: false`. An operator reading the flag saw a healthy audit trail on a process that had already lost a generation of audit rows.

## Why

`audit_degraded` was set on one path only: a pure-observability row released without a commit. A generation that fails to flush, whether the driver died or the commit retries were exhausted, releases every waiting row with an error and incremented only `flush_failures`. Those rows are missing from the audit trail exactly as the pure-observability ones are, and a caller whose admission deadline had already expired was never told.

## The change

- Both flush-failure arms in `crates/khive-runtime/src/audit_batch.rs` set the lifetime flag beside the counter. `degraded_rows` is unchanged and still counts pure-observability releases only.
- Field documentation in `crates/khive-db/src/diagnostics.rs` and `docs/guide/api-reference.md` now states what sets the flag.

## Tests

- `d1_supervisor_panic_fails_waiters_before_background_baseline` additionally asserts the flag is true and `degraded_rows` is 0 after a driver death.
- New `d8_exhausted_commit_retries_set_the_lifetime_degraded_flag`: a store that keeps failing past `max_commit_attempts` yields `Err(StoreFailure)`, `flush_failures` 1, the flag true, `degraded_rows` 0.
- Control: with the driver-death arm reverted, the first test fails on the new assertion; restored, both pass. Run with `--features fault-injection,test-internals`.

## Measurement

Before: on one host, one daemon lifetime, `audit_batch_flush_failures` 1 with `audit_degraded` false. After: the same read on the first daemon lifetime that records a flush failure shows the flag true; the target for the counter itself stays 0 per day.
