### PR TITLE
test(runtime): the denial-receipt tests join the config-ledger serial group

### DIFF
--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -6248,6 +6248,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(config_ledger)]
     async fn denied_dispatch_returns_the_id_of_its_committed_gate_denied_row() {
         let gate = Arc::new(CountingGate {
             calls: AtomicUsize::new(0),
@@ -6282,6 +6283,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(config_ledger)]
     async fn denied_dispatch_without_an_event_store_reports_no_store() {
         let gate = Arc::new(CountingGate {
             calls: AtomicUsize::new(0),


### PR DESCRIPTION
## Summary

The two tests added with the gate-denial receipt build an event-backed registry, which drains the process-wide config ledger at dispatch, so they belong to the ledger's serial group like every other fixture that reaches it. The census test that enforces the group named them; they now carry the attribute.

## Verification

- khive-runtime: `event_store_test_fixtures_are_config_ledger_serialized` passes with the two tests in the group; the denial-receipt tests still pass.
- Pre-commit: fmt and clippy (workspace, all targets, `-D warnings`) at commit time.
