### PR TITLE
ci: stop a third-party apt index failure from reddening the run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,23 @@ jobs:
       - name: Install khive-contract scan dependency (Linux)
         if: env.CI_SUITE == 'full' && matrix.shard == 1 && runner.os == 'Linux'
         run: |
+          # The runner image carries third-party apt lists this job needs
+          # nothing from, and `apt-get update` exits 100 when any one of them
+          # serves a bad index. Google's chrome list did exactly that on
+          # 2026-09-09 (Hash Sum mismatch) and reddened every full-suite
+          # shard. ripgrep comes from the Ubuntu archive, so disable that list
+          # instead of retrying into the same mismatch. apt reads only .list
+          # and .sources files, so a renamed copy is inert, and the Ubuntu
+          # archive itself lives in ubuntu.sources and is untouched. A different
+          # third-party list failing this way needs its own line here, by
+          # name: this is deliberately not a blanket sweep of the directory.
+          for f in /etc/apt/sources.list.d/google-chrome.list \
+                   /etc/apt/sources.list.d/google-chrome.sources; do
+            if [ -e "$f" ]; then sudo mv "$f" "$f.disabled"; fi
+          done
+          # Print what still points at the chrome repo: empty is the pass, a
+          # non-empty line says the rename missed a filename this does not know.
+          sudo grep -rl 'dl[.]google[.]com/linux/chrome' /etc/apt/ || true
           sudo apt-get update
           sudo apt-get install --yes ripgrep
           rg --version
@@ -347,6 +364,20 @@ jobs:
         run: |
           printf 'Acquire::http::Timeout "30";\nAcquire::https::Timeout "30";\nAcquire::Retries "3";\nDPkg::Lock::Timeout "120";\n' \
             | sudo tee /etc/apt/apt.conf.d/99-download-timeouts
+          # The timeouts above bound a stalled mirror. They do not bound a
+          # mirror that answers promptly with a bad index: that fails
+          # `apt-get update` for the whole run, and the retry on the
+          # dependency step re-reads the same index, so the retry cannot
+          # clear it. The browser OS dependencies come from the Ubuntu
+          # archive and Playwright ships its own chromium build, so nothing
+          # in this job needs Google's chrome list.
+          for f in /etc/apt/sources.list.d/google-chrome.list \
+                   /etc/apt/sources.list.d/google-chrome.sources; do
+            if [ -e "$f" ]; then sudo mv "$f" "$f.disabled"; fi
+          done
+          # Print what still points at the chrome repo: empty is the pass, a
+          # non-empty line says the rename missed a filename this does not know.
+          sudo grep -rl 'dl[.]google[.]com/linux/chrome' /etc/apt/ || true
       - name: Cache Playwright browsers
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## What broke

`apt-get update` exits 100 when **any** configured list serves a bad index, whether or not
the job installs anything from it. On 2026-09-09 the runner image's Google chrome list
answered with a Hash Sum mismatch:

```
Err:24 https://dl.google.com/linux/chrome-stable/deb stable/main amd64 Packages
  Hash Sum mismatch
E: Failed to fetch .../chrome-stable/deb/dists/stable/main/binary-amd64/Packages.gz
E: Some index files failed to download.
##[error]Process completed with exit code 100.
```

Two steps died on it, on every branch that ran while the mismatch was live:

- `Install khive-contract scan dependency (Linux)` in every full-suite Linux shard
- `Install browser OS dependencies` in the editor job

## Fix

Neither step needs that repository. ripgrep comes from the Ubuntu archive; Playwright
downloads its own chromium build and `install-deps` pulls OS libraries from the Ubuntu
archive. Both paths now rename the chrome list aside before `apt-get update`.

- apt reads only `.list` and `.sources`, so the renamed file is inert. The Ubuntu archive
  lives in `ubuntu.sources` and is untouched, which is why this is a rename by name and
  not a sweep of `sources.list.d`.
- Both filename spellings are handled, since the noble images have moved some lists to the
  deb822 `.sources` form.
- Each site then prints any file still pointing at that repository. Empty is the pass; a
  non-empty line says the rename missed a name this does not know about, in the log rather
  than silently.

## Why not just retry

The dependency step already retries. The retry re-reads the same index seconds later, so it
cannot clear a bad index; it only doubles the time before the same failure. Nothing about
this class is bounded by the download timeouts either, which bound a *stalled* mirror, not
one that answers promptly with the wrong bytes.

## Verification

- `python3 -m unittest discover -s scripts/tests -p test_ci_workflows.py` — 35 tests, OK.
- The workflow parses (`yaml.safe_load`, 18 jobs).
- The absent-file path was exercised locally: the loop form exits 0 under `set -e` when
  neither file exists, which is the ordinary case once the runner image drops the list.

The real proof is this PR's own Linux shards reaching `rg --version`, which is what to read
before merging.
