### PR TITLE
docs(adr): mark ADR-178 through ADR-182 Accepted

### DIFF
--- a/docs/adr/ADR-178-plan-only-request.md
+++ b/docs/adr/ADR-178-plan-only-request.md
@@ -1,6 +1,6 @@
 # ADR-178: Plan-Only Request — Grammar Check Without Dispatch
 
-- **Status**: Proposed
+- **Status**: Accepted (2026-09-09, implemented by the plan-only request path)
 - **Date**: 2026-09-07
 - **Extends**: [ADR-016](ADR-016-request-dsl.md) (Request DSL: the one `request` tool, three
   syntactic forms, the parser this record reuses)

--- a/docs/adr/ADR-179-operation-identity-memory-remember.md
+++ b/docs/adr/ADR-179-operation-identity-memory-remember.md
@@ -1,6 +1,6 @@
 # ADR-179: Operation Identity on `memory.remember`: Keyed Create, Conflict Names the Holder
 
-- **Status**: Proposed
+- **Status**: Accepted (2026-09-09, implemented by keyed memory.remember)
 - **Date**: 2026-09-08
 - **Extends**: [ADR-021](ADR-021-memory-pack.md) (memory pack: `memory.remember` creates one note
   of kind `memory`)

--- a/docs/adr/ADR-180-tool-pack.md
+++ b/docs/adr/ADR-180-tool-pack.md
@@ -1,6 +1,6 @@
 # ADR-180: Tool Pack: Capability Registry, Ontological Discovery and Use Policy
 
-- **Status**: Proposed
+- **Status**: Accepted (2026-09-09, implemented by the tool pack)
 - **Date**: 2026-09-08
 - **Extends**: [ADR-002](ADR-002-edge-ontology.md) (edge ontology; the registry reuses `project`,
   `concept` and the `implements` edge),

--- a/docs/adr/ADR-181-exec-verb-sandboxed-run.md
+++ b/docs/adr/ADR-181-exec-verb-sandboxed-run.md
@@ -1,6 +1,6 @@
 # ADR-181: Exec Verb: One Declared Command in a Sandbox over a Materialized Tree
 
-- **Status**: Proposed
+- **Status**: Accepted (2026-09-09, implemented by the exec pack)
 - **Date**: 2026-09-08
 - **Extends**: [ADR-111](ADR-111-blob-store.md) (content-addressed objects; this record adds a tree
   manifest over them), [ADR-180](ADR-180-tool-pack.md) (the policy vocabulary every run is checked

--- a/docs/adr/ADR-182-git-dev-loop-verbs.md
+++ b/docs/adr/ADR-182-git-dev-loop-verbs.md
@@ -1,6 +1,6 @@
 # ADR-182: Git Verbs for the Dev Loop: Trees In and Out, Commit as Actor, Policy-Gated Push, Pull Requests
 
-- **Status**: Proposed
+- **Status**: Accepted (2026-09-09, implemented by the git pack dev-loop verbs)
 - **Date**: 2026-09-08
 - **Extends**: [ADR-108](ADR-108-git-write-surface.md) and its Amendment 1 (write verbs over an
   allow-listed repo set, force-push denied, hooks disabled; all of it stands),


### PR DESCRIPTION
Status lines only. Each record's implementation is on main: the plan-only request path (ADR-178), keyed `memory.remember` (ADR-179), the tool pack (ADR-180), the exec pack (ADR-181) and the git pack dev-loop verbs (ADR-182). The bodies and their amendments are unchanged; the status lint passes.
