### PR TITLE
feat(kg): expose serving build identity in whoami

### DIFF
--- a/crates/khive-pack-kg/src/handler_defs.rs
+++ b/crates/khive-pack-kg/src/handler_defs.rs
@@ -1262,8 +1262,10 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 24] = [
         description: "Report the caller's identity as the runtime already resolved it for \
                       this request: actor_id, actor_kind, whether the actor is the \
                       unattributed/anonymous fallback, the write namespace, and the \
-                      read-visible namespace set. Never returns tokens or credentials — \
-                      only labels the runtime already computed before dispatch.",
+                      read-visible namespace set. Also returns build.version and \
+                      build.revision from the serving process's compile-time metadata, \
+                      without database diagnostics or a checkpoint probe. Never returns \
+                      tokens or credentials.",
         visibility: Visibility::Verb,
         category: VerbCategory::Assertive,
         params: &[],

--- a/crates/khive-pack-kg/src/handlers/whoami.rs
+++ b/crates/khive-pack-kg/src/handlers/whoami.rs
@@ -2,6 +2,7 @@
 
 use serde_json::{json, Value};
 
+use khive_runtime::build_info::{BUILD_INFO, PACKAGE_VERSION};
 use khive_runtime::{actor_is_unattributed, NamespaceToken, RuntimeError};
 
 use super::common::{deser, WhoamiParams};
@@ -10,8 +11,9 @@ use crate::KgPack;
 impl KgPack {
     /// Report the identity the runtime already resolved for this request: the
     /// caller's actor reference, write namespace, and read-visible namespace
-    /// set. A projection of existing `NamespaceToken` state, not new state —
-    /// every field here is already computed before dispatch reaches a handler.
+    /// set, together with the serving process's compile-time build identity.
+    /// These values come from existing token state and immutable build metadata;
+    /// the handler performs no database diagnostics or checkpoint probe.
     ///
     /// `unattributed` uses the same id-based fallback predicate as gate
     /// checks, token minting, and comm attribution (`actor_is_unattributed`),
@@ -31,6 +33,10 @@ impl KgPack {
             "unattributed": actor_is_unattributed(actor),
             "namespace": token.namespace().as_str(),
             "visible_namespaces": token.visible_namespace_strs(),
+            "build": {
+                "version": PACKAGE_VERSION,
+                "revision": BUILD_INFO.source_revision,
+            },
         }))
     }
 }

--- a/crates/khive-runtime/src/build_info.rs
+++ b/crates/khive-runtime/src/build_info.rs
@@ -1,5 +1,8 @@
 //! Compile-time identity for the source and build that produced this runtime.
 
+/// Package version shared by runtime diagnostics and lightweight identity probes.
+pub const PACKAGE_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 #[cfg(test)]
 #[path = "build_info_support.rs"]
 mod build_info_support;

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -624,8 +624,10 @@ impl KhiveRuntime {
         let build_hash = crate::build_info::BUILD_INFO
             .is_stamped()
             .then_some(crate::build_info::BUILD_INFO.source_revision);
-        let build =
-            khive_db::diagnostics::BuildIdentity::from_env(env!("CARGO_PKG_VERSION"), build_hash);
+        let build = khive_db::diagnostics::BuildIdentity::from_env(
+            crate::build_info::PACKAGE_VERSION,
+            build_hash,
+        );
 
         khive_db::diagnostics::collect_with_runtime_audit_metrics_interruptibly(
             pool,

--- a/crates/kkernel/tests/whoami_build_identity.rs
+++ b/crates/kkernel/tests/whoami_build_identity.rs
@@ -1,0 +1,84 @@
+//! The lightweight identity probe reports the build of the binary serving it.
+
+use std::process::{Command, Output};
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn command(home: &TempDir) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_kkernel"));
+    for (name, _) in std::env::vars_os() {
+        if name.to_string_lossy().starts_with("KHIVE_") {
+            command.env_remove(name);
+        }
+    }
+    command
+        .current_dir(home.path())
+        .env("HOME", home.path())
+        .env("KHIVE_NO_DAEMON", "1")
+        .env("KHIVE_PACKS", "kg")
+        .env("RUST_LOG", "error");
+    command
+}
+
+fn successful(output: Output) -> Vec<u8> {
+    assert!(
+        output.status.success(),
+        "command failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output.stdout
+}
+
+fn request(home: &TempDir, ops: &str) -> Value {
+    let output = command(home)
+        .args([
+            "exec",
+            ops,
+            "--db",
+            ":memory:",
+            "--presentation",
+            "verbose",
+            "--strict",
+        ])
+        .output()
+        .expect("run identity probe");
+    let envelope: Value = serde_json::from_slice(&successful(output)).expect("JSON envelope");
+    assert_eq!(envelope["results"][0]["ok"], true);
+    envelope["results"][0]["result"].clone()
+}
+
+#[test]
+fn whoami_build_matches_binary_version() {
+    let home = TempDir::new().expect("isolated home");
+    let version = String::from_utf8(successful(
+        command(&home)
+            .arg("--version")
+            .output()
+            .expect("run binary version"),
+    ))
+    .expect("version is UTF-8");
+    let identity = request(&home, "whoami()");
+    let build = identity["build"].as_object().expect("build object");
+    assert_eq!(build.len(), 2, "only version and revision are exposed");
+    let package_version = build["version"].as_str().expect("package version");
+    let revision = build["revision"].as_str().expect("source revision");
+    let version_prefix = format!("kkernel {package_version} (revision {revision}, built ");
+    assert!(
+        version.starts_with(&version_prefix),
+        "whoami build must match the same executable's --version: {version:?}, {build:?}"
+    );
+    assert_eq!(identity["actor_id"], "local");
+    assert_eq!(identity["unattributed"], true);
+}
+
+#[test]
+fn whoami_help_describes_build_fields() {
+    let home = TempDir::new().expect("isolated home");
+    let help = request(&home, "whoami(help=true)");
+    let description = help["description"].as_str().expect("help description");
+    assert!(description.contains("build.version"), "{description}");
+    assert!(description.contains("build.revision"), "{description}");
+    assert!(help["params"].as_array().expect("parameters").is_empty());
+}

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -836,9 +836,16 @@ request(ops="resolve(refs=[\"the old record\", \"<uuid>\"])")
 
 ### `whoami` — Assertive
 
-Report the caller identity and namespace scope the runtime already resolved for this request.
-It takes no parameters and returns only identity labels, never tokens or credentials:
-`{actor_id, actor_kind, unattributed, namespace, visible_namespaces}`.
+Report the caller identity and namespace scope the runtime already resolved for this request,
+plus the serving process's build identity. It takes no parameters and never returns tokens or
+credentials: `{actor_id, actor_kind, unattributed, namespace, visible_namespaces, build: {version, revision}}`.
+
+`build.version` is the package version; `build.revision` is the source revision shown by that
+process's `kkernel --version`, including any `-dirty` suffix or the explicit `unstamped` fallback.
+These compile-time values share the source used by `db_diagnostics().build`; diagnostics calls
+the optional revision field `build_hash` and reports it as null for an unstamped build.
+Use `whoami()` for a lightweight build-identity probe: its handler reads existing token state
+and immutable build metadata without invoking database diagnostics or a checkpoint probe.
 
 ```
 request(ops="whoami()")


### PR DESCRIPTION
## Summary

`whoami` now reports the serving process's build identity beside the existing actor and namespace fields:

```json
"build": {"version": "<package version>", "revision": "<source revision>"}
```

The values come from the immutable compile-time build metadata already used by `kkernel --version` (the dirty suffix and the explicit unstamped fallback are unchanged), so a client can tell which executable answered without invoking database diagnostics or a checkpoint. Diagnostics keeps its own optional `build_hash` field, which is `null` when unstamped; the API reference explains the two shapes.

`PACKAGE_VERSION` centralizes the package-version source used by both `whoami` and diagnostics.

## Tests

A black-box test runs the built executable and checks that `whoami` and its help response agree with the same executable's `--version` output.

## Verification

- `cargo fmt --all -- --check` and `cargo clippy -p khive-pack-kg -p khive-runtime -p kkernel -p khive-mcp --all-targets -- -D warnings`: clean.
- `cargo test --no-fail-fast` on khive-pack-kg (543), khive-runtime (1637), kkernel (563) and khive-mcp (842): all passing, 0 failed.
