### PR TITLE
fix(daemon): keep clients served across a daemon restart

### DIFF
--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -1340,7 +1340,8 @@ async fn kill_stale_daemon_inner(
 
 /// Remove `pid_file`/the daemon socket only if ownership has not changed since
 /// `expected_snapshot` was observed: the PID file must be unchanged or absent,
-/// and the socket path must not already have a live listener answering it.
+/// and connecting to the socket must report absence or connection refusal.
+/// Other connect errors leave ownership uncertain and refuse cleanup.
 /// Either signal changing means a replacement daemon claimed the rendezvous
 /// between the observation and this call, and unlinking would delete its live
 /// paths instead of the truly-stale ones (#645).
@@ -8711,13 +8712,20 @@ mod tests {
     #[test]
     #[serial]
     fn remove_daemon_paths_if_still_stale_removes_when_pid_unchanged() {
+        let _cleanup = RecoveryTestGuard::new();
         clear_daemon_env();
         let dir = tempfile::tempdir().expect("tempdir");
         let pid_file = dir.path().join("khived.pid");
         let sock = dir.path().join("khived.sock");
         std::env::set_var("KHIVE_SOCKET", &sock);
         std::fs::write(&pid_file, "4242").expect("write pid file");
-        std::fs::write(&sock, "stale socket placeholder").expect("write stale sock placeholder");
+        drop(std::os::unix::net::UnixListener::bind(&sock).expect("bind stale socket"));
+        assert_eq!(
+            std::os::unix::net::UnixStream::connect(&sock)
+                .expect_err("closed listener must refuse connections")
+                .kind(),
+            std::io::ErrorKind::ConnectionRefused,
+        );
 
         assert!(remove_daemon_paths_if_still_stale(
             &pid_file,
@@ -8727,6 +8735,34 @@ mod tests {
         assert!(!pid_file.exists(), "unchanged pid file must be removed");
         assert!(!sock.exists(), "stale socket must be removed");
         clear_daemon_env();
+    }
+
+    #[test]
+    #[serial]
+    fn remove_daemon_paths_if_still_stale_skips_when_socket_probe_is_uncertain() {
+        let _cleanup = RecoveryTestGuard::new();
+        clear_daemon_env();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pid_file = dir.path().join("khived.pid");
+        let blocker = dir.path().join("not-a-directory");
+        let sock = blocker.join("khived.sock");
+        std::env::set_var("KHIVE_SOCKET", &sock);
+        std::fs::write(&pid_file, "4242").expect("write pid file");
+        std::fs::write(&blocker, "not a socket directory").expect("write path blocker");
+        assert_eq!(
+            std::os::unix::net::UnixStream::connect(&sock)
+                .expect_err("a non-directory parent makes the probe uncertain")
+                .kind(),
+            std::io::ErrorKind::NotADirectory,
+        );
+
+        assert!(!remove_daemon_paths_if_still_stale(
+            &pid_file,
+            &PidFileSnapshot::read(&pid_file),
+        ));
+
+        assert_eq!(std::fs::read(&pid_file).unwrap(), b"4242");
+        assert_eq!(std::fs::read(&blocker).unwrap(), b"not a socket directory");
     }
 
     #[test]

--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -551,9 +551,10 @@ enum ForwardOutcome {
         kind: std::io::ErrorKind,
         os_error_code: Option<i32>,
     },
-    /// Connected but the response could not be decoded — most likely a stale
-    /// daemon speaking a different wire format.
+    /// Invalid response framing/JSON or a response timeout after a full write.
     ParseFailure,
+    /// EOF/reset after a full write; distinct from malformed frames/timeouts.
+    ResponseLost,
     /// Connected and decoded a response, but the daemon's `daemon_protocol_version`
     /// does not match [`PROTOCOL_VERSION`], in either direction. Below: the
     /// new-client + old-daemon scenario, implicit (a pre-versioning daemon ignores
@@ -583,6 +584,13 @@ fn classify_socket_connect_error(error: std::io::Error) -> ForwardOutcome {
 }
 
 async fn try_forward_inner(frame: &DaemonRequestFrame) -> ForwardOutcome {
+    try_forward_before(frame, None).await
+}
+
+async fn try_forward_before(
+    frame: &DaemonRequestFrame,
+    retry_deadline: Option<tokio::time::Instant>,
+) -> ForwardOutcome {
     let sock = socket_path();
     #[cfg(test)]
     {
@@ -613,6 +621,7 @@ async fn try_forward_inner(frame: &DaemonRequestFrame) -> ForwardOutcome {
         .unwrap_or_else(|| {
             tokio::time::Instant::now() + khive_storage::request_read_timeout_from_env()
         });
+    let deadline = retry_deadline.map_or(deadline, |retry| retry.min(deadline));
 
     let mut stream = match tokio::time::timeout_at(deadline, UnixStream::connect(&sock)).await {
         Ok(Ok(s)) => s,
@@ -668,16 +677,24 @@ async fn try_forward_inner(frame: &DaemonRequestFrame) -> ForwardOutcome {
         Ok(Ok(r)) => r,
         Ok(Err(e)) => {
             // The request was sent but the daemon closed the connection before
-            // sending a response frame — likely a daemon crash or panic during
-            // dispatch. Treat as ParseFailure (not NoSocket): the request may
-            // already have committed, so the caller must return a terminal
-            // ambiguity error without lifecycle actions or local dispatch.
+            // sending a response frame. This does not establish why it closed
+            // or whether dispatch completed. Only classified reads can replay;
+            // mutations remain ambiguous, with no recovery or local fallback.
             tracing::warn!(
                 error = %e,
-                "daemon closed connection without sending a response \
-                 (crash during dispatch?) — returning terminal ambiguity"
+                "daemon response unavailable after full request write"
             );
-            return ForwardOutcome::ParseFailure;
+            return if matches!(
+                e.kind(),
+                std::io::ErrorKind::UnexpectedEof
+                    | std::io::ErrorKind::ConnectionReset
+                    | std::io::ErrorKind::ConnectionAborted
+                    | std::io::ErrorKind::BrokenPipe
+            ) {
+                ForwardOutcome::ResponseLost
+            } else {
+                ForwardOutcome::ParseFailure
+            };
         }
         Err(_elapsed) => {
             // The daemon never answered within the deadline. The write
@@ -736,6 +753,84 @@ async fn try_forward_inner(frame: &DaemonRequestFrame) -> ForwardOutcome {
             ForwardOutcome::ParseFailure
         }
     }
+}
+
+const HANDOVER_RETRY_WINDOW: std::time::Duration = std::time::Duration::from_secs(10);
+const HANDOVER_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
+
+fn bounded_retry_deadline() -> tokio::time::Instant {
+    let deadline = tokio::time::Instant::now() + HANDOVER_RETRY_WINDOW;
+    khive_storage::capture_request_read_context()
+        .deadline()
+        .map(khive_storage::RequestReadDeadline::async_at)
+        .map_or(deadline, |caller| caller.min(deadline))
+}
+
+fn recorded_daemon_is_alive() -> bool {
+    std::fs::read_to_string(pid_path())
+        .ok()
+        .and_then(|pid| pid.trim().parse::<u32>().ok())
+        .is_some_and(process_is_alive)
+}
+
+async fn sleep_until_retry(deadline: tokio::time::Instant) {
+    tokio::time::sleep_until((tokio::time::Instant::now() + HANDOVER_RETRY_INTERVAL).min(deadline))
+        .await;
+}
+
+struct ReadReplayBudget {
+    remaining: usize,
+    deadline: Option<tokio::time::Instant>,
+}
+
+impl ReadReplayBudget {
+    fn new(enabled: bool) -> Self {
+        Self {
+            remaining: if enabled { 2 } else { 0 },
+            deadline: None,
+        }
+    }
+}
+
+async fn try_forward_with_read_replay(
+    frame: &DaemonRequestFrame,
+    replay: &mut ReadReplayBudget,
+    attempt_deadline: Option<tokio::time::Instant>,
+) -> ForwardOutcome {
+    let outcome = try_forward_before(frame, attempt_deadline).await;
+    if !matches!(outcome, ForwardOutcome::ResponseLost) || replay.remaining == 0 {
+        return outcome;
+    }
+    let deadline = *replay.deadline.get_or_insert_with(|| {
+        let deadline = bounded_retry_deadline();
+        attempt_deadline.map_or(deadline, |attempt| attempt.min(deadline))
+    });
+    while replay.remaining > 0
+        && tokio::time::Instant::now() < deadline
+        && !khive_storage::request_read_is_cancelled()
+    {
+        sleep_until_retry(deadline).await;
+        if tokio::time::Instant::now() >= deadline || khive_storage::request_read_is_cancelled() {
+            break;
+        }
+        match try_forward_before(frame, Some(deadline)).await {
+            ForwardOutcome::NoSocket => {}
+            ForwardOutcome::ResponseLost => replay.remaining -= 1,
+            ForwardOutcome::Response(response)
+                if response.config_mismatch
+                    || response.namespace_mismatch
+                    || response.served_config_id.as_deref() != Some(frame.config_id.as_str()) =>
+            {
+                // A later identity rejection cannot erase the first dispatch
+                // or permit map_response to select local fallback.
+                return ForwardOutcome::ResponseLost;
+            }
+            other => return other,
+        }
+    }
+    // A read may have executed before losing its response. Even if its retry
+    // only saw missing sockets, never convert this to recovery/local fallback.
+    ForwardOutcome::ResponseLost
 }
 
 fn daemon_mcp_error(message: impl Into<String>, data: Option<serde_json::Value>) -> McpError {
@@ -1164,21 +1259,45 @@ async fn wait_for_process_exit(pid: u32, timeout: std::time::Duration) -> bool {
     }
 }
 
-/// Signal the daemon named by the PID file and remove its rendezvous files
-/// only after its PID is positively confirmed dead (caller holds the recovery
-/// lock). The PID is captured before SIGTERM and ownership is re-checked by
-/// [`remove_daemon_paths_if_still_stale`] immediately before unlinking.
-async fn kill_stale_daemon_inner(exit_timeout: std::time::Duration) -> Result<(), RecoveryError> {
+#[derive(Debug, PartialEq, Eq)]
+enum PidFileSnapshot {
+    Missing,
+    Present(Vec<u8>),
+    Unreadable,
+}
+
+impl PidFileSnapshot {
+    fn read(path: &std::path::Path) -> Self {
+        match std::fs::read(path) {
+            Ok(bytes) => Self::Present(bytes),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Self::Missing,
+            Err(_) => Self::Unreadable,
+        }
+    }
+
+    fn pid(&self) -> Option<u32> {
+        match self {
+            Self::Present(bytes) => std::str::from_utf8(bytes).ok()?.trim().parse().ok(),
+            Self::Missing | Self::Unreadable => None,
+        }
+    }
+}
+
+/// Signal under the boot lock, but release it before waiting: the incumbent
+/// needs that same lock to finish its own shutdown cleanup.
+async fn kill_stale_daemon_inner(
+    exit_timeout: std::time::Duration,
+    boot_guard: Option<std::fs::File>,
+) -> Result<PidFileSnapshot, RecoveryError> {
     #[cfg(test)]
     KILL_COUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 
     let pid_file = pid_path();
-    let expected_pid = std::fs::read_to_string(&pid_file)
-        .ok()
-        .and_then(|s| s.trim().parse::<u32>().ok());
+    let expected_snapshot = PidFileSnapshot::read(&pid_file);
+    let expected_pid = expected_snapshot.pid();
 
-    if let Some(pid) = expected_pid {
-        let wait_for_exit = match classify_pid_identity(pid) {
+    let wait_for_exit = if let Some(pid) = expected_pid {
+        match classify_pid_identity(pid) {
             PidIdentity::KhiveDaemon => {
                 if let Ok(signed) = i32::try_from(pid) {
                     if signed > 0 {
@@ -1205,34 +1324,45 @@ async fn kill_stale_daemon_inner(exit_timeout: std::time::Duration) -> Result<()
                 );
                 true
             }
-        };
+        }
+    } else {
+        false
+    };
+    drop(boot_guard);
+    if let Some(pid) = expected_pid {
         if wait_for_exit && !wait_for_process_exit(pid, exit_timeout).await {
             return Err(RecoveryError::IncumbentStillAlive { pid });
         }
     }
 
-    remove_daemon_paths_if_still_stale(&pid_file, expected_pid);
-    Ok(())
+    Ok(expected_snapshot)
 }
 
 /// Remove `pid_file`/the daemon socket only if ownership has not changed since
-/// `expected_pid` was observed: the PID file must still name `expected_pid`,
+/// `expected_snapshot` was observed: the PID file must be unchanged or absent,
 /// and the socket path must not already have a live listener answering it.
 /// Either signal changing means a replacement daemon claimed the rendezvous
 /// between the observation and this call, and unlinking would delete its live
 /// paths instead of the truly-stale ones (#645).
-fn remove_daemon_paths_if_still_stale(pid_file: &std::path::Path, expected_pid: Option<u32>) {
-    let current_pid = std::fs::read_to_string(pid_file)
-        .ok()
-        .and_then(|s| s.trim().parse::<u32>().ok());
-    if current_pid != expected_pid {
+fn remove_daemon_paths_if_still_stale(
+    pid_file: &std::path::Path,
+    expected_snapshot: &PidFileSnapshot,
+) -> bool {
+    let current_snapshot = PidFileSnapshot::read(pid_file);
+    if matches!(expected_snapshot, PidFileSnapshot::Unreadable)
+        || matches!(current_snapshot, PidFileSnapshot::Unreadable)
+    {
+        return false;
+    }
+    // Graceful incumbent cleanup may already have removed its own PID file.
+    if current_snapshot != PidFileSnapshot::Missing && &current_snapshot != expected_snapshot {
         tracing::warn!(
-            expected_pid = ?expected_pid,
-            current_pid = ?current_pid,
+            expected_pid = ?expected_snapshot.pid(),
+            current_pid = ?current_snapshot.pid(),
             "pid file changed during stale-daemon cleanup — a replacement daemon \
              already claimed it; skipping unlink to avoid deleting its live paths"
         );
-        return;
+        return false;
     }
 
     let sock = socket_path();
@@ -1241,17 +1371,27 @@ fn remove_daemon_paths_if_still_stale(pid_file: &std::path::Path, expected_pid: 
     // that bound after our probe found the old one dead. Combined with the
     // PID-file recheck above, this closes the window even when the recovery
     // lock alone did not exclude the replacement's boot.
-    if std::os::unix::net::UnixStream::connect(&sock).is_ok() {
-        tracing::warn!(
-            socket = ?sock,
-            "a live listener now answers the daemon socket — skipping unlink to \
-             avoid deleting a replacement daemon's rendezvous"
-        );
-        return;
+    match std::os::unix::net::UnixStream::connect(&sock) {
+        Ok(_) => {
+            tracing::warn!(socket = ?sock, "live listener claimed rendezvous; skipping cleanup and launch");
+            return false;
+        }
+        Err(error)
+            if matches!(
+                error.kind(),
+                std::io::ErrorKind::NotFound | std::io::ErrorKind::ConnectionRefused
+            ) => {}
+        Err(_) => return false,
     }
 
-    let _ = std::fs::remove_file(pid_file);
-    let _ = std::fs::remove_file(&sock);
+    for path in [pid_file, sock.as_path()] {
+        if let Err(error) = std::fs::remove_file(path) {
+            if error.kind() != std::io::ErrorKind::NotFound {
+                return false;
+            }
+        }
+    }
+    true
 }
 
 /// Outcome of the under-lock identity probe.
@@ -1358,6 +1498,7 @@ async fn probe_daemon_identity(config_id: &str, namespace: &str, timeout_ms: u64
         Ok(
             ForwardOutcome::NoSocket
             | ForwardOutcome::ParseFailure
+            | ForwardOutcome::ResponseLost
             | ForwardOutcome::ProtocolMismatch { .. },
         ) => ProbeOutcome::Dead,
         Ok(ForwardOutcome::Unreachable {
@@ -1667,18 +1808,30 @@ where
             Ok(RecoveryOutcome::Uncertain)
         }
         ProbeOutcome::Dead => {
-            // Also take the shared boot/recovery lock for the kill+spawn step
-            // itself, matching `acquire_recovery_lock`'s existing role of
-            // serializing this against the daemon server's own
-            // cleanup→bind→pid-write critical section. No deadlock risk: this
-            // is a distinct lock file from `recoverer_guard` above, acquired
-            // and dropped entirely within this arm.
+            let boot_lock = acquire_recovery_lock();
+            match probe_daemon_identity(config_id, namespace, BOOT_FENCE_PROBE_TIMEOUT_MS).await {
+                ProbeOutcome::Alive | ProbeOutcome::Timeout => return Ok(RecoveryOutcome::Skipped),
+                ProbeOutcome::LockContended => return Ok(RecoveryOutcome::Uncertain),
+                ProbeOutcome::Dead => {}
+            }
+            let expected_snapshot = kill_stale_daemon_inner(exit_timeout, boot_lock).await?;
+            // Keep the recoverer-only lock throughout, but let graceful exit
+            // take the boot lock. An independently started successor can win
+            // while we wait, so recheck under the boot lock before unlink/spawn.
             let _boot_lock = acquire_recovery_lock();
-            kill_stale_daemon_inner(exit_timeout).await?;
-            launcher
-                .launch()
-                .map(RecoveryOutcome::Spawned)
-                .map_err(RecoveryError::Spawn)
+            match probe_daemon_identity(config_id, namespace, BOOT_FENCE_PROBE_TIMEOUT_MS).await {
+                ProbeOutcome::Alive | ProbeOutcome::Timeout => Ok(RecoveryOutcome::Skipped),
+                ProbeOutcome::LockContended => Ok(RecoveryOutcome::Uncertain),
+                ProbeOutcome::Dead => {
+                    if !remove_daemon_paths_if_still_stale(&pid_path(), &expected_snapshot) {
+                        return Ok(RecoveryOutcome::Uncertain);
+                    }
+                    launcher
+                        .launch()
+                        .map(RecoveryOutcome::Spawned)
+                        .map_err(RecoveryError::Spawn)
+                }
+            }
         }
     };
     drop(recoverer_guard);
@@ -2304,6 +2457,16 @@ pub async fn forward_or_spawn_with_config_and_packs(
     db: Option<&str>,
     packs: Option<&[String]>,
 ) -> Option<Result<String, McpError>> {
+    forward_or_spawn_with_replay_policy(frame, config, db, packs, false).await
+}
+
+pub(crate) async fn forward_or_spawn_with_replay_policy(
+    frame: &DaemonRequestFrame,
+    config: Option<&std::path::Path>,
+    db: Option<&str>,
+    packs: Option<&[String]>,
+    replay_read_only: bool,
+) -> Option<Result<String, McpError>> {
     #[cfg(any(test, feature = "test-forward-seam"))]
     if let Some(intercepted) = test_forward_seam::intercept(frame, packs) {
         return intercepted;
@@ -2312,7 +2475,7 @@ pub async fn forward_or_spawn_with_config_and_packs(
         let exe = std::env::current_exe()?;
         spawn_daemon_with_exe_and_config(&exe, config, db, packs)
     };
-    forward_or_spawn_with(frame, &spawn).await
+    forward_or_spawn_with_policy(frame, &spawn, replay_read_only).await
 }
 
 /// Forward a request, spawning the daemon if needed, without an explicit
@@ -2419,11 +2582,49 @@ async fn forward_or_spawn_with<F>(
 where
     F: Fn() -> std::io::Result<std::process::Child> + Sync,
 {
+    forward_or_spawn_with_policy(frame, spawn, false).await
+}
+
+async fn forward_or_spawn_with_policy<F>(
+    frame: &DaemonRequestFrame,
+    spawn: &F,
+    replay_read_only: bool,
+) -> Option<Result<String, McpError>>
+where
+    F: Fn() -> std::io::Result<std::process::Child> + Sync,
+{
     if env_truthy("KHIVE_NO_DAEMON") {
         return None;
     }
 
-    match try_forward_inner(frame).await {
+    let mut replay = ReadReplayBudget::new(replay_read_only);
+    let mut first = try_forward_with_read_replay(frame, &mut replay, None).await;
+    if matches!(first, ForwardOutcome::NoSocket) && recorded_daemon_is_alive() {
+        let deadline = bounded_retry_deadline();
+        while matches!(first, ForwardOutcome::NoSocket)
+            && tokio::time::Instant::now() < deadline
+            && !khive_storage::request_read_is_cancelled()
+        {
+            sleep_until_retry(deadline).await;
+            if tokio::time::Instant::now() >= deadline || khive_storage::request_read_is_cancelled()
+            {
+                break;
+            }
+            first = try_forward_with_read_replay(frame, &mut replay, Some(deadline)).await;
+        }
+    }
+    if matches!(first, ForwardOutcome::NoSocket)
+        && (khive_storage::request_read_is_cancelled()
+            || khive_storage::capture_request_read_context()
+                .deadline()
+                .is_some_and(|deadline| tokio::time::Instant::now() >= deadline.async_at()))
+    {
+        return Some(Err(daemon_mcp_error(
+            "daemon reconnect deadline expired or request cancelled before dispatch; no lifecycle recovery attempted",
+            Some(serde_json::json!({"reason": "daemon_reconnect_expired"})),
+        )));
+    }
+    match first {
         ForwardOutcome::Response(resp) => {
             return map_response(*resp, &frame.config_id, &frame.namespace)
         }
@@ -2435,7 +2636,7 @@ where
             kind,
             os_error_code,
         } => return Some(Err(daemon_unreachable_error(frame, kind, os_error_code))),
-        ForwardOutcome::ParseFailure => {
+        ForwardOutcome::ParseFailure | ForwardOutcome::ResponseLost => {
             let config_id = opaque_config_id(&frame.config_id);
             tracing::warn!(
                 config_id = %config_id,
@@ -2514,11 +2715,12 @@ where
         }
     }
 
-    // Send the real frame exactly once now that a daemon is confirmed ready
+    // Send the real frame now that a daemon is confirmed ready
     // (or believed ready via Skipped). The connect attempt inside
     // `try_forward_inner` doubles as the readiness check — a `NoSocket`
     // outcome here just means "not listening yet" (nothing written), so keep
-    // retrying; any other outcome is terminal and returned immediately.
+    // retrying. Only the explicit read policy may replay a lost response;
+    // every other post-write outcome is terminal and returned immediately.
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
     loop {
         if tokio::time::Instant::now() >= deadline {
@@ -2556,11 +2758,11 @@ where
                 BootFenceOutcome::HardError(err) => return Some(Err(err)),
             }
         }
-        match try_forward_inner(frame).await {
+        match try_forward_with_read_replay(frame, &mut replay, None).await {
             ForwardOutcome::Response(resp) => {
                 return map_response(*resp, &frame.config_id, &frame.namespace)
             }
-            ForwardOutcome::ParseFailure => {
+            ForwardOutcome::ParseFailure | ForwardOutcome::ResponseLost => {
                 let config_id = opaque_config_id(&frame.config_id);
                 tracing::warn!(
                     config_id = %config_id,
@@ -2687,6 +2889,368 @@ mod tests {
 
     const CFG: &str = "packs=[kg];db=:memory:;embed=none;extra=[];backend=main";
     const NS: &str = "test";
+
+    mod handover {
+        use super::*;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::time::Duration;
+
+        fn request(ops: &str) -> DaemonRequestFrame {
+            DaemonRequestFrame {
+                plan: false,
+                ops: ops.to_owned(),
+                presentation: None,
+                presentation_per_op: None,
+                namespace: NS.to_owned(),
+                actor_id: None,
+                process_ref: None,
+                visible_namespaces: Vec::new(),
+                config_id: CFG.to_owned(),
+                protocol_version: PROTOCOL_VERSION,
+                probe_only: false,
+                metrics_only: false,
+                format: None,
+                format_per_op: None,
+                from_wire: true,
+                request_id: Some(17),
+            }
+        }
+
+        fn isolate(dir: &std::path::Path) {
+            clear_daemon_env();
+            reset_counters();
+            std::env::set_var("KHIVE_SOCKET", dir.join("s"));
+            std::env::set_var("KHIVE_PID", dir.join("p"));
+            std::env::set_var("KHIVE_LOCK", dir.join("l"));
+            std::env::set_var("KHIVE_RECOVERER_LOCK", dir.join("r"));
+        }
+
+        fn never_spawn() -> std::io::Result<std::process::Child> {
+            panic!("socket handover must not spawn or invoke local fallback")
+        }
+
+        #[tokio::test]
+        #[serial]
+        async fn reconnect_waits_for_live_owner_socket_gap_without_recovery() {
+            let _cleanup = RecoveryTestGuard::new();
+            for refused in [false, true] {
+                let dir = tempfile::tempdir().unwrap();
+                isolate(dir.path());
+                let sock = socket_path();
+                std::fs::write(pid_path(), std::process::id().to_string()).unwrap();
+                if refused {
+                    drop(tokio::net::UnixListener::bind(&sock).unwrap());
+                }
+                let peer = tokio::spawn(async move {
+                    tokio::time::sleep(Duration::from_millis(150)).await;
+                    if refused {
+                        std::fs::remove_file(&sock).unwrap();
+                    }
+                    let listener = tokio::net::UnixListener::bind(&sock).unwrap();
+                    let (mut stream, _) = listener.accept().await.unwrap();
+                    let frame: DaemonRequestFrame =
+                        serde_json::from_slice(&read_frame(&mut stream).await.unwrap()).unwrap();
+                    assert!(!frame.probe_only, "grace must not enter lifecycle probing");
+                    write_frame(
+                        &mut stream,
+                        &serde_json::to_vec(&frame_ok("gap-ok")).unwrap(),
+                    )
+                    .await
+                    .unwrap();
+                });
+                let result = tokio::time::timeout(
+                    Duration::from_secs(3),
+                    forward_or_spawn_with(&request("stats()"), &never_spawn),
+                )
+                .await
+                .unwrap();
+                assert_eq!(result.unwrap().unwrap(), "gap-ok");
+                peer.await.unwrap();
+                assert_eq!(KILL_COUNT.load(Ordering::SeqCst), 0);
+            }
+        }
+
+        #[tokio::test]
+        #[serial]
+        async fn read_response_loss_replays_only_with_explicit_policy_and_keeps_identity() {
+            let _cleanup = RecoveryTestGuard::new();
+            for enabled in [false, true] {
+                let dir = tempfile::tempdir().unwrap();
+                isolate(dir.path());
+                let listener = tokio::net::UnixListener::bind(socket_path()).unwrap();
+                let expected = request("comm.thread(id=\"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa\")");
+                let expected_json = serde_json::to_value(&expected).unwrap();
+                let calls = Arc::new(AtomicUsize::new(0));
+                let peer_calls = calls.clone();
+                let (done_tx, mut done_rx) = tokio::sync::oneshot::channel::<()>();
+                let peer = tokio::spawn(async move {
+                    loop {
+                        let (mut stream, _) = tokio::select! {
+                            _ = &mut done_rx => break,
+                            accepted = listener.accept() => accepted.unwrap(),
+                        };
+                        let bytes = read_frame(&mut stream).await.unwrap();
+                        assert_eq!(
+                            serde_json::from_slice::<serde_json::Value>(&bytes).unwrap(),
+                            expected_json
+                        );
+                        let attempt = peer_calls.fetch_add(1, Ordering::SeqCst);
+                        if attempt > 0 {
+                            write_frame(
+                                &mut stream,
+                                &serde_json::to_vec(&frame_ok("replayed")).unwrap(),
+                            )
+                            .await
+                            .unwrap();
+                        }
+                    }
+                });
+                let result = tokio::time::timeout(
+                    Duration::from_secs(5),
+                    forward_or_spawn_with_policy(&expected, &never_spawn, enabled),
+                )
+                .await
+                .unwrap();
+                let _ = done_tx.send(());
+                if enabled {
+                    assert_eq!(result.unwrap().unwrap(), "replayed");
+                } else {
+                    assert!(result.unwrap().is_err());
+                }
+                peer.await.unwrap();
+                assert_eq!(calls.load(Ordering::SeqCst), if enabled { 2 } else { 1 });
+                assert_eq!(KILL_COUNT.load(Ordering::SeqCst), 0);
+            }
+        }
+
+        #[tokio::test]
+        #[serial]
+        async fn read_replay_attempt_cap_and_identity_drift_stay_terminal() {
+            let _cleanup = RecoveryTestGuard::new();
+            for drift in [false, true] {
+                let dir = tempfile::tempdir().unwrap();
+                isolate(dir.path());
+                let listener = tokio::net::UnixListener::bind(socket_path()).unwrap();
+                let calls = Arc::new(AtomicUsize::new(0));
+                let peer_calls = calls.clone();
+                let (done_tx, mut done_rx) = tokio::sync::oneshot::channel::<()>();
+                let peer = tokio::spawn(async move {
+                    loop {
+                        let (mut stream, _) = tokio::select! {
+                            _ = &mut done_rx => break,
+                            accepted = listener.accept() => accepted.unwrap(),
+                        };
+                        read_frame(&mut stream).await.unwrap();
+                        let attempt = peer_calls.fetch_add(1, Ordering::SeqCst);
+                        if drift && attempt > 0 {
+                            let mut response = frame_ok("must-not-use");
+                            response.config_mismatch = true;
+                            response.served_config_id = Some("replacement-config".to_owned());
+                            write_frame(&mut stream, &serde_json::to_vec(&response).unwrap())
+                                .await
+                                .unwrap();
+                        }
+                    }
+                });
+                let result = tokio::time::timeout(
+                    Duration::from_secs(5),
+                    forward_or_spawn_with_policy(&request("stats()"), &never_spawn, true),
+                )
+                .await
+                .unwrap();
+                let _ = done_tx.send(());
+                assert!(result.unwrap().is_err());
+                peer.await.unwrap();
+                assert_eq!(calls.load(Ordering::SeqCst), if drift { 2 } else { 3 });
+                assert_eq!(KILL_COUNT.load(Ordering::SeqCst), 0);
+            }
+        }
+
+        #[tokio::test]
+        #[serial]
+        async fn replay_deadline_never_converts_lost_response_to_no_socket() {
+            let _cleanup = RecoveryTestGuard::new();
+            let dir = tempfile::tempdir().unwrap();
+            isolate(dir.path());
+            let listener = tokio::net::UnixListener::bind(socket_path()).unwrap();
+            let peer = tokio::spawn(serve_crash_on_dispatch(listener));
+            let mut budget = ReadReplayBudget::new(true);
+            let deadline = tokio::time::Instant::now() + Duration::from_millis(150);
+            let outcome =
+                try_forward_with_read_replay(&request("stats()"), &mut budget, Some(deadline))
+                    .await;
+            assert!(matches!(outcome, ForwardOutcome::ResponseLost));
+            assert!(tokio::time::Instant::now() < deadline + Duration::from_millis(300));
+            peer.await.unwrap();
+            assert_eq!(KILL_COUNT.load(Ordering::SeqCst), 0);
+        }
+
+        #[tokio::test]
+        #[serial]
+        async fn reconnect_deadline_and_cancellation_prevent_fresh_recovery() {
+            let _cleanup = RecoveryTestGuard::new();
+            for cancel in [false, true] {
+                let dir = tempfile::tempdir().unwrap();
+                isolate(dir.path());
+                std::fs::write(pid_path(), std::process::id().to_string()).unwrap();
+                let (tx, rx) = tokio::sync::watch::channel(false);
+                let canceller = tokio::spawn(async move {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                    if cancel {
+                        tx.send(true).unwrap();
+                    }
+                    tx
+                });
+                let result = khive_storage::scope_request_read_cancellation(
+                    rx,
+                    khive_storage::scope_request_read_deadline(
+                        Duration::from_millis(60),
+                        forward_or_spawn_with(&request("stats()"), &never_spawn),
+                    ),
+                )
+                .await;
+                let error = result.unwrap().unwrap_err();
+                assert_eq!(error.data.unwrap()["reason"], "daemon_reconnect_expired");
+                assert_eq!(KILL_COUNT.load(Ordering::SeqCst), 0);
+                canceller.await.unwrap();
+            }
+        }
+
+        #[tokio::test]
+        #[serial]
+        async fn classified_reads_do_not_replay_malformed_timeout_or_protocol_failures() {
+            let _cleanup = RecoveryTestGuard::new();
+            for kind in ["malformed", "timeout", "protocol"] {
+                let dir = tempfile::tempdir().unwrap();
+                isolate(dir.path());
+                let listener = tokio::net::UnixListener::bind(socket_path()).unwrap();
+                let peer = tokio::spawn(async move {
+                    let (mut stream, _) = listener.accept().await.unwrap();
+                    read_frame(&mut stream).await.unwrap();
+                    match kind {
+                        "malformed" => write_frame(&mut stream, b"not-json").await.unwrap(),
+                        "protocol" => {
+                            let mut response = frame_ok("wrong-version");
+                            response.daemon_protocol_version = PROTOCOL_VERSION + 1;
+                            write_frame(&mut stream, &serde_json::to_vec(&response).unwrap())
+                                .await
+                                .unwrap();
+                        }
+                        _ => tokio::time::sleep(Duration::from_millis(750)).await,
+                    }
+                    assert!(
+                        tokio::time::timeout(Duration::from_millis(150), listener.accept())
+                            .await
+                            .is_err()
+                    );
+                });
+                let mut budget = ReadReplayBudget::new(true);
+                let deadline = tokio::time::Instant::now()
+                    + if kind == "timeout" {
+                        Duration::from_millis(500)
+                    } else {
+                        Duration::from_secs(2)
+                    };
+                let outcome =
+                    try_forward_with_read_replay(&request("stats()"), &mut budget, Some(deadline))
+                        .await;
+                match kind {
+                    "protocol" => {
+                        assert!(matches!(outcome, ForwardOutcome::ProtocolMismatch { .. }))
+                    }
+                    _ => assert!(matches!(outcome, ForwardOutcome::ParseFailure)),
+                }
+                assert_eq!(budget.remaining, 2);
+                peer.await.unwrap();
+            }
+        }
+
+        #[tokio::test]
+        #[ignore = "isolated subprocess fixture"]
+        async fn graceful_incumbent_child() {
+            assert_eq!(
+                std::env::var("KHIVE_HANDOVER_TEST_CHILD").as_deref(),
+                Ok("1")
+            );
+            let _signal =
+                tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()).unwrap();
+            run_daemon(HarnessDispatch::new(NS, "old-config"))
+                .await
+                .unwrap();
+            if let Ok(successor) = std::env::var("KHIVE_HANDOVER_SUCCESSOR_PID") {
+                std::fs::write(pid_path(), successor).unwrap();
+            }
+        }
+
+        #[tokio::test]
+        #[serial]
+        async fn recovery_releases_boot_lock_for_graceful_exit_and_rechecks_owner() {
+            for successor_wins in [false, true] {
+                let dir = tempfile::tempdir().unwrap();
+                let mut cleanup = RecoveryTestGuard::new();
+                isolate(dir.path());
+                let mut command = std::process::Command::new(std::env::current_exe().unwrap());
+                command
+                    .args([
+                        "--exact",
+                        "daemon::tests::handover::graceful_incumbent_child",
+                        "--ignored",
+                        "--nocapture",
+                    ])
+                    .env("HOME", dir.path())
+                    .current_dir(dir.path())
+                    .env("KHIVE_HANDOVER_TEST_CHILD", "1")
+                    .env_remove("KHIVE_HANDOVER_SUCCESSOR_PID")
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null());
+                if successor_wins {
+                    command.env(
+                        "KHIVE_HANDOVER_SUCCESSOR_PID",
+                        std::process::id().to_string(),
+                    );
+                }
+                let incumbent_pid = cleanup.track_child(command.spawn().unwrap());
+                let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+                while !matches!(
+                    probe_daemon_identity("old-config", NS, 100).await,
+                    ProbeOutcome::Alive
+                ) {
+                    assert!(tokio::time::Instant::now() < deadline, "child readiness");
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+                FORCE_PID_IS_DAEMON.store(true, Ordering::SeqCst);
+                let launches = AtomicUsize::new(0);
+                let spawn = || {
+                    assert!(!process_is_alive(incumbent_pid));
+                    launches.fetch_add(1, Ordering::SeqCst);
+                    std::process::Command::new("/bin/sh")
+                        .args(["-c", "exit 0"])
+                        .spawn()
+                };
+                let result =
+                    kill_and_respawn_with_exit_timeout(CFG, NS, &spawn, Duration::from_secs(2))
+                        .await;
+                match (successor_wins, result) {
+                    (false, Ok(RecoveryOutcome::Spawned(mut child))) => {
+                        assert!(child.wait().unwrap().success());
+                    }
+                    (true, Ok(RecoveryOutcome::Uncertain)) => {}
+                    (_, other) => panic!("unexpected recovery outcome: {other:?}"),
+                }
+                assert!(cleanup.child_mut().wait().unwrap().success());
+                assert_eq!(
+                    launches.load(Ordering::SeqCst),
+                    usize::from(!successor_wins)
+                );
+                if successor_wins {
+                    assert_eq!(
+                        std::fs::read_to_string(pid_path()).unwrap(),
+                        std::process::id().to_string()
+                    );
+                }
+            }
+        }
+    }
 
     fn frame_ok(result: &str) -> DaemonResponseFrame {
         DaemonResponseFrame {
@@ -5524,7 +6088,7 @@ mod tests {
     #[tokio::test]
     #[serial]
     #[serial_test::serial(config_ledger)]
-    async fn try_forward_inner_returns_parse_failure_when_daemon_closes_without_response() {
+    async fn try_forward_inner_returns_response_lost_when_daemon_closes_without_response() {
         clear_daemon_env();
         let dir = tempfile::tempdir().expect("tempdir");
         let sock = dir.path().join("khived.sock");
@@ -5570,9 +6134,9 @@ mod tests {
         let _ = tokio::time::timeout(std::time::Duration::from_secs(2), fake_handle).await;
 
         assert!(
-            matches!(outcome, ForwardOutcome::ParseFailure),
+            matches!(outcome, ForwardOutcome::ResponseLost),
             "daemon crash (connection closed without response) must yield \
-             ParseFailure, not NoSocket — got a different variant"
+             ResponseLost, not NoSocket — got a different variant"
         );
 
         clear_daemon_env();
@@ -8155,7 +8719,10 @@ mod tests {
         std::fs::write(&pid_file, "4242").expect("write pid file");
         std::fs::write(&sock, "stale socket placeholder").expect("write stale sock placeholder");
 
-        remove_daemon_paths_if_still_stale(&pid_file, Some(4242));
+        assert!(remove_daemon_paths_if_still_stale(
+            &pid_file,
+            &PidFileSnapshot::read(&pid_file),
+        ));
 
         assert!(!pid_file.exists(), "unchanged pid file must be removed");
         assert!(!sock.exists(), "stale socket must be removed");
@@ -8174,7 +8741,10 @@ mod tests {
         std::fs::write(&pid_file, "5555").expect("write replacement pid file");
         std::fs::write(&sock, "replacement socket placeholder").expect("write sock placeholder");
 
-        remove_daemon_paths_if_still_stale(&pid_file, Some(4242));
+        assert!(!remove_daemon_paths_if_still_stale(
+            &pid_file,
+            &PidFileSnapshot::Present(b"4242".to_vec()),
+        ));
 
         assert!(
             pid_file.exists(),
@@ -8202,7 +8772,10 @@ mod tests {
         // just before its own pid-write).
         let _listener = std::os::unix::net::UnixListener::bind(&sock).expect("bind live socket");
 
-        remove_daemon_paths_if_still_stale(&pid_file, Some(4242));
+        assert!(!remove_daemon_paths_if_still_stale(
+            &pid_file,
+            &PidFileSnapshot::read(&pid_file),
+        ));
 
         assert!(
             sock.exists(),
@@ -8213,6 +8786,52 @@ mod tests {
             "pid file must be left alone alongside the live socket"
         );
         clear_daemon_env();
+    }
+
+    #[test]
+    #[serial]
+    fn remove_daemon_paths_if_still_stale_compares_malformed_pid_bytes() {
+        let _cleanup = RecoveryTestGuard::new();
+        clear_daemon_env();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pid_file = dir.path().join("khived.pid");
+        let sock = dir.path().join("khived.sock");
+        std::env::set_var("KHIVE_SOCKET", &sock);
+
+        for contents in [
+            b"".as_slice(),
+            b"partial-pid".as_slice(),
+            b"\xff".as_slice(),
+        ] {
+            for changed in [false, true] {
+                std::fs::write(&pid_file, contents).expect("write incomplete pid file");
+                let expected_snapshot = PidFileSnapshot::read(&pid_file);
+                assert_eq!(expected_snapshot.pid(), None);
+                drop(std::os::unix::net::UnixListener::bind(&sock).expect("bind stale socket"));
+                let mut current_contents = contents.to_vec();
+                if changed {
+                    current_contents.push(b'\n');
+                    std::fs::write(&pid_file, &current_contents).expect("change pid file bytes");
+                }
+
+                assert_eq!(
+                    remove_daemon_paths_if_still_stale(&pid_file, &expected_snapshot),
+                    !changed,
+                );
+                if changed {
+                    assert_eq!(std::fs::read(&pid_file).unwrap(), current_contents);
+                    assert!(sock.exists(), "changed owner's socket must survive");
+                    std::fs::remove_file(&pid_file).unwrap();
+                    std::fs::remove_file(&sock).unwrap();
+                } else {
+                    assert!(
+                        !pid_file.exists(),
+                        "unchanged incomplete pid must be removed"
+                    );
+                    assert!(!sock.exists(), "unchanged stale socket must be removed");
+                }
+            }
+        }
     }
 
     // ── bridge self-heal on ProtocolMismatch (#714) ───────────────────────────

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -5414,6 +5414,7 @@ mod tests {
         }
 
         #[tokio::test]
+        #[serial_test::serial(config_ledger)]
         async fn custom_same_name_pack_cannot_enable_replay_at_request_boundary() {
             let mut builder = VerbRegistryBuilder::new();
             builder.register(ImpostorCommPack);

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -3328,9 +3328,10 @@ type ForwardFuture = std::pin::Pin<
 /// the real function would receive. `config`/`db` are always `None` at this
 /// call site.
 #[cfg(unix)]
-type ForwardFnPtr = fn(khive_runtime::DaemonRequestFrame, Option<Vec<String>>) -> ForwardFuture;
+type ForwardFnPtr =
+    fn(khive_runtime::DaemonRequestFrame, Option<Vec<String>>, bool) -> ForwardFuture;
 
-/// Adapts the real `forward_or_spawn_with_config_and_packs` to the `ForwardFnPtr`
+/// Adapts the real `forward_or_spawn_with_replay_policy` to the `ForwardFnPtr`
 /// signature. A pure pass-through — the `Some`/`None` decision already
 /// happened at the call site — so this boundary carries no logic a test
 /// spy could fail to observe.
@@ -3338,10 +3339,17 @@ type ForwardFnPtr = fn(khive_runtime::DaemonRequestFrame, Option<Vec<String>>) -
 fn forward_or_spawn_boxed(
     frame: khive_runtime::DaemonRequestFrame,
     packs: Option<Vec<String>>,
+    replay_read_only: bool,
 ) -> ForwardFuture {
     Box::pin(async move {
-        crate::daemon::forward_or_spawn_with_config_and_packs(&frame, None, None, packs.as_deref())
-            .await
+        crate::daemon::forward_or_spawn_with_replay_policy(
+            &frame,
+            None,
+            None,
+            packs.as_deref(),
+            replay_read_only,
+        )
+        .await
     })
 }
 
@@ -3418,9 +3426,15 @@ impl KhiveMcpServer {
         // side-effect-free preflight keeps the local and warm-daemon surfaces on
         // the same RPC contract; valid requests are still parsed authoritatively
         // inside `dispatch_request_inner` at the dispatch seam.
-        if let Err(error) = parse_request(&p.ops) {
-            return Err(dsl_err_to_mcp(error));
-        }
+        let parsed = parse_request(&p.ops).map_err(dsl_err_to_mcp)?;
+        #[cfg(unix)]
+        let replay_read_only = !parsed.ops.is_empty()
+            && parsed
+                .ops
+                .iter()
+                .all(|op| self.registry.is_read_replay_safe(&op.tool));
+        #[cfg(not(unix))]
+        let _ = parsed;
 
         // Forward to the warm daemon when reachable, auto-spawning it
         // on first use. An ordinary no-socket condition, a namespace
@@ -3481,7 +3495,7 @@ impl KhiveMcpServer {
                 .map(khive_storage::RequestReadDeadline::async_at);
             let mut forward_task =
                 tokio::spawn(khive_storage::inherit_request_read_context(async move {
-                    let outcome = forward_fn(frame, Some(resolved_packs)).await;
+                    let outcome = forward_fn(frame, Some(resolved_packs), replay_read_only).await;
                     tracing::debug!(
                         request_id,
                         daemon_outcome_present = outcome.is_some(),
@@ -5169,6 +5183,7 @@ mod tests {
         fn spy_forward(
             _frame: khive_runtime::DaemonRequestFrame,
             packs: Option<Vec<String>>,
+            _replay_read_only: bool,
         ) -> ForwardFuture {
             SPY_CAPTURED_PACKS.with(|c| *c.borrow_mut() = Some(packs));
             Box::pin(async {
@@ -5218,6 +5233,308 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    mod read_replay_tests {
+        use super::*;
+
+        thread_local! {
+            static CAPTURED_FORWARD: std::cell::RefCell<Option<(String, bool)>> =
+                const { std::cell::RefCell::new(None) };
+        }
+
+        fn capture_forward_policy(
+            frame: khive_runtime::DaemonRequestFrame,
+            _packs: Option<Vec<String>>,
+            replay_read_only: bool,
+        ) -> ForwardFuture {
+            CAPTURED_FORWARD.with(|capture| {
+                *capture.borrow_mut() = Some((frame.ops, replay_read_only));
+            });
+            Box::pin(async { Some(Ok("forwarded-policy-fixture".to_string())) })
+        }
+
+        fn live_server() -> KhiveMcpServer {
+            let runtime = KhiveRuntime::new(RuntimeConfig {
+                db_path: None,
+                embedding_model: None,
+                additional_embedding_models: vec![],
+                packs: vec!["kg".to_string(), "comm".to_string(), "memory".to_string()],
+                ..RuntimeConfig::default()
+            })
+            .expect("in-memory replay registry");
+            KhiveMcpServer::new(runtime).expect("live kg, comm and memory handlers")
+        }
+
+        #[tokio::test]
+        #[serial_test::serial(config_ledger)]
+        async fn request_forward_policy_requires_every_operation_to_be_an_opted_in_read() {
+            let server = live_server();
+            let cases = [
+                ("stats()", true),
+                (
+                    "comm.thread(id=\"00000000-0000-0000-0000-000000000001\")",
+                    true,
+                ),
+                ("comm.inbox(wait_ms=30000, box=\"sent\", limit=1)", true),
+                ("comm.unread()", true),
+                (
+                    "comm.delivered(id=\"00000000-0000-0000-0000-000000000001\")",
+                    true,
+                ),
+                ("[stats(), comm.unread(), comm.inbox(limit=1)]", true),
+                ("stats() | comm.unread()", true),
+                (
+                    "comm.thread(id=\"00000000-0000-0000-0000-000000000001\") | \
+                     comm.thread(id=$prev.thread_id) | comm.thread(id=$prev.thread_id)",
+                    true,
+                ),
+                (
+                    r#"[{"tool":"stats"},{"tool":"comm.unread","args":{}}]"#,
+                    true,
+                ),
+                ("stats(help=true)", true),
+                ("comm.send(to=\"bob\", content=\"policy-fixture\")", false),
+                (
+                    "[comm.unread(), comm.send(to=\"bob\", content=\"policy-fixture\")]",
+                    false,
+                ),
+                (
+                    "comm.send(to=\"bob\", content=\"policy-fixture\") | comm.thread(id=$prev.id)",
+                    false,
+                ),
+                ("[stats(), unknown.read()]", false),
+                ("unknown.read()", false),
+                ("unknown.read(help=true)", false),
+                ("comm.send(help=true)", false),
+                ("stats() | comm.send(help=$prev.help)", false),
+                ("memory.prune(dry_run=true)", false),
+                ("merge(dry_run=true)", false),
+                (
+                    "comm.mark_read(ids=[\"00000000-0000-0000-0000-000000000001\"], atomic=true)",
+                    false,
+                ),
+                ("search(kind=\"entity\", query=\"policy-fixture\")", false),
+                ("memory.recall(query=\"policy-fixture\")", false),
+                ("get(id=\"00000000-0000-0000-0000-000000000001\")", false),
+            ];
+
+            for (ops, expected) in cases {
+                CAPTURED_FORWARD.with(|capture| *capture.borrow_mut() = None);
+                let response = server
+                    .request_with_forward(
+                        RequestParams {
+                            ops: ops.to_string(),
+                            ..Default::default()
+                        },
+                        capture_forward_policy,
+                    )
+                    .await
+                    .unwrap_or_else(|error| panic!("forward preflight rejected {ops}: {error}"));
+                assert_eq!(response, "forwarded-policy-fixture");
+                assert_eq!(
+                    CAPTURED_FORWARD.with(|capture| capture.borrow_mut().take()),
+                    Some((ops.to_string(), expected)),
+                    "forwarded replay policy for {ops}",
+                );
+            }
+        }
+
+        #[tokio::test]
+        #[serial_test::serial(config_ledger)]
+        async fn malformed_and_atomic_wrapper_requests_never_reach_forwarding() {
+            let server = live_server();
+            for ops in [
+                "",
+                "stats(",
+                "[stats(), comm.unread()",
+                r#"{"atomic":true,"ops":[{"tool":"stats"}]}"#,
+            ] {
+                CAPTURED_FORWARD.with(|capture| *capture.borrow_mut() = None);
+                let error = server
+                    .request_with_forward(
+                        RequestParams {
+                            ops: ops.to_string(),
+                            ..Default::default()
+                        },
+                        capture_forward_policy,
+                    )
+                    .await
+                    .expect_err("invalid DSL must fail before forwarding");
+                assert_eq!(error.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+                assert_eq!(
+                    error.data.as_ref().and_then(|data| data["reason"].as_str()),
+                    Some("parse-error"),
+                );
+                assert!(CAPTURED_FORWARD.with(|capture| capture.borrow().is_none()));
+            }
+        }
+
+        struct ImpostorCommPack;
+
+        impl khive_types::Pack for ImpostorCommPack {
+            const NAME: &'static str = "comm";
+            const NOTE_KINDS: &'static [&'static str] = &[];
+            const ENTITY_KINDS: &'static [&'static str] = &[];
+            const HANDLERS: &'static [khive_runtime::HandlerDef] = &[khive_runtime::HandlerDef {
+                name: "comm.thread",
+                description: "untrusted same-name replay fixture",
+                visibility: khive_runtime::Visibility::Verb,
+                category: khive_runtime::VerbCategory::Assertive,
+                params: &[],
+            }];
+        }
+
+        #[async_trait::async_trait]
+        impl khive_runtime::PackRuntime for ImpostorCommPack {
+            fn name(&self) -> &str {
+                <Self as khive_types::Pack>::NAME
+            }
+
+            fn note_kinds(&self) -> &'static [&'static str] {
+                &[]
+            }
+
+            fn entity_kinds(&self) -> &'static [&'static str] {
+                &[]
+            }
+
+            fn handlers(&self) -> &'static [khive_runtime::HandlerDef] {
+                <Self as khive_types::Pack>::HANDLERS
+            }
+
+            async fn dispatch(
+                &self,
+                _verb: &str,
+                _params: Value,
+                _registry: &VerbRegistry,
+                _token: &khive_runtime::NamespaceToken,
+            ) -> Result<Value, RuntimeError> {
+                panic!("the forwarding policy fixture must not dispatch locally")
+            }
+        }
+
+        #[tokio::test]
+        async fn custom_same_name_pack_cannot_enable_replay_at_request_boundary() {
+            let mut builder = VerbRegistryBuilder::new();
+            builder.register(ImpostorCommPack);
+            let registry = builder.build().expect("custom comm fixture registry");
+            assert_eq!(
+                registry.verb_category("comm.thread"),
+                Some(khive_runtime::VerbCategory::Assertive),
+            );
+            let server = KhiveMcpServer::from_registry(registry);
+            let ops = "comm.thread(id=\"00000000-0000-0000-0000-000000000001\")";
+            CAPTURED_FORWARD.with(|capture| *capture.borrow_mut() = None);
+            server
+                .request_with_forward(
+                    RequestParams {
+                        ops: ops.to_string(),
+                        ..Default::default()
+                    },
+                    capture_forward_policy,
+                )
+                .await
+                .expect("custom call reaches forwarding without replay permission");
+            assert_eq!(
+                CAPTURED_FORWARD.with(|capture| capture.borrow_mut().take()),
+                Some((ops.to_string(), false)),
+            );
+        }
+
+        #[tokio::test]
+        #[serial_test::serial]
+        #[serial_test::serial(config_ledger)]
+        async fn mixed_comm_batch_commits_once_when_its_daemon_response_is_lost() {
+            clear_daemon_env();
+            let dir = tempfile::tempdir().expect("mixed batch socket directory");
+            let socket = dir.path().join("khived.sock");
+            std::env::set_var("KHIVE_SOCKET", &socket);
+            std::env::set_var("KHIVE_PID", dir.path().join("khived.pid"));
+            let client = live_server();
+            let daemon = live_server();
+            let baseline = client
+                .dispatch_request_local(RequestParams {
+                    ops: "stats()".to_string(),
+                    ..Default::default()
+                })
+                .await
+                .expect("client baseline");
+            let listener = tokio::net::UnixListener::bind(&socket).expect("bind fake daemon");
+            let mutations = Arc::new(AtomicUsize::new(0));
+            let observed_mutations = Arc::clone(&mutations);
+            let (stop_tx, mut stop_rx) = tokio::sync::oneshot::channel::<()>();
+            let daemon_task = tokio::spawn(async move {
+                loop {
+                    let (mut stream, _) = tokio::select! {
+                        _ = &mut stop_rx => break,
+                        incoming = listener.accept() => incoming.expect("accept mixed batch"),
+                    };
+                    let payload = khive_runtime::daemon::read_frame(&mut stream)
+                        .await
+                        .expect("receive full mixed batch");
+                    let frame: khive_runtime::DaemonRequestFrame =
+                        serde_json::from_slice(&payload).expect("decode mixed batch frame");
+                    assert!(
+                        !frame.probe_only,
+                        "mixed response loss must not trigger recovery"
+                    );
+                    let response = daemon
+                        .dispatch_request_local(RequestParams {
+                            ops: frame.ops,
+                            ..Default::default()
+                        })
+                        .await
+                        .expect("execute mixed batch before losing the response");
+                    let envelope: Value = serde_json::from_str(&response).expect("batch response");
+                    assert_eq!(envelope["summary"]["succeeded"], 2, "{envelope}");
+                    let committed = envelope["results"]
+                        .as_array()
+                        .expect("batch entries")
+                        .iter()
+                        .filter(|entry| entry["tool"] == "comm.send" && entry["ok"] == true)
+                        .count();
+                    observed_mutations.fetch_add(committed, Ordering::SeqCst);
+                    drop(stream);
+                }
+            });
+
+            let result = client
+                .request(
+                    Parameters(RequestParams {
+                        ops: "[comm.unread(), comm.send(to=\"bob\", content=\"mixed-replay-fixture\")]"
+                            .to_string(),
+                        ..Default::default()
+                    }),
+                    tokio_util::sync::CancellationToken::new(),
+                )
+                .await;
+            let _ = stop_tx.send(());
+            let stopped = daemon_task.await;
+            clear_daemon_env();
+            stopped.expect("fake daemon exits cleanly");
+
+            let error = result.expect_err("the mixed batch must preserve its ambiguous outcome");
+            assert!(error.message.contains("not retrying"), "{error}");
+            assert_eq!(
+                mutations.load(Ordering::SeqCst),
+                1,
+                "comm.send committed more than once"
+            );
+            let after = client
+                .dispatch_request_local(RequestParams {
+                    ops: "stats()".to_string(),
+                    ..Default::default()
+                })
+                .await
+                .expect("client state after remote response loss");
+            assert_eq!(
+                stats_without_request_local_usage(&after),
+                stats_without_request_local_usage(&baseline),
+                "a lost mixed response must not dispatch comm.send locally",
+            );
+        }
+    }
+
     /// A cancellation notification after daemon admission must not replace the
     /// daemon's actual per-op outcome with a bare RPC-level error. The daemon
     /// response is the only source that can say which independent operations
@@ -5240,6 +5557,7 @@ mod tests {
         fn delayed_partial_forward(
             _frame: khive_runtime::DaemonRequestFrame,
             _packs: Option<Vec<String>>,
+            _replay_read_only: bool,
         ) -> ForwardFuture {
             let started = FORWARD_STARTED
                 .with(|c| c.borrow().clone())
@@ -5323,6 +5641,7 @@ mod tests {
         fn unreachable_forward(
             _frame: khive_runtime::DaemonRequestFrame,
             _packs: Option<Vec<String>>,
+            _replay_read_only: bool,
         ) -> ForwardFuture {
             panic!("save_to must bypass daemon forwarding regardless of cancellation");
         }
@@ -5397,6 +5716,7 @@ mod tests {
         fn cancel_then_none_forward(
             _frame: khive_runtime::DaemonRequestFrame,
             _packs: Option<Vec<String>>,
+            _replay_read_only: bool,
         ) -> ForwardFuture {
             Box::pin(async move {
                 CANCEL_TX.with(|c| {
@@ -5488,6 +5808,7 @@ mod tests {
         fn slow_forward(
             _frame: khive_runtime::DaemonRequestFrame,
             _packs: Option<Vec<String>>,
+            _replay_read_only: bool,
         ) -> ForwardFuture {
             let started = FORWARD_STARTED
                 .with(|c| c.borrow().clone())
@@ -5577,6 +5898,7 @@ mod tests {
         fn never_resolves_forward(
             _frame: khive_runtime::DaemonRequestFrame,
             _packs: Option<Vec<String>>,
+            _replay_read_only: bool,
         ) -> ForwardFuture {
             let started = FORWARD_STARTED
                 .with(|c| c.borrow().clone())
@@ -5661,6 +5983,7 @@ mod tests {
         fn never_resolves_forward(
             _frame: khive_runtime::DaemonRequestFrame,
             _packs: Option<Vec<String>>,
+            _replay_read_only: bool,
         ) -> ForwardFuture {
             let started = FORWARD_STARTED
                 .with(|c| c.borrow().clone())
@@ -5757,6 +6080,7 @@ mod tests {
         fn never_resolves_forward(
             _frame: khive_runtime::DaemonRequestFrame,
             _packs: Option<Vec<String>>,
+            _replay_read_only: bool,
         ) -> ForwardFuture {
             let started = FORWARD_STARTED
                 .with(|c| c.borrow().clone())

--- a/crates/khive-mcp/src/server/disposition_tests.rs
+++ b/crates/khive-mcp/src/server/disposition_tests.rs
@@ -1507,7 +1507,12 @@ async fn a3_same_committed_failure_crosses_mcp_request_and_native_frame_once() {
             *FORWARD.lock().unwrap() = None;
         }
     }
-    fn native_forward(frame: DaemonRequestFrame, _packs: Option<Vec<String>>) -> ForwardFuture {
+    fn native_forward(
+        frame: DaemonRequestFrame,
+        _packs: Option<Vec<String>>,
+        replay_read_only: bool,
+    ) -> ForwardFuture {
+        assert!(!replay_read_only, "comm.send must not be replayed");
         let dispatcher = FORWARD.lock().unwrap().take().expect("one native forward");
         Box::pin(async move {
             let capture = Arc::clone(&dispatcher.capture);

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -1609,10 +1609,10 @@ pub async fn run_daemon<D: DaemonDispatch>(dispatcher: D) -> anyhow::Result<()> 
 /// Run a real daemon server for an in-process multi-launch test.
 ///
 /// Separate production daemon candidates have distinct PIDs, so the boot fence
-/// recognizes a responsive incumbent and makes later candidates exit. Parallel
+/// recognizes a live incumbent and makes later candidates exit. Parallel
 /// test launchers share one OS process and therefore one PID; this explicit
 /// fault-injection entry point preserves the production fence semantics by
-/// allowing a responsive same-PID incumbent to win. Ordinary daemon startup
+/// allowing a live same-PID incumbent to win. Ordinary daemon startup
 /// continues to treat a same-PID rendezvous as stale, protecting PID-reuse
 /// cleanup behavior.
 ///
@@ -1916,7 +1916,7 @@ async fn run_daemon_with_boot_guard_inner<D: DaemonDispatch>(
     let _startup_lock = boot_guard;
 
     if !cleanup_stale_daemon(&sock, &pid_file, allow_same_process_incumbent).await {
-        tracing::info!("a responsive khived is already running; exiting");
+        tracing::info!("a live process already owns the daemon PID file; exiting");
         return Ok(());
     }
 
@@ -2100,6 +2100,10 @@ async fn run_daemon_with_boot_guard_inner<D: DaemonDispatch>(
         _ = shutdown => {}
     }
 
+    // A listening backlog is not admitted work. Close it before draining so
+    // new clients cannot finish writing to a socket nobody will accept.
+    drop(listener);
+
     // Signal the checkpoint task to exit before draining, so `drain()`
     // actually waits on it via `track_background_task` rather than the
     // task outliving the drain window (or the process) unsignalled.
@@ -2254,9 +2258,9 @@ async fn cleanup_stale_daemon(
         if let Ok(pid) = pid_str.trim().parse::<u32>() {
             if pid_can_name_incumbent(pid, std::process::id(), allow_same_process_incumbent)
                 && is_process_running(pid)
-                && sock.exists()
-                && UnixStream::connect(sock).await.is_ok()
             {
+                // A draining incumbent closes its listener before releasing writers.
+                // Ambiguous live PIDs are left for client recovery to classify.
                 return false;
             }
         }
@@ -2728,7 +2732,7 @@ mod tests {
         );
         assert!(
             pid_can_name_incumbent(current, current, true),
-            "the in-process harness must let a responsive same-PID owner win"
+            "the in-process harness must let a live same-PID owner win"
         );
         // Keep the probe two away from `current` so the fixture preserves the
         // off-by-one regression check for adjacent PIDs; wrapping_add avoids
@@ -2757,6 +2761,47 @@ mod tests {
             is_process_running(1),
             "PID 1 always exists; EPERM must not read as dead"
         );
+    }
+
+    #[tokio::test]
+    async fn stale_cleanup_preserves_live_incumbent_without_reachable_socket() {
+        for socket_exists in [false, true] {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let sock = dir.path().join("khived.sock");
+            let pid_file = dir.path().join("khived.pid");
+            if socket_exists {
+                let listener = std::os::unix::net::UnixListener::bind(&sock)
+                    .expect("bind socket before closing listener");
+                drop(listener);
+            }
+            let identity = socket_identity(&sock);
+            assert_eq!(identity.is_some(), socket_exists);
+            let error = UnixStream::connect(&sock)
+                .await
+                .expect_err("incumbent must have no reachable listener");
+            assert_eq!(
+                error.kind(),
+                if socket_exists {
+                    std::io::ErrorKind::ConnectionRefused
+                } else {
+                    std::io::ErrorKind::NotFound
+                }
+            );
+            let live_pid = std::process::id().to_string();
+            std::fs::write(&pid_file, &live_pid).expect("write live incumbent PID");
+
+            // Harness eligibility makes our own stable PID an incumbent;
+            // ordinary same-PID rejection is covered separately above.
+            assert!(
+                !cleanup_stale_daemon(&sock, &pid_file, true).await,
+                "live incumbent must retain ownership with socket_exists={socket_exists}"
+            );
+            assert_eq!(
+                std::fs::read_to_string(&pid_file).expect("live incumbent PID must survive"),
+                live_pid
+            );
+            assert!(socket_identity(&sock) == identity);
+        }
     }
 
     #[test]
@@ -2875,6 +2920,153 @@ mod tests {
         tokio::time::timeout(std::time::Duration::from_secs(1), drain(&active))
             .await
             .expect("empty drain should return immediately");
+    }
+
+    #[test]
+    fn stopped_listener_is_closed_before_drain() {
+        use std::process::{Command, Stdio};
+
+        let dir = tempfile::Builder::new()
+            .prefix("kh-drain-")
+            .tempdir_in("/tmp")
+            .expect("short isolated socket directory");
+        let mut child = Command::new(std::env::current_exe().expect("test executable"))
+            .args([
+                "--exact",
+                "daemon::tests::stopped_listener_is_closed_before_drain_child",
+                "--ignored",
+                "--nocapture",
+                "--test-threads=1",
+            ])
+            .env_clear()
+            .envs(
+                std::env::vars_os().filter(|(key, _)| !key.to_string_lossy().starts_with("KHIVE_")),
+            )
+            .env("HOME", dir.path())
+            .env("KHIVE_DRAIN_TEST_CHILD", "1")
+            .env("KHIVE_SOCKET", dir.path().join("s"))
+            .env("KHIVE_PID", dir.path().join("p"))
+            .env("KHIVE_LOCK", dir.path().join("l"))
+            .env("KHIVE_DRAIN_TIMEOUT_SECS", "10")
+            .current_dir(dir.path())
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn isolated daemon test");
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+        let completed = loop {
+            match child.try_wait() {
+                Ok(Some(_)) => break true,
+                Ok(None) if std::time::Instant::now() < deadline => {
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                }
+                _ => {
+                    let _ = child.kill();
+                    break false;
+                }
+            }
+        };
+        let output = child.wait_with_output().expect("reap daemon test child");
+        assert!(completed, "daemon test child did not finish: {output:?}");
+        assert!(output.status.success(), "daemon test failed: {output:?}");
+        assert!(
+            String::from_utf8_lossy(&output.stdout).contains("STOPPED_LISTENER_DRAIN_VERIFIED"),
+            "child must run the listener witness: {output:?}"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "subprocess helper, invoked by stopped_listener_is_closed_before_drain"]
+    async fn stopped_listener_is_closed_before_drain_child() {
+        assert_eq!(
+            std::env::var("KHIVE_DRAIN_TEST_CHILD").expect("isolated child environment"),
+            "1"
+        );
+        let _sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("install child SIGTERM handler");
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+        let background = spawn_tracked_task(async move {
+            release_rx.await.expect("release held drain task");
+        });
+        let dispatcher = MockDispatch {
+            namespace: "local".to_string(),
+            config_id: "drain-test".to_string(),
+            dispatch_calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            pool: None,
+            dispatch_err: None,
+        };
+        let daemon = tokio::spawn(run_daemon(dispatcher));
+        let sock = socket_path();
+        let mut stream = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                if let Ok(stream) = UnixStream::connect(&sock).await {
+                    break stream;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("daemon must bind");
+        let payload = serde_json::to_vec(&base_request_frame("drain-test"))
+            .expect("encode readiness request");
+        write_frame(&mut stream, &payload)
+            .await
+            .expect("write readiness request");
+        let response =
+            tokio::time::timeout(std::time::Duration::from_secs(2), read_frame(&mut stream))
+                .await
+                .expect("daemon must serve readiness request")
+                .expect("read readiness response");
+        let response: DaemonResponseFrame =
+            serde_json::from_slice(&response).expect("decode readiness response");
+        assert!(response.ok, "daemon readiness failed: {response:?}");
+        drop(stream);
+
+        // SAFETY: the isolated child signals only itself, after installing its handler.
+        let rc = unsafe { libc::kill(std::process::id() as i32, libc::SIGTERM) };
+        assert_eq!(rc, 0, "signal isolated daemon child");
+        tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            daemon_shutdown_token().cancelled(),
+        )
+        .await
+        .expect("daemon must begin shutdown");
+        assert!(
+            !daemon.is_finished(),
+            "held background task must retain drain"
+        );
+        assert!(
+            sock.exists(),
+            "cleanup must not have removed the socket yet"
+        );
+        assert_eq!(
+            std::fs::read_to_string(pid_path()).expect("draining daemon PID"),
+            std::process::id().to_string()
+        );
+
+        // Cancellation is published after listener close but before drain.
+        let late_connect = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            UnixStream::connect(&sock),
+        )
+        .await
+        .expect("late connect must finish promptly");
+        release_tx.send(()).expect("release daemon drain");
+        background.await.expect("held background task must finish");
+        tokio::time::timeout(std::time::Duration::from_secs(2), daemon)
+            .await
+            .expect("released daemon must finish shutdown")
+            .expect("daemon task must not panic")
+            .expect("daemon shutdown must succeed");
+        let error = late_connect.expect_err("stopped listener must not queue new connections");
+        assert_eq!(error.kind(), std::io::ErrorKind::ConnectionRefused);
+        assert!(!sock.exists(), "owned socket must be removed after drain");
+        assert!(
+            !pid_path().exists(),
+            "owned PID must be removed after drain"
+        );
+        println!("STOPPED_LISTENER_DRAIN_VERIFIED");
     }
 
     #[tokio::test(start_paused = true)]
@@ -4263,6 +4455,46 @@ mod tests {
             pid_file.exists(),
             "replacement daemon's pid file must survive"
         );
+    }
+
+    #[test]
+    fn shutdown_cleanup_preserves_atomically_renamed_successor() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sock = dir.path().join("khived.sock");
+        let staged_sock = dir.path().join("next.sock");
+        let pid_file = dir.path().join("khived.pid");
+        let _original_listener =
+            std::os::unix::net::UnixListener::bind(&sock).expect("bind original socket");
+        let successor =
+            std::os::unix::net::UnixListener::bind(&staged_sock).expect("bind staged successor");
+        let original_identity = socket_identity(&sock).expect("original socket identity");
+        let successor_identity = socket_identity(&staged_sock).expect("successor socket identity");
+        assert!(original_identity != successor_identity);
+        let original_pid = std::process::id().to_string();
+        std::fs::write(&pid_file, &original_pid).expect("write original PID");
+
+        std::fs::rename(&staged_sock, &sock).expect("publish successor over original socket");
+        assert!(!staged_sock.exists());
+        assert!(socket_identity(&sock) == Some(successor_identity));
+        // A matching PID must not authorize deleting a different socket inode.
+        assert!(!shutdown_cleanup_if_owned(
+            &sock,
+            &pid_file,
+            Some(original_identity)
+        ));
+        assert!(socket_identity(&sock) == Some(successor_identity));
+        assert_eq!(
+            std::fs::read_to_string(&pid_file).expect("PID must survive stale cleanup"),
+            original_pid
+        );
+        successor
+            .set_nonblocking(true)
+            .expect("bound successor must support nonblocking accept");
+        let _client = std::os::unix::net::UnixStream::connect(&sock)
+            .expect("published successor must remain reachable");
+        let _accepted = successor
+            .accept()
+            .expect("successor must receive connection");
     }
 
     // ── the recovery lock actually serializes two boot sequences ─────────────

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -1839,6 +1839,18 @@ impl VerbRegistry {
         self.degrade_safe_verbs.contains(verb)
     }
 
+    /// Narrow transport replay opt-in. These trusted built-in handlers have no
+    /// domain mutations for any arguments. A repeated dispatch may append a new
+    /// ordinary audit row; its request id remains correlation, not deduplication.
+    /// Unknown and custom handlers cannot inherit safety from a name/category.
+    pub fn is_read_replay_safe(&self, verb: &str) -> bool {
+        self.degrade_safe_verbs.contains(verb)
+            && matches!(
+                verb,
+                "stats" | "comm.thread" | "comm.inbox" | "comm.unread" | "comm.delivered"
+            )
+    }
+
     /// White-box accessor for [`Self::admission_degrade_safe`], needed
     /// because the admission-pressure regression tests in
     /// `tests/read_verb_admission_exhaustion.rs` compile as a separate
@@ -5173,6 +5185,96 @@ pub(crate) mod tests {
             after_build,
             "a miss must not re-scan any pack's handlers() either"
         );
+    }
+
+    #[test]
+    fn read_replay_requires_trusted_owning_pack_for_every_opted_in_verb() {
+        static HANDLERS: [HandlerDef; 5] = [
+            HandlerDef {
+                name: "stats",
+                description: "replay eligibility fixture",
+                visibility: Visibility::Verb,
+                category: VerbCategory::Assertive,
+                params: &[],
+            },
+            HandlerDef {
+                name: "comm.thread",
+                description: "replay eligibility fixture",
+                visibility: Visibility::Verb,
+                category: VerbCategory::Assertive,
+                params: &[],
+            },
+            HandlerDef {
+                name: "comm.inbox",
+                description: "replay eligibility fixture",
+                visibility: Visibility::Verb,
+                category: VerbCategory::Assertive,
+                params: &[],
+            },
+            HandlerDef {
+                name: "comm.unread",
+                description: "replay eligibility fixture",
+                visibility: Visibility::Verb,
+                category: VerbCategory::Assertive,
+                params: &[],
+            },
+            HandlerDef {
+                name: "comm.delivered",
+                description: "replay eligibility fixture",
+                visibility: Visibility::Verb,
+                category: VerbCategory::Assertive,
+                params: &[],
+            },
+        ];
+
+        for (owner, handlers) in [("kg", &HANDLERS[..1]), ("comm", &HANDLERS[1..])] {
+            for (name, trusted, expected) in [
+                (owner, true, true),
+                (owner, false, false),
+                ("custom-impostor", true, false),
+            ] {
+                let mut builder = VerbRegistryBuilder::new();
+                let pack = CountingHandlersPack {
+                    name,
+                    handlers,
+                    calls: Arc::new(AtomicUsize::new(0)),
+                };
+                if trusted {
+                    builder.register_trusted(pack);
+                } else {
+                    builder.register(pack);
+                }
+                let registry = builder.build().expect("replay fixture registry");
+                for handler in handlers {
+                    assert_eq!(
+                        registry.is_read_replay_safe(handler.name),
+                        expected,
+                        "verb={}, owner={name}, trusted={trusted}",
+                        handler.name,
+                    );
+                }
+                assert!(!registry.is_read_replay_safe("unknown.read"));
+            }
+        }
+    }
+
+    #[test]
+    fn read_replay_rejects_a_trusted_opted_in_name_with_mutating_category() {
+        static HANDLERS: [HandlerDef; 1] = [HandlerDef {
+            name: "stats",
+            description: "same name with a state-changing contract",
+            visibility: Visibility::Verb,
+            category: VerbCategory::Commissive,
+            params: &[],
+        }];
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register_trusted(CountingHandlersPack {
+            name: "kg",
+            handlers: &HANDLERS,
+            calls: Arc::new(AtomicUsize::new(0)),
+        });
+        let registry = builder.build().expect("mutating fixture registry");
+        assert!(!registry.is_read_replay_safe("stats"));
     }
 
     /// Re-derives each [`VerbRegistry::SIDE_EFFECTING_ASSERTIVE_VERBS`] entry's

--- a/docs/adr/ADR-049-khived-daemon.md
+++ b/docs/adr/ADR-049-khived-daemon.md
@@ -1050,3 +1050,86 @@ handler's admitted work correlatable in the audit substrate.
   forwarding future from reaching completion.
 - An omitted request id is replaced with a nonzero bridge id exactly once per
   admitted attempt; an explicit caller value is unchanged.
+
+## Amendment 9 (2026-09-10): bounded reconnect and classified read replay
+
+This amendment chooses client-side reconnect rather than simultaneous live-socket
+replacement. Binding a temporary socket and renaming it over the public path is
+not sufficient under the current live-incumbent refusal, exclusive PID claim,
+and boot serialization contract. It would require a separate ownership protocol
+for overlapping daemon lifetimes. The socket path can still be absent or refused
+during a stop/start; there is no atomic-publication or zero-failure guarantee.
+
+### Shutdown and recovery ordering
+
+When the accept loop stops, the daemon closes its listener before draining
+admitted connections and tracked background work. An unaccepted kernel backlog
+is not admitted work and must not accept new frames without a handler. Startup
+preserves an eligible live incumbent PID even when its socket is absent or
+refuses connections: a closed listener does not mean draining work has finished.
+This check protects serving ownership, not bootstrap work performed before the
+dispatcher reaches this check. A recycled live PID can conservatively defer
+direct startup; client recovery retains its separate process-identity check.
+
+Recovery retains its recoverer-only lock across confirmation, signaling, exit
+waiting, and the launch decision. It signals the observed incumbent under the
+boot lock, releases that lock during bounded exit waiting so incumbent shutdown
+can acquire it, then reacquires it and re-probes before cleanup or launch. A
+changed PID or newly answering listener suppresses both unlink and launch.
+The predecessor's shutdown still requires matching PID and socket device/inode
+before unlinking; a same-directory rename by a successor therefore cannot make
+old cleanup remove the successor's socket.
+
+### Retry boundary
+
+For `ENOENT` or `ECONNREFUSED` with a recorded live PID, clients poll at 100 ms
+intervals for at most ten seconds, bounded further by the caller's original
+request deadline. These attempts do not initiate lifecycle recovery. If the
+window ends while the caller remains active, the existing recovery path decides
+whether the daemon is genuinely absent. An expired or cancelled caller does not
+start fresh recovery. Policy/access errors remain terminal, as in Amendment 4.
+
+The MCP bridge additionally classifies the entire parsed request using trusted
+built-in registry membership. Only these five handlers qualify for replay:
+`stats`, `comm.thread`, `comm.inbox`, `comm.unread`, and `comm.delivered`. Each is
+read-only with respect to domain state for every argument combination. Singles,
+parallel batches, and chains qualify only when every operation qualifies,
+including a chain of three `comm.thread` calls. References to previous results
+do not widen this set. Empty, malformed, mixed, mutating, unknown, custom, and
+mounted requests do not qualify. `help=true` and `dry_run=true` do not grant
+exceptions for other verbs. Unclassified forwarding entry points, including CLI
+callers, retain the default no-replay policy. The policy is local to the bridge;
+the wire protocol is unchanged.
+
+Only EOF/reset after a complete request write enables this read-only replay.
+The bridge can make at most two additional completed attempts, with 100 ms
+spacing and a single replay window of at most ten seconds, capped by the
+original caller deadline and any active reconnect deadline. Missing-socket
+polls consume time but not completed-attempt allowance. Cancellation prevents
+another replay but does not abandon an already-admitted exchange. Malformed
+frames/JSON, response timeouts, protocol mismatches, and explicit errors are
+not replayed. An identity rejection after a lost response remains terminal;
+exhaustion or later missing sockets never permit lifecycle recovery or local
+fallback after the original complete write.
+
+Ordinary audit accounting can repeat for a replayed read; no domain mutation
+is repeated. The same request-group id remains correlation, not deduplication.
+Read results can reflect a later snapshot. Every fully written request outside
+this closed opt-in set retains Amendment 3's terminal ambiguity rule. A lost
+response alone establishes neither daemon death nor a socket handover, so this
+policy does not attribute unexplained server-side disconnects to restarts.
+
+### Verification obligations
+
+Tests cover absent/refused live-owner reconnect, listener closure before drain,
+live-owner preservation, graceful exit without boot-lock inversion, changed
+ownership during exit, rename-safe cleanup, trusted whole-request classification,
+read replay limits, deadline/cancellation, terminal framing/protocol failures,
+and a lost mixed batch whose mutation must commit only once.
+
+The performance harness `scripts/perf/socket_handover_bench.py` offers actual MCP
+`stats()` requests every 50 ms during ten isolated stop/start cycles. Run the
+same harness against base and candidate binaries and report both failure counts
+per restart and the longest failure gap in milliseconds, even when the target
+of zero failures is missed. Compilation, tests, and these measurements are
+separate gates; source inspection does not establish their results.

--- a/scripts/perf/socket_handover_bench.py
+++ b/scripts/perf/socket_handover_bench.py
@@ -1,0 +1,593 @@
+#!/usr/bin/env python3
+"""Measure isolated daemon restarts through actual stdio MCP, without building.
+
+Example: uv run python scripts/perf/socket_handover_bench.py --binary /path/to/kkernel \
+    --output /path/to/handover.json
+
+Requires Unix, ps and lsof. Ambiguous process ownership aborts the run and
+preserves its directory. No raw daemon protocol or local-dispatch fallback is used.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+from pathlib import Path
+import shlex
+import shutil
+import signal
+import stat
+import subprocess
+import tempfile
+import time
+
+
+INTERVAL = 0.05
+CYCLES = 10
+REQUEST_TIMEOUT = 30.0
+START_TIMEOUT = 60.0
+STOP_TIMEOUT = 15.0
+SETTLE = 2.0
+
+
+class OwnershipError(RuntimeError):
+    pass
+
+
+def process_table():
+    result = subprocess.run(
+        ["ps", "-ww", "-axo", "pid=,ppid=,lstart=,stat=,command="],
+        check=True, capture_output=True, text=True, timeout=3,
+    )
+    rows = {}
+    for line in result.stdout.splitlines():
+        parts = line.split(None, 8)
+        if len(parts) == 9:
+            rows[int(parts[0])] = {
+                "pid": int(parts[0]), "ppid": int(parts[1]),
+                "started": " ".join(parts[2:7]), "state": parts[7],
+                "command": parts[8],
+            }
+    return rows
+
+
+def process_cwd(pid):
+    result = subprocess.run(
+        ["lsof", "-a", "-p", str(pid), "-d", "cwd", "-Fpn"],
+        check=True, capture_output=True, text=True, timeout=3,
+    )
+    lines = result.stdout.splitlines()
+    if f"p{pid}" not in lines:
+        raise OwnershipError(f"lsof did not identify PID {pid}")
+    paths = [line[1:] for line in lines if line.startswith("n")]
+    if len(paths) != 1:
+        raise OwnershipError(f"ambiguous cwd for PID {pid}: {paths!r}")
+    return Path(paths[0]).resolve()
+
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+class IsolatedProcesses:
+    def __init__(self, root, binary, env):
+        self.root, self.binary, self.env = root, binary, env
+        self.children = {}
+        self.owned = {}
+        self.logs = []
+        self.bridge_pid = None
+        self.pid_file = root / "p"
+
+    async def launch(self, daemon):
+        log = (self.root / f"child-{len(self.logs)}.stderr").open("wb")
+        self.logs.append(log)
+        command = [str(self.binary), "mcp"] + (["--daemon"] if daemon else [])
+        child = await asyncio.create_subprocess_exec(
+            *command, cwd=self.root, env=self.env, stderr=log,
+            stdin=asyncio.subprocess.DEVNULL if daemon else asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.DEVNULL if daemon else asyncio.subprocess.PIPE,
+        )
+        self.children[child.pid] = child
+        if not daemon:
+            self.bridge_pid = child.pid
+        await self.discover()
+        return child
+
+    def _identity(self, row):
+        argv = shlex.split(row["command"])
+        if len(argv) < 2 or argv[:2] != [str(self.binary), "mcp"]:
+            raise OwnershipError(f"unexpected executable/argv for PID {row['pid']}")
+        daemon = "--daemon" in argv[2:]
+        if not daemon and row["pid"] != self.bridge_pid:
+            raise OwnershipError(f"unrecognized bridge PID {row['pid']}")
+        if process_cwd(row["pid"]) != self.root:
+            raise OwnershipError(f"PID {row['pid']} is outside the isolated cwd")
+        return (row["started"], row["command"], daemon)
+
+    def _discover(self):
+        rows = process_table()
+        candidates = {
+            pid: row for pid, row in rows.items()
+            if row["command"].startswith(str(self.binary) + " ")
+        }
+        for pid, row in candidates.items():
+            if "Z" in row["state"]:
+                continue
+            try:
+                identity = self._identity(row)
+            except (subprocess.CalledProcessError, OwnershipError) as error:
+                current = process_table().get(pid)
+                if current is None or "Z" in current["state"]:
+                    continue
+                raise OwnershipError(f"cannot verify live PID {pid}: {error}") from error
+            if pid in self.owned:
+                if identity != self.owned[pid]:
+                    raise OwnershipError(f"PID {pid} changed identity")
+                continue
+            ancestor = pid
+            seen = set()
+            while ancestor not in self.children and ancestor not in self.owned:
+                if ancestor in seen or ancestor not in rows:
+                    raise OwnershipError(f"cannot establish owned ancestry for PID {pid}")
+                seen.add(ancestor)
+                ancestor = rows[ancestor]["ppid"]
+            self.owned[pid] = identity
+        return rows
+
+    async def discover(self):
+        return await asyncio.to_thread(self._discover)
+
+    async def published(self):
+        try:
+            raw = self.pid_file.read_text().strip()
+        except FileNotFoundError:
+            return None
+        if not raw.isdecimal() or int(raw) <= 1:
+            raise OwnershipError(f"invalid isolated PID file: {raw!r}")
+        pid = int(raw)
+        rows = await self.discover()
+        row = rows.get(pid)
+        if row is None or "Z" in row["state"]:
+            return None
+        if pid not in self.owned or not self.owned[pid][2]:
+            raise OwnershipError(f"published PID {pid} is not a verified owned daemon")
+        return pid
+
+    async def wait_published(self, previous=None):
+        deadline = time.monotonic() + START_TIMEOUT
+        while time.monotonic() < deadline:
+            pid = await self.published()
+            if pid is not None and pid != previous:
+                try:
+                    if stat.S_ISSOCK((self.root / "s").lstat().st_mode):
+                        return pid
+                except FileNotFoundError:
+                    pass
+            await asyncio.sleep(0.05)
+        raise TimeoutError("isolated successor did not publish a verified PID/socket")
+
+    async def signal_owned(self, pid, sig, published=False):
+        rows = await asyncio.to_thread(process_table)
+        row = rows.get(pid)
+        if row is None or "Z" in row["state"]:
+            return
+        if pid not in self.owned:
+            raise OwnershipError(f"refusing to signal unverified PID {pid}")
+        identity = await asyncio.to_thread(self._identity, row)
+        if identity != self.owned[pid]:
+            raise OwnershipError(f"refusing to signal changed PID {pid}")
+        if published and self.pid_file.read_text().strip() != str(pid):
+            raise OwnershipError("published PID changed before stop; no signal sent")
+        try:
+            sent_at = time.monotonic()
+            os.kill(pid, sig)
+            return sent_at
+        except ProcessLookupError:
+            return None
+
+    async def wait_gone(self, pid, timeout):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            child = self.children.get(pid)
+            if child is not None and child.returncode is not None:
+                await child.wait()
+                return True
+            rows = await asyncio.to_thread(process_table)
+            row = rows.get(pid)
+            if row is None or "Z" in row["state"]:
+                return True
+            if (row["started"], row["command"]) != self.owned.get(pid, ())[:2]:
+                raise OwnershipError(f"PID {pid} changed while awaiting exit")
+            await asyncio.sleep(0.05)
+        return False
+
+    async def cleanup(self):
+        errors = []
+        try:
+            await self.discover()
+        except Exception as error:
+            errors.append(f"cleanup discovery refused: {error}")
+        try:
+            bridge = self.children.get(self.bridge_pid)
+            if bridge is not None and bridge.stdin is not None:
+                bridge.stdin.close()
+                deadline = time.monotonic() + STOP_TIMEOUT
+                while bridge.returncode is None and time.monotonic() < deadline:
+                    try:
+                        await self.discover()
+                    except Exception as error:
+                        errors.append(f"bridge-drain discovery refused: {error}")
+                        break
+                    await asyncio.sleep(0.05)
+                if bridge.returncode is None:
+                    await self.signal_owned(bridge.pid, signal.SIGTERM)
+                    try:
+                        await asyncio.wait_for(bridge.wait(), STOP_TIMEOUT)
+                    except asyncio.TimeoutError:
+                        await self.signal_owned(bridge.pid, signal.SIGKILL)
+                        await asyncio.wait_for(bridge.wait(), 5)
+                else:
+                    await bridge.wait()
+            try:
+                await self.discover()
+            except Exception as error:
+                errors.append(f"post-bridge discovery refused: {error}")
+            for pid in list(self.owned):
+                if not await self.wait_gone(pid, 0.1):
+                    await self.signal_owned(pid, signal.SIGTERM)
+            for pid in list(self.owned):
+                if not await self.wait_gone(pid, STOP_TIMEOUT):
+                    await self.signal_owned(pid, signal.SIGKILL)
+                    if not await self.wait_gone(pid, 5):
+                        errors.append(f"owned PID {pid} did not exit")
+            for child in self.children.values():
+                await asyncio.wait_for(child.wait(), 5)
+            rows = await self.discover()
+            for pid, row in rows.items():
+                if row["command"].startswith(str(self.binary) + " "):
+                    errors.append(f"isolated process remains: {pid} ({row['state']})")
+        except Exception as error:
+            errors.append(f"cleanup refused or incomplete: {error}")
+        for log in self.logs:
+            log.close()
+        return errors
+
+
+def stats_error(response):
+    if "error" in response:
+        return response["error"]
+    result = response.get("result")
+    if not isinstance(result, dict):
+        return "missing MCP result"
+    if result.get("isError"):
+        return result
+    texts = [item.get("text", "") for item in result.get("content", [])
+             if item.get("type") == "text"]
+    try:
+        body = json.loads("\n".join(texts))
+    except (ValueError, TypeError):
+        return {"invalid_result_content": texts}
+    entries = body.get("results") if isinstance(body, dict) else None
+    if not isinstance(entries, list) or len(entries) != 1:
+        return {"unexpected_stats_envelope": body}
+    if not isinstance(entries[0], dict):
+        return {"invalid_stats_entry": entries[0]}
+    if entries[0].get("ok") is not True or entries[0].get("tool") != "stats":
+        return {"stats_error": entries[0]}
+    if not isinstance(entries[0].get("result"), dict):
+        return {"missing_stats_result": entries[0]}
+    return None
+
+
+class McpProbe:
+    def __init__(self, bridge):
+        self.bridge = bridge
+        self.started = time.monotonic()
+        self.requests = []
+        self.pending = {}
+        self.queue = asyncio.Queue(maxsize=128)
+        self.stop = asyncio.Event()
+        self.protocol_errors = []
+        self.tasks = []
+
+    def ms(self):
+        return (time.monotonic() - self.started) * 1000
+
+    async def initialize(self):
+        message = {"jsonrpc": "2.0", "id": 0, "method": "initialize", "params": {
+            "protocolVersion": "2024-11-05", "capabilities": {},
+            "clientInfo": {"name": "socket-handover-bench", "version": "1.0"},
+        }}
+        self.bridge.stdin.write((json.dumps(message) + "\n").encode())
+        await asyncio.wait_for(self.bridge.stdin.drain(), 5)
+        response = json.loads(await asyncio.wait_for(self.bridge.stdout.readline(), START_TIMEOUT))
+        if response.get("id") != 0 or "error" in response or "result" not in response:
+            raise RuntimeError(f"MCP initialize failed: {response!r}")
+        self.bridge.stdin.write(b'{"jsonrpc":"2.0","method":"notifications/initialized"}\n')
+        await asyncio.wait_for(self.bridge.stdin.drain(), 5)
+
+    def finish(self, record, outcome, error=None):
+        if record["outcome"] != "pending":
+            return
+        record.update(outcome=outcome, completed_ms=self.ms(), error=error)
+        if record["sent_ms"] is not None:
+            record["latency_ms"] = record["completed_ms"] - record["sent_ms"]
+        self.pending.pop(record["id"], None)
+
+    async def offer(self):
+        deadline = time.monotonic()
+        while not self.stop.is_set():
+            await asyncio.sleep(max(0, deadline - time.monotonic()))
+            if self.stop.is_set():
+                break
+            record = {"id": len(self.requests) + 1,
+                      "scheduled_ms": (deadline - self.started) * 1000,
+                      "offered_ms": self.ms(), "sent_ms": None,
+                      "send_lateness_ms": None, "latency_ms": None,
+                      "completed_ms": None, "outcome": "pending", "error": None}
+            record["offer_lateness_ms"] = record["offered_ms"] - record["scheduled_ms"]
+            self.requests.append(record)
+            self.pending[record["id"]] = record
+            try:
+                self.queue.put_nowait(record)
+            except asyncio.QueueFull:
+                self.finish(record, "send_queue_full", "offered cadence exceeded stdin capacity")
+            deadline += INTERVAL
+
+    async def writer(self):
+        while True:
+            record = await self.queue.get()
+            if record["outcome"] != "pending":
+                continue
+            message = {"jsonrpc": "2.0", "id": record["id"], "method": "tools/call",
+                       "params": {"name": "request", "arguments": {"ops": "stats()"}}}
+            try:
+                attempted = self.ms()
+                self.bridge.stdin.write((json.dumps(message) + "\n").encode())
+                record["sent_ms"] = attempted
+                record["send_lateness_ms"] = attempted - record["scheduled_ms"]
+                await asyncio.wait_for(self.bridge.stdin.drain(), 5)
+                record["stdin_drained_ms"] = self.ms()
+            except Exception as error:
+                self.finish(record, "send_error", str(error))
+
+    async def reader(self):
+        try:
+            while True:
+                line = await self.bridge.stdout.readline()
+                if not line:
+                    raise EOFError("MCP stdout closed")
+                response = json.loads(line)
+                if not isinstance(response, dict):
+                    raise ValueError("MCP response is not an object")
+                record = self.pending.get(response.get("id"))
+                if record is None:
+                    request_id = response.get("id")
+                    if isinstance(request_id, int) and 1 <= request_id <= len(self.requests):
+                        self.requests[request_id - 1]["late_response"] = {
+                            "received_ms": self.ms(), "response": response}
+                        continue
+                    self.protocol_errors.append({"received_ms": self.ms(), "response": response})
+                    continue
+                error = stats_error(response)
+                self.finish(record, "success" if error is None else "response_error", error)
+        except Exception as error:
+            self.protocol_errors.append({"reader_error": str(error), "received_ms": self.ms()})
+            for record in list(self.pending.values()):
+                self.finish(record, "transport_error", str(error))
+
+    async def deadlines(self):
+        while True:
+            now = self.ms()
+            for record in list(self.pending.values()):
+                if now - record["offered_ms"] >= REQUEST_TIMEOUT * 1000:
+                    self.finish(record, "timeout", "request deadline exceeded; result unavailable")
+            await asyncio.sleep(INTERVAL)
+
+    def start(self):
+        self.tasks = [asyncio.create_task(task()) for task in
+                      (self.offer, self.writer, self.reader, self.deadlines)]
+
+    async def wait_success(self, scheduled_after_ms):
+        deadline = time.monotonic() + START_TIMEOUT
+        while time.monotonic() < deadline:
+            for record in self.requests:
+                if record["scheduled_ms"] >= scheduled_after_ms and record["outcome"] == "success":
+                    return {"id": record["id"], "scheduled_ms": record["scheduled_ms"],
+                            "completed_ms": record["completed_ms"]}
+            if self.bridge.returncode is not None:
+                raise RuntimeError("MCP bridge exited before a successful stats response")
+            await asyncio.sleep(INTERVAL)
+        raise TimeoutError("no successful post-publication MCP stats response within budget")
+
+    async def settle(self):
+        self.stop.set()
+        deadline = time.monotonic() + REQUEST_TIMEOUT + 1
+        while self.pending and time.monotonic() < deadline:
+            await asyncio.sleep(INTERVAL)
+        for record in list(self.pending.values()):
+            self.finish(record, "unavailable", "benchmark ended before a response")
+        for task in self.tasks:
+            task.cancel()
+        await asyncio.gather(*self.tasks, return_exceptions=True)
+
+
+def summarize(records):
+    if not records:
+        return {"calls": 0, "failed_calls": None, "longest_failure_gap_ms": None,
+                "failure_gap_censored": True}
+    failed = [record for record in records if record["outcome"] != "success"]
+    longest = 0.0
+    beginning = None
+    for record in records:
+        if record["outcome"] != "success":
+            if beginning is None:
+                beginning = record["scheduled_ms"]
+        elif beginning is not None:
+            longest = max(longest, record["scheduled_ms"] - beginning)
+            beginning = None
+    censored = beginning is not None
+    lower_bound = max(longest, records[-1]["scheduled_ms"] + INTERVAL * 1000 - beginning) if censored else longest
+    return {"calls": len(records), "failed_calls": len(failed),
+            "longest_failure_gap_ms": None if censored else longest,
+            "failure_gap_lower_bound_ms": lower_bound, "failure_gap_censored": censored,
+            "max_latency_ms": max((row["latency_ms"] for row in records
+                                   if row["latency_ms"] is not None), default=None),
+            "max_send_lateness_ms": max((row["send_lateness_ms"] for row in records
+                                         if row["send_lateness_ms"] is not None), default=None)}
+
+
+async def benchmark(args):
+    root = Path(tempfile.mkdtemp(prefix="khb-", dir="/tmp")).resolve()
+    source = args.binary.absolute()
+    binary = root / "kkernel-bench"
+    report = {"status": "unavailable", "binary_source": str(source),
+              "binary_copy": str(binary),
+              "isolated_root": str(root), "cycles_requested": CYCLES,
+              "interval_ms": INTERVAL * 1000, "cycles": [], "requests": [],
+              "send_time_definition": "monotonic time when bytes are submitted to asyncio stdin; drain completion is recorded separately",
+              "failure_gap_definition": "consecutive failed offered slots through the next successful offered slot; trailing runs are censored",
+              "restart_attribution": "scheduled offer time from each stop through the next stop (last through end of offering)",
+              "summary_population": "offered slots from the first controlled stop through the end of offering; warmup reported separately",
+              "errors": []}
+    processes = None
+    probe = None
+    ownership_ambiguous = False
+    try:
+        source = source.resolve(strict=True)
+        report["binary_source"] = str(source)
+        if not source.is_file() or not os.access(source, os.X_OK):
+            raise ValueError("--binary must name an existing executable file")
+        if not shutil.which("ps") or not shutil.which("lsof"):
+            raise RuntimeError("ps and lsof are required for positive process ownership checks")
+        await asyncio.to_thread(process_table)
+        await asyncio.to_thread(process_cwd, os.getpid())
+        shutil.copy2(source, binary)
+        report["binary_source_sha256"] = sha256(source)
+        report["binary_copy_sha256"] = sha256(binary)
+        if report["binary_source_sha256"] != report["binary_copy_sha256"]:
+            raise RuntimeError("binary changed while copying")
+        config = root / "c.toml"
+        config.write_text("")
+        env = {key: value for key, value in os.environ.items() if not key.startswith("KHIVE_")}
+        env.update(HOME=str(root), TMPDIR=str(root), XDG_CONFIG_HOME=str(root / "config"),
+                   XDG_DATA_HOME=str(root / "data"), XDG_CACHE_HOME=str(root / "cache"),
+                   XDG_RUNTIME_DIR=str(root), KHIVE_CONFIG=str(config),
+                   KHIVE_DB=str(root / "d.db"), KHIVE_SOCKET=str(root / "s"),
+                   KHIVE_PID=str(root / "p"), KHIVE_LOCK=str(root / "l"),
+                   KHIVE_RECOVERER_LOCK=str(root / "r"), KHIVE_PACKS="kg",
+                   KHIVE_NO_EMBED="true", KHIVE_DAEMON_STRICT="1",
+                   KHIVE_OUTPUT_FORMAT="json", KHIVE_EVENTS_SPLIT="0")
+        processes = IsolatedProcesses(root, binary, env)
+        await processes.launch(daemon=True)
+        await processes.wait_published()
+        bridge = await processes.launch(daemon=False)
+        probe = McpProbe(bridge)
+        await probe.initialize()
+        probe.start()
+        report["warmup_success"] = await probe.wait_success(0)
+        await asyncio.sleep(SETTLE)
+        for number in range(1, CYCLES + 1):
+            previous = await processes.published()
+            if previous is None:
+                raise RuntimeError("no verified published daemon before restart")
+            requested_ms = probe.ms()
+            sent_at = await processes.signal_owned(previous, signal.SIGTERM, published=True)
+            if sent_at is None:
+                raise RuntimeError("published daemon exited before the controlled stop")
+            cycle = {"restart": number, "stop_ms": (sent_at - probe.started) * 1000,
+                     "stop_requested_ms": requested_ms, "previous_pid": previous,
+                     "status": "unavailable", "predecessor_exit_ms": None,
+                     "successor_launch_ms": None, "successor_pid": None,
+                     "successor_published_ms": None, "first_success": None}
+            report["cycles"].append(cycle)
+            if not await processes.wait_gone(previous, STOP_TIMEOUT):
+                raise TimeoutError("predecessor did not stop within the restart budget")
+            cycle["predecessor_exit_ms"] = probe.ms()
+            cycle["successor_launch_ms"] = probe.ms()
+            successor = await processes.launch(daemon=True)
+            cycle["explicit_successor_pid"] = successor.pid
+            cycle["successor_pid"] = await processes.wait_published(previous)
+            cycle["successor_published_ms"] = probe.ms()
+            cycle["first_success"] = await probe.wait_success(cycle["successor_published_ms"])
+            await asyncio.sleep(SETTLE)
+            cycle["status"] = "complete"
+        report["offering_ended_ms"] = probe.ms()
+        report["status"] = "complete"
+    except (Exception, asyncio.CancelledError) as error:
+        ownership_ambiguous = isinstance(error, OwnershipError)
+        report["errors"].append(f"{type(error).__name__}: {error}")
+    finally:
+        if probe is not None:
+            report.setdefault("offering_ended_ms", probe.ms())
+            await probe.settle()
+            report["requests"] = probe.requests
+            report["protocol_errors"] = probe.protocol_errors
+        cleanup_errors = await processes.cleanup() if processes is not None else []
+        report["errors"].extend(cleanup_errors)
+        if cleanup_errors:
+            report["status"] = "unavailable"
+        first_stop = report["cycles"][0]["stop_ms"] if report["cycles"] else None
+        warmup = [row for row in report["requests"]
+                  if first_stop is None or row["scheduled_ms"] < first_stop]
+        measured = [row for row in report["requests"]
+                    if first_stop is not None and row["scheduled_ms"] >= first_stop]
+        report["warmup_summary"] = summarize(warmup)
+        report["summary"] = summarize(measured)
+        if report["status"] != "complete":
+            report["observed_summary"] = report["summary"]
+            report["summary"] = {"calls": len(measured), "failed_calls": None,
+                                 "longest_failure_gap_ms": None,
+                                 "reason": "measurement incomplete; see observed_summary"}
+        for index, cycle in enumerate(report["cycles"]):
+            end = (report["cycles"][index + 1]["stop_ms"]
+                   if index + 1 < len(report["cycles"]) else report.get("offering_ended_ms"))
+            records = [record for record in report["requests"]
+                       if end is not None and cycle["stop_ms"] <= record["scheduled_ms"] < end]
+            summary = summarize(records)
+            if cycle["status"] == "complete":
+                cycle.update(summary)
+            else:
+                cycle.update(observed_summary=summary, failed_calls=None,
+                             longest_failure_gap_ms=None)
+        report["cycles_completed"] = sum(cycle["status"] == "complete" for cycle in report["cycles"])
+        report["stderr"] = {}
+        for path in sorted(root.rglob("*")):
+            if path.is_file() and (path.suffix in (".stderr", ".log")):
+                with path.open("rb") as log:
+                    size = path.stat().st_size
+                    log.seek(max(0, size - 65536))
+                    report["stderr"][str(path.relative_to(root))] = {
+                        "bytes": size, "tail": log.read().decode(errors="replace")}
+        preserve = bool(cleanup_errors) or ownership_ambiguous
+        report["isolated_directory_preserved"] = preserve
+        if not preserve:
+            shutil.rmtree(root)
+    return report
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--binary", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    if args.output.exists():
+        parser.error("--output must not already exist")
+    report = asyncio.run(benchmark(args))
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("x") as output:
+        output.write(json.dumps(report, indent=2) + "\n")
+    print(json.dumps({"status": report["status"], "output": str(args.output),
+                      "summary": report["summary"]}))
+    return 0 if report["status"] == "complete" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Closes #2518. When the daemon is replaced or restarted, clients connecting during the swap found either a stale socket that refused, or a listener the old process still held while it drained, so a burst of requests failed even though a live daemon was seconds away. Client recovery also held the boot lock while waiting for the old process to exit, which is the same lock that process needs to finish its cleanup.

## Change

- Runtime: the stopped listener is dropped before drain, so no connection lands in a backlog nothing will accept. Startup's incumbent check protects an eligible live PID whether or not its socket is reachable, so a draining daemon is not taken over mid-drain. Shutdown's PID plus socket device/inode ownership check is unchanged and now has a real bind-then-rename regression.
- Client recovery: signal under the boot guard, release the boot lock while awaiting the old process's exit, then reacquire and re-probe before unlink or launch. A changed owner suppresses both cleanup and launch. An unchanged empty or invalid PID file left by an interrupted publication still recovers; an unreadable or changed one fails closed.
- Client reconnect: a missing or refused socket with a recorded live PID gets a 100 ms polling window, capped at ten seconds and the caller's own deadline, with no lifecycle action inside the window.
- Read-only replay: when the connection drops after a request was fully written, the MCP path replays at most twice, only when every operation in the request is one of the built-in reads `stats`, `comm.thread`, `comm.inbox`, `comm.unread`, `comm.delivered`. Anything else, including mixed batches, mounted verbs, help and dry-run shapes, keeps the no-replay behaviour. No wire field or protocol version changes.
- ADR-049 Amendment 9 records the mechanism and its bounds.
- `scripts/perf/socket_handover_bench.py` drives ten daemon restarts under a steady stream of stdio MCP `stats` calls at 50 ms slots and reports failed calls and the longest failure gap.

## Before / after

Same machine, same store, the benchmark run three times back to back on the released binary, then this branch, then the released binary again:

| Arm | Calls | Failed calls | Longest failure gap | Max latency |
|---|---|---|---|---|
| Released binary (before) | 465 | 20 | 100 ms | 93 ms |
| This branch | 463 | 0 | 0 ms | 207 ms |
| Released binary again (before) | 464 | 21 | 150 ms | 102 ms |

The single 207 ms maximum on this branch is one call absorbing a restart inside its polling window instead of failing.

## Verification

- `cargo fmt --all --check`, `cargo clippy -p khive-runtime -p khive-mcp --all-targets -- -D warnings`: clean on Rust 1.95.0.
- `cargo test -p khive-runtime -p khive-mcp --no-fail-fast`: all suites pass, including the new drain, rename, boot-lock release, socket-gap wait, replay policy and mixed-mutation regressions.
- The drain test's helper is the negative witness: on the base the retained listener still accepts the late connect.
