### PR TITLE
fix(git): name the config table a git write refusal read

### DIFF
--- a/crates/khive-pack-git/src/credentials.rs
+++ b/crates/khive-pack-git/src/credentials.rs
@@ -28,6 +28,19 @@ impl fmt::Display for CredentialError {
 
 impl std::error::Error for CredentialError {}
 
+/// The refusal payload an `actor_unmapped` receipt carries (ADR-182 Amendment 10).
+/// `table` and `key` name what was consulted, not what was missing, because the
+/// reason covers two states: no row for the label, and a row whose resolution
+/// failed. Membership in the table is the only question that separates them, so it
+/// is asked here rather than carried out of the resolver.
+pub(crate) fn actor_refusal(config: &GitWriteSectionConfig, actor: &str) -> serde_json::Value {
+    serde_json::json!({"refusal": {
+        "table": "git_write.actors",
+        "key": actor,
+        "cause": if config.actors.contains_key(actor) { "resolver" } else { "absent" },
+    }})
+}
+
 pub(crate) async fn resolve_actor(
     config: &GitWriteSectionConfig,
     actor: &str,

--- a/crates/khive-pack-git/src/local_handlers.rs
+++ b/crates/khive-pack-git/src/local_handlers.rs
@@ -472,9 +472,13 @@ impl GitPack {
                     return Err(Failure::refused("expected_head_mismatch"));
                 }
                 let config = &self.runtime().config().git_write;
-                let actor = credentials::resolve_actor(config, &receipt.actor)
-                    .await
-                    .map_err(|_| Failure::refused("actor_unmapped"))?;
+                let actor = match credentials::resolve_actor(config, &receipt.actor).await {
+                    Ok(actor) => actor,
+                    Err(_) => {
+                        receipt.result = credentials::actor_refusal(config, &receipt.actor);
+                        return Err(Failure::refused("actor_unmapped"));
+                    }
+                };
                 receipt.credential = json!({"source":"actor", "ref":actor.credential_ref, "platform_identity":actor.platform_identity});
                 receipts::persist(self.runtime(), receipt).await?;
                 let tree = required(params, "tree")?;

--- a/crates/khive-pack-git/src/local_remote_tests.rs
+++ b/crates/khive-pack-git/src/local_remote_tests.rs
@@ -48,6 +48,7 @@ struct Fixture {
     dir: tempfile::TempDir,
     repo: PathBuf,
     platform_repo: PathBuf,
+    unmapped_repo: PathBuf,
     bare: PathBuf,
     base: String,
     head: String,
@@ -63,10 +64,18 @@ impl Fixture {
         let dir = tempfile::tempdir().unwrap();
         let repo = dir.path().join("repo");
         let platform_repo = dir.path().join("platform");
+        // Allowlisted, and deliberately absent from [git_write.repositories].
+        let unmapped_repo = dir.path().join("unmapped");
         std::fs::create_dir(&repo).unwrap();
         std::fs::create_dir(&platform_repo).unwrap();
+        std::fs::create_dir(&unmapped_repo).unwrap();
         let repo = std::fs::canonicalize(repo).unwrap();
         let platform_repo = std::fs::canonicalize(platform_repo).unwrap();
+        let unmapped_repo = std::fs::canonicalize(unmapped_repo).unwrap();
+        for repo in [&platform_repo, &unmapped_repo] {
+            git(repo, &["init", "-q", "--template=", "-b", "work"]);
+            git(repo, &["commit", "--allow-empty", "-qm", "base"]);
+        }
         git(&repo, &["init", "-q", "--template=", "-b", "work"]);
         git(&repo, &["commit", "--allow-empty", "-qm", "base"]);
         let base = git(&repo, &["rev-parse", "HEAD"]);
@@ -103,7 +112,7 @@ impl Fixture {
         let rt = KhiveRuntime::new(RuntimeConfig {
             db_path: None,
             git_write: GitWriteSectionConfig {
-                allowed: [&repo, &platform_repo]
+                allowed: [&repo, &platform_repo, &unmapped_repo]
                     .into_iter()
                     .map(|repo| GitWriteEntryConfig {
                         repo: repo.display().to_string(),
@@ -177,6 +186,7 @@ impl Fixture {
             dir,
             repo,
             platform_repo,
+            unmapped_repo,
             bare,
             base,
             head,
@@ -375,6 +385,69 @@ async fn local_pr_verbs_refuse_remote_scheme_before_credentials() {
         let receipt = f.refusal(verb, params, "remote_scheme").await;
         assert_eq!(receipt.credential, json!({"source":"none"}));
     }
+}
+
+#[tokio::test]
+async fn remote_refusals_name_the_config_table_they_read() {
+    let f = Fixture::file().await;
+    let unmapped_actor = format!("{}:unmapped", f.actor);
+    let head = git(&f.unmapped_repo, &["rev-parse", "HEAD"]);
+    let repositories = json!({
+        "table": "git_write.repositories",
+        "key": f.unmapped_repo.display().to_string(),
+    });
+
+    // The repository mapping resolves before any credential exists to resolve, so
+    // an allowlisted path with no row refuses on the repositories table whatever
+    // the actor's state (ADR-182 Amendment 10 item 1). The second caller has no
+    // actor row at all, which is the arm that pins the order.
+    for caller in [&f.actor, &unmapped_actor] {
+        let error = f
+            .call(
+                caller,
+                "git.push",
+                json!({"repo":f.unmapped_repo,"branch":"work","expected_local":head,"expected_remote":head}),
+            )
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("repository_unmapped"), "{error}");
+        let receipt = f.last(caller).await;
+        assert_eq!(receipt.reason.as_deref(), Some("repository_unmapped"));
+        assert_eq!(receipt.disposition, Disposition::NotCommitted);
+        assert_eq!(receipt.result["refusal"], repositories);
+        f.no_credential_read();
+    }
+
+    // The actors table answers for two different states and the reason covers both,
+    // so the receipt separates them. This caller has a row; its resolver exits
+    // non-zero, so the row was found and the resolution failed.
+    let pr = json!({"repo":f.platform_repo,"head":"work","base":"main","title":"Fixture","body":"","expected_head":f.head});
+    let error = f
+        .call(&f.actor, "git.pr_open", pr.clone())
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("actor_unmapped"), "{error}");
+    let receipt = f.last(&f.actor).await;
+    assert_eq!(
+        receipt.result["refusal"],
+        json!({"table":"git_write.actors","key":f.actor,"cause":"resolver"})
+    );
+    assert!(f.dir.path().join("credential-read").exists());
+
+    // Same reason, same table, the other state: no row for the label.
+    let error = f
+        .call(&unmapped_actor, "git.pr_open", pr)
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("actor_unmapped"), "{error}");
+    let receipt = f.last(&unmapped_actor).await;
+    assert_eq!(
+        receipt.result["refusal"],
+        json!({"table":"git_write.actors","key":unmapped_actor,"cause":"absent"})
+    );
 }
 
 #[tokio::test]

--- a/crates/khive-pack-git/src/remote_handlers.rs
+++ b/crates/khive-pack-git/src/remote_handlers.rs
@@ -214,6 +214,13 @@ fn decode_file_path(path: &str) -> Result<String, Failure> {
     String::from_utf8(decoded).map_err(|_| Failure::refused("remote_scheme"))
 }
 
+/// The refusal payload a `repository_unmapped` receipt carries (ADR-182 Amendment 10).
+/// The reason alone reads as a statement about the allowlist, which is a different
+/// table and is usually the one such a configuration does have.
+fn repository_refusal(path: &str) -> Value {
+    json!({"refusal": {"table": "git_write.repositories", "key": path}})
+}
+
 impl GitPack {
     pub(crate) fn remote_repository(
         &self,
@@ -406,7 +413,12 @@ impl GitPack {
         receipt: &mut Receipt,
     ) -> Result<Value, Failure> {
         let repo = std::path::PathBuf::from(&receipt.repo);
-        let target = self.remote_repository(&repo)?;
+        let repo_key = receipt.repo.clone();
+        let target = self.remote_repository(&repo).inspect_err(|failure| {
+            if failure.reason == "repository_unmapped" {
+                receipt.result = repository_refusal(&repo_key);
+            }
+        })?;
         if target.slug.is_empty() {
             receipt.credential = json!({"source":"none"});
             if verb != "git.push" {
@@ -427,10 +439,14 @@ impl GitPack {
         if target.slug.is_empty() {
             return self.push_exact(None, &target, params, receipt).await;
         }
-        let (identity, secret) =
-            credentials::resolve_remote(&self.runtime().config().git_write, &receipt.actor)
-                .await
-                .map_err(|_| Failure::refused("actor_unmapped"))?;
+        let config = &self.runtime().config().git_write;
+        let (identity, secret) = match credentials::resolve_remote(config, &receipt.actor).await {
+            Ok(resolved) => resolved,
+            Err(_) => {
+                receipt.result = credentials::actor_refusal(config, &receipt.actor);
+                return Err(Failure::refused("actor_unmapped"));
+            }
+        };
         receipt.credential = json!({"source":"actor", "ref":identity.credential_ref, "platform_identity":identity.platform_identity});
         receipts::persist(self.runtime(), receipt).await?;
         let secret = secret.value();
@@ -882,19 +898,26 @@ impl GitPack {
         if prior.disposition != Disposition::Unknown {
             return Ok(());
         }
-        let target = self.remote_repository(repo)?;
+        let repo_key = prior.repo.clone();
+        let target = self.remote_repository(repo).inspect_err(|failure| {
+            if failure.reason == "repository_unmapped" {
+                prior.result = repository_refusal(&repo_key);
+            }
+        })?;
+        let config = &self.runtime().config().git_write;
         let secret = if target.slug.is_empty() {
             if prior.verb != "git.push" {
                 return Err(Failure::refused("remote_scheme"));
             }
             None
         } else {
-            Some(
-                credentials::resolve_remote(&self.runtime().config().git_write, &prior.actor)
-                    .await
-                    .map_err(|_| Failure::refused("actor_unmapped"))?
-                    .1,
-            )
+            match credentials::resolve_remote(config, &prior.actor).await {
+                Ok(resolved) => Some(resolved.1),
+                Err(_) => {
+                    prior.result = credentials::actor_refusal(config, &prior.actor);
+                    return Err(Failure::refused("actor_unmapped"));
+                }
+            }
         };
         let committed = match prior.verb.as_str() {
             "git.push" => {

--- a/crates/khive-pack-git/src/remote_tests.rs
+++ b/crates/khive-pack-git/src/remote_tests.rs
@@ -1228,8 +1228,15 @@ async fn remote_push_non_fast_forward_and_unmapped_actor_refuse() {
     let f = Fixture::new(true, None).await;
     let unmapped = format!("{}:unmapped", f.actor);
     f.policy(&unmapped, "git.push", "allow").await;
-    f.refusal(&unmapped, "git.push", f.push(), "actor_unmapped")
+    let receipt = f
+        .refusal(&unmapped, "git.push", f.push(), "actor_unmapped")
         .await;
+    // The reason names neither the table it read nor which of the two states it
+    // found there (ADR-182 Amendment 10 item 2).
+    assert_eq!(
+        receipt.result["refusal"],
+        json!({"table":"git_write.actors","key":unmapped,"cause":"absent"})
+    );
     assert!(f.remote.state.lock().unwrap().calls.is_empty());
     git(&f.remote.bare, &["update-ref", "refs/heads/work", &f.head]);
     git(&f.repo, &["update-ref", "refs/heads/work", &f.base]);

--- a/crates/khive-pack-git/tests/dev_loop.rs
+++ b/crates/khive-pack-git/tests/dev_loop.rs
@@ -698,7 +698,14 @@ async fn arm15_overrides_and_unmapped_actor_refuse_before_resolver() {
         }
         if !mapped {
             let error = f.err("git.commit", f.commit_params(&manifest)).await;
-            assert_eq!(f.refusal_receipt(&error).await["reason"], "actor_unmapped");
+            let row = f.refusal_receipt(&error).await;
+            assert_eq!(row["reason"], "actor_unmapped");
+            // The reason alone does not say which table was read, and this verb reads
+            // only the actors one (ADR-182 Amendment 10 item 2).
+            assert_eq!(
+                row["result"]["refusal"],
+                json!({"table":"git_write.actors","key":ACTOR,"cause":"absent"})
+            );
         }
         assert_eq!(f.resolver_count(), 0);
         assert_eq!(f.git_bytes(&["show-ref"]), refs);


### PR DESCRIPTION
Implements ADR-182 Amendment 10 items 1 and 2. Closes #2549.

`repository_unmapped` and `actor_unmapped` are both answers about a config table, and the wire reason alone does not say which one was read. The remote path resolves `[git_write.repositories."<abs path>"]` before any credential exists to resolve, so a call against a path with no row refuses `repository_unmapped` whatever the actor's state, while `git.commit` has no mapping to consult and reaches the actor check first. That is the order Amendment 10 item 1 states; this change does not alter it.

## What lands

- The receipt carries `result.refusal = {table, key}` on both refusals: `git_write.repositories` with the absolute path that was not found, `git_write.actors` with the actor label.
- `actor_unmapped` also carries `cause`, one of `absent` or `resolver`, because that one reason covers two states the caller cannot otherwise tell apart: no row for the label, and a row whose credential resolution failed. Membership in the table is the only question that separates them, so it is asked at the refusal site rather than plumbed out of the resolver's error type.
- Wire reasons are unchanged. Contract arms key on them.

No new value is disclosed. The repository path and the actor label are already fields of the same receipt; the resolver's own output is not added, for the reason Amendment 2 item 3 gives.

## Why it is worth a receipt field

An arm written to prove that a missing actor credential never falls back to a daemon credential passes on the remote path without reaching credential resolution at all, when the repositories row is absent. It is green for a reason unrelated to what it tests and nothing on the receipt says so.

## Arms

`remote_refusals_name_the_config_table_they_read` (new, `local_remote_tests.rs`): an allowlisted repository absent from `[git_write.repositories]` refuses `repository_unmapped` naming that table and the absolute path, for a caller with an actor row and for one without, which is the arm that pins the order; then, on a mapped platform repository, a caller whose row exists but whose resolver exits non-zero refuses `actor_unmapped` with `cause: "resolver"`, and a caller with no row refuses the same reason with `cause: "absent"`.

`remote_push_non_fast_forward_and_unmapped_actor_refuse` and the `git.commit` arm of `arm15` gain the same assertion on their existing refusals, so the two verbs are pinned on their own paths.

The fixture's platform repository is now initialised as a real repository, since a refusal arm that reaches the credential check has to get past the path validation first.

## Gate

Pinned 1.95.0, `crates/` workspace manifest, machine lock held. `cargo fmt --all -- --check` rc 0. `cargo test -p khive-pack-git --no-fail-fast`: 324 + 110 + 31 + 6 passed, 0 failed. `cargo clippy -p khive-pack-git --all-targets -- -D warnings` rc 0.

Mutation controls, both predicted before running, both reddening exactly one arm out of 324:

- hard-wiring `cause` to `absent` fails the resolver assertion (`left: "absent"`, `right: "resolver"`), 323 others green.
- dropping the repository payload assignment fails the repository assertion (`left: Null`), 323 others green.
