### PR TITLE
ci: exec verb tests without embedding models; plan stub at protocol 6

### DIFF
--- a/crates/khive-pack-exec/tests/verbs.rs
+++ b/crates/khive-pack-exec/tests/verbs.rs
@@ -96,6 +96,8 @@ impl Fixture {
         v["tree"].as_str().unwrap().to_string()
     }
 
+    // Read only by the kernel-denial test below, which is macOS-only.
+    #[cfg(target_os = "macos")]
     async fn blob_text(&self, r: &Value) -> String {
         use base64::Engine;
         let v = self.call("blob.get", json!({ "content_ref": r })).await;

--- a/crates/khive-pack-exec/tests/verbs.rs
+++ b/crates/khive-pack-exec/tests/verbs.rs
@@ -34,7 +34,9 @@ fn fixture() -> Fixture {
             keep: false,
             limits: Default::default(),
         },
-        ..RuntimeConfig::default()
+        // No embedding model: tool.register would otherwise build the default
+        // embedder, which needs a model file the test host may not have.
+        ..RuntimeConfig::no_embeddings()
     };
     let rt = KhiveRuntime::new(cfg).expect("file runtime");
     // A file-backed runtime installs no blob store on its own; the pack under

--- a/crates/kkernel/tests/exec_plan.rs
+++ b/crates/kkernel/tests/exec_plan.rs
@@ -111,7 +111,7 @@ mod daemon {
             "config_mismatch": false,
             "served_config_id": frame["config_id"],
             "version_mismatch": false,
-            "daemon_protocol_version": 5
+            "daemon_protocol_version": 6
         })
     }
 


### PR DESCRIPTION
Three test-only repairs for the workspace suites.

- `khive-pack-exec` verb tests: `tool.register` on the default file-backed runtime builds the default embedder, which needs a model file the test host may not have, so two tests panicked on hosts without it. The fixture now starts from `RuntimeConfig::no_embeddings`; none of the tests needed an embedding model.
- `khive-pack-exec` verb tests, Linux Clippy: the `blob_text` helper is read only by the kernel-denial test, which is macOS-only, so on Linux it was dead code under `-D warnings`. The helper now carries the same cfg as its one caller.
- `kkernel` plan round-trip tests: the stub daemon still reported protocol 5 after the wire moved to 6, so both round-trip tests failed with a version mismatch. One literal.

Verification: `cargo test -p khive-pack-exec --test verbs` 9 passed; `cargo test -p kkernel --test exec_plan` 9 passed; all three commits went through the fmt and clippy hooks.
