### PR TITLE
kg: registry rows are opaque to the generic entity verbs

### DIFF
--- a/crates/khive-pack-kg/src/handlers/update.rs
+++ b/crates/khive-pack-kg/src/handlers/update.rs
@@ -7,6 +7,9 @@ use khive_runtime::{
     EdgePatch, EntityPatch, NamespaceToken, NotePatch, RuntimeError, VerbRegistry,
 };
 
+use khive_types::entity::Entity;
+use khive_types::pack::PACK_REGISTRY_TAGS;
+
 use super::common::{
     description_patch, deser, immutable_event_error, normalize_entity_timestamps,
     optional_string_patch, parse_relation, resolve_kind_spec, resolve_uuid_unfiltered,
@@ -14,6 +17,29 @@ use super::common::{
     DeleteParams, KindSpec, UpdateParams,
 };
 use crate::KgPack;
+
+/// Refuse a write to a row a pack owns through its own registry.
+///
+/// The row's fields are policy inputs, not metadata: the tool registry's
+/// `source` names the binary a granted name resolves to, and `side_effect` is
+/// read at run time and handed to the policy decision. The check reads the
+/// row's CURRENT tags, so a patch that would strip the tag first is refused by
+/// the same rule rather than becoming the way around it.
+fn refuse_pack_registry_row(entity: &Entity, verb: &str) -> Result<(), RuntimeError> {
+    let Some(tag) = entity
+        .tags
+        .iter()
+        .find(|tag| PACK_REGISTRY_TAGS.contains(&tag.as_str()))
+    else {
+        return Ok(());
+    };
+    Err(RuntimeError::InvalidInput(format!(
+        "{verb} refuses {}: it is a registry row tagged {tag:?}, whose fields are policy inputs; \
+         the owning pack's own verbs are its only writer, and changing what a registered name \
+         means requires registering a new name",
+        entity.id
+    )))
+}
 
 // Field applicability guard, authoritative field sets per substrate — see
 // docs/api/note-crud-fields.md#reject_inapplicable_fields-handlersupdaters. MUST be updated
@@ -196,6 +222,7 @@ impl KgPack {
         match spec {
             KindSpec::Entity { specific } => {
                 let entity = self.runtime.get_entity(token, id).await?;
+                refuse_pack_registry_row(&entity, "update")?;
                 if let Some(k) = specific.as_ref() {
                     if entity.kind != *k {
                         return Err(RuntimeError::InvalidInput(format!(
@@ -359,17 +386,19 @@ impl KgPack {
 
         match spec {
             KindSpec::Entity { specific } => {
+                // Read the row before deciding: a registry row is refused here
+                // whether or not the caller named a kind, so the guard cannot
+                // be stepped around by omitting one.
+                let entity = if hard {
+                    self.runtime
+                        .get_entity_including_deleted(token, id)
+                        .await?
+                        .ok_or_else(|| RuntimeError::NotFound(format!("entity {}", p.id)))?
+                } else {
+                    self.runtime.get_entity(token, id).await?
+                };
+                refuse_pack_registry_row(&entity, "delete")?;
                 if let Some(ref expected) = specific {
-                    let entity = if hard {
-                        self.runtime
-                            .get_entity_including_deleted(token, id)
-                            .await?
-                            .ok_or_else(|| {
-                                RuntimeError::NotFound(format!("{} {}", expected, p.id))
-                            })?
-                    } else {
-                        self.runtime.get_entity(token, id).await?
-                    };
                     if entity.kind != *expected {
                         return Err(RuntimeError::InvalidInput(format!(
                             "kind mismatch: {} exists with kind '{}', not '{}'",

--- a/crates/khive-pack-kg/src/handlers/update.rs
+++ b/crates/khive-pack-kg/src/handlers/update.rs
@@ -7,7 +7,7 @@ use khive_runtime::{
     EdgePatch, EntityPatch, NamespaceToken, NotePatch, RuntimeError, VerbRegistry,
 };
 
-use khive_types::entity::Entity;
+use khive_storage::Entity;
 use khive_types::pack::PACK_REGISTRY_TAGS;
 
 use super::common::{

--- a/crates/khive-pack-tool/src/vocab.rs
+++ b/crates/khive-pack-tool/src/vocab.rs
@@ -8,8 +8,10 @@ use khive_types::{
 pub const PACK_NAME: &str = "tool";
 
 /// Tag carried by every registry object so listing and search can select
-/// the registry without a schema change.
-pub const REGISTRY_TAG: &str = "tool-registry";
+/// the registry without a schema change. Defined in the shared type crate
+/// because the generic entity verbs refuse to write a row that carries it,
+/// and one definition is what keeps the two sides from drifting apart.
+pub const REGISTRY_TAG: &str = khive_types::pack::TOOL_REGISTRY_TAG;
 
 /// Tag carried by every capability concept.
 pub const CAPABILITY_TAG: &str = "tool-capability";

--- a/crates/khive-pack-tool/tests/verbs.rs
+++ b/crates/khive-pack-tool/tests/verbs.rs
@@ -396,3 +396,91 @@ async fn self_grant_is_refused() {
     let granted = f.call("tool.grant", json!({"id": id2})).await;
     assert_eq!(granted["grant"]["status"], json!("granted"));
 }
+
+// Arm 10: a registry row is opaque to the generic entity verbs. `update` and
+// `delete` refuse a row whose current tags carry the registry tag, and the
+// refusal reads those tags before the write, so stripping the tag is itself
+// refused. The pack's own verbs are unaffected.
+#[tokio::test]
+async fn registry_rows_are_opaque_to_the_generic_entity_verbs() {
+    let f = fixture();
+    let registered = f
+        .call(
+            "tool.register",
+            json!({
+                "name": "fetch_url",
+                "side_effect": "read",
+                "trust": "first_party",
+                "source": "mcp:web@1",
+            }),
+        )
+        .await;
+    let id = s(&registered["tool"], "full_id");
+
+    // The measured hole: moving `properties.source` under a registered name.
+    let err = f
+        .call_err(
+            "update",
+            json!({"id": id, "properties": {"source": "mcp:evil@1"}}),
+        )
+        .await;
+    assert!(
+        err.contains("tool-registry"),
+        "the refusal names the tag it read: {err}"
+    );
+    assert!(
+        err.contains("registering a new name"),
+        "the refusal says what to do instead: {err}"
+    );
+
+    // Strip-then-edit: the strip is the same write, read against the same
+    // pre-write tags, so it is refused by the same rule.
+    let err = f.call_err("update", json!({"id": id, "tags": []})).await;
+    assert!(err.contains("tool-registry"), "{err}");
+
+    let err = f.call_err("delete", json!({"id": id})).await;
+    assert!(err.contains("tool-registry"), "{err}");
+    assert!(err.contains("delete refuses"), "{err}");
+
+    // Nothing moved: the row still answers with its registered source, and the
+    // pack's own verb still writes it.
+    let described = f.call("tool.describe", json!({"tool": "fetch_url"})).await;
+    assert_eq!(described["tool"]["source"], json!("mcp:web@1"));
+    let again = f
+        .call(
+            "tool.register",
+            json!({"name": "fetch_url", "capabilities": ["http"]}),
+        )
+        .await;
+    assert_eq!(again["created"], json!(false));
+    assert_eq!(again["tool"]["full_id"], json!(id));
+}
+
+// Arm 11 (control): the rule keys on the registry tag, not on the entity kind
+// or the pack that is loaded. An untagged entity of the same kind still
+// updates and still deletes.
+#[tokio::test]
+async fn an_untagged_entity_still_updates_and_deletes() {
+    let f = fixture();
+    let created = f
+        .call(
+            "create",
+            json!({"kind": "entity", "entity_kind": "project", "name": "ordinary", "properties": {"source": "before"}}),
+        )
+        .await;
+    let id = created["id"].as_str().expect("created id").to_string();
+
+    let updated = f
+        .call(
+            "update",
+            json!({"id": id, "properties": {"source": "after"}}),
+        )
+        .await;
+    assert_eq!(
+        updated["properties"]["source"],
+        json!("after"),
+        "an untagged entity is still writable by the generic verb: {updated}"
+    );
+    let deleted = f.call("delete", json!({"id": id})).await;
+    assert_eq!(deleted["deleted"], json!(true));
+}

--- a/crates/khive-pack-tool/tests/verbs.rs
+++ b/crates/khive-pack-tool/tests/verbs.rs
@@ -437,6 +437,12 @@ async fn registry_rows_are_opaque_to_the_generic_entity_verbs() {
     // pre-write tags, so it is refused by the same rule.
     let err = f.call_err("update", json!({"id": id, "tags": []})).await;
     assert!(err.contains("tool-registry"), "{err}");
+    let after_strip = f.call("tool.describe", json!({"tool": "fetch_url"})).await;
+    let tags = after_strip["tool"]["tags"].as_array().expect("tags");
+    assert!(
+        tags.contains(&json!("tool-registry")),
+        "the refusal is read before the write, so the tag is still there: {after_strip}"
+    );
 
     let err = f.call_err("delete", json!({"id": id})).await;
     assert!(err.contains("tool-registry"), "{err}");

--- a/crates/khive-pack-tool/tests/verbs.rs
+++ b/crates/khive-pack-tool/tests/verbs.rs
@@ -471,7 +471,7 @@ async fn an_untagged_entity_still_updates_and_deletes() {
     let created = f
         .call(
             "create",
-            json!({"kind": "entity", "entity_kind": "project", "name": "ordinary", "properties": {"source": "before"}}),
+            json!({"kind": "entity", "entity_kind": "project", "name": "ordinary", "tags": ["ordinary-tag"], "properties": {"source": "before"}}),
         )
         .await;
     let id = created["id"].as_str().expect("created id").to_string();
@@ -486,6 +486,11 @@ async fn an_untagged_entity_still_updates_and_deletes() {
         updated["properties"]["source"],
         json!("after"),
         "an untagged entity is still writable by the generic verb: {updated}"
+    );
+    assert_eq!(
+        updated["tags"],
+        json!(["ordinary-tag"]),
+        "a patch that names no tags leaves the row's tags alone: {updated}"
     );
     let deleted = f.call("delete", json!({"id": id})).await;
     assert_eq!(deleted["deleted"], json!(true));

--- a/crates/khive-types/src/pack.rs
+++ b/crates/khive-types/src/pack.rs
@@ -19,6 +19,27 @@ use crate::entity_type::EntityTypeDef;
 /// registry construction enforce one exact contract.
 pub const RESERVED_ENVELOPE_ARGS: &[&str] = &["presentation", "presentation_per_op"];
 
+/// Tag marking a `tool` pack registry object.
+///
+/// The value is on-disk data on every row the tool registry has ever minted,
+/// so it is not free to change.
+pub const TOOL_REGISTRY_TAG: &str = "tool-registry";
+
+/// Tags whose presence makes an entity a pack's registry row.
+///
+/// Such a row is not ordinary metadata: its fields are policy inputs. The
+/// tool registry's `source` names the binary a granted tool name resolves to,
+/// and `side_effect` is read at run time and handed to the policy decision, so
+/// a caller who can patch the row can change what a granted name does without
+/// registering anything. The generic entity verbs therefore refuse to write a
+/// row carrying one of these tags, including a patch that would remove the tag
+/// itself, and the owning pack's verbs are the only writer.
+///
+/// This is a list rather than a field allow-list on purpose: a list of
+/// protected properties goes stale the first time a pack adds a
+/// capability-bearing property, which is exactly how `side_effect` was missed.
+pub const PACK_REGISTRY_TAGS: &[&str] = &[TOOL_REGISTRY_TAG];
+
 /// Visibility tier for a handler.
 ///
 /// `Verb` entries appear on the MCP wire and are invokable by agents.


### PR DESCRIPTION
Closes #2547.

## The hole

A tool registry row's fields are policy inputs, not metadata. `properties.source` names what a granted tool name resolves to, and `properties.side_effect` is read at request time and handed to the policy decision. `tool.register` already refuses to move `source` on an existing row. The base `update` verb did not: a caller holding the row's id could point an already-granted name at something else, or lower its side-effect class, without registering anything and without a receipt that says a registration changed.

## The rule

`update` and `delete` refuse an entity whose tags carry a pack registry tag. The refusal names the tag it read and points at the owning pack's verbs:

```
update refuses <id>: it is a registry row tagged "tool-registry", whose fields are
policy inputs; the owning pack's own verbs are its only writer, and changing what a
registered name means requires registering a new name
```

Two properties are load-bearing:

- **The tags are read before the write.** A patch that would strip the tag first is refused by the same rule, so stripping is not the way around it. The acceptance arm asserts the tag is still on the row after the refused strip, and the mutation that moves the check after the write turns that arm red.
- **The rule keys on a list of tags, not a list of protected fields.** A field allow-list goes stale the first time a pack adds a capability-bearing property, which is exactly how `side_effect` was missed while `source` was being guarded. `PACK_REGISTRY_TAGS` in `khive-types` is the single definition; the tool pack's `REGISTRY_TAG` now points at it, so the pack that writes the tag and the verbs that refuse it cannot drift apart.

`delete` fetches the entity unconditionally now (it previously fetched only when a kind was named), because the tags have to be read before the row goes away.

## What is unchanged

`tool.register`, `tool.describe` and the rest of the pack's verbs write through the runtime directly and are unaffected. An entity without the tag still updates and still deletes; the control arm proves it, and it stays green under the mutation that no-ops the guard, so it isolates the rule rather than restating it.

## Acceptance

`cargo test -p khive-pack-tool` and `cargo test -p khive-pack-kg --no-fail-fast`, `cargo fmt --all --check`, `cargo clippy -p khive-pack-kg -p khive-pack-tool -p khive-types --all-targets -D warnings`, all clean on the pinned toolchain.

Two mutations, both confirmed:

| mutation | arm | result |
|---|---|---|
| the guard returns `Ok(())` unconditionally | `registry_rows_are_opaque_to_the_generic_entity_verbs` | red (`update unexpectedly succeeded`); control arm stays green |
| the guard moves after the entity write | same arm | red |

Both restored green after the patch was reverted, with the tree verified clean between runs.

Grants resolving on the tool id with the source digest pinned at grant time is the next step and is written up separately; this PR is the before-the-fact record, and the resolved source on the receipt is #2545.
