### PR TITLE
daemon: raise PROTOCOL_VERSION to 6 so resident bridges re-exec onto the installed binary

### DIFF
--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -47,7 +47,7 @@ pub const MAX_FRAME_BYTES: usize = 8 * 1024 * 1024;
 /// that names both sides so the operator knows exactly what to do
 /// (`make local` rebuilds the client binary).
 /// See `docs/api/daemon.md#protocol_version` for the version-by-version history.
-pub const PROTOCOL_VERSION: u32 = 5;
+pub const PROTOCOL_VERSION: u32 = 6;
 
 const DEFAULT_DRAIN_TIMEOUT_SECS: u64 = 10;
 
@@ -1331,9 +1331,11 @@ async fn handle_conn_with_shutdown<D: DaemonDispatch>(
             // refused and still carrying the code in `error_detail`, lets every
             // pre-swap bridge replace itself on its first request instead of staying
             // refused until a person reconnects the session. A client above this
-            // protocol keeps the explicit flag. Remove at the next protocol bump:
-            // bridges built with the two-direction re-exec in khive-mcp no longer
-            // read the flag.
+            // protocol keeps the explicit flag. Remove once no live bridge predates
+            // the two-direction re-exec in khive-mcp (an inode census of `kkernel mcp`
+            // processes before the swap): bridges built with it no longer read the
+            // flag, but a bump while older bridges still run must keep this shape so
+            // they replace themselves too.
             version_mismatch: frame.protocol_version > PROTOCOL_VERSION,
             daemon_protocol_version: PROTOCOL_VERSION,
             metrics: None,

--- a/crates/khive-runtime/src/daemon/plan_tests.rs
+++ b/crates/khive-runtime/src/daemon/plan_tests.rs
@@ -75,7 +75,7 @@ async fn plan_daemon_refuses_each_present_companion_including_null() {
 
 #[tokio::test]
 async fn plan_daemon_protocol_rejects_previous_version_without_dispatch() {
-    assert_eq!(PROTOCOL_VERSION, 5);
+    assert_eq!(PROTOCOL_VERSION, 6);
     let (response, calls) = plan_raw_round_trip(serde_json::json!({
         "ops":"missing_verb()", "namespace":"", "plan":true,
         "config_id":"plan-config", "protocol_version":4

--- a/crates/kkernel/tests/exec_plan.rs
+++ b/crates/kkernel/tests/exec_plan.rs
@@ -169,7 +169,7 @@ mod daemon {
             assert_eq!(frame["plan"], true);
             assert_eq!(frame["ops"], ops);
             assert_eq!(frame["namespace"], "");
-            assert_eq!(frame["protocol_version"], 5);
+            assert_eq!(frame["protocol_version"], 6);
             assert!(frame["config_id"].as_str().is_some_and(|id| !id.is_empty()));
             assert_eq!(frame.as_object().unwrap().len(), 5);
         }

--- a/python/khive/transport.py
+++ b/python/khive/transport.py
@@ -47,7 +47,7 @@ from .errors import (
 from .ops import encode, op
 from .models import OpError
 
-PROTOCOL_VERSION = 5
+PROTOCOL_VERSION = 6
 MAX_FRAME_BYTES = 8 * 1024 * 1024
 
 

--- a/python/tests/test_session_plan.py
+++ b/python/tests/test_session_plan.py
@@ -97,7 +97,7 @@ def assert_no_identity_or_rendering(frames):
 
 
 def test_plan_protocol_version_refuses_daemons_that_cannot_plan():
-    assert PROTOCOL_VERSION == 5
+    assert PROTOCOL_VERSION == 6
 
 
 @pytest.mark.parametrize("encoded", [True, False])
@@ -109,12 +109,12 @@ def test_plan_sends_isolated_frame_and_preserves_the_complete_result(encoded):
     assert session.plan(OPS) == PLAN
     assert transport.frames == [
         {
-            "ops": "", "namespace": "", "config_id": "", "protocol_version": 5,
+            "ops": "", "namespace": "", "config_id": "", "protocol_version": 6,
             "metrics_only": True,
         },
         {
             "ops": OPS, "namespace": "", "config_id": "catalog-config",
-            "protocol_version": 5, "plan": True,
+            "protocol_version": 6, "plan": True,
         },
     ]
     assert_no_identity_or_rendering(transport.frames)


### PR DESCRIPTION
## What this changes

Raises the daemon `PROTOCOL_VERSION` from 5 to 6. No behavior change beyond the number.

An install that leaves the protocol number unchanged never triggers the MCP bridge self-heal, so every long-lived bridge keeps serving from the executable image it started with and silently lacks the verbs the new binary registers (the bridge reports a complete, healthy verb list with no warning). Raising the number makes the next request from each older bridge a protocol mismatch, which replaces the process image in place.

- The daemon keeps answering older clients in the implicit mismatch shape they re-exec on, because bridges built before the two-direction check are still running; the comment now states that removal condition (no live bridge predating the two-direction re-exec) instead of naming the next bump.
- The Python client constant and the three tests that pin the number follow it.

Follow-up, separate change: the bridge re-executes on binary identity (its own executable's inode or mtime against the installed file), checked per request, so an install propagates without a protocol bump.
