### PR TITLE
fix(kkernel): report empty graphs in validation summaries

### DIFF
--- a/crates/kkernel/docs/kg-rules.md
+++ b/crates/kkernel/docs/kg-rules.md
@@ -57,6 +57,12 @@ Seven structural checks run unconditionally before configurable rules and cannot
 
 When `notes.ndjson` is present, an eighth **valid note kinds** check runs at `error` severity against the note-kind taxonomy merged from all registered packs. The optional file's absence does not add that rule to the report.
 
+The JSON summary includes `empty`: true when no nonblank records were read from entities,
+edges, or optional notes. This is independent of `passed`: readable empty inputs are
+structurally valid, while missing or unreadable inputs still fail validation. Consumers
+requiring a nonempty graph should also check `summary.empty`. Text output labels an empty
+graph in the summary, and GitHub output emits a notice.
+
 ## CLI Options
 
 ```

--- a/crates/kkernel/src/kg/types.rs
+++ b/crates/kkernel/src/kg/types.rs
@@ -449,6 +449,7 @@ pub struct ValidationSummary {
     pub info: usize,
     pub entities: usize,
     pub edges: usize,
+    pub empty: bool,
     pub passed: bool,
 }
 

--- a/crates/kkernel/src/kg/validate.rs
+++ b/crates/kkernel/src/kg/validate.rs
@@ -127,6 +127,7 @@ pub(super) fn cmd_validate(args: ValidateArgs) -> Result<()> {
 
     let entities = count_ndjson_lines(&entities_path).unwrap_or(0);
     let edges = count_ndjson_lines(&edges_path).unwrap_or(0);
+    let notes = count_ndjson_lines(&notes_path).unwrap_or(0);
 
     let rules_path = args.rules.unwrap_or_else(|| kg_dir.join("rules.toml"));
 
@@ -165,6 +166,7 @@ pub(super) fn cmd_validate(args: ValidateArgs) -> Result<()> {
         info,
         entities,
         edges,
+        empty: entities == 0 && edges == 0 && notes == 0,
         passed,
     };
 
@@ -2010,13 +2012,17 @@ fn print_text_format(report: &ValidationReport, verbose: bool, quiet: bool) {
         }
     }
     let s = &report.summary;
+    let empty = if s.empty { "; empty graph" } else { "" };
     println!(
-        "\nSummary: {} error(s), {} warning(s), {} entities, {} edges",
+        "\nSummary: {} error(s), {} warning(s), {} entities, {} edges{empty}",
         s.errors, s.warnings, s.entities, s.edges
     );
 }
 
 fn print_github_format(report: &ValidationReport) {
+    if report.summary.empty {
+        println!("::notice ::Empty graph: no entity, edge, or note records read");
+    }
     for r in &report.rules {
         for v in &r.violations {
             let level = if r.severity == "error" {

--- a/crates/kkernel/tests/kg_validate_empty_graph.rs
+++ b/crates/kkernel/tests/kg_validate_empty_graph.rs
@@ -1,0 +1,125 @@
+//! Empty input must be explicit without rejecting valid graphs with no edges.
+
+use std::process::{Command, Output};
+
+use serde_json::{json, Value};
+use tempfile::TempDir;
+
+fn fixture(entities: &str, edges: &str, notes: Option<&str>) -> TempDir {
+    let tmp = TempDir::new().expect("create private fixture");
+    let kg_dir = tmp.path().join(".khive/kg");
+    std::fs::create_dir_all(&kg_dir).expect("create KG directory");
+    std::fs::write(kg_dir.join("entities.ndjson"), entities).expect("write entities");
+    std::fs::write(kg_dir.join("edges.ndjson"), edges).expect("write edges");
+    if let Some(notes) = notes {
+        std::fs::write(kg_dir.join("notes.ndjson"), notes).expect("write notes");
+    }
+    tmp
+}
+
+fn validate(tmp: &TempDir, format: &str, extra: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_kkernel"))
+        .args(["kg", "validate", "--repo"])
+        .arg(tmp.path())
+        .args(["--format", format, "--no-rules"])
+        .args(extra)
+        .output()
+        .expect("run validator against private fixture")
+}
+
+fn report(output: &Output) -> Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON report: {error}; stdout={}, stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
+}
+
+#[test]
+fn kg_validate_marks_zero_record_inputs_empty_even_in_strict_mode() {
+    for (entities, edges, notes) in [("", "", None), (" \n\t\n", "\r\n ", Some("\n\t"))] {
+        let tmp = fixture(entities, edges, notes);
+        for extra in [&[][..], &["--strict"][..]] {
+            let output = validate(&tmp, "json", extra);
+            let report = report(&output);
+            assert!(output.status.success(), "{report}");
+            assert_eq!(report["summary"]["passed"], true);
+            assert_eq!(report["summary"]["empty"], true);
+            assert_eq!(report["summary"]["entities"], 0);
+            assert_eq!(report["summary"]["edges"], 0);
+            assert!(report["rules"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .all(|rule| rule["passed"] == true));
+        }
+    }
+}
+
+#[test]
+fn kg_validate_entity_only_and_note_only_graphs_are_nonempty() {
+    let entity = json!({
+        "id": "11111111-1111-1111-1111-111111111111",
+        "kind": "concept",
+        "name": "Private fixture entity"
+    })
+    .to_string();
+    let note = json!({
+        "id": "22222222-2222-2222-2222-222222222222",
+        "kind": "observation",
+        "content": "Private fixture note"
+    })
+    .to_string();
+
+    for (entities, notes, entity_count) in
+        [(entity.as_str(), None, 1), ("", Some(note.as_str()), 0)]
+    {
+        let tmp = fixture(entities, "", notes);
+        let output = validate(&tmp, "json", &["--strict"]);
+        let report = report(&output);
+        assert!(output.status.success(), "{report}");
+        assert_eq!(report["summary"]["passed"], true);
+        assert_eq!(report["summary"]["empty"], false);
+        assert_eq!(report["summary"]["entities"], entity_count);
+        assert_eq!(report["summary"]["edges"], 0);
+    }
+}
+
+#[test]
+fn kg_validate_nonempty_invalid_edges_remain_failed_and_nonempty() {
+    let edge = json!({
+        "source": "11111111-1111-1111-1111-111111111111",
+        "target": "22222222-2222-2222-2222-222222222222",
+        "relation": "extends"
+    })
+    .to_string();
+    for edges in [edge.as_str(), "malformed NDJSON\n"] {
+        let tmp = fixture("", edges, None);
+        let output = validate(&tmp, "json", &[]);
+        let report = report(&output);
+        assert_eq!(output.status.code(), Some(1), "{report}");
+        assert_eq!(report["summary"]["passed"], false);
+        assert_eq!(report["summary"]["empty"], false);
+        assert_eq!(report["summary"]["edges"], 1);
+    }
+}
+
+#[test]
+fn kg_validate_reports_empty_graph_in_text_quiet_and_github_formats() {
+    let tmp = fixture("", "", None);
+    for extra in [&[][..], &["--quiet"][..]] {
+        let output = validate(&tmp, "text", extra);
+        assert!(output.status.success());
+        let stdout = String::from_utf8(output.stdout).expect("text output");
+        assert!(stdout.contains("; empty graph"), "{stdout}");
+    }
+
+    let output = validate(&tmp, "github", &[]);
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("GitHub output"),
+        "::notice ::Empty graph: no entity, edge, or note records read\n"
+    );
+}

--- a/docs/adr/ADR-034-kg-validation-pipelines.md
+++ b/docs/adr/ADR-034-kg-validation-pipelines.md
@@ -12,6 +12,20 @@ valid UTF-8. `notes.ndjson` remains optional when absent, but a present notes pa
 readable UTF-8. Even where a downstream rule skips an unreadable file, the unconditional
 structural rule ensures that an input read failure cannot produce a passing aggregate report.
 
+## Amendment (2026-09-10): explicit empty-graph summary
+
+The validation summary includes `empty`, which is true when zero nonblank NDJSON lines were
+read across `entities.ndjson`, `edges.ndjson`, and optional `notes.ndjson`. Empty and
+whitespace-only inputs therefore report `empty: true`; an entity-only or note-only graph is
+nonempty even when `edges.ndjson` has no records. Malformed nonblank lines still count as
+input records and fail schema validation. Unreadable inputs contribute no counted records
+and still fail `required-input-files`; `empty` does not imply that every input was readable.
+
+This is a content signal independent of `passed` and the exit code. Readable zero-record
+inputs remain structurally valid, including under `--strict`, while consumers requiring a
+nonempty graph can check `summary.empty` explicitly. Text output labels an empty graph in
+the summary (including `--quiet`), and GitHub output emits an empty-graph notice.
+
 ## Context
 
 [ADR-020](ADR-020-git-native-kg-implementation.md) introduced `kkernel kg validate` to guard the
@@ -241,18 +255,20 @@ decorative UI elements — they appear in terminal output and log files alike.
     "info": 0,
     "entities": 420,
     "edges": 1100,
+    "empty": false,
     "passed": true
   }
 }
 ```
 
 `summary.passed` is `true` when `errors == 0`. With `--strict`, `passed` is `true` only
-when `errors == 0 && warnings == 0`.
+when `errors == 0 && warnings == 0`. `summary.empty` reports the absence of nonblank input
+records independently of this validation verdict.
 
 #### GitHub Actions (`--format github`)
 
 Emits `::error file=...::` and `::warning file=...::` annotations so violations surface
-inline in the PR diff view. No output for passing rules.
+inline in the PR diff view. Passing rules emit no violations; an empty graph emits a notice.
 
 ### 6. Exit codes
 


### PR DESCRIPTION
Closes #2510.

`kkernel kg validate` reported a graph with no records as clean, which is the correct verdict and the wrong signal: a pipeline whose export step silently produced nothing got a passing report and no way to tell that case from a real graph that passed.

`summary.empty` is now true when zero nonblank NDJSON lines were read across `entities.ndjson`, `edges.ndjson` and the optional `notes.ndjson`. It is a content signal, independent of `passed` and of the exit code:

- Readable zero-record inputs stay structurally valid, including under `--strict`. Nothing that passed before now fails.
- An entity-only or note-only graph is nonempty, even when `edges.ndjson` has no records.
- Malformed nonblank lines still count as records and still fail schema validation.
- Unreadable inputs contribute no counted records and still fail `required-input-files`, so `empty` never implies that every input was readable.

Text output labels an empty graph in the summary line, including under `--quiet`, and `--format github` emits a notice. A consumer that requires a nonempty graph checks `summary.empty` rather than inferring it from a count.

ADR-034 carries the amendment, since the JSON summary is a published surface.

## Acceptance

Eight focused tests covering the empty case, the whitespace-only case, entity-only and note-only nonempty cases, the malformed-line case, and both output formats' labels. All green, and green again after the mutation was reverted.

Mutation: forcing `empty` to false turns the two empty-graph regressions red while the nonempty tests and four existing validation controls stay green.

Note for review: this amends an accepted ADR, so it merges after sign-off rather than on CI alone.
