### PR TITLE
fix(git): decide git.commit's paths form with the same use policy as every other git verb

### DIFF
--- a/crates/khive-pack-git/src/pack.rs
+++ b/crates/khive-pack-git/src/pack.rs
@@ -160,7 +160,7 @@ impl PackRuntime for GitPack {
             "git.commit" if params.get("tree").is_some() => {
                 self.handle_local(token, registry, verb, params).await
             }
-            "git.commit" => self.handle_commit(token, params).await,
+            "git.commit" => self.handle_commit(token, registry, params).await,
             "git.branch" => self.handle_local(token, registry, verb, params).await,
             "git.push" | "git.pr_open" | "git.pr_review" | "git.pr_merge" => {
                 self.handle_remote(token, registry, verb, params).await

--- a/crates/khive-pack-git/src/write_handlers.rs
+++ b/crates/khive-pack-git/src/write_handlers.rs
@@ -12,6 +12,11 @@
 //! configuration, resolved by `crate::write_policy` against the operator's
 //! `[git_write]` allowlist (ADR-108 Amendment).
 //!
+//! Both enforcement points run before the repository is touched: the
+//! ADR-180 use policy (`tool.check`, consulted by `checked_policy`) and then
+//! the `[git_write]` allowlist. The first is operator-configurable and the
+//! second is not, and a write proceeds only when both permit it (#2572).
+//!
 //! `enforce_write_policy` returns the **canonical** repo path on success, and
 //! every git invocation for that call uses it from that point on — never the
 //! raw caller-supplied `repo` (ADR-108 review r2 High finding: reusing the
@@ -36,10 +41,11 @@ use std::sync::{Arc, Mutex as StdMutex, OnceLock};
 use serde_json::{json, Value};
 use tokio::sync::Mutex as AsyncMutex;
 
-use khive_runtime::{NamespaceToken, RuntimeError};
+use khive_runtime::{NamespaceToken, RuntimeError, VerbRegistry};
 use khive_storage::event::Event;
 use khive_types::{EventKind, EventOutcome, SubstrateKind};
 
+use crate::local_handlers::checked_policy;
 use crate::write_argv::{build_add_argv, build_commit_argv, validate_repo_path, GitArgError};
 use crate::write_policy::{GitWritePolicy, GitWritePolicyError};
 use crate::GitPack;
@@ -295,11 +301,43 @@ impl GitPack {
     pub(crate) async fn handle_commit(
         &self,
         token: &NamespaceToken,
+        registry: &VerbRegistry,
         params: Value,
     ) -> Result<Value, RuntimeError> {
         let repo = self
             .parse_audited_repo(token, "git.commit", &params)
             .await?;
+
+        // #2572: every other git verb, including the `tree` form of this one,
+        // refuses unless `tool.check` answers `allow`; the `paths` form consulted
+        // only the `[git_write]` allowlist below. An operator who allowlisted a
+        // repository and then restricted `git.*` through policy got reads that
+        // honoured the restriction and a write that ignored it, which is the
+        // permissive direction on the one verb in the set that mutates a
+        // repository. The decision is taken before the repo lock and before any
+        // git process starts, and a denial is audited like the allowlist denial.
+        //
+        // When the policy surface itself is unreachable — the tool pack is not
+        // loaded at all — this form keeps committing, which is the behaviour
+        // `arm30_tool_pack_absence_refuses_tree_commit_but_preserves_legacy_paths`
+        // pins deliberately: the `tree` form refuses there and the `paths` form
+        // does not. That asymmetry is a compatibility decision, not part of this
+        // fix; the `[git_write]` allowlist is still enforced below either way.
+        if let Ok(decision) = checked_policy(registry, token, "git.commit").await {
+            if decision["decision"] != "allow" {
+                return Err(self
+                    .audit_early_failure(
+                        token,
+                        "git.commit",
+                        &repo,
+                        None,
+                        EventOutcome::Denied,
+                        RuntimeError::InvalidInput("policy_denied".into()),
+                    )
+                    .await);
+            }
+        }
+
         let lock = repo_write_lock(&repo);
         let _guard = lock.lock().await;
         let CommitPreflight {
@@ -386,6 +424,30 @@ impl GitPack {
         }
     }
 
+    /// Legacy unit-test convenience: the production dispatch path supplies the
+    /// real registry, which is where `git.commit`'s use-policy decision comes
+    /// from (#2572).
+    #[cfg(test)]
+    pub(crate) async fn handle_commit_fixture(
+        &self,
+        token: &NamespaceToken,
+        params: Value,
+    ) -> Result<Value, RuntimeError> {
+        let registry = self.fixture_registry();
+        self.handle_commit(token, &registry, params).await
+    }
+
+    #[cfg(test)]
+    fn fixture_registry(&self) -> khive_runtime::VerbRegistry {
+        let mut builder = khive_runtime::VerbRegistryBuilder::new();
+        builder.register(khive_pack_kg::KgPack::new(self.runtime().clone()));
+        builder.register(khive_pack_tool::ToolPack::new(self.runtime().clone()));
+        builder
+            .with_runtime_event_store(self.runtime())
+            .expect("fixture audit store");
+        builder.build().expect("fixture registry")
+    }
+
     #[cfg(test)]
     pub(crate) async fn handle_branch(
         &self,
@@ -394,13 +456,7 @@ impl GitPack {
     ) -> Result<Value, RuntimeError> {
         // Legacy unit tests call this crate-private convenience directly; production
         // dispatch always supplies the actual registry and its per-pack backends.
-        let mut builder = khive_runtime::VerbRegistryBuilder::new();
-        builder.register(khive_pack_kg::KgPack::new(self.runtime().clone()));
-        builder.register(khive_pack_tool::ToolPack::new(self.runtime().clone()));
-        builder
-            .with_runtime_event_store(self.runtime())
-            .expect("fixture audit store");
-        let registry = builder.build().expect("fixture registry");
+        let registry = self.fixture_registry();
         self.handle_local(token, &registry, "git.branch", params)
             .await
     }

--- a/crates/khive-pack-git/src/write_handlers_tests.rs
+++ b/crates/khive-pack-git/src/write_handlers_tests.rs
@@ -102,6 +102,19 @@ async fn pack_and_token_with_policy(git_write: GitWriteSectionConfig) -> (GitPac
         )
         .await
         .expect("legacy branch policy");
+    // #2572 put `git.commit` behind the same use policy as every other git verb,
+    // so the legacy fixture has to grant it to keep exercising what it was written
+    // for. `commit_denied_when_use_policy_does_not_allow` is the arm that asserts
+    // the check itself.
+    registry
+        .dispatch(
+            "tool.policy",
+            json!({
+                "actor": "*", "tool": "git.commit", "decision": "allow"
+            }),
+        )
+        .await
+        .expect("legacy commit policy");
     (GitPack::new(rt), token)
 }
 
@@ -206,7 +219,7 @@ async fn commit_with_no_paths_commits_all_tracked_changes() {
     std::fs::write(repo.path().join("a.txt"), b"changed").unwrap();
 
     let result = pack
-        .handle_commit(
+        .handle_commit_fixture(
             &token,
             json!({ "repo": repo.path().to_str().unwrap(), "message": "update a.txt" }),
         )
@@ -250,7 +263,7 @@ async fn commit_ignores_hostile_ambient_global_config_in_tests() {
 
     std::fs::write(repo.path().join("a.txt"), b"changed").unwrap();
 
-    pack.handle_commit(
+    pack.handle_commit_fixture(
         &token,
         json!({ "repo": repo.path().to_str().unwrap(), "message": "update a.txt" }),
     )
@@ -268,7 +281,7 @@ async fn commit_with_paths_scopes_to_those_paths() {
     std::fs::write(repo.path().join("b.txt"), b"new-b").unwrap();
 
     let result = pack
-        .handle_commit(
+        .handle_commit_fixture(
             &token,
             json!({
                 "repo": repo.path().to_str().unwrap(),
@@ -309,7 +322,7 @@ async fn commit_literalizes_pathspec_magic_in_caller_path() {
     )
     .unwrap();
 
-    pack.handle_commit(
+    pack.handle_commit_fixture(
         &token,
         json!({
             "repo": repo.path().to_str().unwrap(),
@@ -338,7 +351,7 @@ async fn commit_accepts_special_and_unicode_literal_filename() {
     std::fs::create_dir_all(repo.path().join("docs")).unwrap();
     std::fs::write(repo.path().join(path), b"literal").unwrap();
 
-    pack.handle_commit(
+    pack.handle_commit_fixture(
         &token,
         json!({
             "repo": repo.path().to_str().unwrap(),
@@ -370,7 +383,7 @@ async fn commit_rejects_empty_message() {
     let (pack, token) = pack_and_token_with_policy(GitWriteSectionConfig::default()).await;
 
     let err = pack
-        .handle_commit(
+        .handle_commit_fixture(
             &token,
             json!({ "repo": repo.path().to_str().unwrap(), "message": "" }),
         )
@@ -386,7 +399,7 @@ async fn commit_treats_flag_shaped_path_as_literal() {
     let (pack, token) = pack_and_token_with_policy(policy(repo.path(), &["main"])).await;
     std::fs::write(repo.path().join("--upload-pack=evil"), b"literal").unwrap();
 
-    pack.handle_commit(
+    pack.handle_commit_fixture(
         &token,
         json!({
             "repo": repo.path().to_str().unwrap(),
@@ -404,7 +417,7 @@ async fn commit_invalid_path_emits_deny_audit() {
     let (repo, _remote) = init_repo_with_remote();
     let (pack, token) = pack_and_token_with_policy(policy(repo.path(), &["main"])).await;
 
-    pack.handle_commit(
+    pack.handle_commit_fixture(
         &token,
         json!({
             "repo": repo.path().to_str().unwrap(),
@@ -428,7 +441,7 @@ async fn commit_rejects_non_repo_path() {
     let (pack, token) = pack_and_token_with_policy(GitWriteSectionConfig::default()).await;
 
     let err = pack
-        .handle_commit(
+        .handle_commit_fixture(
             &token,
             json!({ "repo": dir.path().to_str().unwrap(), "message": "msg" }),
         )
@@ -450,7 +463,7 @@ async fn commit_rejects_non_string_author_without_committing() {
         .stdout;
 
     let err = pack
-        .handle_commit(
+        .handle_commit_fixture(
             &token,
             json!({
                 "repo": repo.path().to_str().unwrap(),
@@ -481,7 +494,7 @@ async fn commit_denied_when_no_policy_configured() {
     std::fs::write(repo.path().join("a.txt"), b"changed").unwrap();
 
     let err = pack
-        .handle_commit(
+        .handle_commit_fixture(
             &token,
             json!({ "repo": repo.path().to_str().unwrap(), "message": "update a.txt" }),
         )
@@ -503,7 +516,7 @@ async fn commit_denied_for_non_allowlisted_repo() {
     std::fs::write(repo.path().join("a.txt"), b"changed").unwrap();
 
     let err = pack
-        .handle_commit(
+        .handle_commit_fixture(
             &token,
             json!({ "repo": repo.path().to_str().unwrap(), "message": "update a.txt" }),
         )
@@ -521,7 +534,7 @@ async fn commit_denied_for_branch_outside_patterns() {
     std::fs::write(repo.path().join("a.txt"), b"changed").unwrap();
 
     let err = pack
-        .handle_commit(
+        .handle_commit_fixture(
             &token,
             json!({ "repo": repo.path().to_str().unwrap(), "message": "update a.txt" }),
         )
@@ -557,7 +570,7 @@ async fn commit_does_not_execute_repo_configured_hooks() {
 
     std::fs::write(repo.path().join("a.txt"), b"changed").unwrap();
 
-    pack.handle_commit(
+    pack.handle_commit_fixture(
         &token,
         json!({ "repo": repo.path().to_str().unwrap(), "message": "update a.txt" }),
     )
@@ -568,6 +581,165 @@ async fn commit_does_not_execute_repo_configured_hooks() {
         !sentinel.exists(),
         "pre-commit hook must not have executed during a khive-mediated commit"
     );
+}
+
+// -- git.commit use policy (#2572) ----------------------------------------
+
+/// Builds a runtime whose `git.commit` use policy is exactly `decision`, or
+/// carries no policy row at all when `decision` is `None`, and returns the
+/// registry so the verb is driven through the real dispatch path.
+async fn registry_with_commit_decision(
+    git_write: GitWriteSectionConfig,
+    decision: Option<&str>,
+) -> (khive_runtime::VerbRegistry, GitPack, NamespaceToken) {
+    let config = RuntimeConfig {
+        db_path: None,
+        packs: vec!["kg".to_string()],
+        brain_profile: None,
+        actor_id: None,
+        git_write,
+        ..RuntimeConfig::no_embeddings()
+    };
+    let rt = KhiveRuntime::new(config).expect("in-memory runtime");
+    let token = rt.authorize(Namespace::local()).expect("authorize");
+    let mut builder = khive_runtime::VerbRegistryBuilder::new();
+    builder.register(khive_pack_kg::KgPack::new(rt.clone()));
+    builder.register(khive_pack_tool::ToolPack::new(rt.clone()));
+    builder.register(GitPack::new(rt.clone()));
+    builder
+        .with_runtime_event_store(&rt)
+        .expect("fixture audit store");
+    let registry = builder.build().expect("fixture registry");
+    registry.apply_schema_plans(rt.backend());
+    if let Some(decision) = decision {
+        registry
+            .dispatch(
+                "tool.policy",
+                json!({ "actor": "*", "tool": "git.commit", "decision": decision }),
+            )
+            .await
+            .expect("seed git.commit policy");
+    }
+    (registry, GitPack::new(rt), token)
+}
+
+/// Every supplementary write audit for `verb` carrying a `repo` payload, which
+/// is what `emit_write_audit` writes; the dispatch-level gate audit does not.
+async fn write_audits(
+    pack: &GitPack,
+    token: &NamespaceToken,
+    verb: &str,
+) -> Vec<khive_storage::event::Event> {
+    let events_store = pack.runtime().events(token).expect("events store");
+    events_store
+        .query_events(
+            khive_storage::event::EventFilter {
+                verbs: vec![verb.to_string()],
+                ..Default::default()
+            },
+            khive_storage::types::PageRequest {
+                offset: 0,
+                limit: 50,
+            },
+        )
+        .await
+        .expect("query events")
+        .items
+        .into_iter()
+        .filter(|event| event.payload.get("repo").is_some())
+        .collect()
+}
+
+fn head_sha(repo: &Path) -> String {
+    String::from_utf8_lossy(
+        &git_command(repo)
+            .args(["rev-parse", "HEAD"])
+            .output()
+            .expect("git rev-parse")
+            .stdout,
+    )
+    .trim()
+    .to_string()
+}
+
+/// #2572: the `paths` form of `git.commit` was the one git verb that never
+/// consulted the use policy, so an allowlisted repository could be written by a
+/// caller whose reads of the same repository were refused.
+#[tokio::test]
+async fn commit_paths_form_refuses_when_use_policy_does_not_allow() {
+    let _env_guard = crate::cache::ENV_MUTEX.lock().await;
+    let (repo, _remote) = init_repo_with_remote();
+    let before = head_sha(repo.path());
+
+    for decision in [None, Some("ask"), Some("deny")] {
+        let (registry, pack, token) =
+            registry_with_commit_decision(policy(repo.path(), &["*"]), decision).await;
+        std::fs::write(repo.path().join("b.txt"), b"gate probe").unwrap();
+
+        let error = registry
+            .dispatch(
+                "git.commit",
+                json!({
+                    "repo": repo.path().to_str().unwrap(),
+                    "message": "gate probe",
+                    "paths": ["b.txt"],
+                }),
+            )
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains("policy_denied"),
+            "#2572: decision {decision:?} must refuse with policy_denied; got {error}"
+        );
+        assert_eq!(
+            head_sha(repo.path()),
+            before,
+            "#2572: decision {decision:?} must leave the repository untouched"
+        );
+
+        // Dispatching through the registry also fires the dispatch-level
+        // gate-check audit, so this looks for the supplementary write audit by
+        // its own payload rather than asserting a single git.commit event.
+        let denials = write_audits(&pack, &token, "git.commit")
+            .await
+            .into_iter()
+            .filter(|event| {
+                event.outcome == EventOutcome::Denied && event.payload["decision"] == "deny"
+            })
+            .count();
+        assert_eq!(
+            denials, 1,
+            "#2572: decision {decision:?} must leave exactly one denied write audit"
+        );
+    }
+}
+
+/// The companion arm: the same call with an allowing policy still commits, so
+/// the refusal above is the policy and not a broken fixture.
+#[tokio::test]
+async fn commit_paths_form_still_commits_when_use_policy_allows() {
+    let _env_guard = crate::cache::ENV_MUTEX.lock().await;
+    let (repo, _remote) = init_repo_with_remote();
+    let before = head_sha(repo.path());
+    let (registry, _pack, _token) =
+        registry_with_commit_decision(policy(repo.path(), &["*"]), Some("allow")).await;
+    std::fs::write(repo.path().join("b.txt"), b"gate probe").unwrap();
+
+    let result = registry
+        .dispatch(
+            "git.commit",
+            json!({
+                "repo": repo.path().to_str().unwrap(),
+                "message": "gate probe",
+                "paths": ["b.txt"],
+            }),
+        )
+        .await
+        .expect("#2572: an allowing policy must still commit");
+    let sha = result["sha"].as_str().expect("sha in result");
+    assert_ne!(sha, before, "#2572: HEAD must advance");
+    assert_eq!(head_sha(repo.path()), sha);
 }
 
 // -- git.branch -----------------------------------------------------------
@@ -716,7 +888,7 @@ async fn invalid_repo_values_emit_denied_audits_without_invoking_git() {
     for (verb, params, expected_error) in cases {
         let (pack, token) = pack_and_token_with_policy(GitWriteSectionConfig::default()).await;
         let result = match verb {
-            "git.commit" => pack.handle_commit(&token, params).await,
+            "git.commit" => pack.handle_commit_fixture(&token, params).await,
             "git.branch" => pack.handle_branch(&token, params).await,
             _ => unreachable!("fixed test case verb"),
         };
@@ -759,7 +931,7 @@ async fn commit_via_symlink_resolves_and_lands_in_canonical_repo() {
     std::fs::write(real_repo.path().join("a.txt"), b"changed-via-link").unwrap();
 
     let result = pack
-        .handle_commit(
+        .handle_commit_fixture(
             &token,
             json!({ "repo": link.to_str().unwrap(), "message": "via symlink" }),
         )
@@ -796,7 +968,7 @@ async fn commit_audit_captures_resolved_branch_and_sha() {
 
     std::fs::write(repo.path().join("a.txt"), b"changed").unwrap();
     let result = pack
-        .handle_commit(
+        .handle_commit_fixture(
             &token,
             json!({ "repo": repo.path().to_str().unwrap(), "message": "audit check" }),
         )
@@ -848,7 +1020,7 @@ async fn commit_denial_emits_deny_decision_audit() {
 
     std::fs::write(repo.path().join("a.txt"), b"changed").unwrap();
     let err = pack
-        .handle_commit(
+        .handle_commit_fixture(
             &token,
             json!({ "repo": repo.path().to_str().unwrap(), "message": "denied" }),
         )
@@ -892,7 +1064,7 @@ async fn detached_head_commit_failure_emits_error_audit() {
     run(repo.path(), &["checkout", "-q", "--detach", "HEAD"]);
     std::fs::write(repo.path().join("a.txt"), b"detached change").unwrap();
 
-    pack.handle_commit(
+    pack.handle_commit_fixture(
         &token,
         json!({ "repo": repo.path().to_str().unwrap(), "message": "detached" }),
     )


### PR DESCRIPTION
## What

`git.commit(repo, paths=[...])` was the only git verb that never consulted
`tool.check`. Every read verb (`git.status`, `git.log`, `git.checkout`) and
`git.branch` refuse unless the decision is `allow`, and so does `git.commit` in
its `tree` form, which dispatches through the same handler as `git.branch`. The
`paths` form checked the `[git_write]` allowlist and nothing else.

The consequence was measurable from outside: on one daemon with one allowlisted
repository and no policy registered, `git.status` and `git.log` refused with
`policy_denied` while `git.commit(..., paths=[...])` wrote a commit to the same
repository in the same call sequence. The permissive direction, on the one verb
in the set that mutates a repository.

## Change

`handle_commit` now takes the registry and asks `checked_policy` for
`git.commit`, refusing with `policy_denied` on any answer other than `allow`.
The decision is taken after the repo argument is parsed and before the
repository lock and before any git process starts, and a denial emits the same
supplementary write audit (`decision: "deny"`, outcome `Denied`) that an
allowlist denial does. One policy row covers both forms of the verb, since the
`tree` form already checks the same name.

## What this deliberately does not change

When the policy surface itself is unreachable, because the tool pack is not
loaded at all, the `paths` form still commits. That is the behaviour
`arm30_tool_pack_absence_refuses_tree_commit_but_preserves_legacy_paths` pins on
purpose: the `tree` form refuses there and the `paths` form does not. Closing
that asymmetry is a separate decision about deployments without the tool pack,
and it is not smuggled in here. The `[git_write]` allowlist is enforced either
way.

## Verification

- `cargo test -p khive-pack-git --no-fail-fast` on rust 1.95.0: 323 + 110 + 30 + 6
  passed, 0 failed. `cargo clippy -p khive-pack-git --all-targets -- -D warnings`
  and `cargo check --workspace --all-targets` both clean; `cargo fmt --check` clean.
- New arm `commit_paths_form_refuses_when_use_policy_does_not_allow` drives the
  verb through real dispatch for three states (no policy row, `ask`, `deny`),
  asserting `policy_denied`, that HEAD does not move, and that exactly one denied
  write audit is written each time.
- Companion arm `commit_paths_form_still_commits_when_use_policy_allows` proves
  the refusal is the policy and not a broken fixture.
- Mutation control: with the new check disabled, the refusal arm fails and the
  allow arm still passes.
- The legacy handler fixture now grants `git.commit` alongside `git.branch`,
  which is why its 19 existing call sites keep testing what they were written for.

Closes #2572.
