### PR TITLE
docs(brain): name the results element shape in auto_feedback help

### DIFF
--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -354,7 +354,7 @@ pub(crate) static BRAIN_HANDLERS: &[HandlerDef] = &[
                 name: "results",
                 param_type: "array",
                 required: true,
-                description: "Recall result objects retained as candidate context. No result is credited by rank position.",
+                description: "Recall result objects retained as candidate context: an array of objects, each with an id field (the result UUID or compact id) and optionally served_by_profile_id; bare id strings are rejected. No result is credited by rank position.",
                 resolution_mode: IdResolutionMode::NotApplicable,
             },
             khive_types::ParamDef {

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -1387,7 +1387,7 @@ right after `memory.recall` instead of hand-building `brain.feedback`.
 | Param                  | Type   | Required    | Notes                                                                  |
 | ---------------------- | ------ | ----------- | ---------------------------------------------------------------------- |
 | `query`                | string | yes         | The recall query that produced the results.                            |
-| `results`              | array  | yes         | Recall result objects retained as candidate context.                   |
+| `results`              | array  | yes         | Recall result objects retained as candidate context: objects with an `id` field (result UUID or compact id) and optionally `served_by_profile_id`; bare id strings are rejected. |
 | `target_id`            | string | with signal | Full UUID or compact id; must exactly equal one `results[].id`.        |
 | `signal`               | string | no          | Omission abstains: no feedback event or posterior update.              |
 | `served_by_profile_id` | string | no          | Profile that served the recall.                                        |

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -1384,17 +1384,17 @@ request(ops="brain.feedback(target_id=\"<uuid>\", signal=\"useful\")")
 Emit caller-attributed feedback for one recall result — the convenience verb to call
 right after `memory.recall` instead of hand-building `brain.feedback`.
 
-| Param                  | Type   | Required    | Notes                                                                  |
-| ---------------------- | ------ | ----------- | ---------------------------------------------------------------------- |
-| `query`                | string | yes         | The recall query that produced the results.                            |
+| Param                  | Type   | Required    | Notes                                                                                                                                                                            |
+| ---------------------- | ------ | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `query`                | string | yes         | The recall query that produced the results.                                                                                                                                      |
 | `results`              | array  | yes         | Recall result objects retained as candidate context: objects with an `id` field (result UUID or compact id) and optionally `served_by_profile_id`; bare id strings are rejected. |
-| `target_id`            | string | with signal | Full UUID or compact id; must exactly equal one `results[].id`.        |
-| `signal`               | string | no          | Omission abstains: no feedback event or posterior update.              |
-| `served_by_profile_id` | string | no          | Profile that served the recall.                                        |
-| `serve_attribution`    | string | no          | Serve-time tri-state; otherwise copied from the selected result.       |
-| `scorer_run_id`        | string | no          | Forwarded verbatim to `brain.feedback`; pairs with `serve_ledger_id`.  |
-| `serve_ledger_id`      | string | no          | Forwarded verbatim to `brain.feedback`; pairs with `scorer_run_id`.    |
-| `namespace`            | string | no          | Exact namespace for the event and posterior fold; invalid values fail. |
+| `target_id`            | string | with signal | Full UUID or compact id; must exactly equal one `results[].id`.                                                                                                                  |
+| `signal`               | string | no          | Omission abstains: no feedback event or posterior update.                                                                                                                        |
+| `served_by_profile_id` | string | no          | Profile that served the recall.                                                                                                                                                  |
+| `serve_attribution`    | string | no          | Serve-time tri-state; otherwise copied from the selected result.                                                                                                                 |
+| `scorer_run_id`        | string | no          | Forwarded verbatim to `brain.feedback`; pairs with `serve_ledger_id`.                                                                                                            |
+| `serve_ledger_id`      | string | no          | Forwarded verbatim to `brain.feedback`; pairs with `scorer_run_id`.                                                                                                              |
+| `namespace`            | string | no          | Exact namespace for the event and posterior fold; invalid values fail.                                                                                                           |
 
 Top-level serve-attribution fields are one pair and take precedence over the selected
 result's pair. If neither top-level field is supplied, both fields are copied from the


### PR DESCRIPTION
## Summary

`brain.auto_feedback(results=...)` takes an array of objects, each carrying an `id` (and optionally `served_by_profile_id`), but the parameter description only said "recall result objects retained as candidate context". A caller who passes the ids read off a recall gets `invalid type: string "...", expected struct AutoFeedbackResult` after the write attempt, and nothing in `help=true` says which shape was expected.

## Change

The parameter description in the verb schema and the matching row in `docs/guide/api-reference.md` now name the element shape and its required field, and say that bare id strings are rejected. Text only; no behaviour change.
