### PR TITLE
docs(memory): document memory.recall's degraded response shapes

### DIFF
--- a/crates/khive-pack-memory/src/pack.rs
+++ b/crates/khive-pack-memory/src/pack.rs
@@ -188,7 +188,7 @@ static MEMORY_HANDLERS: [HandlerDef; 10] = [
     // Assertive: retrieves memory notes via decay-aware ranking
     HandlerDef {
         name: "memory.recall",
-        description: "Recall memory notes with decay-aware hybrid ranking. Each hit carries resolved (read-model) values: memory_type defaults to \"episodic\" when not stored, salience and decay_factor reflect the effective defaults used for ranking. Default responses are arrays; budget-capped hits carry truncated: true per result. When the budget removes every ranked candidate, the response is {results: [], truncated: true} so the cutoff stays distinguishable from a genuine no-match.",
+        description: "Recall memory notes with decay-aware hybrid ranking. Each hit carries resolved (read-model) values: memory_type defaults to \"episodic\" when not stored, salience and decay_factor reflect the effective defaults used for ranking. Default responses are arrays; budget-capped hits carry truncated: true per result. When the budget removes every ranked candidate, the response is {results: [], truncated: true} so the cutoff stays distinguishable from a genuine no-match. Degraded serving is a third state and never changes ok: it stays true, and the degradation is reported in-band. A non-empty degraded response keeps the array shape and stamps each hit with degraded: \"ann_unavailable\" plus a degraded_reason naming the failure site; when degradation leaves no hits the response is {results: [], degraded: true, degraded_reason} for the same reason the capped-empty response changes shape. A caller that reads only ok cannot tell a degraded serve from a healthy one, so read degraded.",
         visibility: Visibility::Verb,
         category: VerbCategory::Assertive,
         params: &[


### PR DESCRIPTION
`memory.recall` has three response shapes and the help text names one of them.

The description already explains that a budget-capped empty response becomes `{results: [], truncated: true}`, and it explains why: a bare `[]` cannot be told apart from a genuine no-match. Degradation does the same thing for the same reason and the description is silent about it. A consumer wrote its reader against the array form, hit the dict on the one run where the ANN leg sat out, and learned the second shape from a red test.

This states all three, in the order a caller meets them:

- a non-empty degraded serve keeps the array and stamps each hit with `degraded: "ann_unavailable"` plus a `degraded_reason`,
- an empty one becomes `{results: [], degraded: true, degraded_reason}`,
- `ok` stays `true` either way, because degradation is a third state reported in band, so a caller that reads only `ok` cannot tell a degraded serve from a healthy one.

Description text only; no behaviour changes.

Gate: `cargo fmt --all -- --check` and `cargo check -p khive-pack-memory` on the pinned 1.95.0 toolchain, both clean.
