### PR TITLE
feat(cli): backfill legacy entity types into entity_type

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2103,6 +2103,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-util",
+ "toml",
  "tracing",
  "tracing-subscriber",
  "uuid",

--- a/crates/khive-mcp/Cargo.toml
+++ b/crates/khive-mcp/Cargo.toml
@@ -87,6 +87,7 @@ pack-moodboard = ["khive-pack-moodboard"]
 test-forward-seam = []
 
 [dev-dependencies]
+toml = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 khive-runtime = { version = "0.8.0", path = "../khive-runtime", features = ["fault-injection", "test-internals"] }
 khive-storage = { version = "0.8.0", path = "../khive-storage", features = ["test-support"] }

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -2215,7 +2215,8 @@ fn effective_backend_configs(backends: &[BackendConfig], force_memory: bool) -> 
         .collect()
 }
 
-fn validate_effective_backend_alias_modes(backends: &[BackendConfig]) -> anyhow::Result<()> {
+/// Reject conflicting access modes without opening any configured database.
+pub fn validate_effective_backend_alias_modes(backends: &[BackendConfig]) -> anyhow::Result<()> {
     let mut physical_sqlite: HashMap<std::path::PathBuf, (&str, bool)> = HashMap::new();
     for backend in backends {
         let Some(canonical) = canonical_backend_path(backend)? else {
@@ -2558,6 +2559,7 @@ fn file_identity(path: &std::path::Path) -> Option<FileIdentity> {
     }
 }
 
+/// An identity-bound database target, shared by one-database admin commands.
 /// The `kkernel reindex` database target as
 /// [`validate_reindex_db_target_with_source`] resolved it: the canonical path
 /// reindex must open, plus the filesystem identity observed at validation
@@ -2572,6 +2574,30 @@ pub struct ValidatedReindexTarget {
     /// string, which may still name a symlink.
     pub path: PathBuf,
     identity: Option<FileIdentity>,
+}
+
+/// Capture an existing regular database file without opening SQLite or creating paths.
+/// Callers must open the returned canonical path and reverify its identity immediately
+/// before a writable open, using [`reverify_reindex_target_identity`].
+pub fn capture_existing_database_target(
+    path: &std::path::Path,
+) -> anyhow::Result<ValidatedReindexTarget> {
+    let path = canonical_path_no_side_effects(path)?;
+    let metadata = std::fs::metadata(&path)
+        .with_context(|| format!("database {} must already exist", path.display()))?;
+    anyhow::ensure!(
+        metadata.is_file(),
+        "database {} is not a regular file",
+        path.display()
+    );
+    let identity = file_identity(&path);
+    #[cfg(unix)]
+    anyhow::ensure!(
+        identity.is_some(),
+        "cannot capture database identity for {}",
+        path.display()
+    );
+    Ok(ValidatedReindexTarget { path, identity })
 }
 
 /// Re-stat a validated reindex target and refuse if its filesystem identity
@@ -3001,6 +3027,34 @@ async fn prepare_configured_storage_topology(
     })
 }
 
+/// Resolve one pack's declared backend using the serving route: an explicit
+/// `[packs.<name>]` assignment wins, otherwise the pack uses `main`.
+/// This inspects configuration only and never opens a backend.
+pub fn resolve_pack_backend_config<'a>(
+    khive_cfg: &'a KhiveConfig,
+    pack_name: &str,
+) -> anyhow::Result<(&'a BackendConfig, bool)> {
+    let (backend_name, no_embed) = match khive_cfg.packs.get(pack_name) {
+        Some(pack) => (pack.backend.as_str(), pack.no_embed),
+        None => (BackendId::MAIN, false),
+    };
+    let mut matching = khive_cfg
+        .backends
+        .iter()
+        .filter(|backend| backend.name == backend_name);
+    let backend = matching.next().ok_or_else(|| {
+        let defined = khive_cfg.backends.iter().map(|backend| backend.name.as_str()).collect::<Vec<_>>().join(", ");
+        anyhow::anyhow!(
+            "absent backend route: [packs.{pack_name}].backend = {backend_name:?} references an unknown backend; defined backends: {defined}"
+        )
+    })?;
+    anyhow::ensure!(
+        matching.next().is_none(),
+        "ambiguous backend route: [packs.{pack_name}].backend = {backend_name:?} has duplicate backend names"
+    );
+    Ok((backend, no_embed))
+}
+
 async fn build_registry_for_multi_backend_inner(
     base_config: RuntimeConfig,
     khive_cfg: &KhiveConfig,
@@ -3031,19 +3085,13 @@ async fn build_registry_for_multi_backend_inner(
     let pack_names = &base_config.packs;
     let mut per_pack_runtimes_local: HashMap<String, KhiveRuntime> = HashMap::new();
     for pack_name in pack_names {
-        let (backend_name, backend, no_embed) = match khive_cfg.packs.get(pack_name.as_str()) {
-            None => (BackendId::MAIN, main_backend.clone(), false),
-            Some(pack_cfg) => {
-                let backend_name = pack_cfg.backend.as_str();
-                let backend = backends.get(backend_name).cloned().ok_or_else(|| {
-                    let defined = backends.keys().cloned().collect::<Vec<_>>().join(", ");
-                    anyhow::anyhow!(
-                        "[packs.{pack_name}].backend = {backend_name:?} references an unknown backend; defined backends: {defined}"
-                    )
-                })?;
-                (backend_name, backend, pack_cfg.no_embed)
-            }
-        };
+        let (backend_config, no_embed) = resolve_pack_backend_config(khive_cfg, pack_name)?;
+        let backend_name = backend_config.name.as_str();
+        let backend = backends.get(backend_name).cloned().ok_or_else(|| {
+            anyhow::anyhow!(
+                "resolved backend {backend_name:?} for pack {pack_name:?} was not prepared"
+            )
+        })?;
         let mut rt_config = base_config.clone();
         rt_config.backend_id = BackendId::parse(backend_name)?;
         if no_embed {
@@ -4504,6 +4552,49 @@ fn apply_config_pack_selection(
 mod tests {
     use super::*;
     use khive_runtime::{BlobConfig, Namespace, StorageSectionConfig};
+
+    #[test]
+    fn pack_backend_config_uses_main_or_explicit_assignment() {
+        let mut config: KhiveConfig = toml::from_str(
+            "[[backends]]\nname = 'main'\npath = 'main.db'\n\
+             [[backends]]\nname = 'other'\npath = 'other.db'\n\
+             [packs.kg]\nbackend = 'other'\nno_embed = true\n",
+        )
+        .unwrap();
+        let (backend, no_embed) = resolve_pack_backend_config(&config, "kg").unwrap();
+        assert_eq!(backend.name, "other");
+        assert!(no_embed);
+        config.packs.clear();
+        let (backend, no_embed) = resolve_pack_backend_config(&config, "kg").unwrap();
+        assert_eq!(backend.name, "main");
+        assert!(!no_embed);
+    }
+
+    #[test]
+    fn pack_backend_config_refuses_missing_and_duplicate_routes() {
+        let mut config: KhiveConfig = toml::from_str(
+            "[[backends]]\nname = 'main'\npath = 'main.db'\n\
+             [packs.kg]\nbackend = 'missing'\n",
+        )
+        .unwrap();
+        let error = resolve_pack_backend_config(&config, "kg")
+            .unwrap_err()
+            .to_string();
+        assert!(error.starts_with("absent backend route:"), "{error}");
+        assert!(error.contains("defined backends: main"), "{error}");
+        config.packs.clear();
+        config.backends.push(config.backends[0].clone());
+        let error = resolve_pack_backend_config(&config, "kg")
+            .unwrap_err()
+            .to_string();
+        assert!(error.starts_with("ambiguous backend route:"), "{error}");
+        assert!(error.contains("duplicate backend names"), "{error}");
+        config.backends.clear();
+        assert!(resolve_pack_backend_config(&config, "kg")
+            .unwrap_err()
+            .to_string()
+            .starts_with("absent backend route:"));
+    }
 
     #[tokio::test(flavor = "current_thread")]
     async fn schema_prepare_waits_for_gc_owner_off_the_async_worker() {

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -879,7 +879,28 @@ impl KhiveRuntime {
         id: Uuid,
         patch: EntityPatch,
     ) -> RuntimeResult<(Entity, bool, Vec<&'static str>, i64, Option<i64>)> {
+        self.prepare_guarded_entity_update(token, id, patch, None, &[])
+            .await
+    }
+
+    async fn prepare_guarded_entity_update(
+        &self,
+        token: &NamespaceToken,
+        id: Uuid,
+        patch: EntityPatch,
+        expected: Option<&Entity>,
+        remove_properties: &[&str],
+    ) -> RuntimeResult<(Entity, bool, Vec<&'static str>, i64, Option<i64>)> {
         crate::secret_gate::reject_reserved_secret_gate_property(patch.properties.as_ref())?;
+        if !remove_properties.is_empty() {
+            let removals = Value::Object(
+                remove_properties
+                    .iter()
+                    .map(|key| ((*key).to_string(), Value::Null))
+                    .collect(),
+            );
+            crate::secret_gate::reject_reserved_secret_gate_property(Some(&removals))?;
+        }
         if let Some(ref name) = patch.name {
             crate::secret_gate::check(name)?;
         }
@@ -893,10 +914,22 @@ impl KhiveRuntime {
             crate::secret_gate::check_tags(tags)?;
         }
         let store = self.entities(token)?;
-        let mut entity = store
-            .get_entity(id)
-            .await?
-            .ok_or_else(|| RuntimeError::NotFound(format!("entity {id}")))?;
+        let mut entity = store.get_entity(id).await?.ok_or_else(|| {
+            if expected.is_some() {
+                stale_entity_snapshot_error(id)
+            } else {
+                RuntimeError::NotFound(format!("entity {id}"))
+            }
+        })?;
+        if let Some(expected) = expected {
+            let actual = serde_json::to_value(&entity)
+                .map_err(|error| RuntimeError::Internal(error.to_string()))?;
+            let expected = serde_json::to_value(expected)
+                .map_err(|error| RuntimeError::Internal(error.to_string()))?;
+            if actual != expected {
+                return Err(stale_entity_snapshot_error(id));
+            }
+        }
         let expected_updated_at = entity.updated_at;
         let expected_deleted_at = entity.deleted_at;
         #[cfg(test)]
@@ -936,6 +969,15 @@ impl KhiveRuntime {
             entity.properties = merged;
             changed_fields.push("properties");
         }
+        if let Some(Value::Object(properties)) = entity.properties.as_mut() {
+            let mut removed = false;
+            for key in remove_properties {
+                removed |= properties.remove(*key).is_some();
+            }
+            if removed && !changed_fields.contains(&"properties") {
+                changed_fields.push("properties");
+            }
+        }
         if let Some(tags) = patch.tags {
             entity.tags = tags;
             changed_fields.push("tags");
@@ -944,6 +986,16 @@ impl KhiveRuntime {
             reindex_required |= entity.entity_type != entity_type;
             entity.entity_type = entity_type;
             changed_fields.push("entity_type");
+        }
+
+        if expected.is_some() && changed_fields.is_empty() {
+            return Ok((
+                entity,
+                reindex_required,
+                changed_fields,
+                expected_updated_at,
+                expected_deleted_at,
+            ));
         }
 
         // `updated_at` is also the optimistic-concurrency revision for
@@ -989,6 +1041,63 @@ impl KhiveRuntime {
         let (entity, reindex_required, changed_fields, expected_updated_at, expected_deleted_at) =
             self.prepare_update_entity(token, id, patch).await?;
 
+        self.persist_prepared_entity_update(
+            token,
+            entity,
+            reindex_required,
+            changed_fields,
+            expected_updated_at,
+            expected_deleted_at,
+        )
+        .await
+    }
+
+    /// Apply an admin patch only if the entity still matches the full read snapshot.
+    /// Property removals apply after the normal merge and preserve all other keys.
+    /// Missing keys alone are a no-op; reserved runtime-owned keys cannot be removed.
+    /// A changed, deleted, or missing entity returns a conflict without writing.
+    pub async fn update_entity_if_unchanged(
+        &self,
+        token: &NamespaceToken,
+        expected: &Entity,
+        patch: EntityPatch,
+        remove_properties: &[&str],
+    ) -> RuntimeResult<Entity> {
+        let (entity, reindex_required, changed_fields, expected_updated_at, expected_deleted_at) =
+            self.prepare_guarded_entity_update(
+                token,
+                expected.id,
+                patch,
+                Some(expected),
+                remove_properties,
+            )
+            .await?;
+        if changed_fields.is_empty() {
+            return Ok(entity);
+        }
+        Ok(self
+            .persist_prepared_entity_update(
+                token,
+                entity,
+                reindex_required,
+                changed_fields,
+                expected_updated_at,
+                expected_deleted_at,
+            )
+            .await?
+            .0)
+    }
+
+    async fn persist_prepared_entity_update(
+        &self,
+        token: &NamespaceToken,
+        entity: Entity,
+        reindex_required: bool,
+        changed_fields: Vec<&'static str>,
+        expected_updated_at: i64,
+        expected_deleted_at: Option<i64>,
+    ) -> RuntimeResult<(Entity, crate::retrieval::EmbeddingTruncationReport)> {
+        let id = entity.id;
         let store = self.entities(token)?;
         let persisted = store
             .replace_entity_if_unchanged(entity.clone(), expected_updated_at, expected_deleted_at)
@@ -4137,6 +4246,28 @@ mod tests {
         KhiveRuntime::memory().unwrap()
     }
 
+    async fn entity_update_events(
+        runtime: &KhiveRuntime,
+        token: &NamespaceToken,
+    ) -> Vec<khive_storage::event::Event> {
+        runtime
+            .events(token)
+            .unwrap()
+            .query_events(
+                khive_storage::event::EventFilter {
+                    kinds: vec![EventKind::EntityUpdated],
+                    ..Default::default()
+                },
+                khive_storage::types::PageRequest {
+                    limit: 100,
+                    offset: 0,
+                },
+            )
+            .await
+            .unwrap()
+            .items
+    }
+
     fn outbound_message_note() -> Note {
         let mut note = Note::new("local", "message", "hello");
         note.properties = Some(serde_json::json!({"direction": "outbound"}));
@@ -4961,6 +5092,315 @@ mod tests {
         assert_eq!(updated.name, "OriginalName");
         assert_eq!(updated.description.as_deref(), Some("new desc"));
         assert_eq!(updated.properties, Some(serde_json::json!({"k":"v"})));
+    }
+
+    #[tokio::test]
+    async fn update_entity_if_unchanged_removes_properties_after_merge() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let entity = rt
+            .create_entity(
+                &tok,
+                "concept",
+                None,
+                "LegacyEcho",
+                Some("keep description"),
+                Some(serde_json::json!({
+                    "type": " Concept ",
+                    "nested": {"items": [1, {"value": null}], "keep": true},
+                    "label": "verbatim"
+                })),
+                vec!["keep-tag".to_string()],
+            )
+            .await
+            .unwrap();
+
+        let updated = rt
+            .update_entity_if_unchanged(
+                &tok,
+                &entity,
+                EntityPatch {
+                    properties: Some(serde_json::json!({"type": "also remove", "added": 7})),
+                    ..Default::default()
+                },
+                &["type", "absent", "type"],
+            )
+            .await
+            .expect("remove only the requested key after merging");
+
+        let mut expected = entity.clone();
+        expected.properties = Some(serde_json::json!({
+            "nested": {"items": [1, {"value": null}], "keep": true},
+            "label": "verbatim",
+            "added": 7
+        }));
+        assert!(updated.updated_at > entity.updated_at);
+        expected.updated_at = updated.updated_at;
+        assert_eq!(serde_json::json!(updated), serde_json::json!(expected));
+        assert_eq!(
+            serde_json::json!(rt.get_entity(&tok, entity.id).await.unwrap()),
+            serde_json::json!(expected)
+        );
+        let events = entity_update_events(&rt, &tok).await;
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].payload["changed_fields"],
+            serde_json::json!(["properties"])
+        );
+    }
+
+    #[tokio::test]
+    async fn update_entity_if_unchanged_missing_removals_are_no_op() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        for properties in [
+            None,
+            Some(serde_json::json!({"keep": [true, null]})),
+            Some(serde_json::json!(["not an object"])),
+        ] {
+            let entity = rt
+                .create_entity(&tok, "concept", None, "NoRemoval", None, properties, vec![])
+                .await
+                .unwrap();
+            let unchanged = rt
+                .update_entity_if_unchanged(&tok, &entity, EntityPatch::default(), &["absent"])
+                .await
+                .unwrap();
+            assert_eq!(serde_json::json!(unchanged), serde_json::json!(entity));
+            assert_eq!(
+                serde_json::json!(rt.get_entity(&tok, entity.id).await.unwrap()),
+                serde_json::json!(entity)
+            );
+        }
+        assert!(entity_update_events(&rt, &tok).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn update_entity_if_unchanged_refuses_stale_full_snapshot() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let entity = rt
+            .create_entity(
+                &tok,
+                "concept",
+                None,
+                "StaleBackfill",
+                None,
+                Some(serde_json::json!({"type": "concept", "keep": true})),
+                vec![],
+            )
+            .await
+            .unwrap();
+        for field in ["properties", "entity_type", "deleted_at", "updated_at"] {
+            let mut stale = entity.clone();
+            match field {
+                "properties" => stale.properties = Some(serde_json::json!({"type": "algorithm"})),
+                "entity_type" => stale.entity_type = Some("algorithm".to_string()),
+                "deleted_at" => stale.deleted_at = Some(entity.updated_at),
+                "updated_at" => stale.updated_at -= 1,
+                _ => unreachable!(),
+            }
+            let error = rt
+                .update_entity_if_unchanged(
+                    &tok,
+                    &stale,
+                    EntityPatch {
+                        entity_type: Some(Some("algorithm".to_string())),
+                        ..Default::default()
+                    },
+                    &["type"],
+                )
+                .await
+                .expect_err("every stale snapshot field must refuse before edits");
+            assert!(
+                matches!(error, RuntimeError::Khive(ref error) if error.kind() == khive_types::ErrorKind::Conflict),
+                "{field}: {error}"
+            );
+            assert_eq!(
+                serde_json::json!(rt.get_entity(&tok, entity.id).await.unwrap()),
+                serde_json::json!(entity),
+                "{field}"
+            );
+        }
+
+        let store = rt.entities(&tok).unwrap();
+        store
+            .delete_entity(entity.id, khive_storage::types::DeleteMode::Soft)
+            .await
+            .unwrap();
+        let tombstone = store
+            .get_entity_including_deleted(entity.id)
+            .await
+            .unwrap()
+            .unwrap();
+        let error = rt
+            .update_entity_if_unchanged(&tok, &entity, EntityPatch::default(), &["type"])
+            .await
+            .expect_err("a deleted candidate must not be resurrected");
+        assert!(
+            matches!(error, RuntimeError::Khive(ref error) if error.kind() == khive_types::ErrorKind::Conflict),
+            "{error}"
+        );
+        assert_eq!(
+            serde_json::json!(store
+                .get_entity_including_deleted(entity.id)
+                .await
+                .unwrap()
+                .unwrap()),
+            serde_json::json!(tombstone)
+        );
+        assert!(entity_update_events(&rt, &tok).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn update_entity_if_unchanged_refuses_concurrent_writer_after_snapshot_check() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let entity = rt
+            .create_entity(
+                &tok,
+                "concept",
+                None,
+                "RacingBackfill",
+                None,
+                Some(serde_json::json!({"type": "concept", "keep": true})),
+                vec![],
+            )
+            .await
+            .unwrap();
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+        let (guarded, normal) = tokio::join!(
+            race_seam::AFTER_READ_BARRIER.scope(
+                Arc::clone(&barrier),
+                rt.update_entity_if_unchanged(&tok, &entity, EntityPatch::default(), &["type"]),
+            ),
+            race_seam::AFTER_READ_BARRIER.scope(
+                barrier,
+                rt.update_entity(
+                    &tok,
+                    entity.id,
+                    EntityPatch {
+                        properties: Some(serde_json::json!({"normal_writer": true})),
+                        ..Default::default()
+                    },
+                ),
+            ),
+        );
+        assert_eq!(
+            usize::from(guarded.is_ok()) + usize::from(normal.is_ok()),
+            1
+        );
+        let (winner, refused) = match (guarded, normal) {
+            (Ok(winner), Err(refused)) | (Err(refused), Ok(winner)) => (winner, refused),
+            results => panic!("exactly one writer must win: {results:?}"),
+        };
+        assert!(
+            matches!(refused, RuntimeError::Khive(ref error) if error.kind() == khive_types::ErrorKind::Conflict),
+            "{refused}"
+        );
+        assert_eq!(
+            serde_json::json!(rt.get_entity(&tok, entity.id).await.unwrap()),
+            serde_json::json!(winner)
+        );
+        assert_eq!(entity_update_events(&rt, &tok).await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn update_entity_if_unchanged_normalizes_type_with_installed_validator() {
+        let rt = rt();
+        let composed = khive_types::EntityTypeRegistry::with_extra([khive_types::EntityTypeDef {
+            kind: khive_types::EntityKind::Document,
+            type_name: "backfill_test_report",
+            aliases: &["field_report"],
+        }]);
+        rt.install_entity_type_validator(Arc::new(move |kind, raw| {
+            let kind = kind
+                .parse::<khive_types::EntityKind>()
+                .map_err(|error| RuntimeError::InvalidInput(error.to_string()))?;
+            composed
+                .resolve(kind, raw)
+                .map(|resolved| resolved.entity_type)
+                .map_err(RuntimeError::from)
+        }));
+        let tok = NamespaceToken::local();
+        let entity = rt
+            .create_entity(
+                &tok,
+                "document",
+                None,
+                "LegacySubtype",
+                None,
+                Some(serde_json::json!({"type": " Field-Report ", "keep": [1, 2]})),
+                vec![],
+            )
+            .await
+            .unwrap();
+        let updated = rt
+            .update_entity_if_unchanged(
+                &tok,
+                &entity,
+                EntityPatch {
+                    entity_type: Some(Some(" Field-Report ".to_string())),
+                    ..Default::default()
+                },
+                &[],
+            )
+            .await
+            .expect("normal write validation resolves pack-supplied aliases");
+        assert_eq!(updated.entity_type.as_deref(), Some("backfill_test_report"));
+        assert_eq!(updated.properties, entity.properties);
+        assert_eq!(
+            rt.get_entity(&tok, entity.id).await.unwrap().entity_type,
+            updated.entity_type
+        );
+        let error = rt
+            .update_entity_if_unchanged(
+                &tok,
+                &updated,
+                EntityPatch {
+                    entity_type: Some(Some("not_registered".to_string())),
+                    ..Default::default()
+                },
+                &["type"],
+            )
+            .await
+            .expect_err("invalid subtype refuses the entire patch and removal");
+        assert!(matches!(error, RuntimeError::InvalidInput(_)), "{error}");
+        assert_eq!(
+            serde_json::json!(rt.get_entity(&tok, entity.id).await.unwrap()),
+            serde_json::json!(updated)
+        );
+        let events = entity_update_events(&rt, &tok).await;
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].payload["changed_fields"],
+            serde_json::json!(["entity_type"])
+        );
+    }
+
+    #[tokio::test]
+    async fn update_entity_if_unchanged_refuses_reserved_property_removal() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let entity = rt
+            .create_entity(&tok, "concept", None, "ReservedRemoval", None, None, vec![])
+            .await
+            .unwrap();
+        let error = rt
+            .update_entity_if_unchanged(
+                &tok,
+                &entity,
+                EntityPatch::default(),
+                &[crate::secret_gate::RESERVED_SECRET_GATE_KEY],
+            )
+            .await
+            .expect_err("removal must share the reserved-property write validator");
+        assert!(matches!(error, RuntimeError::InvalidInput(_)), "{error}");
+        assert_eq!(
+            serde_json::json!(rt.get_entity(&tok, entity.id).await.unwrap()),
+            serde_json::json!(entity)
+        );
+        assert!(entity_update_events(&rt, &tok).await.is_empty());
     }
 
     #[tokio::test]

--- a/crates/khive-types/src/entity_type.rs
+++ b/crates/khive-types/src/entity_type.rs
@@ -503,6 +503,11 @@ impl EntityTypeRegistry {
         Self::new(defs)
     }
 
+    /// Definitions in this composed registry, including canonical names and aliases.
+    pub fn definitions(&self) -> &[EntityTypeDef] {
+        &self.defs
+    }
+
     /// Boot-time collision check across the composed registry `with_extra`
     /// builds: built-in defs plus every caller-supplied `(owner, def)` extra.
     ///

--- a/crates/kkernel/src/cli.rs
+++ b/crates/kkernel/src/cli.rs
@@ -90,6 +90,9 @@ enum Command {
     /// every configured embedding engine (resolved like `kkernel mcp`).
     Reindex(reindex::ReindexArgs),
 
+    /// Promote registered legacy entity subtypes and remove redundant kind echoes.
+    EntityTypeBackfill(crate::entity_type_backfill::EntityTypeBackfillArgs),
+
     /// Execute a verb DSL expression (same syntax as MCP `request` tool).
     Exec(exec::ExecArgs),
 
@@ -303,6 +306,9 @@ pub async fn cli_main() -> Result<()> {
         Command::Engine(e) => engine::run_engine(e).await,
         Command::Vector(v) => vector::run_vector(v),
         Command::Reindex(r) => reindex::run_reindex(r).await,
+        Command::EntityTypeBackfill(args) => {
+            crate::entity_type_backfill::run_entity_type_backfill(args).await
+        }
         Command::Exec(e) => {
             let result = exec::run_exec(e).await;
             if let Err(error) = &result {

--- a/crates/kkernel/src/code_ingest.rs
+++ b/crates/kkernel/src/code_ingest.rs
@@ -676,7 +676,9 @@ async fn dry_run_report(
 /// returned `TempDir` alive for as long as the backend is used; dropping it
 /// deletes the snapshot. Any `-shm` maintenance the read-only open performs
 /// lands on this disposable copy, never on `db_path`'s own sidecar.
-fn open_read_only_snapshot(db_path: &Path) -> Result<(StorageBackend, tempfile::TempDir)> {
+pub(crate) fn open_read_only_snapshot(
+    db_path: &Path,
+) -> Result<(StorageBackend, tempfile::TempDir)> {
     let snapshot_dir = tempfile::TempDir::new()
         .context("failed to create a scratch directory for the dry-run db snapshot")?;
     let file_name = db_path

--- a/crates/kkernel/src/entity_type_backfill.rs
+++ b/crates/kkernel/src/entity_type_backfill.rs
@@ -1,0 +1,461 @@
+//! Offline, registry-driven repair of legacy entity subtype properties.
+//!
+//! The copied database is the classification population. Apply revalidates each
+//! full preimage against the writable store; it never blindly replaces a row
+//! changed since the scan. Stop other writers while taking the filesystem copy.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{bail, ensure, Context, Result};
+use clap::Parser;
+use khive_runtime::curation::EntityPatch;
+use khive_runtime::pack::{IngestAuditStore, PackRegistry, VerbRegistry};
+use khive_runtime::{KhiveRuntime, NamespaceToken};
+use khive_storage::entity::{Entity, EntityFilter};
+use khive_storage::types::{SqlStatement, SqlValue};
+use khive_types::{to_snake_case, EntityKind, EntityTypeError, EntityTypeRegistry};
+use serde::Serialize;
+use uuid::Uuid;
+
+const PAGE_SIZE: u32 = 256;
+const MAX_SCAN: u64 = 1_000_000;
+
+mod target;
+
+#[derive(Debug, Parser)]
+#[command(group(clap::ArgGroup::new("mode").required(true).args(["dry_run", "apply"])))]
+#[command(
+    long_about = "Repair legacy entity subtype properties using the configured pack registry. Both modes require stopped writers while the database and sidecars are copied; this is an offline maintenance command, not a live-store migration. Dry-run writes nothing to the source. Limited runs report complete=false when the namespace scan is unfinished."
+)]
+pub struct EntityTypeBackfillArgs {
+    /// Classify without modifying the database or its sidecars. Stop other writers first.
+    #[arg(long)]
+    pub dry_run: bool,
+    /// Apply guarded updates. Stop other writers before running this offline command.
+    #[arg(long)]
+    pub apply: bool,
+    #[arg(long, env = "KHIVE_DB")]
+    pub db: Option<String>,
+    #[arg(long, env = "KHIVE_CONFIG")]
+    pub config: Option<PathBuf>,
+    #[arg(long, env = "KHIVE_NAMESPACE")]
+    pub namespace: Option<String>,
+    /// Maximum live entities visited, including ineligible rows (default 1000000).
+    /// A limited prefix is not a complete namespace repair; inspect complete.
+    #[arg(long, value_parser = clap::value_parser!(u64).range(1..=MAX_SCAN))]
+    pub limit: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BackfillFailure {
+    pub id: Option<Uuid>,
+    pub error: String,
+    /// Normal runtime updates can persist before indexing or audit fails.
+    pub write_may_have_committed: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct EntityTypeBackfillReport {
+    pub mode: &'static str,
+    pub namespace: String,
+    pub source_revision: &'static str,
+    pub loaded_packs: Vec<String>,
+    pub registry_types: BTreeMap<String, Vec<String>>,
+    pub target: PathBuf,
+    pub backend: String,
+    pub count_scope: &'static str,
+    pub effective_limit: u64,
+    pub scanned: u64,
+    pub eligible: u64,
+    pub promote: u64,
+    pub echo: u64,
+    pub untouched: u64,
+    pub wrong_kind: u64,
+    pub nullable_before: u64,
+    pub nullable_after: Option<u64>,
+    pub projected_nullable_after: u64,
+    pub after_count_basis: &'static str,
+    pub promoted: u64,
+    pub echo_removed: u64,
+    pub complete: bool,
+    pub failures: Vec<BackfillFailure>,
+}
+
+enum Classification<'a> {
+    Ineligible,
+    Promote(&'a str),
+    Echo,
+    Untouched { wrong_kind: bool },
+}
+
+fn classify<'a>(entity: &'a Entity, registry: &EntityTypeRegistry) -> Classification<'a> {
+    if entity.entity_type.is_some() || entity.deleted_at.is_some() {
+        return Classification::Ineligible;
+    }
+    let Some(raw) = entity
+        .properties
+        .as_ref()
+        .and_then(|props| props.get("type"))
+        .and_then(serde_json::Value::as_str)
+    else {
+        return Classification::Ineligible;
+    };
+    if to_snake_case(raw.trim()) == to_snake_case(entity.kind.trim()) {
+        return Classification::Echo;
+    }
+    let Ok(kind) = entity.kind.parse::<EntityKind>() else {
+        return Classification::Untouched { wrong_kind: false };
+    };
+    match registry.resolve(kind, Some(raw)) {
+        // Deliberately pass RAW to the normal write path. Its installed
+        // validator, not this read-side classification, must canonicalize it.
+        Ok(_) => Classification::Promote(raw),
+        Err(EntityTypeError::WrongKind { .. }) => Classification::Untouched { wrong_kind: true },
+        Err(_) => Classification::Untouched { wrong_kind: false },
+    }
+}
+
+fn compose_registry(runtime: &KhiveRuntime) -> Result<(VerbRegistry, EntityTypeRegistry)> {
+    ensure!(
+        runtime.config().packs.iter().any(|name| name == "kg"),
+        "entity-type-backfill requires the kg pack"
+    );
+    let registry = PackRegistry::build_ingest_registry(runtime, IngestAuditStore::Detach)?;
+    registry.call_register_entity_type_validators(runtime);
+    let types = EntityTypeRegistry::with_extra(registry.all_entity_types());
+    Ok((registry, types))
+}
+
+fn validate_args(args: &EntityTypeBackfillArgs) -> Result<()> {
+    ensure!(
+        args.dry_run != args.apply,
+        "specify exactly one of --dry-run or --apply"
+    );
+    ensure!(
+        args.limit
+            .is_none_or(|limit| (1..=MAX_SCAN).contains(&limit)),
+        "--limit must be between 1 and {MAX_SCAN}"
+    );
+    Ok(())
+}
+
+async fn nullable_count(runtime: &KhiveRuntime, namespace: &str) -> Result<u64> {
+    let mut reader = runtime.sql().reader().await?;
+    match reader.query_scalar(SqlStatement {
+        sql: "SELECT COUNT(*) FROM entities WHERE namespace = ?1 AND deleted_at IS NULL AND entity_type IS NULL".into(),
+        params: vec![SqlValue::Text(namespace.into())],
+        label: Some("entity-type-backfill nullable census".into()),
+    }).await? {
+        Some(SqlValue::Integer(count)) if count >= 0 => Ok(count as u64),
+        _ => bail!("entity-type-backfill census did not return a nonnegative integer"),
+    }
+}
+
+async fn scan(
+    snapshot: &KhiveRuntime,
+    token: &NamespaceToken,
+    types: &EntityTypeRegistry,
+    apply: Option<&KhiveRuntime>,
+    report: &mut EntityTypeBackfillReport,
+    page_size: u32,
+) -> Result<()> {
+    let entities = snapshot.entities(token)?;
+    let write_token = apply
+        .map(|runtime| runtime.authorize(token.namespace().clone()))
+        .transpose()?;
+    let mut cursor = None;
+    loop {
+        let remaining = report.effective_limit - report.scanned;
+        if remaining == 0 {
+            return Ok(());
+        }
+        let page = entities
+            .query_entities_after(
+                &report.namespace,
+                EntityFilter::default(),
+                cursor,
+                u32::try_from(remaining.min(u64::from(page_size)))?,
+            )
+            .await?;
+        cursor = page.next_after;
+        for entity in page.items {
+            report.scanned += 1;
+            let class = classify(&entity, types);
+            let (patch, removals): (EntityPatch, &[&str]) = match class {
+                Classification::Ineligible => continue,
+                Classification::Promote(raw) => {
+                    report.eligible += 1;
+                    report.promote += 1;
+                    (
+                        EntityPatch {
+                            entity_type: Some(Some(raw.to_string())),
+                            ..Default::default()
+                        },
+                        &[],
+                    )
+                }
+                Classification::Echo => {
+                    report.eligible += 1;
+                    report.echo += 1;
+                    (EntityPatch::default(), &["type"])
+                }
+                Classification::Untouched { wrong_kind } => {
+                    report.eligible += 1;
+                    report.untouched += 1;
+                    report.wrong_kind += u64::from(wrong_kind);
+                    continue;
+                }
+            };
+            if let Some((runtime, token)) = apply.zip(write_token.as_ref()) {
+                if let Err(error) = runtime
+                    .update_entity_if_unchanged(token, &entity, patch, removals)
+                    .await
+                {
+                    report.failures.push(BackfillFailure {
+                        id: Some(entity.id),
+                        error: error.to_string(),
+                        write_may_have_committed: true,
+                    });
+                    return Ok(());
+                }
+                if removals.is_empty() {
+                    report.promoted += 1;
+                } else {
+                    report.echo_removed += 1;
+                }
+            }
+        }
+        if cursor.is_none() {
+            report.complete = true;
+            return Ok(());
+        }
+    }
+}
+
+/// Run against a private classification copy, and optionally guarded live writes.
+/// `--apply` is an offline operator operation, never a live-store migration.
+pub async fn entity_type_backfill(
+    args: &EntityTypeBackfillArgs,
+) -> Result<EntityTypeBackfillReport> {
+    validate_args(args)?;
+    let target = target::resolve_target(args)?;
+    backfill_resolved(args, &target).await
+}
+
+async fn backfill_resolved(
+    args: &EntityTypeBackfillArgs,
+    target: &target::ResolvedTarget,
+) -> Result<EntityTypeBackfillReport> {
+    target.reverify()?;
+    let config = &target.config;
+    let path = &target.path;
+    let (backend, _snapshot_dir) = crate::code_ingest::open_read_only_snapshot(path)?;
+    target.reverify()?;
+    // Validate current schema on the read-only copy before any writable open.
+    backend.prepare_core_schema()?;
+    let snapshot = KhiveRuntime::from_backend(Arc::new(backend), config.clone());
+    let (registry, types) = compose_registry(&snapshot)?;
+    let namespace = config.default_namespace.clone();
+    let token = snapshot.authorize(namespace.clone())?;
+    let before = nullable_count(&snapshot, namespace.as_str()).await?;
+    let mut loaded_packs: Vec<_> = registry
+        .pack_names()
+        .into_iter()
+        .map(str::to_owned)
+        .collect();
+    loaded_packs.sort();
+    let mut report = EntityTypeBackfillReport {
+        mode: if args.apply { "apply" } else { "dry_run" },
+        namespace: namespace.as_str().to_owned(),
+        source_revision: khive_runtime::BUILD_INFO.source_revision,
+        loaded_packs,
+        registry_types: EntityKind::ALL.into_iter().map(|kind| {
+            let mut names: Vec<_> = types.definitions().iter().filter(|def| def.kind == kind)
+                .map(|def| def.type_name.to_owned()).collect();
+            names.sort();
+            names.dedup();
+            (kind.name().to_owned(), names)
+        }).collect(),
+        target: path.to_path_buf(),
+        backend: target.backend_name.clone(),
+        count_scope: "live entities in one exact namespace; classification and before count from a private offline copy",
+        effective_limit: args.limit.unwrap_or(MAX_SCAN),
+        scanned: 0, eligible: 0, promote: 0, echo: 0, untouched: 0, wrong_kind: 0,
+        nullable_before: before, nullable_after: Some(before), projected_nullable_after: before,
+        after_count_basis: "unchanged dry-run snapshot",
+        promoted: 0, echo_removed: 0, complete: false, failures: Vec::new(),
+    };
+    if !args.apply {
+        scan(&snapshot, &token, &types, None, &mut report, PAGE_SIZE).await?;
+    } else {
+        target.reverify()?;
+        let runtime = KhiveRuntime::new(config.clone())?;
+        let mut write_registry = None;
+        let result: Result<()> = async {
+            ensure!(
+                !runtime.is_read_only(),
+                "--apply requires a writable database"
+            );
+            write_registry = Some(compose_registry(&runtime)?.0);
+            scan(
+                &snapshot,
+                &token,
+                &types,
+                Some(&runtime),
+                &mut report,
+                PAGE_SIZE,
+            )
+            .await
+        }
+        .await;
+        if let Err(error) = result {
+            report.failures.push(BackfillFailure {
+                id: None,
+                error: error.to_string(),
+                write_may_have_committed: report.promoted + report.echo_removed > 0,
+            });
+        }
+        report.after_count_basis =
+            "independent observed post-apply census; not an atomic before/after transaction";
+        match nullable_count(&runtime, namespace.as_str()).await {
+            Ok(after) => report.nullable_after = Some(after),
+            Err(error) => {
+                report.nullable_after = None;
+                report.failures.push(BackfillFailure {
+                    id: None,
+                    error: format!("after census failed: {error}"),
+                    write_may_have_committed: true,
+                });
+            }
+        }
+        drop(write_registry);
+        let join = runtime.backend().pool().take_writer_task_join();
+        let missing_join = join.is_none()
+            && runtime.backend().pool().write_queue_active()
+            && runtime.backend().pool().writer_task_join_was_stored();
+        drop(runtime);
+        let drain_error = if missing_join {
+            Some("writer task drain ownership unavailable".to_string())
+        } else if let Some(join) = join {
+            match tokio::time::timeout(Duration::from_secs(30), join).await {
+                Ok(Ok(())) => None,
+                Ok(Err(error)) => Some(format!("writer task failed: {error}")),
+                Err(_) => Some(
+                    "writer task did not drain in 30s; database state may still be unsettled"
+                        .into(),
+                ),
+            }
+        } else {
+            None
+        };
+        if let Some(error) = drain_error {
+            report.failures.push(BackfillFailure {
+                id: None,
+                error,
+                write_may_have_committed: true,
+            });
+        }
+    }
+    report.projected_nullable_after = before - report.promote;
+    report.complete &= report.failures.is_empty();
+    Ok(report)
+}
+
+pub async fn run_entity_type_backfill(args: EntityTypeBackfillArgs) -> Result<()> {
+    use std::io::Write;
+
+    validate_args(&args)?;
+    let target = target::resolve_target(&args)?;
+    println!("target: {}", target.path.display());
+    std::io::stdout()
+        .flush()
+        .context("print resolved backfill target")?;
+    let report = backfill_resolved(&args, &target).await?;
+    println!("{}", serde_json::to_string_pretty(&report)?);
+    ensure!(report.failures.is_empty(), "entity-type-backfill stopped with failures; inspect the report before retrying (writes may have committed)");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use khive_runtime::RuntimeConfig;
+    use serde_json::json;
+
+    #[test]
+    fn classifier_uses_composed_types_and_preserves_raw_promotion_for_validation() {
+        let runtime = KhiveRuntime::new(RuntimeConfig {
+            db_path: None,
+            embedding_model: None,
+            additional_embedding_models: Vec::new(),
+            packs: vec!["kg".into(), "git".into()],
+            ..RuntimeConfig::default()
+        })
+        .unwrap();
+        let (_registry, types) = compose_registry(&runtime).unwrap();
+        for (kind, raw, canonical) in [
+            ("document", "paper", "paper"),
+            ("concept", " ALGO ", "algorithm"),
+            ("document", " Architecture--Decision__Record ", "adr"),
+        ] {
+            let entity =
+                Entity::new("local", kind, "fixture").with_properties(json!({"type": raw}));
+            assert!(
+                matches!(classify(&entity, &types), Classification::Promote(value) if value == raw)
+            );
+            assert_eq!(
+                types
+                    .resolve(kind.parse().unwrap(), Some(raw))
+                    .unwrap()
+                    .entity_type
+                    .as_deref(),
+                Some(canonical)
+            );
+        }
+        let echo = Entity::new("local", "concept", "echo")
+            .with_properties(json!({"type": " __CoNcEpT-- "}));
+        assert!(matches!(classify(&echo, &types), Classification::Echo));
+        let wrong =
+            Entity::new("local", "concept", "wrong").with_properties(json!({"type": "Article"}));
+        assert!(matches!(
+            classify(&wrong, &types),
+            Classification::Untouched { wrong_kind: true }
+        ));
+        let unknown = Entity::new("local", "document", "unknown")
+            .with_properties(json!({"type": "unregistered-backfill-test"}));
+        assert!(matches!(
+            classify(&unknown, &types),
+            Classification::Untouched { wrong_kind: false }
+        ));
+        for properties in [
+            None,
+            Some(json!({"type": null})),
+            Some(json!({"type": 7})),
+            Some(json!({"type": ["paper"]})),
+        ] {
+            let mut entity = Entity::new("local", "document", "ineligible");
+            entity.properties = properties;
+            assert!(matches!(
+                classify(&entity, &types),
+                Classification::Ineligible
+            ));
+        }
+        let typed = Entity::new("local", "document", "typed")
+            .with_entity_type(Some("report"))
+            .with_properties(json!({"type": "paper"}));
+        assert!(matches!(
+            classify(&typed, &types),
+            Classification::Ineligible
+        ));
+        let mut deleted =
+            Entity::new("local", "document", "deleted").with_properties(json!({"type": "paper"}));
+        deleted.deleted_at = Some(1);
+        assert!(matches!(
+            classify(&deleted, &types),
+            Classification::Ineligible
+        ));
+    }
+}

--- a/crates/kkernel/src/entity_type_backfill/target.rs
+++ b/crates/kkernel/src/entity_type_backfill/target.rs
@@ -1,0 +1,303 @@
+//! Side-effect-free selection of the database that serves KG operations.
+
+use std::path::PathBuf;
+
+use anyhow::{ensure, Context, Result};
+use khive_mcp::serve::{
+    capture_existing_database_target, config_discovery_db_anchor,
+    reject_conflicting_db_override_with_source, resolve_pack_backend_config,
+    resolve_runtime_config, reverify_reindex_target_identity,
+    validate_effective_backend_alias_modes, RuntimeConfigInputs, ValidatedReindexTarget,
+};
+use khive_runtime::{BackendId, BackendKind, ConfigError, KhiveConfig, Namespace, RuntimeConfig};
+
+use super::EntityTypeBackfillArgs;
+
+pub(super) struct ResolvedTarget {
+    pub(super) config: RuntimeConfig,
+    pub(super) path: PathBuf,
+    pub(super) backend_name: String,
+    validated: ValidatedReindexTarget,
+}
+
+impl ResolvedTarget {
+    pub(super) fn reverify(&self) -> Result<()> {
+        ensure!(
+            self.path == self.validated.path && self.config.db_path.as_ref() == Some(&self.path),
+            "entity-type-backfill target no longer matches the resolved database path"
+        );
+        ensure!(
+            self.path.is_file(),
+            "entity-type-backfill target {} is no longer an existing file",
+            self.path.display()
+        );
+        reverify_reindex_target_identity(&self.validated)
+            .context("entity-type-backfill target identity verification failed")
+    }
+}
+
+pub(super) fn resolve_target(args: &EntityTypeBackfillArgs) -> Result<ResolvedTarget> {
+    let anchor = config_discovery_db_anchor(args.db.as_deref());
+    let loaded =
+        KhiveConfig::load_with_home_fallback_and_source(args.config.as_deref(), anchor.as_deref())
+            .map_err(target_config_error)?;
+    let source = loaded.as_ref().map(|(_, source)| source.as_path());
+    let khive_config = loaded
+        .as_ref()
+        .map(|(config, _)| config.clone())
+        .unwrap_or_default();
+    reject_conflicting_db_override_with_source(args.db.as_deref(), &khive_config.backends, source)?;
+
+    let namespace = Namespace::parse(args.namespace.as_deref().unwrap_or("local"))?;
+    let mut config = resolve_runtime_config(RuntimeConfigInputs {
+        db: args.db.as_deref(),
+        config: args.config.as_deref(),
+        namespace,
+        namespace_explicit: args.namespace.is_some(),
+        actor_explicit: false,
+        no_embed: true,
+        packs: None,
+        brain_profile: None,
+    })?;
+    ensure!(
+        config.db_path.is_some(),
+        "entity-type-backfill requires an existing file-backed database, not :memory:"
+    );
+    ensure!(
+        config.packs.iter().any(|pack| pack == "kg"),
+        "entity-type-backfill requires the kg pack"
+    );
+    validate_effective_backend_alias_modes(&khive_config.backends)?;
+
+    let (backend_name, path) = if khive_config.backends.is_empty() {
+        (
+            BackendId::MAIN.to_string(),
+            config.db_path.clone().expect("checked file-backed config"),
+        )
+    } else {
+        let (backend, _) = resolve_pack_backend_config(&khive_config, "kg").with_context(|| {
+            format!(
+                "resolve KG backend from {}",
+                source
+                    .map(|path| path.display().to_string())
+                    .unwrap_or_else(|| "discovered configuration".into())
+            )
+        })?;
+        ensure!(
+            backend.kind == BackendKind::Sqlite,
+            "KG backend {:?} is not file-backed SQLite",
+            backend.name
+        );
+        ensure!(
+            !args.apply || !backend.read_only,
+            "KG backend {:?} is read_only; --apply requires a writable target",
+            backend.name
+        );
+        (
+            backend.name.clone(),
+            backend
+                .path
+                .clone()
+                .with_context(|| format!("KG backend {:?} has no database path", backend.name))?,
+        )
+    };
+    let validated = capture_existing_database_target(&path)
+        .with_context(|| format!("resolve existing KG database for backend {backend_name:?}"))?;
+    let path = validated.path.clone();
+    config.db_path = Some(path.clone());
+    config.backend_id = BackendId::parse(&backend_name)?;
+    config.embedding_model = None;
+    config.additional_embedding_models.clear();
+    // This detached command must not open the discovery anchor's event plane.
+    config.events_split = None;
+    let target = ResolvedTarget {
+        config,
+        path,
+        backend_name,
+        validated,
+    };
+    target.reverify()?;
+    Ok(target)
+}
+
+fn target_config_error(error: ConfigError) -> anyhow::Error {
+    let mut cause = &error;
+    while let ConfigError::InFile { source, .. } = cause {
+        cause = source;
+    }
+    let context = match cause {
+        ConfigError::DuplicateBackendName { .. } => {
+            "ambiguous entity-type-backfill target configuration"
+        }
+        ConfigError::UnknownPackBackend { .. } => "absent entity-type-backfill backend route",
+        ConfigError::ExplicitConfigMissing { .. } => {
+            "absent entity-type-backfill target configuration"
+        }
+        _ => "invalid entity-type-backfill target configuration",
+    };
+    anyhow::Error::new(error).context(context)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(config: PathBuf) -> EntityTypeBackfillArgs {
+        EntityTypeBackfillArgs {
+            dry_run: true,
+            apply: false,
+            db: None,
+            config: Some(config),
+            namespace: Some("backfill-test".into()),
+            limit: None,
+        }
+    }
+
+    fn fleet_config(dir: &std::path::Path, route: Option<&str>) -> PathBuf {
+        let main = dir.join("main.db");
+        let other = dir.join("other.db");
+        std::fs::write(&main, b"main fixture; resolver must not open SQLite").unwrap();
+        std::fs::write(&other, b"other fixture; resolver must not open SQLite").unwrap();
+        let mut config = format!(
+            "[[backends]]\nname = \"main\"\npath = {:?}\n\
+             [[backends]]\nname = \"other\"\npath = {:?}\n\
+             [[backends]]\nname = \"sessions\"\npath = {:?}\n\
+             [[backends]]\nname = \"comm\"\npath = {:?}\n\
+             [[backends]]\nname = \"knowledge\"\npath = {:?}\n\
+             [packs.session]\nbackend = \"sessions\"\n\
+             [packs.comm]\nbackend = \"comm\"\n\
+             [packs.knowledge]\nbackend = \"knowledge\"\n",
+            main.to_str().unwrap(),
+            other.to_str().unwrap(),
+            dir.join("unopened/sessions.db").to_str().unwrap(),
+            dir.join("unopened/comm.db").to_str().unwrap(),
+            dir.join("unopened/knowledge.db").to_str().unwrap(),
+        );
+        if let Some(route) = route {
+            config.push_str(&format!("[packs.kg]\nbackend = {route:?}\n"));
+        }
+        let path = dir.join("khive.toml");
+        std::fs::write(&path, config).unwrap();
+        path
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn resolve_target_uses_serving_route_without_opening_unrelated_backends() {
+        for (route, expected) in [
+            (None, "main"),
+            (Some("main"), "main"),
+            (Some("other"), "other"),
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let config_path = fleet_config(dir.path(), route);
+            let target = resolve_target(&args(config_path)).unwrap();
+            assert_eq!(target.backend_name, expected);
+            assert_eq!(
+                target.path,
+                dir.path()
+                    .join(format!("{expected}.db"))
+                    .canonicalize()
+                    .unwrap()
+            );
+            assert_eq!(target.config.db_path.as_ref(), Some(&target.path));
+            assert_eq!(target.config.backend_id.as_str(), expected);
+            assert_eq!(target.config.default_namespace.as_str(), "backfill-test");
+            assert!(target.config.embedding_model.is_none());
+            assert!(target.config.additional_embedding_models.is_empty());
+            assert!(target.config.events_split.is_none());
+            assert!(!dir.path().join("unopened").exists());
+            assert_eq!(
+                std::fs::read(dir.path().join("main.db")).unwrap(),
+                b"main fixture; resolver must not open SQLite"
+            );
+            assert_eq!(
+                std::fs::read(dir.path().join("other.db")).unwrap(),
+                b"other fixture; resolver must not open SQLite"
+            );
+            target.reverify().unwrap();
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn resolve_target_refuses_missing_ambiguous_and_unowned_targets() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = fleet_config(dir.path(), Some("missing"));
+        let error = resolve_target(&args(path)).err().unwrap();
+        assert!(error
+            .to_string()
+            .starts_with("absent entity-type-backfill backend route"));
+        assert!(format!("{error:#}")
+            .contains("defined backends: main, other, sessions, comm, knowledge"));
+
+        let path = fleet_config(dir.path(), None);
+        std::fs::remove_file(dir.path().join("main.db")).unwrap();
+        assert!(resolve_target(&args(path))
+            .err()
+            .unwrap()
+            .to_string()
+            .contains("existing KG database"));
+        assert!(!dir.path().join("main.db").exists());
+
+        let path = fleet_config(dir.path(), None);
+        let mut config = std::fs::read_to_string(&path).unwrap();
+        config.push_str("[[backends]]\nname = \"main\"\npath = \"duplicate.db\"\n");
+        std::fs::write(&path, config).unwrap();
+        let error = resolve_target(&args(path)).err().unwrap();
+        assert!(error
+            .to_string()
+            .starts_with("ambiguous entity-type-backfill target configuration"));
+        assert!(format!("{error:#}").contains("duplicate backend name"));
+
+        let path = fleet_config(dir.path(), None);
+        let mut request = args(path);
+        request.db = Some(dir.path().join("other.db").to_str().unwrap().into());
+        assert!(
+            resolve_target(&request).is_err(),
+            "ordinary serving override guard must reject a non-main override"
+        );
+        assert!(!dir.path().join("unopened").exists());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn resolve_target_single_backend_requires_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = dir.path().join("khive.toml");
+        std::fs::write(&config, "").unwrap();
+        let database = dir.path().join("single.db");
+        std::fs::write(&database, b"existing fixture").unwrap();
+        let mut request = args(config);
+        request.db = Some(database.to_str().unwrap().into());
+        let target = resolve_target(&request).unwrap();
+        assert_eq!(target.path, database.canonicalize().unwrap());
+        assert_eq!(target.backend_name, "main");
+        request.db = Some(":memory:".into());
+        assert!(resolve_target(&request).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[serial_test::serial]
+    fn resolve_target_pins_symlink_and_rejects_replaced_identity() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = dir.path().join("khive.toml");
+        std::fs::write(&config, "").unwrap();
+        let database = dir.path().join("first.db");
+        let second = dir.path().join("second.db");
+        let alias = dir.path().join("alias.db");
+        std::fs::write(&database, b"first").unwrap();
+        std::fs::write(&second, b"second").unwrap();
+        std::os::unix::fs::symlink(&database, &alias).unwrap();
+        let mut request = args(config);
+        request.db = Some(alias.to_str().unwrap().into());
+        let target = resolve_target(&request).unwrap();
+        std::fs::remove_file(&alias).unwrap();
+        std::os::unix::fs::symlink(&second, &alias).unwrap();
+        assert_eq!(target.path, database.canonicalize().unwrap());
+        target.reverify().unwrap();
+        std::fs::rename(&second, &database).unwrap();
+        assert!(format!("{:#}", target.reverify().unwrap_err()).contains("changed identity"));
+    }
+}

--- a/crates/kkernel/src/lib.rs
+++ b/crates/kkernel/src/lib.rs
@@ -7,6 +7,7 @@ pub mod code_ingest;
 pub mod coordinator;
 pub mod dbpath;
 pub mod engine;
+pub mod entity_type_backfill;
 pub mod exec;
 pub mod git_ingest;
 pub mod kg;

--- a/crates/kkernel/tests/entity_type_backfill_cli.rs
+++ b/crates/kkernel/tests/entity_type_backfill_cli.rs
@@ -143,26 +143,20 @@ impl Fixture {
             .pool()
             .reader()
             .expect("fixture reader");
-        let mut statement = reader
-            .prepare(
-                "SELECT id, json_object( \
+        let encoded = reader
+            .query_row(
+                "SELECT json_group_object(id, json(snapshot)) FROM ( \
+                 SELECT id, json_object( \
                  'namespace', namespace, 'kind', kind, 'entity_type', entity_type, \
                  'name', name, 'description', description, 'properties', json(properties), \
                  'tags', json(tags), 'created_at', created_at, 'updated_at', updated_at, \
-                 'deleted_at', deleted_at, 'merged_into', merged_into, 'merge_event_id', merge_event_id) \
-                 FROM entities ORDER BY id",
+                 'deleted_at', deleted_at, 'merged_into', merged_into, 'merge_event_id', merge_event_id) AS snapshot \
+                 FROM entities ORDER BY id)",
+                [],
+                |row| row.get::<_, String>(0),
             )
-            .expect("prepare exact entity snapshot");
-        let rows = statement
-            .query_map([], |row| {
-                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-            })
             .expect("query exact entity snapshot");
-        rows.map(|row| {
-            let (id, encoded) = row.expect("entity row");
-            (id, serde_json::from_str(&encoded).expect("entity JSON"))
-        })
-        .collect()
+        serde_json::from_str(&encoded).expect("entity snapshot JSON")
     }
 
     fn freeze_sidecars(&self) -> Vec<(PathBuf, std::fs::Permissions)> {
@@ -509,6 +503,7 @@ fn entity_type_backfill_routes_only_to_the_configured_kg_backend() {
     for route in ["main", "other"] {
         let main = Fixture::new();
         let other = Fixture::new();
+        let logs = tempfile::tempdir().expect("private writer diagnostics");
         let config = main.root.path().join("multi.toml");
         let encoded = toml::to_string(&json!({
             "runtime":{"packs":["kg", "git"]},
@@ -531,6 +526,8 @@ fn entity_type_backfill_routes_only_to_the_configured_kg_backend() {
         let discovery_events = discovery_parent.join("khive.db.events.db");
         assert!(!discovery_parent.exists());
         let output = isolated_command(main.root.path())
+            // Process diagnostics are not discovery or backend database writes.
+            .env("KHIVE_WRITER_TIMEOUT_SINK_DIR", logs.path())
             .env_remove("KHIVE_EVENTS_SPLIT")
             .args(["entity-type-backfill", "--apply", "--config"])
             .arg(&config)
@@ -550,7 +547,8 @@ fn entity_type_backfill_routes_only_to_the_configured_kg_backend() {
         assert_eq!(target.entities()[&id(4)]["entity_type"], "adr");
         assert!(
             !discovery_events.exists() && !discovery_parent.exists(),
-            "default-on events split must not materialize the discovery store ({route})"
+            "default-on events split must not materialize the discovery store ({route}): {:?}",
+            files(main.root.path()).keys().collect::<Vec<_>>()
         );
         for fixture in [&main, &other] {
             assert!(

--- a/crates/kkernel/tests/entity_type_backfill_cli.rs
+++ b/crates/kkernel/tests/entity_type_backfill_cli.rs
@@ -1,0 +1,665 @@
+//! Exercise the admin boundary against private legacy-entity fixtures.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use khive_runtime::{KhiveRuntime, RuntimeConfig};
+use serde_json::{json, Value};
+use tempfile::TempDir;
+
+const NAMESPACE: &str = "fixture";
+
+struct Fixture {
+    root: TempDir,
+    db: PathBuf,
+    config: PathBuf,
+    runtime: KhiveRuntime,
+}
+
+fn id(index: usize) -> String {
+    format!("00000000-0000-0000-0000-{index:012x}")
+}
+
+fn isolated_command(root: &Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_kkernel"));
+    for (key, _) in std::env::vars_os() {
+        if key.to_string_lossy().starts_with("KHIVE_") {
+            command.env_remove(key);
+        }
+    }
+    command
+        .current_dir(root)
+        .env("HOME", root)
+        .env("KHIVE_NO_DAEMON", "1")
+        .env("KHIVE_NO_EMBED", "true")
+        .env("KHIVE_EVENTS_SPLIT", "0");
+    command
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let root = tempfile::tempdir().expect("private backfill fixture");
+        let db = root.path().join("entities.db");
+        let config = root.path().join("config.toml");
+        std::fs::write(
+            &config,
+            "[runtime]\npacks = [\"kg\", \"git\"]\n[actor]\nid = \"fixture\"\n",
+        )
+        .expect("write isolated pack configuration");
+        let runtime = KhiveRuntime::new(RuntimeConfig {
+            db_path: Some(db.clone()),
+            ..RuntimeConfig::no_embeddings()
+        })
+        .expect("migrate private fixture");
+        let rows = [
+            (
+                "concept",
+                Some("algorithm"),
+                json!({"type":"not_a_registered_subtype", "keep":"served"}),
+            ),
+            ("document", None, json!({"type":"paper"})),
+            ("concept", None, json!({"type":" ALGO "})),
+            (
+                "document",
+                None,
+                json!({"type":" Architecture--Decision__Record "}),
+            ),
+            (
+                "concept",
+                None,
+                json!({
+                    "type":" __CoNcEpT-- ",
+                    "nested":{"type":"keep", "number":12},
+                    "items":[null, true, {"label":" unchanged "}]
+                }),
+            ),
+            ("concept", None, json!({"type":"Article", "keep":true})),
+            ("document", None, json!({"type":"not_a_registered_subtype"})),
+            ("concept", None, json!({"other":"missing type"})),
+            ("concept", None, json!({"type":null})),
+            ("concept", None, json!({"type":42})),
+        ];
+        {
+            let writer = runtime.backend().pool().writer().expect("seed writer");
+            for (index, (kind, entity_type, properties)) in rows.into_iter().enumerate() {
+                writer
+                    .execute(
+                        "INSERT INTO entities \
+                         (id, namespace, kind, entity_type, name, description, properties, tags, \
+                          created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?9)",
+                        (
+                            id(index + 1),
+                            NAMESPACE,
+                            kind,
+                            entity_type,
+                            format!("Legacy fixture {}", index + 1),
+                            "Preserve the description",
+                            properties.to_string(),
+                            "[\"keep\"]",
+                            (index + 1) as i64,
+                        ),
+                    )
+                    .expect("seed legacy entity without write-time normalization");
+            }
+            for (index, namespace, deleted_at) in
+                [(11, "other", None), (12, NAMESPACE, Some(99_i64))]
+            {
+                writer
+                    .execute(
+                        "INSERT INTO entities \
+                         (id, namespace, kind, name, properties, created_at, updated_at, deleted_at) \
+                         VALUES (?1, ?2, 'document', 'Excluded entity', '{\"type\":\"paper\"}', 99, 99, ?3)",
+                        (id(index), namespace, deleted_at),
+                    )
+                    .expect("seed namespace and tombstone controls");
+            }
+        }
+        Self {
+            root,
+            db,
+            config,
+            runtime,
+        }
+    }
+
+    fn run(&self, extra: &[&str]) -> Output {
+        isolated_command(self.root.path())
+            .arg("entity-type-backfill")
+            .arg("--db")
+            .arg(&self.db)
+            .arg("--config")
+            .arg(&self.config)
+            .args(["--namespace", NAMESPACE])
+            .args(extra)
+            .output()
+            .expect("run admin command against private fixture")
+    }
+
+    fn entities(&self) -> BTreeMap<String, Value> {
+        let reader = self
+            .runtime
+            .backend()
+            .pool()
+            .reader()
+            .expect("fixture reader");
+        let mut statement = reader
+            .prepare(
+                "SELECT id, json_object( \
+                 'namespace', namespace, 'kind', kind, 'entity_type', entity_type, \
+                 'name', name, 'description', description, 'properties', json(properties), \
+                 'tags', json(tags), 'created_at', created_at, 'updated_at', updated_at, \
+                 'deleted_at', deleted_at, 'merged_into', merged_into, 'merge_event_id', merge_event_id) \
+                 FROM entities ORDER BY id",
+            )
+            .expect("prepare exact entity snapshot");
+        let rows = statement
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .expect("query exact entity snapshot");
+        rows.map(|row| {
+            let (id, encoded) = row.expect("entity row");
+            (id, serde_json::from_str(&encoded).expect("entity JSON"))
+        })
+        .collect()
+    }
+
+    fn freeze_sidecars(&self) -> Vec<(PathBuf, std::fs::Permissions)> {
+        ["-wal", "-shm"]
+            .into_iter()
+            .filter_map(|suffix| {
+                let mut name = self.db.as_os_str().to_os_string();
+                name.push(suffix);
+                let path = PathBuf::from(name);
+                let original = std::fs::metadata(&path).ok()?.permissions();
+                let mut frozen = original.clone();
+                frozen.set_readonly(true);
+                std::fs::set_permissions(&path, frozen).expect("freeze private snapshot sidecar");
+                Some((path, original))
+            })
+            .collect()
+    }
+}
+
+fn restore_permissions(sidecars: Vec<(PathBuf, std::fs::Permissions)>) {
+    for (path, permissions) in sidecars {
+        std::fs::set_permissions(path, permissions).expect("restore private sidecar permissions");
+    }
+}
+
+fn files(root: &Path) -> BTreeMap<PathBuf, Option<Vec<u8>>> {
+    fn visit(root: &Path, current: &Path, result: &mut BTreeMap<PathBuf, Option<Vec<u8>>>) {
+        for entry in std::fs::read_dir(current).expect("read fixture directory") {
+            let path = entry.expect("fixture entry").path();
+            let relative = path
+                .strip_prefix(root)
+                .expect("private fixture path")
+                .to_path_buf();
+            if path.is_dir() {
+                result.insert(relative, None);
+                visit(root, &path, result);
+            } else {
+                result.insert(
+                    relative,
+                    Some(std::fs::read(path).expect("snapshot fixture file")),
+                );
+            }
+        }
+    }
+    let mut result = BTreeMap::new();
+    visit(root, root, &mut result);
+    result
+}
+
+fn report(output: &Output) -> Value {
+    assert!(
+        output.status.success(),
+        "admin command failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = std::str::from_utf8(&output.stdout).expect("admin stdout must be UTF-8");
+    let (target_line, encoded) = stdout.split_once('\n').expect("target must precede counts");
+    let target = target_line
+        .strip_prefix("target: ")
+        .expect("resolved target line");
+    assert!(
+        Path::new(target).is_absolute(),
+        "target must be absolute: {target}"
+    );
+    let value: Value = serde_json::from_str(encoded).expect("JSON report after target line");
+    assert_eq!(value["target"], target, "target line and report must agree");
+    value
+}
+
+fn assert_classification(value: &Value, mode: &str) {
+    assert_eq!(value["namespace"], NAMESPACE);
+    assert_eq!(value["mode"], mode);
+    assert_eq!(value["effective_limit"], 1_000_000);
+    assert_eq!(value["scanned"], 10);
+    assert_eq!(value["eligible"], 6);
+    assert_eq!(value["promote"], 3);
+    assert_eq!(value["echo"], 1);
+    assert_eq!(value["untouched"], 2);
+    assert_eq!(value["wrong_kind"], 1);
+    assert_eq!(value["nullable_before"], 9);
+    assert_eq!(value["projected_nullable_after"], 6);
+    assert_eq!(value["complete"], true);
+    assert_eq!(value["failures"], json!([]));
+    let packs = value["loaded_packs"]
+        .as_array()
+        .expect("reported composed packs");
+    assert!(packs.contains(&json!("kg")));
+    assert!(packs.contains(&json!("git")));
+    assert!(value["registry_types"]["document"]
+        .as_array()
+        .expect("reported document subtypes")
+        .contains(&json!("adr")));
+    assert!(!value["source_revision"]
+        .as_str()
+        .expect("source revision")
+        .is_empty());
+}
+
+#[test]
+fn entity_type_backfill_dry_run_classifies_without_changing_db_or_sidecars() {
+    let fixture = Fixture::new();
+    let entities_before = fixture.entities();
+    let frozen = fixture.freeze_sidecars();
+    assert_eq!(frozen.len(), 2, "fixture must retain both WAL and SHM");
+    let before = files(fixture.root.path());
+    let output = fixture.run(&["--dry-run"]);
+    let after = files(fixture.root.path());
+    restore_permissions(frozen);
+    assert_eq!(
+        before, after,
+        "dry-run must leave all fixture files byte-identical"
+    );
+    let value = report(&output);
+    assert_classification(&value, "dry_run");
+    assert_eq!(value["nullable_after"], 9);
+    assert_eq!(value["promoted"], 0);
+    assert_eq!(value["echo_removed"], 0);
+    assert_eq!(fixture.entities(), entities_before);
+}
+
+#[test]
+fn entity_type_backfill_apply_canonicalizes_preserves_controls_and_is_idempotent() {
+    let fixture = Fixture::new();
+    let before = fixture.entities();
+    let value = report(&fixture.run(&["--apply"]));
+    assert_classification(&value, "apply");
+    assert_eq!(value["nullable_after"], 6);
+    assert_eq!(value["promoted"], 3);
+    assert_eq!(value["echo_removed"], 1);
+
+    let after = fixture.entities();
+    assert_eq!(
+        after.len(),
+        before.len(),
+        "backfill must not delete entities"
+    );
+    for (index, canonical) in [(2, "paper"), (3, "algorithm"), (4, "adr")] {
+        let mut expected = before[&id(index)].clone();
+        expected["entity_type"] = json!(canonical);
+        expected["updated_at"] = after[&id(index)]["updated_at"].clone();
+        assert_eq!(
+            after[&id(index)],
+            expected,
+            "promotion changes only subtype and revision"
+        );
+    }
+    let mut expected_echo = before[&id(5)].clone();
+    expected_echo["properties"]
+        .as_object_mut()
+        .unwrap()
+        .remove("type");
+    expected_echo["updated_at"] = after[&id(5)]["updated_at"].clone();
+    assert_eq!(
+        after[&id(5)],
+        expected_echo,
+        "echo removes only the top-level type key"
+    );
+    for index in [1, 6, 7, 8, 9, 10, 11, 12] {
+        assert_eq!(
+            after[&id(index)],
+            before[&id(index)],
+            "excluded entity {index} changed"
+        );
+    }
+
+    let frozen = fixture.freeze_sidecars();
+    let output = fixture.run(&["--dry-run"]);
+    restore_permissions(frozen);
+    let again = report(&output);
+    assert_eq!(again["promote"], 0);
+    assert_eq!(again["echo"], 0);
+    assert_eq!(again["eligible"], 2);
+    assert_eq!(again["untouched"], 2);
+    assert_eq!(again["wrong_kind"], 1);
+    assert_eq!(again["nullable_before"], 6);
+    assert_eq!(again["nullable_after"], 6);
+    assert_eq!(again["projected_nullable_after"], 6);
+    assert_eq!(again["complete"], true);
+    assert_eq!(fixture.entities(), after);
+}
+
+#[test]
+fn entity_type_backfill_limit_counts_live_scanned_entities_not_only_candidates() {
+    let fixture = Fixture::new();
+    let before = fixture.entities();
+    let value = report(&fixture.run(&["--apply", "--limit", "1"]));
+    assert_eq!(value["scanned"], 1);
+    assert_eq!(value["effective_limit"], 1);
+    assert_eq!(value["eligible"], 0);
+    for field in [
+        "promote",
+        "echo",
+        "untouched",
+        "wrong_kind",
+        "promoted",
+        "echo_removed",
+    ] {
+        assert_eq!(value[field], 0, "{field}");
+    }
+    assert_eq!(value["nullable_before"], 9);
+    assert_eq!(value["nullable_after"], 9);
+    assert_eq!(value["projected_nullable_after"], 9);
+    assert_eq!(value["complete"], false);
+    assert_eq!(value["failures"], json!([]));
+    assert_eq!(fixture.entities(), before);
+}
+
+#[test]
+fn entity_type_backfill_applies_across_pages_and_second_scan_is_idempotent() {
+    let fixture = Fixture::new();
+    {
+        let writer = fixture
+            .runtime
+            .backend()
+            .pool()
+            .writer()
+            .expect("page fixture writer");
+        for offset in 0..260 {
+            let index = offset + 13;
+            let (kind, legacy_type) = if offset % 2 == 0 {
+                ("document", " Article ")
+            } else {
+                ("concept", " CONCEPT ")
+            };
+            writer
+                .execute(
+                    "INSERT INTO entities \
+                     (id, namespace, kind, name, properties, created_at, updated_at) \
+                     VALUES (?1, ?2, ?3, 'Page boundary entity', ?4, ?5, ?5)",
+                    (
+                        id(index),
+                        NAMESPACE,
+                        kind,
+                        json!({"type":legacy_type, "keep":{"index":index}}).to_string(),
+                        index as i64,
+                    ),
+                )
+                .expect("seed bounded multi-page legacy population");
+        }
+    }
+    let value = report(&fixture.run(&["--apply"]));
+    assert_eq!(value["scanned"], 270);
+    assert_eq!(value["eligible"], 266);
+    assert_eq!(value["promote"], 133);
+    assert_eq!(value["echo"], 131);
+    assert_eq!(value["promoted"], 133);
+    assert_eq!(value["echo_removed"], 131);
+    assert_eq!(value["untouched"], 2);
+    assert_eq!(value["wrong_kind"], 1);
+    assert_eq!(value["nullable_before"], 269);
+    assert_eq!(value["nullable_after"], 136);
+    assert_eq!(value["projected_nullable_after"], 136);
+    assert_eq!(value["complete"], true);
+    assert_eq!(value["failures"], json!([]));
+    let after = fixture.entities();
+    assert_eq!(after.len(), 272);
+    for offset in 0..260 {
+        let index = offset + 13;
+        let entity = &after[&id(index)];
+        assert_eq!(entity["properties"]["keep"], json!({"index":index}));
+        if offset % 2 == 0 {
+            assert_eq!(
+                entity["entity_type"], "paper",
+                "promotion at entity {index}"
+            );
+        } else {
+            assert!(entity["entity_type"].is_null());
+            assert!(
+                entity["properties"].get("type").is_none(),
+                "echo at entity {index}"
+            );
+        }
+    }
+    let frozen = fixture.freeze_sidecars();
+    let output = fixture.run(&["--dry-run"]);
+    restore_permissions(frozen);
+    let again = report(&output);
+    assert_eq!(again["scanned"], 270);
+    assert_eq!(again["eligible"], 2);
+    assert_eq!(again["promote"], 0);
+    assert_eq!(again["echo"], 0);
+    assert_eq!(again["nullable_before"], 136);
+    assert_eq!(again["nullable_after"], 136);
+    assert_eq!(again["complete"], true);
+    assert_eq!(fixture.entities(), after);
+}
+
+#[test]
+fn entity_type_backfill_rejects_missing_or_conflicting_modes_and_invalid_limits() {
+    let root = tempfile::tempdir().expect("private argument fixture");
+    let db = root.path().join("missing-parent/missing.db");
+    for args in [
+        vec![],
+        vec!["--dry-run", "--apply"],
+        vec!["--dry-run", "--limit", "0"],
+        vec!["--apply", "--limit", "1000001"],
+    ] {
+        let output = isolated_command(root.path())
+            .arg("entity-type-backfill")
+            .arg("--db")
+            .arg(&db)
+            .args(&args)
+            .output()
+            .expect("run invalid CLI arguments");
+        assert_eq!(
+            output.status.code(),
+            Some(2),
+            "clap must reject {args:?}: {output:?}"
+        );
+        assert!(
+            !db.parent().unwrap().exists(),
+            "invalid args must not create a database directory"
+        );
+    }
+}
+
+#[test]
+fn entity_type_backfill_dry_run_missing_database_does_not_create_files() {
+    let root = tempfile::tempdir().expect("private missing database fixture");
+    let config = root.path().join("config.toml");
+    std::fs::write(&config, "[runtime]\npacks = [\"kg\", \"git\"]\n").unwrap();
+    let db = root.path().join("missing-parent/missing.db");
+    let before = files(root.path());
+    let output = isolated_command(root.path())
+        .arg("entity-type-backfill")
+        .args(["--dry-run", "--db"])
+        .arg(&db)
+        .arg("--config")
+        .arg(&config)
+        .output()
+        .expect("run missing database dry-run");
+    assert!(!output.status.success(), "missing source must be refused");
+    assert_eq!(
+        files(root.path()),
+        before,
+        "refusal must not create files or parents"
+    );
+    assert!(!db.parent().unwrap().exists());
+}
+
+#[test]
+fn entity_type_backfill_routes_only_to_the_configured_kg_backend() {
+    for route in ["main", "other"] {
+        let main = Fixture::new();
+        let other = Fixture::new();
+        let config = main.root.path().join("multi.toml");
+        let encoded = toml::to_string(&json!({
+            "runtime":{"packs":["kg", "git"]},
+            "packs":{"kg":{"backend":route}, "git":{"backend":"other"}},
+            "backends":[
+                {"name":"main", "path":main.db},
+                {"name":"other", "path":other.db}
+            ]
+        }))
+        .expect("serialize isolated backend config");
+        std::fs::write(&config, encoded).expect("write multi-backend config");
+        let (target, untouched) = if route == "main" {
+            (&main, &other)
+        } else {
+            (&other, &main)
+        };
+        let untouched_entities = untouched.entities();
+        let untouched_before = files(untouched.root.path());
+        let discovery_parent = main.root.path().join(".khive");
+        let discovery_events = discovery_parent.join("khive.db.events.db");
+        assert!(!discovery_parent.exists());
+        let output = isolated_command(main.root.path())
+            .env_remove("KHIVE_EVENTS_SPLIT")
+            .args(["entity-type-backfill", "--apply", "--config"])
+            .arg(&config)
+            .args(["--namespace", NAMESPACE])
+            .output()
+            .expect("run configured-backend apply");
+        let untouched_after = files(untouched.root.path());
+        let value = report(&output);
+        assert_classification(&value, "apply");
+        assert_eq!(value["nullable_after"], 6);
+        assert_eq!(value["promoted"], 3);
+        assert_eq!(value["echo_removed"], 1);
+        assert_eq!(
+            std::fs::canonicalize(value["target"].as_str().unwrap()).unwrap(),
+            std::fs::canonicalize(&target.db).unwrap()
+        );
+        assert_eq!(target.entities()[&id(4)]["entity_type"], "adr");
+        assert!(
+            !discovery_events.exists() && !discovery_parent.exists(),
+            "default-on events split must not materialize the discovery store ({route})"
+        );
+        for fixture in [&main, &other] {
+            assert!(
+                !fixture.root.path().join("entities.db.events.db").exists(),
+                "backfill must keep mutation events in the selected database ({route})"
+            );
+        }
+        assert_eq!(
+            untouched_before, untouched_after,
+            "unrelated backend files must remain byte-identical ({route})"
+        );
+        assert_eq!(untouched.entities(), untouched_entities);
+    }
+}
+
+#[test]
+fn entity_type_backfill_refuses_conflicting_alias_access_modes_before_writes() {
+    let fixture = Fixture::new();
+    let config = fixture.root.path().join("conflicting-aliases.toml");
+    let encoded = toml::to_string(&json!({
+        "runtime":{"packs":["kg", "git"]},
+        "packs":{"kg":{"backend":"other"}},
+        "backends":[
+            {"name":"main", "path":fixture.db, "read_only":true},
+            {"name":"other", "path":fixture.db, "read_only":false}
+        ]
+    }))
+    .expect("serialize conflicting aliases");
+    std::fs::write(&config, encoded).expect("write conflicting aliases");
+    let entities_before = fixture.entities();
+    let before = files(fixture.root.path());
+    #[cfg(unix)]
+    let identity_before = {
+        use std::os::unix::fs::MetadataExt;
+        let metadata = std::fs::metadata(&fixture.db).expect("fixture identity");
+        (metadata.dev(), metadata.ino())
+    };
+    for mode in ["--dry-run", "--apply"] {
+        let output = isolated_command(fixture.root.path())
+            .env_remove("KHIVE_EVENTS_SPLIT")
+            .args(["entity-type-backfill", mode, "--config"])
+            .arg(&config)
+            .args(["--namespace", NAMESPACE])
+            .output()
+            .expect("run conflicting alias refusal");
+        assert!(
+            !output.status.success(),
+            "contradictory access aliases must refuse {mode}: {output:?}"
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("every alias of one database must use the same access mode"),
+            "refusal must use the ordinary server alias validation: {stderr}"
+        );
+        assert_eq!(
+            files(fixture.root.path()),
+            before,
+            "alias refusal must preserve all files and directories ({mode})"
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            let metadata = std::fs::metadata(&fixture.db).expect("preserved fixture identity");
+            assert_eq!(
+                (metadata.dev(), metadata.ino()),
+                identity_before,
+                "alias refusal must preserve the database identity ({mode})"
+            );
+        }
+    }
+    assert_eq!(fixture.entities(), entities_before);
+}
+
+#[test]
+fn entity_type_backfill_refuses_missing_backend_reference_before_writes() {
+    let fixture = Fixture::new();
+    let other = Fixture::new();
+    let config = fixture.root.path().join("missing-backend.toml");
+    let encoded = toml::to_string(&json!({
+        "runtime":{"packs":["kg", "git"]},
+        "packs":{"kg":{"backend":"missing"}},
+        "backends":[
+            {"name":"main", "path":fixture.db},
+            {"name":"other", "path":other.db}
+        ]
+    }))
+    .expect("serialize missing-reference config");
+    std::fs::write(&config, encoded).expect("write missing-reference config");
+    let before = files(fixture.root.path());
+    let other_before = files(other.root.path());
+    let output = isolated_command(fixture.root.path())
+        .args(["entity-type-backfill", "--apply", "--config"])
+        .arg(&config)
+        .args(["--namespace", NAMESPACE])
+        .output()
+        .expect("run missing-backend refusal");
+    assert!(
+        !output.status.success(),
+        "missing KG target must be refused"
+    );
+    assert!(String::from_utf8_lossy(&output.stderr).contains("missing"));
+    assert_eq!(
+        files(fixture.root.path()),
+        before,
+        "refusal must not modify main"
+    );
+    assert_eq!(
+        files(other.root.path()),
+        other_before,
+        "refusal must not modify another backend"
+    );
+}


### PR DESCRIPTION
## What

`kkernel entity-type-backfill --dry-run | --apply`: an admin subcommand that promotes an entity's
legacy `properties.type` into the `entity_type` column.

## Why

`entity_type` was added after the corpus existed, so rows carry their subtype in a property and the
read side falls back to it. That fallback cannot be retired while rows still need it, so this lane
is upstream of removing it.

## The classification rule, which is the part that matters

Rows are classified against the **composed runtime registry** — the built-in table plus every
loaded pack — not against `EntityTypeRegistry::builtin()`. This is not a style choice. A census of
this population taken against the built-in table alone under-reported by 682 rows, because
`document:adr` is declared by the git pack and not by the built-in table, and the same mistake in
the tool would leave those rows untouched while reporting them classified.

Three groups, three different treatments:

- **Promote**: the property value resolves in the composed registry, and it becomes `entity_type`,
  passing through the registry's own write-time validator rather than a second copy of the rule.
- **Echo**: the value merely repeats the entity's kind and carries nothing. The top-level `type`
  property is removed and `entity_type` stays NULL.
- **Wrong-kind and unknown**: left completely alone. Changing an entity's kind moves the validity of
  every edge incident to it, which is not this tool's decision to make.

So only the promote group reduces the NULL projection, and the command says so rather than letting
a reader infer that a clean run empties the column.

## Safety shape

Both modes require quiescent writers while the database and its sidecars are copied; dry-run opens
only a disposable read-only copy. Apply pins the selected file identity, re-checks the schema on the
copy before opening anything writable, and compares each full entity preimage before a normal
runtime update through the ordinary CAS, reindex and event path — no direct SQL writes.

The resolved canonical absolute target is printed and flushed **before** any census or write, so an
operator can see which store answered before anything happens to it. Missing targets, unresolvable
routes, duplicate names, memory targets, conflicting physical alias access modes and read-only apply
targets all refuse before a writable handle exists. In a multi-backend configuration KG routes by
the same explicit rule the serving path uses, and unrelated stores are never opened.

Two hazards found during source review and fixed before this opened: the detached command now
disables split-event routing so it cannot materialize an unrelated event database beside the
discovery anchor, and it reuses the server's alias-mode validation before opening rather than
duplicating it.

## Honest reporting

`--limit` caps visited live rows and a capped scan **discloses that it was incomplete**. Apply's
after-count is labelled as a separate observed census rather than an atomic before/after snapshot. A
post-write failure is reported as possibly committed, and the report does not authorize a blind
retry. Idempotence is the state where both promote and echo counts are zero.

## Verification

Pinned 1.95.0, `KHIVE_PACKS` and `KHIVE_ADDITIONAL_EMBEDDING_MODELS` unset, worktree-local target:

- `cargo fmt --all -- --check` — 0
- `cargo clippy --workspace --all-targets -- -D warnings` — 0
- `cargo test -p kkernel -p khive-runtime -p khive-mcp -p khive-types --no-fail-fast` — 3362
  passed, 0 failed

Mutation control, stated before running: making the promotion write the raw property value instead
of the validated subtype must fail the exact stored-value assertion. Observed exactly that; the
source was restored by hash and the canonicalization test passed again.

No live `--apply` has been run against any production store by this branch.

## Note for the reviewer

The first head of this branch did not compile: `khive-mcp` was missing a test-only `toml`
dependency, and a test called `prepare` on a guard type that has no such method. A byte-exact source
review had returned approve on it, which is worth stating rather than quietly fixing — both errors
resolve across crate boundaries, so a review of the bytes in one file cannot see either one. The
gate numbers above are from the corrected head.
