### PR TITLE
fix(streams): refuse recreated keys and batch stream preparation

### DIFF
--- a/crates/khive-db/src/backend.rs
+++ b/crates/khive-db/src/backend.rs
@@ -164,6 +164,21 @@ fn warn_scan_fallback_once(table: &str) {
     });
 }
 
+fn validate_vector_model_key(model_key: &str) -> Result<(), SqliteError> {
+    if model_key.is_empty()
+        || !model_key
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_')
+    {
+        return Err(SqliteError::InvalidData(format!(
+            "invalid model_key '{}': must be non-empty and contain only \
+             alphanumeric/underscore characters",
+            model_key
+        )));
+    }
+    Ok(())
+}
+
 fn validate_vector_table_columns(
     conn: &rusqlite::Connection,
     table: &str,
@@ -701,68 +716,69 @@ impl StorageBackend {
         dimensions: usize,
         namespace: &str,
     ) -> Result<Arc<dyn khive_storage::VectorStore>, SqliteError> {
-        if model_key.is_empty()
-            || !model_key
-                .chars()
-                .all(|c| c.is_ascii_alphanumeric() || c == '_')
-        {
-            return Err(SqliteError::InvalidData(format!(
-                "invalid model_key '{}': must be non-empty and contain only \
-                 alphanumeric/underscore characters",
-                model_key
-            )));
-        }
+        validate_vector_model_key(model_key)?;
         if namespace.trim().is_empty() {
             return Err(SqliteError::InvalidData(
                 "vector store namespace must be non-empty".to_string(),
             ));
         }
+        self.ensure_vector_tables(&[(model_key, dimensions)])?;
+        Ok(Arc::new(vectors::SqliteVecStore::new(
+            Arc::clone(&self.pool),
+            self.is_file_backed,
+            model_key.to_string(),
+            embedding_model.to_string(),
+            dimensions,
+            namespace.trim().to_string(),
+        )?))
+    }
+
+    /// Ensure all requested vector tables with one schema-writer acquisition.
+    /// Read-only backends inspect the same tables using one reader instead.
+    pub fn ensure_vector_tables(&self, models: &[(&str, usize)]) -> Result<(), SqliteError> {
+        for (model_key, _) in models {
+            validate_vector_model_key(model_key)?;
+        }
+        if models.is_empty() {
+            return Ok(());
+        }
 
         // Ensure sqlite-vec is registered before creating vec0 tables.
         crate::extension::ensure_extensions_loaded();
-
-        let table = format!("vec_{}", model_key);
 
         if self.is_read_only() {
             // Snapshot inspection must not check schema through the pool's
             // query-only writer slot: even a SELECT there is a writer-class
             // acquisition and violates ADR-028 A2's write-free lifecycle.
             let reader = self.pool.reader()?;
-            if !sqlite_table_exists(reader.conn(), &table)? {
-                return Err(SqliteError::InvalidData(format!(
-                    "read-only database has no vector table '{table}'; create and populate it in \
-                     a writable copy before opening the snapshot"
-                )));
+            for (model_key, _) in models {
+                let table = format!("vec_{model_key}");
+                if !sqlite_table_exists(reader.conn(), &table)? {
+                    return Err(SqliteError::InvalidData(format!(
+                        "read-only database has no vector table '{table}'; create and populate it in \
+                         a writable copy before opening the snapshot"
+                    )));
+                }
+                validate_vector_table_columns(reader.conn(), &table)?;
             }
-            validate_vector_table_columns(reader.conn(), &table)?;
-            drop(reader);
-            return Ok(Arc::new(vectors::SqliteVecStore::new(
-                Arc::clone(&self.pool),
-                self.is_file_backed,
-                model_key.to_string(),
-                embedding_model.to_string(),
-                dimensions,
-                namespace.trim().to_string(),
-            )?));
+            return Ok(());
         }
 
         let writer = self.constructor_writer()?;
 
         // Detect old-schema vec0 tables that predate the `field` column.
-        // vec0 virtual tables do not support ALTER TABLE, so we must drop and recreate
-        // the table if it exists without the `field` column. Vector data is a cache —
-        // callers can re-embed from the source record after the table is rebuilt.
         // Use pragma_table_info to check columns directly; substring matching on the
         // CREATE DDL is fragile (a model_key containing "field" would false-match).
-        let table_exists = sqlite_table_exists(writer.conn(), &table)?;
-
-        if table_exists {
+        for (model_key, _) in models {
+            let table = format!("vec_{model_key}");
             // V17 migration (vector_embedding_model_tag_preserving_rebuild) adds
             // `field` and `embedding_model` to all pre-existing vec0 tables at
             // migration time.  If this table still lacks either column post-migration
             // that indicates the database was not migrated — return a hard error
             // rather than silently dropping data.
-            validate_vector_table_columns(writer.conn(), &table)?;
+            if sqlite_table_exists(writer.conn(), &table)? {
+                validate_vector_table_columns(writer.conn(), &table)?;
+            }
         }
 
         // Ensure the _embedding_models registry table exists.
@@ -790,29 +806,22 @@ impl StorageBackend {
             .conn()
             .execute_batch(crate::migrations::ANN_CONSUMER_PENDING_DDL)?;
 
-        // Create the vec0 virtual table. Idempotent on fresh databases and after the
-        // old-schema rebuild above.
-        let ddl = format!(
-            "CREATE VIRTUAL TABLE IF NOT EXISTS vec_{} USING vec0(\
-             subject_id TEXT PRIMARY KEY, \
-             namespace TEXT NOT NULL, \
-             kind TEXT NOT NULL, \
-             field TEXT NOT NULL, \
-             embedding_model TEXT NOT NULL, \
-             embedding float[{}] distance_metric=cosine\
-             )",
-            model_key, dimensions
-        );
-        writer.conn().execute_batch(&ddl)?;
-
-        Ok(Arc::new(vectors::SqliteVecStore::new(
-            Arc::clone(&self.pool),
-            self.is_file_backed,
-            model_key.to_string(),
-            embedding_model.to_string(),
-            dimensions,
-            namespace.trim().to_string(),
-        )?))
+        // Create missing vec0 tables without changing existing vector data.
+        for (model_key, dimensions) in models {
+            let ddl = format!(
+                "CREATE VIRTUAL TABLE IF NOT EXISTS vec_{} USING vec0(\
+                 subject_id TEXT PRIMARY KEY, \
+                 namespace TEXT NOT NULL, \
+                 kind TEXT NOT NULL, \
+                 field TEXT NOT NULL, \
+                 embedding_model TEXT NOT NULL, \
+                 embedding float[{}] distance_metric=cosine\
+                 )",
+                model_key, dimensions
+            );
+            writer.conn().execute_batch(&ddl)?;
+        }
+        Ok(())
     }
 
     /// Register an embedding model in the `_embedding_models` registry table.

--- a/crates/khive-runtime/src/atomic_message.rs
+++ b/crates/khive-runtime/src/atomic_message.rs
@@ -37,7 +37,7 @@
 //! version of `dual_write_message` used to document is closed by
 //! construction.
 
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
 use serde_json::Value;
 use uuid::Uuid;
@@ -73,7 +73,7 @@ pub struct AtomicNoteSpec<'a> {
     pub properties: Option<Value>,
 }
 
-#[derive(Default)]
+#[derive(Clone, Copy, Default)]
 pub(crate) struct AtomicNoteOptions<'a> {
     pub salience: Option<f64>,
     pub decay_factor: Option<f64>,
@@ -82,6 +82,11 @@ pub(crate) struct AtomicNoteOptions<'a> {
     pub embed: Option<bool>,
     pub key: Option<&'a str>,
     pub fence: Option<&'a crate::note_write::NoteFences>,
+}
+
+pub(crate) struct AtomicNoteRequest<'a> {
+    pub spec: AtomicNoteSpec<'a>,
+    pub options: AtomicNoteOptions<'a>,
 }
 
 pub(crate) struct PreparedAtomicNotes {
@@ -320,6 +325,23 @@ pub(crate) async fn prepare_atomic_notes(
     specs: Vec<AtomicNoteSpec<'_>>,
     options: AtomicNoteOptions<'_>,
 ) -> RuntimeResult<PreparedAtomicNotes> {
+    validate_atomic_note_options(&options)?;
+    if options.embed != Some(false) {
+        if let Some(model) = options.embedding_model {
+            runtime.resolve_embedding_model(Some(model))?;
+        }
+    }
+    prepare_atomic_note_requests(
+        runtime,
+        specs
+            .into_iter()
+            .map(|spec| AtomicNoteRequest { spec, options })
+            .collect(),
+    )
+    .await
+}
+
+fn validate_atomic_note_options(options: &AtomicNoteOptions<'_>) -> RuntimeResult<()> {
     if let Some(value) = options.salience {
         if !value.is_finite() || !(0.0..=1.0).contains(&value) {
             return Err(RuntimeError::InvalidInput(
@@ -334,18 +356,45 @@ pub(crate) async fn prepare_atomic_notes(
             ));
         }
     }
-    let embed_model_names = if options.embed == Some(false) {
-        Vec::new()
-    } else if let Some(model) = options.embedding_model {
-        runtime.resolve_embedding_model(Some(model))?;
-        vec![model.to_owned()]
-    } else {
-        runtime.registered_embedding_model_names()
-    };
+    Ok(())
+}
+
+pub(crate) async fn prepare_atomic_note_requests(
+    runtime: &KhiveRuntime,
+    requests: Vec<AtomicNoteRequest<'_>>,
+) -> RuntimeResult<PreparedAtomicNotes> {
+    let mut embed_model_names = Vec::new();
+    let mut note_models = Vec::with_capacity(requests.len());
+    for request in &requests {
+        let options = &request.options;
+        validate_atomic_note_options(options)?;
+        let models = if options.embed == Some(false) {
+            Vec::new()
+        } else if let Some(model) = options.embedding_model {
+            runtime.resolve_embedding_model(Some(model))?;
+            vec![model.to_owned()]
+        } else {
+            runtime.registered_embedding_model_names()
+        };
+        let mut indices = Vec::with_capacity(models.len());
+        for model in models {
+            let index = match embed_model_names.iter().position(|name| name == &model) {
+                Some(index) => index,
+                None => {
+                    embed_model_names.push(model);
+                    embed_model_names.len() - 1
+                }
+            };
+            indices.push(index);
+        }
+        note_models.push(indices);
+    }
     // ---- 1. Validate + build Note objects (all pre-write checks, same as
     // create_note_inner, before any embedding or DML is attempted). ----
-    let mut notes: Vec<Note> = Vec::with_capacity(specs.len());
-    for spec in &specs {
+    let mut notes: Vec<Note> = Vec::with_capacity(requests.len());
+    for request in &requests {
+        let spec = &request.spec;
+        let options = &request.options;
         runtime.validate_note_kind(spec.kind)?;
         // Same owned-identity derivation every other note-write site runs
         // (`operations.rs`'s create funnel, `atomic_prepare::prepare_add_note`):
@@ -384,14 +433,15 @@ pub(crate) async fn prepare_atomic_notes(
         notes.push(note);
     }
 
-    // ---- 2. Embed every distinct (content, model) pair in parallel, BEFORE
+    // ---- 2. Batch distinct content per model in parallel, BEFORE
     // opening any transaction. Any failure aborts here — no write has been
     // attempted. Identical note siblings reuse the same computed vector. ----
     let mut content_group_by_text: HashMap<&str, usize> = HashMap::new();
     let mut content_groups: Vec<Vec<usize>> = Vec::new();
     let mut note_content_groups: Vec<usize> = Vec::with_capacity(notes.len());
     for (note_idx, note) in notes.iter().enumerate() {
-        let text = options
+        let text = requests[note_idx]
+            .options
             .embedding_content
             .unwrap_or_else(|| crate::curation::note_embedding_text_ref(note));
         let content_group_idx = match content_group_by_text.get(text) {
@@ -417,56 +467,84 @@ pub(crate) async fn prepare_atomic_notes(
             .collect();
     let mut embedding_truncation = crate::retrieval::EmbeddingTruncationReport::default();
 
-    // `specs` is empty when a caller prepares a note set every member of
+    // `requests` is empty when a caller prepares a note set every member of
     // which was refused before preparation: there is nothing to embed, no
     // token to read, and the lazy vector-table create belongs to a write
     // that is not going to happen.
-    if !embed_model_names.is_empty() && !specs.is_empty() {
+    if !embed_model_names.is_empty() {
         // Ensure every model's vector table exists before the commit pass —
-        // the same lazy-create side effect `vectors_for_model` performs on
-        // the non-atomic path, done once per model rather than per note.
-        for model_name in &embed_model_names {
-            runtime.vectors_for_model(specs[0].token, model_name)?;
-        }
+        // the same lazy-create side effect as vector-store construction, with
+        // all model tables sharing one schema-writer acquisition.
+        let models = embed_model_names
+            .iter()
+            .map(|name| {
+                runtime
+                    .vector_model_metadata(name)
+                    .map(|(name, dimensions)| (crate::config::sanitize_key(&name), dimensions))
+            })
+            .collect::<RuntimeResult<Vec<_>>>()?;
+        let model_specs: Vec<_> = models
+            .iter()
+            .map(|(key, dimensions)| (key.as_str(), *dimensions))
+            .collect();
+        runtime.backend().ensure_vector_tables(&model_specs)?;
 
         let usage_ctx = crate::usage::current();
         let mut join_set = tokio::task::JoinSet::new();
-        for (content_group_idx, note_indices) in content_groups.iter().enumerate() {
-            let note_idx = note_indices[0];
-            let spec = &specs[note_idx];
-            let note = &notes[note_idx];
-            // Spawned tasks need owned text; share one content allocation across
-            // every model instead of cloning the note body per task.
-            let text: Arc<str> = Arc::from(
-                options
-                    .embedding_content
-                    .unwrap_or_else(|| crate::curation::note_embedding_text_ref(note)),
-            );
-            for (model_idx, model_name) in embed_model_names.iter().enumerate() {
-                let rt = runtime.clone();
-                let token = spec.token.clone();
-                let name = model_name.clone();
-                let text = Arc::clone(&text);
-                let ctx = usage_ctx.clone();
-                join_set.spawn(async move {
-                    let fut = rt.embed_document_with_model_outcome_for_token(
-                        &token,
-                        &name,
-                        text.as_ref(),
-                    );
-                    let result = match ctx {
-                        Some(ctx) => crate::usage::scope(ctx, fut).await,
-                        None => fut.await,
-                    };
-                    (content_group_idx, model_idx, result)
-                });
+        for (model_idx, model_name) in embed_model_names.iter().enumerate() {
+            let mut groups = Vec::new();
+            let mut texts = Vec::new();
+            let mut token = None;
+            for (group_idx, note_indices) in content_groups.iter().enumerate() {
+                let Some(&note_idx) = note_indices
+                    .iter()
+                    .find(|&&index| note_models[index].contains(&model_idx))
+                else {
+                    continue;
+                };
+                token.get_or_insert_with(|| requests[note_idx].spec.token.clone());
+                groups.push(group_idx);
+                texts.push(
+                    requests[note_idx]
+                        .options
+                        .embedding_content
+                        .unwrap_or_else(|| {
+                            crate::curation::note_embedding_text_ref(&notes[note_idx])
+                        })
+                        .to_owned(),
+                );
             }
+            let rt = runtime.clone();
+            let token = token.expect("a selected model has at least one note");
+            let name = model_name.clone();
+            let ctx = usage_ctx.clone();
+            join_set.spawn(async move {
+                let fut = async {
+                    let mut outcomes = Vec::with_capacity(texts.len());
+                    for chunk in texts.chunks(lattice_embed::DEFAULT_MAX_BATCH_SIZE) {
+                        outcomes.extend(
+                            rt.embed_document_batch_with_model_outcomes_for_token(
+                                &token, &name, chunk,
+                            )
+                            .await?,
+                        );
+                    }
+                    Ok::<_, RuntimeError>(outcomes)
+                };
+                let result = match ctx {
+                    Some(ctx) => crate::usage::scope(ctx, fut).await,
+                    None => fut.await,
+                };
+                (groups, model_idx, result)
+            });
         }
 
         while let Some(joined) = join_set.join_next().await {
             match joined {
-                Ok((content_group_idx, model_idx, Ok(outcome))) => {
-                    embedding_outcomes[content_group_idx][model_idx] = Some(outcome);
+                Ok((groups, model_idx, Ok(outcomes))) => {
+                    for (group_idx, outcome) in groups.into_iter().zip(outcomes) {
+                        embedding_outcomes[group_idx][model_idx] = Some(outcome);
+                    }
                 }
                 Ok((_, _, Err(e))) => {
                     join_set.abort_all();
@@ -484,8 +562,11 @@ pub(crate) async fn prepare_atomic_notes(
 
     // Preserve the report's logical note/model accounting even when identical
     // siblings share one provider invocation.
-    for &content_group_idx in &note_content_groups {
-        for outcome in embedding_outcomes[content_group_idx].iter().flatten() {
+    for (note_idx, &content_group_idx) in note_content_groups.iter().enumerate() {
+        for &model_idx in &note_models[note_idx] {
+            let outcome = embedding_outcomes[content_group_idx][model_idx]
+                .as_ref()
+                .expect("every requested embedding was observed");
             embedding_truncation.observe(outcome);
             if outcome.truncated {
                 tracing::warn!(
@@ -564,8 +645,9 @@ pub(crate) async fn prepare_atomic_notes(
         if let Some(fault) = maybe_inject_vector_failure(&note.namespace, "fault-injected-vector") {
             statements.push(fault);
         } else {
-            for (model_name, outcome) in embed_model_names.iter().zip(outcomes_for_note) {
-                let outcome = outcome
+            for &model_idx in &note_models[note_idx] {
+                let model_name = &embed_model_names[model_idx];
+                let outcome = outcomes_for_note[model_idx]
                     .as_ref()
                     .expect("every model index observed exactly once");
                 let table = format!("vec_{}", crate::config::sanitize_key(model_name));
@@ -583,10 +665,10 @@ pub(crate) async fn prepare_atomic_notes(
 
         plans.push(AtomicOpPlan::AddNote(AddNotePlan {
             note_guard: Some(crate::note_write::NoteWriteGuard {
-                namespace: specs[note_idx].token.namespace().as_str().into(),
+                namespace: requests[note_idx].spec.token.namespace().as_str().into(),
                 target_id: note.id,
                 expected_version: None,
-                fence: options.fence.cloned(),
+                fence: requests[note_idx].options.fence.cloned(),
                 create_key: note
                     .key
                     .as_ref()
@@ -610,6 +692,7 @@ mod tests {
     use super::*;
     use async_trait::async_trait;
     use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService, MAX_TEXT_BYTES};
+    use std::sync::{Arc, Mutex};
 
     use khive_types::Namespace;
 
@@ -726,6 +809,168 @@ mod tests {
         async fn build(&self) -> RuntimeResult<std::sync::Arc<dyn EmbeddingService>> {
             Ok(std::sync::Arc::new(DedupService { name: self.name }))
         }
+    }
+
+    struct BatchCountingService {
+        name: &'static str,
+        calls: Arc<Mutex<Vec<Vec<String>>>>,
+    }
+
+    #[async_trait]
+    impl EmbeddingService for BatchCountingService {
+        async fn embed(
+            &self,
+            texts: &[String],
+            _model: EmbeddingModel,
+        ) -> Result<Vec<Vec<f32>>, EmbedError> {
+            self.calls.lock().unwrap().push(texts.to_vec());
+            Ok(texts.iter().map(|_| vec![0.25; DEDUP_DIMS]).collect())
+        }
+
+        fn supports_model(&self, _model: EmbeddingModel) -> bool {
+            true
+        }
+
+        fn name(&self) -> &'static str {
+            self.name
+        }
+    }
+
+    struct BatchCountingProvider {
+        name: &'static str,
+        calls: Arc<Mutex<Vec<Vec<String>>>>,
+    }
+
+    #[async_trait]
+    impl EmbedderProvider for BatchCountingProvider {
+        fn name(&self) -> &str {
+            self.name
+        }
+
+        fn dimensions(&self) -> usize {
+            DEDUP_DIMS
+        }
+
+        async fn build(&self) -> RuntimeResult<Arc<dyn EmbeddingService>> {
+            Ok(Arc::new(BatchCountingService {
+                name: self.name,
+                calls: Arc::clone(&self.calls),
+            }))
+        }
+    }
+
+    #[tokio::test]
+    async fn heterogeneous_notes_batch_models_with_one_schema_writer() {
+        let runtime = KhiveRuntime::memory().unwrap();
+        let token = runtime
+            .authorize(Namespace::parse("batch-notes").unwrap())
+            .unwrap();
+        let names = ["batch-notes-a", "batch-notes-b"];
+        let mut counters = Vec::new();
+        for name in names {
+            let calls = Arc::new(Mutex::new(Vec::new()));
+            runtime.register_embedder(BatchCountingProvider {
+                name,
+                calls: Arc::clone(&calls),
+            });
+            runtime.embedder_with_token(&token, name).await.unwrap();
+            counters.push(calls);
+        }
+        let inputs = [
+            ("first", "shared text", true, 0.2),
+            ("second", "shared text", true, 0.4),
+            ("third", "different text", true, 0.6),
+            ("disabled", "shared text", false, 0.8),
+        ];
+        let requests = inputs
+            .iter()
+            .map(|&(key, content, embed, salience)| AtomicNoteRequest {
+                spec: AtomicNoteSpec {
+                    token: &token,
+                    id: None,
+                    kind: "observation",
+                    name: None,
+                    content,
+                    properties: Some(serde_json::json!({"key": key})),
+                },
+                options: AtomicNoteOptions {
+                    key: Some(key),
+                    salience: Some(salience),
+                    embed: Some(embed),
+                    ..Default::default()
+                },
+            })
+            .collect();
+        let before = runtime.backend().pool().writer_acquisition_snapshot();
+        let prepared = prepare_atomic_note_requests(&runtime, requests)
+            .await
+            .unwrap();
+        let after = runtime.backend().pool().writer_acquisition_snapshot();
+        assert_eq!(after.acquisitions - before.acquisitions, 1);
+        for calls in &counters {
+            assert_eq!(
+                *calls.lock().unwrap(),
+                vec![vec!["shared text".to_owned(), "different text".to_owned()]],
+            );
+        }
+        for (note, &(key, content, _, salience)) in prepared.notes.iter().zip(&inputs) {
+            assert_eq!(note.key.as_deref(), Some(key));
+            assert_eq!(note.content, content);
+            assert_eq!(note.salience, Some(salience));
+            assert_eq!(note.properties.as_ref().unwrap()["key"], key);
+        }
+        assert!(matches!(
+            crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), prepared.plans)
+                .await
+                .unwrap(),
+            AtomicRunOutcome::Committed { .. }
+        ));
+        for name in names {
+            assert_eq!(
+                runtime
+                    .vectors_for_model(&token, name)
+                    .unwrap()
+                    .count()
+                    .await
+                    .unwrap(),
+                3,
+                "disabled notes must not inherit a sibling's shared vector",
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn atomic_note_batch_chunks_only_above_provider_limit() {
+        let runtime = KhiveRuntime::memory().unwrap();
+        let token = runtime.authorize(Namespace::local()).unwrap();
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        runtime.register_embedder(BatchCountingProvider {
+            name: "batch-notes-large",
+            calls: Arc::clone(&calls),
+        });
+        let contents: Vec<_> = (0..=lattice_embed::DEFAULT_MAX_BATCH_SIZE)
+            .map(|index| format!("distinct document {index}"))
+            .collect();
+        let specs = contents
+            .iter()
+            .map(|content| AtomicNoteSpec {
+                token: &token,
+                id: None,
+                kind: "observation",
+                name: None,
+                content,
+                properties: None,
+            })
+            .collect();
+        let prepared = prepare_atomic_notes(&runtime, specs, AtomicNoteOptions::default())
+            .await
+            .unwrap();
+        assert_eq!(prepared.notes.len(), contents.len());
+        let calls = calls.lock().unwrap();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].len(), lattice_embed::DEFAULT_MAX_BATCH_SIZE);
+        assert_eq!(calls[1].len(), 1);
+        assert_eq!(calls.concat(), contents);
     }
 
     /// A minimal note-write validator standing in for a pack's real one (e.g.

--- a/crates/khive-runtime/src/atomic_runner.rs
+++ b/crates/khive-runtime/src/atomic_runner.rs
@@ -12,7 +12,7 @@
 //!
 //! # Safety: suspend-free invariant
 //!
-//! [`run_prepared_atomic_unit`] owns the failure and commit protocol shared by
+//! `run_prepared_atomic_unit` owns the failure and commit protocol shared by
 //! the atomic-plan and stream-batch paths. It builds an [`AtomicUnitOp`]
 //! closure for [`SqlAccess::atomic_unit`], whose contract
 //! requires the closure's future to resolve on its first poll — synchronous

--- a/crates/khive-runtime/src/atomic_runner.rs
+++ b/crates/khive-runtime/src/atomic_runner.rs
@@ -1331,4 +1331,231 @@ mod tests {
             other => panic!("expected Committed, got {other:?}"),
         }
     }
+
+    mod acknowledgement {
+        use super::*;
+        use khive_storage::{SqlReader, WriterTaskRequestState};
+
+        #[derive(Clone, Copy, Debug)]
+        enum Fault {
+            Request(WriterTaskRequestState),
+            Terminated(WriterTaskRequestState),
+        }
+
+        impl Fault {
+            fn error(self) -> StorageError {
+                match self {
+                    Self::Request(request_state) => StorageError::WriterTaskRequestFailed {
+                        request_state,
+                        source: Box::new(StorageError::Internal(
+                            "lost atomic acknowledgement".into(),
+                        )),
+                    },
+                    Self::Terminated(request_state) => {
+                        StorageError::WriterTaskTerminated { request_state }
+                    }
+                }
+            }
+
+            fn assert_preserved(self, error: StorageError) {
+                match (self, error) {
+                    (
+                        Self::Request(expected),
+                        StorageError::WriterTaskRequestFailed {
+                            request_state,
+                            source,
+                        },
+                    ) => {
+                        assert_eq!(request_state, expected);
+                        assert!(matches!(*source, StorageError::Internal(ref message)
+                            if message == "lost atomic acknowledgement"));
+                    }
+                    (
+                        Self::Terminated(expected),
+                        StorageError::WriterTaskTerminated { request_state },
+                    ) => assert_eq!(request_state, expected),
+                    (expected, actual) => panic!("expected {expected:?}, got {actual:?}"),
+                }
+            }
+        }
+
+        struct FaultAccess {
+            bridge: SqlBridge,
+            fault: Fault,
+            invoke: bool,
+            callback_result: StdArc<Mutex<Option<bool>>>,
+        }
+
+        #[async_trait::async_trait]
+        impl SqlAccess for FaultAccess {
+            async fn reader(&self) -> StorageResultAlias<Box<dyn SqlReader>> {
+                self.bridge.reader().await
+            }
+
+            async fn writer(&self) -> StorageResultAlias<Box<dyn SqlWriter>> {
+                self.bridge.writer().await
+            }
+
+            async fn atomic_unit(
+                &self,
+                op: AtomicUnitOp,
+            ) -> StorageResultAlias<Box<dyn Any + Send>> {
+                if self.invoke {
+                    let callback_result = StdArc::clone(&self.callback_result);
+                    let result = self
+                        .bridge
+                        .atomic_unit(Box::new(move |writer| {
+                            Box::pin(async move {
+                                let result = op(writer).await;
+                                *callback_result.lock().expect("callback result") =
+                                    Some(result.is_ok());
+                                result
+                            })
+                        }))
+                        .await;
+                    assert_eq!(
+                        Some(result.is_ok()),
+                        *self.callback_result.lock().expect("callback result"),
+                        "the real transaction must finish before replacing its acknowledgement"
+                    );
+                }
+                Err(self.fault.error())
+            }
+        }
+
+        fn fault_access(pool: &TestPool, fault: Fault, invoke: bool) -> FaultAccess {
+            FaultAccess {
+                bridge: SqlBridge::new(StdArc::clone(pool), true),
+                fault,
+                invoke,
+                callback_result: StdArc::new(Mutex::new(None)),
+            }
+        }
+
+        fn effect_plan(id: Uuid) -> AtomicOpPlan {
+            let AtomicOpPlan::Update(mut plan) = rename_plan(id, "changed", "rename") else {
+                unreachable!()
+            };
+            plan.post_commit = PostCommitEffect::ReindexEntity { entity_id: id };
+            AtomicOpPlan::Update(plan)
+        }
+
+        #[tokio::test]
+        async fn recorded_failure_recovers_only_after_confirmed_rollback() {
+            let pool = scratch_pool("recorded_rollback");
+            seed_schema(&pool);
+            let id = Uuid::new_v4();
+            insert_entity(&pool, id, "original");
+            let before = entities_snapshot(&pool);
+            let access = fault_access(
+                &pool,
+                Fault::Request(WriterTaskRequestState::TransactionRolledBack),
+                true,
+            );
+            let result = run_atomic_unit(
+                &access,
+                vec![
+                    effect_plan(id),
+                    rename_plan(Uuid::new_v4(), "missing", "missing-target"),
+                ],
+            )
+            .await
+            .expect("confirmed rollback recovers the recorded refusal");
+            assert_eq!(
+                result,
+                AtomicRunOutcome::RolledBack {
+                    failed_op_index: 1,
+                    failure: AtomicOpFailure::GuardFailed {
+                        statement_label: Some("missing-target".into()),
+                        expected: AffectedRowGuard::exactly(1),
+                        observed: 0,
+                    },
+                },
+            );
+            assert_eq!(*access.callback_result.lock().unwrap(), Some(false));
+            assert_eq!(entities_snapshot(&pool), before);
+        }
+
+        #[tokio::test]
+        async fn recorded_failure_does_not_mask_unknown_or_terminal_outcomes() {
+            for fault in [
+                Fault::Request(WriterTaskRequestState::SideEffectsUnknown),
+                Fault::Terminated(WriterTaskRequestState::SideEffectsUnknown),
+                Fault::Terminated(WriterTaskRequestState::TransactionRolledBack),
+            ] {
+                let pool = scratch_pool("recorded_uncertain");
+                seed_schema(&pool);
+                let id = Uuid::new_v4();
+                insert_entity(&pool, id, "original");
+                let before = entities_snapshot(&pool);
+                let access = fault_access(&pool, fault, true);
+                let error = run_atomic_unit(
+                    &access,
+                    vec![
+                        effect_plan(id),
+                        rename_plan(Uuid::new_v4(), "missing", "missing-target"),
+                    ],
+                )
+                .await
+                .expect_err("a recorded refusal cannot replace the outer outcome");
+                fault.assert_preserved(error.0);
+                assert_eq!(*access.callback_result.lock().unwrap(), Some(false));
+                assert_eq!(entities_snapshot(&pool), before);
+            }
+        }
+
+        #[tokio::test]
+        async fn failure_before_callback_cannot_manufacture_recorded_refusal() {
+            for fault in [
+                Fault::Request(WriterTaskRequestState::NotStarted),
+                Fault::Request(WriterTaskRequestState::TransactionRolledBack),
+                Fault::Terminated(WriterTaskRequestState::NotStarted),
+            ] {
+                let pool = scratch_pool("empty_failure_slot");
+                seed_schema(&pool);
+                let id = Uuid::new_v4();
+                insert_entity(&pool, id, "original");
+                let before = entities_snapshot(&pool);
+                let access = fault_access(&pool, fault, false);
+                let error = run_atomic_unit(&access, vec![effect_plan(id)])
+                    .await
+                    .expect_err("an empty slot must preserve the outer failure");
+                fault.assert_preserved(error.0);
+                assert_eq!(*access.callback_result.lock().unwrap(), None);
+                assert_eq!(entities_snapshot(&pool), before);
+            }
+        }
+
+        #[tokio::test]
+        async fn successful_callback_with_lost_acknowledgement_returns_no_commit_token() {
+            for fault in [
+                Fault::Request(WriterTaskRequestState::SideEffectsUnknown),
+                Fault::Terminated(WriterTaskRequestState::SideEffectsUnknown),
+            ] {
+                let pool = scratch_pool("committed_ack_lost");
+                seed_schema(&pool);
+                let id = Uuid::new_v4();
+                insert_entity(&pool, id, "original");
+                let access = fault_access(&pool, fault, true);
+                let error = run_atomic_unit(&access, vec![effect_plan(id)])
+                    .await
+                    .expect_err("callback success is not a committed-effects token");
+                fault.assert_preserved(error.0);
+                assert_eq!(*access.callback_result.lock().unwrap(), Some(true));
+                let writer = pool.try_writer().expect("writer");
+                let name: String = writer
+                    .conn()
+                    .query_row(
+                        "SELECT name FROM entities WHERE id=?1",
+                        rusqlite::params![id.to_string()],
+                        |row| row.get(0),
+                    )
+                    .expect("persisted write");
+                assert_eq!(
+                    name, "changed",
+                    "the lost acknowledgement does not imply rollback"
+                );
+            }
+        }
+    }
 }

--- a/crates/khive-runtime/src/atomic_runner.rs
+++ b/crates/khive-runtime/src/atomic_runner.rs
@@ -12,14 +12,14 @@
 //!
 //! # Safety: suspend-free invariant
 //!
-//! [`run_atomic_unit`] is the one place in this crate that builds an
-//! [`AtomicUnitOp`] closure for [`SqlAccess::atomic_unit`], whose contract
+//! [`run_prepared_atomic_unit`] owns the failure and commit protocol shared by
+//! the atomic-plan and stream-batch paths. It builds an [`AtomicUnitOp`]
+//! closure for [`SqlAccess::atomic_unit`], whose contract
 //! requires the closure's future to resolve on its first poll — synchronous
 //! DML against the provided `&mut dyn SqlWriter` only, never a suspending
-//! `.await`. Every statement driven here comes from
-//! `AtomicOpPlan::plan_statements`, which can only ever produce
-//! [`PlanStatement`]s (plain parameterized SQL), so no code path in this
-//! module can hand `atomic_unit` a suspending future. The paired
+//! `.await`. Prepared callbacks drive only parameterized statements, guards
+//! and stream-ledger reads through the provided writer. They must not perform
+//! asynchronous preparation or other I/O. The paired
 //! suspend-trap tests at the bottom of this file check both the happy-path
 //! (real commit pass resolves on first poll) and the misuse-is-caught case
 //! (a hand-built suspending closure fails loudly through the same seam). See
@@ -28,7 +28,7 @@
 use std::any::Any;
 use std::sync::{Arc, Mutex};
 
-use khive_storage::{AtomicUnitOp, SqlAccess, SqlStatement, SqlWriter, StorageError};
+use khive_storage::{AtomicUnitOp, BoxFuture, SqlAccess, SqlStatement, SqlWriter, StorageError};
 
 use crate::atomic_plan::{
     AddEntityPlan, AddNotePlan, AffectedRowGuard, DeletePlan, GovernancePlan, GtdCompletePlan,
@@ -152,7 +152,7 @@ pub enum AtomicOpFailure {
 
 /// Deferred effects whose owning atomic unit has committed successfully.
 ///
-/// Only this crate's atomic and stream-batch commit owners construct this token.
+/// Only the shared prepared-unit commit owner constructs this token.
 /// Consumers may inspect
 /// its effects through [`CommittedPostCommitEffects::as_slice`], while the
 /// phase-3 executor takes the token by value; no public API exposes the owned
@@ -177,7 +177,7 @@ pub struct CommittedPostCommitEffects {
 }
 
 impl CommittedPostCommitEffects {
-    pub(crate) fn new(effects: Vec<PostCommitEffect>) -> Self {
+    fn new(effects: Vec<PostCommitEffect>) -> Self {
         Self { effects }
     }
 
@@ -441,10 +441,7 @@ pub(crate) async fn run_atomic_unit_with_note_versions(
     plans: Vec<AtomicOpPlan>,
     capture_note_versions: bool,
 ) -> Result<(AtomicRunOutcome, Vec<i64>), AtomicRunnerError> {
-    let failure_slot: Arc<Mutex<Option<(usize, AtomicOpFailure)>>> = Arc::new(Mutex::new(None));
-    let failure_slot_for_closure = Arc::clone(&failure_slot);
-
-    let op: AtomicUnitOp = Box::new(move |writer| {
+    let op: PreparedAtomicOp<Vec<i64>, (usize, AtomicOpFailure)> = Box::new(move |writer| {
         Box::pin(async move {
             let mut post_commit = Vec::new();
             let mut note_versions = Vec::new();
@@ -471,50 +468,105 @@ pub(crate) async fn run_atomic_unit_with_note_versions(
                         // guarantee, only a diagnostic nicety.
                         let _ = rollback_to_savepoint(writer, &savepoint).await;
                         let _ = release_savepoint(writer, &savepoint).await;
-                        *failure_slot_for_closure
-                            .lock()
-                            .expect("atomic runner failure slot poisoned") =
-                            Some((op_index, failure));
-                        return Err(StorageError::Internal(format!(
-                            "ADR-099 atomic unit aborted at op {op_index}"
-                        )));
+                        return Err(PreparedAtomicError::Refused {
+                            failure: (op_index, failure),
+                            message: format!("ADR-099 atomic unit aborted at op {op_index}"),
+                        });
                     }
                 }
             }
-            Ok(Box::new((post_commit, note_versions)) as Box<dyn Any + Send>)
+            Ok((note_versions, post_commit))
         })
     });
 
+    match run_prepared_atomic_unit(access, op)
+        .await
+        .map_err(AtomicRunnerError)?
+    {
+        PreparedAtomicOutcome::Committed { value, post_commit } => {
+            Ok((AtomicRunOutcome::Committed { post_commit }, value))
+        }
+        PreparedAtomicOutcome::RolledBack((failed_op_index, failure)) => Ok((
+            AtomicRunOutcome::RolledBack {
+                failed_op_index,
+                failure,
+            },
+            Vec::new(),
+        )),
+    }
+}
+
+pub(crate) enum PreparedAtomicError<E> {
+    Refused { failure: E, message: String },
+    Storage(StorageError),
+}
+
+impl<E> From<StorageError> for PreparedAtomicError<E> {
+    fn from(error: StorageError) -> Self {
+        Self::Storage(error)
+    }
+}
+
+pub(crate) enum PreparedAtomicOutcome<T, E> {
+    Committed {
+        value: T,
+        post_commit: CommittedPostCommitEffects,
+    },
+    RolledBack(E),
+}
+
+pub(crate) type PreparedAtomicOp<T, E> = Box<
+    dyn for<'w> FnOnce(
+            &'w mut dyn SqlWriter,
+        )
+            -> BoxFuture<'w, Result<(T, Vec<PostCommitEffect>), PreparedAtomicError<E>>>
+        + Send,
+>;
+
+/// Recover a recorded refusal only after the storage owner proves rollback;
+/// effects become executable only after that same owner confirms commit.
+pub(crate) async fn run_prepared_atomic_unit<T: Send + 'static, E: Send + 'static>(
+    access: &dyn SqlAccess,
+    prepared: PreparedAtomicOp<T, E>,
+) -> Result<PreparedAtomicOutcome<T, E>, StorageError> {
+    let failure_slot = Arc::new(Mutex::new(None));
+    let recorded = Arc::clone(&failure_slot);
+    let op: AtomicUnitOp = Box::new(move |writer| {
+        Box::pin(async move {
+            match prepared(writer).await {
+                Ok(value) => Ok(Box::new(value) as Box<dyn Any + Send>),
+                Err(PreparedAtomicError::Storage(error)) => Err(error),
+                Err(PreparedAtomicError::Refused { failure, message }) => {
+                    *recorded
+                        .lock()
+                        .expect("atomic runner failure slot poisoned") = Some(failure);
+                    Err(StorageError::Internal(message))
+                }
+            }
+        })
+    });
     match access.atomic_unit(op).await {
         Ok(boxed) => {
-            let (post_commit, note_versions) = *boxed
-                .downcast::<(Vec<PostCommitEffect>, Vec<i64>)>()
-                .expect("atomic runner closure returns committed effects and note versions");
-            Ok((
-                AtomicRunOutcome::Committed {
-                    post_commit: CommittedPostCommitEffects::new(post_commit),
-                },
-                note_versions,
-            ))
+            let (value, effects) = *boxed
+                .downcast::<(T, Vec<PostCommitEffect>)>()
+                .map_err(|_| StorageError::Internal("invalid prepared atomic outcome".into()))?;
+            Ok(PreparedAtomicOutcome::Committed {
+                value,
+                post_commit: CommittedPostCommitEffects::new(effects),
+            })
         }
         Err(storage_err) => {
             // A recorded op failure does not prove the outer transaction rolled back.
             if !atomic_unit_error_allows_recorded_refusal(&storage_err) {
-                return Err(AtomicRunnerError(storage_err));
+                return Err(storage_err);
             }
             let recorded = failure_slot
                 .lock()
                 .expect("atomic runner failure slot poisoned")
                 .take();
             match recorded {
-                Some((failed_op_index, failure)) => Ok((
-                    AtomicRunOutcome::RolledBack {
-                        failed_op_index,
-                        failure,
-                    },
-                    Vec::new(),
-                )),
-                None => Err(AtomicRunnerError(storage_err)),
+                Some(failure) => Ok(PreparedAtomicOutcome::RolledBack(failure)),
+                None => Err(storage_err),
             }
         }
     }

--- a/crates/khive-runtime/src/retrieval.rs
+++ b/crates/khive-runtime/src/retrieval.rs
@@ -452,13 +452,40 @@ impl KhiveRuntime {
         model_name: &str,
         texts: &[String],
     ) -> RuntimeResult<Vec<DocumentEmbeddingOutcome>> {
+        self.embed_document_batch_with_model_outcomes_inner(None, model_name, texts)
+            .await
+    }
+
+    pub(crate) async fn embed_document_batch_with_model_outcomes_for_token(
+        &self,
+        token: &NamespaceToken,
+        model_name: &str,
+        texts: &[String],
+    ) -> RuntimeResult<Vec<DocumentEmbeddingOutcome>> {
+        self.embed_document_batch_with_model_outcomes_inner(Some(token), model_name, texts)
+            .await
+    }
+
+    async fn embed_document_batch_with_model_outcomes_inner(
+        &self,
+        token: Option<&NamespaceToken>,
+        model_name: &str,
+        texts: &[String],
+    ) -> RuntimeResult<Vec<DocumentEmbeddingOutcome>> {
         if texts.is_empty() {
             return Ok(vec![]);
         }
         let model = parse_embedding_model_alias(model_name);
-        let service = self.embedder(model_name).await?;
+        let service = match token {
+            Some(token) => self.embedder_with_token(token, model_name).await?,
+            None => self.embedder(model_name).await?,
+        };
         let emb_model = model.unwrap_or_default();
         let budget = document_embedding_budget(model_name);
+        if token.is_some() {
+            // Atomic preparation records issued work even if its task is cancelled.
+            crate::usage::count(crate::usage::UsageUnit::EmbedCalls, texts.len() as u64);
+        }
         let out = if texts.iter().all(|text| text.len() <= budget) {
             service.embed_passage(texts, emb_model).await
         } else {
@@ -468,7 +495,9 @@ impl KhiveRuntime {
                 .collect();
             service.embed_passage(&bounded_texts, emb_model).await
         };
-        crate::usage::count(crate::usage::UsageUnit::EmbedCalls, texts.len() as u64);
+        if token.is_none() {
+            crate::usage::count(crate::usage::UsageUnit::EmbedCalls, texts.len() as u64);
+        }
         let vectors = out?;
         if vectors.len() != texts.len() {
             return Err(RuntimeError::Internal(format!(

--- a/crates/khive-runtime/src/streams.rs
+++ b/crates/khive-runtime/src/streams.rs
@@ -3,7 +3,7 @@
 //! rows. A batch is that transaction over several members (atomic mode) or one
 //! such transaction per member, in list order (per-member mode).
 use std::any::Any;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use khive_storage::{
     AtomicUnitOp, Note, SqlAccess, SqlRow, SqlStatement, SqlValue, SqlWriter, StorageCapability,
@@ -14,7 +14,10 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 use uuid::Uuid;
 
-use crate::atomic_message::{prepare_atomic_notes, AtomicNoteOptions, AtomicNoteSpec};
+use crate::atomic_message::{
+    prepare_atomic_note_requests, prepare_atomic_notes, AtomicNoteOptions, AtomicNoteRequest,
+    AtomicNoteSpec,
+};
 use crate::atomic_plan::{PlanStatement, PostCommitEffect};
 use crate::atomic_runner::{
     apply_plan, run_prepared_atomic_unit, AtomicOpFailure, AtomicOpPlan,
@@ -192,6 +195,19 @@ struct StreamCreateFields {
     embed: Option<bool>,
 }
 
+struct PreparedStreamCreate {
+    key: String,
+    kind: String,
+    fields: StreamCreateFields,
+    args: Value,
+}
+
+enum StreamBatchPreparation {
+    Ready(Box<PreparedBatchAction>),
+    Append(Box<(StreamAppendSpec, String)>),
+    Create(Box<PreparedStreamCreate>),
+}
+
 fn batch_create_hooks(members: &[PreparedBatchMember]) -> Vec<(Uuid, String, Value)> {
     members
         .iter()
@@ -312,6 +328,7 @@ async fn run_prepared_stream_batch(
             }
             let mut results = Vec::with_capacity(members.len());
             let mut effects = Vec::new();
+            let mut heads = HashMap::new();
             // Member fences observe the transaction's initial state, even when
             // an earlier keyed write changes a fenced note in this batch.
             for member in &members {
@@ -335,7 +352,8 @@ async fn run_prepared_stream_batch(
                 }
             }
             for member in members {
-                let result = apply_stream_member(writer, &namespace, member.action).await;
+                let result =
+                    apply_stream_member(writer, &namespace, &mut heads, member.action).await;
                 match result {
                     Ok((value, effect)) => {
                         results.push(value);
@@ -408,6 +426,7 @@ async fn insert_stream_entry(
 async fn apply_stream_member(
     writer: &mut dyn SqlWriter,
     namespace: &str,
+    heads: &mut HashMap<String, i64>,
     action: PreparedBatchAction,
 ) -> RuntimeResult<(Value, Option<PostCommitEffect>)> {
     match action {
@@ -419,22 +438,27 @@ async fn apply_stream_member(
             plan,
             ..
         } => {
-            let head = writer.query_scalar(statement(
-                "SELECT COALESCE(MAX(seq), 0) FROM note_streams WHERE namespace=?1 AND stream=?2",
-                vec![SqlValue::Text(namespace.into()), SqlValue::Text(stream.clone())],
-            )).await?;
-            let Some(SqlValue::Integer(mut head)) = head else {
-                return Err(RuntimeError::Internal("invalid stream head".into()));
+            let head = match heads.entry(stream.clone()) {
+                std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    let head = writer.query_scalar(statement(
+                        "SELECT COALESCE(MAX(seq), 0) FROM note_streams WHERE namespace=?1 AND stream=?2",
+                        vec![SqlValue::Text(namespace.into()), SqlValue::Text(stream.clone())],
+                    )).await?;
+                    let Some(SqlValue::Integer(head)) = head else {
+                        return Err(RuntimeError::Internal("invalid stream head".into()));
+                    };
+                    entry.insert(head)
+                }
             };
-            let next =
-                allocate_sequence(&mut head, expected_seq).map_err(|refusal| match refusal {
-                    SequenceRefusal::Exhausted => {
-                        RuntimeError::InvalidInput("stream sequence exhausted".into())
-                    }
-                    SequenceRefusal::Conflict { expected, next } => {
-                        seq_conflict(&stream, expected, next, None).into()
-                    }
-                })?;
+            let next = allocate_sequence(head, expected_seq).map_err(|refusal| match refusal {
+                SequenceRefusal::Exhausted => {
+                    RuntimeError::InvalidInput("stream sequence exhausted".into())
+                }
+                SequenceRefusal::Conflict { expected, next } => {
+                    seq_conflict(&stream, expected, next, None).into()
+                }
+            })?;
             let applied = apply_plan(writer, &plan, false).await.map_err(|error| {
                 RuntimeError::Internal(format!("stream append plan failed: {error:?}"))
             })?;
@@ -458,15 +482,32 @@ async fn apply_stream_member(
             )),
             Err(AtomicOpFailure::NoteConflict(conflict)) => Err(conflict.into_error().into()),
             Err(AtomicOpFailure::GuardFailed { .. }) => {
-                let holder = writer.query_scalar(statement(
-                        "SELECT id FROM notes WHERE namespace=?1 AND kind=?2 AND key=?3 AND deleted_at IS NULL",
+                let holder = writer.query_row(statement(
+                        "SELECT id, version FROM notes WHERE namespace=?1 AND kind=?2 AND key=?3 AND deleted_at IS NULL",
                         vec![SqlValue::Text(namespace.into()), SqlValue::Text(kind), SqlValue::Text(key.clone())],
                     )).await?;
-                if holder.is_none() {
-                    Err(missing_write(&key).into())
-                } else {
-                    Err(crate::curation::stale_note_snapshot_error(id))
+                let Some(holder) = holder else {
+                    return Err(missing_write(&key).into());
+                };
+                // Versions are local to a note identity. A replacement can be
+                // at the expected version without being the prepared target.
+                if text(&holder, "id")? != id.to_string() {
+                    if let AtomicOpPlan::Update(update) = &plan {
+                        if let Some(expected) = update
+                            .note_guard
+                            .as_ref()
+                            .and_then(|guard| guard.expected_version)
+                        {
+                            return Err(NoteWriteConflict::Version {
+                                expected,
+                                current: integer(&holder, "version")?,
+                            }
+                            .into_error()
+                            .into());
+                        }
+                    }
                 }
+                Err(crate::curation::stale_note_snapshot_error(id))
             }
             Err(error) => Err(RuntimeError::Internal(format!(
                 "stream write plan failed: {error:?}"
@@ -721,7 +762,7 @@ impl KhiveRuntime {
         token: &NamespaceToken,
         spec: StreamWriteSpec,
         registry: &VerbRegistry,
-    ) -> RuntimeResult<PreparedBatchAction> {
+    ) -> RuntimeResult<StreamBatchPreparation> {
         let content = serde_json::to_string(&spec.doc)
             .map_err(|error| RuntimeError::InvalidInput(error.to_string()))?;
         if let Some(expected) = spec.expected_version {
@@ -733,7 +774,9 @@ impl KhiveRuntime {
                 Err(RuntimeError::Khive(error))
                     if error.kind() == khive_types::ErrorKind::NotFound =>
                 {
-                    return Ok(PreparedBatchAction::Refused(missing_write(&spec.key)));
+                    return Ok(StreamBatchPreparation::Ready(Box::new(
+                        PreparedBatchAction::Refused(missing_write(&spec.key)),
+                    )));
                 }
                 Err(error) => return Err(error),
             };
@@ -760,14 +803,16 @@ impl KhiveRuntime {
                 self, token, &args, None, snapshot,
             )
             .await?;
-            return Ok(PreparedBatchAction::Write {
-                key: spec.key,
-                kind: spec.kind,
-                id,
-                version,
-                plan,
-                after_create: None,
-            });
+            return Ok(StreamBatchPreparation::Ready(Box::new(
+                PreparedBatchAction::Write {
+                    key: spec.key,
+                    kind: spec.kind,
+                    id,
+                    version,
+                    plan,
+                    after_create: None,
+                },
+            )));
         }
         let mut args = json!({
             "kind": "note", "note_kind": spec.kind, "key": spec.key,
@@ -784,7 +829,7 @@ impl KhiveRuntime {
         }
         let mut fields: StreamCreateFields = serde_json::from_value(args.clone())
             .map_err(|error| RuntimeError::InvalidInput(format!("stream write fields: {error}")))?;
-        if let Some(tags) = fields.tags.filter(|tags| !tags.is_empty()) {
+        if let Some(tags) = fields.tags.take().filter(|tags| !tags.is_empty()) {
             let mut properties = match fields.properties.take() {
                 None => serde_json::Map::new(),
                 Some(Value::Object(properties)) => properties,
@@ -801,45 +846,14 @@ impl KhiveRuntime {
         candidate.name = fields.name.clone();
         candidate.properties = fields.properties.clone();
         crate::note_write::validate_head(&candidate)?;
-        let (mut prepared, _) = crate::note_create::prepare_note_create(
-            self,
-            AtomicNoteSpec {
-                token,
-                id: None,
-                kind: &spec.kind,
-                name: fields.name.as_deref(),
-                content: &fields.content,
-                properties: fields.properties,
+        Ok(StreamBatchPreparation::Create(Box::new(
+            PreparedStreamCreate {
+                key: spec.key,
+                kind: spec.kind,
+                fields,
+                args,
             },
-            AtomicNoteOptions {
-                salience: fields.salience,
-                key: Some(&spec.key),
-                embed: Some(fields.embed.unwrap_or(spec.kind != "head")),
-                ..Default::default()
-            },
-            &[],
-            crate::note_create::KeyPublication::AtInsert,
-        )
-        .await?;
-        let note = prepared.notes.remove(0);
-        let mut plan = prepared.plans.remove(0);
-        let AtomicOpPlan::AddNote(add) = &mut plan else {
-            return Err(RuntimeError::Internal(
-                "stream keyed create did not prepare a note".into(),
-            ));
-        };
-        add.post_commit = PostCommitEffect::NoteChanged {
-            note_id: note.id,
-            kind: note.kind.clone(),
-        };
-        Ok(PreparedBatchAction::Write {
-            key: spec.key,
-            kind: spec.kind,
-            id: note.id,
-            version: note.version,
-            plan,
-            after_create: Some(args),
-        })
+        )))
     }
 
     async fn prepare_stream_batch(
@@ -848,55 +862,104 @@ impl KhiveRuntime {
         members: Vec<StreamBatchMember>,
         registry: &VerbRegistry,
     ) -> RuntimeResult<Vec<PreparedBatchMember>> {
-        let appends: Vec<_> = members
-            .iter()
-            .filter_map(|member| match member {
-                StreamBatchMember::Append(spec) => Some(spec),
-                _ => None,
-            })
-            .collect();
-        let contents: Vec<_> = appends
-            .iter()
-            .map(|spec| serde_json::to_string(&spec.record))
-            .collect::<Result<_, _>>()
-            .map_err(|error| RuntimeError::InvalidInput(error.to_string()))?;
-        let append_specs = appends
-            .iter()
-            .zip(&contents)
-            .map(|(spec, content)| AtomicNoteSpec {
-                token,
-                id: None,
-                kind: &spec.note_kind,
-                name: None,
-                content,
-                properties: spec.tags.clone().map(|tags| json!({"tags": tags})),
-            })
-            .collect();
-        let notes = prepare_atomic_notes(self, append_specs, AtomicNoteOptions::default()).await?;
-        let mut append_plans = notes.notes.into_iter().zip(notes.plans);
-        let mut prepared = Vec::with_capacity(members.len());
-        for (index, member) in members.into_iter().enumerate() {
+        let mut pending = Vec::with_capacity(members.len());
+        for member in members {
             let action = match member {
-                StreamBatchMember::Refused(error) => PreparedBatchAction::Refused(error),
+                StreamBatchMember::Refused(error) => {
+                    StreamBatchPreparation::Ready(Box::new(PreparedBatchAction::Refused(error)))
+                }
                 StreamBatchMember::Write(spec) => {
                     match self.prepare_stream_write(token, spec, registry).await {
                         Ok(action) => action,
                         Err(RuntimeError::Khive(error))
                             if error.kind() == khive_types::ErrorKind::Conflict =>
                         {
-                            PreparedBatchAction::Refused(error)
+                            StreamBatchPreparation::Ready(Box::new(PreparedBatchAction::Refused(
+                                error,
+                            )))
                         }
                         Err(error) => return Err(error),
                     }
                 }
                 StreamBatchMember::Append(spec) => {
-                    let (note, plan) = append_plans.next().expect("one plan per append");
+                    let content = serde_json::to_string(&spec.record)
+                        .map_err(|error| RuntimeError::InvalidInput(error.to_string()))?;
+                    StreamBatchPreparation::Append(Box::new((spec, content)))
+                }
+            };
+            pending.push(action);
+        }
+        let requests = pending
+            .iter()
+            .filter_map(|action| match action {
+                StreamBatchPreparation::Ready(_) => None,
+                StreamBatchPreparation::Append(append) => {
+                    let (spec, content) = append.as_ref();
+                    Some(AtomicNoteRequest {
+                        spec: AtomicNoteSpec {
+                            token,
+                            id: None,
+                            kind: &spec.note_kind,
+                            name: None,
+                            content,
+                            properties: spec.tags.clone().map(|tags| json!({"tags": tags})),
+                        },
+                        options: AtomicNoteOptions::default(),
+                    })
+                }
+                StreamBatchPreparation::Create(create) => Some(AtomicNoteRequest {
+                    spec: AtomicNoteSpec {
+                        token,
+                        id: None,
+                        kind: &create.kind,
+                        name: create.fields.name.as_deref(),
+                        content: &create.fields.content,
+                        properties: create.fields.properties.clone(),
+                    },
+                    options: AtomicNoteOptions {
+                        salience: create.fields.salience,
+                        key: Some(&create.key),
+                        embed: Some(create.fields.embed.unwrap_or(create.kind != "head")),
+                        ..Default::default()
+                    },
+                }),
+            })
+            .collect();
+        let notes = prepare_atomic_note_requests(self, requests).await?;
+        let mut note_plans = notes.notes.into_iter().zip(notes.plans);
+        let mut prepared = Vec::with_capacity(pending.len());
+        for (index, pending) in pending.into_iter().enumerate() {
+            let action = match pending {
+                StreamBatchPreparation::Ready(action) => *action,
+                StreamBatchPreparation::Append(append) => {
+                    let (spec, _) = *append;
+                    let (note, plan) = note_plans.next().expect("one plan per new note");
                     PreparedBatchAction::Append {
                         stream: spec.stream,
                         expected_seq: spec.expected_seq,
                         note: Box::new(note),
                         plan,
                         fence: spec.fence,
+                    }
+                }
+                StreamBatchPreparation::Create(create) => {
+                    let (note, mut plan) = note_plans.next().expect("one plan per new note");
+                    let AtomicOpPlan::AddNote(add) = &mut plan else {
+                        return Err(RuntimeError::Internal(
+                            "stream keyed create did not prepare a note".into(),
+                        ));
+                    };
+                    add.post_commit = PostCommitEffect::NoteChanged {
+                        note_id: note.id,
+                        kind: note.kind.clone(),
+                    };
+                    PreparedBatchAction::Write {
+                        key: create.key,
+                        kind: create.kind,
+                        id: note.id,
+                        version: note.version,
+                        plan,
+                        after_create: Some(create.args),
                     }
                 }
             };

--- a/crates/khive-runtime/src/streams.rs
+++ b/crates/khive-runtime/src/streams.rs
@@ -4,7 +4,6 @@
 //! such transaction per member, in list order (per-member mode).
 use std::any::Any;
 use std::collections::HashSet;
-use std::sync::{Arc, Mutex};
 
 use khive_storage::{
     AtomicUnitOp, Note, SqlAccess, SqlRow, SqlStatement, SqlValue, SqlWriter, StorageCapability,
@@ -18,8 +17,8 @@ use uuid::Uuid;
 use crate::atomic_message::{prepare_atomic_notes, AtomicNoteOptions, AtomicNoteSpec};
 use crate::atomic_plan::{PlanStatement, PostCommitEffect};
 use crate::atomic_runner::{
-    apply_plan, atomic_unit_error_allows_recorded_refusal, AtomicOpFailure, AtomicOpPlan,
-    CommittedPostCommitEffects,
+    apply_plan, run_prepared_atomic_unit, AtomicOpFailure, AtomicOpPlan,
+    CommittedPostCommitEffects, PreparedAtomicError, PreparedAtomicOp, PreparedAtomicOutcome,
 };
 use crate::note_write::{
     NoteFence, NoteFences, NoteWriteConflict, NoteWriteGuard, NoteWriteOptions,
@@ -288,9 +287,7 @@ async fn run_prepared_stream_batch(
     fence: Option<NoteFence>,
     observed: Vec<StreamObservation>,
 ) -> RuntimeResult<Result<(Vec<Value>, CommittedPostCommitEffects), StreamBatchRefusal>> {
-    let failure = Arc::new(Mutex::new(None::<BatchFailure>));
-    let recorded = Arc::clone(&failure);
-    let op: AtomicUnitOp = Box::new(move |writer| {
+    let op: PreparedAtomicOp<Vec<Value>, BatchFailure> = Box::new(move |writer| {
         Box::pin(async move {
             let guard = NoteWriteGuard {
                 namespace: namespace.clone(),
@@ -305,13 +302,13 @@ async fn run_prepared_stream_batch(
                 check_observed(writer, &namespace, &observed).await?
             };
             if let Some(error) = predicate_error {
-                *recorded.lock().expect("stream failure slot") = Some(BatchFailure {
-                    member: None,
-                    error: error.into(),
+                return Err(PreparedAtomicError::Refused {
+                    failure: BatchFailure {
+                        member: None,
+                        error: error.into(),
+                    },
+                    message: "stream batch predicate refused".into(),
                 });
-                return Err(StorageError::Internal(
-                    "stream batch predicate refused".into(),
-                ));
             }
             let mut results = Vec::with_capacity(members.len());
             let mut effects = Vec::new();
@@ -327,11 +324,13 @@ async fn run_prepared_stream_batch(
                         create_key: None,
                     };
                     if let Some(conflict) = guard.check_fence(writer).await? {
-                        *recorded.lock().expect("stream failure slot") = Some(BatchFailure {
-                            member: Some(member.index),
-                            error: conflict.into_error().into(),
+                        return Err(PreparedAtomicError::Refused {
+                            failure: BatchFailure {
+                                member: Some(member.index),
+                                error: conflict.into_error().into(),
+                            },
+                            message: "stream append fence refused".into(),
                         });
-                        return Err(StorageError::Internal("stream append fence refused".into()));
                     }
                 }
             }
@@ -345,42 +344,65 @@ async fn run_prepared_stream_batch(
                         }
                     }
                     Err(error) => {
-                        *recorded.lock().expect("stream failure slot") = Some(BatchFailure {
-                            member: Some(member.index),
-                            error,
+                        return Err(PreparedAtomicError::Refused {
+                            failure: BatchFailure {
+                                member: Some(member.index),
+                                error,
+                            },
+                            message: "stream batch member refused".into(),
                         });
-                        return Err(StorageError::Internal("stream batch member refused".into()));
                     }
                 }
             }
-            Ok(Box::new((results, effects)) as Box<dyn Any + Send>)
+            Ok((results, effects))
         })
     });
-    match access.atomic_unit(op).await {
-        Ok(payload) => {
-            let (results, effects) = *payload
-                .downcast::<(Vec<Value>, Vec<PostCommitEffect>)>()
-                .map_err(|_| RuntimeError::Internal("invalid stream batch outcome".into()))?;
-            Ok(Ok((results, CommittedPostCommitEffects::new(effects))))
-        }
-        Err(error) => {
-            if !atomic_unit_error_allows_recorded_refusal(&error) {
-                return Err(error.into());
-            }
-            let recorded = failure.lock().expect("stream failure slot").take();
-            match recorded {
-                Some(BatchFailure {
-                    member: Some(member),
-                    error: RuntimeError::Khive(error),
-                }) => Ok(Err(StreamBatchRefusal {
-                    member,
-                    error: place_member(error, Some(member))?,
-                })),
-                Some(BatchFailure { error, .. }) => Err(error),
-                None => Err(error.into()),
-            }
-        }
+    match run_prepared_atomic_unit(access, op).await? {
+        PreparedAtomicOutcome::Committed { value, post_commit } => Ok(Ok((value, post_commit))),
+        PreparedAtomicOutcome::RolledBack(BatchFailure {
+            member: Some(member),
+            error: RuntimeError::Khive(error),
+        }) => Ok(Err(StreamBatchRefusal {
+            member,
+            error: place_member(error, Some(member))?,
+        })),
+        PreparedAtomicOutcome::RolledBack(BatchFailure { error, .. }) => Err(error),
     }
+}
+
+enum SequenceRefusal {
+    Exhausted,
+    Conflict { expected: i64, next: i64 },
+}
+
+fn allocate_sequence(head: &mut i64, expected: Option<i64>) -> Result<i64, SequenceRefusal> {
+    let next = head.checked_add(1).ok_or(SequenceRefusal::Exhausted)?;
+    if let Some(expected) = expected.filter(|expected| *expected != next) {
+        return Err(SequenceRefusal::Conflict { expected, next });
+    }
+    *head = next;
+    Ok(next)
+}
+
+async fn insert_stream_entry(
+    writer: &mut dyn SqlWriter,
+    namespace: &str,
+    stream: String,
+    seq: i64,
+    note_id: String,
+) -> Result<(), StorageError> {
+    writer
+        .execute(statement(
+            "INSERT INTO note_streams(namespace,stream,seq,note_id) VALUES (?1,?2,?3,?4)",
+            vec![
+                SqlValue::Text(namespace.into()),
+                SqlValue::Text(stream),
+                SqlValue::Integer(seq),
+                SqlValue::Text(note_id),
+            ],
+        ))
+        .await?;
+    Ok(())
 }
 
 async fn apply_stream_member(
@@ -401,29 +423,22 @@ async fn apply_stream_member(
                 "SELECT COALESCE(MAX(seq), 0) FROM note_streams WHERE namespace=?1 AND stream=?2",
                 vec![SqlValue::Text(namespace.into()), SqlValue::Text(stream.clone())],
             )).await?;
-            let Some(SqlValue::Integer(head)) = head else {
+            let Some(SqlValue::Integer(mut head)) = head else {
                 return Err(RuntimeError::Internal("invalid stream head".into()));
             };
-            let next = head
-                .checked_add(1)
-                .ok_or_else(|| RuntimeError::InvalidInput("stream sequence exhausted".into()))?;
-            if let Some(expected) = expected_seq.filter(|expected| *expected != next) {
-                return Err(seq_conflict(&stream, expected, next, None).into());
-            }
+            let next =
+                allocate_sequence(&mut head, expected_seq).map_err(|refusal| match refusal {
+                    SequenceRefusal::Exhausted => {
+                        RuntimeError::InvalidInput("stream sequence exhausted".into())
+                    }
+                    SequenceRefusal::Conflict { expected, next } => {
+                        seq_conflict(&stream, expected, next, None).into()
+                    }
+                })?;
             let applied = apply_plan(writer, &plan, false).await.map_err(|error| {
                 RuntimeError::Internal(format!("stream append plan failed: {error:?}"))
             })?;
-            writer
-                .execute(statement(
-                    "INSERT INTO note_streams(namespace,stream,seq,note_id) VALUES (?1,?2,?3,?4)",
-                    vec![
-                        SqlValue::Text(namespace.into()),
-                        SqlValue::Text(stream),
-                        SqlValue::Integer(next),
-                        SqlValue::Text(note.id.to_string()),
-                    ],
-                ))
-                .await?;
+            insert_stream_entry(writer, namespace, stream, next, note.id.to_string()).await?;
             Ok((
                 json!({"seq": next, "id": note.id, "created_at": micros_to_iso(note.created_at)}),
                 applied.effect,
@@ -570,13 +585,17 @@ impl KhiveRuntime {
                         .find(|(known, _)| known == stream)
                         .map(|(_, head)| head)
                         .ok_or_else(|| write_failure("stream head missing"))?;
-                    let next = head
-                        .checked_add(1)
-                        .ok_or_else(|| write_failure("stream sequence exhausted"))?;
-                    if expected_seq.is_some_and(|expected| expected != next) {
-                        return Ok(Box::new(BatchOutcome::Conflict { next }) as Box<dyn Any + Send>);
-                    }
-                    *head = next;
+                    let next = match allocate_sequence(head, *expected_seq) {
+                        Ok(next) => next,
+                        Err(SequenceRefusal::Exhausted) => {
+                            return Err(write_failure("stream sequence exhausted"));
+                        }
+                        Err(SequenceRefusal::Conflict { next, .. }) => {
+                            return Ok(
+                                Box::new(BatchOutcome::Conflict { next }) as Box<dyn Any + Send>
+                            );
+                        }
+                    };
                     assigned.push(next);
                 }
                 for ((stream, _, note_id, statements, _), seq) in
@@ -591,17 +610,7 @@ impl KhiveRuntime {
                             return Err(write_failure("prepared note write guard failed"));
                         }
                     }
-                    writer
-                        .execute(statement(
-                            "INSERT INTO note_streams(namespace,stream,seq,note_id) VALUES (?1,?2,?3,?4)",
-                            vec![
-                                SqlValue::Text(ns.clone()),
-                                SqlValue::Text(stream),
-                                SqlValue::Integer(seq),
-                                SqlValue::Text(note_id),
-                            ],
-                        ))
-                        .await?;
+                    insert_stream_entry(writer, &ns, stream, seq, note_id).await?;
                 }
                 Ok(Box::new(BatchOutcome::Appended(assigned)) as Box<dyn Any + Send>)
             })

--- a/crates/khive-runtime/src/streams_batch_tests.rs
+++ b/crates/khive-runtime/src/streams_batch_tests.rs
@@ -1,8 +1,9 @@
 use super::*;
 use async_trait::async_trait;
-use khive_storage::{SqlReader, StorageResult};
+use khive_storage::{SqlReader, StorageError, StorageResult, WriterTaskRequestState};
 use khive_types::{HandlerDef, Namespace, Pack};
 use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService};
+use std::sync::{Arc, Mutex};
 
 use crate::embedder_registry::EmbedderProvider;
 use crate::pack::{KindHook, PackRuntime, VerbRegistryBuilder};
@@ -40,6 +41,41 @@ impl EmbedderProvider for Provider {
     }
     async fn build(&self) -> RuntimeResult<Arc<dyn EmbeddingService>> {
         Ok(Arc::new(Service))
+    }
+}
+
+struct CountingService(Arc<Mutex<Vec<Vec<String>>>>);
+
+#[async_trait]
+impl EmbeddingService for CountingService {
+    async fn embed(
+        &self,
+        texts: &[String],
+        _: EmbeddingModel,
+    ) -> Result<Vec<Vec<f32>>, EmbedError> {
+        self.0.lock().unwrap().push(texts.to_vec());
+        Ok(texts.iter().map(|_| vec![0.5; 4]).collect())
+    }
+    fn supports_model(&self, _: EmbeddingModel) -> bool {
+        true
+    }
+    fn name(&self) -> &'static str {
+        MODEL
+    }
+}
+
+struct CountingProvider(Arc<Mutex<Vec<Vec<String>>>>);
+
+#[async_trait]
+impl EmbedderProvider for CountingProvider {
+    fn name(&self) -> &str {
+        MODEL
+    }
+    fn dimensions(&self) -> usize {
+        4
+    }
+    async fn build(&self) -> RuntimeResult<Arc<dyn EmbeddingService>> {
+        Ok(Arc::new(CountingService(self.0.clone())))
     }
 }
 
@@ -112,6 +148,85 @@ async fn vectors(runtime: &KhiveRuntime, token: &NamespaceToken) -> u64 {
         .count()
         .await
         .unwrap()
+}
+
+#[tokio::test]
+async fn stream_batch_embeds_distinct_appends_and_eligible_creates_in_one_call() {
+    let runtime = KhiveRuntime::memory().unwrap();
+    runtime.install_kind_registry(vec![], vec!["head".into(), "observation".into()]);
+    let token = runtime.authorize(Namespace::local()).unwrap();
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    runtime.register_embedder(CountingProvider(calls.clone()));
+    runtime.embedder_with_token(&token, MODEL).await.unwrap();
+    let registry = VerbRegistryBuilder::new().build().unwrap();
+    let mut members = vec![append("embedding", None)];
+    for (key, kind, embed) in [
+        ("first", "observation", None),
+        ("second", "observation", None),
+        ("explicit-on", "head", Some(true)),
+        ("default-off", "head", None),
+        ("explicit-off", "observation", Some(false)),
+    ] {
+        let mut spec = write(key, None);
+        spec.kind = kind.into();
+        spec.doc = json!({"marker": key});
+        spec.embed = embed;
+        members.push(StreamBatchMember::Write(spec));
+    }
+    let prepared = runtime
+        .prepare_stream_batch(&token, members, &registry)
+        .await
+        .unwrap();
+    {
+        let calls = calls.lock().unwrap();
+        assert_eq!(
+            calls.len(),
+            1,
+            "one provider request for the complete eligible create set"
+        );
+        assert_eq!(calls[0].len(), 4);
+        assert_eq!(calls[0].iter().collect::<HashSet<_>>().len(), 4);
+        for doc in [
+            json!({"event": "batch"}),
+            json!({"marker": "first"}),
+            json!({"marker": "second"}),
+            json!({"marker": "explicit-on"}),
+        ] {
+            let text = serde_json::to_string(&doc).unwrap();
+            assert!(
+                calls[0].iter().any(|input| input.contains(&text)),
+                "missing document {text:?}"
+            );
+        }
+        assert!(calls[0]
+            .iter()
+            .all(|input| !input.contains("default-off") && !input.contains("explicit-off")));
+    }
+    assert_eq!(
+        vectors(&runtime, &token).await,
+        0,
+        "preparation must not insert vectors"
+    );
+    let (values, effects) = run_prepared_stream_batch(
+        runtime.sql().as_ref(),
+        token.namespace().as_str().into(),
+        prepared,
+        None,
+        vec![],
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert_eq!(values.len(), 6);
+    assert_eq!(values[0]["seq"], 1);
+    for value in &values[1..] {
+        assert_eq!(value["version"], 1);
+    }
+    crate::atomic_prepare::apply_post_commit_effects_with_report(&runtime, &token, effects)
+        .await
+        .unwrap();
+    assert_eq!(vectors(&runtime, &token).await, 4);
+    assert_eq!(calls.lock().unwrap().len(), 1);
 }
 
 #[tokio::test]
@@ -349,6 +464,307 @@ fn file_fixture() -> (
     )
 }
 
+async fn stream_store_snapshot(runtime: &KhiveRuntime) -> Value {
+    let mut reader = runtime.sql().reader().await.unwrap();
+    let mut snapshot = serde_json::Map::new();
+    for (table, order) in [
+        ("notes", "id"),
+        ("notes_seq", "seq"),
+        ("note_streams", "namespace, stream, seq"),
+        ("events", "id"),
+        ("fts_notes", "rowid"),
+        ("fts_notes_rowids", "rowid"),
+        ("fts_notes_rowids_state", "key"),
+        ("ann_write_log", "rowid"),
+        ("sqlite_sequence", "name"),
+    ] {
+        let rows = reader
+            .query_all(statement(
+                &format!("SELECT * FROM {table} ORDER BY {order}"),
+                vec![],
+            ))
+            .await
+            .unwrap();
+        snapshot.insert(table.into(), serde_json::to_value(rows).unwrap());
+    }
+    Value::Object(snapshot)
+}
+
+#[tokio::test]
+async fn stream_batch_recreated_key_between_prepare_and_commit_is_version_conflict() {
+    for replacement in [None, Some(false), Some(true)] {
+        let (_dir, runtime, peer, token, registry) = file_fixture();
+        let peer_token = peer.authorize(Namespace::local()).unwrap();
+        let first = batch_write(&runtime, &token, &registry, write("target", None)).await;
+        let first_id = Uuid::parse_str(first["id"].as_str().unwrap()).unwrap();
+        let fired = Arc::new(Mutex::new(Vec::new()));
+        let hook_fired = fired.clone();
+        runtime.install_note_mutation_hook(Arc::new(move |kind: String, id: Uuid| {
+            let fired = hook_fired.clone();
+            Box::pin(async move { fired.lock().unwrap().push((kind, id)) })
+        }));
+        let prepared = runtime
+            .prepare_stream_batch(
+                &token,
+                vec![
+                    StreamBatchMember::Write(write("candidate", None)),
+                    append("recreated", None),
+                    StreamBatchMember::Write(write("target", Some(1))),
+                    append("recreated", None),
+                ],
+                &registry,
+            )
+            .await
+            .unwrap();
+        if let Some(hard) = replacement {
+            // The old identity disappears after preparation; its replacement has
+            // the same version, so comparing only versions cannot detect this race.
+            assert!(peer.delete_note(&peer_token, first_id, hard).await.unwrap());
+            let mut recreated = write("target", None);
+            recreated.doc = json!({"replacement": true});
+            let holder = batch_write(&peer, &peer_token, &registry, recreated).await;
+            assert_ne!(holder["id"], first["id"]);
+            assert_eq!(holder["version"], 1);
+        }
+        let holder_before = runtime
+            .get_note_by_key(&token, "target", Some("head"), false)
+            .await
+            .unwrap();
+        let baseline = stream_store_snapshot(&runtime).await;
+        let outcome = run_prepared_stream_batch(
+            runtime.sql().as_ref(),
+            token.namespace().as_str().into(),
+            prepared,
+            None,
+            vec![],
+        )
+        .await
+        .unwrap();
+        if replacement.is_some() {
+            let refusal = outcome
+                .err()
+                .expect("a recreated holder refuses the stale plan");
+            assert_eq!(refusal.member, 2);
+            let error = serde_json::to_value(refusal.error).unwrap();
+            assert_eq!(error["kind"], "conflict");
+            assert_eq!(error["details"]["reason"], "version_conflict");
+            assert_eq!(error["details"]["member"], "2");
+            assert_eq!(error["details"]["expected_version"], "1");
+            assert_eq!(error["details"]["current_version"], "1");
+            assert_eq!(stream_store_snapshot(&runtime).await, baseline);
+            assert_eq!(
+                runtime
+                    .get_note_by_key(&token, "target", Some("head"), false)
+                    .await
+                    .unwrap(),
+                holder_before,
+            );
+            assert_eq!(
+                runtime.stream_stat(&token, "recreated").await.unwrap()["count"],
+                0
+            );
+            assert!(fired.lock().unwrap().is_empty());
+        } else {
+            let (values, effects) = outcome.ok().expect("an unchanged holder commits");
+            assert_eq!(values[2]["id"], first["id"]);
+            assert_eq!(values[2]["version"], 2);
+            assert_eq!(values[1]["seq"], 1);
+            assert_eq!(values[3]["seq"], 2);
+            assert!(!effects.as_slice().is_empty());
+            assert!(fired.lock().unwrap().is_empty());
+            crate::atomic_prepare::apply_post_commit_effects_with_report(&runtime, &token, effects)
+                .await
+                .unwrap();
+            assert!(fired.lock().unwrap().iter().any(|(_, id)| *id == first_id));
+            assert_eq!(
+                runtime.stream_stat(&token, "recreated").await.unwrap()["count"],
+                2
+            );
+        }
+    }
+}
+
+struct OutcomeAccess {
+    inner: Arc<dyn SqlAccess>,
+    invoke: bool,
+    expect_success: bool,
+    terminate: bool,
+    state: WriterTaskRequestState,
+    callback: Arc<Mutex<Option<bool>>>,
+}
+
+#[async_trait]
+impl SqlAccess for OutcomeAccess {
+    async fn reader(&self) -> StorageResult<Box<dyn SqlReader>> {
+        self.inner.reader().await
+    }
+    async fn writer(&self) -> StorageResult<Box<dyn SqlWriter>> {
+        self.inner.writer().await
+    }
+    async fn atomic_unit(&self, op: AtomicUnitOp) -> StorageResult<Box<dyn Any + Send>> {
+        if self.invoke {
+            let callback = self.callback.clone();
+            let traced: AtomicUnitOp = Box::new(move |writer| {
+                Box::pin(async move {
+                    let outcome = op(writer).await;
+                    *callback.lock().unwrap() = Some(outcome.is_ok());
+                    outcome
+                })
+            });
+            let outcome = self.inner.atomic_unit(traced).await;
+            assert_eq!(outcome.is_ok(), self.expect_success);
+        }
+        if self.terminate {
+            Err(StorageError::WriterTaskTerminated {
+                request_state: self.state,
+            })
+        } else {
+            Err(StorageError::WriterTaskRequestFailed {
+                request_state: self.state,
+                source: Box::new(StorageError::Pool {
+                    operation: "stream_test_ack".into(),
+                    message: "injected acknowledgment failure".into(),
+                }),
+            })
+        }
+    }
+}
+
+#[tokio::test]
+async fn stream_batch_recovers_failure_slot_only_after_confirmed_rollback() {
+    use WriterTaskRequestState::{NotStarted, SideEffectsUnknown, TransactionRolledBack};
+    for (invoke, terminate, state) in [
+        (true, false, TransactionRolledBack),
+        (true, false, SideEffectsUnknown),
+        (true, true, SideEffectsUnknown),
+        (true, true, TransactionRolledBack),
+        (false, false, NotStarted),
+        (false, false, TransactionRolledBack),
+    ] {
+        let (_dir, runtime, _peer, token, registry) = file_fixture();
+        let prepared = runtime
+            .prepare_stream_batch(
+                &token,
+                vec![
+                    StreamBatchMember::Write(write("candidate", None)),
+                    append("refused", Some(9)),
+                ],
+                &registry,
+            )
+            .await
+            .unwrap();
+        let baseline = stream_store_snapshot(&runtime).await;
+        let callback = Arc::new(Mutex::new(None));
+        let access = OutcomeAccess {
+            inner: runtime.sql(),
+            invoke,
+            expect_success: false,
+            terminate,
+            state,
+            callback: callback.clone(),
+        };
+        let outcome = run_prepared_stream_batch(
+            &access,
+            token.namespace().as_str().into(),
+            prepared,
+            None,
+            vec![],
+        )
+        .await;
+        assert_eq!(*callback.lock().unwrap(), invoke.then_some(false));
+        if invoke && !terminate && state == TransactionRolledBack {
+            let refusal = outcome
+                .unwrap()
+                .err()
+                .expect("recover the recorded member failure");
+            assert_eq!(refusal.member, 1);
+            let error = serde_json::to_value(refusal.error).unwrap();
+            assert_eq!(error["details"]["reason"], "seq_conflict");
+            assert_eq!(error["details"]["member"], "1");
+            assert_eq!(error["details"]["next_seq"], "1");
+        } else {
+            match outcome.err().expect("preserve the outer storage failure") {
+                RuntimeError::Storage(StorageError::WriterTaskTerminated { request_state }) => {
+                    assert!(terminate);
+                    assert_eq!(request_state, state);
+                }
+                RuntimeError::Storage(StorageError::WriterTaskRequestFailed {
+                    request_state,
+                    source,
+                }) => {
+                    assert!(!terminate);
+                    assert_eq!(request_state, state);
+                    assert!(
+                        matches!(*source, StorageError::Pool { operation, .. } if operation == "stream_test_ack")
+                    );
+                }
+                error => panic!("unexpected storage outcome: {error:?}"),
+            }
+        }
+        assert_eq!(stream_store_snapshot(&runtime).await, baseline);
+    }
+}
+
+#[tokio::test]
+async fn stream_batch_commit_ack_failure_returns_no_executable_effects() {
+    let (_dir, runtime, _peer, token, registry) = file_fixture();
+    let fired = Arc::new(Mutex::new(Vec::new()));
+    let hook_fired = fired.clone();
+    runtime.install_note_mutation_hook(Arc::new(move |kind: String, id: Uuid| {
+        let fired = hook_fired.clone();
+        Box::pin(async move { fired.lock().unwrap().push((kind, id)) })
+    }));
+    let prepared = runtime
+        .prepare_stream_batch(
+            &token,
+            vec![
+                StreamBatchMember::Write(write("acknowledgment", None)),
+                append("acknowledgment", None),
+            ],
+            &registry,
+        )
+        .await
+        .unwrap();
+    let callback = Arc::new(Mutex::new(None));
+    let access = OutcomeAccess {
+        inner: runtime.sql(),
+        invoke: true,
+        expect_success: true,
+        terminate: true,
+        state: WriterTaskRequestState::SideEffectsUnknown,
+        callback: callback.clone(),
+    };
+    let outcome = run_prepared_stream_batch(
+        &access,
+        token.namespace().as_str().into(),
+        prepared,
+        None,
+        vec![],
+    )
+    .await;
+    assert!(matches!(
+        outcome,
+        Err(RuntimeError::Storage(StorageError::WriterTaskTerminated {
+            request_state: WriterTaskRequestState::SideEffectsUnknown,
+        }))
+    ));
+    assert_eq!(*callback.lock().unwrap(), Some(true));
+    assert!(fired.lock().unwrap().is_empty());
+    // The injected error loses the acknowledgment, not the committed writes.
+    assert_eq!(
+        runtime.stream_stat(&token, "acknowledgment").await.unwrap()["count"],
+        1
+    );
+    assert_eq!(
+        runtime
+            .get_note_by_key(&token, "acknowledgment", Some("head"), false)
+            .await
+            .unwrap()
+            .version,
+        1
+    );
+}
+
 #[tokio::test]
 async fn stream_batch_fence_rechecks_after_writer_admission() {
     let (_dir, runtime, peer, token, registry) = file_fixture();
@@ -567,6 +983,120 @@ impl SqlAccess for TraceAccess {
         ));
         result
     }
+}
+
+fn interleaved_appends() -> Vec<StreamBatchMember> {
+    ["a", "b", "a", "a", "b"]
+        .into_iter()
+        .enumerate()
+        .map(|(index, stream)| {
+            let StreamBatchMember::Append(mut spec) = append(stream, None) else {
+                unreachable!()
+            };
+            spec.record = json!({"position": index});
+            StreamBatchMember::Append(spec)
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn stream_batch_reads_each_stream_head_once_and_allocates_in_order() {
+    let (runtime, token, registry) = fixture();
+    let prepared = runtime
+        .prepare_stream_batch(&token, interleaved_appends(), &registry)
+        .await
+        .unwrap();
+    let trace = TraceAccess(Arc::new(Mutex::new(vec![])));
+    let (values, _) = run_prepared_stream_batch(
+        &trace,
+        token.namespace().as_str().into(),
+        prepared,
+        None,
+        vec![],
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert_eq!(values.len(), 5);
+    let trace = trace.0.lock().unwrap();
+    let heads: Vec<_> = trace
+        .iter()
+        .filter(|statement| statement.sql.contains("MAX(seq)"))
+        .collect();
+    assert_eq!(heads.len(), 2, "one head query per distinct stream");
+    for (head, stream) in heads.iter().zip(["a", "b"]) {
+        assert!(matches!(&head.params[0], SqlValue::Text(ns) if ns == token.namespace().as_str()));
+        assert!(matches!(&head.params[1], SqlValue::Text(name) if name == stream));
+    }
+    let inserts: Vec<_> = trace
+        .iter()
+        .filter(|statement| statement.sql.starts_with("INSERT INTO note_streams"))
+        .collect();
+    assert_eq!(inserts.len(), 5);
+    for ((insert, value), (stream, seq)) in
+        inserts
+            .iter()
+            .zip(&values)
+            .zip([("a", 1), ("b", 1), ("a", 2), ("a", 3), ("b", 2)])
+    {
+        assert!(matches!(&insert.params[1], SqlValue::Text(name) if name == stream));
+        assert!(matches!(&insert.params[2], SqlValue::Integer(actual) if *actual == seq));
+        assert!(
+            matches!(&insert.params[3], SqlValue::Text(id) if Some(id.as_str()) == value["id"].as_str())
+        );
+        assert_eq!(value["seq"], seq);
+    }
+    assert_eq!(trace.first().unwrap().sql, "BEGIN");
+    assert_eq!(trace.last().unwrap().sql, "COMMIT");
+}
+
+#[tokio::test]
+async fn stream_batch_head_allocation_persists_order_and_refreshes_next_transaction() {
+    let (_dir, runtime, _peer, token, registry) = file_fixture();
+    for expected in [[1, 1, 2, 3, 2], [4, 3, 5, 6, 4]] {
+        let values = runtime
+            .stream_batch_atomic(&token, interleaved_appends(), None, vec![], &registry)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(values.len(), 5);
+        for (value, seq) in values.iter().zip(expected) {
+            assert_eq!(value["seq"], seq);
+        }
+    }
+    for (stream, positions) in [("a", vec![0, 2, 3, 0, 2, 3]), ("b", vec![1, 4, 1, 4])] {
+        let page = runtime.stream_read(&token, stream, 0, 100).await.unwrap();
+        assert_eq!(page["head_seq"], positions.len());
+        let entries = page["entries"].as_array().unwrap();
+        assert_eq!(entries.len(), positions.len());
+        for (index, (entry, position)) in entries.iter().zip(positions).enumerate() {
+            assert_eq!(entry["seq"], index + 1);
+            assert_eq!(entry["record"]["position"], position);
+        }
+    }
+    let baseline = stream_store_snapshot(&runtime).await;
+    let refusal = runtime
+        .stream_batch_atomic(
+            &token,
+            vec![
+                append("a", Some(7)),
+                append("b", Some(5)),
+                append("a", Some(7)),
+            ],
+            None,
+            vec![],
+            &registry,
+        )
+        .await
+        .unwrap()
+        .unwrap_err();
+    assert_eq!(refusal.member, 2);
+    let error = serde_json::to_value(refusal.error).unwrap();
+    assert_eq!(error["details"]["reason"], "seq_conflict");
+    assert_eq!(error["details"]["member"], "2");
+    assert_eq!(error["details"]["expected_seq"], "7");
+    assert_eq!(error["details"]["next_seq"], "8");
+    assert_eq!(stream_store_snapshot(&runtime).await, baseline);
 }
 
 #[tokio::test]

--- a/crates/khive-runtime/src/streams_batch_tests.rs
+++ b/crates/khive-runtime/src/streams_batch_tests.rs
@@ -541,9 +541,7 @@ async fn stream_batch_recreated_key_between_prepare_and_commit_is_version_confli
         .await
         .unwrap();
         if replacement.is_some() {
-            let refusal = outcome
-                .err()
-                .expect("a recreated holder refuses the stale plan");
+            let refusal = outcome.expect_err("a recreated holder refuses the stale plan");
             assert_eq!(refusal.member, 2);
             let error = serde_json::to_value(refusal.error).unwrap();
             assert_eq!(error["kind"], "conflict");
@@ -565,7 +563,7 @@ async fn stream_batch_recreated_key_between_prepare_and_commit_is_version_confli
             );
             assert!(fired.lock().unwrap().is_empty());
         } else {
-            let (values, effects) = outcome.ok().expect("an unchanged holder commits");
+            let (values, effects) = outcome.expect("an unchanged holder commits");
             assert_eq!(values[2]["id"], first["id"]);
             assert_eq!(values[2]["version"], 2);
             assert_eq!(values[1]["seq"], 1);
@@ -675,15 +673,14 @@ async fn stream_batch_recovers_failure_slot_only_after_confirmed_rollback() {
         if invoke && !terminate && state == TransactionRolledBack {
             let refusal = outcome
                 .unwrap()
-                .err()
-                .expect("recover the recorded member failure");
+                .expect_err("recover the recorded member failure");
             assert_eq!(refusal.member, 1);
             let error = serde_json::to_value(refusal.error).unwrap();
             assert_eq!(error["details"]["reason"], "seq_conflict");
             assert_eq!(error["details"]["member"], "1");
             assert_eq!(error["details"]["next_seq"], "1");
         } else {
-            match outcome.err().expect("preserve the outer storage failure") {
+            match outcome.expect_err("preserve the outer storage failure") {
                 RuntimeError::Storage(StorageError::WriterTaskTerminated { request_state }) => {
                     assert!(terminate);
                     assert_eq!(request_state, state);

--- a/docs/adr/ADR-172-versioned-notes-compare-and-set.md
+++ b/docs/adr/ADR-172-versioned-notes-compare-and-set.md
@@ -465,6 +465,10 @@ indices. This whole class is an `invalid_input` error carried in the message tex
 client must not look for one here. Identical keys in different note kinds remain distinct. Omitting `fence` keeps today's
 unfenced behaviour. A list never changes the successful response or adds writes to a lease.
 
+Clarification (2026-09-10): the once-per-`(kind, key)` target rule applies independently to each ordered
+fence list and to the keyed-write members of [ADR-174 A1.1](ADR-174-ordered-streams-append.md); it does
+not expand the batch-wide `fence`, which deliberately remains object-only.
+
 The Python client accepts a dictionary or list of dictionaries and preserves entry order. Its generic
 `stream.append` builder preserves explicitly supplied null so the server can reject it.
 

--- a/docs/adr/ADR-174-ordered-streams-append.md
+++ b/docs/adr/ADR-174-ordered-streams-append.md
@@ -342,6 +342,10 @@ its Amendment 2 defines them, `embed` defaulting by the note kind). Common to bo
   a second write to the same key inside one request would either observe a stale version or
   conflict with its own sibling, and neither outcome is useful to a caller. Create-then-update is
   two requests, the second carrying the version the first returned.
+  Clarification (2026-09-10): this once-per-`(kind, key)` target rule is shared with ordered fence lists in
+  [ADR-172 Amendment 3](ADR-172-versioned-notes-compare-and-set.md): it applies independently to each
+  fence list and to a batch's keyed-write members. The batch-wide `fence` deliberately remains
+  object-only.
 - A member refusal, wherever it surfaces, carries the ADR-172 §2 error shape plus
   `domain_disposition: not_committed` (ADR-133 Amendment 3), and a `key_conflict` names the holder
   as `existing_id` (ADR-179 D5), so the consumer rule of ADR-133 Amendment 3 reads it without a
@@ -373,6 +377,16 @@ is written, and the error carries that member's refusal plus `member` (the list 
 disposition is the `domain_disposition: not_committed` every member refusal already carries, and
 no parallel boolean rides beside it. The caller may ignore the result list on success, because
 success means every member committed.
+
+Correction (2026-09-10): if a positive-version `write` member's prepared target is deleted and
+recreated under the same `(kind, key)` before commit, the member refuses with `version_conflict`.
+The atomic batch returns `member` and `domain_disposition: not_committed`, with no member writes
+committed; the replacement does not turn this confirmed refusal into an unknown storage outcome.
+
+Allocation (2026-09-10): a successful atomic batch reads each appended stream's initial head once
+inside its writer transaction, then allocates that stream's sequences from a transaction-local
+cache in member order. The cache is never reused across transactions; per-member mode retains
+its independently admitted transactions and permits intervening writers.
 
 **Per-member (unfenced) mode.** Each member runs in its own writer transaction, in list order, so
 one stream's numbers increase with list position but need not be adjacent. A member's own refusal (`unknown_op`, `seq_conflict`,
@@ -496,6 +510,13 @@ as `invalid_input` and nothing is written. A `stream.batch` append member carrie
 with the same defaults, and the keyed `write` member carries `tags` and `embed` as ADR-172 Amendment 2
 defines them (A1.1's member shape lists both), `embed` defaulting to `false` for the `head` kind and
 `true` for every other kind.
+
+Preparation (2026-09-10): eligible embedded append and keyed-create members are prepared together
+before the member write transactions: one embedding request per selected model within its supported
+batch size, bounded chunks above that size, and one shared vector-schema writer acquisition across
+those models. This adds no aggregate admission limit. Positive-version keyed updates retain their
+separate preparation; embedding defaults and model selection are unchanged.
+With no eligible embeddings, this preparation invokes no embedding provider or vector-schema writer.
 
 The note's content limit, the audit event and the ledger row are unchanged; an unembedded entry is a
 whole entry in every respect this ADR defines.


### PR DESCRIPTION
## Summary

Three follow-ups on atomic stream batches (ADR-172, ADR-174), plus the refactor they sit on.

- **Recreated key between prepare and commit.** A positive-version `write` member whose target was deleted and recreated under the same `(kind, key)` before commit now refuses with `version_conflict`: the batch reports the member index and `domain_disposition: not_committed`, with no member writes committed. Previously the replacement holder could surface as an unknown storage outcome.
- **Stream heads read once per transaction.** A successful atomic batch reads each appended stream's head once inside its writer transaction and allocates sequences from a transaction-local cache in member order. The cache is dropped at transaction end; per-member mode keeps its independent transactions.
- **Batched embedding preparation.** Eligible embedded appends and keyed creates are prepared together before the member transactions: one embedding request per selected model within the provider's batch size, ordered chunks above it, and one vector-schema writer acquisition across models. No provider call or writer acquisition happens when nothing is eligible. Positive-version keyed updates keep their separate preparation.
- **Shared atomic runner.** Ordinary atomic plans and prepared stream batches share one failure-slot recovery, sentinel conversion and committed-effects path (`atomic_runner.rs`), so acknowledgement-loss and rollback classification are the same on both.

ADR-172 and ADR-174 carry dated amendments for the refusal, the head allocation, the preparation step, and the shared once-per-`(kind, key)` rule across fence lists and keyed-write members.

## Tests

New runtime tests cover: two connections recreating a key between prepare and commit (refusal, no writes, full store snapshot unchanged) with an unchanged-holder twin that commits; an A/B/A/A/B append trace with exactly two head queries and sequences 1/1/2/3/2; order persistence across two transactions; failure-slot recovery only after a confirmed rollback; commit-ack loss returning no executable effects; mixed appends and creates embedded in one provider call; heterogeneous models with one schema-writer acquisition; 1001 documents chunked as 1000 + 1. The removed-guard checks for the first two were run and fail without the change.

## Verification

Rust 1.95.0: `cargo fmt --all -- --check`, `cargo clippy -p khive-runtime -p khive-mcp -p khive-pack-kg -p khive-db --all-targets -- -D warnings`, and `cargo test -p khive-db -p khive-runtime -p khive-mcp --no-fail-fast` (3607 passed, 0 failed) at the head.
