### PR TITLE
python: typed recall outcome and Session.recall

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -66,6 +66,25 @@ ordinary request. Plan frames omit caller identity and rendering options; the
 required namespace field is sent empty. `session.request(...)` retains its
 ordinary dispatch behavior and returns per-operation results.
 
+## Typed recall outcome
+
+`Session.recall(query, ...)` runs one `memory.recall` and returns a `RecallOutcome`
+instead of a raw row list, so the response class the daemon distinguishes survives
+the client boundary:
+
+```python
+outcome = session.recall("what did we decide about retries", limit=5)
+for hit in outcome.hits:          # RecallHit rows: id, score, content, ...
+    print(hit.id, hit.score, hit.is_degraded, hit.is_truncated)
+print(outcome.degraded, outcome.truncated, outcome.degraded_reason, outcome.envelope_class)
+```
+
+A non-empty recall is a bare row array with per-row `degraded` and `truncated`
+stamps; an empty recall that needs a reason arrives as an object envelope
+(`degraded`, `truncated`, or both). `RecallOutcome.from_result` reads either shape,
+`enveloped` records which one arrived, and a clean empty recall has both flags false.
+A failed op raises `OperationError` with the daemon's error object unchanged.
+
 ## Scratch database
 
 Experiments should run against a scratch daemon, not a production store:

--- a/python/khive/__init__.py
+++ b/python/khive/__init__.py
@@ -16,7 +16,18 @@ from .errors import (
     RequestRejected,
     TransportError,
 )
-from .models import Edge, EdgeRelation, Entity, Incidence, Note, OpError, OpResult, Page
+from .models import (
+    Edge,
+    EdgeRelation,
+    Entity,
+    Incidence,
+    Note,
+    OpError,
+    OpResult,
+    Page,
+    RecallHit,
+    RecallOutcome,
+)
 from .ops import encode, op
 from .transport import Session, SocketTransport, Transport
 
@@ -36,6 +47,8 @@ __all__ = [
     "OperationError",
     "Page",
     "ProtocolMismatch",
+    "RecallHit",
+    "RecallOutcome",
     "RequestRejected",
     "Session",
     "SocketTransport",

--- a/python/khive/models.py
+++ b/python/khive/models.py
@@ -227,3 +227,107 @@ class OpResult(BaseModel):
         if value is None:
             raise ValueError("domain_disposition must name a domain outcome when present")
         return value
+
+
+class RecallHit(BaseModel):
+    """One `memory.recall` row, as the server stamps it.
+
+    `degraded` is the server's per-row marker (`"ann_unavailable"`) on a
+    non-empty degraded response; `truncated` is the per-row marker on a
+    non-empty budget-capped response. Both stay optional so a clean row
+    decodes to a different value from a stamped one.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    score: float
+    rank_score: float | None = None
+    raw_score: float | None = None
+    content: str | None = None
+    salience: float | None = None
+    decay_factor: float | None = None
+    memory_type: str | None = None
+    created_at: datetime | None = None
+    source_id: str | None = None
+    degraded: str | None = None
+    degraded_reason: str | None = None
+    truncated: bool | None = None
+    served_by_profile_id: str | None = None
+    serve_attribution: Any = None
+    breakdown: Any = None
+
+    @property
+    def is_degraded(self) -> bool:
+        return self.degraded is not None
+
+    @property
+    def is_truncated(self) -> bool:
+        return self.truncated is True
+
+
+class RecallOutcome(BaseModel):
+    """The typed outcome of one `memory.recall`, preserving its envelope class.
+
+    The server answers a non-empty recall with a bare array of rows and
+    stamps degradation and truncation on each row. It changes shape only
+    when the response is empty for a reason a bare `[]` could not carry:
+    `{"results": [], "degraded": true, "degraded_reason": ...}`,
+    `{"results": [], "truncated": true}`, or both. `from_result` reads either
+    shape into one value: `hits` are the typed rows, `degraded` and
+    `truncated` are true when either the envelope or any row says so, and
+    `enveloped` records whether the server used the object shape. A clean
+    empty recall is `hits=[]`, both flags false, `enveloped=False`.
+    """
+
+    hits: list[RecallHit] = Field(default_factory=list)
+    degraded: bool = False
+    truncated: bool = False
+    degraded_reason: str | None = None
+    enveloped: bool = False
+
+    @property
+    def envelope_class(self) -> str:
+        """One of the response classes the server distinguishes, as a label."""
+        flags = []
+        if self.degraded:
+            flags.append("degraded")
+        if self.truncated:
+            flags.append("truncated")
+        base = "empty" if not self.hits else "rows"
+        return "_".join([*flags, base]) if flags else f"clean_{base}"
+
+    @classmethod
+    def from_result(cls, result: Any) -> RecallOutcome:
+        """Build from an `OpResult.result` of `memory.recall` without dropping its shape."""
+        if isinstance(result, list):
+            rows = result
+            enveloped = False
+            envelope: dict[str, Any] = {}
+        elif isinstance(result, dict) and isinstance(result.get("results"), list):
+            rows = result["results"]
+            enveloped = True
+            envelope = result
+        else:
+            raise TypeError(
+                "memory.recall result is neither a row array nor a results envelope: "
+                f"{str(result)[:200]}"
+            )
+        for key in ("degraded", "truncated"):
+            if key in envelope and type(envelope[key]) is not bool:
+                raise ValueError(f"memory.recall envelope field {key!r} must be a boolean")
+        hits = [RecallHit.model_validate(row) for row in rows]
+        degraded = envelope.get("degraded") is True or any(hit.is_degraded for hit in hits)
+        truncated = envelope.get("truncated") is True or any(hit.is_truncated for hit in hits)
+        reason = envelope.get("degraded_reason")
+        if reason is None:
+            reason = next((hit.degraded_reason for hit in hits if hit.degraded_reason), None)
+        if reason is not None and not isinstance(reason, str):
+            raise ValueError("memory.recall degraded_reason must be a string")
+        return cls(
+            hits=hits,
+            degraded=degraded,
+            truncated=truncated,
+            degraded_reason=reason,
+            enveloped=enveloped,
+        )

--- a/python/khive/transport.py
+++ b/python/khive/transport.py
@@ -40,12 +40,13 @@ from .envelope import (
 from .errors import (
     ConfigMismatch,
     FrameTooLarge,
+    OperationError,
     ProtocolMismatch,
     RequestRejected,
     TransportError,
 )
+from .models import OpError, RecallOutcome
 from .ops import encode, op
-from .models import OpError
 
 PROTOCOL_VERSION = 6
 MAX_FRAME_BYTES = 8 * 1024 * 1024
@@ -226,6 +227,73 @@ class Session:
         if len(results) != 1 or results[0]["tool"] != "memory.remember":
             raise TransportError("response from daemon is not a single memory.remember result")
         return results[0]
+
+    def recall(
+        self,
+        query: str,
+        *,
+        limit: int | None = None,
+        top_k: int | None = None,
+        min_score: float | None = None,
+        score_floor: float | None = None,
+        min_salience: float | None = None,
+        memory_type: str | None = None,
+        created_after: str | None = None,
+        created_before: str | None = None,
+        tags: list[str] | None = None,
+        tag_mode: str | None = None,
+        exclude_tags: list[str] | None = None,
+        include_source_id: bool | None = None,
+        full_content: bool | None = None,
+        profile_id: str | None = None,
+        embedding_model: str | None = None,
+        namespace: str | None = None,
+        timeout: float | None = None,
+    ) -> RecallOutcome:
+        """Run one memory.recall and return its typed outcome.
+
+        The outcome keeps the server's response class (clean, degraded,
+        budget-capped, or both, empty or not) instead of flattening to rows;
+        see `RecallOutcome`. A failed op raises `OperationError` with the
+        server's error object unchanged.
+        """
+        results = self.request(
+            encode(
+                [
+                    op(
+                        "memory.recall",
+                        query=query,
+                        limit=limit,
+                        top_k=top_k,
+                        min_score=min_score,
+                        score_floor=score_floor,
+                        min_salience=min_salience,
+                        memory_type=memory_type,
+                        created_after=created_after,
+                        created_before=created_before,
+                        tags=tags,
+                        tag_mode=tag_mode,
+                        exclude_tags=exclude_tags,
+                        include_source_id=include_source_id,
+                        full_content=full_content,
+                        profile_id=profile_id,
+                        embedding_model=embedding_model,
+                        namespace=namespace,
+                    )
+                ]
+            ),
+            timeout=timeout,
+        )
+        if len(results) != 1 or results[0]["tool"] != "memory.recall":
+            raise TransportError("response from daemon is not a single memory.recall result")
+        entry = results[0]
+        if not entry.get("ok"):
+            raise OperationError("memory.recall", entry.get("error") or "unknown error")
+        try:
+            return RecallOutcome.from_result(entry.get("result"))
+        except (TypeError, ValueError) as exc:
+            raise TransportError(f"response from daemon: {exc}") from exc
+
     def plan(self, ops: str, *, timeout: float | None = None) -> dict[str, Any]:
         """Parse ops without dispatch; return a plan, including parsed=false errors.
 

--- a/python/tests/test_recall_outcome.py
+++ b/python/tests/test_recall_outcome.py
@@ -1,0 +1,211 @@
+"""Typed recall outcomes: the envelope class survives the client boundary.
+
+Scripted transport, no daemon. The server answers `memory.recall` with a bare
+row array, or with an object envelope when an empty answer needs a reason
+(`degraded`, `truncated`, or both). The control at the end is the red
+mutation the packet names: a rows-only conversion makes a degraded empty
+recall equal to a clean empty one, and that assertion fails.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+
+import pytest
+
+from khive import RecallHit, RecallOutcome, Session, Transport
+from khive.errors import OperationError, TransportError
+
+HIT_ID = "00000000-0000-4000-8000-000000000011"
+CLEAN_ROW = {
+    "id": HIT_ID,
+    "full_id": HIT_ID,
+    "score": 0.81,
+    "rank_score": 0.64,
+    "raw_score": 0.81,
+    "content": "a remembered line",
+    "salience": 0.5,
+    "decay_factor": 0.01,
+    "memory_type": "semantic",
+    "created_at": "2026-09-08T12:00:00Z",
+    "serve_attribution": "default",
+}
+DEGRADED_ROW = CLEAN_ROW | {
+    "degraded": "ann_unavailable",
+    "degraded_reason": "ann index unavailable for model test-model",
+}
+TRUNCATED_ROW = CLEAN_ROW | {"truncated": True}
+CLEAN_EMPTY: list = []
+DEGRADED_EMPTY = {
+    "results": [],
+    "degraded": True,
+    "degraded_reason": "ann index unavailable for model test-model",
+}
+TRUNCATED_EMPTY = {"results": [], "truncated": True}
+BOTH_EMPTY = {
+    "results": [],
+    "truncated": True,
+    "degraded": True,
+    "degraded_reason": "ann index unavailable for model test-model",
+}
+
+
+class ScriptedTransport(Transport):
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.dispatches = []
+
+    def round_trip(self, frame, timeout):
+        if frame.get("metrics_only"):
+            return {"ok": True, "served_config_id": "test-config"}
+        self.dispatches.append((copy.deepcopy(frame), timeout))
+        ops = json.loads(frame["ops"])
+        assert len(ops) == 1 and ops[0]["tool"] == "memory.recall"
+        assert self.responses, "unexpected additional operation dispatch"
+        response = self.responses.pop(0)
+        return {"ok": True, "result": json.dumps({"results": [response]})}
+
+
+def _entry(result):
+    return {"ok": True, "tool": "memory.recall", "result": result}
+
+
+def _session(*results) -> tuple[Session, ScriptedTransport]:
+    transport = ScriptedTransport([_entry(r) for r in results])
+    return Session(transport, namespace="frame-only", actor_id="test-client"), transport
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        (CLEAN_EMPTY, ("clean_empty", False, False, False, 0)),
+        (DEGRADED_EMPTY, ("degraded_empty", True, False, True, 0)),
+        (TRUNCATED_EMPTY, ("truncated_empty", False, True, True, 0)),
+        (BOTH_EMPTY, ("degraded_truncated_empty", True, True, True, 0)),
+        ([CLEAN_ROW], ("clean_rows", False, False, False, 1)),
+        ([DEGRADED_ROW], ("degraded_rows", True, False, False, 1)),
+        ([TRUNCATED_ROW], ("truncated_rows", False, True, False, 1)),
+        ([DEGRADED_ROW | {"truncated": True}], ("degraded_truncated_rows", True, True, False, 1)),
+    ],
+)
+def test_every_response_class_keeps_its_shape(payload, expected):
+    label, degraded, truncated, enveloped, count = expected
+    outcome = RecallOutcome.from_result(copy.deepcopy(payload))
+    assert outcome.envelope_class == label
+    assert (outcome.degraded, outcome.truncated, outcome.enveloped) == (
+        degraded,
+        truncated,
+        enveloped,
+    )
+    assert len(outcome.hits) == count
+    if degraded:
+        assert outcome.degraded_reason == "ann index unavailable for model test-model"
+    else:
+        assert outcome.degraded_reason is None
+
+
+def test_degraded_row_and_clean_row_decode_to_different_values():
+    clean = RecallHit.model_validate(CLEAN_ROW)
+    degraded = RecallHit.model_validate(DEGRADED_ROW)
+    assert clean.id == degraded.id == HIT_ID
+    assert clean.score == degraded.score == 0.81
+    assert not clean.is_degraded and degraded.is_degraded
+    assert clean != degraded
+    assert clean.model_dump().get("degraded") is None
+    assert degraded.degraded == "ann_unavailable"
+
+
+def test_session_recall_forwards_arguments_and_returns_typed_outcome():
+    session, transport = _session([DEGRADED_ROW])
+    outcome = session.recall(
+        "a remembered line",
+        limit=3,
+        tags=["lesson"],
+        exclude_tags=["superseded"],
+        memory_type="semantic",
+        namespace="caller-pinned",
+        timeout=2.5,
+    )
+    assert isinstance(outcome, RecallOutcome)
+    assert outcome.envelope_class == "degraded_rows"
+    assert outcome.hits[0].id == HIT_ID and outcome.hits[0].is_degraded
+    frame, timeout = transport.dispatches[0]
+    assert timeout == 2.5
+    assert json.loads(frame["ops"]) == [
+        {
+            "tool": "memory.recall",
+            "args": {
+                "query": "a remembered line",
+                "limit": 3,
+                "memory_type": "semantic",
+                "tags": ["lesson"],
+                "exclude_tags": ["superseded"],
+                "namespace": "caller-pinned",
+            },
+        }
+    ]
+    assert not transport.responses
+
+
+def test_session_recall_raises_operation_error_with_the_server_error_object():
+    transport = ScriptedTransport(
+        [
+            {
+                "ok": False,
+                "tool": "memory.recall",
+                "error": {"kind": "invalid_params", "message": "query is required"},
+            }
+        ]
+    )
+    session = Session(transport, namespace="frame-only", actor_id="test-client")
+    with pytest.raises(OperationError) as raised:
+        session.recall("")
+    assert raised.value.tool == "memory.recall"
+    assert raised.value.error == {"kind": "invalid_params", "message": "query is required"}
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"rows": []},
+        "not a recall result",
+        {"results": [], "degraded": "yes"},
+        {"results": [], "truncated": 1},
+        [{"score": 0.5}],
+    ],
+)
+def test_malformed_recall_results_are_transport_errors(payload):
+    session, _ = _session(payload)
+    with pytest.raises(TransportError):
+        session.recall("anything")
+
+
+def test_rows_only_conversion_is_the_red_mutation():
+    # A conversion that keeps only the rows cannot tell a degraded empty recall
+    # from a clean one. The typed outcome must; if it collapsed to rows, these
+    # two values would compare equal and this test would fail.
+    degraded = RecallOutcome.from_result(copy.deepcopy(DEGRADED_EMPTY))
+    clean = RecallOutcome.from_result(copy.deepcopy(CLEAN_EMPTY))
+    assert degraded.hits == clean.hits == []
+    assert degraded != clean
+    assert (degraded.degraded, clean.degraded) == (True, False)
+
+
+def test_live_recall_returns_a_typed_outcome(scratch_daemon):
+    from khive import SocketTransport
+
+    session = Session(
+        SocketTransport(scratch_daemon["socket"]), namespace="local", actor_id="test-client"
+    )
+    remembered = session.remember("typed recall outcome live probe", memory_type="semantic")
+    assert remembered["ok"], remembered
+    outcome = session.recall("typed recall outcome live probe", limit=5)
+    assert isinstance(outcome, RecallOutcome)
+    assert isinstance(outcome.degraded, bool) and isinstance(outcome.truncated, bool)
+    if outcome.hits:
+        assert all(isinstance(hit, RecallHit) for hit in outcome.hits)
+        assert any(hit.id == remembered["result"]["id"] for hit in outcome.hits)
+    else:
+        # An empty live answer must say why, or be a clean empty.
+        assert outcome.envelope_class in {"clean_empty", "degraded_empty"}


### PR DESCRIPTION
`memory.recall` answers a non-empty query with a bare row array that carries per-row `degraded` and `truncated` stamps, and switches to an object envelope (`{"results": [], "degraded": true, ...}`, `{"results": [], "truncated": true}`, or both) only when an empty answer needs a reason. A rows-only client conversion loses that distinction.

This adds `RecallHit` and `RecallOutcome` to `khive.models` and `Session.recall(...)` to the Python client. `RecallOutcome.from_result` reads either shape into one value: typed `hits`, `degraded`, `truncated`, `degraded_reason`, and `enveloped` (whether the object shape arrived), plus an `envelope_class` label. A failed op raises `OperationError` with the daemon's error object unchanged; a malformed result is a `TransportError`.

Tests: every response class keeps its shape; a degraded row and a clean row decode to different values; argument forwarding; malformed results; the rows-only control (a degraded empty recall must not equal a clean empty one); one live remember-then-recall against the scratch daemon. README gains a short section.
