### PR TITLE
fix(git): name git's exit status on a classified read refusal

### DIFF
--- a/crates/khive-pack-git/src/local_git.rs
+++ b/crates/khive-pack-git/src/local_git.rs
@@ -327,13 +327,17 @@ fn run_git_output(
             // when a later HEAD reflog write fails. Only known CAS refusals settle.
             return Err(LocalGitError::after_start(operation, true));
         }
+        // #2539: the exit status is the only bounded, non-sensitive fact that
+        // separates a lock contention from a usage error, and without it a
+        // classified refusal teaches nothing on the run that produced it. stderr
+        // stays where it is: retained for classification, never exposed.
         return Err(LocalGitError::new(
             if ref_effect {
                 "not_committed"
             } else {
                 "git_failed"
             },
-            format!("git {operation} refused the operation"),
+            format!("git {operation} refused the operation with exit status {exit_code}"),
         ));
     }
     let (bytes, exceeded) = out

--- a/crates/khive-pack-git/src/local_handlers.rs
+++ b/crates/khive-pack-git/src/local_handlers.rs
@@ -39,6 +39,16 @@ impl Failure {
     }
 }
 
+/// #2539: the read verbs used to surface the classification code alone, so a
+/// `git_failed` from a real `git` non-zero exit and one from an unparseable
+/// record were the same four words and neither named an exit status. Every
+/// `LocalGitError` message is an authored literal — `git`'s stderr is retained
+/// for classification and never reaches one — so rendering the whole error is
+/// bounded and carries nothing the caller did not cause.
+fn read_refusal(error: LocalGitError) -> RuntimeError {
+    RuntimeError::InvalidInput(error.to_string())
+}
+
 impl From<LocalGitError> for Failure {
     fn from(error: LocalGitError) -> Self {
         Self {
@@ -712,7 +722,7 @@ impl GitPack {
         let (canonical, index) = self.read_gate(token, registry, "git.status", repo).await?;
         let result = local_git::status(&canonical, untracked, limit)
             .await
-            .map_err(|error| RuntimeError::InvalidInput(error.code().into()))?;
+            .map_err(read_refusal)?;
         let entries = serde_json::to_value(&result.entries)
             .map_err(|_| RuntimeError::Internal("status entries did not serialize".into()))?;
         let branch = serde_json::to_value(&result.branch)
@@ -751,7 +761,7 @@ impl GitPack {
         let (canonical, index) = self.read_gate(token, registry, "git.log", repo).await?;
         let commits = local_git::log(&canonical, reference, limit, path)
             .await
-            .map_err(|error| RuntimeError::InvalidInput(error.code().into()))?;
+            .map_err(read_refusal)?;
         let truncated = commits.len() == limit;
         let commits = serde_json::to_value(&commits)
             .map_err(|_| RuntimeError::Internal("log entries did not serialize".into()))?;

--- a/crates/khive-pack-git/tests/dev_loop.rs
+++ b/crates/khive-pack-git/tests/dev_loop.rs
@@ -1696,6 +1696,22 @@ async fn status_reports_a_detached_head_as_a_null_branch_beside_a_real_sha() {
         ),
         None,
     );
+    // #2539: the verb call used to follow `checkout --detach` with nothing
+    // between them and intermittently refused `git_failed` on the macOS runner.
+    // These two reads are a barrier as well as an assertion: they prove the
+    // detach landed, so a failure below is about `git.status` reading a settled
+    // repository rather than one still being written.
+    assert_eq!(
+        f.git_text(&["rev-parse", "--verify", "HEAD"]),
+        f.base,
+        "the detached HEAD must resolve to the same commit before status reads it"
+    );
+    assert_eq!(
+        f.git_text(&["branch", "--show-current"]),
+        "",
+        "the fixture must be detached before the verb is called"
+    );
+
     let detached = f.call("git.status", json!({"repo": f.repo})).await;
     assert_eq!(
         detached["branch"]["head"],
@@ -1706,6 +1722,36 @@ async fn status_reports_a_detached_head_as_a_null_branch_beside_a_real_sha() {
         detached["branch"]["oid"],
         json!(f.base),
         "the sha is still readable while detached: {detached}"
+    );
+}
+
+/// #2539: a refusal from a real non-zero `git` exit used to be the same four
+/// words as one from an unparseable record, so a flake on a runner taught
+/// nothing. The classification still leads; the exit status follows it.
+#[tokio::test]
+#[serial_test::serial(git_dev_loop_env)]
+async fn log_refusal_names_the_git_exit_status() {
+    let f = Fixture::new(true, true).await;
+    f.policy("git.log", "allow").await;
+    let control = f.call("git.log", json!({"repo": f.repo, "limit": 1})).await;
+    assert!(
+        control["commits"].as_array().is_some_and(|c| !c.is_empty()),
+        "control: the same verb reads the repository fine: {control}"
+    );
+
+    let error = f
+        .err(
+            "git.log",
+            json!({"repo": f.repo, "ref": "refs/heads/absent-on-purpose"}),
+        )
+        .await;
+    assert!(
+        error.contains("git_failed"),
+        "#2539: the classification still leads the message; got {error}"
+    );
+    assert!(
+        error.contains("exit status"),
+        "#2539: the refusal must name git's exit status; got {error}"
     );
 }
 


### PR DESCRIPTION
## What

`git.status` and `git.log` mapped a classified failure to its code and dropped everything else, so
a refusal caused by a real non-zero `git` exit and one caused by an unparseable porcelain record
arrived as the same four words, `invalid input: git_failed`, and neither named an exit status. An
intermittent macOS failure of the detached-head status test (#2539) produced exactly that and
nothing else, which is the property that makes a flake permanent: each occurrence costs a rerun
and teaches nothing.

Two changes, either useful alone:

- The non-zero-exit refusal message carries `git`'s exit status, which is bounded and
  non-sensitive and is what separates a lock contention from a usage error.
- The two read verbs render the classified error rather than only its code. Every
  `LocalGitError` message is an authored literal; `git`'s stderr is still captured for
  precondition classification only and never reaches one, so nothing new about the caller's
  environment is exposed.

The classification still leads the message, so a consumer matching on `git_failed` as a prefix or
a substring is unaffected. Nothing outside `local_git.rs` keyed on the old exact string.

## Also

The detached-head test asserts the detach landed, by resolving `HEAD` and reading an empty
`branch --show-current`, before calling the verb. That is a barrier as well as an assertion: a
future failure there is about `git.status` reading a settled repository rather than one still
being written. It does not claim to have found the race; it removes the first candidate the issue
names.

## Verification

- `cargo test -p khive-pack-git --no-fail-fast` on rust 1.95.0: 321 + 110 + 30 + 6 passed, plus
  the new arm. `cargo clippy -p khive-pack-git --all-targets -- -D warnings` and
  `cargo fmt --check` clean.
- New arm `log_refusal_names_the_git_exit_status` drives `git.log` at an absent ref through real
  dispatch and asserts the refusal still carries the classification and now also the exit status,
  with a control on the same verb reading the repository fine.
- Mutation control: with the read mapping reverted to the code alone, that arm fails on exactly
  the exit-status assertion and prints `invalid input: git_failed`.

Closes #2539.
