### PR TITLE
docs(adr): ADR-172 Amendment 4, absence as a fence predicate

### DIFF
--- a/docs/adr/ADR-172-versioned-notes-compare-and-set.md
+++ b/docs/adr/ADR-172-versioned-notes-compare-and-set.md
@@ -506,3 +506,53 @@ shapes and kinds are validated before any member transaction starts.
 This amendment enables append-member fences only. The batch-wide `fence` and
 `observed` fields, their mode defaults, and the `write` member retain their
 existing availability rules.
+
+## Amendment 4 (2026-09-11): absence as a fence predicate
+
+**Status**: Proposed.
+
+A fence may assert that no live note holds a key. `expected_version: null` on any fence entry, on
+singleton note `create`, note `update` and `stream.append`, alike in the object form and in
+Amendment 3's list form, succeeds when the resolved `(kind, key)` has no live row and refuses when
+one exists:
+
+```json
+{ "fence": [{ "kind": "head", "key": "run/lease", "expected_version": null }] }
+```
+
+This supersedes the sentence in Amendment 3 that made an explicit null `invalid_input`. The rest of
+that paragraph stands: an empty list, a malformed entry, an unknown entry field, an invalid key or
+note kind, a non-positive version, and a repeated `(kind, key)` remain `invalid_input` before the
+write transaction opens.
+
+**Why it is a correction and not a new capability.** The predicate already exists in the system.
+[ADR-174](ADR-174-ordered-streams-append.md)'s `stream.batch` reads a null `version` in its
+`observed` set as exactly this assertion, and the fence evaluation on the single-write path already
+resolves the current version into an optional value: the absent case was representable where the
+comparison happens and rejected where the parameter was parsed. A client whose contract is "fenced
+on an ownership head whenever one exists" could express the "whenever one exists" half on one route
+out of four, and the workaround was to send a single append as a `stream.batch`, which turns one
+write into a transaction with a different result shape.
+
+**The field is required and only its value may be null.** A fence entry that omits
+`expected_version` is refused, exactly as an `observed` member that omits `version` is refused.
+Absence is asserted deliberately or not at all: a field that defaults to "assert absent" when a
+caller forgets it would be a worse failure than the refusal it replaces.
+
+**One member shape across the routes.** The fence object additionally accepts `version` as a
+deserialization alias for `expected_version`, so the member a caller builds for `observed` is
+accepted by a fence unchanged. `expected_version` remains the canonical name: it is what this ADR
+documents, what a fence refusal carries in its details, and what serialization emits. No alias is
+added in the other direction, and `observed`'s own field name does not change.
+
+**Refusal.** A violated absence fence keeps `reason: "fence_conflict"` and the message `note fence
+precondition failed`. Its `details.expected_version` is the string `absent`, and `current_version`
+carries the live version that violated it. `details.index` follows Amendment 3's list rule. A
+satisfied absence fence adds nothing to the response.
+
+**Soft deletes.** A soft-deleted row satisfies absence, because the fence read already filters on
+`deleted_at IS NULL`. This is the same rule the keyed create-if-absent path applies, and it is
+stated here because a caller reasoning about a tombstone should not have to derive it from the SQL.
+
+Out of scope, both on the same object: a deadline or expiry on the fence, and any fence on entities
+or edges.


### PR DESCRIPTION
## What

ADR-172 Amendment 4: a fence entry may assert that no live note holds a key, by sending
`expected_version: null`, on singleton note `create`, note `update` and `stream.append`, in both the
object form and Amendment 3's list form.

This supersedes one sentence of Amendment 3, the one that made an explicit null `invalid_input`.
The rest of that paragraph stands unchanged: empty list, malformed entry, unknown field, invalid key
or note kind, non-positive version and a repeated `(kind, key)` are still refused before the write
transaction opens.

## Why it is a correction rather than a new capability

The predicate already exists in the system and is reachable from exactly one route. ADR-174's
`stream.batch` reads a null `version` in `observed` as this exact assertion, and the single-write
fence evaluation already resolves the current version into an optional value, so the absent case is
representable where the comparison happens and rejected where the parameter is parsed. A client
whose contract is "fenced on an ownership head whenever one exists" had to send a single append as a
one-member transaction to express half of it. Reported in #2571.

## What the amendment fixes in place

- The field is required and only its value may be null. A fence omitting `expected_version` stays a
  refusal, matching `observed`'s presence rule. A field that defaulted to "assert absent" when a
  caller forgot it would be worse than the refusal it replaces.
- The fence object accepts `version` as a deserialization alias, so one member shape works on every
  route. `expected_version` stays canonical in the documentation, in refusal details and in
  serialization; no alias is added in the other direction and `observed` is unchanged.
- A violated absence fence keeps `reason: "fence_conflict"` with `details.expected_version` reading
  `absent` and `current_version` carrying the live version that violated it.
- A soft-deleted row satisfies absence, because the fence read already filters on `deleted_at IS
  NULL`.

Out of scope and stated as such: a deadline on the same object (#2551), and fences on entities or
edges.

## Verification

`deno fmt --check`, `scripts/lint-adr-refs.sh` (427 files, 241 titled references) and
`scripts/lint-adr-status.py` (185 records, 0 failing) all clean. Docs only; the implementation lands
separately and this gates it.
