### PR TITLE
fix(knowledge): a batch refusal names the atom and field it came from

### DIFF
--- a/crates/khive-pack-knowledge/src/knowledge/crud.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/crud.rs
@@ -268,24 +268,26 @@ impl KnowledgeHandlers {
             };
             validate_atom_content(&content)?;
             // Secret gate: scan all caller-supplied text and structured fields
-            // before any reader/writer is acquired.
-            khive_runtime::secret_gate::check(&slug)?;
-            khive_runtime::secret_gate::check(&atom_in.name)?;
-            khive_runtime::secret_gate::check(&content)?;
+            // before any reader/writer is acquired. Every refusal is located to the
+            // atom that produced it: this loop returns ONE error for the whole batch,
+            // and the matched text is by construction text the caller cannot place
+            // without being told which atom it came from (#2605).
+            use khive_runtime::secret_gate::{self, locate};
+            locate(secret_gate::check(&slug), &slug, "slug")?;
+            locate(secret_gate::check(&atom_in.name), &slug, "name")?;
+            locate(secret_gate::check(&content), &slug, "content")?;
             if let Some(ref tags_vec) = atom_in.tags {
-                khive_runtime::secret_gate::check_tags(tags_vec)?;
+                locate(secret_gate::check_tags(tags_vec), &slug, "tags")?;
             }
             if let Some(ref props) = atom_in.properties {
-                khive_runtime::secret_gate::check_json(props)?;
+                locate(secret_gate::check_json(props), &slug, "properties")?;
             }
-            khive_runtime::secret_gate::reject_reserved_secret_gate_property(
-                atom_in.properties.as_ref(),
-            )?;
+            secret_gate::reject_reserved_secret_gate_property(atom_in.properties.as_ref())?;
             if let Some(Some(uri)) = &atom_in.source_uri {
-                khive_runtime::secret_gate::check(uri)?;
+                locate(secret_gate::check(uri), &slug, "source_uri")?;
             }
             if let Some(Some(st)) = &atom_in.source_type {
-                khive_runtime::secret_gate::check(st)?;
+                locate(secret_gate::check(st), &slug, "source_type")?;
             }
         }
 

--- a/crates/khive-pack-knowledge/src/knowledge/crud.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/crud.rs
@@ -252,7 +252,7 @@ impl KnowledgeHandlers {
         let sql = runtime.sql();
         let now = now_us();
 
-        for atom_in in &p.atoms {
+        for (index, atom_in) in p.atoms.iter().enumerate() {
             let slug = atom_in.slug.trim().to_string();
             if slug.is_empty() {
                 return Err(RuntimeError::InvalidInput(
@@ -269,25 +269,26 @@ impl KnowledgeHandlers {
             validate_atom_content(&content)?;
             // Secret gate: scan all caller-supplied text and structured fields
             // before any reader/writer is acquired. Every refusal is located to the
-            // atom that produced it: this loop returns ONE error for the whole batch,
-            // and the matched text is by construction text the caller cannot place
-            // without being told which atom it came from (#2605).
+            // atom that produced it by POSITION, never by slug: this loop returns ONE
+            // error for the whole batch, the slug is itself a scanned field, and two
+            // atoms may share a slug within one payload (#2605).
             use khive_runtime::secret_gate::{self, locate};
-            locate(secret_gate::check(&slug), &slug, "slug")?;
-            locate(secret_gate::check(&atom_in.name), &slug, "name")?;
-            locate(secret_gate::check(&content), &slug, "content")?;
+            let record = format!("atoms[{index}]");
+            locate(secret_gate::check(&slug), &record, "slug")?;
+            locate(secret_gate::check(&atom_in.name), &record, "name")?;
+            locate(secret_gate::check(&content), &record, "content")?;
             if let Some(ref tags_vec) = atom_in.tags {
-                locate(secret_gate::check_tags(tags_vec), &slug, "tags")?;
+                locate(secret_gate::check_tags(tags_vec), &record, "tags")?;
             }
             if let Some(ref props) = atom_in.properties {
-                locate(secret_gate::check_json(props), &slug, "properties")?;
+                locate(secret_gate::check_json(props), &record, "properties")?;
             }
             secret_gate::reject_reserved_secret_gate_property(atom_in.properties.as_ref())?;
             if let Some(Some(uri)) = &atom_in.source_uri {
-                locate(secret_gate::check(uri), &slug, "source_uri")?;
+                locate(secret_gate::check(uri), &record, "source_uri")?;
             }
             if let Some(Some(st)) = &atom_in.source_type {
-                locate(secret_gate::check(st), &slug, "source_type")?;
+                locate(secret_gate::check(st), &record, "source_type")?;
             }
         }
 

--- a/crates/khive-pack-knowledge/tests/integration.rs
+++ b/crates/khive-pack-knowledge/tests/integration.rs
@@ -4050,12 +4050,12 @@ async fn upsert_atoms_refusal_names_the_offending_atom_not_just_the_text() {
                     {
                         "slug": "clean-sibling-atom",
                         "name": "Clean Sibling",
-                        "content": "This atom carries ordinary prose about retrieval augmented generation and contains nothing credential shaped anywhere in it.",
+                        "content": "This atom carries ordinary prose about retrieval augmented generation and contains nothing credential shaped anywhere in it, only plain words about ranking and recall quality.",
                     },
                     {
                         "slug": "atom-carrying-the-credential",
                         "name": "Offending Atom",
-                        "content": "deploy token ghp_FakeGitHubToken0000000000000000000", // gitleaks:allow
+                        "content": "The deploy token for the staging cluster is ghp_FakeGitHubToken0000000000000000000 and it must be rotated before the next release ships to every tenant.", // gitleaks:allow
                     },
                 ]
             }),

--- a/crates/khive-pack-knowledge/tests/integration.rs
+++ b/crates/khive-pack-knowledge/tests/integration.rs
@@ -4035,6 +4035,48 @@ fn is_secret_detected(err: &RuntimeError) -> bool {
     matches!(err, RuntimeError::SecretDetected(_))
 }
 
+/// A batch refusal names the atom it came from. Without this the caller holds N
+/// atoms and one error describing text that lives in whichever sibling refused,
+/// so a clean atom and a refusing one are indistinguishable in the response
+/// (#2605).
+#[tokio::test]
+async fn upsert_atoms_refusal_names_the_offending_atom_not_just_the_text() {
+    let f = pack(rt());
+    let result = f
+        .dispatch(
+            "knowledge.upsert_atoms",
+            json!({
+                "atoms": [
+                    {
+                        "slug": "clean-sibling-atom",
+                        "name": "Clean Sibling",
+                        "content": "This atom carries ordinary prose about retrieval augmented generation and contains nothing credential shaped anywhere in it.",
+                    },
+                    {
+                        "slug": "atom-carrying-the-credential",
+                        "name": "Offending Atom",
+                        "content": "deploy token ghp_FakeGitHubToken0000000000000000000", // gitleaks:allow
+                    },
+                ]
+            }),
+        )
+        .await;
+    let err = result.expect_err("a credential in the second atom must refuse the call");
+    assert!(
+        is_secret_detected(&err),
+        "the refusal must stay classified as a secret detection; got: {err:?}"
+    );
+    let rendered = err.to_string();
+    assert!(
+        rendered.contains("atom-carrying-the-credential"),
+        "the refusal must name the atom that produced it; got: {rendered}"
+    );
+    assert!(
+        !rendered.contains("clean-sibling-atom"),
+        "the refusal must not name a bystander atom; got: {rendered}"
+    );
+}
+
 /// knowledge.upsert_domains with a credential-shaped slug must be rejected.
 #[tokio::test]
 async fn upsert_domains_blocks_secret_in_slug_insert() {

--- a/crates/khive-pack-knowledge/tests/integration.rs
+++ b/crates/khive-pack-knowledge/tests/integration.rs
@@ -4035,10 +4035,11 @@ fn is_secret_detected(err: &RuntimeError) -> bool {
     matches!(err, RuntimeError::SecretDetected(_))
 }
 
-/// A batch refusal names the atom it came from. Without this the caller holds N
-/// atoms and one error describing text that lives in whichever sibling refused,
-/// so a clean atom and a refusing one are indistinguishable in the response
-/// (#2605).
+/// A batch refusal names the atom it came from, by position. Without this the
+/// caller holds N atoms and one error describing text that lives in whichever
+/// sibling refused, so a clean atom and a refusing one are indistinguishable in
+/// the response (#2605). The location is positional because the slug is itself a
+/// scanned field: echoing it would return the very text the gate refused.
 #[tokio::test]
 async fn upsert_atoms_refusal_names_the_offending_atom_not_just_the_text() {
     let f = pack(rt());
@@ -4068,12 +4069,17 @@ async fn upsert_atoms_refusal_names_the_offending_atom_not_just_the_text() {
     );
     let rendered = err.to_string();
     assert!(
-        rendered.contains("atom-carrying-the-credential"),
-        "the refusal must name the atom that produced it; got: {rendered}"
+        rendered.contains("in atoms[1].content"),
+        "the refusal must locate the atom and field that produced it; got: {rendered}"
     );
     assert!(
-        !rendered.contains("clean-sibling-atom"),
-        "the refusal must not name a bystander atom; got: {rendered}"
+        !rendered.contains("atoms[0]"),
+        "the refusal must not point at a bystander atom; got: {rendered}"
+    );
+    assert!(
+        !rendered.contains("atom-carrying-the-credential")
+            && !rendered.contains("clean-sibling-atom"),
+        "the location is positional: a slug is itself a scanned field and never echoed; got: {rendered}"
     );
 }
 

--- a/crates/khive-runtime/src/error.rs
+++ b/crates/khive-runtime/src/error.rs
@@ -1032,11 +1032,13 @@ mod channel_ingest_failure_class_tests {
             detector: "fixture",
             trigger: None,
             masked: "first-rendering".to_string(),
+            location: None,
         });
         let second = RuntimeError::SecretDetected(SecretMatch {
             detector: "fixture",
             trigger: Some("token"),
             masked: "completely-different-rendering".to_string(),
+            location: None,
         });
 
         assert_ne!(first.to_string(), second.to_string());

--- a/crates/khive-runtime/src/secret_gate.rs
+++ b/crates/khive-runtime/src/secret_gate.rs
@@ -63,6 +63,9 @@ pub struct SecretMatch {
     pub trigger: Option<&'static str>,
     /// `first6...N` — the first 6 chars of the match followed by the total length.
     pub masked: String,
+    /// Which record and field the match came from, when the caller scanned a
+    /// batch. `None` for a single-record scan, where the caller already knows.
+    pub location: Option<String>,
 }
 
 impl std::fmt::Display for SecretMatch {
@@ -70,6 +73,9 @@ impl std::fmt::Display for SecretMatch {
         write!(f, "content matches secret pattern {}", self.detector)?;
         if let Some(trigger) = self.trigger {
             write!(f, " near '{trigger}'")?;
+        }
+        if let Some(location) = &self.location {
+            write!(f, " in {location}")?;
         }
         write!(f, ". {}", block_guidance(self.detector))
     }
@@ -131,6 +137,24 @@ pub fn check_tags(tags: &[String]) -> RuntimeResult<()> {
         check(tag)?;
     }
     Ok(())
+}
+
+/// Name the record and field a batch-loop refusal came from.
+///
+/// A batch verb scans each record and returns on the first refusal, so the
+/// caller gets ONE error for N records. Without this the error names only the
+/// matched text, which by construction is text the caller cannot find: it sits
+/// in whichever sibling record refused, and every other record in the call is
+/// rejected with it (khive #2605). Pass through anything that is not a gate
+/// refusal unchanged — this adds identity, it does not reclassify.
+pub fn locate<T>(result: RuntimeResult<T>, record: &str, field: &str) -> RuntimeResult<T> {
+    result.map_err(|error| match error {
+        RuntimeError::SecretDetected(matched) => RuntimeError::SecretDetected(SecretMatch {
+            location: Some(format!("{record}.{field}")),
+            ..matched
+        }),
+        other => other,
+    })
 }
 
 // ─── Reserved property key (ADR-115 Amendment 1) ────────────────────────────
@@ -2499,6 +2523,7 @@ fn build_match(detector: &'static str, candidate: &str) -> SecretMatch {
         detector,
         trigger: None,
         masked,
+        location: None,
     }
 }
 


### PR DESCRIPTION
## What

`knowledge.upsert_atoms` scans every atom with the secret gate and returns on the
first refusal. The caller gets one error for the whole list, and the error
describes only the matched text, which by construction lives in whichever
sibling atom refused. Every other atom in the call is rejected with it.

Measured: a batched run parked 97 atoms on one refusal. Re-sent one atom per
call, 90 committed and 7 refuse on their own. Of the 97, 57 do not contain the
reported trigger word anywhere in their own fields.

## Change

- `secret_gate::locate(result, record, field)` attaches the record's identity
  and the field name to a `SecretDetected` refusal and passes every other error
  through unchanged. It adds identity; it does not reclassify.
- `SecretMatch` gains `location: Option<String>`, rendered as ` in <record>.<field>`
  by `Display`. The masked value is unchanged.
- The atom loop wraps each scan in `locate(..., &slug, "<field>")` for slug,
  name, content, tags, properties, source_uri and source_type.

The batch is still all-or-nothing. That part of the contract is the subject of
ADR-183 (#2607); this change is the half that is true either way and lands first,
because an all-or-nothing batch whose single error cannot be located is unusable
whether or not partial commit exists.

## Test

`upsert_atoms_refusal_names_the_offending_atom_not_just_the_text`: a two-atom
batch whose second atom carries a credential must refuse, stay classified as a
secret detection, name the second atom's slug, and not name the clean sibling.

Closes the first ask in #2605.
