### PR TITLE
fix: the test reds that surfaced once every shard reports to completion

### DIFF
--- a/crates/khive-pack-comm/src/vocab.rs
+++ b/crates/khive-pack-comm/src/vocab.rs
@@ -137,7 +137,7 @@ pub(crate) static COMM_HANDLERS: [HandlerDef; 14] = [
                 param_type: "uuid",
                 required: false,
                 description: "Full thread UUID matched against properties.thread_id in either box before offset and limit. Alternate UUID spellings are canonicalized; short prefixes are rejected.",
-                resolution_mode: IdResolutionMode::FullUuidOnlyScopedToPrimary,
+                resolution_mode: IdResolutionMode::UnscopedFullUuidOnly,
             },
             ParamDef {
                 name: "limit",

--- a/crates/khive-pack-comm/src/vocab.rs
+++ b/crates/khive-pack-comm/src/vocab.rs
@@ -137,7 +137,7 @@ pub(crate) static COMM_HANDLERS: [HandlerDef; 14] = [
                 param_type: "uuid",
                 required: false,
                 description: "Full thread UUID matched against properties.thread_id in either box before offset and limit. Alternate UUID spellings are canonicalized; short prefixes are rejected.",
-                resolution_mode: IdResolutionMode::NotApplicable,
+                resolution_mode: IdResolutionMode::FullUuidOnlyScopedToPrimary,
             },
             ParamDef {
                 name: "limit",

--- a/crates/khive-pack-git/src/remote_vocab.rs
+++ b/crates/khive-pack-git/src/remote_vocab.rs
@@ -30,20 +30,63 @@ const NUMBER: ParamDef = p("number", "integer", true, "Positive pull request num
 const BODY: ParamDef = p("body", "string", true, "Body text; may be empty.");
 const SESSION: ParamDef = crate::local_vocab::SESSION;
 
-pub(crate) const PUSH:HandlerDef=HandlerDef {
-    name:"git.push", description:"Push an exact local SHA with a server-side expected-remote compare after fast-forward proof. Expected remote null means must not exist. All caller force/remote/refspec overrides refuse. Actor-only credentials, durable receipt, no retries.",
-    visibility:Visibility::Verb, category:VerbCategory::Commissive,
-    params:&[REPO,p("branch","string",true,"Branch to push."),p("expected_local","string",true,"Required exact 40-hex local branch head."),p("expected_remote","string|null",true,"Required exact remote SHA, or explicit null only when the remote branch must not exist. Omission is invalid_params."),SESSION],
+pub(crate) const PUSH: HandlerDef = HandlerDef {
+    name: "git.push",
+    description: "Push an exact local SHA with a server-side expected-remote compare after fast-forward proof. Expected remote null means must not exist. All caller force/remote/refspec overrides refuse. Actor-only credentials, durable receipt, no retries.",
+    visibility: Visibility::Verb,
+    category: VerbCategory::Commissive,
+    params: &[
+        REPO,
+        p("branch", "string", true, "Branch to push."),
+        p("expected_local", "string", true, "Required exact 40-hex local branch head."),
+        p("expected_remote", "string|null", true, "Required exact remote SHA, or explicit null only when the remote branch must not exist. Omission is invalid_params."),
+        SESSION,
+    ],
 };
-pub(crate) const PR_OPEN:HandlerDef=HandlerDef {
-    name:"git.pr_open",description:"Open a pull request after checking configured slug, visibility and exact platform head. Uses the actor credential and returns number, url, head_sha and receipt_id.",visibility:Visibility::Verb,category:VerbCategory::Commissive,
-    params:&[REPO,p("head","string",true,"Head branch."),p("base","string",true,"Base branch."),p("title","string",true,"Pull request title."),BODY,HEAD,SESSION],
+
+pub(crate) const PR_OPEN: HandlerDef = HandlerDef {
+    name: "git.pr_open",
+    description: "Open a pull request after checking configured slug, visibility and exact platform head. Uses the actor credential and returns number, url, head_sha and receipt_id.",
+    visibility: Visibility::Verb,
+    category: VerbCategory::Commissive,
+    params: &[
+        REPO,
+        p("head", "string", true, "Head branch."),
+        p("base", "string", true, "Base branch."),
+        p("title", "string", true, "Pull request title."),
+        BODY,
+        HEAD,
+        SESSION,
+    ],
 };
-pub(crate) const PR_REVIEW:HandlerDef=HandlerDef {
-    name:"git.pr_review",description:"Submit a review bound to expected_head. Approval requires a different opening actor, credential reference and platform account; fork approvals additionally require git.pr_review.fork. Returns review_id, head_sha, state and receipt_id.",visibility:Visibility::Verb,category:VerbCategory::Commissive,
-    params:&[REPO,NUMBER,p("verdict","string",true,"approve, request_changes or comment."),BODY,HEAD,SESSION],
+
+pub(crate) const PR_REVIEW: HandlerDef = HandlerDef {
+    name: "git.pr_review",
+    description: "Submit a review bound to expected_head. Approval requires a different opening actor, credential reference and platform account; fork approvals additionally require git.pr_review.fork. Returns review_id, head_sha, state and receipt_id.",
+    visibility: Visibility::Verb,
+    category: VerbCategory::Commissive,
+    params: &[
+        REPO,
+        NUMBER,
+        p("verdict", "string", true, "approve, request_changes or comment."),
+        BODY,
+        HEAD,
+        SESSION,
+    ],
 };
-pub(crate) const PR_MERGE:HandlerDef=HandlerDef {
-    name:"git.pr_merge",description:"Merge with a platform head comparison after caller policy and current-head approval by another account. Forks require git.pr_merge.fork; no administrator bypass is requested. Returns merged_head_sha, merged_sha and receipt_id.",visibility:Visibility::Verb,category:VerbCategory::Commissive,
-    params:&[REPO,NUMBER,p("method","string",true,"squash or merge."),p("subject","string",true,"Merge commit subject."),BODY,HEAD,SESSION],
+
+pub(crate) const PR_MERGE: HandlerDef = HandlerDef {
+    name: "git.pr_merge",
+    description: "Merge with a platform head comparison after caller policy and current-head approval by another account. Forks require git.pr_merge.fork; no administrator bypass is requested. Returns merged_head_sha, merged_sha and receipt_id.",
+    visibility: Visibility::Verb,
+    category: VerbCategory::Commissive,
+    params: &[
+        REPO,
+        NUMBER,
+        p("method", "string", true, "squash or merge."),
+        p("subject", "string", true, "Merge commit subject."),
+        BODY,
+        HEAD,
+        SESSION,
+    ],
 };

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -1667,6 +1667,9 @@ impl VerbRegistry {
     /// - `knowledge.search`, `knowledge.suggest`, and auto
     ///   `knowledge.compose` may start persistent ANN consumer/checkpoint
     ///   maintenance from their nominal read path.
+    /// - `git.checkout`, `git.diff` and `git.reconcile` persist a durable
+    ///   receipt on every dispatch (checkout and diff also write a manifest
+    ///   or diff blob), so their accounting row is not droppable.
     ///
     /// What membership here means, precisely: the verb performs no domain
     /// mutation, so its OWN per-dispatch audit/accounting row may be dropped
@@ -1702,6 +1705,19 @@ impl VerbRegistry {
     const ADMISSION_DEGRADE_SAFE_VERBS: &'static [(&'static str, &'static str)] = &[
         // agent
         ("agent", "agent.observe"),
+        // exec (reads of the blob store, the run receipt and event tables, or
+        // the resolved configuration; the writers are exec.tree, a Declaration,
+        // and exec.run, a Directive)
+        ("exec", "exec.tree_get"),
+        ("exec", "exec.tree_diff"),
+        ("exec", "exec.receipt"),
+        ("exec", "exec.runs"),
+        ("exec", "exec.events"),
+        ("exec", "exec.identity"),
+        // git (receipt list and allowlist reads; checkout, diff and reconcile
+        // persist receipts and are excluded)
+        ("git", "git.receipts"),
+        ("git", "git.gates"),
         // blob
         ("blob", "blob.get"),
         ("blob", "blob.stat"),
@@ -1733,6 +1749,8 @@ impl VerbRegistry {
         ("kg", "resolve"),
         ("kg", "whoami"),
         ("kg", "verbs"),
+        ("kg", "stream.read"),
+        ("kg", "stream.stat"),
         // knowledge (ANN-maintaining search/suggest/compose are excluded)
         ("knowledge", "knowledge.get"),
         ("knowledge", "knowledge.list"),
@@ -1749,6 +1767,14 @@ impl VerbRegistry {
         ("session", "session.list"),
         ("session", "session.resume"),
         ("session", "session.export"),
+        // tool (registry, grant and policy reads; tool.suggest runs the same
+        // hybrid search as the kg search and context verbs above)
+        ("tool", "tool.suggest"),
+        ("tool", "tool.describe"),
+        ("tool", "tool.list"),
+        ("tool", "tool.check"),
+        ("tool", "tool.requests"),
+        ("tool", "tool.policies"),
     ];
 
     /// Sorted copy of [`Self::ADMISSION_DEGRADE_SAFE_VERBS`], built once, so
@@ -4611,6 +4637,9 @@ pub(crate) mod tests {
     /// any name were re-added to the allowlist.
     const KNOWN_INCIDENTAL_WRITE_VERBS: &[&str] = &[
         "db_diagnostics",
+        "git.checkout",
+        "git.diff",
+        "git.reconcile",
         "knowledge.compose",
         "knowledge.search",
         "knowledge.suggest",

--- a/crates/khive-runtime/src/presentation.rs
+++ b/crates/khive-runtime/src/presentation.rs
@@ -1114,6 +1114,7 @@ mod tests {
             "notes": [],
             "edges": [],
             "results": [],
+            "entries": [],
             "next_after": null,
             "requested_limit": 10,
             "effective_limit": 10,


### PR DESCRIPTION
## Summary

Now that the test workflow runs every shard to completion (`--no-fail-fast`), three tests that earlier shards had cancelled past are visible on main. Each fix is a one-file change with no behaviour change for callers.

- **git remote vocab shape.** `crates/khive-pack-git/src/remote_vocab.rs` declared `git.push`, `git.pr_open`, `git.pr_review` and `git.pr_merge` as compact one-line `HandlerDef` literals. The admission census classifies handler definitions from their field lines (`name:` on the first field line, then `visibility:` and `category:`), so the compact shape left the whole file unclassified and the census test red. The four literals now take the shape every other vocab file uses. Descriptions, params and categories are unchanged.
- **Admission census classification.** Once the remote literals parsed, the census reached its second assertion: nineteen public Assertive verbs from the exec, git, stream and tool surfaces had never been classified. Each was reviewed at its handler source. Pure reads (blob store, receipt and event tables, stream tables, registry, grant and policy tables, resolved configuration) join `ADMISSION_DEGRADE_SAFE_VERBS`: the six exec read verbs, `git.receipts`, `git.gates`, `stream.read`, `stream.stat` and the six tool read verbs (`tool.suggest` runs the same hybrid search the kg `search` and `context` verbs already run under that classification). `git.checkout`, `git.diff` and `git.reconcile` persist a durable receipt on every dispatch (checkout and diff also write a manifest or diff blob), so they join `KNOWN_INCIDENTAL_WRITE_VERBS` and keep strict admission. No new census class; the commit message lists every verb with its reason.
- **comm.inbox `thread_id` resolution mode.** The filter is a `uuid` parameter and the handler already refuses anything but a full UUID, but the parameter declared `IdResolutionMode::NotApplicable`. It now declares `UnscopedFullUuidOnly`: the handler canonicalizes the UUID and matches it against stored properties, and the namespace scoping comes from the inbox query itself, which is the contract that variant documents. The uuid-param invariant test passes and `describe_verb` renders the actual contract.
- **presentation test payload.** `agent_preserves_empty_list_page_arrays` iterates `EMPTY_ARRAY_PRESERVE`, which gained `"entries"` when stream pages landed; the fixture payload now carries that key. Test-only.

## Verification

Reproduced on the host at the current main head before the change: the census test, the presentation test and the uuid-param invariant test all fail at the lines the workflow reports. After the change the census test (with the rest of the `pack::tests` module), the presentation test, the uuid-param test and the comm pack suite pass; the pre-commit hook ran `cargo fmt --check` and `cargo clippy --workspace --all-targets -D warnings` on both commits.

`pack_handler_for_kg_returns_full_surface` in `kkernel` is a separate red (kg surface count after the stream verbs joined the registry) and is not touched here.
