### PR TITLE
fix(storage): page guarded batch refusals and format only reported details

### DIFF
--- a/crates/khive-db/docs/api/graph.md
+++ b/crates/khive-db/docs/api/graph.md
@@ -97,3 +97,33 @@ every edge has been confirmed does it fall through to the plain
 refusing entry's index and its `MissingEndpoints` are captured by this same
 pre-check pass and returned as `GuardedBatchOutcome::refused` — the runtime
 layer no longer re-probes endpoints after the fact.
+
+### Enumerating Refused Writes Beyond the Sample (#2375)
+
+Storage callers can retain the original ordered `Vec<Edge>` and use
+`GuardedBatchOutcome::refusal_page(&original, class, PageRequest { offset, limit })`
+after one guarded batch call. No write is resubmitted and no endpoint is re-read.
+The default `BatchWriteSummary`, its 128-detail sample, and legacy `first_error`
+remain unchanged. Pages use that same 128-detail cap and message bound.
+
+`class=None` enumerates every refused write in original input order. Only the
+first guard-refused entry is `InvalidInput/Permanent`; all siblings are
+`BatchAborted/Unknown`. Later siblings were not necessarily examined, and paging
+does not claim they all have missing endpoints. The initial summary and pages
+share the same classification and detail formatter.
+
+An optional class filter is applied before offset and limit, and `Page.total`
+is the complete matching population. Add `items.len()` to the offset to continue
+until that total is reached. A requested limit above 128 is clamped to 128; zero
+returns count metadata only and is not a progressing enumeration request.
+Success, an empty successful batch, and offsets at/beyond the filtered population
+return empty pages. Skipped/filtered entries are never formatted.
+
+The supplied slice length must equal `summary.attempted`, and a refusal index
+must be within that slice. The caller must retain the exact batch contents and
+order: length validation cannot detect a substituted same-length batch. The
+original `first_error` supplies the refusing entry's diagnostic unchanged.
+
+This is a synchronous, in-memory storage API, not a new MCP/runtime endpoint or
+durable cursor. Runtime `link_many` currently discards the summary in favor of
+its first guarded-write failure; this change does not expand that wire response.

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -10,11 +10,11 @@ use uuid::Uuid;
 
 use khive_storage::error::StorageError;
 use khive_storage::types::{
-    BatchWriteErrorClass, BatchWriteRetryability, BatchWriteSummary, DeleteMode,
-    DirectedNeighborHit, Direction, Edge, EdgeFilter, EdgeSeekPage, EdgeSortField, GraphPath,
-    GuardedBatchOutcome, GuardedBatchRefusal, GuardedWriteOutcome, MissingEndpoints, NeighborHit,
-    NeighborQuery, Page, PageRequest, PathNode, SeekCursor, SeekPage, SortDirection, SortOrder,
-    SqlStatement, SqlValue, TraversalExecutionBudget, TraversalOptions, TraversalRequest,
+    BatchWriteSummary, DeleteMode, DirectedNeighborHit, Direction, Edge, EdgeFilter, EdgeSeekPage,
+    EdgeSortField, GraphPath, GuardedBatchOutcome, GuardedBatchRefusal, GuardedWriteOutcome,
+    MissingEndpoints, NeighborHit, NeighborQuery, Page, PageRequest, PathNode, SeekCursor,
+    SeekPage, SortDirection, SortOrder, SqlStatement, SqlValue, TraversalExecutionBudget,
+    TraversalOptions, TraversalRequest,
 };
 use khive_storage::GraphStore;
 use khive_storage::LinkId;
@@ -1204,37 +1204,16 @@ fn batch_upsert_edges_guarded(
             // is not first in input order. The details themselves remain in
             // input order below.
             summary.first_error = message.clone();
+            let refusal = GuardedBatchRefusal {
+                entry_index: index,
+                missing,
+            };
             for (failed_index, failed_edge) in edges.iter().enumerate() {
-                let (class, retryability, detail) = if failed_index == index {
-                    (
-                        BatchWriteErrorClass::InvalidInput,
-                        BatchWriteRetryability::Permanent,
-                        message.clone(),
-                    )
-                } else {
-                    (
-                        BatchWriteErrorClass::BatchAborted,
-                        BatchWriteRetryability::Unknown,
-                        format!(
-                            "batch entry {failed_index} was not written because guarded batch \
-                             entry {index} was refused"
-                        ),
-                    )
-                };
-                summary.record_failure(
-                    failed_index,
-                    Some(failed_edge.id.to_string()),
-                    class,
-                    retryability,
-                    detail,
-                );
+                refusal.record_failure(&mut summary, failed_index, failed_edge, &message);
             }
             return Ok(GuardedBatchOutcome {
                 summary,
-                refused: Some(GuardedBatchRefusal {
-                    entry_index: index,
-                    missing,
-                }),
+                refused: Some(refusal),
             });
         }
     }

--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -3,6 +3,7 @@ use crate::pool::PoolConfig;
 use khive_storage::types::{
     Direction, TraversalExecutionBudget, TraversalOptions, MAX_TRAVERSAL_DEPTH, MAX_TRAVERSAL_ROOTS,
 };
+use khive_storage::{BatchWriteErrorClass, BatchWriteRetryability};
 use rusqlite::hooks::{AuthAction, AuthContext, Authorization};
 use serial_test::serial;
 use std::collections::{HashMap, HashSet};
@@ -4246,6 +4247,97 @@ async fn upsert_edges_guarded_writes_nothing_when_one_endpoint_vanishes() {
             store.get_edge(id).await.unwrap().is_none(),
             "batch must be all-or-nothing: {id:?} must not be persisted"
         );
+    }
+}
+
+#[tokio::test]
+async fn upsert_edges_guarded_preserves_refusal_beyond_summary_cap() {
+    let (pool, store) = setup_memory_store_with_substrates();
+    let source = Uuid::new_v4();
+    let target = Uuid::new_v4();
+    let missing_target = Uuid::new_v4();
+    insert_live_entity(&pool, source);
+    insert_live_entity(&pool, target);
+    let cap = khive_storage::MAX_BATCH_WRITE_ERROR_DETAILS;
+    let mut edges: Vec<_> = (0..cap + 3)
+        .map(|_| make_edge(source, target, EdgeRelation::Extends, 1.0))
+        .collect();
+    edges[cap + 1] = make_edge(source, missing_target, EdgeRelation::Extends, 1.0);
+    let ids: Vec<_> = edges.iter().map(|edge| edge.id).collect();
+
+    let outcome = store.upsert_edges_guarded(edges.clone()).await.unwrap();
+    let refusal = outcome.refused.as_ref().unwrap();
+    assert_eq!(refusal.entry_index, cap + 1);
+    assert!(!refusal.missing.source);
+    assert!(refusal.missing.target);
+    let summary = &outcome.summary;
+    assert_eq!(summary.affected, 0);
+    assert_eq!(summary.attempted, (cap + 3) as u64);
+    assert_eq!(summary.failed, summary.attempted);
+    assert_eq!(summary.errors.len(), cap);
+    assert_eq!(summary.errors_omitted, 3);
+    assert!(summary.errors_truncated);
+    assert_eq!(summary.first_error, format!(
+        "batch entry {}: edge endpoint no longer exists at write time: source {source} or target {missing_target}",
+        cap + 1,
+    ));
+    for (index, error) in summary.errors.iter().enumerate() {
+        assert_eq!(error.index, index as u64);
+        assert_eq!(error.item_id, Some(ids[index].to_string()));
+        assert_eq!(error.class, BatchWriteErrorClass::BatchAborted);
+        assert_eq!(error.retryability, BatchWriteRetryability::Unknown);
+        assert_eq!(
+            error.message,
+            format!(
+                "batch entry {index} was not written because guarded batch entry {} was refused",
+                cap + 1,
+            )
+        );
+    }
+    assert_eq!(summary.error_counts.len(), 2);
+    assert_eq!(
+        summary.error_counts[0].class,
+        BatchWriteErrorClass::InvalidInput
+    );
+    assert_eq!(summary.error_counts[0].count, 1);
+    assert_eq!(
+        summary.error_counts[1].class,
+        BatchWriteErrorClass::BatchAborted
+    );
+    assert_eq!(summary.error_counts[1].count, (cap + 2) as u64);
+    let mut enumerated = Vec::new();
+    while enumerated.len() < edges.len() {
+        let page = outcome
+            .refusal_page(
+                &edges,
+                None,
+                PageRequest {
+                    offset: enumerated.len() as u64,
+                    limit: u32::MAX,
+                },
+            )
+            .unwrap();
+        assert_eq!(page.total, Some(edges.len() as u64));
+        assert!(!page.items.is_empty());
+        assert!(page.items.len() <= cap);
+        enumerated.extend(page.items);
+    }
+    assert_eq!(enumerated.len(), edges.len());
+    assert_eq!(&enumerated[..cap], summary.errors.as_slice());
+    for (index, error) in enumerated.iter().enumerate() {
+        assert_eq!(error.index, index as u64);
+        assert_eq!(error.item_id, Some(ids[index].to_string()));
+        if index == cap + 1 {
+            assert_eq!(error.class, BatchWriteErrorClass::InvalidInput);
+            assert_eq!(error.retryability, BatchWriteRetryability::Permanent);
+            assert_eq!(error.message, summary.first_error);
+        } else {
+            assert_eq!(error.class, BatchWriteErrorClass::BatchAborted);
+            assert_eq!(error.retryability, BatchWriteRetryability::Unknown);
+        }
+    }
+    for id in ids {
+        assert!(store.get_edge(id).await.unwrap().is_none());
     }
 }
 

--- a/crates/khive-storage/src/graph.rs
+++ b/crates/khive-storage/src/graph.rs
@@ -77,6 +77,8 @@ pub trait GraphStore: Send + Sync + 'static {
     /// `GuardedBatchOutcome::refused` names the first failing batch entry and
     /// its missing endpoint(s) — determined by the same in-transaction
     /// pre-check that aborted the batch, not a post-hoc re-read.
+    /// Retain the original ordered input to enumerate every aborted write via
+    /// [`GuardedBatchOutcome::refusal_page`] beyond the default bounded sample.
     ///
     /// Default returns `StorageError::Unsupported`, for the same reason as
     /// [`GraphStore::upsert_edge_guarded`]'s default.

--- a/crates/khive-storage/src/types/mod.rs
+++ b/crates/khive-storage/src/types/mod.rs
@@ -132,11 +132,20 @@ impl BatchWriteSummary {
         retryability: BatchWriteRetryability,
         message: impl Into<String>,
     ) {
-        let message = message.into();
+        self.record_failure_with(index, class, retryability, || (item_id, message.into()));
+    }
+
+    /// Record a refusal without constructing an item identity or message that
+    /// will be omitted. The closure runs only for a sampled detail or when the
+    /// legacy `first_error` still needs to be populated.
+    pub fn record_failure_with(
+        &mut self,
+        index: usize,
+        class: BatchWriteErrorClass,
+        retryability: BatchWriteRetryability,
+        detail: impl FnOnce() -> (Option<String>, String),
+    ) {
         self.failed = self.failed.saturating_add(1);
-        if self.first_error.is_empty() {
-            self.first_error = message.clone();
-        }
 
         match self
             .error_counts
@@ -155,7 +164,14 @@ impl BatchWriteSummary {
             }
         }
 
-        if self.errors.len() < MAX_BATCH_WRITE_ERROR_DETAILS {
+        let sampled = self.errors.len() < MAX_BATCH_WRITE_ERROR_DETAILS;
+        let detail = (sampled || self.first_error.is_empty()).then(detail);
+        if let Some((_, message)) = &detail {
+            if self.first_error.is_empty() {
+                self.first_error = message.clone();
+            }
+        }
+        if let Some((item_id, message)) = detail.filter(|_| sampled) {
             self.errors.push(BatchWriteError {
                 index: u64::try_from(index).unwrap_or(u64::MAX),
                 item_id,
@@ -183,9 +199,363 @@ fn bounded_batch_error_message(message: &str) -> String {
     bounded
 }
 
+impl GuardedBatchRefusal {
+    fn error_metadata(&self, index: usize) -> (BatchWriteErrorClass, BatchWriteRetryability) {
+        if index == self.entry_index {
+            (
+                BatchWriteErrorClass::InvalidInput,
+                BatchWriteRetryability::Permanent,
+            )
+        } else {
+            (
+                BatchWriteErrorClass::BatchAborted,
+                BatchWriteRetryability::Unknown,
+            )
+        }
+    }
+
+    fn format_failure(
+        &self,
+        index: usize,
+        edge: &Edge,
+        first_error: &str,
+    ) -> (Option<String>, String) {
+        let message = if index == self.entry_index {
+            first_error.to_owned()
+        } else {
+            format!(
+                "batch entry {index} was not written because guarded batch entry {} was refused",
+                self.entry_index,
+            )
+        };
+        (Some(edge.id.to_string()), message)
+    }
+
+    /// Record one original batch entry using the same classification and
+    /// diagnostic as [`GuardedBatchOutcome::refusal_page`]. Siblings are aborted,
+    /// not independently diagnosed as having missing endpoints.
+    pub fn record_failure(
+        &self,
+        summary: &mut BatchWriteSummary,
+        index: usize,
+        edge: &Edge,
+        first_error: &str,
+    ) {
+        let (class, retryability) = self.error_metadata(index);
+        summary.record_failure_with(index, class, retryability, || {
+            self.format_failure(index, edge, first_error)
+        });
+    }
+}
+
+impl GuardedBatchOutcome {
+    /// Enumerate the refused writes from the caller-retained original batch,
+    /// without resubmitting or rechecking endpoints. Retain the exact original
+    /// edges and order: only their length and the refusal index can be validated.
+    ///
+    /// The class filter applies before offset/limit. Every page is capped at
+    /// [`MAX_BATCH_WRITE_ERROR_DETAILS`]; zero limit returns only the matching
+    /// total. Continue by adding the returned item count to `page.offset`.
+    /// Success and offsets beyond the matching population return empty pages.
+    /// This is an in-memory storage API, not a new runtime/MCP endpoint.
+    pub fn refusal_page(
+        &self,
+        original_edges: &[Edge],
+        class: Option<BatchWriteErrorClass>,
+        page: PageRequest,
+    ) -> StorageResult<Page<BatchWriteError>> {
+        self.refusal_page_with(
+            original_edges,
+            class,
+            page,
+            GuardedBatchRefusal::format_failure,
+        )
+    }
+
+    fn refusal_page_with(
+        &self,
+        original_edges: &[Edge],
+        class: Option<BatchWriteErrorClass>,
+        page: PageRequest,
+        mut format: impl FnMut(&GuardedBatchRefusal, usize, &Edge, &str) -> (Option<String>, String),
+    ) -> StorageResult<Page<BatchWriteError>> {
+        let invalid = |message| StorageError::InvalidInput {
+            capability: crate::capability::StorageCapability::Graph,
+            operation: "guarded_batch_refusal_page".into(),
+            message,
+        };
+        let len = u64::try_from(original_edges.len()).unwrap_or(u64::MAX);
+        if len != self.summary.attempted {
+            return Err(invalid(format!(
+                "original batch length {len} does not match attempted count {}",
+                self.summary.attempted,
+            )));
+        }
+        let Some(refusal) = &self.refused else {
+            return Ok(Page {
+                items: Vec::new(),
+                total: Some(0),
+            });
+        };
+        if refusal.entry_index >= original_edges.len() {
+            return Err(invalid(format!(
+                "refusal index {} is outside original batch length {len}",
+                refusal.entry_index,
+            )));
+        }
+        let matching = (0..original_edges.len())
+            .filter(|index| class.is_none_or(|class| refusal.error_metadata(*index).0 == class));
+        let total = matching.clone().count() as u64;
+        let offset = usize::try_from(page.offset).unwrap_or(usize::MAX);
+        let limit = (page.limit as usize).min(MAX_BATCH_WRITE_ERROR_DETAILS);
+        let items = matching
+            .skip(offset)
+            .take(limit)
+            .map(|index| {
+                let (class, retryability) = refusal.error_metadata(index);
+                let (item_id, message) = format(
+                    refusal,
+                    index,
+                    &original_edges[index],
+                    &self.summary.first_error,
+                );
+                BatchWriteError {
+                    index: index as u64,
+                    item_id,
+                    class,
+                    retryability,
+                    message: bounded_batch_error_message(&message),
+                }
+            })
+            .collect();
+        Ok(Page {
+            items,
+            total: Some(total),
+        })
+    }
+}
+
 #[cfg(test)]
 mod batch_write_summary_tests {
     use super::*;
+
+    fn guarded_refusal_fixture(
+        len: usize,
+        refused_index: usize,
+    ) -> (Vec<Edge>, GuardedBatchOutcome) {
+        let edges: Vec<_> = (0..len)
+            .map(|index| Edge {
+                id: LinkId(uuid::Uuid::from_u128(index as u128 + 1)),
+                namespace: "local".into(),
+                source_id: uuid::Uuid::from_u128(1001),
+                target_id: uuid::Uuid::from_u128(1002),
+                relation: khive_types::EdgeRelation::Extends,
+                weight: 1.0,
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+                deleted_at: None,
+                metadata: None,
+                target_backend: None,
+            })
+            .collect();
+        let refusal = GuardedBatchRefusal {
+            entry_index: refused_index,
+            missing: MissingEndpoints {
+                source: false,
+                target: true,
+            },
+        };
+        let mut summary = BatchWriteSummary {
+            attempted: len as u64,
+            first_error: "original guard refusal".into(),
+            ..Default::default()
+        };
+        for (index, edge) in edges.iter().enumerate() {
+            refusal.record_failure(&mut summary, index, edge, "original guard refusal");
+        }
+        (
+            edges,
+            GuardedBatchOutcome {
+                summary,
+                refused: Some(refusal),
+            },
+        )
+    }
+
+    #[test]
+    fn guarded_refusal_page_formats_only_filtered_page_with_shared_cap() {
+        let cap = MAX_BATCH_WRITE_ERROR_DETAILS;
+        let (edges, outcome) = guarded_refusal_fixture(cap * 2 + 9, cap + 2);
+        for (class, offset, expected_len, expected_total, expected_first) in [
+            (None, cap as u64, cap, edges.len(), Some(cap)),
+            (
+                Some(BatchWriteErrorClass::InvalidInput),
+                0,
+                1,
+                1,
+                Some(cap + 2),
+            ),
+            (
+                Some(BatchWriteErrorClass::BatchAborted),
+                (cap + 3) as u64,
+                cap,
+                edges.len() - 1,
+                Some(cap + 4),
+            ),
+            (Some(BatchWriteErrorClass::Conflict), 0, 0, 0, None),
+        ] {
+            let mut formatted = Vec::new();
+            let page = outcome
+                .refusal_page_with(
+                    &edges,
+                    class,
+                    PageRequest {
+                        offset,
+                        limit: u32::MAX,
+                    },
+                    |refusal, index, edge, message| {
+                        formatted.push(index);
+                        refusal.format_failure(index, edge, message)
+                    },
+                )
+                .unwrap();
+            assert_eq!(page.items.len(), expected_len);
+            assert_eq!(formatted.len(), expected_len);
+            assert_eq!(formatted.first().copied(), expected_first);
+            assert_eq!(page.total, Some(expected_total as u64));
+            assert_eq!(
+                formatted,
+                page.items
+                    .iter()
+                    .map(|error| error.index as usize)
+                    .collect::<Vec<_>>()
+            );
+            if let Some(class) = class {
+                assert!(page.items.iter().all(|error| error.class == class));
+            }
+        }
+    }
+
+    #[test]
+    fn guarded_refusal_page_handles_empty_success_and_page_boundaries() {
+        let (edges, outcome) = guarded_refusal_fixture(3, 1);
+        for page in [
+            PageRequest {
+                offset: 0,
+                limit: 0,
+            },
+            PageRequest {
+                offset: 3,
+                limit: 1,
+            },
+            PageRequest {
+                offset: u64::MAX,
+                limit: u32::MAX,
+            },
+        ] {
+            let result = outcome
+                .refusal_page_with(&edges, None, page, |_, _, _, _| {
+                    panic!("empty page must not format a detail")
+                })
+                .unwrap();
+            assert!(result.items.is_empty());
+            assert_eq!(result.total, Some(3));
+        }
+        let success = GuardedBatchOutcome {
+            summary: BatchWriteSummary {
+                attempted: 3,
+                affected: 3,
+                ..Default::default()
+            },
+            refused: None,
+        };
+        let page = success
+            .refusal_page(&edges, None, PageRequest::default())
+            .unwrap();
+        assert!(page.items.is_empty());
+        assert_eq!(page.total, Some(0));
+        let empty = GuardedBatchOutcome {
+            summary: BatchWriteSummary::default(),
+            refused: None,
+        };
+        let page = empty
+            .refusal_page(&[], None, PageRequest::default())
+            .unwrap();
+        assert!(page.items.is_empty());
+        assert_eq!(page.total, Some(0));
+    }
+
+    #[test]
+    fn guarded_refusal_page_rejects_wrong_batch_length_and_refusal_index() {
+        let (edges, mut outcome) = guarded_refusal_fixture(3, 1);
+        let error = outcome
+            .refusal_page(&edges[..2], None, PageRequest::default())
+            .unwrap_err();
+        assert!(error.to_string().contains("does not match attempted count"));
+        outcome.refused.as_mut().unwrap().entry_index = edges.len();
+        let error = outcome
+            .refusal_page(&edges, None, PageRequest::default())
+            .unwrap_err();
+        assert!(error.to_string().contains("refusal index 3 is outside"));
+        let empty = GuardedBatchOutcome {
+            summary: BatchWriteSummary::default(),
+            refused: outcome.refused,
+        };
+        assert!(empty
+            .refusal_page(&[], None, PageRequest::default())
+            .is_err());
+    }
+
+    #[test]
+    fn lazy_refusal_formats_only_sampled_details_with_identical_summary() {
+        let total = MAX_BATCH_WRITE_ERROR_DETAILS + 7;
+        let calls = std::cell::Cell::new(0);
+        let mut eager = BatchWriteSummary::default();
+        let mut lazy = BatchWriteSummary::default();
+        for index in 0..total {
+            let class = BatchWriteErrorClass::InvalidInput;
+            let retryability = BatchWriteRetryability::Permanent;
+            eager.record_failure(
+                index,
+                Some(index.to_string()),
+                class,
+                retryability,
+                "bad item",
+            );
+            lazy.record_failure_with(index, class, retryability, || {
+                calls.set(calls.get() + 1);
+                (Some(index.to_string()), "bad item".into())
+            });
+        }
+        assert_eq!(calls.get(), MAX_BATCH_WRITE_ERROR_DETAILS);
+        assert_eq!(
+            serde_json::to_value(lazy).unwrap(),
+            serde_json::to_value(eager).unwrap()
+        );
+    }
+
+    #[test]
+    fn lazy_refusal_preserves_first_error_after_empty_sample_messages() {
+        let mut summary = BatchWriteSummary::default();
+        for index in 0..MAX_BATCH_WRITE_ERROR_DETAILS {
+            summary.record_failure(
+                index,
+                None,
+                BatchWriteErrorClass::Unknown,
+                BatchWriteRetryability::Unknown,
+                "",
+            );
+        }
+        summary.record_failure_with(
+            MAX_BATCH_WRITE_ERROR_DETAILS,
+            BatchWriteErrorClass::Driver,
+            BatchWriteRetryability::Unknown,
+            || (None, "first nonempty error".into()),
+        );
+        assert_eq!(summary.first_error, "first nonempty error");
+        assert_eq!(summary.errors.len(), MAX_BATCH_WRITE_ERROR_DETAILS);
+        assert_eq!(summary.errors_omitted, 1);
+    }
 
     #[test]
     fn refusal_sample_is_bounded_but_counts_cover_the_complete_batch() {


### PR DESCRIPTION
Closes #2375. Closes #2376.

A guarded batch write that aborts reports a bounded sample of 128 error details,
so a caller with a larger batch could see that the write was refused but not which
of its entries were affected. Two changes, both confined to the storage layer.

**Enumerating beyond the sample (#2375).** `GuardedBatchOutcome::refusal_page`
pages the refused writes from the caller's own retained input, with no
resubmission and no endpoint re-read. An optional class filter applies before
offset and limit, `Page.total` is the full matching population, and a limit above
the 128 cap is clamped. The page uses the same classification and the same detail
formatter as the summary, so the enumeration cannot drift from the sample it
extends: exactly one entry is `InvalidInput/Permanent`, every sibling is
`BatchAborted/Unknown`, and paging makes no claim that the siblings were examined.

Validation is honest about what it can check. The supplied slice must match
`summary.attempted` in length and the refusal index must fall inside it, but a
same-length substituted batch cannot be detected, so the contract says to retain
the exact contents and order. This is a synchronous in-memory API, not a runtime
endpoint and not a durable cursor.

**Formatting only what is reported (#2376).** `BatchWriteSummary::record_failure`
now delegates to `record_failure_with`, which takes a closure and invokes it only
when the detail will actually be kept: either the entry falls inside the 128-detail
sample, or `first_error` is still empty. A thousand-entry batch that aborts on its
first entry no longer builds 999 abort messages to discard them.

`BatchWriteSummary`, the sample size, and the legacy `first_error` field keep
their existing behaviour, and the runtime wire response is untouched: `link_many`
still surfaces its first guarded-write failure and this change does not widen it.
