### PR TITLE
fix(git): keep destination hooks out of local pushes

### DIFF
--- a/crates/khive-pack-git/src/local_remote_tests.rs
+++ b/crates/khive-pack-git/src/local_remote_tests.rs
@@ -280,6 +280,39 @@ async fn local_file_push_moves_native_ref_without_credentials() {
 }
 
 #[tokio::test]
+async fn local_push_leaves_destination_hooks_unrun() {
+    let f = Fixture::file().await;
+    let marker = f.dir.path().join("hook-ran");
+    let quoted = format!("'{}'", marker.display().to_string().replace('\'', "'\\''"));
+    let hook = f.bare.join("hooks").join("update");
+    std::fs::create_dir_all(hook.parent().unwrap()).unwrap();
+    std::fs::write(&hook, format!("#!/bin/sh\nprintf ran > {quoted}\nexit 0\n")).unwrap();
+    std::fs::set_permissions(&hook, std::fs::Permissions::from_mode(0o755)).unwrap();
+    f.call(&f.actor, "git.push", f.push()).await.unwrap();
+    assert_eq!(f.remote_head(), f.head);
+    assert!(
+        !marker.exists(),
+        "the destination update hook ran during the daemon's push"
+    );
+    // Control: a plain push with the same client-side hooks path runs the destination hook,
+    // so its silence above is the transport's doing and not the hook's.
+    git(
+        &f.repo,
+        &[
+            "push",
+            "-q",
+            f.bare.to_str().unwrap(),
+            &format!("{}:refs/heads/control", f.head),
+        ],
+    );
+    assert!(
+        marker.exists(),
+        "control: a plain push must run the destination update hook"
+    );
+    f.no_credential_read();
+}
+
+#[tokio::test]
 async fn local_path_push_allows_unmapped_actor_and_absent_remote_branch() {
     let f = Fixture::new(|bare| bare.display().to_string(), "").await;
     let actor = format!("{}:unmapped", f.actor);

--- a/crates/khive-pack-git/src/remote_transport.rs
+++ b/crates/khive-pack-git/src/remote_transport.rs
@@ -314,19 +314,28 @@ pub(crate) async fn push_native(
     }
     let alternate = serde_json::to_string(&objects.display().to_string())
         .map_err(|_| RemoteError::Unavailable)?;
+    let mut args = vec![
+        "push",
+        "--porcelain",
+        "--no-verify",
+        "--no-follow-tags",
+        "--recurse-submodules=no",
+    ];
+    if allow_file {
+        // Local transport runs the destination's receive-pack as this process, and the
+        // client-side hooks path above does not reach it: the destination's own hooks would
+        // run. The receive-pack invocation carries its own hooks path instead.
+        args.push("--receive-pack=git -c core.hooksPath=/dev/null receive-pack");
+    }
+    args.extend([
+        lease.as_str(),
+        "--",
+        request.remote.as_str(),
+        refspec.as_str(),
+    ]);
     command
         .env("GIT_ALTERNATE_OBJECT_DIRECTORIES", alternate)
-        .args([
-            "push",
-            "--porcelain",
-            "--no-verify",
-            "--no-follow-tags",
-            "--recurse-submodules=no",
-            &lease,
-            "--",
-            &request.remote,
-            &refspec,
-        ]);
+        .args(args);
     let (success, bytes) = run(command, None, true).await?;
     let text = std::str::from_utf8(&bytes).map_err(|_| RemoteError::Unknown)?;
     let status = text.lines().find_map(|line| {


### PR DESCRIPTION
## Summary

A push to a local target ran hooks installed in the destination repository.

Over the local file transport git runs the destination's `receive-pack` as a child of the pushing process. The hardened environment sets `core.hooksPath=/dev/null`, but that setting belongs to the client invocation and is not passed to `receive-pack`, so the destination's own `update`, `pre-receive` and `post-receive` hooks executed with the runtime's privileges whenever `git.push` targeted a local mapping. An untrusted or swapped local target could therefore run arbitrary code.

The push now supplies `--receive-pack` for local targets so the receiving side carries its own hooks path. Platform (HTTPS) pushes are unchanged: they never spawn a local `receive-pack`.

## Tests

`local_push_leaves_destination_hooks_unrun` installs an `update` hook in the destination bare repository, pushes through the verb, and asserts the hook left no trace while the ref still moved. Its control is a plain `git push` with the same client-side hooks path, which does fire the hook — so the silence in the first half is the transport's doing and not the hook's.

## Verification

Rust 1.95.0, git 2.55.0: `cargo fmt --all -- --check` (rc 0), `cargo clippy -p khive-pack-git -p khive-runtime --all-targets -- -D warnings` (rc 0, 0 errors), `cargo test -p khive-pack-git --no-fail-fast` (rc 0; 316 + 106 + 30 passed, 0 failed).

Mutation, run at the head: with the `--receive-pack` argument removed the hook test fails (`rc 101`, panic at the marker assertion); restored, it passes (`rc 0`, 1 passed).
