### PR TITLE
fix(build): read git status without touching the index in the runtime build script

### DIFF
--- a/crates/khive-runtime/src/build_info_support.rs
+++ b/crates/khive-runtime/src/build_info_support.rs
@@ -34,6 +34,7 @@ fn git_command(cwd: &Path) -> Command {
     command
         .env_remove("GIT_DIR")
         .env_remove("GIT_WORK_TREE")
+        .arg("--no-optional-locks")
         .arg("-C")
         .arg(cwd);
     command


### PR DESCRIPTION
The runtime build script registers `.git/index` as a rerun input and runs `git status` to decide whether the revision is dirty. `git status` refreshes the index, so the script rewrote its own input on every run, the next build reran it, `KHIVE_BUILD_TIME` moved, and khive-runtime plus every crate above it recompiled. `--no-optional-locks` keeps the dirtiness read and drops the index write.

Measured on a no-change rebuild of `cargo test -p khive-mcp --lib --no-run` at main (rust 1.95.0): before, the second run recompiled khive-runtime in 10.6 s; after, the second and third runs compiled nothing and finished in 0.13 s. The CI daemon-recovery gate runs that command 25 times in a row and recompiled the workspace on every repeat (about 20 s each on an idle runner, about 60 s each under runner contention, which pushed the step past its 25-minute limit on the last two main runs).
