### PR TITLE
feat: a gate refusal carries the id of its audit row

### DIFF
--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -2729,7 +2729,24 @@ fn runtime_error_value(error: RuntimeError, disposition: DomainDisposition) -> V
         },
         _ => None,
     };
+    // The refusal text is the same Display string every consumer already
+    // matches on; the receipt fields ride beside it.
+    let denial_message =
+        matches!(error, RuntimeError::PermissionDenied { .. }).then(|| error.to_string());
     let payload = match error {
+        RuntimeError::PermissionDenied {
+            verb,
+            reason,
+            receipt,
+        } => json!({
+            "kind": "runtime_error",
+            "code": "permission_denied",
+            "message": denial_message.unwrap_or_default(),
+            "verb": verb,
+            "reason": reason,
+            "audit_event_id": receipt.audit_event_id.map(|id| id.to_string()),
+            "audit_outcome": receipt.audit_outcome.wire_code(),
+        }),
         RuntimeError::AuditObligation {
             failure,
             domain_result,
@@ -2765,7 +2782,6 @@ fn runtime_error_value(error: RuntimeError, disposition: DomainDisposition) -> V
         | RuntimeError::PackRedeclared { .. }
         | RuntimeError::VerbCollision { .. }
         | RuntimeError::ReservedEnvelopeParam { .. }
-        | RuntimeError::PermissionDenied { .. }
         | RuntimeError::GateUnavailable { .. }
         | RuntimeError::NamespaceMismatch { .. }
         | RuntimeError::AmbiguousPrefix { .. }

--- a/crates/khive-mcp/src/server/disposition_tests.rs
+++ b/crates/khive-mcp/src/server/disposition_tests.rs
@@ -1645,3 +1645,41 @@ async fn a3_same_committed_failure_crosses_mcp_request_and_native_frame_once() {
         file.write_all(b"\n").unwrap();
     }
 }
+
+#[test]
+#[serial_test::serial(config_ledger)]
+fn a_gate_refusal_projects_its_audit_receipt_beside_the_denial_text() {
+    let id = uuid::Uuid::new_v4();
+    let error = runtime_error_value(
+        RuntimeError::PermissionDenied {
+            verb: "create".into(),
+            reason: "denied for test".into(),
+            receipt: Box::new(khive_runtime::DenialReceipt {
+                audit_event_id: Some(id),
+                audit_outcome: khive_runtime::DenialAuditOutcome::Committed,
+            }),
+        },
+        DomainDisposition::NotCommitted,
+    );
+    assert_eq!(error["kind"], "runtime_error");
+    assert_eq!(error["code"], "permission_denied");
+    assert_eq!(
+        error["message"],
+        "permission denied for verb \"create\": denied for test"
+    );
+    assert_eq!(error["verb"], "create");
+    assert_eq!(error["reason"], "denied for test");
+    assert_eq!(error["audit_event_id"], id.to_string());
+    assert_eq!(error["audit_outcome"], "committed");
+
+    let unaudited = runtime_error_value(
+        RuntimeError::permission_denied("authorize", "gate denied"),
+        DomainDisposition::NotCommitted,
+    );
+    assert_eq!(unaudited["audit_event_id"], Value::Null);
+    assert_eq!(unaudited["audit_outcome"], "not_audited");
+    assert!(unaudited["message"]
+        .as_str()
+        .unwrap()
+        .starts_with("permission denied for verb"));
+}

--- a/crates/khive-mounts/tests/acceptance.rs
+++ b/crates/khive-mounts/tests/acceptance.rs
@@ -174,7 +174,7 @@ async fn gate_denial_has_no_foreign_call_or_additional_process() {
     let starts = count(&path, ".starts");
     let mounted = registry.dispatch("demo.A", json!({})).await.unwrap_err();
     let native = registry.dispatch("stats", json!({})).await.unwrap_err();
-    let khive_runtime::RuntimeError::PermissionDenied { verb, reason } = mounted else {
+    let khive_runtime::RuntimeError::PermissionDenied { verb, reason, .. } = mounted else {
         panic!("mounted gate refusal")
     };
     let khive_runtime::RuntimeError::PermissionDenied {

--- a/crates/khive-pack-comm/src/message.rs
+++ b/crates/khive-pack-comm/src/message.rs
@@ -298,6 +298,7 @@ pub(crate) async fn dual_write_message(
             if !allowed {
                 return Err(RuntimeError::PermissionDenied {
                     verb: "comm.send".to_string(),
+                    receipt: Box::new(khive_runtime::DenialReceipt::not_audited()),
                     reason: format!(
                         "cross-namespace delivery to {recipient_ns_str:?} is not permitted; \
                          add {recipient_ns_str:?} to actor.allowed_outbound_namespaces in \

--- a/crates/khive-runtime/src/engine_config.rs
+++ b/crates/khive-runtime/src/engine_config.rs
@@ -2691,7 +2691,7 @@ grant_unattributed = false
         let runtime = crate::KhiveRuntime::new(denied).expect("runtime");
         assert!(matches!(
             runtime.authorize(Namespace::local()),
-            Err(crate::RuntimeError::PermissionDenied { ref verb, ref reason })
+            Err(crate::RuntimeError::PermissionDenied { ref verb, ref reason, .. })
                 if verb == "authorize" && reason == "actor is not enrolled"
         ));
     }

--- a/crates/khive-runtime/src/error.rs
+++ b/crates/khive-runtime/src/error.rs
@@ -435,6 +435,67 @@ impl std::error::Error for CircularPackDependency {}
 
 /// All errors produced by the khive-runtime layer.
 ///
+/// Where the `GateDenied` audit row of a refused dispatch ended up.
+///
+/// A refusal reaches the caller whatever happens to its audit row; this value
+/// says whether the row the caller could cite exists.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DenialAuditOutcome {
+    /// The row committed, or an identical row was already present, and
+    /// `audit_event_id` on the refusal names it.
+    Committed,
+    /// The row was built and submitted but did not commit; the audit
+    /// obligation wire code says why.
+    NotCommitted(&'static str),
+    /// No event store is configured, so no row was written.
+    NoStore,
+    /// The refusal comes from a path that writes no audit row (namespace
+    /// authorization, channel policy).
+    NotAudited,
+}
+
+impl DenialAuditOutcome {
+    /// Closed wire spelling: `committed`, `not_committed:<code>`, `no_store`,
+    /// `not_audited`.
+    pub fn wire_code(&self) -> String {
+        match self {
+            Self::Committed => "committed".to_string(),
+            Self::NotCommitted(code) => format!("not_committed:{code}"),
+            Self::NoStore => "no_store".to_string(),
+            Self::NotAudited => "not_audited".to_string(),
+        }
+    }
+}
+
+/// What a refused dispatch can cite: the `GateDenied` audit row's id when
+/// one committed, and where the row ended up otherwise. Boxed on the error
+/// so a refusal does not widen every `Result<_, RuntimeError>` in the tree.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DenialReceipt {
+    /// The audit row's event id when `audit_outcome` is `Committed`.
+    pub audit_event_id: Option<uuid::Uuid>,
+    /// Whether the row the caller could cite exists.
+    pub audit_outcome: DenialAuditOutcome,
+}
+
+impl DenialReceipt {
+    /// The refusal's path writes no audit row.
+    pub fn not_audited() -> Self {
+        Self {
+            audit_event_id: None,
+            audit_outcome: DenialAuditOutcome::NotAudited,
+        }
+    }
+
+    /// No event store is configured, so no row was written.
+    pub fn no_store() -> Self {
+        Self {
+            audit_event_id: None,
+            audit_outcome: DenialAuditOutcome::NoStore,
+        }
+    }
+}
+
 /// Variants cover storage, query, validation, namespace isolation, and permission failures.
 /// Callers should match on `InvalidInput` for bad arguments, `NotFound` for missing records,
 /// and `NamespaceMismatch` (reported as not-found) for cross-namespace access attempts.
@@ -547,8 +608,16 @@ pub enum RuntimeError {
     /// Returned by `VerbRegistry::dispatch` when the configured `Gate` returns
     /// `GateDecision::Deny`. The pack is never invoked. The `reason` field
     /// carries the deny message produced by the gate implementation.
+    ///
+    /// `receipt` carries the id of the `GateDenied` audit row when one
+    /// committed, so the caller can cite the refusal, and says whether such
+    /// a row exists.
     #[error("permission denied for verb {verb:?}: {reason}")]
-    PermissionDenied { verb: String, reason: String },
+    PermissionDenied {
+        verb: String,
+        reason: String,
+        receipt: Box<DenialReceipt>,
+    },
 
     /// The configured gate could not produce an authorization decision.
     ///
@@ -673,6 +742,15 @@ impl From<khive_db::SqliteError> for RuntimeError {
 }
 
 impl RuntimeError {
+    /// A gate refusal from a path that writes no audit row.
+    pub fn permission_denied(verb: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self::PermissionDenied {
+            verb: verb.into(),
+            reason: reason.into(),
+            receipt: Box::new(DenialReceipt::not_audited()),
+        }
+    }
+
     /// Classify a failed inbound channel write without inspecting rendered
     /// error text.
     ///

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -90,10 +90,10 @@ pub use engine_config::{
 };
 pub use error::{
     fts_text_leg_or_err, AdmissionFailureContext, AuditObligationFailure, AuditObligationReason,
-    ChannelIngestFailureClass, DispatchError, DomainDisposition, GuardedWriteFailure, RuntimeError,
-    RuntimeResult, WriterPoolCheckoutTimeoutContext, WriterTaskFailureContext,
-    WRITER_ADMISSION_SCOPE, WRITER_POOL_CHECKOUT_TIMEOUT_STAGE, WRITER_QUEUE_SATURATED_STAGE,
-    WRITER_TASK_REQUEST_FAILED_STAGE, WRITER_TASK_TERMINATED_STAGE,
+    ChannelIngestFailureClass, DenialAuditOutcome, DenialReceipt, DispatchError, DomainDisposition,
+    GuardedWriteFailure, RuntimeError, RuntimeResult, WriterPoolCheckoutTimeoutContext,
+    WriterTaskFailureContext, WRITER_ADMISSION_SCOPE, WRITER_POOL_CHECKOUT_TIMEOUT_STAGE,
+    WRITER_QUEUE_SATURATED_STAGE, WRITER_TASK_REQUEST_FAILED_STAGE, WRITER_TASK_TERMINATED_STAGE,
 };
 pub use event_store_guard::EventAttribution;
 pub use fusion::FusionStrategy;

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -1947,14 +1947,10 @@ impl VerbRegistry {
         let req = GateRequest::new(actor, ns, "authorize", serde_json::Value::Null);
         match self.gate.check(&req) {
             Ok(decision) if decision.is_allow() => Ok(()),
-            Ok(GateDecision::Deny { reason }) => Err(RuntimeError::PermissionDenied {
-                verb: "authorize".to_string(),
-                reason,
-            }),
-            Ok(_) => Err(RuntimeError::PermissionDenied {
-                verb: "authorize".to_string(),
-                reason: "gate denied".to_string(),
-            }),
+            Ok(GateDecision::Deny { reason }) => {
+                Err(RuntimeError::permission_denied("authorize", reason))
+            }
+            Ok(_) => Err(RuntimeError::permission_denied("authorize", "gate denied")),
             Err(e) => {
                 tracing::warn!(
                     error = %crate::secret_gate::bounded_masked_log_text(&e.to_string()),
@@ -2024,6 +2020,36 @@ impl VerbRegistry {
             .map_err(DispatchError::into_source)
     }
 
+    /// Append the `GateDenied` row of a refused dispatch and report what the
+    /// caller may cite: the row's id when it committed, otherwise why not.
+    async fn append_gate_denied_row(
+        &self,
+        store: &Arc<dyn EventStore>,
+        event: Event,
+        verb: &str,
+    ) -> crate::error::DenialReceipt {
+        let audit_event_id = event.id;
+        match append_audit_event_best_effort(
+            self.audit_batch.as_ref(),
+            store,
+            event,
+            verb,
+            crate::audit_batch::AuditProducer::GateDenied,
+            false,
+        )
+        .await
+        {
+            Ok(()) => crate::error::DenialReceipt {
+                audit_event_id: Some(audit_event_id),
+                audit_outcome: crate::error::DenialAuditOutcome::Committed,
+            },
+            Err(failure) => crate::error::DenialReceipt {
+                audit_event_id: None,
+                audit_outcome: crate::error::DenialAuditOutcome::NotCommitted(failure.wire_code()),
+            },
+        }
+    }
+
     /// Execute an intercepted operation while retaining this boundary's failure provenance.
     /// Successful canonical results and typed metadata are returned unchanged.
     pub async fn dispatch_intercepted_with_metadata_and_disposition<M, F, Fut>(
@@ -2050,33 +2076,29 @@ impl VerbRegistry {
                     "gate.check"
                 );
                 if let GateDecision::Deny { reason } = decision {
-                    if let Some(store) = &self.event_store {
-                        let event = build_audit_storage_event(
-                            &gate_req,
-                            &audit,
-                            EventOutcome::Denied,
-                            Some(crate::cost_unit::base_resource_payload(request_id)),
-                        );
-                        // The dispatch already returns `PermissionDenied`
-                        // below regardless of whether this row commits — a
-                        // deny never reports success — so a persistent
-                        // commit failure here has no caller-visible outcome
-                        // to fold into; it is still logged and counted by
-                        // the helper.
-                        let _ = append_audit_event_best_effort(
-                            self.audit_batch.as_ref(),
-                            store,
-                            event,
-                            verb,
-                            crate::audit_batch::AuditProducer::GateDenied,
-                            false,
-                        )
-                        .await;
-                    }
+                    let receipt = match &self.event_store {
+                        Some(store) => {
+                            let event = build_audit_storage_event(
+                                &gate_req,
+                                &audit,
+                                EventOutcome::Denied,
+                                Some(crate::cost_unit::base_resource_payload(request_id)),
+                            );
+                            // The dispatch returns `PermissionDenied` below
+                            // whether or not this row commits — a deny never
+                            // reports success — so a commit failure has no
+                            // caller-visible outcome to fold into; the receipt
+                            // on the refusal says whether the row the caller
+                            // could cite exists.
+                            self.append_gate_denied_row(store, event, verb).await
+                        }
+                        None => crate::error::DenialReceipt::no_store(),
+                    };
                     return Err(DispatchError::before_dispatch(
                         RuntimeError::PermissionDenied {
                             verb: verb.to_string(),
                             reason,
+                            receipt: Box::new(receipt),
                         },
                     ));
                 }
@@ -2462,41 +2484,37 @@ impl VerbRegistry {
                 // ingest writes with no response and no completed receipt.
                 let defer_audit = !is_deny;
 
-                // Persist to EventStore immediately only for denied calls.
-                if !defer_audit {
-                    if let Some(store) = &self.event_store {
-                        // ADR-103 Decision (a): the closed `work_class` enum
-                        // is stamped on every event, denial included -- only
-                        // `resource.cost_unit` is scoped to a successful
-                        // dispatch by Amendment 1. `base_resource_payload()`
-                        // carries `work_class` alone, no `cost_unit` key.
-                        let storage_event = build_audit_storage_event(
-                            &gate_req,
-                            &audit,
-                            EventOutcome::Denied,
-                            Some(crate::cost_unit::base_resource_payload(request_id)),
-                        );
-                        // As above (line ~1513): this path always returns
-                        // `PermissionDenied` below regardless, so there is no
-                        // success outcome to fold a commit failure into.
-                        let _ = append_audit_event_best_effort(
-                            self.audit_batch.as_ref(),
-                            store,
-                            storage_event,
-                            verb,
-                            crate::audit_batch::AuditProducer::GateDenied,
-                            false,
-                        )
-                        .await;
-                    }
-                }
-
+                // Persist to EventStore immediately only for denied calls;
+                // the receipt rides on the refusal so the caller can cite
+                // the row.
                 let reason = if is_deny {
                     let reason = match decision {
                         GateDecision::Deny { reason } => reason,
                         _ => String::new(),
                     };
-                    Some(reason)
+                    let receipt = match &self.event_store {
+                        Some(store) => {
+                            // ADR-103 Decision (a): the closed `work_class` enum
+                            // is stamped on every event, denial included -- only
+                            // `resource.cost_unit` is scoped to a successful
+                            // dispatch by Amendment 1. `base_resource_payload()`
+                            // carries `work_class` alone, no `cost_unit` key.
+                            let storage_event = build_audit_storage_event(
+                                &gate_req,
+                                &audit,
+                                EventOutcome::Denied,
+                                Some(crate::cost_unit::base_resource_payload(request_id)),
+                            );
+                            // This path always returns `PermissionDenied`
+                            // below, so there is no success outcome to fold a
+                            // commit failure into; the receipt says whether
+                            // the row exists.
+                            self.append_gate_denied_row(store, storage_event, verb)
+                                .await
+                        }
+                        None => crate::error::DenialReceipt::no_store(),
+                    };
+                    Some((reason, receipt))
                 } else {
                     None
                 };
@@ -2512,11 +2530,12 @@ impl VerbRegistry {
         };
 
         // Hard enforcement: Deny is authoritative.
-        if let Some(reason) = gate_blocked {
+        if let Some((reason, receipt)) = gate_blocked {
             return Err(DispatchError::before_dispatch(
                 RuntimeError::PermissionDenied {
                     verb: verb.to_string(),
                     reason,
+                    receipt: Box::new(receipt),
                 },
             ));
         }
@@ -6229,6 +6248,97 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
+    async fn denied_dispatch_returns_the_id_of_its_committed_gate_denied_row() {
+        let gate = Arc::new(CountingGate {
+            calls: AtomicUsize::new(0),
+            deny_verb: Some("create"),
+        });
+        let store = Arc::new(MemoryEventStore::default());
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(AlphaPack);
+        builder.with_gate(gate);
+        builder.with_event_store(store.clone());
+        let reg = builder.build().expect("registry builds");
+
+        let err = reg.dispatch("create", Value::Null).await.unwrap_err();
+        let RuntimeError::PermissionDenied { receipt, .. } = err else {
+            panic!("expected PermissionDenied, got {err:?}");
+        };
+        assert_eq!(
+            receipt.audit_outcome,
+            crate::error::DenialAuditOutcome::Committed
+        );
+        let audit_event_id = receipt
+            .audit_event_id
+            .expect("a committed row carries its id");
+        let events = store.events.lock().unwrap();
+        let row = events
+            .iter()
+            .find(|e| e.id == audit_event_id)
+            .expect("the receipt names a row the store holds");
+        assert_eq!(row.outcome, EventOutcome::Denied);
+        assert_eq!(row.kind, EventKind::Audit);
+        assert_eq!(row.verb, "create");
+    }
+
+    #[tokio::test]
+    async fn denied_dispatch_without_an_event_store_reports_no_store() {
+        let gate = Arc::new(CountingGate {
+            calls: AtomicUsize::new(0),
+            deny_verb: Some("create"),
+        });
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(AlphaPack);
+        builder.with_gate(gate);
+        let reg = builder.build().expect("registry builds");
+
+        let err = reg.dispatch("create", Value::Null).await.unwrap_err();
+        assert!(
+            matches!(
+                err,
+                RuntimeError::PermissionDenied { ref receipt, .. }
+                    if **receipt == crate::error::DenialReceipt::no_store()
+            ),
+            "expected a no-store receipt, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(config_ledger)]
+    #[serial_test::serial(audit_append_failures)]
+    #[serial_test::serial(audit_obligation_append_failures)]
+    async fn denied_dispatch_whose_row_fails_to_commit_still_refuses_and_names_no_row() {
+        let gate = Arc::new(CountingGate {
+            calls: AtomicUsize::new(0),
+            deny_verb: Some("create"),
+        });
+        let store = Arc::new(MemoryEventStore {
+            fail_appends: true,
+            ..MemoryEventStore::default()
+        });
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(AlphaPack);
+        builder.with_gate(gate);
+        builder.with_event_store(store.clone());
+        let reg = builder.build().expect("registry builds");
+
+        let err = reg.dispatch("create", Value::Null).await.unwrap_err();
+        let RuntimeError::PermissionDenied { verb, receipt, .. } = err else {
+            panic!("expected PermissionDenied, got {err:?}");
+        };
+        assert_eq!(verb, "create");
+        assert_eq!(
+            receipt.audit_event_id, None,
+            "a row that did not commit is not cited"
+        );
+        assert_eq!(
+            receipt.audit_outcome,
+            crate::error::DenialAuditOutcome::NotCommitted("store_failure")
+        );
+        assert!(store.events.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
     async fn dispatch_allow_verb_succeeds_even_with_deny_gate_for_other_verb() {
         // Deny only "create" — "list" must still work.
         let gate = Arc::new(CountingGate {
@@ -6807,7 +6917,7 @@ pub(crate) mod tests {
 
         let err = reg.dispatch("create", Value::Null).await.unwrap_err();
         assert!(
-            matches!(err, RuntimeError::PermissionDenied { ref verb, ref reason }
+            matches!(err, RuntimeError::PermissionDenied { ref verb, ref reason, .. }
                 if verb == "create" && reason == "policy evaluation failed"),
             "expected PermissionDenied with the static classified reason for a missing rego entrypoint, got {err:?}"
         );
@@ -8507,15 +8617,30 @@ pub(crate) mod tests {
             .await
             .expect_err("explicit gate denial must refuse intercepted dispatch");
 
-        assert!(matches!(
-            err,
-            RuntimeError::PermissionDenied { ref verb, ref reason }
-                if verb == "list" && reason == "intercepted policy denied"
-        ));
+        let RuntimeError::PermissionDenied {
+            verb,
+            reason,
+            receipt,
+        } = err
+        else {
+            panic!("expected PermissionDenied, got {err:?}");
+        };
+        assert_eq!(verb, "list");
+        assert_eq!(reason, "intercepted policy denied");
+        assert_eq!(
+            receipt.audit_outcome,
+            crate::error::DenialAuditOutcome::Committed,
+            "the intercepted path commits its denial row before refusing"
+        );
         assert_eq!(invoked.load(Ordering::SeqCst), 0);
 
         let events = store.events.lock().unwrap();
         assert_eq!(events.len(), 1);
+        assert_eq!(
+            Some(events[0].id),
+            receipt.audit_event_id,
+            "the receipt names the committed row"
+        );
         assert_eq!(events[0].outcome, EventOutcome::Denied);
         assert_eq!(events[0].payload["decision"], "deny");
         assert_eq!(
@@ -8712,7 +8837,7 @@ pub(crate) mod tests {
 
         let err = reg.dispatch("guarded", Value::Null).await.unwrap_err();
         assert!(
-            matches!(err, RuntimeError::PermissionDenied { ref verb, ref reason } if verb == "guarded" && reason.contains("always deny")),
+            matches!(err, RuntimeError::PermissionDenied { ref verb, ref reason, .. } if verb == "guarded" && reason.contains("always deny")),
             "expected PermissionDenied with verb=guarded and reason, got: {err:?}"
         );
         assert_eq!(
@@ -8825,7 +8950,7 @@ pub(crate) mod tests {
             .expect_err("denied absent-id update must not resolve the id");
 
         let denial = |error: RuntimeError| match error {
-            RuntimeError::PermissionDenied { verb, reason } => (verb, reason),
+            RuntimeError::PermissionDenied { verb, reason, .. } => (verb, reason),
             other => panic!("expected gate refusal, got {other:?}"),
         };
         let present_denial = denial(present_error);

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -1073,15 +1073,12 @@ impl KhiveRuntime {
                 Ok(NamespaceToken::mint_authorized(ns, actor))
             }
             Ok(khive_gate::GateDecision::Deny { reason }) => {
-                Err(crate::RuntimeError::PermissionDenied {
-                    verb: "authorize".to_string(),
-                    reason,
-                })
+                Err(crate::RuntimeError::permission_denied("authorize", reason))
             }
-            Ok(_) => Err(crate::RuntimeError::PermissionDenied {
-                verb: "authorize".to_string(),
-                reason: "gate denied".to_string(),
-            }),
+            Ok(_) => Err(crate::RuntimeError::permission_denied(
+                "authorize",
+                "gate denied",
+            )),
             Err(e) => {
                 tracing::warn!(
                     namespace = %ns.as_str(),
@@ -1149,22 +1146,19 @@ impl KhiveRuntime {
                     match self.config.gate.check(&extra_req) {
                         Ok(ref extra_decision) if extra_decision.is_allow() => {}
                         Ok(khive_gate::GateDecision::Deny { reason }) => {
-                            return Err(crate::RuntimeError::PermissionDenied {
-                                verb: "authorize".to_string(),
-                                reason: format!(
+                            return Err(crate::RuntimeError::permission_denied(
+                                "authorize",
+                                format!(
                                     "visibility namespace {:?} denied: {reason}",
                                     extra.as_str()
                                 ),
-                            });
+                            ));
                         }
                         Ok(_) => {
-                            return Err(crate::RuntimeError::PermissionDenied {
-                                verb: "authorize".to_string(),
-                                reason: format!(
-                                    "visibility namespace {:?} denied by gate",
-                                    extra.as_str()
-                                ),
-                            });
+                            return Err(crate::RuntimeError::permission_denied(
+                                "authorize",
+                                format!("visibility namespace {:?} denied by gate", extra.as_str()),
+                            ));
                         }
                         Err(e) => {
                             tracing::warn!(
@@ -1186,15 +1180,12 @@ impl KhiveRuntime {
                 ))
             }
             Ok(khive_gate::GateDecision::Deny { reason }) => {
-                Err(crate::RuntimeError::PermissionDenied {
-                    verb: "authorize".to_string(),
-                    reason,
-                })
+                Err(crate::RuntimeError::permission_denied("authorize", reason))
             }
-            Ok(_) => Err(crate::RuntimeError::PermissionDenied {
-                verb: "authorize".to_string(),
-                reason: "gate denied".to_string(),
-            }),
+            Ok(_) => Err(crate::RuntimeError::permission_denied(
+                "authorize",
+                "gate denied",
+            )),
             Err(e) => {
                 tracing::warn!(
                     namespace = %primary.as_str(),


### PR DESCRIPTION
## Summary

A denied dispatch returned `PermissionDenied` with the verb and the deny reason, while its `GateDenied` audit row was appended on the side with the result discarded. A caller that wanted to cite the refusal had nothing to cite.

`PermissionDenied` now carries a boxed receipt: `audit_event_id`, the id of the audit row when it committed, and `audit_outcome`, which says whether that row exists (`committed`, `not_committed:<audit wire code>`, `no_store` when the registry has no event store, `not_audited` for the refusals that never write a row). Both dispatch paths append the row through one helper and wait for its commit before returning the refusal. On the wire the `runtime_error` envelope keeps its message and gains `code`, `verb`, `reason`, `audit_event_id` and `audit_outcome`.

## Verification

- khive-runtime: a denied dispatch with a memory store returns the id of a row the store holds (outcome Denied, kind Audit); without a store the outcome is `no_store`; with a store that rejects appends the refusal still returns and names no row; the intercepted path commits its row and the receipt names it.
- khive-mcp: the projection carries the receipt beside the unchanged denial text; the coordinator's existing denial-shape test still passes.
- Pre-commit: fmt and clippy (workspace, all targets, `-D warnings`) at commit time.
