### PR TITLE
fix(exec): record the resolved tool source on the run receipt

### DIFF
--- a/crates/khive-pack-exec/src/handlers.rs
+++ b/crates/khive-pack-exec/src/handlers.rs
@@ -580,6 +580,7 @@ pub async fn run(
 struct Ready {
     binary: PathBuf,
     registered: String,
+    registry_id: Uuid,
     entries: Vec<TreeEntry>,
 }
 
@@ -656,6 +657,7 @@ async fn preflight(
     Ok(Ready {
         binary,
         registered,
+        registry_id: entity.id,
         entries,
     })
 }
@@ -819,6 +821,8 @@ async fn execute(
     receipt.sandbox = Some(json!({
         "profile_digest": profile_ref.as_str(),
         "tool_binary_digest": digest_hex(&binary_bytes),
+        "tool_source": format!("exec:{}", ready.registered),
+        "tool_registry_id": ready.registry_id.to_string(),
         "read_roots_digest": sandbox::read_roots_digest(&cfg.read_roots),
     }));
     receipt.profile_ref = Some(profile_ref.as_str().to_string());

--- a/crates/khive-pack-exec/src/vocab.rs
+++ b/crates/khive-pack-exec/src/vocab.rs
@@ -94,7 +94,7 @@ pub static EXEC_HANDLERS: [HandlerDef; 9] = [
     },
     HandlerDef {
         name: "exec.run",
-        description: "Run one registered tool over a materialized tree inside the seatbelt sandbox under tool.check; returns {receipt, changed}. Every refusal writes a receipt and names it in the error as receipt_id=<id>. New receipts always include limiting_resource: cpu_seconds | address_space | file_size | nproc | null. Only a directly waited SIGXCPU with cpu_seconds configured or SIGXFSZ with file_size configured names a resource; normal exits, other signals and timeout record null. Child ENOMEM/EAGAIN are not visible to the wrapper, so address_space and nproc remain null (and are refused at startup on macOS). Older stored receipts are unchanged. The sandbox is macOS seatbelt only: a host without /usr/bin/sandbox-exec refuses the call at startup and names the platform.",
+        description: "Run one registered tool over a materialized tree inside the seatbelt sandbox under tool.check; returns {receipt, changed}. Once the sandbox is prepared, sandbox.tool_source records the resolved registry exec:<absolute path> and sandbox.tool_registry_id its canonical row UUID, beside tool_binary_digest. These report the registration used, not a check against the caller's expected source; earlier failures keep sandbox null. Every refusal writes a receipt and names it in the error as receipt_id=<id>. New receipts always include limiting_resource: cpu_seconds | address_space | file_size | nproc | null. Only a directly waited SIGXCPU with cpu_seconds configured or SIGXFSZ with file_size configured names a resource; normal exits, other signals and timeout record null. Child ENOMEM/EAGAIN are not visible to the wrapper, so address_space and nproc remain null (and are refused at startup on macOS). Older stored receipts are unchanged. The sandbox is macOS seatbelt only: a host without /usr/bin/sandbox-exec refuses the call at startup and names the platform.",
         visibility: Visibility::Verb,
         category: VerbCategory::Directive,
         params: &[
@@ -112,7 +112,7 @@ pub static EXEC_HANDLERS: [HandlerDef; 9] = [
     },
     HandlerDef {
         name: "exec.receipt",
-        description: "Read one run receipt by id. New receipts always include limiting_resource: cpu_seconds | address_space | file_size | nproc | null. Only a directly waited SIGXCPU with cpu_seconds configured or SIGXFSZ with file_size configured names a resource; normal exits, other signals and timeout record null. Child ENOMEM/EAGAIN are not visible to the wrapper, so address_space and nproc remain null (and are refused at startup on macOS). Older stored receipts are unchanged.",
+        description: "Read one run receipt by id. New receipts whose sandbox was prepared include sandbox.tool_source (the resolved registry exec:<absolute path>) and sandbox.tool_registry_id (its canonical row UUID) beside tool_binary_digest; earlier failures keep sandbox null. New receipts always include limiting_resource: cpu_seconds | address_space | file_size | nproc | null. Only a directly waited SIGXCPU with cpu_seconds configured or SIGXFSZ with file_size configured names a resource; normal exits, other signals and timeout record null. Child ENOMEM/EAGAIN are not visible to the wrapper, so address_space and nproc remain null (and are refused at startup on macOS). Older stored receipts are unchanged.",
         visibility: Visibility::Verb,
         category: VerbCategory::Assertive,
         params: &[

--- a/crates/khive-pack-exec/tests/verbs.rs
+++ b/crates/khive-pack-exec/tests/verbs.rs
@@ -122,24 +122,26 @@ impl Fixture {
         String::from_utf8_lossy(&bytes).into_owned()
     }
 
-    async fn register_sh(&self, name: &str, decision: &str) {
-        self.call(
-            "tool.register",
-            json!({
-                "name": name,
-                "kind": "tool",
-                "description": "shell",
-                "source": "exec:/bin/sh",
-                "side_effect": "write",
-                "trust": "first_party",
-            }),
-        )
-        .await;
+    async fn register_sh(&self, name: &str, decision: &str) -> Value {
+        let registered = self
+            .call(
+                "tool.register",
+                json!({
+                    "name": name,
+                    "kind": "tool",
+                    "description": "shell",
+                    "source": "exec:/bin/sh",
+                    "side_effect": "write",
+                    "trust": "first_party",
+                }),
+            )
+            .await;
         self.call(
             "tool.policy",
             json!({ "actor": "*", "tool": name, "decision": decision }),
         )
         .await;
+        registered
     }
 }
 
@@ -1173,7 +1175,12 @@ async fn run_capture_read_failure_persists_failed_receipt_and_cleans_up() {
 #[tokio::test]
 async fn run_captures_output_changes_and_receipt() {
     let f = fixture();
-    f.register_sh("sh", "allow").await;
+    let registered = f.register_sh("sh", "allow").await;
+    let registry_id = registered["tool"]["full_id"].as_str().unwrap();
+    assert_eq!(
+        uuid::Uuid::parse_str(registry_id).unwrap().to_string(),
+        registry_id
+    );
     let tree = f
         .tree(&[
             ("modify", b"old", 644),
@@ -1232,12 +1239,15 @@ async fn run_captures_output_changes_and_receipt() {
     assert_eq!(receipt["stdout_capture"], "complete");
     assert!(receipt["stdout_produced_bytes"].as_u64().unwrap() > 0);
     assert_eq!(receipt["sandbox"]["profile_digest"], receipt["profile_ref"]);
+    assert_eq!(receipt["sandbox"]["tool_source"], "exec:/bin/sh");
+    assert_eq!(receipt["sandbox"]["tool_registry_id"], registry_id);
     let stored = f.call("exec.receipt", json!({ "id": receipt["id"] })).await;
     assert_eq!(&stored, receipt, "wire receipt equals the durable row");
     let runs = f
         .call("exec.runs", json!({ "actor": "local", "session_id": "s1" }))
         .await;
     assert_eq!(runs["count"], 1);
+    assert_eq!(&runs["runs"][0], receipt);
     let events = f
         .call("exec.events", json!({ "run_id": receipt["id"] }))
         .await;
@@ -1249,6 +1259,49 @@ async fn run_captures_output_changes_and_receipt() {
         .collect();
     assert_eq!(kinds, vec!["materialized", "launched", "exited"]);
     assert!(root_is_empty(&f));
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn run_receipt_reports_first_registration_when_name_is_taken() {
+    let f = fixture();
+    let first = f.register_sh("occupied", "allow").await;
+    assert_eq!(first["created"], true);
+    let second = f
+        .call(
+            "tool.register",
+            json!({
+                "name": "occupied", "kind": "tool", "source": "exec:/bin/echo",
+                "side_effect": "write", "trust": "first_party"
+            }),
+        )
+        .await;
+    assert_eq!(second["created"], false);
+    assert_eq!(second["tool"]["full_id"], first["tool"]["full_id"]);
+    assert_eq!(second["tool"]["source"], "exec:/bin/sh");
+    let tree = f.tree(&[]).await;
+    let out = f
+        .call(
+            "exec.run",
+            json!({
+                "tree": tree, "tool": "occupied", "actor": "local",
+                "args": ["-c", "printf source-witness"]
+            }),
+        )
+        .await;
+    let receipt = &out["receipt"];
+    assert_eq!(receipt["success"], true, "{receipt}");
+    assert_eq!(f.blob_text(&receipt["stdout_ref"]).await, "source-witness");
+    assert_eq!(receipt["sandbox"]["tool_source"], "exec:/bin/sh");
+    assert_eq!(
+        receipt["sandbox"]["tool_registry_id"],
+        first["tool"]["full_id"]
+    );
+    let stored = f.call("exec.receipt", json!({"id": receipt["id"]})).await;
+    assert_eq!(&stored, receipt);
+    let runs = f.call("exec.runs", json!({"actor": "local"})).await;
+    assert_eq!(runs["count"], 1);
+    assert_eq!(&runs["runs"][0], receipt);
 }
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
Closes #2545.

`exec.run` resolves a registered tool name to a binary through the registry and records `sandbox.tool_binary_digest`, the digest of the bytes that ran. A digest answers "was it these bytes" only for a caller who can independently produce the expected bytes at check time. It does not answer "was it the registration I declared", which is the question a caller with a declared tool set actually has.

The receipt now carries the resolved source beside the digest:

```json
"sandbox": {
  "profile_digest": "...",
  "tool_binary_digest": "...",
  "tool_source": "exec:/absolute/path",
  "tool_registry_id": "<registry row uuid>",
  "read_roots_digest": "..."
}
```

Both come from the same resolved entity the run used, so they describe the registration that ran rather than the one a caller read a moment earlier. That matters because `tool.register` is idempotent by name in the first-writer-wins direction: a second registration of a taken name reports success and its source is dropped. A caller can narrow that by reading `tool.describe` before the run, and a careful caller does, but the window between that read and the run stays open by construction. The receipt closes it after the fact.

The sibling before-the-fact record is #2550, which makes a registry row opaque to the generic `update` and `delete` verbs, so the row cannot be moved out from under a grant by those verbs while a run is in flight.

`exec.run`'s help names the two fields, since a receipt field nobody can find is not a record.

## Acceptance

`cargo fmt --all --check`, `cargo clippy -p khive-pack-exec --all-targets -D warnings`, and `cargo test -p khive-pack-exec --no-fail-fast` (22 unit, 43 integration) all clean on the pinned toolchain.

Mutation: removing the `tool_source` line turns `run_captures_output_changes_and_receipt` and `run_receipt_reports_first_registration_when_name_is_taken` red and leaves the other 41 integration arms green; restored green with the tree verified clean between runs. The second arm is the first-writer-wins case: register a name, register it again pointing elsewhere, run, and the receipt names the first registration.
