### PR TITLE
feat(exec): report the observed limiting resource on run receipts

### DIFF
--- a/crates/khive-pack-exec/src/handlers.rs
+++ b/crates/khive-pack-exec/src/handlers.rs
@@ -339,6 +339,7 @@ struct Receipt {
     tree_out: Option<String>,
     exit_code: Option<i64>,
     exit_signal: Option<i64>,
+    limiting_resource: Option<&'static str>,
     timed_out: bool,
     denied: bool,
     success: bool,
@@ -378,6 +379,7 @@ impl Receipt {
             "tree_out": self.tree_out,
             "exit_code": self.exit_code,
             "exit_signal": self.exit_signal,
+            "limiting_resource": self.limiting_resource,
             "timed_out": self.timed_out,
             "denied": self.denied,
             "success": self.success,
@@ -523,6 +525,7 @@ pub async fn run(
         tree_out: None,
         exit_code: None,
         exit_signal: None,
+        limiting_resource: None,
         timed_out: false,
         denied: false,
         success: false,
@@ -945,7 +948,18 @@ async fn execute(
     let err_task = tokio::spawn(async move { drain(stderr, cap).await });
 
     let status = match tokio::time::timeout(req.timeout, child.wait()).await {
-        Ok(Ok(status)) => Some(status),
+        Ok(Ok(status)) => {
+            use std::os::unix::process::ExitStatusExt;
+            // Only the delivered signal for a configured limit is observable
+            // here. ENOMEM/EAGAIN inside a child and generic SIGKILL are not
+            // resource evidence; timeout keeps the initial explicit null.
+            receipt.limiting_resource = match status.signal() {
+                Some(libc::SIGXCPU) if cfg.limits.cpu_seconds.is_some() => Some("cpu_seconds"),
+                Some(libc::SIGXFSZ) if cfg.limits.file_size.is_some() => Some("file_size"),
+                _ => None,
+            };
+            Some(status)
+        }
         Ok(Err(_)) => None,
         Err(_) => {
             receipt.timed_out = true;

--- a/crates/khive-pack-exec/src/vocab.rs
+++ b/crates/khive-pack-exec/src/vocab.rs
@@ -94,7 +94,7 @@ pub static EXEC_HANDLERS: [HandlerDef; 9] = [
     },
     HandlerDef {
         name: "exec.run",
-        description: "Run one registered tool over a materialized tree inside the seatbelt sandbox under tool.check; returns {receipt, changed}. Every refusal writes a receipt and names it in the error as receipt_id=<id>.",
+        description: "Run one registered tool over a materialized tree inside the seatbelt sandbox under tool.check; returns {receipt, changed}. Every refusal writes a receipt and names it in the error as receipt_id=<id>. New receipts always include limiting_resource: cpu_seconds | address_space | file_size | nproc | null. Only a directly waited SIGXCPU with cpu_seconds configured or SIGXFSZ with file_size configured names a resource; normal exits, other signals and timeout record null. Child ENOMEM/EAGAIN are not visible to the wrapper, so address_space and nproc remain null (and are refused at startup on macOS). Older stored receipts are unchanged.",
         visibility: Visibility::Verb,
         category: VerbCategory::Directive,
         params: &[
@@ -112,7 +112,7 @@ pub static EXEC_HANDLERS: [HandlerDef; 9] = [
     },
     HandlerDef {
         name: "exec.receipt",
-        description: "Read one run receipt by id.",
+        description: "Read one run receipt by id. New receipts always include limiting_resource: cpu_seconds | address_space | file_size | nproc | null. Only a directly waited SIGXCPU with cpu_seconds configured or SIGXFSZ with file_size configured names a resource; normal exits, other signals and timeout record null. Child ENOMEM/EAGAIN are not visible to the wrapper, so address_space and nproc remain null (and are refused at startup on macOS). Older stored receipts are unchanged.",
         visibility: Visibility::Verb,
         category: VerbCategory::Assertive,
         params: &[

--- a/crates/khive-pack-exec/tests/verbs.rs
+++ b/crates/khive-pack-exec/tests/verbs.rs
@@ -7,7 +7,7 @@ use khive_pack_blob::BlobPack;
 use khive_pack_exec::ExecPack;
 use khive_pack_kg::KgPack;
 use khive_pack_tool::ToolPack;
-use khive_runtime::engine_config::ExecSectionConfig;
+use khive_runtime::engine_config::{ExecLimitsConfig, ExecSectionConfig};
 use khive_runtime::{KhiveRuntime, RuntimeConfig, VerbRegistry, VerbRegistryBuilder};
 use serde_json::{json, Value};
 
@@ -23,6 +23,10 @@ fn fixture() -> Fixture {
 }
 
 fn fixture_with_keep(keep: bool) -> Fixture {
+    fixture_with_limits(keep, ExecLimitsConfig::default())
+}
+
+fn fixture_with_limits(keep: bool, limits: ExecLimitsConfig) -> Fixture {
     let dir = tempfile::tempdir().expect("tempdir");
     let root = dir.path().join("exec-root");
     let db = dir.path().join("khive.db");
@@ -37,7 +41,7 @@ fn fixture_with_keep(keep: bool) -> Fixture {
             timeout_default_s: Some(5.0),
             timeout_max_s: Some(10.0),
             keep,
-            limits: Default::default(),
+            limits,
         },
         // No embedding model: tool.register would otherwise build the default
         // embedder, which needs a model file the test host may not have.
@@ -1658,4 +1662,197 @@ async fn run_denies_version_control_and_the_never_set_at_the_kernel() {
             "{cmd}: the kernel refusal is in stderr: {stderr:?}"
         );
     }
+}
+
+#[cfg(target_os = "macos")]
+const LIMIT_SPIN: &str = "while :; do :; done";
+
+#[cfg(target_os = "macos")]
+fn observable_limits() -> ExecLimitsConfig {
+    ExecLimitsConfig {
+        cpu_seconds: Some(1),
+        file_size: Some(1024),
+        ..Default::default()
+    }
+}
+
+/// Check the JSON key itself: indexing a missing key also produces Value::Null.
+#[cfg(target_os = "macos")]
+async fn check_limiting_resource(f: &Fixture, receipt: &Value, expected: Value) {
+    assert_eq!(
+        receipt.get("limiting_resource"),
+        Some(&expected),
+        "{receipt}"
+    );
+    let stored = f.call("exec.receipt", json!({"id": receipt["id"]})).await;
+    assert_eq!(&stored, receipt, "returned and persisted receipt agree");
+    assert_eq!(stored.get("limiting_resource"), Some(&expected));
+    let runs = f.call("exec.runs", json!({"actor": "local"})).await;
+    let listed = runs["runs"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|r| r["id"] == receipt["id"])
+        .expect("receipt listed");
+    assert_eq!(listed.get("limiting_resource"), Some(&expected));
+    assert!(root_is_empty(f), "run directory and profile are cleaned up");
+}
+
+#[cfg(target_os = "macos")]
+async fn limit_run(f: &Fixture, script: &str, timeout_s: f64) -> Value {
+    f.register_sh("limit-sh", "allow").await;
+    let tree = f.tree(&[]).await;
+    f.call(
+        "exec.run",
+        json!({"tree": tree, "tool": "limit-sh", "args": ["-c", script],
+               "actor": "local", "timeout_s": timeout_s}),
+    )
+    .await["receipt"]
+        .clone()
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn limiting_resource_cpu_seconds_observed_on_wait() {
+    let f = fixture_with_limits(false, observable_limits());
+    let r = limit_run(&f, LIMIT_SPIN, 9.0).await;
+    assert_eq!(r["timed_out"], false, "{r}");
+    assert_eq!(r["exit_signal"], libc::SIGXCPU, "{r}");
+    // Signal termination retains the existing null exit_code representation.
+    assert!(r["exit_code"].is_null(), "{r}");
+    assert_eq!(r["success"], false, "{r}");
+    assert_eq!(r["limits"]["enforced"]["cpu_seconds"], 1, "{r}");
+    check_limiting_resource(&f, &r, json!("cpu_seconds")).await;
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn limiting_resource_file_size_observed_on_wait() {
+    let f = fixture_with_limits(false, observable_limits());
+    // exec preserves the directly waited PID. The default signal disposition
+    // of yes avoids a shell translating its child's signal to an exit code.
+    let r = limit_run(&f, "exec /usr/bin/yes > capped", 9.0).await;
+    assert_eq!(r["timed_out"], false, "{r}");
+    assert_eq!(r["exit_signal"], libc::SIGXFSZ, "{r}");
+    assert!(r["exit_code"].is_null(), "{r}");
+    assert_eq!(r["success"], false, "{r}");
+    assert_eq!(r["limits"]["enforced"]["file_size"], 1024, "{r}");
+    check_limiting_resource(&f, &r, json!("file_size")).await;
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn limiting_resource_exit_zero_is_present_null() {
+    let f = fixture_with_limits(false, observable_limits());
+    let r = limit_run(&f, "exit 0", 5.0).await;
+    assert_eq!(r["exit_code"], 0, "{r}");
+    assert_eq!(r["success"], true, "{r}");
+    assert_eq!(r["timed_out"], false, "{r}");
+    check_limiting_resource(&f, &r, Value::Null).await;
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn limiting_resource_sigterm_is_present_null() {
+    let f = fixture_with_limits(false, observable_limits());
+    let r = limit_run(&f, "kill -TERM $$", 5.0).await;
+    assert_eq!(r["exit_signal"], libc::SIGTERM, "{r}");
+    assert_eq!(r["timed_out"], false, "{r}");
+    assert_eq!(r["success"], false, "{r}");
+    check_limiting_resource(&f, &r, Value::Null).await;
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn limiting_resource_timeout_is_present_null() {
+    let f = fixture_with_limits(false, observable_limits());
+    let r = limit_run(&f, "exec /bin/sleep 5", 0.2).await;
+    assert_eq!(r["timed_out"], true, "{r}");
+    assert_eq!(r["success"], false, "{r}");
+    assert!(r["exit_signal"].is_null(), "{r}");
+    check_limiting_resource(&f, &r, Value::Null).await;
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn limiting_resource_spin_without_cpu_limit_reaches_timeout() {
+    let f = fixture();
+    let r = limit_run(&f, LIMIT_SPIN, 0.2).await;
+    assert_eq!(r["timed_out"], true, "no CPU limit ended this child: {r}");
+    assert!(r["limits"]["requested"].get("cpu_seconds").is_none());
+    assert!(r["limits"]["enforced"].get("cpu_seconds").is_none());
+    check_limiting_resource(&f, &r, Value::Null).await;
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn limiting_resource_requires_the_matching_configured_limit() {
+    for (script, signal, limits) in [
+        (
+            "kill -XCPU $$",
+            libc::SIGXCPU,
+            ExecLimitsConfig {
+                file_size: Some(1024),
+                ..Default::default()
+            },
+        ),
+        (
+            "kill -XFSZ $$",
+            libc::SIGXFSZ,
+            ExecLimitsConfig {
+                cpu_seconds: Some(1),
+                ..Default::default()
+            },
+        ),
+    ] {
+        let f = fixture_with_limits(false, limits);
+        let r = limit_run(&f, script, 5.0).await;
+        assert_eq!(r["exit_signal"], signal, "{r}");
+        assert_eq!(r["timed_out"], false, "{r}");
+        check_limiting_resource(&f, &r, Value::Null).await;
+    }
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn limiting_resource_generic_sigkill_is_present_null() {
+    let f = fixture_with_limits(false, observable_limits());
+    let r = limit_run(&f, "kill -KILL $$", 5.0).await;
+    assert_eq!(r["exit_signal"], libc::SIGKILL, "{r}");
+    assert_eq!(r["timed_out"], false, "{r}");
+    check_limiting_resource(&f, &r, Value::Null).await;
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn limiting_resource_nonzero_exit_is_present_null() {
+    let f = fixture_with_limits(false, observable_limits());
+    let r = limit_run(&f, "exit 7", 5.0).await;
+    assert_eq!(r["exit_code"], 7, "{r}");
+    assert!(r["exit_signal"].is_null(), "{r}");
+    assert_eq!(r["success"], false, "{r}");
+    check_limiting_resource(&f, &r, Value::Null).await;
+}
+
+#[tokio::test]
+async fn limiting_resource_refusal_is_present_null() {
+    let f = fixture();
+    let tree = f.tree(&[]).await;
+    let error = f
+        .call_err(
+            "exec.run",
+            json!({
+                "tree": tree, "tool": "unregistered-limit-tool", "actor": "local"
+            }),
+        )
+        .await;
+    assert!(error.contains("receipt_id="), "{error}");
+    let runs = f.call("exec.runs", json!({"actor": "local"})).await;
+    assert_eq!(runs["count"], 1, "{runs}");
+    let listed = &runs["runs"][0];
+    assert_eq!(listed["denied"], true);
+    assert_eq!(listed.get("limiting_resource"), Some(&Value::Null));
+    let stored = f.call("exec.receipt", json!({"id": listed["id"]})).await;
+    assert_eq!(stored.get("limiting_resource"), Some(&Value::Null));
+    assert!(root_is_empty(&f));
 }

--- a/docs/adr/ADR-181-exec-verb-sandboxed-run.md
+++ b/docs/adr/ADR-181-exec-verb-sandboxed-run.md
@@ -286,3 +286,36 @@ succeeds; 35 capture records links without descending through directory links;
 36 tracked file, directory and dangling symlinks round-trip through the manifest
 to a Git tree with an empty `git diff-tree`, and a link-to-file conversion emits
 the native `120000` to `100644` change.
+
+## Amendment 6 (2026-09-10): observed limiting resource on receipts
+
+Every newly written run receipt, including a refusal receipt, carries the explicit
+`limiting_resource` key. Its closed vocabulary is `cpu_seconds | address_space |
+file_size | nproc | null`; `null` is serialized rather than omitted. `exec.run`,
+`exec.receipt` and `exec.runs` return the same stored value. Historical receipts are
+not rewritten or assigned an inferred cause.
+
+The wait site records `cpu_seconds` only for a delivered `SIGXCPU` when that run
+configured `cpu_seconds`, and `file_size` only for a delivered `SIGXFSZ` when it
+configured `file_size`. Normal exits, nonzero exit codes, unrelated signals
+(including generic `SIGKILL`), wait errors and the run-timeout path leave `null`.
+The field is not derived afterwards from the exit code or merely from a requested
+limit. Existing signal termination keeps `exit_code: null` and the delivered
+signal in `exit_signal`; enforcement and timeout behavior are unchanged.
+
+The observation is limited to the directly waited child's signal. A descendant
+whose parent converts a signal into an ordinary exit code supplies no such
+observation. Likewise, `ENOMEM` from an address-space limit and `EAGAIN` from a
+process limit occur inside the child, so this wrapper records `null` for
+`address_space` and `nproc` even on Linux. An ignored `SIGXFSZ` followed by an
+`EFBIG` write error is not inferred as `file_size`. The macOS startup refusal for
+unsupported `address_space` and `nproc` remains unchanged and produces no receipt.
+
+Acceptance arms added: 37 a spinning child under a one-second CPU limit records
+`cpu_seconds`; 38 a child writing past a file-size limit records `file_size`; 39
+exit zero, nonzero exit, `SIGTERM`, generic `SIGKILL` and timeout each retain a
+present JSON null; 40 the same spin without a CPU limit reaches its wall timeout
+and retains null; 41 each resource signal without its matching configured limit
+retains null. The arms read back the durable receipt and its listing as well as
+the run reply. Replacing observation with a nonzero-exit heuristic must fail the
+unrelated-signal arm; omitting null must fail the exit-zero arm.


### PR DESCRIPTION
Every newly written `exec.run` receipt carries `limiting_resource`: `"cpu_seconds" | "address_space" | "file_size" | "nproc"` or an explicit `null` (present key, never omitted). The wait site records `cpu_seconds` for a delivered `SIGXCPU` when the run configured `cpu_seconds`, and `file_size` for `SIGXFSZ` when it configured `file_size`. Normal exits, nonzero exit codes, unrelated signals (generic `SIGKILL` included), wait errors and the timeout path leave `null`. Nothing is derived from the exit code or from a requested limit alone. `exec.receipt` and `exec.runs` return the stored value; historical receipts are not rewritten.

`address_space` and `nproc` are observed inside the child (`ENOMEM`, `EAGAIN`) and reach the wrapper as no signal, so they record `null` on every host; the help text and ADR-181 Amendment 6 say so.

Before this change a run terminated by the CPU limit reported `exit_code: null` with the signal in `exit_signal` and no field naming the resource. After it, the same run reads `limiting_resource: "cpu_seconds"`.

Tests (`crates/khive-pack-exec/tests/verbs.rs`, ten arms): cpu_seconds observed on wait; file_size observed on wait; exit zero, nonzero exit, `SIGTERM`, generic `SIGKILL`, timeout and refusal receipts each carry a present JSON null; a spin without a CPU limit reaches the wall timeout with null; a resource signal without its matching configured limit reads null.

Gate at the head (rust 1.95.0): `cargo fmt --all -- --check` rc 0; `cargo clippy -p khive-pack-exec -p khive-runtime --all-targets -- -D warnings` rc 0; `cargo test -p khive-pack-exec --no-fail-fast` 20 + 42 passed, 0 failed.
