### PR TITLE
fix(tool): resolve the policy decision in SQL, not from the newest 1000 rows

### DIFF
--- a/crates/khive-pack-tool/src/policy.rs
+++ b/crates/khive-pack-tool/src/policy.rs
@@ -74,24 +74,6 @@ pub(crate) fn pattern_matches(pattern: &str, value: &str) -> bool {
     pattern == value
 }
 
-fn specificity(pattern: &str) -> u8 {
-    if pattern == "*" {
-        0
-    } else if pattern.ends_with('*') {
-        1
-    } else {
-        2
-    }
-}
-
-fn decision_rank(decision: &str) -> u8 {
-    match decision {
-        "deny" => 2,
-        "ask" => 1,
-        _ => 0,
-    }
-}
-
 #[derive(Debug, Clone)]
 pub(crate) struct PolicyRow {
     pub id: String,
@@ -210,6 +192,55 @@ pub(crate) async fn list_policies(
         .filter_map(PolicyRow::from_row)
         .filter(|p| actor.is_none_or(|a| pattern_matches(&p.actor, a) || p.actor == a))
         .collect())
+}
+
+/// Resolve the single deciding policy row for `(actor, tool)` in SQL.
+///
+/// The match predicate and the ranking both live in the statement, so the
+/// query returns one row and needs no row cap. The previous form fetched the
+/// newest 1,000 rows and ranked them in Rust: `tool_policy` is append-only,
+/// correcting a policy means appending another row, and once the table passed
+/// the cap an older `deny` stopped being consulted with no error and no
+/// marker. On an authorization surface that direction is fail-open (#2596).
+///
+/// `pattern_matches` admits exactly three shapes -- `*`, `prefix*`, and an
+/// exact string -- so the SQL predicate is the same three cases. For a pattern
+/// ending in `*`, `substr(value, 1, length(pattern) - 1)` compared against the
+/// pattern's own prefix is the prefix test without any LIKE escaping; `*`
+/// itself has length 1 and both sides reduce to the empty string.
+pub(crate) async fn select_deciding_policy(
+    rt: &KhiveRuntime,
+    ns: &str,
+    actor: &str,
+    tool: &str,
+) -> Result<Option<PolicyRow>, RuntimeError> {
+    const MATCHES: &str = "(%COL% = ?%N% OR (%COL% LIKE '%*' \
+         AND substr(?%N%, 1, length(%COL%) - 1) = substr(%COL%, 1, length(%COL%) - 1)))";
+    let actor_match = MATCHES.replace("%COL%", "actor").replace("%N%", "2");
+    let tool_match = MATCHES.replace("%COL%", "tool").replace("%N%", "3");
+    let rank =
+        |col: &str| format!("CASE WHEN {col} = '*' THEN 0 WHEN {col} LIKE '%*' THEN 1 ELSE 2 END");
+    let mut reader = rt.sql().reader().await?;
+    let rows = reader
+        .query_all(SqlStatement {
+            sql: format!(
+                "SELECT {POLICY_COLUMNS} FROM tool_policy \
+                 WHERE namespace = ?1 AND {actor_match} AND {tool_match} \
+                 ORDER BY ({} + {}) DESC, \
+                 CASE decision WHEN 'deny' THEN 2 WHEN 'ask' THEN 1 ELSE 0 END DESC \
+                 LIMIT 1",
+                rank("actor"),
+                rank("tool"),
+            ),
+            params: vec![
+                SqlValue::Text(ns.to_string()),
+                SqlValue::Text(actor.to_string()),
+                SqlValue::Text(tool.to_string()),
+            ],
+            label: Some("tool_policy_decide".into()),
+        })
+        .await?;
+    Ok(rows.first().and_then(PolicyRow::from_row))
 }
 
 pub(crate) async fn insert_policy(
@@ -451,17 +482,8 @@ pub async fn decide(
             side_effect: side_effect.map(str::to_string),
         });
     }
-    let policies = list_policies(rt, ns, None, 1000).await?;
-    let best = policies
-        .iter()
-        .filter(|p| pattern_matches(&p.actor, actor) && pattern_matches(&p.tool, tool))
-        .max_by_key(|p| {
-            (
-                specificity(&p.actor) + specificity(&p.tool),
-                decision_rank(&p.decision),
-            )
-        });
-    if let Some(p) = best {
+    let best = select_deciding_policy(rt, ns, actor, tool).await?;
+    if let Some(p) = best.as_ref() {
         return Ok(Decision {
             decision: p.decision.clone(),
             source: "policy".into(),

--- a/crates/khive-pack-tool/src/policy.rs
+++ b/crates/khive-pack-tool/src/policy.rs
@@ -208,6 +208,16 @@ pub(crate) async fn list_policies(
 /// ending in `*`, `substr(value, 1, length(pattern) - 1)` compared against the
 /// pattern's own prefix is the prefix test without any LIKE escaping; `*`
 /// itself has length 1 and both sides reduce to the empty string.
+///
+/// The trailing `created_at ASC, id ASC` is not decoration. Two different
+/// patterns can sum to the same specificity (`lambda:*` with `t.x` against
+/// `lambda:a` with `t.*`), and `DECISIONS` is closed and strictly ranked, so
+/// such a tie always carries the same decision and only the reported
+/// `policy_id` varies. Without a third key SQLite's choice among equals is
+/// unspecified and moves with the plan, so one question answered twice can
+/// cite different rows and an audit cannot reproduce itself. Oldest-first is
+/// also what the previous Rust path did: `max_by_key` returns the LAST
+/// maximal element and its input arrived `created_at DESC`.
 pub(crate) async fn select_deciding_policy(
     rt: &KhiveRuntime,
     ns: &str,
@@ -227,7 +237,8 @@ pub(crate) async fn select_deciding_policy(
                 "SELECT {POLICY_COLUMNS} FROM tool_policy \
                  WHERE namespace = ?1 AND {actor_match} AND {tool_match} \
                  ORDER BY ({} + {}) DESC, \
-                 CASE decision WHEN 'deny' THEN 2 WHEN 'ask' THEN 1 ELSE 0 END DESC \
+                 CASE decision WHEN 'deny' THEN 2 WHEN 'ask' THEN 1 ELSE 0 END DESC, \
+                 created_at ASC, id ASC \
                  LIMIT 1",
                 rank("actor"),
                 rank("tool"),

--- a/crates/khive-pack-tool/tests/verbs.rs
+++ b/crates/khive-pack-tool/tests/verbs.rs
@@ -495,3 +495,55 @@ async fn an_untagged_entity_still_updates_and_deletes() {
     let deleted = f.call("delete", json!({"id": id})).await;
     assert_eq!(deleted["deleted"], json!(true));
 }
+
+/// #2596: `tool_policy` is append-only, so a namespace's row count only grows.
+/// The decision used to read the newest 1,000 rows and rank them in Rust, which
+/// made an older matching `deny` invisible once the table passed the cap --
+/// fail-open on an authorization surface. The decision is resolved in SQL now,
+/// so the row count does not bound what it can see.
+#[tokio::test]
+async fn a_matching_deny_still_decides_after_a_thousand_later_rows() {
+    let f = fixture();
+    f.call(
+        "tool.register",
+        json!({"name": "read_file", "source": "builtin", "side_effect": "read"}),
+    )
+    .await;
+    let deny = f
+        .call(
+            "tool.policy",
+            json!({"actor": "agent:a", "tool": "read_file", "decision": "deny"}),
+        )
+        .await;
+
+    let before = f
+        .call(
+            "tool.check",
+            json!({"tool": "read_file", "actor": "agent:a"}),
+        )
+        .await;
+    assert_eq!(before["decision"], json!("deny"));
+    assert_eq!(before["policy_id"], deny["policy"]["id"]);
+
+    for i in 0..1_050 {
+        f.call(
+            "tool.policy",
+            json!({"actor": format!("agent:filler{i}"), "tool": "other_tool", "decision": "allow"}),
+        )
+        .await;
+    }
+
+    let after = f
+        .call(
+            "tool.check",
+            json!({"tool": "read_file", "actor": "agent:a"}),
+        )
+        .await;
+    assert_eq!(
+        after["decision"],
+        json!("deny"),
+        "the deny must still decide with 1,050 newer rows in the table: {after}"
+    );
+    assert_eq!(after["source"], json!("policy"));
+    assert_eq!(after["policy_id"], deny["policy"]["id"]);
+}

--- a/crates/khive-pack-tool/tests/verbs.rs
+++ b/crates/khive-pack-tool/tests/verbs.rs
@@ -547,3 +547,41 @@ async fn a_matching_deny_still_decides_after_a_thousand_later_rows() {
     assert_eq!(after["source"], json!("policy"));
     assert_eq!(after["policy_id"], deny["policy"]["id"]);
 }
+
+/// Two different patterns can sum to the same specificity, and `DECISIONS` is
+/// closed and strictly ranked, so such a tie always carries the same decision:
+/// only the reported `policy_id` can vary. It must not. Oldest-first is the
+/// stated rule, and it is what the previous Rust path did by accident.
+#[tokio::test]
+async fn an_exact_specificity_tie_resolves_to_the_older_row() {
+    let f = fixture();
+    f.call(
+        "tool.register",
+        json!({"name": "t.x", "source": "builtin", "side_effect": "write"}),
+    )
+    .await;
+    let first = f
+        .call(
+            "tool.policy",
+            json!({"actor": "lambda:*", "tool": "t.x", "decision": "deny"}),
+        )
+        .await;
+    let second = f
+        .call(
+            "tool.policy",
+            json!({"actor": "lambda:a", "tool": "t.*", "decision": "deny"}),
+        )
+        .await;
+    assert_ne!(first["policy"]["id"], second["policy"]["id"]);
+
+    for _ in 0..5 {
+        let checked = f
+            .call("tool.check", json!({"tool": "t.x", "actor": "lambda:a"}))
+            .await;
+        assert_eq!(checked["decision"], json!("deny"));
+        assert_eq!(
+            checked["policy_id"], first["policy"]["id"],
+            "an equal-specificity tie must cite the older row every time: {checked}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`decide()` resolved a policy from at most the newest 1,000 rows in the namespace: `list_policies(.., None, 1000)` against `ORDER BY created_at DESC LIMIT ?`, ranked in Rust. `tool_policy` is append-only — no upsert, no delete, and `tool.revoke` takes a grant id — so correcting a policy means appending another row and the row count only grows. Past the cap an older matching `deny` stopped being consulted, with no error and no marker: fail-open on an authorization surface (#2596).

The match predicate and the ranking now live in the statement. It returns one row and needs no cap.

`pattern_matches` admits exactly three shapes: `*`, `prefix*`, and an exact string. The SQL predicate is those three cases. For a pattern ending in `*`, comparing `substr(value, 1, length(pattern) - 1)` against the pattern's own prefix is the prefix test without any LIKE escaping, and `*` has length 1 so both sides reduce to the empty string.

`specificity` and `decision_rank` are deleted rather than left beside the SQL that now expresses them, because two definitions of one ranking is how they drift. The existing acceptance arms pin the semantics from the verb surface — more specific beats wildcard, `deny` beats `allow` on a tie — and pass unchanged.

## The equal-specificity tie

Two patterns can sum to the same specificity: an actor wildcard with an exact tool, against an exact actor with a tool wildcard. `DECISIONS` is closed and strictly ranked, so such a tie always carries the same decision and this is not a fail-open direction — only the reported `policy_id` varies. But with no third ordering key SQLite's choice among equals is unspecified and moves with the plan, so one question answered twice can cite different rows and an audit cannot reproduce itself. The in-memory path it replaces was deterministic by accident: `max_by_key` returns the last maximal element and its input arrived `created_at DESC`, so exact ties resolved to the oldest row.

`created_at ASC, id ASC` restores that and states it. This matters before the upsert contract in #2597, which will be written against this statement, and a contract over an unspecified order is a contract about nothing.

## Verification

Pinned 1.95.0, `KHIVE_PACKS` and `KHIVE_ADDITIONAL_EMBEDDING_MODELS` unset:

- `cargo test --no-fail-fast -p khive-pack-tool` — 13 passed, 0 failed
- `cargo clippy -p khive-pack-tool --all-targets -- -D warnings` — 0
- `cargo fmt --all -- --check` — 0

`a_matching_deny_still_decides_after_a_thousand_later_rows` writes a matching `deny`, confirms it decides, appends 1,050 unrelated rows, and requires the same `deny` and the same `policy_id` afterwards.

`an_exact_specificity_tie_resolves_to_the_older_row` seeds the tie described above with both rows carrying `deny`, and asserts the older `policy_id` on five consecutive checks.

Mutation controls, both stated before running:

- Restoring the cap (`AND id IN (SELECT id FROM tool_policy WHERE namespace = ?1 ORDER BY created_at DESC LIMIT 1000)`) must redden the cap arm and nothing else. Observed exactly that — 11 passed, 1 failed.
- Reversing the new keys to `created_at DESC, id DESC` must redden the tie arm on the newer row. Observed exactly that: the assertion failed citing the newer `policy_id`. Source restored and re-gated afterwards.

## What this does not change

The grant half of `decide()` keeps its own cap, `list_grants(.., Some("granted"), .., 500)`. Dropping an old grant denies, which is the safe direction, and changing it would also change which of several matching grants wins. It stays named in #2596 rather than folded in here.

The correction mechanics — append-only with no inverse, and an appended correction losing the tie — are #2597 and are untouched by this.
