### PR TITLE
fix(kg): list entity-type filtering falls back to a legacy properties.type

### DIFF
--- a/crates/khive-db/src/stores/entity.rs
+++ b/crates/khive-db/src/stores/entity.rs
@@ -576,7 +576,13 @@ fn build_entity_where(
                 format!("?{}", params.len())
             })
             .collect();
-        conditions.push(format!("entity_type IN ({})", placeholders.join(", ")));
+        let type_expr = if filter.legacy_entity_type_fallback {
+            "COALESCE(entity_type, CASE WHEN json_type(properties, '$.type') = 'text' \
+             THEN json_extract(properties, '$.type') END)"
+        } else {
+            "entity_type"
+        };
+        conditions.push(format!("{type_expr} IN ({})", placeholders.join(", ")));
     }
 
     if let Some(ref prefix) = filter.name_prefix {

--- a/crates/khive-db/src/stores/entity_tests.rs
+++ b/crates/khive-db/src/stores/entity_tests.rs
@@ -874,6 +874,127 @@ async fn test_query_by_kind_and_entity_type() {
     assert_eq!(result.items[0].entity_type, Some("researcher".to_string()));
 }
 
+#[tokio::test]
+async fn test_legacy_entity_type_filter_is_opt_in_and_preserves_column_precedence() {
+    let store = setup_memory_store();
+    let legacy = Entity::new("local", "concept", "Legacy")
+        .with_properties(serde_json::json!({"type": "algorithm"}));
+    let typed = Entity::new("local", "concept", "Typed")
+        .with_entity_type(Some("algorithm"))
+        .with_properties(serde_json::json!({"type": "technique"}));
+    let overridden = Entity::new("local", "concept", "Overridden")
+        .with_entity_type(Some("technique"))
+        .with_properties(serde_json::json!({"type": "algorithm"}));
+    for entity in [&legacy, &typed, &overridden] {
+        store.upsert_entity(entity.clone()).await.unwrap();
+    }
+    for properties in [
+        serde_json::json!({}),
+        serde_json::json!({"type": null}),
+        serde_json::json!({"type": 7}),
+        serde_json::json!({"type": true}),
+        serde_json::json!({"type": ["algorithm"]}),
+        serde_json::json!({"type": {"name": "algorithm"}}),
+        serde_json::json!({"type": "Algorithm"}),
+    ] {
+        store
+            .upsert_entity(Entity::new("local", "concept", "Unmatched").with_properties(properties))
+            .await
+            .unwrap();
+    }
+    store
+        .upsert_entity(Entity::new("local", "concept", "NoProperties"))
+        .await
+        .unwrap();
+    store
+        .upsert_entity(
+            Entity::new("foreign", "concept", "Foreign")
+                .with_properties(serde_json::json!({"type": "algorithm"})),
+        )
+        .await
+        .unwrap();
+    let mut deleted = Entity::new("local", "concept", "Deleted")
+        .with_properties(serde_json::json!({"type": "algorithm"}));
+    deleted.deleted_at = Some(deleted.created_at);
+    store.upsert_entity(deleted).await.unwrap();
+
+    let exact = EntityFilter {
+        entity_types: vec!["algorithm".into()],
+        ..Default::default()
+    };
+    let control = store
+        .query_entities("local", exact.clone(), PageRequest::default())
+        .await
+        .unwrap();
+    assert_eq!(control.items.len(), 1);
+    assert_eq!(control.items[0].id, typed.id);
+    assert_eq!(control.total, Some(1));
+
+    let fallback = EntityFilter {
+        legacy_entity_type_fallback: true,
+        ..exact
+    };
+    let non_string_filter = EntityFilter {
+        entity_types: vec![
+            "7".into(),
+            "1".into(),
+            "[\"algorithm\"]".into(),
+            "{\"name\":\"algorithm\"}".into(),
+        ],
+        ..fallback.clone()
+    };
+    assert_eq!(
+        store
+            .count_entities("local", non_string_filter)
+            .await
+            .unwrap(),
+        0
+    );
+    assert_eq!(
+        store
+            .count_entities("local", fallback.clone())
+            .await
+            .unwrap(),
+        2
+    );
+    let mut page_ids = Vec::new();
+    for offset in 0..2 {
+        let page = store
+            .query_entities("local", fallback.clone(), PageRequest { offset, limit: 1 })
+            .await
+            .unwrap();
+        assert_eq!(page.total, Some(2));
+        assert_eq!(page.items.len(), 1);
+        page_ids.push(page.items[0].id);
+    }
+    page_ids.sort_unstable();
+    let mut expected = vec![legacy.id, typed.id];
+    expected.sort_unstable();
+    assert_eq!(page_ids, expected);
+
+    let first = store
+        .query_entities_after("local", fallback.clone(), None, 1)
+        .await
+        .unwrap();
+    assert_eq!(first.items.len(), 1);
+    assert_eq!(first.items[0].id, legacy.id);
+    let second = store
+        .query_entities_after("local", fallback.clone(), first.next_after, 1)
+        .await
+        .unwrap();
+    assert_eq!(second.items.len(), 1);
+    assert_eq!(second.items[0].id, typed.id);
+    assert!(second.next_after.is_none());
+    let unchanged = store.get_entity(legacy.id).await.unwrap().unwrap();
+    assert!(unchanged.entity_type.is_none());
+    assert_eq!(unchanged.properties, legacy.properties);
+
+    let mut cleared = overridden;
+    cleared.entity_type = None;
+    store.upsert_entity(cleared).await.unwrap();
+    assert_eq!(store.count_entities("local", fallback).await.unwrap(), 3);
+}
+
 /// UUID is globally unique (id TEXT PRIMARY KEY). Upserting the same UUID in a
 /// different namespace overwrites the row (INSERT OR REPLACE). get_entity by ID
 /// returns whichever namespace currently owns that UUID.

--- a/crates/khive-pack-kg/src/handler_defs.rs
+++ b/crates/khive-pack-kg/src/handler_defs.rs
@@ -295,7 +295,7 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 24] = [
                 name: "entity_type",
                 param_type: "string",
                 required: false,
-                description: "Filter by entity type field when kind=\"entity\" (e.g. \"paper\", \"algorithm\", \"tool\").",
+                description: "Filter entities by entity_type (e.g. \"paper\", \"algorithm\", \"tool\"); only when that column is null, match a string properties.type instead. A non-null column takes precedence. Filtering happens before pagination and does not change returned fields or stored rows.",
                 resolution_mode: IdResolutionMode::NotApplicable,
             },
             ParamDef {

--- a/crates/khive-pack-kg/src/handlers/list.rs
+++ b/crates/khive-pack-kg/src/handlers/list.rs
@@ -379,6 +379,7 @@ impl KgPack {
                                 .as_deref()
                                 .map(|t| vec![t.to_string()])
                                 .unwrap_or_default(),
+                            legacy_entity_type_fallback: true,
                             tags_any: tag_list.clone(),
                             namespaces: token
                                 .visible_namespace_strs()

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -4260,8 +4260,122 @@ async fn update_entity_without_kind_resolves_from_uuid() {
     );
 }
 
-/// A property-only historical type can be promoted into the indexed
-/// `entity_type` column without replacing any unrelated entity fields.
+#[tokio::test]
+async fn list_entity_type_legacy_fallback_covers_tagged_offset_and_cursor_pages() {
+    let pack = pack();
+    let mut created = Vec::new();
+    for (name, entity_type, tags) in [
+        ("LegacyListedType", None, json!(["visible"])),
+        ("ColumnListedType", Some("algorithm"), json!(["visible"])),
+        ("UntaggedLegacyType", None, json!([])),
+        (
+            "ColumnOverridesLegacyType",
+            Some("technique"),
+            json!(["visible"]),
+        ),
+    ] {
+        let row = pack
+            .dispatch(
+                "create",
+                json!({
+                    "kind": "concept", "name": name, "entity_type": entity_type,
+                    "properties": {"type": "algorithm"}, "tags": tags,
+                    "skip_dedup_check": true
+                }),
+            )
+            .await
+            .expect("create type fixture");
+        created.push(row["id"].as_str().expect("entity id").to_string());
+    }
+
+    for tags in [None, Some(json!([])), Some(json!(["visible"]))] {
+        let mut expected = vec![created[0].clone(), created[1].clone()];
+        if tags != Some(json!(["visible"])) {
+            expected.push(created[2].clone());
+        }
+        expected.sort_unstable();
+        let mut params = json!({"kind": "entity", "entity_type": "algorithm", "limit": 1});
+        if let Some(tags) = tags {
+            params["tags"] = tags;
+        }
+        let mut offset_ids = Vec::new();
+        for offset in 0..expected.len() {
+            let mut page_params = params.clone();
+            page_params["offset"] = json!(offset);
+            let page = pack
+                .dispatch("list", page_params)
+                .await
+                .expect("offset page");
+            let items = list_items(&page);
+            assert_eq!(items.len(), 1, "{page}");
+            assert_eq!(page["limit_clamped"], false);
+            offset_ids.push(items[0]["id"].as_str().unwrap().to_string());
+        }
+        offset_ids.sort_unstable();
+        assert_eq!(offset_ids, expected);
+
+        let mut cursor_ids = Vec::new();
+        let mut after = json!("");
+        for index in 0..expected.len() {
+            let mut page_params = params.clone();
+            page_params["after"] = after;
+            let page = pack
+                .dispatch("list", page_params)
+                .await
+                .expect("cursor page");
+            let items = page["entities"].as_array().expect("cursor entities");
+            assert_eq!(items.len(), 1, "{page}");
+            cursor_ids.push(items[0]["id"].as_str().unwrap().to_string());
+            after = page["next_after"].clone();
+            assert_eq!(after.is_null(), index + 1 == expected.len(), "{page}");
+        }
+        cursor_ids.sort_unstable();
+        assert_eq!(cursor_ids, expected);
+    }
+    let legacy = pack
+        .dispatch("get", json!({"id": created[0]}))
+        .await
+        .expect("get historical entity");
+    assert!(legacy["entity_type"].is_null());
+    assert_eq!(legacy["properties"], json!({"type": "algorithm"}));
+}
+
+#[tokio::test]
+async fn search_entity_type_remains_exact_column_filter() {
+    let pack = pack();
+    let mut typed_id = Value::Null;
+    for (name, entity_type) in [
+        ("TypedFilterWitness legacy", None),
+        ("TypedFilterWitness column", Some("algorithm")),
+    ] {
+        let created = pack
+            .dispatch(
+                "create",
+                json!({
+                    "kind": "concept", "name": name, "entity_type": entity_type,
+                    "properties": {"type": "algorithm"}, "skip_dedup_check": true
+                }),
+            )
+            .await
+            .expect("create search control");
+        if entity_type.is_some() {
+            typed_id = created["id"].clone();
+        }
+    }
+    let found = pack
+        .dispatch(
+            "search",
+            json!({"kind": "entity", "query": "TypedFilterWitness", "entity_type": "algorithm"}),
+        )
+        .await
+        .expect("search with exact type filter");
+    let hits = found.as_array().expect("search hits");
+    assert_eq!(hits.len(), 1, "{found}");
+    assert_eq!(hits[0]["id"], typed_id);
+}
+
+/// Promoting a historical property type keeps its listing membership and
+/// preserves unrelated fields while populating the canonical column.
 #[tokio::test]
 async fn update_entity_type_promotes_property_type_into_typed_listing() {
     let pack = pack();
@@ -4296,10 +4410,13 @@ async fn update_entity_type_promotes_property_type_into_typed_listing() {
         )
         .await
         .expect("typed list before backfill must succeed");
-    assert!(
-        list_items(&before).iter().all(|item| item["id"] != id),
-        "a property-only historical type must not satisfy the column-backed filter"
-    );
+    let before_items = list_items(&before);
+    assert_eq!(before_items.len(), 1);
+    assert_eq!(before_items[0]["id"], id);
+    assert!(before_items[0]["entity_type"].is_null());
+    let stored_before = pack.dispatch("get", json!({"id": id})).await.unwrap();
+    assert!(stored_before["entity_type"].is_null());
+    assert_eq!(stored_before["properties"], created["properties"]);
 
     let updated = pack
         .dispatch("update", json!({"id": id, "entity_type": "algorithm"}))

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -1863,6 +1863,7 @@ impl KhiveRuntime {
     }
 
     /// List entities visible to the token, optionally filtered by kind and entity_type.
+    /// A null entity_type falls back to a string properties.type for filtering only.
     ///
     /// When the token carries a multi-namespace visible set, entities from all
     /// visible namespaces are returned. When the visible set is `[primary]`
@@ -1889,6 +1890,7 @@ impl KhiveRuntime {
                 Some(t) => vec![t.to_string()],
                 None => vec![],
             },
+            legacy_entity_type_fallback: true,
             namespaces: ns_strs,
             ..Default::default()
         };
@@ -1945,6 +1947,7 @@ impl KhiveRuntime {
             entity_types: entity_type
                 .map(|value| vec![value.to_string()])
                 .unwrap_or_default(),
+            legacy_entity_type_fallback: true,
             tags_any: tags_any.to_vec(),
             namespaces: token
                 .visible_namespaces()

--- a/crates/khive-storage/src/entity.rs
+++ b/crates/khive-storage/src/entity.rs
@@ -96,6 +96,11 @@ pub struct EntityFilter {
     pub kinds: Vec<String>,
     /// Filter by exact `entity_type` value. Multiple values are ORed.
     pub entity_types: Vec<String>,
+    /// For entity listing, fall back to a string `properties.type` only when
+    /// `entity_type` is null. Does not change the returned entity or apply when
+    /// `entity_types` is empty. Other query callers retain exact-column filtering.
+    #[serde(default)]
+    pub legacy_entity_type_fallback: bool,
     pub name_prefix: Option<String>,
     /// Deterministic, case-sensitive equality on `entities.name` (binary
     /// comparison — SQLite's default collation for `=` on a `TEXT` column

--- a/docs/adr/ADR-001-entity-kind-taxonomy.md
+++ b/docs/adr/ADR-001-entity-kind-taxonomy.md
@@ -102,6 +102,20 @@ pub struct Entity {
 
 `entity_type` replaces raw `properties.type` as the canonical subtype field.
 
+#### Entity-list compatibility (2026-09-10)
+
+For `list` entity-type filtering only, a non-null `entity_type` is authoritative.
+When that column is null, a string-valued `properties.type` is compared instead.
+Missing, null, and non-string property values do not supply a fallback type. The
+legacy value is compared exactly, without write-time alias normalization.
+
+This read-side rule applies before counts and pagination, including tagged and
+cursor listings. It neither migrates stored rows nor synthesizes `entity_type`
+in returned records: a matched legacy row still returns `entity_type: null`.
+Clearing an explicit column therefore makes any retained legacy string eligible
+again. Search, endpoint validation, and other exact-column filter consumers do
+not opt into this listing compatibility rule.
+
 #### Registry contract
 
 The `EntityTypeRegistry` governs which `entity_type` values are valid for each `EntityKind`:

--- a/docs/adr/ADR-001-entity-kind-taxonomy.md
+++ b/docs/adr/ADR-001-entity-kind-taxonomy.md
@@ -116,6 +116,10 @@ Clearing an explicit column therefore makes any retained legacy string eligible
 again. Search, endpoint validation, and other exact-column filter consumers do
 not opt into this listing compatibility rule.
 
+This rule is a bridge, not a second canonical field: it is retired by a later amendment once
+the legacy population (rows with a null `entity_type` and a string `properties.type`, the
+count issue 2559 measures) reads zero after backfill.
+
 #### Registry contract
 
 The `EntityTypeRegistry` governs which `entity_type` values are valid for each `EntityKind`:

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -263,6 +263,12 @@ annotation discovery is namespace-agnostic under ADR-007, matching the fetched e
 
 List records with optional filtering.
 
+For entity `entity_type` filtering, the non-null column takes precedence. Only
+when it is null does `list` compare a string-valued `properties.type`, before
+pagination. Returned fields and stored rows are unchanged; a matched legacy row
+can still return `entity_type: null`. This fallback is specific to `list`, not
+`search`.
+
 | Param                        | Type                     | Required | Notes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | ---------------------------- | ------------------------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `kind`                       | string                   | yes      | `entity`\|`note`\|`edge`\|`event`\|`proposal`\|`message`, or a granular kind.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |


### PR DESCRIPTION
Closes #2528.

`list(kind=entity, entity_type=...)` filtered on the `entity_type` column alone. Rows written before that column existed carry their subtype in `properties.type` and have a null column, so they were silently excluded: the call succeeded, the count looked right, and the rows were simply not there.

For entity listing only, a null `entity_type` now falls back to a string-valued `properties.type`. The rules, all of them narrow on purpose:

- A non-null `entity_type` is authoritative. The fallback never overrides an explicit column.
- Missing, null and non-string property values supply no type. Only a string counts.
- The legacy value is compared exactly, with no write-time alias normalization.
- The rule applies before counts and pagination, so tagged and cursor listings agree with it.
- Nothing is migrated and nothing is synthesized: a matched legacy row still returns `entity_type: null`.
- Search, endpoint validation and every other exact-column consumer keep exact-column filtering. The opt-in is a field on the filter, not a global change.

ADR-001 carries the read-side rule.

## The query plan changes, and here is the measurement

`idx_entities_kind_entity_type` is on `(namespace, kind, entity_type)`. Wrapping the column in `COALESCE(...)` makes the predicate non-sargable, so the seek drops one column:

```
exact column       SEARCH entities USING INDEX idx_entities_kind_entity_type (namespace=? AND kind=? AND entity_type=?)
coalesce fallback  SEARCH entities USING INDEX idx_entities_kind_entity_type (namespace=? AND kind=?)
```

A list by entity type now scans the `(namespace, kind)` group instead of seeking within it. On a small graph that is nothing; on a large one it is the same class of cost as #2517 and #2519.

Rewriting it as a disjunction does not recover the seek, measured with and without a supporting index. What does recover it is a `UNION ALL` of two selects with a partial expression index on the legacy branch, which keeps both sides indexed but has to be reconciled with ordering and cursor paging. That is filed separately rather than bundled here, so the correctness fix is not held behind an indexing design.

## Acceptance

`cargo fmt --all --check` clean, `cargo clippy -p khive-db -p khive-pack-kg --all-targets -D warnings` clean, `cargo test -p khive-db -p khive-pack-kg --no-fail-fast` green on the pinned toolchain: 310 unit plus the new db and integration arms.

Mutation: forcing exact-column-only filtering turns the new db fallback arms, the public list fallback arm and the updated promotion tests red, while the db exact-column and public search controls stay green. Restored source reran green with `git diff --exit-code` clean.

Note for review: this amends an accepted ADR, so it merges after sign-off rather than on CI alone.
