### PR TITLE
test: separate precondition failures from timing in two flaky tests

### DIFF
--- a/crates/khive-db/src/stores/note_tests.rs
+++ b/crates/khive-db/src/stores/note_tests.rs
@@ -1199,7 +1199,7 @@ async fn assert_filtered_count_partitions_share_snapshot(query: SnapshotCountQue
 
     let (reached_rx, proceed_tx) =
         page_snapshot_seam::install(query.operation(), namespace.clone());
-    let query_task = {
+    let mut query_task = {
         let store = Arc::clone(&store);
         let namespace = namespace.clone();
         let filters = filters.clone();
@@ -1208,10 +1208,45 @@ async fn assert_filtered_count_partitions_share_snapshot(query: SnapshotCountQue
         )
     };
 
-    tokio::task::spawn_blocking(move || reached_rx.recv_timeout(std::time::Duration::from_secs(5)))
-        .await
-        .expect("waiting for the count snapshot seam must not panic")
-        .expect("count query must reach the seam after its first partition");
+    // Hang protection only: query outcomes, not expected scheduling latency,
+    // determine whether the seam precondition succeeds.
+    let mut seam_task = tokio::task::spawn_blocking(move || {
+        reached_rx.recv_timeout(std::time::Duration::from_secs(60))
+    });
+    tokio::select! {
+        reached = &mut seam_task => {
+            if !matches!(&reached, Ok(Ok(()))) {
+                page_snapshot_seam::uninstall();
+                drop(proceed_tx);
+                query_task.abort();
+                let query_outcome = query_task.await;
+                if matches!(
+                    &reached,
+                    Ok(Err(std::sync::mpsc::RecvTimeoutError::Timeout))
+                ) {
+                    panic!(
+                        "precondition timeout: {query:?} count snapshot seam exceeded its 60s hang watchdog; \
+                         query outcome after cleanup: {query_outcome:?}"
+                    );
+                }
+                panic!(
+                    "precondition: {query:?} count snapshot seam waiter failed; \
+                     seam outcome: {reached:?}; query outcome after cleanup: {query_outcome:?}"
+                );
+            }
+        }
+        outcome = &mut query_task => {
+            page_snapshot_seam::uninstall();
+            drop(proceed_tx);
+            // Uninstall drops the sender if the query never entered the hook,
+            // so the blocking waiter must also finish before this test exits.
+            let seam_outcome = seam_task.await;
+            panic!(
+                "precondition: {query:?} count query completed while waiting for its snapshot seam; \
+                 query outcome: {outcome:?}; seam outcome: {seam_outcome:?}"
+            );
+        }
+    }
 
     let writer = pool.writer().unwrap();
     writer

--- a/crates/khive-pack-memory/src/pack.rs
+++ b/crates/khive-pack-memory/src/pack.rs
@@ -1119,10 +1119,11 @@ mod note_mutation_hook_tests {
             .await
             .expect("warm recall");
 
+        ann::wait_until_warm_idle(ann, &mutation_hook_ann_key()).await;
         assert!(
             ann::is_current(ann, &mutation_hook_ann_key()).await,
-            "sanity: warm-up recall must leave the ANN cache current before \
-             the mutation under test"
+            "precondition: completed ANN warm-up must leave the cache current \
+             before testing mutation invalidation"
         );
         id
     }


### PR DESCRIPTION
Closes #2354. Closes #2356.

Both tests failed on a precondition rather than on the behaviour they exist to
check, and in both cases the precondition was a timing assumption.

**#2356.** The snapshot-seam wait was a flat 5 s `recv_timeout`, which a coverage
build can miss without anything being wrong. The wait is now a 60 s hang watchdog
and the test `select!`s the seam against the query task, so the two failure modes
separate: if the seam is never reached the panic says so and carries the query's
outcome, and if the query finishes without entering the seam that is reported as
its own precondition failure rather than surfacing as a timeout. Both arms
uninstall the seam, drop the proceed channel and settle the outstanding task
before panicking, so a failing run leaves nothing behind for the next test.

**#2354.** The ANN warm-up assertion raced the background rebuild: the test
asserted the cache was current immediately after the warm recall returned, while
the rebuild chain could still be in flight. It now awaits
`ann::wait_until_warm_idle` first, so the assertion tests invalidation rather than
scheduling. The release is RAII on the warming key, so the wait ends on success,
error or panic of the warm task.

The assertion messages in both tests now say `precondition:` and name what was
expected, so a future failure reads as a setup problem rather than as the tested
behaviour breaking.

Test-only. No production code paths change.
