### PR TITLE
test(kg-editor): await the settled state in the alias-canonicalizing case

### DIFF
--- a/apps/kg-editor/src/components/showcase/showcase.test.tsx
+++ b/apps/kg-editor/src/components/showcase/showcase.test.tsx
@@ -237,14 +237,21 @@ describe("materialized repository lookup", () => {
         pool.source_path,
       )
     );
-    expect(container.querySelector('[data-view-id="dependency_topology"]'))
-      .toHaveAttribute("aria-current", "page");
-    expect(new URL(window.location.href).searchParams.get("repo")).toBe(
-      bundle.meta.repository.canonical_url,
-    );
-    expect(new URL(window.location.href).searchParams.get("module")).toBe(
-      pool.source_path,
-    );
+    // The inspector heading and the view selection settle on separate passes,
+    // so awaiting the heading does not order this. Read live: on a loaded
+    // machine the heading arrives first and aria-current is still null. The
+    // three read together because they are one settled state, and a member
+    // that never arrives still fails the block.
+    await waitFor(() => {
+      expect(container.querySelector('[data-view-id="dependency_topology"]'))
+        .toHaveAttribute("aria-current", "page");
+      expect(new URL(window.location.href).searchParams.get("repo")).toBe(
+        bundle.meta.repository.canonical_url,
+      );
+      expect(new URL(window.location.href).searchParams.get("module")).toBe(
+        pool.source_path,
+      );
+    });
   });
 
   it("sends the operator bearer token on catalog discovery and still merges dynamic entries", async () => {


### PR DESCRIPTION
## The failure

`showcase.test.tsx > materialized repository lookup > preserves a direct investigation while
canonicalizing a curated alias`, intermittently in CI:

```
Error: expect(element).toHaveAttribute("aria-current", "page")
Expected the element to have attribute: aria-current="page"
Received: null
 ❯ src/components/showcase/showcase.test.tsx:241:8
```

Observed on three separate PR heads today, including a documentation-only branch, and green on
two others off the same main. So it is not any branch's change.

## Why it happens

The case awaits the inspector heading, then reads three things synchronously: the current
view's `aria-current`, and the canonicalized `repo` and `module` search params. The heading and
the view selection settle on separate passes, so awaiting the heading imposes no order on the
rest. The received value is `null` rather than a wrong string, which is the element existing
and not yet being marked current.

## The change

Those three assertions move inside one `waitFor`. They are one settled state, and reading them
together keeps the case's meaning: a member that never arrives still fails the block.

## Verification, including what did not work

- The full editor suite passes on this branch.
- **The reproduction attempt failed.** Five rounds of the unpatched case under eight spinning
  load generators all passed, so the control never fired. This fix is therefore untested
  against the condition it names, and the honest status is that the mechanism is argued from
  the failure's own shape, not demonstrated.
- It cannot regress the case: `waitFor` with an already-true predicate returns on its first
  tick, which is what every local run does.

If the case fails again after this lands, the next thing to read is whether `aria-current` ever
becomes `page` at all under that load, because that would move the defect from the test into
the view selection.
