### PR TITLE
fix(runtime): scope bare revision triggers to their line

### DIFF
--- a/crates/khive-runtime/docs/api/secret_gate.md
+++ b/crates/khive-runtime/docs/api/secret_gate.md
@@ -10,13 +10,14 @@ module doc-comment carries only a concise summary and points here.
 
 Allowlist (false-positive suppression) — **all of the following are prose-context exemptions,
 not unconditional passes: a credential trigger word in the surrounding window dominates, with
-exactly two narrow trigger-context exceptions (file paths and VCS revisions, defined below),
-both of which run only after the reconstruction checks and only outside credential-value syntax
-per the clause-label guard.** A UUID or a sha-prefixed content hash sitting directly beside
+narrow exemptions for file paths and explicit VCS revisions (defined below), gated by the
+clause-label guard, and a separate line-local trigger rule for bare Git-length hex values.
+The latter changes only which trigger context applies; it does not change fragment reconstruction.** A UUID or a sha-prefixed content hash sitting directly beside
 "api_key"/"secret"/"auth" is exactly as ambiguous as any other high-entropy candidate and falls
 through to explicit detection instead of being silently allowed.
 
-- Pure hex strings (sha256, git SHA) — passed when not near a trigger.
+- Pure hex strings (sha256, git SHA) — passed when not near a trigger in their applicable context.
+  Bare 40-hex values use the line-local rule below; other lengths retain the cross-line window.
 - UUID canonical form (`xxxxxxxx-xxxx-…`) — passed when not near a trigger.
 - Base64/base64url content hashes with an explicit `sha<N>-` prefix (SRI hashes, npm lockfile
   integrity) — passed when not near a trigger and not preceded by a known-vendor prefix. Bare
@@ -201,6 +202,45 @@ credential-config compounds keep firing: `SECRET_KEY=...` (Django/Flask-style co
 half. This is implemented by parameterizing the boundary rule (`contains_word`'s
 `underscore_is_word_char` argument) rather than sharing one rule between the two callers.
 
+## Bare Git-length hex context and refusal diagnostics (2026-09-10)
+
+A standalone token of exactly 40 ASCII hex digits after delimiter stripping uses its own physical
+line as trigger context,
+within the existing 120-byte radius on either side. CR, LF, and CRLF delimit lines. The radius is
+in bytes, snapped to UTF-8 boundaries, not 120 Unicode characters. The candidate itself remains
+excluded from context. A trigger on a different line does not label this bare value, with one
+conservative exception: the immediately preceding line contributes its trigger if its last
+non-whitespace character is `:` or `=`. Indentation and outer backticks around the value do not
+remove that association. A blank intervening line breaks it; a preceding line without a delimiter
+does not contribute. The existing radius still bounds the previous-line check.
+
+Examples: `auth changes`, then `ready`, then a bare 40-hex revision is allowed, as is a trigger
+more than 120 bytes away. Direct `sha:` / `commit` references retain their existing guarded
+exemption. `token: <40hex>` on one line and `token:` or `token=` followed immediately by a newline
+and the value remain blocked. Any genuine trigger on the same line still counts, including one
+after the value. Tokens with a `0x`/`0X` prefix do not qualify. An anchor with multiple fragments in the existing
+bounded bridge retains full-window context for checking and masking, so the line-local rule
+cannot leave one fragment visible. Bridgeability also crosses newlines and admits alphanumeric
+neighbors of at least eight characters, so `auth changes`, then `completed`, then a bare revision
+retains the conservative block: the line-local exception is for isolated candidates, and cannot
+classify a bridgeable neighbor as prose. Inline assignments, separator-bearing tokens, pure
+32/64/128-hex values, UUIDs, base64 values, provider prefixes and entropy thresholds retain their
+existing rules. A caller can therefore place a real bare 40-hex credential on a different line
+without an immediate delimited label and pass this heuristic; this is the explicit ambiguity
+tradeoff for unmarked Git revisions, not proof that an allowed value is public.
+
+The public `SecretMatch` includes `trigger: Option<&'static str>`. Layer-2 detections carry a
+canonical trigger selected by the same context helper used for detection; UUID diagnostics use
+the narrower credential-label predicate. Selection is deterministic: context before the token,
+then after it, then inline labels, then a previous-line assignment label; within a context the
+existing trigger-table order wins, not nearest distance. Compound labels may report their bare
+trigger component when that component matches the existing word-boundary rule. Only names from
+the closed trigger vocabulary are returned; no source window is copied. Known-prefix rules have
+no trigger. Caller-visible refusals name the detector and, when present, `near '<trigger>'`, then
+existing guidance. They show no candidate text, even its first six characters. The existing
+`masked` field remains a bounded internal excerpt; typed error classification and masking spans
+are unchanged. `check` and `mask_secrets` share the same detection context.
+
 ## find_prefix_token
 
 Known provider-prefix matching remains context-free and requires both a token boundary and the
@@ -318,7 +358,8 @@ For each token, in order:
    which require an exact shape match. This is a small bounded iteration over separator positions
    in one token, not an allocation-heavy scan. Off-trigger, a UUID or content hash is allowlisted
    outright.
-2. **Pure hex off-trigger** is allowlisted (git SHA, checksum digests). Trigger-adjacent hex
+2. **Pure hex off-trigger** is allowlisted (git SHA, checksum digests), using the line-local rule
+   above for bare 40-hex values. Trigger-adjacent hex
    requires an explicit VCS coordinate marker (`commit`, `revision`, `rev`, `sha`) to earn the
    same exemption, and only when the surrounding clause carries no credential label (`api key
    value is commit <hex>` is a labeled credential wearing a marker, not a VCS citation). The

--- a/crates/khive-runtime/src/error.rs
+++ b/crates/khive-runtime/src/error.rs
@@ -1026,10 +1026,12 @@ mod channel_ingest_failure_class_tests {
     fn secret_detected_is_permanent_by_typed_variant_not_display_text() {
         let first = RuntimeError::SecretDetected(SecretMatch {
             detector: "fixture",
+            trigger: None,
             masked: "first-rendering".to_string(),
         });
         let second = RuntimeError::SecretDetected(SecretMatch {
             detector: "fixture",
+            trigger: Some("token"),
             masked: "completely-different-rendering".to_string(),
         });
 

--- a/crates/khive-runtime/src/secret_gate.rs
+++ b/crates/khive-runtime/src/secret_gate.rs
@@ -2,7 +2,8 @@
 //!
 //! Scans caller-supplied content strings before any storage write. A match
 //! causes a hard `RuntimeError::SecretDetected` that names the detector and
-//! carries a masked excerpt — it never echoes the full candidate back.
+//! carries a masked excerpt internally. Its display names the rule and trigger
+//! without echoing any candidate text.
 //!
 //! Scope: **credentials only** — API keys, tokens, private keys, passwords,
 //! and connection strings with embedded credentials. General PII (emails,
@@ -58,19 +59,19 @@ use crate::error::{RuntimeError, RuntimeResult};
 pub struct SecretMatch {
     /// Human-readable name of the detector that fired.
     pub detector: &'static str,
+    /// Canonical trigger from the matched context; known-prefix rules need none.
+    pub trigger: Option<&'static str>,
     /// `first6...N` — the first 6 chars of the match followed by the total length.
     pub masked: String,
 }
 
 impl std::fmt::Display for SecretMatch {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "content matches secret pattern {} at masked excerpt {}. {}",
-            self.detector,
-            self.masked,
-            block_guidance(self.detector)
-        )
+        write!(f, "content matches secret pattern {}", self.detector)?;
+        if let Some(trigger) = self.trigger {
+            write!(f, " near '{trigger}'")?;
+        }
+        write!(f, ". {}", block_guidance(self.detector))
     }
 }
 
@@ -221,6 +222,7 @@ thread_local! {
 /// verbatim, so a non-leftmost match would leak an earlier secret detected by a
 /// lower-priority detector (e.g. an `sk-ant-` key sitting to the left of a
 /// `ghp_` token). Both detector layers are folded through [`keep_leftmost`].
+#[cfg(test)]
 fn scan_match(text: &str) -> Option<(&str, &'static str)> {
     let tokens = tokenize_entropy_tokens(text);
     scan_from(text, 0, &tokens)
@@ -276,7 +278,23 @@ fn keep_leftmost<'a>(
 
 /// Return the first `SecretMatch` found in `text`, or `None`.
 fn scan(text: &str) -> Option<SecretMatch> {
-    scan_match(text).map(|(slice, detector)| build_match(detector, slice))
+    let tokens = tokenize_entropy_tokens(text);
+    scan_from(text, 0, &tokens).map(|(slice, detector)| {
+        let mut matched = build_match(detector, slice);
+        if matches!(
+            detector,
+            "high-entropy-token"
+                | "uuid-near-trigger"
+                | "content-hash-near-trigger"
+                | "hex-credential-token"
+        ) {
+            let offset = slice.as_ptr() as usize - text.as_ptr() as usize;
+            let index = tokens.partition_point(|&(start, _)| start <= offset) - 1;
+            matched.trigger =
+                entropy_trigger(text, &tokens, index, detector == "uuid-near-trigger");
+        }
+        matched
+    })
 }
 
 /// Redact every detected secret span in `text`, replacing each with
@@ -919,6 +937,55 @@ fn tokenize_entropy_tokens(text: &str) -> Vec<(usize, &str)> {
         .collect()
 }
 
+// A bare Git-length value uses line-local context. The preceding label line
+// remains authoritative when it explicitly ends in an assignment delimiter.
+// Bridge anchors retain full-window context so masking cannot leave a fragment behind.
+fn entropy_trigger(
+    text: &str,
+    tokens: &[(usize, &str)],
+    index: usize,
+    credential_label_only: bool,
+) -> Option<&'static str> {
+    let (offset, raw) = tokens[index];
+    let window_start = floor_char_boundary(text, offset.saturating_sub(TRIGGER_WINDOW));
+    let window_end = floor_char_boundary(text, offset + raw.len() + TRIGGER_WINDOW);
+    let token = strip_delimiters(raw);
+    let standalone_revision = token.len() == 40
+        && token.bytes().all(|b| b.is_ascii_hexdigit())
+        && bridge_fragment_chain(tokens, text, index).len() == 1;
+    let (start, end, preceding_label) = if standalone_revision {
+        let line_start = text[window_start..offset]
+            .rfind(['\r', '\n'])
+            .map_or(window_start, |i| window_start + i + 1);
+        let line_end = text[offset + raw.len()..window_end]
+            .find(['\r', '\n'])
+            .map_or(window_end, |i| offset + raw.len() + i);
+        let before_line = &text[window_start..line_start];
+        let previous = before_line
+            .strip_suffix("\r\n")
+            .or_else(|| before_line.strip_suffix(['\r', '\n']))
+            .unwrap_or("");
+        let previous_start = previous.rfind(['\r', '\n']).map_or(0, |i| i + 1);
+        let previous = previous[previous_start..].trim_end();
+        let label = if previous.ends_with([':', '=']) {
+            find_trigger(previous, credential_label_only)
+        } else {
+            None
+        };
+        (
+            line_start.max(window_start),
+            line_end.min(window_end),
+            label,
+        )
+    } else {
+        (window_start, window_end, None)
+    };
+    find_trigger(&text[start..offset], credential_label_only)
+        .or_else(|| find_trigger(&text[offset + raw.len()..end], credential_label_only))
+        .or_else(|| inline_credential_trigger(raw))
+        .or(preceding_label)
+}
+
 /// `from` restricts which tokens may be RETURNED (only those starting at or
 /// after `from`), but the trigger-context window is still computed over the full
 /// `text`. This lets [`mask_secrets`] advance past an earlier redaction without
@@ -934,7 +1001,7 @@ fn check_entropy_heuristic<'a>(
         token_offset < from
     });
 
-    for (idx, &(tok_offset, raw_token)) in tokens.iter().enumerate().skip(first_token) {
+    for (idx, &(_, raw_token)) in tokens.iter().enumerate().skip(first_token) {
         // Strip common delimiters that wrap the actual value.
         let token = strip_delimiters(raw_token);
         // Only RETURN tokens at or after `from` (already-redacted spans lie
@@ -958,21 +1025,8 @@ fn check_entropy_heuristic<'a>(
         // UUIDs require credential-label context rather than a generic mention
         // of `token`; base64 content-hash exemptions remain trigger-sensitive.
         // VCS revisions and file paths use narrower syntactic context below.
-        let window_start = floor_char_boundary(text, tok_offset.saturating_sub(TRIGGER_WINDOW));
-        let window_end = floor_char_boundary(text, tok_offset + raw_token.len() + TRIGGER_WINDOW);
-        let window = &text[window_start..window_end];
-        let raw_start = tok_offset - window_start;
-        let raw_end = raw_start + raw_token.len();
-
-        // Must not provide its own trigger context (e.g. a path slug like
-        // `ADR-051-cli-auth-and-kg-git-workflow.md`); see
-        // docs/api/secret_gate.md#check_entropy_heuristic--per-token-flagging-sequence.
-        let near_trigger = contains_trigger(&window[..raw_start])
-            || contains_trigger(&window[raw_end..])
-            || has_inline_credential_trigger(raw_token);
-        let uuid_near_credential_label = contains_credential_label_trigger(&window[..raw_start])
-            || contains_credential_label_trigger(&window[raw_end..])
-            || has_inline_credential_trigger(raw_token);
+        let near_trigger = entropy_trigger(text, tokens, idx, false).is_some();
+        let uuid_near_credential_label = entropy_trigger(text, tokens, idx, true).is_some();
 
         // Step 1 (see doc: per-token flagging sequence). UUIDs fall through only
         // beside an explicit credential label; the generic word `token` remains
@@ -1742,11 +1796,11 @@ fn contains_bounded_word(low_window: &str, needle: &str) -> bool {
     contains_word(low_window, needle, false)
 }
 
-/// Returns `true` when a compound credential label begins at an identifier
+/// Finds a canonical compound credential label beginning at an identifier
 /// boundary. The trailing edge is deliberately unbounded so version suffixes
 /// and larger underscore-composed labels remain protected.
-fn contains_compound_trigger(low_text: &str) -> bool {
-    COMPOUND_TRIGGER_WORDS.iter().any(|needle| {
+fn compound_trigger(low_text: &str) -> Option<&'static str> {
+    COMPOUND_TRIGGER_WORDS.iter().copied().find(|needle| {
         let mut start = 0;
         while let Some(rel) = low_text[start..].find(needle) {
             let abs = start + rel;
@@ -1764,29 +1818,18 @@ fn contains_compound_trigger(low_text: &str) -> bool {
     })
 }
 
-/// Returns `true` when `text` contains a boundary-delimited credential trigger.
-fn contains_trigger(text: &str) -> bool {
+fn find_trigger(text: &str, credential_label_only: bool) -> Option<&'static str> {
     let low = text.to_ascii_lowercase();
     TRIGGER_WORDS
         .iter()
-        .any(|tw| contains_bounded_word(&low, tw))
-        || contains_compound_trigger(&low)
-        || has_standalone_token(&low)
-        || has_token_assignment(&low)
-        || has_assignment_credential_trigger(&low)
-}
-
-/// UUID-shaped values need an explicit credential label. A standalone mention
-/// of `token` is intentionally omitted because it is common design language;
-/// assignment forms such as `token=<uuid>` remain authoritative.
-fn contains_credential_label_trigger(text: &str) -> bool {
-    let low = text.to_ascii_lowercase();
-    TRIGGER_WORDS
-        .iter()
-        .any(|tw| contains_bounded_word(&low, tw))
-        || contains_compound_trigger(&low)
-        || has_token_assignment(&low)
-        || has_assignment_credential_trigger(&low)
+        .copied()
+        .find(|tw| contains_bounded_word(&low, tw))
+        .or_else(|| compound_trigger(&low))
+        .or_else(|| {
+            ((!credential_label_only && has_standalone_token(&low)) || has_token_assignment(&low))
+                .then_some("token")
+        })
+        .or_else(|| assignment_credential_trigger(&low))
 }
 
 /// Detect a credential-bearing assignment label before an `=` or `:`.
@@ -1794,10 +1837,10 @@ fn contains_credential_label_trigger(text: &str) -> bool {
 /// The separator may be preceded by whitespace or a JSON quote. Compound
 /// triggers deliberately retain substring matching inside the label so common
 /// version suffixes such as `api_keyv2` remain protected.
-fn has_assignment_credential_trigger(low_text: &str) -> bool {
-    low_text.char_indices().any(|(index, ch)| {
+fn assignment_credential_trigger(low_text: &str) -> Option<&'static str> {
+    low_text.char_indices().find_map(|(index, ch)| {
         if !matches!(ch, '=' | ':') {
-            return false;
+            return None;
         }
         let before =
             low_text[..index].trim_end_matches(|c: char| !c.is_ascii_alphanumeric() && c != '_');
@@ -1807,11 +1850,15 @@ fn has_assignment_credential_trigger(low_text: &str) -> bool {
             .unwrap_or_default();
         COMPOUND_TRIGGER_WORDS
             .iter()
-            .any(|needle| label.contains(needle))
-            || TRIGGER_WORDS
-                .iter()
-                .any(|tw| contains_bounded_word(label, tw))
-            || label == "token"
+            .copied()
+            .find(|needle| label.contains(needle))
+            .or_else(|| {
+                TRIGGER_WORDS
+                    .iter()
+                    .copied()
+                    .find(|tw| contains_bounded_word(label, tw))
+            })
+            .or_else(|| (label == "token").then_some("token"))
     })
 }
 
@@ -1824,20 +1871,27 @@ fn has_assignment_credential_trigger(low_text: &str) -> bool {
 /// without an assignment are retained for compatibility with shapes such as
 /// `session_secret_<value>`.
 fn has_inline_credential_trigger(raw_token: &str) -> bool {
+    inline_credential_trigger(raw_token).is_some()
+}
+
+fn inline_credential_trigger(raw_token: &str) -> Option<&'static str> {
     let low = raw_token.to_ascii_lowercase();
-
-    if has_assignment_credential_trigger(&low) {
-        return true;
-    }
-
-    !low.contains(['/', '-', '.'])
-        && low.contains('_')
-        && (COMPOUND_TRIGGER_WORDS
-            .iter()
-            .any(|needle| low.contains(needle))
-            || TRIGGER_WORDS
+    assignment_credential_trigger(&low).or_else(|| {
+        if !low.contains(['/', '-', '.']) && low.contains('_') {
+            COMPOUND_TRIGGER_WORDS
                 .iter()
-                .any(|tw| contains_bounded_word(&low, tw)))
+                .copied()
+                .find(|needle| low.contains(needle))
+                .or_else(|| {
+                    TRIGGER_WORDS
+                        .iter()
+                        .copied()
+                        .find(|tw| contains_bounded_word(&low, tw))
+                })
+        } else {
+            None
+        }
+    })
 }
 
 /// Returns `true` when `low_window` contains the word `token` as a standalone
@@ -2152,7 +2206,11 @@ fn build_match(detector: &'static str, candidate: &str) -> SecretMatch {
     let chars: Vec<char> = candidate.chars().collect();
     let preview: String = chars.iter().take(6).collect();
     let masked = format!("{}...{}chars", preview, chars.len());
-    SecretMatch { detector, masked }
+    SecretMatch {
+        detector,
+        trigger: None,
+        masked,
+    }
 }
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
@@ -3297,6 +3355,144 @@ mod tests {
             "hex40 near 'commit sha' context must be allowed; fired: {:?}",
             scan(&commit_line)
         );
+    }
+
+    const GIT_LENGTH_FIXTURE: &str = "da39a3ee5e6b4b0d3255bfef95601890afd80709";
+
+    #[test]
+    fn bare_forty_hex_line_three_allows_trigger_on_line_one_within_window() {
+        let content = format!("auth changes\nready\n{GIT_LENGTH_FIXTURE}");
+        assert!(content.len() < TRIGGER_WINDOW);
+        assert!(check(&content).is_ok());
+        assert_eq!(mask_secrets(&content), content);
+    }
+
+    #[test]
+    fn bare_forty_hex_line_three_allows_trigger_beyond_window() {
+        let content = format!("auth changes\n{}\n{GIT_LENGTH_FIXTURE}", "-".repeat(150));
+        assert!(check(&content).is_ok());
+    }
+
+    #[test]
+    fn forty_hex_allows_direct_sha_or_commit_marker_in_prose() {
+        for marker in ["sha:", "commit"] {
+            let content = format!("auth changes\nready\n{marker} {GIT_LENGTH_FIXTURE}");
+            assert!(check(&content).is_ok(), "{marker}");
+        }
+    }
+
+    #[test]
+    fn forty_hex_refuses_same_line_token_assignment() {
+        let content = format!("token: {GIT_LENGTH_FIXTURE}");
+        let matched = scan(&content).expect("explicit credential assignment");
+        assert_eq!(matched.detector, "hex-credential-token");
+        assert_eq!(matched.trigger, Some("token"));
+        assert!(check(&content).is_err());
+        assert!(!mask_secrets(&content).contains(GIT_LENGTH_FIXTURE));
+    }
+
+    #[test]
+    fn forty_hex_refuses_previous_label_line_ending_colon_or_equals() {
+        for newline in ["\n", "\r\n", "\r"] {
+            for delimiter in [":", "="] {
+                let content = format!("token{delimiter}{newline}  `{GIT_LENGTH_FIXTURE}`");
+                let matched = scan(&content).expect("previous line labels the value");
+                assert_eq!(matched.detector, "hex-credential-token");
+                assert_eq!(matched.trigger, Some("token"));
+                assert!(!mask_secrets(&content).contains(GIT_LENGTH_FIXTURE));
+            }
+        }
+    }
+
+    #[test]
+    fn forty_hex_context_stays_on_line_except_immediate_assignment_label() {
+        for content in [
+            format!("token\n{GIT_LENGTH_FIXTURE}"),
+            format!("token:\n\n{GIT_LENGTH_FIXTURE}"),
+            format!("{GIT_LENGTH_FIXTURE}\nauth changes"),
+            format!("token_count:\n{GIT_LENGTH_FIXTURE}"),
+            format!("authorized:\n{GIT_LENGTH_FIXTURE}"),
+            format!("{}\n{GIT_LENGTH_FIXTURE}\n密钥", "文".repeat(80)),
+        ] {
+            assert!(check(&content).is_ok(), "{content}");
+        }
+        for content in [
+            format!("{GIT_LENGTH_FIXTURE} auth"),
+            format!("api_keyv2 =\n{GIT_LENGTH_FIXTURE}"),
+            format!("secret for deploy: \n{GIT_LENGTH_FIXTURE}"),
+        ] {
+            assert!(check(&content).is_err(), "{content}");
+        }
+    }
+
+    #[test]
+    fn other_hex_lengths_still_refuse_cross_line_trigger_context() {
+        for length in [32, 64, 128] {
+            let value = "a".repeat(length);
+            let content = format!("auth changes\nready\n{value}");
+            let matched = scan(&content).expect("unchanged cross-line context");
+            assert_eq!(matched.detector, "hex-credential-token");
+            assert_eq!(matched.trigger, Some("auth"));
+        }
+    }
+
+    #[test]
+    fn prefixed_hex_of_forty_bytes_keeps_cross_line_trigger_context() {
+        for prefix in ["0x", "0X"] {
+            let value = format!("{prefix}{}", "a".repeat(38));
+            let content = format!("auth changes\nready\n{value}");
+            assert!(check(&content).is_err());
+            assert!(!mask_secrets(&content).contains(&value));
+        }
+    }
+
+    #[test]
+    fn forty_hex_beside_bridgeable_prose_keeps_conservative_trigger_context() {
+        let content = format!("auth changes\ncompleted\n{GIT_LENGTH_FIXTURE}");
+        assert!(check(&content).is_err());
+        assert!(!mask_secrets(&content).contains(GIT_LENGTH_FIXTURE));
+    }
+
+    #[test]
+    fn forty_hex_bridge_fragments_keep_cross_line_detection_and_full_masking() {
+        for lengths in [(40, 24), (24, 40), (40, 40)] {
+            let first = "a".repeat(lengths.0);
+            let second = "b".repeat(lengths.1);
+            let content = format!("auth changes\nready\n{first}\u{200B}{second}");
+            let matched = scan(&content).expect("fragment keeps original trigger context");
+            assert_eq!(matched.detector, "hex-credential-token");
+            assert_eq!(matched.trigger, Some("auth"));
+            let masked = mask_secrets(&content);
+            assert!(!masked.contains(&first), "first fragment remains");
+            assert!(!masked.contains(&second), "second fragment remains");
+            assert_eq!(
+                masked,
+                "auth changes\nready\n***MASKED***\u{200B}***MASKED***"
+            );
+        }
+    }
+
+    #[test]
+    fn refusal_names_rule_and_canonical_trigger_without_candidate_text() {
+        for (label, trigger) in [
+            ("token", "token"),
+            ("AUTH", "auth"),
+            ("api_keyv2", "api_key"),
+        ] {
+            let content = format!("{label}: {GIT_LENGTH_FIXTURE}");
+            let error = check(&content).unwrap_err().to_string();
+            assert!(error.contains("hex-credential-token"));
+            assert!(error.contains(&format!("near '{trigger}'")), "{error}");
+            assert!(!error.contains(&GIT_LENGTH_FIXTURE[..6]));
+        }
+        let opaque = "Xk9mZ2vQpLrT8nJwYuAeHfBsDcGiONvMabcdef"; // gitleaks:allow
+        let error = check(&format!("secret: {opaque}")).unwrap_err().to_string();
+        assert!(error.contains("high-entropy-token near 'secret'"));
+        assert!(!error.contains(&opaque[..6]));
+        let provider = "AKIAFAKEKEY1234567890";
+        let matched = scan(provider).unwrap();
+        assert_eq!(matched.trigger, None);
+        assert!(!matched.to_string().contains(&provider[..6]));
     }
 
     #[test]

--- a/docs/adr/ADR-115-secret-gate-content-manifest-exemption.md
+++ b/docs/adr/ADR-115-secret-gate-content-manifest-exemption.md
@@ -903,3 +903,22 @@ amendment with an explicit source of truth and acceptance fixture.
   non-executable; silently dropping a failed best-effort audit is also rejected.
 - Interpreting staleness as age is rejected because no clock, threshold, or revocation authority is
   defined.
+
+## Amendment: bare revision context and refusal diagnostics (2026-09-10)
+
+The ordinary detector treats a standalone, delimiter-stripped token of exactly 40 ASCII hex
+digits as line-local within the
+existing 120-byte context radius. A delimited credential-label line immediately preceding the
+value remains trigger context; blank intervening lines break that association. Other hex
+lengths, inline assignments, reconstruction and provider/entropy rules retain their contracts.
+Multi-fragment bridge anchors and `0x`/`0X`-prefixed values retain full-window context.
+This is an explicit heuristic ambiguity tradeoff: unmarked revisions and real 40-hex values
+without local credential syntax cannot be distinguished by content alone. It does not confer
+provenance or alter manifest authorization. The precise CR/LF, radius and label rules are in
+[the algorithm specification](../../crates/khive-runtime/docs/api/secret_gate.md#bare-git-length-hex-context-and-refusal-diagnostics-2026-09-10).
+
+`SecretMatch` gains an optional canonical trigger name. Its display includes the detector and
+trigger when applicable, with no candidate excerpt. The existing masked field remains available
+in the structured value. Known-prefix detections need no trigger; typed permanent-failure
+classification does not depend on the display string. This amendment changes neither storage
+schema nor exemption-manifest identity.


### PR DESCRIPTION
## Summary

The secret gate's entropy heuristic reads 120 bytes of context on either side of a candidate token. A standalone 40-hex value (a git revision) on one line was refused whenever a genuine `token`/`key`/`auth` mention sat within that radius on a different line, so ordinary commit references in prose near unrelated credential vocabulary were blocked.

## Change

- A delimiter-stripped token of exactly 40 ASCII hex digits is now judged against its own physical line (CR, LF, CRLF), still within the existing byte radius. A label line immediately preceding it that ends in `:` or `=` keeps contributing its trigger; a blank line breaks that association.
- Other hex lengths, inline assignments (`token=<40 hex>` on the same line), multi-fragment bridge anchors, `0x`/`0X`-prefixed values, and the provider and entropy rules keep their contracts and their full-window context.
- `SecretMatch` carries an optional canonical trigger name; the refusal display names the detector and trigger with no candidate excerpt. The masked structured field is unchanged.
- ADR-115 and the secret gate API document record the tradeoff: a bare 40-hex credential with no local credential syntax is indistinguishable from a revision and passes the heuristic.

## Tests

Fixtures for: trigger on line one with the value on line three (allowed, within and beyond the radius); `sha`/`commit` markers in prose; same-line assignment (refused, masked); a preceding label line ending in `:` or `=` across LF, CRLF and CR with indentation and wrapping (refused, masked); following-line triggers; blank separators; compound labels; 0x-prefixed values; 40+24, 24+40 and 40+40 fragment masking; non-ASCII context; refusal diagnostics for the hex, high-entropy and known-prefix detectors.

## Verification

Rust 1.95.0: `cargo fmt --all -- --check`, `cargo clippy -p khive-runtime --all-targets -- -D warnings`, `cargo test -p khive-runtime --no-fail-fast` (1988 passed, 0 failed) at the head.
