### PR TITLE
feat(exec): preserve symlinks in tree manifests

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2287,6 +2287,7 @@ dependencies = [
  "chrono",
  "clap",
  "inventory",
+ "khive-db",
  "khive-pack-blob",
  "khive-pack-exec",
  "khive-pack-kg",

--- a/crates/khive-pack-exec/src/capture.rs
+++ b/crates/khive-pack-exec/src/capture.rs
@@ -67,16 +67,27 @@ pub async fn drain<R: AsyncRead + Unpin>(mut reader: R, cap: u64) -> Tail {
     tail
 }
 
-/// A regular file found in the run directory after the run.
+/// A regular file or symlink found in the run directory after the run.
 #[derive(Debug, Clone)]
 pub struct Found {
     pub abs: PathBuf,
     pub mode: u32,
 }
 
-/// Walk `root` without following symlinks. Symlinks are reported by relative
-/// path in `skipped` and never opened; directories are descended; anything
-/// else (sockets, fifos, devices) is skipped as well.
+impl Found {
+    pub fn read_content(&self) -> std::io::Result<Vec<u8>> {
+        if self.mode == 120000 {
+            Ok(std::fs::read_link(&self.abs)?
+                .into_os_string()
+                .into_encoded_bytes())
+        } else {
+            std::fs::read(&self.abs)
+        }
+    }
+}
+
+/// Walk `root` without following symlinks. Files and symlinks become entries;
+/// directories are descended; sockets, fifos and devices are reported in `skipped`.
 pub fn walk(root: &Path) -> std::io::Result<(BTreeMap<String, Found>, Vec<String>)> {
     let mut files = BTreeMap::new();
     let mut skipped = Vec::new();
@@ -100,7 +111,7 @@ pub fn walk(root: &Path) -> std::io::Result<(BTreeMap<String, Found>, Vec<String
             };
             let ft = meta.file_type();
             if ft.is_symlink() {
-                skipped.push(child_rel);
+                files.insert(child_rel, Found { abs, mode: 120000 });
                 continue;
             }
             if ft.is_dir() {
@@ -150,17 +161,75 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn walk_skips_symlinks() {
+    fn walk_captures_file_directory_and_dangling_symlinks_without_following() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("a"), b"1").unwrap();
         std::fs::create_dir(dir.path().join("sub")).unwrap();
         std::fs::write(dir.path().join("sub/b"), b"2").unwrap();
-        std::os::unix::fs::symlink("/etc/passwd", dir.path().join("escape")).unwrap();
+        for (name, target) in [
+            ("file-link", "a"),
+            ("dir-link", "sub"),
+            ("dangling-link", "missing"),
+            ("escape-link", "/etc/passwd"),
+        ] {
+            std::os::unix::fs::symlink(target, dir.path().join(name)).unwrap();
+        }
         let (files, skipped) = walk(dir.path()).unwrap();
         assert_eq!(
             files.keys().cloned().collect::<Vec<_>>(),
-            vec!["a", "sub/b"]
+            vec![
+                "a",
+                "dangling-link",
+                "dir-link",
+                "escape-link",
+                "file-link",
+                "sub/b"
+            ]
         );
-        assert_eq!(skipped, vec!["escape"]);
+        assert!(skipped.is_empty());
+        assert_eq!(files["a"].read_content().unwrap(), b"1");
+        assert_eq!(files["sub/b"].read_content().unwrap(), b"2");
+        for (name, target) in [
+            ("file-link", "a"),
+            ("dir-link", "sub"),
+            ("dangling-link", "missing"),
+            ("escape-link", "/etc/passwd"),
+        ] {
+            assert_eq!(files[name].mode, 120000);
+            assert_eq!(files[name].read_content().unwrap(), target.as_bytes());
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn walk_preserves_non_utf8_and_unnormalized_symlink_target_bytes() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = b"../missing//\xff/./target\n";
+        std::os::unix::fs::symlink(
+            std::ffi::OsString::from_vec(target.to_vec()),
+            dir.path().join("link"),
+        )
+        .unwrap();
+        let (files, skipped) = walk(dir.path()).unwrap();
+        assert!(skipped.is_empty());
+        assert_eq!(files["link"].mode, 120000);
+        assert_eq!(files["link"].read_content().unwrap(), target);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn walk_still_skips_sockets_and_fifos() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let _socket = std::os::unix::net::UnixListener::bind(dir.path().join("socket")).unwrap();
+        let fifo = std::ffi::CString::new(dir.path().join("fifo").as_os_str().as_bytes()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(fifo.as_ptr(), 0o600) }, 0);
+        let (files, mut skipped) = walk(dir.path()).unwrap();
+        assert!(files.is_empty());
+        skipped.sort();
+        assert_eq!(skipped, vec!["fifo", "socket"]);
     }
 }

--- a/crates/khive-pack-exec/src/handlers.rs
+++ b/crates/khive-pack-exec/src/handlers.rs
@@ -658,9 +658,23 @@ fn materialize(
     entries: &[TreeEntry],
     bytes: &BTreeMap<String, Vec<u8>>,
 ) -> std::io::Result<()> {
+    std::fs::create_dir(run_dir)?;
+    let result = materialize_entries(run_dir, entries, bytes);
+    if result.is_err() {
+        // Remove only the fresh root we own, never a pre-existing root whose
+        // create_dir failed. A partial input tree is not a keepable run.
+        let _ = std::fs::remove_dir_all(run_dir);
+    }
+    result
+}
+
+fn materialize_entries(
+    run_dir: &Path,
+    entries: &[TreeEntry],
+    bytes: &BTreeMap<String, Vec<u8>>,
+) -> std::io::Result<()> {
     use std::io::Write;
 
-    std::fs::create_dir(run_dir)?;
     // Populate directories and files before creating any links. Filesystem aliases
     // (including case-insensitive names) must not redirect a later materialization write.
     for entry in entries {
@@ -770,9 +784,13 @@ async fn execute(
         RuntimeError::Unconfigured(format!("exec root {}: {e}", cfg.root.display()))
     })?;
     let run_dir = root.join(&receipt.id);
-    materialize(&run_dir, &ready.entries, &bytes).map_err(|e| {
-        RuntimeError::Unconfigured(format!("materialize {}: {e}", run_dir.display()))
-    })?;
+    if let Err(error) = materialize(&run_dir, &ready.entries, &bytes) {
+        receipt.success = false;
+        receipt.reason = Some(format!("materialize {}: {error}", run_dir.display()));
+        receipt.finished_at = Some(receipts::now_micros());
+        // No profile or child exists yet. Return through run's receipt insertion.
+        return Ok(());
+    }
     receipts::event(
         rt,
         ns,
@@ -1199,22 +1217,23 @@ mod tests {
             let root = dir.path().join("run");
             let result = materialize(&root, &entries, &bytes);
             assert_eq!(std::fs::read(&sentinel).unwrap(), b"unchanged");
-            let aliases = std::fs::symlink_metadata(root.join("A"))
-                .unwrap()
-                .file_type();
-            if aliases.is_symlink() {
-                // A case-sensitive filesystem can represent both distinct paths safely.
-                result.unwrap();
-            } else {
-                assert_eq!(
-                    result.unwrap_err().kind(),
-                    std::io::ErrorKind::AlreadyExists
-                );
+            match result {
+                Ok(()) => {
+                    // A case-sensitive filesystem can represent both paths safely.
+                    assert!(std::fs::symlink_metadata(root.join("A"))
+                        .unwrap()
+                        .file_type()
+                        .is_symlink());
+                    assert_eq!(
+                        std::fs::read(root.join(if descendant { "a/child" } else { "a" })).unwrap(),
+                        b"replacement"
+                    );
+                }
+                Err(error) => {
+                    assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+                    assert!(!root.exists(), "the partial input tree must be removed");
+                }
             }
-            assert_eq!(
-                std::fs::read(root.join(if descendant { "a/child" } else { "a" })).unwrap(),
-                b"replacement"
-            );
         }
     }
 

--- a/crates/khive-pack-exec/src/handlers.rs
+++ b/crates/khive-pack-exec/src/handlers.rs
@@ -88,10 +88,10 @@ fn edit_mode(edit: &Value, index: usize) -> Result<Option<u64>, RuntimeError> {
             let mode = value.as_u64().ok_or_else(|| {
                 RuntimeError::InvalidInput(format!("edits[{index}].mode must be an integer"))
             })?;
-            // Modes here are the decimal 644 and 755 the manifest stores, not octal literals.
-            if mode != 644 && mode != 755 {
+            // Manifest modes are decimal spellings, not octal permission literals.
+            if mode != 644 && mode != 755 && mode != 120000 {
                 return Err(RuntimeError::InvalidInput(format!(
-                    "edits[{index}].mode must be 644 or 755, got {mode}"
+                    "edits[{index}].mode must be 644, 755 or 120000, got {mode}"
                 )));
             }
             Ok(Some(mode))
@@ -656,22 +656,52 @@ fn materialize(
     entries: &[TreeEntry],
     bytes: &BTreeMap<String, Vec<u8>>,
 ) -> std::io::Result<()> {
-    std::fs::create_dir_all(run_dir)?;
+    use std::io::Write;
+
+    std::fs::create_dir(run_dir)?;
+    // Populate directories and files before creating any links. Filesystem aliases
+    // (including case-insensitive names) must not redirect a later materialization write.
     for entry in entries {
         let target = run_dir.join(&entry.path);
         if let Some(parent) = target.parent() {
             std::fs::create_dir_all(parent)?;
         }
+        if entry.mode == 120000 {
+            continue;
+        }
         let data = bytes
             .get(&entry.content_ref)
             .map(Vec::as_slice)
             .unwrap_or(&[]);
-        std::fs::write(&target, data)?;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&target)?;
+        file.write_all(data)?;
         let mode = if entry.mode == 755 { 0o755 } else { 0o644 };
         #[cfg(unix)]
-        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(mode))?;
+        file.set_permissions(std::fs::Permissions::from_mode(mode))?;
         #[cfg(not(unix))]
         let _ = mode;
+    }
+    for entry in entries.iter().filter(|entry| entry.mode == 120000) {
+        let data = bytes
+            .get(&entry.content_ref)
+            .map(Vec::as_slice)
+            .unwrap_or(&[]);
+        #[cfg(unix)]
+        {
+            use std::os::unix::ffi::OsStrExt;
+            std::os::unix::fs::symlink(
+                std::ffi::OsStr::from_bytes(data),
+                run_dir.join(&entry.path),
+            )?;
+        }
+        #[cfg(not(unix))]
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "symlink materialization requires a unix host",
+        ));
     }
     Ok(())
 }
@@ -953,7 +983,9 @@ async fn execute(
     let mut changes: Vec<Change> = Vec::new();
     let mut undeclared: BTreeSet<String> = BTreeSet::new();
     for (path, file) in &found {
-        let data = std::fs::read(&file.abs).unwrap_or_default();
+        let data = file
+            .read_content()
+            .map_err(|e| RuntimeError::Unconfigured(format!("capture entry {path:?}: {e}")))?;
         let digest = digest_hex(&data);
         match input.get(path.as_str()) {
             Some(old) if old.content_ref == digest && old.mode == file.mode => {
@@ -1068,4 +1100,122 @@ fn read_limit_report(reader: libc::c_int) -> Value {
     let mut text = String::new();
     let _ = file.read_to_string(&mut text);
     serde_json::from_str(&text).unwrap_or_else(|_| json!({}))
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::os::unix::ffi::OsStrExt;
+
+    #[test]
+    fn materialize_preserves_literal_symlink_targets() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("run");
+        let targets: &[(&str, &[u8])] = &[
+            ("inside", b"sub/../file"),
+            ("escape", b"../../x"),
+            ("absolute", b"/absolute/missing"),
+            ("non_utf8", b"target-\xff"),
+        ];
+        let mut entries = vec![TreeEntry {
+            path: "file".into(),
+            content_ref: digest_hex(b"content"),
+            mode: 644,
+        }];
+        let mut blobs = BTreeMap::from([(digest_hex(b"content"), b"content".to_vec())]);
+        for (path, target) in targets {
+            let content_ref = digest_hex(target);
+            entries.push(TreeEntry {
+                path: (*path).into(),
+                content_ref: content_ref.clone(),
+                mode: 120000,
+            });
+            blobs.insert(content_ref, target.to_vec());
+        }
+        materialize(&root, &entries, &blobs).unwrap();
+        assert_eq!(std::fs::read(root.join("file")).unwrap(), b"content");
+        for (path, expected) in targets {
+            let path = root.join(path);
+            assert!(std::fs::symlink_metadata(&path)
+                .unwrap()
+                .file_type()
+                .is_symlink());
+            assert_eq!(
+                std::fs::read_link(path).unwrap().as_os_str().as_bytes(),
+                *expected
+            );
+        }
+    }
+
+    #[test]
+    fn materialize_symlink_aliases_never_redirect_file_writes() {
+        for descendant in [false, true] {
+            let dir = tempfile::tempdir().unwrap();
+            let outside = dir.path().join("outside");
+            std::fs::create_dir(&outside).unwrap();
+            let sentinel = outside.join("child");
+            std::fs::write(&sentinel, b"unchanged").unwrap();
+            let link_target = if descendant {
+                outside.clone()
+            } else {
+                sentinel.clone()
+            };
+            let target = link_target.as_os_str().as_bytes().to_vec();
+            let link_ref = digest_hex(&target);
+            let file_ref = digest_hex(b"replacement");
+            let entries = vec![
+                TreeEntry {
+                    path: "A".into(),
+                    content_ref: link_ref.clone(),
+                    mode: 120000,
+                },
+                TreeEntry {
+                    path: if descendant { "a/child" } else { "a" }.into(),
+                    content_ref: file_ref.clone(),
+                    mode: 644,
+                },
+            ];
+            let bytes = BTreeMap::from([(link_ref, target), (file_ref, b"replacement".to_vec())]);
+            let root = dir.path().join("run");
+            let result = materialize(&root, &entries, &bytes);
+            assert_eq!(std::fs::read(&sentinel).unwrap(), b"unchanged");
+            let aliases = std::fs::symlink_metadata(root.join("A"))
+                .unwrap()
+                .file_type();
+            if aliases.is_symlink() {
+                // A case-sensitive filesystem can represent both distinct paths safely.
+                result.unwrap();
+            } else {
+                assert_eq!(
+                    result.unwrap_err().kind(),
+                    std::io::ErrorKind::AlreadyExists
+                );
+            }
+            assert_eq!(
+                std::fs::read(root.join(if descendant { "a/child" } else { "a" })).unwrap(),
+                b"replacement"
+            );
+        }
+    }
+
+    #[test]
+    fn materialize_refuses_an_existing_root_before_writes() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("run");
+        std::fs::create_dir(&root).unwrap();
+        let existing = root.join("file");
+        std::fs::write(&existing, b"unchanged").unwrap();
+        let content_ref = digest_hex(b"replacement");
+        let entries = vec![TreeEntry {
+            path: "file".into(),
+            content_ref: content_ref.clone(),
+            mode: 644,
+        }];
+        let bytes = BTreeMap::from([(content_ref, b"replacement".to_vec())]);
+        assert_eq!(
+            materialize(&root, &entries, &bytes).unwrap_err().kind(),
+            std::io::ErrorKind::AlreadyExists
+        );
+        assert_eq!(std::fs::read(existing).unwrap(), b"unchanged");
+    }
 }

--- a/crates/khive-pack-exec/src/handlers.rs
+++ b/crates/khive-pack-exec/src/handlers.rs
@@ -642,7 +642,9 @@ async fn preflight(
     tree::verify_blobs(rt, &entries)
         .await
         .map_err(|e| format!("tree: {e}"))?;
-    let cwd = tree::validate_cwd(&req.cwd).map_err(|e| e.to_string())?;
+    let cwd = tree::resolve_cwd(rt, &entries, &req.cwd)
+        .await
+        .map_err(|e| e.to_string())?;
     receipt.cwd = cwd;
     Ok(Ready {
         binary,
@@ -974,81 +976,99 @@ async fn execute(
     receipt.stdout_ref = Some(store.put(out_bytes).await?.as_str().to_string());
     receipt.stderr_ref = Some(store.put(err_bytes).await?.as_str().to_string());
 
-    // Capture the tree.
-    let (found, skipped) = walk(&run_dir).unwrap_or_default();
-    receipt.skipped = skipped;
-    let input: BTreeMap<&str, &TreeEntry> =
-        ready.entries.iter().map(|e| (e.path.as_str(), e)).collect();
-    let mut out_entries: Vec<TreeEntry> = Vec::new();
-    let mut changes: Vec<Change> = Vec::new();
-    let mut undeclared: BTreeSet<String> = BTreeSet::new();
-    for (path, file) in &found {
-        let data = file
-            .read_content()
-            .map_err(|e| RuntimeError::Unconfigured(format!("capture entry {path:?}: {e}")))?;
-        let digest = digest_hex(&data);
-        match input.get(path.as_str()) {
-            Some(old) if old.content_ref == digest && old.mode == file.mode => {
-                out_entries.push((*old).clone());
-            }
-            existing => {
-                let allowed = req
-                    .declared
-                    .as_ref()
-                    .is_none_or(|d| declared_covers(d, path));
-                if !allowed {
-                    undeclared.insert(path.clone());
-                    if let Some(old) = existing {
-                        out_entries.push((*old).clone());
-                    }
-                    continue;
+    // Capture errors describe a completed, unsuccessful run. Finalize its
+    // receipt rather than propagating past receipt insertion in `run`.
+    let captured: Result<(), RuntimeError> = async {
+        let (found, skipped) =
+            walk(&run_dir).map_err(|e| RuntimeError::Unconfigured(format!("capture tree: {e}")))?;
+        receipt.skipped = skipped;
+        let input: BTreeMap<&str, &TreeEntry> =
+            ready.entries.iter().map(|e| (e.path.as_str(), e)).collect();
+        let mut out_entries: Vec<TreeEntry> = Vec::new();
+        let mut changes: Vec<Change> = Vec::new();
+        let mut undeclared: BTreeSet<String> = BTreeSet::new();
+        for (path, file) in &found {
+            let data = file
+                .read_content()
+                .map_err(|e| RuntimeError::Unconfigured(format!("capture entry {path:?}: {e}")))?;
+            let digest = digest_hex(&data);
+            match input.get(path.as_str()) {
+                Some(old) if old.content_ref == digest && old.mode == file.mode => {
+                    out_entries.push((*old).clone());
                 }
-                let stored = store.put(data).await?;
-                let entry = TreeEntry {
-                    path: path.clone(),
-                    content_ref: stored.as_str().to_string(),
-                    mode: file.mode,
-                };
-                changes.push(Change {
-                    path: path.clone(),
-                    op: if existing.is_some() {
-                        "modified"
-                    } else {
-                        "added"
-                    },
-                    content_ref: Some(entry.content_ref.clone()),
-                    base_ref: existing.map(|e| e.content_ref.clone()),
-                });
-                out_entries.push(entry);
+                existing => {
+                    let allowed = req
+                        .declared
+                        .as_ref()
+                        .is_none_or(|d| declared_covers(d, path));
+                    if !allowed {
+                        undeclared.insert(path.clone());
+                        if let Some(old) = existing {
+                            out_entries.push((*old).clone());
+                        }
+                        continue;
+                    }
+                    let stored = store.put(data).await?;
+                    let entry = TreeEntry {
+                        path: path.clone(),
+                        content_ref: stored.as_str().to_string(),
+                        mode: file.mode,
+                    };
+                    changes.push(Change {
+                        path: path.clone(),
+                        op: if existing.is_some() {
+                            "modified"
+                        } else {
+                            "added"
+                        },
+                        content_ref: Some(entry.content_ref.clone()),
+                        base_ref: existing.map(|e| e.content_ref.clone()),
+                    });
+                    out_entries.push(entry);
+                }
             }
         }
-    }
-    for (path, old) in &input {
-        if found.contains_key(*path) {
-            continue;
+        for (path, old) in &input {
+            if found.contains_key(*path) {
+                continue;
+            }
+            let allowed = req
+                .declared
+                .as_ref()
+                .is_none_or(|d| declared_covers(d, path));
+            if !allowed {
+                undeclared.insert(path.to_string());
+                out_entries.push((*old).clone());
+                continue;
+            }
+            changes.push(Change {
+                path: path.to_string(),
+                op: "deleted",
+                content_ref: None,
+                base_ref: Some(old.content_ref.clone()),
+            });
         }
-        let allowed = req
-            .declared
-            .as_ref()
-            .is_none_or(|d| declared_covers(d, path));
-        if !allowed {
-            undeclared.insert(path.to_string());
-            out_entries.push((*old).clone());
-            continue;
-        }
-        changes.push(Change {
-            path: path.to_string(),
-            op: "deleted",
-            content_ref: None,
-            base_ref: Some(old.content_ref.clone()),
-        });
+        changes.sort_by(|a, b| a.path.cmp(&b.path));
+        receipt.changed = changes;
+        receipt.undeclared = undeclared.into_iter().collect();
+        receipt.tree_out = Some(tree::store(rt, &out_entries).await?);
+        receipt.success =
+            !receipt.timed_out && receipt.exit_code == Some(0) && receipt.undeclared.is_empty();
+
+        Ok(())
     }
-    changes.sort_by(|a, b| a.path.cmp(&b.path));
-    receipt.changed = changes;
-    receipt.undeclared = undeclared.into_iter().collect();
-    receipt.tree_out = Some(tree::store(rt, &out_entries).await?);
-    receipt.success =
-        !receipt.timed_out && receipt.exit_code == Some(0) && receipt.undeclared.is_empty();
+    .await;
+    if let Err(error) = captured {
+        receipt.success = false;
+        receipt.reason = Some(error.to_string());
+        receipt.tree_out = None;
+        receipt.changed.clear();
+        receipt.undeclared.clear();
+        // A partial capture is never retained as a purported output tree,
+        // including when successful runs would otherwise be kept.
+        cleanup(&run_dir, &profile_path, false);
+        return Ok(());
+    }
 
     cleanup(&run_dir, &profile_path, cfg.keep);
     Ok(())

--- a/crates/khive-pack-exec/src/tree.rs
+++ b/crates/khive-pack-exec/src/tree.rs
@@ -17,6 +17,12 @@ use crate::vocab::TREE_SCHEMA;
 /// Largest manifest the pack will read back.
 pub const MAX_MANIFEST_BYTES: u64 = 8 * 1024 * 1024;
 
+// Preflight has no child timeout: bound both each expansion and retained work.
+const MAX_CWD_PATH_BYTES: usize = 64 * 1024;
+const MAX_CWD_PATH_COMPONENTS: usize = 1024;
+const MAX_CWD_PENDING_BYTES: usize = 256 * 1024;
+const MAX_CWD_PENDING_COMPONENTS: usize = 4096;
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TreeEntry {
     pub path: String,
@@ -60,10 +66,66 @@ pub fn validate_relative_path(path: &str, what: &str) -> Result<String, RuntimeE
 /// Validate a working directory relative to the tree root. `.` and the empty
 /// string mean the root; anything else must be a normalized relative path.
 pub fn validate_cwd(cwd: &str) -> Result<String, RuntimeError> {
+    cwd_component_cost(cwd)?;
     if cwd.is_empty() || cwd == "." {
         return Ok(".".to_string());
     }
     validate_relative_path(cwd, "cwd")
+}
+
+fn cwd_component_cost(path: &str) -> Result<(usize, usize), RuntimeError> {
+    if path.len() > MAX_CWD_PATH_BYTES {
+        return Err(RuntimeError::InvalidInput(format!(
+            "cwd symlink resolution path exceeds {MAX_CWD_PATH_BYTES} bytes"
+        )));
+    }
+    let mut queued_components = 0;
+    let mut queued_bytes = 0;
+    for (index, part) in path.split('/').enumerate() {
+        if index >= MAX_CWD_PATH_COMPONENTS {
+            return Err(RuntimeError::InvalidInput(format!(
+                "cwd symlink resolution path exceeds {MAX_CWD_PATH_COMPONENTS} components"
+            )));
+        }
+        if !part.is_empty() && part != "." {
+            queued_components += 1;
+            queued_bytes += part.len();
+        }
+    }
+    Ok((queued_components, queued_bytes))
+}
+
+fn prepend_cwd_components(
+    pending: &mut VecDeque<String>,
+    pending_bytes: &mut usize,
+    path: &str,
+) -> Result<(), RuntimeError> {
+    let (components, bytes) = cwd_component_cost(path)?;
+    pending
+        .len()
+        .checked_add(components)
+        .filter(|count| *count <= MAX_CWD_PENDING_COMPONENTS)
+        .ok_or_else(|| {
+            RuntimeError::InvalidInput(format!(
+                "cwd symlink resolution pending component budget exceeds {MAX_CWD_PENDING_COMPONENTS}"
+            ))
+        })?;
+    let total_bytes = pending_bytes
+        .checked_add(bytes)
+        .filter(|count| *count <= MAX_CWD_PENDING_BYTES)
+        .ok_or_else(|| {
+            RuntimeError::InvalidInput(format!(
+                "cwd symlink resolution pending byte budget exceeds {MAX_CWD_PENDING_BYTES}"
+            ))
+        })?;
+    // Validate the entire expansion before allocating any owned components.
+    for part in path.split('/').rev() {
+        if !part.is_empty() && part != "." {
+            pending.push_front(part.to_string());
+        }
+    }
+    *pending_bytes = total_bytes;
+    Ok(())
 }
 
 /// Resolve cwd against the immutable manifest before materialization. Only
@@ -92,21 +154,20 @@ pub async fn resolve_cwd(
         })
         .collect();
     let store = blob_store(rt)?;
-    let mut pending: VecDeque<String> = cwd.split('/').map(str::to_string).collect();
+    let mut pending = VecDeque::new();
+    let mut pending_bytes = 0;
+    prepend_cwd_components(&mut pending, &mut pending_bytes, &cwd)?;
     let mut resolved: Vec<String> = Vec::new();
     let mut expansions = 0;
     while let Some(component) = pending.pop_front() {
-        match component.as_str() {
-            "" | "." => continue,
-            ".." => {
-                if resolved.pop().is_none() {
-                    return Err(RuntimeError::InvalidInput(format!(
-                        "cwd {cwd:?} symlink target escapes the tree root"
-                    )));
-                }
-                continue;
+        pending_bytes -= component.len();
+        if component == ".." {
+            if resolved.pop().is_none() {
+                return Err(RuntimeError::InvalidInput(format!(
+                    "cwd {cwd:?} symlink target escapes the tree root"
+                )));
             }
-            _ => {}
+            continue;
         }
         let path = if resolved.is_empty() {
             component.clone()
@@ -128,8 +189,13 @@ pub async fn resolve_cwd(
             let reference = ContentRef::from_hex(&entry.content_ref)
                 .map_err(|e| RuntimeError::InvalidInput(format!("cwd entry {path:?}: {e}")))?;
             let bytes = store
-                .get_bounded_verified(&reference, khive_storage::MAX_BLOB_WHOLE_BYTES)
-                .await?;
+                .get_bounded_verified(&reference, MAX_CWD_PATH_BYTES as u64)
+                .await
+                .map_err(|e| {
+                    RuntimeError::InvalidInput(format!(
+                        "cwd symlink target at {path:?} cannot be read within {MAX_CWD_PATH_BYTES} bytes: {e}"
+                    ))
+                })?;
             let target = std::str::from_utf8(&bytes).map_err(|_| {
                 RuntimeError::InvalidInput(format!(
                     "cwd entry {path:?} target cannot name a UTF-8 manifest directory"
@@ -146,9 +212,7 @@ pub async fn resolve_cwd(
                 )));
             }
             // A relative target starts in the link's parent, not at the link.
-            for part in target.split('/').rev() {
-                pending.push_front(part.to_string());
-            }
+            prepend_cwd_components(&mut pending, &mut pending_bytes, target)?;
         } else if directories.contains(path.as_str()) {
             resolved.push(component);
         } else {
@@ -379,6 +443,67 @@ mod tests {
         );
         assert_eq!(validate_cwd("").unwrap(), ".");
         assert!(validate_cwd("package/../package").is_err());
+    }
+
+    #[test]
+    fn cwd_component_cost_bounds_raw_paths_before_skipping_noops() {
+        let bytes = "a".repeat(MAX_CWD_PATH_BYTES);
+        assert_eq!(cwd_component_cost(&bytes).unwrap(), (1, bytes.len()));
+        assert!(cwd_component_cost(&(bytes + "a")).is_err());
+
+        let components = "/".repeat(MAX_CWD_PATH_COMPONENTS - 1);
+        assert_eq!(cwd_component_cost(&components).unwrap(), (0, 0));
+        assert!(cwd_component_cost(&(components + "/")).is_err());
+    }
+
+    #[test]
+    fn cwd_queue_bounds_components_before_mutation() {
+        let mut pending = VecDeque::new();
+        let mut bytes = 0;
+        let path = vec!["a"; MAX_CWD_PATH_COMPONENTS].join("/");
+        for _ in 0..MAX_CWD_PENDING_COMPONENTS / MAX_CWD_PATH_COMPONENTS {
+            prepend_cwd_components(&mut pending, &mut bytes, &path).unwrap();
+        }
+        assert_eq!(pending.len(), MAX_CWD_PENDING_COMPONENTS);
+        assert_eq!(bytes, MAX_CWD_PENDING_COMPONENTS);
+        let before = pending.clone();
+        let error = prepend_cwd_components(&mut pending, &mut bytes, "a")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("pending component budget"), "{error}");
+        assert_eq!(pending, before);
+        assert_eq!(bytes, MAX_CWD_PENDING_COMPONENTS);
+    }
+
+    #[test]
+    fn cwd_queue_bounds_bytes_before_mutation() {
+        let mut pending = VecDeque::new();
+        let mut bytes = 0;
+        let path = "a".repeat(MAX_CWD_PATH_BYTES);
+        for _ in 0..MAX_CWD_PENDING_BYTES / MAX_CWD_PATH_BYTES {
+            prepend_cwd_components(&mut pending, &mut bytes, &path).unwrap();
+        }
+        assert_eq!(bytes, MAX_CWD_PENDING_BYTES);
+        let before = pending.clone();
+        let error = prepend_cwd_components(&mut pending, &mut bytes, "a")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("pending byte budget"), "{error}");
+        assert_eq!(pending, before);
+        assert_eq!(bytes, MAX_CWD_PENDING_BYTES);
+    }
+
+    #[test]
+    fn cwd_queue_skips_noops_without_reordering_parent_components() {
+        let mut pending = VecDeque::new();
+        let mut bytes = 0;
+        prepend_cwd_components(&mut pending, &mut bytes, "tail").unwrap();
+        prepend_cwd_components(&mut pending, &mut bytes, "first//./../second/.").unwrap();
+        assert_eq!(
+            pending,
+            VecDeque::from(["first", "..", "second", "tail"].map(str::to_string))
+        );
+        assert_eq!(bytes, 17);
     }
 
     #[test]

--- a/crates/khive-pack-exec/src/tree.rs
+++ b/crates/khive-pack-exec/src/tree.rs
@@ -4,7 +4,8 @@
 //! serialization is canonical (entries sorted by path, compact JSON) so two
 //! runs that leave identical content produce identical tree references.
 
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::collections::{BTreeMap, VecDeque};
+use std::ops::Bound::{Included, Unbounded};
 
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -144,15 +145,6 @@ pub async fn resolve_cwd(
         .iter()
         .map(|entry| (entry.path.as_str(), entry))
         .collect();
-    let directories: BTreeSet<&str> = entries
-        .iter()
-        .flat_map(|entry| {
-            entry
-                .path
-                .match_indices('/')
-                .map(move |(i, _)| &entry.path[..i])
-        })
-        .collect();
     let store = blob_store(rt)?;
     let mut pending = VecDeque::new();
     let mut pending_bytes = 0;
@@ -213,12 +205,19 @@ pub async fn resolve_cwd(
             }
             // A relative target starts in the link's parent, not at the link.
             prepend_cwd_components(&mut pending, &mut pending_bytes, target)?;
-        } else if directories.contains(path.as_str()) {
-            resolved.push(component);
         } else {
-            return Err(RuntimeError::InvalidInput(format!(
-                "cwd {cwd:?} directory {path:?} is absent from the manifest"
-            )));
+            // Seek the slash boundary so lexical siblings cannot mask descendants.
+            let prefix = format!("{path}/");
+            let is_directory = by_path
+                .range::<str, _>((Included(prefix.as_str()), Unbounded))
+                .next()
+                .is_some_and(|(entry_path, _)| entry_path.starts_with(&prefix));
+            if !is_directory {
+                return Err(RuntimeError::InvalidInput(format!(
+                    "cwd {cwd:?} directory {path:?} is absent from the manifest"
+                )));
+            }
+            resolved.push(component);
         }
     }
     Ok(if resolved.is_empty() {

--- a/crates/khive-pack-exec/src/tree.rs
+++ b/crates/khive-pack-exec/src/tree.rs
@@ -4,7 +4,7 @@
 //! serialization is canonical (entries sorted by path, compact JSON) so two
 //! runs that leave identical content produce identical tree references.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -64,6 +64,104 @@ pub fn validate_cwd(cwd: &str) -> Result<String, RuntimeError> {
         return Ok(".".to_string());
     }
     validate_relative_path(cwd, "cwd")
+}
+
+/// Resolve cwd against the immutable manifest before materialization. Only
+/// directory prefixes in the manifest can be working directories. Expand each
+/// link before interpreting subsequent `..` components, as path lookup does.
+pub async fn resolve_cwd(
+    rt: &KhiveRuntime,
+    entries: &[TreeEntry],
+    cwd: &str,
+) -> Result<String, RuntimeError> {
+    let cwd = validate_cwd(cwd)?;
+    if cwd == "." {
+        return Ok(cwd);
+    }
+    let by_path: BTreeMap<&str, &TreeEntry> = entries
+        .iter()
+        .map(|entry| (entry.path.as_str(), entry))
+        .collect();
+    let directories: BTreeSet<&str> = entries
+        .iter()
+        .flat_map(|entry| {
+            entry
+                .path
+                .match_indices('/')
+                .map(move |(i, _)| &entry.path[..i])
+        })
+        .collect();
+    let store = blob_store(rt)?;
+    let mut pending: VecDeque<String> = cwd.split('/').map(str::to_string).collect();
+    let mut resolved: Vec<String> = Vec::new();
+    let mut expansions = 0;
+    while let Some(component) = pending.pop_front() {
+        match component.as_str() {
+            "" | "." => continue,
+            ".." => {
+                if resolved.pop().is_none() {
+                    return Err(RuntimeError::InvalidInput(format!(
+                        "cwd {cwd:?} symlink target escapes the tree root"
+                    )));
+                }
+                continue;
+            }
+            _ => {}
+        }
+        let path = if resolved.is_empty() {
+            component.clone()
+        } else {
+            format!("{}/{component}", resolved.join("/"))
+        };
+        if let Some(entry) = by_path.get(path.as_str()) {
+            if entry.mode != 120000 {
+                return Err(RuntimeError::InvalidInput(format!(
+                    "cwd {cwd:?} traverses non-directory entry {path:?}"
+                )));
+            }
+            expansions += 1;
+            if expansions > 40 {
+                return Err(RuntimeError::InvalidInput(format!(
+                    "cwd {cwd:?} symlink chain exceeds 40 expansions (possible cycle)"
+                )));
+            }
+            let reference = ContentRef::from_hex(&entry.content_ref)
+                .map_err(|e| RuntimeError::InvalidInput(format!("cwd entry {path:?}: {e}")))?;
+            let bytes = store
+                .get_bounded_verified(&reference, khive_storage::MAX_BLOB_WHOLE_BYTES)
+                .await?;
+            let target = std::str::from_utf8(&bytes).map_err(|_| {
+                RuntimeError::InvalidInput(format!(
+                    "cwd entry {path:?} target cannot name a UTF-8 manifest directory"
+                ))
+            })?;
+            if target.starts_with('/') {
+                return Err(RuntimeError::InvalidInput(format!(
+                    "cwd {cwd:?} symlink target at {path:?} is absolute and escapes the tree root"
+                )));
+            }
+            if target.is_empty() || target.contains('\0') {
+                return Err(RuntimeError::InvalidInput(format!(
+                    "cwd entry {path:?} has an empty or NUL-containing symlink target"
+                )));
+            }
+            // A relative target starts in the link's parent, not at the link.
+            for part in target.split('/').rev() {
+                pending.push_front(part.to_string());
+            }
+        } else if directories.contains(path.as_str()) {
+            resolved.push(component);
+        } else {
+            return Err(RuntimeError::InvalidInput(format!(
+                "cwd {cwd:?} directory {path:?} is absent from the manifest"
+            )));
+        }
+    }
+    Ok(if resolved.is_empty() {
+        ".".to_string()
+    } else {
+        resolved.join("/")
+    })
 }
 
 /// The one entry validator: paths, modes, duplicates, ref format, and the rule that an entry

--- a/crates/khive-pack-exec/src/tree.rs
+++ b/crates/khive-pack-exec/src/tree.rs
@@ -66,7 +66,7 @@ pub fn validate_cwd(cwd: &str) -> Result<String, RuntimeError> {
     validate_relative_path(cwd, "cwd")
 }
 
-/// The one entry validator: paths, modes, duplicates, ref format, and the rule that a file
+/// The one entry validator: paths, modes, duplicates, ref format, and the rule that an entry
 /// cannot also be a directory prefix of another entry. Exposed so `exec.tree_put` validates
 /// a whole candidate manifest through this function rather than reimplementing its rules.
 pub(crate) fn parse_entries(value: &Value) -> Result<Vec<TreeEntry>, RuntimeError> {
@@ -86,16 +86,15 @@ pub(crate) fn parse_entries(value: &Value) -> Result<Vec<TreeEntry>, RuntimeErro
             .ok_or_else(|| RuntimeError::InvalidInput("entry.ref must be a string".into()))?;
         ContentRef::from_hex(content_ref)
             .map_err(|e| RuntimeError::InvalidInput(format!("entry {path:?} ref: {e}")))?;
-        let mode = item
-            .get("mode")
-            .and_then(Value::as_u64)
-            .ok_or_else(|| RuntimeError::InvalidInput("entry.mode must be 644 or 755".into()))?;
-        if mode != 644 && mode != 755 {
+        let mode = item.get("mode").and_then(Value::as_u64).ok_or_else(|| {
+            RuntimeError::InvalidInput("entry.mode must be 644, 755 or 120000".into())
+        })?;
+        if !matches!(mode, 644 | 755 | 120000) {
             return Err(RuntimeError::InvalidInput(format!(
-                "entry {path:?} mode must be 644 or 755; got {mode} (symlinks and other modes are refused)"
+                "entry {path:?} mode must be 644, 755 or 120000; got {mode}"
             )));
         }
-        // A file cannot also be a directory prefix of another entry.
+        // Neither a file nor a symlink can be a directory prefix of another entry.
         for existing in seen.keys() {
             if existing.starts_with(&format!("{path}/"))
                 || path.starts_with(&format!("{existing}/"))
@@ -285,18 +284,45 @@ mod tests {
     }
 
     #[test]
+    fn accepts_regular_executable_and_symlink_modes() {
+        let r = digest_hex(b"target");
+        let entries = parse_entries(&json!([
+            {"path": "a", "ref": r, "mode": 644},
+            {"path": "b", "ref": r, "mode": 755},
+            {"path": "c", "ref": r, "mode": 120000}
+        ]))
+        .unwrap();
+        assert_eq!(
+            entries.iter().map(|entry| entry.mode).collect::<Vec<_>>(),
+            vec![644, 755, 120000]
+        );
+    }
+
+    #[test]
     fn rejects_duplicates_and_modes() {
         let r = digest_hex(b"x");
         let dup =
             json!([{"path": "a", "ref": r, "mode": 644}, {"path": "a", "ref": r, "mode": 644}]);
         assert!(parse_entries(&dup).is_err());
-        let mode = json!([{"path": "a", "ref": r, "mode": 777}]);
-        assert!(parse_entries(&mode).is_err());
-        let link = json!([{"path": "a", "ref": r, "mode": 0o120777}]);
-        assert!(parse_entries(&link).is_err());
-        let nested =
-            json!([{"path": "a", "ref": r, "mode": 644}, {"path": "a/b", "ref": r, "mode": 644}]);
-        assert!(parse_entries(&nested).is_err());
+        for mode in [0, 777, 0o120777, 0o120000, 100644, 100755, 120001, u64::MAX] {
+            let entries = json!([{"path": "a", "ref": r, "mode": mode}]);
+            assert!(parse_entries(&entries).is_err(), "mode {mode}");
+        }
+    }
+
+    #[test]
+    fn rejects_entries_beneath_files_and_symlinks_in_either_order() {
+        let r = digest_hex(b"target");
+        for mode in [644, 755, 120000] {
+            let mut entries = vec![
+                json!({"path": "a", "ref": r, "mode": mode}),
+                json!({"path": "a/b", "ref": r, "mode": 644}),
+            ];
+            for _ in 0..2 {
+                assert!(parse_entries(&json!(entries)).is_err(), "mode {mode}");
+                entries.reverse();
+            }
+        }
     }
 
     #[test]

--- a/crates/khive-pack-exec/src/vocab.rs
+++ b/crates/khive-pack-exec/src/vocab.rs
@@ -55,11 +55,11 @@ const P_TREE: ParamDef = ParamDef {
 pub static EXEC_HANDLERS: [HandlerDef; 9] = [
     HandlerDef {
         name: "exec.tree",
-        description: "Store a tree manifest from entries [{path, ref, mode}] and return its reference. Paths are relative and normalized, modes are 644 or 755, duplicates and symlinks are refused.",
+        description: "Store a tree manifest from entries [{path, ref, mode}] and return its reference. Paths are relative and normalized; modes are 644, 755 or 120000 (symlink with literal target bytes in its blob). Duplicates and entries below a file or symlink path are refused.",
         visibility: Visibility::Verb,
         category: VerbCategory::Declaration,
         params: &[
-            ParamDef { name: "entries", param_type: "array", required: true, description: "Entries [{path, ref, mode}]; an empty array is the empty tree.", resolution_mode: IdResolutionMode::NotApplicable },
+            ParamDef { name: "entries", param_type: "array", required: true, description: "Entries [{path, ref, mode}]; modes 644/755 are files and 120000 is a symlink. An empty array is the empty tree.", resolution_mode: IdResolutionMode::NotApplicable },
             P_NAMESPACE,
         ],
     },
@@ -77,7 +77,7 @@ pub static EXEC_HANDLERS: [HandlerDef; 9] = [
         category: VerbCategory::Declaration,
         params: &[
             P_TREE,
-            ParamDef { name: "edits", param_type: "array", required: true, description: "Edits [{path, and exactly one of ref | content | delete:true, plus optional mode}]; an empty array is refused.", resolution_mode: IdResolutionMode::NotApplicable },
+            ParamDef { name: "edits", param_type: "array", required: true, description: "Edits [{path, and exactly one of ref | content | delete:true, plus optional mode}]; modes are 644, 755 or 120000 (literal symlink target bytes). Omitted mode preserves an existing mode or defaults to 644; an empty array is refused.", resolution_mode: IdResolutionMode::NotApplicable },
             P_NAMESPACE,
         ],
     },

--- a/crates/khive-pack-exec/tests/verbs.rs
+++ b/crates/khive-pack-exec/tests/verbs.rs
@@ -787,6 +787,130 @@ async fn run_refuses_symlink_cwd_escapes_and_cycles_before_materialization() {
     }
 }
 
+async fn cwd_preflight_refusal(f: &Fixture, tree: &str, cwd: &str) -> String {
+    let error = f
+        .call_err(
+            "exec.run",
+            json!({"tree":tree,"tool":"sh","args":["-c","true"],
+                "actor":"local","cwd":cwd}),
+        )
+        .await;
+    let id = error
+        .split("receipt_id=")
+        .nth(1)
+        .expect("refusal names its durable receipt")
+        .trim_end_matches(')');
+    let receipt = f.call("exec.receipt", json!({"id":id})).await;
+    assert_eq!(receipt["denied"], true, "{receipt}");
+    assert_eq!(receipt["success"], false);
+    assert_eq!(receipt["decision"]["decision"], "allow");
+    assert!(receipt["started_at"].is_null());
+    assert!(receipt["exit_code"].is_null());
+    assert!(receipt["tree_out"].is_null());
+    let reason = receipt["reason"]
+        .as_str()
+        .expect("preflight refusal reason");
+    assert!(
+        reason.contains("cwd") && reason.contains("symlink"),
+        "{reason}"
+    );
+    assert!(error.contains(reason), "{error}");
+    assert!(root_is_empty(f), "preflight must not materialize anything");
+    assert_eq!(
+        f.call("exec.events", json!({"run_id":id})).await["count"],
+        0
+    );
+    reason.to_string()
+}
+
+#[tokio::test]
+async fn run_refuses_oversized_symlink_cwd_target_before_materialization() {
+    let f = fixture();
+    f.register_sh("sh", "allow").await;
+    let target = format!("link{}", "/".repeat(1024 * 1024));
+    let tree = f.tree(&[("link", target.as_bytes(), 120000)]).await;
+    let reason = cwd_preflight_refusal(&f, &tree, "link").await;
+    assert!(
+        reason.contains("target") && reason.contains("read"),
+        "{reason}"
+    );
+    assert!(
+        reason.contains("65536") && reason.contains("bytes"),
+        "{reason}"
+    );
+    assert!(!reason.contains("cycle"), "{reason}");
+}
+
+#[tokio::test]
+async fn run_refuses_raw_cwd_path_budgets_before_materialization() {
+    let f = fixture();
+    f.register_sh("sh", "allow").await;
+    let tree = f.tree(&[("dir/file", b"unchanged", 644)]).await;
+    for (cwd, unit) in [
+        ("x".repeat(64 * 1024 + 1), "bytes"),
+        (format!("dir{}", "/".repeat(1024)), "components"),
+    ] {
+        let reason = cwd_preflight_refusal(&f, &tree, &cwd).await;
+        assert!(
+            reason.contains("path exceeds") && reason.contains(unit),
+            "{reason}"
+        );
+        assert!(!reason.contains("cycle"), "{reason}");
+    }
+}
+
+#[tokio::test]
+async fn run_bounds_raw_symlink_components_and_skips_pending_noops() {
+    let f = fixture();
+    f.register_sh("sh", "allow").await;
+    let target = format!("link{}", "/".repeat(1024));
+    let tree = f.tree(&[("link", target.as_bytes(), 120000)]).await;
+    let reason = cwd_preflight_refusal(&f, &tree, "link").await;
+    assert!(
+        reason.contains("path exceeds") && reason.contains("components"),
+        "{reason}"
+    );
+    assert!(!reason.contains("cycle"), "{reason}");
+
+    for suffix in ["/", "/."] {
+        let target = format!("link{}", suffix.repeat(1023));
+        let tree = f.tree(&[("link", target.as_bytes(), 120000)]).await;
+        let reason = cwd_preflight_refusal(&f, &tree, "link").await;
+        assert!(reason.contains("cycle"), "{reason}");
+        assert!(!reason.contains("budget"), "{reason}");
+    }
+}
+
+#[tokio::test]
+async fn run_refuses_symlink_cwd_pending_component_budget_before_cycle() {
+    let f = fixture();
+    f.register_sh("sh", "allow").await;
+    let target = format!("link{}", "/..".repeat(1023));
+    let tree = f.tree(&[("link", target.as_bytes(), 120000)]).await;
+    let reason = cwd_preflight_refusal(&f, &tree, "link").await;
+    assert!(reason.contains("pending component budget"), "{reason}");
+    assert!(reason.contains("4096"), "{reason}");
+    assert!(!reason.contains("cycle"), "{reason}");
+}
+
+#[tokio::test]
+async fn run_refuses_symlink_cwd_pending_byte_budget_before_cycle() {
+    let f = fixture();
+    f.register_sh("sh", "allow").await;
+    let target = format!("link/{}", "x".repeat(32 * 1024));
+    let tree = f.tree(&[("link", target.as_bytes(), 120000)]).await;
+    let reason = cwd_preflight_refusal(&f, &tree, "link").await;
+    assert!(reason.contains("pending byte budget"), "{reason}");
+    assert!(reason.contains("262144"), "{reason}");
+    assert!(!reason.contains("cycle"), "{reason}");
+
+    let name = "x".repeat(32 * 1024);
+    let tree = f.tree(&[(name.as_str(), name.as_bytes(), 120000)]).await;
+    let reason = cwd_preflight_refusal(&f, &tree, &name).await;
+    assert!(reason.contains("cycle"), "{reason}");
+    assert!(!reason.contains("budget"), "{reason}");
+}
+
 #[cfg(target_os = "macos")]
 #[tokio::test]
 async fn run_resolves_relative_symlink_cwd_chains_inside_the_manifest() {

--- a/crates/khive-pack-exec/tests/verbs.rs
+++ b/crates/khive-pack-exec/tests/verbs.rs
@@ -943,6 +943,61 @@ async fn run_resolves_relative_symlink_cwd_chains_inside_the_manifest() {
     }
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn run_materialize_symlink_failure_persists_receipt_and_cleans_up() {
+    for keep in [false, true] {
+        let f = fixture_with_keep(keep);
+        f.register_sh("sh", "allow").await;
+        let tree = f
+            .tree(&[
+                ("a-file", b"materialized before failure", 644),
+                ("b-link", b"a-file", 120000),
+                ("c-invalid-link", b"a-file\0suffix", 120000),
+            ])
+            .await;
+        let out = f
+            .call(
+                "exec.run",
+                json!({"tree":tree,"tool":"sh","actor":"local","cwd":".",
+                    "args":["-c","printf launched > child-output"]}),
+            )
+            .await;
+        let receipt = &out["receipt"];
+        assert_eq!(receipt["denied"], false, "{receipt}");
+        assert_eq!(receipt["success"], false);
+        assert_eq!(receipt["decision"]["decision"], "allow");
+        assert!(receipt["reason"]
+            .as_str()
+            .unwrap()
+            .starts_with("materialize "));
+        assert!(receipt["finished_at"].is_string());
+        assert!(receipt["started_at"].is_null());
+        assert!(receipt["exit_code"].is_null());
+        assert!(receipt["tree_out"].is_null());
+        assert!(receipt["profile_ref"].is_null());
+        assert!(receipt["sandbox"].is_null());
+        assert_eq!(receipt["changed"], json!([]));
+        assert_eq!(out["changed"], json!([]));
+        let stored = f.call("exec.receipt", json!({"id":receipt["id"]})).await;
+        assert_eq!(&stored, receipt, "the materialization failure is durable");
+        assert_eq!(
+            f.call("exec.events", json!({"run_id":receipt["id"]})).await["count"],
+            0,
+            "a partial materialization is not a materialized or launched run"
+        );
+
+        let id = receipt["id"].as_str().unwrap();
+        let run_dir = f.root.join(id);
+        assert!(!f.root.join(format!("{id}.sb")).exists());
+        assert!(!run_dir.exists());
+        assert!(
+            root_is_empty(&f),
+            "partial trees must be removed even when keep={keep}"
+        );
+    }
+}
+
 #[cfg(target_os = "macos")]
 #[tokio::test]
 async fn run_capture_read_failure_persists_failed_receipt_and_cleans_up() {

--- a/crates/khive-pack-exec/tests/verbs.rs
+++ b/crates/khive-pack-exec/tests/verbs.rs
@@ -732,6 +732,147 @@ async fn refusals_write_receipts_and_touch_no_disk() {
     assert!(root_is_empty(&f));
 }
 
+#[tokio::test]
+async fn run_refuses_symlink_cwd_escapes_and_cycles_before_materialization() {
+    let f = fixture();
+    f.register_sh("sh", "allow").await;
+    let cases = [
+        vec![("link", b"/usr".as_slice(), 120000)],
+        vec![("link", b"../outside".as_slice(), 120000)],
+        vec![
+            ("link", b"links/hop".as_slice(), 120000),
+            ("links/hop", b"../../outside".as_slice(), 120000),
+        ],
+        // Lexically cancelling redirect/.. before following redirect would
+        // incorrectly hide this absolute escape.
+        vec![
+            ("link", b"redirect/..".as_slice(), 120000),
+            ("redirect", b"/usr".as_slice(), 120000),
+        ],
+        vec![
+            ("link", b"next".as_slice(), 120000),
+            ("next", b"link".as_slice(), 120000),
+        ],
+    ];
+    for entries in cases {
+        let tree = f.tree(&entries).await;
+        let error = f
+            .call_err(
+                "exec.run",
+                json!({"tree":tree,"tool":"sh","args":["-c","true"],
+                    "actor":"local","cwd":"link"}),
+            )
+            .await;
+        assert!(
+            error.contains("cwd") && error.contains("symlink"),
+            "{error}"
+        );
+        let id = error
+            .split("receipt_id=")
+            .nth(1)
+            .expect("refusal names its receipt")
+            .trim_end_matches(')');
+        let receipt = f.call("exec.receipt", json!({"id":id})).await;
+        assert_eq!(receipt["denied"], true, "{receipt}");
+        assert_eq!(receipt["success"], false);
+        assert_eq!(receipt["decision"]["decision"], "allow");
+        assert!(receipt["reason"].as_str().unwrap().contains("cwd"));
+        assert!(receipt["tree_out"].is_null());
+        assert!(receipt["started_at"].is_null());
+        assert!(root_is_empty(&f), "preflight must not materialize anything");
+        assert_eq!(
+            f.call("exec.events", json!({"run_id":id})).await["count"],
+            0
+        );
+    }
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn run_resolves_relative_symlink_cwd_chains_inside_the_manifest() {
+    let f = fixture();
+    f.register_sh("sh", "allow").await;
+    let tree = f
+        .tree(&[
+            ("dir/file", b"from directory", 644),
+            ("dir/inner/keep", b"nested", 644),
+            ("links/hop", b"../alias", 120000),
+            ("alias", b"dir/./inner/..", 120000),
+        ])
+        .await;
+    for cwd in ["dir", "links/hop"] {
+        let out = f
+            .call(
+                "exec.run",
+                json!({"tree":tree,"tool":"sh","args":["-c","cat file"],
+                    "actor":"local","cwd":cwd}),
+            )
+            .await;
+        assert_eq!(out["receipt"]["success"], true, "{out}");
+        assert_eq!(out["receipt"]["cwd"], "dir");
+        assert_eq!(
+            f.blob_text(&out["receipt"]["stdout_ref"]).await,
+            "from directory"
+        );
+        assert_eq!(out["receipt"]["tree_out"], tree);
+        assert!(root_is_empty(&f));
+    }
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn run_capture_read_failure_persists_failed_receipt_and_cleans_up() {
+    // chmod 000 must make a real read fail; a root test runner is not a
+    // substitute for the daemon's unprivileged execution environment.
+    assert_ne!(
+        unsafe { libc::geteuid() },
+        0,
+        "run this regression as a non-root user"
+    );
+    for keep in [false, true] {
+        let f = fixture_with_keep(keep);
+        f.register_sh("sh", "allow").await;
+        let tree = f.tree(&[]).await;
+        let out = f
+            .call(
+                "exec.run",
+                json!({"tree":tree,"tool":"sh","actor":"local",
+                    "args":["-c","printf readable > a-readable && printf secret > z-unreadable && chmod 000 z-unreadable && printf created"]}),
+            )
+            .await;
+        let receipt = &out["receipt"];
+        assert_eq!(receipt["exit_code"], 0, "the command completed: {receipt}");
+        assert_eq!(f.blob_text(&receipt["stdout_ref"]).await, "created");
+        assert_eq!(receipt["denied"], false);
+        assert_eq!(receipt["success"], false);
+        assert!(receipt["reason"]
+            .as_str()
+            .unwrap()
+            .contains("capture entry \"z-unreadable\""));
+        assert!(
+            receipt["tree_out"].is_null(),
+            "no partial tree may be claimed"
+        );
+        assert_eq!(receipt["changed"], json!([]));
+        assert_eq!(out["changed"], json!([]));
+        assert!(receipt["finished_at"].is_string());
+        let stored = f.call("exec.receipt", json!({"id":receipt["id"]})).await;
+        assert_eq!(&stored, receipt, "the failed receipt is durable");
+        let events = f.call("exec.events", json!({"run_id":receipt["id"]})).await;
+        let kinds: Vec<&str> = events["events"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|event| event["kind"].as_str().unwrap())
+            .collect();
+        assert_eq!(kinds, ["materialized", "launched", "exited"]);
+        assert!(
+            root_is_empty(&f),
+            "both the run directory and profile must be removed"
+        );
+    }
+}
+
 #[cfg(target_os = "macos")]
 #[tokio::test]
 async fn run_captures_output_changes_and_receipt() {

--- a/crates/khive-pack-exec/tests/verbs.rs
+++ b/crates/khive-pack-exec/tests/verbs.rs
@@ -19,6 +19,10 @@ struct Fixture {
 }
 
 fn fixture() -> Fixture {
+    fixture_with_keep(false)
+}
+
+fn fixture_with_keep(keep: bool) -> Fixture {
     let dir = tempfile::tempdir().expect("tempdir");
     let root = dir.path().join("exec-root");
     let db = dir.path().join("khive.db");
@@ -32,7 +36,7 @@ fn fixture() -> Fixture {
             max_output_bytes: Some(128),
             timeout_default_s: Some(5.0),
             timeout_max_s: Some(10.0),
-            keep: false,
+            keep,
             limits: Default::default(),
         },
         // No embedding model: tool.register would otherwise build the default
@@ -262,6 +266,141 @@ async fn tree_put_applies_edits_and_leaves_the_base_tree_alone() {
 }
 
 #[tokio::test]
+async fn tree_put_preserves_symlink_targets_and_classifies_mode_flips() {
+    let f = fixture();
+    let base = f
+        .tree(&[("plain", b"target", 644), ("executable", b"target", 755)])
+        .await;
+    let target_ref = f.put(b"target").await;
+    let created = f
+        .call(
+            "exec.tree_put",
+            json!({ "tree": base, "edits": [
+                { "path": "link", "content": "./target", "mode": 120000 },
+                { "path": "plain", "ref": target_ref, "mode": 120000 },
+                { "path": "executable", "ref": target_ref, "mode": 120000 },
+            ]}),
+        )
+        .await;
+    let linked = created["tree"].as_str().unwrap();
+    let entries = entries_of(&f, linked).await;
+    assert!(entries.iter().all(|(_, _, mode)| *mode == 120000));
+    assert_eq!(entries[1].1, f.put(b"./target").await);
+    let changes: Vec<(&str, &str)> = created["changed"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|c| (c["path"].as_str().unwrap(), c["op"].as_str().unwrap()))
+        .collect();
+    assert_eq!(
+        changes,
+        vec![
+            ("executable", "modified"),
+            ("link", "added"),
+            ("plain", "modified"),
+        ]
+    );
+    assert_eq!(
+        created["changed"],
+        f.call("exec.tree_diff", json!({ "base": base, "head": linked }))
+            .await["changed"]
+    );
+
+    let retargeted = f
+        .call(
+            "exec.tree_put",
+            json!({ "tree": linked, "edits": [
+                { "path": "link", "content": "../other" },
+                { "path": "plain", "content": "target", "mode": 644 },
+                { "path": "executable", "ref": target_ref, "mode": 755 },
+            ]}),
+        )
+        .await;
+    let head = retargeted["tree"].as_str().unwrap();
+    assert_eq!(
+        entries_of(&f, head).await,
+        vec![
+            ("executable".into(), target_ref.clone(), 755),
+            ("link".into(), f.put(b"../other").await, 120000),
+            ("plain".into(), target_ref.clone(), 644),
+        ]
+    );
+    assert_eq!(retargeted["changed"].as_array().unwrap().len(), 3);
+    assert!(retargeted["changed"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .all(|change| change["op"] == "modified"));
+    assert_eq!(
+        retargeted["changed"],
+        f.call("exec.tree_diff", json!({ "base": linked, "head": head }))
+            .await["changed"]
+    );
+
+    let deleted = f
+        .call(
+            "exec.tree_put",
+            json!({ "tree": head, "edits": [{ "path": "link", "delete": true }] }),
+        )
+        .await;
+    assert_eq!(deleted["changed"].as_array().unwrap().len(), 1);
+    assert_eq!(deleted["changed"][0]["path"], "link");
+    assert_eq!(deleted["changed"][0]["op"], "deleted");
+    assert_eq!(
+        deleted["tree"], base,
+        "all original file modes are restored"
+    );
+    assert_eq!(entries_of(&f, linked).await, entries, "trees are immutable");
+}
+
+#[tokio::test]
+async fn tree_symlink_mode_does_not_allow_invalid_modes_or_descendant_entries() {
+    let f = fixture();
+    let target_ref = f.put(b"../outside").await;
+    let tree = f.tree(&[("link", b"../outside", 120000)]).await;
+    assert_eq!(
+        entries_of(&f, &tree).await,
+        vec![("link".into(), target_ref.clone(), 120000)]
+    );
+    for mode in [777, 0o120777, 0o120000, 100644] {
+        let err = f
+            .call_err(
+                "exec.tree",
+                json!({ "entries": [{ "path": "link", "ref": target_ref, "mode": mode }] }),
+            )
+            .await;
+        assert!(err.contains("mode"), "{err}");
+        let err = f
+            .call_err(
+                "exec.tree_put",
+                json!({ "tree": tree, "edits": [{ "path": "link", "ref": target_ref, "mode": mode }] }),
+            )
+            .await;
+        assert!(err.contains("mode"), "{err}");
+    }
+    let err = f
+        .call_err(
+            "exec.tree",
+            json!({ "entries": [
+                { "path": "link", "ref": target_ref, "mode": 120000 },
+                { "path": "link/child", "ref": target_ref, "mode": 644 },
+            ]}),
+        )
+        .await;
+    assert!(err.contains("link"), "{err}");
+    let before = blob_object_count(&f);
+    let err = f
+        .call_err(
+            "exec.tree_put",
+            json!({ "tree": tree, "edits": [{ "path": "link/child", "content": "child" }] }),
+        )
+        .await;
+    assert!(err.contains("link"), "{err}");
+    assert_eq!(blob_object_count(&f), before);
+    assert_eq!(entries_of(&f, &tree).await.len(), 1);
+}
+
+#[tokio::test]
 async fn tree_put_deletes_only_paths_the_tree_holds() {
     let f = fixture();
     let base = f.tree(&[("a", b"1", 644), ("b", b"2", 644)]).await;
@@ -346,12 +485,12 @@ async fn tree_put_refuses_edits_that_do_not_name_exactly_one_action() {
         ),
         (
             json!([{ "path": "a", "content": "x", "mode": 777 }]),
-            "644 or 755",
+            "644, 755 or 120000",
         ),
         (json!([{ "path": "../escape", "content": "x" }]), "escape"),
         (
             json!([{ "path": "a", "content": "x", "mode": 0o644 }]),
-            "644 or 755",
+            "644, 755 or 120000",
         ),
     ] {
         let err = f
@@ -673,6 +812,263 @@ async fn run_captures_output_changes_and_receipt() {
         .collect();
     assert_eq!(kinds, vec!["materialized", "launched", "exited"]);
     assert!(root_is_empty(&f));
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn run_captures_symlink_creation_retargeting_removal_and_mode_flips() {
+    let f = fixture();
+    f.register_sh("sh", "allow").await;
+    let tree = f
+        .tree(&[
+            ("target", b"body", 644),
+            ("dir/file", b"nested", 644),
+            ("retarget", b"target", 120000),
+            ("remove", b"target", 120000),
+            ("to-file", b"target", 120000),
+            ("to-link", b"target", 644),
+        ])
+        .await;
+    let script = "set -e; ln -s './dir/../target' created; \
+        rm retarget; ln -s dir/file retarget; rm remove; ln -s dir dir-link; \
+        rm to-file; printf target > to-file; rm to-link; ln -s target to-link";
+    let out = f
+        .call(
+            "exec.run",
+            json!({ "tree": tree, "tool": "sh", "args": ["-c", script], "actor": "local" }),
+        )
+        .await;
+    let receipt = &out["receipt"];
+    assert_eq!(receipt["exit_code"], 0, "{receipt}");
+    assert_eq!(receipt["success"], true, "{receipt}");
+    assert_eq!(receipt["skipped"], json!([]));
+    let changed: Vec<(&str, &str)> = out["changed"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|c| (c["path"].as_str().unwrap(), c["op"].as_str().unwrap()))
+        .collect();
+    assert_eq!(
+        changed,
+        vec![
+            ("created", "added"),
+            ("dir-link", "added"),
+            ("remove", "deleted"),
+            ("retarget", "modified"),
+            ("to-file", "modified"),
+            ("to-link", "modified"),
+        ]
+    );
+    let head = receipt["tree_out"].as_str().unwrap();
+    assert_eq!(
+        entries_of(&f, head).await,
+        vec![
+            ("created".into(), f.put(b"./dir/../target").await, 120000),
+            ("dir-link".into(), f.put(b"dir").await, 120000),
+            ("dir/file".into(), f.put(b"nested").await, 644),
+            ("retarget".into(), f.put(b"dir/file").await, 120000),
+            ("target".into(), f.put(b"body").await, 644),
+            ("to-file".into(), f.put(b"target").await, 644),
+            ("to-link".into(), f.put(b"target").await, 120000),
+        ],
+        "directory links are entries, and their descendants are never captured"
+    );
+    assert_eq!(
+        out["changed"],
+        f.call("exec.tree_diff", json!({ "base": tree, "head": head }))
+            .await["changed"]
+    );
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn run_denies_writes_through_escaping_symlinks_and_allows_inside_targets() {
+    use std::os::unix::ffi::OsStrExt;
+
+    let f = fixture();
+    f.register_sh("sh", "allow").await;
+    let outside = f._dir.path().join("outside.txt");
+    std::fs::write(&outside, b"unchanged").expect("outside control file");
+    for target in [
+        b"../../outside.txt".as_slice(),
+        outside.as_os_str().as_bytes(),
+    ] {
+        let tree = f
+            .tree(&[
+                ("inside", b"before", 644),
+                ("inside-link", b"inside", 120000),
+                ("escape", target, 120000),
+            ])
+            .await;
+        let out = f
+            .call(
+                "exec.run",
+                json!({
+                    "tree": tree, "tool": "sh", "actor": "local",
+                    "args": ["-c", "set -e; printf changed > inside-link; printf escaped > escape"],
+                    "declared_write_paths": ["inside", "inside-link", "escape"],
+                }),
+            )
+            .await;
+        let receipt = &out["receipt"];
+        assert_ne!(receipt["exit_code"], 0, "{receipt}");
+        assert_eq!(receipt["success"], false, "{receipt}");
+        assert_eq!(receipt["denied"], false, "the tool was launched: {receipt}");
+        let stderr = f.blob_text(&receipt["stderr_ref"]).await;
+        assert!(
+            stderr.contains("ermitted") || stderr.contains("ermission"),
+            "the kernel refusal must be reported in stderr: {stderr:?}"
+        );
+        assert_eq!(std::fs::read(&outside).unwrap(), b"unchanged");
+        assert_eq!(receipt["undeclared_changes"], json!([]));
+        assert_eq!(
+            entries_of(&f, receipt["tree_out"].as_str().unwrap()).await,
+            vec![
+                ("escape".into(), f.put(target).await, 120000),
+                ("inside".into(), f.put(b"changed").await, 644),
+                ("inside-link".into(), f.put(b"inside").await, 120000),
+            ],
+            "the inside write control succeeds while the outside target stays unchanged"
+        );
+    }
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn run_materialized_symlinks_round_trip_losslessly_through_git() {
+    use std::os::unix::fs::symlink;
+    use std::path::Path;
+    use std::process::Command;
+
+    let f = fixture_with_keep(true);
+    f.register_sh("sh", "allow").await;
+    let repo = tempfile::tempdir().expect("git fixture");
+    let git_dir = repo.path().join(".git");
+    let git = |worktree: &Path, args: &[&str]| {
+        let output = Command::new("git")
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
+            .arg("--git-dir")
+            .arg(&git_dir)
+            .arg("--work-tree")
+            .arg(worktree)
+            .args(["-c", "core.symlinks=true", "-c", "core.filemode=true"])
+            .args(args)
+            .current_dir(worktree)
+            .output()
+            .expect("launch fixture git");
+        assert!(
+            output.status.success(),
+            "git {args:?}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        output.stdout
+    };
+    git(repo.path(), &["init", "--quiet"]);
+    std::fs::write(repo.path().join("target.txt"), b"payload\n").unwrap();
+    std::fs::create_dir(repo.path().join("dir")).unwrap();
+    std::fs::write(repo.path().join("dir/child.txt"), b"nested\n").unwrap();
+    for (name, target) in [
+        ("file-link", "target.txt"),
+        ("dir-link", "dir"),
+        ("dangling-link", "missing"),
+    ] {
+        symlink(target, repo.path().join(name)).expect("tracked fixture symlink");
+    }
+    git(repo.path(), &["add", "--force", "--all", "."]);
+    let original = String::from_utf8(git(repo.path(), &["write-tree"]))
+        .unwrap()
+        .trim()
+        .to_string();
+    let index = String::from_utf8(git(repo.path(), &["ls-files", "-s", "-z"]))
+        .expect("fixture index paths are UTF-8");
+    let mut manifest = Vec::new();
+    let mut symlinks = 0;
+    for entry in index.split('\0').filter(|entry| !entry.is_empty()) {
+        let (header, path) = entry.split_once('\t').expect("git index entry");
+        let mut fields = header.split_whitespace();
+        let mode = match fields.next().expect("git mode") {
+            "100644" => 644,
+            "100755" => 755,
+            "120000" => {
+                symlinks += 1;
+                120000
+            }
+            mode => panic!("unexpected fixture mode: {mode}"),
+        };
+        let object = fields.next().expect("git blob id");
+        assert_eq!(fields.next(), Some("0"));
+        let bytes = git(repo.path(), &["cat-file", "blob", object]);
+        manifest.push(json!({ "path": path, "ref": f.put(&bytes).await, "mode": mode }));
+    }
+    assert_eq!(symlinks, 3, "the source index must contain actual symlinks");
+    let input = f.call("exec.tree", json!({ "entries": manifest })).await;
+    let tree = input["tree"].as_str().unwrap();
+    let out = f
+        .call(
+            "exec.run",
+            json!({ "tree": tree, "tool": "sh", "args": ["-c", ":"], "actor": "local" }),
+        )
+        .await;
+    let receipt = &out["receipt"];
+    assert_eq!(receipt["exit_code"], 0, "{receipt}");
+    assert_eq!(receipt["success"], true, "{receipt}");
+    let materialized = f.root.join(receipt["id"].as_str().unwrap());
+
+    // Git reads the actual materialization, so matching target blobs cannot conceal a mode loss.
+    git(&materialized, &["add", "--force", "--all", "."]);
+    let rebuilt = String::from_utf8(git(&materialized, &["write-tree"]))
+        .unwrap()
+        .trim()
+        .to_string();
+    let diff = git(
+        &materialized,
+        &["diff-tree", "--no-commit-id", "-r", &original, &rebuilt],
+    );
+    assert!(
+        diff.is_empty(),
+        "materializing the manifest must preserve Git's tree: {}",
+        String::from_utf8_lossy(&diff)
+    );
+    assert_eq!(receipt["tree_out"], tree);
+    assert_eq!(receipt["skipped"], json!([]));
+    for (name, target) in [
+        ("file-link", "target.txt"),
+        ("dir-link", "dir"),
+        ("dangling-link", "missing"),
+    ] {
+        assert!(std::fs::symlink_metadata(materialized.join(name))
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert_eq!(
+            std::fs::read_link(materialized.join(name)).unwrap(),
+            Path::new(target)
+        );
+    }
+
+    std::fs::remove_file(materialized.join("file-link")).unwrap();
+    std::fs::write(materialized.join("file-link"), b"target.txt").unwrap();
+    git(&materialized, &["add", "--all", "."]);
+    let changed = String::from_utf8(git(&materialized, &["write-tree"]))
+        .unwrap()
+        .trim()
+        .to_string();
+    let patch = String::from_utf8(git(
+        &materialized,
+        &[
+            "diff-tree",
+            "--no-commit-id",
+            "-r",
+            "-p",
+            &original,
+            &changed,
+        ],
+    ))
+    .unwrap();
+    assert!(patch.contains("deleted file mode 120000"), "{patch}");
+    assert!(patch.contains("new file mode 100644"), "{patch}");
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/khive-pack-exec/tests/verbs.rs
+++ b/crates/khive-pack-exec/tests/verbs.rs
@@ -787,6 +787,77 @@ async fn run_refuses_symlink_cwd_escapes_and_cycles_before_materialization() {
     }
 }
 
+#[tokio::test]
+async fn run_deep_shared_prefix_manifest_refuses_missing_cwd_before_materialization() {
+    let f = fixture();
+    f.register_sh("sh", "allow").await;
+    let content_ref = f.put(b"x").await;
+    let mut tree = f
+        .tree(&[("a-sibling/file", b"x", 644), ("start", b"a", 120000)])
+        .await;
+    let prefix = "a/".repeat(250_000);
+    for leaf in 0..12 {
+        let params = json!({"tree":tree,"edits":[{
+            "path":format!("{prefix}leaf-{leaf}"),"ref":content_ref,"mode":644,
+        }]});
+        assert!(serde_json::to_vec(&params).unwrap().len() < 1024 * 1024);
+        let out = f.call("exec.tree_put", params).await;
+        assert_eq!(out["entries"], json!(leaf + 3));
+        tree = out["tree"].as_str().unwrap().to_string();
+    }
+    let stat = f.call("blob.stat", json!({"content_ref":tree})).await;
+    let manifest_bytes = stat["size"].as_u64().unwrap();
+    assert!(manifest_bytes >= 6_000_000, "{stat}");
+    assert!(manifest_bytes < 8 * 1024 * 1024, "{stat}");
+    assert!(!f.root.exists());
+
+    for (cwd, missing) in [
+        ("missing", "missing"),
+        ("a/missing", "a/missing"),
+        ("start/missing", "a/missing"),
+    ] {
+        let error = f
+            .call_err(
+                "exec.run",
+                json!({"tree":tree,"tool":"sh","actor":"local","cwd":cwd,
+                    "args":["-c","printf launched > child-output"]}),
+            )
+            .await;
+        let id = error
+            .split("receipt_id=")
+            .nth(1)
+            .expect("missing-directory refusal names its durable receipt")
+            .trim_end_matches(')');
+        let receipt = f.call("exec.receipt", json!({"id":id})).await;
+        let reason = khive_runtime::RuntimeError::InvalidInput(format!(
+            "cwd {cwd:?} directory {missing:?} is absent from the manifest"
+        ))
+        .to_string();
+        assert_eq!(receipt["reason"], json!(reason));
+        assert!(error.contains(&reason), "{error}");
+        assert_eq!(receipt["denied"], true);
+        assert_eq!(receipt["success"], false);
+        assert_eq!(receipt["decision"]["decision"], "allow");
+        assert_eq!(receipt["cwd"], json!(cwd));
+        assert!(receipt["started_at"].is_null());
+        assert!(receipt["exit_code"].is_null());
+        assert!(receipt["tree_out"].is_null());
+        assert!(receipt["profile_ref"].is_null());
+        assert!(receipt["sandbox"].is_null());
+        assert!(receipt["pids"].is_null());
+        assert!(receipt["stdout_ref"].is_null());
+        assert!(receipt["stderr_ref"].is_null());
+        assert_eq!(receipt["changed"], json!([]));
+        assert_eq!(
+            f.call("exec.events", json!({"run_id":id})).await["count"],
+            0
+        );
+        assert!(!f.root.join(id).exists());
+        assert!(!f.root.join(format!("{id}.sb")).exists());
+        assert!(!f.root.exists(), "preflight must not create the run root");
+    }
+}
+
 async fn cwd_preflight_refusal(f: &Fixture, tree: &str, cwd: &str) -> String {
     let error = f
         .call_err(

--- a/crates/khive-pack-git/Cargo.toml
+++ b/crates/khive-pack-git/Cargo.toml
@@ -48,6 +48,7 @@ windows-sys = { version = "0.61", features = [
 ] }
 
 [dev-dependencies]
+khive-db = { version = "0.8.0", path = "../khive-db" }
 khive-pack-blob = { version = "0.8.0", path = "../khive-pack-blob" }
 tokio = { workspace = true, features = ["full"] }
 khive-pack-kg = { version = "0.8.0", path = "../khive-pack-kg" }

--- a/crates/khive-pack-git/src/local_git.rs
+++ b/crates/khive-pack-git/src/local_git.rs
@@ -613,10 +613,16 @@ pub(crate) async fn write_manifest_tree(
             .or_default()
             .push(GitEntry {
                 name: name.to_string(),
-                mode: if entry.mode == 755 {
-                    "100755"
-                } else {
-                    "100644"
+                mode: match entry.mode {
+                    644 => "100644",
+                    755 => "100755",
+                    120000 => "120000",
+                    _ => {
+                        return Err(LocalGitError::new(
+                            "invalid_params",
+                            "tree entry mode must be 644, 755, or 120000",
+                        ))
+                    }
                 },
                 kind: "blob",
                 oid,
@@ -1395,6 +1401,113 @@ pub(crate) async fn log(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn manifest_roundtrip_preserves_git_symlink_modes_and_target_bytes() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().expect("fixture directory");
+        let repo = dir.path().join("repo");
+        std::fs::create_dir(&repo).expect("repo directory");
+        run_async(&repo, &["init", "-q", "--template="], None)
+            .await
+            .expect("initialize fixture");
+        std::fs::write(repo.join("file.txt"), b"file contents\n").expect("file");
+        std::fs::create_dir(repo.join("dir")).expect("directory");
+        std::fs::write(repo.join("dir/nested.txt"), b"nested contents\n").expect("nested file");
+        for (path, target) in [
+            ("file-link", b"./file.txt".as_slice()),
+            ("directory-link", b"./dir".as_slice()),
+            ("dangling-link", b"../missing-\xff".as_slice()),
+        ] {
+            symlink(OsStr::from_bytes(target), repo.join(path)).expect("symlink");
+        }
+        run_async(&repo, &["add", "--all"], None)
+            .await
+            .expect("index fixture");
+        let original = oid_output(
+            &run_async(&repo, &["write-tree"], None)
+                .await
+                .expect("original tree"),
+        )
+        .expect("tree object id");
+
+        let rt = KhiveRuntime::new(khive_runtime::RuntimeConfig {
+            db_path: Some(dir.path().join("runtime.db")),
+            ..khive_runtime::RuntimeConfig::no_embeddings()
+        })
+        .expect("runtime");
+        let blobs = khive_db::stores::blob::FsBlobStore::new(dir.path().join("blobs"), 0)
+            .expect("fixture blob store");
+        rt.install_blob_store(std::sync::Arc::new(blobs))
+            .expect("install blob store");
+        let store = tree::blob_store(&rt).expect("blob store");
+        let listing = run_async(&repo, &["ls-files", "-s", "-z"], None)
+            .await
+            .expect("index listing");
+        let mut entries = Vec::new();
+        let mut symlinks = 0;
+        for record in listing
+            .split(|byte| *byte == 0)
+            .filter(|row| !row.is_empty())
+        {
+            let tab = record.iter().position(|byte| *byte == b'\t').unwrap();
+            let metadata = std::str::from_utf8(&record[..tab]).unwrap();
+            let fields: Vec<_> = metadata.split_whitespace().collect();
+            assert_eq!(fields.len(), 3);
+            assert_eq!(fields[2], "0", "fixture must have no unmerged entries");
+            let mode = match fields[0] {
+                "100644" => 644,
+                "100755" => 755,
+                "120000" => {
+                    symlinks += 1;
+                    120000
+                }
+                mode => panic!("unexpected index mode {mode}"),
+            };
+            let path = std::str::from_utf8(&record[tab + 1..]).unwrap();
+            let bytes = run_async(&repo, &["cat-file", "blob", fields[1]], None)
+                .await
+                .expect("index blob");
+            if mode == 120000 {
+                assert_eq!(
+                    bytes,
+                    std::fs::read_link(repo.join(path))
+                        .expect("literal target")
+                        .as_os_str()
+                        .as_bytes()
+                );
+            }
+            let content = store.put(bytes).await.expect("store index blob");
+            entries.push(serde_json::json!({"path":path,"ref":content.as_str(),"mode":mode}));
+        }
+        assert_eq!(symlinks, 3, "all three symlinks must be indexed as links");
+        let manifest = tree::store_from_value(&rt, &serde_json::json!(entries))
+            .await
+            .expect("store manifest");
+        let roundtrip = write_manifest_tree(&rt, &repo, &manifest)
+            .await
+            .expect("write manifest tree");
+        assert_eq!(roundtrip, original);
+        let diff = run_async(
+            &repo,
+            &[
+                "diff-tree",
+                "-r",
+                "-p",
+                "--no-ext-diff",
+                &original,
+                &roundtrip,
+            ],
+            None,
+        )
+        .await
+        .expect("roundtrip diff");
+        assert!(diff.is_empty(), "roundtrip must have no git differences");
+    }
 
     #[test]
     fn listing_preserves_delimiters_and_refuses_unsupported_modes() {

--- a/crates/khive-pack-git/src/local_vocab.rs
+++ b/crates/khive-pack-git/src/local_vocab.rs
@@ -36,7 +36,7 @@ pub(crate) const CHECKOUT: HandlerDef = HandlerDef {
 };
 pub(crate) const DIFF: HandlerDef = HandlerDef {
     name: "git.diff",
-    description: "Compare commits or khive tree manifests through diff-tree with external diff, text conversion, color and rename detection disabled. Returns the diff blob, input pair, summary and receipt_id.",
+    description: "Compare commits or khive tree manifests through diff-tree with external diff, text conversion, color and rename detection disabled. Tree entries support regular files (644/755) and symlinks (120000), whose blobs contain literal target bytes. Returns the diff blob, input pair, summary and receipt_id.",
     visibility: Visibility::Verb,
     category: VerbCategory::Assertive,
     params: &[REPO, param("input_kind", true, "Either commits or trees."), param("base", true, "Base commit/ref or tree manifest, according to input_kind."), param("head", true, "Head commit/ref or tree manifest, according to input_kind."), SESSION],

--- a/crates/khive-pack-git/tests/dev_loop.rs
+++ b/crates/khive-pack-git/tests/dev_loop.rs
@@ -612,11 +612,10 @@ async fn manifest_commit_preserves_symlink_mode_and_literal_target() {
     let error = f
         .err("git.checkout", json!({"repo":f.repo,"ref":sha}))
         .await;
-    assert!(
-        error.contains("unsupported_entry") && error.contains("symlinks"),
-        "{error}"
-    );
-    f.refusal_receipt(&error).await;
+    assert!(error.contains("unsupported_entry"), "{error}");
+    let receipt = f.refusal_receipt(&error).await;
+    assert_eq!(receipt["verb"], "git.checkout");
+    assert_eq!(receipt["reason"], "unsupported_entry");
 }
 
 #[tokio::test]

--- a/crates/khive-pack-git/tests/dev_loop.rs
+++ b/crates/khive-pack-git/tests/dev_loop.rs
@@ -351,6 +351,36 @@ impl Fixture {
             .to_string()
     }
 
+    async fn indexed_tree(&self) -> String {
+        let blobs = tree::blob_store(&self.rt).expect("blob store");
+        let listing = self.git_bytes(&["ls-files", "-s", "-z"]);
+        let mut entries = Vec::new();
+        for record in listing
+            .split(|byte| *byte == 0)
+            .filter(|row| !row.is_empty())
+        {
+            let tab = record.iter().position(|byte| *byte == b'\t').unwrap();
+            let metadata = std::str::from_utf8(&record[..tab]).unwrap();
+            let fields: Vec<_> = metadata.split_whitespace().collect();
+            assert_eq!(fields.len(), 3);
+            assert_eq!(fields[2], "0", "fixture must have no unmerged entries");
+            let mode = match fields[0] {
+                "100644" => 644,
+                "100755" => 755,
+                "120000" => 120000,
+                mode => panic!("unexpected index mode {mode}"),
+            };
+            let path = std::str::from_utf8(&record[tab + 1..]).unwrap();
+            let bytes = self.git_bytes(&["cat-file", "blob", fields[1]]);
+            let content = blobs.put(bytes).await.expect("store index blob");
+            entries.push(json!({"path":path,"ref":content.as_str(),"mode":mode}));
+        }
+        self.call("exec.tree", json!({"entries":entries})).await["tree"]
+            .as_str()
+            .expect("tree ref")
+            .to_string()
+    }
+
     async fn blob(&self, reference: &str) -> Vec<u8> {
         tree::blob_store(&self.rt)
             .expect("blob store")
@@ -972,6 +1002,87 @@ async fn diff_bytes_and_inputs_match_independent_native_oracle_for_commits_and_t
             row["inputs"],
             json!({"input_kind":kind,"base":base,"head":target})
         );
+    }
+}
+
+#[tokio::test]
+#[serial_test::serial(git_dev_loop_env)]
+async fn tree_diff_symlink_changes_match_native_git_patches() {
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::symlink;
+
+    let f = Fixture::new(true, false).await;
+    let mut base = f.indexed_tree().await;
+    let mut base_git = f.git_text(&["write-tree"]);
+    let unchanged = f
+        .call(
+            "git.diff",
+            json!({"repo":f.repo,"input_kind":"trees","base":base,"head":base}),
+        )
+        .await;
+    assert!(f.blob(unchanged["diff"].as_str().unwrap()).await.is_empty());
+    assert_eq!(
+        unchanged["summary"],
+        json!({"files":0,"additions":0,"deletions":0})
+    );
+
+    for (change, mode, bytes) in [
+        ("add", Some(120000), b"./a.txt".as_slice()),
+        ("retarget", Some(120000), b"./removed.txt".as_slice()),
+        ("symlink_to_file", Some(644), b"./removed.txt".as_slice()),
+        ("file_to_symlink", Some(120000), b"./removed.txt".as_slice()),
+        ("remove", None, b"".as_slice()),
+    ] {
+        let link = f.repo.join("link");
+        if std::fs::symlink_metadata(&link).is_ok() {
+            std::fs::remove_file(&link).expect("remove previous entry");
+        }
+        match mode {
+            Some(120000) => symlink(OsStr::from_bytes(bytes), &link).expect("symlink"),
+            Some(644) => std::fs::write(&link, bytes).expect("regular file"),
+            None => {}
+            _ => unreachable!("fixture modes are fixed"),
+        }
+        f.git_bytes(&["add", "--all"]);
+        let head = f.indexed_tree().await;
+        let head_git = f.git_text(&["write-tree"]);
+        let oracle = f.git_bytes(&[
+            "diff-tree",
+            "-p",
+            "--no-ext-diff",
+            "--no-textconv",
+            "--no-color",
+            "--no-renames",
+            &base_git,
+            &head_git,
+        ]);
+        let result = f
+            .call(
+                "git.diff",
+                json!({"repo":f.repo,"input_kind":"trees","base":base,"head":head}),
+            )
+            .await;
+        let patch = f.blob(result["diff"].as_str().unwrap()).await;
+        assert_eq!(patch, oracle, "{change} must match native Git");
+        let text = std::str::from_utf8(&patch).expect("fixture diff is UTF-8");
+        let expected: &[&str] = match change {
+            "add" => &["new file mode 120000", "+./a.txt"],
+            "retarget" => &[" 120000", "-./a.txt", "+./removed.txt"],
+            "symlink_to_file" => &["deleted file mode 120000", "new file mode 100644"],
+            "file_to_symlink" => &["deleted file mode 100644", "new file mode 120000"],
+            "remove" => &["deleted file mode 120000", "-./removed.txt"],
+            _ => unreachable!("fixture changes are fixed"),
+        };
+        for marker in expected {
+            assert!(
+                text.contains(marker),
+                "{change}: missing {marker:?} in {text}"
+            );
+        }
+        f.success_receipt(&result).await;
+        base = head;
+        base_git = head_git;
     }
 }
 

--- a/crates/khive-pack-git/tests/dev_loop.rs
+++ b/crates/khive-pack-git/tests/dev_loop.rs
@@ -583,6 +583,44 @@ async fn arm14_ref_move_race_preserves_rival_with_atomic_compare() {
 
 #[tokio::test]
 #[serial_test::serial(git_dev_loop_env)]
+async fn manifest_commit_preserves_symlink_mode_and_literal_target() {
+    let f = Fixture::new(true, true).await;
+    f.policy("git.commit", "allow").await;
+    let index = std::fs::read(f.repo.join(".git/index")).expect("index before");
+    let worktree = std::fs::read(f.repo.join("a.txt")).expect("worktree before");
+    let target = b"../missing-\xff\n";
+    let manifest = f.tree(&[("link", target, 120000)]).await;
+    let result = f.call("git.commit", f.commit_params(&manifest)).await;
+    let sha = result["sha"].as_str().expect("commit SHA");
+    assert_eq!(f.git_text(&["rev-parse", &format!("{sha}^")]), f.base);
+    assert_eq!(
+        f.git_bytes(&["ls-tree", "-r", "--name-only", sha]),
+        b"link\n"
+    );
+    assert!(f
+        .git_text(&["ls-tree", "-r", sha, "link"])
+        .starts_with("120000 blob "));
+    assert_eq!(
+        f.git_bytes(&["cat-file", "blob", &format!("{sha}:link")]),
+        target
+    );
+    assert_eq!(f.git_text(&["rev-parse", "refs/heads/work"]), sha);
+    assert_eq!(std::fs::read(f.repo.join(".git/index")).unwrap(), index);
+    assert_eq!(std::fs::read(f.repo.join("a.txt")).unwrap(), worktree);
+    assert!(std::fs::symlink_metadata(f.repo.join("link")).is_err());
+    f.success_receipt(&result).await;
+    let error = f
+        .err("git.checkout", json!({"repo":f.repo,"ref":sha}))
+        .await;
+    assert!(
+        error.contains("unsupported_entry") && error.contains("symlinks"),
+        "{error}"
+    );
+    f.refusal_receipt(&error).await;
+}
+
+#[tokio::test]
+#[serial_test::serial(git_dev_loop_env)]
 async fn arm14_manifest_commit_preserves_index_and_worktree_residue() {
     let f = Fixture::new(true, true).await;
     f.policy("git.commit", "allow").await;

--- a/docs/adr/ADR-181-exec-verb-sandboxed-run.md
+++ b/docs/adr/ADR-181-exec-verb-sandboxed-run.md
@@ -241,3 +241,48 @@ literal mode is refused as the 420 it is, and an escaping path is refused; 28 ad
 last edit fails normalization leaves the blob store object count unchanged, with the same list
 minus that edit as a positive control that moves the count; 30 a `ref` naming no stored object is
 refused with the count unchanged, so the good edit's blob was not written first.
+
+## Amendment 5 (2026-09-10): symlink entries
+
+1. **Manifest modes.** `khive-tree/v1` accepts the decimal modes `644`, `755` and
+   `120000`. The third mode represents a symlink: its blob contains the literal
+   target path bytes, exactly as a Git `120000` blob does, with no added newline,
+   encoding conversion or normalization. This is an additive entry mode, not a
+   new manifest shape, so the schema string remains `khive-tree/v1` and existing
+   manifests remain valid. Entry paths retain their existing validation; no entry
+   may be below a file or symlink entry, and duplicate paths are refused.
+
+2. **Tree editing and comparison.** `exec.tree` and `exec.tree_put` accept
+   `120000`; `exec.tree_get` returns it. For a symlink put, `content` supplies the
+   target's UTF-8 bytes or `ref` names a blob holding arbitrary target bytes.
+   Omitted mode preserves the existing entry mode, and deletion is unchanged.
+   Changing the target or switching between a file and a symlink is `modified`.
+   `git.diff(input_kind="trees")` maps this mode to Git's `120000` blob entry,
+   retaining native symlink add, retarget, remove and file-conversion patches.
+
+3. **Materialization and containment.** Materialization creates a real symlink
+   with its literal target, whether relative, absolute, dangling or outside the
+   tree. The target is not constrained to the tree root. A fresh run directory
+   receives all directories and exclusively created files before any symlinks,
+   so filesystem name aliases cannot redirect materialization writes. The seatbelt profile
+   remains the read/write boundary: writing through a symlink does not grant
+   write access to its resolved target outside the run directory. A denied write
+   is visible through the command's exit status and captured stderr.
+   `declared_write_paths` still names tree-relative paths, not resolved targets;
+   it filters captured changes and grants no additional filesystem access.
+
+4. **Capture.** The capture walk records symlinks with mode `120000` and reads
+   their target bytes without following them. Directory symlinks are entries,
+   never traversal roots. Created, retargeted, removed and mode-flipped links
+   appear in `changed` under the same declaration rules as files. Sockets,
+   FIFOs and devices remain skipped.
+
+Acceptance arms added: 31 valid symlink entries pass while unsupported modes and
+entries beneath symlinks fail; 32 tree edits preserve target bytes and classify
+all link transitions; 33 materialization preserves literal relative, escaping,
+absolute and non-UTF-8 targets; 34 an escaping-link write leaves its outside
+target unchanged and reports a sandbox denial, while an inside-tree write
+succeeds; 35 capture records links without descending through directory links;
+36 tracked file, directory and dangling symlinks round-trip through the manifest
+to a Git tree with an empty `git diff-tree`, and a link-to-file conversion emits
+the native `120000` to `100644` change.

--- a/docs/adr/ADR-182-git-dev-loop-verbs.md
+++ b/docs/adr/ADR-182-git-dev-loop-verbs.md
@@ -135,6 +135,9 @@ item 1 is amended again in item 3.
    `hash-object -w --no-filters`, `mktree`, `commit-tree` and `update-ref`; no checkout, index or
    working tree is touched; a path the manifest omits is a deletion; `100644` and `100755` are the
    only modes. This replaces the Decision's detached-worktree materialization.
+   **Amended 2026-09-10:** `git.commit` also accepts symlink mode `120000` through
+   the shared `write_manifest_tree` writer, preserving the literal target blob;
+   `git.checkout` retains its independent symlink refusal.
 3. **Actor-only credentials (amends Amendment 1 item 1).** `git.commit`, `git.push`, `git.pr_open`,
    `git.pr_review` and `git.pr_merge` resolve the caller's `[git_write.actors]` row at every call; an
    actor without a row refuses with reason `actor_unmapped`; these verbs have no daemon fallback and

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -2170,6 +2170,48 @@ request(ops="session.export(id=\"<session-id>\", format=\"markdown\")")
 
 ---
 
+## `exec` tree manifests
+
+The exec pack uses immutable `khive-tree/v1` manifests, also consumed by Git tree
+operations. See [ADR-181](../adr/ADR-181-exec-verb-sandboxed-run.md) for run and
+sandbox semantics.
+
+### `exec.tree`, `exec.tree_get`, `exec.tree_put`, `exec.tree_diff`
+
+| Verb             | Parameters                                                      | Result                           |
+| ---------------- | --------------------------------------------------------------- | -------------------------------- |
+| `exec.tree`      | `entries: [{path, ref, mode}]`                                  | `{tree}`                         |
+| `exec.tree_get`  | `tree`                                                          | `{tree, entries}`                |
+| `exec.tree_put`  | `tree`, nonempty `edits: [{path, ref\|content\|delete, mode?}]` | `{tree, base, entries, changed}` |
+| `exec.tree_diff` | `base`, `head`                                                  | `{base, head, changed}`          |
+
+Entry modes are decimal `644` (file), `755` (executable file) or `120000`
+(symlink). A symlink's blob holds its literal target bytes, without an added
+newline or normalization. Entry paths must be relative and normalized, with no
+duplicates or entries below a file or symlink path. Empty `entries` is an empty
+tree. The schema string remains `khive-tree/v1`; existing file-only manifests
+remain valid.
+
+A put edit supplies exactly one of `ref`, `content` (UTF-8 text), or
+`delete: true`. Use `ref` for arbitrary target bytes. Its optional mode preserves
+an existing mode or defaults to `644` for a new path; deletes cannot carry a mode.
+Retargeting a link or switching between a symlink and a file is `modified`.
+Unsupported modes, duplicate edit paths and deletion of a missing path refuse
+the call without publishing a new tree.
+
+`exec.run` materializes real symlinks, including absolute or escaping targets.
+Seatbelt constrains access to resolved targets; `declared_write_paths` names
+tree-relative paths and does not expand sandbox access. Capture records link
+targets without following them, never descends through directory symlinks, and
+reports link additions, retargeting, removal and mode changes in `changed`.
+Sockets, FIFOs and devices remain skipped.
+
+`git.diff(input_kind="trees")` preserves symlink mode `120000` and target blobs,
+so its patches use Git's native symlink and file-conversion representation.
+This does not change the separate `git.checkout` symlink-refusal contract.
+
+---
+
 ## `git` pack — 15 verbs
 
 The entries below cover the ingest and write surface; the dev-loop verbs


### PR DESCRIPTION
## Summary

Tree manifests now carry symbolic links. A manifest entry with mode `120000` is a link whose blob holds the raw target bytes, and every path that consumes or produces a manifest agrees on that shape:

- `exec.tree`, `exec.tree_get` and `exec.tree_put` accept and return `120000` entries; `parse_entries` keeps its duplicate, path-prefix and unsupported-mode refusals.
- Materialization creates the link with the literal target instead of writing a regular file. A two-pass scheme with a fresh exclusive root means a link cannot redirect a later pre-sandbox write. A materialization failure removes the root it created (also with `keep=true`) and finalizes a failed receipt.
- The `cwd` preflight resolves relative link chains inside the manifest with bounded expansion (64 KiB and 1,024 components per target, 4,096 components and 256 KiB of pending work per resolution), refuses a `cwd` that escapes the manifest with a durable denial receipt, and finds a directory's descendants with one ordered seek in the entry map instead of enumerating every path prefix.
- Capture no longer skips links: the walk records them with `read_link`, never through the target, so dangling links and non-UTF-8 or unnormalized target bytes survive a round trip. A capture read failure finalizes a failed receipt and cleans up.
- The git side writes `120000` blobs from a manifest instead of coercing every non-executable entry to `100644`. `git.checkout` keeps its own link refusal.

## Witness

A checkout with tracked symlinks, read as `git ls-files -s`, converted to a manifest, written back with `write_manifest_tree` and compared with `git diff-tree` against the original tree object, yields an empty diff.

## Verification

- `cargo fmt --all -- --check`, `cargo clippy -p khive-pack-exec -p khive-pack-git -p khive-mcp --all-targets -- -D warnings`: clean.
- `cargo test --no-fail-fast` on khive-pack-exec (52) and khive-mcp (842): all passing. khive-pack-git: 430 passing, one intermittent failure in `tests/dev_loop.rs` under parallel execution (a native `git` spawn returning `ENOENT`), green on a serial rerun of the same binary; tracked as #2515, and this change does not touch the git pack's read path.
- Two mutation controls, each restored byte-exact and re-run green (18 passed):
  - materialize writes link targets as regular files: 5 tests fail, including the literal-target, git round-trip and failure-cleanup witnesses.
  - capture skips links: 6 tests fail, including the dangling-link walk, the raw-target-bytes walk and the creation/retarget/removal/mode-flip run.
- A deep shared-prefix manifest (twelve entries sharing a 250,000-deep directory prefix, about 6 MB) with an absent `cwd` is refused through the receipt path without materialization.

ADR-181 and ADR-182 gain dated amendments for the link entry shape and the commit-mode handling; the API reference documents the new mode and the preflight bounds.
