### PR TITLE
fix(exec): refuse in preflight on a host with no sandbox backend

### DIFF
--- a/crates/khive-pack-exec/src/handlers.rs
+++ b/crates/khive-pack-exec/src/handlers.rs
@@ -649,6 +649,10 @@ async fn preflight(
         .await
         .map_err(|e| e.to_string())?;
     receipt.cwd = cwd;
+    // Sandbox backend, last: every more specific refusal above still wins, and
+    // a host with no backend refuses here, naming the platform, instead of
+    // materializing a tree that could only ever fail at spawn.
+    sandbox::check_backend(sandbox::SANDBOX_EXEC)?;
     Ok(Ready {
         binary,
         registered,
@@ -834,7 +838,7 @@ async fn execute(
     } else {
         run_dir.join(&receipt.cwd)
     };
-    let mut command = Command::new("/usr/bin/sandbox-exec");
+    let mut command = Command::new(sandbox::SANDBOX_EXEC);
     command
         .arg("-f")
         .arg(&profile_path)

--- a/crates/khive-pack-exec/src/sandbox.rs
+++ b/crates/khive-pack-exec/src/sandbox.rs
@@ -34,6 +34,29 @@ pub const SYSTEM_READ_ROOTS: &[&str] = &[
 /// inside a sandbox, it runs through the git verbs.
 pub const FORBIDDEN_BASENAMES: &[&str] = &["git", "gh"];
 
+/// The sandbox launcher. Every run is a child of this binary, so its absence
+/// is the whole reason the pack runs on macOS only.
+pub const SANDBOX_EXEC: &str = "/usr/bin/sandbox-exec";
+
+/// Refuse before any work is done when the host has no sandbox backend.
+///
+/// The check reads the backend's own dependency rather than a compile-time
+/// target, so a macOS host that is missing `sandbox-exec` refuses for the same
+/// stated reason a Linux host does, and the reason names the platform instead
+/// of arriving later as a failed spawn.
+pub fn check_backend(path: &str) -> Result<(), String> {
+    if Path::new(path).exists() {
+        return Ok(());
+    }
+    Err(format!(
+        "no sandbox backend on this host: every run is executed under the macOS \
+         seatbelt sandbox, which needs {path}, and this host is {os}, where that \
+         binary does not exist. Runs are macOS-only until a backend for this \
+         platform ships.",
+        os = std::env::consts::OS
+    ))
+}
+
 fn quote(path: &Path) -> String {
     let s = path.to_string_lossy();
     format!("\"{}\"", s.replace('\\', "\\\\").replace('"', "\\\""))
@@ -252,6 +275,23 @@ pub fn check_binary(registered: &str, never: &[PathBuf]) -> Result<PathBuf, Bina
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn check_backend_accepts_a_backend_that_is_present() {
+        // Positive control: a path that exists on every host running this suite,
+        // so the refusal arm below is about absence and not about the check.
+        check_backend("/bin/sh").expect("an existing path reads as a present backend");
+    }
+
+    #[test]
+    fn check_backend_refuses_and_names_the_platform_when_absent() {
+        let missing = "/usr/bin/sandbox-exec-that-is-not-installed";
+        assert!(!Path::new(missing).exists());
+        let error = check_backend(missing).unwrap_err();
+        assert!(error.contains(missing), "{error}");
+        assert!(error.contains(std::env::consts::OS), "{error}");
+        assert!(error.contains("seatbelt"), "{error}");
+    }
 
     #[test]
     fn profile_names_run_dir_and_roots_only() {

--- a/crates/khive-pack-exec/src/vocab.rs
+++ b/crates/khive-pack-exec/src/vocab.rs
@@ -94,7 +94,7 @@ pub static EXEC_HANDLERS: [HandlerDef; 9] = [
     },
     HandlerDef {
         name: "exec.run",
-        description: "Run one registered tool over a materialized tree inside the seatbelt sandbox under tool.check; returns {receipt, changed}. Every refusal writes a receipt and names it in the error as receipt_id=<id>. New receipts always include limiting_resource: cpu_seconds | address_space | file_size | nproc | null. Only a directly waited SIGXCPU with cpu_seconds configured or SIGXFSZ with file_size configured names a resource; normal exits, other signals and timeout record null. Child ENOMEM/EAGAIN are not visible to the wrapper, so address_space and nproc remain null (and are refused at startup on macOS). Older stored receipts are unchanged.",
+        description: "Run one registered tool over a materialized tree inside the seatbelt sandbox under tool.check; returns {receipt, changed}. Every refusal writes a receipt and names it in the error as receipt_id=<id>. New receipts always include limiting_resource: cpu_seconds | address_space | file_size | nproc | null. Only a directly waited SIGXCPU with cpu_seconds configured or SIGXFSZ with file_size configured names a resource; normal exits, other signals and timeout record null. Child ENOMEM/EAGAIN are not visible to the wrapper, so address_space and nproc remain null (and are refused at startup on macOS). Older stored receipts are unchanged. The sandbox is macOS seatbelt only: a host without /usr/bin/sandbox-exec refuses the call at startup and names the platform.",
         visibility: Visibility::Verb,
         category: VerbCategory::Directive,
         params: &[

--- a/crates/khive-pack-exec/tests/verbs.rs
+++ b/crates/khive-pack-exec/tests/verbs.rs
@@ -1018,7 +1018,49 @@ async fn run_resolves_relative_symlink_cwd_chains_inside_the_manifest() {
     }
 }
 
-#[cfg(unix)]
+// The other half of the arm below: on a host with no sandbox backend the run
+// refuses in preflight with the platform named, writes its receipt, and leaves
+// the exec root untouched.
+#[cfg(all(unix, not(target_os = "macos")))]
+#[tokio::test]
+async fn run_refuses_a_host_without_a_sandbox_backend_and_names_the_platform() {
+    let f = fixture();
+    f.register_sh("sh", "allow").await;
+    let tree = f.tree(&[("a-file", b"input", 644)]).await;
+    let error = f
+        .call_err(
+            "exec.run",
+            json!({"tree":tree,"tool":"sh","args":["-c","printf launched > out"],
+                "actor":"local","cwd":"."}),
+        )
+        .await;
+    let id = error
+        .split("receipt_id=")
+        .nth(1)
+        .expect("refusal names its durable receipt")
+        .trim_end_matches(')');
+    let receipt = f.call("exec.receipt", json!({"id":id})).await;
+    assert_eq!(receipt["denied"], true, "{receipt}");
+    assert_eq!(receipt["success"], false, "{receipt}");
+    assert_eq!(receipt["decision"]["decision"], "allow", "{receipt}");
+    assert!(receipt["started_at"].is_null(), "{receipt}");
+    assert!(receipt["exit_code"].is_null(), "{receipt}");
+    assert!(receipt["tree_out"].is_null(), "{receipt}");
+    let reason = receipt["reason"]
+        .as_str()
+        .expect("preflight refusal reason");
+    assert!(reason.contains("no sandbox backend"), "{reason}");
+    assert!(reason.contains("/usr/bin/sandbox-exec"), "{reason}");
+    assert!(reason.contains(std::env::consts::OS), "{reason}");
+    assert!(
+        root_is_empty(&f),
+        "a run refused for the platform writes nothing to the exec root"
+    );
+}
+
+// Materialization is only reachable on a host that has a sandbox backend:
+// without one the run refuses in preflight, before any tree is written.
+#[cfg(target_os = "macos")]
 #[tokio::test]
 async fn run_materialize_symlink_failure_persists_receipt_and_cleans_up() {
     for keep in [false, true] {


### PR DESCRIPTION
`exec.run` launches every registered tool through the macOS seatbelt sandbox. On a host without `/usr/bin/sandbox-exec` the run used to get all the way through preflight, materialize a tree, render a profile, and only then fail at spawn with a missing-file error that named neither the platform nor the reason.

**What changes**

- `preflight` checks the sandbox backend last, after every more specific refusal. A host without one refuses with a named reason, writes its receipt like any other refusal, and leaves the exec root untouched.
- The check reads the backend's own dependency (`Path::exists`) rather than a compile-time target, so a macOS host that is missing `sandbox-exec` refuses for the same stated reason a Linux host does.
- The spawn site now uses the same `SANDBOX_EXEC` constant instead of a second literal.
- `exec.run(help=true)` states that the sandbox is macOS seatbelt only. ADR-181 already records this under Known rough edges; the verb surface did not.

**Acceptance**

- Two unit arms over `check_backend`: a path that does not exist refuses and the reason names the path, the platform and the sandbox; a path that does exist passes (positive control, so the refusal arm is about absence and not about the check).
- One verb-level arm gated to hosts without the backend: a valid run refuses, the error names its receipt, the stored receipt has `denied: true`, an `allow` decision, null `started_at`/`exit_code`/`tree_out`, a reason naming the missing backend and the platform, and the exec root is empty.
- The materialization-failure arm is macOS-only now. Without a backend, materialization is unreachable, so that arm's precondition is a host that has one; the macOS CI leg runs it.

Local gate on the branch head: `cargo fmt --all -- --check` clean, `cargo clippy -p khive-pack-exec --all-targets -- -D warnings` clean, `cargo test -p khive-pack-exec --no-fail-fast` 22 + 42 passed. The non-macOS arm was type-checked by temporarily widening its `cfg` and running `cargo test --no-run`.

Second half of #2541. The Linux sandbox backend itself is the other half and is not in this change.
