### PR TITLE
perf(knowledge): covering indexes for the stats and list counts

### DIFF
--- a/crates/khive-db/Cargo.toml
+++ b/crates/khive-db/Cargo.toml
@@ -70,5 +70,7 @@ path = "benches/db_hot_path.rs"
 required-features = ["vectors"]
 
 [features]
+# Exposes the task-scoped SQLite progress probe for dependent-crate tests.
+test-support = []
 default = []
 vectors = ["dep:sqlite-vec"]

--- a/crates/khive-db/sql/032-knowledge-count-indexes.sql
+++ b/crates/khive-db/sql/032-knowledge-count-indexes.sql
@@ -1,0 +1,8 @@
+-- LIKE uses SQLite's default ASCII case folding; match it without changing
+-- the stored verb or the count's predicate.
+CREATE INDEX IF NOT EXISTS idx_events_ns_verb ON events(namespace, verb COLLATE NOCASE);
+
+-- Cover the live atom count, optional lifecycle filter, and finalized sum
+-- without fetching each atom's content-bearing table page.
+CREATE INDEX IF NOT EXISTS idx_knowledge_atoms_ns_live_counts
+    ON knowledge_atoms(namespace, deleted_at, status, tags, finalized);

--- a/crates/khive-db/sql/events-ddl.sql
+++ b/crates/khive-db/sql/events-ddl.sql
@@ -31,6 +31,7 @@ CREATE TABLE IF NOT EXISTS event_observations (
 
 CREATE INDEX IF NOT EXISTS idx_events_namespace ON events(namespace);
 CREATE INDEX IF NOT EXISTS idx_events_verb ON events(verb);
+CREATE INDEX IF NOT EXISTS idx_events_ns_verb ON events(namespace, verb COLLATE NOCASE);
 CREATE INDEX IF NOT EXISTS idx_events_kind ON events(kind);
 CREATE INDEX IF NOT EXISTS idx_events_substrate ON events(substrate);
 CREATE INDEX IF NOT EXISTS idx_events_created ON events(created_at DESC);

--- a/crates/khive-db/src/lib.rs
+++ b/crates/khive-db/src/lib.rs
@@ -58,7 +58,7 @@ pub use migrations::{
     MIGRATIONS,
 };
 pub use pool::{ConnectionPool, PoolConfig, ReaderGuard, WriterGuard};
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 pub use read_cancellation::scope_test_read_progress;
 pub use read_cancellation::{sqlite_interrupt_grace_from_env, DEFAULT_SQLITE_INTERRUPT_GRACE_MS};
 pub use sql_bridge::SqlBridge;

--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -160,6 +160,7 @@ const V28_UP: &str = include_str!("../sql/028-notes-key.sql");
 const V29_UP: &str = include_str!("../sql/029-note-streams.sql");
 const V30_UP: &str = include_str!("../sql/030-tool-source-mounts.sql");
 const V31_UP: &str = include_str!("../sql/031-note-versions.sql");
+const V32_UP: &str = include_str!("../sql/032-knowledge-count-indexes.sql");
 
 const V21_STAGE_UP: &str = include_str!("../sql/021-attachments-a-stage.sql");
 
@@ -370,6 +371,11 @@ pub const MIGRATIONS: &[VersionedMigration] = &[
         version: 31,
         name: "note_versions",
         up: V31_UP,
+    },
+    VersionedMigration {
+        version: 32,
+        name: "knowledge_count_indexes",
+        up: V32_UP,
     },
 ];
 

--- a/crates/khive-db/src/migrations_tests.rs
+++ b/crates/khive-db/src/migrations_tests.rs
@@ -4171,3 +4171,61 @@ fn stream_migration_empty_and_populated_previous_version() {
         run_migrations(&mut conn).unwrap();
     }
 }
+
+#[test]
+fn v31_reopen_installs_knowledge_count_covering_indexes() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("count-index-upgrade.db");
+    {
+        let mut conn = Connection::open(&path).unwrap();
+        migrate_through(&mut conn, 31);
+        conn.execute("INSERT INTO events (id, namespace, verb, substrate, actor, outcome, created_at) VALUES ('event-a', 'local', 'Knowledge.learn', 'entity', 'test', 'ok', 0)", []).unwrap();
+    }
+    let mut conn = Connection::open(&path).unwrap();
+    assert_eq!(run_migrations(&mut conn).unwrap(), latest_schema_version());
+    for (table, index) in [
+        ("events", "idx_events_ns_verb"),
+        ("knowledge_atoms", "idx_knowledge_atoms_ns_live_counts"),
+    ] {
+        let exists: bool = conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM pragma_index_list(?1) WHERE name = ?2)",
+                rusqlite::params![table, index],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(exists, "missing {index} after reopening V31");
+    }
+    let event_sql = "SELECT COUNT(*) FROM events WHERE namespace = ?1 AND verb LIKE 'knowledge.%'";
+    let count: i64 = conn
+        .query_row(event_sql, ["local"], |row| row.get(0))
+        .unwrap();
+    assert_eq!(count, 1, "index must preserve ASCII-insensitive LIKE");
+    for (sql, expected) in [
+        (event_sql, "idx_events_ns_verb"),
+        ("SELECT COUNT(*) FROM knowledge_atoms WHERE namespace = ?1 AND deleted_at IS NULL AND tags NOT LIKE '%type:domain%'", "idx_knowledge_atoms_ns_live_counts"),
+        ("SELECT COUNT(*) FROM knowledge_atoms WHERE namespace = ?1 AND deleted_at IS NULL AND tags NOT LIKE '%type:domain%' AND status = 'reviewed'", "idx_knowledge_atoms_ns_live_counts"),
+        ("SELECT COUNT(*), SUM(CASE WHEN finalized = 1 THEN 1 ELSE 0 END) FROM knowledge_atoms WHERE namespace = ?1 AND deleted_at IS NULL AND tags NOT LIKE '%type:domain%'", "idx_knowledge_atoms_ns_live_counts"),
+    ] {
+        let detail: String = conn.query_row(&format!("EXPLAIN QUERY PLAN {sql}"), ["local"], |row| row.get(3)).unwrap();
+        assert!(detail.contains(&format!("COVERING INDEX {expected}")), "{detail}");
+        if expected == "idx_events_ns_verb" {
+            assert!(detail.contains("verb>?") && detail.contains("verb<?"), "{detail}");
+        }
+    }
+    assert_eq!(run_migrations(&mut conn).unwrap(), latest_schema_version());
+}
+
+#[test]
+fn event_store_ddl_upgrades_existing_event_indexes_idempotently() {
+    let conn = open_memory();
+    crate::stores::event::ensure_events_schema(&conn).unwrap();
+    conn.execute_batch("DROP INDEX idx_events_ns_verb").unwrap();
+    crate::stores::event::ensure_events_schema(&conn).unwrap();
+    crate::stores::event::ensure_events_schema(&conn).unwrap();
+    let exists: bool = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM pragma_index_list('events') WHERE name = 'idx_events_ns_verb')",
+        [], |row| row.get(0),
+    ).unwrap();
+    assert!(exists);
+}

--- a/crates/khive-db/src/read_cancellation.rs
+++ b/crates/khive-db/src/read_cancellation.rs
@@ -7,7 +7,7 @@
 //! cancellation races and request deadlines. Write closures never register.
 
 use std::cell::RefCell;
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 use std::future::Future;
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::Arc;
@@ -53,28 +53,31 @@ pub fn sqlite_interrupt_hard_cap_from_env() -> Duration {
     Duration::from_millis(millis)
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 #[derive(Clone, Default)]
 struct DbReadTestContext {
     progress_probe: Option<Arc<std::sync::atomic::AtomicUsize>>,
+    #[cfg(test)]
     fail_progress_clear: bool,
+    #[cfg(test)]
     settlement_bounds: Option<(Duration, Duration)>,
+    #[cfg(test)]
     bounded_wait_probe: Option<Arc<AtomicBool>>,
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 tokio::task_local! {
     static DB_READ_TEST_CONTEXT: DbReadTestContext;
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 fn current_test_context() -> DbReadTestContext {
     DB_READ_TEST_CONTEXT
         .try_with(Clone::clone)
         .unwrap_or_default()
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 pub async fn scope_test_read_progress<F>(
     probe: Arc<std::sync::atomic::AtomicUsize>,
     future: F,
@@ -161,7 +164,7 @@ struct ReadControl {
     operation: &'static str,
     interrupt_grace: Duration,
     interrupt_hard_cap: Duration,
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-support"))]
     progress_probe: Option<Arc<std::sync::atomic::AtomicUsize>>,
     #[cfg(test)]
     fail_progress_clear: bool,
@@ -171,7 +174,7 @@ struct ReadControl {
 
 impl ReadControl {
     fn new(context: &RequestReadContext, operation: &'static str) -> Arc<Self> {
-        #[cfg(test)]
+        #[cfg(any(test, feature = "test-support"))]
         let test_context = current_test_context();
         let default_settlement_bounds = (
             sqlite_interrupt_grace_from_env(),
@@ -195,7 +198,7 @@ impl ReadControl {
             operation,
             interrupt_grace,
             interrupt_hard_cap,
-            #[cfg(test)]
+            #[cfg(any(test, feature = "test-support"))]
             progress_probe: test_context.progress_probe,
             #[cfg(test)]
             fail_progress_clear: test_context.fail_progress_clear,
@@ -234,10 +237,6 @@ impl ReadControl {
     }
 
     fn progress_should_stop(&self) -> bool {
-        #[cfg(test)]
-        if let Some(probe) = &self.progress_probe {
-            probe.fetch_add(1, Ordering::Relaxed);
-        }
         // This callback runs every 1,000 SQLite VM instructions. Never take
         // the lifecycle mutex here: it exists only to protect ownership of
         // the InterruptHandle used by asynchronous cancellers.
@@ -314,9 +313,16 @@ impl ReadControl {
         }
 
         let callback = Arc::clone(self);
-        if let Err(error) =
-            conn.progress_handler(1_000, Some(move || callback.progress_should_stop()))
-        {
+        if let Err(error) = conn.progress_handler(
+            1_000,
+            Some(move || {
+                #[cfg(any(test, feature = "test-support"))]
+                if let Some(probe) = &callback.progress_probe {
+                    probe.fetch_add(1, Ordering::Relaxed);
+                }
+                callback.progress_should_stop()
+            }),
+        ) {
             self.cleanup_failed.store(true, Ordering::Release);
             self.finish();
             return Err(StorageError::driver(capability, self.operation, error));

--- a/crates/khive-db/src/sql_bridge.rs
+++ b/crates/khive-db/src/sql_bridge.rs
@@ -3932,6 +3932,89 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn pooled_stats_count_cancellation_stops_scan_and_releases_reader() {
+        let dir = tempfile::tempdir().unwrap();
+        let pool = Arc::new(
+            ConnectionPool::new(PoolConfig {
+                path: Some(dir.path().join("stats-count-cancel.db")),
+                max_readers: 1,
+                ..PoolConfig::default()
+            })
+            .unwrap(),
+        );
+        // Expand a small file-backed fixture into a long scan, preserving the
+        // handler's exact outer COUNT rather than substituting a SUM query.
+        pool.writer()
+            .unwrap()
+            .conn()
+            .execute_batch(
+                "CREATE TABLE count_fixture(n INTEGER PRIMARY KEY); \
+             WITH RECURSIVE n(x) AS (SELECT 1 UNION ALL SELECT x+1 FROM n WHERE x<1000) \
+             INSERT INTO count_fixture SELECT x FROM n; \
+             CREATE VIEW events AS SELECT 'local' AS namespace, 'knowledge.learn' AS verb \
+             FROM count_fixture a CROSS JOIN count_fixture b CROSS JOIN count_fixture c;",
+            )
+            .unwrap();
+        let bridge = SqlBridge::new(Arc::clone(&pool), true);
+        let mut reader = bridge.reader().await.unwrap();
+        let progress = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+        let query = tokio::spawn(crate::scope_test_read_progress(
+            Arc::clone(&progress),
+            crate::scope_request_read_cancellation(cancel_rx, async move {
+                let result = reader.query_scalar(SqlStatement {
+                    sql: "SELECT COUNT(*) FROM events WHERE namespace = ?1 AND verb LIKE 'knowledge.%'".into(),
+                    params: vec![SqlValue::Text("local".into())],
+                    label: Some("knowledge.stats.event_count".into()),
+                }).await;
+                (reader, result)
+            }),
+        ));
+        wait_for_progress(progress.as_ref()).await;
+        assert!(
+            !query.is_finished(),
+            "COUNT must still be scanning before cancellation"
+        );
+        let started = std::time::Instant::now();
+        let grace = crate::read_cancellation::sqlite_interrupt_grace_from_env();
+        cancel_tx.send(true).unwrap();
+        let (mut reader, result) = tokio::time::timeout(grace, query)
+            .await
+            .expect("COUNT did not settle within the interrupt grace")
+            .unwrap();
+        let elapsed = started.elapsed();
+        assert!(
+            matches!(result, Err(StorageError::Timeout { .. })),
+            "{result:?}"
+        );
+        assert_eq!(
+            pool.available_readers(),
+            1,
+            "COUNT retained the sole pooled reader"
+        );
+        let stopped = progress.load(std::sync::atomic::Ordering::SeqCst);
+        let next = reader
+            .query_scalar(SqlStatement {
+                sql: "SELECT COUNT(*) FROM count_fixture".into(),
+                params: vec![],
+                label: None,
+            })
+            .await
+            .unwrap();
+        assert!(matches!(next, Some(SqlValue::Integer(1000))));
+        assert_eq!(
+            progress.load(std::sync::atomic::Ordering::SeqCst),
+            stopped,
+            "cancelled callback leaked into the next borrower"
+        );
+        eprintln!(
+            "stats_count_cancel_ms={} grace_ms={}",
+            elapsed.as_secs_f64() * 1000.0,
+            grace.as_millis()
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cancellation_before_reader_checkout_is_prompt_and_executes_no_statement() {
         let dir = tempfile::tempdir().unwrap();
         let config = PoolConfig {

--- a/crates/khive-pack-knowledge/src/knowledge/crud.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/crud.rs
@@ -1089,7 +1089,7 @@ impl KnowledgeHandlers {
                         .query_scalar(SqlStatement {
                             sql: count_sql,
                             params: count_params,
-                            label: None,
+                            label: Some("knowledge.list.atom_count".into()),
                         })
                         .await
                         .map_err(|e| sql_err("list atoms count", e))?;
@@ -1245,7 +1245,7 @@ impl KnowledgeHandlers {
                 sql: "SELECT COUNT(*) FROM events WHERE namespace = ?1 AND verb LIKE 'knowledge.%'"
                     .into(),
                 params: vec![SqlValue::Text(ns.clone())],
-                label: None,
+                label: Some("knowledge.stats.event_count".into()),
             })
             .await
             .map_err(|e| sql_err("stats events", e))?;

--- a/crates/khive-pack-knowledge/tests/count_indexes.rs
+++ b/crates/khive-pack-knowledge/tests/count_indexes.rs
@@ -12,6 +12,77 @@ use serde_json::{json, Value};
 const EVENT_COUNT: &str =
     "SELECT COUNT(*) FROM events WHERE namespace = ?1 AND verb LIKE 'knowledge.%'";
 const ATOM_COUNT: &str = "SELECT COUNT(*) FROM knowledge_atoms WHERE namespace = ?1 AND deleted_at IS NULL AND tags NOT LIKE '%type:domain%'";
+const LIST_COUNT: &str = "SELECT COUNT(*) FROM knowledge_atoms WHERE namespace = ?1 AND deleted_at IS NULL AND tags NOT LIKE '%type:domain%' AND (status IS NULL OR status != 'deprecated')";
+
+const SEED_EVENTS: &str =
+    "WITH RECURSIVE n(x) AS (SELECT 1 UNION ALL SELECT x+1 FROM n WHERE x<?1) \
+     INSERT INTO events (id, namespace, verb, substrate, actor, outcome, payload, created_at) \
+     SELECT printf('10000000-0000-4000-8000-%012x', x), CASE x%4 WHEN 0 THEN 'local' ELSE printf('ns-%d', x%4) END, \
+     CASE x%3 WHEN 0 THEN 'knowledge.learn' WHEN 1 THEN 'Knowledge.list' ELSE 'comm.inbox' END, \
+     'entity', 'fixture', 'ok', json_object('padding', printf('%0256d', x)), x FROM n";
+const SEED_ATOMS: &str =
+    "WITH RECURSIVE n(x) AS (SELECT 1 UNION ALL SELECT x+1 FROM n WHERE x<?1) \
+     INSERT INTO knowledge_atoms (id, namespace, slug, name, content, tags, finalized, status, deleted_at, created_at, updated_at) \
+     SELECT printf('00000000-0000-4000-8000-%012x', x), CASE x%4 WHEN 0 THEN 'other' ELSE 'local' END, \
+     printf('atom-%d',x), printf('Atom %d',x), printf('%0512d',x), \
+     CASE WHEN x%11=0 THEN '[\"type:domain\"]' ELSE '[]' END, x%2, \
+     CASE x%3 WHEN 0 THEN 'draft' WHEN 1 THEN 'reviewed' ELSE 'deprecated' END, \
+     CASE WHEN x%13=0 THEN 1 ELSE NULL END, x, x FROM n";
+
+fn fixture(path: &std::path::Path) -> (KhiveRuntime, VerbRegistry) {
+    let runtime = KhiveRuntime::new(RuntimeConfig {
+        db_path: Some(path.into()),
+        embedding_model: None,
+        additional_embedding_models: vec![],
+        events_split: None,
+        actor_id: None,
+        ..RuntimeConfig::default()
+    })
+    .unwrap();
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(runtime.clone()));
+    builder.register(KnowledgePack::new(runtime.clone()));
+    (runtime, builder.build().unwrap())
+}
+
+async fn seed(runtime: &KhiveRuntime, events: i64, atoms: i64) {
+    for (sql, size) in [(SEED_EVENTS, events), (SEED_ATOMS, atoms)] {
+        runtime
+            .sql()
+            .writer()
+            .await
+            .unwrap()
+            .execute(SqlStatement {
+                sql: sql.into(),
+                params: vec![SqlValue::Integer(size)],
+                label: None,
+            })
+            .await
+            .unwrap();
+    }
+}
+
+async fn set_indexes(runtime: &KhiveRuntime, indexed: bool) {
+    if indexed {
+        runtime
+            .backend()
+            .pool()
+            .writer()
+            .unwrap()
+            .conn()
+            .execute_batch(include_str!(
+                "../../khive-db/sql/032-knowledge-count-indexes.sql"
+            ))
+            .unwrap();
+    } else {
+        execute(runtime, "DROP INDEX IF EXISTS idx_events_ns_verb").await;
+        execute(
+            runtime,
+            "DROP INDEX IF EXISTS idx_knowledge_atoms_ns_live_counts",
+        )
+        .await;
+    }
+}
 
 async fn execute(runtime: &KhiveRuntime, sql: &str) {
     runtime
@@ -31,7 +102,7 @@ async fn execute(runtime: &KhiveRuntime, sql: &str) {
 async fn measure(runtime: &KhiveRuntime, registry: &VerbRegistry) -> Value {
     let mut reader = runtime.sql().reader().await.unwrap();
     let mut counts = Vec::new();
-    for sql in [EVENT_COUNT, ATOM_COUNT] {
+    for sql in [EVENT_COUNT, ATOM_COUNT, LIST_COUNT] {
         let statement = SqlStatement {
             sql: sql.into(),
             params: vec![SqlValue::Text("local".into())],
@@ -40,9 +111,12 @@ async fn measure(runtime: &KhiveRuntime, registry: &VerbRegistry) -> Value {
         let started = Instant::now();
         let value = reader.query_scalar(statement.clone()).await.unwrap();
         let elapsed = started.elapsed();
+        let Some(SqlValue::Integer(count)) = value else {
+            panic!("COUNT did not return an integer: {value:?}");
+        };
         let plan = reader.explain(statement).await.unwrap();
         counts.push(json!({
-            "sql": sql, "count": format!("{value:?}"),
+            "sql": sql, "count": count,
             "ms": elapsed.as_secs_f64() * 1000.0, "plan": format!("{plan:?}")
         }));
     }
@@ -53,42 +127,42 @@ async fn measure(runtime: &KhiveRuntime, registry: &VerbRegistry) -> Value {
         .await
         .unwrap();
     json!({"counts": counts, "list_ms": started.elapsed().as_secs_f64() * 1000.0,
-        "list_total": listed["total"], "list_rows": listed["results"].as_array().unwrap().len()})
+        "list_total": listed["total"], "list_rows": listed["results"].as_array().unwrap().len(),
+        "first_list_id": listed["results"][0]["id"]})
+}
+
+fn assert_sample(sample: &Value, expected: [i64; 3], first_id: &str) {
+    for (index, count) in expected.into_iter().enumerate() {
+        assert_eq!(sample["counts"][index]["count"], json!(count), "{sample}");
+    }
+    assert_eq!(sample["list_total"], json!(expected[2]), "{sample}");
+    assert_eq!(sample["list_rows"], json!(1), "{sample}");
+    assert_eq!(sample["first_list_id"], first_id, "{sample}");
 }
 
 #[tokio::test]
+#[serial_test::serial(config_ledger)]
+async fn count_fixture_reaches_public_list_before_and_after_indexes() {
+    let dir = tempfile::tempdir().unwrap();
+    let (runtime, registry) = fixture(&dir.path().join("counts.db"));
+    seed(&runtime, 120, 156).await;
+    for indexed in [false, true] {
+        set_indexes(&runtime, indexed).await;
+        assert_sample(
+            &measure(&runtime, &registry).await,
+            [20, 98, 65],
+            "00000000-0000-4000-8000-000000000099",
+        );
+    }
+}
+
+#[tokio::test]
+#[serial_test::serial(config_ledger)]
 #[ignore = "constructs two million events and 154600 atoms for paired count measurements"]
 async fn benchmark_count_indexes() {
     let dir = tempfile::tempdir().unwrap();
-    let runtime = KhiveRuntime::new(RuntimeConfig {
-        db_path: Some(dir.path().join("counts.db")),
-        embedding_model: None,
-        additional_embedding_models: vec![],
-        events_split: None,
-        actor_id: None,
-        ..RuntimeConfig::default()
-    })
-    .unwrap();
-    let mut builder = VerbRegistryBuilder::new();
-    builder.register(KgPack::new(runtime.clone()));
-    builder.register(KnowledgePack::new(runtime.clone()));
-    let registry = builder.build().unwrap();
-    execute(&runtime,
-        "WITH RECURSIVE n(x) AS (SELECT 1 UNION ALL SELECT x+1 FROM n WHERE x<2000000) \
-         INSERT INTO events (id, namespace, verb, substrate, actor, outcome, payload, created_at) \
-         SELECT printf('fixture-event-%d', x), CASE x%4 WHEN 0 THEN 'local' ELSE printf('ns-%d', x%4) END, \
-         CASE x%3 WHEN 0 THEN 'knowledge.learn' WHEN 1 THEN 'Knowledge.list' ELSE 'comm.inbox' END, \
-         'entity', 'fixture', 'ok', json_object('padding', printf('%0256d', x)), x FROM n"
-    ).await;
-    execute(&runtime,
-        "WITH RECURSIVE n(x) AS (SELECT 1 UNION ALL SELECT x+1 FROM n WHERE x<154600) \
-         INSERT INTO knowledge_atoms (id, namespace, slug, name, content, tags, finalized, status, deleted_at, created_at, updated_at) \
-         SELECT printf('fixture-atom-%d', x), CASE x%4 WHEN 0 THEN 'other' ELSE 'local' END, \
-         printf('atom-%d',x), printf('Atom %d',x), printf('%0512d',x), \
-         CASE WHEN x%11=0 THEN '[\"type:domain\"]' ELSE '[]' END, x%2, \
-         CASE x%3 WHEN 0 THEN 'draft' WHEN 1 THEN 'reviewed' ELSE 'finalized' END, \
-         CASE WHEN x%13=0 THEN 1 ELSE NULL END, x, x FROM n"
-    ).await;
+    let (runtime, registry) = fixture(&dir.path().join("counts.db"));
+    seed(&runtime, 2_000_000, 154_600).await;
     let mut pairs = Vec::new();
     for round in 0..4 {
         let mut pair = serde_json::Map::new();
@@ -98,37 +172,21 @@ async fn benchmark_count_indexes() {
         } else {
             [true, false]
         } {
-            if indexed {
-                runtime
-                    .backend()
-                    .pool()
-                    .writer()
-                    .unwrap()
-                    .conn()
-                    .execute_batch(include_str!(
-                        "../../khive-db/sql/032-knowledge-count-indexes.sql"
-                    ))
-                    .unwrap();
-            } else {
-                execute(&runtime, "DROP INDEX IF EXISTS idx_events_ns_verb").await;
-                execute(
-                    &runtime,
-                    "DROP INDEX IF EXISTS idx_knowledge_atoms_ns_live_counts",
-                )
-                .await;
-            }
+            set_indexes(&runtime, indexed).await;
             pair.insert(
                 if indexed { "after" } else { "before" }.into(),
                 measure(&runtime, &registry).await,
             );
         }
-        assert_eq!(pair["before"]["list_total"], pair["after"]["list_total"]);
-        assert_eq!(pair["before"]["list_rows"], json!(1));
-        for index in 0..2 {
-            assert_eq!(
-                pair["before"]["counts"][index]["count"],
-                pair["after"]["counts"][index]["count"]
+        eprintln!("{}", json!({"round": round, "pair": pair}));
+        for arm in ["before", "after"] {
+            assert_sample(
+                &pair[arm],
+                [333_333, 97_301, 64_867],
+                "00000000-0000-4000-8000-000000025be7",
             );
+        }
+        for index in 0..3 {
             assert!(pair["after"]["counts"][index]["plan"]
                 .as_str()
                 .unwrap()

--- a/crates/khive-pack-knowledge/tests/count_indexes.rs
+++ b/crates/khive-pack-knowledge/tests/count_indexes.rs
@@ -3,6 +3,7 @@
 
 use std::time::Instant;
 
+use khive_pack_kg::KgPack;
 use khive_pack_knowledge::KnowledgePack;
 use khive_runtime::{KhiveRuntime, RuntimeConfig, VerbRegistry, VerbRegistryBuilder};
 use khive_storage::{SqlStatement, SqlValue};
@@ -69,6 +70,7 @@ async fn benchmark_count_indexes() {
     })
     .unwrap();
     let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(runtime.clone()));
     builder.register(KnowledgePack::new(runtime.clone()));
     let registry = builder.build().unwrap();
     execute(&runtime,

--- a/crates/khive-pack-knowledge/tests/count_indexes.rs
+++ b/crates/khive-pack-knowledge/tests/count_indexes.rs
@@ -1,5 +1,7 @@
-//! File-backed count/plan benchmark; no wall-clock comparison. Run with:
+//! File-backed COUNT timings and retained-reader plans. Run with:
 //! cargo test -p khive-pack-knowledge --test count_indexes -- --ignored --nocapture
+
+use std::time::Instant;
 
 use khive_pack_kg::KgPack;
 use khive_pack_knowledge::KnowledgePack;
@@ -81,13 +83,15 @@ fn measure_counts(reader: &khive_db::ReaderGuard<'_>) -> Vec<Value> {
             // retain a stale schema after DDL on another connection, and the
             // SqlReader abstraction acquires a different lease per operation.
             // Keep COUNT and its plan on this one physical reader.
+            let started = Instant::now();
             let count: i64 = reader.query_row(sql, ["local"], |row| row.get(0)).unwrap();
+            let ms = started.elapsed().as_secs_f64() * 1000.0;
             let plan: String = reader
                 .query_row(&format!("EXPLAIN QUERY PLAN {sql}"), ["local"], |row| {
                     row.get(3)
                 })
                 .unwrap();
-            json!({"sql": sql, "count": count, "plan": plan})
+            json!({"sql": sql, "count": count, "ms": ms, "plan": plan})
         })
         .collect()
 }
@@ -110,7 +114,7 @@ async fn measure(runtime: &KhiveRuntime, registry: &VerbRegistry) -> Value {
         (counts, sqlite, installed_indexes)
     };
     // Public dispatch remains on its normal pooled SQL path; no raw reader
-    // lease survives across this await. These observations make no latency claim.
+    // lease survives across this await. Public list dispatch is not timed.
     let listed = registry
         .dispatch("knowledge.list", json!({"limit": 1}))
         .await
@@ -205,7 +209,7 @@ async fn benchmark_count_indexes() {
     let mut pairs = Vec::new();
     for round in 0..4 {
         let mut pair = serde_json::Map::new();
-        // Exercise both DDL transition orders; report plans and counts only.
+        // Alternate arm order across the four rounds; caches are not reset.
         for indexed in if round % 2 == 0 {
             [false, true]
         } else {
@@ -231,9 +235,27 @@ async fn benchmark_count_indexes() {
         assert_eq!(pair["after"]["installed_count_indexes"], json!(2));
         pairs.push(pair);
     }
+    let count_medians_ms: Vec<_> = [EVENT_COUNT, ATOM_COUNT, LIST_COUNT]
+        .into_iter()
+        .enumerate()
+        .map(|(index, sql)| {
+            let median = |arm: &str| {
+                let mut times: Vec<f64> = pairs
+                    .iter()
+                    .map(|pair| pair[arm]["counts"][index]["ms"].as_f64().unwrap())
+                    .collect();
+                times.sort_by(f64::total_cmp);
+                // Each arm has four rounds: average the two middle samples.
+                (times[1] + times[2]) / 2.0
+            };
+            json!({"sql": sql, "before": median("before"), "after": median("after")})
+        })
+        .collect();
     eprintln!(
         "{}",
         json!({"events": 2000000, "atoms":154600,
-        "storage":"file-backed", "measurement":"counts and same-connection plans only; no timing comparison", "pairs":pairs})
+        "storage":"file-backed", "measurement":"COUNT-only wall-clock ms on retained reader; EXPLAIN and public list dispatch excluded",
+        "timing_conditions":"four rounds per arm; alternating order; caches not reset",
+        "count_medians_ms":count_medians_ms, "pairs":pairs})
     );
 }

--- a/crates/khive-pack-knowledge/tests/count_indexes.rs
+++ b/crates/khive-pack-knowledge/tests/count_indexes.rs
@@ -1,0 +1,142 @@
+//! File-backed count benchmark. Run explicitly with:
+//! cargo test -p khive-pack-knowledge --test count_indexes -- --ignored --nocapture
+
+use std::time::Instant;
+
+use khive_pack_knowledge::KnowledgePack;
+use khive_runtime::{KhiveRuntime, RuntimeConfig, VerbRegistry, VerbRegistryBuilder};
+use khive_storage::{SqlStatement, SqlValue};
+use serde_json::{json, Value};
+
+const EVENT_COUNT: &str =
+    "SELECT COUNT(*) FROM events WHERE namespace = ?1 AND verb LIKE 'knowledge.%'";
+const ATOM_COUNT: &str = "SELECT COUNT(*) FROM knowledge_atoms WHERE namespace = ?1 AND deleted_at IS NULL AND tags NOT LIKE '%type:domain%'";
+
+async fn execute(runtime: &KhiveRuntime, sql: &str) {
+    runtime
+        .sql()
+        .writer()
+        .await
+        .unwrap()
+        .execute(SqlStatement {
+            sql: sql.into(),
+            params: vec![],
+            label: None,
+        })
+        .await
+        .unwrap();
+}
+
+async fn measure(runtime: &KhiveRuntime, registry: &VerbRegistry) -> Value {
+    let mut reader = runtime.sql().reader().await.unwrap();
+    let mut counts = Vec::new();
+    for sql in [EVENT_COUNT, ATOM_COUNT] {
+        let statement = SqlStatement {
+            sql: sql.into(),
+            params: vec![SqlValue::Text("local".into())],
+            label: None,
+        };
+        let started = Instant::now();
+        let value = reader.query_scalar(statement.clone()).await.unwrap();
+        let elapsed = started.elapsed();
+        let plan = reader.explain(statement).await.unwrap();
+        counts.push(json!({
+            "sql": sql, "count": format!("{value:?}"),
+            "ms": elapsed.as_secs_f64() * 1000.0, "plan": format!("{plan:?}")
+        }));
+    }
+    drop(reader);
+    let started = Instant::now();
+    let listed = registry
+        .dispatch("knowledge.list", json!({"limit": 1}))
+        .await
+        .unwrap();
+    json!({"counts": counts, "list_ms": started.elapsed().as_secs_f64() * 1000.0,
+        "list_total": listed["total"], "list_rows": listed["results"].as_array().unwrap().len()})
+}
+
+#[tokio::test]
+#[ignore = "constructs two million events and 154600 atoms for paired count measurements"]
+async fn benchmark_count_indexes() {
+    let dir = tempfile::tempdir().unwrap();
+    let runtime = KhiveRuntime::new(RuntimeConfig {
+        db_path: Some(dir.path().join("counts.db")),
+        embedding_model: None,
+        additional_embedding_models: vec![],
+        events_split: None,
+        actor_id: None,
+        ..RuntimeConfig::default()
+    })
+    .unwrap();
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KnowledgePack::new(runtime.clone()));
+    let registry = builder.build().unwrap();
+    execute(&runtime,
+        "WITH RECURSIVE n(x) AS (SELECT 1 UNION ALL SELECT x+1 FROM n WHERE x<2000000) \
+         INSERT INTO events (id, namespace, verb, substrate, actor, outcome, payload, created_at) \
+         SELECT printf('fixture-event-%d', x), CASE x%4 WHEN 0 THEN 'local' ELSE printf('ns-%d', x%4) END, \
+         CASE x%3 WHEN 0 THEN 'knowledge.learn' WHEN 1 THEN 'Knowledge.list' ELSE 'comm.inbox' END, \
+         'entity', 'fixture', 'ok', json_object('padding', printf('%0256d', x)), x FROM n"
+    ).await;
+    execute(&runtime,
+        "WITH RECURSIVE n(x) AS (SELECT 1 UNION ALL SELECT x+1 FROM n WHERE x<154600) \
+         INSERT INTO knowledge_atoms (id, namespace, slug, name, content, tags, finalized, status, deleted_at, created_at, updated_at) \
+         SELECT printf('fixture-atom-%d', x), CASE x%4 WHEN 0 THEN 'other' ELSE 'local' END, \
+         printf('atom-%d',x), printf('Atom %d',x), printf('%0512d',x), \
+         CASE WHEN x%11=0 THEN '[\"type:domain\"]' ELSE '[]' END, x%2, \
+         CASE x%3 WHEN 0 THEN 'draft' WHEN 1 THEN 'reviewed' ELSE 'finalized' END, \
+         CASE WHEN x%13=0 THEN 1 ELSE NULL END, x, x FROM n"
+    ).await;
+    let mut pairs = Vec::new();
+    for round in 0..4 {
+        let mut pair = serde_json::Map::new();
+        // Adjacent paired arms reverse order to expose cache/order sensitivity.
+        for indexed in if round % 2 == 0 {
+            [false, true]
+        } else {
+            [true, false]
+        } {
+            if indexed {
+                runtime
+                    .backend()
+                    .pool()
+                    .writer()
+                    .unwrap()
+                    .conn()
+                    .execute_batch(include_str!(
+                        "../../khive-db/sql/032-knowledge-count-indexes.sql"
+                    ))
+                    .unwrap();
+            } else {
+                execute(&runtime, "DROP INDEX IF EXISTS idx_events_ns_verb").await;
+                execute(
+                    &runtime,
+                    "DROP INDEX IF EXISTS idx_knowledge_atoms_ns_live_counts",
+                )
+                .await;
+            }
+            pair.insert(
+                if indexed { "after" } else { "before" }.into(),
+                measure(&runtime, &registry).await,
+            );
+        }
+        assert_eq!(pair["before"]["list_total"], pair["after"]["list_total"]);
+        assert_eq!(pair["before"]["list_rows"], json!(1));
+        for index in 0..2 {
+            assert_eq!(
+                pair["before"]["counts"][index]["count"],
+                pair["after"]["counts"][index]["count"]
+            );
+            assert!(pair["after"]["counts"][index]["plan"]
+                .as_str()
+                .unwrap()
+                .contains("COVERING INDEX"));
+        }
+        pairs.push(pair);
+    }
+    eprintln!(
+        "{}",
+        json!({"events": 2000000, "atoms":154600, "sqlite": "bundled",
+        "storage":"file-backed", "cache_control":"warm/order-reversed; no OS cache eviction", "pairs":pairs})
+    );
+}

--- a/crates/khive-pack-knowledge/tests/count_indexes.rs
+++ b/crates/khive-pack-knowledge/tests/count_indexes.rs
@@ -1,7 +1,5 @@
-//! File-backed count benchmark. Run explicitly with:
+//! File-backed count/plan benchmark; no wall-clock comparison. Run with:
 //! cargo test -p khive-pack-knowledge --test count_indexes -- --ignored --nocapture
-
-use std::time::Instant;
 
 use khive_pack_kg::KgPack;
 use khive_pack_knowledge::KnowledgePack;
@@ -62,73 +60,89 @@ async fn seed(runtime: &KhiveRuntime, events: i64, atoms: i64) {
     }
 }
 
-async fn set_indexes(runtime: &KhiveRuntime, indexed: bool) {
-    if indexed {
-        runtime
-            .backend()
-            .pool()
-            .writer()
-            .unwrap()
-            .conn()
-            .execute_batch(include_str!(
-                "../../khive-db/sql/032-knowledge-count-indexes.sql"
-            ))
-            .unwrap();
-    } else {
-        execute(runtime, "DROP INDEX IF EXISTS idx_events_ns_verb").await;
-        execute(
-            runtime,
-            "DROP INDEX IF EXISTS idx_knowledge_atoms_ns_live_counts",
-        )
-        .await;
-    }
-}
-
-async fn execute(runtime: &KhiveRuntime, sql: &str) {
-    runtime
-        .sql()
-        .writer()
-        .await
-        .unwrap()
-        .execute(SqlStatement {
-            sql: sql.into(),
-            params: vec![],
-            label: None,
+fn set_indexes(runtime: &KhiveRuntime, indexed: bool) {
+    let writer = runtime.backend().pool().writer().unwrap();
+    writer
+        .conn()
+        .execute_batch(if indexed {
+            include_str!("../../khive-db/sql/032-knowledge-count-indexes.sql")
+        } else {
+            "DROP INDEX IF EXISTS idx_events_ns_verb; \
+             DROP INDEX IF EXISTS idx_knowledge_atoms_ns_live_counts;"
         })
-        .await
         .unwrap();
 }
 
+fn measure_counts(reader: &khive_db::ReaderGuard<'_>) -> Vec<Value> {
+    [EVENT_COUNT, ATOM_COUNT, LIST_COUNT]
+        .into_iter()
+        .map(|sql| {
+            // A real query checks SQLite's schema cookie. EXPLAIN alone can
+            // retain a stale schema after DDL on another connection, and the
+            // SqlReader abstraction acquires a different lease per operation.
+            // Keep COUNT and its plan on this one physical reader.
+            let count: i64 = reader.query_row(sql, ["local"], |row| row.get(0)).unwrap();
+            let plan: String = reader
+                .query_row(&format!("EXPLAIN QUERY PLAN {sql}"), ["local"], |row| {
+                    row.get(3)
+                })
+                .unwrap();
+            json!({"sql": sql, "count": count, "plan": plan})
+        })
+        .collect()
+}
+
 async fn measure(runtime: &KhiveRuntime, registry: &VerbRegistry) -> Value {
-    let mut reader = runtime.sql().reader().await.unwrap();
-    let mut counts = Vec::new();
-    for sql in [EVENT_COUNT, ATOM_COUNT, LIST_COUNT] {
-        let statement = SqlStatement {
-            sql: sql.into(),
-            params: vec![SqlValue::Text("local".into())],
-            label: None,
-        };
-        let started = Instant::now();
-        let value = reader.query_scalar(statement.clone()).await.unwrap();
-        let elapsed = started.elapsed();
-        let Some(SqlValue::Integer(count)) = value else {
-            panic!("COUNT did not return an integer: {value:?}");
-        };
-        let plan = reader.explain(statement).await.unwrap();
-        counts.push(json!({
-            "sql": sql, "count": count,
-            "ms": elapsed.as_secs_f64() * 1000.0, "plan": format!("{plan:?}")
-        }));
-    }
-    drop(reader);
-    let started = Instant::now();
+    let (counts, sqlite, installed_indexes) = {
+        let reader = runtime.backend().pool().reader().unwrap();
+        let counts = measure_counts(&reader);
+        let sqlite: String = reader
+            .query_row("SELECT sqlite_version()", [], |row| row.get(0))
+            .unwrap();
+        let installed_indexes: i64 = reader
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_schema WHERE type = 'index' AND name IN \
+                 ('idx_events_ns_verb', 'idx_knowledge_atoms_ns_live_counts')",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        (counts, sqlite, installed_indexes)
+    };
+    // Public dispatch remains on its normal pooled SQL path; no raw reader
+    // lease survives across this await. These observations make no latency claim.
     let listed = registry
         .dispatch("knowledge.list", json!({"limit": 1}))
         .await
         .unwrap();
-    json!({"counts": counts, "list_ms": started.elapsed().as_secs_f64() * 1000.0,
+    json!({"counts": counts, "sqlite": sqlite, "installed_count_indexes": installed_indexes,
         "list_total": listed["total"], "list_rows": listed["results"].as_array().unwrap().len(),
         "first_list_id": listed["results"][0]["id"]})
+}
+
+fn assert_plans(counts: &[Value], indexed: bool) {
+    assert_eq!(counts.len(), 3);
+    for (sample, expected) in counts.iter().zip([
+        "idx_events_ns_verb",
+        "idx_knowledge_atoms_ns_live_counts",
+        "idx_knowledge_atoms_ns_live_counts",
+    ]) {
+        let plan = sample["plan"].as_str().unwrap();
+        if indexed {
+            assert!(
+                plan.contains(&format!("COVERING INDEX {expected}")),
+                "{sample}"
+            );
+            if expected == "idx_events_ns_verb" {
+                assert!(
+                    plan.contains("verb>?") && plan.contains("verb<?"),
+                    "{sample}"
+                );
+            }
+        } else {
+            assert!(!plan.contains(expected), "stale indexed plan: {sample}");
+        }
+    }
 }
 
 fn assert_sample(sample: &Value, expected: [i64; 3], first_id: &str) {
@@ -147,12 +161,37 @@ async fn count_fixture_reaches_public_list_before_and_after_indexes() {
     let (runtime, registry) = fixture(&dir.path().join("counts.db"));
     seed(&runtime, 120, 156).await;
     for indexed in [false, true] {
-        set_indexes(&runtime, indexed).await;
+        set_indexes(&runtime, indexed);
+        let sample = measure(&runtime, &registry).await;
         assert_sample(
-            &measure(&runtime, &registry).await,
+            &sample,
             [20, 98, 65],
             "00000000-0000-4000-8000-000000000099",
         );
+        assert_plans(sample["counts"].as_array().unwrap(), indexed);
+        assert_eq!(
+            sample["installed_count_indexes"],
+            json!(if indexed { 2 } else { 0 })
+        );
+    }
+}
+
+#[tokio::test]
+#[serial_test::serial(config_ledger)]
+async fn retained_reader_count_plans_follow_index_changes() {
+    let dir = tempfile::tempdir().unwrap();
+    let (runtime, _registry) = fixture(&dir.path().join("counts.db"));
+    seed(&runtime, 120, 156).await;
+    // Hold the same physical connection while a separate writer changes DDL.
+    // Repeated adds and drops exercise stale schemas in both directions.
+    let reader = runtime.backend().pool().reader().unwrap();
+    for indexed in [false, true, false, true] {
+        set_indexes(&runtime, indexed);
+        let counts = measure_counts(&reader);
+        for (sample, expected) in counts.iter().zip([20, 98, 65]) {
+            assert_eq!(sample["count"], json!(expected));
+        }
+        assert_plans(&counts, indexed);
     }
 }
 
@@ -166,13 +205,13 @@ async fn benchmark_count_indexes() {
     let mut pairs = Vec::new();
     for round in 0..4 {
         let mut pair = serde_json::Map::new();
-        // Adjacent paired arms reverse order to expose cache/order sensitivity.
+        // Exercise both DDL transition orders; report plans and counts only.
         for indexed in if round % 2 == 0 {
             [false, true]
         } else {
             [true, false]
         } {
-            set_indexes(&runtime, indexed).await;
+            set_indexes(&runtime, indexed);
             pair.insert(
                 if indexed { "after" } else { "before" }.into(),
                 measure(&runtime, &registry).await,
@@ -186,17 +225,15 @@ async fn benchmark_count_indexes() {
                 "00000000-0000-4000-8000-000000025be7",
             );
         }
-        for index in 0..3 {
-            assert!(pair["after"]["counts"][index]["plan"]
-                .as_str()
-                .unwrap()
-                .contains("COVERING INDEX"));
-        }
+        assert_plans(pair["before"]["counts"].as_array().unwrap(), false);
+        assert_plans(pair["after"]["counts"].as_array().unwrap(), true);
+        assert_eq!(pair["before"]["installed_count_indexes"], json!(0));
+        assert_eq!(pair["after"]["installed_count_indexes"], json!(2));
         pairs.push(pair);
     }
     eprintln!(
         "{}",
-        json!({"events": 2000000, "atoms":154600, "sqlite": "bundled",
-        "storage":"file-backed", "cache_control":"warm/order-reversed; no OS cache eviction", "pairs":pairs})
+        json!({"events": 2000000, "atoms":154600,
+        "storage":"file-backed", "measurement":"counts and same-connection plans only; no timing comparison", "pairs":pairs})
     );
 }

--- a/crates/khive-runtime/Cargo.toml
+++ b/crates/khive-runtime/Cargo.toml
@@ -47,6 +47,7 @@ unicode-general-category = { workspace = true }
 sha2 = { workspace = true }
 
 [dev-dependencies]
+khive-db = { version = "0.8.0", path = "../khive-db", features = ["test-support"] }
 khive-request = { version = "0.8.0", path = "../khive-request" }
 khive-gate-rego = { version = "0.8.0", path = "../khive-gate-rego" }
 khive-storage = { version = "0.8.0", path = "../khive-storage", features = ["test-support"] }

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -3156,6 +3156,7 @@ mod tests {
     struct CancellationAwareDispatch {
         started: Arc<tokio::sync::Notify>,
         cancellation_observed: Arc<std::sync::atomic::AtomicBool>,
+        count_sql: Option<Arc<dyn khive_storage::SqlAccess>>,
     }
 
     #[async_trait]
@@ -3175,6 +3176,24 @@ mod tests {
             _identity: Option<RequestIdentity>,
         ) -> Result<String, String> {
             self.started.notify_one();
+            if let Some(sql) = &self.count_sql {
+                let mut reader = sql.reader().await.map_err(|error| error.to_string())?;
+                let result = reader.query_scalar(khive_storage::SqlStatement {
+                    sql: "SELECT COUNT(*) FROM events WHERE namespace = ?1 AND verb LIKE 'knowledge.%'".into(),
+                    params: vec![khive_storage::SqlValue::Text("local".into())],
+                    label: Some("knowledge.stats.event_count".into()),
+                }).await;
+                self.cancellation_observed.store(
+                    matches!(
+                        result,
+                        Err(khive_storage::error::StorageError::Timeout { .. })
+                    ),
+                    std::sync::atomic::Ordering::SeqCst,
+                );
+                return result
+                    .map(|value| format!("{value:?}"))
+                    .map_err(|error| error.to_string());
+            }
             khive_storage::wait_for_request_read_cancellation().await;
             self.cancellation_observed
                 .store(true, std::sync::atomic::Ordering::SeqCst);
@@ -3480,6 +3499,7 @@ mod tests {
         let dispatcher = CancellationAwareDispatch {
             started: Arc::clone(&started),
             cancellation_observed: Arc::clone(&cancellation_observed),
+            count_sql: None,
         };
         let (mut client, server) = UnixStream::pair().expect("unix stream pair");
         let request = base_request_frame("disconnect-test");
@@ -3499,6 +3519,91 @@ mod tests {
             cancellation_observed.load(std::sync::atomic::Ordering::SeqCst),
             "peer loss did not reach the request-scoped read cancellation signal"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn daemon_disconnect_interrupts_pooled_stats_count() {
+        use khive_storage::{SqlAccess, SqlStatement, SqlValue};
+        let dir = tempfile::tempdir().unwrap();
+        let pool = Arc::new(
+            ConnectionPool::new(khive_db::PoolConfig {
+                path: Some(dir.path().join("disconnect-count.db")),
+                max_readers: 1,
+                ..Default::default()
+            })
+            .unwrap(),
+        );
+        pool.writer()
+            .unwrap()
+            .conn()
+            .execute_batch(
+                "CREATE TABLE count_fixture(n INTEGER PRIMARY KEY); \
+             WITH RECURSIVE n(x) AS (SELECT 1 UNION ALL SELECT x+1 FROM n WHERE x<1000) \
+             INSERT INTO count_fixture SELECT x FROM n; \
+             CREATE VIEW events AS SELECT 'local' AS namespace, 'knowledge.learn' AS verb \
+             FROM count_fixture a CROSS JOIN count_fixture b CROSS JOIN count_fixture c;",
+            )
+            .unwrap();
+        let sql = Arc::new(khive_db::SqlBridge::new(Arc::clone(&pool), true));
+        let cancellation_observed = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let dispatcher = CancellationAwareDispatch {
+            started: Arc::new(tokio::sync::Notify::new()),
+            cancellation_observed: Arc::clone(&cancellation_observed),
+            count_sql: Some(sql.clone()),
+        };
+        let (mut client, server) = UnixStream::pair().unwrap();
+        let request = base_request_frame("disconnect-test");
+        let progress = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let handler = tokio::spawn(khive_db::scope_test_read_progress(
+            Arc::clone(&progress),
+            async move { handle_conn(server, dispatcher).await },
+        ));
+        write_frame(&mut client, &serde_json::to_vec(&request).unwrap())
+            .await
+            .unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while progress.load(std::sync::atomic::Ordering::SeqCst) == 0 {
+                assert!(
+                    !handler.is_finished(),
+                    "COUNT returned before its first SQLite progress callback"
+                );
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        assert!(
+            !handler.is_finished(),
+            "COUNT must be outstanding at disconnect"
+        );
+        let started = std::time::Instant::now();
+        let grace = khive_db::sqlite_interrupt_grace_from_env();
+        drop(client);
+        tokio::time::timeout(grace, handler)
+            .await
+            .expect("disconnected COUNT did not settle within interrupt grace")
+            .unwrap();
+        assert!(cancellation_observed.load(std::sync::atomic::Ordering::SeqCst));
+        let snapshot = pool.reader_acquisition_snapshot();
+        assert_eq!(snapshot.active_pooled_checkouts, 0);
+        assert_eq!(snapshot.available_reader_admission_slots, 1);
+        eprintln!(
+            "daemon_stats_count_disconnect_ms={} grace_ms={}",
+            started.elapsed().as_secs_f64() * 1000.0,
+            grace.as_millis()
+        );
+        let count = sql
+            .reader()
+            .await
+            .unwrap()
+            .query_scalar(SqlStatement {
+                sql: "SELECT COUNT(*) FROM count_fixture".into(),
+                params: vec![],
+                label: None,
+            })
+            .await
+            .unwrap();
+        assert!(matches!(count, Some(SqlValue::Integer(1000))));
     }
 
     /// Protocol v4 makes `process_ref` part of dispatch semantics. A still-warm

--- a/docs/adr/ADR-015-schema-migrations.md
+++ b/docs/adr/ADR-015-schema-migrations.md
@@ -123,6 +123,27 @@ The canonical ledger of database schema migration versions. Migration versions a
 
 ### Post-consolidation migration ledger (live)
 
+#### Knowledge count indexes (2026-09-10)
+
+V32, `knowledge_count_indexes`, adds `idx_events_ns_verb` on
+`events(namespace, verb COLLATE NOCASE)` and `idx_knowledge_atoms_ns_live_counts`
+on `knowledge_atoms(namespace, deleted_at, status, tags, finalized)`.
+V1 remains immutable; both new and existing main databases receive V32 through
+the migration chain. The idempotent events-store DDL also declares the event
+index for separately opened event stores.
+
+`knowledge.stats` uses the main backend's raw SQL capability and counts that
+backend's events table, including when an events sidecar is configured. This
+change preserves that population. `NOCASE` matches the existing ASCII-insensitive
+`LIKE 'knowledge.%'`, allowing a namespace and verb-prefix index range without
+changing mixed-case results. The atom index covers the existing live/non-domain
+predicate, optional status filters, and finalized aggregate. It preserves tag
+substring semantics and avoids a new materialized classifier or counter that
+every writer would need to maintain. Costs are one-time index construction,
+index space proportional to indexed text, and index maintenance on writes.
+The atom predicate still scans qualifying index entries; neither count becomes
+constant-time. No request deadline, interrupt grace, or pool policy changes.
+
 The live sequence starts from the consolidated V1 baseline. This table is the
 canonical allocation ledger for databases created at or after v0.2.8; the table
 above remains the historical pre-consolidation record.


### PR DESCRIPTION
## Summary

`knowledge.stats` and the offset-mode `knowledge.list` total count run `SELECT COUNT(*)` over `events` filtered by namespace and a `verb LIKE 'knowledge.%'` prefix, and over `knowledge_atoms` filtered by namespace, tombstone and a tag substring. Neither had a covering index, so on a large store each count walked the table pages, and under memory pressure the read outlived the client's request deadline.

## Change

- Migration V32 adds `idx_events_ns_verb(namespace, verb COLLATE NOCASE)` and `idx_knowledge_atoms_ns_live_counts(namespace, deleted_at, status, tags, finalized)`. The NOCASE collation matches SQLite's default LIKE case folding, so the count's predicate is unchanged. Separate event stores get the event index through their own DDL.
- The two counts carry statement labels (`knowledge.stats.event_count`, `knowledge.list.atom_count`).
- Tests prove a pooled scalar COUNT is interrupted when the client disconnects mid-scan, the reader returns to the pool, and the next read succeeds. Cancellation was already wired for this path; the tests pin it. The progress observer used by the runtime-side test is behind an optional `test-support` feature on `khive-db`, enabled only as a dev-dependency.
- An ignored benchmark (`cargo test -p khive-pack-knowledge --test count_indexes -- --ignored --nocapture`) seeds 2,000,000 events and 154,600 atoms and prints raw count time, EXPLAIN, and `knowledge.list(limit=1)` dispatch time for both index states in adjacent pairs.
- ADR-015 records the V32 contract.

## Before / after

Ignored benchmark on a file-backed store seeded with 2,000,000 events and 154,600 atoms, SQLite 3.53.2, Rust 1.95.0, on an otherwise idle machine (load average 3.3 at the end of the run). Four rounds per arm in alternating order, caches not reset; the numbers are the per-count wall-clock medians on the retained reader, EXPLAIN and dispatch excluded. The plan is the load-bearing column: a faster time on the same plan would be cache order, so the after arm has to name the new index.

| Count | Plan before | Plan after | Median before | Median after |
|---|---|---|---|---|
| `events` where `verb LIKE 'knowledge.%'` (`knowledge.stats`) | `SEARCH events USING INDEX idx_events_ns_created (namespace=?)` | `SEARCH events USING COVERING INDEX idx_events_ns_verb (namespace=? AND verb>? AND verb<?)` | 462.1 ms | 25.7 ms |
| live `knowledge_atoms` (`knowledge.stats`) | `SEARCH knowledge_atoms USING INDEX idx_knowledge_atoms_ns_created (namespace=?)` | `SEARCH knowledge_atoms USING COVERING INDEX idx_knowledge_atoms_ns_live_counts (namespace=? AND deleted_at=?)` | 90.2 ms | 13.0 ms |
| live `knowledge_atoms` total (`knowledge.list`, offset mode) | same as above | same as above | 79.2 ms | 15.4 ms |

Counts returned by both arms are identical (333,333 events; 97,301 and 64,867 atoms), and `installed_count_indexes` reads 0 before and 2 after.

## Verification

- `cargo fmt --all --check`, `cargo clippy -p khive-db -p khive-pack-knowledge -p khive-runtime --all-targets -- -D warnings`: clean on Rust 1.95.0.
- `cargo test -p khive-db -p khive-pack-knowledge --no-fail-fast`: all suites pass.
- Focused disconnect test: the count settles within the interrupt grace after the client drops (2.0 on this branch and 3.1 on main before the change ms against a 500 ms grace).
