### PR TITLE
test: the kg pack's stream sub-namespace is part of the verb naming contract

### DIFF
--- a/crates/kkernel/src/pack_introspect.rs
+++ b/crates/kkernel/src/pack_introspect.rs
@@ -219,13 +219,14 @@ mod tests {
             "kg pack must expose verbs; got {:?}",
             info.verbs
         );
-        // kg pack ships 20 verbs: 11 base + propose/review/withdraw (3) + verbs
+        // kg pack ships 23 verbs: 11 base + propose/review/withdraw (3) + verbs
         // + stats (2) + context (1, ADR-089) + resolve (1) + whoami (1)
-        // + db_diagnostics (1, ADR-091)
+        // + db_diagnostics (1, ADR-091) + stream.append/read/stat (3, ADR-174
+        // section 2: registered by kg because the entries are its notes)
         assert_eq!(
             info.verbs.len(),
-            20,
-            "kg pack must expose 20 verbs; got {}: {:?}",
+            23,
+            "kg pack must expose 23 verbs; got {}: {:?}",
             info.verbs.len(),
             info.verbs.iter().map(|v| &v.name).collect::<Vec<_>>()
         );

--- a/crates/kkernel/tests/verb_namespace_contract.rs
+++ b/crates/kkernel/tests/verb_namespace_contract.rs
@@ -6,11 +6,21 @@
 //! additional underscore-delimited segment, NOT a second dot:
 //! `memory.recall_embed`, not `memory.recall.embed`.
 //!
+//! One documented exception: the kg pack also carries the `stream`
+//! sub-namespace (`stream.append`, `stream.read`, `stream.stat`). ADR-174
+//! section 2 registers those three verbs under kg because the entries are kg
+//! notes and the append writes the note and the ledger row in one writer
+//! transaction, which a separate pack could only do by reaching into kg's
+//! write path. The exception is pack-scoped and closed: kg may carry exactly
+//! the sub-namespaces listed in `KG_SUB_NAMESPACES` and nothing else; no
+//! other pack may borrow a prefix that is not its own name.
+//!
 //! This test walks every `HandlerDef` across every pack registered in the
 //! `inventory` (i.e. linked into this test binary) and asserts:
 //!   1. A name without a dot must be in the kg-substrate allowlist.
 //!   2. A name with exactly one dot must have a prefix equal to `Pack::NAME`
-//!      (validated via `all_handlers_with_names`).
+//!      (validated via `all_handlers_with_names`), or, for the kg pack only,
+//!      a documented sub-namespace.
 //!   3. A name with two or more dots is always invalid — sub-variants use
 //!      underscore, not nesting dots.
 //!
@@ -70,6 +80,58 @@ const KG_SUBSTRATE_VERBS: &[&str] = &[
     "db_diagnostics",
 ];
 
+/// Dotted prefixes the kg pack may carry beside its bare verbs. Closed list:
+/// `stream` per ADR-174 section 2 ("registered by the kg pack because the
+/// entries are its notes"). Adding a name here is a contract change and
+/// needs the ADR line that grants it.
+const KG_SUB_NAMESPACES: &[&str] = &["stream"];
+
+/// The contract's classification, one place for both tests and the decoy
+/// test below: every violation as a sentence naming the pack and the verb.
+fn violations(handlers: &[(String, String)]) -> Vec<String> {
+    let mut violations: Vec<String> = Vec::new();
+
+    for (pack_name, verb_name) in handlers {
+        let dot_count = verb_name.chars().filter(|&c| c == '.').count();
+
+        match dot_count {
+            // No dot — must be an allowed kg substrate verb.
+            0 => {
+                if !KG_SUBSTRATE_VERBS.contains(&verb_name.as_str()) {
+                    violations.push(format!(
+                        "pack={pack_name:?} verb={verb_name:?}: bare name is not in the \
+                         kg-substrate allowlist. Add `{pack_name}.` prefix."
+                    ));
+                }
+            }
+            // Exactly one dot — prefix must match the pack name, or be one of
+            // the kg pack's documented sub-namespaces.
+            1 => {
+                let prefix = verb_name.split('.').next().unwrap_or("");
+                let documented_kg_sub_namespace =
+                    pack_name == "kg" && KG_SUB_NAMESPACES.contains(&prefix);
+                if prefix != pack_name && !documented_kg_sub_namespace {
+                    violations.push(format!(
+                        "pack={pack_name:?} verb={verb_name:?}: prefix {prefix:?} does not \
+                         match pack name {pack_name:?} and is not a documented kg \
+                         sub-namespace ({KG_SUB_NAMESPACES:?}, ADR-174 section 2)."
+                    ));
+                }
+            }
+            // Two or more dots — always invalid (sub-variants use underscore, not nesting dots).
+            _ => {
+                violations.push(format!(
+                    "pack={pack_name:?} verb={verb_name:?}: name contains {dot_count} dots; \
+                     sub-variants must use underscore, not nested dots. \
+                     Example: `{pack_name}.recall_embed`, not `{pack_name}.recall.embed`."
+                ));
+            }
+        }
+    }
+
+    violations
+}
+
 fn build_full_registry() -> Vec<(String, String)> {
     let config = RuntimeConfig {
         db_path: None,
@@ -96,47 +158,11 @@ fn build_full_registry() -> Vec<(String, String)> {
 }
 
 /// Every non-kg verb name must carry exactly one dot-prefix matching the pack
-/// name that owns it.
+/// name that owns it; the kg pack may also carry its documented sub-namespaces.
 #[test]
 fn every_non_kg_verb_is_namespaced() {
     let handlers = build_full_registry();
-
-    let mut violations: Vec<String> = Vec::new();
-
-    for (pack_name, verb_name) in &handlers {
-        let dot_count = verb_name.chars().filter(|&c| c == '.').count();
-
-        match dot_count {
-            // No dot — must be an allowed kg substrate verb.
-            0 => {
-                if !KG_SUBSTRATE_VERBS.contains(&verb_name.as_str()) {
-                    violations.push(format!(
-                        "pack={pack_name:?} verb={verb_name:?}: bare name is not in the \
-                         kg-substrate allowlist. Add `{pack_name}.` prefix."
-                    ));
-                }
-            }
-            // Exactly one dot — prefix must match the pack name.
-            1 => {
-                let prefix = verb_name.split('.').next().unwrap_or("");
-                if prefix != pack_name {
-                    violations.push(format!(
-                        "pack={pack_name:?} verb={verb_name:?}: prefix {prefix:?} does not \
-                         match pack name {pack_name:?}."
-                    ));
-                }
-            }
-            // Two or more dots — always invalid (sub-variants use underscore, not nesting dots).
-            _ => {
-                violations.push(format!(
-                    "pack={pack_name:?} verb={verb_name:?}: name contains {dot_count} dots; \
-                     sub-variants must use underscore, not nested dots. \
-                     Example: `{pack_name}.recall_embed`, not `{pack_name}.recall.embed`."
-                ));
-            }
-        }
-    }
-
+    let violations = violations(&handlers);
     assert!(
         violations.is_empty(),
         "Verb namespace contract violations:\n{}",
@@ -144,10 +170,50 @@ fn every_non_kg_verb_is_namespaced() {
     );
 }
 
-/// Complementary check: the kg substrate pack must expose all mandated bare
-/// verbs and no dotted ones. This catches regressions in the kg pack itself.
+/// The allow-list is a decoy-tested gate, not a blanket: a dotted kg verb
+/// outside the documented sub-namespace, another pack borrowing the `stream`
+/// prefix, and a two-dot kg name each still redden the contract, while the
+/// live registry alone passes.
 #[test]
-fn kg_pack_exposes_bare_verbs_only() {
+fn a_dotted_kg_verb_outside_the_documented_sub_namespace_still_reddens() {
+    let live = build_full_registry();
+    assert!(
+        violations(&live).is_empty(),
+        "control: the live registry must pass before decoys are judged"
+    );
+    assert!(
+        live.iter()
+            .any(|(pack, verb)| pack == "kg" && verb == "stream.append"),
+        "control: the documented sub-namespace must be present in the live registry"
+    );
+
+    let decoys: Vec<(String, String)> = vec![
+        ("kg".into(), "ledger.append".into()),
+        ("memory".into(), "stream.read".into()),
+        ("kg".into(), "stream.append.now".into()),
+    ];
+    for decoy in &decoys {
+        let mut handlers = live.clone();
+        handlers.push(decoy.clone());
+        let found = violations(&handlers);
+        assert_eq!(
+            found.len(),
+            1,
+            "decoy {decoy:?} must produce exactly one violation; got {found:?}"
+        );
+        assert!(
+            found[0].contains(&format!("verb={:?}", decoy.1)),
+            "the violation must name the decoy verb: {found:?}"
+        );
+    }
+}
+
+/// Complementary check: the kg substrate pack must expose all mandated bare
+/// verbs, and any dotted name it carries must sit in a documented
+/// sub-namespace with exactly one dot. This catches regressions in the kg
+/// pack itself.
+#[test]
+fn kg_pack_exposes_bare_verbs_or_a_documented_sub_namespace() {
     let handlers = build_full_registry();
 
     let kg_verbs: Vec<&str> = handlers
@@ -166,10 +232,20 @@ fn kg_pack_exposes_bare_verbs_only() {
         "kg pack is missing substrate verbs: {missing:?}"
     );
 
-    // No kg verb may carry a dot.
-    let dotted: Vec<&&str> = kg_verbs.iter().filter(|v| v.contains('.')).collect();
+    // A dotted kg verb sits in a documented sub-namespace, one dot only.
+    let undocumented: Vec<&&str> = kg_verbs
+        .iter()
+        .filter(|v| v.contains('.'))
+        .filter(|v| {
+            let mut parts = v.split('.');
+            let prefix = parts.next().unwrap_or("");
+            let rest = parts.next().unwrap_or("");
+            parts.next().is_some() || rest.is_empty() || !KG_SUB_NAMESPACES.contains(&prefix)
+        })
+        .collect();
     assert!(
-        dotted.is_empty(),
-        "kg pack must not use dotted verb names; found: {dotted:?}"
+        undocumented.is_empty(),
+        "kg pack may carry dotted names only under {KG_SUB_NAMESPACES:?} (ADR-174 section 2); \
+         found: {undocumented:?}"
     );
 }


### PR DESCRIPTION
## Summary

Main has been red on `every_non_kg_verb_is_namespaced` and `kg_pack_exposes_bare_verbs_only` since the stream verbs landed: ADR-174 section 2 registers `stream.append`, `stream.read` and `stream.stat` under the kg pack (the entries are kg notes and the append writes the note and the ledger row in one writer transaction), and the verb naming contract predates that and refused every dotted name inside kg.

The contract now names the exception explicitly and pack-scoped: kg may carry the `stream` sub-namespace and nothing else; every other pack still needs its own name as the prefix, and a second dot stays invalid everywhere. The classification is one function shared by both tests. The kg introspection count moves from 20 to 23 for the same reason.

## Verification

- `cargo test -p kkernel --test verb_namespace_contract`: 3 passed, including a new test that feeds the classifier three decoys (a dotted kg verb outside the documented sub-namespace, another pack borrowing the `stream` prefix, a two-dot kg name) and shows each still reddens while the live registry passes.
- `cargo test -p kkernel --lib -- pack_introspect::tests::`: green with the count at 23.
- Pre-commit: fmt and clippy (workspace, all targets, `-D warnings`) at commit time.
