### PR TITLE
feat(git): expose persisted ingest cursor snapshots

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -261,7 +261,7 @@ jobs:
             echo
             echo "> A research knowledge graph runtime for AI agents: typed entities, a closed"
             echo "> 17-relation edge ontology, hybrid FTS+vector search, and GQL/SPARQL queries,"
-            echo "> all dispatched through one MCP tool (\`request\`). 128 verbs across 14 packs."
+            echo "> all dispatched through one MCP tool (\`request\`). 129 verbs across 14 packs."
             echo
             echo "## Docs"
             echo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ behavior isn't written there, it is an unspecified design decision → escalate,
 │  14 default packs (`RuntimeConfig::built_in_packs()`):        │
 │  kg, gtd, memory, brain, comm, schedule, knowledge, session, │
 │  tool, exec, git, code, workspace, blob — together exposing   │
-│  128 public verbs (see the verb-catalog paragraph below       │
+│  129 public verbs (see the verb-catalog paragraph below       │
 │  for the per-pack breakdown)                                   │
 │  khive-vcs         — KG versioning: snapshots/branches (ADR-010)    │
 │  khive-merge       — KG merge algorithm (ADR-039, forward-deployed,  │

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ stdio, and `cargo test` finishes in 4 seconds.
 
 | Capability                  | How                                                                                                                                                      |
 | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **128 verbs, 14 packs**     | KG, GTD, memory, brain, comm, schedule, knowledge, session, tool, exec, git, code, workspace, blob: all load by default                                  |
+| **129 verbs, 14 packs**     | KG, GTD, memory, brain, comm, schedule, knowledge, session, tool, exec, git, code, workspace, blob: all load by default                                  |
 | **Typed entities**          | 9 closed kinds: concept, document, dataset, project, person, org, artifact, service, resource                                                            |
 | **Typed edges**             | 17 closed relations in 9 categories (structure, derivation, provenance, temporal, dependency, impl, lateral, annotation, epistemic)                      |
 | **Typed notes**             | 5 closed kinds: observation, insight, question, decision, reference                                                                                      |
@@ -63,7 +63,7 @@ request(ops="[v1(...), v2(...), v3(...)]")             # parallel batch (max 100
 request(ops="[{\"tool\":\"v1\",\"args\":{...}}, ...]") # equivalent JSON form
 ```
 
-All 14 packs load by default, giving **128 verbs** out of the box (updated from the
+All 14 packs load by default, giving **129 verbs** out of the box (updated from the
 current handler declarations, 2026-09-09; verify again with `request(ops="verbs()")`
 before editing this table):
 
@@ -79,7 +79,7 @@ before editing this table):
 | **session**   | `session.`   | 4     | Session record persistence (store/list/resume/export)                                                                                                                 |
 | **tool**      | `tool.`      | 13    | Capability registry, discovery by capability, and use policy: check/request/grant (ADR-180)                                                                           |
 | **exec**      | `exec.`      | 9     | One declared command in a sandbox over a materialized tree, receipts for every run (ADR-181)                                                                          |
-| **git**       | `git.`       | 15    | Provenance ingest, branch/commit/push writes (ADR-108), dev-loop verbs: checkout, diff, gates, receipts, reconcile, status, log, init, PR open/review/merge (ADR-182) |
+| **git**       | `git.`       | 16    | Provenance ingest, branch/commit/push writes (ADR-108), dev-loop verbs: checkout, diff, gates, receipts, reconcile, status, log, init, PR open/review/merge (ADR-182) |
 | **code**      | _(none)_     | 1     | `code.ingest`: L1 manifest + L1.5 import-scan source ingest (ADR-085 Amendment 2)                                                                                     |
 | **workspace** | _(none)_     | 0     | Adds the `workspace` entity kind + `contains` endpoint rules to git/gtd/session notes (#873)                                                                          |
 | **blob**      | `blob.`      | 3     | Content-addressed object put/get/stat over the `BlobStore` CAS trait (ADR-111)                                                                                        |
@@ -147,7 +147,7 @@ records what's connected, in which direction, and why.
 │  khive-pack-schedule:  reminders + scheduled ops (4 verbs)    │
 │  khive-pack-knowledge: atom KB + embedding rerank (19 verbs)  │
 │  khive-pack-session:   session record persistence (4 verbs)   │
-│  khive-pack-git:       provenance ingest + writes (15 verbs)  │
+│  khive-pack-git:       provenance ingest + writes (16 verbs)  │
 │  khive-pack-code:      source ingest (L1 manifest + L1.5      │
 │                        import-scan; 1 verb)                   │
 │  khive-pack-workspace: workspace entity + contains endpoint   │
@@ -272,7 +272,7 @@ kkernel --version   # confirms the binary and version you just installed
 ```
 
 All 14 packs load by default, a background daemon auto-spawns to keep the runtime warm, and any
-MCP client discovers the `request` tool with the full 128-verb catalog.
+MCP client discovers the `request` tool with the full 129-verb catalog.
 
 ### Alternative: npm
 
@@ -404,7 +404,7 @@ Docs: [ohdearquant.github.io/khive](https://ohdearquant.github.io/khive/) (agent
 
 ## Status
 
-**Main after v0.7.0.** 128 verbs across 14 packs, 9 entity kinds, 17 edge relations, daemon warm startup
+**Main after v0.7.0.** 129 verbs across 14 packs, 9 entity kinds, 17 edge relations, daemon warm startup
 (ADR-049), knowledge search with embedding rerank, Bayesian brain profiles, threaded messaging,
 scheduled verb execution.
 Ready for use with Claude Code and any MCP-compatible agent.

--- a/crates/khive-pack-git/docs/api/handlers.md
+++ b/crates/khive-pack-git/docs/api/handlers.md
@@ -2,6 +2,9 @@
 
 Extracted from `crates/khive-pack-git/src/handlers.rs` doc-comments.
 
+For the separate read of persisted ingest progress, see
+[`git.ingest_cursor`](ingest_cursor.md). It does not run this digest handler.
+
 ## `RemoteRecoveryStage` / `RemoteCommitRecovery`
 
 Issue #765 remote-only repair policy: at most one `git fetch --refetch`,

--- a/crates/khive-pack-git/docs/api/ingest_cursor.md
+++ b/crates/khive-pack-git/docs/api/ingest_cursor.md
@@ -1,0 +1,76 @@
+# `git.ingest_cursor` — persisted ingest position
+
+Proposed contract, 2026-09-10. See the operational rider in
+[ADR-088 Amendment 1](../../../../docs/adr/ADR-088-amendment-1-git-digest.md).
+
+```text
+git.ingest_cursor(project="<full project UUID>", source_kind="issues")
+```
+
+Both arguments are required. `source_kind` accepts `commits`, `issues`, or
+`pull_requests`; prefixes and alternate source-kind names refuse. The live project
+anchor is read through the canonical `get` gate with the caller's actor and resolved
+request namespace. Full UUID reads are namespace-agnostic under the existing runtime
+contract. The namespace inside a checkpoint is continuation metadata, not a separate
+access rule. Missing, deleted, non-project, or denied anchors refuse.
+
+The token retains the namespace used at the originating Gate check separately from
+its primary storage namespace. This read passes that Gate namespace into nested `get`,
+including when an implicit request's storage primary is `local` but its identity or
+registry default is non-local. Explicit `namespace` still wins. Existing nested ingest
+writes continue using their storage-primary helper.
+
+The response has `project_id` (canonical full UUID), `source_kind`, `cursor`, and
+`checkpoint`. Each stored row has this shape:
+
+```json
+{
+  "value": "2026-09-01T12:01:02+00:00",
+  "updated_at": 1788264062000000,
+  "value_bytes": 25,
+  "truncated": false
+}
+```
+
+`value` is the exact stored string, including checkpoint JSON as a string. No timestamp
+normalization, JSON decoding, validity judgment, reset, or repair occurs. `updated_at`
+is the stored integer Unix timestamp in microseconds; it is not reformatted. A missing
+row is `null`. A present row whose value is SQL NULL is an object with `value: null`,
+`value_bytes: null`, and its stored `updated_at`. Cursor and checkpoint can be absent
+independently, including legacy timestamp-only state.
+
+Values over 262,144 UTF-8 bytes per row return `value: null`, their actual `value_bytes`,
+and `truncated: true`. The complete value is omitted, never partially sliced JSON.
+Exactly 262,144 bytes are returned. This limits materialized raw values to 512 KiB per
+pair; JSON escaping can enlarge the wire response. Invalid column types or invalid UTF-8
+in a bounded value refuse with a generic diagnostic that does not copy stored data.
+Bounded text is read as bytes and decoded strictly, avoiding the SQL bridge's lossy text
+conversion. Omitted oversized values are not decoded. Valid text with malformed checkpoint
+JSON remains inspectable.
+
+The handler reads both rows in one SQL statement from `git_mirror_cursor`. Public
+`pull_requests` selects stored `prs` and `prs_checkpoint`; the other kinds select their
+same-named cursor and `_checkpoint` row. The pair shares one SQLite statement snapshot,
+so an atomic producer update cannot be read halfway through. Read presentation is
+`AlwaysVerbose`: full UUIDs, raw strings, and microsecond integers survive MCP output.
+
+This verb reads existing state without starting ingestion or invoking Git, `gh`, a
+remote, or anchor creation. It does not mutate cursor rows, notes, or edges. Normal
+runtime authorization and audit behavior still applies. Pack schema initialization
+remains a separate startup operation.
+
+## Recovery after an ambiguous response
+
+Use the known project UUID and the source kind to inspect persisted position. Keep both
+rows: issue/PR page checkpoints carry exact timestamp-boundary and undated membership;
+commit checkpoints carry a frozen tip and the last completed SHA. The cursor alone does
+not describe all continuation state. These remain opaque, versioned producer records;
+the next `git.digest` applies its existing validation and continuation rules.
+
+This is the current persisted position, not a receipt for the interrupted request,
+proof of `done`, or a promise that the next digest can resume. An in-flight or concurrent
+digest may advance immediately after this read. Do not launch a concurrent replay just
+because a transport stopped waiting. For a particular request's completed report, use
+the durable audit-receipt recovery procedure in ADR-088 Amendment 1. If the original
+call auto-created an unknown project, recover the anchor separately; this read does not
+resolve repositories or create anchors.

--- a/crates/khive-pack-git/docs/api/vocab.md
+++ b/crates/khive-pack-git/docs/api/vocab.md
@@ -14,6 +14,10 @@ for provenance edges. ADR-088 Amendment 1 adds exactly one verb
 parent→child commit lineage). See `crates/khive-pack-git/src/pack.rs` for
 how this vocabulary is wired into `GitPack`.
 
+The proposed 2026-09-10 rider adds the `Assertive` read `git.ingest_cursor` for
+persisted cursor/checkpoint inspection. It uses the existing auxiliary table and
+canonical project read gate; see [its contract](ingest_cursor.md).
+
 ## `GIT_LIFECYCLE`
 
 Lifecycle declaration shared by `issue` and `pull_request` — both track an

--- a/crates/khive-pack-git/src/ingest_cursor.rs
+++ b/crates/khive-pack-git/src/ingest_cursor.rs
@@ -1,0 +1,132 @@
+use khive_runtime::{NamespaceToken, RequestIdentity, RuntimeError, VerbRegistry};
+use khive_storage::types::{SqlRow, SqlStatement, SqlValue};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use crate::GitPack;
+
+const MAX_VALUE_BYTES: i64 = 256 * 1024;
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CursorParams {
+    project: Uuid,
+    source_kind: SourceKind,
+}
+
+#[derive(Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum SourceKind {
+    Commits,
+    Issues,
+    PullRequests,
+}
+
+impl SourceKind {
+    fn names(self) -> (&'static str, &'static str) {
+        match self {
+            Self::Commits => ("commits", "commits"),
+            Self::Issues => ("issues", "issues"),
+            Self::PullRequests => ("pull_requests", "prs"),
+        }
+    }
+}
+
+impl GitPack {
+    pub(crate) async fn handle_ingest_cursor(
+        &self,
+        token: &NamespaceToken,
+        registry: &VerbRegistry,
+        params: Value,
+    ) -> Result<Value, RuntimeError> {
+        let params: CursorParams = serde_json::from_value(params).map_err(|_| {
+            RuntimeError::InvalidInput(
+                "git.ingest_cursor requires a full project UUID and source_kind commits, issues, or pull_requests".into(),
+            )
+        })?;
+        let project_id = params.project.to_string();
+        // Keep project access at the canonical Gate seam, carrying the caller's
+        // identity. A checkpoint's namespace describes continuation, not read isolation.
+        let mut identity = RequestIdentity::from_token(token);
+        // Implicit requests write to local even when Gate used another default.
+        // Use the originating Gate namespace so this read cannot weaken that check.
+        identity.namespace = token.gate_namespace().as_str().to_string();
+        let project = registry
+            .dispatch_with_identity(
+                "get",
+                json!({
+                    "id":project_id,"namespace":identity.namespace,
+                }),
+                Some(identity),
+            )
+            .await?;
+        if project["kind"] != "project" || !project["deleted_at"].is_null() {
+            return Err(RuntimeError::InvalidInput(
+                "project must identify a live project entity".into(),
+            ));
+        }
+        let (source_kind, kind) = params.source_kind.names();
+        let checkpoint_kind = format!("{kind}_checkpoint");
+        // One SELECT snapshot cannot tear the atomically written pair. Limit
+        // materialized value bytes even when a damaged row exceeds writer bounds.
+        let rows = self.runtime().sql().reader().await?.query(SqlStatement {
+            sql: "SELECT kind, updated_at, typeof(cursor_value) AS value_type, \
+                  length(CAST(cursor_value AS BLOB)) AS value_bytes, \
+                  CASE WHEN length(CAST(cursor_value AS BLOB)) <= ?4 THEN CAST(cursor_value AS BLOB) END AS value \
+                  FROM git_mirror_cursor WHERE project_id=?1 AND kind IN (?2, ?3)".into(),
+            params: vec![SqlValue::Text(project_id.clone()), SqlValue::Text(kind.into()),
+                SqlValue::Text(checkpoint_kind.clone()), SqlValue::Integer(MAX_VALUE_BYTES)],
+            label: Some("git.ingest_cursor.snapshot".into()),
+        }).await?;
+        let mut cursor = Value::Null;
+        let mut checkpoint = Value::Null;
+        for row in rows {
+            match row.get("kind") {
+                Some(SqlValue::Text(name)) if name == kind => cursor = render_row(&row)?,
+                Some(SqlValue::Text(name)) if name == &checkpoint_kind => {
+                    checkpoint = render_row(&row)?
+                }
+                _ => return Err(invalid_row()),
+            }
+        }
+        Ok(json!({
+            "project_id": project_id,
+            "source_kind": source_kind,
+            "cursor": cursor,
+            "checkpoint": checkpoint,
+        }))
+    }
+}
+
+fn invalid_row() -> RuntimeError {
+    RuntimeError::InvalidInput(
+        "stored ingest cursor row has invalid column types or text encoding".into(),
+    )
+}
+
+fn render_row(row: &SqlRow) -> Result<Value, RuntimeError> {
+    if !matches!(row.get("value_type"), Some(SqlValue::Text(t)) if t == "text" || t == "null") {
+        return Err(invalid_row());
+    }
+    let value_bytes = match row.get("value_bytes") {
+        Some(SqlValue::Integer(n)) if *n >= 0 => Some(*n),
+        Some(SqlValue::Null) => None,
+        _ => return Err(invalid_row()),
+    };
+    let truncated = value_bytes.is_some_and(|n| n > MAX_VALUE_BYTES);
+    let value = match row.get("value") {
+        Some(SqlValue::Blob(bytes)) => {
+            Value::String(String::from_utf8(bytes.clone()).map_err(|_| invalid_row())?)
+        }
+        Some(SqlValue::Null) => Value::Null,
+        _ => return Err(invalid_row()),
+    };
+    let updated_at = match row.get("updated_at") {
+        Some(SqlValue::Integer(n)) => *n,
+        _ => return Err(invalid_row()),
+    };
+    Ok(
+        json!({"value": value, "updated_at": updated_at, "value_bytes": value_bytes, "truncated": truncated}),
+    )
+}

--- a/crates/khive-pack-git/src/ingest_cursor.rs
+++ b/crates/khive-pack-git/src/ingest_cursor.rs
@@ -70,7 +70,7 @@ impl GitPack {
         let checkpoint_kind = format!("{kind}_checkpoint");
         // One SELECT snapshot cannot tear the atomically written pair. Limit
         // materialized value bytes even when a damaged row exceeds writer bounds.
-        let rows = self.runtime().sql().reader().await?.query(SqlStatement {
+        let rows = self.runtime().sql().reader().await?.query_all(SqlStatement {
             sql: "SELECT kind, updated_at, typeof(cursor_value) AS value_type, \
                   length(CAST(cursor_value AS BLOB)) AS value_bytes, \
                   CASE WHEN length(CAST(cursor_value AS BLOB)) <= ?4 THEN CAST(cursor_value AS BLOB) END AS value \
@@ -83,8 +83,8 @@ impl GitPack {
         let mut checkpoint = Value::Null;
         for row in rows {
             match row.get("kind") {
-                Some(SqlValue::Text(name)) if name == kind => cursor = render_row(&row)?,
-                Some(SqlValue::Text(name)) if name == &checkpoint_kind => {
+                Some(SqlValue::Text(name)) if name.as_str() == kind => cursor = render_row(&row)?,
+                Some(SqlValue::Text(name)) if name.as_str() == checkpoint_kind.as_str() => {
                     checkpoint = render_row(&row)?
                 }
                 _ => return Err(invalid_row()),

--- a/crates/khive-pack-git/src/input_schema.json
+++ b/crates/khive-pack-git/src/input_schema.json
@@ -466,5 +466,27 @@
       "repo"
     ],
     "additionalProperties": false
+  },
+  "git.ingest_cursor": {
+    "type": "object",
+    "properties": {
+      "project": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "source_kind": {
+        "type": "string",
+        "enum": [
+          "commits",
+          "issues",
+          "pull_requests"
+        ]
+      }
+    },
+    "required": [
+      "project",
+      "source_kind"
+    ],
+    "additionalProperties": false
   }
 }

--- a/crates/khive-pack-git/src/lib.rs
+++ b/crates/khive-pack-git/src/lib.rs
@@ -2,11 +2,12 @@
 //! Amendments 1 and 2, plus ADR-108).
 //!
 //! Contributes three note kinds (`commit`, `issue`, `pull_request`) that make
-//! repository provenance queryable through the KG graph, one read/ingest
+//! repository provenance queryable through the KG graph, an ingest
 //! agent-facing verb, `git.digest(source, project?, max_items?, include?)`
 //! (`handlers`), that drives the batch, cursor-based ingester (`ingest`)
 //! against either a local path or a remote `https://` URL (cloned/fetched
-//! into a daemon-owned scratch cache, `cache`), local object operations, and
+//! into a daemon-owned scratch cache, `cache`), persisted position inspection
+//! (`ingest_cursor`), local object operations, and
 //! policy-gated remote writes (ADR-182). Git children use hardened,
 //! allowlisted argv construction; platform operations use actor credentials. See
 //! `docs/adr/ADR-088-git-lifecycle-pack.md`,
@@ -18,6 +19,7 @@
 //!
 //! | Verb | Args | What it does |
 //! | ---- | ---- | ------------ |
+//! | `git.ingest_cursor` | `project`, `source_kind` | Read the exact stored ingest cursor/checkpoint pair in one snapshot |
 //! | `git.digest` | `source`, `project?`, `max_items?`, `include?` | Ingest commit/issue/PR provenance from a local path or `https://` URL, bounded and cursor-resumable |
 //! | `git.commit` | `repo`, `message`, `paths?`, `author?` | Stage and commit against a local repo; returns the resulting SHA |
 //! | `git.branch` | `repo`, `name`, `from?` | Create a branch, optionally from a named ref/SHA |
@@ -36,6 +38,7 @@ mod credentials;
 pub mod handlers;
 pub mod hook;
 pub mod ingest;
+mod ingest_cursor;
 mod input_schema;
 mod local_git;
 mod local_handlers;

--- a/crates/khive-pack-git/src/pack.rs
+++ b/crates/khive-pack-git/src/pack.rs
@@ -17,8 +17,8 @@ use crate::vocab::{GIT_ENTITY_TYPES, GIT_NOTE_KIND_SPECS, GIT_SCHEMA_PLAN_STMTS}
 
 /// Git-lifecycle pack (ADR-088, amended by ADR-088 Amendments 1 and 2, plus
 /// ADR-108) — registers `commit` / `issue` / `pull_request` note kinds populated by
-/// the batch ingester in `src/ingest.rs`, one read/ingest agent-facing verb,
-/// `git.digest` (`src/handlers.rs`), and three write verbs, `git.commit` /
+/// the batch ingester in `src/ingest.rs`, the agent-facing verb
+/// `git.digest` (`src/handlers.rs`), the read `git.ingest_cursor`, and write verbs `git.commit` /
 /// `git.branch` / `git.push` (`src/write_handlers.rs`, ADR-108). Extends the
 /// base edge contract with `precedes` commit→commit (parent→child lineage,
 /// ADR-088 Amendment 1 ingest enrichment) — the only new endpoint rule this
@@ -156,6 +156,7 @@ impl PackRuntime for GitPack {
     ) -> Result<Value, RuntimeError> {
         match verb {
             "git.digest" => self.handle_digest(token, registry, params).await,
+            "git.ingest_cursor" => self.handle_ingest_cursor(token, registry, params).await,
             "git.commit" if params.get("tree").is_some() => {
                 self.handle_local(token, registry, verb, params).await
             }

--- a/crates/khive-pack-git/src/vocab.rs
+++ b/crates/khive-pack-git/src/vocab.rs
@@ -77,7 +77,7 @@ pub(crate) static GIT_ENTITY_TYPES: [EntityTypeDef; 1] = [EntityTypeDef {
 /// still `Commissive` — the speaker commits a persistent change, exactly the
 /// same illocutionary force as `create`/`link`, just against a different
 /// substrate (a git repo instead of khive's own storage).
-pub(crate) static GIT_HANDLERS: [HandlerDef; 15] = [
+pub(crate) static GIT_HANDLERS: [HandlerDef; 16] = [
     crate::local_vocab::INIT,
     crate::local_vocab::CHECKOUT,
     crate::local_vocab::DIFF,
@@ -86,6 +86,28 @@ pub(crate) static GIT_HANDLERS: [HandlerDef; 15] = [
     crate::local_vocab::RECONCILE,
     crate::local_vocab::STATUS,
     crate::local_vocab::LOG,
+    HandlerDef {
+        name: "git.ingest_cursor",
+        description: "Read the stored ingest cursor and checkpoint for a project and source kind in one snapshot. Values are exact opaque strings, not a completion receipt or a guarantee of resumability; oversized values are explicitly omitted. No ingest, remote access, or cursor writes.",
+        visibility: Visibility::Verb,
+        category: VerbCategory::Assertive,
+        params: &[
+            ParamDef {
+                name: "project",
+                param_type: "uuid",
+                required: true,
+                description: "Full UUID of the live project anchor. Canonical get authorization applies with the caller's identity; by-ID reads are namespace-agnostic.",
+                resolution_mode: IdResolutionMode::UnscopedFullUuidOnly,
+            },
+            ParamDef {
+                name: "source_kind",
+                param_type: "string",
+                required: true,
+                description: "One of commits, issues, pull_requests. Commits use a SHA cursor; issues and pull_requests use timestamp cursors with page checkpoints.",
+                resolution_mode: IdResolutionMode::NotApplicable,
+            },
+        ],
+    },
     HandlerDef {
         name: "git.digest",
         description: "Ingest commit/issue/pull_request provenance from a local git repo path or \

--- a/crates/khive-pack-git/tests/ingest_cursor.rs
+++ b/crates/khive-pack-git/tests/ingest_cursor.rs
@@ -1,0 +1,410 @@
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
+};
+
+use khive_pack_git::GitPack;
+use khive_runtime::{
+    Gate, GateDecision, GateError, GateRequest, KhiveRuntime, RequestIdentity, VerbRegistry,
+    VerbRegistryBuilder,
+};
+use khive_storage::types::{SqlStatement, SqlValue};
+use serde_json::{json, Value};
+
+#[derive(Debug, Default)]
+struct InspectGate {
+    deny_get: AtomicBool,
+    deny_get_namespace: Mutex<Option<String>>,
+    seen: Mutex<Vec<GateRequest>>,
+}
+
+impl Gate for InspectGate {
+    fn check(&self, request: &GateRequest) -> Result<GateDecision, GateError> {
+        self.seen.lock().unwrap().push(request.clone());
+        Ok(
+            if request.verb == "get"
+                && (self.deny_get.load(Ordering::SeqCst)
+                    || self.deny_get_namespace.lock().unwrap().as_deref()
+                        == Some(request.namespace.as_str()))
+            {
+                GateDecision::deny("project read denied")
+            } else {
+                GateDecision::allow()
+            },
+        )
+    }
+}
+
+async fn fixture() -> (KhiveRuntime, VerbRegistry, Arc<InspectGate>, String) {
+    fixture_in_namespace("local").await
+}
+
+async fn fixture_in_namespace(
+    namespace: &str,
+) -> (KhiveRuntime, VerbRegistry, Arc<InspectGate>, String) {
+    let runtime = KhiveRuntime::memory().unwrap();
+    let gate = Arc::new(InspectGate::default());
+    let mut builder = VerbRegistryBuilder::new();
+    builder.with_default_namespace(namespace);
+    builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
+    builder.register(GitPack::new(runtime.clone()));
+    builder.with_gate(gate.clone());
+    builder.with_runtime_event_store(&runtime).unwrap();
+    let registry = builder.build().unwrap();
+    runtime.install_edge_rules(registry.all_edge_rules());
+    registry.apply_schema_plans(runtime.backend());
+    let project = registry
+        .dispatch(
+            "create",
+            json!({"kind": "project", "name": "cursor fixture"}),
+        )
+        .await
+        .unwrap();
+    (
+        runtime,
+        registry,
+        gate,
+        project["id"].as_str().unwrap().to_owned(),
+    )
+}
+
+async fn store_pair(
+    runtime: &KhiveRuntime,
+    project: &str,
+    kind: &str,
+    cursor: SqlValue,
+    progress: &str,
+) {
+    runtime.sql().writer().await.unwrap().execute(SqlStatement {
+        sql: "INSERT INTO git_mirror_cursor(project_id, kind, cursor_value, updated_at) VALUES (?1, ?2, ?3, 42), (?1, ?4, ?5, 43) ON CONFLICT(project_id,kind) DO UPDATE SET cursor_value=excluded.cursor_value, updated_at=excluded.updated_at".into(),
+        params: vec![SqlValue::Text(project.into()), SqlValue::Text(kind.into()), cursor,
+            SqlValue::Text(format!("{kind}_checkpoint")), SqlValue::Text(progress.into())],
+        label: None,
+    }).await.unwrap();
+}
+
+async fn inspect(registry: &VerbRegistry, project: &str, source_kind: &str) -> Value {
+    registry
+        .dispatch(
+            "git.ingest_cursor",
+            json!({"project": project, "source_kind": source_kind}),
+        )
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+#[serial_test::serial(config_ledger)]
+async fn absent_cursor_read_does_not_initialize_rows() {
+    let (runtime, registry, _, project) = fixture().await;
+    let expected =
+        json!({"project_id": project, "source_kind": "issues", "cursor": null, "checkpoint": null});
+    assert_eq!(inspect(&registry, &project, "issues").await, expected);
+    assert_eq!(inspect(&registry, &project, "issues").await, expected);
+    let count = runtime
+        .sql()
+        .reader()
+        .await
+        .unwrap()
+        .query_scalar(SqlStatement {
+            sql: "SELECT COUNT(*) FROM git_mirror_cursor".into(),
+            params: vec![],
+            label: None,
+        })
+        .await
+        .unwrap();
+    assert!(matches!(count, Some(SqlValue::Integer(0))));
+    assert_eq!(
+        registry.presentation_policy_for("git.ingest_cursor"),
+        khive_types::VerbPresentationPolicy::AlwaysVerbose
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial(config_ledger)]
+async fn all_source_kinds_preserve_exact_cursor_checkpoint_and_update_times() {
+    let (runtime, registry, _, project) = fixture().await;
+    for (source_kind, stored_kind, value) in [
+        ("commits", "commits", "a".repeat(40)),
+        ("issues", "issues", "2026-09-01T12:01:02+00:00".into()),
+        ("pull_requests", "prs", "2026-09-02T12:01:02Z".into()),
+    ] {
+        let progress = if source_kind == "commits" {
+            json!({"version":1,"namespace":"source-attribution","base_cursor":null,
+                "snapshot_head":"b".repeat(40),"last_completed_sha":value})
+            .to_string()
+        } else {
+            json!({"version":1,"namespace":"source-attribution","floor":value,
+                "at_floor":{"7":"00000000-0000-0000-0000-000000000007"},"undated":{}})
+            .to_string()
+        };
+        store_pair(
+            &runtime,
+            &project,
+            stored_kind,
+            SqlValue::Text(value.clone()),
+            &progress,
+        )
+        .await;
+        let result = inspect(&registry, &project, source_kind).await;
+        assert_eq!(result["project_id"], project);
+        assert_eq!(result["source_kind"], source_kind);
+        assert_eq!(
+            result["cursor"],
+            json!({"value":value, "value_bytes":value.len(), "updated_at":42, "truncated":false})
+        );
+        assert_eq!(
+            result["checkpoint"],
+            json!({"value":progress, "value_bytes":progress.len(), "updated_at":43, "truncated":false})
+        );
+        assert_eq!(inspect(&registry, &project, source_kind).await, result);
+    }
+    let other = registry
+        .dispatch("create", json!({"kind":"project","name":"other anchor"}))
+        .await
+        .unwrap();
+    assert!(inspect(&registry, other["id"].as_str().unwrap(), "issues").await["cursor"].is_null());
+}
+
+#[tokio::test]
+#[serial_test::serial(config_ledger)]
+async fn inspection_preserves_null_invalid_and_oversized_checkpoint_states() {
+    let (runtime, registry, _, project) = fixture().await;
+    store_pair(
+        &runtime,
+        &project,
+        "issues",
+        SqlValue::Null,
+        "invalid checkpoint JSON 文",
+    )
+    .await;
+    let result = inspect(&registry, &project, "issues").await;
+    assert_eq!(
+        result["cursor"],
+        json!({"value":null,"value_bytes":null,"updated_at":42,"truncated":false})
+    );
+    assert_eq!(result["checkpoint"]["value"], "invalid checkpoint JSON 文");
+    let boundary = "x".repeat(256 * 1024);
+    store_pair(&runtime, &project, "issues", SqlValue::Null, &boundary).await;
+    let result = inspect(&registry, &project, "issues").await;
+    assert_eq!(result["checkpoint"]["value"], boundary);
+    assert_eq!(result["checkpoint"]["truncated"], false);
+    let oversized = "文".repeat(100_000);
+    store_pair(
+        &runtime,
+        &project,
+        "issues",
+        SqlValue::Text("invalid timestamp".into()),
+        &oversized,
+    )
+    .await;
+    let result = inspect(&registry, &project, "issues").await;
+    assert_eq!(result["cursor"]["value"], "invalid timestamp");
+    assert_eq!(
+        result["checkpoint"],
+        json!({"value":null,"value_bytes":300_000,"updated_at":43,"truncated":true})
+    );
+    assert!(result.to_string().len() < 1024);
+    assert_eq!(inspect(&registry, &project, "issues").await, result);
+    runtime
+        .sql()
+        .writer()
+        .await
+        .unwrap()
+        .execute(SqlStatement {
+            sql: "DELETE FROM git_mirror_cursor WHERE project_id=?1 AND kind='issues_checkpoint'"
+                .into(),
+            params: vec![SqlValue::Text(project.clone())],
+            label: None,
+        })
+        .await
+        .unwrap();
+    let legacy = inspect(&registry, &project, "issues").await;
+    assert_eq!(legacy["cursor"], result["cursor"]);
+    assert!(legacy["checkpoint"].is_null());
+    runtime
+        .sql()
+        .writer()
+        .await
+        .unwrap()
+        .execute(SqlStatement {
+            sql: "UPDATE git_mirror_cursor SET cursor_value=?2 WHERE project_id=?1".into(),
+            params: vec![
+                SqlValue::Text(project.clone()),
+                SqlValue::Blob(vec![0; 262_145]),
+            ],
+            label: None,
+        })
+        .await
+        .unwrap();
+    let error = registry
+        .dispatch(
+            "git.ingest_cursor",
+            json!({"project":project,"source_kind":"issues"}),
+        )
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("invalid column types"));
+    runtime
+        .sql()
+        .writer()
+        .await
+        .unwrap()
+        .execute(SqlStatement {
+            sql:
+                "UPDATE git_mirror_cursor SET cursor_value=CAST(X'80' AS TEXT) WHERE project_id=?1"
+                    .into(),
+            params: vec![SqlValue::Text(project.clone())],
+            label: None,
+        })
+        .await
+        .unwrap();
+    let error = registry
+        .dispatch(
+            "git.ingest_cursor",
+            json!({"project":project,"source_kind":"issues"}),
+        )
+        .await
+        .unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("invalid column types or text encoding"));
+}
+
+#[tokio::test]
+#[serial_test::serial(config_ledger)]
+async fn project_get_gate_receives_request_identity_and_denial_is_preserved() {
+    let (runtime, registry, gate, project) = fixture().await;
+    store_pair(
+        &runtime,
+        &project,
+        "issues",
+        SqlValue::Text("2026-09-01T00:00:00Z".into()),
+        "{}",
+    )
+    .await;
+    gate.seen.lock().unwrap().clear();
+    let params = json!({"project":project,"source_kind":"issues","namespace":"read-context"});
+    let identity = RequestIdentity {
+        namespace: "identity-default".into(),
+        actor_id: Some("cursor-reader".into()),
+        ..Default::default()
+    };
+    let response = registry
+        .dispatch_with_identity("git.ingest_cursor", params.clone(), Some(identity.clone()))
+        .await
+        .unwrap();
+    assert_eq!(response["cursor"]["updated_at"], 42);
+    {
+        let requests = gate.seen.lock().unwrap();
+        for verb in ["git.ingest_cursor", "get"] {
+            let request = requests.iter().find(|r| r.verb == verb).unwrap();
+            assert_eq!(request.actor.id, "cursor-reader");
+            assert_eq!(request.namespace.as_str(), "read-context");
+        }
+    }
+    gate.deny_get.store(true, Ordering::SeqCst);
+    let error = registry
+        .dispatch_with_identity("git.ingest_cursor", params, Some(identity))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(error, khive_runtime::RuntimeError::PermissionDenied { .. }),
+        "{error:?}"
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial(config_ledger)]
+async fn implicit_gate_namespace_denial_matches_direct_get() {
+    for use_request_identity in [false, true] {
+        let default = if use_request_identity {
+            "local"
+        } else {
+            "restricted"
+        };
+        let (_, registry, gate, project) = fixture_in_namespace(default).await;
+        *gate.deny_get_namespace.lock().unwrap() = Some("restricted".into());
+        let identity = use_request_identity.then(|| RequestIdentity {
+            namespace: "restricted".into(),
+            actor_id: Some("cursor-reader".into()),
+            ..Default::default()
+        });
+        for (verb, params) in [
+            ("get", json!({"id":project})),
+            (
+                "git.ingest_cursor",
+                json!({"project":project,"source_kind":"issues"}),
+            ),
+        ] {
+            gate.seen.lock().unwrap().clear();
+            let error = registry
+                .dispatch_with_identity(verb, params, identity.clone())
+                .await
+                .unwrap_err();
+            assert!(
+                matches!(error, khive_runtime::RuntimeError::PermissionDenied { .. }),
+                "{error:?}"
+            );
+            let requests = gate.seen.lock().unwrap();
+            assert!(requests.iter().any(|r| r.verb == "get"));
+            assert!(requests
+                .iter()
+                .all(|r| r.namespace.as_str() == "restricted"));
+        }
+        gate.seen.lock().unwrap().clear();
+        let result = registry
+            .dispatch_with_identity(
+                "git.ingest_cursor",
+                json!({"project":project,"source_kind":"issues","namespace":"allowed"}),
+                identity,
+            )
+            .await
+            .unwrap();
+        assert!(result["cursor"].is_null());
+        let requests = gate.seen.lock().unwrap();
+        assert!(requests.iter().any(|r| r.verb == "get"));
+        assert!(requests.iter().all(|r| r.namespace.as_str() == "allowed"));
+    }
+}
+
+#[tokio::test]
+#[serial_test::serial(config_ledger)]
+async fn invalid_selector_wrong_kind_missing_and_deleted_projects_refuse() {
+    let (_, registry, _, project) = fixture().await;
+    for params in [
+        json!({"project":&project[..8],"source_kind":"issues"}),
+        json!({"project":project,"source_kind":"prs"}),
+        json!({"project":project,"source_kind":false}),
+        json!({"project":project}),
+        json!({"project":project,"source_kind":"issues","reset":true}),
+        json!({"project":"00000000-0000-0000-0000-000000000007","source_kind":"issues"}),
+    ] {
+        assert!(registry
+            .dispatch("git.ingest_cursor", params)
+            .await
+            .is_err());
+    }
+    let entity = registry
+        .dispatch("create", json!({"kind":"concept","name":"not a project"}))
+        .await
+        .unwrap();
+    assert!(registry
+        .dispatch(
+            "git.ingest_cursor",
+            json!({"project":entity["id"],"source_kind":"issues"})
+        )
+        .await
+        .is_err());
+    registry
+        .dispatch("delete", json!({"id":project}))
+        .await
+        .unwrap();
+    assert!(registry
+        .dispatch(
+            "git.ingest_cursor",
+            json!({"project":project,"source_kind":"issues"})
+        )
+        .await
+        .is_err());
+}

--- a/crates/khive-pack-git/tests/support/digest_commit_resume.rs
+++ b/crates/khive-pack-git/tests/support/digest_commit_resume.rs
@@ -59,6 +59,33 @@ async fn digest_resume_diamond_max_one_reopens_database_and_finishes() {
     let mut positions = BTreeSet::new();
     for pass in 0..5 {
         let (rt, _token, registry) = file_fixture(&db).await;
+        if pass > 0 {
+            let stored = registry
+                .dispatch(
+                    "git.ingest_cursor",
+                    json!({
+                        "project":project.to_string(),"source_kind":"commits",
+                    }),
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                stored["cursor"]["value"],
+                read_git_cursor(&rt, project, "commits").await.unwrap()
+            );
+            assert_eq!(
+                stored["checkpoint"]["value"],
+                read_git_cursor(&rt, project, "commits_checkpoint")
+                    .await
+                    .unwrap()
+            );
+            assert!(stored["checkpoint"]["updated_at"].as_i64().unwrap() > 0);
+            assert_eq!(
+                stored["cursor"]["updated_at"],
+                stored["checkpoint"]["updated_at"]
+            );
+            assert_eq!(stored["checkpoint"]["truncated"], false);
+        }
         let report = digest(&registry, &repo, project, 1).await;
         let visits = report["commits_ingested"].as_u64().unwrap()
             + report["commits_skipped_existing"].as_u64().unwrap();

--- a/crates/khive-pack-git/tests/support/digest_resume.rs
+++ b/crates/khive-pack-git/tests/support/digest_resume.rs
@@ -77,6 +77,40 @@ async fn digest_resume_one_item_handles_undated_ties_and_unseen_lower_numbers() 
                 !report.done,
                 "an exact-budget pass conservatively requests one more call: {report:?}"
             );
+            let source_kind = if prs { "pull_requests" } else { "issues" };
+            let stored_kind = if prs { "prs" } else { "issues" };
+            let stored = registry
+                .dispatch(
+                    "git.ingest_cursor",
+                    json!({
+                        "project":project.to_string(),"source_kind":source_kind,
+                    }),
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                stored["cursor"]["value"],
+                json!(read_git_cursor(&rt, project, stored_kind).await)
+            );
+            let raw = read_git_cursor(&rt, project, &format!("{stored_kind}_checkpoint"))
+                .await
+                .unwrap();
+            assert_eq!(stored["checkpoint"]["value"], raw);
+            let page: Value = serde_json::from_str(&raw).unwrap();
+            assert_eq!(page["undated"].as_object().unwrap().len(), 1);
+            assert_eq!(page["at_floor"].as_object().unwrap().len(), pass);
+            if pass == 0 {
+                assert!(
+                    stored["cursor"].is_null(),
+                    "undated-only progress has no timestamp row"
+                );
+            } else {
+                assert_eq!(
+                    stored["cursor"]["updated_at"],
+                    stored["checkpoint"]["updated_at"]
+                );
+            }
+            assert_eq!(stored["checkpoint"]["truncated"], false);
         }
         // Exact membership matters: a newly visible, smaller number at the same
         // timestamp must not be discarded by a numeric high-water predicate.

--- a/crates/khive-runtime/src/config.rs
+++ b/crates/khive-runtime/src/config.rs
@@ -131,6 +131,7 @@ mod private {
 #[derive(Clone, Debug)]
 pub struct NamespaceToken {
     namespace: Namespace,
+    gate_namespace: Namespace,
     visible: Vec<Namespace>,
     actor: ActorRef,
     process_ref: Option<String>,
@@ -156,6 +157,7 @@ impl NamespaceToken {
         }
         debug_assert!(!visible.is_empty(), "visible set must be non-empty");
         Self {
+            gate_namespace: namespace.clone(),
             namespace,
             visible,
             actor,
@@ -199,6 +201,18 @@ impl NamespaceToken {
         &self.namespace
     }
 
+    /// Return the namespace used by the originating dispatch's Gate check.
+    /// It can differ from the primary storage namespace on an implicit request.
+    /// Tokens minted directly, or reminted by `with_namespace`, use their primary.
+    pub fn gate_namespace(&self) -> &Namespace {
+        &self.gate_namespace
+    }
+
+    pub(crate) fn with_gate_namespace(mut self, namespace: Namespace) -> Self {
+        self.gate_namespace = namespace;
+        self
+    }
+
     /// Return the read-visibility set.
     ///
     /// List, search, and get operations must accept records whose namespace is
@@ -233,6 +247,7 @@ impl NamespaceToken {
     }
 
     /// Return a new token with the same actor but a different namespace.
+    /// The Gate namespace metadata is reset to the new primary namespace.
     ///
     /// The visible set is replaced with `[ns]`: this is a full read+write token
     /// for `ns`, not a type-enforced write-only or append-only capability. It is

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -1720,6 +1720,8 @@ impl VerbRegistry {
         ("git", "git.gates"),
         ("git", "git.status"),
         ("git", "git.log"),
+        // Canonical get project check plus bounded cursor SELECT; no domain writes.
+        ("git", "git.ingest_cursor"),
         // blob
         ("blob", "blob.get"),
         ("blob", "blob.stat"),

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -2625,6 +2625,7 @@ impl VerbRegistry {
             extra_visible.push(Namespace::local()); // 'local' always readable; mint dedups
             NamespaceToken::mint_with_visibility(primary, extra_visible, resolved_actor)
         }
+        .with_gate_namespace(ns.clone())
         .with_process_ref(match identity.as_ref() {
             Some(id) => id.process_ref.clone(),
             None => crate::config::process_ref_from_env(),

--- a/crates/khive-types/src/pack.rs
+++ b/crates/khive-types/src/pack.rs
@@ -186,7 +186,7 @@ pub enum VerbPresentationPolicy {
     ///
     /// Declared verbs: `get`, `link`, `query`, `traverse`, `neighbors`,
     /// `brain.feedback`, `brain.auto_feedback`, `memory.feedback`,
-    /// `comm.delivered`, `git.digest`.
+    /// `comm.delivered`, `git.digest`, `git.ingest_cursor`.
     ///
     /// `link` is included because the returned edge ID is the only handle for
     /// follow-up `neighbors`/`traverse` calls; short-form IDs risk prefix
@@ -205,6 +205,8 @@ pub enum VerbPresentationPolicy {
     /// `git.digest` is included because its successful response is also the
     /// durable receipt payload. Presentation must not shorten `receipt_id` or
     /// otherwise make the returned result differ from the stored result.
+    /// `git.ingest_cursor` preserves raw checkpoint strings, full project UUIDs,
+    /// and stored microsecond timestamps for persisted-position inspection.
     AlwaysVerbose,
 }
 
@@ -228,7 +230,8 @@ impl HandlerDef {
             | "brain.auto_feedback"
             | "memory.feedback"
             | "comm.delivered"
-            | "git.digest" => VerbPresentationPolicy::AlwaysVerbose,
+            | "git.digest"
+            | "git.ingest_cursor" => VerbPresentationPolicy::AlwaysVerbose,
             _ => VerbPresentationPolicy::Standard,
         }
     }
@@ -641,6 +644,7 @@ mod tests {
             "memory.feedback",
             "comm.delivered",
             "git.digest",
+            "git.ingest_cursor",
         ];
         for name in always_verbose {
             let h = HandlerDef {

--- a/docs/adr/ADR-088-amendment-1-git-digest.md
+++ b/docs/adr/ADR-088-amendment-1-git-digest.md
@@ -18,8 +18,9 @@ The directive is to make digestion agent-facing, and to accept a remote URL dire
 agent can point the verb at any repository and ingest its history without a pre-existing
 local clone.
 
-This amendment supersedes ADR-088's "no new agent-facing verbs" clause for exactly one
-verb. Note kinds, edge usage, cursor semantics, secret masking, and the `gh` access path
+This amendment originally superseded ADR-088's "no new agent-facing verbs" clause for
+`git.digest`. The proposed 2026-09-10 operational rider below adds a read-only cursor
+inspection verb. Note kinds, edge usage, cursor semantics, secret masking, and the `gh` access path
 remain unchanged except where the accepted operational rider below narrows GitHub
 capability detection and successful-response durability.
 
@@ -315,6 +316,39 @@ returned `IngestReport`; the field is `0` for a pass with no over-cap commits.
 This reuses the pack-kg `create` verb's existing `embedding_content` parameter (a
 non-empty proper prefix of `content`, subject to the same secret-gate check as any other
 stored text) rather than adding pack-git-local truncation logic.
+
+## Proposed operational rider: persisted cursor inspection (2026-09-10)
+
+Add `git.ingest_cursor(project, source_kind)` as an `Assertive`, `AlwaysVerbose` read.
+Both arguments are required: a full live project UUID and one of `commits`, `issues`,
+or `pull_requests`. Canonical `get` authorization uses the caller's identity and
+resolved request namespace; full UUID access follows the existing namespace-agnostic
+by-ID contract. A checkpoint's namespace remains continuation metadata.
+
+`NamespaceToken` retains the originating Gate namespace separately from the storage
+primary. Dispatch stamps it from the resolved Gate request; direct minting and
+`with_namespace` reminting default it to the primary. This new read uses that metadata
+for nested `get`, so an implicit non-local Gate scope cannot become `local` merely
+because the default storage primary is local. Existing storage namespace, visibility,
+and `RequestIdentity::from_token` projection semantics remain unchanged.
+
+One SQL statement reads the cursor and its `_checkpoint` row from the existing
+`git_mirror_cursor` table (`pull_requests` maps to stored `prs`). Return the canonical
+`project_id`, public `source_kind`, and nullable `cursor` / `checkpoint` objects. Each
+object contains the opaque stored string `value`, integer microsecond `updated_at`,
+nullable UTF-8 `value_bytes`, and boolean `truncated`. Preserve absence separately from
+a present SQL NULL. Values over 256 KiB per row are wholly omitted with `truncated: true`
+and their actual byte count. The pair is one statement snapshot, not two separately
+timed reads. No new schema, ingestion, external process, cursor write, normalization,
+or repair is introduced; ordinary runtime authorization and audit still apply.
+
+This supplies persisted position after terminal ambiguity, including exact page-boundary
+membership that a timestamp alone cannot reveal. It does not identify a request, prove
+completion, establish resumability, or establish that a timed-out request stopped.
+Concurrent ingestion can advance after the snapshot. Receipt recovery above remains
+the way to recover a completed request's report. See the complete
+[API contract](../../crates/khive-pack-git/docs/api/ingest_cursor.md) for row shapes,
+bounds, and recovery guidance. This rider remains proposed pending review and merge.
 
 ## Consequences
 

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -27,7 +27,7 @@ An always-machine-readable copy of this page is at
 | `schedule`  | 4     | `KHIVE_PACKS=kg,schedule`                  | Yes                 |
 | `knowledge` | 19    | `KHIVE_PACKS=kg,knowledge`                 | Yes                 |
 | `session`   | 4     | `KHIVE_PACKS=kg,session`                   | Yes                 |
-| `git`       | 15    | `KHIVE_PACKS=kg,git`                       | Yes                 |
+| `git`       | 16    | `KHIVE_PACKS=kg,git`                       | Yes                 |
 | `code`      | 1     | `KHIVE_PACKS=kg,code`                      | Yes                 |
 | `workspace` | 0     | `KHIVE_PACKS=kg,git,gtd,session,workspace` | Yes                 |
 | `blob`      | 3     | `KHIVE_PACKS=kg,blob`                      | Yes                 |
@@ -36,7 +36,8 @@ An always-machine-readable copy of this page is at
 
 `git` also registers the `commit` / `issue` / `pull_request` note kinds and the shared
 `run_ingest` core (`crates/khive-pack-git/src/ingest.rs`) that both `git.digest` and the
-`kkernel git-ingest` CLI drive. Its fifteen verbs are `git.digest` (read/ingest), the three
+`kkernel git-ingest` CLI drive. Its sixteen verbs are `git.digest` (read/ingest), `git.ingest_cursor` (a read of the
+stored ingest cursor and checkpoint for one project and source kind), the three
 write verbs `git.commit` / `git.branch` / `git.push` (ADR-108) that shell to system git
 with hardened, allowlisted argv construction, the three read verbs `git.status` /
 `git.log` / `git.init`, and the dev-loop verbs `git.checkout` /
@@ -2261,7 +2262,7 @@ This does not change the separate `git.checkout` symlink-refusal contract.
 
 ---
 
-## `git` pack — 15 verbs
+## `git` pack — 16 verbs
 
 The entries below cover the ingest and write surface; the dev-loop verbs
 (`git.checkout`, `git.diff`, `git.gates`, `git.receipts`, `git.reconcile`, `git.status`,
@@ -2369,6 +2370,13 @@ observed 300,000 ms bound is the MCP client's request default, so large
 `max_items` values can outlive a particular caller's wait while the daemon
 continues the pass. The durable receipt is the recovery contract; the item
 bound is not silently clamped to a transport-specific duration.
+
+### `git.ingest_cursor` — Assertive
+
+Reads the stored ingest cursor and checkpoint for a `project` and source kind in one
+snapshot. Values are exact opaque strings, not a completion receipt or a guarantee of
+resumability; oversized values are explicitly omitted. No ingest, remote access, or cursor
+writes (ADR-088 Amendment 1).
 
 ### `git.commit` / `git.branch` / `git.push` — Commissive (ADR-108)
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -9,7 +9,7 @@ graph, and link concepts together.
 khive is a research knowledge graph runtime. When you read papers, form
 concepts, link ideas, record decisions, or track tasks, khive gives that work a
 typed, queryable graph that persists across sessions. Everything is accessible
-through 128 verbs across 14 packs, dispatched through a single MCP tool.
+through 129 verbs across 14 packs, dispatched through a single MCP tool.
 
 ## Install
 

--- a/marketplace/khive/README.md
+++ b/marketplace/khive/README.md
@@ -2,7 +2,7 @@
 
 One plugin for the whole khive surface: a knowledge graph, GTD, memory, inter-agent comm,
 scheduling, and a domain-knowledge corpus, all served by a single MCP server (`kkernel mcp`)
-exposing one tool — `request` — that dispatches 128 verbs across 14 packs.
+exposing one tool — `request` — that dispatches 129 verbs across 14 packs.
 
 This plugin is **guidance, not a second runtime**. It ships the pattern skills that teach an
 agent how to use each pack well, plus the kg stewardship agents. The data and verbs live in the

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,6 +1,6 @@
 # khive
 
-A research knowledge graph runtime — 128 verbs, 14 packs, one MCP tool.
+A research knowledge graph runtime — 129 verbs, 14 packs, one MCP tool.
 
 [![GitHub](https://img.shields.io/github/stars/ohdearquant/khive?style=flat)](https://github.com/ohdearquant/khive)
 [![crates.io](https://img.shields.io/crates/v/khive-mcp.svg)](https://crates.io/crates/khive-mcp)
@@ -34,7 +34,7 @@ runtime warm.
 | **schedule**  | 4     | Reminders and scheduled verb execution                                                                                                           |
 | **knowledge** | 19    | Atom-based KB with embedding rerank search                                                                                                       |
 | **session**   | 4     | Session record persistence (store/list/resume/export)                                                                                            |
-| **git**       | 15    | Git-lifecycle note kinds (commit/issue/pull_request) + batch ingester + `git.digest`; write verbs `git.commit`/`git.branch`/`git.push` (ADR-108) |
+| **git**       | 16    | Git-lifecycle note kinds (commit/issue/pull_request) + batch ingester + `git.digest`; write verbs `git.commit`/`git.branch`/`git.push` (ADR-108) |
 | **code**      | 1     | `code.ingest` L1/L1.5 source ingest; `findings.json` stays admin-CLI (`kkernel code-ingest`)                                                     |
 | **workspace** | 0     | Adds the `workspace` entity kind + `contains` endpoint rules to git/gtd/session notes (#873)                                                     |
 | **blob**      | 3     | Content-addressed blob storage (`blob.put` / `blob.get` / `blob.stat`)                                                                           |

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -292,15 +292,16 @@ def main():
         # until a backend is installed via [storage.blob] or KHIVE_BLOB_ROOT.
         # The kg pack also carries its one documented sub-namespace,
         # stream.append / stream.batch / stream.read / stream.stat (ADR-174
-        # §2); git grew from four verbs to fifteen with the dev-loop surface
+        # §2); git grew from four verbs to sixteen with the dev-loop surface
         # (checkout, diff, gates, receipts, reconcile, status, log, init,
-        # pr_open, pr_review, pr_merge; ADR-182);
+        # pr_open, pr_review, pr_merge; ADR-182) plus git.ingest_cursor
+        # (ADR-088 Amendment 1, the persisted ingest cursor read);
         # tool contributes thirteen verbs and exec nine (the tool registry
         # with use policy and sandboxed runs over trees).
         # Update this number when the pack set or verb surface changes; a
         # silent drift here is the bug this assertion exists to catch.
-        assert verbs_result["total"] == 128, (
-            f"expected 128 user-facing verbs from the 14 default packs "
+        assert verbs_result["total"] == 129, (
+            f"expected 129 user-facing verbs from the 14 default packs "
             f"(session contributes 4 T1 verbs promoted to Visibility::Verb per "
             f"ADR-083; context is the 17th kg-substrate bare verb per ADR-089; "
             f"resolve is the 18th kg-substrate bare verb per the unified-verb "
@@ -319,7 +320,8 @@ def main():
             f"the internal inbound sibling after an ambiguous atomic write), "
             f"kg also carries stream.append/stream.batch/stream.read/stream.stat "
             f"(ADR-174); "
-            f"git contributes fifteen verbs with the ADR-182 dev-loop surface; "
+            f"git contributes sixteen verbs with the ADR-182 dev-loop surface "
+            f"and git.ingest_cursor; "
             f"tool contributes thirteen verbs and exec nine; "
             f"got {verbs_result['total']}: {verbs_result}"
         )


### PR DESCRIPTION
## Summary

Adds `git.ingest_cursor(project, source_kind)`: a read-only verb that returns a project's persisted digest cursor and checkpoint for one source kind (`commits`, `issues`, `pull_requests`) as a single snapshot, so a caller can see where ingestion last stopped without running a digest.

## Behaviour

- One bounded SQL read of the cursor and checkpoint rows keyed by project and kind. Raw cursor and checkpoint strings are returned as stored, with their microsecond update times; absent rows and SQL NULL are reported distinctly.
- Each value is bounded to 256 KiB. An oversized value is omitted whole with its byte count and `truncated: true`. Values are read as bytes and decoded strictly as UTF-8; non-text storage types refuse.
- The project is resolved through the ordinary `get` path with the caller's identity and originating namespace, so visibility and denial match a direct `get`. Invalid, missing, prefix, non-project and deleted anchors refuse.
- A snapshot is not a request receipt or proof of completion; concurrent digestion may advance after the read. The verb performs no ingestion, remote access, cursor write, or schema change.
- The verb is classified admission-degrade-safe (read-only) in the runtime census and presents `AlwaysVerbose`.
- ADR-088 Amendment 1 records the verb and its bounds; the pack API docs carry the reference.

## Tests

Registry tests for absent rows, exact source-kind mapping, raw values and timestamps, project isolation, SQL NULL, legacy cursor-only rows, malformed JSON, Unicode, the exact cap, oversized multibyte values, BLOB storage and invalid UTF-8; the canonical `get` gate with explicit and implicit identity; and the existing digest acceptance tests now inspect commit, issue and pull-request checkpoints after a file-backed reopen.

## Verification

Rust 1.95.0: `cargo fmt --all -- --check`, `cargo clippy -p khive-pack-git -p khive-runtime -p khive-types --all-targets -- -D warnings`, `cargo test -p khive-pack-git --test ingest_cursor`, and `cargo test -p khive-pack-git -p khive-runtime -p khive-types --no-fail-fast` (2290 passed, 0 failed) at the head.
