### PR TITLE
test(git): serialize every dev_loop case against the PATH shim window

### DIFF
--- a/crates/khive-pack-git/tests/dev_loop.rs
+++ b/crates/khive-pack-git/tests/dev_loop.rs
@@ -55,8 +55,16 @@ const SHIM_DIR: &str = "shim-bin";
 /// process-global, so a fixture built concurrently resolves git through the shim and CACHES that
 /// path; the shim's temporary directory is then removed with its fixture and every later spawn of
 /// the cached path fails with ENOENT. Skipping the shim directory here keeps that case's PATH
-/// mutation invisible to every other fixture, which is what serialising the whole file would
-/// otherwise be needed for.
+/// mutation invisible to every other FIXTURE.
+///
+/// It does not keep it invisible to the code under test, which is the other half and the reason
+/// every case in this file now carries `git_dev_loop_env`. `base_command` builds
+/// `Command::new("git")` and hands the process's current PATH to the child, so the verb resolves
+/// its program by name at spawn, against whatever PATH the process holds at that instant. A case
+/// running beside a shim case therefore resolves the shim, or a path inside a fixture directory
+/// being deleted as that case ends, and reports `git_failed` for a reason nothing in its own body
+/// explains. The window is scheduler time, so it opens under load and stays shut on a quiet
+/// machine: 2 of 13 runs failed under one busy loop per core, 0 of 19 without them (#2515).
 fn git_program() -> PathBuf {
     std::env::split_paths(&std::env::var_os("PATH").expect("PATH"))
         .filter(|dir| dir.file_name() != Some(std::ffi::OsStr::new(SHIM_DIR)))
@@ -1606,6 +1614,7 @@ fn status_paths(result: &Value) -> Vec<String> {
 }
 
 #[tokio::test]
+#[serial_test::serial(git_dev_loop_env)]
 async fn status_agrees_with_native_porcelain_and_changes_nothing_on_disk() {
     let f = Fixture::new(true, true).await;
     for verb in ["git.status", "git.log"] {
@@ -1645,6 +1654,7 @@ async fn status_agrees_with_native_porcelain_and_changes_nothing_on_disk() {
 }
 
 #[tokio::test]
+#[serial_test::serial(git_dev_loop_env)]
 async fn status_total_counts_the_whole_repository_even_when_entries_are_capped() {
     let f = Fixture::new(true, true).await;
     f.policy("git.status", "allow").await;
@@ -1668,6 +1678,7 @@ async fn status_total_counts_the_whole_repository_even_when_entries_are_capped()
 }
 
 #[tokio::test]
+#[serial_test::serial(git_dev_loop_env)]
 async fn status_keeps_a_path_holding_a_newline_a_space_and_non_ascii_as_one_entry() {
     let f = Fixture::new(true, true).await;
     f.policy("git.status", "allow").await;
@@ -1684,6 +1695,7 @@ async fn status_keeps_a_path_holding_a_newline_a_space_and_non_ascii_as_one_entr
 }
 
 #[tokio::test]
+#[serial_test::serial(git_dev_loop_env)]
 async fn status_reports_a_detached_head_as_a_null_branch_beside_a_real_sha() {
     let f = Fixture::new(true, true).await;
     f.policy("git.status", "allow").await;
@@ -1763,6 +1775,7 @@ async fn log_refusal_names_the_git_exit_status() {
 }
 
 #[tokio::test]
+#[serial_test::serial(git_dev_loop_env)]
 async fn log_agrees_with_native_rev_list_and_bounds_its_page() {
     let f = Fixture::new(true, true).await;
     f.policy("git.log", "allow").await;
@@ -1806,6 +1819,7 @@ async fn log_agrees_with_native_rev_list_and_bounds_its_page() {
 }
 
 #[tokio::test]
+#[serial_test::serial(git_dev_loop_env)]
 async fn log_treats_a_path_filter_literally_rather_than_as_a_glob() {
     let f = Fixture::new(true, true).await;
     f.policy("git.log", "allow").await;
@@ -1839,6 +1853,7 @@ async fn log_treats_a_path_filter_literally_rather_than_as_a_glob() {
 }
 
 #[tokio::test]
+#[serial_test::serial(git_dev_loop_env)]
 async fn status_and_log_refuse_off_allowlist_and_on_deny_and_write_no_receipt() {
     // No status/log grant is made here on purpose. The allowlist is consulted before the policy,
     // so the off-allowlist arm below refuses without one, which is what proves that ordering.
@@ -1886,6 +1901,7 @@ async fn status_and_log_refuse_off_allowlist_and_on_deny_and_write_no_receipt() 
 }
 
 #[tokio::test]
+#[serial_test::serial(git_dev_loop_env)]
 async fn init_makes_an_allowlisted_empty_directory_a_repository_and_records_a_receipt() {
     let f = Fixture::new(true, true).await;
     f.policy("git.init", "allow").await;
@@ -1931,6 +1947,7 @@ async fn init_makes_an_allowlisted_empty_directory_a_repository_and_records_a_re
 }
 
 #[tokio::test]
+#[serial_test::serial(git_dev_loop_env)]
 async fn init_refuses_a_target_that_already_holds_a_repository_and_leaves_it_untouched() {
     let f = Fixture::new(true, true).await;
     f.policy("git.init", "allow").await;
@@ -1959,6 +1976,7 @@ async fn init_refuses_a_target_that_already_holds_a_repository_and_leaves_it_unt
 }
 
 #[tokio::test]
+#[serial_test::serial(git_dev_loop_env)]
 async fn init_refuses_a_directory_that_is_not_allowlisted() {
     let f = Fixture::new(true, true).await;
     f.policy("git.init", "allow").await;
@@ -1984,6 +2002,7 @@ async fn init_refuses_a_directory_that_is_not_allowlisted() {
 /// the marker on the unhardened control first, because a marker that never fires proves nothing
 /// about the hardened call.
 #[tokio::test]
+#[serial_test::serial(git_dev_loop_env)]
 async fn read_verbs_never_execute_repository_configured_filters_or_signers() {
     let f = Fixture::new(true, true).await;
     f.policy("git.status", "allow").await;


### PR DESCRIPTION
Closes the determinism half of #2515.

Two cases in this file install a shim `git` and replace the process PATH for the length of their body, because that is the only way to make one failure reachable. The file already names the hazard and guards the fixture side of it: `git_program()` refuses to resolve through the shim directory, and a test holds that guard.

The code under test is on the other side of it. `base_command()` builds `Command::new("git")` and hands the process's current PATH to the child, so a verb resolves its program by name at spawn against whatever PATH the process holds at that instant. A case running beside a shim case therefore resolves the shim, or a path inside a fixture directory that is being deleted as the shim case ends, and reports `git_failed` for a reason nothing in its own body explains. The annotations said the same thing from the other side: the two cases that fail in #2515 were among the eleven that did not carry `git_dev_loop_env`.

Every case carries it now.

**Measured**, macOS arm64, 12 cores, git 2.55.0, rustc 1.95.0, `cargo test -p khive-pack-git --test dev_loop --no-fail-fast`:

| arm | before | after |
| --- | --- | --- |
| quiet | 19 runs green across `ulimit -n` 8192/1024/256 and the default | 3 runs green |
| one busy loop per core, ref in the report | 2 of 13 runs failed | — |
| one busy loop per core, main | 0 of 14 runs failed | 0 of 25 runs failed |
| quiet wall time | ~11.5s | ~12.9s |

Against a base rate near 2 in 13, 25 clean loaded runs put the chance of seeing no failure by luck at about 2%. The 14 clean runs on main before this change are not evidence of a fix: the mechanism is present there unchanged, which is why this is a change and not a close.

The cost is the 1.2s. The file was already twenty of thirty-one cases serial, so full serialization is a smaller step than it sounds, and under load the difference is inside the noise (17-23s either way).

**What this does not do.** It does not stop a verb from resolving `git` by name from the process PATH; it removes the only thing in this suite that moves that PATH while another case is running. A configured `git` program on the write surface would fix the underlying resolution and would also let a host pin which `git` the surface uses, which is a separate discussion started on #2515.
