### PR TITLE
ci: plan census admits the mounted catalog read; nextest reports every failure in a shard

### DIFF
--- a/crates/khive-mcp/tests/plan_dependencies.rs
+++ b/crates/khive-mcp/tests/plan_dependencies.rs
@@ -120,10 +120,18 @@ fn assert_adapter_dependencies(method: &syn::ImplItemFn) {
         match method.sig.ident.to_string().as_str() {
             "plan_ops" => (
                 &["khive_request::plan_request"],
+                // The mounted tool catalog is a second read of the registry
+                // (a pinned snapshot, no subprocess call); merging it into the
+                // plan catalog adds iterator and JSON accessor methods only.
                 &[
                     "all_verbs_with_names",
+                    "mounted_verb_snapshot",
                     "into_iter",
                     "map",
+                    "chain",
+                    "as_str",
+                    "unwrap_or_default",
+                    "to_owned",
                     "collect",
                     "to_string",
                 ],

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -212,7 +212,9 @@ phase_tests() {
     # (the default, including every local/non-sharded invocation) keeps the
     # plain `cargo test --workspace` path unchanged.
     if [ -n "${NEXTEST_PARTITION:-}" ]; then
-        run_with_store_sentinel cargo nextest run --workspace --partition "count:${NEXTEST_PARTITION}"
+        # --no-fail-fast: one red test must not cancel the rest of the shard, so a
+        # head reports every failure it has.
+        run_with_store_sentinel cargo nextest run --workspace --no-fail-fast --partition "count:${NEXTEST_PARTITION}"
     else
         run_with_store_sentinel cargo test --workspace
     fi


### PR DESCRIPTION
## What

- `crates/khive-mcp/tests/plan_dependencies.rs`: the plan adapter census rejected `plan_ops` once it chained the mounted tool catalog into the plan catalog (`unexpected adapter method: chain`). The merge is a second read of the registry's pinned snapshot with iterator and JSON accessor methods only, so the `plan_ops` allow-list names them (`mounted_verb_snapshot`, `chain`, `as_str`, `unwrap_or_default`, `to_owned`). Effect calls are still refused by the same census.
- `scripts/ci.sh`: the sharded nextest run takes `--no-fail-fast`, so one red test no longer cancels the rest of its shard. A head now reports every failure it has instead of the first one plus a cancellation count.

## Why

The catalog merge landed with the tool-source mounts and the census on `main` has been red on shard 2 of both runners since, cancelling the remaining tests in that shard. The workflow-level `fail-fast: false` from the previous change only keeps sibling jobs alive; nextest's own fail-fast inside a job needed the flag too.

## Verification

- `cargo test -p khive-mcp --test plan_dependencies`: 2 passed (the census test and the effect-call guard).
- Pre-commit: fmt, clippy `--workspace --all-targets -D warnings`, SQL lint, markdown fmt, ADR reference lint.
