### PR TITLE
fix(git): bound digest visits and checkpoint progress per page

### DIFF
--- a/crates/khive-pack-git/docs/api/ingest.md
+++ b/crates/khive-pack-git/docs/api/ingest.md
@@ -46,10 +46,16 @@ rather than falling back.
 
 ## `Budget`
 
-Bounds the number of new-record creation attempts across a `run_ingest`
-pass (ADR-088 Amendment 1 `max_items`). Only creation attempts (success or
-failure) consume budget — cheap natural-key "already exists" skips do not,
-since they are not the work the bound exists to limit.
+Bounds fresh record visits across commits, PRs, and issues (ADR-088 Amendment 1
+`max_items`). A record consumes one unit **before** its natural-key lookup, whether
+it already exists, creates successfully, or fails validation or creation. Existing
+tracker records therefore cannot turn a small bound into an unbounded database scan.
+An exact durable boundary acknowledgment skips the lookup and consumes no unit;
+these replays do not increment `*_skipped_existing` (that count measures actual
+existence checks). Related lookups and enrichment within one record are not separate
+units. The bound does not limit git snapshot construction, the size of a fetched
+remote page, or subprocess wall time. Exact-budget passes retain the conservative
+`done=false` result; a subsequent pass proves completion.
 
 ## Secret-gate refusal accounting
 
@@ -200,18 +206,39 @@ see `find_document_for_path_tests`).
 
 ## `write_cursor`
 
-Called once per section (commits/prs/issues) after that section's loop
-finishes, with a value that stops advancing at the first per-record create
-failure (see the `cursor_stalled` handling in each `ingest_*` loop) — so
-the next pass re-walks from before the failure and retries it, while
-records that already landed (including ones ingested later in a stalled
-pass) are no-ops via natural-key dedupe.
-While a pass is stalled, the persisted floor also never advances on the
-strength of an ALREADY-EXISTING record walked after the stall point (its
-natural-key lookup proves only its own landing): advancing past one would
-persist a cursor strictly newer than the refused record's timestamp, and
-the next pass's inclusive `updated >= cursor` filter would skip the refused
-record forever instead of retrying it.
+Commits persist their exclusive SHA cursor after each contiguous successful or
+already-existing record. Issues and PRs persist a paired page checkpoint after each
+fetched page is processed, including a partial page stopped by the visit budget,
+and before fetching the next page. A later fetch or database failure therefore
+preserves the earlier saved prefix. A failure within a page can replay that page.
+
+The main `issues`/`prs` cursor remains a canonical timestamp. Versioned JSON in the
+same table under `issues_checkpoint`/`prs_checkpoint` holds the matching floor,
+namespace, and exact number-to-note-UUID maps for acknowledged boundary and undated
+records. Both rows are read in one snapshot and written by one multi-row UPSERT.
+A timestamp-only legacy cursor starts with empty acknowledgments; mismatched,
+malformed, oversized, or unknown-version metadata warns and falls back to the main
+cursor. Invalid main timestamps warn and restart the window, never enter `gh` argv.
+Metadata is not a public cursor format or a schema migration.
+
+Acknowledgments are durable completion facts, not a cache of live note existence.
+Deleting a mirrored note locally does not reset ingest progress, including at the
+inclusive boundary. To deliberately reimport deleted records, reset both the main
+cursor and its checkpoint row for that project/source kind. This is also required
+before relying on refreshed PR UUIDs for enrichment after local deletion.
+
+Acknowledgments remain after completion so a quiescent PR boundary cannot repeatedly
+spend the budget before issues or commits are reached. PR replay restores the merge
+SHA and PR-number linking maps using the stored UUID and current masked remote
+fields. Each map is capped at the 1,000-record remote page limit; undated entries
+are pruned to the currently fetched page. A cap overflow stops with a stalled
+cursor instead of silently dropping progress. Records acknowledged before an upstream
+edit are still governed by the existing append-only natural-key ingest behavior.
+
+Any per-record failure freezes the saved prefix. Neither later new nor existing
+records may advance it or be acknowledged beyond that failure. Publish this stall
+in the report before a fallible checkpoint write. The next pass retries the failed
+record; already-landed later records remain idempotent via natural-key dedupe.
 
 ## Issue #765: commit-snapshot recovery
 
@@ -349,10 +376,10 @@ last fetched page.
 
 `cursor_stalled` mirrors `ingest_commits`: once one record fails to create,
 later records in this pass are still attempted (so every failure surfaces
-in this pass's warnings), but `max_updated` no longer advances past the
+in this pass's warnings), but `checkpoint.floor` no longer advances past the
 stall point — the next pass re-fetches from before the failure and retries
 it, while already-landed records are no-ops via the natural key.
-The freeze applies on every `max_updated` advance, including the
+The freeze applies on every `checkpoint.floor` advance, including the
 already-existing-record branch: while stalled, a later existing record with
 a newer timestamp must not pull the floor past the refused record (see
 `write_cursor` above).
@@ -361,9 +388,19 @@ Each page is already `sort:updated-asc` server-side, but `--search` makes
 no hard ordering guarantee across ties — both loops re-sort defensively so
 the frozen-cursor invariant (records walked in nondecreasing `updated_at`
 order) holds regardless. `is_new` is inclusive (`updated >= cursor`) for
-exactly the tie reason: a successful and a failing record sharing one
-`updated_at` must both be re-examined next pass until the cursor moves past
-that tie.
+exactly the tie reason: a failing or unseen record sharing the boundary
+`updated_at` must remain eligible. Only exact acknowledged numbers at that timestamp
+are replayed without lookup; a lower but unseen number remains eligible. Sorting
+uses `(updated_at, number)` for deterministic local order, not a remote numeric
+high-water predicate. Canonical undated records also retain exact acknowledgments,
+so `max_items=1` can progress without persisting malformed timestamp text.
+
+The existing remote search ceiling remains: a full 1,000-record page at one timestamp
+cannot prove that no further ties exist, so it reports stopped early rather than
+jumping past the timestamp. Arrivals older than an advanced floor remain outside
+this high-water contract. PRs still precede issues and commits to preserve enrichment;
+continuously arriving or permanently failing earlier-source work has no new fairness
+guarantee.
 
 In both `ingest_issues` and `ingest_prs`, the entire fetched page is
 classified before anything else—including the sort and paging-cursor

--- a/crates/khive-pack-git/docs/api/ingest.md
+++ b/crates/khive-pack-git/docs/api/ingest.md
@@ -206,8 +206,17 @@ see `find_document_for_path_tests`).
 
 ## `write_cursor`
 
-Commits persist their exclusive SHA cursor after each contiguous successful or
-already-existing record. Issues and PRs persist a paired page checkpoint after each
+Commits atomically persist a SHA and frozen snapshot continuation after each
+contiguous successful or already-existing record (`write_commit_checkpoint`).
+The sidecar retains the original base, immutable tip, and completed position in a
+topologically ordered walk. This prevents max-one passes from cycling between
+siblings in a merge DAG. The acknowledged prefix consumes no visits on resume;
+both Git history passes and recovery retries use the pinned tip. A completed old
+snapshot with a changed `HEAD` requires another call even with spare budget. See
+[the frozen snapshot contract](../ingest.md#cursor-stall-guarantee) for validation,
+the 8 KiB metadata cap, reset semantics, and failure handling.
+
+Issues and PRs persist a paired page checkpoint after each
 fetched page is processed, including a partial page stopped by the visit budget,
 and before fetching the next page. A later fetch or database failure therefore
 preserves the earlier saved prefix. A failure within a page can replay that page.
@@ -271,7 +280,7 @@ with the metadata format has no clean, unambiguous delimiter.
 `CommitSnapshot` bundles both passes so a classified failure in either one
 can be retried as a single unit. `load_commit_snapshot` mirrors
 `ingest_commits`'s original inline sequencing: `touched_files` (a second,
-unscoped `git log --name-only` pass over the whole history) is skipped
+`git log --name-only` pass over the frozen tip's whole history) is skipped
 entirely when `walk_commits` found no new commits, since there is nothing
 new to annotate with touched paths.
 
@@ -282,7 +291,9 @@ one truthful success warning once the commit phase completes.
 used to repair a classified `GitLogError` — `recover_commit_snapshot`
 retries the snapshot load against that path (the same cache slot for both
 strategies in `cache.rs`, but callers are not required to keep it
-identical).
+identical). The tip is resolved once before recovery and remains fixed across
+retries, even when a replacement clone has a newer `HEAD`. A replacement that
+cannot provide the pinned objects fails without advancing the continuation.
 
 `recover_commit_snapshot` is bounded entirely by `recover`'s own return
 value: `Ok(Some(_))` retries the snapshot load against the recovered repo
@@ -506,13 +517,13 @@ token into two lines, so `grep -av` removes only the header line and the
 deleted commit's path token survives in the stream as the orphan.
 
 Before walking commits, the ingester loads the same-namespace live ADR-085
-module index once for the repository snapshot HEAD. That snapshot is never
-truncated: `walk_commits` issues one unbounded `git log {since}..HEAD`, and
-`max_items` bounds only the create loop (a budget check after the snapshot
-loads), never the walk — so the snapshot HEAD is always the true repository
-HEAD of this pass, and the index anchors to modules-as-of-HEAD regardless of
-how many commits the budget lets this pass create. A module is eligible only
-when both `properties.source_revision` equals that HEAD and
+module index once for the frozen repository snapshot tip. The snapshot is never
+truncated by the visit budget: `walk_commits` reconstructs the original base-to-tip
+range in reverse topological order, and `max_items` bounds the fresh-record loop
+after the acknowledged prefix. The index therefore remains anchored to the same
+immutable tip throughout continuation, even if the repository's current `HEAD`
+advances. A module is eligible only when both `properties.source_revision` equals
+that tip and
 `properties.source_path` exactly equals the changed path. Requiring the
 revision prevents an identically named path in another repository snapshot
 from receiving a fabricated annotation. If more than one live module still

--- a/crates/khive-pack-git/docs/ingest.md
+++ b/crates/khive-pack-git/docs/ingest.md
@@ -103,16 +103,35 @@ mid-walk database error is reported in-band as walked-then-failed rather
 than as a pre-walk hard error (cursor and snapshot failures earlier in the
 function remain pre-walk errors).
 
-The commit snapshot (`walk_commits`) is oldest-first and always includes
-`HEAD` whenever this phase has work, so the last record is the exact
-repository snapshot the ADR-085 module index binds against. The walk
-itself is never truncated — `walk_commits` issues one unbounded
-`git log {since}..HEAD`, and `max_items` bounds only the fresh-record visit loop that
-follows, never the snapshot — so `snapshot_head` is always the true
-repository `HEAD` of the pass regardless of how many commits the budget
-lets it create.
+Commit progress uses a **frozen snapshot continuation**, because the ancestor
+closure of one SHA does not describe a visited prefix across both sides of a
+merge. At the start of a new walk, resolve `HEAD` to an immutable OID. Reconstruct
+`git log --reverse --topo-order {base}..{snapshot_head}` on each resumed call
+(omit the base exclusion for a full-history walk). Metadata, touched paths,
+recovery retries, and the ADR-085 module index all bind to that same snapshot tip.
+The walk itself remains unbounded; `max_items` limits fresh record visits, not
+snapshot construction. Its acknowledged prefix is skipped before any natural-key
+lookup or budget charge.
 
-`cursor_stalled` freezes the persisted SHA at the last contiguous successfully
+After each contiguous success or existing-note visit, one atomic UPSERT stores the
+compatibility `commits` SHA and a versioned `commits_checkpoint` sidecar containing
+namespace, original base, frozen tip, and last completed SHA. The sidecar has
+constant fields and an 8 KiB serialized cap; no list of visited SHAs grows with
+history. Resume validates the paired rows and the position's membership in the
+frozen traversal. An absent sidecar preserves legacy SHA-only startup. Present
+malformed, oversized, unknown-version, or inconsistent metadata fails before
+record visits; it never silently falls back to an incomplete SHA-only prefix.
+An unavailable frozen tip also fails without advancing either row. Reset both
+rows to deliberately replay the history, including after local note deletion.
+
+The frozen tip is the last record in topological order. Once acknowledged, the
+next call may begin a new walk from that tip. If `HEAD` has changed when a frozen
+walk finishes, the response remains `done:false` and `history_exhausted:false`,
+even with unused budget, so callers request the subsequent history. A pass that
+exactly consumes its budget retains the existing `done:false` convention and
+proves completion on the next call. Issue/PR page checkpoints are unchanged.
+
+`cursor_stalled` freezes both commit cursor rows at the last contiguous successfully
 processed commit: once a record fails to create, later records in the same
 pass are still attempted (so a run surfaces every failure it can, not just
 the first), but the persisted cursor no longer advances past the failure.

--- a/crates/khive-pack-git/docs/ingest.md
+++ b/crates/khive-pack-git/docs/ingest.md
@@ -25,7 +25,7 @@ instrumentation gap that would have to exist for the slot to still be
 
 `run_ingest` distinguishes a **never-walked** source (its first page/first
 fetch failed) from a **walked-then-failed** source (a continuation-page
-fetch, a per-record existence lookup, or the final cursor write failed
+fetch, a per-record existence lookup, or the page or per-commit checkpoint write failed
 after the walk was already underway) by reading the source's own state
 slot: `None` means the walker never got as far as recording anything, so
 the source was never walked; `Some` means the walker had already recorded a
@@ -35,8 +35,8 @@ occurred, so the walk did happen.
 For pull requests and issues this is checked directly (`report.sources.pull_requests.is_none()` /
 `report.sources.issues.is_none()`). For commits, `ingest_commits` records
 its source slot at every walker exit, so a `Some` slot beside an `Err` means
-the walk ran (possibly to completion) and the pass failed *after* it — the
-final cursor write is the canonical case for that. A `None` slot for
+the walk ran (possibly to completion) and the pass failed _after_ it — the
+page or per-commit checkpoint write is the canonical case for that. A `None` slot for
 commits is a pre-walk failure (snapshot recovery, cursor read) and stays a
 hard error, since the recovery contract depends on those surfacing.
 
@@ -44,7 +44,7 @@ When the source did walk before failing:
 
 - A completed walk whose pass then fails is downgraded from `Completed` to
   `StoppedEarly`, so `completed` never outlives a pass whose durability
-  turned out to be unproven (e.g. the final cursor write never landed).
+  turned out to be unproven (e.g. the page or per-commit checkpoint write never landed).
 - The resume loop must not treat the source as finished: `report.done` is
   forced to `false`.
 
@@ -68,7 +68,7 @@ as a real stop reason.
 
 **Fabrication risk**, named here for the next maintainer touching a walker:
 in release builds the `debug_assert!` guarding these arms is a no-op, so a
-future walker that sets its completion flag *without* also recording a
+future walker that sets its completion flag _without_ also recording a
 source state would silently produce a fabricated `Completed` /
 `StoppedEarly` here with no real reason behind it. The invariant every
 walker must uphold is that it records its own exit state; these fallback
@@ -80,7 +80,7 @@ reason instead of leaving the slot silently empty.
 ### Ancestor-divergence check
 
 An empty `{cursor}..HEAD` commit range is a genuine completion only when
-the cursor is an ancestor of the tip being walked. A cursor that is *not*
+the cursor is an ancestor of the tip being walked. A cursor that is _not_
 an ancestor means this source's history lags or diverged from whatever
 advanced the cursor — measured directly: a scratch clone whose `HEAD`
 trailed the cursor by weeks walked nothing and reported a clean pass
@@ -107,12 +107,12 @@ The commit snapshot (`walk_commits`) is oldest-first and always includes
 `HEAD` whenever this phase has work, so the last record is the exact
 repository snapshot the ADR-085 module index binds against. The walk
 itself is never truncated — `walk_commits` issues one unbounded
-`git log {since}..HEAD`, and `max_items` bounds only the create loop that
+`git log {since}..HEAD`, and `max_items` bounds only the fresh-record visit loop that
 follows, never the snapshot — so `snapshot_head` is always the true
 repository `HEAD` of the pass regardless of how many commits the budget
 lets it create.
 
-`cursor_stalled` freezes `last_sha` at the last contiguous successfully
+`cursor_stalled` freezes the persisted SHA at the last contiguous successfully
 processed commit: once a record fails to create, later records in the same
 pass are still attempted (so a run surfaces every failure it can, not just
 the first), but the persisted cursor no longer advances past the failure.
@@ -125,9 +125,9 @@ natural key, so a retried pass never double-creates them.
 `local_sha_to_id` maps parent SHA to note id for commits created earlier in
 the same pass. Combined with `find_commit_by_sha`'s database lookup, it
 resolves `precedes` parent edges regardless of which pass the parent
-landed in. The stall guard applies to every `last_sha` advance in the loop:
+landed in. The stall guard applies to every cursor write in the loop:
 once a commit create fails, advancing the cursor past a later
-refused/failed record — including past a later *existing* record, whose
+refused/failed record — including past a later _existing_ record, whose
 natural-key lookup proves only its own landing, not the failed record's —
 would strand the failed commit behind the floor and skip it forever instead
 of retrying it on the next pass.

--- a/crates/khive-pack-git/src/ingest.rs
+++ b/crates/khive-pack-git/src/ingest.rs
@@ -1247,57 +1247,101 @@ async fn load_code_modules_by_snapshot_path(
     Ok(modules)
 }
 
-/// Read the last-ingested cursor value for `(project_id, kind)`, if any.
-async fn read_cursor(
+/// A single SHA cannot describe a visited prefix of a branching DAG. Retain
+/// the immutable walk and a position inside its deterministic topological order.
+#[derive(Debug, Serialize, Deserialize)]
+struct CommitCheckpoint {
+    version: u8,
+    namespace: String,
+    base_cursor: Option<String>,
+    snapshot_head: String,
+    last_completed_sha: String,
+}
+
+const COMMIT_CHECKPOINT_MAX_BYTES: usize = 8 * 1024;
+
+fn is_commit_oid(value: &str) -> bool {
+    matches!(value.len(), 40 | 64) && value.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+/// Read both rows at one SQL snapshot. A present invalid continuation cannot
+/// safely fall back to a SHA range: that would lose the already visited DAG prefix.
+async fn read_commit_checkpoint(
     runtime: &KhiveRuntime,
+    token: &NamespaceToken,
     project_id: Uuid,
-    kind: &str,
-) -> Result<Option<String>> {
+) -> Result<(Option<String>, Option<CommitCheckpoint>)> {
     let sql = runtime.sql();
     let mut r = sql.reader().await.map_err(anyhow::Error::new)?;
     let row = r
         .query_row(SqlStatement {
-            sql: "SELECT cursor_value FROM git_mirror_cursor WHERE project_id=?1 AND kind=?2"
+            sql: "SELECT \
+                  (SELECT cursor_value FROM git_mirror_cursor WHERE project_id=?1 AND kind='commits') AS cursor, \
+                  (SELECT cursor_value FROM git_mirror_cursor WHERE project_id=?1 AND kind='commits_checkpoint') AS progress"
                 .into(),
-            params: vec![
-                SqlValue::Text(project_id.to_string()),
-                SqlValue::Text(kind.to_string()),
-            ],
-            label: Some("git_ingest_read_cursor".into()),
+            params: vec![SqlValue::Text(project_id.to_string())],
+            label: Some("git_ingest_read_commit_checkpoint".into()),
         })
         .await
         .map_err(anyhow::Error::new)?;
-    Ok(row.and_then(|r| match r.get("cursor_value") {
-        Some(SqlValue::Text(s)) => Some(s.clone()),
-        _ => None,
-    }))
+    let value = |name| {
+        row.as_ref().and_then(|r| match r.get(name) {
+            Some(SqlValue::Text(s)) => Some(s.clone()),
+            _ => None,
+        })
+    };
+    let cursor = value("cursor");
+    let Some(raw) = value("progress") else {
+        return Ok((cursor, None));
+    };
+    if raw.len() > COMMIT_CHECKPOINT_MAX_BYTES {
+        return Err(anyhow!("commits checkpoint exceeds the size limit; reset both commit cursor rows to replay history"));
+    }
+    let checkpoint: CommitCheckpoint = serde_json::from_str(&raw)
+        .context("invalid commits checkpoint; reset both commit cursor rows to replay history")?;
+    if checkpoint.version != 1
+        || checkpoint.namespace != token.namespace().as_str()
+        || !is_commit_oid(&checkpoint.snapshot_head)
+        || !is_commit_oid(&checkpoint.last_completed_sha)
+        || checkpoint
+            .base_cursor
+            .as_deref()
+            .is_some_and(|sha| !is_commit_oid(sha))
+        || cursor.as_deref() != Some(checkpoint.last_completed_sha.as_str())
+    {
+        return Err(anyhow!(
+            "inconsistent commits checkpoint; reset both commit cursor rows to replay history"
+        ));
+    }
+    Ok((cursor, Some(checkpoint)))
 }
 
-/// Advance the `(project_id, kind)` cursor. See
-/// crates/khive-pack-git/docs/api/ingest.md#write_cursor for the
-/// stall-then-retry cursor semantics.
-async fn write_cursor(
+/// Atomically publish the compatibility SHA and its frozen-walk continuation.
+async fn write_commit_checkpoint(
     runtime: &KhiveRuntime,
     project_id: Uuid,
-    kind: &str,
-    value: &str,
+    checkpoint: &CommitCheckpoint,
 ) -> Result<()> {
+    let progress = serde_json::to_string(checkpoint)?;
+    if progress.len() > COMMIT_CHECKPOINT_MAX_BYTES {
+        return Err(anyhow!("commits checkpoint exceeds the size limit"));
+    }
     let sql = runtime.sql();
     let mut w = sql.writer().await.map_err(anyhow::Error::new)?;
     w.execute(SqlStatement {
         sql: "INSERT INTO git_mirror_cursor(project_id, kind, cursor_value, updated_at) \
-              VALUES(?1, ?2, ?3, ?4) \
+              VALUES(?1, 'commits_checkpoint', ?2, ?4), (?1, 'commits', ?3, ?4) \
               ON CONFLICT(project_id, kind) DO UPDATE SET \
                 cursor_value=excluded.cursor_value, \
                 updated_at=excluded.updated_at"
             .into(),
         params: vec![
             SqlValue::Text(project_id.to_string()),
-            SqlValue::Text(kind.to_string()),
-            SqlValue::Text(value.to_string()),
+            SqlValue::Text(progress),
+            SqlValue::Text(checkpoint.last_completed_sha.clone()),
             SqlValue::Integer(Utc::now().timestamp_micros()),
         ],
-        label: Some("git_ingest_write_cursor".into()),
+        label: Some("git_ingest_write_commit_checkpoint".into()),
     })
     .await
     .map_err(anyhow::Error::new)?;
@@ -1506,7 +1550,11 @@ impl GitLogError {
 
 /// Walk local git history via `git log` with a stable, machine-parseable
 /// format. See crates/khive-pack-git/docs/api/ingest.md#issue-765-commit-snapshot-recovery.
-fn walk_commits(repo: &Path, since_sha: Option<&str>) -> Result<Vec<RawCommit>> {
+fn walk_commits(
+    repo: &Path,
+    since_sha: Option<&str>,
+    snapshot_head: &str,
+) -> Result<Vec<RawCommit>> {
     // Raw control-byte separators embedded directly in the format string
     // (not git's `%xHH` escape syntax) — passed as a single argv element
     // (never through a shell), so the literal bytes survive intact and git's
@@ -1515,11 +1563,14 @@ fn walk_commits(repo: &Path, since_sha: Option<&str>) -> Result<Vec<RawCommit>> 
     let mut args = vec![
         "log".to_string(),
         "--reverse".to_string(),
+        "--topo-order".to_string(),
         format!("--pretty=format:{format}"),
     ];
-    if let Some(sha) = since_sha {
-        args.push(format!("{sha}..HEAD"));
-    }
+    args.push(match since_sha {
+        Some(sha) => format!("{sha}..{snapshot_head}"),
+        None => snapshot_head.to_string(),
+    });
+    args.push("--".into());
     let output = Command::new("git")
         .arg("-C")
         .arg(repo)
@@ -1571,7 +1622,7 @@ fn walk_commits(repo: &Path, since_sha: Option<&str>) -> Result<Vec<RawCommit>> 
 /// `sha -> [touched paths]` for every commit in `repo`'s history, via a
 /// separate NUL-delimited `--name-only` pass. See
 /// crates/khive-pack-git/docs/api/ingest.md#changed-paths-and-code-module-annotations.
-fn touched_files(repo: &Path) -> Result<HashMap<String, Vec<String>>> {
+fn touched_files(repo: &Path, snapshot_head: &str) -> Result<HashMap<String, Vec<String>>> {
     let output = Command::new("git")
         .arg("-C")
         .arg(repo)
@@ -1584,6 +1635,8 @@ fn touched_files(repo: &Path) -> Result<HashMap<String, Vec<String>>> {
         // can start with `/`. This absolute-looking prefix is therefore an
         // unambiguous header sentinel in the NUL-delimited token stream.
         .arg(format!("--pretty=format:/{RECORD_SEP}%H"))
+        .arg(snapshot_head)
+        .arg("--")
         .output()
         .context("spawning git log --name-only")?;
     if !output.status.success() {
@@ -1773,22 +1826,48 @@ mod touched_file_parser_tests {
 struct CommitSnapshot {
     commits: Vec<RawCommit>,
     files_by_sha: HashMap<String, Vec<String>>,
+    head: String,
+    repo: PathBuf,
+}
+
+/// Resolve the ref without peeling objects so missing-promisor recovery still
+/// runs through the classified git-log boundary. Never retarget a retry to HEAD.
+fn resolve_commit_head(repo: &Path) -> Result<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["rev-parse", "--verify", "HEAD"])
+        .output()
+        .context("resolving commit snapshot HEAD")?;
+    let head = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if !output.status.success() || !is_commit_oid(&head) {
+        return Err(anyhow!("could not resolve commit snapshot HEAD"));
+    }
+    Ok(head)
 }
 
 /// Load one commit-history snapshot; skips `touched_files` entirely when
 /// `walk_commits` found no new commits.
-fn load_commit_snapshot(repo: &Path, since_sha: Option<&str>) -> Result<CommitSnapshot> {
-    let commits = walk_commits(repo, since_sha)?;
+fn load_commit_snapshot(
+    repo: &Path,
+    since_sha: Option<&str>,
+    snapshot_head: &str,
+) -> Result<CommitSnapshot> {
+    let commits = walk_commits(repo, since_sha, snapshot_head)?;
     if commits.is_empty() {
         return Ok(CommitSnapshot {
             commits,
             files_by_sha: HashMap::new(),
+            head: snapshot_head.to_string(),
+            repo: repo.to_path_buf(),
         });
     }
-    let files_by_sha = touched_files(repo)?;
+    let files_by_sha = touched_files(repo, snapshot_head)?;
     Ok(CommitSnapshot {
         commits,
         files_by_sha,
+        head: snapshot_head.to_string(),
+        repo: repo.to_path_buf(),
     })
 }
 
@@ -1825,12 +1904,17 @@ fn cache_repair_warning(strategy: CacheRepairStrategy) -> String {
 fn recover_commit_snapshot(
     repo: &Path,
     since_sha: Option<&str>,
+    snapshot_head: Option<&str>,
     mut recover: impl FnMut(&Path, &GitLogError) -> Result<Option<RecoveredRepo>>,
 ) -> Result<(CommitSnapshot, Option<String>)> {
+    let snapshot_head = match snapshot_head {
+        Some(head) => head.to_string(),
+        None => resolve_commit_head(repo)?,
+    };
     let mut repo_path = repo.to_path_buf();
     let mut recovery_warning: Option<String> = None;
     loop {
-        match load_commit_snapshot(&repo_path, since_sha) {
+        match load_commit_snapshot(&repo_path, since_sha, &snapshot_head) {
             Ok(snapshot) => return Ok((snapshot, recovery_warning)),
             Err(e) => {
                 let classified = e
@@ -1947,18 +2031,47 @@ async fn ingest_commits(
     recover: &mut (dyn FnMut(&Path, &GitLogError) -> Result<Option<RecoveredRepo>> + Send),
     walk_complete: &mut bool,
 ) -> Result<()> {
-    let since = read_cursor(runtime, project_id, "commits").await?;
-    let (snapshot, recovery_warning) = recover_commit_snapshot(repo, since.as_deref(), recover)?;
+    let (since, checkpoint) = read_commit_checkpoint(runtime, token, project_id).await?;
+    let pending = checkpoint
+        .as_ref()
+        .filter(|c| c.last_completed_sha != c.snapshot_head);
+    let base_cursor = match pending {
+        Some(c) => c.base_cursor.clone(),
+        None => since.clone(),
+    };
+    if base_cursor
+        .as_deref()
+        .is_some_and(|sha| !is_commit_oid(sha))
+    {
+        return Err(anyhow!(
+            "invalid commits cursor; reset both commit cursor rows to replay history"
+        ));
+    }
+    let (snapshot, recovery_warning) = recover_commit_snapshot(
+        repo,
+        base_cursor.as_deref(),
+        pending.map(|c| c.snapshot_head.as_str()),
+        recover,
+    )?;
     let CommitSnapshot {
-        commits,
+        mut commits,
         files_by_sha,
+        head: snapshot_head,
+        repo: snapshot_repo,
     } = snapshot;
+    if let Some(c) = pending {
+        let position = commits.iter().position(|record| record.sha == c.last_completed_sha)
+            .ok_or_else(|| anyhow!("commits checkpoint position is absent from its frozen snapshot; reset both commit cursor rows to replay history"))?;
+        // Reconstructing the snapshot does no natural-key lookups. Its
+        // acknowledged prefix consumes no fresh-record visit budget.
+        commits.drain(..=position);
+    }
     if commits.is_empty() {
         // An empty range is a genuine completion only when the cursor is an
         // ancestor of HEAD. See crates/khive-pack-git/docs/ingest.md
         // #commit-walk-ancestor-divergence-and-cursor-stall.
         let cursor_not_ancestor = last_sha_of(&since).is_some_and(|since_sha| {
-            let not_ancestor = !is_ancestor_of_head(repo, since_sha);
+            let not_ancestor = !is_ancestor_of_head(&snapshot_repo, since_sha);
             if not_ancestor {
                 report.warnings.push(format!(
                     "commits cursor {since_sha} is not an ancestor of this \
@@ -1981,6 +2094,11 @@ async fn ingest_commits(
                  lags or diverged from the history that advanced the cursor (issue #1644)"
                     .into(),
             ));
+        } else if resolve_commit_head(&snapshot_repo)? != snapshot_head {
+            report.done = false;
+            report.sources.commits = Some(IngestSourceState::StoppedEarly(
+                "source HEAD changed after the frozen commit snapshot; call again for the new history".into(),
+            ));
         } else {
             report.sources.commits = Some(IngestSourceState::Completed);
             *walk_complete = true;
@@ -1993,14 +2111,13 @@ async fn ingest_commits(
     report.sources.commits = Some(IngestSourceState::StoppedEarly(
         COMMIT_WALK_SEED_REASON.into(),
     ));
-    // The last record (walk is oldest-first) is the exact snapshot HEAD the
-    // module index binds against; the walk itself is never truncated by
-    // `max_items` — only the record-visit loop below is.
-    let snapshot_head = commits
-        .last()
-        .expect("non-empty commit snapshot checked above")
-        .sha
-        .clone();
+    let mut checkpoint = CommitCheckpoint {
+        version: 1,
+        namespace: token.namespace().as_str().to_string(),
+        base_cursor,
+        snapshot_head: snapshot_head.clone(),
+        last_completed_sha: String::new(),
+    };
     // Module annotation is best-effort enrichment: a failed index load
     // degrades to no module annotation with a warning carrying the load
     // error's text rather than aborting the pass that records the durable
@@ -2046,7 +2163,8 @@ async fn ingest_commits(
             local_sha_to_id.insert(c.sha.clone(), existing);
             report.commits_skipped_existing += 1;
             if !cursor_stalled {
-                write_cursor(runtime, project_id, "commits", &c.sha).await?;
+                checkpoint.last_completed_sha.clone_from(&c.sha);
+                write_commit_checkpoint(runtime, project_id, &checkpoint).await?;
             }
             continue;
         }
@@ -2245,9 +2363,10 @@ async fn ingest_commits(
             }
         }
         if !cursor_stalled {
-            // Exclusive SHA resume: each contiguous success survives a later
-            // database, subprocess, or request-deadline failure.
-            write_cursor(runtime, project_id, "commits", &c.sha).await?;
+            // Each contiguous success survives later failures without treating
+            // the ancestor closure of one SHA as the visited DAG prefix.
+            checkpoint.last_completed_sha.clone_from(&c.sha);
+            write_commit_checkpoint(runtime, project_id, &checkpoint).await?;
         }
     }
 
@@ -2268,8 +2387,15 @@ async fn ingest_commits(
             // `None` from an instrumentation gap) is rewritten to
             // `Completed`. Any other reason was written by a real
             // early-stop arm and is preserved.
-            report.sources.commits = Some(IngestSourceState::Completed);
-            *walk_complete = true;
+            if resolve_commit_head(&snapshot_repo)? != snapshot_head {
+                report.done = false;
+                report.sources.commits = Some(IngestSourceState::StoppedEarly(
+                    "source HEAD changed after the frozen commit snapshot; call again for the new history".into(),
+                ));
+            } else {
+                report.sources.commits = Some(IngestSourceState::Completed);
+                *walk_complete = true;
+            }
         }
     }
     // One bounded line per run (never one per path): filenames are
@@ -3400,7 +3526,7 @@ mod recovery_classifier_tests {
         let dir = tempfile::tempdir().expect("tempdir");
         init_repo_with_commit(dir.path());
         let mut recover_calls = 0;
-        let (snapshot, warning) = recover_commit_snapshot(dir.path(), None, |_repo, _err| {
+        let (snapshot, warning) = recover_commit_snapshot(dir.path(), None, None, |_repo, _err| {
             recover_calls += 1;
             Ok(None)
         })
@@ -3419,7 +3545,7 @@ mod recovery_classifier_tests {
         // Not a git repo at all -- `git log` fails with a plain spawn/repo
         // error, not a classified promisor one.
         let mut recover_calls = 0;
-        let result = recover_commit_snapshot(dir.path(), None, |_repo, _err| {
+        let result = recover_commit_snapshot(dir.path(), None, None, |_repo, _err| {
             recover_calls += 1;
             Ok(Some(RecoveredRepo {
                 repo: dir.path().to_path_buf(),

--- a/crates/khive-pack-git/src/ingest.rs
+++ b/crates/khive-pack-git/src/ingest.rs
@@ -4,7 +4,7 @@
 //! the standard `create` verb. See crates/khive-pack-git/docs/api/ingest.md
 //! and crates/khive-pack-git/docs/ingest.md for the full design notes.
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -93,7 +93,7 @@ impl IngestOptions {
     }
 }
 
-/// Bounds new-record creation attempts across a `run_ingest` pass. See
+/// Bounds fresh record visits, including existing records and failed attempts. See
 /// crates/khive-pack-git/docs/api/ingest.md#budget.
 struct Budget {
     remaining: Option<u64>,
@@ -114,6 +114,14 @@ impl Budget {
     fn exhausted(&self) -> bool {
         matches!(self.remaining, Some(0))
     }
+}
+
+/// Publish the stall at its origin: a later fallible read or checkpoint must
+/// not erase the already-observed record failure from the structured report.
+fn stall_cursor(cursor_stalled: &mut bool, report: &mut IngestReport) {
+    *cursor_stalled = true;
+    report.cursor_stalled = true;
+    report.done = false;
 }
 
 /// A newly created note this pass, for `link_references`'s
@@ -1296,6 +1304,149 @@ async fn write_cursor(
     Ok(())
 }
 
+/// The timestamp remains the public cursor. Exact boundary acknowledgments let
+/// an inclusive search resume even with max_items=1, without dropping unseen
+/// ties. UUIDs also restore PR linking maps without another natural-key lookup.
+#[derive(Debug, Serialize, Deserialize)]
+struct PageCheckpoint {
+    version: u8,
+    namespace: String,
+    floor: Option<String>,
+    at_floor: BTreeMap<u64, Uuid>,
+    undated: BTreeMap<u64, Uuid>,
+}
+
+impl PageCheckpoint {
+    fn new(namespace: &str, floor: Option<String>) -> Self {
+        Self {
+            version: 1,
+            namespace: namespace.into(),
+            floor,
+            at_floor: BTreeMap::new(),
+            undated: BTreeMap::new(),
+        }
+    }
+
+    fn acknowledged(&self, number: u64, updated: Option<&str>) -> Option<Uuid> {
+        match updated {
+            None => self.undated.get(&number).copied(),
+            Some(u) if self.floor.as_deref() == Some(u) => self.at_floor.get(&number).copied(),
+            Some(_) => None,
+        }
+    }
+
+    /// Only called before a stall. Refuse an unbounded acknowledgment set;
+    /// dropping an entry would otherwise make a tiny-budget pass cycle forever.
+    fn acknowledge(&mut self, number: u64, updated: Option<&str>, id: Uuid) -> bool {
+        let entries = match updated {
+            None => &mut self.undated,
+            Some(u) => {
+                if self.floor.as_deref().is_none_or(|floor| u > floor) {
+                    self.floor = Some(u.to_owned());
+                    self.at_floor.clear();
+                }
+                if self.floor.as_deref() != Some(u) {
+                    return true;
+                }
+                &mut self.at_floor
+            }
+        };
+        if entries.len() >= PAGE_LIMIT && !entries.contains_key(&number) {
+            return false;
+        }
+        entries.insert(number, id);
+        true
+    }
+}
+
+async fn read_page_checkpoint(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    project_id: Uuid,
+    kind: &str,
+    warnings: &mut Vec<String>,
+) -> Result<PageCheckpoint> {
+    // One read snapshot: a concurrent atomic checkpoint cannot tear this pair.
+    let row = runtime.sql().reader().await?.query_row(SqlStatement {
+        sql: "SELECT \
+              (SELECT cursor_value FROM git_mirror_cursor WHERE project_id=?1 AND kind=?2) AS floor, \
+              (SELECT cursor_value FROM git_mirror_cursor WHERE project_id=?1 AND kind=?3) AS progress".into(),
+        params: vec![SqlValue::Text(project_id.to_string()), SqlValue::Text(kind.into()),
+            SqlValue::Text(format!("{kind}_checkpoint"))],
+        label: Some("git_ingest_read_page_checkpoint".into()),
+    }).await?;
+    let floor = match row.as_ref().and_then(|r| r.get("floor")) {
+        Some(SqlValue::Text(raw)) => match chrono::DateTime::parse_from_rfc3339(raw) {
+            Ok(dt) => Some(
+                dt.with_timezone(&Utc)
+                    .to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+            ),
+            Err(_) => {
+                warnings.push(format!(
+                    "{kind}: invalid stored timestamp cursor; restarting the window"
+                ));
+                None
+            }
+        },
+        _ => None,
+    };
+    let namespace = token.namespace().as_str();
+    if let Some(SqlValue::Text(raw)) = row.as_ref().and_then(|r| r.get("progress")) {
+        // Two maps of at most PAGE_LIMIT UUIDs fit comfortably below this cap.
+        let parsed = (raw.len() <= 256 * 1024)
+            .then(|| serde_json::from_str::<PageCheckpoint>(raw).ok())
+            .flatten();
+        if let Some(progress) = parsed.filter(|p| {
+            p.version == 1
+                && p.namespace == namespace
+                && p.floor == floor
+                && p.at_floor.len() <= PAGE_LIMIT
+                && p.undated.len() <= PAGE_LIMIT
+                && (p.floor.is_some() || p.at_floor.is_empty())
+        }) {
+            return Ok(progress);
+        }
+        warnings.push(format!(
+            "{kind}: incompatible checkpoint metadata; resuming from the timestamp cursor"
+        ));
+    }
+    Ok(PageCheckpoint::new(namespace, floor))
+}
+
+async fn write_page_checkpoint(
+    runtime: &KhiveRuntime,
+    project_id: Uuid,
+    kind: &str,
+    checkpoint: &PageCheckpoint,
+) -> Result<()> {
+    // One statement commits the timestamp and exact acknowledgments together.
+    // An undated-only window has no main timestamp row yet.
+    let mut statement = SqlStatement {
+        sql: "INSERT INTO git_mirror_cursor(project_id, kind, cursor_value, updated_at) \
+              VALUES(?1, ?2, ?3, ?4)"
+            .into(),
+        params: vec![
+            SqlValue::Text(project_id.to_string()),
+            SqlValue::Text(format!("{kind}_checkpoint")),
+            SqlValue::Text(serde_json::to_string(checkpoint)?),
+            SqlValue::Integer(Utc::now().timestamp_micros()),
+        ],
+        label: Some("git_ingest_write_page_checkpoint".into()),
+    };
+    if let Some(floor) = &checkpoint.floor {
+        statement.sql.push_str(", (?1, ?5, ?6, ?4)");
+        statement
+            .params
+            .extend([SqlValue::Text(kind.into()), SqlValue::Text(floor.clone())]);
+    }
+    statement.sql.push_str(
+        " ON CONFLICT(project_id, kind) DO UPDATE SET \
+        cursor_value=excluded.cursor_value, updated_at=excluded.updated_at",
+    );
+    runtime.sql().writer().await?.execute(statement).await?;
+    Ok(())
+}
+
 // ── commits ─────────────────────────────────────────────────────────────────
 
 const RECORD_SEP: char = '\u{1e}';
@@ -1844,7 +1995,7 @@ async fn ingest_commits(
     ));
     // The last record (walk is oldest-first) is the exact snapshot HEAD the
     // module index binds against; the walk itself is never truncated by
-    // `max_items` — only the create loop below is.
+    // `max_items` — only the record-visit loop below is.
     let snapshot_head = commits
         .last()
         .expect("non-empty commit snapshot checked above")
@@ -1866,11 +2017,10 @@ async fn ingest_commits(
             }
         };
 
-    // `cursor_stalled` freezes `last_sha` at the last contiguous success so a
+    // `cursor_stalled` freezes the persisted SHA at the last contiguous success so a
     // failed record is retried next pass instead of skipped forever; later
     // records this pass are still attempted. See crates/khive-pack-git/docs/
     // ingest.md#commit-walk-ancestor-divergence-and-cursor-stall.
-    let mut last_sha: Option<String> = since;
     let mut cursor_stalled = false;
     // Bounded detail for the per-run ambiguous-module-skip warning: the
     // masked skipped paths in encounter order, capped so one pathological
@@ -1880,26 +2030,25 @@ async fn ingest_commits(
     let mut ambiguous_module_skip_paths: Vec<String> = Vec::new();
     // Parent SHA -> note id for commits created earlier this pass; combined
     // with `find_commit_by_sha`'s DB lookup, resolves parent edges regardless
-    // of which pass the parent landed in. The stall guard on the `last_sha`
-    // advances below prevents stranding a failed commit behind an advanced
+    // of which pass the parent landed in. The stall guard on the cursor
+    // writes below prevents stranding a failed commit behind an advanced
     // floor. See crates/khive-pack-git/docs/ingest.md
     // #commit-walk-ancestor-divergence-and-cursor-stall.
     let mut local_sha_to_id: HashMap<String, Uuid> = HashMap::new();
     for c in &commits {
-        if let Some(existing) = find_commit_by_sha(runtime, token, &c.sha).await? {
-            local_sha_to_id.insert(c.sha.clone(), existing);
-            report.commits_skipped_existing += 1;
-            if !cursor_stalled {
-                last_sha = Some(c.sha.clone());
-            }
-            continue;
-        }
-
-        if budget.exhausted() {
+        if !budget.try_consume() {
             report.sources.commits = Some(IngestSourceState::StoppedEarly(
                 "budget exhausted before the commit history was exhausted".into(),
             ));
             break;
+        }
+        if let Some(existing) = find_commit_by_sha(runtime, token, &c.sha).await? {
+            local_sha_to_id.insert(c.sha.clone(), existing);
+            report.commits_skipped_existing += 1;
+            if !cursor_stalled {
+                write_cursor(runtime, project_id, "commits", &c.sha).await?;
+            }
+            continue;
         }
 
         let masked = MaskedCommitFields::new(c);
@@ -1914,7 +2063,7 @@ async fn ingest_commits(
         // passes disagree; surface it instead of silently storing the `[]`
         // the contract reserves for a genuinely empty commit.
         let Some(touched_paths) = files_by_sha.get(&c.sha) else {
-            cursor_stalled = true;
+            stall_cursor(&mut cursor_stalled, report);
             let recipient_detail = commits
                 .iter()
                 .position(|candidate| candidate.sha == c.sha)
@@ -2038,15 +2187,11 @@ async fn ingest_commits(
             create_request["embedding_content"] = json!(head);
         }
 
-        budget.try_consume();
         match crate::dispatch_from_token(registry, token, "create", create_request).await {
             Ok(v) => {
                 report.commits_ingested += 1;
                 if embedding_head.is_some() {
                     report.commit_embeddings_truncated += 1;
-                }
-                if !cursor_stalled {
-                    last_sha = Some(c.sha.clone());
                 }
                 if let Some(id) = v
                     .get("id")
@@ -2096,13 +2241,17 @@ async fn ingest_commits(
             }
             Err(e) => {
                 record_write_failure(report, "create", "commit", c.sha.clone(), e);
-                cursor_stalled = true;
+                stall_cursor(&mut cursor_stalled, report);
             }
+        }
+        if !cursor_stalled {
+            // Exclusive SHA resume: each contiguous success survives a later
+            // database, subprocess, or request-deadline failure.
+            write_cursor(runtime, project_id, "commits", &c.sha).await?;
         }
     }
 
     if cursor_stalled {
-        report.cursor_stalled = true;
         report.done = false;
         report.sources.commits = Some(IngestSourceState::StoppedEarly(
             "a per-record write failure froze the commits cursor (cursor_stalled)".into(),
@@ -2122,15 +2271,6 @@ async fn ingest_commits(
             report.sources.commits = Some(IngestSourceState::Completed);
             *walk_complete = true;
         }
-    }
-    if let Some(sha) = last_sha {
-        // A stalled cursor has already frozen `last_sha` at the last
-        // contiguous success above; the write persists exactly that floor.
-        // A failure here surfaces at the call site, which distinguishes it
-        // from a pre-walk failure by the already-recorded source state and
-        // downgrades the pass to stopped-early in-band (never a hard
-        // abort of the whole ingest).
-        write_cursor(runtime, project_id, "commits", &sha).await?;
     }
     // One bounded line per run (never one per path): filenames are
     // attacker/repo-controlled and may be long, so the count is the
@@ -2594,22 +2734,23 @@ async fn ingest_prs(
     new_records: &mut Vec<NewRecordForRef>,
     walk_complete: &mut bool,
 ) -> Result<()> {
-    let since = match read_cursor(runtime, project_id, "prs").await {
-        Ok(since) => since,
-        Err(e) => {
-            report.sources.pull_requests = Some(IngestSourceState::Skipped(format!(
-                "local cursor/database read failed before pull request listing: {e}"
-            )));
-            return Err(e);
-        }
-    };
+    let mut checkpoint =
+        match read_page_checkpoint(runtime, token, project_id, "prs", &mut report.warnings).await {
+            Ok(checkpoint) => checkpoint,
+            Err(e) => {
+                report.sources.pull_requests = Some(IngestSourceState::Skipped(format!(
+                    "local cursor/database read failed before pull request listing: {e}"
+                )));
+                return Err(e);
+            }
+        };
 
     // `cursor_stalled` mirrors `ingest_commits`: once one PR fails to create,
     // later PRs in this pass are still attempted (so every failure surfaces
-    // in this pass's warnings), but `max_updated` no longer advances past the
+    // in this pass's warnings), but `checkpoint.floor` no longer advances past the
     // stall point — the next pass re-fetches from before the failure and
     // retries it, while already-landed PRs are no-ops via the natural key.
-    let mut max_updated: Option<String> = since.clone();
+    let since = checkpoint.floor.clone();
     let mut cursor_stalled = false;
     let mut floor = since.clone();
     let mut window_complete = true;
@@ -2645,10 +2786,36 @@ async fn ingest_prs(
         // Re-sorted defensively for the frozen-cursor invariant; `is_new` is
         // inclusive for tie handling. See crates/khive-pack-git/docs/api/
         // ingest.md#ingest_prs--ingest_issues-cursor-semantics.
-        page.sort_by(|a, b| a.updated_at.cmp(&b.updated_at));
+        page.sort_by(|a, b| {
+            a.updated_at
+                .cmp(&b.updated_at)
+                .then(a.number.cmp(&b.number))
+        });
         let last_updated_at = page.last().and_then(|pr| pr.updated_at.clone());
+        let undated: BTreeSet<u64> = page
+            .iter()
+            .filter(|p| p.updated_at.is_none())
+            .map(|p| p.number)
+            .collect();
+        checkpoint
+            .undated
+            .retain(|number, _| undated.contains(number));
 
         for masked in page {
+            if let Some(existing) =
+                checkpoint.acknowledged(masked.number, masked.updated_at.as_deref())
+            {
+                number_to_pr.insert(masked.number, existing);
+                if let Some(oid) = masked.merge_commit_oid.as_ref() {
+                    merge_sha_to_pr.insert(oid.clone(), existing);
+                }
+                continue;
+            }
+            if !budget.try_consume() {
+                window_complete = false;
+                stop_reason = Some("budget exhausted before the pull_request window completed");
+                break;
+            }
             if let Some(existing) =
                 find_by_number(runtime, token, "pull_request", project_id, masked.number).await?
             {
@@ -2657,19 +2824,17 @@ async fn ingest_prs(
                     merge_sha_to_pr.insert(oid, existing);
                 }
                 report.prs_skipped_existing += 1;
-                // Advancing the floor past a stalled pass's later records
-                // would skip the refused record forever; see
-                // crates/khive-pack-git/docs/api/ingest.md#ingest_prs--ingest_issues-cursor-semantics.
-                if !cursor_stalled {
-                    if let Some(u) = &masked.updated_at {
-                        if max_updated
-                            .as_deref()
-                            .map(|m| u.as_str() > m)
-                            .unwrap_or(true)
-                        {
-                            max_updated = Some(u.clone());
-                        }
-                    }
+                if !cursor_stalled
+                    && !checkpoint.acknowledge(
+                        masked.number,
+                        masked.updated_at.as_deref(),
+                        existing,
+                    )
+                {
+                    report
+                        .warnings
+                        .push("prs: checkpoint boundary exceeds the remote page limit".into());
+                    stall_cursor(&mut cursor_stalled, report);
                 }
                 continue;
             }
@@ -2685,14 +2850,7 @@ async fn ingest_prs(
             if !is_new {
                 continue;
             }
-            if budget.exhausted() {
-                // Records after this point were never visited even on a short
-                // page — a short page proves only the remote window ended, not
-                // that the local walk covered it.
-                window_complete = false;
-                stop_reason = Some("budget exhausted before the pull request window completed");
-                break;
-            }
+
             let content = masked.body;
             let properties = json!({
                 "number": masked.number,
@@ -2710,7 +2868,6 @@ async fn ingest_prs(
                 NAME_MAX_CHARS,
             );
 
-            budget.try_consume();
             let result = match crate::dispatch_from_token(
                 registry,
                 token,
@@ -2734,16 +2891,16 @@ async fn ingest_prs(
                         format!("#{}", masked.number),
                         e,
                     );
-                    cursor_stalled = true;
+                    stall_cursor(&mut cursor_stalled, report);
                     continue;
                 }
             };
 
-            if let Some(id) = result
+            let id = result
                 .get("id")
                 .and_then(|v| v.as_str())
-                .and_then(|s| Uuid::parse_str(s).ok())
-            {
+                .and_then(|s| Uuid::parse_str(s).ok());
+            if let Some(id) = id {
                 number_to_pr.insert(masked.number, id);
                 if let Some(oid) = masked.merge_commit_oid {
                     merge_sha_to_pr.insert(oid, id);
@@ -2755,18 +2912,27 @@ async fn ingest_prs(
             }
             report.prs_ingested += 1;
             if !cursor_stalled {
-                if let Some(u) = &masked.updated_at {
-                    if max_updated
-                        .as_deref()
-                        .map(|m| u.as_str() > m)
-                        .unwrap_or(true)
-                    {
-                        max_updated = Some(u.clone());
+                match id {
+                    Some(id)
+                        if checkpoint.acknowledge(
+                            masked.number,
+                            masked.updated_at.as_deref(),
+                            id,
+                        ) => {}
+                    _ => {
+                        report.warnings.push(
+                            "prs: record could not be acknowledged in the bounded checkpoint"
+                                .into(),
+                        );
+                        stall_cursor(&mut cursor_stalled, report);
                     }
                 }
             }
         }
 
+        // Save completed and budget-truncated pages before another fetch can
+        // fail. A stalled pass persists only its contiguous-success prefix.
+        write_page_checkpoint(runtime, project_id, "prs", &checkpoint).await?;
         match decide_page_outcome(
             page_len,
             floor.as_deref(),
@@ -2811,7 +2977,6 @@ async fn ingest_prs(
         // A stalled PR cursor means records past the frozen floor were never
         // retried; `done: true` here would tell the caller the slot is
         // complete when it is permanently behind (issue #1645).
-        report.cursor_stalled = true;
         report.done = false;
         // See the `!window_complete` arm above for the seed invariant.
         pin_stopped_early(
@@ -2827,9 +2992,6 @@ async fn ingest_prs(
         *walk_complete = true;
     }
 
-    if let Some(cursor) = max_updated {
-        write_cursor(runtime, project_id, "prs", &cursor).await?;
-    }
     Ok(())
 }
 
@@ -2846,8 +3008,16 @@ async fn ingest_issues(
     new_records: &mut Vec<NewRecordForRef>,
     walk_complete: &mut bool,
 ) -> Result<()> {
-    let since = match read_cursor(runtime, project_id, "issues").await {
-        Ok(since) => since,
+    let mut checkpoint = match read_page_checkpoint(
+        runtime,
+        token,
+        project_id,
+        "issues",
+        &mut report.warnings,
+    )
+    .await
+    {
+        Ok(checkpoint) => checkpoint,
         Err(e) => {
             report.sources.issues = Some(IngestSourceState::Skipped(format!(
                 "local cursor/database read failed before issue listing: {e}"
@@ -2858,10 +3028,10 @@ async fn ingest_issues(
 
     // `cursor_stalled` mirrors `ingest_commits`/`ingest_prs`: a per-record
     // create failure is aggregated as a warning and later records in this
-    // pass are still attempted, but `max_updated` freezes at the stall point
+    // pass are still attempted, but `checkpoint.floor` freezes at the stall point
     // so the next pass retries the failed record instead of skipping it
     // forever; already-landed records are no-ops via the natural key.
-    let mut max_updated: Option<String> = since.clone();
+    let since = checkpoint.floor.clone();
     let mut cursor_stalled = false;
     let mut floor = since.clone();
     let mut window_complete = true;
@@ -2897,31 +3067,51 @@ async fn ingest_issues(
         // walking records in nondecreasing updated_at order, which `--search
         // sort:updated-asc` does not itself guarantee across ties — sort
         // defensively, using the canonicalized (not raw) timestamp.
-        masked_page.sort_by(|a, b| a.updated_at.cmp(&b.updated_at));
+        masked_page.sort_by(|a, b| {
+            a.updated_at
+                .cmp(&b.updated_at)
+                .then(a.number.cmp(&b.number))
+        });
         let last_updated_at = masked_page.last().and_then(|i| i.updated_at.clone());
+        // Undated acknowledgments cover this fetched window, not every undated
+        // record ever encountered. Retain present rows across timestamp advances
+        // (tiny budgets must not replay them forever), and prune absent rows.
+        let undated: BTreeSet<u64> = masked_page
+            .iter()
+            .filter(|i| i.updated_at.is_none())
+            .map(|i| i.number)
+            .collect();
+        checkpoint
+            .undated
+            .retain(|number, _| undated.contains(number));
 
         for masked in masked_page {
-            if find_by_number(runtime, token, "issue", project_id, masked.number)
-                .await?
+            if checkpoint
+                .acknowledged(masked.number, masked.updated_at.as_deref())
                 .is_some()
             {
+                continue;
+            }
+            if !budget.try_consume() {
+                window_complete = false;
+                stop_reason = Some("budget exhausted before the issue window completed");
+                break;
+            }
+            if let Some(existing) =
+                find_by_number(runtime, token, "issue", project_id, masked.number).await?
+            {
                 report.issues_skipped_existing += 1;
-                // See `ingest_prs`: while this pass is stalled, advancing
-                // the floor past records walked after the stall point would
-                // persist a cursor strictly newer than the refused record's
-                // timestamp and skip it forever instead of retrying it. A
-                // clean (non-stalled) all-existing pass still advances
-                // normally.
-                if !cursor_stalled {
-                    if let Some(u) = &masked.updated_at {
-                        if max_updated
-                            .as_deref()
-                            .map(|m| u.as_str() > m)
-                            .unwrap_or(true)
-                        {
-                            max_updated = Some(u.clone());
-                        }
-                    }
+                if !cursor_stalled
+                    && !checkpoint.acknowledge(
+                        masked.number,
+                        masked.updated_at.as_deref(),
+                        existing,
+                    )
+                {
+                    report
+                        .warnings
+                        .push("issues: checkpoint boundary exceeds the remote page limit".into());
+                    stall_cursor(&mut cursor_stalled, report);
                 }
                 continue;
             }
@@ -2935,15 +3125,6 @@ async fn ingest_issues(
             if !is_new {
                 continue;
             }
-            if budget.exhausted() {
-                // See `ingest_prs`: unvisited records remain, so the walk
-                // stops early even when the page is short; the
-                // exact-budget boundary resolves conservatively and a
-                // resumed pass completes idempotently.
-                window_complete = false;
-                stop_reason = Some("budget exhausted before the issue window completed");
-                break;
-            }
 
             let number = masked.number;
             let updated_at = masked.updated_at.clone();
@@ -2956,7 +3137,7 @@ async fn ingest_issues(
                 report.warnings.push(format!(
                     "issue #{number}: stateReason is not one of the governed values, record skipped"
                 ));
-                cursor_stalled = true;
+                stall_cursor(&mut cursor_stalled, report);
                 continue;
             }
 
@@ -2976,7 +3157,6 @@ async fn ingest_issues(
             }
             let name = refs::truncate_chars(&format!("#{number} {safe_title}"), NAME_MAX_CHARS);
 
-            budget.try_consume();
             let result = match crate::dispatch_from_token(
                 registry,
                 token,
@@ -2994,15 +3174,15 @@ async fn ingest_issues(
                 Ok(v) => v,
                 Err(e) => {
                     record_write_failure(report, "create", "issue", format!("#{number}"), e);
-                    cursor_stalled = true;
+                    stall_cursor(&mut cursor_stalled, report);
                     continue;
                 }
             };
-            if let Some(id) = result
+            let id = result
                 .get("id")
                 .and_then(|v| v.as_str())
-                .and_then(|s| Uuid::parse_str(s).ok())
-            {
+                .and_then(|s| Uuid::parse_str(s).ok());
+            if let Some(id) = id {
                 new_records.push(NewRecordForRef {
                     id,
                     text: content.clone(),
@@ -3011,18 +3191,23 @@ async fn ingest_issues(
 
             report.issues_ingested += 1;
             if !cursor_stalled {
-                if let Some(u) = &updated_at {
-                    if max_updated
-                        .as_deref()
-                        .map(|m| u.as_str() > m)
-                        .unwrap_or(true)
-                    {
-                        max_updated = Some(u.clone());
+                match id {
+                    Some(id)
+                        if checkpoint.acknowledge(masked.number, updated_at.as_deref(), id) => {}
+                    _ => {
+                        report.warnings.push(
+                            "issues: record could not be acknowledged in the bounded checkpoint"
+                                .into(),
+                        );
+                        stall_cursor(&mut cursor_stalled, report);
                     }
                 }
             }
         }
 
+        // Save completed and budget-truncated pages before another fetch can
+        // fail. A stalled pass persists only its contiguous-success prefix.
+        write_page_checkpoint(runtime, project_id, "issues", &checkpoint).await?;
         match decide_page_outcome(
             page_len,
             floor.as_deref(),
@@ -3062,7 +3247,6 @@ async fn ingest_issues(
         // Same contract as the commits and PR paths: a frozen issue cursor
         // means unretried records exist past the floor, so the slot is not
         // complete (issue #1645).
-        report.cursor_stalled = true;
         report.done = false;
         // See the `!window_complete` arm above for the seed invariant.
         pin_stopped_early(
@@ -3077,9 +3261,6 @@ async fn ingest_issues(
         *walk_complete = true;
     }
 
-    if let Some(cursor) = max_updated {
-        write_cursor(runtime, project_id, "issues", &cursor).await?;
-    }
     Ok(())
 }
 

--- a/crates/khive-pack-git/tests/acceptance.rs
+++ b/crates/khive-pack-git/tests/acceptance.rs
@@ -30,6 +30,9 @@ use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService};
 use serde_json::{json, Value};
 use uuid::Uuid;
 
+#[path = "support/digest_scale.rs"]
+mod digest_scale;
+
 fn rt() -> KhiveRuntime {
     KhiveRuntime::memory().expect("memory runtime")
 }

--- a/crates/khive-pack-git/tests/acceptance.rs
+++ b/crates/khive-pack-git/tests/acceptance.rs
@@ -30,6 +30,8 @@ use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService};
 use serde_json::{json, Value};
 use uuid::Uuid;
 
+#[path = "support/digest_commit_resume.rs"]
+mod digest_commit_resume;
 #[path = "support/digest_resume.rs"]
 mod digest_resume;
 #[path = "support/digest_scale.rs"]
@@ -7347,7 +7349,7 @@ async fn ingest_truncates_over_cap_commit_embedding_and_reports_it() {
     let sql = rt.sql();
     let mut w = sql.writer().await.expect("sql writer");
     w.execute(SqlStatement {
-        sql: "DELETE FROM git_mirror_cursor WHERE project_id=?1 AND kind='commits'".into(),
+        sql: "DELETE FROM git_mirror_cursor WHERE project_id=?1 AND kind IN ('commits','commits_checkpoint')".into(),
         params: vec![SqlValue::Text(project_id.to_string())],
         label: Some("test_reset_commits_cursor".into()),
     })

--- a/crates/khive-pack-git/tests/acceptance.rs
+++ b/crates/khive-pack-git/tests/acceptance.rs
@@ -30,6 +30,8 @@ use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService};
 use serde_json::{json, Value};
 use uuid::Uuid;
 
+#[path = "support/digest_resume.rs"]
+mod digest_resume;
 #[path = "support/digest_scale.rs"]
 mod digest_scale;
 
@@ -4195,8 +4197,8 @@ async fn issue_ingest_sorts_by_updated_at_so_frozen_cursor_survives_out_of_order
         "only #20 (now corrected) is newly created on pass 2: {report2:?}"
     );
     assert_eq!(
-        report2.issues_skipped_existing, 2,
-        "#5 and #10 are found by natural key, not duplicated: {report2:?}"
+        report2.issues_skipped_existing, 1,
+        "#5 replays its checkpoint; #10 is found by natural key; neither duplicates: {report2:?}"
     );
     assert!(
         report2.warnings.iter().all(|w| !w.contains("issue #20")),
@@ -4330,8 +4332,8 @@ async fn pr_ingest_sorts_by_updated_at_so_frozen_cursor_survives_out_of_order_li
         "only #20 (embedder fuse now spent) is newly created on pass 2: {report2:?}"
     );
     assert_eq!(
-        report2.prs_skipped_existing, 2,
-        "#5 and #10 are found by natural key, not duplicated: {report2:?}"
+        report2.prs_skipped_existing, 1,
+        "#5 replays its checkpoint; #10 is found by natural key; neither duplicates: {report2:?}"
     );
     assert!(
         report2
@@ -4576,9 +4578,8 @@ async fn issue_ingest_retries_tie_at_cursor_timestamp() {
          tied timestamp did not strand it: {report2:?}"
     );
     assert_eq!(
-        report2.issues_skipped_existing, 1,
-        "#5 is found by natural key, not duplicated, even though it is \
-         re-examined every pass at the tied cursor timestamp: {report2:?}"
+        report2.issues_skipped_existing, 0,
+        "#5 is acknowledged at the tied cursor; no duplicate or repeat lookup: {report2:?}"
     );
     assert!(
         report2.warnings.iter().all(|w| !w.contains("issue #20")),
@@ -4689,9 +4690,8 @@ async fn pr_ingest_retries_tie_at_cursor_timestamp() {
          tied timestamp did not strand it: {report2:?}"
     );
     assert_eq!(
-        report2.prs_skipped_existing, 1,
-        "#5 is found by natural key, not duplicated, even though it is \
-         re-examined every pass at the tied cursor timestamp: {report2:?}"
+        report2.prs_skipped_existing, 0,
+        "#5 is acknowledged at the tied cursor; no duplicate or repeat lookup: {report2:?}"
     );
     assert!(
         report2
@@ -5967,7 +5967,7 @@ esac
 
 /// The walked-then-failed invariant (the walked-then-failed finding), driven
 /// through the one post-visit Err site the standing stub infra can reach:
-/// the cursor write at the end of the issue walk. A pass that walks the
+/// the checkpoint write after the issue page. A pass that walks the
 /// window to completion and THEN fails persisting the cursor must never
 /// regress to `skipped` ("never walked") — and must not stay `completed`
 /// either: the walk happened but the pass failed, so the state downgrades
@@ -6004,8 +6004,8 @@ async fn ingest_walked_then_cursor_write_fails_never_reports_skipped() {
     // Sabotage ONLY the cursor write: read_cursor must keep working (it is
     // the walker's first statement, before any page fetch), so the table
     // stays, with a trigger that aborts every INSERT. The walker then runs
-    // the full pass — records land, completion states are recorded — and
-    // fails at the final `write_cursor`, after the walk.
+    // page — records land and the walk-start state is recorded — and
+    // fails saving the page checkpoint before completion is reported.
     let mut writer = rt.sql().writer().await.expect("writer");
     writer
         .execute(SqlStatement {
@@ -6032,9 +6032,9 @@ async fn ingest_walked_then_cursor_write_fails_never_reports_skipped() {
     match &report.sources.issues {
         Some(khive_pack_git::ingest::IngestSourceState::StoppedEarly(reason)) => {
             assert!(
-                reason.contains("walk completed but the pass then failed")
+                reason.contains("pass then failed after the walk")
                     && reason.contains("sabotaged cursor write"),
-                "the completed walk downgrades to stopped-early with the cause: {reason:?}"
+                "the walked page stays stopped-early with the cause: {reason:?}"
             );
         }
         other => panic!("a walked-then-failed source is never skipped or completed: {other:?}"),
@@ -6169,7 +6169,10 @@ async fn pr_cursor_does_not_advance_past_refused_record_on_later_existing() {
         report2.prs_ingested, 1,
         "the refused record is retried and lands once the upstream failure clears: {report2:?}"
     );
-    assert_eq!(report2.prs_skipped_existing, 2, "{report2:?}");
+    assert_eq!(
+        report2.prs_skipped_existing, 1,
+        "#5 is acknowledged; #10 needs a lookup: {report2:?}"
+    );
     assert!(!report2.cursor_stalled, "{report2:?}");
 
     let cursor_after_pass2 = read_git_cursor(&rt, project_id, "prs")
@@ -6270,7 +6273,10 @@ async fn issue_cursor_does_not_advance_past_refused_record_on_later_existing() {
         .await
         .expect("ingest ok (pass 2)");
     assert_eq!(report2.issues_ingested, 1, "{report2:?}");
-    assert_eq!(report2.issues_skipped_existing, 2, "{report2:?}");
+    assert_eq!(
+        report2.issues_skipped_existing, 1,
+        "#5 is acknowledged; #10 needs a lookup: {report2:?}"
+    );
     assert!(!report2.cursor_stalled, "{report2:?}");
 
     let cursor_after_pass2 = read_git_cursor(&rt, project_id, "issues")
@@ -6414,7 +6420,7 @@ async fn ingest_commit_walked_then_cursor_write_fails_stays_in_band() {
     commit(&repo, &["README.md"], "Initial commit");
 
     // Sabotage ONLY the cursor write: the commit itself must land first, so
-    // the walker records `completed` before the final `write_cursor` fails.
+    // the walker has recorded its walk-start state before the checkpoint fails.
     let mut writer = rt.sql().writer().await.expect("writer");
     writer
         .execute(SqlStatement {
@@ -6441,9 +6447,9 @@ async fn ingest_commit_walked_then_cursor_write_fails_stays_in_band() {
     match &report.sources.commits {
         Some(khive_pack_git::ingest::IngestSourceState::StoppedEarly(reason)) => {
             assert!(
-                reason.contains("walk completed but the pass then failed")
+                reason.contains("pass then failed after the walk")
                     && reason.contains("sabotaged cursor write"),
-                "the completed commit walk downgrades to stopped-early with the cause: {reason:?}"
+                "the walked commit stays stopped-early with the cause: {reason:?}"
             );
         }
         other => {

--- a/crates/khive-pack-git/tests/support/digest_commit_resume.rs
+++ b/crates/khive-pack-git/tests/support/digest_commit_resume.rs
@@ -1,0 +1,221 @@
+//! Public commits-only continuation across a DAG and file-backed pool reopening.
+use super::digest_scale::file_fixture;
+use super::*;
+use std::collections::BTreeSet;
+
+fn diamond(repo: &Path) -> Vec<String> {
+    init_repo(repo);
+    write(repo, "root.txt", "root\n");
+    commit(repo, &["root.txt"], "R");
+    let root = head_sha(repo);
+    git(repo, &["checkout", "-q", "-b", "side"]);
+    write(repo, "side.txt", "side\n");
+    commit(repo, &["side.txt"], "B");
+    let side = head_sha(repo);
+    git(repo, &["checkout", "-q", "main"]);
+    write(repo, "main.txt", "main\n");
+    commit(repo, &["main.txt"], "A");
+    let main = head_sha(repo);
+    git(repo, &["merge", "-q", "--no-ff", "side", "-m", "M"]);
+    vec![root, main, side, head_sha(repo)]
+}
+
+async fn digest(registry: &VerbRegistry, repo: &Path, project: Uuid, max: u64) -> Value {
+    registry
+        .dispatch(
+            "git.digest",
+            json!({
+                "source":repo.to_str().unwrap(), "project":project.to_string(),
+                "include":["commits"], "max_items":max,
+            }),
+        )
+        .await
+        .expect("public commits-only digest")
+}
+
+async fn checkpoint(rt: &KhiveRuntime, project: Uuid) -> Value {
+    serde_json::from_str(
+        &read_git_cursor(rt, project, "commits_checkpoint")
+            .await
+            .unwrap(),
+    )
+    .unwrap()
+}
+
+#[tokio::test]
+#[serial_test::serial(config_ledger)]
+async fn digest_resume_diamond_max_one_reopens_database_and_finishes() {
+    let _guard = ENV_MUTEX.lock().await;
+    let dir = tempfile::tempdir().unwrap();
+    let repo = dir.path().join("repo");
+    std::fs::create_dir(&repo).unwrap();
+    let shas = diamond(&repo);
+    let db = dir.path().join("mirror.db");
+    let (rt, token, registry) = file_fixture(&db).await;
+    let project = create(&registry, json!({"kind":"project","name":"diamond"})).await;
+    drop(registry);
+    drop(token);
+    drop(rt);
+    let mut positions = BTreeSet::new();
+    for pass in 0..5 {
+        let (rt, _token, registry) = file_fixture(&db).await;
+        let report = digest(&registry, &repo, project, 1).await;
+        let visits = report["commits_ingested"].as_u64().unwrap()
+            + report["commits_skipped_existing"].as_u64().unwrap();
+        assert!(visits <= 1, "fresh visits are bounded: {report}");
+        assert_eq!(
+            report["commits_skipped_existing"], 0,
+            "acknowledged prefix is free: {report}"
+        );
+        assert_eq!(report["commits_ingested"], u64::from(pass < 4), "{report}");
+        assert_eq!(
+            report["done"],
+            pass == 4,
+            "four landings then empty completion: {report}"
+        );
+        let progress = checkpoint(&rt, project).await;
+        assert_eq!(progress["snapshot_head"], shas[3]);
+        assert_eq!(progress["base_cursor"], Value::Null);
+        let cursor = read_git_cursor(&rt, project, "commits").await.unwrap();
+        assert_eq!(progress["last_completed_sha"], cursor);
+        if pass < 4 {
+            assert!(positions.insert(cursor), "no cursor cycle");
+        }
+        let notes = registry
+            .dispatch("list", json!({"kind":"commit","limit":10}))
+            .await
+            .unwrap();
+        assert_eq!(list_items(&notes).len(), (pass + 1).min(4));
+        if pass == 4 {
+            let stored: BTreeSet<_> = list_items(&notes)
+                .iter()
+                .map(|n| n["properties"]["sha"].as_str().unwrap().to_string())
+                .collect();
+            assert_eq!(stored, shas.iter().cloned().collect());
+            assert_eq!(report["history_exhausted"], true);
+            let merge = list_items(&notes)
+                .iter()
+                .find(|n| n["properties"]["sha"] == shas[3])
+                .unwrap();
+            assert_eq!(merge["properties"]["changed_paths"], json!(["side.txt"]));
+        }
+        // All runtime handles go out of scope before the next pass opens the DB.
+    }
+}
+
+#[tokio::test]
+#[serial_test::serial(config_ledger)]
+async fn digest_resume_frozen_diamond_requests_new_head_even_with_spare_budget() {
+    let _guard = ENV_MUTEX.lock().await;
+    let dir = tempfile::tempdir().unwrap();
+    let repo = dir.path().join("repo");
+    std::fs::create_dir(&repo).unwrap();
+    let shas = diamond(&repo);
+    let db = dir.path().join("mirror.db");
+    let (rt, token, registry) = file_fixture(&db).await;
+    let project = create(
+        &registry,
+        json!({"kind":"project","name":"advancing diamond"}),
+    )
+    .await;
+    assert_eq!(
+        digest(&registry, &repo, project, 1).await["commits_ingested"],
+        1
+    );
+    drop(registry);
+    drop(token);
+    drop(rt);
+    write(&repo, "later.txt", "later\n");
+    commit(&repo, &["later.txt"], "after frozen tip");
+    let new_head = head_sha(&repo);
+    let (rt, token, registry) = file_fixture(&db).await;
+    let resumed = digest(&registry, &repo, project, 20).await;
+    assert_eq!(
+        resumed["commits_ingested"], 3,
+        "only the frozen remainder: {resumed}"
+    );
+    assert_eq!(resumed["commits_skipped_existing"], 0);
+    assert_eq!(resumed["done"], false);
+    assert_eq!(resumed["history_exhausted"], false);
+    assert!(resumed["sources"]["commits"]["reason"]
+        .as_str()
+        .unwrap()
+        .contains("HEAD changed"));
+    assert_eq!(checkpoint(&rt, project).await["snapshot_head"], shas[3]);
+    drop(registry);
+    drop(token);
+    drop(rt);
+    let (rt, _token, registry) = file_fixture(&db).await;
+    let next = digest(&registry, &repo, project, 20).await;
+    assert_eq!(
+        next["commits_ingested"], 1,
+        "new tip still needs its own visit: {next}"
+    );
+    assert_eq!(next["commits_skipped_existing"], 0);
+    assert_eq!(next["done"], true);
+    assert_eq!(checkpoint(&rt, project).await["snapshot_head"], new_head);
+}
+
+#[tokio::test]
+#[serial_test::serial(config_ledger)]
+async fn digest_resume_invalid_commit_continuation_fails_without_advancing() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, _token, registry) = fixture().await;
+    let dir = tempfile::tempdir().unwrap();
+    let shas = diamond(dir.path());
+    let project = create(
+        &registry,
+        json!({"kind":"project","name":"invalid continuation"}),
+    )
+    .await;
+    digest(&registry, dir.path(), project, 1).await;
+    let good = checkpoint(&rt, project).await;
+    let mut invalid = vec!["{".to_string(), " ".repeat(8193)];
+    for (key, value) in [
+        ("version", json!(2)),
+        ("namespace", json!("other")),
+        ("snapshot_head", json!("--all")),
+        ("snapshot_head", json!("0".repeat(40))),
+        ("last_completed_sha", json!(shas[1])),
+    ] {
+        let mut bad = good.clone();
+        bad[key] = value;
+        invalid.push(bad.to_string());
+    }
+    // Syntactically valid, matching main SHA but absent from base..tip.
+    let mut missing = good.clone();
+    missing["base_cursor"] = json!(shas[0]);
+    invalid.push(missing.to_string());
+    for raw in invalid {
+        rt.sql().writer().await.unwrap().execute(SqlStatement {
+            sql:"UPDATE git_mirror_cursor SET cursor_value=?1 WHERE project_id=?2 AND kind='commits_checkpoint'".into(),
+            params:vec![SqlValue::Text(raw.clone()),SqlValue::Text(project.to_string())], label:None,
+        }).await.unwrap();
+        let failed = registry
+            .dispatch(
+                "git.digest",
+                json!({"source":dir.path().to_str().unwrap(),
+            "project":project.to_string(),"include":["commits"],"max_items":1}),
+            )
+            .await;
+        assert!(
+            failed.is_err(),
+            "invalid continuation must fail before record visits: {failed:?}"
+        );
+        assert_eq!(
+            read_git_cursor(&rt, project, "commits").await.as_deref(),
+            Some(shas[0].as_str())
+        );
+        assert_eq!(
+            read_git_cursor(&rt, project, "commits_checkpoint")
+                .await
+                .as_deref(),
+            Some(raw.as_str())
+        );
+        let notes = registry
+            .dispatch("list", json!({"kind":"commit","limit":10}))
+            .await
+            .unwrap();
+        assert_eq!(list_items(&notes).len(), 1);
+    }
+}

--- a/crates/khive-pack-git/tests/support/digest_resume.rs
+++ b/crates/khive-pack-git/tests/support/digest_resume.rs
@@ -313,17 +313,39 @@ async fn digest_resume_first_page_survives_second_fetch_failure() {
         let (dir, repo, logs, _path) = remote_fixture(&pr_rows, &issue_rows);
         let script_path = dir.path().join("bin/gh");
         let script = std::fs::read_to_string(&script_path).unwrap();
+        let outage_log = repo.join("second-fetch-outage.log");
         // First fetch has no floor. The next fetch fails only after that full
         // page has been walked, so an end-of-pass-only checkpoint loses it.
-        let sabotage =
-            "case \"$*\" in *'updated:>='*) echo 'second-page outage' >&2; exit 1 ;; esac\n";
+        // gh_json intentionally omits stderr on nonzero exits. Record the
+        // injected failure in this fixture's cwd, independently of the report.
+        let sabotage = r#"case "$*" in
+  *'updated:>='*)
+    printf '%s\n' "$*" >> second-fetch-outage.log
+    echo 'second-page outage' >&2
+    exit 1
+    ;;
+esac
+"#;
         std::fs::write(
             &script_path,
             script.replacen("#!/bin/sh\n", &format!("#!/bin/sh\n{sabotage}"), 1),
         )
         .unwrap();
+        assert!(!outage_log.exists());
         let opts = options(&repo, project, prs, 1001);
         let first = run_ingest(&rt, &token, &registry, opts).await.unwrap();
+        let outage = std::fs::read_to_string(&outage_log)
+            .expect("the second fetch must reach the injected nonzero exit");
+        let operation = if prs { "pr" } else { "issue" };
+        assert_eq!(outage.lines().count(), 1, "{outage}");
+        assert!(
+            outage.starts_with(&format!("{operation} list ")),
+            "{outage}"
+        );
+        assert!(
+            outage.contains(&format!("--search sort:updated-asc updated:>={TIE}")),
+            "{outage}"
+        );
         assert_eq!(
             first.prs_skipped_existing + first.issues_skipped_existing,
             1000,
@@ -337,7 +359,8 @@ async fn digest_resume_first_page_survives_second_fetch_failure() {
         };
         assert!(
             matches!(first_source,Some(IngestSourceState::StoppedEarly(reason))
-            if reason.contains("pass then failed after the walk") && reason.contains("second-page outage")),
+            if reason.contains("pass then failed after the walk")
+                && reason.contains(&format!("gh {operation} list failed"))),
             "the second fetch must actually fail during this pass: {first:?}"
         );
         assert_eq!(

--- a/crates/khive-pack-git/tests/support/digest_resume.rs
+++ b/crates/khive-pack-git/tests/support/digest_resume.rs
@@ -1,0 +1,552 @@
+//! Bounded visits and durable continuation through the real ingest boundary.
+use super::*;
+use khive_pack_git::ingest::IngestSourceState;
+
+const TIE: &str = "2026-01-01T00:00:01Z";
+
+fn remote_fixture(
+    prs: &[Value],
+    issues: &[Value],
+) -> (tempfile::TempDir, PathBuf, PathBuf, PathGuard) {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = dir.path().join("repo");
+    let bin = dir.path().join("bin");
+    let logs = dir.path().join("logs");
+    for path in [&repo, &bin, &logs] {
+        std::fs::create_dir(path).unwrap();
+    }
+    init_repo(&repo);
+    write_fake_gh(
+        &repo,
+        &bin,
+        &logs,
+        &json!(prs).to_string(),
+        &json!(issues).to_string(),
+    );
+    let guard = PathGuard::install(&bin);
+    (dir, repo, logs, guard)
+}
+
+fn options(repo: &Path, project: Uuid, prs: bool, max: u64) -> IngestOptions {
+    IngestOptions {
+        repo: repo.into(),
+        expected_github_repo: Some("fixture/repository".into()),
+        project: project.to_string(),
+        max_items: Some(max),
+        include: IngestInclude {
+            commits: false,
+            issues: !prs,
+            pull_requests: prs,
+        },
+    }
+}
+
+#[tokio::test]
+#[serial_test::serial(config_ledger)]
+async fn digest_resume_one_item_handles_undated_ties_and_unseen_lower_numbers() {
+    let _lock = ENV_MUTEX.lock().await;
+    for prs in [false, true] {
+        let (rt, token, registry) = fixture().await;
+        let project = create(&registry, json!({"kind":"project","name":"bounded ties"})).await;
+        let make = if prs { pr_fixture } else { issue_fixture };
+        let mut undated = make(10, "undated", TIE);
+        undated["updatedAt"] = Value::Null;
+        let mut rows = vec![make(30, "third", TIE), make(20, "second", TIE), undated];
+        let (pr_rows, issue_rows) = if prs {
+            (rows.clone(), vec![])
+        } else {
+            (vec![], rows.clone())
+        };
+        let (_dir, repo, logs, _path) = remote_fixture(&pr_rows, &issue_rows);
+        let opts = options(&repo, project, prs, 1);
+        for pass in 0..3 {
+            let report = run_ingest(&rt, &token, &registry, opts.clone())
+                .await
+                .unwrap();
+            assert_eq!(
+                report.prs_ingested + report.issues_ingested,
+                1,
+                "pass={pass}: {report:?}"
+            );
+            assert_eq!(
+                report.prs_skipped_existing + report.issues_skipped_existing,
+                0,
+                "acknowledged boundaries do not perform a lookup: {report:?}"
+            );
+            assert!(
+                !report.done,
+                "an exact-budget pass conservatively requests one more call: {report:?}"
+            );
+        }
+        // Exact membership matters: a newly visible, smaller number at the same
+        // timestamp must not be discarded by a numeric high-water predicate.
+        rows.push(make(5, "late boundary arrival", TIE));
+        let response = if prs {
+            "pr_response.json"
+        } else {
+            "issue_response.json"
+        };
+        std::fs::write(logs.join(response), json!(rows).to_string()).unwrap();
+        let report = run_ingest(&rt, &token, &registry, opts.clone())
+            .await
+            .unwrap();
+        assert_eq!(
+            report.prs_ingested + report.issues_ingested,
+            1,
+            "{report:?}"
+        );
+        assert!(!report.done, "exact-budget pass: {report:?}");
+        let final_report = run_ingest(&rt, &token, &registry, opts).await.unwrap();
+        assert_eq!(
+            final_report.prs_ingested
+                + final_report.issues_ingested
+                + final_report.prs_skipped_existing
+                + final_report.issues_skipped_existing,
+            0,
+            "{final_report:?}"
+        );
+        assert!(
+            final_report.done,
+            "a free boundary replay proves completion: {final_report:?}"
+        );
+        let kind = if prs { "pull_request" } else { "issue" };
+        let listed = registry
+            .dispatch("list", json!({"kind":kind,"limit":20}))
+            .await
+            .unwrap();
+        assert_eq!(list_items(&listed).len(), 4);
+    }
+}
+
+#[tokio::test]
+#[serial_test::serial(config_ledger)]
+async fn digest_resume_legacy_timestamp_charges_existing_before_new_records() {
+    let _lock = ENV_MUTEX.lock().await;
+    for prs in [false, true] {
+        let (rt, token, registry) = fixture().await;
+        let project = create(&registry, json!({"kind":"project","name":"legacy cursor"})).await;
+        let kind = if prs { "pull_request" } else { "issue" };
+        let cursor_kind = if prs { "prs" } else { "issues" };
+        create(&registry, json!({"kind":kind,"name":"existing","content":"existing",
+            "properties":{"number":10,"project_id":project.to_string()},"annotates":[project.to_string()]})).await;
+        rt.sql().writer().await.unwrap().execute(SqlStatement {
+            sql: "INSERT INTO git_mirror_cursor(project_id,kind,cursor_value,updated_at) VALUES(?1,?2,?3,0)".into(),
+            params: vec![SqlValue::Text(project.to_string()),SqlValue::Text(cursor_kind.into()),SqlValue::Text(TIE.into())],label:None,
+        }).await.unwrap();
+        let make = if prs { pr_fixture } else { issue_fixture };
+        let rows = vec![make(10, "existing", TIE), make(20, "new", TIE)];
+        let (pr_rows, issue_rows) = if prs { (rows, vec![]) } else { (vec![], rows) };
+        let (_dir, repo, _logs, _path) = remote_fixture(&pr_rows, &issue_rows);
+        let opts = options(&repo, project, prs, 1);
+        let first = run_ingest(&rt, &token, &registry, opts.clone())
+            .await
+            .unwrap();
+        assert_eq!(
+            first.prs_skipped_existing + first.issues_skipped_existing,
+            1,
+            "{first:?}"
+        );
+        assert_eq!(first.prs_ingested + first.issues_ingested, 0, "{first:?}");
+        assert!(!first.done, "{first:?}");
+        let second = run_ingest(&rt, &token, &registry, opts).await.unwrap();
+        assert_eq!(
+            second.prs_ingested + second.issues_ingested,
+            1,
+            "{second:?}"
+        );
+        assert_eq!(
+            second.prs_skipped_existing + second.issues_skipped_existing,
+            0,
+            "{second:?}"
+        );
+        assert!(!second.done, "exact-budget pass: {second:?}");
+    }
+}
+
+#[tokio::test]
+#[serial_test::serial(config_ledger)]
+async fn digest_resume_rejected_tie_is_charged_and_retried() {
+    let _lock = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+    let project = create(&registry, json!({"kind":"project","name":"retry boundary"})).await;
+    let mut rejected = issue_fixture(20, "rejected", TIE);
+    rejected["stateReason"] = json!("unknown");
+    let rows = vec![
+        issue_fixture(10, "good", TIE),
+        rejected,
+        issue_fixture(30, "later", TIE),
+    ];
+    let (_dir, repo, logs, _path) = remote_fixture(&[], &rows);
+    let opts = options(&repo, project, false, 1);
+    let first = run_ingest(&rt, &token, &registry, opts.clone())
+        .await
+        .unwrap();
+    assert_eq!(first.issues_ingested, 1, "{first:?}");
+    for _ in 0..2 {
+        let failed = run_ingest(&rt, &token, &registry, opts.clone())
+            .await
+            .unwrap();
+        assert_eq!(
+            failed.issues_ingested, 0,
+            "failure consumes the one visit before #30: {failed:?}"
+        );
+        assert_eq!(failed.issues_skipped_existing, 0, "{failed:?}");
+        assert!(failed.cursor_stalled && !failed.done, "{failed:?}");
+        assert!(
+            failed.warnings.iter().any(|w| w.contains("issue #20")),
+            "{failed:?}"
+        );
+        assert_eq!(
+            read_git_cursor(&rt, project, "issues").await.as_deref(),
+            Some(TIE)
+        );
+    }
+    let corrected = vec![
+        issue_fixture(10, "good", TIE),
+        issue_fixture(20, "corrected", TIE),
+        issue_fixture(30, "later", TIE),
+    ];
+    std::fs::write(
+        logs.join("issue_response.json"),
+        json!(corrected).to_string(),
+    )
+    .unwrap();
+    let retry = run_ingest(&rt, &token, &registry, opts.clone())
+        .await
+        .unwrap();
+    assert_eq!(retry.issues_ingested, 1, "{retry:?}");
+    assert!(!retry.done && !retry.cursor_stalled, "{retry:?}");
+    let last = run_ingest(&rt, &token, &registry, opts).await.unwrap();
+    assert_eq!(last.issues_ingested, 1, "{last:?}");
+    assert!(!last.done, "exact-budget pass: {last:?}");
+}
+
+#[tokio::test]
+#[serial_test::serial(config_ledger)]
+async fn digest_resume_completed_pr_yields_to_issue_and_commit_with_merge_annotation() {
+    let _lock = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+    let project = create(
+        &registry,
+        json!({"kind":"project","name":"shared visit budget"}),
+    )
+    .await;
+    let (_dir, repo, logs, _path) = remote_fixture(&[], &[issue_fixture(2, "issue", TIE)]);
+    write(&repo, "README.md", "test\n");
+    commit(
+        &repo,
+        &["README.md"],
+        "ordinary merge without a PR-number suffix",
+    );
+    let mut pr = pr_fixture(1, "merged PR", TIE);
+    pr["mergeCommit"] = json!({"oid":head_sha(&repo)});
+    std::fs::write(logs.join("pr_response.json"), json!([pr]).to_string()).unwrap();
+    let mut opts = IngestOptions::unbounded(repo, project.to_string());
+    opts.max_items = Some(1);
+    let first = run_ingest(&rt, &token, &registry, opts.clone())
+        .await
+        .unwrap();
+    assert_eq!(
+        (
+            first.prs_ingested,
+            first.issues_ingested,
+            first.commits_ingested
+        ),
+        (1, 0, 0),
+        "{first:?}"
+    );
+    let second = run_ingest(&rt, &token, &registry, opts.clone())
+        .await
+        .unwrap();
+    assert_eq!(
+        (
+            second.prs_ingested,
+            second.issues_ingested,
+            second.commits_ingested
+        ),
+        (0, 1, 0),
+        "{second:?}"
+    );
+    let third = run_ingest(&rt, &token, &registry, opts).await.unwrap();
+    assert_eq!(
+        (
+            third.prs_ingested,
+            third.issues_ingested,
+            third.commits_ingested
+        ),
+        (0, 0, 1),
+        "{third:?}"
+    );
+    assert!(!third.done, "exact-budget pass: {third:?}");
+    let prs = registry
+        .dispatch("list", json!({"kind":"pull_request","limit":10}))
+        .await
+        .unwrap();
+    let pr_id = Uuid::parse_str(list_items(&prs)[0]["id"].as_str().unwrap()).unwrap();
+    assert_eq!(
+        incoming_annotating_ids(&registry, pr_id).await.len(),
+        1,
+        "replayed PR must populate the merge-SHA map without a fresh lookup"
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial(config_ledger)]
+async fn digest_resume_first_page_survives_second_fetch_failure() {
+    let _lock = ENV_MUTEX.lock().await;
+    for prs in [false, true] {
+        let (rt, token, registry) = fixture().await;
+        let project = create(
+            &registry,
+            json!({"kind":"project","name":"page durability"}),
+        )
+        .await;
+        let kind = if prs { "pull_request" } else { "issue" };
+        let cursor_kind = if prs { "prs" } else { "issues" };
+        let make = if prs { pr_fixture } else { issue_fixture };
+        let rows: Vec<_> = (1..=1000).map(|n| make(n, "existing", TIE)).collect();
+        {
+            let writer = rt.backend().pool().try_writer().unwrap();
+            writer.conn().execute("WITH RECURSIVE n(i) AS (VALUES(1) UNION ALL SELECT i+1 FROM n WHERE i<1000) INSERT INTO notes(id,namespace,kind,name,content,properties,created_at,updated_at) SELECT printf('10000000-0000-4000-8000-%012x',i),'local',?1,'existing','existing',json_object('number',i,'project_id',?2),i,i FROM n", (kind,project.to_string())).unwrap();
+        }
+        let (pr_rows, issue_rows) = if prs { (rows, vec![]) } else { (vec![], rows) };
+        let (dir, repo, logs, _path) = remote_fixture(&pr_rows, &issue_rows);
+        let script_path = dir.path().join("bin/gh");
+        let script = std::fs::read_to_string(&script_path).unwrap();
+        // First fetch has no floor. The next fetch fails only after that full
+        // page has been walked, so an end-of-pass-only checkpoint loses it.
+        let sabotage =
+            "case \"$*\" in *'updated:>='*) echo 'second-page outage' >&2; exit 1 ;; esac\n";
+        std::fs::write(
+            &script_path,
+            script.replacen("#!/bin/sh\n", &format!("#!/bin/sh\n{sabotage}"), 1),
+        )
+        .unwrap();
+        let opts = options(&repo, project, prs, 1001);
+        let first = run_ingest(&rt, &token, &registry, opts).await.unwrap();
+        assert_eq!(
+            first.prs_skipped_existing + first.issues_skipped_existing,
+            1000,
+            "{first:?}"
+        );
+        assert!(!first.done, "{first:?}");
+        let first_source = if prs {
+            &first.sources.pull_requests
+        } else {
+            &first.sources.issues
+        };
+        assert!(
+            matches!(first_source,Some(IngestSourceState::StoppedEarly(reason))
+            if reason.contains("pass then failed after the walk") && reason.contains("second-page outage")),
+            "the second fetch must actually fail during this pass: {first:?}"
+        );
+        assert_eq!(
+            read_git_cursor(&rt, project, cursor_kind).await.as_deref(),
+            Some(TIE)
+        );
+        std::fs::write(&script_path, script).unwrap();
+        let resumed = run_ingest(&rt, &token, &registry, options(&repo, project, prs, 1))
+            .await
+            .unwrap();
+        assert_eq!(
+            resumed.prs_skipped_existing + resumed.issues_skipped_existing,
+            0,
+            "{resumed:?}"
+        );
+        assert!(
+            !resumed.done,
+            "a full 1000-record timestamp tie cannot prove exhaustion: {resumed:?}"
+        );
+        assert!(matches!(
+            if prs {
+                resumed.sources.pull_requests
+            } else {
+                resumed.sources.issues
+            },
+            Some(IngestSourceState::StoppedEarly(_))
+        ));
+        assert!(std::fs::read_to_string(logs.join("args.log"))
+            .unwrap()
+            .contains(&format!("updated:>={TIE}")));
+    }
+}
+
+#[tokio::test]
+#[serial_test::serial(config_ledger)]
+async fn digest_resume_commit_prefix_survives_later_cursor_write_failure() {
+    let _lock = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+    let project = create(
+        &registry,
+        json!({"kind":"project","name":"commit checkpoint"}),
+    )
+    .await;
+    let (_dir, repo, _logs, _path) = remote_fixture(&[], &[]);
+    write(&repo, "README.md", "one\n");
+    commit(&repo, &["README.md"], "first");
+    let first_sha = head_sha(&repo);
+    write(&repo, "README.md", "two\n");
+    commit(&repo, &["README.md"], "second");
+    let second_sha = head_sha(&repo);
+    rt.sql().writer().await.unwrap().execute(SqlStatement {
+        sql:format!("CREATE TRIGGER fail_second_cursor BEFORE INSERT ON git_mirror_cursor WHEN NEW.kind='commits' AND NEW.cursor_value='{second_sha}' BEGIN SELECT RAISE(ABORT,'second cursor failure'); END"),params:vec![],label:None,
+    }).await.unwrap();
+    let mut opts = options(&repo, project, false, 2);
+    opts.include = IngestInclude {
+        commits: true,
+        issues: false,
+        pull_requests: false,
+    };
+    let failed = run_ingest(&rt, &token, &registry, opts.clone())
+        .await
+        .unwrap();
+    assert_eq!(failed.commits_ingested, 2, "{failed:?}");
+    assert!(!failed.done, "{failed:?}");
+    assert_eq!(
+        read_git_cursor(&rt, project, "commits").await.as_deref(),
+        Some(first_sha.as_str())
+    );
+    rt.sql()
+        .writer()
+        .await
+        .unwrap()
+        .execute(SqlStatement {
+            sql: "DROP TRIGGER fail_second_cursor".into(),
+            params: vec![],
+            label: None,
+        })
+        .await
+        .unwrap();
+    opts.max_items = Some(1);
+    let resumed = run_ingest(&rt, &token, &registry, opts).await.unwrap();
+    assert_eq!(resumed.commits_skipped_existing, 1, "{resumed:?}");
+    assert_eq!(resumed.commits_ingested, 0, "{resumed:?}");
+    assert!(!resumed.done, "exact-budget pass: {resumed:?}");
+    assert_eq!(
+        read_git_cursor(&rt, project, "commits").await.as_deref(),
+        Some(second_sha.as_str())
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial(config_ledger)]
+async fn digest_resume_record_stall_survives_atomic_checkpoint_failure() {
+    let _lock = ENV_MUTEX.lock().await;
+    for prs in [false, true] {
+        let (rt, token, registry) = fixture().await;
+        rt.register_embedder(FailOnceEmbedderProvider);
+        let project = create(&registry, json!({"kind":"project","name":"two failures"})).await;
+        let make = if prs { pr_fixture } else { issue_fixture };
+        let mut rejected = make(20, "rejected", TIE);
+        if prs {
+            rejected["body"] = json!(CURSOR_FAIL_SENTINEL);
+        } else {
+            rejected["stateReason"] = json!("unknown");
+        }
+        let rows = vec![make(10, "good", TIE), rejected];
+        let (pr_rows, issue_rows) = if prs { (rows, vec![]) } else { (vec![], rows) };
+        let (_dir, repo, _logs, _path) = remote_fixture(&pr_rows, &issue_rows);
+        let kind = if prs { "prs" } else { "issues" };
+        // Sidecar is the first VALUES row, main timestamp the second. Failure
+        // of the main-row INSERT must roll back both rows as one checkpoint.
+        rt.sql().writer().await.unwrap().execute(SqlStatement {
+            sql:format!("CREATE TRIGGER fail_main_cursor BEFORE INSERT ON git_mirror_cursor WHEN NEW.kind='{kind}' BEGIN SELECT RAISE(ABORT,'checkpoint refused'); END"),params:vec![],label:None,
+        }).await.unwrap();
+        let failed = run_ingest(&rt, &token, &registry, options(&repo, project, prs, 2))
+            .await
+            .unwrap();
+        assert_eq!(
+            failed.prs_ingested + failed.issues_ingested,
+            1,
+            "{failed:?}"
+        );
+        assert!(
+            failed.cursor_stalled && !failed.done,
+            "the storage error must preserve the record failure: {failed:?}"
+        );
+        assert!(
+            failed
+                .warnings
+                .iter()
+                .any(|w| w.contains("checkpoint refused")),
+            "{failed:?}"
+        );
+        assert_eq!(read_git_cursor(&rt, project, kind).await, None);
+        assert_eq!(
+            read_git_cursor(&rt, project, &format!("{kind}_checkpoint")).await,
+            None,
+            "main-row failure must not leave a replay hint"
+        );
+    }
+}
+
+#[tokio::test]
+#[serial_test::serial(config_ledger)]
+async fn digest_resume_undated_acknowledgments_do_not_fill_across_windows() {
+    let _lock = ENV_MUTEX.lock().await;
+    for prs in [false, true] {
+        let (rt, token, registry) = fixture().await;
+        let project = create(
+            &registry,
+            json!({"kind":"project","name":"undated window rotation"}),
+        )
+        .await;
+        let kind = if prs { "pull_request" } else { "issue" };
+        let make = if prs { pr_fixture } else { issue_fixture };
+        let rows: Vec<_> = (1..=1000)
+            .map(|n| {
+                let mut v = make(n, "existing", TIE);
+                v["updatedAt"] = Value::Null;
+                v
+            })
+            .collect();
+        {
+            let writer = rt.backend().pool().try_writer().unwrap();
+            writer.conn().execute("WITH RECURSIVE n(i) AS (VALUES(1) UNION ALL SELECT i+1 FROM n WHERE i<1000) INSERT INTO notes(id,namespace,kind,name,content,properties,created_at,updated_at) SELECT printf('10000000-0000-4000-8000-%012x',i),'local',?1,'existing','existing',json_object('number',i,'project_id',?2),i,i FROM n", (kind,project.to_string())).unwrap();
+        }
+        let (pr_rows, issue_rows) = if prs { (rows, vec![]) } else { (vec![], rows) };
+        let (_dir, repo, logs, _path) = remote_fixture(&pr_rows, &issue_rows);
+        let first = run_ingest(&rt, &token, &registry, options(&repo, project, prs, 1001))
+            .await
+            .unwrap();
+        assert_eq!(
+            first.prs_skipped_existing + first.issues_skipped_existing,
+            1000,
+            "{first:?}"
+        );
+        assert!(
+            !first.done,
+            "a full undated page cannot prove exhaustion: {first:?}"
+        );
+        let mut next = make(1001, "new undated", TIE);
+        next["updatedAt"] = Value::Null;
+        let response = if prs {
+            "pr_response.json"
+        } else {
+            "issue_response.json"
+        };
+        std::fs::write(
+            logs.join(response),
+            json!([next, make(1002, "dated", TIE)]).to_string(),
+        )
+        .unwrap();
+        let second = run_ingest(&rt, &token, &registry, options(&repo, project, prs, 3))
+            .await
+            .unwrap();
+        assert_eq!(
+            second.prs_ingested + second.issues_ingested,
+            2,
+            "{second:?}"
+        );
+        assert!(
+            second.done && !second.cursor_stalled,
+            "old absent undated IDs must not permanently fill the checkpoint: {second:?}"
+        );
+        assert_eq!(
+            read_git_cursor(&rt, project, if prs { "prs" } else { "issues" })
+                .await
+                .as_deref(),
+            Some(TIE)
+        );
+    }
+}

--- a/crates/khive-pack-git/tests/support/digest_resume.rs
+++ b/crates/khive-pack-git/tests/support/digest_resume.rs
@@ -429,6 +429,17 @@ async fn digest_resume_commit_prefix_survives_later_cursor_write_failure() {
         read_git_cursor(&rt, project, "commits").await.as_deref(),
         Some(first_sha.as_str())
     );
+    let progress: Value = serde_json::from_str(
+        &read_git_cursor(&rt, project, "commits_checkpoint")
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        progress["last_completed_sha"], first_sha,
+        "the failed main-row write rolls back its paired continuation"
+    );
+    assert_eq!(progress["snapshot_head"], second_sha);
     rt.sql()
         .writer()
         .await

--- a/crates/khive-pack-git/tests/support/digest_scale.rs
+++ b/crates/khive-pack-git/tests/support/digest_scale.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 const ISSUES: usize = 5_000;
 const UNRELATED: usize = 50_000;
 
-async fn file_fixture(path: &Path) -> (KhiveRuntime, NamespaceToken, VerbRegistry) {
+pub(super) async fn file_fixture(path: &Path) -> (KhiveRuntime, NamespaceToken, VerbRegistry) {
     let rt = KhiveRuntime::new(RuntimeConfig {
         db_path: Some(path.to_path_buf()),
         ..RuntimeConfig::no_embeddings()

--- a/crates/khive-pack-git/tests/support/digest_scale.rs
+++ b/crates/khive-pack-git/tests/support/digest_scale.rs
@@ -1,0 +1,321 @@
+//! Opt-in diagnostic: full-history replay against existing file-backed issue notes.
+//! Run with `cargo test -p khive-pack-git --test acceptance digest_scale -- --ignored --nocapture`.
+//! Timing is evidence, not a normal CI assertion or proof about another store.
+
+use super::*;
+use std::time::{Duration, Instant};
+
+const ISSUES: usize = 5_000;
+const UNRELATED: usize = 50_000;
+const VISITS: u64 = 5_005; // Inclusive paging revisits each of five boundary rows.
+
+async fn file_fixture(path: &Path) -> (KhiveRuntime, NamespaceToken, VerbRegistry) {
+    let rt = KhiveRuntime::new(RuntimeConfig {
+        db_path: Some(path.to_path_buf()),
+        ..RuntimeConfig::no_embeddings()
+    })
+    .expect("file-backed runtime");
+    let token = rt.authorize(Namespace::local()).expect("authorize fixture");
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    builder.register(GitPack::new(rt.clone()));
+    builder.with_runtime_event_store(&rt).unwrap();
+    let registry = builder.build().unwrap();
+    rt.install_edge_rules(registry.all_edge_rules());
+    registry.call_register_entity_type_validators(&rt);
+    registry.apply_schema_plans(rt.backend());
+    (rt, token, registry)
+}
+
+fn timestamp(index: usize) -> String {
+    chrono::DateTime::from_timestamp(1_735_689_600 + index as i64, 0)
+        .unwrap()
+        .to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+fn shell_quote(text: &str) -> String {
+    format!("'{}'", text.replace('\'', "'\"'\"'"))
+}
+
+/// Uses the acceptance harness's PATH boundary; no live GitHub process is called.
+/// Each response is selected by the exact inclusive search floor, not call order.
+fn paged_gh(repo: &Path, bin: &Path, logs: &Path) {
+    write_fake_gh(repo, bin, logs, "[]", "[]");
+    let rows: Vec<Value> = (0..ISSUES)
+        .map(|i| {
+            json!({"number":i+1,"title":format!("Fixture issue {}",i+1),
+                "author":{"login":"fixture"},"createdAt":timestamp(i),
+                "updatedAt":timestamp(i),"closedAt":null,"stateReason":null,
+                "labels":[],"body":"Already stored fixture issue."})
+        })
+        .collect();
+    let mut arms = String::new();
+    let mut first = 0;
+    let mut floor = "sort:updated-asc".to_string();
+    loop {
+        let end = (first + 1_000).min(rows.len());
+        let file = logs.join(format!("page-{first}.json"));
+        std::fs::write(&file, serde_json::to_vec(&rows[first..end]).unwrap()).unwrap();
+        arms.push_str(&format!(
+            "    {}) cat {} ;;\n",
+            shell_quote(&floor),
+            shell_quote(file.to_str().unwrap())
+        ));
+        if end == rows.len() {
+            break;
+        }
+        first = end - 1;
+        floor = format!("sort:updated-asc updated:>={}", timestamp(first));
+    }
+    let script = format!(
+        r#"#!/bin/sh
+set -eu
+if [ "$1" = repo ]; then
+  [ "$2" = view ] && [ "$3" = fixture/repository ] || exit 2
+  printf '%s\n' '{{"nameWithOwner":"fixture/repository","url":"https://github.com/fixture/repository"}}'
+  exit 0
+fi
+[ "$1" = issue ] && [ "$2" = list ] || exit 3
+search= repo=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --search) search="$2"; shift ;;
+    --repo) repo="$2"; shift ;;
+  esac
+  shift
+done
+[ "$repo" = fixture/repository ] || exit 4
+printf '%s\n' "$search" >> {log}
+case "$search" in
+{arms}    *) printf '%s\n' 'unexpected fixture floor' >&2; exit 5 ;;
+esac
+"#,
+        log = shell_quote(logs.join("pages.log").to_str().unwrap())
+    );
+    // write_fake_gh already set the executable bit on this exact file.
+    std::fs::write(bin.join("gh"), script).unwrap();
+}
+
+fn stmt(label: &str, sql: &str, params: Vec<SqlValue>) -> SqlStatement {
+    SqlStatement {
+        sql: sql.into(),
+        params,
+        label: Some(label.into()),
+    }
+}
+
+/// Copies the labelled SELECTs on the canonical-project, issues-only path.
+/// Keep predicates and bound value types identical to handlers.rs / ingest.rs.
+fn reader_statements(project: Uuid) -> Vec<SqlStatement> {
+    let ns = SqlValue::Text("local".into());
+    let id = SqlValue::Text(project.to_string());
+    let slug = SqlValue::Text("github.com/fixture/repository".into());
+    vec![
+        stmt("git_digest_find_projects_by_slug", "SELECT id FROM entities WHERE kind='project' AND namespace=?1 AND deleted_at IS NULL AND json_extract(properties,'$.repo_slug')=?2 ORDER BY created_at ASC, id ASC", vec![ns.clone(),slug.clone()]),
+        stmt("git_digest_find_projects_without_canonical_slug", "SELECT id, json_extract(properties,'$.repo_url') AS repo_url FROM entities WHERE kind='project' AND namespace=?1 AND deleted_at IS NULL AND json_extract(properties,'$.repo_url') IS NOT NULL AND (json_extract(properties,'$.repo_slug') IS NULL OR json_extract(properties,'$.repo_slug')<>?2) ORDER BY created_at ASC, id ASC", vec![ns.clone(),slug]),
+        stmt("git_ingest_read_cursor", "SELECT cursor_value FROM git_mirror_cursor WHERE project_id=?1 AND kind=?2", vec![id.clone(),SqlValue::Text("issues".into())]),
+        stmt("git_ingest_find_by_number", "SELECT id FROM notes WHERE kind=?1 AND namespace=?2 AND deleted_at IS NULL AND json_extract(properties,'$.number')=?3 AND json_extract(properties,'$.project_id')=?4 LIMIT 1", vec![SqlValue::Text("issue".into()),ns.clone(),SqlValue::Integer(ISSUES as i64),id.clone()]),
+        stmt("git_ingest_count_commit_notes", "SELECT COUNT(*) FROM notes n JOIN graph_edges e ON e.source_id = n.id AND e.namespace = n.namespace WHERE n.kind = 'commit' AND n.namespace = ?1 AND n.deleted_at IS NULL AND e.relation = 'annotates' AND e.target_id = ?2 AND e.deleted_at IS NULL", vec![ns,id]),
+    ]
+}
+
+async fn query_plans(rt: &KhiveRuntime, project: Uuid) {
+    for query in reader_statements(project) {
+        let mut explain = query.clone();
+        explain.sql = format!("EXPLAIN QUERY PLAN {}", query.sql);
+        let mut reader = rt.sql().reader().await.unwrap();
+        let plan = reader.query_all(explain).await.expect("read query plan");
+        let started = Instant::now();
+        let result = reader.query_all(query.clone()).await;
+        println!(
+            "DIGEST_SCALE_PLAN {}",
+            json!({"label":query.label,"sql":query.sql,
+            "params":query.params,"plan":plan,"probe_us":started.elapsed().as_micros(),
+            "probe_error":result.err().map(|e|e.to_string())})
+        );
+    }
+    // SqlReader (and queue-backed SqlWriter::explain) correctly refuses an
+    // INSERT capability, even under EXPLAIN. Use only this fixture's raw
+    // connection for its write plan. EXPLAIN never executes the cursor write.
+    let query = stmt("git_ingest_write_cursor", "INSERT INTO git_mirror_cursor(project_id, kind, cursor_value, updated_at) VALUES(?1, ?2, ?3, ?4) ON CONFLICT(project_id, kind) DO UPDATE SET cursor_value=excluded.cursor_value, updated_at=excluded.updated_at", vec![SqlValue::Text(project.to_string()),SqlValue::Text("issues".into()),SqlValue::Text(timestamp(ISSUES-1)),SqlValue::Integer(0)]);
+    let writer = rt.backend().pool().try_writer().unwrap();
+    let mut prepared = writer
+        .conn()
+        .prepare(&format!("EXPLAIN QUERY PLAN {}", query.sql))
+        .unwrap();
+    let plan: Vec<Value> = prepared
+        .query_map(
+            (project.to_string(), "issues", timestamp(ISSUES - 1), 0_i64),
+            |row| {
+                Ok(
+                    json!({"id": row.get::<_, i64>(0)?, "parent": row.get::<_, i64>(1)?,
+            "aux": row.get::<_, i64>(2)?, "detail": row.get::<_, String>(3)?}),
+                )
+            },
+        )
+        .unwrap()
+        .map(|row| row.unwrap())
+        .collect();
+    println!(
+        "DIGEST_SCALE_PLAN {}",
+        json!({"label":query.label,"sql":query.sql,
+        "params":query.params,"plan":plan,"probe_us":null,"probe_error":null,
+        "write_executed":false,"plan_connection":"fixture_raw_writer"})
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial(config_ledger)]
+#[ignore = "file-backed ingest scale measurement; run explicitly with --ignored --nocapture"]
+async fn digest_scale_existing_tracker() {
+    let _env_lock = ENV_MUTEX.lock().await;
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("tracker.db");
+    let repo = dir.path().join("repo");
+    std::fs::create_dir(&repo).unwrap();
+    init_repo(&repo);
+    let bin = dir.path().join("bin");
+    let logs = dir.path().join("logs");
+    std::fs::create_dir(&bin).unwrap();
+    std::fs::create_dir(&logs).unwrap();
+    paged_gh(&repo, &bin, &logs);
+    let _path = PathGuard::install(&bin);
+
+    println!(
+        "DIGEST_SCALE_CONTROLS {}",
+        json!({
+        "issues":ISSUES,"unrelated_notes":UNRELATED,"unrelated_kind":"observation",
+        "namespace":"local","expected_visits":VISITS,"expected_pages":6,
+        "max_items":[10,200,20000],"new_creates_expected":0,
+        "deadline_seconds":30,"timing_assertions":false,
+        "cursor":"absent/full-history-replay; cleared before each arm",
+        "seed_shape":"minimal issue properties number/project_id plus annotates edges; small content; no live-store import",
+        "background_index_scope":"observation notes share namespace but not the issue kind index range",
+        "failure_observability":"terminal error only; first failing SQL and visited count unavailable on error",
+        "hold_observability":"maximum since each fresh pool opened, including disclosed bootstrap maximum",
+        "expectation":"unscoped core completes with all existing; scoped verb either completes or reports actual deadline failure; no production fix inferred from source alone"})
+    );
+
+    let project;
+    {
+        let (rt, _token, registry) = file_fixture(&db).await;
+        project = create(&registry, json!({"kind":"project","name":"fixture/repository",
+            "properties":{"repo_slug":"github.com/fixture/repository","repo_url":"https://github.com/fixture/repository"}})).await;
+        let writer = rt.backend().pool().try_writer().unwrap();
+        writer.conn().execute_batch(&format!(
+            "BEGIN; \
+             WITH RECURSIVE n(i) AS (VALUES(1) UNION ALL SELECT i+1 FROM n WHERE i<{UNRELATED}) \
+             INSERT INTO notes(id,namespace,kind,name,content,properties,created_at,updated_at) \
+             SELECT printf('20000000-0000-4000-8000-%012x',i),'local','observation','Unrelated fixture note','Background.', '{{}}',i,i FROM n; \
+             WITH RECURSIVE n(i) AS (VALUES(1) UNION ALL SELECT i+1 FROM n WHERE i<{ISSUES}) \
+             INSERT INTO notes(id,namespace,kind,name,content,properties,created_at,updated_at) \
+             SELECT printf('10000000-0000-4000-8000-%012x',i),'local','issue','Fixture issue','Already stored fixture issue.',json_object('number',i,'project_id','{project}'),i,i FROM n; \
+             INSERT INTO graph_edges(namespace,id,source_id,target_id,relation,weight,created_at,updated_at) \
+             SELECT namespace,replace(id,'10000000-','30000000-'),id,'{project}','annotates',1,created_at,updated_at FROM notes WHERE kind='issue'; COMMIT;"
+        )).expect("seed exact fixture population");
+        let count: i64 = writer
+            .conn()
+            .query_row("SELECT COUNT(*) FROM notes", [], |r| r.get(0))
+            .unwrap();
+        // Project creation is an entity; its audit records are in events, not notes.
+        assert_eq!(count, (ISSUES + UNRELATED) as i64);
+        drop(writer);
+        query_plans(&rt, project).await;
+    }
+
+    let mut failures = Vec::new();
+    for max_items in [10_u64, 200, 20_000] {
+        for scoped in [false, true] {
+            // Reset outside the measured interval, then reconstruct the entire pool.
+            {
+                let (rt, _, _) = file_fixture(&db).await;
+                rt.backend()
+                    .pool()
+                    .try_writer()
+                    .unwrap()
+                    .conn()
+                    .execute("DELETE FROM git_mirror_cursor", [])
+                    .unwrap();
+            }
+            std::fs::write(logs.join("pages.log"), "").unwrap();
+            let (rt, token, registry) = file_fixture(&db).await;
+            let before = rt.backend().pool().reader_acquisition_snapshot();
+            let started = Instant::now();
+            let result: Result<Value, String> = if scoped {
+                khive_storage::scope_request_read_deadline(
+                    Duration::from_secs(30),
+                    registry.dispatch(
+                        "git.digest",
+                        json!({"source":"https://github.com/fixture/repository",
+                        "include":["issues"],"max_items":max_items}),
+                    ),
+                )
+                .await
+                .map_err(|e| e.to_string())
+            } else {
+                run_ingest(
+                    &rt,
+                    &token,
+                    &registry,
+                    IngestOptions {
+                        repo: repo.clone(),
+                        expected_github_repo: Some("fixture/repository".into()),
+                        project: project.to_string(),
+                        max_items: Some(max_items),
+                        include: IngestInclude {
+                            commits: false,
+                            issues: true,
+                            pull_requests: false,
+                        },
+                    },
+                )
+                .await
+                .map(|r| serde_json::to_value(r).unwrap())
+                .map_err(|e| e.to_string())
+            };
+            let elapsed = started.elapsed();
+            let after = rt.backend().pool().reader_acquisition_snapshot();
+            let pages = std::fs::read_to_string(logs.join("pages.log"))
+                .unwrap()
+                .lines()
+                .count();
+            let visited = result
+                .as_ref()
+                .ok()
+                .and_then(|r| r["issues_skipped_existing"].as_u64());
+            println!(
+                "DIGEST_SCALE_RESULT {}",
+                json!({"max_items":max_items,
+                "scope":if scoped {"verb_30s_deadline"} else {"core_unscoped"},
+                "elapsed_ms":elapsed.as_secs_f64()*1000.0,"visited":visited,"pages":pages,
+                "first_failing_sql_observed":false,"first_failing_sql":null,
+                "visited_observation":if visited.is_some() {"successful report"} else {"unobserved on error"},
+                "per_item_us":visited.filter(|n|*n>0).map(|n|elapsed.as_secs_f64()*1e6/n as f64),
+                "completed_hold_max_us_since_pool_open":after.max_completed_hold_micros,
+                "bootstrap_hold_max_us":before.max_completed_hold_micros,
+                "acquisitions":after.acquisitions-before.acquisitions,
+                "checkout_timeouts":after.checkout_timeouts-before.checkout_timeouts,
+                "active_checkouts":after.active_pooled_checkouts,
+                "free_reader_slots":after.available_reader_admission_slots,
+                "reader_capacity":after.reader_admission_capacity,"result":result})
+            );
+            assert_eq!(after.active_pooled_checkouts, 0);
+            assert_eq!(
+                after.available_reader_admission_slots,
+                after.reader_admission_capacity
+            );
+            match result {
+                Ok(report) => {
+                    assert_eq!(report["issues_ingested"], 0);
+                    assert_eq!(report["issues_skipped_existing"], VISITS);
+                    assert_eq!(report["sources"]["issues"]["state"], "completed");
+                    assert_eq!(pages, 6);
+                }
+                Err(error) => {
+                    failures.push(format!("max_items={max_items} scoped={scoped}: {error}"))
+                }
+            }
+        }
+    }
+    assert!(failures.is_empty(), "digest scale failures: {failures:#?}");
+}

--- a/crates/khive-pack-git/tests/support/digest_scale.rs
+++ b/crates/khive-pack-git/tests/support/digest_scale.rs
@@ -1,13 +1,13 @@
 //! Opt-in diagnostic: full-history replay against existing file-backed issue notes.
 //! Run with `cargo test -p khive-pack-git --test acceptance digest_scale -- --ignored --nocapture`.
-//! Timing is evidence, not a normal CI assertion or proof about another store.
+//! The explicit scale run asserts bounded visits and a controlled 30-second resume.
+//! Timings are evidence about this fixture, not proof about another store.
 
 use super::*;
 use std::time::{Duration, Instant};
 
 const ISSUES: usize = 5_000;
 const UNRELATED: usize = 50_000;
-const VISITS: u64 = 5_005; // Inclusive paging revisits each of five boundary rows.
 
 async fn file_fixture(path: &Path) -> (KhiveRuntime, NamespaceToken, VerbRegistry) {
     let rt = KhiveRuntime::new(RuntimeConfig {
@@ -49,23 +49,23 @@ fn paged_gh(repo: &Path, bin: &Path, logs: &Path) {
                 "labels":[],"body":"Already stored fixture issue."})
         })
         .collect();
-    let mut arms = String::new();
-    let mut first = 0;
-    let mut floor = "sort:updated-asc".to_string();
-    loop {
-        let end = (first + 1_000).min(rows.len());
-        let file = logs.join(format!("page-{first}.json"));
-        std::fs::write(&file, serde_json::to_vec(&rows[first..end]).unwrap()).unwrap();
+    let rows_file = logs.join("issues.jsonl");
+    std::fs::write(
+        &rows_file,
+        rows.iter()
+            .map(Value::to_string)
+            .collect::<Vec<_>>()
+            .join("\n")
+            + "\n",
+    )
+    .unwrap();
+    let mut arms = "    'sort:updated-asc') first=1 ;;\n".to_owned();
+    for first in 0..ISSUES {
         arms.push_str(&format!(
-            "    {}) cat {} ;;\n",
-            shell_quote(&floor),
-            shell_quote(file.to_str().unwrap())
+            "    {}) first={} ;;\n",
+            shell_quote(&format!("sort:updated-asc updated:>={}", timestamp(first))),
+            first + 1
         ));
-        if end == rows.len() {
-            break;
-        }
-        first = end - 1;
-        floor = format!("sort:updated-asc updated:>={}", timestamp(first));
     }
     let script = format!(
         r#"#!/bin/sh
@@ -89,7 +89,11 @@ printf '%s\n' "$search" >> {log}
 case "$search" in
 {arms}    *) printf '%s\n' 'unexpected fixture floor' >&2; exit 5 ;;
 esac
+printf '['
+sed -n "${{first}},$((first + 999))p" {rows_file} | paste -sd, -
+printf ']\n'
 "#,
+        rows_file = shell_quote(rows_file.to_str().unwrap()),
         log = shell_quote(logs.join("pages.log").to_str().unwrap())
     );
     // write_fake_gh already set the executable bit on this exact file.
@@ -113,7 +117,7 @@ fn reader_statements(project: Uuid) -> Vec<SqlStatement> {
     vec![
         stmt("git_digest_find_projects_by_slug", "SELECT id FROM entities WHERE kind='project' AND namespace=?1 AND deleted_at IS NULL AND json_extract(properties,'$.repo_slug')=?2 ORDER BY created_at ASC, id ASC", vec![ns.clone(),slug.clone()]),
         stmt("git_digest_find_projects_without_canonical_slug", "SELECT id, json_extract(properties,'$.repo_url') AS repo_url FROM entities WHERE kind='project' AND namespace=?1 AND deleted_at IS NULL AND json_extract(properties,'$.repo_url') IS NOT NULL AND (json_extract(properties,'$.repo_slug') IS NULL OR json_extract(properties,'$.repo_slug')<>?2) ORDER BY created_at ASC, id ASC", vec![ns.clone(),slug]),
-        stmt("git_ingest_read_cursor", "SELECT cursor_value FROM git_mirror_cursor WHERE project_id=?1 AND kind=?2", vec![id.clone(),SqlValue::Text("issues".into())]),
+        stmt("git_ingest_read_page_checkpoint", "SELECT (SELECT cursor_value FROM git_mirror_cursor WHERE project_id=?1 AND kind=?2) AS floor, (SELECT cursor_value FROM git_mirror_cursor WHERE project_id=?1 AND kind=?3) AS progress", vec![id.clone(),SqlValue::Text("issues".into()),SqlValue::Text("issues_checkpoint".into())]),
         stmt("git_ingest_find_by_number", "SELECT id FROM notes WHERE kind=?1 AND namespace=?2 AND deleted_at IS NULL AND json_extract(properties,'$.number')=?3 AND json_extract(properties,'$.project_id')=?4 LIMIT 1", vec![SqlValue::Text("issue".into()),ns.clone(),SqlValue::Integer(ISSUES as i64),id.clone()]),
         stmt("git_ingest_count_commit_notes", "SELECT COUNT(*) FROM notes n JOIN graph_edges e ON e.source_id = n.id AND e.namespace = n.namespace WHERE n.kind = 'commit' AND n.namespace = ?1 AND n.deleted_at IS NULL AND e.relation = 'annotates' AND e.target_id = ?2 AND e.deleted_at IS NULL", vec![ns,id]),
     ]
@@ -137,7 +141,7 @@ async fn query_plans(rt: &KhiveRuntime, project: Uuid) {
     // SqlReader (and queue-backed SqlWriter::explain) correctly refuses an
     // INSERT capability, even under EXPLAIN. Use only this fixture's raw
     // connection for its write plan. EXPLAIN never executes the cursor write.
-    let query = stmt("git_ingest_write_cursor", "INSERT INTO git_mirror_cursor(project_id, kind, cursor_value, updated_at) VALUES(?1, ?2, ?3, ?4) ON CONFLICT(project_id, kind) DO UPDATE SET cursor_value=excluded.cursor_value, updated_at=excluded.updated_at", vec![SqlValue::Text(project.to_string()),SqlValue::Text("issues".into()),SqlValue::Text(timestamp(ISSUES-1)),SqlValue::Integer(0)]);
+    let query = stmt("git_ingest_write_page_checkpoint", "INSERT INTO git_mirror_cursor(project_id, kind, cursor_value, updated_at) VALUES(?1, ?2, ?3, ?4), (?1, ?5, ?6, ?4) ON CONFLICT(project_id, kind) DO UPDATE SET cursor_value=excluded.cursor_value, updated_at=excluded.updated_at", vec![SqlValue::Text(project.to_string()),SqlValue::Text("issues_checkpoint".into()),SqlValue::Text("{}".into()),SqlValue::Integer(0),SqlValue::Text("issues".into()),SqlValue::Text(timestamp(ISSUES-1))]);
     let writer = rt.backend().pool().try_writer().unwrap();
     let mut prepared = writer
         .conn()
@@ -145,7 +149,14 @@ async fn query_plans(rt: &KhiveRuntime, project: Uuid) {
         .unwrap();
     let plan: Vec<Value> = prepared
         .query_map(
-            (project.to_string(), "issues", timestamp(ISSUES - 1), 0_i64),
+            (
+                project.to_string(),
+                "issues_checkpoint",
+                "{}",
+                0_i64,
+                "issues",
+                timestamp(ISSUES - 1),
+            ),
             |row| {
                 Ok(
                     json!({"id": row.get::<_, i64>(0)?, "parent": row.get::<_, i64>(1)?,
@@ -185,15 +196,16 @@ async fn digest_scale_existing_tracker() {
         "DIGEST_SCALE_CONTROLS {}",
         json!({
         "issues":ISSUES,"unrelated_notes":UNRELATED,"unrelated_kind":"observation",
-        "namespace":"local","expected_visits":VISITS,"expected_pages":6,
+        "namespace":"local","expected_visits":"min(effective max_items, 5000); acknowledged boundary rows cost no lookup",
         "max_items":[10,200,20000],"new_creates_expected":0,
-        "deadline_seconds":30,"timing_assertions":false,
+        "deadline_seconds":30,"timing_assertions":"scoped max_items=10 first and resumed call each below 30s",
         "cursor":"absent/full-history-replay; cleared before each arm",
         "seed_shape":"minimal issue properties number/project_id plus annotates edges; small content; no live-store import",
         "background_index_scope":"observation notes share namespace but not the issue kind index range",
         "failure_observability":"terminal error only; first failing SQL and visited count unavailable on error",
         "hold_observability":"maximum since each fresh pool opened, including disclosed bootstrap maximum",
-        "expectation":"unscoped core completes with all existing; scoped verb either completes or reports actual deadline failure; no production fix inferred from source alone"})
+        "baseline":"28d8c58d9: all six arms Ok in about 11.3s, 5005 visits each; original timeout not reproduced",
+        "expectation":"existing visits are bounded; incomplete windows stop early; second scoped max10 call reloads the database and visits the next ten records"})
     );
 
     let project;
@@ -307,13 +319,84 @@ async fn digest_scale_existing_tracker() {
             match result {
                 Ok(report) => {
                     assert_eq!(report["issues_ingested"], 0);
-                    assert_eq!(report["issues_skipped_existing"], VISITS);
-                    assert_eq!(report["sources"]["issues"]["state"], "completed");
-                    assert_eq!(pages, 6);
+                    let effective = if scoped {
+                        max_items.min(2000)
+                    } else {
+                        max_items
+                    };
+                    let expected = effective.min(ISSUES as u64);
+                    assert_eq!(report["issues_skipped_existing"], expected);
+                    assert_eq!(
+                        report["sources"]["issues"]["state"],
+                        if expected < ISSUES as u64 {
+                            "stopped_early"
+                        } else {
+                            "completed"
+                        }
+                    );
+                    assert_eq!(report["done"], expected == ISSUES as u64);
+                    let expected_pages = if expected <= 1000 {
+                        1
+                    } else {
+                        (expected as usize - 1001) / 999 + 2
+                    };
+                    assert_eq!(pages, expected_pages);
+                    assert_eq!(
+                        read_git_cursor(&rt, project, "issues").await,
+                        Some(timestamp(expected as usize - 1))
+                    );
                 }
                 Err(error) => {
                     failures.push(format!("max_items={max_items} scoped={scoped}: {error}"))
                 }
+            }
+            if scoped && max_items == 10 {
+                assert!(
+                    elapsed < Duration::from_secs(30),
+                    "first max10 call: {elapsed:?}"
+                );
+                drop(registry);
+                drop(token);
+                drop(rt);
+                // Reconstruct the pool/registry: continuation must come from
+                // disk, never this invocation's in-memory checkpoint.
+                let (rt, _token, registry) = file_fixture(&db).await;
+                assert_eq!(
+                    read_git_cursor(&rt, project, "issues").await,
+                    Some(timestamp(9))
+                );
+                std::fs::write(logs.join("pages.log"), "").unwrap();
+                let started = Instant::now();
+                let resumed = khive_storage::scope_request_read_deadline(
+                    Duration::from_secs(30),
+                    registry.dispatch(
+                        "git.digest",
+                        json!({"source":"https://github.com/fixture/repository",
+                        "include":["issues"],"max_items":10}),
+                    ),
+                )
+                .await
+                .unwrap();
+                let elapsed = started.elapsed();
+                let cursor = read_git_cursor(&rt, project, "issues").await;
+                let searches = std::fs::read_to_string(logs.join("pages.log")).unwrap();
+                println!(
+                    "DIGEST_SCALE_RESUME {}",
+                    json!({"elapsed_ms":elapsed.as_secs_f64()*1000.0,
+                    "cursor_before":timestamp(9),"cursor_after":cursor,"searches":searches,"result":resumed})
+                );
+                assert!(
+                    elapsed < Duration::from_secs(30),
+                    "resumed max10 call: {elapsed:?}"
+                );
+                assert_eq!(resumed["issues_skipped_existing"], 10);
+                assert_eq!(resumed["issues_ingested"], 0);
+                assert_eq!(resumed["sources"]["issues"]["state"], "stopped_early");
+                assert_eq!(cursor, Some(timestamp(19)));
+                assert_eq!(
+                    searches.lines().collect::<Vec<_>>(),
+                    vec![format!("sort:updated-asc updated:>={}", timestamp(9))]
+                );
             }
         }
     }


### PR DESCRIPTION
## Summary

`git.digest` on a repository whose tracker records already exist in the store used to visit every remote record before writing its cursor once at the end of the pass, so `max_items` bounded only what was ingested, not what was visited, and a daemon client with a read timeout saw the call as hung on large trackers. This change makes the visit budget the bound and checkpoints progress per page.

- A record consumes one unit of `max_items` before its natural-key lookup, whether it already exists, is created, or fails. Existing records can no longer turn a small bound into a full scan.
- Issues and PRs persist a paired page checkpoint after each processed page (including a page cut short by the budget) and before the next fetch; commits persist their SHA cursor after each contiguous record. A later failure keeps the saved prefix, and the next pass resumes from it.
- Exact boundary acknowledgments (versioned JSON beside the timestamp cursor) let a resumed pass skip already-acknowledged records at the boundary timestamp without a lookup, so `max_items=1` makes progress on undated or tied records.
- Any per-record failure freezes the saved prefix and is published in the report before the checkpoint write.
- Commit digests resume through a frozen DAG snapshot: the original range and the completed position persist beside the commit cursor, so a `max_items=1` pass crosses both branches of a merge without cycling on the existing sibling. Metadata, touched paths and recovery pin to the frozen tip; when the source `HEAD` has advanced past it, the report requests a subsequent pass instead of mixing ranges. An invalid continuation fails without advancing the cursor.

Documented in `crates/khive-pack-git/docs/ingest.md` and `docs/api/ingest.md`. The checkpoint metadata is not a public cursor format and adds no schema migration.

## Measurement

Same fixture before and after: 5,000 pre-existing issues, file-backed SQLite store, `max_items` 10 / 200 / 20,000 (the public verb clamps to 2,000).

| | visits per call | cursor writes | wall (max 10) |
|---|---|---|---|
| before | 5,005 at every `max_items` | one, at the end of the pass | 11.3 s |
| after | 10 / 200 / 5,000 (public: 10 / 200 / 2,000) | one per processed page | 0.08 to 0.27 s |

A second bounded call after the first resumes from the stored checkpoint and visits only the next window (`max_items` 10: cursor 00:09 to 00:19, 80 ms). Reader checkout timeouts: 0 in every arm before and after.

## Tests

- `tests/support/digest_resume.rs` (new): first page survives a second-page fetch failure, commit prefix survives a later cursor write failure, record stall survives a checkpoint failure, rejected ties are charged and retried, undated acknowledgments do not fill across windows, one-item resume handles undated ties, completed PRs yield to issues and commits with merge annotation, legacy timestamp cursors charge existing records before new ones.
- `tests/support/digest_commit_resume.rs` (new): a diamond history at `max_items=1` reopens the database between passes and finishes; a frozen diamond requests a new head even with spare budget; an invalid commit continuation fails without advancing.
- `tests/support/digest_scale.rs`: file-backed scale and resume diagnostic (ignored by default) printing per-arm visits, pages, acquisitions and hold times.
- `khive-pack-git` and `khive-db` suites.
