### PR TITLE
test(git): keep git resolvable while the gh fixture shadows PATH

### DIFF
--- a/crates/khive-pack-git/src/remote_transport.rs
+++ b/crates/khive-pack-git/src/remote_transport.rs
@@ -460,7 +460,27 @@ mod tests {
             std::fs::Permissions::from_mode(0o755),
         )
         .unwrap();
-        std::env::set_var("PATH", dir.path());
+        // Prepend rather than replace: `PATH` is process-global and every other case in
+        // this binary resolves `git` by name through it, so a replacement makes their spawns
+        // fail with NotFound for the length of this case (#2589). Prepending still shadows
+        // `gh`, which is all this fixture needs.
+        let shimmed = match std::env::var_os("PATH") {
+            Some(prior) => {
+                let mut paths = vec![dir.path().to_path_buf()];
+                paths.extend(std::env::split_paths(&prior));
+                std::env::join_paths(paths).unwrap()
+            }
+            None => dir.path().as_os_str().to_os_string(),
+        };
+        std::env::set_var("PATH", shimmed);
+        assert!(
+            std::process::Command::new("git")
+                .arg("--version")
+                .output()
+                .is_ok_and(|out| out.status.success()),
+            "this case must leave `git` resolvable on PATH: the variable is process-global and \
+             concurrent cases in this binary spawn `git` by name"
+        );
         let pr = json!({"headRefOid":"a".repeat(40),"reviewDecision":"APPROVED"});
         let data = json!({"data":{"repository":{"pullRequest":pr}}});
         for (response, expected) in [


### PR DESCRIPTION
## Summary

`graphql_review_read_binds_variables_and_rejects_partial_errors` replaced the process `PATH` with a temp dir holding only a `gh` shim. `PATH` is process-global and `base_command()` hands the process's current `PATH` to every git child, resolving the program by name at spawn, so for the length of that case any concurrent test in the same binary that spawned git got `NotFound` instead of a git. Three of 327 did on a quiet machine (#2589).

Prepending the shim dir shadows `gh` exactly as before, because `PATH` is searched left to right, and leaves the real git reachable behind it.

## Control

The assertion after the assignment spawns `git --version` under the shimmed `PATH`. It is pointed at the fix, so restoring the replacement form reddens the case that introduces the hazard rather than a random neighbour.

Measured, pinned 1.95.0:

- `cargo test --no-fail-fast -p khive-pack-git` — 325 + 110 + 31 + 6 passed, 0 failed
- `cargo clippy -p khive-pack-git --all-targets -- -D warnings` — 0
- `cargo fmt --all -- --check` — 0
- mutation: with `set_var("PATH", dir.path())` restored, exactly one arm of 325 fails, on the new assertion

## What this does not do

#2589 has a second half this does not touch. `remote_tests.rs` installs a wrapper that answers `git --version` and `git reflog -h` for **every** caller, which is the point of that fixture: it is the only way to reach the `unsupported_toolchain` refusal while the capability probe resolves `git` by name. Interposition cannot be made local by prepending. That case needs to be alone in its process, or the write surface needs to take a configured `git` program. Left open on the issue with both options stated.
