### PR TITLE
fix(brain): accept either recall result id alias in auto_feedback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,7 +180,8 @@ submitted again unchanged.
 `brain.auto_feedback(namespace=...)` writes and folds feedback only in that exact namespace;
 it does not train the default/live namespace's posterior state.
 Omitting `signal` is an abstention and emits no feedback event. When `signal` is present, `target_id`
-must exactly match one `results[].id`; rank position never supplies a judgment.
+must exactly match one result's `full_id` (falling back to `id` when absent); default JSON
+recall results can be forwarded unchanged. Rank position never supplies a judgment.
 
 ### Comm pack — 10 verbs (`comm.` prefix)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,8 +180,11 @@ submitted again unchanged.
 `brain.auto_feedback(namespace=...)` writes and folds feedback only in that exact namespace;
 it does not train the default/live namespace's posterior state.
 Omitting `signal` is an abstention and emits no feedback event. When `signal` is present, `target_id`
-must exactly match one result's `full_id` (falling back to `id` when absent); default JSON
-recall results can be forwarded unchanged. Rank position never supplies a judgment.
+must exactly match `id` or `full_id` on exactly one result object. Equal aliases on the same
+object count once; matches across different objects are ambiguous and rejected. The selected
+object's non-null `full_id`, when supplied, must be a full UUID and determines canonical
+attribution; otherwise `id` is resolved. Default JSON recall results can be forwarded unchanged and judged
+using either alias. Rank position never supplies a judgment.
 
 ### Comm pack — 10 verbs (`comm.` prefix)
 

--- a/crates/khive-pack-brain/docs/design.md
+++ b/crates/khive-pack-brain/docs/design.md
@@ -137,6 +137,8 @@ $$\text{Beta}(\alpha_1 + \alpha_2 - \alpha_{\text{prior}},\; \beta_1 + \beta_2 -
   present an authorized token whose namespace matches the parameter; the handler validates that
   equality and never treats the business parameter itself as authority (issue #1505).
 - `brain.auto_feedback` never infers utility from rank. An omitted `signal` returns a no-emit
-  abstention. A supplied signal requires `target_id` to equal exactly one `results[].id`, and
+  abstention. A supplied signal requires `target_id` to equal exactly one result's `full_id`,
+  falling back to `id` when `full_id` is absent. This accepts Agent JSON recall results without
+  rewriting their compact display IDs (#2434). Raw `candidate_ids` audit context retains `id`, and
   result-level serve attribution is copied from that selected result rather than the first hit
   (issue #1588).

--- a/crates/khive-pack-brain/docs/design.md
+++ b/crates/khive-pack-brain/docs/design.md
@@ -137,8 +137,11 @@ $$\text{Beta}(\alpha_1 + \alpha_2 - \alpha_{\text{prior}},\; \beta_1 + \beta_2 -
   present an authorized token whose namespace matches the parameter; the handler validates that
   equality and never treats the business parameter itself as authority (issue #1505).
 - `brain.auto_feedback` never infers utility from rank. An omitted `signal` returns a no-emit
-  abstention. A supplied signal requires `target_id` to equal exactly one result's `full_id`,
-  falling back to `id` when `full_id` is absent. This accepts Agent JSON recall results without
-  rewriting their compact display IDs (#2434). Raw `candidate_ids` audit context retains `id`, and
+  abstention. A supplied signal requires `target_id` to equal `id` or `full_id` on exactly one
+  result object. Equal aliases on that object count once; matches across objects are rejected.
+  The selected object's supplied `full_id` must be a full UUID and determines canonical
+  attribution, with no fallback on malformed values; absent or null `full_id`, the existing `id`
+  resolver applies. This accepts either alias from Agent JSON recall results without rewriting
+  their compact display IDs (#2434). Raw `candidate_ids` audit context retains `id`, and
   result-level serve attribution is copied from that selected result rather than the first hit
   (issue #1588).

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -354,14 +354,14 @@ pub(crate) static BRAIN_HANDLERS: &[HandlerDef] = &[
                 name: "results",
                 param_type: "array",
                 required: true,
-                description: "Recall result objects retained as candidate context: an array of objects, each with an id field (the result UUID or compact id) and optionally served_by_profile_id; bare id strings are rejected. No result is credited by rank position.",
+                description: "Recall result objects retained as candidate context: each object has id (UUID or compact id), optionally full_id and served_by_profile_id. When supplied, full_id is the matching and resolution identity; otherwise id is used. Bare id strings are rejected. No result is credited by rank position.",
                 resolution_mode: IdResolutionMode::NotApplicable,
             },
             khive_types::ParamDef {
                 name: "target_id",
                 param_type: "string",
                 required: false,
-                description: "Exact full UUID or compact id value of the one result being judged. Required when signal is supplied and must occur exactly once in results.",
+                description: "Exact full_id of the one result being judged, falling back to its id (full UUID or compact id) when full_id is absent. Required when signal is supplied and must match exactly once in results.",
                 resolution_mode: IdResolutionMode::NotApplicable,
             },
             khive_types::ParamDef {
@@ -2128,6 +2128,7 @@ impl BrainPack {
         #[derive(Deserialize)]
         struct AutoFeedbackResult {
             id: String,
+            full_id: Option<String>,
             served_by_profile_id: Option<String>,
             serve_attribution: Option<ServeAttribution>,
         }
@@ -2184,17 +2185,17 @@ impl BrainPack {
 
         let selected_id = p.target_id.as_deref().ok_or_else(|| {
             RuntimeError::InvalidInput(
-                "auto_feedback: `target_id` is required when `signal` is supplied; it must exactly match one results[].id"
+                "auto_feedback: `target_id` is required when `signal` is supplied; it must exactly match one results[].full_id (falling back to id)"
                     .to_string(),
             )
         })?;
         let mut matching_results = p
             .results
             .iter()
-            .filter(|result| result.id.as_str() == selected_id);
+            .filter(|result| result.full_id.as_deref().unwrap_or(&result.id) == selected_id);
         let selected = matching_results.next().ok_or_else(|| {
             RuntimeError::InvalidInput(format!(
-                "auto_feedback: target_id {selected_id:?} does not match any results[].id"
+                "auto_feedback: target_id {selected_id:?} does not match any results[].full_id (falling back to id)"
             ))
         })?;
         if matching_results.next().is_some() {
@@ -2203,7 +2204,11 @@ impl BrainPack {
             )));
         }
 
-        let target = resolve_auto_feedback_target(&self.runtime, &selected.id).await?;
+        let target = resolve_auto_feedback_target(
+            &self.runtime,
+            selected.full_id.as_deref().unwrap_or(&selected.id),
+        )
+        .await?;
 
         let mut feedback_params = json!({
             "target_id": target.to_string(),

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -354,14 +354,14 @@ pub(crate) static BRAIN_HANDLERS: &[HandlerDef] = &[
                 name: "results",
                 param_type: "array",
                 required: true,
-                description: "Recall result objects retained as candidate context: each object has id (UUID or compact id), optionally full_id and served_by_profile_id. When supplied, full_id is the matching and resolution identity; otherwise id is used. Bare id strings are rejected. No result is credited by rank position.",
+                description: "Recall result objects retained as candidate context: each object has id (UUID or compact id), optionally full_id and served_by_profile_id. Match target_id by id or full_id on exactly one result object; equal aliases on that object count once. Supplied full_id must be a full UUID and determines canonical attribution; otherwise id is resolved. Bare id strings are rejected. No result is credited by rank position.",
                 resolution_mode: IdResolutionMode::NotApplicable,
             },
             khive_types::ParamDef {
                 name: "target_id",
                 param_type: "string",
                 required: false,
-                description: "Exact full_id of the one result being judged, falling back to its id (full UUID or compact id) when full_id is absent. Required when signal is supplied and must match exactly once in results.",
+                description: "Exact id (full UUID or compact id) or full_id of the result being judged. Required when signal is supplied and must match exactly one result object across both aliases; equal aliases on that object count once. Supplied full_id determines canonical attribution and must be a full UUID; otherwise id is resolved.",
                 resolution_mode: IdResolutionMode::NotApplicable,
             },
             khive_types::ParamDef {
@@ -2185,17 +2185,16 @@ impl BrainPack {
 
         let selected_id = p.target_id.as_deref().ok_or_else(|| {
             RuntimeError::InvalidInput(
-                "auto_feedback: `target_id` is required when `signal` is supplied; it must exactly match one results[].full_id (falling back to id)"
+                "auto_feedback: `target_id` is required when `signal` is supplied; it must exactly match one result object's id or full_id"
                     .to_string(),
             )
         })?;
-        let mut matching_results = p
-            .results
-            .iter()
-            .filter(|result| result.full_id.as_deref().unwrap_or(&result.id) == selected_id);
+        let mut matching_results = p.results.iter().filter(|result| {
+            result.id == selected_id || result.full_id.as_deref() == Some(selected_id)
+        });
         let selected = matching_results.next().ok_or_else(|| {
             RuntimeError::InvalidInput(format!(
-                "auto_feedback: target_id {selected_id:?} does not match any results[].full_id (falling back to id)"
+                "auto_feedback: target_id {selected_id:?} does not match any results[].id or results[].full_id"
             ))
         })?;
         if matching_results.next().is_some() {
@@ -2204,11 +2203,14 @@ impl BrainPack {
             )));
         }
 
-        let target = resolve_auto_feedback_target(
-            &self.runtime,
-            selected.full_id.as_deref().unwrap_or(&selected.id),
-        )
-        .await?;
+        let target = match selected.full_id.as_deref() {
+            Some(full_id) => full_id.parse::<uuid::Uuid>().map_err(|_| {
+                RuntimeError::InvalidInput(format!(
+                    "auto_feedback: invalid full_id {full_id:?}; expected full UUID"
+                ))
+            })?,
+            None => resolve_auto_feedback_target(&self.runtime, &selected.id).await?,
+        };
 
         let mut feedback_params = json!({
             "target_id": target.to_string(),

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -3382,6 +3382,172 @@ async fn brain_auto_feedback_credits_only_the_selected_result() {
 }
 
 #[tokio::test]
+#[serial_test::serial(config_ledger)]
+async fn brain_auto_feedback_accepts_presented_recall_results() {
+    use khive_runtime::presentation::{
+        prepare_format_value, present, OutputFormat, PresentationMode,
+    };
+
+    let (pack, rt) = make_pack();
+    let token = rt.authorize(Namespace::local()).unwrap();
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(khive_pack_kg::KgPack::new(rt.clone()));
+    builder.register(khive_pack_memory::MemoryPack::new(rt.clone()));
+    let registry = builder.build().expect("memory registry");
+    let remembered = registry
+        .dispatch(
+            "memory.remember",
+            json!({
+                "content": "Cobalt recall forwarding preserves feedback identity",
+                "memory_type": "semantic",
+                "salience": 0.9
+            }),
+        )
+        .await
+        .expect("remember fixture");
+    let canonical = registry
+        .dispatch(
+            "memory.recall",
+            json!({"query": "Cobalt recall forwarding", "limit": 1, "min_score": 0.0}),
+        )
+        .await
+        .expect("recall fixture");
+    let results = prepare_format_value(
+        present(canonical, PresentationMode::Agent, 0),
+        OutputFormat::Json,
+        PresentationMode::Agent,
+    );
+    assert_eq!(results.as_array().expect("recall array").len(), 1);
+    assert_eq!(results[0]["full_id"], remembered["id"]);
+    assert_eq!(results[0]["id"].as_str().unwrap().len(), 8);
+    let compact_id = results[0]["id"].clone();
+    let result = pack
+        .dispatch(
+            "brain.auto_feedback",
+            json!({
+                "query": "Cobalt recall forwarding",
+                "results": results,
+                "target_id": remembered["id"],
+                "signal": "implicit_positive"
+            }),
+            &registry,
+            &token,
+        )
+        .await
+        .expect("presented recall results can be forwarded unchanged");
+    assert_eq!(result["emitted"], true);
+    assert_eq!(result["target_id"], remembered["id"]);
+    let event_id = result["event_id"].as_str().unwrap().parse().unwrap();
+    let event = rt
+        .events(&token)
+        .expect("event store")
+        .get_event(event_id)
+        .await
+        .unwrap()
+        .expect("feedback event");
+    assert_eq!(event.payload["candidate_ids"], json!([compact_id]));
+}
+
+#[tokio::test]
+async fn brain_auto_feedback_full_id_precedes_id_and_retains_selected_attribution() {
+    let (pack, rt) = make_pack();
+    let registry = empty_registry();
+    let token = rt.authorize(Namespace::local()).unwrap();
+    let first = create_test_entity(&rt, &token).await;
+    let selected = create_test_entity(&rt, &token).await;
+    let results = json!([
+        {"id": selected, "full_id": first},
+        {"id": first, "full_id": selected, "serve_attribution": "unattributed"}
+    ]);
+    let result = pack
+        .dispatch(
+            "brain.auto_feedback",
+            json!({
+                "query": "full identity precedence",
+                "results": results,
+                "target_id": selected,
+                "signal": "implicit_positive"
+            }),
+            &registry,
+            &token,
+        )
+        .await
+        .expect("full_id selects and resolves the second result");
+    assert_eq!(result["target_id"], selected);
+    assert_eq!(result["serve_attribution"], "unattributed");
+    assert_eq!(pack.snapshot().balanced_recall.total_events, 0);
+}
+
+#[tokio::test]
+async fn brain_auto_feedback_full_id_rejects_conflicts_duplicates_and_malformed_values() {
+    let (pack, rt) = make_pack();
+    let registry = empty_registry();
+    let token = rt.authorize(Namespace::local()).unwrap();
+    let target = create_test_entity(&rt, &token).await;
+    let other = create_test_entity(&rt, &token).await;
+    for (results, selected, message) in [
+        (
+            json!([{"id": &other[..8], "full_id": other}]),
+            target.as_str(),
+            "does not match any results[].full_id",
+        ),
+        (
+            json!([{"id": target, "full_id": other}]),
+            target.as_str(),
+            "does not match any results[].full_id",
+        ),
+        (
+            json!([{"id": other, "full_id": target}, {"id": target}]),
+            target.as_str(),
+            "matches more than one result",
+        ),
+        (
+            json!([{"id": target, "full_id": "not-an-id"}]),
+            "not-an-id",
+            "invalid id",
+        ),
+        (
+            json!([{"id": target, "full_id": 42}]),
+            target.as_str(),
+            "invalid type",
+        ),
+    ] {
+        let error = pack
+            .dispatch(
+                "brain.auto_feedback",
+                json!({
+                    "query": "invalid full identity",
+                    "results": results,
+                    "target_id": selected,
+                    "signal": "useful"
+                }),
+                &registry,
+                &token,
+            )
+            .await
+            .expect_err("invalid or ambiguous effective identity must refuse");
+        assert!(error.to_string().contains(message), "{error}");
+    }
+    assert_eq!(pack.snapshot().balanced_recall.total_events, 0);
+    let events = rt
+        .events(&token)
+        .expect("event store")
+        .query_events(
+            khive_storage::event::EventFilter {
+                kinds: vec![khive_types::EventKind::FeedbackExplicit],
+                ..Default::default()
+            },
+            khive_storage::types::PageRequest {
+                limit: 10,
+                offset: 0,
+            },
+        )
+        .await
+        .unwrap();
+    assert!(events.items.is_empty());
+}
+
+#[tokio::test]
 async fn brain_auto_feedback_without_signal_abstains_without_writing() {
     let (pack, rt) = make_pack();
     let registry = empty_registry();
@@ -3484,7 +3650,7 @@ async fn brain_auto_feedback_signal_requires_a_unique_result_target() {
         .expect_err("a target outside results must be rejected");
     assert!(outside
         .to_string()
-        .contains("does not match any results[].id"));
+        .contains("does not match any results[].full_id"));
 
     let duplicate = pack
         .dispatch(
@@ -4152,6 +4318,7 @@ mod help_tests {
         );
         assert!(
             target_id.description.contains("compact id")
+                && target_id.description.contains("full_id")
                 && target_id.description.contains("Required when signal")
                 && target_id.description.contains("exactly once"),
             "target_id help must describe conditional uniqueness: {:?}",

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -3421,50 +3421,93 @@ async fn brain_auto_feedback_accepts_presented_recall_results() {
     assert_eq!(results[0]["full_id"], remembered["id"]);
     assert_eq!(results[0]["id"].as_str().unwrap().len(), 8);
     let compact_id = results[0]["id"].clone();
-    let result = pack
-        .dispatch(
-            "brain.auto_feedback",
-            json!({
-                "query": "Cobalt recall forwarding",
-                "results": results,
-                "target_id": remembered["id"],
-                "signal": "implicit_positive"
-            }),
-            &registry,
-            &token,
-        )
-        .await
-        .expect("presented recall results can be forwarded unchanged");
-    assert_eq!(result["emitted"], true);
-    assert_eq!(result["target_id"], remembered["id"]);
-    let event_id = result["event_id"].as_str().unwrap().parse().unwrap();
-    let event = rt
-        .events(&token)
-        .expect("event store")
-        .get_event(event_id)
-        .await
-        .unwrap()
-        .expect("feedback event");
-    assert_eq!(event.payload["candidate_ids"], json!([compact_id]));
+    for target_id in [&compact_id, &remembered["id"]] {
+        let result = pack
+            .dispatch(
+                "brain.auto_feedback",
+                json!({
+                    "query": "Cobalt recall forwarding",
+                    "results": results,
+                    "target_id": target_id,
+                    "signal": "implicit_positive"
+                }),
+                &registry,
+                &token,
+            )
+            .await
+            .expect("either presented recall alias selects the unchanged result");
+        assert_eq!(result["emitted"], true);
+        assert_eq!(result["target_id"], remembered["id"]);
+        let event_id = result["event_id"].as_str().unwrap().parse().unwrap();
+        let event = rt
+            .events(&token)
+            .expect("event store")
+            .get_event(event_id)
+            .await
+            .unwrap()
+            .expect("feedback event");
+        assert_eq!(event.payload["candidate_ids"], json!([compact_id]));
+    }
 }
 
 #[tokio::test]
-async fn brain_auto_feedback_full_id_precedes_id_and_retains_selected_attribution() {
+async fn brain_auto_feedback_aliases_resolve_full_id_and_retain_selected_attribution() {
     let (pack, rt) = make_pack();
     let registry = empty_registry();
     let token = rt.authorize(Namespace::local()).unwrap();
     let first = create_test_entity(&rt, &token).await;
     let selected = create_test_entity(&rt, &token).await;
+    let alias_record = create_test_entity(&rt, &token).await;
+    let compact_alias = &alias_record[..8];
     let results = json!([
-        {"id": selected, "full_id": first},
-        {"id": first, "full_id": selected, "serve_attribution": "unattributed"}
+        {"id": first, "full_id": first},
+        {"id": compact_alias, "full_id": selected, "serve_attribution": "unattributed"}
     ]);
+    for target_id in [compact_alias, selected.as_str()] {
+        let result = pack
+            .dispatch(
+                "brain.auto_feedback",
+                json!({
+                    "query": "full identity attribution",
+                    "results": results,
+                    "target_id": target_id,
+                    "signal": "implicit_positive"
+                }),
+                &registry,
+                &token,
+            )
+            .await
+            .expect("either alias selects the second result and resolves its full_id");
+        assert_eq!(result["target_id"], selected);
+        assert_eq!(result["serve_attribution"], "unattributed");
+        let event_id = result["event_id"].as_str().unwrap().parse().unwrap();
+        let event = rt
+            .events(&token)
+            .expect("event store")
+            .get_event(event_id)
+            .await
+            .unwrap()
+            .expect("feedback event");
+        assert_eq!(
+            event.payload["candidate_ids"],
+            json!([first, compact_alias])
+        );
+    }
+    assert_eq!(pack.snapshot().balanced_recall.total_events, 0);
+}
+
+#[tokio::test]
+async fn brain_auto_feedback_equal_aliases_on_one_result_count_once() {
+    let (pack, rt) = make_pack();
+    let registry = empty_registry();
+    let token = rt.authorize(Namespace::local()).unwrap();
+    let selected = create_test_entity(&rt, &token).await;
     let result = pack
         .dispatch(
             "brain.auto_feedback",
             json!({
-                "query": "full identity precedence",
-                "results": results,
+                "query": "equal aliases on one result",
+                "results": [{"id": selected, "full_id": selected}],
                 "target_id": selected,
                 "signal": "implicit_positive"
             }),
@@ -3472,10 +3515,10 @@ async fn brain_auto_feedback_full_id_precedes_id_and_retains_selected_attributio
             &token,
         )
         .await
-        .expect("full_id selects and resolves the second result");
+        .expect("equal aliases identify one result, not two matches");
+    assert_eq!(result["emitted"], true);
     assert_eq!(result["target_id"], selected);
-    assert_eq!(result["serve_attribution"], "unattributed");
-    assert_eq!(pack.snapshot().balanced_recall.total_events, 0);
+    assert_eq!(pack.snapshot().balanced_recall.total_events, 1);
 }
 
 #[tokio::test]
@@ -3485,16 +3528,17 @@ async fn brain_auto_feedback_full_id_rejects_conflicts_duplicates_and_malformed_
     let token = rt.authorize(Namespace::local()).unwrap();
     let target = create_test_entity(&rt, &token).await;
     let other = create_test_entity(&rt, &token).await;
+    let before = json!(pack.snapshot());
     for (results, selected, message) in [
         (
             json!([{"id": &other[..8], "full_id": other}]),
             target.as_str(),
-            "does not match any results[].full_id",
+            "does not match any results[].id or results[].full_id",
         ),
         (
-            json!([{"id": target, "full_id": other}]),
+            json!([{"id": target, "full_id": other}, {"id": other, "full_id": target}]),
             target.as_str(),
-            "does not match any results[].full_id",
+            "matches more than one result",
         ),
         (
             json!([{"id": other, "full_id": target}, {"id": target}]),
@@ -3502,9 +3546,44 @@ async fn brain_auto_feedback_full_id_rejects_conflicts_duplicates_and_malformed_
             "matches more than one result",
         ),
         (
+            json!([{"id": &target[..8], "full_id": target}, {"id": &target[..8], "full_id": other}]),
+            &target[..8],
+            "matches more than one result",
+        ),
+        (
+            json!([{"id": &target[..8], "full_id": target}, {"id": other, "full_id": target}]),
+            target.as_str(),
+            "matches more than one result",
+        ),
+        (
+            json!([{"id": target, "full_id": target}, {"id": target, "full_id": target}]),
+            target.as_str(),
+            "matches more than one result",
+        ),
+        (
             json!([{"id": target, "full_id": "not-an-id"}]),
             "not-an-id",
-            "invalid id",
+            "invalid full_id",
+        ),
+        (
+            json!([{"id": target, "full_id": "not-an-id"}]),
+            target.as_str(),
+            "invalid full_id",
+        ),
+        (
+            json!([{"id": &target[..8], "full_id": "not-an-id"}]),
+            &target[..8],
+            "invalid full_id",
+        ),
+        (
+            json!([{"id": target, "full_id": &target[..8]}]),
+            target.as_str(),
+            "invalid full_id",
+        ),
+        (
+            json!([{"id": target, "full_id": ""}]),
+            target.as_str(),
+            "invalid full_id",
         ),
         (
             json!([{"id": target, "full_id": 42}]),
@@ -3519,14 +3598,15 @@ async fn brain_auto_feedback_full_id_rejects_conflicts_duplicates_and_malformed_
                     "query": "invalid full identity",
                     "results": results,
                     "target_id": selected,
-                    "signal": "useful"
+                    "signal": "implicit_positive"
                 }),
                 &registry,
                 &token,
             )
             .await
-            .expect_err("invalid or ambiguous effective identity must refuse");
+            .expect_err("invalid canonical identity or ambiguous aliases must refuse");
         assert!(error.to_string().contains(message), "{error}");
+        assert_eq!(json!(pack.snapshot()), before, "{error}");
     }
     assert_eq!(pack.snapshot().balanced_recall.total_events, 0);
     let events = rt
@@ -3650,7 +3730,7 @@ async fn brain_auto_feedback_signal_requires_a_unique_result_target() {
         .expect_err("a target outside results must be rejected");
     assert!(outside
         .to_string()
-        .contains("does not match any results[].full_id"));
+        .contains("does not match any results[].id or results[].full_id"));
 
     let duplicate = pack
         .dispatch(
@@ -3964,7 +4044,7 @@ async fn brain_auto_feedback_empty_results_returns_no_emit() {
         .expect_err("an empty result set cannot contain the named target");
     assert!(out_of_set
         .to_string()
-        .contains("does not match any results[].id"));
+        .contains("does not match any results[].id or results[].full_id"));
     assert_eq!(pack.snapshot().balanced_recall.total_events, 0);
 }
 
@@ -3977,23 +4057,28 @@ async fn brain_auto_feedback_accepts_short_note_id_prefix() {
     // Use 8-char prefix as Agent mode would return from memory.recall.
     let prefix = &target[..8];
 
-    let result = pack
-        .dispatch(
-            "brain.auto_feedback",
-            json!({
-                "query": "prefix resolution test",
-                "results": [{ "id": prefix }],
-                "target_id": prefix,
-                "signal": "implicit_positive"
-            }),
-            &registry,
-            &token,
-        )
-        .await
-        .expect("auto_feedback with 8-char prefix succeeds");
+    for candidate in [
+        json!({"id": prefix}),
+        json!({"id": prefix, "full_id": null}),
+    ] {
+        let result = pack
+            .dispatch(
+                "brain.auto_feedback",
+                json!({
+                    "query": "prefix resolution test",
+                    "results": [candidate],
+                    "target_id": prefix,
+                    "signal": "implicit_positive"
+                }),
+                &registry,
+                &token,
+            )
+            .await
+            .expect("absent or null full_id preserves 8-char prefix resolution");
 
-    assert_eq!(result["emitted"], json!(true));
-    assert_eq!(result["target_id"].as_str().unwrap_or("").len(), 36);
+        assert_eq!(result["emitted"], json!(true));
+        assert_eq!(result["target_id"], target);
+    }
 }
 
 /// #1505 direct-call defense: PackRuntime callers must provide a token for the
@@ -4302,9 +4387,19 @@ mod help_tests {
             h.params.iter().any(|p| p.name == "query" && p.required),
             "brain.auto_feedback must have required query param"
         );
+        let results = h
+            .params
+            .iter()
+            .find(|p| p.name == "results")
+            .unwrap_or_else(|| panic!("brain.auto_feedback must declare results"));
+        assert!(results.required, "results must be required");
         assert!(
-            h.params.iter().any(|p| p.name == "results" && p.required),
-            "brain.auto_feedback must have required results param"
+            results.description.contains("id or full_id")
+                && results.description.contains("exactly one result object")
+                && results.description.contains("count once")
+                && results.description.contains("full_id must be a full UUID"),
+            "results help must describe alias uniqueness and canonical identity: {:?}",
+            results.description
         );
         let target_id = h
             .params
@@ -4320,7 +4415,9 @@ mod help_tests {
             target_id.description.contains("compact id")
                 && target_id.description.contains("full_id")
                 && target_id.description.contains("Required when signal")
-                && target_id.description.contains("exactly once"),
+                && target_id.description.contains("exactly one result object")
+                && target_id.description.contains("count once")
+                && target_id.description.contains("must be a full UUID"),
             "target_id help must describe conditional uniqueness: {:?}",
             target_id.description
         );

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -3528,7 +3528,21 @@ async fn brain_auto_feedback_full_id_rejects_conflicts_duplicates_and_malformed_
     let token = rt.authorize(Namespace::local()).unwrap();
     let target = create_test_entity(&rt, &token).await;
     let other = create_test_entity(&rt, &token).await;
-    let before = json!(pack.snapshot());
+    // The default profile is rebuilt with a fresh `created_at` the first time a
+    // dispatch loads state, so that one field moves for reasons unrelated to
+    // feedback. Everything else in the snapshot must stay byte-identical.
+    let snapshot_without_profile_creation_times = |pack: &BrainPack| {
+        let mut value = json!(pack.snapshot());
+        if let Some(profiles) = value.get_mut("profiles").and_then(Value::as_object_mut) {
+            for profile in profiles.values_mut() {
+                if let Some(fields) = profile.as_object_mut() {
+                    fields.remove("created_at");
+                }
+            }
+        }
+        value
+    };
+    let before = snapshot_without_profile_creation_times(&pack);
     for (results, selected, message) in [
         (
             json!([{"id": &other[..8], "full_id": other}]),
@@ -3606,7 +3620,11 @@ async fn brain_auto_feedback_full_id_rejects_conflicts_duplicates_and_malformed_
             .await
             .expect_err("invalid canonical identity or ambiguous aliases must refuse");
         assert!(error.to_string().contains(message), "{error}");
-        assert_eq!(json!(pack.snapshot()), before, "{error}");
+        assert_eq!(
+            snapshot_without_profile_creation_times(&pack),
+            before,
+            "{error}"
+        );
     }
     assert_eq!(pack.snapshot().balanced_recall.total_events, 0);
     let events = rt


### PR DESCRIPTION
Closes #2434.

`brain.auto_feedback` matched `target_id` against `results[].id` only, while
`memory.recall` presents each hit with `id` as the compact prefix and the full
UUID in `full_id`. Forwarding recall output verbatim was refused, so every
caller had to rewrite the hits first.

## What changed

- `AutoFeedbackResult` gains an optional `full_id`, and `target_id` now matches
  either alias on a result object. Equal aliases on the same object count once;
  a `target_id` matching two different objects stays ambiguous and is rejected
  before any mutation.
- When the selected object carries a non-null `full_id`, that value is the
  canonical attribution target and must parse as a full UUID; a malformed value
  is refused rather than silently falling back. With `full_id` absent or null the
  existing prefix resolver still runs, so the previous call shape is unchanged.
- Raw `candidate_ids` audit context keeps the presented `id`, and result-level
  serve attribution still comes from the selected result rather than the first
  hit.
- Verb parameter descriptions, `AGENTS.md`, and the brain pack design note state
  the new matching rule; the existing error-message assertions were updated to
  match.

## Tests

The recall-shaped test now judges both aliases, plus controls for cross-object
collision, equal aliases on one object, a malformed `full_id` on the selected
object, null/omitted `full_id`, and a whole-snapshot no-mutation arm.
