### PR TITLE
exec: compile on Linux and refuse on non-unix hosts

### DIFF
--- a/crates/khive-pack-exec/src/capture.rs
+++ b/crates/khive-pack-exec/src/capture.rs
@@ -111,12 +111,17 @@ pub fn walk(root: &Path) -> std::io::Result<(BTreeMap<String, Found>, Vec<String
                 skipped.push(child_rel);
                 continue;
             }
-            use std::os::unix::fs::PermissionsExt;
-            let mode = if meta.permissions().mode() & 0o111 != 0 {
-                755
-            } else {
-                644
+            #[cfg(unix)]
+            let mode = {
+                use std::os::unix::fs::PermissionsExt;
+                if meta.permissions().mode() & 0o111 != 0 {
+                    755
+                } else {
+                    644
+                }
             };
+            #[cfg(not(unix))]
+            let mode = 644;
             files.insert(child_rel, Found { abs, mode });
         }
     }
@@ -143,6 +148,7 @@ mod tests {
         assert_eq!(small.retained(), b"ok\n");
     }
 
+    #[cfg(unix)]
     #[test]
     fn walk_skips_symlinks() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/khive-pack-exec/src/handlers.rs
+++ b/crates/khive-pack-exec/src/handlers.rs
@@ -4,6 +4,7 @@
 //! receipt.
 
 use std::collections::{BTreeMap, BTreeSet};
+#[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -505,7 +506,10 @@ fn materialize(
             .unwrap_or(&[]);
         std::fs::write(&target, data)?;
         let mode = if entry.mode == 755 { 0o755 } else { 0o644 };
+        #[cfg(unix)]
         std::fs::set_permissions(&target, std::fs::Permissions::from_mode(mode))?;
+        #[cfg(not(unix))]
+        let _ = mode;
     }
     Ok(())
 }
@@ -516,6 +520,31 @@ fn declared_covers(declared: &[String], path: &str) -> bool {
         .any(|d| d == path || path.starts_with(&format!("{d}/")))
 }
 
+/// The resource identifier `setrlimit` takes: an enum-typed integer on glibc,
+/// a plain `c_int` on every other unix libc.
+#[cfg(all(unix, target_os = "linux", target_env = "gnu"))]
+type RlimitResource = libc::__rlimit_resource_t;
+#[cfg(all(unix, not(all(target_os = "linux", target_env = "gnu"))))]
+type RlimitResource = libc::c_int;
+
+/// Launching a tool needs a process group, resource limits, a close-on-exec
+/// pipe for the limit report and the sandbox: unix facilities. On any other
+/// host `exec.run` refuses before touching the store or the filesystem.
+#[cfg(not(unix))]
+async fn execute(
+    _rt: &KhiveRuntime,
+    _ns: &str,
+    _cfg: &Resolved,
+    _req: &Request,
+    _ready: Ready,
+    _receipt: &mut Receipt,
+) -> Result<(), RuntimeError> {
+    Err(RuntimeError::Unconfigured(
+        "exec.run launches tools on unix hosts only; this host provides none of the process-group, resource-limit and sandbox facilities the run contract requires".into(),
+    ))
+}
+
+#[cfg(unix)]
 async fn execute(
     rt: &KhiveRuntime,
     ns: &str,
@@ -615,7 +644,7 @@ async fn execute(
             let mut report = String::from("{");
             let mut first = true;
             let mut apply =
-                |name: &str, resource: libc::c_int, value: u64| -> std::io::Result<()> {
+                |name: &str, resource: RlimitResource, value: u64| -> std::io::Result<()> {
                     let lim = libc::rlimit {
                         rlim_cur: value as libc::rlim_t,
                         rlim_max: value as libc::rlim_t,
@@ -838,6 +867,7 @@ fn cleanup(run_dir: &Path, profile_path: &Path, keep: bool) {
     }
 }
 
+#[cfg(unix)]
 fn kill_group(pid: i32) {
     if pid <= 0 {
         return;
@@ -847,6 +877,7 @@ fn kill_group(pid: i32) {
     }
 }
 
+#[cfg(unix)]
 fn limit_pipe() -> Result<(libc::c_int, libc::c_int), RuntimeError> {
     let mut fds = [0 as libc::c_int; 2];
     // SAFETY: plain pipe creation; both ends are marked close-on-exec so the
@@ -866,6 +897,7 @@ fn limit_pipe() -> Result<(libc::c_int, libc::c_int), RuntimeError> {
     Ok((fds[0], fds[1]))
 }
 
+#[cfg(unix)]
 fn read_limit_report(reader: libc::c_int) -> Value {
     use std::io::Read;
     use std::os::unix::io::FromRawFd;

--- a/crates/khive-pack-exec/src/sandbox.rs
+++ b/crates/khive-pack-exec/src/sandbox.rs
@@ -278,6 +278,7 @@ mod tests {
         assert_eq!(a, digest_hex(br#"["/a"]"#));
     }
 
+    #[cfg(unix)]
     #[test]
     fn forbidden_basenames_refuse() {
         let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## What this changes

The exec pack did not compile on Linux with glibc or on Windows, which left the workspace red on both CI targets.

- On glibc, `setrlimit` and `getrlimit` take an enum-typed resource identifier while every other unix libc takes a plain `c_int`; the limit-applying closure now names that type per target instead of assuming `c_int`.
- The launch path (process group, resource limits, the close-on-exec limit-report pipe, the sandbox) exists only for unix hosts. It is now gated on `unix`; on any other host `exec.run` refuses with an `Unconfigured` error before touching the store or the filesystem.
- Tree materialization sets file modes only on unix; capture reads modes on unix and records the default elsewhere.
- The symlink-dependent tests are unix-only.

No behavior change on macOS or Linux hosts that already compiled.
