### PR TITLE
fix(db): index recipient-scoped read and all inbox listings

### DIFF
--- a/crates/khive-db/sql/033-notes-message-recipient-direction.sql
+++ b/crates/khive-db/sql/033-notes-message-recipient-direction.sql
@@ -1,0 +1,22 @@
+-- Recipient seeks for read/all inbox listings (#2377, #2517).
+-- Match EqOrLegacyIndexed's expression exactly, including the legacy empty
+-- sentinel and direction key. Do not restrict kind: callers bind it.
+CREATE INDEX IF NOT EXISTS idx_notes_message_recipient_direction
+    ON notes(namespace, kind,
+             ifnull(json_extract(properties, '$.to_actor'), ''),
+             json_extract(properties, '$.direction'),
+             created_at DESC, id ASC)
+    WHERE deleted_at IS NULL;
+
+-- The same-key partial index must follow the full index in the schema catalog
+-- so unread queries keep their selective plan even before ANALYZE. This rebuild
+-- is versioned once, never part of the per-store idempotent bootstrap.
+DROP INDEX IF EXISTS idx_notes_unread_probe_recipient_direction;
+CREATE INDEX idx_notes_unread_probe_recipient_direction
+    ON notes(namespace, kind,
+             ifnull(json_extract(properties, '$.to_actor'), ''),
+             json_extract(properties, '$.direction'),
+             created_at DESC, id ASC)
+    WHERE (json_type(properties, '$.read') IS NULL
+           OR json_type(properties, '$.read') != 'true')
+      AND deleted_at IS NULL;

--- a/crates/khive-db/sql/notes-ddl.sql
+++ b/crates/khive-db/sql/notes-ddl.sql
@@ -38,6 +38,15 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_notes_namespace_kind_key
     ON notes(namespace, kind, key)
     WHERE key IS NOT NULL AND deleted_at IS NULL;
 
+-- Full recipient index for read/all inbox listings (migration V33). Create it
+-- before the same-key unread partial index to preserve unread plan selection.
+CREATE INDEX IF NOT EXISTS idx_notes_message_recipient_direction
+    ON notes(namespace, kind,
+             ifnull(json_extract(properties, '$.to_actor'), ''),
+             json_extract(properties, '$.direction'),
+             created_at DESC, id ASC)
+    WHERE deleted_at IS NULL;
+
 -- Partial index for the unread-message probe (comm unread badge + inbox
 -- unread listing/count projection). Its WHERE clause is the exact predicate the
 -- JsonTypeNeMissing filter op generates (with the json_type value inlined

--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -161,6 +161,7 @@ const V29_UP: &str = include_str!("../sql/029-note-streams.sql");
 const V30_UP: &str = include_str!("../sql/030-tool-source-mounts.sql");
 const V31_UP: &str = include_str!("../sql/031-note-versions.sql");
 const V32_UP: &str = include_str!("../sql/032-knowledge-count-indexes.sql");
+const V33_UP: &str = include_str!("../sql/033-notes-message-recipient-direction.sql");
 
 const V21_STAGE_UP: &str = include_str!("../sql/021-attachments-a-stage.sql");
 
@@ -376,6 +377,11 @@ pub const MIGRATIONS: &[VersionedMigration] = &[
         version: 32,
         name: "knowledge_count_indexes",
         up: V32_UP,
+    },
+    VersionedMigration {
+        version: 33,
+        name: "notes_message_recipient_direction",
+        up: V33_UP,
     },
 ];
 

--- a/crates/khive-db/src/migrations_tests.rs
+++ b/crates/khive-db/src/migrations_tests.rs
@@ -1291,6 +1291,58 @@ fn latest_schema_version_matches_the_newest_migrations_entry() {
 }
 
 #[test]
+fn v33_recipient_indexes_match_fresh_schema_and_preserve_notes() {
+    const NOTES_DDL: &str = include_str!("../sql/notes-ddl.sql");
+    let fresh = open_memory();
+    fresh.execute_batch(NOTES_DDL).unwrap();
+    let upgraded = open_memory();
+    upgraded.execute_batch(NOTES_DDL).unwrap();
+    upgraded
+        .execute_batch("DROP INDEX idx_notes_message_recipient_direction")
+        .unwrap();
+    upgraded.execute("INSERT INTO notes (id, namespace, kind, properties, created_at, updated_at) VALUES ('kept', 'default', 'message', '{\"read\":true}', 1, 1)", []).unwrap();
+    let migration = MIGRATIONS
+        .iter()
+        .find(|migration| migration.version == 33)
+        .unwrap();
+    assert_eq!(migration.name, "notes_message_recipient_direction");
+    upgraded.execute_batch(migration.up).unwrap();
+    upgraded.execute_batch(migration.up).unwrap();
+    for name in [
+        "idx_notes_message_recipient_direction",
+        "idx_notes_unread_probe_recipient_direction",
+    ] {
+        let definition = |conn: &Connection| -> String {
+            conn.query_row(
+                "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?1",
+                [name],
+                |row| row.get(0),
+            )
+            .unwrap()
+        };
+        assert_eq!(definition(&upgraded), definition(&fresh), "{name}");
+    }
+    assert_eq!(
+        upgraded
+            .query_row(
+                "SELECT properties FROM notes WHERE id = 'kept'",
+                [],
+                |row| row.get::<_, String>(0)
+            )
+            .unwrap(),
+        "{\"read\":true}"
+    );
+    let before: i64 = upgraded
+        .query_row("PRAGMA schema_version", [], |row| row.get(0))
+        .unwrap();
+    upgraded.execute_batch(NOTES_DDL).unwrap();
+    let after: i64 = upgraded
+        .query_row("PRAGMA schema_version", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(before, after, "normal bootstrap must not rebuild indexes");
+}
+
+#[test]
 fn migration_versions_advance_by_exactly_one() {
     for pair in MIGRATIONS.windows(2) {
         assert_eq!(

--- a/crates/khive-db/src/stores/comm_filter_plan_tests.rs
+++ b/crates/khive-db/src/stores/comm_filter_plan_tests.rs
@@ -275,15 +275,7 @@ fn comm_filter_query_plan_candidates_record_foreign_mailbox_growth() {
 }
 
 fn full_then_unread_ddl() -> String {
-    let schema = include_str!("../../sql/notes-ddl.sql");
-    let start = schema
-        .find("CREATE INDEX IF NOT EXISTS idx_notes_unread_probe_recipient_direction")
-        .unwrap();
-    let end = schema[start..].find(';').unwrap() + start + 1;
-    format!(
-        "{FULL_RECIPIENT}; DROP INDEX idx_notes_unread_probe_recipient_direction; {}",
-        &schema[start..end]
-    )
+    include_str!("../../sql/033-notes-message-recipient-direction.sql").to_owned()
 }
 
 fn assert_actor_seek(result: &Value, status: &str) {
@@ -304,6 +296,28 @@ fn assert_actor_seek(result: &Value, status: &str) {
         plan.contains("namespace=? AND kind=? AND <expr>=? AND <expr>=?"),
         "actor and direction must both constrain the {status} search: {plan}"
     );
+}
+
+#[test]
+fn comm_filter_fresh_bootstrap_preserves_recipient_plans_without_rebuilds() {
+    let conn = Connection::open_in_memory().unwrap();
+    let ddl = include_str!("../../sql/notes-ddl.sql");
+    conn.execute_batch(ddl).unwrap();
+    register_comm_indexes(&conn);
+    let version: i64 = conn
+        .query_row("PRAGMA schema_version", [], |row| row.get(0))
+        .unwrap();
+    for _ in 0..2 {
+        for status in ["unread", "read", "all"] {
+            assert_actor_seek(&measure(&conn, &inbox_filter(status, false)), status);
+        }
+        conn.execute_batch(ddl).unwrap();
+        assert_eq!(
+            conn.query_row("PRAGMA schema_version", [], |row| row.get::<_, i64>(0))
+                .unwrap(),
+            version
+        );
+    }
 }
 
 #[test]
@@ -378,7 +392,88 @@ fn comm_filter_recreated_unread_index_preserves_fresh_reopen_and_analyzed_plans(
 }
 
 #[test]
-#[ignore = "planner proof for the recreated unread-probe index; the production index and its migration are a follow-up"]
+fn comm_filter_preanalyzed_upgrade_preserves_existing_comm_indexes() {
+    fn comm_catalog(conn: &Connection) -> Vec<(String, i64, i64, String)> {
+        conn.prepare(
+            "SELECT name, rowid, rootpage, sql FROM sqlite_schema \
+             WHERE type = 'index' AND name GLOB 'idx_comm_message_*' ORDER BY name",
+        )
+        .unwrap()
+        .query_map([], |row| {
+            Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
+        })
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap()
+    }
+
+    fn comm_stats(conn: &Connection) -> Vec<(String, String)> {
+        conn.prepare(
+            "SELECT idx, stat FROM sqlite_stat1 WHERE idx GLOB 'idx_comm_message_*' ORDER BY idx",
+        )
+        .unwrap()
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap()
+    }
+
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("preanalyzed-mailbox.sqlite");
+    let mut conn = fixture_with_connection(Connection::open(&path).unwrap(), 6000, 10_000, None);
+    conn.execute_batch("ANALYZE").unwrap();
+    let catalog_before = comm_catalog(&conn);
+    let stats_before = comm_stats(&conn);
+    assert_eq!(catalog_before.len(), 4);
+    assert_eq!(stats_before.len(), 4);
+    let filters: Vec<_> = ["unread", "read", "all", "sent"]
+        .iter()
+        .map(|status| {
+            if *status == "sent" {
+                sent_filter()
+            } else {
+                inbox_filter(status, false)
+            }
+        })
+        .collect();
+    let baseline: Vec<_> = filters
+        .iter()
+        .map(|filter| measure(&conn, filter))
+        .collect();
+
+    // Existing pack indexes survive CREATE IF NOT EXISTS registration during
+    // a real upgrade, including their catalog positions and ANALYZE statistics.
+    conn.execute_batch(&full_then_unread_ddl()).unwrap();
+    let mut measurements = Vec::new();
+    for stage in ["upgraded", "reopened"] {
+        if stage == "reopened" {
+            drop(conn);
+            conn = Connection::open(&path).unwrap();
+        }
+        assert_eq!(comm_catalog(&conn), catalog_before, "{stage}");
+        assert_eq!(comm_stats(&conn), stats_before, "{stage}");
+        for (index, status) in ["unread", "read", "all", "sent"].iter().enumerate() {
+            let result = measure(&conn, &filters[index]);
+            assert_actor_seek(&result, status);
+            assert_eq!(result["ids"], baseline[index]["ids"]);
+            if *status == "unread" {
+                let before = baseline[index]["vm_steps"].as_u64().unwrap();
+                let after = result["vm_steps"].as_u64().unwrap();
+                assert!(
+                    after <= before + 128,
+                    "{stage}: unread work regressed ({before} -> {after})"
+                );
+            }
+            measurements.push(json!({"stage":stage,"status":status,"result":result}));
+        }
+    }
+    println!(
+        "{}",
+        json!({"sqlite_version":rusqlite::version(),"preanalyzed_upgrade":measurements})
+    );
+}
+
+#[test]
 fn comm_filter_recreated_unread_index_bounds_work_as_other_mailboxes_grow() {
     let migration = full_then_unread_ddl();
     let mut measurements = Vec::new();

--- a/crates/khive-db/src/stores/comm_filter_plan_tests.rs
+++ b/crates/khive-db/src/stores/comm_filter_plan_tests.rs
@@ -482,6 +482,15 @@ fn comm_filter_recreated_unread_index_bounds_work_as_other_mailboxes_grow() {
         for foreign_count in [0, 6000] {
             let temp = tempfile::tempdir().unwrap();
             let path = temp.path().join("mailbox.sqlite");
+            // Sent already changes plans after ANALYZE as the population grows.
+            // Compare this inbox migration to an identical no-full-index cell.
+            let baseline_path = temp.path().join("baseline.sqlite");
+            let mut baseline_conn = fixture_with_connection(
+                Connection::open(&baseline_path).unwrap(),
+                foreign_count,
+                0,
+                None,
+            );
             let mut conn = fixture_with_connection(
                 Connection::open(&path).unwrap(),
                 foreign_count,
@@ -491,7 +500,16 @@ fn comm_filter_recreated_unread_index_bounds_work_as_other_mailboxes_grow() {
             if !fresh_schema {
                 conn.execute_batch(&migration).unwrap();
                 register_comm_indexes(&conn);
+                register_comm_indexes(&baseline_conn);
             }
+            let full_exists: bool = baseline_conn
+                .query_row(
+                    "SELECT EXISTS(SELECT 1 FROM sqlite_schema WHERE name = 'idx_notes_message_recipient_direction')",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert!(!full_exists, "sent baseline must exclude the full index");
             for (stage_index, stage) in [
                 "fresh_connection",
                 "reopened",
@@ -504,9 +522,12 @@ fn comm_filter_recreated_unread_index_bounds_work_as_other_mailboxes_grow() {
                 if stage.ends_with("reopened") {
                     drop(conn);
                     conn = Connection::open(&path).unwrap();
+                    drop(baseline_conn);
+                    baseline_conn = Connection::open(&baseline_path).unwrap();
                 }
                 if *stage == "analyzed" {
                     conn.execute_batch("ANALYZE").unwrap();
+                    baseline_conn.execute_batch("ANALYZE").unwrap();
                 }
                 for (index, status) in ["unread", "read", "all", "sent"].iter().enumerate() {
                     let filter = if *status == "sent" {
@@ -515,18 +536,31 @@ fn comm_filter_recreated_unread_index_bounds_work_as_other_mailboxes_grow() {
                         inbox_filter(status, false)
                     };
                     let result = measure(&conn, &filter);
-                    assert_actor_seek(&result, status);
+                    let sent_baseline =
+                        (*status == "sent").then(|| measure(&baseline_conn, &filter));
+                    if let Some(before) = &sent_baseline {
+                        assert_eq!(result["sql"], before["sql"]);
+                        assert_eq!(result["ids"], before["ids"]);
+                        let before_steps = before["vm_steps"].as_u64().unwrap();
+                        let after_steps = result["vm_steps"].as_u64().unwrap();
+                        assert!(after_steps <= before_steps,
+                            "{fresh_schema}/{foreign_count}/{stage}: sent work regressed ({before} -> {result})");
+                    } else {
+                        assert_actor_seek(&result, status);
+                    }
                     if foreign_count == 0 {
                         small_results.push(result.clone());
                     } else {
                         let baseline: &Value = &small_results[stage_index * 4 + index];
                         assert_eq!(result["ids"], baseline["ids"]);
-                        let steps = result["vm_steps"].as_u64().unwrap();
-                        let baseline_steps = baseline["vm_steps"].as_u64().unwrap();
-                        assert!(steps <= baseline_steps + 128,
-                            "{fresh_schema}/{stage}/{status}: foreign mailbox growth must not add row-proportional work ({baseline_steps} -> {steps})");
+                        if *status != "sent" {
+                            let steps = result["vm_steps"].as_u64().unwrap();
+                            let baseline_steps = baseline["vm_steps"].as_u64().unwrap();
+                            assert!(steps <= baseline_steps + 128,
+                                "{fresh_schema}/{stage}/{status}: foreign mailbox growth must not add row-proportional work ({baseline_steps} -> {steps})");
+                        }
                     }
-                    measurements.push(json!({"fresh_schema":fresh_schema,"stage":stage,"foreign_count":foreign_count,"status":status,"result":result}));
+                    measurements.push(json!({"fresh_schema":fresh_schema,"stage":stage,"foreign_count":foreign_count,"status":status,"result":result,"sent_baseline":sent_baseline}));
                 }
             }
         }

--- a/crates/khive-db/src/stores/note_tests.rs
+++ b/crates/khive-db/src/stores/note_tests.rs
@@ -3485,13 +3485,15 @@ async fn unread_probe_bounded_by_inbound_not_by_recipients_own_outbound_history(
 
     // -- Control: reproduce the pre-fix (direction-blind) index shape and
     // show the same assertion fails, proving the bound above is real and not
-    // an artifact of small numbers or an unrelated planner choice. --
+    // an artifact of small numbers or an unrelated planner choice. V33's
+    // full index also supplies direction, so remove it only in this control. --
     let control_pool = setup_pool();
     {
         let writer = control_pool.writer().unwrap();
         let conn = writer.conn();
         conn.execute_batch(
             "DROP INDEX idx_notes_unread_probe_recipient_direction;
+             DROP INDEX idx_notes_message_recipient_direction;
              CREATE INDEX idx_notes_unread_probe_recipient_control
                  ON notes(namespace, kind,
                           ifnull(json_extract(properties, '$.to_actor'), ''),
@@ -4452,18 +4454,11 @@ async fn json_type_ne_missing_rejects_non_vocabulary_value() {
 }
 
 /// khive#2392: `fetch_notes_after`'s `status="all"`/`status="read"` inbox
-/// listings (no `$.read` filter, or `JsonTypeEq` rather than the tuned
-/// `JsonTypeNeMissing` probe) have no index ending in `(created_at DESC, id
-/// ASC)` for their `(namespace, kind, direction, to_actor[, read])`
-/// partition, so the lt-branch (`created_at < ? ORDER BY created_at DESC, id
-/// ASC`) still costs a full partition scan plus a temp-b-tree sort on every
-/// internal page — pins the expected-arm SCAN-plus-sort plan so a future
-/// index addition is a deliberate, measured change rather than a silent
-/// drift. See `candidate_created_at_id_seek_index_flips_unread_probe_plan`
-/// for why the natural fix (a general `(namespace, kind, created_at DESC, id
-/// ASC)` index) was measured and rejected rather than shipped.
+/// listings now seek recipient, direction and timestamp through V33. The
+/// caller and legacy-recipient partitions still require a merged sort; the
+/// regression forbids falling back to a namespace-wide scan before that sort.
 #[tokio::test]
-async fn comm_inbox_status_all_lt_branch_has_no_seek_index() {
+async fn comm_inbox_status_all_lt_branch_seeks_recipient_index() {
     use khive_storage::note::{FilterOp, NoteFilter, PropertyFilter as NotePropFilter};
     use khive_storage::types::SqlValue;
 
@@ -4539,18 +4534,17 @@ async fn comm_inbox_status_all_lt_branch_has_no_seek_index() {
     let plan = plan_details(reader.conn(), &lt_sql, &lt_params);
     assert!(
         plan.contains("USE TEMP B-TREE FOR ORDER BY"),
-        "expected arm: the lt-branch still sorts because no index ends in \
-         (created_at DESC, id ASC) for this partition, got:\n{plan}"
+        "the two recipient partitions still require a merged ordering, got:\n{plan}"
     );
     assert!(
-        !plan.contains("idx_notes_kind_created_seek"),
-        "no such index exists in production schema; a name match here would mean \
-         this test started reading stale state"
+        plan.contains("idx_notes_message_recipient_direction")
+            && plan.contains("namespace=? AND kind=? AND <expr>=? AND <expr>=? AND created_at<?"),
+        "the lt-branch must seek recipient, direction, and timestamp: {plan}"
     );
 }
 
 /// khive#2392: the natural seekable fix for the gap pinned by
-/// `comm_inbox_status_all_lt_branch_has_no_seek_index` — a general
+/// the pre-V33 inbox schema — a general
 /// `(namespace, kind, created_at DESC, id ASC) WHERE deleted_at IS NULL`
 /// index — was measured, not just assumed, before deciding not to ship it.
 /// Standalone it cuts the lt-branch scan from 57,473 to 7,223 VM steps for a

--- a/crates/khive-pack-comm/docs/api/message-lifecycle.md
+++ b/crates/khive-pack-comm/docs/api/message-lifecycle.md
@@ -235,17 +235,15 @@ Direction + read-status + `to_actor` filters are pushed into SQL. For
 `idx_notes_unread_probe_recipient_direction`'s key, so the listing seeks that
 recipient-scoped partial index the same way the unread count does: work scales
 with the caller's own unread inbound set, never with other actors' backlog or
-the caller's own outbound send history. For `status="read"`/`"all"`, no index
-in the current schema carries that same `ifnull(...)` key outside the
-unread-only partial index — and, measured directly rather than assumed, even
-forcing the general, non-partial `idx_comm_message_to_actor` index (keyed on
-the raw `json_extract(...)` expression, without the `ifnull` wrapper) does not
-yield a recipient-scoped seek for this `OR`-shaped predicate. Both listings
-therefore still fall back to `idx_comm_message_direction` (namespace + kind +
-direction + read only) and scan every inbound, or every, message in the
-namespace regardless of recipient. That gap is unresolved by this change;
-closing it needs a new non-partial `ifnull`-keyed index (a schema/migration
-change), not a `FilterOp` change. The read filter uses `json_type` to match
+the caller's own outbound send history. For `status="read"`/`"all"`, migration
+V33 adds `idx_notes_message_recipient_direction`, with the same `ifnull(...)`
+recipient and direction keys over all live notes (#2377, #2517). These listings
+seek the caller and legacy-recipient partitions instead of scanning every
+actor's inbox. The read-status predicate remains residual, so the cost of a read
+listing can still depend on the caller's own unread backlog. The migration
+recreates the unread partial index after the full index to preserve unread plan
+selection before `ANALYZE`; normal store access does not rebuild either index.
+The read filter uses `json_type` to match
 the old `as_bool().unwrap_or(false)` semantics — only JSON boolean `true`
 counts as read, missing/false/string/integer all count as unread. Exact
 `from_actor` and inclusive `since` (`created_at >=`) also stay in SQL.


### PR DESCRIPTION
Closes #2377.

## Scope

Adds a recipient/direction index for the `read` and `all` inbox listings.
It does not optimize sent listings: those filter `from_actor`, while this index
keys `to_actor`. Unread retains its selective partial index. This does not by
itself establish the cause of the daemon CPU report in #2517.

## Query Plans

Native SQLite 3.53.2, production SQL builder, 80 caller inbound and 80 caller
outbound rows, plus 6,000 foreign inbound and 6,000 foreign outbound rows.
The table shows the upgrade-order fixture before and after ANALYZE. `NS/K/D/R/S`
denote namespace, kind, direction, recipient and sender equality constraints.
Every plan below also reports `USE TEMP B-TREE FOR ORDER BY`.

| Listing / stage | Without full-recipient index | VM steps | With full-recipient index | VM steps |
| --- | --- | ---: | --- | ---: |
| unread / fresh or analyzed | idx_notes_unread_probe_recipient_direction (NS/K/R/D) | 1,158 | unchanged | 1,158 |
| read / fresh | idx_comm_message_outbound_ref (NS/K/D) | 56,404 | idx_notes_message_recipient_direction (NS/K/R/D) | 1,380 |
| all / fresh | idx_comm_message_outbound_ref (NS/K/D) | 57,722 | idx_notes_message_recipient_direction (NS/K/R/D) | 1,158 |
| read / analyzed | idx_comm_message_direction (NS/K/D) | 56,062 | idx_notes_message_recipient_direction (NS/K/R/D) | 1,380 |
| all / analyzed | idx_comm_message_direction (NS/K/D) | 56,840 | idx_notes_message_recipient_direction (NS/K/R/D) | 1,158 |
| sent / fresh or analyzed | idx_comm_message_outbound_ref (NS/K/D/S) | 2,517 | unchanged | 2,517 |

With zero foreign rows after ANALYZE, sent selects idx_comm_message_direction
at 1,695 VM steps in both schema arms. All 16 paired sent cells have identical
SQL, plans, returned IDs and VM steps. The growth regression therefore checks
sent work against its matched no-full-index population/lifecycle, not a fixed
index name or a bound across different planner choices. Inbox actor seeks and
foreign-growth work bounds remain strict, and sent row identities remain stable.

## Legacy Exit Condition

While live pre-ADR-057 recipient-less messages remain, EqOrLegacyIndexed includes
both the requested recipient and the legacy empty sentinel using `IN (?, '')`.
The new index narrows the scan but does not eliminate the sort across those two
recipient walks. Once a census of the served population reports zero remaining
recipient-less messages, the fallback can be retired in a separate change and
the predicate reduced to EqOrMissingIndexed equality. The same index can then
serve the `created_at DESC, id ASC` order. No fallback is removed here and no
zero-population census is claimed by this change.

## Verification

- True no-full-index baseline control: 1 passed, all 16 sent pairs identical.
- Focused comm plan tests on the fixed source: 6 passed.
- Candidate-only sent-index removal: intended sent work assertion failed at
  2,517 -> 37,695 VM steps; SQL and rows stayed identical; the other 5 tests passed.
- Mutation restored to exact committed bytes; git diff exit status 0.
- Formatting passed. The V33 migration tests, the full workspace suite and
  clippy run in CI on this head.
