### PR TITLE
feat(git): explicitly local push targets for the push verbs

### DIFF
--- a/crates/khive-pack-git/src/lib.rs
+++ b/crates/khive-pack-git/src/lib.rs
@@ -39,6 +39,8 @@ pub mod ingest;
 mod input_schema;
 mod local_git;
 mod local_handlers;
+#[cfg(all(test, unix))]
+mod local_remote_tests;
 mod local_vocab;
 mod pack;
 #[cfg(test)]

--- a/crates/khive-pack-git/src/local_handlers.rs
+++ b/crates/khive-pack-git/src/local_handlers.rs
@@ -786,8 +786,16 @@ impl GitPack {
             std::fs::canonicalize(&row.repo).ok().filter(|path| *path == canonical)
                 .map(|_| json!({"id":id, "repo":canonical.display().to_string(), "branches":row.branches}))
         }).collect();
+        let target = match self.remote_repository(&canonical) {
+            Ok(target) => json!({
+                "kind": if target.slug.is_empty() { "local" } else { "platform" },
+                "remote": target.remote, "slug": target.slug, "visibility": target.visibility,
+            }),
+            Err(error) if error.reason == "repository_unmapped" => Value::Null,
+            Err(error) => json!({"kind":"unavailable", "reason":error.reason}),
+        };
         Ok(
-            json!({"repo":canonical.display().to_string(), "gate":{"decision":"allow","source":"git_write.allowed","id":index},"gates":rows}),
+            json!({"repo":canonical.display().to_string(), "gate":{"decision":"allow","source":"git_write.allowed","id":index},"gates":rows,"target":target}),
         )
     }
 }

--- a/crates/khive-pack-git/src/local_remote_tests.rs
+++ b/crates/khive-pack-git/src/local_remote_tests.rs
@@ -37,6 +37,12 @@ fn git(repo: &Path, args: &[&str]) -> String {
     String::from_utf8(out.stdout).unwrap().trim().into()
 }
 
+fn file_url(path: &Path) -> String {
+    format!("file://{}", path.display())
+        .replace('%', "%25")
+        .replace(' ', "%20")
+}
+
 struct Fixture {
     _env_guard: tokio::sync::MutexGuard<'static, ()>,
     dir: tempfile::TempDir,
@@ -69,7 +75,7 @@ impl Fixture {
         let tree = git(&repo, &["rev-parse", "HEAD^{tree}"]);
         let rival = git(&repo, &["commit-tree", &tree, "-p", &base, "-m", "rival"]);
         git(&repo, &["update-ref", "refs/heads/rival", &rival]);
-        let bare = dir.path().join("remote.git");
+        let bare = dir.path().join("remote % space.git");
         git(
             &repo,
             &[
@@ -181,7 +187,7 @@ impl Fixture {
         }
     }
     async fn file() -> Self {
-        Self::new(|bare| format!("file://{}", bare.display()), "").await
+        Self::new(file_url, "").await
     }
     async fn call(
         &self,
@@ -353,7 +359,7 @@ async fn local_gates_distinguish_https_platform_in_same_config() {
         .unwrap();
     assert_eq!(
         local["target"],
-        json!({"kind":"local","remote":format!("file://{}",f.bare.display()),"slug":"","visibility":"private"})
+        json!({"kind":"local","remote":file_url(&f.bare),"slug":"","visibility":"private"})
     );
     assert_eq!(
         platform["target"],
@@ -435,4 +441,23 @@ async fn local_push_reconcile_requires_marker_and_exact_remote_without_credentia
         Disposition::Unknown
     );
     f.no_credential_read();
+}
+
+#[tokio::test]
+async fn local_file_url_rejects_decoded_controls_slashes_and_invalid_encoding() {
+    for remote in [
+        "file:///tmp/line%0Abreak.git",
+        "file:///tmp/line%0dbreak.git",
+        "file:///tmp/nul%00.git",
+        "file:///%2Fprivate/tmp/remote.git",
+        "file:///%2fprivate/tmp/remote.git",
+        "file://%2Fprivate/tmp/remote.git",
+        "file:///tmp/bad%",
+        "file:///tmp/bad%2",
+        "file:///tmp/bad%ZZ",
+        "file:///tmp/bad%FF",
+    ] {
+        let f = Fixture::new(|_| remote.into(), "").await;
+        f.refusal("git.push", f.push(), "remote_scheme").await;
+    }
 }

--- a/crates/khive-pack-git/src/local_remote_tests.rs
+++ b/crates/khive-pack-git/src/local_remote_tests.rs
@@ -1,0 +1,438 @@
+use crate::receipts::{self, Disposition, Receipt};
+use crate::GitPack;
+use khive_pack_kg::KgPack;
+use khive_pack_tool::ToolPack;
+use khive_runtime::engine_config::{
+    GitWriteActorConfig, GitWriteEntryConfig, GitWriteRepositoryConfig, GitWriteSectionConfig,
+};
+use khive_runtime::{
+    KhiveRuntime, RequestIdentity, RuntimeConfig, RuntimeError, VerbRegistry, VerbRegistryBuilder,
+};
+use serde_json::{json, Value};
+use std::collections::BTreeMap;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn git(repo: &Path, args: &[&str]) -> String {
+    let out = Command::new("git")
+        .env_clear()
+        .env("PATH", std::env::var_os("PATH").unwrap())
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_AUTHOR_NAME", "Fixture")
+        .env("GIT_AUTHOR_EMAIL", "fixture@example.invalid")
+        .env("GIT_COMMITTER_NAME", "Fixture")
+        .env("GIT_COMMITTER_EMAIL", "fixture@example.invalid")
+        .args(["-c", "core.hooksPath=/dev/null", "-C"])
+        .arg(repo)
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "{args:?}: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8(out.stdout).unwrap().trim().into()
+}
+
+struct Fixture {
+    _env_guard: tokio::sync::MutexGuard<'static, ()>,
+    dir: tempfile::TempDir,
+    repo: PathBuf,
+    platform_repo: PathBuf,
+    bare: PathBuf,
+    base: String,
+    head: String,
+    rival: String,
+    actor: String,
+    rt: KhiveRuntime,
+    registry: VerbRegistry,
+}
+
+impl Fixture {
+    async fn new(remote: impl FnOnce(&Path) -> String, slug: &str) -> Self {
+        let env_guard = crate::cache::ENV_MUTEX.lock().await;
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        let platform_repo = dir.path().join("platform");
+        std::fs::create_dir(&repo).unwrap();
+        std::fs::create_dir(&platform_repo).unwrap();
+        let repo = std::fs::canonicalize(repo).unwrap();
+        let platform_repo = std::fs::canonicalize(platform_repo).unwrap();
+        git(&repo, &["init", "-q", "--template=", "-b", "work"]);
+        git(&repo, &["commit", "--allow-empty", "-qm", "base"]);
+        let base = git(&repo, &["rev-parse", "HEAD"]);
+        git(&repo, &["commit", "--allow-empty", "-qm", "head"]);
+        let head = git(&repo, &["rev-parse", "HEAD"]);
+        let tree = git(&repo, &["rev-parse", "HEAD^{tree}"]);
+        let rival = git(&repo, &["commit-tree", &tree, "-p", &base, "-m", "rival"]);
+        git(&repo, &["update-ref", "refs/heads/rival", &rival]);
+        let bare = dir.path().join("remote.git");
+        git(
+            &repo,
+            &[
+                "clone",
+                "-q",
+                "--bare",
+                repo.to_str().unwrap(),
+                bare.to_str().unwrap(),
+            ],
+        );
+        let bare = std::fs::canonicalize(bare).unwrap();
+        git(&bare, &["update-ref", "refs/heads/work", &base]);
+
+        // Any accidental resolver use both leaves evidence and refuses the operation.
+        let resolver = dir.path().join("resolver");
+        let marker = dir.path().join("credential-read");
+        let quoted = format!("'{}'", marker.display().to_string().replace('\'', "'\\''"));
+        std::fs::write(
+            &resolver,
+            format!("#!/bin/sh\nprintf invoked > {quoted}\nexit 91\n"),
+        )
+        .unwrap();
+        std::fs::set_permissions(&resolver, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let actor = format!("local-remote:{}", uuid::Uuid::new_v4());
+        let rt = KhiveRuntime::new(RuntimeConfig {
+            db_path: None,
+            git_write: GitWriteSectionConfig {
+                allowed: [&repo, &platform_repo]
+                    .into_iter()
+                    .map(|repo| GitWriteEntryConfig {
+                        repo: repo.display().to_string(),
+                        branches: vec!["work".into(), "new".into()],
+                    })
+                    .collect(),
+                actors: BTreeMap::from([(
+                    actor.clone(),
+                    GitWriteActorConfig {
+                        name: "Fixture".into(),
+                        email: "fixture@example.invalid".into(),
+                        credential_ref: "must-not-resolve".into(),
+                        platform_identity: "fixture".into(),
+                    },
+                )]),
+                repositories: BTreeMap::from([
+                    (
+                        repo.display().to_string(),
+                        GitWriteRepositoryConfig {
+                            remote: remote(&bare),
+                            slug: slug.into(),
+                            visibility: "private".into(),
+                            merge_refusals: vec![],
+                        },
+                    ),
+                    (
+                        platform_repo.display().to_string(),
+                        GitWriteRepositoryConfig {
+                            remote: "https://github.com/fixture/project.git".into(),
+                            slug: "fixture/project".into(),
+                            visibility: "private".into(),
+                            merge_refusals: vec![],
+                        },
+                    ),
+                ]),
+                credential_resolver: vec![resolver.display().to_string(), "{ref}".into()],
+                ..Default::default()
+            },
+            ..RuntimeConfig::no_embeddings()
+        })
+        .unwrap();
+        let mut builder = VerbRegistryBuilder::new();
+        builder.with_actor_id(Some(actor.clone()));
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(ToolPack::new(rt.clone()));
+        builder.register(GitPack::new(rt.clone()));
+        builder.with_runtime_event_store(&rt).unwrap();
+        let registry = builder.build().unwrap();
+        registry.apply_schema_plans(rt.backend());
+        rt.install_edge_rules(registry.all_edge_rules());
+        for caller in [&actor, &format!("{actor}:unmapped")] {
+            for verb in [
+                "git.push",
+                "git.pr_open",
+                "git.pr_review",
+                "git.pr_merge",
+                "git.gates",
+                "git.reconcile",
+            ] {
+                registry
+                    .dispatch(
+                        "tool.policy",
+                        json!({"actor":caller,"tool":verb,"decision":"allow"}),
+                    )
+                    .await
+                    .unwrap();
+            }
+        }
+        Self {
+            _env_guard: env_guard,
+            dir,
+            repo,
+            platform_repo,
+            bare,
+            base,
+            head,
+            rival,
+            actor,
+            rt,
+            registry,
+        }
+    }
+    async fn file() -> Self {
+        Self::new(|bare| format!("file://{}", bare.display()), "").await
+    }
+    async fn call(
+        &self,
+        actor: &str,
+        verb: &str,
+        mut params: Value,
+    ) -> Result<Value, RuntimeError> {
+        if verb != "git.reconcile" && params.get("repo").is_none() {
+            params["repo"] = json!(self.repo);
+        }
+        self.registry
+            .dispatch_with_identity(
+                verb,
+                params,
+                Some(RequestIdentity {
+                    namespace: "local".into(),
+                    actor_id: Some(actor.into()),
+                    ..Default::default()
+                }),
+            )
+            .await
+    }
+    fn push(&self) -> Value {
+        json!({"branch":"work","expected_local":self.head,"expected_remote":self.base})
+    }
+    fn remote_head(&self) -> String {
+        let out = Command::new("git")
+            .env_clear()
+            .env("PATH", std::env::var_os("PATH").unwrap())
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .arg("--git-dir")
+            .arg(&self.bare)
+            .args(["rev-parse", "--verify", "refs/heads/work"])
+            .output()
+            .unwrap();
+        assert!(out.status.success());
+        String::from_utf8(out.stdout).unwrap().trim().into()
+    }
+    fn no_credential_read(&self) {
+        assert!(!self.dir.path().join("credential-read").exists());
+    }
+    async fn last(&self, actor: &str) -> Receipt {
+        receipts::list_owned(&self.rt, "local", actor, None, None, 500, 0)
+            .await
+            .unwrap()
+            .receipts
+            .pop()
+            .unwrap()
+    }
+    async fn refusal(&self, verb: &str, params: Value, reason: &str) -> Receipt {
+        let before = self.remote_head();
+        let local = git(&self.repo, &["show-ref"]);
+        let error = self
+            .call(&self.actor, verb, params)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains(reason), "{error}");
+        let receipt = self.last(&self.actor).await;
+        assert!(error.contains(&receipt.id));
+        assert_eq!(receipt.reason.as_deref(), Some(reason));
+        assert_eq!(receipt.disposition, Disposition::NotCommitted);
+        assert_eq!(self.remote_head(), before);
+        assert_eq!(git(&self.repo, &["show-ref"]), local);
+        self.no_credential_read();
+        receipt
+    }
+}
+
+#[tokio::test]
+async fn local_file_push_moves_native_ref_without_credentials() {
+    let f = Fixture::file().await;
+    assert_eq!(f.remote_head(), f.base);
+    let reply = f.call(&f.actor, "git.push", f.push()).await.unwrap();
+    assert_eq!(f.remote_head(), f.head);
+    assert_eq!(reply["sha"], f.head);
+    let receipt = f.last(&f.actor).await;
+    assert_eq!(receipt.disposition, Disposition::Committed);
+    assert_eq!(receipt.credential, json!({"source":"none"}));
+    assert_eq!(receipt.actor, f.actor);
+    assert_eq!(receipt.gate["decision"], "allow");
+    assert_eq!(receipt.policy["decision"], "allow");
+    assert!(
+        crate::local_git::operation_recorded(&f.repo, "work", &f.head, &receipt.id)
+            .await
+            .unwrap()
+    );
+    f.no_credential_read();
+}
+
+#[tokio::test]
+async fn local_path_push_allows_unmapped_actor_and_absent_remote_branch() {
+    let f = Fixture::new(|bare| bare.display().to_string(), "").await;
+    let actor = format!("{}:unmapped", f.actor);
+    git(&f.repo, &["branch", "new", &f.head]);
+    let params = json!({"branch":"new","expected_local":f.head,"expected_remote":null});
+    f.call(&actor, "git.push", params).await.unwrap();
+    assert_eq!(git(&f.bare, &["rev-parse", "refs/heads/new"]), f.head);
+    assert_eq!(f.last(&actor).await.credential, json!({"source":"none"}));
+    f.no_credential_read();
+}
+
+#[tokio::test]
+async fn local_push_stale_expected_remote_preserves_refs() {
+    let f = Fixture::file().await;
+    let receipt = f
+        .refusal(
+            "git.push",
+            json!({"branch":"work","expected_local":f.head,"expected_remote":f.rival}),
+            "expected_remote_mismatch",
+        )
+        .await;
+    assert_eq!(receipt.credential, json!({"source":"none"}));
+    f.refusal(
+        "git.push",
+        json!({"branch":"work","expected_local":f.head,"expected_remote":null}),
+        "expected_remote_mismatch",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn local_push_divergent_remote_preserves_refs() {
+    let f = Fixture::file().await;
+    git(&f.bare, &["update-ref", "refs/heads/work", &f.rival]);
+    f.refusal(
+        "git.push",
+        json!({"branch":"work","expected_local":f.head,"expected_remote":f.rival}),
+        "non_fast_forward",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn local_pr_verbs_refuse_remote_scheme_before_credentials() {
+    let f = Fixture::file().await;
+    for (verb, params) in [
+        (
+            "git.pr_open",
+            json!({"head":"work","base":"main","title":"Fixture","body":"","expected_head":f.head}),
+        ),
+        (
+            "git.pr_review",
+            json!({"number":1,"verdict":"approve","body":"","expected_head":f.head}),
+        ),
+        (
+            "git.pr_merge",
+            json!({"number":1,"method":"merge","subject":"Fixture","body":"","expected_head":f.head}),
+        ),
+    ] {
+        let receipt = f.refusal(verb, params, "remote_scheme").await;
+        assert_eq!(receipt.credential, json!({"source":"none"}));
+    }
+}
+
+#[tokio::test]
+async fn local_gates_distinguish_https_platform_in_same_config() {
+    let f = Fixture::file().await;
+    let before = receipts::list_owned(&f.rt, "local", &f.actor, None, None, 500, 0)
+        .await
+        .unwrap()
+        .receipts
+        .len();
+    let local = f.call(&f.actor, "git.gates", json!({})).await.unwrap();
+    let platform = f
+        .call(&f.actor, "git.gates", json!({"repo":f.platform_repo}))
+        .await
+        .unwrap();
+    assert_eq!(
+        local["target"],
+        json!({"kind":"local","remote":format!("file://{}",f.bare.display()),"slug":"","visibility":"private"})
+    );
+    assert_eq!(
+        platform["target"],
+        json!({"kind":"platform","remote":"https://github.com/fixture/project.git","slug":"fixture/project","visibility":"private"})
+    );
+    assert_eq!(local["gates"][0]["branches"], json!(["work", "new"]));
+    assert_eq!(
+        receipts::list_owned(&f.rt, "local", &f.actor, None, None, 500, 0)
+            .await
+            .unwrap()
+            .receipts
+            .len(),
+        before
+    );
+    f.no_credential_read();
+}
+
+#[tokio::test]
+async fn local_mapping_rejects_unknown_scheme_and_missing_opt_in() {
+    for (remote, slug) in [
+        ("ssh://host/repo", ""),
+        ("ssh://host/repo", "owner/repo"),
+        ("file://host/remote.git", ""),
+        ("relative.git", ""),
+        ("//host/repo", ""),
+        ("file:////host/repo", ""),
+        ("/tmp/bad\npath", ""),
+        ("/tmp/remote.git", "owner/repo"),
+    ] {
+        let f = Fixture::new(|_| remote.into(), slug).await;
+        f.refusal("git.push", f.push(), "remote_scheme").await;
+        let gates = f.call(&f.actor, "git.gates", json!({})).await.unwrap();
+        assert_eq!(
+            gates["target"],
+            json!({"kind":"unavailable","reason":"remote_scheme"})
+        );
+    }
+}
+
+#[tokio::test]
+async fn local_push_reconcile_requires_marker_and_exact_remote_without_credentials() {
+    let f = Fixture::file().await;
+    f.call(&f.actor, "git.push", f.push()).await.unwrap();
+    let mut receipt = f.last(&f.actor).await;
+    receipt.disposition = Disposition::Unknown;
+    receipts::persist(&f.rt, &receipt).await.unwrap();
+    git(&f.bare, &["update-ref", "refs/heads/work", &f.rival]);
+    f.call(&f.actor, "git.reconcile", json!({"receipt":receipt.id}))
+        .await
+        .unwrap();
+    assert_eq!(
+        receipts::load_owned(&f.rt, "local", &f.actor, &receipt.id)
+            .await
+            .unwrap()
+            .disposition,
+        Disposition::Unknown
+    );
+    git(&f.bare, &["update-ref", "refs/heads/work", &f.head]);
+    f.call(&f.actor, "git.reconcile", json!({"receipt":receipt.id}))
+        .await
+        .unwrap();
+    assert_eq!(
+        receipts::load_owned(&f.rt, "local", &f.actor, &receipt.id)
+            .await
+            .unwrap()
+            .disposition,
+        Disposition::Committed
+    );
+    receipt.id = uuid::Uuid::new_v4().to_string();
+    receipts::insert(&f.rt, &receipt).await.unwrap();
+    f.call(&f.actor, "git.reconcile", json!({"receipt":receipt.id}))
+        .await
+        .unwrap();
+    assert_eq!(
+        receipts::load_owned(&f.rt, "local", &f.actor, &receipt.id)
+            .await
+            .unwrap()
+            .disposition,
+        Disposition::Unknown
+    );
+    f.no_credential_read();
+}

--- a/crates/khive-pack-git/src/local_remote_tests.rs
+++ b/crates/khive-pack-git/src/local_remote_tests.rs
@@ -403,9 +403,18 @@ async fn local_mapping_rejects_unknown_scheme_and_missing_opt_in() {
 async fn local_push_reconcile_requires_marker_and_exact_remote_without_credentials() {
     let f = Fixture::file().await;
     f.call(&f.actor, "git.push", f.push()).await.unwrap();
-    let mut receipt = f.last(&f.actor).await;
+    let committed = f.last(&f.actor).await;
+    assert_eq!(committed.disposition, Disposition::Committed);
+    // Seed an unfinished observation of the completed native effect. Terminal
+    // receipts cannot be downgraded; this fixture needs its own row and marker.
+    let mut receipt = committed.clone();
+    receipt.id = uuid::Uuid::new_v4().to_string();
     receipt.disposition = Disposition::Unknown;
-    receipts::persist(&f.rt, &receipt).await.unwrap();
+    receipt.finished_at = None;
+    receipts::insert(&f.rt, &receipt).await.unwrap();
+    crate::local_git::record_push_marker(&f.repo, "work", &f.head, &receipt.id)
+        .await
+        .unwrap();
     git(&f.bare, &["update-ref", "refs/heads/work", &f.rival]);
     f.call(&f.actor, "git.reconcile", json!({"receipt":receipt.id}))
         .await
@@ -428,6 +437,15 @@ async fn local_push_reconcile_requires_marker_and_exact_remote_without_credentia
             .disposition,
         Disposition::Committed
     );
+    assert_eq!(
+        receipts::load_owned(&f.rt, "local", &f.actor, &committed.id)
+            .await
+            .unwrap()
+            .disposition,
+        Disposition::Committed,
+        "the original terminal receipt is unchanged"
+    );
+    // This still-unfinished in-memory copy gets a new ID with no matching marker.
     receipt.id = uuid::Uuid::new_v4().to_string();
     receipts::insert(&f.rt, &receipt).await.unwrap();
     f.call(&f.actor, "git.reconcile", json!({"receipt":receipt.id}))

--- a/crates/khive-pack-git/src/local_vocab.rs
+++ b/crates/khive-pack-git/src/local_vocab.rs
@@ -56,14 +56,14 @@ pub(crate) const RECEIPTS: HandlerDef = HandlerDef {
 };
 pub(crate) const GATES: HandlerDef = HandlerDef {
     name: "git.gates",
-    description: "Read effective repository allowlist rows, preserving their configured entry indices and branch patterns.",
+    description: "Read effective repository allowlist rows, preserving their configured entry indices and branch patterns. target names the configured remote, slug, visibility and kind (local or platform); absent mappings return null and invalid mappings return kind=unavailable with a reason.",
     visibility: Visibility::Verb,
     category: VerbCategory::Assertive,
     params: &[REPO],
 };
 pub(crate) const RECONCILE: HandlerDef = HandlerDef {
     name: "git.reconcile",
-    description: "Settle a caller-owned unknown receipt using observed evidence. Local receipts require the receipt marker and SHA in the ref reflog, with that SHA at the current head or an ancestor. Push receipts require an acknowledged local marker and exact remote SHA; merge receipts read platform merged state and SHA. Missing evidence leaves unknown. Never repeats a write.",
+    description: "Settle a caller-owned unknown receipt using observed evidence. Local receipts require the receipt marker and SHA in the ref reflog, with that SHA at the current head or an ancestor. Push receipts require an acknowledged local marker and exact remote SHA; explicitly local remote mappings read that SHA without resolving credentials; merge receipts read platform merged state and SHA. Missing evidence leaves unknown. Never repeats a write.",
     visibility: Visibility::Verb,
     category: VerbCategory::Assertive,
     params: &[param("receipt", true, "Caller-owned receipt UUID of a branch, tree commit, push or PR merge operation.")],

--- a/crates/khive-pack-git/src/remote_handlers.rs
+++ b/crates/khive-pack-git/src/remote_handlers.rs
@@ -194,7 +194,10 @@ fn after_effect(error: Failure) -> Failure {
 }
 
 impl GitPack {
-    fn remote_repository(&self, repo: &Path) -> Result<GitWriteRepositoryConfig, Failure> {
+    pub(crate) fn remote_repository(
+        &self,
+        repo: &Path,
+    ) -> Result<GitWriteRepositoryConfig, Failure> {
         let configured = &self.runtime().config().git_write.repositories;
         let mut matches = configured
             .iter()
@@ -205,6 +208,17 @@ impl GitPack {
             .ok_or_else(|| Failure::refused("repository_unmapped"))?;
         if matches.next().is_some() {
             return Err(Failure::refused("repository_ambiguous"));
+        }
+        let path = row.remote.strip_prefix("file://").unwrap_or(&row.remote);
+        if row.slug.is_empty()
+            && path.starts_with('/')
+            && !path.starts_with("//")
+            && !row.remote.chars().any(char::is_control)
+        {
+            if !matches!(row.visibility.as_str(), "public" | "private" | "internal") {
+                return Err(Failure::refused("repository_identity"));
+            }
+            return Ok(row);
         }
         let rest = row
             .remote
@@ -368,6 +382,12 @@ impl GitPack {
     ) -> Result<Value, Failure> {
         let repo = std::path::PathBuf::from(&receipt.repo);
         let target = self.remote_repository(&repo)?;
+        if target.slug.is_empty() {
+            receipt.credential = json!({"source":"none"});
+            if verb != "git.push" {
+                return Err(Failure::refused("remote_scheme"));
+            }
+        }
         if verb == "git.push" {
             let (version, supported) = local_git::push_marker_support(&repo).await?;
             if !supported {
@@ -379,6 +399,9 @@ impl GitPack {
                 return Err(Failure::refused("expected_local_mismatch"));
             }
         }
+        if target.slug.is_empty() {
+            return self.push_exact(None, &target, params, receipt).await;
+        }
         let (identity, secret) =
             credentials::resolve_remote(&self.runtime().config().git_write, &receipt.actor)
                 .await
@@ -387,7 +410,9 @@ impl GitPack {
         receipts::persist(self.runtime(), receipt).await?;
         let secret = secret.value();
         if verb == "git.push" {
-            return self.push_exact(secret, &target, params, receipt).await;
+            return self
+                .push_exact(Some(secret), &target, params, receipt)
+                .await;
         }
         // gh's GitHub endpoint must name the same repository as configured Git.
         if target.remote.trim_end_matches(".git") != format!("https://github.com/{}", target.slug) {
@@ -571,7 +596,7 @@ impl GitPack {
 
     async fn push_exact(
         &self,
-        secret: &str,
+        secret: Option<&str>,
         target: &GitWriteRepositoryConfig,
         params: &Value,
         receipt: &mut Receipt,
@@ -833,10 +858,19 @@ impl GitPack {
             return Ok(());
         }
         let target = self.remote_repository(repo)?;
-        let (_, secret) =
-            credentials::resolve_remote(&self.runtime().config().git_write, &prior.actor)
-                .await
-                .map_err(|_| Failure::refused("actor_unmapped"))?;
+        let secret = if target.slug.is_empty() {
+            if prior.verb != "git.push" {
+                return Err(Failure::refused("remote_scheme"));
+            }
+            None
+        } else {
+            Some(
+                credentials::resolve_remote(&self.runtime().config().git_write, &prior.actor)
+                    .await
+                    .map_err(|_| Failure::refused("actor_unmapped"))?
+                    .1,
+            )
+        };
         let committed = match prior.verb.as_str() {
             "git.push" => {
                 let branch = required(&prior.inputs, "branch")?;
@@ -849,7 +883,11 @@ impl GitPack {
                     .unwrap_or(false)
                     && self
                         .remote_transport()
-                        .remote_ref(secret.value(), &target.remote, branch)
+                        .remote_ref(
+                            secret.as_ref().map(|secret| secret.value()),
+                            &target.remote,
+                            branch,
+                        )
                         .await
                         .ok()
                         .flatten()
@@ -865,7 +903,10 @@ impl GitPack {
                 let n = number(&prior.inputs)?;
                 let pr = self
                     .api(
-                        secret.value(),
+                        secret
+                            .as_ref()
+                            .ok_or_else(|| Failure::refused("remote_scheme"))?
+                            .value(),
                         "GET",
                         endpoint(&target.slug, &format!("pulls/{n}")),
                         None,

--- a/crates/khive-pack-git/src/remote_handlers.rs
+++ b/crates/khive-pack-git/src/remote_handlers.rs
@@ -193,6 +193,27 @@ fn after_effect(error: Failure) -> Failure {
     Failure::unknown(error.reason)
 }
 
+fn decode_file_path(path: &str) -> Result<String, Failure> {
+    if !path.starts_with('/') {
+        return Err(Failure::refused("remote_scheme"));
+    }
+    let mut decoded = Vec::with_capacity(path.len());
+    let mut bytes = path.bytes();
+    while let Some(byte) = bytes.next() {
+        if byte == b'%' {
+            let high = bytes.next().and_then(|b| char::from(b).to_digit(16));
+            let low = bytes.next().and_then(|b| char::from(b).to_digit(16));
+            match (high, low) {
+                (Some(high), Some(low)) => decoded.push((high * 16 + low) as u8),
+                _ => return Err(Failure::refused("remote_scheme")),
+            }
+        } else {
+            decoded.push(byte);
+        }
+    }
+    String::from_utf8(decoded).map_err(|_| Failure::refused("remote_scheme"))
+}
+
 impl GitPack {
     pub(crate) fn remote_repository(
         &self,
@@ -209,11 +230,15 @@ impl GitPack {
         if matches.next().is_some() {
             return Err(Failure::refused("repository_ambiguous"));
         }
-        let path = row.remote.strip_prefix("file://").unwrap_or(&row.remote);
+        // Git decodes file URL paths before opening them; plain paths keep literal '%'.
+        let path = match row.remote.strip_prefix("file://") {
+            Some(path) => decode_file_path(path)?,
+            None => row.remote.clone(),
+        };
         if row.slug.is_empty()
             && path.starts_with('/')
             && !path.starts_with("//")
-            && !row.remote.chars().any(char::is_control)
+            && !path.chars().any(char::is_control)
         {
             if !matches!(row.visibility.as_str(), "public" | "private" | "internal") {
                 return Err(Failure::refused("repository_identity"));

--- a/crates/khive-pack-git/src/remote_tests.rs
+++ b/crates/khive-pack-git/src/remote_tests.rs
@@ -126,18 +126,18 @@ impl RemoteTransport for Recording {
     }
     async fn remote_ref(
         &self,
-        token: &str,
+        token: Option<&str>,
         _remote: &str,
         _branch: &str,
     ) -> Result<Option<String>, RemoteError> {
         let mut s = self.state.lock().unwrap();
-        s.calls.push(json!({"op":"remote_ref","token_hash":blake3::hash(token.as_bytes()).to_hex().to_string()}));
+        s.calls.push(json!({"op":"remote_ref","token_hash":blake3::hash(token.expect("platform credential").as_bytes()).to_hex().to_string()}));
         if s.api_failure {
             return Err(RemoteError::Unavailable);
         }
         Ok(remote_head(&self.bare))
     }
-    async fn push(&self, token: &str, mut request: PushRequest) -> Result<(), RemoteError> {
+    async fn push(&self, token: Option<&str>, mut request: PushRequest) -> Result<(), RemoteError> {
         let (race, lost) = {
             let mut s = self.state.lock().unwrap();
             s.push_calls += 1;

--- a/crates/khive-pack-git/src/remote_transport.rs
+++ b/crates/khive-pack-git/src/remote_transport.rs
@@ -45,13 +45,14 @@ pub trait RemoteTransport: Send + Sync {
         slug: &str,
         number: u64,
     ) -> Result<Value, RemoteError>;
+    /// None is the explicitly local, credential-free Git transport; HTTPS uses Some.
     async fn remote_ref(
         &self,
-        token: &str,
+        token: Option<&str>,
         remote: &str,
         branch: &str,
     ) -> Result<Option<String>, RemoteError>;
-    async fn push(&self, token: &str, request: PushRequest) -> Result<(), RemoteError>;
+    async fn push(&self, token: Option<&str>, request: PushRequest) -> Result<(), RemoteError>;
 }
 
 pub struct GhTransport;
@@ -244,15 +245,24 @@ impl RemoteTransport for GhTransport {
             .ok_or(RemoteError::InvalidResponse)
     }
 
+    /// None is the explicitly local, credential-free Git transport; HTTPS uses Some.
     async fn remote_ref(
         &self,
-        token: &str,
+        token: Option<&str>,
         remote: &str,
         branch: &str,
     ) -> Result<Option<String>, RemoteError> {
         let scratch = bare().await?;
         let reference = format!("refs/heads/{branch}");
-        let mut command = git_command(scratch.path(), Some(token));
+        let mut command = git_command(scratch.path(), token);
+        if token.is_none() {
+            command.args([
+                "-c",
+                "protocol.file.allow=always",
+                "-c",
+                "protocol.https.allow=never",
+            ]);
+        }
         command.args(["ls-remote", "--refs", "--", remote, &reference]);
         let (success, bytes) = run(command, None, false).await?;
         if !success {
@@ -273,13 +283,13 @@ impl RemoteTransport for GhTransport {
         Ok(Some(sha.to_ascii_lowercase()))
     }
 
-    async fn push(&self, token: &str, request: PushRequest) -> Result<(), RemoteError> {
-        push_native(token, request, false).await
+    async fn push(&self, token: Option<&str>, request: PushRequest) -> Result<(), RemoteError> {
+        push_native(token, request, token.is_none()).await
     }
 }
 
 pub(crate) async fn push_native(
-    token: &str,
+    token: Option<&str>,
     request: PushRequest,
     allow_file: bool,
 ) -> Result<(), RemoteError> {
@@ -293,9 +303,14 @@ pub(crate) async fn push_native(
         "--force-with-lease={reference}:{}",
         request.expected_remote.as_deref().unwrap_or("")
     );
-    let mut command = git_command(scratch.path(), Some(token));
+    let mut command = git_command(scratch.path(), token);
     if allow_file {
-        command.args(["-c", "protocol.file.allow=always"]);
+        command.args([
+            "-c",
+            "protocol.file.allow=always",
+            "-c",
+            "protocol.https.allow=never",
+        ]);
     }
     let alternate = serde_json::to_string(&objects.display().to_string())
         .map_err(|_| RemoteError::Unavailable)?;

--- a/crates/khive-pack-git/src/remote_vocab.rs
+++ b/crates/khive-pack-git/src/remote_vocab.rs
@@ -32,7 +32,7 @@ const SESSION: ParamDef = crate::local_vocab::SESSION;
 
 pub(crate) const PUSH: HandlerDef = HandlerDef {
     name: "git.push",
-    description: "Push an exact local SHA with a server-side expected-remote compare after fast-forward proof. Expected remote null means must not exist. All caller force/remote/refspec overrides refuse. Actor-only credentials, durable receipt, no retries.",
+    description: "Push an exact local SHA with a server-side expected-remote compare after fast-forward proof. Expected remote null means must not exist. All caller force/remote/refspec overrides refuse. HTTPS uses actor-only credentials. An absolute path or file:/// remote configured with slug=\"\" uses no credential or actor row and records credential.source=none. Durable receipt, no retries.",
     visibility: Visibility::Verb,
     category: VerbCategory::Commissive,
     params: &[
@@ -46,7 +46,7 @@ pub(crate) const PUSH: HandlerDef = HandlerDef {
 
 pub(crate) const PR_OPEN: HandlerDef = HandlerDef {
     name: "git.pr_open",
-    description: "Open a pull request after checking configured slug, visibility and exact platform head. Uses the dispatching actor credential: [git_write] actors.<actor>.credential_ref is resolved through credential_resolver (by default the login keychain item with that service name), never stored, and an unmapped actor or a failed resolver refuses actor_unmapped before any network call. The resolved token must belong to the actor configured platform_identity or the act refuses platform_identity_mismatch. Returns number, url, head_sha and receipt_id.",
+    description: "Open a pull request after checking configured slug, visibility and exact platform head. Local mappings refuse remote_scheme before resolving credentials; PR verbs require HTTPS. Uses the dispatching actor credential: [git_write] actors.<actor>.credential_ref is resolved through credential_resolver (by default the login keychain item with that service name), never stored, and an unmapped actor or a failed resolver refuses actor_unmapped before any network call. The resolved token must belong to the actor configured platform_identity or the act refuses platform_identity_mismatch. Returns number, url, head_sha and receipt_id.",
     visibility: Visibility::Verb,
     category: VerbCategory::Commissive,
     params: &[
@@ -62,7 +62,7 @@ pub(crate) const PR_OPEN: HandlerDef = HandlerDef {
 
 pub(crate) const PR_REVIEW: HandlerDef = HandlerDef {
     name: "git.pr_review",
-    description: "Submit a review bound to expected_head. Approval requires a different opening actor, credential reference and platform account; fork approvals additionally require git.pr_review.fork. Returns review_id, head_sha, state and receipt_id.",
+    description: "Submit a review bound to expected_head. Local mappings refuse remote_scheme before any credential or platform read; PR verbs require HTTPS. Approval requires a different opening actor, credential reference and platform account; fork approvals additionally require git.pr_review.fork. Returns review_id, head_sha, state and receipt_id.",
     visibility: Visibility::Verb,
     category: VerbCategory::Commissive,
     params: &[
@@ -77,7 +77,7 @@ pub(crate) const PR_REVIEW: HandlerDef = HandlerDef {
 
 pub(crate) const PR_MERGE: HandlerDef = HandlerDef {
     name: "git.pr_merge",
-    description: "Merge with a platform head comparison after caller policy and current-head approval by another account. The merge presents as the dispatching actor credential, resolved the same way as git.pr_open. The approval precondition is an approving review at expected_head from a platform account other than the LAST PUSHER of that head, not other than the author. A repository row may list merge_refusals: opener refuses a merge dispatched by the account or actor that opened the pull request (merge_by_opener) and last_pusher refuses one dispatched by the login on the newest push receipt for expected_head (merge_by_last_pusher), both before any platform write and named on the receipt; with no list a merge dispatched by the opener is not refused. Forks require git.pr_merge.fork; no administrator bypass is requested. Returns merged_head_sha, merged_sha and receipt_id.",
+    description: "Merge with a platform head comparison after caller policy and current-head approval by another account. Local mappings refuse remote_scheme before any credential or review read; PR verbs require HTTPS. The merge presents as the dispatching actor credential, resolved the same way as git.pr_open. The approval precondition is an approving review at expected_head from a platform account other than the LAST PUSHER of that head, not other than the author. A repository row may list merge_refusals: opener refuses a merge dispatched by the account or actor that opened the pull request (merge_by_opener) and last_pusher refuses one dispatched by the login on the newest push receipt for expected_head (merge_by_last_pusher), both before any platform write and named on the receipt; with no list a merge dispatched by the opener is not refused. Forks require git.pr_merge.fork; no administrator bypass is requested. Returns merged_head_sha, merged_sha and receipt_id.",
     visibility: Visibility::Verb,
     category: VerbCategory::Commissive,
     params: &[

--- a/crates/khive-runtime/src/engine_config.rs
+++ b/crates/khive-runtime/src/engine_config.rs
@@ -467,7 +467,9 @@ pub struct GitWriteSectionConfig {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GitWriteRepositoryConfig {
+    /// HTTPS platform remote, or an absolute path / file:/// URL with an empty slug.
     pub remote: String,
+    /// owner/name for HTTPS; empty explicitly opts into credential-free local pushes.
     pub slug: String,
     pub visibility: String,
     /// Merge dispatch refusals for this repository (ADR-182 Amendment 7):

--- a/docs/adr/ADR-182-git-dev-loop-verbs.md
+++ b/docs/adr/ADR-182-git-dev-loop-verbs.md
@@ -496,3 +496,48 @@ Two additions, from gating this amendment rather than from writing it.
    Both are therefore admission-degrade-safe and are listed under the `git` pack beside
    `git.receipts` and `git.gates`. `git.init` is Commissive and writes a receipt, so the census
    does not reach it.
+
+## Amendment 9 (2026-09-10): explicitly local push targets
+
+Amends Amendment 2 items 3–4 for push targets only, implementing issue #2508.
+A repository mapping with `slug = ""` explicitly opts into a local remote: `remote`
+is an absolute POSIX path or an authority-free `file:///absolute/path` URL, and
+`visibility` remains one of `public`, `private`, `internal`. Relative paths,
+file URLs with a host, double-leading-slash paths, control characters and other
+schemes (including `ssh://`) refuse `remote_scheme`. A local path with a nonempty
+slug also refuses; HTTPS retains its owner/name slug and existing validation.
+
+```toml
+[git_write.repositories."/abs/checkout"]
+remote = "file:///abs/remote.git"
+slug = ""
+visibility = "private"
+```
+
+`git.push` on this mapping takes the same allowlist, tool policy, exact local and
+remote comparisons, fast-forward proof, server-side lease, readback and acknowledged
+push marker as HTTPS. It resolves neither an actor row nor a credential, including
+when an actor row exists, and its receipt records `credential: {"source":"none"}`.
+Its Git transport enables file access only for the explicit local path, disables
+HTTPS for that operation and injects no authorization header. HTTPS credential
+resolution is unchanged. `git.reconcile` reads a local push target without a
+credential and still needs both the receipt marker and the exact remote SHA.
+
+`git.pr_open`, `git.pr_review`, and `git.pr_merge` on a local mapping refuse
+`remote_scheme` before resolving credentials or reading platform/review state.
+Reconciliation of a platform merge against a local mapping also refuses
+`remote_scheme`. No local platform behavior is synthesized.
+
+`git.gates` preserves its existing allowlist rows and adds `target` with `kind`
+(`local` or `platform`), `remote`, `slug`, and `visibility`. An absent mapping
+returns `target: null`; an invalid or ambiguous mapping returns
+`target: {kind: "unavailable", reason}` without echoing the invalid remote.
+
+Acceptance arms: a production-transport push to a temporary bare `file:///` target
+succeeds with credential source `none` and an independently read remote SHA;
+absolute-path and unmapped-actor controls also succeed; stale expected-remote and
+divergent-head pushes refuse without moving refs; local PR verbs refuse before a
+credential read; gates distinguish local and HTTPS mappings in one configuration;
+unknown schemes and local targets lacking the empty slug refuse; reconciliation
+requires the marker and exact remote SHA. Mutation expectation: restoring the
+HTTPS-only scheme check makes the successful local-file push arm fail.

--- a/docs/adr/ADR-182-git-dev-loop-verbs.md
+++ b/docs/adr/ADR-182-git-dev-loop-verbs.md
@@ -504,7 +504,10 @@ A repository mapping with `slug = ""` explicitly opts into a local remote: `remo
 is an absolute POSIX path or an authority-free `file:///absolute/path` URL, and
 `visibility` remains one of `public`, `private`, `internal`. Relative paths,
 file URLs with a host, double-leading-slash paths, control characters and other
-schemes (including `ssh://`) refuse `remote_scheme`. A local path with a nonempty
+schemes (including `ssh://`) refuse `remote_scheme`. File-URL paths are percent-decoded
+before these checks; malformed escapes or decoded non-UTF-8 paths also refuse.
+Encoded spaces remain supported, and ordinary absolute paths keep literal percent signs.
+A local path with a nonempty
 slug also refuses; HTTPS retains its owner/name slug and existing validation.
 
 ```toml


### PR DESCRIPTION
Implements issue #2508: a `git_write.repositories` mapping may opt into a local push target explicitly (`slug = ""`, `remote` = absolute POSIX path or authority-free `file:///` URL). `git.push` and `git.reconcile` run over the same transport, comparisons, fast-forward proof, lease, readback and push marker as HTTPS, resolve no credential, and record `credential: {"source": "none"}` in the receipt. PR verbs and platform reconciliation refuse `remote_scheme` on a local mapping. `git.gates` gains a `target` object (`kind: local | platform`, `remote`, `slug`, `visibility`; `null` when unmapped; `unavailable` with a reason for an invalid mapping).

Validation tightened for the local form: relative paths, file URLs with a host, double-leading-slash paths, control characters, other schemes (`ssh://` included), malformed percent escapes and decoded non-UTF-8 all refuse `remote_scheme`; a local remote with a nonempty slug refuses.

ADR-182 Amendment 9 states the mapping, its refusals and the receipt field.

Tests (`crates/khive-pack-git/src/local_remote_tests.rs`): local file push moves the native ref without credentials; absolute path and unmapped actor accepted; stale expected remote and divergent remote refuse and preserve refs; PR verbs refuse `remote_scheme` before any credential read; gates distinguish local and HTTPS in one config; reconciliation requires marker plus exact remote SHA.

Gate at the head (rust 1.95.0): `cargo fmt --all -- --check` rc 0; `cargo clippy -p khive-pack-git -p khive-runtime --all-targets -- -D warnings` rc 0; `cargo test -p khive-pack-git --no-fail-fast` 315 + 106 + 30 passed, 0 failed.
