### PR TITLE
comm: drop the duplicated exec field in the inbox filter fixture

### DIFF
--- a/crates/khive-pack-comm/src/inbox_filter_tests.rs
+++ b/crates/khive-pack-comm/src/inbox_filter_tests.rs
@@ -33,7 +33,6 @@ fn actor_registry(
             visible_namespaces: vec![],
             allowed_outbound_namespaces: vec![],
             actor_id: Some(actor.to_string()),
-            exec: Default::default(),
         },
     );
     let mut builder = VerbRegistryBuilder::new();


### PR DESCRIPTION
Two changes each added the `exec` field to the same `RuntimeConfig` literal in the comm inbox filter fixture, and the merge kept both, so the crate's test target no longer compiled (`E0062`). One line removed; no behaviour change.
