### PR TITLE
fix(brain): scope actor reads to the caller

### DIFF
--- a/crates/khive-gate/src/actor.rs
+++ b/crates/khive-gate/src/actor.rs
@@ -2,6 +2,12 @@ use serde::{Deserialize, Serialize};
 
 use crate::GateValidationError;
 
+/// Kind prefixes reserved by runtime event attribution and its identity fixtures.
+///
+/// Add newly stamped kinds here and extend the per-kind event scope regressions.
+/// This is not a closed taxonomy: [`ActorRef::try_new`] accepts any non-empty kind.
+pub const RUNTIME_STAMPED_ACTOR_KINDS: &[&str] = &["actor", "anonymous", "agent"];
+
 /// Caller identity with non-empty `kind` and `id`, validated on construction and deserialization.
 ///
 /// See `crates/khive-gate/docs/api/policy-types.md`.

--- a/crates/khive-gate/src/lib.rs
+++ b/crates/khive-gate/src/lib.rs
@@ -10,7 +10,7 @@ mod gate;
 mod obligation;
 mod request;
 
-pub use actor::ActorRef;
+pub use actor::{ActorRef, RUNTIME_STAMPED_ACTOR_KINDS};
 pub use audit::{AuditDecision, AuditEvent};
 pub use context::GateContext;
 pub use decision::GateDecision;

--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -242,6 +242,7 @@ struct ConfigIdFields<'a> {
     outbound: &'a str,
     gate: &'a str,
     git_write: &'a str,
+    brain: &'a str,
     display_timezone: &'a str,
     backends: Option<&'a str>,
     pack_backends: Option<&'a str>,
@@ -261,6 +262,9 @@ fn parse_config_id(config_id: &str) -> Option<ConfigIdFields<'_>> {
     let (packs, rest) = base.split_once("];db=")?;
     let (rest, display_timezone) = rest
         .rsplit_once(";display_tz=")
+        .unwrap_or((rest, "<legacy-absent>"));
+    let (rest, brain) = rest
+        .rsplit_once(";brain=")
         .unwrap_or((rest, "<legacy-absent>"));
     let (rest, git_write) = rest.rsplit_once(";git_write=")?;
     let (rest, gate) = rest
@@ -291,6 +295,7 @@ fn parse_config_id(config_id: &str) -> Option<ConfigIdFields<'_>> {
         outbound,
         gate,
         git_write,
+        brain,
         display_timezone,
         backends,
         pack_backends,
@@ -325,6 +330,8 @@ fn first_config_mismatch_field(client: &str, daemon: Option<&str>) -> &'static s
         "gate"
     } else if client.git_write != daemon.git_write {
         "git_write"
+    } else if client.brain != daemon.brain {
+        "brain"
     } else if client.display_timezone != daemon.display_timezone {
         "display_tz"
     } else if client.backends != daemon.backends {
@@ -3139,6 +3146,19 @@ mod tests {
         let daemon = crate::server::compute_config_id_with_ann_fresh_tail(&revoked, None, true);
 
         assert_eq!(first_config_mismatch_field(&client, Some(&daemon)), "gate");
+    }
+
+    #[test]
+    fn first_config_mismatch_field_names_brain_read_policy() {
+        let config = RuntimeConfig::no_embeddings();
+        let mut changed = config.clone();
+        changed.brain.fleet_readers = vec!["lambda:reader".to_string()];
+        let client =
+            crate::server::compute_config_id_with_runtime_policies(&config, None, true, false);
+        let daemon =
+            crate::server::compute_config_id_with_runtime_policies(&changed, None, true, false);
+
+        assert_eq!(first_config_mismatch_field(&client, Some(&daemon)), "brain");
     }
 
     #[test]

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -824,6 +824,16 @@ pub(crate) fn compute_config_id_with_runtime_policies(
     );
     let git_write = format!("{:x}", git_write_hasher.finalize());
 
+    let mut fleet_readers = config.brain.fleet_readers.clone();
+    fleet_readers.sort();
+    fleet_readers.dedup();
+    let mut brain_hasher = Sha256::new();
+    brain_hasher.update(b"khive.brain-read-policy.v1");
+    brain_hasher.update(
+        serde_json::to_vec(&fleet_readers).expect("brain read policy is JSON serializable"),
+    );
+    let brain = format!("{:x}", brain_hasher.finalize());
+
     let backend = if storage_read_only {
         format!("{:?}:read_only", config.backend_id)
     } else {
@@ -858,7 +868,7 @@ pub(crate) fn compute_config_id_with_runtime_policies(
     // a one-time operational cost that ends when the daemon is restarted, by
     // whoever restarts it.
     let base = format!(
-        "packs=[{}];db={};embed={};extra=[{}];fresh_tail={};blob_hydration_bytes={};backend={};outbound=[{}]{};git_write={};display_tz={}",
+        "packs=[{}];db={};embed={};extra=[{}];fresh_tail={};blob_hydration_bytes={};backend={};outbound=[{}]{};git_write={};brain={};display_tz={}",
         packs.join(","),
         db,
         primary,
@@ -869,6 +879,7 @@ pub(crate) fn compute_config_id_with_runtime_policies(
         outbound.join(","),
         gate,
         git_write,
+        brain,
         config.display_timezone.name(),
     );
 
@@ -6009,6 +6020,35 @@ mod tests {
         }
         assert!(!original.contains("example-reference"));
         assert_eq!(original, fingerprint(&base.clone()));
+    }
+
+    #[test]
+    fn config_id_separates_brain_read_policy_and_normalizes_reader_sets() {
+        let base = RuntimeConfig::no_embeddings();
+        let fingerprint = |config: &RuntimeConfig| {
+            compute_config_id_with_runtime_policies(config, None, true, false)
+        };
+        let mut configured = base.clone();
+        configured.brain.fleet_readers =
+            vec!["lambda:reader".to_string(), "lambda:auditor".to_string()];
+        let configured_id = fingerprint(&configured);
+        assert_ne!(configured_id, fingerprint(&base));
+        assert!(!configured_id.contains("lambda:reader"));
+        assert!(!configured_id.contains("lambda:auditor"));
+
+        let mut reordered = configured.clone();
+        reordered.brain.fleet_readers.reverse();
+        reordered
+            .brain
+            .fleet_readers
+            .push("lambda:reader".to_string());
+        assert_eq!(configured_id, fingerprint(&reordered));
+
+        let mut revoked = configured;
+        revoked.brain.fleet_readers.pop();
+        assert_ne!(configured_id, fingerprint(&revoked));
+        revoked.brain.fleet_readers.clear();
+        assert_eq!(fingerprint(&revoked), fingerprint(&base));
     }
 
     #[test]

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -3361,6 +3361,48 @@ async fn help_brain_feedback_params_non_empty_with_target_and_signal() -> anyhow
 }
 
 #[tokio::test]
+async fn help_brain_actor_reads_expose_caller_scope_and_fleet_gate() -> anyhow::Result<()> {
+    let client = connect_full().await?;
+    for verb in ["brain.event_counts", "brain.resolve", "brain.bindings"] {
+        let schema = help_schema(&client, verb).await?;
+        let description = schema["description"]
+            .as_str()
+            .expect("verb help description")
+            .to_ascii_lowercase();
+        assert!(description.contains("caller"), "{verb}: {description}");
+        let params = schema["params"].as_array().expect("help params");
+        let actor = params
+            .iter()
+            .find(|param| param["name"] == "actor")
+            .expect("actor read help includes actor");
+        assert_eq!(actor["type"], "string", "{verb}: {actor}");
+        assert_eq!(actor["required"], false, "{verb}: {actor}");
+        let actor_scope = actor["description"]
+            .as_str()
+            .expect("actor scope description")
+            .to_ascii_lowercase();
+        assert!(actor_scope.contains("caller"), "{verb}: {actor_scope}");
+        assert!(actor_scope.contains("visible"), "{verb}: {actor_scope}");
+
+        let all_actors = params.iter().find(|param| param["name"] == "all_actors");
+        if verb == "brain.event_counts" {
+            let all_actors = all_actors.expect("event counts advertises fleet reads");
+            assert_eq!(all_actors["type"], "boolean");
+            assert_eq!(all_actors["required"], false);
+            let fleet_scope = all_actors["description"]
+                .as_str()
+                .expect("fleet read scope description")
+                .to_ascii_lowercase();
+            assert!(fleet_scope.contains("fleet_readers"), "{fleet_scope}");
+            assert!(fleet_scope.contains("actor"), "{fleet_scope}");
+        } else {
+            assert!(all_actors.is_none(), "{verb} has no fleet read parameter");
+        }
+    }
+    Ok(())
+}
+
+#[tokio::test]
 async fn help_propose_params_non_empty_with_title_description_changeset() -> anyhow::Result<()> {
     let client = connect_full().await?;
     let schema = help_schema(&client, "propose").await?;

--- a/crates/khive-pack-brain/README.md
+++ b/crates/khive-pack-brain/README.md
@@ -39,10 +39,17 @@ verbs through the MCP `request` DSL, not called directly as a Rust API:
 
 ```text
 request(ops="brain.create_profile(name=\"my-profile-v1\", consumer_kind=\"recall\")")
-request(ops="brain.resolve(consumer_kind=\"recall\", actor=\"agent:docs\")")
+request(ops="brain.resolve(consumer_kind=\"recall\")")
 request(ops="brain.feedback(target_id=\"<uuid>\", signal=\"useful\")")
 request(ops="brain.auto_feedback(query=\"why\", results=[{\"id\": \"<uuid>\"}], target_id=\"<uuid>\", signal=\"implicit_positive\")")
 ```
+
+Event counts, profile resolution, and binding listing default to the authorized
+caller's actor scope. An explicit foreign actor requires visibility; aggregate
+event counts additionally require `all_actors=true` and a serving-runtime
+`[brain] fleet_readers` entry. See the
+[API reference](../../docs/guide/api-reference.md#brainevent_counts--assertive)
+for the exact actor filters and anonymous-caller behavior.
 
 The `Fold` implementations are exposed as a Rust API for embedding a profile's
 reduction logic in another crate:

--- a/crates/khive-pack-brain/src/fold_gate.rs
+++ b/crates/khive-pack-brain/src/fold_gate.rs
@@ -525,6 +525,7 @@ mod tests {
 
         let rt = KhiveRuntime::new(RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             exec: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
@@ -636,6 +637,7 @@ mod tests {
         let db_path = dir.path().join(db_name);
         let rt = KhiveRuntime::new(RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             exec: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -10,7 +10,7 @@ use serde_json::{json, Value};
 use khive_runtime::time_anchor::anchor_date_to_earliest_instant;
 use khive_runtime::{
     micros_to_iso, DispatchHook, EventAttribution, EventView, KhiveRuntime, Namespace,
-    NamespaceToken, RuntimeError, VerbRegistry,
+    NamespaceToken, RuntimeError, VerbRegistry, RUNTIME_STAMPED_ACTOR_KINDS,
 };
 use khive_storage::event::{Event, EventFilter};
 use khive_storage::types::PageRequest;
@@ -131,8 +131,9 @@ pub(crate) static BRAIN_HANDLERS: &[HandlerDef] = &[
                 required: false,
                 description: "Defaults to the caller; a named foreign actor must be visible to the caller. \
                     Ordinary actor ids match actor: plus the unchanged id; a historical bare alias also \
-                    matches only when the id does not begin actor:. An explicit actor:-prefixed value \
-                    matches exactly and authorizes the id after removing one prefix. Default-scoped \
+                    matches only when the id has no reserved runtime kind prefix (actor:, anonymous:, agent:). \
+                    An explicit reserved-prefix value matches exactly and checks structural caller identity; \
+                    visibility uses the id after one actor: prefix, otherwise the unchanged label. Default-scoped \
                     counts use one caller-label key.",
                 resolution_mode: IdResolutionMode::NotApplicable,
             },
@@ -905,6 +906,12 @@ impl BrainPack {
         }
     }
 
+    fn split_stamped_actor_label(label: &str) -> Option<(&str, &str)> {
+        label
+            .split_once(':')
+            .filter(|(kind, _)| RUNTIME_STAMPED_ACTOR_KINDS.contains(kind))
+    }
+
     fn check_read_actor(token: &NamespaceToken, actor: &str) -> Result<(), RuntimeError> {
         if actor != Self::caller_actor_label(token)
             && !token.visible_namespace_strs().contains(&actor)
@@ -964,8 +971,18 @@ impl BrainPack {
         }
         let caller = Self::caller_actor_label(token);
         if let Some(actor) = p.actor.as_deref() {
-            let identity = actor.strip_prefix("actor:").unwrap_or(actor);
-            Self::check_read_actor(token, identity)?;
+            let (identity, is_self) = match Self::split_stamped_actor_label(actor) {
+                Some((kind, id)) => (
+                    if kind == "actor" { id } else { actor },
+                    token.actor().kind == kind && token.actor().id == id,
+                ),
+                None => (actor, actor == caller),
+            };
+            if !is_self && !token.visible_namespace_strs().contains(&identity) {
+                return Err(RuntimeError::InvalidInput(format!(
+                    "actor {identity:?} is not visible to this caller"
+                )));
+            }
         }
         let default_scope = !all_actors && p.actor.is_none();
 
@@ -994,10 +1011,12 @@ impl BrainPack {
         // A prefixed id has no bare alias: that spelling belongs to another
         // principal's canonical events. Only default scope coalesces actor keys.
         let actor_filters: Vec<String> = match p.actor.as_deref() {
-            Some(a) if a.starts_with("actor:") => vec![a.to_string()],
+            Some(a) if Self::split_stamped_actor_label(a).is_some() => vec![a.to_string()],
             Some(a) => vec![a.to_string(), format!("actor:{a}")],
             None if all_actors => Vec::new(),
-            None if token.actor().kind == "actor" && caller.starts_with("actor:") => {
+            None if token.actor().kind == "actor"
+                && Self::split_stamped_actor_label(&caller).is_some() =>
+            {
                 vec![format!("actor:{caller}")]
             }
             None if token.actor().kind == "actor" => {

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -106,7 +106,8 @@ pub(crate) static BRAIN_HANDLERS: &[HandlerDef] = &[
             the live event plane: rows appended while the call paginates may be excluded; \
             bound `until` in the past for a closed population. Exhaustive windows matching more than \
             2,000,000 events are rejected rather than returned as partial aggregates; narrow \
-            since/until or add actor/kind filters.",
+            since/until or add actor/kind filters. Scope defaults to the caller; named foreign \
+            actors must be visible, and all_actors=true requires the serving brain.fleet_readers allowlist.",
         visibility: khive_types::Visibility::Verb,
         category: khive_types::VerbCategory::Assertive,
         params: &[
@@ -128,10 +129,16 @@ pub(crate) static BRAIN_HANDLERS: &[HandlerDef] = &[
                 name: "actor",
                 param_type: "string",
                 required: false,
-                description: "Filter to a single actor. Stored actor strings are prefixed \
-                    (e.g. \"actor:lambda:khive\"); pass either the bare seat form \
-                    (\"lambda:khive\") or the stored prefixed form — both match. Omit for all \
-                    actors.",
+                description: "Defaults to the caller; a named foreign actor must be visible to the caller. \
+                    Bare actor labels also match their stored actor:-prefixed spelling; an explicitly \
+                    prefixed label is an exact event filter. Default-scoped counts collapse both spellings.",
+                resolution_mode: IdResolutionMode::NotApplicable,
+            },
+            khive_types::ParamDef {
+                name: "all_actors",
+                param_type: "boolean",
+                required: false,
+                description: "Default false; true reads all actors only when the caller's actor id is in the serving brain.fleet_readers config and cannot be combined with actor.",
                 resolution_mode: IdResolutionMode::NotApplicable,
             },
             khive_types::ParamDef {
@@ -185,7 +192,7 @@ pub(crate) static BRAIN_HANDLERS: &[HandlerDef] = &[
     },
     HandlerDef {
         name: "brain.resolve",
-        description: "Show which profile would serve a caller context",
+        description: "Show which profile would serve the caller; a named foreign actor must be visible to the caller.",
         visibility: khive_types::Visibility::Verb,
         category: khive_types::VerbCategory::Assertive,
         params: &[
@@ -200,7 +207,7 @@ pub(crate) static BRAIN_HANDLERS: &[HandlerDef] = &[
                 name: "actor",
                 param_type: "string",
                 required: false,
-                description: "Caller actor identifier. Defaults to the caller's dispatch identity; anonymous callers match only wildcard bindings. Pass explicitly to query another identity.",
+                description: "Defaults to the caller's dispatch identity; a named foreign actor must be visible to the caller, and omitted anonymous actors match only wildcard bindings.",
                 resolution_mode: IdResolutionMode::NotApplicable,
             },
             khive_types::ParamDef {
@@ -547,7 +554,7 @@ pub(crate) static BRAIN_HANDLERS: &[HandlerDef] = &[
     },
     HandlerDef {
         name: "brain.bindings",
-        description: "List rows in the profile resolution table, optionally filtered",
+        description: "List the caller's profile binding rows; a named foreign actor must be visible to the caller.",
         visibility: khive_types::Visibility::Verb,
         category: khive_types::VerbCategory::Assertive,
         params: &[
@@ -562,7 +569,7 @@ pub(crate) static BRAIN_HANDLERS: &[HandlerDef] = &[
                 name: "actor",
                 param_type: "string",
                 required: false,
-                description: "Filter bindings by actor.",
+                description: "Defaults to the caller's actor label; a named foreign actor must be visible to the caller.",
                 resolution_mode: IdResolutionMode::NotApplicable,
             },
             khive_types::ParamDef {
@@ -887,6 +894,26 @@ impl BrainPack {
         }
     }
 
+    fn caller_actor_label(token: &NamespaceToken) -> String {
+        let actor = token.actor();
+        if actor.kind == "actor" {
+            actor.id.clone()
+        } else {
+            format!("{}:{}", actor.kind, actor.id)
+        }
+    }
+
+    fn check_read_actor(token: &NamespaceToken, actor: &str) -> Result<(), RuntimeError> {
+        if actor != Self::caller_actor_label(token)
+            && !token.visible_namespace_strs().contains(&actor)
+        {
+            return Err(RuntimeError::InvalidInput(format!(
+                "actor {actor:?} is not visible to this caller"
+            )));
+        }
+        Ok(())
+    }
+
     pub(crate) async fn handle_event_counts(
         &self,
         token: &NamespaceToken,
@@ -896,6 +923,7 @@ impl BrainPack {
         #[serde(deny_unknown_fields)]
         struct EventCountsParams {
             actor: Option<String>,
+            all_actors: Option<bool>,
             kind: Option<String>,
             // `Option`, not a required `String`: a bare-missing `since` must go through
             // the same named-field-plus-example-format error as a malformed one, not
@@ -912,6 +940,36 @@ impl BrainPack {
         }
         let p: EventCountsParams = serde_json::from_value(params)
             .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
+
+        let all_actors = p.all_actors.unwrap_or(false);
+        if all_actors && p.actor.is_some() {
+            return Err(RuntimeError::InvalidInput(
+                "all_actors=true cannot be combined with actor".into(),
+            ));
+        }
+        if all_actors
+            && !self
+                .runtime
+                .config()
+                .brain
+                .fleet_readers
+                .contains(&token.actor().id)
+        {
+            return Err(RuntimeError::InvalidInput(format!(
+                "actor {:?} is not a configured fleet reader",
+                token.actor().id
+            )));
+        }
+        let caller = Self::caller_actor_label(token);
+        if let Some(actor) = p.actor.as_deref() {
+            let identity = if actor == caller {
+                actor
+            } else {
+                actor.strip_prefix("actor:").unwrap_or(actor)
+            };
+            Self::check_read_actor(token, identity)?;
+        }
+        let default_scope = !all_actors && p.actor.is_none();
 
         let since_raw = p.since.as_deref().ok_or_else(|| {
             RuntimeError::InvalidInput(
@@ -935,15 +993,16 @@ impl BrainPack {
             None => None,
         };
 
-        // Stored actor strings are prefixed (`actor:<kind>:<id>`). Callers naturally pass the
-        // bare seat form (e.g. "lambda:khive"), which would silently match nothing against an
-        // exact-match filter. Match either spelling by expanding the filter to both forms —
-        // `EventFilter.actors` is an IN-list, so this is a pure OR, never a guess. A caller who
-        // already passes the stored `actor:`-prefixed form keeps exact-match behavior.
+        // Preserve explicit event-filter spellings. Only the default scope coalesces
+        // the ordinary actor's bare and attributed forms into the caller's one key.
         let actor_filters: Vec<String> = match p.actor.as_deref() {
             Some(a) if a.starts_with("actor:") => vec![a.to_string()],
             Some(a) => vec![a.to_string(), format!("actor:{a}")],
-            None => Vec::new(),
+            None if all_actors => Vec::new(),
+            None if token.actor().kind == "actor" => {
+                vec![caller.clone(), format!("actor:{caller}")]
+            }
+            None => vec![caller.clone()],
         };
 
         let store = self.runtime.events(token)?;
@@ -1009,7 +1068,8 @@ impl BrainPack {
             *counts_by_kind
                 .entry(event.kind.name().to_string())
                 .or_insert(0) += 1;
-            *counts_by_actor.entry(event.actor.clone()).or_insert(0) += 1;
+            let actor_key = if default_scope { &caller } else { &event.actor };
+            *counts_by_actor.entry(actor_key.clone()).or_insert(0) += 1;
             *counts_by_verb.entry(event.verb.clone()).or_insert(0) += 1;
             if event.kind == khive_types::EventKind::FeedbackExplicit {
                 let originating_verb = event
@@ -1222,14 +1282,15 @@ impl BrainPack {
         let p: ResolveParams = serde_json::from_value(params)
             .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
 
-        // #741: an omitted `actor` defaults to the caller's dispatch identity so
-        // this introspection verb reports what the serve path (#708) actually
-        // does. Anonymous callers stay `None` and match only wildcard bindings;
-        // an explicit `actor` param wins so evaluation tooling can query other
-        // identities.
+        let caller = Self::caller_actor_label(token);
+        // Anonymous omission must retain the serve path's wildcard-only resolution.
         let actor = match p.actor.as_deref() {
-            Some(a) => Some(a),
-            None => token.actor().binding_id(),
+            Some(a) => {
+                Self::check_read_actor(token, a)?;
+                Some(a)
+            }
+            None if token.actor().is_anonymous() => None,
+            None => Some(caller.as_str()),
         };
 
         let state = self.state.lock().unwrap();
@@ -2510,7 +2571,11 @@ impl BrainPack {
 
     // ── brain.bindings ────────────────────────────────────────────────────
 
-    pub(crate) async fn handle_bindings(&self, params: Value) -> Result<Value, RuntimeError> {
+    pub(crate) async fn handle_bindings(
+        &self,
+        token: &NamespaceToken,
+        params: Value,
+    ) -> Result<Value, RuntimeError> {
         // Inspection verb — list binding rows, optionally filtered.
         #[derive(Deserialize)]
         struct BindingsParams {
@@ -2522,13 +2587,17 @@ impl BrainPack {
         let p: BindingsParams = serde_json::from_value(params)
             .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
 
+        let caller = Self::caller_actor_label(token);
+        let actor = p.actor.as_deref().unwrap_or(&caller);
+        Self::check_read_actor(token, actor)?;
+
         let state = self.state.lock().unwrap();
         let rows: Vec<Value> = state
             .bindings
             .iter()
             .filter(|b| {
                 p.profile_id.as_ref().is_none_or(|id| &b.profile_id == id)
-                    && p.actor.as_ref().is_none_or(|a| &b.actor == a)
+                    && b.actor == actor
                     && p.namespace.as_ref().is_none_or(|n| &b.namespace == n)
                     && p.consumer_kind
                         .as_ref()
@@ -3403,7 +3472,7 @@ impl khive_runtime::pack::PackRuntime for BrainPack {
             "brain.profiles" => self.handle_profiles(params).await,
             "brain.profile" => self.handle_profile(params).await,
             "brain.resolve" => self.handle_resolve(token, params).await,
-            "brain.bindings" => self.handle_bindings(params).await,
+            "brain.bindings" => self.handle_bindings(token, params).await,
             // Commissive
             "brain.activate" => self.handle_activate(token, params).await,
             "brain.deactivate" => self.handle_deactivate(token, params).await,

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -130,8 +130,10 @@ pub(crate) static BRAIN_HANDLERS: &[HandlerDef] = &[
                 param_type: "string",
                 required: false,
                 description: "Defaults to the caller; a named foreign actor must be visible to the caller. \
-                    Bare actor labels also match their stored actor:-prefixed spelling; an explicitly \
-                    prefixed label is an exact event filter. Default-scoped counts collapse both spellings.",
+                    Ordinary actor ids match actor: plus the unchanged id; a historical bare alias also \
+                    matches only when the id does not begin actor:. An explicit actor:-prefixed value \
+                    matches exactly and authorizes the id after removing one prefix. Default-scoped \
+                    counts use one caller-label key.",
                 resolution_mode: IdResolutionMode::NotApplicable,
             },
             khive_types::ParamDef {
@@ -962,11 +964,7 @@ impl BrainPack {
         }
         let caller = Self::caller_actor_label(token);
         if let Some(actor) = p.actor.as_deref() {
-            let identity = if actor == caller {
-                actor
-            } else {
-                actor.strip_prefix("actor:").unwrap_or(actor)
-            };
+            let identity = actor.strip_prefix("actor:").unwrap_or(actor);
             Self::check_read_actor(token, identity)?;
         }
         let default_scope = !all_actors && p.actor.is_none();
@@ -993,12 +991,15 @@ impl BrainPack {
             None => None,
         };
 
-        // Preserve explicit event-filter spellings. Only the default scope coalesces
-        // the ordinary actor's bare and attributed forms into the caller's one key.
+        // A prefixed id has no bare alias: that spelling belongs to another
+        // principal's canonical events. Only default scope coalesces actor keys.
         let actor_filters: Vec<String> = match p.actor.as_deref() {
             Some(a) if a.starts_with("actor:") => vec![a.to_string()],
             Some(a) => vec![a.to_string(), format!("actor:{a}")],
             None if all_actors => Vec::new(),
+            None if token.actor().kind == "actor" && caller.starts_with("actor:") => {
+                vec![format!("actor:{caller}")]
+            }
             None if token.actor().kind == "actor" => {
                 vec![caller.clone(), format!("actor:{caller}")]
             }

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -10135,6 +10135,224 @@ mod read_scope_tests {
         }
     }
 
+    async fn append_attributed_actor_events(
+        rt: &KhiveRuntime,
+        token: &NamespaceToken,
+        count: usize,
+    ) {
+        let events = rt.events(token).expect("attributed event store");
+        let canonical_actor = format!("{}:{}", token.actor().kind, token.actor().id);
+        for _ in 0..count {
+            let mut event = khive_storage::event::Event::new(
+                token.namespace().as_str(),
+                "search",
+                EventKind::SearchExecuted,
+                khive_types::SubstrateKind::Note,
+                "caller-supplied",
+            );
+            event.created_at = 1_000_000;
+            event.payload = json!({"result_kind": "note"});
+            let id = event.id;
+            events
+                .append_event(event)
+                .await
+                .expect("append attributed event");
+            let stored = events.get_event(id).await.unwrap().unwrap();
+            assert_eq!(stored.actor, canonical_actor);
+        }
+    }
+
+    async fn assert_stamped_kind_raw_id_scope(kind: &str, raw_id: &str) {
+        let (pack, rt) = make_pack_with_read_scope(Some("serving-actor"), &[], &[]);
+        let (_, caller_rt) = make_pack_with_read_scope(Some(raw_id), &[], &[]);
+        let token = caller_rt
+            .authorize(Namespace::local())
+            .expect("named caller token");
+        assert_eq!(token.actor().kind, "actor");
+        assert_eq!(token.actor().id, raw_id);
+        append_attributed_actor_events(&rt, &token, 2).await;
+
+        let (_, unrelated_rt) = make_pack_with_read_scope(Some("unrelated-caller"), &[], &[]);
+        let unrelated = unrelated_rt
+            .authorize(Namespace::local())
+            .expect("unrelated token");
+        append_attributed_actor_events(&rt, &unrelated, 3).await;
+
+        let visible_identity = match kind {
+            "actor" => {
+                let (_, other_rt) = make_pack_with_read_scope(Some("x"), &[], &[]);
+                let other = other_rt
+                    .authorize(Namespace::local())
+                    .expect("other actor token");
+                append_attributed_actor_events(&rt, &other, 1).await;
+                "x"
+            }
+            "anonymous" => {
+                let (_, other_rt) = make_pack_with_read_scope(None, &[], &[]);
+                let other = other_rt
+                    .authorize(Namespace::local())
+                    .expect("anonymous token");
+                append_attributed_actor_events(&rt, &other, 1).await;
+                for exhaustive in [false, true] {
+                    let mut params = event_params();
+                    params["actor"] = json!(raw_id);
+                    params["exhaustive"] = json!(exhaustive);
+                    let own = pack
+                        .dispatch("brain.event_counts", params, &empty_registry(), &other)
+                        .await
+                        .expect("anonymous canonical self filter uses structural identity");
+                    assert_eq!(own["counts_by_actor"], json!({"anonymous:local": 1}));
+                    assert_eq!(own["total"], json!(1));
+                    assert_eq!(own["window_event_total"], json!(1));
+                }
+                raw_id
+            }
+            "agent" => {
+                // Agent-kind tokens have no public runtime minting path; use the
+                // trusted fixture for this reserved canonical stamp.
+                super::event_counts_tests::seed_event(
+                    &rt,
+                    &token,
+                    "search",
+                    EventKind::SearchExecuted,
+                    raw_id,
+                    1_000_000,
+                    json!({"result_kind": "note"}),
+                )
+                .await;
+                raw_id
+            }
+            _ => panic!("unexpected stamped actor kind {kind}"),
+        };
+        let (_, visible_rt) = make_pack_with_read_scope(Some(raw_id), &[visible_identity], &[]);
+        let visible = visible_rt
+            .authorize_with_visibility(Namespace::local(), visible_rt.visible_namespaces().to_vec())
+            .expect("named caller token with the other principal visible");
+        let canonical_self = format!("actor:{raw_id}");
+        let registry = empty_registry();
+        for exhaustive in [false, true] {
+            let mut params = event_params();
+            params["exhaustive"] = json!(exhaustive);
+            let own = pack
+                .dispatch("brain.event_counts", params.clone(), &registry, &token)
+                .await
+                .expect("default scope excludes the ambiguous raw alias");
+            let mut expected = json!({});
+            expected[raw_id] = json!(2);
+            assert_eq!(own["counts_by_actor"], expected);
+            assert_eq!(own["total"], json!(2));
+            assert_eq!(own["window_event_total"], json!(2));
+
+            params["actor"] = json!(canonical_self);
+            let explicit_self = pack
+                .dispatch("brain.event_counts", params.clone(), &registry, &token)
+                .await
+                .expect("canonical self filter identifies the named principal");
+            let mut expected = json!({});
+            expected[canonical_self.as_str()] = json!(2);
+            assert_eq!(explicit_self["counts_by_actor"], expected);
+            assert_eq!(explicit_self["total"], json!(2));
+            assert_eq!(explicit_self["window_event_total"], json!(2));
+
+            params["actor"] = json!(raw_id);
+            let denied = pack
+                .dispatch("brain.event_counts", params.clone(), &registry, &token)
+                .await
+                .expect_err(
+                    "a matching raw id cannot authorize another principal's canonical stamp",
+                );
+            assert_actor_refused(denied, visible_identity);
+            let other = pack
+                .dispatch("brain.event_counts", params, &registry, &visible)
+                .await
+                .expect("visible stamped-kind filter reads exactly the other principal");
+            let mut expected = json!({});
+            expected[raw_id] = json!(1);
+            assert_eq!(other["counts_by_actor"], expected);
+            assert_eq!(other["total"], json!(1));
+            assert_eq!(other["window_event_total"], json!(1));
+        }
+    }
+
+    #[test]
+    fn stamped_actor_kind_cases_cover_runtime_kinds() {
+        let mut kinds = khive_runtime::RUNTIME_STAMPED_ACTOR_KINDS.to_vec();
+        kinds.sort_unstable();
+        assert_eq!(kinds, ["actor", "agent", "anonymous"]);
+    }
+
+    #[tokio::test]
+    async fn default_actor_prefixed_raw_id_excludes_colliding_principal_events() {
+        assert_stamped_kind_raw_id_scope("actor", "actor:x").await;
+    }
+
+    #[tokio::test]
+    async fn default_anonymous_prefixed_raw_id_excludes_colliding_principal_events() {
+        assert_stamped_kind_raw_id_scope("anonymous", "anonymous:local").await;
+    }
+
+    #[tokio::test]
+    async fn default_agent_prefixed_raw_id_excludes_colliding_principal_events() {
+        assert_stamped_kind_raw_id_scope("agent", "agent:x").await;
+    }
+
+    #[tokio::test]
+    async fn default_ordinary_actor_preserves_bare_historical_alias() {
+        let (pack, rt) = make_pack_with_read_scope(Some("caller-a"), &[], &[]);
+        let token = rt
+            .authorize(Namespace::local())
+            .expect("ordinary actor token");
+        append_attributed_actor_events(&rt, &token, 2).await;
+        super::event_counts_tests::seed_event(
+            &rt,
+            &token,
+            "search",
+            EventKind::SearchExecuted,
+            "caller-a",
+            1_000_000,
+            json!({"result_kind": "note"}),
+        )
+        .await;
+        let (_, other_rt) = make_pack_with_read_scope(Some("unrelated-caller"), &[], &[]);
+        let other = other_rt
+            .authorize(Namespace::local())
+            .expect("unrelated token");
+        append_attributed_actor_events(&rt, &other, 3).await;
+        let registry = empty_registry();
+        for exhaustive in [false, true] {
+            let mut params = event_params();
+            params["exhaustive"] = json!(exhaustive);
+            let own = pack
+                .dispatch("brain.event_counts", params.clone(), &registry, &token)
+                .await
+                .expect("ordinary default scope includes its historical alias");
+            assert_eq!(own["counts_by_actor"], json!({"caller-a": 3}));
+            assert_eq!(own["total"], json!(3));
+            assert_eq!(own["window_event_total"], json!(3));
+
+            params["actor"] = json!("caller-a");
+            let bare = pack
+                .dispatch("brain.event_counts", params.clone(), &registry, &token)
+                .await
+                .expect("ordinary bare filter preserves both stored spellings");
+            assert_eq!(
+                bare["counts_by_actor"],
+                json!({"caller-a": 1, "actor:caller-a": 2})
+            );
+            assert_eq!(bare["total"], json!(3));
+            assert_eq!(bare["window_event_total"], json!(3));
+
+            params["actor"] = json!("actor:caller-a");
+            let canonical = pack
+                .dispatch("brain.event_counts", params, &registry, &token)
+                .await
+                .expect("ordinary canonical filter remains exact");
+            assert_eq!(canonical["counts_by_actor"], json!({"actor:caller-a": 2}));
+            assert_eq!(canonical["total"], json!(2));
+            assert_eq!(canonical["window_event_total"], json!(2));
+        }
+    }
+
     #[tokio::test]
     async fn all_actor_event_counts_require_serving_runtime_fleet_reader() {
         let (pack, rt) = make_pack_with_read_scope(Some("caller-a"), &[], &["caller-a"]);

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -59,6 +59,29 @@ fn make_pack() -> (BrainPack, KhiveRuntime) {
     (pack, rt)
 }
 
+fn make_pack_with_read_scope(
+    actor: Option<&str>,
+    visible_actors: &[&str],
+    fleet_readers: &[&str],
+) -> (BrainPack, KhiveRuntime) {
+    let mut config = khive_runtime::KhiveConfig::default();
+    config.actor.id = actor.map(str::to_string);
+    config.actor.visible_namespaces = Some(visible_actors.iter().map(|s| s.to_string()).collect());
+    config.brain.fleet_readers = fleet_readers.iter().map(|s| s.to_string()).collect();
+    let rt = KhiveRuntime::new(khive_runtime::runtime_config_from_khive_config(
+        &config,
+        RuntimeConfig {
+            db_path: None,
+            packs: vec!["kg".to_string()],
+            brain_profile: None,
+            actor_id: None,
+            ..RuntimeConfig::no_embeddings()
+        },
+    ))
+    .expect("in-memory runtime with actor read scope");
+    (BrainPack::new(rt.clone()), rt)
+}
+
 /// Like `make_pack`, with the display timezone pinned so date-only
 /// `since`/`until` anchoring is deterministic regardless of the host zone
 /// (`RuntimeConfig::default()` resolves the machine's own zone).
@@ -440,7 +463,7 @@ async fn dispatch_activate_nonexistent_profile_returns_not_found() {
 
 #[tokio::test]
 async fn dispatch_bind_and_resolve_explicit_binding() {
-    let (pack, rt) = make_pack();
+    let (pack, rt) = make_pack_with_actor("agent-x");
     let registry = empty_registry();
     let token = rt.authorize(Namespace::local()).unwrap();
 
@@ -1770,7 +1793,7 @@ async fn w4_h1_create_profile_duplicate_rejected() {
 // H2: brain.bindings lists binding rows.
 #[tokio::test]
 async fn w4_h2_bindings_lists_rows() {
-    let (pack, rt) = make_pack();
+    let (pack, rt) = make_pack_with_actor("agent-a");
     let registry = empty_registry();
     let token = rt.authorize(Namespace::local()).unwrap();
 
@@ -1842,7 +1865,7 @@ async fn bind_rejects_unregistered_consumer_kind_with_valid_list() {
 // H2: brain.bindings supports filtering.
 #[tokio::test]
 async fn w4_h2_bindings_filtered() {
-    let (pack, rt) = make_pack();
+    let (pack, rt) = make_pack_with_actor("agent-1");
     let registry = empty_registry();
     let token = rt.authorize(Namespace::local()).unwrap();
 
@@ -2130,9 +2153,11 @@ async fn r2_create_profile_rejects_whitespace_consumer_kind() {
 // brain.bindings AND-semantics pinned with ≥3 bindings and combined filters.
 #[tokio::test]
 async fn r2_bindings_and_semantics_multi_filter() {
-    let (pack, rt) = make_pack();
+    let (pack, rt) = make_pack_with_read_scope(Some("agent-A"), &["agent-B"], &[]);
     let registry = empty_registry();
-    let token = rt.authorize(Namespace::local()).unwrap();
+    let token = rt
+        .authorize_with_visibility(Namespace::local(), rt.visible_namespaces().to_vec())
+        .unwrap();
 
     // Create two extra profiles for variety.
     for name in ["alpha-v1", "beta-v1"] {
@@ -2434,6 +2459,7 @@ fn make_pack_with_actor(actor_id: &str) -> (BrainPack, KhiveRuntime) {
     let rt = KhiveRuntime::new(khive_runtime::RuntimeConfig {
         mounts: Vec::new(),
         git_write: Default::default(),
+        brain: Default::default(),
         exec: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         events_split: None,
@@ -4398,8 +4424,9 @@ mod help_tests {
     fn make_brain_registry() -> (khive_runtime::VerbRegistry, KhiveRuntime) {
         use khive_pack_kg::KgPack;
         use khive_runtime::VerbRegistryBuilder;
-        let rt = KhiveRuntime::memory().expect("in-memory runtime for brain registry");
+        let (_, rt) = make_pack_with_actor("alice");
         let mut builder = VerbRegistryBuilder::new();
+        builder.with_actor_id(Some("alice".to_string()));
         builder.register(KgPack::new(rt.clone()));
         builder.register(BrainPack::new(rt.clone()));
         let registry = builder.build().expect("kg+brain registry builds");
@@ -4781,7 +4808,7 @@ async fn ensure_loaded_publication_is_atomic() {
     use core::convert::TryFrom;
     use khive_runtime::Namespace;
 
-    let rt = KhiveRuntime::memory().expect("in-memory runtime");
+    let (_, rt) = make_pack_with_actor("actor-a");
     let pack = BrainPack::new(rt.clone());
     let registry = empty_registry();
 
@@ -4961,6 +4988,7 @@ async fn warm_pack_refreshes_profiles_and_bindings_written_by_peer() {
     let dir = tempfile::tempdir().expect("tempdir");
     let config = khive_runtime::RuntimeConfig {
         db_path: Some(dir.path().join("cross-process-visibility.db")),
+        actor_id: Some("peer-actor".to_string()),
         ..khive_runtime::RuntimeConfig::no_embeddings()
     };
     let writer_rt = KhiveRuntime::new(config.clone()).expect("writer runtime");
@@ -5406,8 +5434,10 @@ async fn ensure_loaded_cross_namespace_concurrent_does_not_corrupt_saved_states(
 
     let ns_x = Namespace::try_from("xns-x").expect("x");
     let ns_y = Namespace::try_from("xns-y").expect("y");
-    let token_x = rt.authorize(ns_x).expect("token x");
-    let token_y = rt.authorize(ns_y).expect("token y");
+    let (_, actor_x_rt) = make_pack_with_actor("x-actor");
+    let (_, actor_y_rt) = make_pack_with_actor("y-actor");
+    let token_x = actor_x_rt.authorize(ns_x).expect("token x");
+    let token_y = actor_y_rt.authorize(ns_y).expect("token y");
     let token_x = std::sync::Arc::new(token_x);
     let token_y = std::sync::Arc::new(token_y);
 
@@ -5482,7 +5512,8 @@ async fn concurrent_cold_load_does_not_clobber_live_state() {
     let registry = empty_registry();
 
     let ns = Namespace::try_from("race-ns-det").expect("race namespace");
-    let token = Arc::new(rt.authorize(ns).expect("race token"));
+    let (_, actor_rt) = make_pack_with_actor("racer");
+    let token = Arc::new(actor_rt.authorize(ns).expect("race token"));
 
     // ── Step 1: register the hook for Loader B ────────────────────────────────
     // B will fire the hook once it has finished the cold DB load.
@@ -5574,8 +5605,9 @@ async fn dispatch_gate_race_is_observable_without_gate() {
 
     let ns_a = Namespace::try_from("bare-ns-a").expect("ns-a");
     let ns_b = Namespace::try_from("bare-ns-b").expect("ns-b");
-    let token_a = rt.authorize(ns_a).expect("token a");
-    let token_b = rt.authorize(ns_b).expect("token b");
+    let (_, actor_rt) = make_pack_with_actor("racer-a");
+    let token_a = actor_rt.authorize(ns_a).expect("token a");
+    let token_b = actor_rt.authorize(ns_b).expect("token b");
 
     // Step 1: A calls ensure_loaded(ns-a). Slot is now ns-a.
     pack.ensure_loaded(&token_a).await.expect("ensure_loaded a");
@@ -5650,8 +5682,10 @@ async fn dispatch_gate_prevents_cross_namespace_slot_swap() {
 
     let ns_a = Namespace::try_from("gate-ns-a").expect("ns-a");
     let ns_b = Namespace::try_from("gate-ns-b").expect("ns-b");
-    let token_a = Arc::new(rt.authorize(ns_a).expect("token a"));
-    let token_b = Arc::new(rt.authorize(ns_b).expect("token b"));
+    let (_, actor_a_rt) = make_pack_with_actor("racer-a");
+    let (_, actor_b_rt) = make_pack_with_actor("racer-b");
+    let token_a = Arc::new(actor_a_rt.authorize(ns_a).expect("token a"));
+    let token_b = Arc::new(actor_b_rt.authorize(ns_b).expect("token b"));
 
     // ── Step 1: register the dispatch-gap hook for Dispatch A ─────────────────
     let (reached_tx, reached_rx) = oneshot::channel::<()>();
@@ -7257,7 +7291,7 @@ mod durable_write_tests {
     /// verification criteria — not a peek at the first pack's in-memory state.
     #[tokio::test]
     async fn profile_management_mutations_survive_restart() {
-        let (pack, rt) = make_pack();
+        let (pack, rt) = make_pack_with_actor("alice");
         let registry = empty_registry();
         let token = rt.authorize(Namespace::local()).unwrap();
 
@@ -7349,7 +7383,7 @@ mod durable_write_tests {
     /// same durable-write helper, different mutations.
     #[tokio::test]
     async fn reset_and_unbind_survive_restart() {
-        let (pack, rt) = make_pack();
+        let (pack, rt) = make_pack_with_actor("bob");
         let registry = empty_registry();
         let token = rt.authorize(Namespace::local()).unwrap();
         let target = create_test_entity(&rt, &token).await;
@@ -7531,7 +7565,7 @@ mod event_counts_tests {
     /// payload precisely instead of relying on wall-clock timing. Production
     /// pack code must use `KhiveRuntime::events`, whose token-scoped decorator
     /// intentionally seals actor and namespace attribution.
-    async fn seed_event(
+    pub(super) async fn seed_event(
         rt: &KhiveRuntime,
         token: &NamespaceToken,
         verb: &str,
@@ -7582,7 +7616,7 @@ mod event_counts_tests {
 
     #[tokio::test]
     async fn window_boundaries_include_since_exclude_until() {
-        let (pack, rt) = make_pack();
+        let (pack, rt) = make_pack_with_actor("lambda:a");
         let registry = empty_registry();
         let token = rt.authorize(Namespace::local()).unwrap();
 
@@ -8183,7 +8217,7 @@ mod event_counts_tests {
     /// as exact; pagination mechanics are covered separately with injected limits.
     #[tokio::test]
     async fn exhaustive_mode_returns_exact_response_shape() {
-        let (pack, rt) = make_pack();
+        let (pack, rt) = make_pack_with_actor("lambda:a");
         let registry = empty_registry();
         let token = rt.authorize(Namespace::local()).unwrap();
 
@@ -8279,7 +8313,7 @@ mod event_counts_tests {
 
     #[tokio::test]
     async fn kind_filter_scopes_counts() {
-        let (pack, rt) = make_pack();
+        let (pack, rt) = make_pack_with_actor("lambda:a");
         let registry = empty_registry();
         let token = rt.authorize(Namespace::local()).unwrap();
 
@@ -8497,9 +8531,11 @@ mod event_counts_tests {
 
     #[tokio::test]
     async fn actor_filter_scopes_counts() {
-        let (pack, rt) = make_pack();
+        let (pack, rt) = make_pack_with_read_scope(Some("lambda:a"), &["lambda:b"], &[]);
         let registry = empty_registry();
-        let token = rt.authorize(Namespace::local()).unwrap();
+        let token = rt
+            .authorize_with_visibility(Namespace::local(), rt.visible_namespaces().to_vec())
+            .unwrap();
 
         seed_event(
             &rt,
@@ -8546,9 +8582,11 @@ mod event_counts_tests {
     /// form must keep matching exactly as before.
     #[tokio::test]
     async fn actor_filter_matches_bare_and_prefixed_spelling() {
-        let (pack, rt) = make_pack();
+        let (pack, rt) = make_pack_with_read_scope(Some("lambda:atlas"), &["lambda:khive"], &[]);
         let registry = empty_registry();
-        let token = rt.authorize(Namespace::local()).unwrap();
+        let token = rt
+            .authorize_with_visibility(Namespace::local(), rt.visible_namespaces().to_vec())
+            .unwrap();
 
         seed_event(
             &rt,
@@ -8620,7 +8658,7 @@ mod event_counts_tests {
     /// same truncation semantics as `counts_by_kind`/`counts_by_actor`.
     #[tokio::test]
     async fn counts_by_verb_aggregates_per_verb() {
-        let (pack, rt) = make_pack();
+        let (pack, rt) = make_pack_with_actor("lambda:a");
         let registry = empty_registry();
         let token = rt.authorize(Namespace::local()).unwrap();
 
@@ -8672,7 +8710,7 @@ mod event_counts_tests {
 
     #[tokio::test]
     async fn feedback_events_split_by_served_by_profile_id() {
-        let (pack, rt) = make_pack();
+        let (pack, rt) = make_pack_with_actor("lambda:a");
         let registry = empty_registry();
         let token = rt.authorize(Namespace::local()).unwrap();
 
@@ -8742,7 +8780,7 @@ mod event_counts_tests {
     /// in one call, mirroring the profile-only split above.
     #[tokio::test]
     async fn feedback_events_split_by_signal_and_crossed_with_profile() {
-        let (pack, rt) = make_pack();
+        let (pack, rt) = make_pack_with_actor("lambda:a");
         let registry = empty_registry();
         let token = rt.authorize(Namespace::local()).unwrap();
 
@@ -9036,7 +9074,8 @@ mod event_counts_tests {
     async fn date_only_until_includes_the_whole_named_day() {
         let (pack, rt) = make_pack_with_tz("America/New_York");
         let registry = empty_registry();
-        let token = rt.authorize(Namespace::local()).unwrap();
+        let (_, actor_rt) = make_pack_with_actor("lambda:a");
+        let token = actor_rt.authorize(Namespace::local()).unwrap();
 
         let us = |s: &str| {
             chrono::DateTime::parse_from_rfc3339(s)
@@ -9210,7 +9249,7 @@ mod event_counts_tests {
 
     #[tokio::test]
     async fn work_class_split_reads_phase_payload_not_resource_fallback() {
-        let (pack, rt) = make_pack();
+        let (pack, rt) = make_pack_with_actor("lambda:khive");
         let registry = empty_registry();
         let token = rt.authorize(Namespace::local()).unwrap();
 
@@ -9326,7 +9365,7 @@ mod event_counts_tests {
 
     #[tokio::test]
     async fn work_class_split_absent_when_no_event_carries_it() {
-        let (pack, rt) = make_pack();
+        let (pack, rt) = make_pack_with_actor("lambda:a");
         let registry = empty_registry();
         let token = rt.authorize(Namespace::local()).unwrap();
 
@@ -9431,7 +9470,7 @@ mod event_counts_tests {
     /// keys must be entirely absent, not zero-filled.
     #[tokio::test]
     async fn cost_unit_fields_absent_when_no_event_carries_cost_unit() {
-        let (pack, rt) = make_pack();
+        let (pack, rt) = make_pack_with_actor("lambda:khive");
         let registry = empty_registry();
         let token = rt.authorize(Namespace::local()).unwrap();
 
@@ -9484,7 +9523,7 @@ mod event_counts_tests {
     /// `counts_by_kind`/`counts_by_actor`/`counts_by_work_class`.
     #[tokio::test]
     async fn cost_unit_sums_total_and_per_verb() {
-        let (pack, rt) = make_pack();
+        let (pack, rt) = make_pack_with_read_scope(Some("lambda:a"), &[], &["lambda:a"]);
         let registry = empty_registry();
         let token = rt.authorize(Namespace::local()).unwrap();
 
@@ -9550,7 +9589,7 @@ mod event_counts_tests {
         let result = pack
             .dispatch(
                 "brain.event_counts",
-                json!({"since": micros_to_iso(0)}),
+                json!({"since": micros_to_iso(0), "all_actors": true}),
                 &registry,
                 &token,
             )
@@ -9584,7 +9623,7 @@ mod event_counts_tests {
     /// contribute to `total_cost_unit`.
     #[tokio::test]
     async fn cost_unit_respects_window_filter() {
-        let (pack, rt) = make_pack();
+        let (pack, rt) = make_pack_with_actor("lambda:a");
         let registry = empty_registry();
         let token = rt.authorize(Namespace::local()).unwrap();
 
@@ -9631,7 +9670,7 @@ mod event_counts_tests {
     /// rather than panic when individual `cost_unit` values are extreme.
     #[tokio::test]
     async fn cost_unit_total_saturates_on_overflow_instead_of_panicking() {
-        let (pack, rt) = make_pack();
+        let (pack, rt) = make_pack_with_actor("lambda:a");
         let registry = empty_registry();
         let token = rt.authorize(Namespace::local()).unwrap();
 
@@ -9719,6 +9758,531 @@ mod event_counts_tests {
             BrainPack::truncatable_total_key("total_cost_unit", true),
             "total_cost_unit_page_scoped"
         );
+    }
+}
+
+mod read_scope_tests {
+    use super::*;
+    use khive_types::EventKind;
+
+    async fn seed_actor_events(rt: &KhiveRuntime, token: &NamespaceToken) {
+        for actor in ["caller-a", "actor:caller-a", "caller-b"] {
+            super::event_counts_tests::seed_event(
+                rt,
+                token,
+                "search",
+                EventKind::SearchExecuted,
+                actor,
+                1_000_000,
+                json!({}),
+            )
+            .await;
+        }
+    }
+
+    async fn seed_actor_bindings(pack: &BrainPack, token: &NamespaceToken) {
+        let registry = empty_registry();
+        for (actor, profile) in [("caller-a", "profile-a"), ("caller-b", "profile-b")] {
+            pack.dispatch(
+                "brain.create_profile",
+                json!({"name": profile, "consumer_kind": "recall"}),
+                &registry,
+                token,
+            )
+            .await
+            .expect("create actor profile");
+            pack.dispatch(
+                "brain.activate",
+                json!({"profile_id": profile}),
+                &registry,
+                token,
+            )
+            .await
+            .expect("activate actor profile");
+            pack.dispatch(
+                "brain.bind",
+                json!({
+                    "actor": actor,
+                    "profile_id": profile,
+                    "consumer_kind": "recall",
+                }),
+                &registry,
+                token,
+            )
+            .await
+            .expect("bind actor profile");
+        }
+    }
+
+    fn event_params() -> Value {
+        json!({"since": "1970-01-01T00:00:00Z"})
+    }
+
+    fn assert_actor_refused(err: RuntimeError, actor: &str) {
+        let RuntimeError::InvalidInput(message) = err else {
+            panic!("expected InvalidInput, got {err:?}");
+        };
+        assert!(
+            message.contains(actor),
+            "actor missing from refusal: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn omitted_actor_counts_only_caller_and_collapses_event_aliases() {
+        let (pack, rt) = make_pack_with_read_scope(Some("serving-actor"), &[], &[]);
+        let (_, caller_rt) = make_pack_with_read_scope(Some("caller-a"), &["caller-b"], &[]);
+        let token = caller_rt
+            .authorize_with_visibility(Namespace::local(), caller_rt.visible_namespaces().to_vec())
+            .expect("caller token");
+        let registry = empty_registry();
+        seed_actor_events(&rt, &token).await;
+
+        let own = pack
+            .dispatch("brain.event_counts", event_params(), &registry, &token)
+            .await
+            .expect("default caller counts");
+        assert_eq!(own["counts_by_actor"], json!({"caller-a": 2}));
+        assert_eq!(own["window_event_total"], json!(2));
+        assert_eq!(own["total"], json!(2));
+
+        let mut params = event_params();
+        params["actor"] = json!("caller-a");
+        let explicit = pack
+            .dispatch("brain.event_counts", params.clone(), &registry, &token)
+            .await
+            .expect("explicit actor preserves stored grouping");
+        assert_eq!(
+            explicit["counts_by_actor"],
+            json!({"caller-a": 1, "actor:caller-a": 1})
+        );
+        assert_eq!(explicit["window_event_total"], json!(2));
+        params["actor"] = json!("caller-b");
+        let other = pack
+            .dispatch("brain.event_counts", params, &registry, &token)
+            .await
+            .expect("visible actor control");
+        assert_eq!(other["counts_by_actor"], json!({"caller-b": 1}));
+        assert_eq!(other["window_event_total"], json!(1));
+    }
+
+    #[tokio::test]
+    async fn omitted_actor_reads_only_caller_bindings_and_resolution() {
+        let (pack, _) = make_pack_with_read_scope(Some("serving-actor"), &[], &[]);
+        let (_, caller_rt) = make_pack_with_read_scope(Some("caller-a"), &["caller-b"], &[]);
+        let token = caller_rt
+            .authorize_with_visibility(Namespace::local(), caller_rt.visible_namespaces().to_vec())
+            .expect("caller token");
+        let registry = empty_registry();
+        seed_actor_bindings(&pack, &token).await;
+
+        let own_bindings = pack
+            .dispatch("brain.bindings", json!({}), &registry, &token)
+            .await
+            .expect("default caller bindings");
+        assert_eq!(own_bindings["count"], json!(1));
+        assert_eq!(own_bindings["bindings"][0]["actor"], json!("caller-a"));
+        let own_profile = pack
+            .dispatch(
+                "brain.resolve",
+                json!({"consumer_kind": "recall"}),
+                &registry,
+                &token,
+            )
+            .await
+            .expect("default caller profile");
+        assert_eq!(own_profile["resolved_profile_id"], json!("profile-a"));
+
+        let other = pack
+            .dispatch(
+                "brain.resolve",
+                json!({"consumer_kind": "recall", "actor": "caller-b"}),
+                &registry,
+                &token,
+            )
+            .await
+            .expect("visible actor profile control");
+        assert_eq!(other["resolved_profile_id"], json!("profile-b"));
+    }
+
+    #[tokio::test]
+    async fn foreign_actor_requires_visibility_for_each_read_verb() {
+        let (pack, rt) = make_pack_with_read_scope(Some("caller-a"), &[], &[]);
+        let hidden_token = rt.authorize(Namespace::local()).expect("caller token");
+        let (_, visible_rt) = make_pack_with_read_scope(Some("caller-a"), &["caller-b"], &[]);
+        let visible_token = visible_rt
+            .authorize_with_visibility(Namespace::local(), visible_rt.visible_namespaces().to_vec())
+            .expect("caller token with configured visibility");
+        let registry = empty_registry();
+        seed_actor_events(&rt, &hidden_token).await;
+        seed_actor_bindings(&pack, &hidden_token).await;
+
+        for (verb, mut params) in [
+            ("brain.event_counts", event_params()),
+            ("brain.resolve", json!({"consumer_kind": "recall"})),
+            ("brain.bindings", json!({})),
+        ] {
+            params["actor"] = json!("caller-b");
+            let denied = pack
+                .dispatch(verb, params.clone(), &registry, &hidden_token)
+                .await
+                .expect_err("foreign actor without visibility must be refused");
+            assert_actor_refused(denied, "caller-b");
+
+            let allowed = pack
+                .dispatch(verb, params, &registry, &visible_token)
+                .await
+                .expect("the same foreign actor is readable with visibility");
+            match verb {
+                "brain.event_counts" => {
+                    assert_eq!(allowed["counts_by_actor"], json!({"caller-b": 1}));
+                    assert_eq!(allowed["window_event_total"], json!(1));
+                }
+                "brain.resolve" => {
+                    assert_eq!(allowed["resolved_profile_id"], json!("profile-b"));
+                }
+                "brain.bindings" => {
+                    assert_eq!(allowed["count"], json!(1));
+                    assert_eq!(allowed["bindings"][0]["actor"], json!("caller-b"));
+                }
+                _ => unreachable!(),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn prefixed_foreign_event_actor_requires_visibility() {
+        let (pack, rt) = make_pack_with_read_scope(Some("caller-a"), &[], &[]);
+        let hidden_token = rt.authorize(Namespace::local()).expect("caller token");
+        let (_, visible_rt) = make_pack_with_read_scope(Some("caller-a"), &["caller-b"], &[]);
+        let visible_token = visible_rt
+            .authorize_with_visibility(Namespace::local(), visible_rt.visible_namespaces().to_vec())
+            .expect("caller token with configured visibility");
+        let registry = empty_registry();
+        seed_actor_events(&rt, &hidden_token).await;
+        super::event_counts_tests::seed_event(
+            &rt,
+            &hidden_token,
+            "search",
+            EventKind::SearchExecuted,
+            "actor:caller-b",
+            1_000_000,
+            json!({}),
+        )
+        .await;
+        let mut params = event_params();
+        params["actor"] = json!("actor:caller-b");
+        let denied = pack
+            .dispatch(
+                "brain.event_counts",
+                params.clone(),
+                &registry,
+                &hidden_token,
+            )
+            .await
+            .expect_err("a stored actor prefix cannot bypass visibility");
+        assert_actor_refused(denied, "caller-b");
+        let prefixed = pack
+            .dispatch(
+                "brain.event_counts",
+                params.clone(),
+                &registry,
+                &visible_token,
+            )
+            .await
+            .expect("visible prefixed actor keeps exact stored matching");
+        assert_eq!(prefixed["counts_by_actor"], json!({"actor:caller-b": 1}));
+        assert_eq!(prefixed["window_event_total"], json!(1));
+        params["actor"] = json!("caller-b");
+        let bare = pack
+            .dispatch("brain.event_counts", params, &registry, &visible_token)
+            .await
+            .expect("visible bare actor matches both stored spellings");
+        assert_eq!(
+            bare["counts_by_actor"],
+            json!({"caller-b": 1, "actor:caller-b": 1})
+        );
+        assert_eq!(bare["window_event_total"], json!(2));
+    }
+
+    #[tokio::test]
+    async fn literal_prefixed_actor_id_can_read_its_own_event_counts() {
+        let (pack, rt) = make_pack_with_read_scope(Some("actor:caller-a"), &[], &[]);
+        let token = rt.authorize(Namespace::local()).expect("caller token");
+        let registry = empty_registry();
+        for actor in [
+            "actor:caller-a",
+            "actor:actor:caller-a",
+            "caller-a",
+            "actor:caller-b",
+        ] {
+            super::event_counts_tests::seed_event(
+                &rt,
+                &token,
+                "search",
+                EventKind::SearchExecuted,
+                actor,
+                1_000_000,
+                json!({}),
+            )
+            .await;
+        }
+
+        let own = pack
+            .dispatch("brain.event_counts", event_params(), &registry, &token)
+            .await
+            .expect("default scope preserves the literal caller id");
+        assert_eq!(own["counts_by_actor"], json!({"actor:caller-a": 2}));
+        assert_eq!(own["window_event_total"], json!(2));
+
+        let mut params = event_params();
+        params["actor"] = json!("actor:caller-a");
+        let explicit = pack
+            .dispatch("brain.event_counts", params.clone(), &registry, &token)
+            .await
+            .expect("a literal prefixed actor id is an authorized self read");
+        assert_eq!(explicit["counts_by_actor"], json!({"actor:caller-a": 1}));
+        assert_eq!(explicit["window_event_total"], json!(1));
+
+        params["actor"] = json!("actor:caller-b");
+        let denied = pack
+            .dispatch("brain.event_counts", params, &registry, &token)
+            .await
+            .expect_err("a literal prefixed caller cannot read a foreign actor");
+        assert_actor_refused(denied, "caller-b");
+    }
+
+    #[tokio::test]
+    async fn all_actor_event_counts_require_serving_runtime_fleet_reader() {
+        let (pack, rt) = make_pack_with_read_scope(Some("caller-a"), &[], &["caller-a"]);
+        let token = rt
+            .authorize(Namespace::local())
+            .expect("listed caller token");
+        let registry = empty_registry();
+        seed_actor_events(&rt, &token).await;
+
+        let mut params = event_params();
+        params["all_actors"] = json!(true);
+        let fleet = pack
+            .dispatch("brain.event_counts", params.clone(), &registry, &token)
+            .await
+            .expect("listed caller can read all actors");
+        assert_eq!(fleet["total"], json!(3));
+        assert_eq!(fleet["window_event_total"], json!(3));
+        assert_eq!(
+            fleet["counts_by_actor"],
+            json!({"caller-a": 1, "actor:caller-a": 1, "caller-b": 1})
+        );
+
+        let own = pack
+            .dispatch("brain.event_counts", event_params(), &registry, &token)
+            .await
+            .expect("listed readers still default to their own actor");
+        assert_eq!(own["counts_by_actor"], json!({"caller-a": 2}));
+
+        let (_, other_rt) =
+            make_pack_with_read_scope(Some("caller-b"), &["caller-a"], &["caller-b"]);
+        let other_token = other_rt.authorize(Namespace::local()).expect("other token");
+        let denied = pack
+            .dispatch(
+                "brain.event_counts",
+                params.clone(),
+                &registry,
+                &other_token,
+            )
+            .await
+            .expect_err("client configuration cannot grant fleet read access");
+        assert_actor_refused(denied, "caller-b");
+
+        let (unlisted_pack, _) = make_pack_with_read_scope(Some("caller-a"), &[], &[]);
+        let denied = unlisted_pack
+            .dispatch("brain.event_counts", params, &registry, &token)
+            .await
+            .expect_err("an empty serving allowlist must deny even a listed client");
+        assert_actor_refused(denied, "caller-a");
+    }
+
+    #[tokio::test]
+    async fn all_actors_conflicts_with_explicit_actor() {
+        let (pack, rt) = make_pack_with_read_scope(Some("caller-a"), &["caller-b"], &["caller-a"]);
+        let token = rt
+            .authorize_with_visibility(Namespace::local(), rt.visible_namespaces().to_vec())
+            .expect("listed caller token");
+        let registry = empty_registry();
+        seed_actor_events(&rt, &token).await;
+        let mut params = event_params();
+        params["actor"] = json!("caller-b");
+        params["all_actors"] = json!(false);
+        let scoped = pack
+            .dispatch("brain.event_counts", params.clone(), &registry, &token)
+            .await
+            .expect("false all_actors permits an explicit visible actor");
+        assert_eq!(scoped["counts_by_actor"], json!({"caller-b": 1}));
+        params["all_actors"] = json!(true);
+        let denied = pack
+            .dispatch("brain.event_counts", params, &registry, &token)
+            .await
+            .expect_err("fleet scope and an actor filter conflict");
+        let RuntimeError::InvalidInput(message) = denied else {
+            panic!("expected InvalidInput, got {denied:?}");
+        };
+        assert!(message.contains("all_actors"), "{message}");
+        assert!(message.contains("actor"), "{message}");
+    }
+
+    #[tokio::test]
+    async fn anonymous_reads_scope_events_and_bindings_and_resolve_wildcards() {
+        let (pack, rt) = make_pack_with_read_scope(None, &["caller-b"], &[]);
+        let token = rt
+            .authorize_with_visibility(Namespace::local(), rt.visible_namespaces().to_vec())
+            .expect("anonymous token");
+        let registry = empty_registry();
+        assert_eq!(token.actor().kind, "anonymous");
+        pack.dispatch("brain.mark_turn", json!({}), &registry, &token)
+            .await
+            .expect("anonymous actor event");
+        for actor in ["caller-b", "local", "actor:local", "actor:anonymous:local"] {
+            super::event_counts_tests::seed_event(
+                &rt,
+                &token,
+                "search",
+                EventKind::SearchExecuted,
+                actor,
+                1_000_000,
+                json!({}),
+            )
+            .await;
+        }
+        let own = pack
+            .dispatch("brain.event_counts", event_params(), &registry, &token)
+            .await
+            .expect("anonymous caller counts");
+        assert_eq!(own["counts_by_actor"], json!({"anonymous:local": 1}));
+        assert_eq!(own["window_event_total"], json!(1));
+        let mut params = event_params();
+        params["actor"] = json!("caller-b");
+        let other = pack
+            .dispatch("brain.event_counts", params, &registry, &token)
+            .await
+            .expect("visible actor control for anonymous caller");
+        assert_eq!(other["counts_by_actor"], json!({"caller-b": 1}));
+
+        seed_actor_bindings(&pack, &token).await;
+        pack.dispatch(
+            "brain.bind",
+            json!({
+                "actor": "anonymous:local",
+                "profile_id": "profile-b",
+                "consumer_kind": "recall",
+            }),
+            &registry,
+            &token,
+        )
+        .await
+        .expect("anonymous actor binding");
+        pack.dispatch(
+            "brain.bind",
+            json!({
+                "actor": "local",
+                "profile_id": "profile-b",
+                "consumer_kind": "recall",
+            }),
+            &registry,
+            &token,
+        )
+        .await
+        .expect("explicit local actor binding");
+        pack.dispatch(
+            "brain.bind",
+            json!({
+                "actor": "*",
+                "profile_id": "profile-a",
+                "consumer_kind": "recall",
+            }),
+            &registry,
+            &token,
+        )
+        .await
+        .expect("wildcard profile binding");
+        let bindings = pack
+            .dispatch("brain.bindings", json!({}), &registry, &token)
+            .await
+            .expect("anonymous caller bindings");
+        assert_eq!(bindings["count"], json!(1));
+        assert_eq!(bindings["bindings"][0]["actor"], json!("anonymous:local"));
+        let resolved = pack
+            .dispatch(
+                "brain.resolve",
+                json!({"consumer_kind": "recall"}),
+                &registry,
+                &token,
+            )
+            .await
+            .expect("anonymous caller profile");
+        assert_eq!(resolved["resolved_profile_id"], json!("profile-a"));
+        let explicit = pack
+            .dispatch(
+                "brain.resolve",
+                json!({"consumer_kind": "recall", "actor": "anonymous:local"}),
+                &registry,
+                &token,
+            )
+            .await
+            .expect("explicit anonymous actor binding control");
+        assert_eq!(explicit["resolved_profile_id"], json!("profile-b"));
+        let local = pack
+            .dispatch(
+                "brain.resolve",
+                json!({"consumer_kind": "recall", "actor": "local"}),
+                &registry,
+                &token,
+            )
+            .await
+            .expect("explicit local actor binding control");
+        assert_eq!(local["resolved_profile_id"], json!("profile-b"));
+        let local_bindings = pack
+            .dispatch(
+                "brain.bindings",
+                json!({"actor": "local"}),
+                &registry,
+                &token,
+            )
+            .await
+            .expect("explicit local actor bindings control");
+        assert_eq!(local_bindings["count"], json!(1));
+        assert_eq!(local_bindings["bindings"][0]["actor"], json!("local"));
+    }
+
+    #[tokio::test]
+    async fn actor_read_params_reject_unknown_fields_and_wrong_types() {
+        let (pack, rt) = make_pack_with_read_scope(Some("caller-a"), &[], &[]);
+        let token = rt.authorize(Namespace::local()).expect("caller token");
+        let registry = empty_registry();
+        for (verb, params) in [
+            ("brain.event_counts", event_params()),
+            ("brain.resolve", json!({"consumer_kind": "recall"})),
+            ("brain.bindings", json!({})),
+        ] {
+            pack.dispatch(verb, params.clone(), &registry, &token)
+                .await
+                .expect("valid params control");
+            for (field, value) in [
+                ("unknown_scope", json!(true)),
+                ("actor", json!(42)),
+                ("all_actors", json!("true")),
+            ] {
+                if verb == "brain.bindings" && field != "actor" {
+                    continue;
+                }
+                let mut invalid = params.clone();
+                invalid[field] = value;
+                let err = pack
+                    .dispatch(verb, invalid, &registry, &token)
+                    .await
+                    .expect_err("invalid actor read params must fail");
+                assert!(matches!(err, RuntimeError::InvalidInput(_)), "{err:?}");
+            }
+        }
     }
 }
 

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -10006,50 +10006,133 @@ mod read_scope_tests {
     }
 
     #[tokio::test]
-    async fn literal_prefixed_actor_id_can_read_its_own_event_counts() {
-        let (pack, rt) = make_pack_with_read_scope(Some("actor:caller-a"), &[], &[]);
-        let token = rt.authorize(Namespace::local()).expect("caller token");
-        let registry = empty_registry();
-        for actor in [
-            "actor:caller-a",
-            "actor:actor:caller-a",
-            "caller-a",
-            "actor:caller-b",
-        ] {
-            super::event_counts_tests::seed_event(
-                &rt,
-                &token,
-                "search",
-                EventKind::SearchExecuted,
-                actor,
-                1_000_000,
-                json!({}),
+    async fn attributed_prefixed_actor_ids_keep_event_counts_principal_scoped() {
+        let (pack, rt) = make_pack_with_read_scope(Some("serving-actor"), &[], &[]);
+        let (_, caller_a_rt) = make_pack_with_read_scope(Some("caller-a"), &[], &[]);
+        let (_, caller_b_rt) = make_pack_with_read_scope(Some("actor:caller-a"), &[], &[]);
+        let token_a = caller_a_rt
+            .authorize(Namespace::local())
+            .expect("caller A token");
+        let token_b = caller_b_rt
+            .authorize(Namespace::local())
+            .expect("caller B token");
+        let (_, visible_a_rt) =
+            make_pack_with_read_scope(Some("caller-a"), &["actor:caller-a"], &[]);
+        let (_, visible_b_rt) =
+            make_pack_with_read_scope(Some("actor:caller-a"), &["caller-a"], &[]);
+        let visible_a = visible_a_rt
+            .authorize_with_visibility(
+                Namespace::local(),
+                visible_a_rt.visible_namespaces().to_vec(),
             )
-            .await;
+            .expect("caller A token with caller B visible");
+        let visible_b = visible_b_rt
+            .authorize_with_visibility(
+                Namespace::local(),
+                visible_b_rt.visible_namespaces().to_vec(),
+            )
+            .expect("caller B token with caller A visible");
+        let registry = empty_registry();
+        for (token, canonical_actor, count) in [
+            (&token_a, "actor:caller-a", 1),
+            (&token_b, "actor:actor:caller-a", 2),
+        ] {
+            let events = rt.events(token).expect("attributed event store");
+            for _ in 0..count {
+                let mut event = khive_storage::event::Event::new(
+                    token.namespace().as_str(),
+                    "search",
+                    EventKind::SearchExecuted,
+                    khive_types::SubstrateKind::Note,
+                    "caller-supplied",
+                );
+                event.created_at = 1_000_000;
+                event.payload = json!({"result_kind": "note"});
+                let id = event.id;
+                events
+                    .append_event(event)
+                    .await
+                    .expect("append attributed event");
+                let stored = events.get_event(id).await.unwrap().unwrap();
+                assert_eq!(stored.actor, canonical_actor);
+            }
         }
 
-        let own = pack
-            .dispatch("brain.event_counts", event_params(), &registry, &token)
-            .await
-            .expect("default scope preserves the literal caller id");
-        assert_eq!(own["counts_by_actor"], json!({"actor:caller-a": 2}));
-        assert_eq!(own["window_event_total"], json!(2));
+        for exhaustive in [false, true] {
+            let mut params = event_params();
+            params["exhaustive"] = json!(exhaustive);
+            for (token, caller, canonical_actor, count) in [
+                (&token_a, "caller-a", "actor:caller-a", 1),
+                (&token_b, "actor:caller-a", "actor:actor:caller-a", 2),
+            ] {
+                let own = pack
+                    .dispatch("brain.event_counts", params.clone(), &registry, token)
+                    .await
+                    .expect("default scope reads only the attributed principal");
+                let mut expected = json!({});
+                expected[caller] = json!(count);
+                assert_eq!(own["counts_by_actor"], expected);
+                assert_eq!(own["total"], json!(count));
+                assert_eq!(own["window_event_total"], json!(count));
 
-        let mut params = event_params();
-        params["actor"] = json!("actor:caller-a");
-        let explicit = pack
-            .dispatch("brain.event_counts", params.clone(), &registry, &token)
-            .await
-            .expect("a literal prefixed actor id is an authorized self read");
-        assert_eq!(explicit["counts_by_actor"], json!({"actor:caller-a": 1}));
-        assert_eq!(explicit["window_event_total"], json!(1));
+                let mut explicit_params = params.clone();
+                explicit_params["actor"] = json!(canonical_actor);
+                let explicit = pack
+                    .dispatch("brain.event_counts", explicit_params, &registry, token)
+                    .await
+                    .expect("canonical self scope reads only the attributed principal");
+                let mut expected = json!({});
+                expected[canonical_actor] = json!(count);
+                assert_eq!(explicit["counts_by_actor"], expected);
+                assert_eq!(explicit["total"], json!(count));
+                assert_eq!(explicit["window_event_total"], json!(count));
+            }
 
-        params["actor"] = json!("actor:caller-b");
-        let denied = pack
-            .dispatch("brain.event_counts", params, &registry, &token)
-            .await
-            .expect_err("a literal prefixed caller cannot read a foreign actor");
-        assert_actor_refused(denied, "caller-b");
+            let mut bare_params = params.clone();
+            bare_params["actor"] = json!("caller-a");
+            let bare = pack
+                .dispatch("brain.event_counts", bare_params, &registry, &token_a)
+                .await
+                .expect("ordinary bare self filter still matches canonical events");
+            assert_eq!(bare["counts_by_actor"], json!({"actor:caller-a": 1}));
+            assert_eq!(bare["total"], json!(1));
+            assert_eq!(bare["window_event_total"], json!(1));
+
+            for (hidden, visible, other, canonical_actor, count) in [
+                (
+                    &token_a,
+                    &visible_a,
+                    "actor:caller-a",
+                    "actor:actor:caller-a",
+                    2,
+                ),
+                (&token_b, &visible_b, "caller-a", "actor:caller-a", 1),
+            ] {
+                let mut foreign_params = params.clone();
+                foreign_params["actor"] = json!(canonical_actor);
+                let denied = pack
+                    .dispatch(
+                        "brain.event_counts",
+                        foreign_params.clone(),
+                        &registry,
+                        hidden,
+                    )
+                    .await
+                    .expect_err(
+                        "canonical foreign scope requires the other principal to be visible",
+                    );
+                assert_actor_refused(denied, other);
+                let allowed = pack
+                    .dispatch("brain.event_counts", foreign_params, &registry, visible)
+                    .await
+                    .expect("explicit foreign scope is allowed with configured visibility");
+                let mut expected = json!({});
+                expected[canonical_actor] = json!(count);
+                assert_eq!(allowed["counts_by_actor"], expected);
+                assert_eq!(allowed["total"], json!(count));
+                assert_eq!(allowed["window_event_total"], json!(count));
+            }
+        }
     }
 
     #[tokio::test]

--- a/crates/khive-pack-brain/tests/adr133_serve_batch.rs
+++ b/crates/khive-pack-brain/tests/adr133_serve_batch.rs
@@ -16,6 +16,7 @@ use serde_json::json;
 fn file_backed_runtime(db_path: std::path::PathBuf) -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         mounts: Vec::new(),
+        brain: Default::default(),
         git_write: Default::default(),
         exec: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),

--- a/crates/khive-pack-brain/tests/resolve_actor.rs
+++ b/crates/khive-pack-brain/tests/resolve_actor.rs
@@ -13,6 +13,7 @@ use serde_json::json;
 fn runtime_with_actor(actor_id: Option<&str>) -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         mounts: Vec::new(),
+        brain: Default::default(),
         git_write: Default::default(),
         exec: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
@@ -102,12 +103,27 @@ async fn resolve_defaults_actor_from_dispatch_identity() {
 /// evaluation tooling can query other identities.
 #[tokio::test]
 async fn explicit_actor_param_overrides_dispatch_identity() {
-    let rt = runtime_with_actor(Some("lambda:other-seat"));
+    let mut config = khive_runtime::KhiveConfig::default();
+    config.actor.id = Some("lambda:other-seat".to_string());
+    config.actor.visible_namespaces = Some(vec!["lambda:test-seat".to_string()]);
+    let rt = KhiveRuntime::new(khive_runtime::runtime_config_from_khive_config(
+        &config,
+        RuntimeConfig {
+            db_path: None,
+            packs: vec!["kg".to_string()],
+            brain_profile: None,
+            actor_id: None,
+            ..RuntimeConfig::no_embeddings()
+        },
+    ))
+    .expect("runtime with actor visibility");
     let brain = Arc::new(BrainPack::new(rt.clone()));
     bind_seat_profile(&brain, &rt, "lambda:test-seat").await;
 
     let registry = VerbRegistryBuilder::new().build().expect("registry");
-    let token = rt.authorize(Namespace::local()).expect("token");
+    let token = rt
+        .authorize_with_visibility(Namespace::local(), rt.visible_namespaces().to_vec())
+        .expect("token");
     let out = brain
         .dispatch(
             "brain.resolve",

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -3602,6 +3602,7 @@ mod tests {
         let ns = format!("ingest-dedup-{}", Uuid::new_v4().simple());
         let runtime = super::KhiveRuntime::new(RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             events_split: None,
@@ -4704,6 +4705,7 @@ mod tests {
         let ns = format!("mark-read-cas-{}", Uuid::new_v4().simple());
         let runtime = super::KhiveRuntime::new(RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             events_split: None,
@@ -4826,6 +4828,7 @@ mod tests {
             let ns = format!("mark-read-non-object-{case}-{}", Uuid::new_v4().simple());
             let runtime = super::KhiveRuntime::new(RuntimeConfig {
                 mounts: Vec::new(),
+                brain: Default::default(),
                 git_write: Default::default(),
                 display_timezone: khive_runtime::config::resolve_default_display_timezone(),
                 events_split: None,

--- a/crates/khive-pack-comm/src/idempotency_tests.rs
+++ b/crates/khive-pack-comm/src/idempotency_tests.rs
@@ -21,6 +21,7 @@ fn actor_registry(
         backend,
         RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             exec: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),

--- a/crates/khive-pack-comm/src/inbox_filter_tests.rs
+++ b/crates/khive-pack-comm/src/inbox_filter_tests.rs
@@ -19,6 +19,7 @@ fn actor_registry(
         RuntimeConfig {
             mounts: Vec::new(),
             exec: Default::default(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             events_split: None,

--- a/crates/khive-pack-comm/src/message.rs
+++ b/crates/khive-pack-comm/src/message.rs
@@ -530,6 +530,7 @@ mod tests {
 
         let runtime = KhiveRuntime::new(RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             events_split: None,
@@ -611,6 +612,7 @@ mod tests {
 
         let runtime = KhiveRuntime::new(RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             events_split: None,
@@ -757,6 +759,7 @@ mod tests {
 
         let runtime = KhiveRuntime::new(RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             events_split: None,
@@ -922,6 +925,7 @@ mod tests {
 
         let runtime = KhiveRuntime::new(RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             events_split: None,

--- a/crates/khive-pack-comm/tests/adr133_read_flags.rs
+++ b/crates/khive-pack-comm/tests/adr133_read_flags.rs
@@ -16,6 +16,7 @@ fn file_backed_registry(
 ) -> (khive_runtime::VerbRegistry, KhiveRuntime) {
     let rt = KhiveRuntime::new(RuntimeConfig {
         mounts: Vec::new(),
+        brain: Default::default(),
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         events_split: None,

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -3546,6 +3546,7 @@ fn build_crossns_registry(
 ) -> (VerbRegistry, KhiveRuntime) {
     let config = RuntimeConfig {
         mounts: Vec::new(),
+        brain: Default::default(),
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         events_split: None,
@@ -4490,6 +4491,7 @@ fn build_actor_registry(
 ) -> (VerbRegistry, KhiveRuntime) {
     let config = RuntimeConfig {
         mounts: Vec::new(),
+        brain: Default::default(),
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         events_split: None,
@@ -4788,6 +4790,7 @@ async fn t_c2_gate_receives_configured_actor_not_anonymous() {
     let backend = shared_backend();
     let config = RuntimeConfig {
         mounts: Vec::new(),
+        brain: Default::default(),
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         events_split: None,
@@ -4907,6 +4910,7 @@ async fn i199_anonymous_inbox_cannot_read_messages_addressed_to_other_actor() {
     // An anonymous (unconfigured) caller on the same backend must NOT see B's message.
     let config_anon = RuntimeConfig {
         mounts: Vec::new(),
+        brain: Default::default(),
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         events_split: None,

--- a/crates/khive-pack-comm/tests/mark_read_failure_status.rs
+++ b/crates/khive-pack-comm/tests/mark_read_failure_status.rs
@@ -14,6 +14,7 @@ async fn lock_contention_reports_failed_mark_read_statuses() {
     std::env::set_var("KHIVE_WRITE_QUEUE", "0");
     let runtime = KhiveRuntime::new(RuntimeConfig {
         mounts: Vec::new(),
+        brain: Default::default(),
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         events_split: None,

--- a/crates/khive-pack-comm/tests/probe.rs
+++ b/crates/khive-pack-comm/tests/probe.rs
@@ -1016,6 +1016,7 @@ async fn probe_backfills_pre_existing_messages_across_v6_to_v7_upgrade() {
     // `run_migrations` to latest, including V7's backfill.
     let config = RuntimeConfig {
         mounts: Vec::new(),
+        brain: Default::default(),
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         events_split: None,
@@ -1204,6 +1205,7 @@ async fn probe_repairs_partial_notes_seq_left_by_original_v7_on_reopen() {
     // fixed anti-join lazy bootstrap.
     let config = RuntimeConfig {
         mounts: Vec::new(),
+        brain: Default::default(),
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         events_split: None,

--- a/crates/khive-pack-git/tests/acceptance.rs
+++ b/crates/khive-pack-git/tests/acceptance.rs
@@ -7562,6 +7562,7 @@ async fn ingest_over_cap_commit_embedding_is_semantically_retrievable() {
     let _guard = ENV_MUTEX.lock().await;
     let rt = KhiveRuntime::new(RuntimeConfig {
         mounts: Vec::new(),
+        brain: Default::default(),
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         events_split: None,

--- a/crates/khive-pack-knowledge/benches/knowledge_bench.rs
+++ b/crates/khive-pack-knowledge/benches/knowledge_bench.rs
@@ -20,6 +20,7 @@ use khive_types::Namespace;
 fn build_runtime() -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         mounts: Vec::new(),
+        brain: Default::default(),
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         events_split: None,

--- a/crates/khive-pack-knowledge/benches/search_latency.rs
+++ b/crates/khive-pack-knowledge/benches/search_latency.rs
@@ -27,6 +27,7 @@ use std::sync::Arc;
 fn rt_with_embedder() -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         mounts: Vec::new(),
+        brain: Default::default(),
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         events_split: None,

--- a/crates/khive-pack-knowledge/src/handlers.rs
+++ b/crates/khive-pack-knowledge/src/handlers.rs
@@ -1053,6 +1053,7 @@ mod tests {
         // runners and fails entity creation with `ModelInitialization`.
         let rt = KhiveRuntime::new(khive_runtime::RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             events_split: None,

--- a/crates/khive-pack-knowledge/src/knowledge/ann_degrade_tests.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/ann_degrade_tests.rs
@@ -183,6 +183,7 @@ impl EmbedderProvider for ControlledRankingProvider {
 fn rt_with_fake_embedder() -> KhiveRuntime {
     let rt = KhiveRuntime::new(RuntimeConfig {
         mounts: Vec::new(),
+        brain: Default::default(),
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         events_split: None,
@@ -268,6 +269,7 @@ fn rt_with_counting_embedder() -> (KhiveRuntime, Arc<AtomicUsize>) {
     let calls = Arc::new(AtomicUsize::new(0));
     let rt = KhiveRuntime::new(RuntimeConfig {
         mounts: Vec::new(),
+        brain: Default::default(),
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         events_split: None,
@@ -295,6 +297,7 @@ fn rt_with_counting_embedder() -> (KhiveRuntime, Arc<AtomicUsize>) {
 fn rt_with_controlled_ranking(fail_fresh_rerank: bool) -> KhiveRuntime {
     let rt = KhiveRuntime::new(RuntimeConfig {
         mounts: Vec::new(),
+        brain: Default::default(),
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         events_split: None,
@@ -324,6 +327,7 @@ fn rt_with_controlled_ranking(fail_fresh_rerank: bool) -> KhiveRuntime {
 fn file_rt_with_fake_embedder(db_path: std::path::PathBuf) -> KhiveRuntime {
     let rt = KhiveRuntime::new(RuntimeConfig {
         mounts: Vec::new(),
+        brain: Default::default(),
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         events_split: None,

--- a/crates/khive-pack-knowledge/src/knowledge/search.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/search.rs
@@ -5094,6 +5094,7 @@ mod tests {
         let texts = Arc::new(Mutex::new(Vec::new()));
         let runtime = KhiveRuntime::new(RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             events_split: None,
@@ -5271,6 +5272,7 @@ mod tests {
         let fail_query = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         let runtime = KhiveRuntime::new(khive_runtime::RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             events_split: None,

--- a/crates/khive-pack-knowledge/src/knowledge/suggest_ranking_tests.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/suggest_ranking_tests.rs
@@ -167,6 +167,7 @@ impl EmbedderProvider for FixtureEmbedProvider {
 fn rt_with_fixture_embedder() -> KhiveRuntime {
     let rt = KhiveRuntime::new(RuntimeConfig {
         mounts: Vec::new(),
+        brain: Default::default(),
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         events_split: None,

--- a/crates/khive-pack-knowledge/src/knowledge/vamana.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/vamana.rs
@@ -4847,6 +4847,7 @@ mod tests {
     fn rt_with_embedder(db_path: Option<std::path::PathBuf>) -> KhiveRuntime {
         let rt = KhiveRuntime::new(RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             events_split: None,

--- a/crates/khive-pack-knowledge/tests/bench.rs
+++ b/crates/khive-pack-knowledge/tests/bench.rs
@@ -27,6 +27,7 @@ use std::sync::Arc;
 fn rt_with_embedder() -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         mounts: Vec::new(),
+        brain: Default::default(),
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         events_split: None,

--- a/crates/khive-pack-knowledge/tests/feedback.rs
+++ b/crates/khive-pack-knowledge/tests/feedback.rs
@@ -40,6 +40,7 @@ fn make_rt(brain_profile: Option<String>, with_brain: bool) -> KhiveRuntime {
 fn make_rt_with_actor(actor: &str) -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         mounts: Vec::new(),
+        brain: Default::default(),
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         events_split: None,

--- a/crates/khive-pack-knowledge/tests/fixes.rs
+++ b/crates/khive-pack-knowledge/tests/fixes.rs
@@ -1735,6 +1735,7 @@ fn rt_with_default_embedder() -> KhiveRuntime {
 
     KhiveRuntime::new(RuntimeConfig {
         mounts: Vec::new(),
+        brain: Default::default(),
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         events_split: None,
@@ -2415,6 +2416,7 @@ mod embed_failure_tests {
     fn rt_with_fake(fake: impl EmbedderProvider + 'static) -> KhiveRuntime {
         let rt = KhiveRuntime::new(RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             events_split: None,
@@ -2606,6 +2608,7 @@ mod embed_failure_tests {
 
         let rt = KhiveRuntime::new(RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             events_split: None,
@@ -2925,6 +2928,7 @@ mod ann_bypass_regression {
     fn rt_with_correct_embedder() -> KhiveRuntime {
         let rt = KhiveRuntime::new(RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             events_split: None,
@@ -3528,6 +3532,7 @@ mod edit_inline_reembed {
     fn rt_with_embedder() -> KhiveRuntime {
         let rt = KhiveRuntime::new(RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             events_split: None,
@@ -3936,6 +3941,7 @@ mod ann_type_filter_regression {
     fn rt_with_embedder() -> KhiveRuntime {
         let rt = KhiveRuntime::new(RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             events_split: None,
@@ -4345,6 +4351,7 @@ mod compose_explain_sections {
     fn rt_with_embedder() -> KhiveRuntime {
         let rt = KhiveRuntime::new(RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             events_split: None,

--- a/crates/khive-pack-knowledge/tests/integration.rs
+++ b/crates/khive-pack-knowledge/tests/integration.rs
@@ -2283,6 +2283,7 @@ async fn index_reembed_paging_sweep_covers_equal_created_at_in_order() {
     let recorded = Arc::new(Mutex::new(Vec::<String>::new()));
     let rt = KhiveRuntime::new(RuntimeConfig {
         mounts: Vec::new(),
+        brain: Default::default(),
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         events_split: None,
@@ -4683,6 +4684,7 @@ mod kg_blend {
     ) -> KhiveRuntime {
         let rt = KhiveRuntime::new(RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             events_split: None,
@@ -5046,6 +5048,7 @@ mod kg_blend {
         let calls = Arc::new(Mutex::new(0usize));
         let rt = KhiveRuntime::new(RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             events_split: None,
@@ -5464,6 +5467,7 @@ mod kg_blend {
     fn rt_with_failing_blend_embedder() -> KhiveRuntime {
         let rt = KhiveRuntime::new(RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             events_split: None,

--- a/crates/khive-pack-knowledge/tests/search_candidate_refill.rs
+++ b/crates/khive-pack-knowledge/tests/search_candidate_refill.rs
@@ -143,6 +143,7 @@ impl EmbedderProvider for RefillVectorProvider {
 fn runtime_with_embedder() -> KhiveRuntime {
     let runtime = KhiveRuntime::new(RuntimeConfig {
         mounts: Vec::new(),
+        brain: Default::default(),
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         events_split: None,

--- a/crates/khive-pack-moodboard/src/preference_handlers.rs
+++ b/crates/khive-pack-moodboard/src/preference_handlers.rs
@@ -1734,6 +1734,7 @@ mod tests {
     fn persistent_runtime_config(db_path: &Path, actor_id: &str) -> RuntimeConfig {
         RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             exec: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),

--- a/crates/khive-pack-session/src/mirror/ingest.rs
+++ b/crates/khive-pack-session/src/mirror/ingest.rs
@@ -1144,6 +1144,7 @@ mod tests {
         let db_path = dir.path().join("test.db");
         let rt = KhiveRuntime::new(RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             events_split: None,

--- a/crates/khive-pack-session/src/mirror/service.rs
+++ b/crates/khive-pack-session/src/mirror/service.rs
@@ -2662,6 +2662,7 @@ mod cursor_retry_tests {
         let db_path = dir.path().join("test.db");
         let rt = KhiveRuntime::new(RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: khive_runtime::config::resolve_default_display_timezone(),
             events_split: None,

--- a/crates/khive-pack-session/tests/integration.rs
+++ b/crates/khive-pack-session/tests/integration.rs
@@ -21,6 +21,7 @@ use tempfile::TempDir;
 fn file_rt(db_path: std::path::PathBuf) -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         mounts: Vec::new(),
+        brain: Default::default(),
         git_write: Default::default(),
         display_timezone: khive_runtime::config::resolve_default_display_timezone(),
         events_split: None,

--- a/crates/khive-runtime/src/config.rs
+++ b/crates/khive-runtime/src/config.rs
@@ -363,6 +363,8 @@ pub struct RuntimeConfig {
     /// `ActorRef::anonymous()` and inbox is scoped to party-line messages —
     /// those addressed to `"local"` or carrying no `to_actor` stamp.
     pub actor_id: Option<String>,
+    /// Resolved `[brain]` policy from the serving process's configuration.
+    pub brain: crate::engine_config::BrainSectionConfig,
     /// Resolved `[git_write]` policy allowlist (ADR-108 Amendment), populated
     /// from `khive.toml`'s `[[git_write.allowed]]` entries by
     /// [`runtime_config_from_khive_config`]. Threaded through so
@@ -469,6 +471,7 @@ impl Default for RuntimeConfig {
             visible_namespaces: vec![],
             allowed_outbound_namespaces: vec![],
             actor_id,
+            brain: crate::engine_config::BrainSectionConfig::default(),
             git_write: crate::engine_config::GitWriteSectionConfig::default(),
             exec: crate::engine_config::ExecSectionConfig::default(),
             mounts: Vec::new(),
@@ -819,6 +822,7 @@ pub fn runtime_config_from_khive_config(
         })
         .unwrap_or_else(|| base.gate.clone());
 
+    let brain = khive_cfg.brain.clone();
     let git_write = khive_cfg.git_write.clone();
     let exec = khive_cfg.exec.clone();
     let blob_hydration_bytes = khive_cfg
@@ -845,6 +849,7 @@ pub fn runtime_config_from_khive_config(
             allowed_outbound_namespaces,
             actor_id,
             gate,
+            brain,
             git_write,
             exec,
             mounts,
@@ -885,6 +890,7 @@ pub fn runtime_config_from_khive_config(
         allowed_outbound_namespaces,
         actor_id,
         gate,
+        brain,
         git_write,
         exec,
         mounts,

--- a/crates/khive-runtime/src/engine_config.rs
+++ b/crates/khive-runtime/src/engine_config.rs
@@ -408,6 +408,15 @@ pub struct StorageSectionConfig {
     pub blob: Option<BlobConfig>,
 }
 
+/// `[brain]` read policy resolved by the serving process.
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct BrainSectionConfig {
+    /// Actor ids permitted to request fleet-wide `brain.event_counts` reads.
+    #[serde(default)]
+    pub fleet_readers: Vec<String>,
+}
+
 // ---- git-write policy (ADR-108 Amendment) ----
 
 /// One `[[git_write.allowed]]` entry: a repo this operator has declared
@@ -718,12 +727,13 @@ pub struct ExecSectionConfig {
 /// - `[actor]`: default namespace / identity (OSS actor model)
 /// - `[gate]`: built-in caller enrollment
 /// - `[runtime]`: runtime knobs (pack selection, brain profile, output format)
+/// - `[brain]`: actor read policy
 /// - `[[backends]]`: storage backend declarations (ADR-028)
 /// - `[packs.<name>]`: per-pack backend assignments (ADR-028)
 /// - `[display]`: rendering timezone (ADR-169)
 ///
 /// Unknown top-level keys are silently ignored by serde for forward
-/// compatibility. The security-sensitive `[gate]` table itself is closed with
+/// compatibility. The security-sensitive `[gate]` and `[brain]` tables are closed with
 /// `deny_unknown_fields` so a misspelled policy key always fails startup.
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct KhiveConfig {
@@ -776,6 +786,10 @@ pub struct KhiveConfig {
     /// must appear in `backends`.
     #[serde(default)]
     pub packs: std::collections::HashMap<String, PackConfig>,
+
+    /// Actor read policy. An absent or empty list grants no fleet-wide reads.
+    #[serde(default)]
+    pub brain: BrainSectionConfig,
 
     /// Git-write policy allowlist (ADR-108 Amendment). Absent or empty
     /// `allowed` fails closed — `khive-pack-git`'s write verbs are
@@ -2792,6 +2806,71 @@ grant_unattributed = false
         KhiveConfig::load(Some(&path))
             .expect("unrelated future config stays forward compatible")
             .expect("config exists");
+    }
+
+    #[test]
+    fn brain_fleet_readers_default_to_empty() {
+        assert!(KhiveConfig::default().brain.fleet_readers.is_empty());
+        assert!(in_memory_runtime_config().brain.fleet_readers.is_empty());
+
+        let dir = tempfile::tempdir().unwrap();
+        for engines in [
+            "",
+            "[[engines]]\nname = \"primary\"\nmodel = \"all-minilm-l6-v2\"\ndefault = true\n",
+        ] {
+            for brain in ["", "[brain]\n", "[brain]\nfleet_readers = []\n"] {
+                let path = write_toml(&dir, &format!("{engines}\n{brain}"));
+                let config = KhiveConfig::load(Some(&path))
+                    .expect("load")
+                    .expect("config exists");
+                assert!(config.brain.fleet_readers.is_empty());
+
+                let mut base = in_memory_runtime_config();
+                base.brain.fleet_readers = vec!["lambda:previous".to_string()];
+                let resolved = crate::runtime_config_from_khive_config(&config, base);
+                assert!(resolved.brain.fleet_readers.is_empty());
+            }
+        }
+    }
+
+    #[test]
+    fn brain_fleet_readers_parse_and_resolve_with_or_without_engines() {
+        let dir = tempfile::tempdir().unwrap();
+        for engines in [
+            "",
+            "[[engines]]\nname = \"primary\"\nmodel = \"all-minilm-l6-v2\"\ndefault = true\n",
+        ] {
+            let path = write_toml(
+                &dir,
+                &format!(
+                    "{engines}\n[brain]\nfleet_readers = [\"lambda:reader\", \"lambda:auditor\"]\n"
+                ),
+            );
+            let config = KhiveConfig::load(Some(&path))
+                .expect("load")
+                .expect("config exists");
+            assert_eq!(
+                config.brain.fleet_readers,
+                vec!["lambda:reader", "lambda:auditor"]
+            );
+
+            let mut base = in_memory_runtime_config();
+            base.brain.fleet_readers = vec!["lambda:previous".to_string()];
+            let resolved = crate::runtime_config_from_khive_config(&config, base);
+            assert_eq!(
+                resolved.brain.fleet_readers,
+                vec!["lambda:reader", "lambda:auditor"]
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_brain_key_fails_startup() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_toml(&dir, "[brain]\nfleet_reader = [\"lambda:reader\"]\n");
+        let err = KhiveConfig::load(Some(&path)).expect_err("unknown brain key must fail");
+        assert!(matches!(err, ConfigError::Parse { .. }));
+        assert!(err.to_string().contains("unknown field"), "{err}");
     }
 
     // ── [git_write] section (ADR-108 Amendment) ─────────────────────────────

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -92,9 +92,9 @@ pub use daemon::{
 };
 pub use embedder_registry::{EmbedderProvider, EmbedderRegistry, LatticeEmbedderProvider};
 pub use engine_config::{
-    config_from_env, BackendConfig, BackendKind, BlobConfig, ConfigError, EngineConfig,
-    GateSectionConfig, GitWriteEntryConfig, GitWriteSectionConfig, KhiveConfig, PackConfig,
-    StorageSectionConfig,
+    config_from_env, BackendConfig, BackendKind, BlobConfig, BrainSectionConfig, ConfigError,
+    EngineConfig, GateSectionConfig, GitWriteEntryConfig, GitWriteSectionConfig, KhiveConfig,
+    PackConfig, StorageSectionConfig,
 };
 pub use error::{
     fts_text_leg_or_err, AdmissionFailureContext, AuditObligationFailure, AuditObligationReason,

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -112,7 +112,7 @@ pub use khive_db::{
 };
 pub use khive_gate::{
     ActorRef, AllowAllGate, AuditDecision, AuditEvent, CallerEnrollmentGate, Gate, GateContext,
-    GateDecision, GateError, GateRef, GateRequest, Obligation,
+    GateDecision, GateError, GateRef, GateRequest, Obligation, RUNTIME_STAMPED_ACTOR_KINDS,
 };
 pub use khive_storage::types::TraversalOptions;
 pub use khive_storage::{EventObservation, EventView, ObservationRole, ReferentKind};

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -2108,6 +2108,7 @@ mod tests {
         let path = dir.path().join("test.db");
         let config = RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
             events_split: None,
@@ -2143,6 +2144,7 @@ mod tests {
         let sidecar_path = dir.path().join("main.db.events.db");
         let config = RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
             events_split: Some(crate::events_split::EventsSplitConfig {
@@ -2203,6 +2205,7 @@ mod tests {
         let backend = Arc::new(StorageBackend::memory().expect("memory backend"));
         let config = RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
             events_split: None,
@@ -2230,6 +2233,7 @@ mod tests {
         let path = dir.path().join("test.db");
         let config = RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
             events_split: None,
@@ -2261,6 +2265,7 @@ mod tests {
         let path = dir.path().join("read_only_runtime.db");
         let base = RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
             events_split: None,
@@ -2323,6 +2328,7 @@ mod tests {
         let path = dir.path().join("explicit_read_only_runtime.db");
         let config = RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
             events_split: None,
@@ -2472,6 +2478,7 @@ mod tests {
         let path = dir.path().join("read_only_blob_seam.db");
         let config = RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
             db_path: Some(path.clone()),
@@ -2708,6 +2715,7 @@ mod tests {
 
             let make_config = |db_path: std::path::PathBuf| RuntimeConfig {
                 mounts: Vec::new(),
+                brain: Default::default(),
                 git_write: Default::default(),
                 display_timezone: chrono_tz::Tz::UTC,
                 events_split: None,
@@ -2758,6 +2766,7 @@ mod tests {
         let backend = Arc::new(StorageBackend::memory().expect("memory backend"));
         let config = RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
             events_split: None,
@@ -3014,6 +3023,7 @@ mod tests {
         // asserts the write-routing invariant only.
         let base = RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
             events_split: None,
@@ -3044,6 +3054,7 @@ mod tests {
     fn runtime_config_from_khive_config_empty_actor_id_keeps_base_namespace() {
         let base = RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
             events_split: None,
@@ -3082,6 +3093,7 @@ mod tests {
     fn runtime_config_from_khive_config_absent_actor_id_keeps_base_namespace() {
         let base = RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
             events_split: None,
@@ -3112,6 +3124,7 @@ mod tests {
     fn runtime_config_from_khive_config_actor_id_with_engines() {
         let base = RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
             events_split: None,
@@ -3160,6 +3173,7 @@ mod tests {
     fn runtime_config_from_khive_config_display_timezone_overrides_base() {
         let base = RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
             events_split: None,
@@ -3195,6 +3209,7 @@ mod tests {
     fn runtime_config_from_khive_config_absent_display_timezone_keeps_base() {
         let base = RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: "Asia/Tokyo".parse().unwrap(),
             events_split: None,
@@ -3344,6 +3359,7 @@ mod tests {
     fn secondary_config() -> RuntimeConfig {
         RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             exec: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
@@ -3426,6 +3442,7 @@ mod tests {
 
         let main_config = RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
             events_split: None,
@@ -3568,6 +3585,7 @@ mod tests {
             backend,
             RuntimeConfig {
                 mounts: Vec::new(),
+                brain: Default::default(),
                 git_write: Default::default(),
                 display_timezone: chrono_tz::Tz::UTC,
                 events_split: None,

--- a/crates/khive-runtime/tests/integration.rs
+++ b/crates/khive-runtime/tests/integration.rs
@@ -1941,6 +1941,7 @@ async fn file_backed_runtime_persists() {
     {
         let config = RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
             events_split: None,
@@ -1969,6 +1970,7 @@ async fn file_backed_runtime_persists() {
     {
         let config = RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
             events_split: None,
@@ -2595,6 +2597,7 @@ mod embedder_registry_tests {
     fn memory_rt_no_model() -> KhiveRuntime {
         KhiveRuntime::new(RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
             events_split: None,
@@ -2752,6 +2755,7 @@ mod embedder_registry_tests {
         use khive_runtime::RuntimeConfig;
         let rt = KhiveRuntime::new(RuntimeConfig {
             mounts: Vec::new(),
+            brain: Default::default(),
             git_write: Default::default(),
             display_timezone: chrono_tz::Tz::UTC,
             events_split: None,

--- a/docs/adr/ADR-103-resource-attribution-model.md
+++ b/docs/adr/ADR-103-resource-attribution-model.md
@@ -1140,7 +1140,10 @@ when its kind is `actor`, and `kind:id` for other actor kinds.
   default to their own `anonymous:local` label, not all actors.
 
 An explicit `actor` is allowed when it names the caller itself or when the
-requested actor id is in the token's visible namespace set. Other actor reads
+requested actor id is in the token's visible namespace set. That visibility test
+is exact string equality between the requested actor id and one entry of the
+token's `visible_namespaces` list: no prefix match, no pattern, and no
+derivation of a namespace from the actor id. Other actor reads
 fail with `InvalidInput` naming the refused actor. A bare event-count actor filter
 matches bare and `actor:`-prefixed stored labels; an explicitly prefixed filter
 matches that stored label exactly. An exact caller label is permitted before

--- a/docs/adr/ADR-103-resource-attribution-model.md
+++ b/docs/adr/ADR-103-resource-attribution-model.md
@@ -1126,8 +1126,11 @@ the registry or started the serving process. The caller label is the actor id
 when its kind is `actor`, and `kind:id` for other actor kinds.
 
 - With `actor` omitted, `brain.event_counts` counts only that caller's events.
-  For kind `actor`, historical bare and `actor:`-prefixed event spellings both
-  match. Only this default view combines those aliases into one
+  For kind `actor`, the canonical stored label is `actor:` followed by the
+  unmodified raw principal id, prepending that prefix exactly once even when the
+  id already begins with `actor:`. A historical bare alias also matches only when
+  the raw id does not begin with `actor:`; prefixed ids match only their canonical
+  stored label. Only this default view combines the permitted spellings into one
   `counts_by_actor` key, using the caller label; other kinds match their exact
   caller label. An empty result has no actor keys.
 - With `actor` omitted, `brain.bindings` returns only binding rows whose actor is
@@ -1144,13 +1147,20 @@ requested actor id is in the token's visible namespace set. That visibility test
 is exact string equality between the requested actor id and one entry of the
 token's `visible_namespaces` list: no prefix match, no pattern, and no
 derivation of a namespace from the actor id. Other actor reads
-fail with `InvalidInput` naming the refused actor. A bare event-count actor filter
-matches bare and `actor:`-prefixed stored labels; an explicitly prefixed filter
-matches that stored label exactly. An exact caller label is permitted before
-prefix interpretation; foreign-actor visibility is checked against the unprefixed
-actor identity. This is a query-scope rule using the
+fail with `InvalidInput` naming the refused actor. An event-count actor filter
+without an `actor:` prefix matches bare and canonical stored labels. Every filter
+beginning with `actor:` matches that stored label exactly, and authorization
+removes exactly one prefix to obtain the actor identity. There is no exception
+for a filter equal to the caller label. This is a query-scope rule using the
 already-authorized token, not a new storage-isolation boundary. Existing namespace
 and consumer-kind filters retain their meaning.
+
+**Stored-label clarification (2026-09-10).** The distinct ordinary principals
+`caller-a` and `actor:caller-a` write canonical labels `actor:caller-a` and
+`actor:actor:caller-a`, respectively. The second principal has no bare alias and
+uses `actor="actor:actor:caller-a"` for an explicit self read. Its query with
+`actor="actor:caller-a"` selects the first principal's canonical label instead
+and requires visibility of `caller-a`.
 
 ### Explicit aggregate event counts
 

--- a/docs/adr/ADR-103-resource-attribution-model.md
+++ b/docs/adr/ADR-103-resource-attribution-model.md
@@ -1113,3 +1113,60 @@ amendment signed before that branch lands. The census equality assertion enforce
 mechanically: a wider list fails the test until its amendment exists.
 
 ADR-133 Amendment 2 carries the corresponding qualification of D4/INV-1 scope.
+
+## Amendment 5 (2026-09-10): Caller-Scoped Brain Reads
+
+**Status**: Accepted.
+
+### Default and explicit actor scope
+
+`brain.event_counts`, `brain.resolve`, and `brain.bindings` derive their default
+actor scope from the authorized request token, not the identity that constructed
+the registry or started the serving process. The caller label is the actor id
+when its kind is `actor`, and `kind:id` for other actor kinds.
+
+- With `actor` omitted, `brain.event_counts` counts only that caller's events.
+  For kind `actor`, historical bare and `actor:`-prefixed event spellings both
+  match. Only this default view combines those aliases into one
+  `counts_by_actor` key, using the caller label; other kinds match their exact
+  caller label. An empty result has no actor keys.
+- With `actor` omitted, `brain.bindings` returns only binding rows whose actor is
+  the caller label. This is an exact row filter, not the wildcard fallback used
+  during profile resolution.
+- With `actor` omitted, `brain.resolve` resolves the caller's profile, retaining
+  the existing wildcard binding fallback. Anonymous callers remain the exception:
+  their absent actor resolves only wildcard bindings, never an explicit `local`
+  or `anonymous:local` binding. Anonymous event-count and binding-list reads still
+  default to their own `anonymous:local` label, not all actors.
+
+An explicit `actor` is allowed when it names the caller itself or when the
+requested actor id is in the token's visible namespace set. Other actor reads
+fail with `InvalidInput` naming the refused actor. A bare event-count actor filter
+matches bare and `actor:`-prefixed stored labels; an explicitly prefixed filter
+matches that stored label exactly. An exact caller label is permitted before
+prefix interpretation; foreign-actor visibility is checked against the unprefixed
+actor identity. This is a query-scope rule using the
+already-authorized token, not a new storage-isolation boundary. Existing namespace
+and consumer-kind filters retain their meaning.
+
+### Explicit aggregate event counts
+
+`brain.event_counts` accepts optional boolean `all_actors`, defaulting to false.
+`all_actors=true` removes the actor filter only when the serving runtime's
+`brain.fleet_readers` contains the caller's exact actor id. The corresponding
+`[brain] fleet_readers` configuration is a list of strings (`Vec<String>`) and
+defaults to empty. The serving process's resolved configuration is authoritative;
+neither a client's local configuration nor a wider visible namespace set grants
+aggregate access. Allowlisted callers still receive only their own events unless
+they explicitly request `all_actors=true`.
+
+`all_actors=true` and an explicit `actor` are mutually exclusive and fail with
+`InvalidInput`. False or omitted `all_actors` permits an authorized explicit actor
+filter. `all_actors` does not add an aggregate mode to profile resolution or
+binding listing.
+
+Explicit actor filters and aggregate reads preserve historical stored actor keys
+in `counts_by_actor`; alias collapse applies only to the omitted-actor default.
+All existing time-window, event-kind, pagination, truncation, and cost aggregation
+rules remain unchanged within the selected actor scope. No event rows are rewritten,
+and `brain.bind` and `brain.unbind` retain their write contracts.

--- a/docs/adr/ADR-103-resource-attribution-model.md
+++ b/docs/adr/ADR-103-resource-attribution-model.md
@@ -1185,6 +1185,17 @@ attributed-event tests that exercise the event-count consumer, so a separate
 hard-coded consumer list cannot silently omit the new kind. Custom kinds outside
 that slice are not covered by this alias-separation guarantee.
 
+**Binding readback clarification (2026-09-10).** A successful binding write does
+not grant read visibility. For example, caller `service:writer` may bind an
+existing profile to `service:reader`, but its subsequent `brain.bindings()` still
+filters for `service:writer` and does not return that foreign binding.
+`brain.bindings(actor="service:reader")` fails with `InvalidInput` unless
+`service:reader` is in the caller's visible set. Even with that visibility, the
+explicit actor filter is required; default reads remain caller-scoped. Binding
+rows identify the target actor, not the writer, and there is no "created by me"
+read exception. A write/read check must therefore bind the caller's own actor,
+or explicitly read a foreign actor that is visible to the caller.
+
 ### Explicit aggregate event counts
 
 `brain.event_counts` accepts optional boolean `all_actors`, defaulting to false.

--- a/docs/adr/ADR-103-resource-attribution-model.md
+++ b/docs/adr/ADR-103-resource-attribution-model.md
@@ -1173,3 +1173,18 @@ in `counts_by_actor`; alias collapse applies only to the omitted-actor default.
 All existing time-window, event-kind, pagination, truncation, and cost aggregation
 rules remain unchanged within the selected actor scope. No event rows are rewritten,
 and `brain.bind` and `brain.unbind` retain their write contracts.
+
+### Consequences
+
+Stage 1's windowed per-actor read, `brain.event_counts`, was minted to answer what
+the daemon was doing and on whose behalf. After this amendment it answers that
+question for the caller by default: a plain call returns the caller's own events
+and nothing else. The cross-actor answer, every actor at once, is no longer
+available to a caller by widening its own visibility; it requires `all_actors=true`
+and the caller's actor id in the serving daemon's `[brain] fleet_readers` list,
+which is empty by default and is set only in the serving configuration. An
+operator who wants the fleet-wide view therefore adds their actor id to that
+list and restarts or reconfigures the serving daemon; a client-side setting
+cannot grant it. The same narrowing applies to `brain.resolve` and
+`brain.bindings`: a caller sees its own profile and its own binding rows unless
+it names an actor it is allowed to see.

--- a/docs/adr/ADR-103-resource-attribution-model.md
+++ b/docs/adr/ADR-103-resource-attribution-model.md
@@ -1128,11 +1128,12 @@ when its kind is `actor`, and `kind:id` for other actor kinds.
 - With `actor` omitted, `brain.event_counts` counts only that caller's events.
   For kind `actor`, the canonical stored label is `actor:` followed by the
   unmodified raw principal id, prepending that prefix exactly once even when the
-  id already begins with `actor:`. A historical bare alias also matches only when
-  the raw id does not begin with `actor:`; prefixed ids match only their canonical
-  stored label. Only this default view combines the permitted spellings into one
-  `counts_by_actor` key, using the caller label; other kinds match their exact
-  caller label. An empty result has no actor keys.
+  id already begins with a reserved stamped-kind prefix. A historical bare alias
+  also matches only when the raw id does not begin with `<kind>:` for any kind in
+  `RUNTIME_STAMPED_ACTOR_KINDS`: `actor`, `anonymous`, or `agent`. Such prefixed ids
+  match only their canonical stored label. Only this default view combines the
+  permitted spellings into one `counts_by_actor` key, using the caller label;
+  other kinds match their exact caller label. An empty result has no actor keys.
 - With `actor` omitted, `brain.bindings` returns only binding rows whose actor is
   the caller label. This is an exact row filter, not the wildcard fallback used
   during profile resolution.
@@ -1148,11 +1149,15 @@ is exact string equality between the requested actor id and one entry of the
 token's `visible_namespaces` list: no prefix match, no pattern, and no
 derivation of a namespace from the actor id. Other actor reads
 fail with `InvalidInput` naming the refused actor. An event-count actor filter
-without an `actor:` prefix matches bare and canonical stored labels. Every filter
-beginning with `actor:` matches that stored label exactly, and authorization
-removes exactly one prefix to obtain the actor identity. There is no exception
-for a filter equal to the caller label. This is a query-scope rule using the
-already-authorized token, not a new storage-isolation boundary. Existing namespace
+without a reserved stamped-kind prefix matches bare and canonical stored labels.
+Every filter beginning with a reserved stamped-kind prefix matches that stored
+label exactly. Authorization parses the prefix once: self access requires both
+the kind and the remaining id to match the token's kind and id. For foreign
+access, an `actor:` filter checks the remaining raw id against visibility;
+`anonymous:` and `agent:` filters check the full, unchanged label. There is no
+self-access exception for a filter equal to the caller's collapsed label. This
+is a query-scope rule using the already-authorized token, not a new
+storage-isolation boundary. Existing namespace
 and consumer-kind filters retain their meaning.
 
 **Stored-label clarification (2026-09-10).** The distinct ordinary principals
@@ -1161,6 +1166,24 @@ and consumer-kind filters retain their meaning.
 uses `actor="actor:actor:caller-a"` for an explicit self read. Its query with
 `actor="actor:caller-a"` selects the first principal's canonical label instead
 and requires visibility of `caller-a`.
+
+**Runtime-kind clarification (2026-09-10).** The shared
+`RUNTIME_STAMPED_ACTOR_KINDS` slice next to `ActorRef` in `khive-gate` reserves
+`actor:`, `anonymous:`, and `agent:` from historical bare aliases. A named
+principal with raw id `anonymous:local` therefore matches only its canonical
+`actor:anonymous:local` stamp by default and uses that same label for an explicit
+self filter. The filter `anonymous:local` instead selects the anonymous
+principal's canonical stamp; a named caller needs that full label in its visible
+set to read it. The same distinction applies to a named id such as `agent:worker`
+and the stamp of kind `agent`, id `worker`.
+
+This guarantee is limited to the reserved runtime-stamped kinds in the shared
+slice. The kind space remains open: `ActorRef::try_new` accepts any nonempty kind
+(and requires a nonempty id); the slice is not a closed validation enum. Adding
+a new runtime-stamped kind must extend the shared slice and include per-kind
+attributed-event tests that exercise the event-count consumer, so a separate
+hard-coded consumer list cannot silently omit the new kind. Custom kinds outside
+that slice are not covered by this alias-separation guarantee.
 
 ### Explicit aggregate event counts
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -76,6 +76,36 @@ through `RuntimeConfig::gate` when `[gate]` is absent.
 `load_with_roots`, `crates/khive-runtime/src/engine_config.rs`, the `load`
 family starting around line 298.)
 
+### Brain read scope
+
+Brain event counts, profile resolution, and binding listing default to the
+authorized caller's actor scope. An explicit foreign `actor` must be in the
+caller's visible namespace set; adding a visible namespace does not widen the
+default actor scope.
+
+The optional `[brain]` table grants selected actor ids permission to request
+aggregate event counts:
+
+```toml
+[brain]
+fleet_readers = []
+# To permit a named aggregate reader instead:
+# fleet_readers = ["service:metrics"]
+```
+
+`fleet_readers` is a list of strings (`Vec<String>`), defaulting to empty when the
+table or key is absent. Entries are exact actor ids, not display names, namespace
+patterns, or stored event actor prefixes. The empty list grants no caller access
+to `brain.event_counts(all_actors=true)`. A listed caller must still explicitly
+request `all_actors=true`; its ordinary requests remain scoped to itself.
+
+The serving process's resolved configuration controls this permission. Changing a
+client-local list does not grant access on an already-running daemon. Unknown keys
+inside `[brain]` fail startup. This setting does not enroll callers with the Gate,
+widen their namespace visibility, or grant an aggregate mode to profile resolution
+or binding listing. See the [brain API reference](guide/api-reference.md#brainevent_counts--assertive)
+for actor-filter and anonymous-caller behavior.
+
 ### The naming wrinkle: `khive.toml` vs `config.toml`
 
 The two accepted filenames are not interchangeable at every tier, and this

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -1219,13 +1219,13 @@ zero-filled, when no event in the window carries `cost_unit`. Events without a `
 `truncated` is `true`, these sums are computed over the fetched page only, same as the other
 `counts_by_*` fields.
 
-| Param        | Type   | Required | Notes                                                                                                                                                                                                                                                                          |
-| ------------ | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `since`      | string | yes      | Window start, ISO-8601/RFC-3339 datetime. Inclusive.                                                                                                                                                                                                                           |
-| `until`      | string | no       | Window end, ISO-8601/RFC-3339 datetime. Exclusive. Defaults to now.                                                                                                                                                                                                            |
-| `actor`      | string | no       | Defaults to the authorized caller. An explicit foreign actor must be in the caller's visible namespace set. An `actor:`-prefixed filter matches a stored label exactly and checks the actor identity after removing one prefix; other filters match bare and canonical labels. |
-| `all_actors` | bool   | no       | Default false. True requests all actors and requires the caller's exact actor id in the serving runtime's `[brain] fleet_readers`. Cannot be combined with an explicit `actor`.                                                                                                |
-| `kind`       | string | no       | Filter to a single EventKind (e.g. `"recall_executed"`). Omit for all.                                                                                                                                                                                                         |
+| Param        | Type   | Required | Notes                                                                                                                                                                                                                                                                                                                                      |
+| ------------ | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `since`      | string | yes      | Window start, ISO-8601/RFC-3339 datetime. Inclusive.                                                                                                                                                                                                                                                                                       |
+| `until`      | string | no       | Window end, ISO-8601/RFC-3339 datetime. Exclusive. Defaults to now.                                                                                                                                                                                                                                                                        |
+| `actor`      | string | no       | Defaults to the authorized caller. A filter prefixed with `actor:`, `anonymous:`, or `agent:` matches a stored label exactly. Self access compares kind and id; foreign access checks the raw id for `actor:` and the full label for other reserved kinds against the caller's visible set. Other filters match bare and canonical labels. |
+| `all_actors` | bool   | no       | Default false. True requests all actors and requires the caller's exact actor id in the serving runtime's `[brain] fleet_readers`. Cannot be combined with an explicit `actor`.                                                                                                                                                            |
+| `kind`       | string | no       | Filter to a single EventKind (e.g. `"recall_executed"`). Omit for all.                                                                                                                                                                                                                                                                     |
 
 ```
 request(ops="brain.event_counts(since=\"2026-07-01T00:00:00Z\")")
@@ -1234,7 +1234,8 @@ request(ops="brain.event_counts(since=\"2026-07-01T00:00:00Z\")")
 For an actor of kind `actor`, the canonical stored label is `actor:` followed by
 the unmodified raw principal id, prepending the prefix exactly once. The default
 scope also matches a historical bare alias only when the raw id does not begin
-with `actor:`; prefixed ids match only their canonical stored label. The default
+with any prefix reserved by `RUNTIME_STAMPED_ACTOR_KINDS`: `actor:`, `anonymous:`,
+or `agent:`. Such prefixed ids match only their canonical stored label. The default
 `counts_by_actor` combines the permitted spellings under one caller-label key, or
 has no keys when no events match. Other actor kinds match their exact caller label.
 Explicit `actor` and `all_actors=true` reads preserve stored actor keys. The caller
@@ -1248,7 +1249,16 @@ For example, principal id `actor:caller-a` writes `actor:actor:caller-a` and use
 `actor="actor:actor:caller-a"` for an explicit self read. The filter
 `actor="actor:caller-a"` instead selects the canonical label for principal
 `caller-a`, requiring visibility of that identity even when the filter equals
-the caller's raw id. See
+the caller's raw id. Likewise, a named principal with id `anonymous:local` uses
+`actor="actor:anonymous:local"` for an explicit self read; the exact filter
+`actor="anonymous:local"` selects the anonymous principal and requires visibility
+of that full label. Prefix parsing happens once, and self access compares the
+token's kind and id rather than its collapsed caller label.
+
+The reserved-kind list is shared with the gate's `ActorRef` definition, not a
+closed kind enum. Custom kinds outside that list are not covered by the
+historical-alias separation guarantee. A new runtime-stamped kind must be added
+to the shared list and covered by per-kind event-count tests. See
 [configuration](../configuration.md#brain-read-scope) and
 [ADR-103 Amendment 5](../adr/ADR-103-resource-attribution-model.md#amendment-5-2026-09-10-caller-scoped-brain-reads).
 

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -1219,16 +1219,29 @@ zero-filled, when no event in the window carries `cost_unit`. Events without a `
 `truncated` is `true`, these sums are computed over the fetched page only, same as the other
 `counts_by_*` fields.
 
-| Param   | Type   | Required | Notes                                                                                                                                                       |
-| ------- | ------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `since` | string | yes      | Window start, ISO-8601/RFC-3339 datetime. Inclusive.                                                                                                        |
-| `until` | string | no       | Window end, ISO-8601/RFC-3339 datetime. Exclusive. Defaults to now.                                                                                         |
-| `actor` | string | no       | Filter to a single actor. Stored actor strings are prefixed (`actor:lambda:khive`); bare (`lambda:khive`) or prefixed form both match. Omit for all actors. |
-| `kind`  | string | no       | Filter to a single EventKind (e.g. `"recall_executed"`). Omit for all.                                                                                      |
+| Param        | Type   | Required | Notes                                                                                                                                                                                                                                                       |
+| ------------ | ------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `since`      | string | yes      | Window start, ISO-8601/RFC-3339 datetime. Inclusive.                                                                                                                                                                                                        |
+| `until`      | string | no       | Window end, ISO-8601/RFC-3339 datetime. Exclusive. Defaults to now.                                                                                                                                                                                         |
+| `actor`      | string | no       | Defaults to the authorized caller. An explicit foreign actor must be in the caller's visible namespace set. A bare filter (`service:indexer`) matches bare and `actor:`-prefixed event labels; a prefixed filter (`actor:service:indexer`) matches exactly. |
+| `all_actors` | bool   | no       | Default false. True requests all actors and requires the caller's exact actor id in the serving runtime's `[brain] fleet_readers`. Cannot be combined with an explicit `actor`.                                                                             |
+| `kind`       | string | no       | Filter to a single EventKind (e.g. `"recall_executed"`). Omit for all.                                                                                                                                                                                      |
 
 ```
 request(ops="brain.event_counts(since=\"2026-07-01T00:00:00Z\")")
 ```
+
+For an actor of kind `actor`, the default `counts_by_actor` combines the caller's
+historical bare and prefixed event aliases under one caller-label key, or has no
+keys when no events match. Other actor kinds match their exact caller label.
+Explicit `actor` and `all_actors=true` reads preserve stored actor keys. The caller
+label is the actor id for kind `actor`, otherwise `kind:id`; an anonymous caller
+therefore defaults to `anonymous:local`. A visible foreign actor is readable only
+when explicitly requested. An allowlisted aggregate reader also defaults to its
+own events unless it supplies `all_actors=true`. Client-local configuration cannot
+grant aggregate access on a serving daemon. See
+[configuration](../configuration.md#brain-read-scope) and
+[ADR-103 Amendment 5](../adr/ADR-103-resource-attribution-model.md#amendment-5-2026-09-10-caller-scoped-brain-reads).
 
 ### `brain.profiles` — Assertive
 
@@ -1258,15 +1271,20 @@ request(ops="brain.profile(profile_id=\"implementer-recall-v1\")")
 
 Show which profile would serve a caller context.
 
-| Param           | Type   | Required | Notes                                                        |
-| --------------- | ------ | -------- | ------------------------------------------------------------ |
-| `consumer_kind` | string | yes      | Verb/operation type about to be performed (e.g. `"recall"`). |
-| `actor`         | string | no       | Default `*` (wildcard match).                                |
-| `namespace`     | string | no       | Default `*` (wildcard match).                                |
+| Param           | Type   | Required | Notes                                                                                                       |
+| --------------- | ------ | -------- | ----------------------------------------------------------------------------------------------------------- |
+| `consumer_kind` | string | yes      | Verb/operation type about to be performed (e.g. `"recall"`).                                                |
+| `actor`         | string | no       | Defaults to the authorized caller. An explicit foreign actor must be in the caller's visible namespace set. |
+| `namespace`     | string | no       | Default `*` (wildcard match).                                                                               |
 
 ```
-request(ops="brain.resolve(consumer_kind=\"recall\", actor=\"agent:docs\")")
+request(ops="brain.resolve(consumer_kind=\"recall\")")
 ```
+
+Resolution retains wildcard binding fallback. For anonymous callers, an omitted
+actor remains wildcard-only and does not match explicit `local` or
+`anonymous:local` bindings. An explicit caller label is permitted; other actor ids
+require visibility. There is no `all_actors` resolution mode.
 
 ### `brain.activate` — Commissive
 
@@ -1417,18 +1435,23 @@ the same count for compatibility.
 
 ### `brain.bindings` — Assertive
 
-List rows in the profile resolution table, optionally filtered.
+List the authorized caller's rows in the profile resolution table, optionally
+narrowed by profile, namespace, and consumer kind. The actor filter matches exact
+binding rows; wildcard fallback belongs to profile resolution, not this listing.
 
-| Param           | Type   | Required | Notes |
-| --------------- | ------ | -------- | ----- |
-| `profile_id`    | string | no       |       |
-| `actor`         | string | no       |       |
-| `namespace`     | string | no       |       |
-| `consumer_kind` | string | no       |       |
+| Param           | Type   | Required | Notes                                                                                                                                              |
+| --------------- | ------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `profile_id`    | string | no       |                                                                                                                                                    |
+| `actor`         | string | no       | Defaults to the caller label (`anonymous:local` for an anonymous caller). An explicit foreign actor must be in the caller's visible namespace set. |
+| `namespace`     | string | no       |                                                                                                                                                    |
+| `consumer_kind` | string | no       |                                                                                                                                                    |
 
 ```
 request(ops="brain.bindings(consumer_kind=\"recall\")")
 ```
+
+The caller's own label is always permitted as an explicit actor filter. There is
+no `all_actors` binding-list mode.
 
 ### `brain.create_profile` — Declaration
 

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -1219,27 +1219,36 @@ zero-filled, when no event in the window carries `cost_unit`. Events without a `
 `truncated` is `true`, these sums are computed over the fetched page only, same as the other
 `counts_by_*` fields.
 
-| Param        | Type   | Required | Notes                                                                                                                                                                                                                                                       |
-| ------------ | ------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `since`      | string | yes      | Window start, ISO-8601/RFC-3339 datetime. Inclusive.                                                                                                                                                                                                        |
-| `until`      | string | no       | Window end, ISO-8601/RFC-3339 datetime. Exclusive. Defaults to now.                                                                                                                                                                                         |
-| `actor`      | string | no       | Defaults to the authorized caller. An explicit foreign actor must be in the caller's visible namespace set. A bare filter (`service:indexer`) matches bare and `actor:`-prefixed event labels; a prefixed filter (`actor:service:indexer`) matches exactly. |
-| `all_actors` | bool   | no       | Default false. True requests all actors and requires the caller's exact actor id in the serving runtime's `[brain] fleet_readers`. Cannot be combined with an explicit `actor`.                                                                             |
-| `kind`       | string | no       | Filter to a single EventKind (e.g. `"recall_executed"`). Omit for all.                                                                                                                                                                                      |
+| Param        | Type   | Required | Notes                                                                                                                                                                                                                                                                          |
+| ------------ | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `since`      | string | yes      | Window start, ISO-8601/RFC-3339 datetime. Inclusive.                                                                                                                                                                                                                           |
+| `until`      | string | no       | Window end, ISO-8601/RFC-3339 datetime. Exclusive. Defaults to now.                                                                                                                                                                                                            |
+| `actor`      | string | no       | Defaults to the authorized caller. An explicit foreign actor must be in the caller's visible namespace set. An `actor:`-prefixed filter matches a stored label exactly and checks the actor identity after removing one prefix; other filters match bare and canonical labels. |
+| `all_actors` | bool   | no       | Default false. True requests all actors and requires the caller's exact actor id in the serving runtime's `[brain] fleet_readers`. Cannot be combined with an explicit `actor`.                                                                                                |
+| `kind`       | string | no       | Filter to a single EventKind (e.g. `"recall_executed"`). Omit for all.                                                                                                                                                                                                         |
 
 ```
 request(ops="brain.event_counts(since=\"2026-07-01T00:00:00Z\")")
 ```
 
-For an actor of kind `actor`, the default `counts_by_actor` combines the caller's
-historical bare and prefixed event aliases under one caller-label key, or has no
-keys when no events match. Other actor kinds match their exact caller label.
+For an actor of kind `actor`, the canonical stored label is `actor:` followed by
+the unmodified raw principal id, prepending the prefix exactly once. The default
+scope also matches a historical bare alias only when the raw id does not begin
+with `actor:`; prefixed ids match only their canonical stored label. The default
+`counts_by_actor` combines the permitted spellings under one caller-label key, or
+has no keys when no events match. Other actor kinds match their exact caller label.
 Explicit `actor` and `all_actors=true` reads preserve stored actor keys. The caller
 label is the actor id for kind `actor`, otherwise `kind:id`; an anonymous caller
 therefore defaults to `anonymous:local`. A visible foreign actor is readable only
 when explicitly requested. An allowlisted aggregate reader also defaults to its
 own events unless it supplies `all_actors=true`. Client-local configuration cannot
-grant aggregate access on a serving daemon. See
+grant aggregate access on a serving daemon.
+
+For example, principal id `actor:caller-a` writes `actor:actor:caller-a` and uses
+`actor="actor:actor:caller-a"` for an explicit self read. The filter
+`actor="actor:caller-a"` instead selects the canonical label for principal
+`caller-a`, requiring visibility of that identity even when the filter equals
+the caller's raw id. See
 [configuration](../configuration.md#brain-read-scope) and
 [ADR-103 Amendment 5](../adr/ADR-103-resource-attribution-model.md#amendment-5-2026-09-10-caller-scoped-brain-reads).
 

--- a/docs/khive-config-example.toml
+++ b/docs/khive-config-example.toml
@@ -14,13 +14,14 @@
 #   4. ~/.khive/config.toml                           (user-global)
 #
 # Unknown keys are ignored (forward-compatible), except inside the security-sensitive
-# [gate] table: its schema is closed, so misspelled or unknown policy keys fail startup.
+# [gate] and [brain] tables: their schemas are closed, so unknown keys fail startup.
 #
 # Sections in this file:
 #   [actor]         default identity + namespace read/write scope
 #   [runtime]       brain profile + default output format
 #   [display]       rendering timezone (ADR-169)
 #   [gate]          optional static caller-enrollment allowlist
+#   [brain]         actor ids permitted to request aggregate event counts
 #   [[engines]]     embedding engines (replaces the KHIVE_EMBEDDING_MODEL env pair)
 #   [[backends]]    named storage backends (ADR-028)
 #   [packs.<name>]  per-pack backend assignment (ADR-028)
@@ -118,6 +119,21 @@
 # [gate]
 # granted_actors = ["lambda:khive", "service:indexer"]
 # grant_unattributed = false
+
+# -- [brain] -- aggregate event-count read permission ----------------------------
+#
+# Brain reads default to the authorized caller. This exact actor-id allowlist
+# permits brain.event_counts(all_actors=true), not automatic aggregate reads.
+# The serving process's resolved configuration is authoritative; a client's local
+# list cannot grant access on a daemon. This does not grant Gate enrollment or
+# change [actor].visible_namespaces. Unknown keys in this table fail startup.
+
+[brain]
+# List of strings (Vec<String>). Absent table or key defaults to the empty list,
+# which grants no aggregate readers. Use actor ids, not prefixed event-row labels.
+fleet_readers = []
+# Example granting one aggregate reader instead:
+# fleet_readers = ["service:metrics"]
 
 # ── Embedding engines ──────────────────────────────────────────────────────────
 #

--- a/tests/smoke_brain.py
+++ b/tests/smoke_brain.py
@@ -312,21 +312,25 @@ def brain_smoke():
 
         # ── 11. bind + bindings ────────────────────────────────────────────────
         try:
+            identity = call_verb(proc, "whoami", {})
+            binding_actor = identity["actor_id"] if identity["actor_kind"] == "actor" else (
+                f"{identity['actor_kind']}:{identity['actor_id']}"
+            )
             bind_result = call_verb(proc, "brain.bind", {
                 "profile_id": "balanced-recall-v1",
-                "actor": "test-actor",
+                "actor": binding_actor,
                 "consumer_kind": "recall",
             })
             assert bind_result.get("bound") is True, f"bind must return bound=true: {bind_result}"
-            assert bind_result.get("actor") == "test-actor", f"actor mismatch: {bind_result}"
+            assert bind_result.get("actor") == binding_actor, f"actor mismatch: {bind_result}"
 
             bindings = call_verb(proc, "brain.bindings", {})
             rows = bindings.get("bindings", [])
             found = any(
-                r.get("actor") == "test-actor" and r.get("consumer_kind") == "recall"
+                r.get("actor") == binding_actor and r.get("consumer_kind") == "recall"
                 for r in rows
             )
-            assert found, f"test-actor/recall binding must appear in bindings: {rows}"
+            assert found, f"{binding_actor}/recall binding must appear in bindings: {rows}"
             ok(f"bind + bindings — binding appears in listing")
         except Exception as e:
             fail("bind + bindings", e)
@@ -334,7 +338,7 @@ def brain_smoke():
         # ── 12. unbind ────────────────────────────────────────────────────────
         try:
             unbind_result = call_verb(proc, "brain.unbind", {
-                "actor": "test-actor",
+                "actor": binding_actor,
                 "consumer_kind": "recall",
             })
             removed = unbind_result.get("unbound", 0)
@@ -343,7 +347,7 @@ def brain_smoke():
             bindings_after = call_verb(proc, "brain.bindings", {})
             rows_after = bindings_after.get("bindings", [])
             still_there = any(
-                r.get("actor") == "test-actor" and r.get("consumer_kind") == "recall"
+                r.get("actor") == binding_actor and r.get("consumer_kind") == "recall"
                 for r in rows_after
             )
             assert not still_there, (

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -1158,10 +1158,22 @@ def brain_smoke():
 
         # brain.bind / brain.bindings / brain.unbind: use the always-present
         # balanced-recall-v1 profile (Active by default) for binding coverage
+        identity = call_verb(proc, "whoami", {})
+        binding_actor = identity["actor_id"] if identity["actor_kind"] == "actor" else (
+            f"{identity['actor_kind']}:{identity['actor_id']}"
+        )
+        foreign_actor = "smoke-foreign-actor"
+        assert foreign_actor != binding_actor
+        foreign_bound = call_verb(proc, "brain.bind", {
+            "profile_id": "balanced-recall-v1",
+            "consumer_kind": "recall",
+            "actor": foreign_actor,
+        })
+        assert foreign_bound.get("bound") is True, foreign_bound
         bound = call_verb(proc, "brain.bind", {
             "profile_id": "balanced-recall-v1",
             "consumer_kind": "recall",
-            "actor": "smoke-actor",
+            "actor": binding_actor,
         })
         assert bound.get("bound") is True, (
             f"brain.bind must return bound=true: {bound}"
@@ -1170,14 +1182,25 @@ def brain_smoke():
 
         bindings = call_verb(proc, "brain.bindings", {"profile_id": "balanced-recall-v1"})
         binding_actors = [b.get("actor") for b in bindings.get("bindings", [])]
-        assert "smoke-actor" in binding_actors, (
-            f"smoke-actor must appear in bindings after brain.bind: {binding_actors}"
+        assert binding_actor in binding_actors, (
+            f"caller {binding_actor} must appear in bindings after brain.bind: {binding_actors}"
         )
+        assert foreign_actor not in binding_actors, (
+            f"writing a foreign binding must not grant readback: {binding_actors}"
+        )
+        foreign_read = _call_request_raw(proc, json.dumps([{
+            "tool": "brain.bindings", "args": {"actor": foreign_actor},
+        }]))["results"][0]
+        assert foreign_read.get("ok") is False, foreign_read
+        foreign_error = foreign_read.get("error", "")
+        if isinstance(foreign_error, dict):
+            foreign_error = foreign_error.get("message", "")
+        assert foreign_actor in foreign_error and "not visible" in foreign_error, foreign_read
         print(f"  [brain] brain.bindings -- {bindings['count']} binding(s)")
 
         unbound = call_verb(proc, "brain.unbind", {
             "profile_id": "balanced-recall-v1",
-            "actor": "smoke-actor",
+            "actor": binding_actor,
         })
         assert unbound.get("unbound", 0) >= 1, (
             f"brain.unbind must remove at least one binding: {unbound}"
@@ -1187,13 +1210,18 @@ def brain_smoke():
         # Confirm the binding is gone
         after = call_verb(proc, "brain.bindings", {
             "profile_id": "balanced-recall-v1",
-            "actor": "smoke-actor",
+            "actor": binding_actor,
         })
         remaining_actors = [b.get("actor") for b in after.get("bindings", [])]
-        assert "smoke-actor" not in remaining_actors, (
-            f"smoke-actor must be absent after unbind: {remaining_actors}"
+        assert binding_actor not in remaining_actors, (
+            f"caller {binding_actor} must be absent after unbind: {remaining_actors}"
         )
-        print(f"  [brain] brain.bindings post-unbind -- smoke-actor removed")
+        foreign_unbound = call_verb(proc, "brain.unbind", {
+            "profile_id": "balanced-recall-v1",
+            "actor": foreign_actor,
+        })
+        assert foreign_unbound.get("unbound", 0) == 1, foreign_unbound
+        print(f"  [brain] brain.bindings post-unbind -- caller binding removed")
 
         print(f"\n  BRAIN PACK SMOKE TESTS PASSED")
     finally:


### PR DESCRIPTION
## Summary

Brain read verbs are scoped to the caller. `brain.event_counts`, `brain.resolve` and `brain.bindings` derive their default actor scope from the authorized request token, not from the identity that built the registry or started the serving process.

- `actor` omitted: `event_counts` counts only the caller's events, `bindings` lists only the caller's rows (an exact filter, not the wildcard fallback), `resolve` resolves the caller's profile with the existing wildcard fallback. Anonymous callers keep their own `anonymous:local` label and never widen to all actors.
- `actor` explicit: allowed for the caller itself or for an actor id in the token's visible namespace set; any other actor is refused with `InvalidInput` naming it. A bare filter matches bare and prefixed stored labels; a prefixed filter is exact.
- `all_actors` (new, default false) removes the actor filter only when the serving runtime's `[brain] fleet_readers` list names the caller. A client-side allow-list or wider visibility does not grant the aggregate read. `all_actors=true` with an explicit `actor` is refused.
- `[brain] fleet_readers` is a serving-side configuration list (empty by default, unknown keys rejected). Both config conversion paths replace the base policy, so an absent or empty list revokes. The daemon config fingerprint includes a domain-separated hash of the sorted, deduplicated list and reports a brain-policy mismatch, so a policy change needs a matching serving configuration.
- Event aliases respect the runtime's stamped kinds. The runtime stamps identities as `actor:`, `anonymous:` or `agent:` (`RUNTIME_STAMPED_ACTOR_KINDS` in `khive-gate`, re-exported by the runtime). A stored label carrying one of these reserved prefixes is a principal spelling and is never folded into the bare alias of a different actor whose raw id equals the suffix; an ordinary prefixed id (a non-reserved kind) keeps its historical bare alias. The reserved list is exactly the kinds the runtime stamps today; a kind added to the runtime later must be added to the list, and ADR-103 Amendment 5 records that limitation with the date.
- The smoke suites derive the caller label from `whoami` instead of a fixed label. The main smoke also proves that a binding written for a foreign actor persists, is absent from the caller's default listing, is refused by an explicit foreign read, and is removed by exactly one unbind. Bindings identify the target actor, not the writer, so writing does not grant a foreign read; ADR-103 Amendment 5 documents the readback rule with a dated example.

Handler descriptions and the API reference state the scope rules; ADR-103 gains Amendment 5 with its Consequences section; the configuration guide and example carry the new section.

## Tests

The read-scope family in the brain crate's test module covers the caller default, self-read with a primary-only token, prefixed self-read, foreign actors with and without visibility for each read verb, prefixed foreign actors, anonymous callers, `all_actors` with and without the serving policy, the bindings exact filter, `all_actors` conflicting with an explicit actor, reserved-prefix exclusion for each stamped kind, the ordinary-kind bare alias, attributed prefixed ids staying principal-scoped, and a completeness check that the reserved list matches the runtime's stamped kinds. MCP help coverage checks the new parameter. Runtime configuration literals across the workspace gained the new section.

## Verification

- `cargo fmt --all -- --check`, `cargo clippy -p khive-pack-brain -p khive-runtime -p khive-mcp --all-targets -- -D warnings`: clean.
- `cargo test --no-fail-fast` on khive-pack-brain (322), khive-runtime (1640), khive-mcp (845), khive-pack-memory (431): all passing, 0 failed. The final commit changes documentation and the smoke scripts only.
- Three mutation controls, each restored byte-exact and re-run green (14 passed in the scope filter):
  - caller/visibility check disabled: the per-verb foreign-visibility test fails.
  - serving reader list emptied: the `all_actors` positive arm fails.
  - reserved kinds reduced to `actor` alone: the anonymous and agent exclusion tests and the completeness check fail (3).
- `scripts/ci.sh release` + `scripts/ci.sh smoke-tests` at the head: every smoke section passes, including the bindings check that the previous smoke script failed under the new scope.
