### PR TITLE
memory: recall limit=0 returns no hits, the same as top_k=0

### DIFF
--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -219,13 +219,16 @@ impl MemoryPack {
             normalize_min_score(raw).map_err(RuntimeError::from)?
         };
 
+        // `limit` and `top_k` agree on zero: both mean no hits. A caller that
+        // computes a limit which reaches zero gets an empty page, never a
+        // single result smuggled in by a lower clamp.
         let limit = if let Some(k) = p.top_k {
             k.min(crate::scoring::MAX_RECALL_LIMIT)
         } else {
             p.limit
                 .map(|v| v as usize)
                 .unwrap_or(10)
-                .clamp(1, crate::scoring::MAX_RECALL_LIMIT)
+                .min(crate::scoring::MAX_RECALL_LIMIT)
         };
         let limit_u32 = u32::try_from(limit).unwrap_or(u32::MAX);
 
@@ -1389,6 +1392,67 @@ mod tests {
         fn enter(&self, _: &tracing::span::Id) {}
 
         fn exit(&self, _: &tracing::span::Id) {}
+    }
+
+    /// `limit=0` returns no hits, the same as `top_k=0`; a lower clamp of one
+    /// used to turn it into a single hit.
+    #[tokio::test]
+    #[serial(background_tasks)]
+    #[serial_test::serial(config_ledger)]
+    async fn recall_limit_zero_returns_no_hits_like_top_k_zero() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let ns = Namespace::parse("local").expect("local namespace");
+        let token = rt.authorize(ns).expect("authorize local");
+        for i in 0..3 {
+            rt.create_note(
+                &token,
+                "memory",
+                None,
+                &format!("limit zero probe note {i}"),
+                Some(0.7),
+                None,
+                vec![],
+            )
+            .await
+            .expect("create note");
+        }
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(MemoryPack::new(rt.clone()));
+        let registry = builder.build().expect("registry");
+
+        let hits_for = |params: serde_json::Value| {
+            let registry = &registry;
+            async move {
+                let out = registry
+                    .dispatch("memory.recall", params)
+                    .await
+                    .expect("recall dispatch");
+                match out {
+                    serde_json::Value::Array(items) => items.len(),
+                    serde_json::Value::Object(map) => map
+                        .get("results")
+                        .and_then(serde_json::Value::as_array)
+                        .map(Vec::len)
+                        .unwrap_or(0),
+                    _ => panic!("unexpected recall shape"),
+                }
+            }
+        };
+
+        let control =
+            hits_for(serde_json::json!({"query": "limit zero probe note", "limit": 2})).await;
+        assert_eq!(
+            control, 2,
+            "limit=2 is the control and must return two hits"
+        );
+        let by_top_k =
+            hits_for(serde_json::json!({"query": "limit zero probe note", "top_k": 0})).await;
+        assert_eq!(by_top_k, 0, "top_k=0 returns no hits");
+        let by_limit =
+            hits_for(serde_json::json!({"query": "limit zero probe note", "limit": 0})).await;
+        assert_eq!(by_limit, 0, "limit=0 returns no hits, the same as top_k=0");
     }
 
     /// Exercises `$` sanitization; serialized because non-empty recall tracks background work.

--- a/crates/khive-pack-memory/src/pack.rs
+++ b/crates/khive-pack-memory/src/pack.rs
@@ -203,14 +203,14 @@ static MEMORY_HANDLERS: [HandlerDef; 10] = [
                 name: "limit",
                 param_type: "integer",
                 required: false,
-                description: "Maximum memories to return (default 10).",
+                description: "Maximum memories to return (default 10, max 100); 0 returns no hits.",
                 resolution_mode: IdResolutionMode::NotApplicable,
             },
             ParamDef {
                 name: "top_k",
                 param_type: "integer",
                 required: false,
-                description: "Override result limit (max 100). Takes priority over limit.",
+                description: "Override result limit (max 100); 0 returns no hits. Takes priority over limit.",
                 resolution_mode: IdResolutionMode::NotApplicable,
             },
             ParamDef {


### PR DESCRIPTION
## What this changes

`memory.recall` with `limit=0` now returns no hits, the same as `top_k=0` already does. Before, the handler treated `0` as "unset" and fell back to the default of ten, so a caller asking for zero rows received one page of results.

- The limit is resolved once: `top_k` wins when present, otherwise `limit`, otherwise the default of ten; every path is clipped at the maximum of one hundred.
- Regression test with three stored memories: `limit=2` returns two (control), `top_k=0` returns none, `limit=0` returns none.
- The verb help states that `0` returns no hits for both parameters.

Fixes #2466.
