### PR TITLE
fix(comm): stop id-resolution refusals from echoing the resolved id

### DIFF
--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -1255,8 +1255,11 @@ async fn validate_read_target(
         .and_then(Value::as_str)
     {
         if to_actor != caller_actor {
+            // The resolved uuid stays out of this message: a caller who asked by
+            // 8-char prefix would otherwise learn both that a message exists and
+            // its full id from a refusal (issue #2564).
             return Err(RuntimeError::InvalidInput(format!(
-                "read: message {id} is not addressed to caller actor {caller_actor:?}"
+                "read: that message is not addressed to caller actor {caller_actor:?}"
             )));
         }
     } else {
@@ -1538,8 +1541,11 @@ pub(crate) async fn handle_reply(
         let is_participant = original_from_actor.as_deref() == Some(caller_actor)
             || original_to_actor.as_deref() == Some(caller_actor);
         if !is_participant {
+            // Same non-disclosure rule as `read` above: the refusal names the
+            // caller's own actor and nothing the caller did not already supply
+            // (issue #2564).
             return Err(RuntimeError::InvalidInput(format!(
-                "reply: message {id} is not addressed to or from caller actor {caller_actor:?}"
+                "reply: that message is not addressed to or from caller actor {caller_actor:?}"
             )));
         }
     } else {

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -2171,6 +2171,72 @@ async fn t87_non_addressee_read_rejected_and_stays_unread() {
     );
 }
 
+/// #2564: a third party who asks by 8-char prefix must not learn the resolved
+/// uuid from the refusal. The prefix is the caller's own input; the remaining 28
+/// characters are not, and printing them confirms both that a message exists and
+/// exactly which one.
+#[tokio::test]
+async fn issue2564_third_party_refusal_does_not_disclose_the_resolved_id() {
+    let backend = shared_backend();
+    let (registry_a, _rt_a) = build_actor_registry(backend.clone(), "lambda:a");
+    let (_registry_b, rt_b) = build_actor_registry(backend.clone(), "lambda:b");
+    let (registry_c, _rt_c) = build_actor_registry(backend.clone(), "lambda:c");
+
+    registry_a
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "lambda:b", "content": "for B's eyes only" }),
+        )
+        .await
+        .expect("A sends to B");
+
+    let local_tok = rt_b.authorize(Namespace::parse("local").unwrap()).unwrap();
+    let notes = rt_b
+        .list_notes(&local_tok, Some("message"), 100, 0)
+        .await
+        .unwrap();
+    let inbound_id = notes
+        .iter()
+        .find(|n| {
+            n.deleted_at.is_none()
+                && n.properties
+                    .as_ref()
+                    .and_then(|p| p.get("direction"))
+                    .and_then(|v| v.as_str())
+                    == Some("inbound")
+        })
+        .map(|n| n.id.as_hyphenated().to_string())
+        .expect("inbound copy addressed to lambda:b must exist");
+    let prefix = inbound_id[..8].to_string();
+    let tail = inbound_id[8..].to_string();
+
+    for verb in ["comm.read", "comm.reply"] {
+        let mut args = serde_json::json!({ "id": prefix });
+        if verb == "comm.reply" {
+            args["content"] = serde_json::json!("attempted reply");
+        }
+        let error = registry_c
+            .dispatch(verb, args)
+            .await
+            .expect_err("#2564: a third party must be refused")
+            .to_string();
+        assert!(
+            !error.contains(&tail),
+            "#2564: {verb} refusal must not disclose the resolved uuid; got {error:?}"
+        );
+        assert!(
+            !error.contains(&inbound_id),
+            "#2564: {verb} refusal must not print the full id; got {error:?}"
+        );
+        assert!(
+            error.contains("lambda:c")
+                && !error.contains("lambda:a")
+                && !error.contains("lambda:b"),
+            "#2564: the refusal names only the caller's own actor; got {error:?}"
+        );
+    }
+}
+
 /// The anonymous/"local" single-actor deployment (no actor.id configured) must keep working: caller and to_actor both resolve to "local", so the equality check passes.
 #[tokio::test]
 async fn t87_anonymous_local_single_actor_read_still_works() {
@@ -11158,7 +11224,9 @@ async fn i1387_atomic_mark_read_reuses_addressee_validation_before_mutation() {
         .await
         .expect_err("A cannot mark B's inbound delivery state");
     let error = error.to_string();
-    assert!(error.contains("read: message"));
+    // #2564 reworded this refusal so it no longer echoes the resolved id; the
+    // assertion still pins the error to the read-path addressee check.
+    assert!(error.contains("read: that message is not addressed"));
     assert!(error.contains("lambda:a"));
     assert!(!error.contains("lambda:b"));
 


### PR DESCRIPTION
## What

`comm.read` and `comm.reply` resolve a short id prefix to a message before they
check whether the caller may act on it. Both refusals printed the resolved uuid,
so a caller who supplied eight characters got back the other twenty-eight along
with confirmation that a message with that prefix exists — from a path that is
supposed to tell a non-party nothing. Both messages now name only the caller's
own actor, which the caller already supplied.

## Scope

Two call sites in `crates/khive-pack-comm/src/handlers.rs`. The addressee and the
original sender were already withheld from these refusals; this removes the last
field in them that the caller did not provide.

Deliberately unchanged: the `"no record matches prefix"` message emitted when a
prefix resolves to nothing. That wording is a shared convention across six packs
(kg, gtd, knowledge, schedule and comm's own message resolver) with tests keyed
on it, and it discloses nothing beyond the caller's own input. The right
statement there is a contract one rather than a code change: a presence check
must not be built on refusal text, and `comm.thread` already returns a structured
`thread_id` for callers that need one.

## Verification

- `cargo test -p khive-pack-comm --no-fail-fast` on rust 1.95.0: 259 passed, 0 failed.
- New test `issue2564_third_party_refusal_does_not_disclose_the_resolved_id`
  dispatches both verbs from a third actor using an 8-character prefix and asserts
  the refusal contains neither the full id nor its unsupplied remainder.
- Mutation control: with the two format strings restored to their previous form,
  that test fails on exactly the disclosure assertion, and the reported error text
  carries the full resolved uuid, so the arm is load-bearing.
- One existing assertion moved with the text: the atomic `mark_read` test pinned
  the refusal to the read path via the substring `read: message`; it now pins the
  same path via `read: that message is not addressed`. The three reply-side tests
  key on `not addressed to or from caller actor`, which is unchanged.

Closes #2564.
