### PR TITLE
fix(gtd): exclude unknown stored task states from the default listing

### DIFF
--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -881,6 +881,23 @@ fn build_note_filter_where(
                     "CASE WHEN {type_expr} = 'text' THEN {expr} ELSE ?{n} END = ?{n}"
                 ));
             }
+            FilterOp::TextInOrNonText(values) => {
+                let expr = json_extract_expr(&pf.json_path);
+                let type_expr = json_type_expr(&pf.json_path);
+                let mut placeholders = Vec::with_capacity(values.len());
+                for value in values {
+                    params.push(sql_value_param(value)?);
+                    placeholders.push(format!("?{}", params.len()));
+                }
+                let text_match = if placeholders.is_empty() {
+                    "0".to_string()
+                } else {
+                    format!("{expr} IN ({})", placeholders.join(", "))
+                };
+                conditions.push(format!(
+                    "CASE WHEN {type_expr} = 'text' THEN {text_match} ELSE 1 END"
+                ));
+            }
             FilterOp::JsonTypeEq => {
                 let type_expr = json_type_expr(&pf.json_path);
                 params.push(sql_value_param(&pf.value)?);
@@ -965,6 +982,7 @@ fn build_note_filter_where(
                     FilterOp::EqOrMissing
                     | FilterOp::EqOrMissingIndexed
                     | FilterOp::TextEqOrNonText
+                    | FilterOp::TextInOrNonText(_)
                     | FilterOp::JsonTypeEq
                     | FilterOp::JsonTypeMissing
                     | FilterOp::JsonTypeMissingOrNullIndexed

--- a/crates/khive-db/src/stores/note_tests.rs
+++ b/crates/khive-db/src/stores/note_tests.rs
@@ -4697,25 +4697,18 @@ async fn narrowing_hot_property_index_to_kind_task_is_not_chosen() {
     );
 }
 
-/// khive#2392: `gtd.tasks()` with no `status=` filter compiles
+/// Historical khive#2392 control: the former default GTD filter compiled
 /// `FilterOp::NotInOrMissing(["done", "cancelled"])` on `$.status`
-/// (`handle_tasks` in `crates/khive-pack-gtd/src/handlers.rs`), which
-/// `build_note_filter_where` turns into `(expr IS NULL OR expr NOT IN
+/// which `build_note_filter_where` turns into `(expr IS NULL OR expr NOT IN
 /// (...))` -- an open exclusion, not a bounded set, so `idx_notes_task_status`
 /// cannot narrow it to an index range seek; the planner can only walk the
 /// `(namespace, kind)` partition.
 ///
-/// No seekable rewrite preserves the documented semantics either: the
-/// listing must keep a task whose `$.status` is missing *or* any unrecognized
-/// legacy value (see `handle_tasks`'s comment on why `NotInOrMissing` was
-/// chosen over `Ne`), so the exclusion set is open-ended and cannot be
-/// rewritten as `status IN (<the 5 known non-terminal statuses>)` -- that
-/// would silently drop a task carrying a status string outside
-/// `TASK_STATUSES`, which is exactly the case this predicate exists to keep.
-/// This test measures and pins the current (unindexed) plan rather than
-/// leaving the claim unverified.
+/// Issue #2394 replaces GTD's open-ended exclusion with a canonical text
+/// allowlist plus non-text fallback. This test retains the old predicate's
+/// measured plan as a control; it does not claim the new predicate is seekable.
 #[tokio::test]
-async fn gtd_tasks_default_listing_not_in_or_missing_has_no_seek_index() {
+async fn legacy_gtd_tasks_not_in_or_missing_has_no_seek_index() {
     use khive_storage::note::{FilterOp, NoteFilter, PropertyFilter as NotePropFilter};
     use khive_storage::types::SqlValue;
 
@@ -4753,4 +4746,75 @@ async fn gtd_tasks_default_listing_not_in_or_missing_has_no_seek_index() {
          keyed index seek, so idx_notes_task_status must not appear in the plan, \
          got:\n{plan}"
     );
+}
+
+#[tokio::test]
+async fn text_in_or_non_text_filters_before_pagination_with_count_parity() {
+    use khive_storage::note::{FilterOp, NoteFilter, PropertyFilter};
+    use khive_storage::types::SqlValue;
+
+    let store = setup_memory_store();
+    let properties = [
+        serde_json::json!({}),
+        serde_json::json!({"status": null}),
+        serde_json::json!({"status": false}),
+        serde_json::json!({"status": 4}),
+        serde_json::json!({"status": []}),
+        serde_json::json!({"status": {}}),
+        serde_json::json!({"status": "inbox"}),
+        serde_json::json!({"status": "next"}),
+        serde_json::json!({"status": "archived"}),
+        serde_json::json!({"status": "done"}),
+        serde_json::json!({"status": ""}),
+    ];
+    let mut ids = Vec::new();
+    for (index, properties) in properties.into_iter().enumerate() {
+        let mut note = make_note_with_props("default", "task", "predicate fixture", properties);
+        note.created_at = index as i64 + 1;
+        ids.push(note.id);
+        store.upsert_note(note).await.unwrap();
+    }
+    for (values, matching) in [
+        (
+            vec![
+                SqlValue::Text("inbox".into()),
+                SqlValue::Text("next".into()),
+            ],
+            8,
+        ),
+        (vec![], 6),
+    ] {
+        let filter = NoteFilter {
+            kind: Some("task".into()),
+            property_filters: vec![PropertyFilter {
+                json_path: "$.status".into(),
+                op: FilterOp::TextInOrNonText(values),
+                value: SqlValue::Null,
+            }],
+            ..Default::default()
+        };
+        for offset in 0..=matching {
+            let page = PageRequest {
+                limit: 1,
+                offset: offset as u64,
+            };
+            let counted = store
+                .query_notes_filtered("default", &filter, page.clone())
+                .await
+                .unwrap();
+            let count_free = store
+                .query_notes_filtered_count_free("default", &filter, page)
+                .await
+                .unwrap();
+            assert_eq!(counted.total, Some(matching as u64));
+            assert_eq!(count_free.total, None);
+            assert_eq!(counted.items, count_free.items);
+            if offset == matching {
+                assert!(count_free.items.is_empty());
+            } else {
+                assert_eq!(count_free.items.len(), 1);
+                assert_eq!(count_free.items[0].id, ids[matching - offset - 1]);
+            }
+        }
+    }
 }

--- a/crates/khive-pack-gtd/docs/api/task-query.md
+++ b/crates/khive-pack-gtd/docs/api/task-query.md
@@ -5,6 +5,25 @@ population by `property_filters` (status, assignee, priority) without either
 scanning the entire table on every call or missing older matching tasks
 behind a wall of newer non-matching churn.
 
+## Legacy state filtering (#2394)
+
+Default `gtd.tasks` selects canonical open status strings before pagination;
+terminal and unrecognized strings such as `archived` do not consume page slots.
+Missing and non-text statuses retain the legacy `inbox` fallback. Explicit
+canonical status filters and caller aliases are unchanged.
+
+When matching records were excluded and the default page is empty, the existing
+object envelope lists `done`, `cancelled`, and `unrecognized_status` under
+`filter_excluded`. Inspect historical rows with `list(kind="task")` or by-ID `get`;
+the query never rewrites their status, history, or timestamps. Unknown-state
+blockers are reported as `invalid` with a `broken` dependency state.
+
+`gtd.transition` and `gtd.complete`, including atomic preparation, reject unknown
+stored string states with an explicit invalid-stored-status error. Repair needs
+reviewed source evidence, preserving `archived_at` and transition history. The
+timestamp repair sub-request is deferred: the original units/replacement dates
+are unverified, storage uses microseconds, and no `gtd.stats` verb exists.
+
 ## `fetch_all_matching_tasks` — bounded single-snapshot scan (issue #772, #825)
 
 Fetches every `task` note matching `property_filters` in a single bounded

--- a/crates/khive-pack-gtd/src/dependency.rs
+++ b/crates/khive-pack-gtd/src/dependency.rs
@@ -153,6 +153,10 @@ fn diagnose_task(
                 broken = true;
                 blocked_by.push(json!({"id": raw, "state": "cancelled"}));
             }
+            status if !crate::schema::TASK_STATUSES.contains(&status) => {
+                broken = true;
+                blocked_by.push(json!({"id": raw, "state": "invalid", "status": status}));
+            }
             status => blocked_by.push(json!({
                 "id": raw,
                 "state": "pending",

--- a/crates/khive-pack-gtd/src/handlers.rs
+++ b/crates/khive-pack-gtd/src/handlers.rs
@@ -26,7 +26,7 @@ use khive_storage::types::{PageRequest, SqlStatement, SqlValue};
 
 use crate::schema::{
     allowed_transitions, can_transition, is_terminal, is_valid_priority, is_valid_status,
-    normalize_status, TASK_LIFECYCLE_HELP,
+    normalize_status, TASK_LIFECYCLE_HELP, TASK_STATUSES,
 };
 use crate::GtdPack;
 
@@ -865,6 +865,14 @@ async fn load_task(
     }
 
     let current = task_status(note.properties.as_ref());
+    if !TASK_STATUSES.contains(&current.as_str()) {
+        return Err(RuntimeError::InvalidInput(format!(
+            "task {} has invalid stored status {current:?}; valid stored statuses: {}; \
+             legacy state requires reviewed repair, not a lifecycle transition",
+            short_id(note.id),
+            TASK_STATUSES.join(", ")
+        )));
+    }
     Ok((note, current))
 }
 
@@ -1475,11 +1483,13 @@ impl GtdPack {
         // empty even though done tasks exist), and deep pages re-scanned the
         // same rows since the underlying fetch offset never advanced.
         //
-        // When no status= is provided, exclude terminal states (done,
-        // cancelled) so the default listing shows only active work, while
-        // still counting a task with no `status` property yet as `inbox`
-        // (non-terminal, included) — hence `NotInOrMissing` rather than `Ne`,
-        // which would silently drop rows where `$.status` is absent.
+        // Only canonical open strings are work. Missing and non-text legacy
+        // values retain the same semantic inbox fallback as task_status.
+        let open_statuses: Vec<SqlValue> = TASK_STATUSES
+            .iter()
+            .filter(|status| !is_terminal(status))
+            .map(|status| SqlValue::Text((*status).to_string()))
+            .collect();
         let mut property_filters = vec![match status_filter.as_deref() {
             Some(want) => PropertyFilter {
                 json_path: "$.status".to_string(),
@@ -1498,10 +1508,7 @@ impl GtdPack {
             },
             None => PropertyFilter {
                 json_path: "$.status".to_string(),
-                op: FilterOp::NotInOrMissing(vec![
-                    SqlValue::Text("done".to_string()),
-                    SqlValue::Text("cancelled".to_string()),
-                ]),
+                op: FilterOp::TextInOrNonText(open_statuses.clone()),
                 value: SqlValue::Null,
             },
         }];
@@ -1571,20 +1578,22 @@ impl GtdPack {
             .collect();
 
         // #96: a bare `[]` is indistinguishable from "no such task" when the
-        // *default* terminal-status exclusion is what emptied the result —
+        // *default* state exclusion is what emptied the result —
         // the common case a caller hits right after `gtd.complete`. Probe for
-        // a terminal task with the same namespace/assignee/priority filters
+        // an excluded task with the same namespace/assignee/priority filters
         // before changing the response shape; other empty results keep the
         // established bare array.
         if result.is_empty() && status_filter.is_none() {
             property_filters[0] = PropertyFilter {
                 json_path: "$.status".to_string(),
-                op: FilterOp::In(vec![
-                    SqlValue::Text("done".to_string()),
-                    SqlValue::Text("cancelled".to_string()),
-                ]),
+                op: FilterOp::NotInOrMissing(open_statuses),
                 value: SqlValue::Null,
             };
+            property_filters.push(PropertyFilter {
+                json_path: "$.status".to_string(),
+                op: FilterOp::JsonTypeEq,
+                value: SqlValue::Text("text".to_string()),
+            });
             let terminal_filter = NoteFilter {
                 kind: Some("task".to_string()),
                 property_filters,
@@ -1608,10 +1617,11 @@ impl GtdPack {
             if !terminal_page.items.is_empty() {
                 return Ok(json!({
                     "tasks": result,
-                    "filter_excluded": ["done", "cancelled"],
-                    "hint": "no tasks matched, but the default filter excludes done/cancelled \
-                              tasks — pass status=\"done\" or status=\"cancelled\" to check \
-                              whether a completed task exists before concluding it doesn't",
+                    "filter_excluded": ["done", "cancelled", "unrecognized_status"],
+                    "hint": "no tasks matched, but the default filter excludes terminal and \
+                              unrecognized stored statuses; pass status=\"done\" or \
+                              status=\"cancelled\" for terminal tasks, or use list(kind=\"task\") \
+                              to inspect legacy records before a reviewed repair",
                 }));
             }
         }

--- a/crates/khive-pack-gtd/src/vocab.rs
+++ b/crates/khive-pack-gtd/src/vocab.rs
@@ -233,12 +233,14 @@ pub(crate) static GTD_HANDLERS: [HandlerDef; 5] = [
     HandlerDef {
         name: "gtd.tasks",
         description: "List tasks filtered by status, assignee, priority. DEFAULT (no `status` \
-                       given): excludes terminal statuses (done, cancelled) so the default \
+                       given): includes canonical open states and the legacy missing/non-text \
+                       inbox fallback; excludes terminal and unrecognized stored statuses so the default \
                        listing shows only active work. Pass status=\"done\" or \
                        status=\"cancelled\" explicitly to see completed/cancelled tasks — an \
                        empty result under the default filter does NOT mean the task doesn't \
                        exist; the response carries `filter_excluded` when the default filter \
-                       is the reason the result is empty (issue #96).",
+                       is the reason the result is empty (issue #96). Inspect legacy records \
+                       through list(kind=\"task\"); they are not silently rewritten.",
         visibility: Visibility::Verb,
         category: VerbCategory::Assertive,
         params: &[

--- a/crates/khive-pack-gtd/tests/legacy_state.rs
+++ b/crates/khive-pack-gtd/tests/legacy_state.rs
@@ -1,0 +1,278 @@
+mod common;
+use common::*;
+
+use khive_pack_gtd::handlers::{prepare_complete, prepare_transition};
+use khive_pack_gtd::schema::TASK_STATUSES;
+use khive_runtime::{KhiveRuntime, Namespace, RuntimeError};
+use khive_storage::Note;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+async fn seed(runtime: &KhiveRuntime, properties: Value, created_at: i64) -> Note {
+    let token = runtime.authorize(Namespace::local()).unwrap();
+    let mut note = Note::new("local", "task", "private legacy fixture");
+    note.name = Some("private legacy fixture".into());
+    note.properties = Some(properties);
+    note.created_at = created_at;
+    note.updated_at = created_at;
+    runtime
+        .notes(&token)
+        .unwrap()
+        .upsert_note(note.clone())
+        .await
+        .unwrap();
+    note
+}
+
+#[tokio::test]
+async fn legacy_state_default_filter_excludes_unknown_strings_before_pagination() {
+    let runtime = rt();
+    let pack = pack(runtime.clone());
+    let older = seed(&runtime, json!({"status": "waiting"}), 1).await;
+    let newer = seed(&runtime, json!({"status": "next"}), 2).await;
+    for (index, status) in ["archived", "unknown", "todo", "", "done", "cancelled"]
+        .into_iter()
+        .enumerate()
+    {
+        seed(&runtime, json!({"status": status}), 10 + index as i64).await;
+    }
+    for (offset, expected) in [(0, newer.id), (1, older.id)] {
+        let page = pack
+            .dispatch("gtd.tasks", json!({"limit": 1, "offset": offset}))
+            .await
+            .unwrap();
+        assert_eq!(page.as_array().unwrap().len(), 1);
+        assert_eq!(page[0]["full_id"], expected.to_string());
+    }
+    for status in ["done", "cancelled"] {
+        let page = pack
+            .dispatch("gtd.tasks", json!({"status": status}))
+            .await
+            .unwrap();
+        assert_eq!(page.as_array().unwrap().len(), 1);
+        assert_eq!(page[0]["status"], status);
+    }
+    let next = pack.dispatch("gtd.next", json!({})).await.unwrap();
+    assert_eq!(next.as_array().unwrap().len(), 1);
+    assert_eq!(next[0]["full_id"], newer.id.to_string());
+    assert!(pack
+        .dispatch("gtd.tasks", json!({"status": "archived"}))
+        .await
+        .is_err());
+}
+
+#[tokio::test]
+async fn legacy_state_default_filter_preserves_non_text_inbox_fallback() {
+    let runtime = rt();
+    let pack = pack(runtime.clone());
+    for (index, properties) in [
+        json!({}),
+        json!({"status": null}),
+        json!({"status": false}),
+        json!({"status": 4}),
+        json!({"status": []}),
+        json!({"status": {}}),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        seed(&runtime, properties, index as i64 + 1).await;
+    }
+    let default = pack.dispatch("gtd.tasks", json!({})).await.unwrap();
+    let inbox = pack
+        .dispatch("gtd.tasks", json!({"status": "inbox"}))
+        .await
+        .unwrap();
+    assert_eq!(default, inbox);
+    assert_eq!(default.as_array().unwrap().len(), 6);
+    assert!(default
+        .as_array()
+        .unwrap()
+        .iter()
+        .all(|task| task["status"] == "inbox"));
+}
+
+#[tokio::test]
+async fn legacy_state_refusal_preserves_history_on_canonical_and_atomic_prepare_paths() {
+    let runtime = rt();
+    let pack = pack(runtime.clone());
+    let token = runtime.authorize(Namespace::local()).unwrap();
+    let legacy = seed(
+        &runtime,
+        json!({
+            "status": "archived", "archived_at": 1_772_323_200_000_i64,
+            "transition_history": [{"from": "active", "to": "archived"}],
+        }),
+        1_772_323_200,
+    )
+    .await;
+    let id = legacy.id.to_string();
+    for verb in ["gtd.transition", "gtd.complete"] {
+        let error = pack
+            .dispatch(verb, json!({"id": id, "status": "cancelled"}))
+            .await
+            .unwrap_err();
+        assert!(matches!(error, RuntimeError::InvalidInput(_)));
+        assert!(error
+            .to_string()
+            .contains("invalid stored status \"archived\""));
+    }
+    let transition_error = prepare_transition(&runtime, &token, &id, "cancelled", None)
+        .await
+        .err()
+        .expect("atomic transition preparation rejects invalid stored state");
+    let complete_error = prepare_complete(&runtime, &token, &id, Some("cancelled"), None)
+        .await
+        .err()
+        .expect("atomic completion preparation rejects invalid stored state");
+    for error in [transition_error, complete_error] {
+        assert!(error
+            .to_string()
+            .contains("invalid stored status \"archived\""));
+    }
+    let persisted = runtime
+        .notes(&token)
+        .unwrap()
+        .get_note(legacy.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(persisted, legacy);
+    let hidden = pack.dispatch("gtd.tasks", json!({})).await.unwrap();
+    assert_eq!(hidden["tasks"], json!([]));
+    assert!(hidden["filter_excluded"]
+        .as_array()
+        .unwrap()
+        .contains(&json!("unrecognized_status")));
+    assert_eq!(
+        pack.dispatch("get", json!({"id": id})).await.unwrap()["properties"]["status"],
+        "archived"
+    );
+    assert_eq!(
+        pack.dispatch("gtd.tasks", json!({"assignee": "unrelated"}))
+            .await
+            .unwrap(),
+        json!([])
+    );
+}
+
+#[tokio::test]
+async fn legacy_state_blockers_are_broken_not_pending_work() {
+    let runtime = rt();
+    let pack = pack(runtime.clone());
+    let legacy = seed(&runtime, json!({"status": "archived"}), 1).await;
+    let dependent = assign(
+        &pack,
+        json!({
+            "title": "dependent", "status": "next", "depends_on": [legacy.id.to_string()],
+        }),
+    )
+    .await;
+    assert_eq!(
+        pack.dispatch("gtd.next", json!({})).await.unwrap(),
+        json!([])
+    );
+    let page = pack
+        .dispatch("gtd.next", json!({"include_blocked": true}))
+        .await
+        .unwrap();
+    assert_eq!(page.as_array().unwrap().len(), 1);
+    assert_eq!(page[0]["full_id"], dependent["full_id"]);
+    assert_eq!(page[0]["dependency_state"], "broken");
+    assert_eq!(page[0]["actionable"], false);
+    assert_eq!(page[0]["blocked_by"][0]["state"], "invalid");
+    assert_eq!(page[0]["blocked_by"][0]["status"], "archived");
+}
+
+#[tokio::test]
+async fn legacy_state_census_public_writes_store_only_canonical_statuses() {
+    let runtime = rt();
+    let pack = pack(runtime.clone());
+    let token = runtime.authorize(Namespace::local()).unwrap();
+    let mut ids = Vec::new();
+    for verb in ["gtd.assign", "create"] {
+        for status in [
+            "inbox",
+            "next",
+            "waiting",
+            "someday",
+            "active",
+            "todo",
+            "in_progress",
+            "blocked",
+            "later",
+        ] {
+            let mut args = json!({"title": "canonical state census", "status": status});
+            if verb == "create" {
+                args["kind"] = json!("task");
+            }
+            let created = pack.dispatch(verb, args).await.unwrap();
+            ids.push(Uuid::parse_str(created["full_id"].as_str().unwrap()).unwrap());
+        }
+        for status in ["archived", "unknown"] {
+            let mut args = json!({"title": "invalid state", "status": status});
+            if verb == "create" {
+                args["kind"] = json!("task");
+            }
+            assert!(pack.dispatch(verb, args).await.is_err());
+            assert!(pack.dispatch("create", json!({
+                "kind": "task", "title": "invalid nested state", "properties": {"status": status},
+            })).await.is_err());
+        }
+    }
+    pack.dispatch(
+        "gtd.transition",
+        json!({"id": ids[0], "status": "finished"}),
+    )
+    .await
+    .unwrap();
+    pack.dispatch("gtd.complete", json!({"id": ids[1], "status": "cancelled"}))
+        .await
+        .unwrap();
+    for id in &ids {
+        assert!(pack
+            .dispatch(
+                "update",
+                json!({"id": id, "properties": {"status": "archived"}})
+            )
+            .await
+            .is_err());
+    }
+    let notes = runtime
+        .notes(&token)
+        .unwrap()
+        .query_notes_filtered_count_free(
+            "local",
+            &khive_storage::note::NoteFilter {
+                kind: Some("task".into()),
+                ..Default::default()
+            },
+            khive_storage::types::PageRequest {
+                limit: 200,
+                offset: 0,
+            },
+        )
+        .await
+        .unwrap()
+        .items;
+    assert_eq!(
+        notes.len(),
+        ids.len(),
+        "rejected creates must not leave rows"
+    );
+    let mut observed = std::collections::BTreeSet::new();
+    for note in notes {
+        let status = note.properties.as_ref().unwrap()["status"]
+            .as_str()
+            .unwrap();
+        assert!(TASK_STATUSES.contains(&status), "{}: {status:?}", note.id);
+        observed.insert(status.to_string());
+    }
+    assert_eq!(
+        observed,
+        TASK_STATUSES
+            .iter()
+            .map(|status| status.to_string())
+            .collect()
+    );
+}

--- a/crates/khive-pack-gtd/tests/legacy_state.rs
+++ b/crates/khive-pack-gtd/tests/legacy_state.rs
@@ -207,7 +207,18 @@ async fn legacy_state_census_public_writes_store_only_canonical_statuses() {
                 args["kind"] = json!("task");
             }
             let created = pack.dispatch(verb, args).await.unwrap();
-            ids.push(Uuid::parse_str(created["full_id"].as_str().unwrap()).unwrap());
+            // `gtd.assign` answers with `full_id`; the generic `create` verb
+            // answers with the record's own `id`. Both are full UUIDs.
+            let created_id = created
+                .get("full_id")
+                .or_else(|| created.get("id"))
+                .and_then(|v| v.as_str())
+                .unwrap_or_else(|| {
+                    panic!("{verb} response carries neither full_id nor id: {created}")
+                });
+            ids.push(Uuid::parse_str(created_id).unwrap_or_else(|e| {
+                panic!("{verb} returned a non-UUID id {created_id:?}: {e}")
+            }));
         }
         for status in ["archived", "unknown"] {
             let mut args = json!({"title": "invalid state", "status": status});

--- a/crates/khive-pack-gtd/tests/legacy_state.rs
+++ b/crates/khive-pack-gtd/tests/legacy_state.rs
@@ -216,9 +216,11 @@ async fn legacy_state_census_public_writes_store_only_canonical_statuses() {
                 .unwrap_or_else(|| {
                     panic!("{verb} response carries neither full_id nor id: {created}")
                 });
-            ids.push(Uuid::parse_str(created_id).unwrap_or_else(|e| {
-                panic!("{verb} returned a non-UUID id {created_id:?}: {e}")
-            }));
+            ids.push(
+                Uuid::parse_str(created_id).unwrap_or_else(|e| {
+                    panic!("{verb} returned a non-UUID id {created_id:?}: {e}")
+                }),
+            );
         }
         for status in ["archived", "unknown"] {
             let mut args = json!({"title": "invalid state", "status": status});

--- a/crates/khive-storage/src/note.rs
+++ b/crates/khive-storage/src/note.rs
@@ -508,6 +508,10 @@ pub enum FilterOp {
     /// value END = value`, mirroring callers whose read model assigns one
     /// textual default to absent, JSON-null, and malformed legacy values.
     TextEqOrNonText,
+    /// Matches a JSON text field against the supplied set, or any missing or
+    /// non-text value. The non-text branch still matches when the set is empty.
+    /// `PropertyFilter.value` is unused; the set lives in this variant.
+    TextInOrNonText(Vec<SqlValue>),
     Ne,
     Lt,
     Lte,
@@ -525,15 +529,13 @@ pub enum FilterOp {
     JsonTypeNeMissing,
     /// Matches rows where `json_extract(properties, path)` equals any value in
     /// the set. A row with a missing/NULL property does not match — use
-    /// `NotInOrMissing` with the complementary set when "absent" should count
-    /// as included. `PropertyFilter.value` is unused for this op; the set
+    /// `TextInOrNonText` when a textual read model includes missing/non-text
+    /// legacy values. `PropertyFilter.value` is unused for this op; the set
     /// lives in the variant itself.
     In(Vec<SqlValue>),
     /// Matches rows where the property is missing/NULL OR its value is not in
-    /// the set. Used for "exclude a small closed set of terminal values, but
-    /// treat a still-unset property as included" (e.g. GTD default task
-    /// listing excludes `done`/`cancelled` while a task with no `status` yet
-    /// still counts as `inbox`, i.e. included). `PropertyFilter.value` is
+    /// the set. Used to exclude a closed set while treating an unset property
+    /// as included (e.g. comm inbox excludes `outbound`). `PropertyFilter.value` is
     /// unused for this op; the set lives in the variant itself.
     NotInOrMissing(Vec<SqlValue>),
 }

--- a/docs/adr/ADR-019-gtd-pack.md
+++ b/docs/adr/ADR-019-gtd-pack.md
@@ -726,3 +726,48 @@ The per-pack plugin this ADR describes (`marketplace/gtd/`, a `plugin.json` pinn
 still reachable by setting `KHIVE_PACKS=gtd` on that server's environment, which is the runtime
 selection §Configuration describes. The `marketplace/gtd/plugin.json` lines above are the design at
 acceptance and are kept as history; the shipping manifest is `.claude-plugin/marketplace.json`.
+
+## Amendment 2 (2026-09-10): legacy task state boundaries (#2394)
+
+Default `gtd.tasks` includes only the canonical open strings (`inbox`, `next`,
+`waiting`, `someday`, `active`). Missing and non-text stored statuses retain the
+existing semantic `inbox` fallback. Unknown strings, including legacy `archived`
+and unnormalized aliases, are excluded before pagination, like terminal records;
+this does not declare them successfully completed or change their stored state.
+Explicit filters still accept canonical statuses and normalize caller aliases.
+
+The property-filter adapter adds `TextInOrNonText`: membership for JSON text and
+inclusion for missing/non-text values. Existing filters combine only with AND;
+the single-value `TextEqOrNonText` cannot express this set, and `In` would discard
+the documented legacy fallback. An empty set matches only the non-text branch.
+No index-seek or latency improvement is asserted by this correctness change.
+
+The existing empty-default-list envelope now identifies `unrecognized_status`
+alongside `done` and `cancelled` in `filter_excluded` when a matching excluded
+record exists. Generic `list(kind="task")` and by-ID `get` retain access to the
+original records. Lifecycle preparation shared by canonical and atomic
+`gtd.transition`/`gtd.complete` rejects a noncanonical stored string explicitly;
+it does not reinterpret `archived` as `done` or `cancelled`. Unknown-state blockers
+are diagnostically `invalid`/`broken`, not pending actionable work.
+
+Public task creation continues to normalize accepted aliases and reject unknown
+statuses. Generic task updates cannot patch the lifecycle-owned `status`,
+`completed_at`, or `transition_history` fields; lifecycle changes belong to the
+GTD verbs. These rules govern supported writes, not a migration or a reinterpretation
+of historical imports. Private-fixture census tests cover both creation forms,
+lifecycle writes, and refused generic status updates.
+
+Legacy repair is an evidence-driven curation operation, not a read side effect.
+Establish the intended terminal state from the original import or audit evidence
+before correcting `archived`, and retain `archived_at` and the original transition
+history as provenance. Neither successful completion nor cancellation may be
+inferred solely from the old spelling.
+
+The timestamp sub-request of #2394 is deferred. Storage timestamps are microseconds
+since the Unix epoch; the report alone does not establish the import's original
+units or a correct replacement instant. There is no `gtd.stats` verb. Do not infer
+a replacement `created_at`/`updated_at` from `archived_at` or rewrite dates during
+reads or lifecycle validation. Any manual repair requires independently verified
+source timestamps/units, an operator-reviewed correction, and preserved original
+values; this amendment supplies neither an automatic repair nor speculative
+timestamp diagnostics.


### PR DESCRIPTION
Addresses the task-state half of #2394. The timestamp half is deliberately not
in this PR and #2394 stays open for it; the reason is in the amendment.

A task row whose stored `status` is a string nobody recognises, such as a legacy
`archived`, listed as open work and then refused every transition, so it could
neither be worked nor closed. The default listing was built as "exclude the
terminal states", which admits anything that is not `done` or `cancelled` —
including strings the lifecycle has no rules for.

The default now includes only the canonical open states (`inbox`, `next`,
`waiting`, `someday`, `active`), plus the existing semantic `inbox` fallback for a
missing or non-text status. Unknown strings are excluded before pagination, the
same as terminal ones. Nothing is rewritten: the records keep their stored value
and stay reachable through `list(kind="task")` and by-id `get`.

Three supporting changes:

- `FilterOp::TextInOrNonText` expresses "in this set, or missing/non-text" in one
  filter. Filters combine only with AND, so the single-value `TextEqOrNonText`
  cannot say it and a plain `In` would drop the documented legacy fallback.
- The empty-result envelope from #96 now lists `unrecognized_status` beside
  `done` and `cancelled` in `filter_excluded`, with a hint pointing at
  `list(kind="task")`. Without this the new exclusion would be a second silent
  emptiness, which is the defect #96 was about.
- Lifecycle loading refuses a noncanonical stored status explicitly, naming the
  value and the valid set, rather than failing somewhere further in. It does not
  reinterpret `archived` as `done` or `cancelled`: which terminal state a legacy
  row should have is an evidence question about the original import, not something
  a read path may infer.

ADR-019 gains Amendment 2 stating the boundary, why the timestamp half is
deferred (stored timestamps are microseconds since the epoch and the report does
not establish the import's units or a correct replacement instant), and that
repairing a legacy row is a reviewed curation operation that preserves
`archived_at` and the original transition history.
