### PR TITLE
ci: fail the infra-retry job when it declines to retry

### DIFF
--- a/.github/workflows/ci-infra-retry.yml
+++ b/.github/workflows/ci-infra-retry.yml
@@ -5,6 +5,10 @@ name: CI infra retry
 # failures are deliberately excluded: a green retry must not hide a flake.
 # If matrix fail-fast cancelled a sibling, rerun the whole workflow so that
 # cancellation cannot leave main red after the failed job recovers.
+# A declined retry fails this job. This workflow only runs after a failed CI
+# attempt, so a green check here would sit beside a red CI on the same commit
+# and read as a pass to anyone scanning the check list; a red one names the
+# failed jobs and the reason no retry was made.
 on:
   workflow_run:
     workflows: [CI]
@@ -132,7 +136,9 @@ jobs:
               echo "Run ${RUN_ID} had ${failed_count} failed leaf job(s), ${infra_count} setup-only leaf failure(s), ${gate_infra_count}/${gate_failed_count} setup-only CI gate failure(s), and ${cancelled_count} cancelled leaf job(s)."
               echo "Failed jobs: ${failed_names:-none}."
             } >> "$GITHUB_STEP_SUMMARY"
-            exit 0
+            echo "No automatic retry: ${failed_count} failed leaf job(s), ${infra_count} setup-only. Failed jobs: ${failed_names:-none}."
+            echo "CI stays red on this commit; this job fails so the check list says so."
+            exit 1
           fi
 
           if [ "$cancelled_count" -eq 0 ]; then


### PR DESCRIPTION
The infra-retry workflow runs only after a CI attempt on main concluded failure. When it declines to retry because a repository step failed, it exited 0, so the check list showed a green `CI infra retry` beside a red `CI` on the same commit. That green was read as a pass for several hours today while the contract suite was failing underneath.

A declined retry now exits 1, printing the failed job names and the counts that made the run ineligible. The eligible path (setup-only failures) is unchanged: it re-requests the run and the retried CI decides.

No pre-commit hook run on the commit: the workspace clippy lane was occupied; the change is a workflow file only.
