### PR TITLE
git: guarded remote push, PR open, review, merge and reconciliation

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2181,6 +2181,7 @@ version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64 0.22.1",
  "blake3",
  "chrono",
  "clap",

--- a/crates/khive-pack-comm/src/inbox_filter_tests.rs
+++ b/crates/khive-pack-comm/src/inbox_filter_tests.rs
@@ -18,6 +18,7 @@ fn actor_registry(
         backend,
         RuntimeConfig {
             git_write: Default::default(),
+            exec: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             events_split: None,
             db_path: None,

--- a/crates/khive-pack-git/Cargo.toml
+++ b/crates/khive-pack-git/Cargo.toml
@@ -24,6 +24,7 @@ khive-runtime = { version = "0.8.0", path = "../khive-runtime" }
 inventory = { workspace = true }
 khive-storage = { version = "0.8.0", path = "../khive-storage" }
 async-trait = { workspace = true }
+base64 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }

--- a/crates/khive-pack-git/src/credentials.rs
+++ b/crates/khive-pack-git/src/credentials.rs
@@ -51,9 +51,27 @@ pub(crate) async fn resolve_actor(
 }
 
 #[cfg(any(unix, test))]
-struct Secret {
+pub(crate) struct Secret {
     bytes: Zeroizing<Box<[u8]>>,
     len: usize,
+}
+
+#[cfg(any(unix, test))]
+impl Secret {
+    pub(crate) fn value(&self) -> &str {
+        std::str::from_utf8(&self.bytes[..self.len]).expect("validated resolver UTF-8")
+    }
+}
+
+#[cfg(unix)]
+pub(crate) async fn resolve_remote(
+    config: &GitWriteSectionConfig,
+    actor: &str,
+) -> Result<(GitWriteActorConfig, Secret), CredentialError> {
+    config.validate_dev_loop().map_err(|_| CredentialError)?;
+    let identity = config.actors.get(actor).ok_or(CredentialError)?.clone();
+    let secret = resolve_reference(config, &identity.credential_ref).await?;
+    Ok((identity, secret))
 }
 
 #[cfg(any(unix, test))]

--- a/crates/khive-pack-git/src/input_schema.json
+++ b/crates/khive-pack-git/src/input_schema.json
@@ -1,0 +1,397 @@
+{
+  "git.digest": {
+    "type": "object",
+    "properties": {
+      "source": {
+        "type": "string",
+        "minLength": 1
+      },
+      "project": {
+        "type": "string"
+      },
+      "max_items": {
+        "type": "integer"
+      },
+      "include": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "required": [
+      "source"
+    ],
+    "additionalProperties": false
+  },
+  "git.branch": {
+    "type": "object",
+    "properties": {
+      "repo": {
+        "type": "string",
+        "minLength": 1
+      },
+      "name": {
+        "type": "string",
+        "minLength": 1
+      },
+      "from": {
+        "type": "string",
+        "minLength": 1
+      },
+      "expected": {
+        "type": "string",
+        "pattern": "^[a-fA-F0-9]{40}$"
+      },
+      "session_id": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "required": [
+      "repo",
+      "name"
+    ],
+    "additionalProperties": false
+  },
+  "git.commit": {
+    "type": "object",
+    "properties": {
+      "repo": {
+        "type": "string",
+        "minLength": 1
+      },
+      "message": {
+        "type": "string",
+        "minLength": 1
+      },
+      "paths": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "author": {
+        "type": "string"
+      },
+      "tree": {
+        "type": "string",
+        "minLength": 1
+      },
+      "branch": {
+        "type": "string",
+        "minLength": 1
+      },
+      "expected_head": {
+        "type": "string",
+        "pattern": "^[a-fA-F0-9]{40}$"
+      },
+      "session_id": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "required": [
+      "repo",
+      "message"
+    ],
+    "additionalProperties": false,
+    "allOf": [
+      {
+        "if": {
+          "required": [
+            "tree"
+          ]
+        },
+        "then": {
+          "required": [
+            "branch",
+            "expected_head"
+          ],
+          "not": {
+            "anyOf": [
+              {
+                "required": [
+                  "paths"
+                ]
+              },
+              {
+                "required": [
+                  "author"
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "git.push": {
+    "type": "object",
+    "properties": {
+      "repo": {
+        "type": "string",
+        "minLength": 1
+      },
+      "branch": {
+        "type": "string",
+        "minLength": 1
+      },
+      "expected_local": {
+        "type": "string",
+        "pattern": "^[a-fA-F0-9]{40}$"
+      },
+      "expected_remote": {
+        "type": [
+          "string",
+          "null"
+        ],
+        "pattern": "^[a-fA-F0-9]{40}$"
+      },
+      "session_id": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "required": [
+      "repo",
+      "branch",
+      "expected_local",
+      "expected_remote"
+    ],
+    "additionalProperties": false
+  },
+  "git.checkout": {
+    "type": "object",
+    "properties": {
+      "repo": {
+        "type": "string",
+        "minLength": 1
+      },
+      "ref": {
+        "type": "string",
+        "minLength": 1
+      },
+      "session_id": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "required": [
+      "repo",
+      "ref"
+    ],
+    "additionalProperties": false
+  },
+  "git.diff": {
+    "type": "object",
+    "properties": {
+      "repo": {
+        "type": "string",
+        "minLength": 1
+      },
+      "input_kind": {
+        "enum": [
+          "commits",
+          "trees"
+        ]
+      },
+      "base": {
+        "type": "string",
+        "minLength": 1
+      },
+      "head": {
+        "type": "string",
+        "minLength": 1
+      },
+      "session_id": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "required": [
+      "repo",
+      "input_kind",
+      "base",
+      "head"
+    ],
+    "additionalProperties": false
+  },
+  "git.receipts": {
+    "type": "object",
+    "properties": {
+      "repo": {
+        "type": "string",
+        "minLength": 1
+      },
+      "session_id": {
+        "type": "string",
+        "minLength": 1
+      },
+      "actor": {
+        "type": "string",
+        "minLength": 1
+      },
+      "limit": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 500
+      },
+      "offset": {
+        "type": "integer",
+        "minimum": 0
+      }
+    },
+    "required": [],
+    "additionalProperties": false
+  },
+  "git.gates": {
+    "type": "object",
+    "properties": {
+      "repo": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "required": [
+      "repo"
+    ],
+    "additionalProperties": false
+  },
+  "git.reconcile": {
+    "type": "object",
+    "properties": {
+      "receipt": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "required": [
+      "receipt"
+    ],
+    "additionalProperties": false
+  },
+  "git.pr_open": {
+    "type": "object",
+    "properties": {
+      "repo": {
+        "type": "string",
+        "minLength": 1
+      },
+      "head": {
+        "type": "string",
+        "minLength": 1
+      },
+      "base": {
+        "type": "string",
+        "minLength": 1
+      },
+      "title": {
+        "type": "string",
+        "minLength": 1
+      },
+      "body": {
+        "type": "string"
+      },
+      "expected_head": {
+        "type": "string",
+        "pattern": "^[a-fA-F0-9]{40}$"
+      },
+      "session_id": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "required": [
+      "repo",
+      "head",
+      "base",
+      "title",
+      "body",
+      "expected_head"
+    ],
+    "additionalProperties": false
+  },
+  "git.pr_review": {
+    "type": "object",
+    "properties": {
+      "repo": {
+        "type": "string",
+        "minLength": 1
+      },
+      "number": {
+        "type": "integer",
+        "minimum": 1
+      },
+      "verdict": {
+        "enum": [
+          "approve",
+          "request_changes",
+          "comment"
+        ]
+      },
+      "body": {
+        "type": "string"
+      },
+      "expected_head": {
+        "type": "string",
+        "pattern": "^[a-fA-F0-9]{40}$"
+      },
+      "session_id": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "required": [
+      "repo",
+      "number",
+      "verdict",
+      "body",
+      "expected_head"
+    ],
+    "additionalProperties": false
+  },
+  "git.pr_merge": {
+    "type": "object",
+    "properties": {
+      "repo": {
+        "type": "string",
+        "minLength": 1
+      },
+      "number": {
+        "type": "integer",
+        "minimum": 1
+      },
+      "method": {
+        "enum": [
+          "squash",
+          "merge"
+        ]
+      },
+      "subject": {
+        "type": "string",
+        "minLength": 1
+      },
+      "body": {
+        "type": "string"
+      },
+      "expected_head": {
+        "type": "string",
+        "pattern": "^[a-fA-F0-9]{40}$"
+      },
+      "session_id": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "required": [
+      "repo",
+      "number",
+      "method",
+      "subject",
+      "body",
+      "expected_head"
+    ],
+    "additionalProperties": false
+  }
+}

--- a/crates/khive-pack-git/src/input_schema.rs
+++ b/crates/khive-pack-git/src/input_schema.rs
@@ -1,0 +1,11 @@
+use serde_json::Value;
+use std::sync::LazyLock;
+
+static SCHEMAS: LazyLock<Value> = LazyLock::new(|| {
+    serde_json::from_str(include_str!("input_schema.json"))
+        .expect("git input schemas are valid JSON")
+});
+
+pub(crate) fn for_verb(verb: &str) -> Option<Value> {
+    SCHEMAS.get(verb).cloned()
+}

--- a/crates/khive-pack-git/src/lib.rs
+++ b/crates/khive-pack-git/src/lib.rs
@@ -6,20 +6,25 @@
 //! agent-facing verb, `git.digest(source, project?, max_items?, include?)`
 //! (`handlers`), that drives the batch, cursor-based ingester (`ingest`)
 //! against either a local path or a remote `https://` URL (cloned/fetched
-//! into a daemon-owned scratch cache, `cache`), and three write verbs
-//! (`write_handlers`, ADR-108) that shell to system git with hardened,
-//! allowlisted argv construction (`write_argv`). See
+//! into a daemon-owned scratch cache, `cache`), local object operations, and
+//! policy-gated remote writes (ADR-182). Git children use hardened,
+//! allowlisted argv construction; platform operations use actor credentials. See
 //! `docs/adr/ADR-088-git-lifecycle-pack.md`,
 //! `docs/adr/ADR-088-amendment-1-git-digest.md`,
 //! `docs/adr/ADR-088-amendment-2-anchor-identity.md`, and
-//! `docs/adr/ADR-108-git-write-surface.md`.
+//! `docs/adr/ADR-108-git-write-surface.md` and
+//! `docs/adr/ADR-182-git-dev-loop-verbs.md`. The pack's input schema describes
+//! the complete local and remote wire surface.
 //!
 //! | Verb | Args | What it does |
 //! | ---- | ---- | ------------ |
 //! | `git.digest` | `source`, `project?`, `max_items?`, `include?` | Ingest commit/issue/PR provenance from a local path or `https://` URL, bounded and cursor-resumable |
 //! | `git.commit` | `repo`, `message`, `paths?`, `author?` | Stage and commit against a local repo; returns the resulting SHA |
 //! | `git.branch` | `repo`, `name`, `from?` | Create a branch, optionally from a named ref/SHA |
-//! | `git.push` | `repo`, `branch`, `remote?` | Push a branch to a remote; force-push is always denied |
+//! | `git.push` | `repo`, `branch`, `expected_local`, `expected_remote` | Compare both heads and push to the configured remote; null remote means absent |
+//! | `git.pr_open` | `repo`, `head`, `base`, `title`, `body`, `expected_head` | Open a pull request after checking repository identity and head |
+//! | `git.pr_review` | `repo`, `number`, `verdict`, `body`, `expected_head` | Review the expected commit; self-approval refuses |
+//! | `git.pr_merge` | `repo`, `number`, `method`, `subject`, `body`, `expected_head` | Merge with an exact head comparison and an independent approval |
 //!
 //! `kkernel git-ingest` remains the unbounded, all-kinds admin CLI path over
 //! the same shared `ingest::run_ingest` core.
@@ -31,6 +36,7 @@ mod credentials;
 pub mod handlers;
 pub mod hook;
 pub mod ingest;
+mod input_schema;
 mod local_git;
 mod local_handlers;
 mod local_vocab;
@@ -41,6 +47,11 @@ mod receipts;
 #[cfg(test)]
 mod recovery_tests;
 pub mod refs;
+mod remote_handlers;
+#[cfg(all(test, unix))]
+mod remote_tests;
+pub mod remote_transport;
+mod remote_vocab;
 pub mod source;
 pub(crate) mod vocab;
 pub mod write_argv;

--- a/crates/khive-pack-git/src/local_git.rs
+++ b/crates/khive-pack-git/src/local_git.rs
@@ -949,6 +949,87 @@ pub(crate) async fn diff(
     })
 }
 
+pub(crate) async fn is_ancestor(repo: &Path, base: &str, head: &str) -> Result<bool> {
+    validate_oid(base, "base")?;
+    validate_oid(head, "head")?;
+    let (repo, base, head) = (repo.to_path_buf(), base.to_string(), head.to_string());
+    blocking("merge-base", false, move || {
+        Ok(run_git_output(
+            &repo,
+            &["merge-base", "--is-ancestor", &base, &head],
+            None,
+            None,
+            false,
+            Some(1),
+        )?
+        .exit_code
+            == 0)
+    })
+    .await
+}
+
+pub(crate) async fn object_directory(repo: &Path) -> Result<std::path::PathBuf> {
+    let repo = repo.to_path_buf();
+    blocking("rev-parse", false, move || {
+        let bytes = run_git(
+            &repo,
+            &["rev-parse", "--git-path", "objects"],
+            None,
+            None,
+            false,
+        )?;
+        let text = std::str::from_utf8(&bytes)
+            .map_err(|_| LocalGitError::new("git_output", "invalid object path"))?
+            .trim();
+        let path = repo.join(text);
+        std::fs::canonicalize(path)
+            .map_err(|_| LocalGitError::new("git_output", "object directory unavailable"))
+    })
+    .await
+}
+
+pub(crate) async fn record_push_marker(
+    repo: &Path,
+    branch: &str,
+    sha: &str,
+    receipt_id: &str,
+) -> Result<()> {
+    validate_oid(sha, "pushed head")?;
+    let reference = branch_ref(branch)?;
+    let marker = receipt_marker(receipt_id)?;
+    let repo = repo.to_path_buf();
+    let sha = sha.to_string();
+    blocking("reflog", false, move || {
+        require_direct_ref(&repo, &reference)?;
+        // update-ref suppresses reflog writes for an unchanged SHA. An explicit
+        // reflog write records acknowledgement without changing any source ref.
+        run_git(
+            &repo,
+            &["reflog", "write", &reference, &sha, &sha, &marker],
+            None,
+            None,
+            false,
+        )?;
+        Ok(())
+    })
+    .await
+}
+
+pub(crate) async fn push_marker_support(repo: &Path) -> Result<(String, bool)> {
+    let repo = repo.to_path_buf();
+    blocking("reflog", false, move || {
+        let version = run_git(&repo, &["--version"], None, None, false)?;
+        let version = String::from_utf8(version)
+            .map_err(|_| LocalGitError::new("git_output", "invalid Git version"))?;
+        let help = run_git_output(&repo, &["reflog", "-h"], None, None, false, Some(129))?;
+        Ok((
+            version.trim().to_owned(),
+            String::from_utf8_lossy(&help.stdout).contains("git reflog write "),
+        ))
+    })
+    .await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/khive-pack-git/src/local_handlers.rs
+++ b/crates/khive-pack-git/src/local_handlers.rs
@@ -15,14 +15,14 @@ use crate::write_handlers::repo_write_lock;
 use crate::write_policy::{GitWritePolicy, GitWritePolicyError};
 use crate::GitPack;
 
-struct Failure {
-    reason: &'static str,
-    ambiguous: bool,
-    detail: Option<String>,
+pub(crate) struct Failure {
+    pub(crate) reason: &'static str,
+    pub(crate) ambiguous: bool,
+    pub(crate) detail: Option<String>,
 }
 
 impl Failure {
-    fn invalid(detail: impl Into<String>) -> Self {
+    pub(crate) fn invalid(detail: impl Into<String>) -> Self {
         Self {
             reason: "invalid_params",
             ambiguous: false,
@@ -30,7 +30,7 @@ impl Failure {
         }
     }
 
-    fn refused(reason: &'static str) -> Self {
+    pub(crate) fn refused(reason: &'static str) -> Self {
         Self {
             reason,
             ambiguous: false,
@@ -59,7 +59,7 @@ impl From<RuntimeError> for Failure {
     }
 }
 
-fn required<'a>(params: &'a Value, key: &str) -> Result<&'a str, Failure> {
+pub(crate) fn required<'a>(params: &'a Value, key: &str) -> Result<&'a str, Failure> {
     match params.get(key) {
         None => Err(Failure::invalid(format!("{key} is required"))),
         Some(value) => value.as_str().filter(|s| !s.is_empty()).ok_or_else(|| {
@@ -68,7 +68,7 @@ fn required<'a>(params: &'a Value, key: &str) -> Result<&'a str, Failure> {
     }
 }
 
-fn optional<'a>(params: &'a Value, key: &str) -> Result<Option<&'a str>, Failure> {
+pub(crate) fn optional<'a>(params: &'a Value, key: &str) -> Result<Option<&'a str>, Failure> {
     if params.get(key).is_none() {
         Ok(None)
     } else {
@@ -76,7 +76,7 @@ fn optional<'a>(params: &'a Value, key: &str) -> Result<Option<&'a str>, Failure
     }
 }
 
-fn validate_keys(params: &Value, allowed: &[&str]) -> Result<(), Failure> {
+pub(crate) fn validate_keys(params: &Value, allowed: &[&str]) -> Result<(), Failure> {
     let map = params
         .as_object()
         .ok_or_else(|| Failure::refused("invalid_params"))?;
@@ -86,7 +86,7 @@ fn validate_keys(params: &Value, allowed: &[&str]) -> Result<(), Failure> {
     Ok(())
 }
 
-fn oid(value: &str) -> Result<(), Failure> {
+pub(crate) fn oid(value: &str) -> Result<(), Failure> {
     if value.len() == 40 && value.bytes().all(|b| b.is_ascii_hexdigit()) {
         Ok(())
     } else {
@@ -168,11 +168,11 @@ fn safe_inputs(verb: &str, params: &Value) -> Value {
     Value::Object(inputs)
 }
 
-fn denied(reason: &str) -> Value {
+pub(crate) fn denied(reason: &str) -> Value {
     json!({"decision":"deny", "source":"git_write.allowed", "id":format!("deny:{reason}")})
 }
 
-fn gate_reason(error: &GitWritePolicyError) -> &'static str {
+pub(crate) fn gate_reason(error: &GitWritePolicyError) -> &'static str {
     match error {
         GitWritePolicyError::NotConfigured => "not_configured",
         GitWritePolicyError::RepoNotAllowlisted(_) => "repo_not_allowlisted",
@@ -190,7 +190,7 @@ fn wire_error(receipt: &Receipt) -> RuntimeError {
     }
 }
 
-async fn checked_policy(
+pub(crate) async fn checked_policy(
     registry: &VerbRegistry,
     token: &NamespaceToken,
     verb: &str,
@@ -358,7 +358,7 @@ impl GitPack {
         self.finish_local(token, receipt, outcome).await
     }
 
-    async fn require_receipt_storage(
+    pub(crate) async fn require_receipt_storage(
         &self,
         token: &NamespaceToken,
         receipt: &Receipt,
@@ -472,6 +472,10 @@ impl GitPack {
                     &prior.id,
                 )
                 .await?;
+                if matches!(prior.verb.as_str(), "git.push" | "git.pr_merge") {
+                    self.reconcile_remote(repo, &mut prior).await?;
+                    return Ok(json!({"receipt":prior.to_value()}));
+                }
                 if !matches!(prior.verb.as_str(), "git.branch" | "git.commit") {
                     return Err(Failure::refused("local_receipt_required"));
                 }
@@ -502,7 +506,7 @@ impl GitPack {
         }
     }
 
-    async fn finish_local(
+    pub(crate) async fn finish_local(
         &self,
         token: &NamespaceToken,
         mut receipt: Receipt,
@@ -530,7 +534,15 @@ impl GitPack {
         };
         receipt.finished_at = Some(chrono::Utc::now().timestamp_micros());
         let settled = receipts::persist(self.runtime(), &receipt).await.is_ok();
-        if matches!(receipt.verb.as_str(), "git.branch" | "git.commit") {
+        if matches!(
+            receipt.verb.as_str(),
+            "git.branch"
+                | "git.commit"
+                | "git.push"
+                | "git.pr_open"
+                | "git.pr_review"
+                | "git.pr_merge"
+        ) {
             self.emit_write_audit(
                 token,
                 &receipt.verb,
@@ -556,6 +568,16 @@ impl GitPack {
             // The independent audit attempt above must not depend on receipt storage health.
             return Err(RuntimeError::Internal(format!(
                 "receipt settlement unknown; receipt_id={}",
+                receipt.id
+            )));
+        }
+        if outcome.is_ok()
+            && self.runtime().config().git_write.contract_faults
+            && self.runtime().config().git_write.fault.as_deref()
+                == Some(&format!("{}:audit-fails-after-effect", receipt.verb))
+        {
+            return Err(RuntimeError::Internal(format!(
+                "audit append fault after committed effect; receipt_id={}",
                 receipt.id
             )));
         }

--- a/crates/khive-pack-git/src/local_vocab.rs
+++ b/crates/khive-pack-git/src/local_vocab.rs
@@ -63,8 +63,8 @@ pub(crate) const GATES: HandlerDef = HandlerDef {
 };
 pub(crate) const RECONCILE: HandlerDef = HandlerDef {
     name: "git.reconcile",
-    description: "Settle a caller-owned unknown local receipt only when its receipt marker and SHA appear in the ref reflog and that SHA is the current head or an ancestor. Missing evidence leaves unknown. Never retries a repository write or accesses a remote.",
+    description: "Settle a caller-owned unknown receipt using observed evidence. Local receipts require the receipt marker and SHA in the ref reflog, with that SHA at the current head or an ancestor. Push receipts require an acknowledged local marker and exact remote SHA; merge receipts read platform merged state and SHA. Missing evidence leaves unknown. Never repeats a write.",
     visibility: Visibility::Verb,
     category: VerbCategory::Assertive,
-    params: &[param("receipt", true, "Caller-owned receipt UUID of a local branch or tree commit operation.")],
+    params: &[param("receipt", true, "Caller-owned receipt UUID of a branch, tree commit, push or PR merge operation.")],
 };

--- a/crates/khive-pack-git/src/pack.rs
+++ b/crates/khive-pack-git/src/pack.rs
@@ -25,6 +25,7 @@ use crate::vocab::{GIT_ENTITY_TYPES, GIT_NOTE_KIND_SPECS, GIT_SCHEMA_PLAN_STMTS}
 /// pack contributes; everything else uses the base `annotates` contract.
 pub struct GitPack {
     runtime: KhiveRuntime,
+    remote: Arc<dyn crate::remote_transport::RemoteTransport>,
 }
 
 impl Pack for GitPack {
@@ -45,7 +46,21 @@ impl Pack for GitPack {
 impl GitPack {
     /// Create a new `GitPack` bound to the given runtime.
     pub fn new(runtime: KhiveRuntime) -> Self {
-        Self { runtime }
+        Self {
+            runtime,
+            remote: Arc::new(crate::remote_transport::GhTransport),
+        }
+    }
+
+    pub fn with_remote_transport(
+        runtime: KhiveRuntime,
+        remote: Arc<dyn crate::remote_transport::RemoteTransport>,
+    ) -> Self {
+        Self { runtime, remote }
+    }
+
+    pub(crate) fn remote_transport(&self) -> &dyn crate::remote_transport::RemoteTransport {
+        self.remote.as_ref()
     }
 
     /// Accessor for `src/handlers.rs`, which lives in a sibling module and
@@ -92,6 +107,10 @@ impl PackRuntime for GitPack {
 
     fn handlers(&self) -> &'static [HandlerDef] {
         <GitPack as Pack>::HANDLERS
+    }
+
+    fn input_schema(&self, verb: &str) -> Option<Value> {
+        crate::input_schema::for_verb(verb)
     }
 
     fn edge_rules(&self) -> &'static [EdgeEndpointRule] {
@@ -142,7 +161,9 @@ impl PackRuntime for GitPack {
             }
             "git.commit" => self.handle_commit(token, params).await,
             "git.branch" => self.handle_local(token, registry, verb, params).await,
-            "git.push" => self.handle_push(token, params).await,
+            "git.push" | "git.pr_open" | "git.pr_review" | "git.pr_merge" => {
+                self.handle_remote(token, registry, verb, params).await
+            }
             "git.checkout" | "git.diff" | "git.reconcile" => {
                 self.handle_local(token, registry, verb, params).await
             }

--- a/crates/khive-pack-git/src/remote_handlers.rs
+++ b/crates/khive-pack-git/src/remote_handlers.rs
@@ -1,0 +1,768 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use khive_pack_tool::policy;
+use khive_runtime::engine_config::GitWriteRepositoryConfig;
+use khive_runtime::{NamespaceToken, RuntimeError, VerbRegistry};
+use khive_storage::types::{SqlStatement, SqlValue};
+use serde_json::{json, Value};
+
+use crate::local_handlers::{
+    checked_policy, denied, gate_reason, oid, optional, required, validate_keys, Failure,
+};
+use crate::receipts::{self, Disposition, Receipt};
+use crate::remote_transport::{ApiRequest, PushRequest, RemoteError};
+use crate::write_argv::{validate_ref_name, validate_repo_path};
+use crate::{credentials, local_git, GitPack};
+
+impl Failure {
+    fn unknown(reason: &'static str) -> Self {
+        Self {
+            reason,
+            ambiguous: true,
+            detail: None,
+        }
+    }
+}
+
+impl From<RemoteError> for Failure {
+    fn from(error: RemoteError) -> Self {
+        match error {
+            RemoteError::Refused => Self::refused("remote_refused"),
+            RemoteError::Unavailable => Self::refused("remote_unavailable"),
+            RemoteError::InvalidResponse => Self::refused("remote_response"),
+            RemoteError::Unknown => Self::unknown("remote_unknown"),
+        }
+    }
+}
+
+fn keys(verb: &str) -> &'static [&'static str] {
+    match verb {
+        "git.push" => &[
+            "repo",
+            "branch",
+            "expected_local",
+            "expected_remote",
+            "session_id",
+        ],
+        "git.pr_open" => &[
+            "repo",
+            "head",
+            "base",
+            "title",
+            "body",
+            "expected_head",
+            "session_id",
+        ],
+        "git.pr_review" => &[
+            "repo",
+            "number",
+            "verdict",
+            "body",
+            "expected_head",
+            "session_id",
+        ],
+        "git.pr_merge" => &[
+            "repo",
+            "number",
+            "method",
+            "subject",
+            "body",
+            "expected_head",
+            "session_id",
+        ],
+        _ => &[],
+    }
+}
+
+fn text<'a>(value: &'a Value, name: &str) -> Result<&'a str, Failure> {
+    value
+        .get(name)
+        .and_then(Value::as_str)
+        .ok_or_else(|| Failure::invalid(format!("{name} must be a string")))
+}
+
+fn number(params: &Value) -> Result<u64, Failure> {
+    params
+        .get("number")
+        .and_then(Value::as_u64)
+        .filter(|n| *n > 0)
+        .ok_or_else(|| Failure::invalid("number must be a positive integer"))
+}
+
+fn validate(verb: &str, params: &Value) -> Result<(), Failure> {
+    validate_keys(params, keys(verb))?;
+    validate_repo_path(Path::new(required(params, "repo")?))
+        .map_err(|_| Failure::invalid("repo must be an absolute repository path"))?;
+    optional(params, "session_id")?;
+    // Bound durable input and CLI stdin, including malformed calls.
+    if params.to_string().len() > 1024 * 1024 {
+        return Err(Failure::invalid("inputs exceed limit"));
+    }
+    if verb == "git.push" {
+        validate_ref_name("branch", required(params, "branch")?)
+            .map_err(|_| Failure::invalid("invalid branch"))?;
+        oid(required(params, "expected_local")?)?;
+        match params.get("expected_remote") {
+            None => {
+                return Err(Failure::invalid(
+                    "expected_remote is required; use null only for an absent remote branch",
+                ))
+            }
+            Some(Value::Null) => {}
+            Some(Value::String(sha)) => oid(sha)?,
+            _ => {
+                return Err(Failure::invalid(
+                    "expected_remote must be a 40-hex SHA or null",
+                ))
+            }
+        }
+    } else {
+        oid(required(params, "expected_head")?)?;
+        text(params, "body")?;
+        if verb == "git.pr_open" {
+            for field in ["head", "base"] {
+                validate_ref_name(field, required(params, field)?)
+                    .map_err(|_| Failure::invalid("invalid branch"))?;
+            }
+            required(params, "title")?;
+        } else {
+            number(params)?;
+            match verb {
+                "git.pr_review"
+                    if matches!(
+                        required(params, "verdict")?,
+                        "approve" | "request_changes" | "comment"
+                    ) => {}
+                "git.pr_merge" if matches!(required(params, "method")?, "squash" | "merge") => {
+                    required(params, "subject")?;
+                }
+                _ => return Err(Failure::invalid("unsupported verdict or merge method")),
+            }
+        }
+    }
+    Ok(())
+}
+
+fn safe_inputs(verb: &str, params: &Value) -> Value {
+    let mut result = serde_json::Map::new();
+    for key in keys(verb)
+        .iter()
+        .filter(|key| !matches!(**key, "repo" | "session_id"))
+    {
+        if let Some(value) = params.get(*key) {
+            if value.is_null()
+                || value.is_u64()
+                || value.as_str().is_some_and(|s| s.len() <= 1024 * 1024)
+            {
+                result.insert((*key).into(), value.clone());
+            }
+        }
+    }
+    Value::Object(result)
+}
+
+fn endpoint(slug: &str, suffix: &str) -> String {
+    format!("repos/{slug}/{suffix}")
+}
+fn segment(value: &str) -> String {
+    let mut encoded = String::new();
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || b"-._~".contains(&byte) {
+            encoded.push(char::from(byte));
+        } else {
+            encoded.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    encoded
+}
+
+fn observed_string<'a>(value: &'a Value, pointer: &str) -> Result<&'a str, Failure> {
+    value
+        .pointer(pointer)
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| Failure::refused("remote_response"))
+}
+fn observed_sha(value: &Value, pointer: &str) -> Result<String, Failure> {
+    let sha = observed_string(value, pointer)?;
+    oid(sha).map_err(|_| Failure::refused("remote_response"))?;
+    Ok(sha.to_ascii_lowercase())
+}
+fn after_effect(error: Failure) -> Failure {
+    Failure::unknown(error.reason)
+}
+
+impl GitPack {
+    fn remote_repository(&self, repo: &Path) -> Result<GitWriteRepositoryConfig, Failure> {
+        let configured = &self.runtime().config().git_write.repositories;
+        let mut matches = configured
+            .iter()
+            .filter(|(path, _)| std::fs::canonicalize(path).ok().as_deref() == Some(repo));
+        let row = matches
+            .next()
+            .map(|(_, row)| row.clone())
+            .ok_or_else(|| Failure::refused("repository_unmapped"))?;
+        if matches.next().is_some() {
+            return Err(Failure::refused("repository_ambiguous"));
+        }
+        let rest = row
+            .remote
+            .strip_prefix("https://")
+            .ok_or_else(|| Failure::refused("remote_scheme"))?;
+        let (host, path) = rest
+            .split_once('/')
+            .ok_or_else(|| Failure::refused("remote_scheme"))?;
+        if host.is_empty()
+            || !host
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || b".-".contains(&b))
+            || path.is_empty()
+            || !path
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || b"-._/".contains(&b))
+            || path.split('/').any(|s| matches!(s, "" | "." | ".."))
+        {
+            return Err(Failure::refused("remote_scheme"));
+        }
+        if row.slug.split('/').count() != 2
+            || row.slug.split('/').any(|s| {
+                s.is_empty()
+                    || !s
+                        .bytes()
+                        .all(|b| b.is_ascii_alphanumeric() || b"-._".contains(&b))
+            })
+            || !matches!(row.visibility.as_str(), "public" | "private" | "internal")
+        {
+            return Err(Failure::refused("repository_identity"));
+        }
+        Ok(row)
+    }
+
+    pub(crate) async fn handle_remote(
+        &self,
+        token: &NamespaceToken,
+        registry: &VerbRegistry,
+        verb: &str,
+        params: Value,
+    ) -> Result<Value, RuntimeError> {
+        let actor = policy::actor_label(token);
+        let mut receipt = Receipt::new(
+            token.namespace().as_str(),
+            &actor,
+            verb,
+            params
+                .get("repo")
+                .and_then(Value::as_str)
+                .unwrap_or("<invalid-repo>"),
+            safe_inputs(verb, &params),
+            denied("invalid_params"),
+            Value::Null,
+        );
+        receipt.session_id = params
+            .get("session_id")
+            .and_then(Value::as_str)
+            .map(str::to_owned);
+        let preflight = self
+            .remote_preflight(token, registry, verb, &params, &mut receipt)
+            .await;
+        self.require_receipt_storage(
+            token,
+            &receipt,
+            receipts::insert(self.runtime(), &receipt).await,
+        )
+        .await?;
+        let outcome = match preflight {
+            Err(error) => Err(error),
+            Ok(()) => {
+                self.perform_remote(token, registry, verb, &params, &mut receipt)
+                    .await
+            }
+        };
+        let outcome = if outcome.is_ok() && self.runtime().config().git_write.contract_faults {
+            match self.runtime().config().git_write.fault.as_deref() {
+                Some(fault) if fault == format!("{verb}:reply-lost-after-effect") => {
+                    Err(Failure::unknown("post_effect_fault"))
+                }
+                _ => outcome,
+            }
+        } else {
+            outcome
+        };
+        self.finish_local(token, receipt, outcome).await
+    }
+
+    async fn remote_preflight(
+        &self,
+        token: &NamespaceToken,
+        registry: &VerbRegistry,
+        verb: &str,
+        params: &Value,
+        receipt: &mut Receipt,
+    ) -> Result<(), Failure> {
+        validate(verb, params)?;
+        let branch = match verb {
+            "git.push" => params["branch"].as_str(),
+            "git.pr_open" => params["head"].as_str(),
+            _ => None,
+        };
+        let policy =
+            crate::write_policy::GitWritePolicy::from_config(&self.runtime().config().git_write);
+        let (canonical, index) = policy
+            .match_entry(Path::new(&receipt.repo), branch)
+            .map_err(|error| {
+                let reason = gate_reason(&error);
+                receipt.gate = denied(reason);
+                Failure::refused(reason)
+            })?;
+        receipt.repo = canonical.display().to_string();
+        receipt.gate = json!({"decision":"allow", "source":"git_write.allowed", "id":index});
+        receipt.policy = checked_policy(registry, token, verb).await.unwrap_or_else(
+            |_| json!({"decision":"deny", "source":"policy_unavailable", "id":null}),
+        );
+        if receipt.policy["decision"] != "allow" {
+            return Err(Failure::refused(
+                if receipt.policy["source"] == "policy_unavailable" {
+                    "policy_unavailable"
+                } else {
+                    "policy_denied"
+                },
+            ));
+        }
+        Ok(())
+    }
+
+    async fn api(
+        &self,
+        secret: &str,
+        method: &'static str,
+        path: String,
+        body: Option<Value>,
+    ) -> Result<Value, Failure> {
+        self.remote_transport()
+            .api(secret, ApiRequest { method, path, body })
+            .await
+            .map_err(Failure::from)
+    }
+
+    #[cfg(not(unix))]
+    async fn perform_remote(
+        &self,
+        _token: &NamespaceToken,
+        _registry: &VerbRegistry,
+        _verb: &str,
+        _params: &Value,
+        _receipt: &mut Receipt,
+    ) -> Result<Value, Failure> {
+        Err(Failure::refused("actor_unmapped"))
+    }
+
+    #[cfg(unix)]
+    async fn perform_remote(
+        &self,
+        token: &NamespaceToken,
+        registry: &VerbRegistry,
+        verb: &str,
+        params: &Value,
+        receipt: &mut Receipt,
+    ) -> Result<Value, Failure> {
+        let repo = std::path::PathBuf::from(&receipt.repo);
+        let target = self.remote_repository(&repo)?;
+        if verb == "git.push" {
+            let (version, supported) = local_git::push_marker_support(&repo).await?;
+            if !supported {
+                receipt.result = json!({"toolchain":{"git_version":version,"missing_capability":"reflog write"}});
+                return Err(Failure::refused("unsupported_toolchain"));
+            }
+            let expected = required(params, "expected_local")?.to_ascii_lowercase();
+            if local_git::branch_head(&repo, required(params, "branch")?).await? != expected {
+                return Err(Failure::refused("expected_local_mismatch"));
+            }
+        }
+        let (identity, secret) =
+            credentials::resolve_remote(&self.runtime().config().git_write, &receipt.actor)
+                .await
+                .map_err(|_| Failure::refused("actor_unmapped"))?;
+        receipt.credential = json!({"source":"actor", "ref":identity.credential_ref, "platform_identity":identity.platform_identity});
+        receipts::persist(self.runtime(), receipt).await?;
+        let secret = secret.value();
+        if verb == "git.push" {
+            return self.push_exact(secret, &target, params, receipt).await;
+        }
+        // gh's GitHub endpoint must name the same repository as configured Git.
+        if target.remote.trim_end_matches(".git") != format!("https://github.com/{}", target.slug) {
+            return Err(Failure::refused("repository_identity"));
+        }
+        let user = self.api(secret, "GET", "user".into(), None).await?;
+        let login = observed_string(&user, "/login")?;
+        if !login.eq_ignore_ascii_case(&identity.platform_identity) {
+            return Err(Failure::refused("platform_identity_mismatch"));
+        }
+        let remote = self
+            .api(secret, "GET", format!("repos/{}", target.slug), None)
+            .await?;
+        if observed_string(&remote, "/full_name")? != target.slug
+            || observed_string(&remote, "/visibility")? != target.visibility
+        {
+            return Err(Failure::refused("repository_identity_mismatch"));
+        }
+        if verb == "git.pr_open" {
+            return self.open_pr(secret, &target, params, receipt).await;
+        }
+        let n = number(params)?;
+        let pr = self
+            .api(
+                secret,
+                "GET",
+                endpoint(&target.slug, &format!("pulls/{n}")),
+                None,
+            )
+            .await?;
+        let head = observed_sha(&pr, "/head/sha")?;
+        let expected = required(params, "expected_head")?.to_ascii_lowercase();
+        if head != expected {
+            return Err(Failure::refused("expected_head_mismatch"));
+        }
+        if pr.get("merged").and_then(Value::as_bool) == Some(true)
+            || pr.get("state").and_then(Value::as_str) != Some("open")
+        {
+            return Err(Failure::refused("pull_request_closed"));
+        }
+        if observed_string(&pr, "/base/repo/full_name")? != target.slug {
+            return Err(Failure::refused("repository_identity_mismatch"));
+        }
+        let author = observed_string(&pr, "/user/login")?;
+        let fork = observed_string(&pr, "/head/repo/full_name")? != target.slug;
+        if fork && (verb == "git.pr_merge" || params["verdict"] == "approve") {
+            receipt.fork_policy = checked_policy(registry, token, &format!("{verb}.fork"))
+                .await
+                .unwrap_or_else(
+                    |_| json!({"decision":"deny", "source":"policy_unavailable", "id":null}),
+                );
+            receipts::persist(self.runtime(), receipt).await?;
+            if receipt.fork_policy["decision"] != "allow" {
+                return Err(Failure::refused("fork_policy_denied"));
+            }
+        }
+        if verb == "git.pr_review" {
+            if params["verdict"] == "approve" {
+                // A different runtime actor on the same platform account is not a reviewer.
+                if login.eq_ignore_ascii_case(author) {
+                    return Err(Failure::refused("self_approval"));
+                }
+                if self
+                    .opened_by_actor_or_reference(receipt, n, &identity.credential_ref)
+                    .await?
+                {
+                    return Err(Failure::refused("self_approval"));
+                }
+            }
+            let verdict = match required(params, "verdict")? {
+                "approve" => "APPROVE",
+                "request_changes" => "REQUEST_CHANGES",
+                _ => "COMMENT",
+            };
+            receipt.result = json!({"number":n, "head_sha":expected, "reviewer":login});
+            receipts::persist(self.runtime(), receipt).await?;
+            let reply = self
+                .api(
+                    secret,
+                    "POST",
+                    endpoint(&target.slug, &format!("pulls/{n}/reviews")),
+                    Some(
+                        json!({"event":verdict, "body":text(params,"body")?, "commit_id":expected}),
+                    ),
+                )
+                .await?;
+            let sha = observed_sha(&reply, "/commit_id").map_err(after_effect)?;
+            let state = observed_string(&reply, "/state")
+                .map_err(after_effect)?
+                .to_ascii_lowercase();
+            let id = reply
+                .get("id")
+                .and_then(Value::as_u64)
+                .ok_or_else(|| Failure::unknown("remote_response"))?;
+            if sha != expected
+                || state
+                    != match verdict {
+                        "APPROVE" => "approved",
+                        "REQUEST_CHANGES" => "changes_requested",
+                        _ => "commented",
+                    }
+            {
+                return Err(Failure::unknown("remote_response"));
+            }
+            let result = json!({"review_id":id, "head_sha":sha, "state":state});
+            receipt.result = result.clone();
+            return Ok(result);
+        }
+        self.require_review(secret, &target.slug, n, &expected, author)
+            .await?;
+        receipt.result = json!({"number":n, "merged_head_sha":expected, "slug":target.slug, "remote":target.remote});
+        receipts::persist(self.runtime(), receipt).await?;
+        let merged = self.api(secret, "PUT", endpoint(&target.slug, &format!("pulls/{n}/merge")), Some(json!({"merge_method":params["method"], "commit_title":params["subject"], "commit_message":params["body"], "sha":expected}))).await?;
+        match merged.get("merged").and_then(Value::as_bool) {
+            Some(true) => {}
+            Some(false) => return Err(Failure::refused("merge_refused")),
+            None => return Err(Failure::unknown("remote_response")),
+        }
+        let sha = observed_sha(&merged, "/sha").map_err(after_effect)?;
+        let result = json!({"number":n,"merged_head_sha":expected,"merged_sha":sha,"slug":target.slug,"remote":target.remote});
+        receipt.result = result.clone();
+        Ok(result)
+    }
+
+    async fn push_exact(
+        &self,
+        secret: &str,
+        target: &GitWriteRepositoryConfig,
+        params: &Value,
+        receipt: &mut Receipt,
+    ) -> Result<Value, Failure> {
+        let branch = required(params, "branch")?;
+        let expected = required(params, "expected_local")?.to_ascii_lowercase();
+        let old = params["expected_remote"]
+            .as_str()
+            .map(str::to_ascii_lowercase);
+        if old.as_deref() == Some(expected.as_str()) {
+            return Err(Failure::refused("already_at_target"));
+        }
+        let observed = self
+            .remote_transport()
+            .remote_ref(secret, &target.remote, branch)
+            .await?;
+        if observed != old {
+            return Err(Failure::refused("expected_remote_mismatch"));
+        }
+        if let Some(old) = &old {
+            if !local_git::is_ancestor(Path::new(&receipt.repo), old, &expected).await? {
+                return Err(Failure::refused("non_fast_forward"));
+            }
+        }
+        let result = json!({"ref":format!("refs/heads/{branch}"), "sha":expected, "remote":target.remote, "refspec":format!("{expected}:refs/heads/{branch}")});
+        receipt.result = result.clone();
+        receipts::persist(self.runtime(), receipt).await?;
+        self.remote_transport()
+            .push(
+                secret,
+                PushRequest {
+                    repo: receipt.repo.clone().into(),
+                    remote: target.remote.clone(),
+                    branch: branch.into(),
+                    expected_local: expected.clone(),
+                    expected_remote: old,
+                },
+            )
+            .await?;
+        let observed = self
+            .remote_transport()
+            .remote_ref(secret, &target.remote, branch)
+            .await
+            .map_err(|_| Failure::unknown("remote_readback_unavailable"))?;
+        if observed.as_deref() != Some(&expected) {
+            return Err(Failure::unknown("remote_readback_mismatch"));
+        }
+        // A marker records an acknowledged effect, never an intention to push.
+        local_git::record_push_marker(Path::new(&receipt.repo), branch, &expected, &receipt.id)
+            .await
+            .map_err(|_| Failure::unknown("marker_unavailable"))?;
+        Ok(result)
+    }
+
+    async fn open_pr(
+        &self,
+        secret: &str,
+        target: &GitWriteRepositoryConfig,
+        params: &Value,
+        receipt: &mut Receipt,
+    ) -> Result<Value, Failure> {
+        let head = required(params, "head")?;
+        let expected = required(params, "expected_head")?.to_ascii_lowercase();
+        let branch = self
+            .api(
+                secret,
+                "GET",
+                endpoint(&target.slug, &format!("git/ref/heads/{}", segment(head))),
+                None,
+            )
+            .await?;
+        if observed_sha(&branch, "/object/sha")? != expected {
+            return Err(Failure::refused("expected_head_mismatch"));
+        }
+        let reply = self.api(secret,"POST", endpoint(&target.slug,"pulls"), Some(json!({"head":head,"base":params["base"],"title":params["title"],"body":params["body"]}))).await?;
+        let sha = observed_sha(&reply, "/head/sha").map_err(after_effect)?;
+        let n = reply
+            .get("number")
+            .and_then(Value::as_u64)
+            .ok_or_else(|| Failure::unknown("remote_response"))?;
+        let url = observed_string(&reply, "/html_url").map_err(after_effect)?;
+        if url != format!("https://github.com/{}/pull/{n}", target.slug) {
+            return Err(Failure::unknown("remote_response"));
+        }
+        let result = json!({"number":n,"url":url,"head_sha":sha});
+        receipt.result = result.clone();
+        if sha != expected {
+            return Err(Failure::unknown("opened_head_mismatch"));
+        }
+        Ok(result)
+    }
+
+    async fn opened_by_actor_or_reference(
+        &self,
+        receipt: &Receipt,
+        number: u64,
+        reference: &str,
+    ) -> Result<bool, Failure> {
+        let mut reader = self
+            .runtime()
+            .sql()
+            .reader()
+            .await
+            .map_err(RuntimeError::from)?;
+        let rows = reader.query_all(SqlStatement {
+            sql:"SELECT actor, credential FROM git_receipts WHERE namespace=?1 AND repo=?2 AND verb='git.pr_open' AND disposition != 'not_committed' AND json_extract(result,'$.number')=?3 LIMIT 1001".into(),
+            params:vec![SqlValue::Text(receipt.namespace.clone()),SqlValue::Text(receipt.repo.clone()),SqlValue::Integer(i64::try_from(number).map_err(|_| Failure::invalid("number too large"))?)],
+            label:Some("git_pr_opener".into()),
+        }).await.map_err(RuntimeError::from)?;
+        if rows.len() > 1000 {
+            return Err(Failure::refused("opener_evidence_limit"));
+        }
+        for row in rows {
+            if matches!(row.get("actor"),Some(SqlValue::Text(actor)) if actor==&receipt.actor) {
+                return Ok(true);
+            }
+            let credential = match row.get("credential") {
+                Some(SqlValue::Text(value)) => serde_json::from_str::<Value>(value)
+                    .map_err(|_| Failure::refused("opener_evidence_invalid"))?,
+                Some(SqlValue::Json(value)) => value.clone(),
+                _ => Value::Null,
+            };
+            if credential.get("ref").and_then(Value::as_str) == Some(reference) {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    async fn require_review(
+        &self,
+        secret: &str,
+        slug: &str,
+        number: u64,
+        expected: &str,
+        author: &str,
+    ) -> Result<(), Failure> {
+        let mut latest = BTreeMap::<String, (String, String)>::new();
+        for page in 1..=10 {
+            let rows = self
+                .api(
+                    secret,
+                    "GET",
+                    endpoint(
+                        slug,
+                        &format!("pulls/{number}/reviews?per_page=100&page={page}"),
+                    ),
+                    None,
+                )
+                .await?;
+            let rows = rows
+                .as_array()
+                .ok_or_else(|| Failure::refused("remote_response"))?;
+            for review in rows {
+                let login = observed_string(review, "/user/login")?.to_ascii_lowercase();
+                let state = observed_string(review, "/state")?.to_string();
+                // Comment-only reviews do not dismiss a prior approval.
+                if state != "COMMENTED" && state != "PENDING" {
+                    latest.insert(login, (state, observed_sha(review, "/commit_id")?));
+                }
+            }
+            if rows.len() < 100 {
+                if latest.iter().any(|(login, (state, sha))| {
+                    !login.eq_ignore_ascii_case(author) && state == "APPROVED" && sha == expected
+                }) {
+                    return Ok(());
+                }
+                return Err(Failure::refused("missing_review"));
+            }
+        }
+        Err(Failure::refused("review_evidence_limit"))
+    }
+
+    #[cfg(unix)]
+    pub(crate) async fn reconcile_remote(
+        &self,
+        repo: &Path,
+        prior: &mut Receipt,
+    ) -> Result<(), Failure> {
+        if prior.disposition != Disposition::Unknown {
+            return Ok(());
+        }
+        let target = self.remote_repository(repo)?;
+        let (_, secret) =
+            credentials::resolve_remote(&self.runtime().config().git_write, &prior.actor)
+                .await
+                .map_err(|_| Failure::refused("actor_unmapped"))?;
+        let committed = match prior.verb.as_str() {
+            "git.push" => {
+                let branch = required(&prior.inputs, "branch")?;
+                let sha = required(&prior.inputs, "expected_local")?.to_ascii_lowercase();
+                if prior.result.get("remote").and_then(Value::as_str) != Some(&target.remote) {
+                    return Ok(());
+                }
+                local_git::operation_recorded(repo, branch, &sha, &prior.id)
+                    .await
+                    .unwrap_or(false)
+                    && self
+                        .remote_transport()
+                        .remote_ref(secret.value(), &target.remote, branch)
+                        .await
+                        .ok()
+                        .flatten()
+                        .as_deref()
+                        == Some(sha.as_str())
+            }
+            "git.pr_merge" => {
+                if prior.result.get("slug").and_then(Value::as_str) != Some(&target.slug)
+                    || prior.result.get("remote").and_then(Value::as_str) != Some(&target.remote)
+                {
+                    return Ok(());
+                }
+                let n = number(&prior.inputs)?;
+                let pr = self
+                    .api(
+                        secret.value(),
+                        "GET",
+                        endpoint(&target.slug, &format!("pulls/{n}")),
+                        None,
+                    )
+                    .await?;
+                if pr.get("merged").and_then(Value::as_bool) == Some(true)
+                    && observed_sha(&pr, "/head/sha")?
+                        == required(&prior.inputs, "expected_head")?.to_ascii_lowercase()
+                {
+                    prior.result = json!({"number":n,"merged_head_sha":pr["head"]["sha"],"merged_sha":observed_sha(&pr,"/merge_commit_sha")?});
+                    true
+                } else {
+                    false
+                }
+            }
+            _ => false,
+        };
+        if committed {
+            prior.disposition = Disposition::Committed;
+            prior.finished_at = Some(chrono::Utc::now().timestamp_micros());
+            prior.reason = None;
+            receipts::persist(self.runtime(), prior).await?;
+        }
+        Ok(())
+    }
+
+    #[cfg(not(unix))]
+    pub(crate) async fn reconcile_remote(
+        &self,
+        _repo: &Path,
+        _prior: &mut Receipt,
+    ) -> Result<(), Failure> {
+        Err(Failure::refused("actor_unmapped"))
+    }
+}

--- a/crates/khive-pack-git/src/remote_handlers.rs
+++ b/crates/khive-pack-git/src/remote_handlers.rs
@@ -444,8 +444,20 @@ impl GitPack {
                 return Err(Failure::refused("fork_policy_denied"));
             }
         }
+        let last_pusher = if verb == "git.pr_merge" || params["verdict"] == "approve" {
+            self.last_pusher(receipt, &pr, &expected).await?
+        } else {
+            Value::Null
+        };
+        receipt.result = json!({"number":n, "head_sha":expected, "last_pusher":last_pusher});
         if verb == "git.pr_review" {
             if params["verdict"] == "approve" {
+                if last_pusher["platform_identity"]
+                    .as_str()
+                    .is_some_and(|pusher| login.eq_ignore_ascii_case(pusher))
+                {
+                    return Err(Failure::refused("last_pusher"));
+                }
                 // A different runtime actor on the same platform account is not a reviewer.
                 if login.eq_ignore_ascii_case(author) {
                     return Err(Failure::refused("self_approval"));
@@ -462,7 +474,7 @@ impl GitPack {
                 "request_changes" => "REQUEST_CHANGES",
                 _ => "COMMENT",
             };
-            receipt.result = json!({"number":n, "head_sha":expected, "reviewer":login});
+            receipt.result["reviewer"] = json!(login);
             receipts::persist(self.runtime(), receipt).await?;
             let reply = self
                 .api(
@@ -492,13 +504,31 @@ impl GitPack {
             {
                 return Err(Failure::unknown("remote_response"));
             }
-            let result = json!({"review_id":id, "head_sha":sha, "state":state});
+            let result =
+                json!({"review_id":id, "head_sha":sha, "state":state, "last_pusher":last_pusher});
             receipt.result = result.clone();
             return Ok(result);
         }
-        self.require_review(secret, &target.slug, n, &expected, author)
+        let review = self
+            .remote_transport()
+            .review_decision(secret, &target.slug, n)
             .await?;
-        receipt.result = json!({"number":n, "merged_head_sha":expected, "slug":target.slug, "remote":target.remote});
+        receipt.result["review_decision"] = json!({
+            "source":"github.pullRequest.reviewDecision",
+            "value":review.get("reviewDecision"),
+            "head_sha":review.get("headRefOid"),
+        });
+        if observed_sha(&review, "/headRefOid")? != expected {
+            return Err(Failure::refused("expected_head_mismatch"));
+        }
+        if review.get("reviewDecision").and_then(Value::as_str) != Some("APPROVED") {
+            return Err(Failure::refused("review_decision"));
+        }
+        self.require_review(secret, &target.slug, n, &expected, author, &last_pusher)
+            .await?;
+        receipt.result["merged_head_sha"] = json!(expected);
+        receipt.result["slug"] = json!(target.slug);
+        receipt.result["remote"] = json!(target.remote);
         receipts::persist(self.runtime(), receipt).await?;
         let merged = self.api(secret, "PUT", endpoint(&target.slug, &format!("pulls/{n}/merge")), Some(json!({"merge_method":params["method"], "commit_title":params["subject"], "commit_message":params["body"], "sha":expected}))).await?;
         match merged.get("merged").and_then(Value::as_bool) {
@@ -507,9 +537,8 @@ impl GitPack {
             None => return Err(Failure::unknown("remote_response")),
         }
         let sha = observed_sha(&merged, "/sha").map_err(after_effect)?;
-        let result = json!({"number":n,"merged_head_sha":expected,"merged_sha":sha,"slug":target.slug,"remote":target.remote});
-        receipt.result = result.clone();
-        Ok(result)
+        receipt.result["merged_sha"] = json!(sha);
+        Ok(receipt.result.clone())
     }
 
     async fn push_exact(
@@ -644,6 +673,70 @@ impl GitPack {
         Ok(false)
     }
 
+    /// Cross-actor evidence is intentionally restricted to this namespace and
+    /// the PR's exact head repository/ref/SHA, including fork heads.
+    async fn last_pusher(
+        &self,
+        receipt: &Receipt,
+        pr: &Value,
+        expected: &str,
+    ) -> Result<Value, Failure> {
+        let slug = observed_string(pr, "/head/repo/full_name")?;
+        let branch = observed_string(pr, "/head/ref")?;
+        let remote = format!("https://github.com/{slug}").to_ascii_lowercase();
+        let mut reader = self
+            .runtime()
+            .sql()
+            .reader()
+            .await
+            .map_err(RuntimeError::from)?;
+        let rows = reader.query_all(SqlStatement {
+            sql: "SELECT id, repo, disposition, credential FROM git_receipts \
+                  WHERE namespace=?1 AND verb='git.push' AND disposition IN ('committed','unknown') \
+                  AND lower(json_extract(result,'$.sha'))=?2 AND json_extract(result,'$.ref')=?3 \
+                  AND lower(json_extract(result,'$.remote')) IN (?4,?5) \
+                  ORDER BY rowid DESC LIMIT 1001".into(),
+            params: vec![SqlValue::Text(receipt.namespace.clone()),SqlValue::Text(expected.into()),
+                SqlValue::Text(format!("refs/heads/{branch}")),SqlValue::Text(remote.clone()),
+                SqlValue::Text(format!("{remote}.git"))],
+            label: Some("git_last_pusher".into()),
+        }).await.map_err(RuntimeError::from)?;
+        // No SQL reader is held across local Git process execution.
+        drop(reader);
+        for row in rows.iter().take(1000) {
+            let column = |key| match row.get(key) {
+                Some(SqlValue::Text(value)) => Ok(value.as_str()),
+                _ => Err(Failure::refused("push_evidence_invalid")),
+            };
+            let id = column("id")?;
+            if column("disposition")? != "committed"
+                && !local_git::operation_recorded(Path::new(column("repo")?), branch, expected, id)
+                    .await
+                    .unwrap_or(false)
+            {
+                // A durable intent or a lost transport ACK is not push evidence.
+                continue;
+            }
+            let credential = match row.get("credential") {
+                Some(SqlValue::Text(value)) => serde_json::from_str::<Value>(value)
+                    .map_err(|_| Failure::refused("push_evidence_invalid"))?,
+                Some(SqlValue::Json(value)) => value.clone(),
+                _ => return Err(Failure::refused("push_evidence_invalid")),
+            };
+            let login = credential
+                .get("platform_identity")
+                .and_then(Value::as_str)
+                .filter(|login| !login.is_empty())
+                .ok_or_else(|| Failure::refused("push_evidence_invalid"))?;
+            return Ok(json!({"state":"known","source":"git.push.receipt",
+                "platform_identity":login,"push_receipt_id":id}));
+        }
+        if rows.len() > 1000 {
+            return Err(Failure::refused("push_evidence_limit"));
+        }
+        Ok(json!({"state":"unknown","reason":"no_push_receipt"}))
+    }
+
     async fn require_review(
         &self,
         secret: &str,
@@ -651,6 +744,7 @@ impl GitPack {
         number: u64,
         expected: &str,
         author: &str,
+        last_pusher: &Value,
     ) -> Result<(), Failure> {
         let mut latest = BTreeMap::<String, (String, String)>::new();
         for page in 1..=10 {
@@ -677,10 +771,23 @@ impl GitPack {
                 }
             }
             if rows.len() < 100 {
-                if latest.iter().any(|(login, (state, sha))| {
-                    !login.eq_ignore_ascii_case(author) && state == "APPROVED" && sha == expected
+                let approved: Vec<_> = latest
+                    .iter()
+                    .filter(|(login, (state, sha))| {
+                        !login.eq_ignore_ascii_case(author)
+                            && state == "APPROVED"
+                            && sha == expected
+                    })
+                    .collect();
+                if approved.iter().any(|(login, _)| {
+                    !last_pusher["platform_identity"]
+                        .as_str()
+                        .is_some_and(|pusher| login.eq_ignore_ascii_case(pusher))
                 }) {
                     return Ok(());
+                }
+                if !approved.is_empty() {
+                    return Err(Failure::refused("last_pusher"));
                 }
                 return Err(Failure::refused("missing_review"));
             }
@@ -740,7 +847,9 @@ impl GitPack {
                     && observed_sha(&pr, "/head/sha")?
                         == required(&prior.inputs, "expected_head")?.to_ascii_lowercase()
                 {
-                    prior.result = json!({"number":n,"merged_head_sha":pr["head"]["sha"],"merged_sha":observed_sha(&pr,"/merge_commit_sha")?});
+                    prior.result["number"] = json!(n);
+                    prior.result["merged_head_sha"] = pr["head"]["sha"].clone();
+                    prior.result["merged_sha"] = json!(observed_sha(&pr, "/merge_commit_sha")?);
                     true
                 } else {
                     false

--- a/crates/khive-pack-git/src/remote_tests.rs
+++ b/crates/khive-pack-git/src/remote_tests.rs
@@ -1,0 +1,1012 @@
+// The remote-head and platform-account mutation controls are declared in the
+// implementation plan before execution. Native Git refs and SQL receipt reads
+// are independent of the recording platform's request ledger.
+
+use crate::receipts::{self, Disposition, Receipt};
+use crate::remote_transport::{ApiRequest, PushRequest, RemoteError, RemoteTransport};
+use crate::GitPack;
+use async_trait::async_trait;
+use khive_pack_kg::KgPack;
+use khive_pack_tool::ToolPack;
+use khive_runtime::engine_config::{
+    GitWriteActorConfig, GitWriteEntryConfig, GitWriteRepositoryConfig, GitWriteSectionConfig,
+};
+use khive_runtime::{
+    KhiveRuntime, RequestIdentity, RuntimeConfig, RuntimeError, VerbRegistry, VerbRegistryBuilder,
+};
+use khive_storage::types::{SqlStatement, SqlValue};
+use serde_json::{json, Value};
+use std::collections::BTreeMap;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::{Arc, Mutex};
+
+const SLUG: &str = "fixture/project";
+const REMOTE: &str = "https://github.com/fixture/project.git";
+const SECRET: &str = "synthetic-author-secret";
+fn git(repo: &Path, args: &[&str]) -> String {
+    let out = Command::new("git")
+        .env_clear()
+        .env("PATH", std::env::var_os("PATH").unwrap())
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_AUTHOR_NAME", "Fixture")
+        .env("GIT_AUTHOR_EMAIL", "fixture@example.invalid")
+        .env("GIT_COMMITTER_NAME", "Fixture")
+        .env("GIT_COMMITTER_EMAIL", "fixture@example.invalid")
+        .args(["-c", "core.hooksPath=/dev/null", "-C"])
+        .arg(repo)
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "native Git {:?}: {}",
+        args,
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8(out.stdout).unwrap().trim().into()
+}
+fn remote_head(remote: &Path) -> Option<String> {
+    let out = Command::new("git")
+        .arg("--git-dir")
+        .arg(remote)
+        .args(["rev-parse", "--verify", "refs/heads/work"])
+        .output()
+        .unwrap();
+    out.status
+        .success()
+        .then(|| String::from_utf8(out.stdout).unwrap().trim().into())
+}
+fn quote(p: &Path) -> String {
+    format!("'{}'", p.display().to_string().replace('\'', "'\\''"))
+}
+
+struct Recording {
+    bare: PathBuf,
+    state: Mutex<State>,
+}
+struct State {
+    head: String,
+    author: String,
+    fork: bool,
+    mismatch: Option<&'static str>,
+    prs: BTreeMap<u64, Value>,
+    reviews: Vec<Value>,
+    calls: Vec<Value>,
+    push_calls: usize,
+    writes: usize,
+    remote_race: Option<String>,
+    merge_race: Option<String>,
+    lost_ack: bool,
+    api_failure: bool,
+    malformed_merge_reply: bool,
+}
+impl Recording {
+    fn login(token: &str) -> &str {
+        if token.contains("reviewer") {
+            "reviewer"
+        } else {
+            "author"
+        }
+    }
+    fn pr(&self, n: u64) -> Value {
+        self.state.lock().unwrap().prs[&n].clone()
+    }
+    fn writes(&self) -> usize {
+        self.state.lock().unwrap().writes
+    }
+}
+#[async_trait]
+impl RemoteTransport for Recording {
+    async fn remote_ref(
+        &self,
+        token: &str,
+        _remote: &str,
+        _branch: &str,
+    ) -> Result<Option<String>, RemoteError> {
+        let mut s = self.state.lock().unwrap();
+        s.calls.push(json!({"op":"remote_ref","token_hash":blake3::hash(token.as_bytes()).to_hex().to_string()}));
+        if s.api_failure {
+            return Err(RemoteError::Unavailable);
+        }
+        Ok(remote_head(&self.bare))
+    }
+    async fn push(&self, token: &str, mut request: PushRequest) -> Result<(), RemoteError> {
+        let (race, lost) = {
+            let mut s = self.state.lock().unwrap();
+            s.push_calls += 1;
+            s.calls.push(json!({"op":"push","sha":request.expected_local,"expected_remote":request.expected_remote}));
+            (s.remote_race.take(), s.lost_ack)
+        };
+        if let Some(sha) = race {
+            git(&self.bare, &["update-ref", "refs/heads/work", &sha]);
+        }
+        request.remote = self.bare.display().to_string();
+        crate::remote_transport::push_native(token, request, true).await?;
+        self.state.lock().unwrap().writes += 1;
+        if lost {
+            Err(RemoteError::Unknown)
+        } else {
+            Ok(())
+        }
+    }
+    async fn api(&self, token: &str, request: ApiRequest) -> Result<Value, RemoteError> {
+        let mut s = self.state.lock().unwrap();
+        s.calls.push(json!({"method":request.method,"path":request.path,"body":request.body,"token_hash":blake3::hash(token.as_bytes()).to_hex().to_string()}));
+        if s.api_failure {
+            return Err(RemoteError::Unavailable);
+        }
+        let path = request.path.as_str();
+        if path == "user" {
+            return Ok(json!({"login":Self::login(token)}));
+        }
+        if path == format!("repos/{SLUG}") {
+            return Ok(
+                json!({"full_name":if s.mismatch==Some("slug"){"wrong/repo"}else{SLUG},"visibility":if s.mismatch==Some("visibility"){"public"}else{"private"}}),
+            );
+        }
+        if path.contains("/git/ref/heads/") {
+            return Ok(json!({"object":{"sha":s.head}}));
+        }
+        if path == format!("repos/{SLUG}/pulls") && request.method == "POST" {
+            let n = s.prs.len() as u64 + 1;
+            let pr = json!({"number":n,"html_url":format!("https://github.com/{SLUG}/pull/{n}"),"state":"open","merged":false,"head":{"sha":s.head,"repo":{"full_name":if s.fork{"fork/project"}else{SLUG}}},"base":{"repo":{"full_name":SLUG}},"user":{"login":s.author}});
+            s.prs.insert(n, pr.clone());
+            s.writes += 1;
+            return Ok(pr);
+        }
+        if path.contains("/reviews?") {
+            return Ok(json!(s.reviews));
+        }
+        let part = path
+            .strip_prefix(&format!("repos/{SLUG}/pulls/"))
+            .ok_or(RemoteError::InvalidResponse)?;
+        let n = part
+            .split('/')
+            .next()
+            .unwrap()
+            .parse::<u64>()
+            .map_err(|_| RemoteError::InvalidResponse)?;
+        if part.ends_with("/reviews") && request.method == "POST" {
+            let b = request.body.unwrap();
+            let state = match b["event"].as_str().unwrap() {
+                "APPROVE" => "APPROVED",
+                "REQUEST_CHANGES" => "CHANGES_REQUESTED",
+                _ => "COMMENTED",
+            };
+            let review = json!({"id":s.reviews.len()+1,"commit_id":b["commit_id"],"state":state,"user":{"login":Self::login(token)}});
+            s.reviews.push(review.clone());
+            s.writes += 1;
+            return Ok(review);
+        }
+        if part.ends_with("/merge") {
+            if let Some(sha) = s.merge_race.take() {
+                s.prs.get_mut(&n).unwrap()["head"]["sha"] = json!(sha);
+            }
+            let body = request.body.unwrap();
+            let pr = s.prs.get_mut(&n).ok_or(RemoteError::Refused)?;
+            if pr["head"]["sha"] != body["sha"] {
+                return Err(RemoteError::Refused);
+            }
+            if pr["merged"] == true {
+                return Err(RemoteError::Refused);
+            }
+            pr["merged"] = json!(true);
+            pr["state"] = json!("closed");
+            pr["merge_commit_sha"] = json!("d".repeat(40));
+            s.writes += 1;
+            if s.lost_ack {
+                return Err(RemoteError::Unknown);
+            }
+            if s.malformed_merge_reply {
+                return Ok(json!({"sha":"d".repeat(40)}));
+            }
+            return Ok(json!({"merged":true,"sha":"d".repeat(40)}));
+        }
+        s.prs.get(&n).cloned().ok_or(RemoteError::Refused)
+    }
+}
+
+struct Fixture {
+    _env_guard: tokio::sync::MutexGuard<'static, ()>,
+    dir: tempfile::TempDir,
+    repo: PathBuf,
+    base: String,
+    middle: String,
+    head: String,
+    actor: String,
+    reviewer: String,
+    alias: String,
+    rt: KhiveRuntime,
+    registry: VerbRegistry,
+    remote: Arc<Recording>,
+}
+impl Fixture {
+    async fn new(allowed: bool, fault: Option<&str>) -> Self {
+        let env_guard = crate::cache::ENV_MUTEX.lock().await;
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        std::fs::create_dir(&repo).unwrap();
+        let repo = std::fs::canonicalize(repo).unwrap();
+        git(&repo, &["init", "-q", "-b", "work"]);
+        git(&repo, &["commit", "--allow-empty", "-qm", "base"]);
+        let base = git(&repo, &["rev-parse", "HEAD"]);
+        git(&repo, &["commit", "--allow-empty", "-qm", "middle"]);
+        let middle = git(&repo, &["rev-parse", "HEAD"]);
+        git(&repo, &["commit", "--allow-empty", "-qm", "head"]);
+        let head = git(&repo, &["rev-parse", "HEAD"]);
+        let bare = dir.path().join("remote.git");
+        git(
+            &repo,
+            &[
+                "clone",
+                "-q",
+                "--bare",
+                repo.to_str().unwrap(),
+                bare.to_str().unwrap(),
+            ],
+        );
+        git(&bare, &["update-ref", "refs/heads/work", &base]);
+        let resolver = dir.path().join("resolver");
+        std::fs::write(
+            &resolver,
+            format!(
+                "#!/bin/sh\nprintf '%s\\n' \"$1\" >> {}\nexec /bin/cat {}/\"$1\"\n",
+                quote(&dir.path().join("reads")),
+                quote(dir.path())
+            ),
+        )
+        .unwrap();
+        std::fs::set_permissions(&resolver, std::fs::Permissions::from_mode(0o755)).unwrap();
+        for (reference, value) in [
+            ("author-ref", SECRET),
+            ("reviewer-ref", "synthetic-reviewer-secret"),
+            ("alias-ref", "synthetic-alias-secret"),
+        ] {
+            std::fs::write(dir.path().join(reference), value).unwrap();
+        }
+        let actor = format!("remote:{}", uuid::Uuid::new_v4());
+        let reviewer = format!("{actor}:reviewer");
+        let alias = format!("{actor}:alias");
+        let mut actors = BTreeMap::new();
+        for (actor, reference, login) in [
+            (&actor, "author-ref", "author"),
+            (&reviewer, "reviewer-ref", "reviewer"),
+            (&alias, "alias-ref", "author"),
+        ] {
+            actors.insert(
+                actor.clone(),
+                GitWriteActorConfig {
+                    name: "Fixture".into(),
+                    email: "fixture@example.invalid".into(),
+                    credential_ref: reference.into(),
+                    platform_identity: login.into(),
+                },
+            );
+        }
+        let rt = KhiveRuntime::new(RuntimeConfig {
+            db_path: None,
+            git_write: GitWriteSectionConfig {
+                allowed: if allowed {
+                    vec![GitWriteEntryConfig {
+                        repo: repo.display().to_string(),
+                        branches: vec!["work".into()],
+                    }]
+                } else {
+                    vec![]
+                },
+                actors,
+                repositories: BTreeMap::from([(
+                    repo.display().to_string(),
+                    GitWriteRepositoryConfig {
+                        remote: REMOTE.into(),
+                        slug: SLUG.into(),
+                        visibility: "private".into(),
+                    },
+                )]),
+                credential_resolver: vec![resolver.display().to_string(), "{ref}".into()],
+                contract_faults: fault.is_some(),
+                fault: fault.map(str::to_string),
+            },
+            ..RuntimeConfig::no_embeddings()
+        })
+        .unwrap();
+        let remote = Arc::new(Recording {
+            bare,
+            state: Mutex::new(State {
+                head: head.clone(),
+                author: "author".into(),
+                fork: false,
+                mismatch: None,
+                prs: BTreeMap::new(),
+                reviews: vec![],
+                calls: vec![],
+                push_calls: 0,
+                writes: 0,
+                remote_race: None,
+                merge_race: None,
+                lost_ack: false,
+                api_failure: false,
+                malformed_merge_reply: false,
+            }),
+        });
+        let mut builder = VerbRegistryBuilder::new();
+        builder.with_actor_id(Some(actor.clone()));
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(ToolPack::new(rt.clone()));
+        builder.register(GitPack::with_remote_transport(rt.clone(), remote.clone()));
+        builder.with_runtime_event_store(&rt).unwrap();
+        let registry = builder.build().unwrap();
+        registry.apply_schema_plans(rt.backend());
+        rt.install_edge_rules(registry.all_edge_rules());
+        let f = Self {
+            _env_guard: env_guard,
+            dir,
+            repo,
+            base,
+            middle,
+            head,
+            actor,
+            reviewer,
+            alias,
+            rt,
+            registry,
+            remote,
+        };
+        for actor in [&f.actor, &f.reviewer, &f.alias] {
+            for verb in [
+                "git.push",
+                "git.pr_open",
+                "git.pr_review",
+                "git.pr_merge",
+                "git.reconcile",
+            ] {
+                f.policy(actor, verb, "allow").await;
+            }
+        }
+        f
+    }
+    async fn call(&self, actor: &str, verb: &str, mut p: Value) -> Result<Value, RuntimeError> {
+        if verb != "git.reconcile" {
+            p["repo"] = json!(self.repo);
+        }
+        self.registry
+            .dispatch_with_identity(
+                verb,
+                p,
+                Some(RequestIdentity {
+                    namespace: "local".into(),
+                    actor_id: Some(actor.into()),
+                    ..Default::default()
+                }),
+            )
+            .await
+    }
+    async fn policy(&self, actor: &str, verb: &str, decision: &str) -> String {
+        let mut writer = self.rt.sql().writer().await.unwrap();
+        writer
+            .execute(SqlStatement {
+                sql: "DELETE FROM tool_policy WHERE namespace='local' AND actor=?1 AND tool=?2"
+                    .into(),
+                params: vec![SqlValue::Text(actor.into()), SqlValue::Text(verb.into())],
+                label: Some("fixture_replace_policy".into()),
+            })
+            .await
+            .unwrap();
+        drop(writer);
+        self.registry
+            .dispatch(
+                "tool.policy",
+                json!({"actor":actor,"tool":verb,"decision":decision}),
+            )
+            .await
+            .unwrap()["policy"]["id"]
+            .as_str()
+            .unwrap()
+            .into()
+    }
+    fn push(&self) -> Value {
+        json!({"branch":"work","expected_local":self.head,"expected_remote":self.base})
+    }
+    fn merge(&self, n: u64) -> Value {
+        json!({"number":n,"method":"merge","subject":"Fixture merge","body":"","expected_head":self.head})
+    }
+    async fn open(&self) -> u64 {
+        self.call(&self.actor,"git.pr_open",json!({"head":"work","base":"main","title":"Fixture","body":"","expected_head":self.head})).await.unwrap()["number"].as_u64().unwrap()
+    }
+    async fn review(&self, actor: &str, n: u64) -> Result<Value, RuntimeError> {
+        self.call(
+            actor,
+            "git.pr_review",
+            json!({"number":n,"verdict":"approve","body":"","expected_head":self.head}),
+        )
+        .await
+    }
+    async fn last(&self, actor: &str) -> Receipt {
+        receipts::list_owned(&self.rt, "local", actor, None, None, 500, 0)
+            .await
+            .unwrap()
+            .receipts
+            .pop()
+            .unwrap()
+    }
+    async fn refusal(&self, actor: &str, verb: &str, p: Value, reason: &str) -> Receipt {
+        let before = self.remote.writes();
+        let local = git(&self.repo, &["show-ref"]);
+        let remote = remote_head(&self.remote.bare);
+        let error = self.call(actor, verb, p).await.unwrap_err().to_string();
+        assert!(error.contains(reason), "{error}");
+        let receipt = self.last(actor).await;
+        assert_eq!(receipt.disposition, Disposition::NotCommitted);
+        assert!(error.contains(&receipt.id));
+        assert_eq!(self.remote.writes(), before);
+        assert_eq!(git(&self.repo, &["show-ref"]), local);
+        assert_eq!(remote_head(&self.remote.bare), remote);
+        receipt
+    }
+}
+
+#[tokio::test]
+async fn remote_push_gate_policy_and_positive_control() {
+    for (gate, decision) in [(false, "allow"), (true, "deny"), (true, "allow")] {
+        let f = Fixture::new(gate, None).await;
+        let id = f.policy(&f.actor, "git.push", decision).await;
+        let before = crate::local_handlers::policy_check_count(&f.actor);
+        if !gate || decision == "deny" {
+            f.refusal(
+                &f.actor,
+                "git.push",
+                f.push(),
+                if gate {
+                    "policy_denied"
+                } else {
+                    "not_configured"
+                },
+            )
+            .await;
+            assert_eq!(f.remote.state.lock().unwrap().push_calls, 0);
+            assert!(f.remote.state.lock().unwrap().calls.is_empty());
+        } else {
+            let result = f.call(&f.actor, "git.push", f.push()).await.unwrap();
+            assert_eq!(result["sha"], f.head);
+            assert_eq!(remote_head(&f.remote.bare), Some(f.head.clone()));
+        }
+        assert_eq!(
+            crate::local_handlers::policy_check_count(&f.actor) - before,
+            usize::from(gate)
+        );
+        let receipt = f.last(&f.actor).await;
+        assert_eq!(
+            receipt.gate["decision"],
+            if gate { "allow" } else { "deny" }
+        );
+        if gate {
+            assert_eq!(receipt.policy["id"], id);
+            assert_eq!(receipt.policy["decision"], decision);
+        } else {
+            assert!(receipt.policy.is_null());
+        }
+    }
+}
+
+#[tokio::test]
+async fn remote_push_compares_at_local_remote_and_native_effect_seams() {
+    for seam in ["local", "remote", "effect"] {
+        let f = Fixture::new(true, None).await;
+        if seam == "local" {
+            git(&f.repo, &["update-ref", "refs/heads/work", &f.middle]);
+        }
+        if seam == "remote" {
+            git(
+                &f.remote.bare,
+                &["update-ref", "refs/heads/work", &f.middle],
+            );
+        }
+        if seam == "effect" {
+            f.remote.state.lock().unwrap().remote_race = Some(f.middle.clone());
+        }
+        let result = f.call(&f.actor, "git.push", f.push()).await;
+        assert!(result.is_err(), "{seam}: rival remote was overwritten");
+        assert_eq!(
+            f.last(&f.actor).await.disposition,
+            Disposition::NotCommitted
+        );
+        assert_eq!(
+            remote_head(&f.remote.bare),
+            Some(if seam == "local" {
+                f.base.clone()
+            } else {
+                f.middle.clone()
+            })
+        );
+        assert_eq!(
+            git(&f.repo, &["rev-parse", "work"]),
+            if seam == "local" {
+                f.middle.as_str()
+            } else {
+                f.head.as_str()
+            }
+        );
+    }
+}
+
+#[tokio::test]
+async fn remote_push_rejects_every_force_and_omission_before_network() {
+    let f = Fixture::new(true, None).await;
+    for extra in [
+        json!({"force":true}),
+        json!({"force":1}),
+        json!({"force":"true"}),
+        json!({"force":[]}),
+        json!({"force_with_lease":true}),
+        json!({"force_with_lease":false}),
+        json!({"refspec":"+HEAD:refs/heads/main"}),
+        json!({"argv":["--force"]}),
+        json!({"remote":"elsewhere"}),
+        json!({"actor":"spoof"}),
+        json!({"credential":SECRET}),
+    ] {
+        let mut p = f.push();
+        p.as_object_mut()
+            .unwrap()
+            .extend(extra.as_object().unwrap().clone());
+        f.refusal(&f.actor, "git.push", p, "invalid_params").await;
+    }
+    let mut p = f.push();
+    p.as_object_mut().unwrap().remove("expected_remote");
+    f.refusal(&f.actor, "git.push", p, "expected_remote is required")
+        .await;
+    assert!(f.remote.state.lock().unwrap().calls.is_empty());
+}
+
+#[tokio::test]
+async fn remote_push_null_is_create_only_and_equal_sha_is_not_an_effect() {
+    let f = Fixture::new(true, None).await;
+    let mut p = f.push();
+    p["expected_remote"] = Value::Null;
+    f.refusal(&f.actor, "git.push", p.clone(), "expected_remote_mismatch")
+        .await;
+    git(&f.remote.bare, &["update-ref", "-d", "refs/heads/work"]);
+    let refs = git(&f.repo, &["show-ref"]);
+    f.call(&f.actor, "git.push", p.clone()).await.unwrap();
+    assert_eq!(remote_head(&f.remote.bare), Some(f.head.clone()));
+    assert_eq!(git(&f.repo, &["show-ref"]), refs);
+    f.refusal(&f.actor, "git.push", p, "expected_remote_mismatch")
+        .await;
+    let mut p = f.push();
+    p["expected_remote"] = json!(f.head);
+    f.refusal(&f.actor, "git.push", p, "already_at_target")
+        .await;
+}
+
+#[tokio::test]
+async fn remote_pr_identity_mismatch_has_no_effect_and_open_binds_head() {
+    let f = Fixture::new(true, None).await;
+    let p = json!({"head":"work","base":"main","title":"Fixture","body":"","expected_head":f.head});
+    for field in ["slug", "visibility"] {
+        f.remote.state.lock().unwrap().mismatch = Some(field);
+        f.refusal(
+            &f.actor,
+            "git.pr_open",
+            p.clone(),
+            "repository_identity_mismatch",
+        )
+        .await;
+    }
+    f.remote.state.lock().unwrap().mismatch = None;
+    let result = f.call(&f.actor, "git.pr_open", p).await.unwrap();
+    assert_eq!(result["head_sha"], f.head);
+    assert_eq!(result["url"], f.remote.pr(1)["html_url"]);
+}
+
+#[tokio::test]
+async fn remote_pr_self_actor_and_same_account_refuse_then_second_account_approves() {
+    let f = Fixture::new(true, None).await;
+    let n = f.open().await;
+    for actor in [&f.actor, &f.alias] {
+        let before = f.remote.writes();
+        let review = f.review(actor, n).await;
+        assert_eq!(
+            f.remote.writes(),
+            before,
+            "unexpected platform review: {}",
+            json!(f.remote.state.lock().unwrap().reviews)
+        );
+        assert!(review.unwrap_err().to_string().contains("self_approval"));
+        assert_eq!(f.last(actor).await.disposition, Disposition::NotCommitted);
+    }
+    let result = f.review(&f.reviewer, n).await.unwrap();
+    assert_eq!(result["head_sha"], f.head);
+    assert_eq!(result["state"], "approved");
+    let s = f.remote.state.lock().unwrap();
+    assert_eq!(s.reviews[0]["commit_id"], f.head);
+    assert_eq!(s.reviews[0]["user"]["login"], "reviewer");
+}
+
+#[tokio::test]
+async fn remote_review_and_merge_head_races_preserve_rival() {
+    for seam in ["review", "before-merge", "during-merge"] {
+        let f = Fixture::new(true, None).await;
+        let n = f.open().await;
+        if seam != "review" {
+            f.review(&f.reviewer, n).await.unwrap();
+        }
+        if seam == "during-merge" {
+            f.remote.state.lock().unwrap().merge_race = Some(f.middle.clone());
+        } else {
+            f.remote.state.lock().unwrap().prs.get_mut(&n).unwrap()["head"]["sha"] =
+                json!(f.middle);
+        }
+        let result = if seam == "review" {
+            f.review(&f.reviewer, n).await
+        } else {
+            f.call(&f.actor, "git.pr_merge", f.merge(n)).await
+        };
+        assert!(result.is_err());
+        assert_eq!(f.remote.pr(n)["head"]["sha"], f.middle);
+        assert_eq!(f.remote.pr(n)["merged"], false);
+    }
+}
+
+#[tokio::test]
+async fn remote_merge_policy_and_second_account_review_are_both_required() {
+    let f = Fixture::new(true, None).await;
+    let n = f.open().await;
+    f.refusal(&f.actor, "git.pr_merge", f.merge(n), "missing_review")
+        .await;
+    f.review(&f.reviewer, n).await.unwrap();
+    for decision in ["ask", "deny"] {
+        f.policy(&f.actor, "git.pr_merge", decision).await;
+        f.refusal(&f.actor, "git.pr_merge", f.merge(n), "policy_denied")
+            .await;
+    }
+    let id = f.policy(&f.actor, "git.pr_merge", "allow").await;
+    let result = f.call(&f.actor, "git.pr_merge", f.merge(n)).await.unwrap();
+    assert_eq!(result["merged_head_sha"], f.head);
+    assert_eq!(result["merged_sha"], f.remote.pr(n)["merge_commit_sha"]);
+    assert_eq!(f.last(&f.actor).await.policy["id"], id);
+    f.refusal(&f.actor, "git.pr_merge", f.merge(n), "pull_request_closed")
+        .await;
+}
+
+#[tokio::test]
+async fn remote_fork_approval_and_merge_require_named_rows() {
+    let f = Fixture::new(true, None).await;
+    f.remote.state.lock().unwrap().fork = true;
+    let n = f.open().await;
+    f.policy(&f.actor, "git.pr_merge.admin", "allow").await;
+    for decision in ["ask", "deny"] {
+        f.policy(&f.reviewer, "git.pr_review.fork", decision).await;
+        assert!(f
+            .review(&f.reviewer, n)
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("fork_policy_denied"));
+    }
+    let id = f.policy(&f.reviewer, "git.pr_review.fork", "allow").await;
+    f.review(&f.reviewer, n).await.unwrap();
+    assert_eq!(f.last(&f.reviewer).await.fork_policy["id"], id);
+    for decision in ["ask", "deny"] {
+        f.policy(&f.actor, "git.pr_merge.fork", decision).await;
+        f.refusal(&f.actor, "git.pr_merge", f.merge(n), "fork_policy_denied")
+            .await;
+    }
+    let id = f.policy(&f.actor, "git.pr_merge.fork", "allow").await;
+    f.call(&f.actor, "git.pr_merge", f.merge(n)).await.unwrap();
+    assert_eq!(f.last(&f.actor).await.fork_policy["id"], id);
+    assert!(!json!(f.remote.state.lock().unwrap().calls)
+        .to_string()
+        .contains("admin"));
+}
+
+#[tokio::test]
+async fn remote_rotated_credential_is_resolved_once_and_never_stored() {
+    for error in [false, true] {
+        let f = Fixture::new(true, None).await;
+        let rotated = format!("{SECRET}-rotated");
+        std::fs::write(f.dir.path().join("author-ref"), &rotated).unwrap();
+        f.remote.state.lock().unwrap().api_failure = error;
+        let reply = f.call(&f.actor, "git.push", f.push()).await;
+        if error {
+            assert!(reply.is_err());
+        } else {
+            assert!(reply.is_ok());
+        }
+        assert_eq!(
+            std::fs::read_to_string(f.dir.path().join("reads")).unwrap(),
+            "author-ref\n"
+        );
+        let mut reader = f.rt.sql().reader().await.unwrap();
+        let rows = reader
+            .query_all(SqlStatement {
+                sql: "SELECT * FROM git_receipts".into(),
+                params: vec![],
+                label: None,
+            })
+            .await
+            .unwrap();
+        let receipt = f.last(&f.actor).await;
+        let calls = f.remote.state.lock().unwrap().calls.clone();
+        let raw = format!("{reply:?} {rows:?} {} {calls:?}", receipt.to_value());
+        assert!(!raw.contains(SECRET));
+        assert!(!raw.contains("GH_TOKEN="));
+        assert!(!raw.contains("Authorization: Bearer "));
+        assert_eq!(
+            calls[0]["token_hash"],
+            blake3::hash(rotated.as_bytes()).to_hex().to_string()
+        );
+    }
+}
+
+#[tokio::test]
+async fn remote_lost_ack_without_marker_stays_unknown_and_never_retries() {
+    let f = Fixture::new(true, None).await;
+    f.remote.state.lock().unwrap().lost_ack = true;
+    assert!(f.call(&f.actor, "git.push", f.push()).await.is_err());
+    let receipt = f.last(&f.actor).await;
+    assert_eq!(receipt.disposition, Disposition::Unknown);
+    assert_eq!(remote_head(&f.remote.bare), Some(f.head.clone()));
+    let result = f
+        .call(&f.actor, "git.reconcile", json!({"receipt":receipt.id}))
+        .await
+        .unwrap();
+    assert_eq!(result["receipt"]["disposition"], "unknown");
+    assert_eq!(f.remote.state.lock().unwrap().push_calls, 1);
+    f.refusal(&f.actor, "git.push", f.push(), "expected_remote_mismatch")
+        .await;
+}
+
+#[tokio::test]
+async fn remote_unsupported_git_is_receipted_before_credentials_or_network() {
+    struct RestorePath(std::ffi::OsString);
+    impl Drop for RestorePath {
+        fn drop(&mut self) {
+            std::env::set_var("PATH", &self.0);
+        }
+    }
+    let f = Fixture::new(true, None).await;
+    let old_path = std::env::var_os("PATH").unwrap();
+    let git_path = Command::new("/usr/bin/which").arg("git").output().unwrap();
+    assert!(git_path.status.success());
+    let git_path = PathBuf::from(String::from_utf8(git_path.stdout).unwrap().trim());
+    let bin = f.dir.path().join("old-git");
+    std::fs::create_dir(&bin).unwrap();
+    let wrapper = bin.join("git");
+    std::fs::write(&wrapper, format!("#!/bin/sh\ncase \"$*\" in\n*' --version') echo 'git version 2.40.0'; exit 0;;\n*' reflog -h') echo 'usage: git reflog show'; exit 129;;\nesac\nexec {} \"$@\"\n", quote(&git_path))).unwrap();
+    std::fs::set_permissions(&wrapper, std::fs::Permissions::from_mode(0o700)).unwrap();
+    let mut paths = vec![bin];
+    paths.extend(std::env::split_paths(&old_path));
+    let _restore = RestorePath(old_path);
+    std::env::set_var("PATH", std::env::join_paths(paths).unwrap());
+    f.refusal(&f.actor, "git.push", f.push(), "unsupported_toolchain")
+        .await;
+    let receipt = f.last(&f.actor).await;
+    assert_eq!(
+        receipt.result["toolchain"]["git_version"],
+        "git version 2.40.0"
+    );
+    assert_eq!(
+        receipt.result["toolchain"]["missing_capability"],
+        "reflog write"
+    );
+    assert!(receipt.credential.is_null());
+    assert!(f.remote.state.lock().unwrap().calls.is_empty());
+    assert_eq!(remote_head(&f.remote.bare), Some(f.base.clone()));
+}
+
+#[tokio::test]
+async fn remote_malformed_merge_reply_stays_unknown_until_readback() {
+    let f = Fixture::new(true, None).await;
+    let n = f.open().await;
+    f.review(&f.reviewer, n).await.unwrap();
+    f.remote.state.lock().unwrap().malformed_merge_reply = true;
+    assert!(f.call(&f.actor, "git.pr_merge", f.merge(n)).await.is_err());
+    let receipt = f.last(&f.actor).await;
+    assert_eq!(receipt.disposition, Disposition::Unknown);
+    assert_eq!(f.remote.pr(n)["merged"], true);
+    let writes = f.remote.writes();
+    let result = f
+        .call(&f.actor, "git.reconcile", json!({"receipt":receipt.id}))
+        .await
+        .unwrap();
+    assert_eq!(result["receipt"]["disposition"], "committed");
+    assert_eq!(f.remote.writes(), writes);
+}
+
+#[cfg(feature = "contract-faults")]
+#[tokio::test]
+async fn remote_post_effect_faults_reconcile_without_repeating_native_write() {
+    for verb in ["git.push", "git.pr_merge"] {
+        for point in ["reply-lost-after-effect", "audit-fails-after-effect"] {
+            let fault = format!("{verb}:{point}");
+            let f = Fixture::new(true, Some(&fault)).await;
+            let mut params = if verb == "git.push" {
+                f.push()
+            } else {
+                let n = f.open().await;
+                f.review(&f.reviewer, n).await.unwrap();
+                f.merge(n)
+            };
+            // Accepted hexadecimal spelling must not obstruct later reconciliation.
+            let compare = if verb == "git.push" {
+                "expected_local"
+            } else {
+                "expected_head"
+            };
+            params[compare] = json!(f.head.to_ascii_uppercase());
+            assert!(f.call(&f.actor, verb, params.clone()).await.is_err());
+            let receipt = f.last(&f.actor).await;
+            assert_eq!(
+                receipt.disposition,
+                if point == "audit-fails-after-effect" {
+                    Disposition::Committed
+                } else {
+                    Disposition::Unknown
+                }
+            );
+            let writes = f.remote.writes();
+            let result = f
+                .call(&f.actor, "git.reconcile", json!({"receipt":receipt.id}))
+                .await
+                .unwrap();
+            assert_eq!(
+                result["receipt"]["disposition"], "committed",
+                "{verb}:{point}: {result}"
+            );
+            assert_eq!(f.remote.writes(), writes);
+            assert!(f.call(&f.actor, verb, params).await.is_err());
+            assert_eq!(f.remote.writes(), writes);
+        }
+    }
+}
+
+#[tokio::test]
+async fn remote_pack_schema_covers_all_verbs_with_required_nullable_compare() {
+    let f = Fixture::new(true, None).await;
+    for verb in [
+        "git.digest",
+        "git.branch",
+        "git.commit",
+        "git.push",
+        "git.checkout",
+        "git.diff",
+        "git.receipts",
+        "git.gates",
+        "git.reconcile",
+        "git.pr_open",
+        "git.pr_review",
+        "git.pr_merge",
+    ] {
+        let help = f.registry.describe_verb(verb).unwrap();
+        assert_eq!(help["input_schema"]["type"], "object");
+        assert_eq!(help["input_schema"]["additionalProperties"], false);
+    }
+    let help = f.registry.describe_verb("git.push").unwrap();
+    let schema = &help["input_schema"];
+    assert!(schema["required"]
+        .as_array()
+        .unwrap()
+        .contains(&json!("expected_remote")));
+    assert_eq!(
+        schema["properties"]["expected_remote"]["type"],
+        json!(["string", "null"])
+    );
+    assert!(help["params"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|p| p["name"] == "expected_remote"
+            && p["type"] == "string|null"
+            && p["required"] == true));
+}
+
+#[tokio::test]
+async fn remote_push_refuses_remote_move_at_effect_control() {
+    let f = Fixture::new(true, None).await;
+    f.remote.state.lock().unwrap().remote_race = Some(f.middle.clone());
+    let result = f.call(&f.actor, "git.push", f.push()).await;
+    assert_eq!(
+        remote_head(&f.remote.bare),
+        Some(f.middle.clone()),
+        "candidate={} result={result:?}",
+        f.head
+    );
+    assert!(
+        result.is_err(),
+        "removed compare permitted a push over the rival ref"
+    );
+    assert_eq!(
+        f.last(&f.actor).await.disposition,
+        Disposition::NotCommitted
+    );
+}
+
+#[tokio::test]
+async fn remote_merge_grants_bind_actor_tool_and_expiry() {
+    for condition in ["expired", "foreign", "wrong-tool", "valid"] {
+        let f = Fixture::new(true, None).await;
+        let n = f.open().await;
+        f.review(&f.reviewer, n).await.unwrap();
+        f.policy(&f.actor, "git.pr_merge", "ask").await;
+        let actor = if condition == "foreign" {
+            &f.alias
+        } else {
+            &f.actor
+        };
+        let tool = if condition == "wrong-tool" {
+            "git.pr_open"
+        } else {
+            "git.pr_merge"
+        };
+        f.policy(actor, tool, "ask").await;
+        let request=f.registry.dispatch("tool.request",json!({"actor":actor,"tool":tool,"scope":"free text, not an authorization constraint"})).await.unwrap();
+        let id = request["request_id"].as_str().unwrap();
+        let mut grant = json!({"id":id});
+        if condition == "expired" {
+            grant["expires_in_s"] = json!(0);
+        }
+        f.registry
+            .dispatch_with_identity(
+                "tool.grant",
+                grant,
+                Some(RequestIdentity {
+                    namespace: "local".into(),
+                    actor_id: Some(format!("{}:operator", f.actor)),
+                    ..Default::default()
+                }),
+            )
+            .await
+            .unwrap();
+        if condition == "valid" {
+            f.call(&f.actor, "git.pr_merge", f.merge(n)).await.unwrap();
+            let receipt = f.last(&f.actor).await;
+            assert_eq!(receipt.policy["source"], "grant");
+            assert_eq!(receipt.policy["id"], id);
+        } else {
+            f.refusal(&f.actor, "git.pr_merge", f.merge(n), "policy_denied")
+                .await;
+        }
+    }
+}
+
+#[tokio::test]
+async fn remote_push_non_fast_forward_and_unmapped_actor_refuse() {
+    let f = Fixture::new(true, None).await;
+    let unmapped = format!("{}:unmapped", f.actor);
+    f.policy(&unmapped, "git.push", "allow").await;
+    f.refusal(&unmapped, "git.push", f.push(), "actor_unmapped")
+        .await;
+    assert!(f.remote.state.lock().unwrap().calls.is_empty());
+    git(&f.remote.bare, &["update-ref", "refs/heads/work", &f.head]);
+    git(&f.repo, &["update-ref", "refs/heads/work", &f.base]);
+    f.refusal(
+        &f.actor,
+        "git.push",
+        json!({"branch":"work","expected_local":f.base,"expected_remote":f.head}),
+        "non_fast_forward",
+    )
+    .await;
+    assert_eq!(f.remote.state.lock().unwrap().push_calls, 0);
+}
+
+#[tokio::test]
+async fn remote_stale_or_dismissed_approvals_do_not_authorize_merge() {
+    let f = Fixture::new(true, None).await;
+    let n = f.open().await;
+    f.review(&f.reviewer, n).await.unwrap();
+    f.remote.state.lock().unwrap().reviews[0]["commit_id"] = json!(f.middle);
+    f.refusal(&f.actor, "git.pr_merge", f.merge(n), "missing_review")
+        .await;
+    f.remote.state.lock().unwrap().reviews[0]["commit_id"] = json!(f.head);
+    f.remote
+        .state
+        .lock()
+        .unwrap()
+        .reviews
+        .push(json!({"id":2,"commit_id":f.head,"state":"DISMISSED","user":{"login":"reviewer"}}));
+    f.refusal(&f.actor, "git.pr_merge", f.merge(n), "missing_review")
+        .await;
+}

--- a/crates/khive-pack-git/src/remote_tests.rs
+++ b/crates/khive-pack-git/src/remote_tests.rs
@@ -82,10 +82,14 @@ struct State {
     lost_ack: bool,
     api_failure: bool,
     malformed_merge_reply: bool,
+    review_decision: Value,
+    decision_head: Option<String>,
 }
 impl Recording {
     fn login(token: &str) -> &str {
-        if token.contains("reviewer") {
+        if token.contains("third") {
+            "third"
+        } else if token.contains("reviewer") {
             "reviewer"
         } else {
             "author"
@@ -100,6 +104,26 @@ impl Recording {
 }
 #[async_trait]
 impl RemoteTransport for Recording {
+    async fn review_decision(
+        &self,
+        token: &str,
+        slug: &str,
+        number: u64,
+    ) -> Result<Value, RemoteError> {
+        assert_eq!(slug, SLUG);
+        let mut s = self.state.lock().unwrap();
+        s.calls.push(json!({"op":"review_decision","number":number,
+            "token_hash":blake3::hash(token.as_bytes()).to_hex().to_string()}));
+        if s.api_failure {
+            return Err(RemoteError::Unavailable);
+        }
+        // The separate field models a head moving between REST and GraphQL.
+        let head = s
+            .decision_head
+            .as_ref()
+            .map_or_else(|| s.prs[&number]["head"]["sha"].clone(), |head| json!(head));
+        Ok(json!({"reviewDecision":s.review_decision,"headRefOid":head}))
+    }
     async fn remote_ref(
         &self,
         token: &str,
@@ -152,7 +176,7 @@ impl RemoteTransport for Recording {
         }
         if path == format!("repos/{SLUG}/pulls") && request.method == "POST" {
             let n = s.prs.len() as u64 + 1;
-            let pr = json!({"number":n,"html_url":format!("https://github.com/{SLUG}/pull/{n}"),"state":"open","merged":false,"head":{"sha":s.head,"repo":{"full_name":if s.fork{"fork/project"}else{SLUG}}},"base":{"repo":{"full_name":SLUG}},"user":{"login":s.author}});
+            let pr = json!({"number":n,"html_url":format!("https://github.com/{SLUG}/pull/{n}"),"state":"open","merged":false,"head":{"sha":s.head,"ref":"work","repo":{"full_name":if s.fork{"fork/project"}else{SLUG}}},"base":{"repo":{"full_name":SLUG}},"user":{"login":s.author}});
             s.prs.insert(n, pr.clone());
             s.writes += 1;
             return Ok(pr);
@@ -219,6 +243,7 @@ struct Fixture {
     actor: String,
     reviewer: String,
     alias: String,
+    third: String,
     rt: KhiveRuntime,
     registry: VerbRegistry,
     remote: Arc<Recording>,
@@ -264,17 +289,20 @@ impl Fixture {
             ("author-ref", SECRET),
             ("reviewer-ref", "synthetic-reviewer-secret"),
             ("alias-ref", "synthetic-alias-secret"),
+            ("third-ref", "synthetic-third-secret"),
         ] {
             std::fs::write(dir.path().join(reference), value).unwrap();
         }
         let actor = format!("remote:{}", uuid::Uuid::new_v4());
         let reviewer = format!("{actor}:reviewer");
         let alias = format!("{actor}:alias");
+        let third = format!("{actor}:third");
         let mut actors = BTreeMap::new();
         for (actor, reference, login) in [
             (&actor, "author-ref", "author"),
             (&reviewer, "reviewer-ref", "reviewer"),
             (&alias, "alias-ref", "author"),
+            (&third, "third-ref", "third"),
         ] {
             actors.insert(
                 actor.clone(),
@@ -330,6 +358,8 @@ impl Fixture {
                 lost_ack: false,
                 api_failure: false,
                 malformed_merge_reply: false,
+                review_decision: json!("APPROVED"),
+                decision_head: None,
             }),
         });
         let mut builder = VerbRegistryBuilder::new();
@@ -351,11 +381,12 @@ impl Fixture {
             actor,
             reviewer,
             alias,
+            third,
             rt,
             registry,
             remote,
         };
-        for actor in [&f.actor, &f.reviewer, &f.alias] {
+        for actor in [&f.actor, &f.reviewer, &f.alias, &f.third] {
             for verb in [
                 "git.push",
                 "git.pr_open",
@@ -446,6 +477,215 @@ impl Fixture {
         assert_eq!(remote_head(&self.remote.bare), remote);
         receipt
     }
+}
+
+#[tokio::test]
+async fn remote_last_pusher_refuses_review_and_merge_then_third_login_succeeds() {
+    let f = Fixture::new(true, None).await;
+    f.call(&f.reviewer, "git.push", f.push()).await.unwrap();
+    assert_eq!(remote_head(&f.remote.bare), Some(f.head.clone()));
+    let push = f.last(&f.reviewer).await;
+    let n = f.open().await;
+    let before = f.remote.writes();
+    assert!(f
+        .review(&f.reviewer, n)
+        .await
+        .unwrap_err()
+        .to_string()
+        .contains("last_pusher"));
+    assert_eq!(f.remote.writes(), before);
+    let refused = f.last(&f.reviewer).await;
+    assert_eq!(refused.disposition, Disposition::NotCommitted);
+    assert_eq!(refused.reason.as_deref(), Some("last_pusher"));
+    assert_eq!(refused.result["last_pusher"]["push_receipt_id"], push.id);
+    assert_eq!(
+        refused.result["last_pusher"]["platform_identity"],
+        "reviewer"
+    );
+
+    // An externally submitted approval by the known pusher is ineligible even
+    // if the aggregate decision currently says APPROVED.
+    f.remote
+        .state
+        .lock()
+        .unwrap()
+        .reviews
+        .push(json!({"id":1,"commit_id":f.head,
+        "state":"APPROVED","user":{"login":"REVIEWER"}}));
+    let refused = f
+        .refusal(&f.actor, "git.pr_merge", f.merge(n), "last_pusher")
+        .await;
+    assert_eq!(refused.result["last_pusher"]["push_receipt_id"], push.id);
+    assert_eq!(refused.result["review_decision"]["value"], "APPROVED");
+    assert!(!f
+        .remote
+        .state
+        .lock()
+        .unwrap()
+        .calls
+        .iter()
+        .any(|call| call["method"] == "PUT"));
+
+    let review = f.review(&f.third, n).await.unwrap();
+    assert_eq!(review["last_pusher"]["push_receipt_id"], push.id);
+    let result = f.call(&f.actor, "git.pr_merge", f.merge(n)).await.unwrap();
+    assert_eq!(f.remote.pr(n)["merged"], true);
+    assert_eq!(result["last_pusher"]["push_receipt_id"], push.id);
+    assert_eq!(result["review_decision"]["value"], "APPROVED");
+    assert_eq!(f.last(&f.actor).await.result, result);
+}
+
+#[tokio::test]
+async fn remote_unknown_pusher_allows_review_but_platform_decision_gates_merge() {
+    let f = Fixture::new(true, None).await;
+    let n = f.open().await;
+    let review = f.review(&f.reviewer, n).await.unwrap();
+    let unknown = json!({"state":"unknown","reason":"no_push_receipt"});
+    assert_eq!(review["last_pusher"], unknown);
+    assert_eq!(f.last(&f.reviewer).await.result["last_pusher"], unknown);
+    assert_eq!(
+        f.remote.state.lock().unwrap().reviews[0]["state"],
+        "APPROVED"
+    );
+    for decision in [
+        json!("REVIEW_REQUIRED"),
+        json!("CHANGES_REQUESTED"),
+        Value::Null,
+    ] {
+        f.remote.state.lock().unwrap().review_decision = decision.clone();
+        let refused = f
+            .refusal(&f.actor, "git.pr_merge", f.merge(n), "review_decision")
+            .await;
+        assert_eq!(refused.reason.as_deref(), Some("review_decision"));
+        assert_eq!(refused.result["review_decision"]["value"], decision);
+        assert_eq!(refused.result["last_pusher"], unknown);
+        assert!(!f
+            .remote
+            .state
+            .lock()
+            .unwrap()
+            .calls
+            .iter()
+            .any(|call| call["method"] == "PUT"));
+    }
+    f.remote.state.lock().unwrap().review_decision = json!("APPROVED");
+    f.call(&f.actor, "git.pr_merge", f.merge(n)).await.unwrap();
+    assert_eq!(f.remote.pr(n)["merged"], true);
+}
+
+#[tokio::test]
+async fn remote_review_decision_is_bound_to_the_compared_head() {
+    let f = Fixture::new(true, None).await;
+    let n = f.open().await;
+    f.review(&f.reviewer, n).await.unwrap();
+    f.remote.state.lock().unwrap().decision_head = Some(f.middle.clone());
+    let refused = f
+        .refusal(
+            &f.actor,
+            "git.pr_merge",
+            f.merge(n),
+            "expected_head_mismatch",
+        )
+        .await;
+    assert_eq!(refused.result["review_decision"]["head_sha"], f.middle);
+    assert!(!f
+        .remote
+        .state
+        .lock()
+        .unwrap()
+        .calls
+        .iter()
+        .any(|call| call["method"] == "PUT"));
+    f.remote.state.lock().unwrap().decision_head = None;
+    f.call(&f.actor, "git.pr_merge", f.merge(n)).await.unwrap();
+}
+
+#[tokio::test]
+async fn remote_push_ledger_uses_newest_acknowledged_matching_receipt() {
+    let f = Fixture::new(true, None).await;
+    f.call(&f.reviewer, "git.push", f.push()).await.unwrap();
+    // Simulate the ref moving away, then a later acknowledged push at the same
+    // SHA by a different login. Commit identity cannot distinguish these pushes.
+    git(&f.remote.bare, &["update-ref", "refs/heads/work", &f.base]);
+    f.call(&f.third, "git.push", f.push()).await.unwrap();
+    let acknowledged = f.last(&f.third).await;
+    // A newer lost-ACK attempt at the same SHA is not an acknowledged push.
+    git(&f.remote.bare, &["update-ref", "refs/heads/work", &f.base]);
+    f.remote.state.lock().unwrap().lost_ack = true;
+    assert!(f.call(&f.reviewer, "git.push", f.push()).await.is_err());
+    assert_eq!(f.last(&f.reviewer).await.disposition, Disposition::Unknown);
+    f.remote.state.lock().unwrap().lost_ack = false;
+    let n = f.open().await;
+    let reviewed = f.review(&f.reviewer, n).await.unwrap();
+    assert_eq!(reviewed["last_pusher"]["push_receipt_id"], acknowledged.id);
+    assert_eq!(reviewed["last_pusher"]["platform_identity"], "third");
+    assert!(f
+        .review(&f.third, n)
+        .await
+        .unwrap_err()
+        .to_string()
+        .contains("last_pusher"));
+    assert_eq!(
+        f.last(&f.third).await.result["last_pusher"]["push_receipt_id"],
+        acknowledged.id
+    );
+}
+
+#[tokio::test]
+async fn remote_push_ledger_does_not_confuse_repository_ref_or_sha() {
+    for mismatch in ["repository", "ref", "sha"] {
+        let f = Fixture::new(true, None).await;
+        f.call(&f.reviewer, "git.push", f.push()).await.unwrap();
+        let n = f.open().await;
+        {
+            let mut s = f.remote.state.lock().unwrap();
+            let pr = s.prs.get_mut(&n).unwrap();
+            match mismatch {
+                "repository" => pr["head"]["repo"]["full_name"] = json!("fork/project"),
+                "ref" => pr["head"]["ref"] = json!("other"),
+                _ => pr["head"]["sha"] = json!(f.middle),
+            }
+        }
+        f.policy(&f.reviewer, "git.pr_review.fork", "allow").await;
+        let expected = if mismatch == "sha" {
+            &f.middle
+        } else {
+            &f.head
+        };
+        let review = f
+            .call(
+                &f.reviewer,
+                "git.pr_review",
+                json!({"number":n,"verdict":"approve",
+            "body":"","expected_head":expected}),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            review["last_pusher"],
+            json!({"state":"unknown","reason":"no_push_receipt"})
+        );
+    }
+}
+
+#[cfg(feature = "contract-faults")]
+#[tokio::test]
+async fn remote_push_marker_preserves_pusher_evidence_after_reply_loss() {
+    let f = Fixture::new(true, Some("git.push:reply-lost-after-effect")).await;
+    assert!(f.call(&f.reviewer, "git.push", f.push()).await.is_err());
+    let push = f.last(&f.reviewer).await;
+    assert_eq!(push.disposition, Disposition::Unknown);
+    let n = f.open().await;
+    assert!(f
+        .review(&f.reviewer, n)
+        .await
+        .unwrap_err()
+        .to_string()
+        .contains("last_pusher"));
+    assert_eq!(
+        f.last(&f.reviewer).await.result["last_pusher"]["push_receipt_id"],
+        push.id
+    );
 }
 
 #[tokio::test]

--- a/crates/khive-pack-git/src/remote_transport.rs
+++ b/crates/khive-pack-git/src/remote_transport.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use base64::Engine;
-use serde_json::Value;
+use serde_json::{json, Value};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
 use tokio::process::Command;
 use zeroize::Zeroizing;
@@ -38,6 +38,13 @@ pub struct PushRequest {
 #[async_trait]
 pub trait RemoteTransport: Send + Sync {
     async fn api(&self, token: &str, request: ApiRequest) -> Result<Value, RemoteError>;
+    /// Read the platform's aggregate review decision and the head it describes.
+    async fn review_decision(
+        &self,
+        token: &str,
+        slug: &str,
+        number: u64,
+    ) -> Result<Value, RemoteError>;
     async fn remote_ref(
         &self,
         token: &str,
@@ -162,11 +169,14 @@ fn valid_oid(value: &str) -> bool {
     value.len() == 40 && value.bytes().all(|b| b.is_ascii_hexdigit())
 }
 
-#[async_trait]
-impl RemoteTransport for GhTransport {
-    async fn api(&self, token: &str, request: ApiRequest) -> Result<Value, RemoteError> {
+impl GhTransport {
+    async fn call_api(
+        &self,
+        token: &str,
+        request: ApiRequest,
+        effect: bool,
+    ) -> Result<Value, RemoteError> {
         let dir = tempfile::tempdir().map_err(|_| RemoteError::Unavailable)?;
-        let effect = request.method != "GET";
         let mut command = isolated("gh");
         command
             .current_dir(dir.path())
@@ -194,6 +204,44 @@ impl RemoteTransport for GhTransport {
         command.arg(request.path);
         let (success, bytes) = run(command, input, effect).await?;
         parse_api_response(success, bytes, token, effect)
+    }
+}
+
+#[async_trait]
+impl RemoteTransport for GhTransport {
+    async fn api(&self, token: &str, request: ApiRequest) -> Result<Value, RemoteError> {
+        let effect = request.method != "GET";
+        self.call_api(token, request, effect).await
+    }
+
+    async fn review_decision(
+        &self,
+        token: &str,
+        slug: &str,
+        number: u64,
+    ) -> Result<Value, RemoteError> {
+        let (owner, name) = slug.split_once('/').ok_or(RemoteError::InvalidResponse)?;
+        let number = i32::try_from(number).map_err(|_| RemoteError::InvalidResponse)?;
+        let response = self.call_api(token, ApiRequest {
+            method: "POST",
+            path: "graphql".into(),
+            body: Some(json!({
+                "query": "query($owner: String!, $name: String!, $number: Int!) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { headRefOid reviewDecision } } }",
+                "variables": {"owner":owner, "name":name, "number":number}
+            })),
+        }, false).await?;
+        // GraphQL can return HTTP 200 with partial data and errors. Neither that
+        // nor a missing/inaccessible PR is an affirmative review decision.
+        if response.get("errors").is_some_and(|errors| {
+            !errors.is_null() && errors.as_array().is_none_or(|errors| !errors.is_empty())
+        }) {
+            return Err(RemoteError::InvalidResponse);
+        }
+        response
+            .pointer("/data/repository/pullRequest")
+            .filter(|pr| pr.is_object())
+            .cloned()
+            .ok_or(RemoteError::InvalidResponse)
     }
 
     async fn remote_ref(
@@ -351,6 +399,87 @@ fn redact(value: Value, token: &str) -> Value {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn graphql_review_read_binds_variables_and_rejects_partial_errors() {
+        use std::os::unix::fs::PermissionsExt;
+        let _lock = crate::cache::ENV_MUTEX.lock().await;
+        struct RestorePath(Option<std::ffi::OsString>);
+        impl Drop for RestorePath {
+            fn drop(&mut self) {
+                if let Some(path) = &self.0 {
+                    std::env::set_var("PATH", path);
+                } else {
+                    std::env::remove_var("PATH");
+                }
+            }
+        }
+        let _restore = RestorePath(std::env::var_os("PATH"));
+        let dir = tempfile::tempdir().unwrap();
+        let quoted = |name: &str| {
+            format!(
+                "'{}'",
+                dir.path()
+                    .join(name)
+                    .display()
+                    .to_string()
+                    .replace('\'', "'\\''")
+            )
+        };
+        std::fs::write(dir.path().join("gh"), format!(
+            "#!/bin/sh\n[ \"$GH_TOKEN\" = 'fixture-secret' ] || exit 91\n/bin/cat > {}\nprintf '%s\\n' \"$@\" > {}\n/bin/cat {}\n",
+            quoted("request"), quoted("argv"), quoted("response"),
+        )).unwrap();
+        std::fs::set_permissions(
+            dir.path().join("gh"),
+            std::fs::Permissions::from_mode(0o755),
+        )
+        .unwrap();
+        std::env::set_var("PATH", dir.path());
+        let pr = json!({"headRefOid":"a".repeat(40),"reviewDecision":"APPROVED"});
+        let data = json!({"data":{"repository":{"pullRequest":pr}}});
+        for (response, expected) in [
+            (format!("HTTP/2.0 200 OK\n\n{data}"), Ok(pr.clone())),
+            (
+                format!(
+                    "HTTP/2.0 200 OK\n\n{}",
+                    json!({"data":data["data"],"errors":[{"message":"denied fixture-secret"}]})
+                ),
+                Err(RemoteError::InvalidResponse),
+            ),
+            (
+                "HTTP/2.0 200 OK\n\n{\"data\":{\"repository\":null}}".into(),
+                Err(RemoteError::InvalidResponse),
+            ),
+            (
+                "HTTP/2.0 503 Unavailable\n\n{}".into(),
+                Err(RemoteError::Unavailable),
+            ),
+        ] {
+            std::fs::write(dir.path().join("response"), response).unwrap();
+            let actual = GhTransport
+                .review_decision("fixture-secret", "owner/project", 42)
+                .await;
+            assert_eq!(actual, expected);
+            assert!(!format!("{actual:?}").contains("fixture-secret"));
+            let request: Value =
+                serde_json::from_slice(&std::fs::read(dir.path().join("request")).unwrap())
+                    .unwrap();
+            assert_eq!(
+                request["variables"],
+                json!({"owner":"owner","name":"project","number":42})
+            );
+            let query = request["query"].as_str().unwrap();
+            assert!(query.starts_with("query("));
+            assert!(query.contains("headRefOid reviewDecision"));
+            assert!(!request.to_string().contains("fixture-secret"));
+            let argv = std::fs::read_to_string(dir.path().join("argv")).unwrap();
+            assert!(argv.contains("--method\nPOST\n"));
+            assert!(argv.ends_with("--input\n-\ngraphql\n"));
+            assert!(!argv.contains("fixture-secret"));
+        }
+    }
 
     #[test]
     fn api_redacts_json_escaped_credentials_in_keys_and_values() {

--- a/crates/khive-pack-git/src/remote_transport.rs
+++ b/crates/khive-pack-git/src/remote_transport.rs
@@ -1,0 +1,401 @@
+//! Remote effects are injectable independently of authorization and receipt storage.
+
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use base64::Engine;
+use serde_json::Value;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
+use tokio::process::Command;
+use zeroize::Zeroizing;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RemoteError {
+    Refused,
+    Unavailable,
+    Unknown,
+    InvalidResponse,
+}
+
+#[derive(Debug, Clone)]
+pub struct ApiRequest {
+    pub method: &'static str,
+    pub path: String,
+    pub body: Option<Value>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PushRequest {
+    pub repo: PathBuf,
+    pub remote: String,
+    pub branch: String,
+    pub expected_local: String,
+    pub expected_remote: Option<String>,
+}
+
+#[async_trait]
+pub trait RemoteTransport: Send + Sync {
+    async fn api(&self, token: &str, request: ApiRequest) -> Result<Value, RemoteError>;
+    async fn remote_ref(
+        &self,
+        token: &str,
+        remote: &str,
+        branch: &str,
+    ) -> Result<Option<String>, RemoteError>;
+    async fn push(&self, token: &str, request: PushRequest) -> Result<(), RemoteError>;
+}
+
+pub struct GhTransport;
+
+fn isolated(program: &str) -> Command {
+    let mut command = Command::new(program);
+    command.env_clear();
+    if let Some(path) = std::env::var_os("PATH") {
+        command.env("PATH", path);
+    }
+    command
+        .env("LC_ALL", "C")
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_ATTR_NOSYSTEM", "1")
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_NO_REPLACE_OBJECTS", "1")
+        .env("GIT_NO_LAZY_FETCH", "1")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    command
+}
+
+fn git_command(repo: &Path, token: Option<&str>) -> Command {
+    let mut command = isolated("git");
+    for setting in [
+        "core.hooksPath=/dev/null",
+        "core.fsmonitor=false",
+        "commit.gpgsign=false",
+        "credential.helper=",
+        "core.sshCommand=/usr/bin/false",
+        "protocol.allow=never",
+        "protocol.https.allow=always",
+        "http.sslVerify=true",
+        "http.followRedirects=false",
+        "http.extraHeader=",
+        "push.followTags=false",
+        "push.recurseSubmodules=no",
+    ] {
+        command.args(["-c", setting]);
+    }
+    if let Some(token) = token {
+        let clear = Zeroizing::new(format!("x-access-token:{token}"));
+        let encoded =
+            Zeroizing::new(base64::engine::general_purpose::STANDARD.encode(clear.as_bytes()));
+        let header = Zeroizing::new(format!("Authorization: Basic {}", encoded.as_str()));
+        command
+            .env("KHIVE_REMOTE_AUTH_HEADER", header.as_str())
+            .arg("--config-env=http.extraHeader=KHIVE_REMOTE_AUTH_HEADER");
+    }
+    command.arg("-C").arg(repo);
+    command
+}
+
+async fn bounded(mut pipe: impl AsyncRead + Unpin, limit: u64) -> std::io::Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    (&mut pipe).take(limit + 1).read_to_end(&mut bytes).await?;
+    if bytes.len() as u64 > limit {
+        return Err(std::io::Error::other("remote output exceeded limit"));
+    }
+    Ok(bytes)
+}
+
+async fn run(
+    mut command: Command,
+    input: Option<Vec<u8>>,
+    effect: bool,
+) -> Result<(bool, Vec<u8>), RemoteError> {
+    if input.is_some() {
+        command.stdin(Stdio::piped());
+    }
+    let mut child = command.spawn().map_err(|_| RemoteError::Unavailable)?;
+    let stdout = child.stdout.take().ok_or(RemoteError::Unavailable)?;
+    let stderr = child.stderr.take().ok_or(RemoteError::Unavailable)?;
+    let failure = if effect {
+        RemoteError::Unknown
+    } else {
+        RemoteError::Unavailable
+    };
+    let result = tokio::time::timeout(Duration::from_secs(60), async {
+        if let Some(input) = input {
+            let mut stdin = child
+                .stdin
+                .take()
+                .ok_or_else(|| std::io::Error::other("missing stdin"))?;
+            stdin.write_all(&input).await?;
+        }
+        let (stdout, _stderr, status) = tokio::try_join!(
+            bounded(stdout, 8 * 1024 * 1024),
+            bounded(stderr, 64 * 1024),
+            child.wait()
+        )?;
+        Ok::<_, std::io::Error>((status.success(), stdout))
+    })
+    .await
+    .map_err(|_| failure)?
+    .map_err(|_| failure)?;
+    Ok(result)
+}
+
+async fn bare() -> Result<tempfile::TempDir, RemoteError> {
+    let dir = tempfile::tempdir().map_err(|_| RemoteError::Unavailable)?;
+    let mut command = git_command(dir.path(), None);
+    command.args(["init", "--bare", "--quiet", "--template="]);
+    if !run(command, None, false).await?.0 {
+        return Err(RemoteError::Unavailable);
+    }
+    Ok(dir)
+}
+
+fn valid_oid(value: &str) -> bool {
+    value.len() == 40 && value.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+#[async_trait]
+impl RemoteTransport for GhTransport {
+    async fn api(&self, token: &str, request: ApiRequest) -> Result<Value, RemoteError> {
+        let dir = tempfile::tempdir().map_err(|_| RemoteError::Unavailable)?;
+        let effect = request.method != "GET";
+        let mut command = isolated("gh");
+        command
+            .current_dir(dir.path())
+            .env("HOME", dir.path())
+            .env("GH_CONFIG_DIR", dir.path())
+            .env("GH_TOKEN", token)
+            .env("GH_PROMPT_DISABLED", "1")
+            .env("GH_NO_UPDATE_NOTIFIER", "1")
+            .args([
+                "api",
+                "--hostname",
+                "github.com",
+                "--include",
+                "--method",
+                request.method,
+                "-H",
+                "Accept: application/vnd.github+json",
+                "-H",
+                "X-GitHub-Api-Version: 2022-11-28",
+            ]);
+        let input = request.body.map(|value| value.to_string().into_bytes());
+        if input.is_some() {
+            command.args(["--input", "-"]);
+        }
+        command.arg(request.path);
+        let (success, bytes) = run(command, input, effect).await?;
+        parse_api_response(success, bytes, token, effect)
+    }
+
+    async fn remote_ref(
+        &self,
+        token: &str,
+        remote: &str,
+        branch: &str,
+    ) -> Result<Option<String>, RemoteError> {
+        let scratch = bare().await?;
+        let reference = format!("refs/heads/{branch}");
+        let mut command = git_command(scratch.path(), Some(token));
+        command.args(["ls-remote", "--refs", "--", remote, &reference]);
+        let (success, bytes) = run(command, None, false).await?;
+        if !success {
+            return Err(RemoteError::Unavailable);
+        }
+        let text = std::str::from_utf8(&bytes).map_err(|_| RemoteError::InvalidResponse)?;
+        if text.is_empty() {
+            return Ok(None);
+        }
+        let mut rows = text.lines();
+        let (sha, actual_ref) = rows
+            .next()
+            .and_then(|row| row.split_once('\t'))
+            .ok_or(RemoteError::InvalidResponse)?;
+        if actual_ref != reference || !valid_oid(sha) || rows.next().is_some() {
+            return Err(RemoteError::InvalidResponse);
+        }
+        Ok(Some(sha.to_ascii_lowercase()))
+    }
+
+    async fn push(&self, token: &str, request: PushRequest) -> Result<(), RemoteError> {
+        push_native(token, request, false).await
+    }
+}
+
+pub(crate) async fn push_native(
+    token: &str,
+    request: PushRequest,
+    allow_file: bool,
+) -> Result<(), RemoteError> {
+    let scratch = bare().await?;
+    let objects = crate::local_git::object_directory(&request.repo)
+        .await
+        .map_err(|_| RemoteError::Unavailable)?;
+    let reference = format!("refs/heads/{}", request.branch);
+    let refspec = format!("{}:{reference}", request.expected_local);
+    let lease = format!(
+        "--force-with-lease={reference}:{}",
+        request.expected_remote.as_deref().unwrap_or("")
+    );
+    let mut command = git_command(scratch.path(), Some(token));
+    if allow_file {
+        command.args(["-c", "protocol.file.allow=always"]);
+    }
+    let alternate = serde_json::to_string(&objects.display().to_string())
+        .map_err(|_| RemoteError::Unavailable)?;
+    command
+        .env("GIT_ALTERNATE_OBJECT_DIRECTORIES", alternate)
+        .args([
+            "push",
+            "--porcelain",
+            "--no-verify",
+            "--no-follow-tags",
+            "--recurse-submodules=no",
+            &lease,
+            "--",
+            &request.remote,
+            &refspec,
+        ]);
+    let (success, bytes) = run(command, None, true).await?;
+    let text = std::str::from_utf8(&bytes).map_err(|_| RemoteError::Unknown)?;
+    let status = text.lines().find_map(|line| {
+        let mut parts = line.split('\t');
+        let flag = parts.next()?;
+        let pair = parts.next()?;
+        let (_source, target) = pair.split_once(':')?;
+        (target == reference).then_some(flag)
+    });
+    match (success, status) {
+        (true, Some(" " | "*")) => Ok(()),
+        (_, Some("!")) => Err(RemoteError::Refused),
+        // '=' is a no-op, not evidence that this operation moved the ref.
+        (true, Some("=")) => Err(RemoteError::Refused),
+        _ => Err(RemoteError::Unknown),
+    }
+}
+
+fn parse_api_response(
+    success: bool,
+    bytes: Vec<u8>,
+    token: &str,
+    effect: bool,
+) -> Result<Value, RemoteError> {
+    let raw = Zeroizing::new(bytes);
+    let text = std::str::from_utf8(&raw).map_err(|_| {
+        if effect {
+            RemoteError::Unknown
+        } else {
+            RemoteError::InvalidResponse
+        }
+    })?;
+    let (headers, body) = text
+        .split_once("\r\n\r\n")
+        .or_else(|| text.split_once("\n\n"))
+        .ok_or(if effect {
+            RemoteError::Unknown
+        } else {
+            RemoteError::InvalidResponse
+        })?;
+    let status = headers
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .and_then(|s| s.parse::<u16>().ok());
+    if !success || !status.is_some_and(|status| (200..300).contains(&status)) {
+        // Only explicit platform refusals prove there was no effect. Server or
+        // transport failures can follow a committed write.
+        return Err(
+            if matches!(status, Some(400 | 401 | 403 | 404 | 405 | 409 | 422)) {
+                RemoteError::Refused
+            } else if effect {
+                RemoteError::Unknown
+            } else {
+                RemoteError::Unavailable
+            },
+        );
+    }
+    // No native diagnostics are exposed, and echoed token material cannot
+    // enter typed results or receipts even when a platform response is hostile.
+    let value = serde_json::from_str(body).map_err(|_| {
+        if effect {
+            RemoteError::Unknown
+        } else {
+            RemoteError::InvalidResponse
+        }
+    })?;
+    Ok(redact(value, token))
+}
+
+fn redact(value: Value, token: &str) -> Value {
+    match value {
+        Value::String(s) => Value::String(s.replace(token, "[redacted]")),
+        Value::Array(a) => Value::Array(a.into_iter().map(|v| redact(v, token)).collect()),
+        Value::Object(o) => Value::Object(
+            o.into_iter()
+                .map(|(k, v)| (k.replace(token, "[redacted]"), redact(v, token)))
+                .collect(),
+        ),
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn api_redacts_json_escaped_credentials_in_keys_and_values() {
+        let response = b"HTTP/2.0 200 OK\r\n\r\n{\"s\\u0065cret\": [\"prefix secret suffix\", {\"nested\": \"s\\u0065cret\"}]}";
+        let value = parse_api_response(true, response.to_vec(), "secret", true).unwrap();
+        assert_eq!(
+            value,
+            json!({"[redacted]": ["prefix [redacted] suffix", {"nested":"[redacted]"}]})
+        );
+        assert!(!value.to_string().contains("secret"));
+    }
+
+    #[test]
+    fn api_ambiguous_effect_replies_are_unknown_and_explicit_refusals_are_not() {
+        for response in [
+            b"HTTP/2.0 503 Unavailable\n\n{}".as_slice(),
+            b"HTTP/2.0 200 OK\n\nnot-json",
+            b"no response headers",
+        ] {
+            assert_eq!(
+                parse_api_response(true, response.to_vec(), "secret", true),
+                Err(RemoteError::Unknown)
+            );
+        }
+        assert_eq!(
+            parse_api_response(
+                false,
+                b"HTTP/2.0 409 Conflict\n\n{}".to_vec(),
+                "secret",
+                true
+            ),
+            Err(RemoteError::Refused)
+        );
+        assert_eq!(
+            parse_api_response(false, b"HTTP/2.0 200 OK\n\n{}".to_vec(), "secret", true),
+            Err(RemoteError::Unknown)
+        );
+        assert_eq!(
+            parse_api_response(
+                true,
+                b"HTTP/2.0 200 OK\n\nnot-json".to_vec(),
+                "secret",
+                false
+            ),
+            Err(RemoteError::InvalidResponse)
+        );
+    }
+}

--- a/crates/khive-pack-git/src/remote_vocab.rs
+++ b/crates/khive-pack-git/src/remote_vocab.rs
@@ -1,0 +1,49 @@
+use khive_types::{HandlerDef, IdResolutionMode, ParamDef, VerbCategory, Visibility};
+
+const fn p(
+    name: &'static str,
+    ty: &'static str,
+    required: bool,
+    description: &'static str,
+) -> ParamDef {
+    ParamDef {
+        name,
+        param_type: ty,
+        required,
+        description,
+        resolution_mode: IdResolutionMode::NotApplicable,
+    }
+}
+const REPO: ParamDef = p(
+    "repo",
+    "string",
+    true,
+    "Absolute allowlisted repository with configured remote expectations.",
+);
+const HEAD: ParamDef = p(
+    "expected_head",
+    "string",
+    true,
+    "Exact 40-hex platform head SHA. Omission and null refuse.",
+);
+const NUMBER: ParamDef = p("number", "integer", true, "Positive pull request number.");
+const BODY: ParamDef = p("body", "string", true, "Body text; may be empty.");
+const SESSION: ParamDef = crate::local_vocab::SESSION;
+
+pub(crate) const PUSH:HandlerDef=HandlerDef {
+    name:"git.push", description:"Push an exact local SHA with a server-side expected-remote compare after fast-forward proof. Expected remote null means must not exist. All caller force/remote/refspec overrides refuse. Actor-only credentials, durable receipt, no retries.",
+    visibility:Visibility::Verb, category:VerbCategory::Commissive,
+    params:&[REPO,p("branch","string",true,"Branch to push."),p("expected_local","string",true,"Required exact 40-hex local branch head."),p("expected_remote","string|null",true,"Required exact remote SHA, or explicit null only when the remote branch must not exist. Omission is invalid_params."),SESSION],
+};
+pub(crate) const PR_OPEN:HandlerDef=HandlerDef {
+    name:"git.pr_open",description:"Open a pull request after checking configured slug, visibility and exact platform head. Uses the actor credential and returns number, url, head_sha and receipt_id.",visibility:Visibility::Verb,category:VerbCategory::Commissive,
+    params:&[REPO,p("head","string",true,"Head branch."),p("base","string",true,"Base branch."),p("title","string",true,"Pull request title."),BODY,HEAD,SESSION],
+};
+pub(crate) const PR_REVIEW:HandlerDef=HandlerDef {
+    name:"git.pr_review",description:"Submit a review bound to expected_head. Approval requires a different opening actor, credential reference and platform account; fork approvals additionally require git.pr_review.fork. Returns review_id, head_sha, state and receipt_id.",visibility:Visibility::Verb,category:VerbCategory::Commissive,
+    params:&[REPO,NUMBER,p("verdict","string",true,"approve, request_changes or comment."),BODY,HEAD,SESSION],
+};
+pub(crate) const PR_MERGE:HandlerDef=HandlerDef {
+    name:"git.pr_merge",description:"Merge with a platform head comparison after caller policy and current-head approval by another account. Forks require git.pr_merge.fork; no administrator bypass is requested. Returns merged_head_sha, merged_sha and receipt_id.",visibility:Visibility::Verb,category:VerbCategory::Commissive,
+    params:&[REPO,NUMBER,p("method","string",true,"squash or merge."),p("subject","string",true,"Merge commit subject."),BODY,HEAD,SESSION],
+};

--- a/crates/khive-pack-git/src/vocab.rs
+++ b/crates/khive-pack-git/src/vocab.rs
@@ -77,7 +77,7 @@ pub(crate) static GIT_ENTITY_TYPES: [EntityTypeDef; 1] = [EntityTypeDef {
 /// still `Commissive` — the speaker commits a persistent change, exactly the
 /// same illocutionary force as `create`/`link`, just against a different
 /// substrate (a git repo instead of khive's own storage).
-pub(crate) static GIT_HANDLERS: [HandlerDef; 9] = [
+pub(crate) static GIT_HANDLERS: [HandlerDef; 12] = [
     crate::local_vocab::CHECKOUT,
     crate::local_vocab::DIFF,
     crate::local_vocab::RECEIPTS,
@@ -209,45 +209,8 @@ pub(crate) static GIT_HANDLERS: [HandlerDef; 9] = [
             },
         ],
     },
-    HandlerDef {
-        name: "git.push",
-        description: "Push a branch to a remote (ADR-108). Force-push is always denied — no \
-                       policy or argument combination can authorize it through this verb.",
-        visibility: Visibility::Verb,
-        category: VerbCategory::Commissive,
-        params: &[
-            ParamDef {
-                name: "repo",
-                param_type: "string",
-                required: true,
-                description: "Absolute local path to a git repository (must contain a .git \
-                               entry).",
-                resolution_mode: IdResolutionMode::NotApplicable,
-            },
-            ParamDef {
-                name: "branch",
-                param_type: "string",
-                required: true,
-                description: "Branch to push.",
-                resolution_mode: IdResolutionMode::NotApplicable,
-            },
-            ParamDef {
-                name: "remote",
-                param_type: "string",
-                required: false,
-                description: "Remote to push to (default: origin).",
-                resolution_mode: IdResolutionMode::NotApplicable,
-            },
-            ParamDef {
-                name: "force",
-                param_type: "bool",
-                required: false,
-                description: "Always rejected when true — force-push is never permitted through \
-                               this verb (ADR-108 hard rule 1). Present only so a caller's \
-                               explicit force=true request fails loudly rather than being \
-                               silently ignored.",
-                resolution_mode: IdResolutionMode::NotApplicable,
-            },
-        ],
-    },
+    crate::remote_vocab::PUSH,
+    crate::remote_vocab::PR_OPEN,
+    crate::remote_vocab::PR_REVIEW,
+    crate::remote_vocab::PR_MERGE,
 ];

--- a/crates/khive-pack-git/src/write_handlers.rs
+++ b/crates/khive-pack-git/src/write_handlers.rs
@@ -40,10 +40,7 @@ use khive_runtime::{NamespaceToken, RuntimeError};
 use khive_storage::event::Event;
 use khive_types::{EventKind, EventOutcome, SubstrateKind};
 
-use crate::write_argv::{
-    build_add_argv, build_commit_argv, build_push_argv, reject_force, validate_repo_path,
-    GitArgError,
-};
+use crate::write_argv::{build_add_argv, build_commit_argv, validate_repo_path, GitArgError};
 use crate::write_policy::{GitWritePolicy, GitWritePolicyError};
 use crate::GitPack;
 
@@ -109,21 +106,6 @@ fn parse_paths_param(params: &Value) -> Result<Vec<String>, RuntimeError> {
             .collect(),
         Some(other) => Err(RuntimeError::InvalidInput(format!(
             "paths must be an array of strings, got {other:?}"
-        ))),
-    }
-}
-
-/// Parses the `force` argument. `true` is caught by [`reject_force`]
-/// downstream; any non-boolean value (a string, number, array, object) is
-/// rejected loudly here rather than silently coerced to `false` — an
-/// explicit but malformed `force` argument must never be interpreted as "no
-/// force requested" (ADR-108: "an explicit force arg is rejected loudly").
-fn parse_force_param(params: &Value) -> Result<Option<bool>, RuntimeError> {
-    match params.get("force") {
-        None | Some(Value::Null) => Ok(None),
-        Some(Value::Bool(b)) => Ok(Some(*b)),
-        Some(other) => Err(RuntimeError::InvalidInput(format!(
-            "force must be a boolean, got {other:?}; force-push is never permitted through this verb"
         ))),
     }
 }
@@ -248,39 +230,6 @@ fn prepare_commit(repo: &Path, params: &Value) -> Result<CommitPreflight, WriteP
         branch,
         add_argv,
         commit_argv,
-    })
-}
-
-struct PushPreflight {
-    branch: String,
-    remote: String,
-    argv: Vec<String>,
-}
-
-fn prepare_push(repo: &Path, params: &Value) -> Result<PushPreflight, WritePreflightError> {
-    validate_repo_path(repo)
-        .map_err(to_invalid_input)
-        .map_err(|e| WritePreflightError::denied(e, None))?;
-    let branch = params
-        .get("branch")
-        .and_then(Value::as_str)
-        .ok_or_else(|| RuntimeError::InvalidInput("git.push requires branch".into()))
-        .map_err(|e| WritePreflightError::denied(e, None))?;
-    let remote = parse_optional_string(params, "remote")
-        .map_err(|e| WritePreflightError::denied(e, Some(branch)))?
-        .unwrap_or("origin");
-    let force =
-        parse_force_param(params).map_err(|e| WritePreflightError::denied(e, Some(branch)))?;
-    reject_force(force)
-        .map_err(to_invalid_input)
-        .map_err(|e| WritePreflightError::denied(e, Some(branch)))?;
-    let argv = build_push_argv(remote, branch)
-        .map_err(to_invalid_input)
-        .map_err(|e| WritePreflightError::denied(e, Some(branch)))?;
-    Ok(PushPreflight {
-        branch: branch.to_string(),
-        remote: remote.to_string(),
-        argv,
     })
 }
 
@@ -456,85 +405,6 @@ impl GitPack {
             .await
     }
 
-    pub(crate) async fn handle_push(
-        &self,
-        token: &NamespaceToken,
-        params: Value,
-    ) -> Result<Value, RuntimeError> {
-        let repo = self.parse_audited_repo(token, "git.push", &params).await?;
-        let lock = repo_write_lock(&repo);
-        let _guard = lock.lock().await;
-        let PushPreflight {
-            branch,
-            remote,
-            argv,
-        } = match prepare_push(&repo, &params) {
-            Ok(preflight) => preflight,
-            Err(failure) => {
-                return Err(self
-                    .audit_early_failure(
-                        token,
-                        "git.push",
-                        &repo,
-                        failure.branch.as_deref(),
-                        failure.outcome,
-                        failure.error,
-                    )
-                    .await)
-            }
-        };
-
-        let canonical_repo = match self.enforce_write_policy(&repo, &branch) {
-            Ok(p) => p,
-            Err(e) => {
-                self.emit_write_audit(
-                    token,
-                    "git.push",
-                    &repo,
-                    Some(&branch),
-                    "deny",
-                    EventOutcome::Denied,
-                    None,
-                )
-                .await;
-                return Err(e);
-            }
-        };
-
-        match run_git(&canonical_repo, &argv) {
-            Ok(_) => {
-                self.emit_write_audit(
-                    token,
-                    "git.push",
-                    &canonical_repo,
-                    Some(&branch),
-                    "allow",
-                    EventOutcome::Success,
-                    None,
-                )
-                .await;
-                Ok(json!({
-                    "repo": canonical_repo.display().to_string(),
-                    "remote": remote,
-                    "branch": branch,
-                }))
-            }
-            Err(e) => {
-                self.emit_write_audit(
-                    token,
-                    "git.push",
-                    &canonical_repo,
-                    Some(&branch),
-                    "allow",
-                    EventOutcome::Error,
-                    None,
-                )
-                .await;
-                Err(e)
-            }
-        }
-    }
-
     /// Appends exactly one supplementary audit `Event` (ADR-108 rule 2) per
     /// write attempt, on every exit path — handler-allowlist-denied,
     /// git-failed, and success alike — carrying `repo`/`branch`/`decision`
@@ -562,6 +432,14 @@ impl GitPack {
         outcome: EventOutcome,
         sha: Option<&str>,
     ) {
+        if outcome == EventOutcome::Success
+            && self.runtime().config().git_write.contract_faults
+            && self.runtime().config().git_write.fault.as_deref()
+                == Some(&format!("{verb}:audit-fails-after-effect"))
+        {
+            tracing::warn!(target: "khive.git", verb, "contract fault: audit append unavailable after effect");
+            return;
+        }
         let Ok(store) = self.runtime().events(token) else {
             return;
         };

--- a/crates/khive-pack-git/src/write_handlers_tests.rs
+++ b/crates/khive-pack-git/src/write_handlers_tests.rs
@@ -681,161 +681,6 @@ async fn branch_denied_when_no_policy_configured() {
     );
 }
 
-// -- git.push -----------------------------------------------------------
-
-#[tokio::test]
-async fn push_sends_branch_to_remote() {
-    let _env_guard = crate::cache::ENV_MUTEX.lock().await;
-    let (repo, remote) = init_repo_with_remote();
-    let (pack, token) = pack_and_token_with_policy(policy(repo.path(), &["feat/*"])).await;
-
-    run(repo.path(), &["checkout", "-q", "-b", "feat/pushme"]);
-    std::fs::write(repo.path().join("c.txt"), b"c").unwrap();
-    run(repo.path(), &["add", "c.txt"]);
-    run(repo.path(), &["commit", "-q", "-m", "add c"]);
-
-    let result = pack
-        .handle_push(
-            &token,
-            json!({ "repo": repo.path().to_str().unwrap(), "branch": "feat/pushme" }),
-        )
-        .await
-        .expect("push succeeds");
-    assert_eq!(
-        result.get("remote").and_then(|v| v.as_str()),
-        Some("origin")
-    );
-
-    let branches = git_command(remote.path())
-        .args(["branch", "--list", "feat/pushme"])
-        .output()
-        .expect("git branch --list on remote");
-    assert!(String::from_utf8_lossy(&branches.stdout).contains("feat/pushme"));
-}
-
-#[tokio::test]
-async fn push_rejects_explicit_force_true() {
-    let _env_guard = crate::cache::ENV_MUTEX.lock().await;
-    let (repo, _remote) = init_repo_with_remote();
-    let (pack, token) = pack_and_token_with_policy(GitWriteSectionConfig::default()).await;
-
-    let err = pack
-        .handle_push(
-            &token,
-            json!({
-                "repo": repo.path().to_str().unwrap(),
-                "branch": "main",
-                "force": true,
-            }),
-        )
-        .await
-        .unwrap_err();
-    assert!(err.to_string().contains("force-push"), "{err}");
-
-    let audit = audit_event(&pack, &token, "git.push").await;
-    assert_eq!(audit.outcome, EventOutcome::Denied);
-    assert_eq!(audit.payload["decision"], "deny");
-    assert_eq!(audit.payload["branch"], "main");
-}
-
-#[tokio::test]
-async fn push_allows_force_false() {
-    let _env_guard = crate::cache::ENV_MUTEX.lock().await;
-    let (repo, _remote) = init_repo_with_remote();
-    let (pack, token) = pack_and_token_with_policy(policy(repo.path(), &["main"])).await;
-
-    let result = pack
-        .handle_push(
-            &token,
-            json!({
-                "repo": repo.path().to_str().unwrap(),
-                "branch": "main",
-                "force": false,
-            }),
-        )
-        .await;
-    assert!(result.is_ok(), "{result:?}");
-}
-
-#[tokio::test]
-async fn push_rejects_non_boolean_force() {
-    let _env_guard = crate::cache::ENV_MUTEX.lock().await;
-    let (repo, _remote) = init_repo_with_remote();
-    let (pack, token) = pack_and_token_with_policy(GitWriteSectionConfig::default()).await;
-
-    let err = pack
-        .handle_push(
-            &token,
-            json!({
-                "repo": repo.path().to_str().unwrap(),
-                "branch": "main",
-                "force": "true",
-            }),
-        )
-        .await
-        .unwrap_err();
-    assert!(err.to_string().contains("boolean"), "{err}");
-}
-
-#[tokio::test]
-async fn push_rejects_injection_shaped_remote() {
-    let _env_guard = crate::cache::ENV_MUTEX.lock().await;
-    let (repo, _remote) = init_repo_with_remote();
-    let (pack, token) = pack_and_token_with_policy(GitWriteSectionConfig::default()).await;
-
-    let err = pack
-        .handle_push(
-            &token,
-            json!({
-                "repo": repo.path().to_str().unwrap(),
-                "branch": "main",
-                "remote": "--upload-pack=evil",
-            }),
-        )
-        .await
-        .unwrap_err();
-    assert!(err.to_string().contains("start with"), "{err}");
-}
-
-#[tokio::test]
-async fn push_rejects_non_string_remote_without_pushing() {
-    let _env_guard = crate::cache::ENV_MUTEX.lock().await;
-    let (repo, remote) = init_repo_with_remote();
-    let (pack, token) = pack_and_token_with_policy(policy(repo.path(), &["feat/*"])).await;
-    run(
-        repo.path(),
-        &["checkout", "-q", "-b", "feat/malformed-remote"],
-    );
-    std::fs::write(repo.path().join("new.txt"), b"new").unwrap();
-    run(repo.path(), &["add", "new.txt"]);
-    run(repo.path(), &["commit", "-q", "-m", "new commit"]);
-
-    let err = pack
-        .handle_push(
-            &token,
-            json!({
-                "repo": repo.path().to_str().unwrap(),
-                "branch": "feat/malformed-remote",
-                "remote": 42,
-            }),
-        )
-        .await
-        .unwrap_err();
-    assert!(err.to_string().contains("remote must be a string"), "{err}");
-
-    let branches = git_command(remote.path())
-        .args(["branch", "--list", "feat/malformed-remote"])
-        .output()
-        .expect("git branch --list on remote");
-    assert!(
-        branches.stdout.is_empty(),
-        "malformed remote must not push to origin"
-    );
-    let audit = audit_event(&pack, &token, "git.push").await;
-    assert_eq!(audit.outcome, EventOutcome::Denied);
-}
-
-#[cfg(unix)]
 #[tokio::test]
 async fn invalid_repo_values_emit_denied_audits_without_invoking_git() {
     use std::os::unix::fs::PermissionsExt;
@@ -853,7 +698,7 @@ async fn invalid_repo_values_emit_denied_audits_without_invoking_git() {
         .expect("make fake git executable");
     let _path = EnvVarGuard::set("PATH", fake_bin.path());
 
-    let cases: [(&str, Value, &str); 6] = [
+    let cases: [(&str, Value, &str); 4] = [
         ("git.commit", json!({ "message": "msg" }), "required"),
         (
             "git.commit",
@@ -866,12 +711,6 @@ async fn invalid_repo_values_emit_denied_audits_without_invoking_git() {
             json!({ "repo": 42, "name": "feat/x" }),
             "string",
         ),
-        ("git.push", json!({ "branch": "main" }), "required"),
-        (
-            "git.push",
-            json!({ "repo": 42, "branch": "main" }),
-            "string",
-        ),
     ];
 
     for (verb, params, expected_error) in cases {
@@ -879,7 +718,6 @@ async fn invalid_repo_values_emit_denied_audits_without_invoking_git() {
         let result = match verb {
             "git.commit" => pack.handle_commit(&token, params).await,
             "git.branch" => pack.handle_branch(&token, params).await,
-            "git.push" => pack.handle_push(&token, params).await,
             _ => unreachable!("fixed test case verb"),
         };
         let err = result.unwrap_err();
@@ -890,60 +728,6 @@ async fn invalid_repo_values_emit_denied_audits_without_invoking_git() {
         assert_eq!(audit.payload["repo"], "<invalid-repo>", "{verb}");
         assert!(!sentinel.exists(), "{verb} must not invoke git");
     }
-}
-
-#[tokio::test]
-async fn push_rejects_nonexistent_branch() {
-    let _env_guard = crate::cache::ENV_MUTEX.lock().await;
-    let (repo, _remote) = init_repo_with_remote();
-    let (pack, token) = pack_and_token_with_policy(policy(repo.path(), &["*"])).await;
-
-    let err = pack
-        .handle_push(
-            &token,
-            json!({
-                "repo": repo.path().to_str().unwrap(),
-                "branch": "does-not-exist",
-            }),
-        )
-        .await
-        .unwrap_err();
-    assert!(err.to_string().contains("git"), "{err}");
-}
-
-#[tokio::test]
-async fn push_denied_when_no_policy_configured() {
-    let _env_guard = crate::cache::ENV_MUTEX.lock().await;
-    let (repo, _remote) = init_repo_with_remote();
-    let (pack, token) = pack_and_token_with_policy(GitWriteSectionConfig::default()).await;
-
-    let err = pack
-        .handle_push(
-            &token,
-            json!({ "repo": repo.path().to_str().unwrap(), "branch": "main" }),
-        )
-        .await
-        .unwrap_err();
-    assert!(
-        err.to_string().contains("git-write policy is configured"),
-        "{err}"
-    );
-}
-
-#[tokio::test]
-async fn push_denied_for_branch_outside_patterns() {
-    let _env_guard = crate::cache::ENV_MUTEX.lock().await;
-    let (repo, _remote) = init_repo_with_remote();
-    let (pack, token) = pack_and_token_with_policy(policy(repo.path(), &["release-*"])).await;
-
-    let err = pack
-        .handle_push(
-            &token,
-            json!({ "repo": repo.path().to_str().unwrap(), "branch": "main" }),
-        )
-        .await
-        .unwrap_err();
-    assert!(err.to_string().contains("branch"), "{err}");
 }
 
 // -- symlink TOCTOU (ADR-108 review r2 High finding) -----------------------

--- a/crates/khive-pack-git/tests/dev_loop.rs
+++ b/crates/khive-pack-git/tests/dev_loop.rs
@@ -226,6 +226,16 @@ impl Fixture {
             ..Default::default()
         };
         let rt = KhiveRuntime::new(config).expect("file runtime");
+        // File runtimes require explicit blob-store installation, as at boot.
+        // Keep the fixture independent of the host's blob-root environment.
+        let blob_store = {
+            let _env = EnvGuard::remove(&["KHIVE_BLOB_ROOT"]);
+            rt.backend()
+                .blob_store(Some(&dir.path().join("blobs")), Some(0))
+                .expect("fixture blob store")
+        };
+        rt.install_blob_store(blob_store)
+            .expect("install fixture blobs");
         let mut builder = VerbRegistryBuilder::new();
         builder.with_actor_id(Some(ACTOR.into()));
         builder.register(KgPack::new(rt.clone()));

--- a/crates/khive-runtime/src/engine_config.rs
+++ b/crates/khive-runtime/src/engine_config.rs
@@ -442,12 +442,22 @@ pub struct GitWriteSectionConfig {
     pub allowed: Vec<GitWriteEntryConfig>,
     #[serde(default)]
     pub actors: BTreeMap<String, GitWriteActorConfig>,
+    #[serde(default)]
+    pub repositories: BTreeMap<String, GitWriteRepositoryConfig>,
     #[serde(default = "default_git_credential_resolver")]
     pub credential_resolver: Vec<String>,
     #[serde(default)]
     pub contract_faults: bool,
     #[serde(default)]
     pub fault: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct GitWriteRepositoryConfig {
+    pub remote: String,
+    pub slug: String,
+    pub visibility: String,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -477,6 +487,7 @@ impl Default for GitWriteSectionConfig {
         Self {
             allowed: Vec::new(),
             actors: BTreeMap::new(),
+            repositories: BTreeMap::new(),
             credential_resolver: default_git_credential_resolver(),
             contract_faults: false,
             fault: None,

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -242,6 +242,11 @@ pub trait PackRuntime: Send + Sync {
     /// Handlers this pack registers — must equal `<Self as Pack>::HANDLERS`.
     fn handlers(&self) -> &'static [HandlerDef];
 
+    /// Optional canonical input schema owned by the pack; ParamDefs remain available.
+    fn input_schema(&self, _verb: &str) -> Option<Value> {
+        None
+    }
+
     /// Pack-extensible edge endpoint rules — must equal `<Self as Pack>::EDGE_RULES`.
     /// Defaults to empty so existing packs that don't extend the edge contract
     /// can ignore it.
@@ -1828,6 +1833,9 @@ impl VerbRegistry {
                         "params": params_arr,
                         "identifier_resolution": identifier_resolution_help(),
                     });
+                    if let Some(schema) = pack.input_schema(verb) {
+                        envelope["input_schema"] = schema;
+                    }
                     if verb == "link" {
                         envelope["endpoint_rules"] = Value::Array(edge_endpoint_table(&self.packs));
                     }


### PR DESCRIPTION
## What this changes

Guarded remote writes for the git pack, per ADR-182 through Amendment 6: `git.push`, `git.pr_open`, `git.pr_review`, `git.pr_merge`, `git.receipts` and `git.reconcile`, with durable receipts for every remote attempt.

- **Push** runs the allowlist gate and then the caller's own `tool.check`, compares the local branch and the remote head, proves fast-forward ancestry, and pushes with an explicit `--force-with-lease` on the exact SHA and refspec. A null expected remote means the branch must not exist yet. Force flags, refspec, remote, actor and credential overrides, and an omitted compare are refused before any network call. An equal-SHA no-op is recorded but is not a committed push.
- **PR open** checks the configured repository slug, its visibility, the platform login and the expected branch head, and binds the returned head.
- **Review** binds the commit id and refuses the opening actor, the opening credential, and any actor on the same platform account.
- **Merge** requires the caller's policy or grant, the platform's aggregate review decision (`APPROVED`) read at the expected head, and a current-head approval from an eligible different account; it then issues the REST merge with the head SHA as the precondition. The last pusher, resolved from the newest acknowledged push receipt for the same repository, ref and SHA, may neither review nor merge; without a receipt the pusher is recorded as unknown.
- **Credentials** resolve once per mutation at call time and reach `gh` and native git only through the child environment; helpers, SSH, hooks, redirects, signing and submodule recursion are disabled, and error text omits native diagnostics.
- **Receipts** use the existing sixteen columns. Post-effect transport uncertainty is recorded as unknown, never as refusal, and is never retried; push settlement needs the acknowledgement, an exact remote read-back and a local reflog marker written with an explicit reflog write. Git installations without that capability are receipted and refused before credentials or network.
- Every git verb now publishes a JSON input schema through `describe_verb` and `help`, via a default `PackRuntime::input_schema` hook.

Tests: unit and acceptance suites in `khive-pack-git` cover each contract arm with disposable native repositories, a bare remote and a recording platform double, including the drift, force, identity, race, grant, reflog-marker and reply-loss arms. Live platform calls are not exercised in the suite.
