### PR TITLE
fix(db): serialize atomic units on the in-memory pool

### DIFF
--- a/crates/khive-db/src/sql_bridge.rs
+++ b/crates/khive-db/src/sql_bridge.rs
@@ -1155,6 +1155,22 @@ async fn acquire_reader_handle_slot(
     result
 }
 
+/// Serialize whole units on the one shared in-memory connection. Event-store
+/// transactions participate in the same budget as raw SQL atomic units.
+/// The permit must outlive the unit's final COMMIT or ROLLBACK.
+pub(crate) async fn acquire_in_memory_write_unit(
+    pool: &ConnectionPool,
+    operation: &'static str,
+) -> Result<OwnedSemaphorePermit, StorageError> {
+    acquire_handle_slot(
+        pool.sql_bridge_writer_slots(),
+        pool.config().checkout_timeout,
+        operation,
+        SlotTimeoutClass::Admission,
+    )
+    .await
+}
+
 async fn acquire_handle_slot(
     slots: Arc<Semaphore>,
     timeout: std::time::Duration,
@@ -3468,9 +3484,11 @@ impl khive_storage::SqlAccess for SqlBridge {
             };
             run_manual_atomic_unit(&mut writer, op, self.pool.origin()).await
         } else {
-            // In-memory pools are exempt (not accept-loop reachable, per the
-            // rework spec's "Out of scope") — preserve the existing
-            // pool-backed manual-transaction behavior.
+            // In-memory units share one SQLite connection. Keep the pool-wide
+            // unit slot across BEGIN, awaited statements, and COMMIT/ROLLBACK;
+            // PoolBackedWriter's per-statement writer guard is a separate lock.
+            let _unit_slot =
+                acquire_in_memory_write_unit(&self.pool, "sql_bridge.atomic_unit_handle").await?;
             let mut writer = PoolBackedWriter {
                 pool: Arc::clone(&self.pool),
             };
@@ -3485,6 +3503,180 @@ mod tests {
     use crate::pool::PoolConfig;
     use khive_storage::types::{SqlStatement, SqlValue};
     use khive_storage::{SqlAccess as _, SqlReader as _};
+
+    #[tokio::test]
+    async fn in_memory_atomic_units_serialize_across_bridges() {
+        let pool = Arc::new(
+            ConnectionPool::new(PoolConfig {
+                path: None,
+                write_queue_enabled: Some(false),
+                ..PoolConfig::default()
+            })
+            .unwrap(),
+        );
+        pool.writer()
+            .unwrap()
+            .conn()
+            .execute_batch("CREATE TABLE atomic_in_memory (id INTEGER PRIMARY KEY)")
+            .unwrap();
+
+        let ready = Arc::new(tokio::sync::Barrier::new(8));
+        let mut jobs = Vec::new();
+        for unit in 0..8_i64 {
+            let pool = Arc::clone(&pool);
+            let ready = Arc::clone(&ready);
+            jobs.push(tokio::spawn(async move {
+                // Separate bridges must share the pool's transaction budget.
+                let bridge = SqlBridge::new(pool, false);
+                ready.wait().await;
+                let op: AtomicUnitOp = Box::new(move |writer| {
+                    Box::pin(async move {
+                        for row in 0..2 {
+                            writer
+                                .execute(SqlStatement {
+                                    sql: "INSERT INTO atomic_in_memory (id) VALUES (?1)".into(),
+                                    params: vec![SqlValue::Integer(unit * 2 + row)],
+                                    label: None,
+                                })
+                                .await?;
+                            if row == 0 {
+                                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                            }
+                        }
+                        Ok(Box::new(()) as Box<dyn std::any::Any + Send>)
+                    })
+                });
+                bridge.atomic_unit(op).await.map(|_| ())
+            }));
+        }
+        let mut errors = Vec::new();
+        for job in jobs {
+            if let Err(error) = job.await.unwrap() {
+                errors.push(error.to_string());
+            }
+        }
+        assert!(
+            errors.is_empty(),
+            "atomic units failed: {}",
+            errors.join("; ")
+        );
+        let count: i64 = pool
+            .writer()
+            .unwrap()
+            .conn()
+            .query_row("SELECT COUNT(*) FROM atomic_in_memory", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(count, 16, "all eight two-row units must commit");
+    }
+
+    #[tokio::test]
+    async fn in_memory_atomic_unit_serializes_with_event_writes() {
+        use khive_storage::EventStore as _;
+
+        // Each ordinary event entry point opens a transaction through with_writer.
+        for mode in 0..3 {
+            let pool = Arc::new(
+                ConnectionPool::new(PoolConfig {
+                    path: None,
+                    write_queue_enabled: Some(false),
+                    ..PoolConfig::default()
+                })
+                .unwrap(),
+            );
+            {
+                let writer = pool.writer().unwrap();
+                crate::stores::event::ensure_events_schema(writer.conn()).unwrap();
+                writer
+                    .conn()
+                    .execute_batch("CREATE TABLE atomic_event_overlap (id INTEGER PRIMARY KEY)")
+                    .unwrap();
+            }
+            let (entered, in_unit) = tokio::sync::oneshot::channel();
+            let (release, released) = tokio::sync::oneshot::channel();
+            let bridge = SqlBridge::new(Arc::clone(&pool), false);
+            let unit = tokio::spawn(async move {
+                let op: AtomicUnitOp = Box::new(move |writer| {
+                    Box::pin(async move {
+                        writer
+                            .execute(SqlStatement {
+                                sql: "INSERT INTO atomic_event_overlap VALUES (1)".into(),
+                                params: vec![],
+                                label: None,
+                            })
+                            .await?;
+                        entered.send(()).unwrap();
+                        released.await.unwrap();
+                        writer
+                            .execute(SqlStatement {
+                                sql: "INSERT INTO atomic_event_overlap VALUES (2)".into(),
+                                params: vec![],
+                                label: None,
+                            })
+                            .await?;
+                        Ok(Box::new(()) as Box<dyn std::any::Any + Send>)
+                    })
+                });
+                bridge.atomic_unit(op).await.map(|_| ())
+            });
+            in_unit.await.unwrap();
+            let store = Arc::new(crate::stores::event::SqlEventStore::new_scoped(
+                Arc::clone(&pool),
+                false,
+                "atomic-event",
+            ));
+            let event = khive_storage::event::Event::new(
+                "atomic-event",
+                "search",
+                khive_types::EventKind::SearchExecuted,
+                khive_types::SubstrateKind::Note,
+                "agent:test",
+            )
+            .with_payload(serde_json::json!({"result_kind": "note"}));
+            let event_id = event.id;
+            let event_store = Arc::clone(&store);
+            let mut event_job = tokio::spawn(async move {
+                match mode {
+                    0 => event_store.append_event(event).await,
+                    1 => event_store.append_events(vec![event]).await.map(|_| ()),
+                    _ => event_store
+                        .append_events_idempotent(vec![event])
+                        .await
+                        .map(|_| ()),
+                }
+            });
+            let early =
+                tokio::time::timeout(std::time::Duration::from_millis(20), &mut event_job).await;
+            let finished_inside_unit = early.is_ok();
+            // Release and join both tasks before asserting, including in the RED control.
+            release.send(()).unwrap();
+            unit.await.unwrap().expect("atomic unit commits both rows");
+            let event_result = match early {
+                Ok(joined) => joined,
+                Err(_) => event_job.await,
+            }
+            .expect("event task joins");
+            assert!(
+                event_result.is_ok(),
+                "event write mode {mode} overlapped the atomic transaction: {event_result:?}"
+            );
+            assert!(
+                !finished_inside_unit,
+                "event write mode {mode} must wait until the atomic unit ends"
+            );
+            assert!(store.get_event(event_id).await.unwrap().is_some());
+            let rows: i64 = pool
+                .writer()
+                .unwrap()
+                .conn()
+                .query_row("SELECT COUNT(*) FROM atomic_event_overlap", [], |row| {
+                    row.get(0)
+                })
+                .unwrap();
+            assert_eq!(rows, 2);
+        }
+    }
 
     fn database_tx_view(pool: &ConnectionPool) -> khive_storage::tx_registry::TxOriginFilter {
         match pool.origin() {

--- a/crates/khive-db/src/stores/event.rs
+++ b/crates/khive-db/src/stores/event.rs
@@ -119,8 +119,13 @@ impl SqlEventStore {
             .await
             .map_err(|e| StorageError::driver(StorageCapability::Events, op, e))?
         } else {
+            // Atomic SQL units release the connection guard between statements;
+            // share their unit budget so this transaction cannot overlap one.
+            let unit_slot = crate::sql_bridge::acquire_in_memory_write_unit(&self.pool, op).await?;
             let pool = Arc::clone(&self.pool);
             tokio::task::spawn_blocking(move || {
+                // Cancellation of the caller must not release the slot before this job ends.
+                let _unit_slot = unit_slot;
                 let guard = pool.try_writer().map_err(|e| map_sqlite_err(e, op))?;
                 f(guard.conn()).map_err(|e| map_err(e, op))
             })

--- a/python/tests/test_stream_integration.py
+++ b/python/tests/test_stream_integration.py
@@ -85,7 +85,7 @@ def test_stream_python_cli_same_result_and_error_objects(scratch_daemon):
     ]:
         ops = encode([op(verb, **args)])
         expected = client.request(ops)[0]
-        proc = subprocess.run([binary, "exec", ops, "--config", str(scratch_daemon["root"] / "khive.toml"), "--db", str(scratch_daemon["root"] / "scratch.db"), "--presentation", "verbose", "--format", "json"], env=env, cwd=scratch_daemon["root"], capture_output=True, text=True, timeout=60)
+        proc = subprocess.run([binary, "exec", ops, "--config", str(scratch_daemon["root"] / "khive.toml"), "--db", str(scratch_daemon["root"] / "scratch.db"), "--presentation", "verbose", "--output-format", "json"], env=env, cwd=scratch_daemon["root"], capture_output=True, text=True, timeout=60)
         envelope = json.loads(proc.stdout)
         actual = envelope["results"][0]
         assert actual["ok"] == expected["ok"], (actual, expected, proc.stderr)


### PR DESCRIPTION
## Summary

On an in-memory pool, an atomic unit ran `BEGIN IMMEDIATE`, its statements, and `COMMIT` through the pool-backed writer, which takes and releases the single pooled connection per statement. Two units running at once interleaved on that connection, the second `BEGIN` failed with `cannot start a transaction within a transaction`, and a parallel batch of `stream.append` rows to one stream lost two of three appends (the chained form passed, because chains run one at a time).

The in-memory arm now holds the pool-wide one-permit unit budget, the same permit the file-backed standalone-writer arm already takes, across `BEGIN`, the awaited statements, and `COMMIT` or `ROLLBACK`, so concurrent units queue. In-memory event-store writes open their own transaction on the same connection, so they take the same permit for the duration of their blocking job. The file-backed paths are unchanged.

## Verification

- khive-db: eight concurrent two-row units on one in-memory pool all commit (sixteen rows); an event append issued while a unit is open waits for the unit to end, for each of the three append entry points. Removing either slot acquisition reproduces the nested-transaction failure; restoring the exact bytes turns both green.
- khive-mcp: the stream contract's parallel array case is green; the integration suite runs whole.
- Python client: the stream integration tests run against the kkernel built from this checkout. The CLI twin had been passing `--format json` to `kkernel exec`, which the binary rejects (the flag is `--output-format`), so it failed on an empty document before comparing anything; it now passes the defined flag and compares the CLI result and error objects against the socket client's.
- Pre-commit: fmt and clippy (workspace, all targets, `-D warnings`) at commit time.
