### PR TITLE
test(smoke): isolate the brain smoke child from the host's khive

### DIFF
--- a/tests/smoke_brain.py
+++ b/tests/smoke_brain.py
@@ -16,10 +16,26 @@ import json
 import subprocess
 import sys
 import os
+import tempfile
 
 from kkernel_binary import resolve_binary_path
 
 BINARY = resolve_binary_path()
+
+# The child must not inherit this host's khive: a HOME that carries a
+# ~/.khive config points the binary at a configured daemon, and a KHIVE_*
+# setting in the parent shell (packs, embedding models, output format) changes
+# what the smoke exercises. Mirrors smoke_child_env in smoke_test.py: drop every
+# KHIVE_* variable, give the child an empty HOME, and forbid the daemon path so
+# the in-memory store under test is the one that answers.
+_SMOKE_HOME = tempfile.TemporaryDirectory(prefix="khive-brain-smoke-home-")
+
+
+def smoke_child_env() -> dict[str, str]:
+    env = {k: v for k, v in os.environ.items() if not k.startswith("KHIVE_")}
+    env["HOME"] = _SMOKE_HOME.name
+    env["KHIVE_NO_DAEMON"] = "1"
+    return env
 
 request_id = 0
 
@@ -115,6 +131,7 @@ def spawn_brain_proc():
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        env=smoke_child_env(),
     )
     send(proc, "initialize", {
         "protocolVersion": "2024-11-05",


### PR DESCRIPTION
## Summary

`tests/smoke_brain.py` spawned its binary with the parent's environment. On a host whose HOME carries a `~/.khive` config, the child resolved that config's daemon and every step failed with `daemon respawn failed` instead of exercising the in-memory store under test. `tests/smoke_test.py` already isolates its children (`smoke_child_env`); the brain smoke did not.

## Change

The brain smoke now gives its child the same environment shape: every `KHIVE_*` variable dropped, an empty temporary HOME, and `KHIVE_NO_DAEMON=1`. Test-only; no runtime code touched.

## Measurement

Host with a configured HOME, `KHIVE_NO_DAEMON` unset in the parent, same release binary:

| script | result |
|---|---|
| before | 26/26 failed (`daemon respawn failed`) |
| after | 26/26 passed |

On a host without such a config both forms pass, so that host cannot discriminate the two; the number above is from the host that can.
