### PR TITLE
fix(comm): report a discarded probe cursor to the caller

### DIFF
--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -2954,6 +2954,12 @@ pub(crate) struct ProbeResponse {
     pub cursor_us: i64,
     pub new_messages: Vec<ProbeMessage>,
     pub stale_unread_count: i64,
+    /// Present and `true` only when the caller's `since_us` was discarded and
+    /// the page was taken from the baseline instead (#2400). A poller that
+    /// cannot see this reads a full baseline page as arrivals, which is
+    /// indistinguishable from real mail and repeats on every pass.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub cursor_reset: bool,
 }
 
 #[derive(serde::Serialize)]
@@ -3092,6 +3098,10 @@ async fn query_probe(
 
     let effective_since = match since_us {
         Some(v) if v > high_water_mark => {
+            // #2400: this reset also travels back to the caller as
+            // `cursor_reset`. A log line the poller cannot read leaves it
+            // deduplicating a baseline page against its own inbox, which is the
+            // cost this warning was silently imposing.
             tracing::warn!(
                 actor,
                 since_us = v,
@@ -3174,6 +3184,7 @@ async fn query_probe(
         cursor_us,
         new_messages,
         stale_unread_count,
+        cursor_reset: since_us.is_some() && effective_since.is_none(),
     })
 }
 

--- a/crates/khive-pack-comm/src/vocab.rs
+++ b/crates/khive-pack-comm/src/vocab.rs
@@ -605,7 +605,9 @@ pub(crate) static COMM_HANDLERS: [HandlerDef; 14] = [
         name: "comm.probe",
         description: "Read-only poll for new inbound message metadata and stale unread count. \
                       Unlike comm.inbox, the actor is not inferred from the caller — pass it \
-                      explicitly via the required `actor` param (khive #93).",
+                      explicitly via the required `actor` param (khive #93). A `since_us` the \
+                      store cannot have issued is discarded and the page comes from the \
+                      baseline; the response then carries `cursor_reset: true` (khive #2400).",
         visibility: Visibility::Verb,
         category: khive_types::VerbCategory::Assertive,
         params: &[
@@ -620,7 +622,7 @@ pub(crate) static COMM_HANDLERS: [HandlerDef; 14] = [
                 name: "since_us",
                 param_type: "integer",
                 required: false,
-                description: "Opaque cursor round-tripped from a previous comm.probe response's cursor_us; only messages committed after it are returned. Omit for a baseline-first probe. Not a computable timestamp.",
+                description: "Opaque cursor round-tripped from a previous comm.probe response's cursor_us; only messages committed after it are returned. Omit for a baseline-first probe. Not a computable timestamp: a microsecond clock reading exceeds any cursor this store has issued, so it is discarded and the response carries cursor_reset: true.",
                 resolution_mode: IdResolutionMode::NotApplicable,
             },
             ParamDef {

--- a/crates/khive-pack-comm/tests/probe.rs
+++ b/crates/khive-pack-comm/tests/probe.rs
@@ -877,6 +877,48 @@ async fn probe_resets_implausible_pre_upgrade_timestamp_cursor_to_baseline() {
         "an implausible pre-upgrade timestamp cursor must reset to baseline, not \
          permanently suppress messages: {messages:?}"
     );
+    // #2400: the reset has to be visible to the caller. Without it a poller
+    // reads a baseline page as arrivals and cannot tell the difference.
+    assert_eq!(
+        result["cursor_reset"],
+        json!(true),
+        "#2400: a discarded cursor must be reported to the caller: {result}"
+    );
+}
+
+/// #2400: `cursor_reset` is an exception report, so it must be absent from the
+/// two ordinary shapes. A poller that treats its presence as a signal would
+/// otherwise reset on every pass.
+#[tokio::test]
+async fn probe_omits_cursor_reset_when_the_cursor_is_honoured() {
+    let (registry, rt) = build_registry();
+    let actor = "lambda:leo";
+    plant_inbound_message(&rt, actor, "lambda:khive", 1_000_000, None, false).await;
+
+    let baseline = registry
+        .dispatch("comm.probe", json!({ "actor": actor }))
+        .await
+        .expect("probe succeeds");
+    assert!(
+        baseline.get("cursor_reset").is_none(),
+        "#2400: a probe with no since_us discarded nothing: {baseline}"
+    );
+    let cursor = baseline["cursor_us"].as_i64().expect("cursor_us");
+
+    plant_inbound_message(&rt, actor, "lambda:khive", 2_000_000, None, false).await;
+    let followed = registry
+        .dispatch("comm.probe", json!({ "actor": actor, "since_us": cursor }))
+        .await
+        .expect("probe succeeds");
+    assert!(
+        followed.get("cursor_reset").is_none(),
+        "#2400: a round-tripped cursor was honoured: {followed}"
+    );
+    assert_eq!(
+        followed["new_messages"].as_array().expect("array").len(),
+        1,
+        "control: the honoured cursor still returns the message planted after it: {followed}"
+    );
 }
 
 /// Regression for #827: `notes_seq` has no fixed ceiling on how


### PR DESCRIPTION
## What the report observed, and what actually produces it

#2400 reports that `comm.probe(since_us=t)` re-delivers messages that were only marked read,
and proposes either sequencing on arrival or returning the read state.

The re-sequencing half does not reproduce at this ref, and it is fenced: `notes_seq` is populated
by an `AFTER INSERT` trigger whose `ON CONFLICT(note_id) DO NOTHING` is load-bearing against an
outer `INSERT OR REPLACE`, and `probe_read_does_not_resurrect_message_via_rowid_churn` dispatches a
real `comm.read` between two probes and asserts the second page is empty. So a mark-read cannot
move a row's probe sequence.

What does produce exactly the reported symptom is the parameter's name. `since_us` is an opaque
sequence cursor, not a timestamp, and any microsecond clock reading exceeds every cursor the store
has issued. The handler treats such a value as a stale pre-upgrade cursor, discards it and serves
the baseline page, which is the right call: the alternative is suppressing every message forever.
But the reset was written only to a tracing warning. A poller therefore received a full baseline
page, indistinguishable from arrivals, on every pass, and the only available defence was to
intersect the page with a second inbox read per poll.

## Change

The response carries `cursor_reset: true` when, and only when, a supplied cursor was discarded.
It is omitted on a baseline probe and on an honoured cursor, so its presence is an exception
report rather than a field every caller must parse. The verb help and the `since_us` parameter
description now say that a clock reading is not a valid cursor and what happens when one is sent.

Not changed: the discard itself, the cursor's sequence keying, and the `since_us` name. Renaming
the parameter is a wire break, and the ambiguity is now answerable from the response rather than
from a log the caller cannot read.

## Verification

- `cargo test -p khive-pack-comm --no-fail-fast` on rust 1.95.0: 107 + 3 + 2 + 259 + 1 + 26
  passed, 0 failed. `clippy --all-targets -- -D warnings` and `fmt --check` clean.
- The existing implausible-cursor test now also asserts `cursor_reset: true`.
- New arm `probe_omits_cursor_reset_when_the_cursor_is_honoured` covers both ordinary shapes, a
  baseline probe and a round-tripped cursor, with a control that the honoured cursor still returns
  the message planted after it.
- Mutation control: with `cursor_reset` hard-wired to `false`, the implausible-cursor arm fails
  and prints the response without the field.

Closes #2400.
