### PR TITLE
test: the red suites assert the shipped contract, not the replaced one

### DIFF
--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -4604,8 +4604,20 @@ mod tests {
         };
         let resp_ver = exchange(&sock, &wrong_version).await;
         assert!(
-            resp_ver.version_mismatch,
-            "wrong protocol version must set version_mismatch"
+            !resp_ver.version_mismatch,
+            "a client below the daemon's protocol is refused with version_mismatch=false: \
+             the flag is reserved for a client that is ahead, and the deployed bridges \
+             re-exec on this shape. The typed code below carries the fact instead."
+        );
+        assert_eq!(
+            resp_ver
+                .error_detail
+                .as_ref()
+                .and_then(|detail| detail.get("code"))
+                .and_then(serde_json::Value::as_str),
+            Some("version_mismatch"),
+            "the refusal must stay typed as a version mismatch; got: {:?}",
+            resp_ver.error_detail
         );
         assert!(!resp_ver.ok);
         assert!(
@@ -7431,30 +7443,9 @@ mod tests {
     // This test asserts try_forward_inner returns ForwardOutcome::Response
     // (not ProtocolMismatch) so map_response produces the hard error.
 
-    fn newer_daemon_version_mismatch_response(config_id: &str) -> DaemonResponseFrame {
-        DaemonResponseFrame {
-            ok: false,
-            result: None,
-            error: Some(format!(
-                "daemon protocol mismatch: client={} daemon={} — \
-                 rebuild/update the client binary (make local)",
-                PROTOCOL_VERSION,
-                PROTOCOL_VERSION + 1
-            )),
-            error_detail: None,
-            namespace_mismatch: false,
-            config_mismatch: false,
-            served_config_id: Some(config_id.to_string()),
-            version_mismatch: true,
-            daemon_protocol_version: PROTOCOL_VERSION + 1,
-            metrics: None,
-            request_id: None,
-        }
-    }
-
     #[tokio::test]
     #[serial]
-    async fn try_forward_inner_newer_daemon_mismatch_yields_response_not_recovery() {
+    async fn try_forward_inner_behind_a_newer_daemon_yields_protocol_mismatch() {
         clear_daemon_env();
         let dir = tempfile::tempdir().expect("tempdir");
         let sock = dir.path().join("khived.sock");
@@ -7469,7 +7460,7 @@ mod tests {
         let listener = tokio::net::UnixListener::bind(&sock).expect("bind newer-daemon socket");
         std::fs::write(&pid_file, std::process::id().to_string()).expect("write pid file");
 
-        let mismatch_resp = newer_daemon_version_mismatch_response(config_id);
+        let mismatch_resp = newer_daemon_response(config_id);
         let fake_handle = tokio::spawn(serve_one_response(listener, mismatch_resp));
 
         let frame = DaemonRequestFrame {
@@ -7496,10 +7487,15 @@ mod tests {
         let _ = tokio::time::timeout(std::time::Duration::from_secs(2), fake_handle).await;
 
         assert!(
-            matches!(outcome, ForwardOutcome::Response(_)),
-            "version_mismatch=true with daemon_protocol_version > PROTOCOL_VERSION \
-             must yield Response (hard error via map_response), not ProtocolMismatch \
-             (the client binary, not the daemon, is stale)"
+            matches!(
+                outcome,
+                ForwardOutcome::ProtocolMismatch {
+                    daemon_protocol_version
+                } if daemon_protocol_version == PROTOCOL_VERSION + 1
+            ),
+            "a daemon ahead of this bridge yields ProtocolMismatch carrying the daemon's \
+             version, so the bridge answers the caller and then re-execs the current \
+             binary; the version_mismatch flag on the frame does not decide this"
         );
 
         clear_daemon_env();

--- a/crates/khive-runtime/src/daemon/plan_tests.rs
+++ b/crates/khive-runtime/src/daemon/plan_tests.rs
@@ -82,7 +82,16 @@ async fn plan_daemon_protocol_rejects_previous_version_without_dispatch() {
     }))
     .await;
     assert!(!response.ok);
-    assert!(response.version_mismatch);
+    assert!(
+        !response.version_mismatch,
+        "a client below this daemon's protocol is refused with the flag clear: it is \
+         reserved for a client that is ahead, and deployed bridges recover on this shape"
+    );
+    assert_eq!(
+        response.error_detail.as_ref().unwrap()["code"],
+        "version_mismatch",
+        "the refusal stays typed even though the flag is clear"
+    );
     assert_eq!(calls, 0);
 }
 

--- a/tests/contract_test.py
+++ b/tests/contract_test.py
@@ -170,6 +170,24 @@ def _tool(proc: subprocess.Popen, name: str, args: dict) -> Any:
     return value
 
 
+def _op_error_text(error: Any) -> str:
+    """Return the human-readable text of a per-op error.
+
+    Per-op errors are structured objects carrying `message` alongside
+    `kind` and `domain_disposition`; servers before that change sent a bare
+    string. The object is the current contract, so a dict that does not carry
+    a string `message` is a contract failure rather than something to coerce.
+    """
+    if isinstance(error, dict):
+        message = error.get("message")
+        assert isinstance(message, str), (
+            f"a structured per-op error must carry a string 'message'; got: {error!r}"
+        )
+        return message
+    assert isinstance(error, str), f"per-op error must be an object or a string; got: {error!r}"
+    return error
+
+
 def _expect_rpc_error(proc: subprocess.Popen, name: str, args: dict) -> str:
     """Assert the verb call fails. Return the error message string.
 
@@ -187,7 +205,7 @@ def _expect_rpc_error(proc: subprocess.Popen, name: str, args: dict) -> str:
         return err.get("message", str(err))
 
     if "_op_error" in result:
-        return result["_op_error"]
+        return _op_error_text(result["_op_error"])
 
     raise AssertionError(
         f"Expected verb '{name}' to fail but got success:\n{result.get('_ok')!r}"


### PR DESCRIPTION
## What this fixes

`cargo test --workspace` and the Python contract suite are red on `main`, and have been at every head since the protocol-recovery and structured-per-op-error changes landed. Four groups of tests assert behaviour those changes deliberately replaced. This PR is test-only: no production code changes.

## The Rust tests

**`daemon_round_trip_dispatches_and_enforces_config_id`** (bridge) and **`plan_daemon_protocol_rejects_previous_version_without_dispatch`** (daemon plan path) both asserted `version_mismatch` is set when a client below the daemon's protocol is refused. The daemon reserves that flag for a client that is *ahead* of it; a below-protocol refusal carries `error_detail.code = "version_mismatch"` instead, which is the shape already-deployed bridges recover on. Both now assert the flag is clear and the typed code is present, so each half of the contract is pinned rather than swapped.

**`try_forward_inner_newer_daemon_mismatch_yields_response_not_recovery`** asserted that a daemon *ahead* of the bridge must yield a plain `Response` rather than `ProtocolMismatch`. That is the case the recovery change fixed: a differing `daemon_protocol_version` in either direction now yields `ProtocolMismatch`, which arms the in-place re-exec. Renamed to `try_forward_inner_behind_a_newer_daemon_yields_protocol_mismatch`, asserting that outcome and the daemon version it carries.

It also deletes `newer_daemon_version_mismatch_response`, a test helper that duplicated `newer_daemon_response` byte for byte; the rewritten test uses the surviving one.

## The Python contract test

`_expect_rpc_error` returned `result["_op_error"]` directly and its six callers compared that value as text. A per-op error is now a structured object carrying `message` beside `kind` and `domain_disposition`, so every one of those comparisons failed against a dict.

The repair is one helper, `_op_error_text`, rather than six call-site edits. It reads `message` out of the object and asserts that a structured error carries a string there, so a server that drops the field fails the contract instead of being coerced into a printable form. A bare string still passes, since that is what an older server sends.

## Why the suites stayed red

The changes were gated with filtered test runs plus one crate's suite. A filter cannot select a test named after the behaviour being removed, so the tests asserting the old contract were invisible to every gate that ran. CI reported one failure at a time, because a failing shard cancels its sibling before the sibling reaches its own failure. The rest were found by enumerating every crate and suite that names the changed symbols instead of trusting a filter.

## Controls

- Reverting the daemon's below-protocol flag to unconditional `true` fails the bridge round-trip test and the plan test; restored, both pass.
- Reverting the bridge decode to the daemon-older-only condition fails the forward test; restored, it passes.
- Removing `_op_error_text` and returning the raw value takes the contract suite from 11 passed to 5 passed, failing exactly the six named cases; restored, 11 pass.
- Full `cargo test -p khive-mcp --lib`: 508 passed, 0 failed. Clippy with all features: clean. The whole-workspace suite, the release build, the lint gate and the contract gate run in the same pass.
