### PR TITLE
feat(git): name the git capability every push case depends on

### DIFF
--- a/crates/khive-pack-git/src/remote_tests.rs
+++ b/crates/khive-pack-git/src/remote_tests.rs
@@ -1007,6 +1007,42 @@ async fn remote_lost_ack_without_marker_stays_unknown_and_never_retries() {
         .await;
 }
 
+/// Every push case in this crate reaches `push_marker_support`, so on a host whose `git` does not
+/// advertise `git reflog write ` each of them fails on the `unsupported_toolchain` refusal and the
+/// run reads as nineteen defects rather than one fact about the host. This case states the fact
+/// once. It holds `ENV_MUTEX` because the case below installs a git that answers `reflog -h` for
+/// every caller while it runs.
+#[tokio::test]
+async fn push_cases_require_a_git_that_advertises_reflog_write() {
+    let _env_guard = crate::cache::ENV_MUTEX.lock().await;
+    let dir = tempfile::tempdir().expect("temp dir");
+    let repo = dir.path().join("probe");
+    let init = Command::new("git")
+        .env_clear()
+        .env("PATH", std::env::var_os("PATH").unwrap())
+        .args(["init", "--quiet"])
+        .arg(&repo)
+        .output()
+        .expect("spawn git init");
+    assert!(
+        init.status.success(),
+        "git init: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+    let (version, supported) = crate::local_git::push_marker_support(&repo)
+        .await
+        .expect("capability probe");
+    assert!(
+        supported,
+        "the git on PATH is {version}, which does not advertise `git reflog write `. \
+         git.push writes its receipt marker with that subcommand, so every push case in \
+         remote_tests and local_remote_tests refuses unsupported_toolchain on this host, and \
+         those failures are about the host and not about the pack. The capability first shipped \
+         in Git 2.51; the pack reads the capability and never the version number. Put a git that \
+         advertises it first on PATH."
+    );
+}
+
 #[tokio::test]
 async fn remote_unsupported_git_is_receipted_before_credentials_or_network() {
     struct RestorePath(std::ffi::OsString);

--- a/crates/khive-pack-git/src/remote_vocab.rs
+++ b/crates/khive-pack-git/src/remote_vocab.rs
@@ -32,7 +32,7 @@ const SESSION: ParamDef = crate::local_vocab::SESSION;
 
 pub(crate) const PUSH: HandlerDef = HandlerDef {
     name: "git.push",
-    description: "Push an exact local SHA with a server-side expected-remote compare after fast-forward proof. Expected remote null means must not exist. All caller force/remote/refspec overrides refuse. HTTPS uses actor-only credentials. An absolute path or file:/// remote configured with slug=\"\" uses no credential or actor row and records credential.source=none. Durable receipt, no retries.",
+    description: "Push an exact local SHA with a server-side expected-remote compare after fast-forward proof. Expected remote null means must not exist. All caller force/remote/refspec overrides refuse. HTTPS uses actor-only credentials. An absolute path or file:/// remote configured with slug=\"\" uses no credential or actor row and records credential.source=none. Durable receipt, no retries. Requires a git that advertises the `git reflog write ` subcommand, which first shipped in Git 2.51: the receipt marker is written with it, and without it the verb refuses unsupported_toolchain before any credential or network use, recording the version found and the missing capability. The check reads the capability, never the version number.",
     visibility: Visibility::Verb,
     category: VerbCategory::Commissive,
     params: &[


### PR DESCRIPTION
Closes the first ask of #2470 and answers the second one honestly rather than cheaply.

On a host whose `git` does not advertise `git reflog write `, every push case in `remote_tests` and `local_remote_tests` fails on the `unsupported_toolchain` refusal. Measured on this branch's base with Apple Git 2.50.1 first on PATH: **19 failures, all of them that refusal**, and nothing in the output says the cause is the host rather than the pack.

**Two statements, no behaviour change.**

`git.push`'s description now says the verb requires a git advertising that subcommand, that it first shipped in Git 2.51, that the refusal lands before any credential or network use and records the version found and the missing capability, and that the check reads the capability and never the version number. That last clause is the part a reader guesses wrong: a distribution can carry the subcommand below 2.51 and a stripped build can lack it above, so a guard keyed on the number would be wrong in both directions.

A new case, `push_cases_require_a_git_that_advertises_reflog_write`, probes the host through the same `push_marker_support` the verb uses and fails with a message naming the version found, the missing capability, which cases it takes down, and what to do. It holds `ENV_MUTEX` because a sibling case installs a git that answers `reflog -h` for every caller while it runs.

**What it does not do.** The issue asks for a guarded skip so a developer sees one line instead of twelve panics. The 19 cases still fail. Skipping them would make them silently green on every host that lacks the capability, including a CI runner that quietly changed, and those same 19 are the population that #2589 is about. One case that explains beside 19 that fail is worse reading than one line, and better evidence.

**Gate**, pinned 1.95.0: `cargo fmt --all -- --check` 0, `cargo clippy -p khive-pack-git --all-targets -- -D warnings` 0, `cargo test -p khive-pack-git --all-features --no-fail-fast` 327 + 110 + 31 + 6 passed, 0 failed.

**Control**, the same case with Apple Git 2.50.1 first on PATH:

```
test result: FAILED. 0 passed; 1 failed
the git on PATH is git version 2.50.1 (Apple Git-155), which does not advertise `git reflog write `.
git.push writes its receipt marker with that subcommand, so every push case in remote_tests and
local_remote_tests refuses unsupported_toolchain on this host, and those failures are about the host
and not about the pack. The capability first shipped in Git 2.51; the pack reads the capability and
never the version number. Put a git that advertises it first on PATH.
```
