### PR TITLE
fix(ci): bound component benchmark phases and retain diagnostics

### DIFF
--- a/.github/workflows/bench-component.yml
+++ b/.github/workflows/bench-component.yml
@@ -14,11 +14,11 @@ on:
       timeout_minutes:
         description: >-
           Job timeout in minutes. Components whose bench-target compile is
-          heavier than the default budget (packs: ~16m compile alone) pass a
-          larger value so the Criterion step keeps its full 10-minute bound.
+          heavier than the default budget pass a larger value. Reserve ten
+          minutes for Criterion and five for setup, termination and publishing.
         required: false
         type: number
-        default: 20
+        default: 30
 
 env:
   CARGO_TERM_COLOR: always
@@ -47,16 +47,30 @@ jobs:
           key: component-${{ inputs.component }}
 
       - name: Compile-check this component's bench targets
+        id: compile
+        continue-on-error: true
         working-directory: crates
         env:
           COMPONENT_CRATES: ${{ inputs.crates }}
+          COMPONENT_JOB_MINUTES: ${{ inputs.timeout_minutes }}
         run: |
           set -euo pipefail
+          compile_seconds=$(( (COMPONENT_JOB_MINUTES - 15) * 60 ))
+          test "$compile_seconds" -gt 0
+          rm -rf target/criterion
           pkg_args=()
           for crate in $COMPONENT_CRATES; do pkg_args+=(-p "$crate"); done
-          cargo bench "${pkg_args[@]}" --all-targets --no-run
+          echo "phase=compile start=$(date -u +%FT%TZ) timeout_seconds=$compile_seconds" | tee -a ../component-phases.log
+          SECONDS=0
+          rc=0
+          timeout --kill-after=30s "$compile_seconds" cargo bench "${pkg_args[@]}" --benches --no-run || rc=$?
+          echo "phase=compile elapsed_seconds=$SECONDS exit_code=$rc" | tee -a ../component-phases.log
+          echo "exit_code=$rc" >> "$GITHUB_OUTPUT"
+          if [ "$rc" -ne 0 ]; then echo "::warning::Component compile failed or timed out (exit $rc)"; fi
+          exit "$rc"
 
       - name: Run Criterion benches (quick profile, bounded to 10 minutes)
+        if: steps.compile.outcome == 'success'
         working-directory: crates
         env:
           COMPONENT_CRATES: ${{ inputs.crates }}
@@ -66,7 +80,14 @@ jobs:
           set -euo pipefail
           pkg_args=()
           for crate in $COMPONENT_CRATES; do pkg_args+=(-p "$crate"); done
-          timeout 600 cargo bench "${pkg_args[@]}" --benches -- --quick || true
+          echo "phase=criterion start=$(date -u +%FT%TZ) timeout_seconds=600" | tee -a ../component-phases.log
+          SECONDS=0
+          rc=0
+          # Bound the whole pass, including every benchmark child. TERM alone
+          # can leave timeout waiting forever for a benchmark that ignores it.
+          timeout --kill-after=30s 600 cargo bench "${pkg_args[@]}" --benches -- --quick || rc=$?
+          echo "phase=criterion elapsed_seconds=$SECONDS exit_code=$rc" | tee -a ../component-phases.log
+          if [ "$rc" -ne 0 ]; then echo "::warning::Criterion pass failed or timed out (exit $rc); retaining partial estimates"; fi
 
       - name: Record component trend ledger entry
         id: record
@@ -93,7 +114,9 @@ jobs:
 
       - name: Write step summary
         if: always()
-        run: cat /tmp/components-trend.md >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
+        run: |
+          cat component-phases.log >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
+          cat /tmp/components-trend.md >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
 
       - name: Upload raw Criterion output
         if: always()
@@ -101,6 +124,7 @@ jobs:
         with:
           name: bench-track-${{ inputs.component }}-${{ github.run_id }}
           path: |
+            component-phases.log
             crates/target/criterion
             bench-data/components.jsonl
           retention-days: 90

--- a/.github/workflows/bench-track.yml
+++ b/.github/workflows/bench-track.yml
@@ -206,9 +206,8 @@ jobs:
     with:
       component: packs
       crates: khive-pack-gtd khive-pack-kg khive-pack-knowledge khive-pack-memory khive-pack-schedule
-      # The packs bench-target compile alone runs ~16m (issue #940); the
-      # default 20m budget killed the Criterion step mid-run on every main
-      # push and the ledger steps skipped, leaving the trend data packs-blind.
+      # Reserve 25 minutes for compilation, ten for Criterion, and five for
+      # setup, bounded termination and publishing even after a phase times out.
       timeout_minutes: 40
 
   # ─────────────────────────────────────────────────────────────────────────

--- a/scripts/tests/test_ci_workflows.py
+++ b/scripts/tests/test_ci_workflows.py
@@ -11,6 +11,7 @@ import shlex
 import subprocess
 import sys
 import tempfile
+import textwrap
 import unittest
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
@@ -159,6 +160,88 @@ class WasmtimeParityWorkflowTests(unittest.TestCase):
 
 
 class BenchTrackWorkflowTests(unittest.TestCase):
+    def test_component_phases_bound_children_and_report_raw_exit_codes(self):
+        workflow = workflow_text("bench-component.yml")
+        for phase, name, limit in [
+            ("compile", "Compile-check this component's bench targets", "1500"),
+            (
+                "criterion",
+                "Run Criterion benches (quick profile, bounded to 10 minutes)",
+                "600",
+            ),
+        ]:
+            step = workflow.split(f"      - name: {name}\n", 1)[1].split(
+                "      - name:", 1
+            )[0]
+            script = textwrap.dedent(step.split("        run: |\n", 1)[1])
+            for rc in (0, 124, 137):
+                with (
+                    self.subTest(phase=phase, rc=rc),
+                    tempfile.TemporaryDirectory() as tmp,
+                ):
+                    root = pathlib.Path(tmp)
+                    work = root / "crates"
+                    work.mkdir()
+                    bins = root / "bin"
+                    bins.mkdir()
+                    timeout = bins / "timeout"
+                    timeout.write_text(
+                        '#!/bin/sh\nprintf "%s\\n" "$@" > "$ARGV_LOG"\nexit "$FAKE_RC"\n'
+                    )
+                    timeout.chmod(0o755)
+                    output = root / "outputs"
+                    args = root / "args"
+                    env = {
+                        **os.environ,
+                        "PATH": f"{bins}:{os.environ['PATH']}",
+                        "COMPONENT_CRATES": "khive-pack-gtd khive-pack-kg",
+                        "COMPONENT_JOB_MINUTES": "40",
+                        "GITHUB_OUTPUT": str(output),
+                        "ARGV_LOG": str(args),
+                        "FAKE_RC": str(rc),
+                    }
+                    result = subprocess.run(
+                        ["bash", "-c", script],
+                        cwd=work,
+                        env=env,
+                        capture_output=True,
+                        text=True,
+                        timeout=5,
+                        check=False,
+                    )
+                    self.assertEqual(
+                        result.returncode,
+                        rc if phase == "compile" else 0,
+                        result.stderr,
+                    )
+                    argv = args.read_text().splitlines()
+                    self.assertEqual(
+                        argv[:4], ["--kill-after=30s", limit, "cargo", "bench"]
+                    )
+                    self.assertIn("--benches", argv)
+                    self.assertNotIn("--all-targets", argv)
+                    log = (root / "component-phases.log").read_text()
+                    self.assertIn(f"phase={phase} start=", log)
+                    self.assertRegex(
+                        log, rf"phase={phase} elapsed_seconds=\d+ exit_code={rc}"
+                    )
+                    if rc:
+                        self.assertIn("::warning::", result.stdout)
+                    if phase == "compile":
+                        self.assertEqual(output.read_text(), f"exit_code={rc}\n")
+
+    def test_component_compile_failure_still_reaches_diagnostics(self):
+        workflow = workflow_text("bench-component.yml")
+        compile_step = workflow.split("      - name: Compile-check", 1)[1].split(
+            "      - name:", 1
+        )[0]
+        self.assertIn("id: compile", compile_step)
+        self.assertIn("continue-on-error: true", compile_step)
+        self.assertIn("if: steps.compile.outcome == 'success'", workflow)
+        self.assertIn("cat component-phases.log", workflow)
+        self.assertIn("            component-phases.log", workflow)
+        self.assertIn("default: 30", workflow)
+
     def test_component_runner_limits_quick_flag_to_bench_targets(self):
         workflow = workflow_text("bench-component.yml")
         bench_commands = [


### PR DESCRIPTION
Closes #2514.

The packs Criterion quick profile was cancelled by its job budget on every run, so the component whose benches most need bounding produced no measurement at all and no diagnosis of why.

Three changes:

1. **The compile phase gets its own bound, derived from the job budget.** `compile_seconds = (job_minutes - 15) * 60`, so fifteen minutes stay reserved for the Criterion pass, termination and publishing. A caller passing a budget of fifteen minutes or less fails the step immediately rather than silently leaving zero seconds for the bench.
2. **Every timeout gets a KILL grace.** `timeout --kill-after=30s` on both phases. TERM alone can leave `timeout` waiting on a benchmark child that ignores it, which is a bounded step that does not end.
3. **A phase log survives whatever happens.** Each phase records its start, elapsed seconds and exit code to `component-phases.log`, the compile step is `continue-on-error` with its outcome gating the bench step, and a failed or timed-out phase emits a warning instead of vanishing. The trend ledger and artifacts are retained either way.

The default job budget moves from 20 to 30 minutes; packs keeps its 40.

One deliberate narrowing, stated because it is a scope reduction: the compile check runs `cargo bench --benches --no-run` rather than `--all-targets --no-run`, so it now compiles what the bench step actually runs. The wider form was covering nothing in practice, since the job was cancelled before reaching the bench.

## Acceptance

`scripts/tests/test_ci_workflows.py`: 37 tests, 69 subtests, all passing, run twice.

Mutation: removing the KILL grace from the bench timeout turns all three new exit-code arms red while two class controls stay green.
