### PR TITLE
fix(runtime): a bound actor reads its own namespace on any identity path

### DIFF
--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -9882,10 +9882,25 @@ mod tests {
             );
             assert_eq!(identity["unattributed"], actor_id.is_none());
             assert_eq!(identity["namespace"], "local");
+            // A replay reads exactly what its verified actor reads on every
+            // other path: `local` plus the actor's own namespace (ADR-007 Rev 4
+            // Rule 3b, folded where the token is minted), and nothing from the
+            // daemon's configured visibility. An anonymous replay keeps `local`.
+            let expected = match actor_id {
+                Some(actor) => json!(["local", actor]),
+                None => json!(["local"]),
+            };
             assert_eq!(
                 identity["visible_namespaces"],
-                json!(["local"]),
-                "replay must inherit neither actor-derived nor daemon visibility: {identity}"
+                expected,
+                "replay inherits its own actor namespace and never the daemon's visibility: {identity}"
+            );
+            assert!(
+                !identity["visible_namespaces"]
+                    .as_array()
+                    .map(|v| v.iter().any(|ns| ns == "daemon-visible"))
+                    .unwrap_or(true),
+                "daemon visibility leaked into a scheduled replay: {identity}"
             );
         }
     }

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -4875,6 +4875,90 @@ mod tests {
         (registry, local_id_1, local_id_2, bench_id)
     }
 
+    /// A bound actor that remembers an episodic memory recalls it on the same
+    /// identity without naming a namespace: the actor namespace joins the
+    /// default read set where the token is minted (ADR-007 Rev 4 Rule 3b), so
+    /// the write scope of `memory.remember` and the read scope of
+    /// `memory.recall` agree for one identity. An anonymous caller keeps
+    /// exactly `local`, and an explicit `namespace=local` stays precise.
+    #[tokio::test]
+    #[serial(background_tasks)]
+    #[serial_test::serial(config_ledger)]
+    async fn bound_actor_recalls_its_episodic_memory_without_a_namespace_param() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(MemoryPack::new(rt.clone()));
+        let registry = builder.build().expect("registry");
+        let identity = || khive_runtime::RequestIdentity {
+            namespace: "local".to_string(),
+            actor_id: Some("lambda:probe".to_string()),
+            visible_namespaces: vec![],
+            ..Default::default()
+        };
+        let remembered = registry
+            .dispatch_with_identity(
+                "memory.remember",
+                json!({
+                    "content": "bound actor probe term episodic arm",
+                    "memory_type": "episodic",
+                    "tags": ["bound-actor-run"],
+                }),
+                Some(identity()),
+            )
+            .await
+            .expect("memory.remember as the bound actor");
+        let id = remembered["id"].as_str().expect("id").to_string();
+        let recall = json!({
+            "query": "bound actor probe term",
+            "tags": ["bound-actor-run"],
+            "limit": 10,
+        });
+        let has = |result: &Value| {
+            result
+                .as_array()
+                .map(|hits| hits.iter().any(|h| h["id"].as_str() == Some(id.as_str())))
+                .unwrap_or(false)
+        };
+
+        let mut result = Value::Null;
+        for _ in 0..300 {
+            result = registry
+                .dispatch_with_identity("memory.recall", recall.clone(), Some(identity()))
+                .await
+                .expect("memory.recall as the bound actor");
+            if has(&result) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        assert!(
+            has(&result),
+            "the bound actor must recall its own episodic memory with no namespace param: {result:?}"
+        );
+
+        // Controls run after the positive arm so the index is warm: an absence
+        // below is scope, not consistency.
+        let anonymous = registry
+            .dispatch("memory.recall", recall.clone())
+            .await
+            .expect("memory.recall anonymous");
+        assert!(
+            !has(&anonymous),
+            "an anonymous caller keeps exactly the local read set: {anonymous:?}"
+        );
+        let mut precise = recall.clone();
+        precise["namespace"] = json!("local");
+        let scoped = registry
+            .dispatch_with_identity("memory.recall", precise, Some(identity()))
+            .await
+            .expect("memory.recall namespace=local as the bound actor");
+        assert!(
+            !has(&scoped),
+            "an explicit namespace=local is a precise scope, never widened: {scoped:?}"
+        );
+    }
+
     /// With no override, recall uses exactly the caller token's visible namespaces.
     #[tokio::test]
     #[serial(background_tasks)]

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -29,12 +29,9 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{UnixListener, UnixStream};
 
 #[cfg(unix)]
-use khive_db::{run_checkpoint_task, CheckpointConfig, CheckpointLifecycleOwner, ConnectionPool};
-#[cfg(unix)]
-use khive_types::Namespace;
-
-#[cfg(unix)]
 use crate::pack::RequestIdentity;
+#[cfg(unix)]
+use khive_db::{run_checkpoint_task, CheckpointConfig, CheckpointLifecycleOwner, ConnectionPool};
 
 /// Maximum frame size accepted in either direction.
 pub const MAX_FRAME_BYTES: usize = 8 * 1024 * 1024;
@@ -437,9 +434,9 @@ pub struct DaemonRequestFrame {
     /// The client's resolved extra read-visibility namespaces (ADR-007 Rule
     /// 3b), carried on the frame so the warm daemon widens read scope to
     /// match the caller's own configuration rather than its own baked
-    /// `visible_namespaces` (ADR-096). At ingress, a valid non-`local`
-    /// `actor_id` is included if absent, matching config loading; an empty
-    /// list therefore still includes that actor in default reads. Explicit
+    /// `visible_namespaces` (ADR-096). A non-`local` `actor_id` joins default
+    /// reads where the registry mints the token (ADR-007 Rev 4 Rule 3b), so
+    /// an empty list still includes that actor in default reads. Explicit
     /// `namespace=` operations remain scoped to exactly that namespace.
     #[serde(default)]
     pub visible_namespaces: Vec<String>,
@@ -1429,18 +1426,13 @@ async fn handle_conn_with_shutdown<D: DaemonDispatch>(
         // `actor_id`/`visible_namespaces` the client resolved (defaulting to
         // `None`/`vec![]` for an older, field-absent payload, which is
         // exactly the prior anonymous/no-extra-visibility behavior).
-        let mut visible_namespaces = frame.visible_namespaces.clone();
-        if let Some(actor_id) = frame.actor_id.as_deref().filter(|actor_id| {
-            *actor_id != Namespace::LOCAL
-                && Namespace::parse(actor_id).is_ok()
-                && !visible_namespaces.iter().any(|ns| ns == *actor_id)
-        }) {
-            visible_namespaces.push(actor_id.to_string());
-        }
+        // The caller's actor namespace joins default reads where the registry
+        // mints the token (ADR-007 Rev 4 Rule 3b), the one seam every identity
+        // path shares; the frame's list is forwarded as sent.
         let identity = RequestIdentity {
             namespace: frame.namespace.clone(),
             actor_id: frame.actor_id.clone(),
-            visible_namespaces,
+            visible_namespaces: frame.visible_namespaces.clone(),
             process_ref: frame.process_ref.clone(),
             request_id: frame.request_id,
         };

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -2590,6 +2590,18 @@ impl VerbRegistry {
                     .collect(),
                 None => self.visible_namespaces.clone(),
             };
+            // ADR-007 Rev 4 Rule 3b, applied once at the seam every identity
+            // path shares: a non-`local` actor reads its own namespace by
+            // default (its episodic memories land there), whether the identity
+            // came from the config loader, a daemon frame, a scheduled replay
+            // or an embedding host. Writes stay pinned to `local` (Rule 0).
+            if let Some(actor_namespace) = resolved_actor
+                .binding_id()
+                .filter(|id| *id != Namespace::LOCAL)
+                .and_then(|id| Namespace::parse(id).ok())
+            {
+                extra_visible.push(actor_namespace);
+            }
             extra_visible.push(Namespace::local()); // 'local' always readable; mint dedups
             NamespaceToken::mint_with_visibility(primary, extra_visible, resolved_actor)
         }
@@ -6720,6 +6732,126 @@ pub(crate) mod tests {
             "gate request actor and storage token actor must carry the same id"
         );
         assert_eq!(gate_actor.id, "actor-alpha");
+    }
+
+    struct VisibilityCapturingPack {
+        visible: Arc<std::sync::Mutex<Vec<Vec<String>>>>,
+    }
+
+    impl Pack for VisibilityCapturingPack {
+        const NAME: &'static str = "alpha";
+        const NOTE_KINDS: &'static [&'static str] = &[];
+        const ENTITY_KINDS: &'static [&'static str] = &[];
+        const HANDLERS: &'static [HandlerDef] = AlphaPack::HANDLERS;
+    }
+
+    #[async_trait]
+    impl PackRuntime for VisibilityCapturingPack {
+        fn name(&self) -> &str {
+            Self::NAME
+        }
+        fn note_kinds(&self) -> &'static [&'static str] {
+            Self::NOTE_KINDS
+        }
+        fn entity_kinds(&self) -> &'static [&'static str] {
+            Self::ENTITY_KINDS
+        }
+        fn handlers(&self) -> &'static [HandlerDef] {
+            Self::HANDLERS
+        }
+        async fn dispatch(
+            &self,
+            verb: &str,
+            _params: Value,
+            _registry: &VerbRegistry,
+            token: &NamespaceToken,
+        ) -> Result<Value, RuntimeError> {
+            self.visible.lock().unwrap().push(
+                token
+                    .visible_namespace_strs()
+                    .into_iter()
+                    .map(str::to_string)
+                    .collect(),
+            );
+            Ok(serde_json::json!({ "pack": "alpha", "verb": verb }))
+        }
+    }
+
+    /// ADR-007 Rev 4 Rule 3b at the token seam: a per-request identity that
+    /// names a non-`local` actor reads that actor's namespace by default even
+    /// when its `visible_namespaces` list is empty, the actor appears once when
+    /// the list already names it, an anonymous identity keeps exactly `local`,
+    /// and an explicit `namespace=` stays a precise single-namespace scope.
+    #[tokio::test]
+    async fn dispatch_with_identity_folds_the_actor_namespace_into_default_reads() {
+        let visible = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(VisibilityCapturingPack {
+            visible: visible.clone(),
+        });
+        let reg = builder.build().expect("registry builds");
+        let identity = |actor: Option<&str>, listed: &[&str]| RequestIdentity {
+            namespace: "local".to_string(),
+            actor_id: actor.map(str::to_string),
+            visible_namespaces: listed.iter().map(|ns| ns.to_string()).collect(),
+            ..Default::default()
+        };
+
+        reg.dispatch_with_identity(
+            "list",
+            Value::Null,
+            Some(identity(Some("lambda:probe"), &[])),
+        )
+        .await
+        .unwrap();
+        reg.dispatch_with_identity(
+            "list",
+            Value::Null,
+            Some(identity(Some("lambda:probe"), &["lambda:probe"])),
+        )
+        .await
+        .unwrap();
+        reg.dispatch_with_identity("list", Value::Null, Some(identity(None, &[])))
+            .await
+            .unwrap();
+        reg.dispatch_with_identity(
+            "list",
+            serde_json::json!({"namespace": "lambda:probe"}),
+            Some(identity(Some("lambda:probe"), &[])),
+        )
+        .await
+        .unwrap();
+
+        let captured = visible.lock().unwrap();
+        let count = |set: &Vec<String>, ns: &str| set.iter().filter(|s| s.as_str() == ns).count();
+        assert_eq!(
+            count(&captured[0], "lambda:probe"),
+            1,
+            "empty list: {:?}",
+            captured[0]
+        );
+        assert_eq!(
+            count(&captured[0], "local"),
+            1,
+            "empty list: {:?}",
+            captured[0]
+        );
+        assert_eq!(
+            count(&captured[1], "lambda:probe"),
+            1,
+            "listed once: {:?}",
+            captured[1]
+        );
+        assert_eq!(
+            captured[2],
+            vec!["local".to_string()],
+            "anonymous keeps exactly local"
+        );
+        assert_eq!(
+            captured[3],
+            vec!["lambda:probe".to_string()],
+            "explicit namespace is a precise scope, never widened"
+        );
     }
 
     /// Same identity check with no configured `actor_id`: both the gate and

--- a/docs/adr/ADR-007-namespace.md
+++ b/docs/adr/ADR-007-namespace.md
@@ -455,6 +455,9 @@ keeps Rev 3 behavior verbatim.
 Daemon request ingress applies the same fold once to forwarded visibility, adding the
 unmodified actor id only when it parses as a non-`'local'` namespace and is not already
 present, without changing explicit `namespace=` scope or replayed token identities.
+Since 2026-09-09 that fold lives where the registry mints the request token, the one seam every
+identity path shares (config load, a daemon frame, a scheduled replay, an embedding host); daemon
+ingress forwards the frame's visibility list as sent, and the outcome is unchanged for it.
 
 The scope applies to all multi-record reads for all packs: list, search, recall, neighbors,
 traverse, query. The runtime supplies the set to the store as a `WHERE namespace IN (...)`


### PR DESCRIPTION
## Summary

A bound actor's `memory.remember` (episodic) lands in the actor's namespace, while `memory.recall` on the same identity read only the token's visible set. The config loader folds the actor into that set at load time and daemon ingress did the same for forwarded frames, but an identity minted anywhere else (a scheduled replay, an embedding host) read exactly `local`, so a caller could remember and then fail to recall its own memory without naming a namespace.

The fold now happens once where the registry mints the request token, the seam every identity path shares: a non-`local` actor's namespace joins the default read set, deduplicated; writes stay pinned to `local`; an explicit `namespace=` remains a precise scope; an anonymous identity keeps exactly `local`. Daemon ingress forwards the frame's visibility list as sent. ADR-007 gains a dated sentence under Rule 3b.

One existing expectation changes: the scheduled-replay identity test pinned a verified actor's visible set to exactly `local`. A replay now reads what its actor reads on every other path, `local` plus the actor's own namespace, and the test keeps asserting that nothing from the daemon's configured visibility reaches it.

## Verification

- New `khive-runtime` test at the seam: an empty list folds the actor once, a list already naming it stays deduplicated, anonymous keeps exactly `local`, explicit `namespace=` is not widened.
- New `khive-pack-memory` test: the bound actor remembers episodic and recalls it with no namespace param; controls after the positive arm: anonymous recall and `namespace=local` recall do not see it.
- Mutation control: disabling the fold at the seam reddens the memory test; restore byte-identical.
- `cargo test -p khive-runtime --lib` (identity, seam, config-ledger census), `-p khive-pack-memory` whole (340), `-p khive-mcp` whole (daemon wire round trip through the seam), `-p kkernel` whole; pre-commit fmt and clippy at each commit.
