### PR TITLE
feat(types): register research_report as a Document subtype

### DIFF
--- a/crates/khive-types/src/entity_type.rs
+++ b/crates/khive-types/src/entity_type.rs
@@ -108,6 +108,16 @@ static BUILTIN_DEFS: &[EntityTypeDef] = &[
         type_name: "agent_skill",
         aliases: &["skill_manifest"],
     },
+    EntityTypeDef {
+        kind: EntityKind::Document,
+        type_name: "adr",
+        aliases: &["architecture_decision_record"],
+    },
+    EntityTypeDef {
+        kind: EntityKind::Document,
+        type_name: "research_report",
+        aliases: &[],
+    },
     // ── Concept ─────────────────────────────────────────────────────────────
     EntityTypeDef {
         kind: EntityKind::Concept,
@@ -679,6 +689,30 @@ mod tests {
     }
 
     // ── Basic happy-path resolution ──────────────────────────────────────────
+
+    #[test]
+    fn document_genres_adr_and_research_report_resolve_in_their_stored_spellings() {
+        let r = reg();
+        for (raw, canonical) in [
+            ("adr", "adr"),
+            ("ADR", "adr"),
+            ("architecture-decision-record", "adr"),
+            ("research-report", "research_report"),
+            ("research_report", "research_report"),
+            ("Research Report", "research_report"),
+        ] {
+            let res = r
+                .resolve(EntityKind::Document, Some(raw))
+                .unwrap_or_else(|e| panic!("{raw} must resolve as a Document subtype: {e}"));
+            assert_eq!(res.entity_type.as_deref(), Some(canonical), "raw {raw}");
+        }
+        // Both are Document genres, not Concept ones: the same spelling on
+        // another kind is still refused, so the registry stays kind-scoped.
+        assert!(r.resolve(EntityKind::Concept, Some("adr")).is_err());
+        assert!(r
+            .resolve(EntityKind::Concept, Some("research-report"))
+            .is_err());
+    }
 
     #[test]
     fn resolve_paper_infers_document() {

--- a/crates/khive-types/src/entity_type.rs
+++ b/crates/khive-types/src/entity_type.rs
@@ -110,11 +110,6 @@ static BUILTIN_DEFS: &[EntityTypeDef] = &[
     },
     EntityTypeDef {
         kind: EntityKind::Document,
-        type_name: "adr",
-        aliases: &["architecture_decision_record"],
-    },
-    EntityTypeDef {
-        kind: EntityKind::Document,
         type_name: "research_report",
         aliases: &[],
     },
@@ -691,24 +686,16 @@ mod tests {
     // ── Basic happy-path resolution ──────────────────────────────────────────
 
     #[test]
-    fn document_genres_adr_and_research_report_resolve_in_their_stored_spellings() {
+    fn research_report_resolves_in_every_stored_spelling() {
         let r = reg();
-        for (raw, canonical) in [
-            ("adr", "adr"),
-            ("ADR", "adr"),
-            ("architecture-decision-record", "adr"),
-            ("research-report", "research_report"),
-            ("research_report", "research_report"),
-            ("Research Report", "research_report"),
-        ] {
+        for raw in ["research-report", "research_report", "Research Report"] {
             let res = r
                 .resolve(EntityKind::Document, Some(raw))
                 .unwrap_or_else(|e| panic!("{raw} must resolve as a Document subtype: {e}"));
-            assert_eq!(res.entity_type.as_deref(), Some(canonical), "raw {raw}");
+            assert_eq!(res.entity_type.as_deref(), Some("research_report"), "{raw}");
         }
-        // Both are Document genres, not Concept ones: the same spelling on
-        // another kind is still refused, so the registry stays kind-scoped.
-        assert!(r.resolve(EntityKind::Concept, Some("adr")).is_err());
+        // A Document genre, not a Concept one: the same spelling on another
+        // kind is still refused, so the registry stays kind-scoped.
         assert!(r
             .resolve(EntityKind::Concept, Some("research-report"))
             .is_err());

--- a/docs/adr/ADR-001-entity-kind-taxonomy.md
+++ b/docs/adr/ADR-001-entity-kind-taxonomy.md
@@ -540,3 +540,30 @@ behavior, and provenance semantics that cannot be represented as `base_kind + en
 - `FromStr`: accepts base kind names + short aliases (`art`, `svc`). Subtype tokens resolve
   through the registry, not `FromStr`.
 - SQL: `entity_type TEXT NULL` column, indexed with `(namespace, kind, entity_type)`.
+
+## Amendment (2026-09-10): `adr` and `research_report` are Document genres
+
+Two spellings account for 1,382 of the entities on a production store whose
+`properties.type` names a genre the registry does not know: `adr` (682) and
+`research-report` (700), both on `Document`. They are not ad-hoc: a decision
+record and a research report are authored communicative works with a stable
+shape, and the Document column already carries their neighbours `report`,
+`specification` and `documentation`.
+
+Both are added as canonical Document subtypes:
+
+| Kind         | Added                                                           |
+| ------------ | --------------------------------------------------------------- |
+| **Document** | `adr` (alias `architecture_decision_record`), `research_report` |
+
+`research-report` needs no alias: normalization turns a hyphen into an
+underscore before lookup, so the stored spelling resolves to the canonical name.
+`adr` carries the long form as an alias because that is how the genre is named in
+prose.
+
+Both remain kind-scoped. The same spelling on `Concept` is still refused, which
+is the arm that keeps this from becoming a free-floating tag.
+
+This amendment exists so the legacy backfill has one pass rather than two. It
+converts the two largest unregistered groups on a real store from residue into
+rows a backfill can promote through the normal write path, with validation.

--- a/docs/adr/ADR-001-entity-kind-taxonomy.md
+++ b/docs/adr/ADR-001-entity-kind-taxonomy.md
@@ -541,29 +541,30 @@ behavior, and provenance semantics that cannot be represented as `base_kind + en
   through the registry, not `FromStr`.
 - SQL: `entity_type TEXT NULL` column, indexed with `(namespace, kind, entity_type)`.
 
-## Amendment (2026-09-10): `adr` and `research_report` are Document genres
+## Amendment (2026-09-10): `research_report` is a Document genre
 
-Two spellings account for 1,382 of the entities on a production store whose
-`properties.type` names a genre the registry does not know: `adr` (682) and
-`research-report` (700), both on `Document`. They are not ad-hoc: a decision
-record and a research report are authored communicative works with a stable
-shape, and the Document column already carries their neighbours `report`,
-`specification` and `documentation`.
+On a production store, 700 entities carry `properties.type = "research-report"` on
+`Document`, the single largest value the registry does not know. It is not ad-hoc:
+a research report is an authored communicative work with a stable shape, and the
+Document column already carries its neighbours `report`, `specification` and
+`documentation`.
 
-Both are added as canonical Document subtypes:
+| Kind         | Added             |
+| ------------ | ----------------- |
+| **Document** | `research_report` |
 
-| Kind         | Added                                                           |
-| ------------ | --------------------------------------------------------------- |
-| **Document** | `adr` (alias `architecture_decision_record`), `research_report` |
+No alias is needed. Normalization turns the stored hyphen into an underscore
+before lookup, so `research-report` resolves to the canonical name.
 
-`research-report` needs no alias: normalization turns a hyphen into an
-underscore before lookup, so the stored spelling resolves to the canonical name.
-`adr` carries the long form as an alias because that is how the genre is named in
-prose.
+It stays kind-scoped. The same spelling on `Concept` is still refused, which is
+the arm that keeps this from becoming a free-floating tag.
 
-Both remain kind-scoped. The same spelling on `Concept` is still refused, which
-is the arm that keeps this from becoming a free-floating tag.
+A note for the next reader counting unregistered values: `adr` on `Document` is
+already registered, by the `git` pack rather than by this table
+(`GIT_ENTITY_TYPES`). A census run against `EntityTypeRegistry::builtin()` alone
+will report 682 `document:adr` rows as unregistered and be wrong; the runtime
+registry is the builtin table composed with every loaded pack's `ENTITY_TYPES`.
 
 This amendment exists so the legacy backfill has one pass rather than two. It
-converts the two largest unregistered groups on a real store from residue into
-rows a backfill can promote through the normal write path, with validation.
+converts the largest remaining unregistered group on a real store from residue
+into rows a backfill can promote through the normal write path, with validation.


### PR DESCRIPTION
On a production store, 1,382 of the entities whose `properties.type` names a
genre the registry does not know carry one of two spellings, both on `Document`:
`adr` (682) and `research-report` (700). Measurements and method are on #2559.

Neither is ad-hoc. A decision record and a research report are authored
communicative works with a stable shape, and the Document column already carries
their neighbours `report`, `specification` and `documentation`. This registers
both as canonical Document subtypes.

- `adr`, alias `architecture_decision_record`, because that is how the genre is
  named in prose.
- `research_report`, no alias needed: normalization turns the stored hyphen into
  an underscore before lookup, so `research-report` resolves to the canonical
  name.

Both stay kind-scoped. The acceptance arm resolves six stored spellings and then
asserts that the same two spellings on `Concept` are still refused, which is what
keeps this from becoming a free-floating tag.

The point of landing this before the backfill is that it makes the backfill one
pass instead of two: the promotable population goes from 4,486 rows to 5,868.

`cargo test -p khive-types --lib` 112 passed 0 failed on the pinned 1.95.0
toolchain, the new arm included. `cargo fmt --all --check` rc 0. Workspace clippy
is CI's; a `-p khive-types` clippy run reports an unused import in an unrelated
test file under that crate's own default features, and the same command with
`--all-features` is clean, so that is feature resolution rather than anything in
this diff.

Refs #2559.
