### PR TITLE
fix(git): bound the digest page fetch by the remaining budget

### DIFF
--- a/crates/khive-pack-git/docs/api/ingest.md
+++ b/crates/khive-pack-git/docs/api/ingest.md
@@ -362,13 +362,21 @@ returns more than this many results for a single query regardless of
 `--limit` — paging works around that ceiling by advancing an `updated:>=`
 floor between calls, not by requesting more than one page can hold.
 
+Each fetch requests the remaining fresh-record visit budget, capped at
+`PAGE_LIMIT`, rather than always requesting 1,000 rows. The limit additionally
+reserves room for exact acknowledged records at the queried inclusive floor and
+for undated acknowledgments, still under the same 1,000-row cap. Those records
+are replayed without spending the visit budget; omitting their allowance would
+strand a `max_items=1` resume behind an already acknowledged timestamp tie.
+An unbounded admin-ingest budget keeps the full page cap.
+
 `PageOutcome` is pure and unit-testable independent of `gh`, the database,
 or async machinery — the entire "was the remote window proven exhausted"
 decision lives here (ADR-088 Amendment 1): a single hard-coded `--limit
 1000` fetch could previously report `done: true` while a repo's remaining
 PRs/issues past position 1000 were never seen.
 
-- `WindowComplete`: the page held fewer than `PAGE_LIMIT` items — the
+- `WindowComplete`: the page held fewer than the actual requested limit — the
   remote window is proven exhausted regardless of local budget state.
 - `StopBudgetExhausted`: the page was full and the local budget is
   exhausted — stop paging, but the window is NOT proven exhausted.
@@ -381,7 +389,9 @@ PRs/issues past position 1000 were never seen.
 
 Only `WindowComplete` lets `done` stay `true` on the local-budget question
 alone; every other outcome means more remote records may exist past the
-last fetched page.
+last fetched page. In particular, a full reduced page does not prove exhaustion
+just because it holds fewer than 1,000 records. The remaining budget and replay
+allowance are recomputed before every subsequent fetch.
 
 ## `ingest_prs` / `ingest_issues` cursor semantics
 

--- a/crates/khive-pack-git/src/ingest.rs
+++ b/crates/khive-pack-git/src/ingest.rs
@@ -2677,12 +2677,29 @@ fn gh_json(repo: &Path, gh_repo: &str, args: &[&str]) -> Result<String> {
 /// crates/khive-pack-git/docs/api/ingest.md#paging-pageoutcome-decide_page_outcome-page_limit.
 const PAGE_LIMIT: usize = 1000;
 
+fn page_fetch_limit(budget: &Budget, checkpoint: &PageCheckpoint, floor: Option<&str>) -> usize {
+    let Some(remaining) = budget.remaining else {
+        return PAGE_LIMIT;
+    };
+    // Inclusive queries replay acknowledged rows for free. Reserve room for
+    // those rows so even a one-visit budget can reach an unseen timestamp tie.
+    let boundary_replays = if checkpoint.floor.as_deref() == floor {
+        checkpoint.at_floor.len()
+    } else {
+        0
+    };
+    (remaining.min(PAGE_LIMIT as u64) as usize)
+        .saturating_add(boundary_replays)
+        .saturating_add(checkpoint.undated.len())
+        .min(PAGE_LIMIT)
+}
+
 /// What a paging loop should do after processing one fetched page — the
 /// entire "was the remote window proven exhausted" decision lives here. See
 /// crates/khive-pack-git/docs/api/ingest.md#paging-pageoutcome-decide_page_outcome-page_limit.
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum PageOutcome {
-    /// Page held fewer than `PAGE_LIMIT` items: remote window proven exhausted.
+    /// Page held fewer than the requested limit: remote window proven exhausted.
     WindowComplete,
     /// Page was full and the local budget is exhausted: stop, not proven exhausted.
     StopBudgetExhausted,
@@ -2694,11 +2711,12 @@ enum PageOutcome {
 
 fn decide_page_outcome(
     page_len: usize,
+    requested_limit: usize,
     current_floor: Option<&str>,
     last_updated_at: Option<&str>,
     budget_exhausted: bool,
 ) -> PageOutcome {
-    if page_len < PAGE_LIMIT {
+    if page_len < requested_limit {
         return PageOutcome::WindowComplete;
     }
     if budget_exhausted {
@@ -2727,8 +2745,14 @@ const PR_FIELDS: &str = "number,title,author,createdAt,mergedAt,closedAt,updated
 const ISSUE_FIELDS: &str =
     "number,title,author,createdAt,closedAt,updatedAt,labels,stateReason,body";
 
-fn fetch_pr_page(repo: &Path, gh_repo: &str, floor: Option<&str>) -> Result<Vec<GhPr>> {
+fn fetch_pr_page(
+    repo: &Path,
+    gh_repo: &str,
+    floor: Option<&str>,
+    limit: usize,
+) -> Result<Vec<GhPr>> {
     let search = search_query(floor);
+    let limit = limit.to_string();
     let raw = gh_json(
         repo,
         gh_repo,
@@ -2740,7 +2764,7 @@ fn fetch_pr_page(repo: &Path, gh_repo: &str, floor: Option<&str>) -> Result<Vec<
             "--search",
             search.as_str(),
             "--limit",
-            "1000",
+            &limit,
             "--json",
             PR_FIELDS,
         ],
@@ -2748,8 +2772,14 @@ fn fetch_pr_page(repo: &Path, gh_repo: &str, floor: Option<&str>) -> Result<Vec<
     serde_json::from_str(&raw).context("parsing gh pr list --json")
 }
 
-fn fetch_issue_page(repo: &Path, gh_repo: &str, floor: Option<&str>) -> Result<Vec<GhIssue>> {
+fn fetch_issue_page(
+    repo: &Path,
+    gh_repo: &str,
+    floor: Option<&str>,
+    limit: usize,
+) -> Result<Vec<GhIssue>> {
     let search = search_query(floor);
+    let limit = limit.to_string();
     let raw = gh_json(
         repo,
         gh_repo,
@@ -2761,7 +2791,7 @@ fn fetch_issue_page(repo: &Path, gh_repo: &str, floor: Option<&str>) -> Result<V
             "--search",
             search.as_str(),
             "--limit",
-            "1000",
+            &limit,
             "--json",
             ISSUE_FIELDS,
         ],
@@ -2890,7 +2920,8 @@ async fn ingest_prs(
         // leaving the loop before the window completes IS stopping early,
         // and the arms below specialize the reason when they fire.
         let first_page = report.sources.pull_requests.is_none();
-        let page = match fetch_pr_page(repo, gh_repo, floor.as_deref()) {
+        let requested_limit = page_fetch_limit(budget, &checkpoint, floor.as_deref());
+        let page = match fetch_pr_page(repo, gh_repo, floor.as_deref(), requested_limit) {
             Ok(page) => {
                 if first_page {
                     report.sources.pull_requests = Some(IngestSourceState::StoppedEarly(
@@ -3061,6 +3092,7 @@ async fn ingest_prs(
         write_page_checkpoint(runtime, project_id, "prs", &checkpoint).await?;
         match decide_page_outcome(
             page_len,
+            requested_limit,
             floor.as_deref(),
             last_updated_at.as_deref(),
             budget.exhausted(),
@@ -3169,7 +3201,8 @@ async fn ingest_issues(
         // the walk-start marker also pre-seeds the stopped-early state that
         // leaving the loop early implies.
         let first_page = report.sources.issues.is_none();
-        let page = match fetch_issue_page(repo, gh_repo, floor.as_deref()) {
+        let requested_limit = page_fetch_limit(budget, &checkpoint, floor.as_deref());
+        let page = match fetch_issue_page(repo, gh_repo, floor.as_deref(), requested_limit) {
             Ok(page) => {
                 if first_page {
                     report.sources.issues = Some(IngestSourceState::StoppedEarly(
@@ -3336,6 +3369,7 @@ async fn ingest_issues(
         write_page_checkpoint(runtime, project_id, "issues", &checkpoint).await?;
         match decide_page_outcome(
             page_len,
+            requested_limit,
             floor.as_deref(),
             last_updated_at.as_deref(),
             budget.exhausted(),
@@ -3408,15 +3442,46 @@ mod paging_tests {
     }
 
     #[test]
+    fn fetch_limit_reserves_only_replayed_boundaries_and_caps_unbounded_budgets() {
+        let mut checkpoint = PageCheckpoint::new("local", Some("A".into()));
+        let budget = Budget { remaining: Some(1) };
+        assert_eq!(page_fetch_limit(&budget, &checkpoint, Some("A")), 1);
+        checkpoint.at_floor.insert(10, Uuid::nil());
+        checkpoint.at_floor.insert(20, Uuid::nil());
+        checkpoint.undated.insert(30, Uuid::nil());
+        assert_eq!(page_fetch_limit(&budget, &checkpoint, Some("A")), 4);
+        assert_eq!(page_fetch_limit(&budget, &checkpoint, Some("B")), 2);
+        for remaining in [None, Some(2000), Some(u64::MAX)] {
+            assert_eq!(
+                page_fetch_limit(&Budget { remaining }, &checkpoint, Some("A")),
+                PAGE_LIMIT
+            );
+        }
+    }
+
+    #[test]
+    fn a_full_reduced_page_does_not_prove_remote_exhaustion() {
+        assert_eq!(
+            decide_page_outcome(1, 1, None, Some("A"), true),
+            PageOutcome::StopBudgetExhausted
+        );
+        assert_eq!(
+            decide_page_outcome(2, 3, Some("A"), Some("A"), false),
+            PageOutcome::WindowComplete
+        );
+    }
+
+    #[test]
     fn short_page_proves_window_complete_regardless_of_budget() {
-        let outcome = decide_page_outcome(42, None, Some("2024-01-01T00:00:00Z"), false);
+        let outcome =
+            decide_page_outcome(42, PAGE_LIMIT, None, Some("2024-01-01T00:00:00Z"), false);
         assert_eq!(outcome, PageOutcome::WindowComplete);
         assert!(page_outcome_proves_window_complete(outcome));
 
         // Even a page that runs out of budget mid-way is still a proof of
         // completeness if the page itself was short — the loop always
         // finishes sorting/processing the whole (short) page first.
-        let outcome = decide_page_outcome(0, None, None, true);
+        let outcome = decide_page_outcome(0, PAGE_LIMIT, None, None, true);
         assert_eq!(outcome, PageOutcome::WindowComplete);
     }
 
@@ -3428,28 +3493,28 @@ mod paging_tests {
     /// not proven exhausted just because the local budget wasn't hit.
     #[test]
     fn full_page_with_stalled_floor_is_not_window_complete_even_with_budget_left() {
-        let outcome = decide_page_outcome(PAGE_LIMIT, Some("X"), Some("X"), false);
+        let outcome = decide_page_outcome(PAGE_LIMIT, PAGE_LIMIT, Some("X"), Some("X"), false);
         assert_eq!(outcome, PageOutcome::StopFloorStalled);
         assert!(!page_outcome_proves_window_complete(outcome));
     }
 
     #[test]
     fn full_page_with_advancing_floor_and_budget_left_continues() {
-        let outcome = decide_page_outcome(PAGE_LIMIT, Some("A"), Some("B"), false);
+        let outcome = decide_page_outcome(PAGE_LIMIT, PAGE_LIMIT, Some("A"), Some("B"), false);
         assert_eq!(outcome, PageOutcome::Continue("B".to_string()));
         assert!(!page_outcome_proves_window_complete(outcome));
     }
 
     #[test]
     fn full_page_with_exhausted_budget_stops_without_proving_completeness() {
-        let outcome = decide_page_outcome(PAGE_LIMIT, Some("A"), Some("B"), true);
+        let outcome = decide_page_outcome(PAGE_LIMIT, PAGE_LIMIT, Some("A"), Some("B"), true);
         assert_eq!(outcome, PageOutcome::StopBudgetExhausted);
         assert!(!page_outcome_proves_window_complete(outcome));
     }
 
     #[test]
     fn full_page_with_no_updated_at_stalls_rather_than_looping_forever() {
-        let outcome = decide_page_outcome(PAGE_LIMIT, Some("A"), None, false);
+        let outcome = decide_page_outcome(PAGE_LIMIT, PAGE_LIMIT, Some("A"), None, false);
         assert_eq!(outcome, PageOutcome::StopFloorStalled);
     }
 }

--- a/crates/khive-pack-git/tests/acceptance.rs
+++ b/crates/khive-pack-git/tests/acceptance.rs
@@ -32,6 +32,8 @@ use uuid::Uuid;
 
 #[path = "support/digest_commit_resume.rs"]
 mod digest_commit_resume;
+#[path = "support/digest_fetch_budget.rs"]
+mod digest_fetch_budget;
 #[path = "support/digest_resume.rs"]
 mod digest_resume;
 #[path = "support/digest_scale.rs"]

--- a/crates/khive-pack-git/tests/support/digest_fetch_budget.rs
+++ b/crates/khive-pack-git/tests/support/digest_fetch_budget.rs
@@ -1,0 +1,399 @@
+//! Issue #2520: remote fetch work follows the remaining record-visit budget.
+use super::*;
+use khive_pack_git::ingest::IngestSourceState;
+use std::collections::BTreeSet;
+
+const TIE: &str = "2026-01-01T00:00:01Z";
+const LATER: &str = "2026-01-01T00:00:02Z";
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+fn write_budgeted_gh(repo: &Path, bin: &Path, logs: &Path, prs: &[Value], issues: &[Value]) {
+    write_fake_gh(repo, bin, logs, "[]", "[]");
+    let mut arms = String::new();
+    for (kind, records) in [("pr", prs), ("issue", issues)] {
+        let mut rows = records.to_vec();
+        // Preserve remote order inside a timestamp tie: local number sorting
+        // must not turn that ordering into a numeric high-water predicate.
+        rows.sort_by(|a, b| a["updatedAt"].as_str().cmp(&b["updatedAt"].as_str()));
+        let file = logs.join(format!("{kind}.jsonl"));
+        let body = rows
+            .iter()
+            .map(|row| format!("{row}\n"))
+            .collect::<String>();
+        std::fs::write(&file, body).unwrap();
+        let undated = rows
+            .iter()
+            .take_while(|row| row["updatedAt"].is_null())
+            .count();
+        let floors: BTreeSet<_> = std::iter::once("")
+            .chain(rows.iter().filter_map(|row| row["updatedAt"].as_str()))
+            .collect();
+        for floor in floors {
+            let first = rows
+                .iter()
+                .position(|row| row["updatedAt"].as_str().is_some_and(|date| date >= floor))
+                .unwrap_or(rows.len())
+                + 1;
+            let search = if floor.is_empty() {
+                "sort:updated-asc".to_owned()
+            } else {
+                format!("sort:updated-asc updated:>={floor}")
+            };
+            arms.push_str(&format!(
+                "  {}) file={}; first={first}; undated={undated} ;;\n",
+                shell_quote(&format!("{kind}|{search}")),
+                shell_quote(file.to_str().unwrap())
+            ));
+        }
+    }
+    let script = format!(
+        r#"#!/bin/sh
+set -eu
+if [ "$1" = repo ]; then
+  [ "$2" = view ] && [ "$3" = fixture/repository ] || exit 2
+  printf '%s\n' '{{"nameWithOwner":"fixture/repository","url":"https://github.com/fixture/repository"}}'
+  exit 0
+fi
+kind="$1"
+[ "$2" = list ] || exit 3
+search= repo= limit=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --search) search="$2"; shift ;;
+    --repo) repo="$2"; shift ;;
+    --limit) limit="$2"; shift ;;
+  esac
+  shift
+done
+[ "$repo" = fixture/repository ] || exit 4
+[ "$limit" -ge 1 ] && [ "$limit" -le 1000 ] || exit 5
+printf '%s %s %s\n' "$kind" "$limit" "$search" >> {log}
+case "$kind|$search" in
+{arms}  *) exit 6 ;;
+esac
+printf '['
+if [ "$limit" -le "$undated" ]; then
+  sed -n "1,${{limit}}p" "$file"
+else
+  if [ "$undated" -gt 0 ]; then
+    sed -n "1,${{undated}}p" "$file"
+  fi
+  sed -n "${{first}},$((first + limit - undated - 1))p" "$file"
+fi | paste -sd, -
+printf ']\n'
+"#,
+        log = shell_quote(logs.join("fetches.log").to_str().unwrap())
+    );
+    std::fs::write(bin.join("gh"), script).unwrap();
+}
+
+fn remote_fixture(
+    prs: &[Value],
+    issues: &[Value],
+) -> (tempfile::TempDir, PathBuf, PathBuf, PathBuf, PathGuard) {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = dir.path().join("repo");
+    let bin = dir.path().join("bin");
+    let logs = dir.path().join("logs");
+    for path in [&repo, &bin, &logs] {
+        std::fs::create_dir(path).unwrap();
+    }
+    init_repo(&repo);
+    write_budgeted_gh(&repo, &bin, &logs, prs, issues);
+    let guard = PathGuard::install(&bin);
+    (dir, repo, bin, logs, guard)
+}
+
+fn options(repo: &Path, project: Uuid, prs: bool, issues: bool, max: u64) -> IngestOptions {
+    IngestOptions {
+        repo: repo.into(),
+        expected_github_repo: Some("fixture/repository".into()),
+        project: project.to_string(),
+        max_items: Some(max),
+        include: IngestInclude {
+            commits: false,
+            issues,
+            pull_requests: prs,
+        },
+    }
+}
+
+fn fetch_limits(logs: &Path) -> Vec<(String, usize)> {
+    std::fs::read_to_string(logs.join("fetches.log"))
+        .unwrap()
+        .lines()
+        .map(|line| {
+            let mut fields = line.split_whitespace();
+            (
+                fields.next().unwrap().to_owned(),
+                fields.next().unwrap().parse().unwrap(),
+            )
+        })
+        .collect()
+}
+
+#[tokio::test]
+#[serial_test::serial(config_ledger)]
+async fn digest_fetch_budget_is_shared_between_remote_sources() {
+    let _lock = ENV_MUTEX.lock().await;
+    for max in [5, 20] {
+        let (rt, token, registry) = fixture().await;
+        let project = create(
+            &registry,
+            json!({"kind":"project","name":"shared fetch budget"}),
+        )
+        .await;
+        let prs = vec![pr_fixture(1, "first", TIE), pr_fixture(2, "second", LATER)];
+        let issues: Vec<_> = (1..=30).map(|n| issue_fixture(n, "issue", TIE)).collect();
+        let (_dir, repo, _bin, logs, _path) = remote_fixture(&prs, &issues);
+        let report = run_ingest(
+            &rt,
+            &token,
+            &registry,
+            options(&repo, project, true, true, max),
+        )
+        .await
+        .unwrap();
+        assert_eq!(report.prs_ingested, 2, "{report:?}");
+        assert_eq!(report.issues_ingested, max - 2, "{report:?}");
+        assert_eq!(
+            fetch_limits(&logs),
+            vec![
+                ("pr".into(), max as usize),
+                ("issue".into(), max as usize - 2)
+            ]
+        );
+        assert!(matches!(
+            report.sources.pull_requests,
+            Some(IngestSourceState::Completed)
+        ));
+        assert!(matches!(
+            report.sources.issues,
+            Some(IngestSourceState::StoppedEarly(_))
+        ));
+        assert!(
+            !report.done,
+            "a full reduced issue page is incomplete: {report:?}"
+        );
+    }
+}
+
+#[tokio::test]
+#[serial_test::serial(config_ledger)]
+async fn digest_fetch_budget_one_visit_resumes_undated_and_timestamp_ties() {
+    let _lock = ENV_MUTEX.lock().await;
+    for prs in [false, true] {
+        let (rt, token, registry) = fixture().await;
+        let project = create(
+            &registry,
+            json!({"kind":"project","name":"fetch boundary ties"}),
+        )
+        .await;
+        let make = if prs { pr_fixture } else { issue_fixture };
+        let mut undated = make(10, "undated", TIE);
+        undated["updatedAt"] = Value::Null;
+        let mut rows = vec![
+            undated,
+            make(30, "third", TIE),
+            make(20, "second", TIE),
+            make(40, "later", LATER),
+        ];
+        let (pr_rows, issue_rows) = if prs {
+            (rows.clone(), vec![])
+        } else {
+            (vec![], rows.clone())
+        };
+        let (_dir, repo, bin, logs, _path) = remote_fixture(&pr_rows, &issue_rows);
+        let opts = options(&repo, project, prs, !prs, 1);
+        for pass in 0..5 {
+            if pass == 3 {
+                rows.push(make(5, "late lower-number tie", TIE));
+                let (pr_rows, issue_rows) = if prs {
+                    (rows.clone(), vec![])
+                } else {
+                    (vec![], rows.clone())
+                };
+                write_budgeted_gh(&repo, &bin, &logs, &pr_rows, &issue_rows);
+            }
+            let report = run_ingest(&rt, &token, &registry, opts.clone())
+                .await
+                .unwrap();
+            assert_eq!(
+                report.prs_ingested + report.issues_ingested,
+                1,
+                "pass={pass}: {report:?}"
+            );
+            assert_eq!(
+                report.prs_skipped_existing + report.issues_skipped_existing,
+                0,
+                "{report:?}"
+            );
+            assert!(
+                !report.done,
+                "an exact-budget pass is incomplete: {report:?}"
+            );
+        }
+        let final_report = run_ingest(&rt, &token, &registry, opts).await.unwrap();
+        assert!(
+            final_report.done,
+            "a short replay proves completion: {final_report:?}"
+        );
+        assert_eq!(
+            final_report.prs_ingested + final_report.issues_ingested,
+            0,
+            "{final_report:?}"
+        );
+        let operation = if prs { "pr" } else { "issue" };
+        assert_eq!(
+            fetch_limits(&logs),
+            [1, 2, 3, 4, 5, 3].map(|limit| (operation.to_owned(), limit))
+        );
+        let kind = if prs { "pull_request" } else { "issue" };
+        let listed = registry
+            .dispatch("list", json!({"kind":kind,"limit":10}))
+            .await
+            .unwrap();
+        let numbers: BTreeSet<_> = list_items(&listed)
+            .iter()
+            .map(|row| row["properties"]["number"].as_u64().unwrap())
+            .collect();
+        assert_eq!(numbers, BTreeSet::from([5, 10, 20, 30, 40]));
+    }
+}
+
+#[tokio::test]
+#[serial_test::serial(config_ledger)]
+async fn digest_fetch_budget_preserves_a_failed_cursor_before_later_existing_rows() {
+    let _lock = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+    let project = create(
+        &registry,
+        json!({"kind":"project","name":"fetch frozen cursor"}),
+    )
+    .await;
+    create(&registry, json!({"kind":"issue","name":"existing","content":"existing",
+        "properties":{"number":30,"project_id":project.to_string()},"annotates":[project.to_string()]})).await;
+    let newest = "2026-01-01T00:00:03Z";
+    let mut rejected = issue_fixture(20, "rejected", LATER);
+    rejected["stateReason"] = json!("unknown");
+    let mut rows = vec![
+        issue_fixture(10, "good", TIE),
+        rejected,
+        issue_fixture(30, "existing", newest),
+    ];
+    let (_dir, repo, bin, logs, _path) = remote_fixture(&[], &rows);
+    let opts = options(&repo, project, false, true, 2);
+    let first = run_ingest(&rt, &token, &registry, opts.clone())
+        .await
+        .unwrap();
+    assert_eq!(first.issues_ingested, 1, "{first:?}");
+    assert!(first.cursor_stalled && !first.done, "{first:?}");
+    let second = run_ingest(&rt, &token, &registry, opts).await.unwrap();
+    assert_eq!(second.issues_skipped_existing, 1, "{second:?}");
+    assert!(second.cursor_stalled && !second.done, "{second:?}");
+    assert_eq!(
+        read_git_cursor(&rt, project, "issues").await.as_deref(),
+        Some(TIE)
+    );
+    rows[1]["stateReason"] = Value::Null;
+    write_budgeted_gh(&repo, &bin, &logs, &[], &rows);
+    let repaired = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        options(&repo, project, false, true, 1),
+    )
+    .await
+    .unwrap();
+    assert_eq!(repaired.issues_ingested, 1, "{repaired:?}");
+    assert!(!repaired.cursor_stalled, "{repaired:?}");
+    assert_eq!(
+        read_git_cursor(&rt, project, "issues").await.as_deref(),
+        Some(LATER)
+    );
+    let finished = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        options(&repo, project, false, true, 2),
+    )
+    .await
+    .unwrap();
+    assert!(finished.done && !finished.cursor_stalled, "{finished:?}");
+    assert_eq!(finished.issues_skipped_existing, 1, "{finished:?}");
+    assert_eq!(
+        fetch_limits(&logs),
+        vec![
+            ("issue".into(), 2),
+            ("issue".into(), 3),
+            ("issue".into(), 2),
+            ("issue".into(), 3)
+        ]
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial(config_ledger)]
+async fn digest_fetch_budget_reduces_the_second_page_and_resumes_existing_history() {
+    let _lock = ENV_MUTEX.lock().await;
+    for prs in [false, true] {
+        let (rt, token, registry) = fixture().await;
+        let project = create(
+            &registry,
+            json!({"kind":"project","name":"second fetch page"}),
+        )
+        .await;
+        let kind = if prs { "pull_request" } else { "issue" };
+        let make = if prs { pr_fixture } else { issue_fixture };
+        let rows: Vec<_> = (1..=1003)
+            .map(|n| {
+                let timestamp = chrono::DateTime::from_timestamp(1_767_225_600 + n as i64, 0)
+                    .unwrap()
+                    .to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+                make(n, "existing", &timestamp)
+            })
+            .collect();
+        {
+            let writer = rt.backend().pool().try_writer().unwrap();
+            writer.conn().execute("WITH RECURSIVE n(i) AS (VALUES(1) UNION ALL SELECT i+1 FROM n WHERE i<1003) INSERT INTO notes(id,namespace,kind,name,content,properties,created_at,updated_at) SELECT printf('25200000-0000-4000-8000-%012x',i),'local',?1,'existing','existing',json_object('number',i,'project_id',?2),i,i FROM n", (kind,project.to_string())).unwrap();
+        }
+        let (pr_rows, issue_rows) = if prs { (rows, vec![]) } else { (vec![], rows) };
+        let (_dir, repo, _bin, logs, _path) = remote_fixture(&pr_rows, &issue_rows);
+        let first = run_ingest(
+            &rt,
+            &token,
+            &registry,
+            options(&repo, project, prs, !prs, 1002),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            first.prs_skipped_existing + first.issues_skipped_existing,
+            1002,
+            "{first:?}"
+        );
+        assert!(!first.done, "{first:?}");
+        let second = run_ingest(
+            &rt,
+            &token,
+            &registry,
+            options(&repo, project, prs, !prs, 5),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            second.prs_skipped_existing + second.issues_skipped_existing,
+            1,
+            "{second:?}"
+        );
+        assert!(second.done, "{second:?}");
+        let operation = if prs { "pr" } else { "issue" };
+        assert_eq!(
+            fetch_limits(&logs),
+            [1000, 3, 6].map(|limit| (operation.to_owned(), limit))
+        );
+    }
+}


### PR DESCRIPTION
Closes #2520.

`git.digest` fetched a full 1000-item page from the platform on every call, whatever `max_items` asked for. A caller asking for ten rows paid for a thousand, and on a repository with a large history that is the dominant cost of the call.

The page request now derives its limit from the remaining budget, with two reservations that keep correctness intact:

- **Inclusive boundary replays.** The floor query is inclusive, so rows already acknowledged at the floor timestamp come back for free. Room is reserved for exactly those, so even a single-item budget can still reach an unseen row that ties the floor timestamp.
- **Undated rows** carried on the checkpoint get the same reservation.

The result is clamped to the existing `PAGE_LIMIT` of 1000, so nothing asks the platform for more than it did before.

`decide_page_outcome` now compares the page length against the limit that was actually requested rather than the constant. That is the part worth reviewing: a short page proves the remote window is exhausted only relative to what was asked for, and keying it on the constant while requesting less would have reported exhaustion on every reduced page. Both remote sources share one budget.

## Acceptance

Four regression arms asserting the exact `--limit` the fetch requests, plus the reduced-page completeness case, in a new `digest_fetch_budget` support module. Host gate on the pinned toolchain: `cargo fmt --all --check` clean, `cargo clippy -p khive-pack-git --all-targets -D warnings` clean, `cargo test -p khive-pack-git --no-fail-fast` 318 unit and 110 acceptance passing, one pre-existing ignored scale test.

Mutation: pinning the requested limit back to a constant 1000 turns all four `--limit` arms red; restored source reran green with the tree verified clean.
