### PR TITLE
fix(git): type remote recovery failures and encode them on the wire

### DIFF
--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -2797,6 +2797,11 @@ fn runtime_error_value(error: RuntimeError, disposition: DomainDisposition) -> V
         }
         RuntimeError::Khive(k) => serde_json::to_value(&k)
             .unwrap_or_else(|_| json!({"kind": "internal", "message": k.to_string()})),
+        RuntimeError::RemoteFetchError { remote, message } => json!({
+            "kind": "remote_fetch_error",
+            "remote": remote,
+            "message": message,
+        }),
         other @ (RuntimeError::Storage(_)
         | RuntimeError::Sqlite(_)
         | RuntimeError::Query(_)
@@ -2826,7 +2831,6 @@ fn runtime_error_value(error: RuntimeError, disposition: DomainDisposition) -> V
         | RuntimeError::RemoteCacheMissing { .. }
         | RuntimeError::AmbiguousId { .. }
         | RuntimeError::CrossNamespaceWrite { .. }
-        | RuntimeError::RemoteFetchError { .. }
         | RuntimeError::WriteBudgetExceeded { .. }
         | RuntimeError::SecretDetected(_)
         | RuntimeError::DeadlineExceeded { .. }) => {
@@ -6537,6 +6541,87 @@ mod tests {
             tool: "probe".to_string(),
             future,
         }
+    }
+
+    struct RemoteFetchErrorPack;
+
+    impl khive_types::Pack for RemoteFetchErrorPack {
+        const NAME: &'static str = "remote-fetch-error-test";
+        const NOTE_KINDS: &'static [&'static str] = &[];
+        const ENTITY_KINDS: &'static [&'static str] = &[];
+        const HANDLERS: &'static [khive_runtime::HandlerDef] = &[khive_runtime::HandlerDef {
+            name: "remote_fetch_failure",
+            description: "returns a typed remote fetch failure",
+            visibility: khive_runtime::Visibility::Verb,
+            category: khive_runtime::VerbCategory::Assertive,
+            params: &[],
+        }];
+    }
+
+    #[async_trait::async_trait]
+    impl khive_runtime::PackRuntime for RemoteFetchErrorPack {
+        fn name(&self) -> &str {
+            <Self as khive_types::Pack>::NAME
+        }
+
+        fn note_kinds(&self) -> &'static [&'static str] {
+            <Self as khive_types::Pack>::NOTE_KINDS
+        }
+
+        fn entity_kinds(&self) -> &'static [&'static str] {
+            <Self as khive_types::Pack>::ENTITY_KINDS
+        }
+
+        fn handlers(&self) -> &'static [khive_runtime::HandlerDef] {
+            <Self as khive_types::Pack>::HANDLERS
+        }
+
+        async fn dispatch(
+            &self,
+            _verb: &str,
+            _params: Value,
+            _registry: &VerbRegistry,
+            _token: &khive_runtime::NamespaceToken,
+        ) -> Result<Value, RuntimeError> {
+            Err(RuntimeError::RemoteFetchError {
+                remote: "broken-origin".to_string(),
+                message: "injected fetch failure".to_string(),
+            })
+        }
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(config_ledger)]
+    async fn request_remote_fetch_error_retains_structured_fields() {
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(RemoteFetchErrorPack);
+        let server = KhiveMcpServer::from_registry(builder.build().expect("test registry"));
+        let response = server
+            .dispatch_request_local(RequestParams {
+                ops: "remote_fetch_failure()".to_string(),
+                presentation: Some("verbose".to_string()),
+                format: Some("json".to_string()),
+                ..Default::default()
+            })
+            .await
+            .expect("remote fetch failure must remain a per-op error");
+        let envelope: Value = serde_json::from_str(&response).expect("request envelope");
+        assert_eq!(envelope["summary"]["failed"], 1, "{envelope}");
+        assert_eq!(envelope["summary"]["succeeded"], 0, "{envelope}");
+        let results = envelope["results"].as_array().expect("per-op results");
+        assert_eq!(results.len(), 1, "{envelope}");
+        assert_eq!(results[0]["ok"], false);
+        assert_eq!(results[0]["tool"], "remote_fetch_failure");
+        assert_eq!(
+            results[0]["error"],
+            json!({
+                "kind": "remote_fetch_error",
+                "remote": "broken-origin",
+                "message": "injected fetch failure",
+                "domain_disposition": "unknown",
+            }),
+            "{envelope}"
+        );
     }
 
     struct LargeResultPack;

--- a/crates/khive-pack-git/Cargo.toml
+++ b/crates/khive-pack-git/Cargo.toml
@@ -44,6 +44,7 @@ windows-sys = { version = "0.61", features = [
     "Win32_Security",
     "Win32_System_JobObjects",
     "Win32_System_Threading",
+    "Win32_System_Pipes",
     "Win32_System_Diagnostics_ToolHelp",
 ] }
 

--- a/crates/khive-pack-git/src/cache.rs
+++ b/crates/khive-pack-git/src/cache.rs
@@ -26,8 +26,10 @@
 //! enforcement, slot serialization).
 
 use std::collections::HashMap;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
 
@@ -109,6 +111,206 @@ impl From<std::io::Error> for CacheError {
     fn from(e: std::io::Error) -> Self {
         CacheError::Io(e)
     }
+}
+
+const MAX_GIT_DIAGNOSTIC_BYTES: usize = 16 * 1024;
+
+pub(crate) fn sanitize_diagnostic(message: &str) -> String {
+    message
+        .lines()
+        .map(|line| {
+            let line: String = line
+                .chars()
+                .filter(|c| !c.is_control() || *c == '\t')
+                .collect();
+            let sanitized = line
+                .split_whitespace()
+                .map(|word| {
+                    // Remove whole URL/address tokens, including a URL cut off
+                    // at the capture bound before its userinfo separator.
+                    if word.contains("://") || word.contains('@') {
+                        "[redacted remote]"
+                    } else {
+                        word
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join(" ");
+            let lower = sanitized.to_ascii_lowercase();
+            if [
+                "authorization:",
+                "cookie:",
+                "password=",
+                "password:",
+                "token=",
+                "token:",
+                "secret=",
+                "secret:",
+            ]
+            .iter()
+            .any(|marker| lower.contains(marker))
+            {
+                return "[redacted credential diagnostic]".to_string();
+            }
+            sanitized
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn capture_diagnostic(mut stderr: impl Read, finished: &AtomicBool) -> std::io::Result<Vec<u8>> {
+    let mut retained = Vec::new();
+    let mut buffer = [0u8; 4096];
+    loop {
+        let count = match stderr.read(&mut buffer) {
+            Ok(count) => count,
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                if finished.load(Ordering::Acquire) {
+                    return Ok(retained);
+                }
+                std::thread::sleep(Duration::from_millis(5));
+                continue;
+            }
+            Err(error) => return Err(error),
+        };
+        if count == 0 {
+            return Ok(retained);
+        }
+        let keep = count.min(MAX_GIT_DIAGNOSTIC_BYTES - retained.len());
+        retained.extend_from_slice(&buffer[..keep]);
+        if retained.len() == MAX_GIT_DIAGNOSTIC_BYTES && finished.load(Ordering::Acquire) {
+            return Ok(retained);
+        }
+    }
+}
+
+struct DiagnosticPipe(std::process::ChildStderr);
+
+impl DiagnosticPipe {
+    fn new(stderr: std::process::ChildStderr) -> std::io::Result<Self> {
+        #[cfg(unix)]
+        {
+            use std::os::fd::AsRawFd;
+            let fd = stderr.as_raw_fd();
+            // The owned pipe has one reader; nonblocking mode lets that
+            // reader stop when git exits even if a descendant retained it.
+            let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+            if flags < 0 || unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0
+            {
+                return Err(std::io::Error::last_os_error());
+            }
+        }
+        Ok(Self(stderr))
+    }
+}
+
+impl Read for DiagnosticPipe {
+    fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+        #[cfg(windows)]
+        {
+            use std::os::windows::io::AsRawHandle;
+            use windows_sys::Win32::Foundation::ERROR_BROKEN_PIPE;
+            use windows_sys::Win32::System::Pipes::PeekNamedPipe;
+            let mut available = 0;
+            let ok = unsafe {
+                PeekNamedPipe(
+                    self.0.as_raw_handle(),
+                    std::ptr::null_mut(),
+                    0,
+                    std::ptr::null_mut(),
+                    &mut available,
+                    std::ptr::null_mut(),
+                )
+            };
+            if ok == 0 {
+                let error = std::io::Error::last_os_error();
+                return if error.raw_os_error() == Some(ERROR_BROKEN_PIPE as i32) {
+                    Ok(0)
+                } else {
+                    Err(error)
+                };
+            }
+            if available == 0 {
+                return Err(std::io::ErrorKind::WouldBlock.into());
+            }
+            let count = buffer.len().min(available as usize);
+            return self.0.read(&mut buffer[..count]);
+        }
+        #[cfg(not(windows))]
+        self.0.read(buffer)
+    }
+}
+
+#[cfg(any(unix, windows))]
+fn with_git_diagnostics(
+    command: &mut Command,
+    operation: &str,
+    run: impl FnOnce(&mut std::process::Child) -> Result<(), CacheError>,
+) -> Result<(), CacheError> {
+    let mut child = command
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|error| CacheError::Git(format!("spawning {operation}: {error}")))?;
+    let stderr = match DiagnosticPipe::new(child.stderr.take().expect("stderr configured as piped"))
+    {
+        Ok(stderr) => stderr,
+        Err(_) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(CacheError::Git(format!(
+                "preparing {operation} diagnostic capture failed"
+            )));
+        }
+    };
+    let finished = AtomicBool::new(false);
+    std::thread::scope(|scope| {
+        // Drain concurrently even after the retained prefix fills, so git
+        // cannot deadlock on a full pipe while the clone-size monitor runs.
+        let captured = match std::thread::Builder::new()
+            .spawn_scoped(scope, || capture_diagnostic(stderr, &finished))
+        {
+            Ok(captured) => captured,
+            Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(CacheError::Git(format!(
+                    "starting {operation} diagnostic reader failed"
+                )));
+            }
+        };
+        let result = run(&mut child);
+        if result.is_err() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        finished.store(true, Ordering::Release);
+        let diagnostic = captured
+            .join()
+            .ok()
+            .and_then(Result::ok)
+            .map(|bytes| sanitize_diagnostic(&String::from_utf8_lossy(&bytes)))
+            .unwrap_or_default();
+        result.map_err(|error| match error {
+            CacheError::Git(message) if !diagnostic.trim().is_empty() => {
+                CacheError::Git(format!("{message}: {diagnostic}"))
+            }
+            other => other,
+        })
+    })
+}
+
+#[cfg(not(any(unix, windows)))]
+fn with_git_diagnostics(
+    command: &mut Command,
+    operation: &str,
+    run: impl FnOnce(&mut std::process::Child) -> Result<(), CacheError>,
+) -> Result<(), CacheError> {
+    let mut child = command
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|error| CacheError::Git(format!("spawning {operation}: {error}")))?;
+    run(&mut child)
 }
 
 fn scratch_root() -> PathBuf {
@@ -1127,62 +1329,60 @@ fn clone(url: &str, dest: &Path, cap: u64) -> Result<(), CacheError> {
         command.creation_flags(windows_job::CREATE_SUSPENDED);
     }
 
-    let mut child = command
-        .spawn()
-        .map_err(|e| CacheError::Git(format!("spawning git clone: {e}")))?;
-
-    #[cfg(windows)]
-    let isolation = match windows_job::CloneJob::create_and_adopt(&child) {
-        Ok(job) => job,
-        Err(e) => {
-            // The child is still suspended and has run no code; a plain kill
-            // (no job needed, since nothing was assigned to one) is enough.
-            let _ = child.kill();
-            let _ = child.wait();
-            return Err(e);
-        }
-    };
-    #[cfg(not(windows))]
-    let isolation: CloneIsolation = ();
-
-    let status = loop {
-        match child.try_wait() {
-            Ok(Some(status)) => break status,
-            Ok(None) => {}
+    with_git_diagnostics(&mut command, "git clone", |child| {
+        #[cfg(windows)]
+        let isolation = match windows_job::CloneJob::create_and_adopt(child) {
+            Ok(job) => job,
             Err(e) => {
-                terminate_clone(&mut child, &isolation)?;
-                return Err(CacheError::Git(format!(
-                    "waiting for git clone {:?}: {e}",
-                    redact_repo_url(url)
-                )));
-            }
-        }
-
-        let walk_start = std::time::Instant::now();
-        let size = match dir_size(dest) {
-            Ok(size) => size,
-            // Git creates the destination itself; it is legitimately absent
-            // for the first few polls after spawn.
-            Err(CacheError::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => 0,
-            Err(e) => {
-                terminate_clone(&mut child, &isolation)?;
+                // The child is still suspended and has run no code; a plain kill
+                // (no job needed, since nothing was assigned to one) is enough.
+                let _ = child.kill();
+                let _ = child.wait();
                 return Err(e);
             }
         };
-        let walk_elapsed = walk_start.elapsed();
-        if size > cap {
-            terminate_clone(&mut child, &isolation)?;
-            return Err(CacheError::CloneTooLarge { bytes: size, cap });
+        #[cfg(not(windows))]
+        let isolation: CloneIsolation = ();
+
+        let status = loop {
+            match child.try_wait() {
+                Ok(Some(status)) => break status,
+                Ok(None) => {}
+                Err(e) => {
+                    terminate_clone(child, &isolation)?;
+                    return Err(CacheError::Git(format!(
+                        "waiting for git clone {:?}: {e}",
+                        redact_repo_url(url)
+                    )));
+                }
+            }
+
+            let walk_start = std::time::Instant::now();
+            let size = match dir_size(dest) {
+                Ok(size) => size,
+                // Git creates the destination itself; it is legitimately absent
+                // for the first few polls after spawn.
+                Err(CacheError::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => 0,
+                Err(e) => {
+                    terminate_clone(child, &isolation)?;
+                    return Err(e);
+                }
+            };
+            let walk_elapsed = walk_start.elapsed();
+            if size > cap {
+                terminate_clone(child, &isolation)?;
+                return Err(CacheError::CloneTooLarge { bytes: size, cap });
+            }
+            std::thread::sleep(poll_sleep_duration(walk_elapsed));
+        };
+        if !status.success() {
+            return Err(CacheError::Git(format!(
+                "git clone {:?} failed (exit {status})",
+                redact_repo_url(url)
+            )));
         }
-        std::thread::sleep(poll_sleep_duration(walk_elapsed));
-    };
-    if !status.success() {
-        return Err(CacheError::Git(format!(
-            "git clone {:?} failed (exit {status})",
-            redact_repo_url(url)
-        )));
-    }
-    Ok(())
+        Ok(())
+    })
 }
 
 /// Stop and reap an in-flight clone. On Unix the child is its own process
@@ -1400,7 +1600,8 @@ fn fetch(repo: &Path, slot: &ValidatedSlot) -> Result<(), CacheError> {
     // on an ancestor repository, and an absolute `--git-dir` still follows a
     // symlink swapped in after revalidation. `git_at_slot` binds the command
     // to the validated directory object itself.
-    let status = git_at_slot(repo, slot)
+    let mut command = git_at_slot(repo, slot);
+    command
         .arg("-c")
         .arg("core.hooksPath=/dev/null")
         .arg("-c")
@@ -1410,16 +1611,19 @@ fn fetch(repo: &Path, slot: &ValidatedSlot) -> Result<(), CacheError> {
         .arg("fetch")
         .arg("--prune")
         .env("GIT_TERMINAL_PROMPT", "0")
-        .stdout(Stdio::null())
-        .status()
-        .map_err(|e| CacheError::Git(format!("spawning git fetch: {e}")))?;
-    if !status.success() {
-        return Err(CacheError::Git(format!(
-            "git fetch in {} failed (exit {status})",
-            repo.display()
-        )));
-    }
-    Ok(())
+        .stdout(Stdio::null());
+    with_git_diagnostics(&mut command, "git fetch", |child| {
+        let status = child
+            .wait()
+            .map_err(|e| CacheError::Git(format!("waiting for git fetch: {e}")))?;
+        if !status.success() {
+            return Err(CacheError::Git(format!(
+                "git fetch in {} failed (exit {status})",
+                repo.display()
+            )));
+        }
+        Ok(())
+    })
 }
 
 /// Issue #765 repair primitive: `git fetch --refetch origin` obtains a
@@ -1427,7 +1631,8 @@ fn fetch(repo: &Path, slot: &ValidatedSlot) -> Result<(), CacheError> {
 /// existing object store.
 fn fetch_refetch(repo: &Path, slot: &ValidatedSlot) -> Result<(), CacheError> {
     // Descriptor-bound — see `fetch` for the discovery and symlink hazards.
-    let status = git_at_slot(repo, slot)
+    let mut command = git_at_slot(repo, slot);
+    command
         .arg("-c")
         .arg("core.hooksPath=/dev/null")
         .arg("-c")
@@ -1438,16 +1643,19 @@ fn fetch_refetch(repo: &Path, slot: &ValidatedSlot) -> Result<(), CacheError> {
         .arg("--refetch")
         .arg("origin")
         .env("GIT_TERMINAL_PROMPT", "0")
-        .stdout(Stdio::null())
-        .status()
-        .map_err(|e| CacheError::Git(format!("spawning git fetch --refetch: {e}")))?;
-    if !status.success() {
-        return Err(CacheError::Git(format!(
-            "git fetch --refetch in {} failed (exit {status})",
-            repo.display()
-        )));
-    }
-    Ok(())
+        .stdout(Stdio::null());
+    with_git_diagnostics(&mut command, "git fetch --refetch", |child| {
+        let status = child
+            .wait()
+            .map_err(|e| CacheError::Git(format!("waiting for git fetch --refetch: {e}")))?;
+        if !status.success() {
+            return Err(CacheError::Git(format!(
+                "git fetch --refetch in {} failed (exit {status})",
+                repo.display()
+            )));
+        }
+        Ok(())
+    })
 }
 
 /// Wraps an I/O error with the operation and path it happened on.
@@ -1865,6 +2073,53 @@ pub(crate) static ENV_MUTEX: std::sync::LazyLock<tokio::sync::Mutex<()>> =
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn git_diagnostic_capture_is_bounded_drained_and_redacted() {
+        let mut input = std::io::Cursor::new(vec![b'x'; MAX_GIT_DIAGNOSTIC_BYTES * 3]);
+        let captured =
+            capture_diagnostic(&mut input, &AtomicBool::new(false)).expect("capture diagnostic");
+        assert_eq!(captured.len(), MAX_GIT_DIAGNOSTIC_BYTES);
+        assert_eq!(input.position(), (MAX_GIT_DIAGNOSTIC_BYTES * 3) as u64);
+
+        let sanitized = sanitize_diagnostic(
+            "fatal: authentication failed for 'https://user:tok3n@example.com/repo?token=SECRET'\nAuthorization: Bearer PRIVATE\nCookie: session=SESSION\nfatal: https://user:partial\nerror: connection refused\u{001b}",
+        );
+        assert!(sanitized.contains("authentication failed"), "{sanitized}");
+        assert!(sanitized.contains("connection refused"), "{sanitized}");
+        for secret in [
+            "user", "tok3n", "SECRET", "PRIVATE", "SESSION", "partial", "\u{001b}",
+        ] {
+            assert!(!sanitized.contains(secret), "{sanitized}");
+        }
+    }
+
+    #[test]
+    fn git_diagnostic_capture_stops_without_descendant_eof() {
+        struct OpenPipe;
+        impl Read for OpenPipe {
+            fn read(&mut self, _buffer: &mut [u8]) -> std::io::Result<usize> {
+                Err(std::io::ErrorKind::WouldBlock.into())
+            }
+        }
+        assert!(capture_diagnostic(OpenPipe, &AtomicBool::new(true))
+            .unwrap()
+            .is_empty());
+        #[cfg(unix)]
+        {
+            use std::io::Write;
+            use std::os::fd::OwnedFd;
+            let (reader, mut retained_writer) = std::os::unix::net::UnixStream::pair().unwrap();
+            retained_writer.write_all(b"fatal: unavailable").unwrap();
+            let stderr = std::process::ChildStderr::from(OwnedFd::from(reader));
+            let pipe = DiagnosticPipe::new(stderr).unwrap();
+            assert_eq!(
+                capture_diagnostic(pipe, &AtomicBool::new(true)).unwrap(),
+                b"fatal: unavailable"
+            );
+            drop(retained_writer);
+        }
+    }
 
     /// Build a directory shaped exactly like a real `ensure_clone` cache slot.
     fn make_owned_entry(root: &Path, key: &str, with_marker: bool) -> PathBuf {

--- a/crates/khive-pack-git/src/handlers.rs
+++ b/crates/khive-pack-git/src/handlers.rs
@@ -7,7 +7,6 @@
 
 use std::path::Path;
 
-use anyhow::anyhow;
 use serde_json::{json, Value};
 use uuid::Uuid;
 
@@ -26,19 +25,27 @@ use crate::source::{
 use crate::GitPack;
 
 /// Recover the typed error when a digest ingest/resolution failure chain
-/// carries a storage-class failure (for example a reader admission timeout
-/// under concurrent load), so resource exhaustion is not reported as the
-/// caller's invalid input. Every other failure keeps the established
-/// invalid-input shape.
+/// carries a storage or remote-cache failure, rather than blaming the
+/// caller's input for an infrastructure failure.
 fn digest_failure_to_runtime(e: anyhow::Error) -> RuntimeError {
     let e = match e.downcast::<RuntimeError>() {
-        Ok(rte @ RuntimeError::Storage(_)) => return rte,
+        Ok(rte @ (RuntimeError::Storage(_) | RuntimeError::RemoteFetchError { .. })) => return rte,
         Ok(other) => return RuntimeError::InvalidInput(other.to_string()),
         Err(e) => e,
     };
     match e.downcast::<khive_storage::StorageError>() {
         Ok(se) => RuntimeError::Storage(se),
         Err(e) => RuntimeError::InvalidInput(e.to_string()),
+    }
+}
+
+fn remote_cache_error(remote: &str, stage: &str, error: CacheError) -> RuntimeError {
+    RuntimeError::RemoteFetchError {
+        remote: redact_repo_url(remote),
+        message: format!(
+            "{stage}: {}",
+            cache::sanitize_diagnostic(&error.to_string())
+        ),
     }
 }
 
@@ -87,18 +94,26 @@ impl RemoteCommitRecovery {
                 // ownership-guard failure is terminal: it is not a signal
                 // that a fresh clone would fare any differently, and is
                 // never worth risking a second destructive operation for.
-                Err(CacheError::Git(_)) => {
+                Err(error @ CacheError::Git(_)) => {
                     self.stage = RemoteRecoveryStage::Refetched;
-                    self.reclone()
+                    self.reclone(Some(error))
                 }
-                Err(e) => Err(anyhow!("cache repair (refetch) failed: {e}")),
+                Err(error) => Err(remote_cache_error(
+                    &self.canonical_url,
+                    "cache repair (refetch) failed",
+                    error,
+                )
+                .into()),
             },
-            RemoteRecoveryStage::Refetched => self.reclone(),
+            RemoteRecoveryStage::Refetched => self.reclone(None),
             RemoteRecoveryStage::Recloned => Ok(None),
         }
     }
 
-    fn reclone(&mut self) -> anyhow::Result<Option<RecoveredRepo>> {
+    fn reclone(
+        &mut self,
+        refetch_error: Option<CacheError>,
+    ) -> anyhow::Result<Option<RecoveredRepo>> {
         match cache::reclone(&self.canonical_url) {
             Ok(repo) => {
                 self.stage = RemoteRecoveryStage::Recloned;
@@ -107,7 +122,16 @@ impl RemoteCommitRecovery {
                     strategy: CacheRepairStrategy::Reclone,
                 }))
             }
-            Err(e) => Err(anyhow!("cache repair (reclone) failed: {e}")),
+            Err(error) => {
+                let stage = match refetch_error {
+                    Some(refetch) => format!(
+                        "cache repair (reclone) failed after refetch failed ({})",
+                        cache::sanitize_diagnostic(&refetch.to_string())
+                    ),
+                    None => "cache repair (reclone) failed".into(),
+                };
+                Err(remote_cache_error(&self.canonical_url, &stage, error).into())
+            }
         }
     }
 }
@@ -169,13 +193,13 @@ impl GitPack {
                     let canonical = canonical.clone();
                     tokio::task::spawn_blocking(move || cache::ensure_clone(&canonical))
                         .await
-                        .map_err(|e| RuntimeError::RemoteFetchError {
+                        .map_err(|_| RuntimeError::RemoteFetchError {
                             remote: redacted.clone(),
-                            message: format!("clone task panicked or was cancelled: {e}"),
+                            message: "initial cache setup: clone task panicked or was cancelled"
+                                .into(),
                         })?
-                        .map_err(|e| RuntimeError::RemoteFetchError {
-                            remote: redacted,
-                            message: e.to_string(),
+                        .map_err(|e| {
+                            remote_cache_error(&redacted, "initial cache setup failed", e)
                         })?
                 } else {
                     std::env::current_dir().map_err(|e| {
@@ -2196,7 +2220,7 @@ mod tests {
     }
 
     #[test]
-    fn digest_failure_preserves_storage_class_and_flattens_the_rest() {
+    fn digest_failure_preserves_storage_and_remote_types() {
         // A storage-class failure inside the ingest chain (here: a
         // writer-handle admission timeout under load) must surface typed,
         // not as the caller's invalid input.
@@ -2227,7 +2251,21 @@ mod tests {
             RuntimeError::Storage(khive_storage::StorageError::Timeout { .. })
         ));
 
-        // Non-storage runtime failures keep the established invalid-input
+        let remote = anyhow::Error::new(remote_cache_error(
+            "https://user:tok3n@example.com/repo?token=SECRET",
+            "cache repair (refetch) failed",
+            CacheError::Io(std::io::Error::other("cache directory unavailable")),
+        ))
+        .context("preparing commit snapshot");
+        assert!(matches!(
+            digest_failure_to_runtime(remote),
+            RuntimeError::RemoteFetchError { remote, message }
+                if remote == "https://example.com/repo"
+                    && message.contains("cache repair (refetch) failed")
+                    && message.contains("scratch-cache I/O error")
+        ));
+
+        // Other runtime failures keep the established invalid-input
         // shape, message intact.
         let not_found = anyhow::Error::new(RuntimeError::NotFound("proj-x".to_string()));
         match digest_failure_to_runtime(not_found) {
@@ -2236,7 +2274,7 @@ mod tests {
         }
 
         // Plain anyhow context errors keep the established shape as well.
-        match digest_failure_to_runtime(anyhow!("gh probe failed")) {
+        match digest_failure_to_runtime(anyhow::anyhow!("gh probe failed")) {
             RuntimeError::InvalidInput(msg) => assert_eq!(msg, "gh probe failed"),
             other => panic!("untyped failure must flatten to InvalidInput, got {other:?}"),
         }

--- a/crates/khive-pack-git/src/recovery_tests.rs
+++ b/crates/khive-pack-git/src/recovery_tests.rs
@@ -254,6 +254,19 @@ LOCAL_ORIGIN="{local_origin}"
 printf '%s\n' "$*" >> "$LOG_DIR/git_args.log"
 
 case " $* " in
+  *" clone "*)
+    COUNT_FILE="$LOG_DIR/clone.count"
+    n=$(cat "$COUNT_FILE" 2>/dev/null || echo 0)
+    n=$((n + 1))
+    echo "$n" > "$COUNT_FILE"
+    if [ "$n" -gt 1 ] && [ -f "$LOG_DIR/fail-reclone" ]; then
+      echo "fatal: simulated authentication failure for '$FAKE_URL'" 1>&2
+      exit 1
+    fi
+    ;;
+esac
+
+case " $* " in
   *" --name-only "*)
     COUNT_FILE="$LOG_DIR/name_only.count"
     n=$(cat "$COUNT_FILE" 2>/dev/null || echo 0)
@@ -261,6 +274,9 @@ case " $* " in
     echo "$n" > "$COUNT_FILE"
     limit="${{KHIVE_TEST_GIT_FAIL_NAME_ONLY_UNTIL:-0}}"
     if [ "$n" -le "$limit" ]; then
+      if [ -f "$LOG_DIR/remove-marker" ]; then
+        rm -- "$(cat "$LOG_DIR/remove-marker")"
+      fi
       echo "fatal: deadbeefdeadbeefdeadbeefdeadbeefdeadbeef is in the commit graph file, but not in the object database" 1>&2
       echo "fatal: could not fetch from promisor remote" 1>&2
       exit 1
@@ -367,6 +383,86 @@ fn add_commit(repo: &Path, rel: &str, contents: &str, message: &str) {
     std::fs::write(repo.join(rel), contents).unwrap();
     git(repo, &["add", rel]);
     git(repo, &["commit", "-q", "-m", message]);
+}
+
+#[tokio::test]
+#[serial_test::serial(config_ledger)]
+async fn public_digest_recovery_cache_failures_keep_remote_type_and_stage() {
+    let _env = env_guard().await;
+    for unsafe_refetch in [true, false] {
+        let bin_dir = tempfile::tempdir().expect("bin dir");
+        let log_dir = tempfile::tempdir().expect("log dir");
+        let scratch = tempfile::tempdir().expect("scratch root");
+        let origin = tempfile::tempdir().expect("origin dir");
+        init_origin_with_one_commit(origin.path());
+        let remote = "https://user:tok3n@github.com/khive-fixture/recovery-type?token=SECRET";
+        write_fake_git_redirecting_clone(bin_dir.path(), log_dir.path(), remote, origin.path());
+        if unsafe_refetch {
+            std::fs::write(
+                log_dir.path().join("remove-marker"),
+                scratch
+                    .path()
+                    .join(crate::source::cache_key(remote))
+                    .join(".khive-last-used")
+                    .to_str()
+                    .unwrap(),
+            )
+            .unwrap();
+        } else {
+            std::fs::write(log_dir.path().join("fail-reclone"), b"").unwrap();
+        }
+        std::env::set_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT", scratch.path());
+        std::env::set_var("KHIVE_TEST_GIT_FAIL_NAME_ONLY_UNTIL", "1");
+        std::env::set_var("KHIVE_TEST_GIT_FAIL_REFETCH_UNTIL", "1");
+        let path_guard = PathGuard::install(bin_dir.path());
+        let (_rt, _token, registry) = fixture().await;
+        let project = create(&registry, json!({"kind":"project", "name":"recovery-type"})).await;
+        let result = registry
+            .dispatch(
+                "git.digest",
+                json!({
+                    "source":remote, "project":project.to_string(), "include":["commits"]
+                }),
+            )
+            .await;
+        drop(path_guard);
+        std::env::remove_var("KHIVE_GIT_DIGEST_SCRATCH_ROOT");
+        std::env::remove_var("KHIVE_TEST_GIT_FAIL_NAME_ONLY_UNTIL");
+        std::env::remove_var("KHIVE_TEST_GIT_FAIL_REFETCH_UNTIL");
+
+        let error = result.expect_err("cache repair must fail");
+        let khive_runtime::RuntimeError::RemoteFetchError { remote, message } = error else {
+            panic!("recovery cache failure must remain typed: {error:?}");
+        };
+        assert_eq!(remote, "https://github.com/khive-fixture/recovery-type");
+        assert!(
+            !message.contains("tok3n") && !message.contains("SECRET"),
+            "{message}"
+        );
+        let args_log = log_dir.path().join("git_args.log");
+        assert_eq!(count_lines(&args_log, "--name-only"), 1);
+        if unsafe_refetch {
+            assert!(
+                message.contains("cache repair (refetch) failed"),
+                "{message}"
+            );
+            assert!(message.contains("owned cache slot"), "{message}");
+            assert_eq!(count_lines(&args_log, "--refetch"), 0);
+            assert_eq!(count_lines(&args_log, " clone "), 1);
+        } else {
+            assert!(
+                message.contains("cache repair (reclone) failed"),
+                "{message}"
+            );
+            assert!(message.contains("simulated refetch failure"), "{message}");
+            assert!(
+                message.contains("simulated authentication failure"),
+                "{message}"
+            );
+            assert_eq!(count_lines(&args_log, "--refetch"), 1);
+            assert_eq!(count_lines(&args_log, " clone "), 2);
+        }
+    }
 }
 
 /// The literal #765 acceptance criterion: a corrupt promisor cache digests

--- a/crates/khive-runtime/src/error.rs
+++ b/crates/khive-runtime/src/error.rs
@@ -685,7 +685,8 @@ pub enum RuntimeError {
     #[error("cross-namespace write denied: cannot write to remote namespace {namespace:?}")]
     CrossNamespaceWrite { namespace: String },
 
-    /// A remote fetch failed (network error, authentication failure, etc.).
+    /// Remote cache setup or repair failed. Producers redact the source and
+    /// sanitize diagnostics before constructing this wire-visible error.
     #[error("remote fetch error for remote={remote:?}: {message}")]
     RemoteFetchError { remote: String, message: String },
 

--- a/docs/adr/ADR-088-amendment-1-git-digest.md
+++ b/docs/adr/ADR-088-amendment-1-git-digest.md
@@ -180,27 +180,30 @@ frozen `until`; temporary absence is not evidence that the pass failed or commit
 4. Cleanup on eviction uses directory removal of the scratch path only (never touches
    user-owned paths).
 
-5. Failure contract (2026-09-02). When the initial clone or fetch that establishes a
-   cache entry (step 1) fails, it returns the typed `RemoteFetchError { remote, message }`
-   in-process rather than a generic error: `remote` is the canonical URL with any embedded
-   credentials and query string redacted, and `message` is the cache/setup error text: a
-   synthesized exit-status summary for a failed git invocation, or the I/O, size-cap, or
-   unsafe-replace guard message for a non-git cache failure; none of these retain git's
-   own stderr. This typed variant reaches in-process `VerbRegistry::dispatch` callers; the
-   MCP `request` envelope has no dedicated wire encoding for it and falls back to
-   rendering the plain error message, so an MCP caller still has to read that text to tell
-   it apart from `InvalidInput`. Because `remote` is redacted before the error is built,
-   the rendered message, in-process or on the wire, never contains the credential or
-   query material stripped from it. A clone/fetch failure hit later, while repairing a
-   missing object during commit walking against an already-cached clone (a bounded
-   refetch-then-reclone attempt), is not raised as `RemoteFetchError`. A git-level refetch
-   failure is followed by the one guarded reclone, and each successful repair earns exactly
-   one more snapshot attempt: the ingest completes normally only when that attempt
-   succeeds. When the bounded repair ultimately fails (a non-git refetch failure, a failed
-   reclone, or a snapshot that still fails after the reclone) the failure is wrapped as a
-   plain error that reaches the caller as `InvalidInput`; no third repair is attempted. A
-   source that cannot be parsed as a local path or a remote URL also stays `InvalidInput`,
-   and storage failures keep their existing error types.
+5. Failure contract (updated 2026-09-10). Initial clone/fetch setup failures and terminal
+   cache failures during bounded refetch/reclone recovery return the same in-process
+   `RemoteFetchError { remote, message }`. The MCP `request` result identifies the
+   originating verb as `tool: "git.digest"`; its `error` is an object with
+   `kind: "remote_fetch_error"`, `remote`, and `message`, plus the existing
+   `domain_disposition` field. `remote` is this digest's canonical source URL with userinfo,
+   query, and fragment removed. It is source data, not a configuration-table name or a
+   git-write receipt. This contract does not change ADR-182's git-write policy tables.
+
+   `message` identifies initial cache setup, recovery refetch, or recovery reclone. When
+   a git-level refetch failure is followed by a failed reclone, both diagnostics are kept.
+   Clone/fetch process failures include exit status and available sanitized stderr: retain
+   at most 16 KiB, remove URL/address tokens and credential-header lines, and remove control
+   characters. Raw stderr is not inherited by the serving process. Capture on Unix and
+   Windows stops after git exits without waiting for a descendant to close its stderr;
+   other platforms retain the exit-status summary without stderr capture. A non-git cache
+   error instead describes I/O, a clone size cap, or an ownership refusal; `message` is
+   therefore not always a git diagnostic and is not a machine-readable cause taxonomy.
+
+   Recovery remains bounded to one refetch and one guarded reclone. A successful repair
+   earns one more snapshot attempt; only a successful snapshot completes the ingest. A
+   snapshot that still fails after the final repair remains `InvalidInput`, as does a
+   source that cannot be parsed as a local path or remote URL. Storage failures keep their
+   existing types. Structured cache errors do not imply rollback of earlier ingest work.
 
 ### Accepted cache crash-residue rider (2026-08-09)
 

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -42,15 +42,17 @@ write verbs `git.commit` / `git.branch` / `git.push` (ADR-108) that shell to sys
 with hardened, allowlisted argv construction, the three read verbs `git.status` /
 `git.log` / `git.init`, and the dev-loop verbs `git.checkout` /
 `git.diff` / `git.gates` / `git.receipts` / `git.reconcile` / `git.pr_open` / `git.pr_review` /
-`git.pr_merge` (ADR-182). A remote `git.digest` source whose initial
-clone or fetch setup fails returns a typed `RemoteFetchError` naming the redacted remote
-to in-process callers; the MCP `request` envelope renders it as a plain error message
-rather than structured fields (ADR-088 Amendment 1, Remote-URL mode, point 5). A
-clone/fetch failure hit later while repairing an already-cached clone surfaces as
-`InvalidInput` only when the bounded refetch-then-reclone repair ultimately fails (a
-successful repair earns one more snapshot attempt, and the digest completes only when
-that attempt succeeds); a source that parses as neither a local path nor a remote URL
-is `InvalidInput` as well.
+`git.pr_merge` (ADR-182). Initial remote cache setup failures and terminal refetch/reclone
+cache failures in `git.digest` return `RemoteFetchError` in-process. On the MCP `request`
+wire, the failed `tool: "git.digest"` result carries
+`error: {kind: "remote_fetch_error", remote, message, domain_disposition}`. `remote`
+is the digest source URL without userinfo, query, or fragment; `message` names the failed
+setup/recovery stage and includes available bounded, sanitized git diagnostics, or the
+non-git I/O, size-cap, or ownership-refusal text. It is not a git-write policy-table or
+receipt error (ADR-088 Amendment 1, Remote-URL mode, point 5). A successful repair earns
+one more snapshot attempt; a snapshot still failing after the bounded repairs remains
+`InvalidInput`. A source that parses as neither a local path nor a remote URL also remains
+`InvalidInput`. An error does not imply rollback of earlier ingest work.
 
 `workspace` requires `kg`, `git`, `gtd`, and `session` to be loaded alongside it (the runtime rejects a pack set that omits a declared dependency), so its minimal example lists all four.
 


### PR DESCRIPTION
Closes #2358.

Two related gaps on the git digest path. A remote failure hit while repairing a
cache entry, rather than while establishing one, was wrapped as a plain error and
reached the caller as `InvalidInput`, so an infrastructure failure was reported as
the caller's bad input. And `RemoteFetchError` had no wire encoding, so an MCP
caller had to parse English to tell it apart from `InvalidInput`.

**Typed through the recovery path.** The bounded refetch-then-reclone repair now
produces `RemoteFetchError { remote, message }` for its terminal failures, the same
type initial cache setup already produced. `message` names which stage failed, and
when a git-level refetch failure is followed by a failed reclone both diagnostics
are kept rather than only the last one. Recovery stays bounded at one refetch and
one guarded reclone; a snapshot that still fails after the final repair remains
`InvalidInput`, as does an unparseable source.

**Wire encoding.** The MCP `request` result now renders the error as an object with
`kind: "remote_fetch_error"`, `remote` and `message`, beside the existing
`domain_disposition`. `remote` is the digest's canonical source URL with userinfo,
query and fragment removed; it is source data, and it is not a configuration-table
name or a git-write receipt, so this does not touch ADR-182's git-write policy
tables.

**Diagnostics.** Clone and fetch process failures now carry exit status and
sanitized stderr: at most 16 KiB retained, URL and address tokens and
credential-header lines removed, control characters removed. Raw stderr is never
inherited by the serving process. Capture stops once git exits rather than waiting
for a descendant to close the pipe, on both Unix and Windows; other platforms keep
the exit-status summary with no stderr. The clone-task join failure deliberately
reports a fixed string rather than the panic payload, since a payload can carry the
material the redaction exists to remove.

`message` describes I/O, a clone size cap or an ownership refusal for a non-git
cache error, so it is a diagnostic and not a machine-readable cause taxonomy. That
is stated in the ADR rather than left for a caller to discover.

ADR-088 Amendment 1 §5 is rewritten to the new contract, superseding the
2026-09-02 text it replaces, since the old paragraph said in as many words that
recovery-path failures are not `RemoteFetchError` and that no wire encoding
exists. Both statements stop being true here, so leaving them beside the new ones
would leave the record self-contradictory.
